### PR TITLE
fix(background-task): remove background_output polling CTA from all launch paths (#5221)

### DIFF
--- a/packages/omo-opencode/src/tools/background-task/constants.ts
+++ b/packages/omo-opencode/src/tools/background-task/constants.ts
@@ -1,6 +1,8 @@
-export const BACKGROUND_TASK_DESCRIPTION = `Run agent task in background. Returns a background task ID (\`bg_...\`) immediately; notifies on completion.
+export const BACKGROUND_TASK_DESCRIPTION = `Run agent task in background. Returns a background task ID (\`bg_...\`) immediately and notifies on completion.
 
-Use \`background_output\` to get results. Prompts MUST be in English.`
+Do NOT poll for results. The system delivers a <system-reminder> when the task finishes.
+
+Prompts MUST be in English.`
 
 export const BACKGROUND_OUTPUT_DESCRIPTION = `Get output from background task. Use full_session=true to fetch session messages with filters. System notifies on completion, so block=true rarely needed. - Timeout values are in milliseconds (ms), NOT seconds.
 

--- a/packages/omo-opencode/src/tools/background-task/create-background-task.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/create-background-task.test.ts
@@ -155,4 +155,33 @@ describe("createBackgroundTask", () => {
     expect(secondResult).toContain("Task ID: task-2")
     expect(secondResult).not.toContain("interrupt")
   })
+
+  test("does not advertise background_output CTA in launch return (issue #5221)", async () => {
+    //#given - a successful launch
+    launchMock.mockResolvedValueOnce({
+      id: "test-task-id",
+      sessionId: "ses-launch-cta",
+      description: "Test task",
+      agent: "test-agent",
+      status: "pending",
+    })
+    getTaskMock.mockReturnValueOnce({
+      id: "test-task-id",
+      sessionId: "ses-launch-cta",
+      description: "Test task",
+      agent: "test-agent",
+      status: "pending",
+    })
+
+    //#when
+    const result = await tool.execute(testArgs, testContext)
+
+    //#then - the return must NOT nudge the model into calling background_output
+    // before the <system-reminder> arrives (Kimi K2 recency bias pulls it through)
+    expect(result).not.toContain("Use `background_output` with task_id=")
+    expect(result).not.toContain("to check.")
+    // ...but the anti-polling instruction must still be present
+    expect(result).toContain("Do NOT call background_output now")
+    expect(result).toContain("<system-reminder>")
+  })
 })

--- a/packages/omo-opencode/src/tools/background-task/create-background-task.ts
+++ b/packages/omo-opencode/src/tools/background-task/create-background-task.ts
@@ -117,9 +117,7 @@ Description: ${task.description}
 Agent: ${task.agent}
 Status: ${task.status}
 
