### PR TITLE
fix(opencode-qa): preserve HOME-based opencode shims

### DIFF
--- a/.agents/skills/opencode-qa/scripts/lib/common.sh
+++ b/.agents/skills/opencode-qa/scripts/lib/common.sh
@@ -54,6 +54,16 @@ oqa_db_query() {
   opencode db "$1" --format json 2>/dev/null
 }
 
+# Preserve HOME-based opencode shims after HOME is sandboxed. Some installed
+# opencode wrappers resolve the real binary via "$HOME/.opencode/bin/opencode";
+# after oqa_mk_isolated_xdg rewrites HOME, that path must still exist.
+oqa_preserve_home_opencode_bin() {
+  local real_home="$1" sandbox_home="$2"
+  [ -d "$real_home/.opencode/bin" ] || return 0
+  mkdir -p "$sandbox_home/.opencode" || return 1
+  ln -s "$real_home/.opencode/bin" "$sandbox_home/.opencode/bin" 2>/dev/null || return 1
+}
+
 # Create an isolated XDG sandbox so a spawned opencode never touches the real
 # DB. Sets globals OQA_XDG_ROOT + OQA_PROJ and exports XDG_*; registers the
 # root for cleanup.
@@ -63,10 +73,12 @@ oqa_db_query() {
 #   oqa_mk_isolated_xdg            # good
 #   root="$OQA_XDG_ROOT"           # read the global afterwards
 oqa_mk_isolated_xdg() {
-  local root
+  local root real_home
   root="$(mktemp -d -t oqa-xdg.XXXXXX)" || return 1
+  real_home="$HOME"
   OQA_TMPDIRS+=("$root")
   mkdir -p "$root/data" "$root/config" "$root/cache" "$root/state" "$root/home" "$root/proj"
+  oqa_preserve_home_opencode_bin "$real_home" "$root/home" || return 1
   export OQA_XDG_ROOT="$root"
   export HOME="$root/home"
   export OPENCODE_TEST_HOME="$root/home"
@@ -212,6 +224,32 @@ oqa__self_check() {
     oqa_pass "isolated HOME points inside sandbox"
   else
     oqa_log "FAIL: sandbox HOME not isolated (HOME='$home' OPENCODE_TEST_HOME='$test_home' root='$isodir')"; fails=$((fails+1))
+  fi
+
+  local shim_marker shim_result
+  shim_marker="$(mktemp -t oqa-shim.XXXXXX)"
+  bash -c '
+    set -u
+    . "'"${BASH_SOURCE[0]}"'"
+    fake_home="$(mktemp -d -t oqa-fake-home.XXXXXX)"
+    mkdir -p "$fake_home/.local/bin" "$fake_home/.opencode/bin"
+    printf "%s\n" "#!/usr/bin/env bash" "exec \"\$HOME/.opencode/bin/opencode\" \"\$@\"" > "$fake_home/.local/bin/opencode"
+    printf "%s\n" "#!/usr/bin/env bash" "exec \"\$HOME/.opencode/bin/opencode-real\" \"\$@\"" > "$fake_home/.opencode/bin/opencode"
+    printf "%s\n" "#!/usr/bin/env bash" "printf fake-opencode-ok" > "$fake_home/.opencode/bin/opencode-real"
+    chmod +x "$fake_home/.local/bin/opencode" "$fake_home/.opencode/bin/opencode" "$fake_home/.opencode/bin/opencode-real"
+    HOME="$fake_home"
+    PATH="$fake_home/.local/bin:$PATH"
+    oqa_mk_isolated_xdg
+    opencode > "'"$shim_marker"'"
+    oqa_cleanup
+    rm -rf "$fake_home"
+  '
+  shim_result="$(cat "$shim_marker" 2>/dev/null)"
+  rm -f "$shim_marker"
+  if [ "$shim_result" = "fake-opencode-ok" ]; then
+    oqa_pass "isolated HOME preserves HOME-based opencode shim"
+  else
+    oqa_log "FAIL: HOME-based opencode shim returned '$shim_result'"; fails=$((fails+1))
   fi
 
   if [ "$fails" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Fixes the opencode-qa isolated HOME sandbox so installed opencode wrappers that resolve through `$HOME/.opencode/bin/opencode` still work after `oqa_mk_isolated_xdg` rewrites HOME.

Adds a self-check regression that creates a fake HOME-based opencode shim, enters the isolated sandbox, and verifies the shim still reaches its real binary.

## Related Issues

- Closes #5263

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Security fix
- [ ] Infrastructure
- [ ] Documentation
- [ ] Tests only

## Affected Components

- `.agents/skills/opencode-qa/scripts/lib/common.sh`
- opencode-qa isolated XDG/HOME sandbox helper
- server and SSE smoke scripts that spawn opencode through the shared helper

## Engineering Evidence

### Rationale

The sandbox must keep opencode runtime data isolated while preserving the installed CLI wrapper contract. Some wrappers resolve the real binary via `$HOME/.opencode/bin/opencode`; after HOME was changed to the sandbox home, that path disappeared and spawned opencode failed before the smoke tests could start.

This change preserves only the installed `.opencode/bin` path inside the sandbox home while leaving XDG data/config/cache/state isolated.

### Alternatives Considered

- Keep the real HOME and isolate only XDG paths. Rejected because the helper explicitly promises an isolated HOME and existing checks assert it.
- Resolve and call the real opencode binary directly. Rejected because the helper should preserve normal command lookup behavior for all scripts using `opencode`.
- Copy binaries into the sandbox. Rejected because symlinking avoids stale copied binaries and keeps the wrapper chain intact.

### Failure Modes

- Missing real `$HOME/.opencode/bin`: helper no-ops, preserving behavior for installations that do not use HOME-based shims.
- Broken symlink creation: helper returns failure before spawning opencode, rather than failing later with a misleading server startup error.
- Real opencode DB pollution: XDG data/config/cache/state remain pointed at the sandbox.

### Verification Boundary

Automated/manual QA performed on this branch:

- `bash -n .agents/skills/opencode-qa/scripts/lib/common.sh` passed.
- LSP diagnostics for `.agents/skills/opencode-qa/scripts/lib/common.sh` reported no diagnostics.
- `bash .agents/skills/opencode-qa/scripts/server-smoke.sh --self-test` passed: health endpoint, OpenAPI docs, and unauthenticated session rejection.
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test` passed: observed `server.connected` on SSE.
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check` confirmed the new HOME-based shim regression passes, but the overall self-check still exits non-zero because `sqlite3` is not installed in this environment. That dependency failure is pre-existing and unrelated to this change.

Evidence was recorded locally under `.omo/evidence/20260614-opencode-qa-home-shim/`; that directory is ignored and intentionally not included in this PR.

### AI Boundary

The patch and PR text were AI-assisted. The behavior claims above are based on actual local command execution against installed opencode 1.17.4.

## Checklist

### 코드 품질
- [x] 린트/포맷 검사 통과
- [x] 타입 검사 통과 또는 해당 없음
- [ ] 기존 테스트 모두 통과
- [x] 새 기능/버그에 대한 테스트 추가

### 보안
- [x] 하드코딩된 시크릿/키 없음
- [x] 입력 검증 적용 또는 해당 없음
- [ ] 보안 관련 변경 시 리뷰어 지정

### 문서
- [x] README 또는 관련 문서 업데이트 필요 없음
- [x] CHANGELOG 기록 필요 없음

## Screenshots / Logs

Key verification output:

```text
PASS: isolated HOME preserves HOME-based opencode shim
PASS: server-smoke
PASS: SSE /event opened and delivered server.connected
```

## Etc

The local `sqlite3` binary is missing, so the common self-check still reports one pre-existing dependency failure even though the new shim regression passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves HOME-based `opencode` shims when the opencode-qa sandbox rewrites HOME, so wrappers resolving through `$HOME/.opencode/bin/opencode` keep working and smoke tests run reliably.

- **Bug Fixes**
  - Symlinks the real `$HOME/.opencode/bin` into the sandbox HOME via `oqa_preserve_home_opencode_bin`, called from `oqa_mk_isolated_xdg` (XDG data/config/cache/state stay isolated).
  - Adds a self-check that builds a fake HOME-based shim and verifies it reaches the real binary.

<sup>Written for commit 00db0265ee4bb349506c077beb39b215f89d0b43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

