### PR TITLE
docs(known-issues): note CJK display-name rendering

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #4170 - CJK characters in custom agent display names can render as mojibake
+
+- **Affects**: OpenCode TUI sessions with custom OMO agent display names that include Chinese, Japanese, or Korean characters.
+- **Symptom**: The ASCII part of the agent name renders normally, but the CJK characters in the TUI header can appear garbled.
+- **Workaround**: Use ASCII-only custom display names such as `Sisyphus - Orchestrator` until the TUI rendering path handles multi-byte character widths reliably.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4170.
+
 ## v4.2.1 - Delegate-task early-failure-fallback (BLOCKER-4, resolved)
 
 BLOCKER-4 is resolved in v4.2.1. Delegated child sessions now retain the first prompt payload before dispatch and consume that bootstrap payload exactly once when runtime fallback must retry an empty-history child session.


### PR DESCRIPTION
Closes #4170.

The issue already lists the safe workaround: keep custom agent display names ASCII-only until the TUI renders CJK-width text correctly.

This adds that note to `docs/reference/known-issues.md` with the affected surface, symptom, workaround, and tracking issue.

Checks:
- `rg -n '4170|CJK characters|ASCII-only custom display names' docs/reference/known-issues.md`
- `git diff --check`
- tmux docs lookup transcript with cleanup receipt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a known-issues entry for #4170 documenting that CJK characters in custom agent display names can render as garbled text in the TUI header. The note lists the affected surface, symptom, an ASCII-only workaround, and links to the tracking issue.

<sup>Written for commit fbae37cc0e97eef99136e6593f92b34d0a087373. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

