### PR TITLE
fix(team-mode): avoid cancelling active tasks on rejected delete

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team-bg-cancel.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team-bg-cancel.test.ts
@@ -3,10 +3,25 @@
 import { afterEach, describe, expect, mock, test } from "bun:test"
 import { rm } from "node:fs/promises"
 
-import type { BackgroundManager } from "../../background-agent/manager"
+import type { BackgroundTask } from "../../background-agent/types"
+import { deleteTeam, type DeleteTeamBackgroundManager } from "./delete-team"
 import { createFixture, updateMemberStatuses } from "./shutdown-test-fixtures"
 
-const { deleteTeam } = await import("./delete-team")
+type BackgroundTaskInput = Pick<BackgroundTask, "id" | "sessionId" | "teamRunId"> & {
+  parentMessageId?: string
+}
+
+function createBackgroundTask(input: BackgroundTaskInput): BackgroundTask {
+  return {
+    ...input,
+    parentMessageId: input.parentMessageId ?? "delegate-task:test-task",
+    parentSessionId: "lead-session",
+    description: "test task",
+    prompt: "test prompt",
+    agent: "sisyphus",
+    status: "running",
+  }
+}
 
 describe("deleteTeam cancels only this team's background tasks", () => {
   const temporaryDirectories: string[] = []
@@ -29,15 +44,15 @@ describe("deleteTeam cancels only this team's background tasks", () => {
     const getTasksByParentSessionMock = mock((sessionId: string) => {
       if (sessionId !== "lead-session") return []
       return [
-        { id: "team-task-a", sessionId: "session-a", parentMessageId: `team-create:${fixture.teamRunId}:member-a` },
-        { id: "team-task-b", sessionId: "session-b", parentMessageId: `team-create:${fixture.teamRunId}:member-b` },
+        createBackgroundTask({ id: "team-task-a", sessionId: "session-a", parentMessageId: `team-create:${fixture.teamRunId}:member-a` }),
+        createBackgroundTask({ id: "team-task-b", sessionId: "session-b", parentMessageId: `team-create:${fixture.teamRunId}:member-b` }),
       ]
     })
-    const cancelTaskMock = mock(async () => true)
+    const cancelTaskMock = mock(async (_taskId: string, _options?: Parameters<DeleteTeamBackgroundManager["cancelTask"]>[1]) => true)
     const bgMgr = {
       getTasksByParentSession: getTasksByParentSessionMock,
       cancelTask: cancelTaskMock,
-    } as BackgroundManager
+    } satisfies DeleteTeamBackgroundManager
 
     // when
     await deleteTeam(fixture.teamRunId, fixture.config, undefined, bgMgr)
@@ -52,6 +67,37 @@ describe("deleteTeam cancels only this team's background tasks", () => {
     expect(secondCall?.[0]).toBe("team-task-b")
   })
 
+  test("does not cancel background tasks when non-force delete rejects active members", async () => {
+    // given
+    const fixture = await createFixture()
+    temporaryDirectories.push(fixture.baseDir)
+
+    const getTasksByParentSessionMock = mock(() => [
+      createBackgroundTask({ id: "team-task-a", sessionId: "session-a", parentMessageId: `team-create:${fixture.teamRunId}:member-a` }),
+    ])
+    const cancelTaskMock = mock(async (_taskId: string, _options?: Parameters<DeleteTeamBackgroundManager["cancelTask"]>[1]) => true)
+    const bgMgr = {
+      getTasksByParentSession: getTasksByParentSessionMock,
+      cancelTask: cancelTaskMock,
+    } satisfies DeleteTeamBackgroundManager
+
+    // when
+    let thrownError: unknown
+    try {
+      await deleteTeam(fixture.teamRunId, fixture.config, undefined, bgMgr)
+    } catch (error) {
+      thrownError = error
+    }
+
+    // then
+    if (!(thrownError instanceof Error)) {
+      throw new Error("deleteTeam should reject active members")
+    }
+    expect(thrownError.message).toContain("members still active")
+    expect(getTasksByParentSessionMock).not.toHaveBeenCalled()
+    expect(cancelTaskMock).not.toHaveBeenCalled()
+  })
+
   test("leaves unrelated sibling tasks on the same lead session alive", async () => {
     // given
     const fixture = await createFixture()
@@ -62,16 +108,16 @@ describe("deleteTeam cancels only this team's background tasks", () => {
     })
 
     const getTasksByParentSessionMock = mock(() => [
-      { id: "team-task-a", sessionId: "session-a", parentMessageId: `team-create:${fixture.teamRunId}:member-a` },
-      { id: "delegate-task-x", sessionId: "session-x", parentMessageId: "delegate-task:plan-refactor" },
-      { id: "background-task-y", sessionId: "session-y", parentMessageId: undefined },
-      { id: "team-task-other", sessionId: "session-other", parentMessageId: "team-create:other-team-id:member-a" },
+      createBackgroundTask({ id: "team-task-a", sessionId: "session-a", parentMessageId: `team-create:${fixture.teamRunId}:member-a` }),
+      createBackgroundTask({ id: "delegate-task-x", sessionId: "session-x", parentMessageId: "delegate-task:plan-refactor" }),
+      createBackgroundTask({ id: "background-task-y", sessionId: "session-y", parentMessageId: "delegate-task:background-task-y" }),
+      createBackgroundTask({ id: "team-task-other", sessionId: "session-other", parentMessageId: "team-create:other-team-id:member-a" }),
     ])
-    const cancelTaskMock = mock(async () => true)
+    const cancelTaskMock = mock(async (_taskId: string, _options?: Parameters<DeleteTeamBackgroundManager["cancelTask"]>[1]) => true)
     const bgMgr = {
       getTasksByParentSession: getTasksByParentSessionMock,
       cancelTask: cancelTaskMock,
-    } as BackgroundManager
+    } satisfies DeleteTeamBackgroundManager
 
     // when
     await deleteTeam(fixture.teamRunId, fixture.config, undefined, bgMgr)

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team.ts
@@ -17,6 +17,8 @@ export type DeleteTeamDeps = {
   log: typeof log
 }
 
+export type DeleteTeamBackgroundManager = Pick<BackgroundManager, "getTasksByParentSession" | "cancelTask">
+
 const defaultDeleteTeamDeps: DeleteTeamDeps = {
   canVisualize,
   removeTeamLayout,
@@ -52,22 +54,12 @@ export async function deleteTeam(
   teamRunId: string,
   config: TeamModeConfig,
   tmuxMgr?: TmuxSessionManager,
-  bgMgr?: BackgroundManager,
+  bgMgr?: DeleteTeamBackgroundManager,
   options?: { force?: boolean },
   deps: DeleteTeamDeps = defaultDeleteTeamDeps,
 ): Promise<{ removedWorktrees: string[]; removedLayout: boolean }> {
   const runtimeState = await loadRuntimeState(teamRunId, config)
   const nonLeadMembers = runtimeState.members.filter((member) => member.agentType !== "leader")
-
-  if (bgMgr && runtimeState.leadSessionId) {
-    const teamMessageMarkerPrefix = `team-create:${teamRunId}:`
-    const teamTasks = bgMgr.getTasksByParentSession(runtimeState.leadSessionId)
-      .filter((task) => task.teamRunId === teamRunId || task.parentMessageId?.startsWith(teamMessageMarkerPrefix))
-    await Promise.all(teamTasks.map((task) => bgMgr.cancelTask(task.id, {
-      source: "team-mode-delete",
-      reason: `delete team ${teamRunId}`,
-    })))
-  }
 
   if (options?.force === true) {
     await transitionRuntimeState(teamRunId, (currentRuntimeState) => ({
@@ -80,6 +72,16 @@ export async function deleteTeam(
     }), config)
   } else if (nonLeadMembers.some((member) => !DELETABLE_MEMBER_STATUSES.has(member.status))) {
     throw new Error("members still active")
+  }
+
+  if (bgMgr && runtimeState.leadSessionId) {
+    const teamMessageMarkerPrefix = `team-create:${teamRunId}:`
+    const teamTasks = bgMgr.getTasksByParentSession(runtimeState.leadSessionId)
+      .filter((task) => task.teamRunId === teamRunId || task.parentMessageId?.startsWith(teamMessageMarkerPrefix))
+    await Promise.all(teamTasks.map((task) => bgMgr.cancelTask(task.id, {
+      source: "team-mode-delete",
+      reason: `delete team ${teamRunId}`,
+    })))
   }
 
   const deletableTeamStatuses = options?.force === true

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team.ts
@@ -61,16 +61,7 @@ export async function deleteTeam(
   const runtimeState = await loadRuntimeState(teamRunId, config)
   const nonLeadMembers = runtimeState.members.filter((member) => member.agentType !== "leader")
 
-  if (options?.force === true) {
-    await transitionRuntimeState(teamRunId, (currentRuntimeState) => ({
-      ...currentRuntimeState,
-      members: currentRuntimeState.members.map((member) => (
-        member.agentType === "leader" || !FORCE_COMPLETABLE_MEMBER_STATUSES.has(member.status)
-          ? member
-          : { ...member, status: "completed" }
-      )),
-    }), config)
-  } else if (nonLeadMembers.some((member) => !DELETABLE_MEMBER_STATUSES.has(member.status))) {
+  if (options?.force !== true && nonLeadMembers.some((member) => !DELETABLE_MEMBER_STATUSES.has(member.status))) {
     throw new Error("members still active")
   }
 
@@ -82,6 +73,17 @@ export async function deleteTeam(
       source: "team-mode-delete",
       reason: `delete team ${teamRunId}`,
     })))
+  }
+
+  if (options?.force === true) {
+    await transitionRuntimeState(teamRunId, (currentRuntimeState) => ({
+      ...currentRuntimeState,
+      members: currentRuntimeState.members.map((member) => (
+        member.agentType === "leader" || !FORCE_COMPLETABLE_MEMBER_STATUSES.has(member.status)
+          ? member
+          : { ...member, status: "completed" }
+      )),
+    }), config)
   }
 
   const deletableTeamStatuses = options?.force === true


### PR DESCRIPTION
## Summary

- Prevent non-force `team_delete` from cancelling active member background tasks before it rejects the delete request.
- Preserve background-task cancellation for valid delete paths after the active-member guard passes.

## Changes

- Move team background-task lookup/cancellation after the non-force active-member guard.
- Narrow the `deleteTeam` background manager dependency to the two methods it uses.
- Add a regression test proving rejected non-force deletes do not call `getTasksByParentSession` or `cancelTask`.

## Testing

- `bun install --frozen-lockfile`
- `bun test packages/omo-opencode/src/features/team-mode/team-runtime/delete-team-bg-cancel.test.ts` -> 3 pass, 0 fail
- LSP diagnostics: no errors for `delete-team.ts` and `delete-team-bg-cancel.test.ts`
- `opencode-qa` harness self-check attempted; blocked by missing host `sqlite3`, while isolated XDG sandbox checks passed.

## Related Issues

Closes #5255

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents non-force team deletes from cancelling background tasks when the delete is rejected, and keeps the correct cancel-first ordering for force deletes.

- **Bug Fixes**
  - Moved the active-member guard before background task lookup/cancel in `deleteTeam` (non-force rejects now throw early).
  - Preserved force-delete behavior: cancel team tasks first, then update member statuses.
  - Exported narrowed background manager type `DeleteTeamBackgroundManager` (`getTasksByParentSession`, `cancelTask`) and added a regression test to ensure rejected non-force deletes do not call the manager.

<sup>Written for commit c35329fceacfa1c3e494c94c286ce341e443b29a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

