### PR TITLE
fix(ulw-loop): avoid ledger writes on resume

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/src/plan-crud.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/plan-crud.ts
@@ -101,7 +101,7 @@ export async function startNextUlwLoop(repoRoot: string, args: { retryFailed?: b
 		const now = iso();
 		if (plan.aggregateCompletion?.status === "complete") return { done: true, plan };
 		const existing = plan.goals.find((goal) => goal.status === "in_progress" && isScheduleEligible(goal));
-		if (existing) { await appendLedger(repoRoot, { at: now, kind: "goal_resumed", goalId: existing.id, status: existing.status, message: "Resuming active ulw-loop" }, scope); return { plan, goal: existing, resumed: true }; }
+		if (existing) return { plan, goal: existing, resumed: true };
 		let next = plan.goals.find((goal) => goal.status === "pending" && isScheduleEligible(goal));
 		if (!next && args.retryFailed) {
 			next = plan.goals.find((goal) => goal.status === "failed" && !goal.nonRetriable && isScheduleEligible(goal));

--- a/packages/omo-codex/plugin/components/ulw-loop/test/cli-complete-goals.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/cli-complete-goals.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ulwLoopCommand } from "../src/cli-commands.ts";
+import { ulwLoopLedgerPath } from "../src/paths.ts";
 
 let testDir: string;
 let out: string[];
@@ -31,6 +32,14 @@ function stdoutJson(): Record<string, unknown> {
 	return JSON.parse(out.join(""));
 }
 
+async function ledgerKinds(sessionId: string): Promise<string[]> {
+	const raw = await readFile(ulwLoopLedgerPath(testDir, { sessionId }), "utf8");
+	return raw
+		.split(/\r?\n/)
+		.filter(Boolean)
+		.map((line) => JSON.parse(line).kind);
+}
+
 async function createPlan(): Promise<void> {
 	expect(await ulwLoopCommand(["create-goals", "--brief", "- Goal A\n- Goal B", "--json"])).toBe(0);
 	resetOutput();
@@ -48,5 +57,23 @@ describe("ulwLoopCommand complete-goals", () => {
 			instruction: { json: { objective: expect.any(String) } },
 		});
 		expect(JSON.stringify(stdoutJson())).not.toContain('"status":"active"');
+	});
+
+	it("#given an in-progress goal #when complete-goals resumes it #then the ledger is not mutated", async () => {
+		const sessionId = "resume-ledger";
+		expect(
+			await ulwLoopCommand(["create-goals", "--brief", "- Goal A\n- Goal B", "--session-id", sessionId, "--json"]),
+		).toBe(0);
+		resetOutput();
+
+		expect(await ulwLoopCommand(["complete-goals", "--session-id", sessionId, "--json"])).toBe(0);
+		expect(stdoutJson()).toMatchObject({ ok: true, resumed: false, goal: { status: "in_progress" } });
+		expect(await ledgerKinds(sessionId)).toEqual(["plan_created", "goal_started"]);
+		resetOutput();
+
+		expect(await ulwLoopCommand(["complete-goals", "--session-id", sessionId, "--json"])).toBe(0);
+
+		expect(stdoutJson()).toMatchObject({ ok: true, resumed: true, goal: { status: "in_progress" } });
+		expect(await ledgerKinds(sessionId)).toEqual(["plan_created", "goal_started"]);
 	});
 });


### PR DESCRIPTION
## Problem

`omo ulw-loop complete-goals --json` is used as the handoff/read path while a run is active. When a goal is already `in_progress`, that read-like resume appended `goal_resumed` every time, so repeated resumes dirtied `ledger.jsonl` without changing plan state.

## What changed

- Return the existing `in_progress` goal without appending a ledger entry.
- Add CLI-level regression coverage that starts a goal, resumes it, and asserts the ledger remains `["plan_created","goal_started"]` while the second response still reports `resumed: true`.

## Validation

- RED: `npm test -- test/cli-complete-goals.test.ts -t "ledger is not mutated"` failed with `goal_resumed` in the ledger before the fix.
- GREEN: `npm test -- test/cli-complete-goals.test.ts -t "ledger is not mutated"`
- `npm test` (ulw-loop component, 294 passed)
- `npm run typecheck`
- `npx biome check src/plan-crud.ts test/cli-complete-goals.test.ts`
- `npm run build`
- `bun run test:codex`
- Built CLI smoke: repeated `complete-goals --session-id smoke --json` kept ledger kinds at `["plan_created","goal_started"]`.
- Isolated Codex install/tmux smoke: local `omo@sisyphuslabs` enabled in a throwaway `CODEX_HOME`; installed ulw-loop hook emitted the expected PreToolUse denial; real `~/.codex/config.toml` hash unchanged.

---

This PR was debugged, implemented, and created with [LazyCodex](https://github.com/code-yeongyu/lazycodex).
Tag: lazycodex-generated


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop writing `goal_resumed` entries when resuming an in-progress goal via `omo ulw-loop complete-goals --json`. This makes resume idempotent and keeps `ledger.jsonl` clean.

- **Bug Fixes**
  - Return the existing `in_progress` goal without appending to the ledger in `startNextUlwLoop`.
  - Added a CLI test ensuring repeated resumes report `resumed: true` but ledger kinds remain `["plan_created","goal_started"]`.

<sup>Written for commit d4e3eaec237657254a39149eed44bc83512ef775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

