### PR TITLE
fix(agents): align GPT apply_patch guidance with upstream tool availability

### DIFF
--- a/packages/omo-opencode/src/agents/builtin-agents/hephaestus-agent.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/hephaestus-agent.ts
@@ -8,7 +8,6 @@ import { createHephaestusAgent } from "../hephaestus"
 import { applyEnvironmentContext } from "./environment-context"
 import { applyCategoryOverride, mergeAgentConfig } from "./agent-overrides"
 import { applyModelResolution, getFirstFallbackModel } from "./model-resolution"
-import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard"
 import { applyFrontierToolSchemaPermission } from "../frontier-tool-schema-guard"
 
 export function maybeCreateHephaestusConfig(input: {
@@ -109,11 +108,6 @@ export function maybeCreateHephaestusConfig(input: {
     hephaestusOverride?.permission,
     (hephaestusOverride as { tools?: Record<string, boolean> } | undefined)?.tools
   )
-
-  const gptDeny = getGptApplyPatchPermission(resolvedModel)
-  if (Object.keys(gptDeny).length > 0 && hephaestusConfig.permission) {
-    Object.assign(hephaestusConfig.permission, gptDeny)
-  }
 
   return hephaestusConfig
 }

--- a/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.test.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.test.ts
@@ -7,7 +7,7 @@ import type { CategoryConfig } from "../../config/schema";
 
 describe("maybeCreateSisyphusConfig", () => {
   describe("#given GPT model with user override allowing apply_patch", () => {
-    test("#when config is created #then apply_patch is still denied", () => {
+    test("#when config is created #then user override is respected", () => {
       // given
       const agentOverrides: AgentOverrides = {
         sisyphus: {
@@ -36,7 +36,7 @@ describe("maybeCreateSisyphusConfig", () => {
       // then
       expect(config).toBeDefined();
       expect(config?.model).toBe("openai/gpt-5.4");
-      expect(config?.permission).toHaveProperty("apply_patch", "deny");
+      expect(config?.permission).toHaveProperty("apply_patch", "allow");
     });
   });
 
@@ -282,7 +282,7 @@ describe("maybeCreateSisyphusConfig", () => {
   });
 
   describe("#given generic GPT model with user override allowing apply_patch", () => {
-    test("#when config is created #then apply_patch is still denied", () => {
+    test("#when config is created #then user override is respected", () => {
       // given
       const agentOverrides: AgentOverrides = {
         sisyphus: {
@@ -311,7 +311,7 @@ describe("maybeCreateSisyphusConfig", () => {
       // then
       expect(config).toBeDefined();
       expect(config?.model).toBe("openai/gpt-4o");
-      expect(config?.permission).toHaveProperty("apply_patch", "deny");
+      expect(config?.permission).toHaveProperty("apply_patch", "allow");
     });
   });
 });

--- a/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.ts
@@ -8,7 +8,6 @@ import { applyEnvironmentContext } from "./environment-context"
 import { applyOverrides } from "./agent-overrides"
 import { applyModelResolution, getFirstFallbackModel } from "./model-resolution"
 import { createSisyphusAgent } from "../sisyphus"
-import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard"
 import { applyFrontierToolSchemaPermission } from "../frontier-tool-schema-guard"
 
 export function maybeCreateSisyphusConfig(input: {
@@ -102,11 +101,6 @@ export function maybeCreateSisyphusConfig(input: {
     sisyphusOverride?.permission,
     (sisyphusOverride as { tools?: Record<string, boolean> } | undefined)?.tools
   )
-
-  const gptDeny = getGptApplyPatchPermission(resolvedModel)
-  if (Object.keys(gptDeny).length > 0 && sisyphusConfig.permission) {
-    Object.assign(sisyphusConfig.permission, gptDeny)
-  }
 
   sisyphusConfig = applyEnvironmentContext(sisyphusConfig, directory, {
     disableOmoEnv,

--- a/packages/omo-opencode/src/agents/gpt-apply-patch-guard.ts
+++ b/packages/omo-opencode/src/agents/gpt-apply-patch-guard.ts
@@ -1,7 +1,5 @@
-import { isGptModel } from "./types"
+export const GPT_APPLY_PATCH_GUIDANCE =
+  "Use `apply_patch` for file edits — it is the only file-editing tool available here. Keep patches small and match the surrounding lines exactly so verification passes."
 
-export const GPT_APPLY_PATCH_GUIDANCE = "Use the `edit` and `write` tools for file changes. Do not use `apply_patch` on GPT models - it is unreliable here and can hang during verification."
-
-export function getGptApplyPatchPermission(model: string): Record<string, "deny"> {
-  return isGptModel(model) ? { apply_patch: "deny" as const } : {}
-}
+export const GPT_FILE_EDIT_GUIDANCE =
+  "Use whichever file-editing tool is exposed in your toolset (`apply_patch`, or `edit`/`write`). Keep each change small and match the surrounding lines exactly so it applies on the first attempt."

--- a/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
@@ -213,8 +213,8 @@ describe("createHephaestusAgent", () => {
     expect(config.prompt).toContain("You build context by examining");
     expect(config.prompt).toContain("Never chain together bash commands");
     expect(config.prompt).toContain("<tool_usage_rules>");
-    expect(config.prompt).toContain("Do not use `apply_patch`");
-    expect(config.prompt).toContain("`edit` and `write`");
+    expect(config.prompt).toContain("Use `apply_patch`");
+    expect(config.prompt).not.toContain("Do not use `apply_patch`");
   });
 
   test("GPT 5.5 model includes GPT-5.5 specific prompt content", () => {
@@ -228,8 +228,8 @@ describe("createHephaestusAgent", () => {
     expect(config.prompt).toContain("based on GPT-5.5");
     expect(config.prompt).toContain("Manual QA Gate");
     expect(config.prompt).toContain("Forbidden stops");
-    expect(config.prompt).toContain("Do not use `apply_patch`");
-    expect(config.prompt).toContain("`edit` and `write`");
+    expect(config.prompt).toContain("Use `apply_patch`");
+    expect(config.prompt).not.toContain("Do not use `apply_patch`");
   });
 
   test("includes Hephaestus identity in prompt", () => {
@@ -244,7 +244,7 @@ describe("createHephaestusAgent", () => {
     expect(config.prompt).toContain("autonomous deep worker");
   });
 
-  test("generic GPT model includes apply_patch workaround guidance", () => {
+  test("generic GPT model gets tool-agnostic file-edit guidance", () => {
     // given
     const model = "openai/gpt-4o";
 
@@ -252,11 +252,12 @@ describe("createHephaestusAgent", () => {
     const config = createHephaestusAgent(model);
 
     // then
-    expect(config.prompt).toContain("Do not use `apply_patch`");
-    expect(config.prompt).toContain("`edit` and `write`");
+    expect(config.prompt).toContain("apply_patch");
+    expect(config.prompt).toContain("`edit`/`write`");
+    expect(config.prompt).not.toContain("Do not use `apply_patch`");
   });
 
-  test("GPT models deny apply_patch while non-GPT models do not", () => {
+  test("GPT and non-GPT models do not force-deny apply_patch", () => {
     // given
     const gpt54Model = "openai/gpt-5.4";
     const gptGenericModel = "openai/gpt-4o";
@@ -268,8 +269,8 @@ describe("createHephaestusAgent", () => {
     const claudeConfig = createHephaestusAgent(claudeModel);
 
     // then
-    expect(gpt54Config.permission ?? {}).toHaveProperty("apply_patch", "deny");
-    expect(gptGenericConfig.permission ?? {}).toHaveProperty("apply_patch", "deny");
+    expect(gpt54Config.permission ?? {}).not.toHaveProperty("apply_patch");
+    expect(gptGenericConfig.permission ?? {}).not.toHaveProperty("apply_patch");
     expect(claudeConfig.permission ?? {}).not.toHaveProperty("apply_patch");
   });
 
@@ -303,9 +304,9 @@ import { maybeCreateHephaestusConfig } from "../builtin-agents/hephaestus-agent"
 import type { AgentOverrides } from "../types";
 import type { CategoryConfig } from "../../config/schema";
 
-describe("maybeCreateHephaestusConfig GPT apply_patch guard", () => {
+describe("maybeCreateHephaestusConfig apply_patch permission", () => {
   describe("#given GPT model with user override allowing apply_patch", () => {
-    test("#when config is created #then apply_patch is still denied", () => {
+    test("#when config is created #then user override is respected", () => {
       // given
       const agentOverrides: AgentOverrides = {
         hephaestus: {
@@ -334,7 +335,7 @@ describe("maybeCreateHephaestusConfig GPT apply_patch guard", () => {
       // then
       expect(config).toBeDefined();
       expect(config?.model).toBe("openai/gpt-5.4");
-      expect(config?.permission).toHaveProperty("apply_patch", "deny");
+      expect(config?.permission).toHaveProperty("apply_patch", "allow");
     });
   });
 
@@ -373,7 +374,7 @@ describe("maybeCreateHephaestusConfig GPT apply_patch guard", () => {
   });
 
   describe("#given generic GPT model with user override allowing apply_patch", () => {
-    test("#when config is created #then apply_patch is still denied", () => {
+    test("#when config is created #then user override is respected", () => {
       // given
       const agentOverrides: AgentOverrides = {
         hephaestus: {
@@ -402,7 +403,7 @@ describe("maybeCreateHephaestusConfig GPT apply_patch guard", () => {
       // then
       expect(config).toBeDefined();
       expect(config?.model).toBe("openai/gpt-4o");
-      expect(config?.permission).toHaveProperty("apply_patch", "deny");
+      expect(config?.permission).toHaveProperty("apply_patch", "allow");
     });
   });
 

--- a/packages/omo-opencode/src/agents/hephaestus/agent.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.ts
@@ -8,7 +8,6 @@ import type {
   AvailableCategory,
 } from "../dynamic-agent-prompt-builder";
 import { categorizeTools, buildAgentIdentitySection } from "../dynamic-agent-prompt-builder";
-import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard";
 import { getFrontierToolSchemaPermission } from "../frontier-tool-schema-guard";
 
 import { buildHephaestusPrompt as buildGptPrompt } from "./gpt";
@@ -128,7 +127,6 @@ export function createHephaestusAgent(
       question: "allow",
       call_omo_agent: "deny",
       ...getFrontierToolSchemaPermission(model),
-      ...getGptApplyPatchPermission(model),
     } as AgentConfig["permission"],
     reasoningEffort: "medium",
   };

--- a/packages/omo-opencode/src/agents/hephaestus/gpt.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt.ts
@@ -1,6 +1,6 @@
 /** Generic GPT Hephaestus prompt - fallback for GPT models without a model-specific variant */
 
-import { GPT_APPLY_PATCH_GUIDANCE } from "../gpt-apply-patch-guard"
+import { GPT_FILE_EDIT_GUIDANCE } from "../gpt-apply-patch-guard"
 import type {
   AvailableAgent,
   AvailableTool,
@@ -312,7 +312,7 @@ ${oracleSection}
 1. SEARCH existing codebase for similar patterns/styles
 2. Match naming, indentation, import styles, error handling conventions
 3. Default to ASCII. Add comments only for non-obvious blocks
-4. ${GPT_APPLY_PATCH_GUIDANCE}
+4. ${GPT_FILE_EDIT_GUIDANCE}
 
 ### After Implementation (MANDATORY - DO NOT SKIP)
 

--- a/packages/omo-opencode/src/agents/sisyphus-agent-config.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-agent-config.ts
@@ -1,6 +1,5 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import { getFrontierToolSchemaPermission } from "./frontier-tool-schema-guard";
-import { getGptApplyPatchPermission } from "./gpt-apply-patch-guard";
 import { buildClaudeThinkingConfig } from "./types";
 import type { AgentMode } from "./types";
 
@@ -12,7 +11,6 @@ function buildSisyphusPermission(model: string): AgentConfig["permission"] {
     question: "allow",
     call_omo_agent: "deny",
     ...getFrontierToolSchemaPermission(model),
-    ...getGptApplyPatchPermission(model),
   } as AgentConfig["permission"];
 }
 

--- a/packages/omo-opencode/src/agents/sisyphus-agent-factory.test.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-agent-factory.test.ts
@@ -91,7 +91,7 @@ describe("createSisyphusAgent", () => {
   });
 
   describe("#given GPT-family Sisyphus models", () => {
-    test("#when creating agents #then preserves reasoning and apply_patch restrictions", () => {
+    test("#when creating agents #then preserves reasoning and leaves apply_patch available", () => {
       // given
       const models = ["openai/gpt-5.5", "openai/gpt-5.4"];
 
@@ -101,7 +101,7 @@ describe("createSisyphusAgent", () => {
 
         // then
         expect(agent.reasoningEffort).toBe("medium");
-        expect(permissionValue(agent.permission, "apply_patch")).toBe("deny");
+        expect(permissionValue(agent.permission, "apply_patch")).toBeUndefined();
         expect(agent.thinking).toBeUndefined();
       }
     });

--- a/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
@@ -19,7 +19,6 @@ import {
   migrateAgentConfig,
   type PermissionValue,
 } from "../../shared/permission-compat"
-import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard"
 
 import { buildDefaultSisyphusJuniorPrompt } from "./default"
 import { buildKimiK26SisyphusJuniorPrompt } from "./kimi-k2-6"
@@ -34,7 +33,6 @@ const MODE: AgentMode = "subagent"
 // Core tools that Sisyphus-Junior must NEVER have access to
 // Note: call_omo_agent is ALLOWED so subagents can spawn explore/librarian
 const BLOCKED_TOOLS = ["task"]
-const GPT_BLOCKED_TOOLS = ["task", "apply_patch"]
 
 export const SISYPHUS_JUNIOR_DEFAULTS = {
   model: "anthropic/claude-sonnet-4-6",
@@ -109,7 +107,7 @@ export function createSisyphusJuniorAgentWithOverrides(
 
   const promptAppend = override?.prompt_append
   const prompt = buildSisyphusJuniorPrompt(model, useTaskSystem, promptAppend)
-  const blockedTools = isGptModel(model) ? GPT_BLOCKED_TOOLS : BLOCKED_TOOLS
+  const blockedTools = BLOCKED_TOOLS
 
   const baseRestrictions = createAgentToolRestrictions(blockedTools)
 
@@ -126,7 +124,6 @@ export function createSisyphusJuniorAgentWithOverrides(
   const toolsConfig = { permission: { ...merged, ...basePermission } as Record<string, PermissionValue> }
   const permission: Record<string, PermissionValue> = {
     ...toolsConfig.permission,
-    ...getGptApplyPatchPermission(model),
   }
 
   const base: AgentConfig = {

--- a/packages/omo-opencode/src/agents/sisyphus-junior/gpt-5-4.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/gpt-5-4.ts
@@ -97,7 +97,7 @@ Style:
 1. SEARCH existing codebase for similar patterns/styles
 2. Match naming, indentation, import styles, error handling conventions
 3. Default to ASCII. Add comments only for non-obvious blocks
-4. For existing files, use the edit tool instead of write/apply_patch. Use write only when creating a new file. Do not use cat or echo for file creation/editing. ${GPT_APPLY_PATCH_GUIDANCE}
+4. Do not use cat or echo for file creation/editing. ${GPT_APPLY_PATCH_GUIDANCE}
 5. Do not chain bash commands with separators - each command should be a separate tool call
 
 ### After Implementation (MANDATORY - DO NOT SKIP)

--- a/packages/omo-opencode/src/agents/sisyphus-junior/gpt.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/gpt.ts
@@ -9,7 +9,7 @@
 
 import { resolvePromptAppend } from "../builtin-agents/resolve-file-uri"
 import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder"
-import { GPT_APPLY_PATCH_GUIDANCE } from "../gpt-apply-patch-guard"
+import { GPT_FILE_EDIT_GUIDANCE } from "../gpt-apply-patch-guard"
 
 export function buildGptSisyphusJuniorPrompt(
   useTaskSystem: boolean,
@@ -94,7 +94,7 @@ Style:
 1. SEARCH existing codebase for similar patterns/styles
 2. Match naming, indentation, import styles, error handling conventions
 3. Default to ASCII. Add comments only for non-obvious blocks
-4. ${GPT_APPLY_PATCH_GUIDANCE}
+4. ${GPT_FILE_EDIT_GUIDANCE}
 
 ### After Implementation (MANDATORY - DO NOT SKIP)
 

--- a/packages/omo-opencode/src/agents/sisyphus-junior/index.test.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/index.test.ts
@@ -181,15 +181,15 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
     })
   })
 
-  describe("GPT-5.4 edit protocol", () => {
-    test("GPT-5.4 prompt prefers edit tool over apply_patch for existing files", () => {
+  describe("GPT-5.4 file-edit protocol", () => {
+    test("GPT-5.4 prompt instructs apply_patch for file edits", () => {
       // given / when
       const prompt = buildSisyphusJuniorPrompt("openai/gpt-5.4-mini", false)
 
       // then
-      expect(prompt).toContain("For existing files, use the edit tool instead of write/apply_patch.")
-      expect(prompt).toContain("Use write only when creating a new file.")
-      expect(prompt).not.toContain("Always use apply_patch for manual code edits.")
+      expect(prompt).toContain("Use `apply_patch`")
+      expect(prompt).not.toContain("Do not use `apply_patch`")
+      expect(prompt).not.toContain("use the edit tool instead of write/apply_patch")
     })
   })
 
@@ -394,8 +394,8 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
       expect(result.prompt).toContain("Scope Discipline")
       expect(result.prompt).toContain("<tool_usage_rules>")
       expect(result.prompt).toContain("Progress Updates")
-      expect(result.prompt).toContain("Do not use `apply_patch`")
-      expect(result.prompt).toContain("`edit` and `write`")
+      expect(result.prompt).toContain("Use `apply_patch`")
+      expect(result.prompt).not.toContain("Do not use `apply_patch`")
     })
 
     test("GPT 5.4 model uses GPT-5.4 specific prompt", () => {
@@ -408,8 +408,8 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
       // then
       expect(result.prompt).toContain("expert coding agent")
       expect(result.prompt).toContain("<tool_usage_rules>")
-      expect(result.prompt).toContain("Do not use `apply_patch`")
-      expect(result.prompt).toContain("`edit` and `write`")
+      expect(result.prompt).toContain("Use `apply_patch`")
+      expect(result.prompt).not.toContain("Do not use `apply_patch`")
       expect(result.prompt).not.toContain("Always use apply_patch")
     })
 
@@ -423,11 +423,11 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
       // then
       expect(result.prompt).toContain("based on GPT-5.5")
       expect(result.prompt).toContain("focused task executor")
-      expect(result.prompt).toContain("Do not use `apply_patch`")
-      expect(result.prompt).toContain("`edit` and `write`")
+      expect(result.prompt).toContain("Use `apply_patch`")
+      expect(result.prompt).not.toContain("Do not use `apply_patch`")
     })
 
-    test("GPT variants deny apply_patch while Claude variants do not", () => {
+    test("no variant force-denies apply_patch", () => {
       // given
       const gpt54Override = { model: "openai/gpt-5.4" }
       const gpt55Override = { model: "openai/gpt-5.5" }
@@ -441,9 +441,9 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
       const claudeResult = createSisyphusJuniorAgentWithOverrides(claudeOverride)
 
       // then
-      expect(gpt54Result.permission ?? {}).toHaveProperty("apply_patch", "deny")
-      expect(gpt55Result.permission ?? {}).toHaveProperty("apply_patch", "deny")
-      expect(gptGenericResult.permission ?? {}).toHaveProperty("apply_patch", "deny")
+      expect(gpt54Result.permission ?? {}).not.toHaveProperty("apply_patch")
+      expect(gpt55Result.permission ?? {}).not.toHaveProperty("apply_patch")
+      expect(gptGenericResult.permission ?? {}).not.toHaveProperty("apply_patch")
       expect(claudeResult.permission ?? {}).not.toHaveProperty("apply_patch")
     })
 
@@ -620,7 +620,7 @@ describe("buildSisyphusJuniorPrompt", () => {
     expect(prompt).toContain("expert coding agent")
     expect(prompt).toContain("Scope Discipline")
     expect(prompt).toContain("<tool_usage_rules>")
-    expect(prompt).toContain("Do not use `apply_patch`")
+    expect(prompt).toContain("Use `apply_patch`")
   })
 
   test("GPT 5.5 model uses GPT-5.5 prompt", () => {
@@ -634,7 +634,7 @@ describe("buildSisyphusJuniorPrompt", () => {
     expect(prompt).toContain("based on GPT-5.5")
     expect(prompt).toContain("focused task executor")
     expect(prompt).toContain("Manual QA Gate")
-    expect(prompt).toContain("Do not use `apply_patch`")
+    expect(prompt).toContain("Use `apply_patch`")
   })
 
   test("generic GPT model uses generic GPT prompt", () => {
@@ -649,7 +649,7 @@ describe("buildSisyphusJuniorPrompt", () => {
     expect(prompt).toContain("Scope Discipline")
     expect(prompt).toContain("<tool_usage_rules>")
     expect(prompt).toContain("Progress Updates")
-    expect(prompt).toContain("Do not use `apply_patch`")
+    expect(prompt).toContain("Use `apply_patch`")
   })
 
   test("Claude model prompt contains Claude-specific sections", () => {

--- a/packages/omo-opencode/src/agents/sisyphus-junior/kimi-k2-6.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/kimi-k2-6.ts
@@ -13,7 +13,6 @@
 
 import { resolvePromptAppend } from "../builtin-agents/resolve-file-uri";
 import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder";
-import { GPT_APPLY_PATCH_GUIDANCE } from "../gpt-apply-patch-guard";
 import { KIMI_TOOL_LOOP_GUARD } from "../kimi-tool-loop-guard";
 
 export function buildKimiK26SisyphusJuniorPrompt(
@@ -135,8 +134,7 @@ Style:
 1. SEARCH existing codebase for similar patterns/styles
 2. Match naming, indentation, import styles, error handling conventions
 3. Default to ASCII. Add comments only for non-obvious blocks
-4. ${GPT_APPLY_PATCH_GUIDANCE}
-5. Do not chain bash commands with separators - each command should be a separate tool call
+4. Do not chain bash commands with separators - each command should be a separate tool call
 
 ### After Implementation (MANDATORY — DO NOT SKIP)
 

--- a/packages/omo-opencode/src/agents/sisyphus-junior/kimi-k2-7.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/kimi-k2-7.ts
@@ -11,7 +11,6 @@
 
 import { resolvePromptAppend } from "../builtin-agents/resolve-file-uri";
 import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder";
-import { GPT_APPLY_PATCH_GUIDANCE } from "../gpt-apply-patch-guard";
 import { KIMI_TOOL_LOOP_GUARD } from "../kimi-tool-loop-guard";
 
 function buildKimiK27TaskDisciplineSection(useTaskSystem: boolean): string {
@@ -62,7 +61,7 @@ ${buildAntiDuplicationSection()}
 
 ## Before you write code
 
-Search for the existing pattern and match it — naming, imports, error handling, indentation. Default to ASCII and comment only the non-obvious. ${GPT_APPLY_PATCH_GUIDANCE} Keep each shell command in its own call rather than chaining with separators.
+Search for the existing pattern and match it — naming, imports, error handling, indentation. Default to ASCII and comment only the non-obvious. Keep each shell command in its own call rather than chaining with separators.
 
 ## Verify before you claim done
 

--- a/packages/omo-opencode/src/agents/sisyphus/kimi-k2-6.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/kimi-k2-6.ts
@@ -27,7 +27,6 @@
  *   8. <style>             - Tone + output contract + token_economy
  */
 
-import { GPT_APPLY_PATCH_GUIDANCE } from "../gpt-apply-patch-guard";
 import type {
   AvailableAgent,
   AvailableTool,
@@ -359,7 +358,7 @@ Every implementation task follows this cycle. No exceptions.
    Skills: if ANY available skill's domain overlaps with the task, load it NOW via \`skill\` tool and include it in \`load_skills\`. When the connection is even remotely plausible, load the skill - the cost of loading an irrelevant skill is near zero, the cost of missing a relevant one is high.
 
 4. EXECUTE_OR_SUPERVISE -
-   If self: surgical changes, match existing patterns, minimal diff. Never suppress type errors. Never commit unless asked. Bugfix rule: fix minimally, never refactor while fixing. ${GPT_APPLY_PATCH_GUIDANCE}
+   If self: surgical changes, match existing patterns, minimal diff. Never suppress type errors. Never commit unless asked. Bugfix rule: fix minimally, never refactor while fixing.
    If delegated: exhaustive 6-section prompt per \`<delegation>\` protocol. Session continuity for follow-ups.
 
 5. VERIFY -

--- a/packages/omo-opencode/src/agents/sisyphus/kimi-k2-7.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/kimi-k2-7.ts
@@ -12,7 +12,6 @@
  * uses; everything else here is authored for this model.
  */
 
-import { GPT_APPLY_PATCH_GUIDANCE } from "../gpt-apply-patch-guard";
 import type {
   AvailableAgent,
   AvailableTool,
@@ -171,7 +170,7 @@ Implementation work runs this loop.
 - Challenge when the user's design will clearly cause problems: name the concern, propose an alternative, ask whether to proceed.
 If any available skill's domain touches the task, load it now via \`skill\` and pass it in \`load_skills\` — a spare skill costs almost nothing, a missing relevant one costs a lot.
 
-**Execute or supervise.** Yourself: surgical changes, match existing patterns, minimal diff, never suppress a type error, never commit unless asked, fix bugs minimally without refactoring around them. ${GPT_APPLY_PATCH_GUIDANCE} Delegating: write the six-section prompt below and reuse the session for follow-ups.
+**Execute or supervise.** Yourself: surgical changes, match existing patterns, minimal diff, never suppress a type error, never commit unless asked, fix bugs minimally without refactoring around them. Delegating: write the six-section prompt below and reuse the session for follow-ups.
 
 **Verify.** Scope the rigor to the change; never skip it.
 

--- a/packages/omo-opencode/src/agents/tool-restrictions.test.ts
+++ b/packages/omo-opencode/src/agents/tool-restrictions.test.ts
@@ -196,7 +196,7 @@ describe("read-only agent tool restrictions", () => {
   })
 
   describe("Sisyphus GPT variants", () => {
-    test("deny apply_patch for GPT models but not Claude models", () => {
+    test("does not force-deny apply_patch for GPT or Claude models", () => {
       // given
       const gpt54Agent = createSisyphusAgent("openai/gpt-5.4")
       const gptGenericAgent = createSisyphusAgent("openai/gpt-5.5")
@@ -208,8 +208,8 @@ describe("read-only agent tool restrictions", () => {
       const claudePermission = (claudeAgent.permission ?? {}) as Record<string, string>
 
       // then
-      expect(gpt54Permission["apply_patch"]).toBe("deny")
-      expect(gptGenericPermission["apply_patch"]).toBe("deny")
+      expect(gpt54Permission["apply_patch"]).toBeUndefined()
+      expect(gptGenericPermission["apply_patch"]).toBeUndefined()
       expect(claudePermission["apply_patch"]).toBeUndefined()
     })
   })


### PR DESCRIPTION
## Problem

OpenCode upstream (`packages/opencode/src/tool/registry.ts`) exposes file-editing tools **mutually exclusively** by model:

- **GPT-family** (`gpt-5.x`) → only `apply_patch`; `edit`/`write` hidden
- **non-GPT** (Claude, Kimi, GLM, …) → only `edit`/`write`; `apply_patch` hidden
- **gpt-4o / gpt-oss** are the exception (`usePatch = gpt && !oss && !gpt-4`) → they keep `edit`/`write`

Our agent prompts told GPT the **opposite** — "use `edit`/`write`, do not use `apply_patch`" — and `getGptApplyPatchPermission` additionally **denied** `apply_patch` on every GPT model. Net result on `gpt-5.x`: `edit`/`write` hidden by upstream **+** `apply_patch` denied/forbidden by us = **no working file-editing tool**. Agents fell back to PowerShell / `node` / `cat` to write files. On non-GPT models the GPT-specific warning was injected as pure noise.

Closes the gap reported in #5258 (and #4697, which was auto-closed by an unrelated PR's `Fixes:` keyword; root cause traces to #3041's `apply_patch`-deny mitigation that upstream's tool-hiding turned into a deadlock).

## Changes

- **`GPT_APPLY_PATCH_GUIDANCE`** → now recommends `apply_patch` (gpt-5.x's only file tool), with "keep patches small, match context exactly" to avoid the verification hang that originally motivated the deny (#3041). Used by the model-specific `gpt-5-4`/`gpt-5-5` prompts (always `apply_patch`).
- **`GPT_FILE_EDIT_GUIDANCE`** (new) → for the base `gpt.ts` catch-all (Hephaestus, Sisyphus-Junior), which also serves `edit`/`write`-only GPT models (`gpt-4o`, `oss`). Points at whichever tool is exposed instead of forcing one — correct for both regimes without threading the model through every prompt builder.
- **Removed `getGptApplyPatchPermission`** entirely (5 call sites) and dropped `apply_patch` from Sisyphus-Junior `GPT_BLOCKED_TOOLS`. Denying it removed GPT's only editor; user `apply_patch: allow` overrides are now respected for all models.
- **Stripped the GPT-specific guidance from non-GPT (Kimi) prompts**, where it was noise.

Net: **16 files, −23 lines** (mostly subtractive).

## QA

`bun test packages/omo-opencode/src/agents/` → **328 pass / 0 fail**. `tsgo` typecheck clean.

Drove the real factory code path (`createHephaestusAgent` / `createSisyphusAgent` / `createSisyphusJuniorAgentWithOverrides`) and asserted regime invariants across `gpt-5.5 / 5.4 / 5.3 / 4o`, `kimi`, `claude` × 3 agents:

```
agent            | model        | deny  | usesAP | forbids | generic | verdict
hephaestus       | gpt-5.5      | false | true   | false   | false   | PASS
sisyphus         | gpt-5.5      | false | true   | false   | false   | PASS
sisyphus-junior  | gpt-5.5      | false | true   | false   | false   | PASS
hephaestus       | gpt-5.4      | false | true   | false   | false   | PASS
... (gpt-5.4 x3, all PASS)
hephaestus       | gpt-5.3      | false | false  | false   | true    | PASS  (base catch-all → generic)
sisyphus-junior  | gpt-5.3      | false | false  | false   | true    | PASS
hephaestus       | gpt-4o       | false | false  | false   | true    | PASS  (edit/write regime → generic)
sisyphus         | gpt-4o       | false | false  | false   | false   | PASS  (Claude default prompt)
sisyphus/sj      | kimi-k2.6    | false | false  | false   | false   | PASS  (no GPT steering)
sisyphus/sj      | claude       | false | false  | false   | false   | PASS

TOTAL: 16  PASS: 16  FAIL: 0
```

Invariants: (a) no model denies `apply_patch`; (b) no prompt forbids it; (c) `gpt-5.4/5.5` recommend it; (d) non-GPT prompts carry no GPT file-edit steering.

**Remaining manual check (why this is a draft):** live verification on a real `gpt-5.5` session that the agent actually calls `apply_patch` successfully. Holding the linked issue open until that's confirmed, per the request in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align GPT file-edit behavior with upstream tools so GPT‑5.x uses `apply_patch` and agents can edit files again. Prompts now give model-aware guidance and the blanket deny on `apply_patch` is removed.

- **Bug Fixes**
  - Model-aware guidance: `GPT_APPLY_PATCH_GUIDANCE` now recommends `apply_patch` for GPT‑5.x; generic GPT prompts use `GPT_FILE_EDIT_GUIDANCE` to prefer whatever file tool is exposed. Removed GPT-specific file-edit text from non‑GPT prompts and deduplicated guidance.
  - Permissions: removed `getGptApplyPatchPermission`, stopped force‑denying `apply_patch` (including from Sisyphus‑Junior blocked tools), and now respect user overrides.

<sup>Written for commit e556cdbd5ed0d8b02056e4339ad9f2419e8a2ae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

