### PR TITLE
docs(known-issues): note custom provider limits

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,23 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #4184 - Custom provider models without `limit` do not auto-compact
+
+- **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.
+- **Symptom**: OpenCode sees the model context as `0`, so auto-compaction never triggers and long sessions can overflow the model window.
+- **Workaround**: Add a `limit` block to each custom provider model in `opencode.json`, for example:
+
+```json
+{
+  "glm-5.1": {
+    "name": "GLM-5.1",
+    "limit": { "context": 200000, "output": 16384 }
+  }
+}
+```
+
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4184.
+
 ## v4.2.1 - Delegate-task early-failure-fallback (BLOCKER-4, resolved)
 
 BLOCKER-4 is resolved in v4.2.1. Delegated child sessions now retain the first prompt payload before dispatch and consume that bootstrap payload exactly once when runtime fallback must retry an empty-history child session.


### PR DESCRIPTION
Closes #4184.

Custom OpenAI-compatible provider models can land in `opencode.json` without a `limit` block. OpenCode then sees a `0` context window, so auto-compaction never fires.

This adds the current workaround to `docs/reference/known-issues.md`: set explicit context and output limits for each custom provider model.

Checks:
- `rg -n '4184|Custom provider models|auto-compact|glm-5\\.1|limit' docs/reference/known-issues.md`
- `git diff --check`
- tmux docs lookup transcript with cleanup receipt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document a known issue where custom OpenAI-compatible provider models without a `limit` block in `opencode.json` are treated as having 0 context, so auto-compaction never runs. Adds a workaround to set explicit `limit` (`context`, `output`) per model, with an example. Closes #4184.

<sup>Written for commit e74ddfe71c44a7b4f887a55ea598277c1b8ed9e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

