### PR TITLE
docs(known-issues): note Windows TUI startup pause

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #4702 - Windows TUI plugin install can pause startup on a Bun npm git error
+
+- **Affects**: Windows OpenCode startup when `tui.json` includes `oh-my-openagent/tui`.
+- **Symptom**: OpenCode's built-in Bun npm client can spend about 62 seconds trying to install the TUI plugin before failing with `NpmInstallFailedError` and an unknown git error. Core OMO agents, skills, commands, and MCP tools still work without the TUI plugin.
+- **Workaround**: Remove `oh-my-openagent/tui` from the `plugin` list in `tui.json` until the Bun npm install path is fixed.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4702.
+
 ## v4.2.1 - Delegate-task early-failure-fallback (BLOCKER-4, resolved)
 
 BLOCKER-4 is resolved in v4.2.1. Delegated child sessions now retain the first prompt payload before dispatch and consume that bootstrap payload exactly once when runtime fallback must retry an empty-history child session.


### PR DESCRIPTION
Closes #4702.

On Windows, OpenCode's Bun npm client can stall startup while trying to install `oh-my-openagent/tui`. The issue report says the rest of OMO still works if the TUI plugin entry is removed.

This adds that workaround to `docs/reference/known-issues.md`.

Checks:
- `rg -n '4702|Windows TUI plugin|oh-my-openagent/tui|NpmInstallFailedError' docs/reference/known-issues.md`
- `git diff --check`
- tmux docs lookup transcript with cleanup receipt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a known-issues entry for Windows startup pauses when Bun npm tries to install `oh-my-openagent/tui`. Documents the symptom and a temporary workaround: remove the plugin from `tui.json` until the install path is fixed.

<sup>Written for commit 9070ab26b9790d4a336d4a41507c0c19f150a8e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

