### PR TITLE
fix(team-mode): treat empty message correlation IDs as omitted

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts
@@ -250,6 +250,27 @@ describe("createTeamSendMessageTool", () => {
     await expect(readdir(escapedInboxRoot)).rejects.toThrow()
   })
 
+  test("treats a host-injected empty correlationId as omitted", async () => {
+    // given
+    const fixture = await createTeamFixture()
+
+    // when
+    const result = await fixture.tool.execute({
+      teamRunId: fixture.teamRunId,
+      to: "m2",
+      body: "hello without metadata",
+      correlationId: "",
+    }, fixture.toolContext(fixture.memberOneSessionId))
+    const parsedResult = parseToolResult(result)
+
+    // then
+    expect(parsedResult.deliveredTo).toEqual(["m2"])
+    const inboxDir = getInboxDir(resolveBaseDir(fixture.config), fixture.teamRunId, "m2")
+    const [messageFile] = (await readdir(inboxDir)).filter((entry) => entry.endsWith(".json"))
+    const message = MessageSchema.parse(JSON.parse(await readFile(path.join(inboxDir, messageFile), "utf8")))
+    expect(message.correlationId).toBeUndefined()
+  })
+
   test("persists optional message metadata from tool arguments", async () => {
     // given
     const fixture = await createTeamFixture()

--- a/packages/omo-opencode/src/features/team-mode/tools/messaging.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/messaging.ts
@@ -30,7 +30,7 @@ const TeamSendMessageArgsSchema = z.object({
   to: z.string().min(1),
   body: z.string(),
   kind: z.enum(MESSAGE_TOOL_KINDS).optional(),
-  correlationId: z.uuid().optional(),
+  correlationId: z.preprocess((value) => value === "" ? undefined : value, z.uuid().optional()),
   summary: z.string().optional(),
   references: z.array(TeamReferenceArgsSchema).optional(),
 })


### PR DESCRIPTION
## Summary

- Treat host-injected empty `correlationId` values for `team_send_message` as omitted.
- Keep non-empty invalid correlation IDs rejected by the existing UUID validation.

## Changes

- Wrap `correlationId` parsing with a Zod preprocess that maps `""` to `undefined`.
- Add a regression test proving `correlationId: ""` delivers the message and persists no correlation ID.

## Testing

- `bun install --frozen-lockfile`
- `bun test packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts` -> 32 pass, 0 fail
- LSP diagnostics: no errors for `messaging.ts` and `messaging.test.ts`
- `opencode-qa` harness self-check attempted; blocked by missing host `sqlite3`, while isolated XDG sandbox checks passed.

## Related Issues

Closes #5254

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat empty `correlationId` values injected by hosts in `team_send_message` as omitted, so messages still deliver and no ID is stored. Non-empty invalid IDs are still rejected; fixes #5254.

- **Bug Fixes**
  - Added Zod preprocess to map `""` to `undefined` before UUID validation.
  - Added regression test to confirm delivery and no persisted `correlationId` when passed `""`.

<sup>Written for commit ef9601a9466976742b03a685004a53b646b615c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