-System notifies on completion. Use \`background_output\` with task_id="${task.id}" to check.
-
-Do NOT call background_output now. Wait for <system-reminder> notification first.`
+Do NOT call background_output now. Wait for <system-reminder> notification first. The system will deliver the result when the task completes; you do not need to poll for it.`
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         return `[ERROR] Failed to launch background task: ${message}`

--- a/packages/omo-opencode/src/tools/call-omo-agent/background-agent-executor.test.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/background-agent-executor.test.ts
@@ -1,0 +1,76 @@
+/// <reference types="bun-types" />
+import { describe, test, expect, mock } from "bun:test"
+import type { BackgroundManager } from "../../features/background-agent"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { executeBackgroundAgent } from "./background-agent-executor"
+
+describe("executeBackgroundAgent", () => {
+  const launchMock = mock(async (): Promise<{
+    id: string
+    sessionId: string | null
+    description: string
+    agent: string
+    status: string
+  }> => ({
+    id: "test-task-id",
+    sessionId: null,
+    description: "Test task",
+    agent: "explore",
+    status: "pending",
+  }))
+  const getTaskMock = mock()
+
+  const mockManager = {
+    launch: launchMock,
+    getTask: getTaskMock,
+  } as unknown as BackgroundManager
+
+  const testContext = {
+    sessionID: "test-session",
+    messageID: "test-message",
+    agent: "test-agent",
+    directory: "/Users/yeongyu/local-workspaces/omo",
+    worktree: "/Users/yeongyu/local-workspaces/omo",
+    abort: new AbortController().signal,
+    metadata: () => {},
+  } as unknown as Parameters<typeof executeBackgroundAgent>[1]
+
+  const testArgs = {
+    description: "Test background task",
+    prompt: "Test prompt",
+    subagent_type: "explore",
+  } as Parameters<typeof executeBackgroundAgent>[0]
+
+  const mockClient = {
+    session: {
+      messages: mock(() => Promise.resolve({ data: [] })),
+    },
+  } as unknown as PluginInput["client"]
+
+  test("does not advertise background_output CTA in launch return (issue #5221)", async () => {
+    //#given - a successful launch
+    launchMock.mockResolvedValueOnce({
+      id: "test-task-id",
+      sessionId: "ses-agent-cta",
+      description: "Test task",
+      agent: "explore",
+      status: "pending",
+    })
+    getTaskMock.mockReturnValueOnce({
+      id: "test-task-id",
+      sessionId: "ses-agent-cta",
+      description: "Test task",
+      agent: "explore",
+      status: "pending",
+    })
+
+    //#when
+    const result = await executeBackgroundAgent(testArgs, testContext, mockManager, mockClient)
+
+    //#then - no polling CTA, anti-polling instruction preserved
+    expect(result).not.toContain("Use `background_output` with task_id=")
+    expect(result).not.toContain("to check.")
+    expect(result).toContain("Do NOT call background_output now")
+    expect(result).toContain("<system-reminder>")
+  })
+})

--- a/packages/omo-opencode/src/tools/call-omo-agent/background-agent-executor.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/background-agent-executor.ts
@@ -82,9 +82,7 @@ Description: ${task.description}
 Agent: ${task.agent} (subagent)
 Status: ${task.status}
 
-System notifies on completion. Use \`background_output\` with task_id="${task.id}" to check.
-
-Do NOT call background_output now. Wait for <system-reminder> notification first.`
+Do NOT call background_output now. Wait for <system-reminder> notification first. The system will deliver the result when the task completes; you do not need to poll for it.`
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
 		return `Failed to launch background agent task: ${message}`

--- a/packages/omo-opencode/src/tools/call-omo-agent/background-executor.test.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/background-executor.test.ts
@@ -254,4 +254,31 @@ describe("executeBackground", () => {
     if (!launchArgs) throw new Error("Expected launch arguments")
     expect(launchArgs.agent).toBe("explore")
   })
+
+  test("does not advertise background_output CTA in launch return (issue #5221)", async () => {
+    //#given - a successful launch
+    launchMock.mockResolvedValueOnce({
+      id: "test-task-id",
+      sessionId: "ses-call-omo-cta",
+      description: "Test task",
+      agent: "test-agent",
+      status: "pending",
+    })
+    getTaskMock.mockReturnValueOnce({
+      id: "test-task-id",
+      sessionId: "ses-call-omo-cta",
+      description: "Test task",
+      agent: "test-agent",
+      status: "pending",
+    })
+
+    //#when
+    const result = await executeBackground(testArgs, testContext, mockManager, mockClient)
+
+    //#then - no polling CTA, but anti-polling instruction preserved
+    expect(result).not.toContain("Use `background_output` with task_id=")
+    expect(result).not.toContain("to check.")
+    expect(result).toContain("Do NOT call background_output now")
+    expect(result).toContain("<system-reminder>")
+  })
 })

--- a/packages/omo-opencode/src/tools/call-omo-agent/background-executor.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/background-executor.ts
@@ -82,7 +82,7 @@ export async function executeBackground(
       metadata: { sessionId: sessionId ?? "pending" },
     })
 
-    return `Background agent task launched successfully.
+		return `Background agent task launched successfully.
 
 Task ID: ${task.id}
 Session ID: ${sessionId ?? "pending"}
@@ -90,9 +90,7 @@ Description: ${task.description}
 Agent: ${task.agent} (subagent)
 Status: ${task.status}
 
-System notifies on completion. Use \`background_output\` with task_id="${task.id}" to check.
-
-Do NOT call background_output now. Wait for <system-reminder> notification first.`
+Do NOT call background_output now. Wait for <system-reminder> notification first. The system will deliver the result when the task completes; you do not need to poll for it.`
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     return `Failed to launch background agent task: ${message}`

--- a/packages/omo-opencode/src/tools/delegate-task/background-continuation.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-continuation.test.ts
@@ -95,4 +95,51 @@ describe("executeBackgroundContinuation - subagent metadata", () => {
     expect(result).toContain("session_id: ses_resumed_456")
     expect(result).not.toContain("subagent:")
   })
+
+  test("does not advertise background_output CTA in continuation return (issue #5221)", async () => {
+    //#given - mock manager.resume
+    const mockManager = {
+      resume: async () => ({
+        id: "bg_task_cta",
+        description: "continue task",
+        agent: "oracle",
+        status: "running",
+        sessionId: "ses_resumed_cta",
+      }),
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-cta",
+      metadata: mock(() => Promise.resolve()),
+    }
+
+    const mockExecutorCtx = {
+      manager: mockManager,
+    }
+
+    const parentContext = {
+      sessionID: "parent-session",
+      messageID: "msg-parent",
+      agent: "sisyphus",
+    }
+
+    const args = {
+      task_id: "ses_resumed_cta",
+      prompt: "continue",
+      description: "resume task",
+      load_skills: [],
+      run_in_background: true,
+    }
+
+    //#when
+    const { executeBackgroundContinuation } = require("./background-continuation")
+    const result = await executeBackgroundContinuation(args, mockCtx, mockExecutorCtx, parentContext)
+
+    //#then - no polling CTA, anti-polling instruction preserved
+    expect(result).not.toContain("Use `background_output` with task_id=")
+    expect(result).not.toContain("to check.")
+    expect(result).toContain("Do NOT call background_output now")
+    expect(result).toContain("<system-reminder>")
+  })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/background-continuation.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-continuation.ts
@@ -66,9 +66,7 @@ Agent: ${task.agent}
 Status: ${task.status}
 
 Agent continues with full previous context preserved.
-System notifies on completion. Use \`background_output\` with task_id="${backgroundTaskId}" to check.
-
-Do NOT call background_output now. Wait for <system-reminder> notification first.
+Do NOT call background_output now. Wait for <system-reminder> notification first. The system will deliver the result when the task completes; you do not need to poll for it.
 
 ${buildTaskMetadataBlock({
       sessionId,

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
@@ -609,4 +609,46 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
     expectFn(launchCalls).toHaveLength(1)
     expectFn(launchCalls[0].agent).toBe("Hephaestus - Deep Agent")
   })
+
+  testFn("does not advertise background_output CTA in launch return (issue #5221)", async () => {
+    //#given - a successful launch
+    const manager = {
+      launch: async () => ({
+        id: "bg_cta_check",
+        sessionId: "ses_cta_check",
+        description: "CTA check",
+        agent: "explore",
+        status: "running",
+      }),
+      getTask: () => ({ sessionId: "ses_cta_check" }),
+    }
+
+    //#when
+    const result = await executeBackgroundTask(
+      {
+        description: "CTA check",
+        prompt: "check",
+        run_in_background: true,
+        load_skills: [],
+      },
+      {
+        sessionID: "ses_parent",
+        callID: "call_cta",
+        metadata: async () => {},
+        abort: new AbortController().signal,
+      },
+      { manager },
+      { sessionID: "ses_parent", messageID: "msg_cta" },
+      "explore",
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    //#then - no polling CTA, anti-polling instruction preserved
+    expectFn(result).not.toContain("Use `background_output` with task_id=")
+    expectFn(result).not.toContain("to check.")
+    expectFn(result).toContain("Do NOT call background_output now")
+    expectFn(result).toContain("<system-reminder>")
+  })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.ts
@@ -218,9 +218,7 @@ Description: ${task.description}
 Agent: ${task.agent}${args.category ? ` (category: ${args.category})` : ""}
 Status: ${task.status}
 
-System notifies on completion. Use \`background_output\` with task_id="${task.id}" to check.
-
-Do NOT call background_output now. Wait for <system-reminder> notification first.${taskMetadataBlock}`
+Do NOT call background_output now. Wait for <system-reminder> notification first. The system will deliver the result when the task completes; you do not need to poll for it.${taskMetadataBlock}`
   } catch (error) {
     return formatDetailedError(error, {
       operation: "Launch background task",


### PR DESCRIPTION
## Problem

Kimi K2 (k2p5/k2p6/k2p7) is especially prone to follow the most recent/repeated instruction (recency bias). The launch return text and `BACKGROUND_TASK_DESCRIPTION` both advertised:

- `Use \`background_output\` to get results`
- `Use \`background_output\` with task_id="..." to check`

