### PR TITLE
docs(features): document older session lookup

### DIFF
--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -652,6 +652,32 @@ These user-facing tool names are served by the built-in local `ast_grep` MCP bac
 | **session_search** | Full-text search across session messages |
 | **session_info**   | Get session metadata and statistics      |
 
+#### Finding older sessions hidden by `/sessions`
+
+OpenCode's built-in `/sessions` picker can omit older sessions even when they still exist in the local session store. Use OMO's session tools to find the ID, then continue it from the TUI.
+
+```ts
+session_list({
+  from_date: "2026-01-01T00:00:00Z",
+  to_date: "2026-02-11T00:00:00Z",
+  project_path: "/absolute/path/to/project",
+  limit: 50,
+})
+```
+
+After you find the session ID, type this in OpenCode:
+
+```text
+/continue <session_id>
+```
+
+If you remember text from the conversation but not the date, search first and then read the matching session:
+
+```ts
+session_search({ query: "migration bug", limit: 20 })
+session_read({ session_id: "ses_...", limit: 200 })
+```
+
 ### Task Management Tools
 
 Requires `experimental.task_system: true` in config.


### PR DESCRIPTION
Closes #1902.

OpenCode's `/sessions` picker can hide older sessions even though OMO can still read them from the session store.

This adds a short Session Tools note that shows:
- `session_list` with date and project filters
- manual `/continue <session_id>` after finding the ID
- `session_search` plus `session_read` when the user remembers text but not the date

Checks:
- `rg -n 'Finding older sessions|/continue <session_id>|session_search' docs/reference/features.md`
- `git diff --check`
- tmux docs lookup transcript with cleanup receipt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for finding and continuing older sessions that the OpenCode `/sessions` picker may hide, addressing Linear #1902. Shows how to use OMO session tools—`session_list` (date/project filters), `session_search` + `session_read`—then continue with `/continue <session_id>`.

<sup>Written for commit cd65b8695f0e76b984de2a9875b544d4826971a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