This CTA overrides the `Do NOT call background_output now` anti-polling line, so the model immediately calls `background_output` instead of waiting for the `<system-reminder>` completion notification.

## Fix

Removed the polling CTAs from all 6 launch/description paths and reworded them to lead with the no-polling instruction:

- `packages/omo-opencode/src/tools/background-task/constants.ts` (BACKGROUND_TASK_DESCRIPTION)
- `packages/omo-opencode/src/tools/background-task/create-background-task.ts` (launch return)
- `packages/omo-opencode/src/tools/call-omo-agent/background-agent-executor.ts` (launch return)
- `packages/omo-opencode/src/tools/call-omo-agent/background-executor.ts` (launch return)
- `packages/omo-opencode/src/tools/delegate-task/background-task.ts` (launch return)
- `packages/omo-opencode/src/tools/delegate-task/background-continuation.ts` (continuation return)

## Footprint confirmation (per review feedback)

The 11-file diff is **6 source files + 5 test files**, all mechanical:

- **6 source files** (`-4 to -6 lines each`): every source change is the **same** mechanical removal — drop the `Use \`background_output\` with task_id="..."` line, keep the `Do NOT call background_output now...` anti-polling instruction (slightly reworded to lead with the no-polling message and clarify that the system delivers the result automatically).
- **5 test files** (`+27 to +76 lines each`): one regression test per affected source file asserting the launch/continuation return no longer contains the polling CTA while still carrying the anti-polling instruction.

No unrelated changes are included.

## Scope (re-scoped from original PR)

The original PR included two changes — the `isKimiK2Model` regex fix (k2p7+) and the `background_output` CTA removal. The regex fix is already in upstream via [80ae81031](https://github.com/code-yeongyu/oh-my-openagent/commit/80ae81031), so this PR carries only the CTA removal. Reduced from 13 to 11 files.

## TDD Evidence

- 5 regression tests added (one per affected source file), each asserting:
  - Launch/continuation return does NOT contain `background_output` polling CTA
  - Launch/continuation return DOES contain anti-polling instruction
- All tests pass after the fix

Fixes #5221