### PR TITLE
docs(install): add Bedrock provider guidance

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -435,6 +435,42 @@ opencode auth login
 
 The plugin supports up to 10 Google accounts. When one account hits rate limits, it automatically switches to the next available account.
 
+##### Amazon Bedrock
+
+OpenCode owns Bedrock authentication. Configure Bedrock in `opencode.json` or through AWS environment variables first, then use Bedrock model IDs in OMO agent or category routing.
+
+```json
+{
+  "provider": {
+    "amazon-bedrock": {
+      "options": {
+        "region": "us-east-1",
+        "profile": "my-aws-profile"
+      }
+    }
+  }
+}
+```
+
+For one-off launches, set the AWS credentials around OpenCode instead:
+
+```bash
+AWS_PROFILE=my-aws-profile AWS_REGION=us-east-1 opencode
+```
+
+After OpenCode sees the provider, reference models with the OpenCode provider prefix:
+
+```json
+{
+  "agents": {
+    "sisyphus": { "model": "amazon-bedrock/us.anthropic.claude-opus-4-7" },
+    "metis": { "model": "amazon-bedrock/us.anthropic.claude-sonnet-4-6" }
+  }
+}
+```
+
+Use OpenCode's [Amazon Bedrock provider guide](https://opencode.ai/docs/providers/#amazon-bedrock) for model access, bearer tokens, named profiles, VPC endpoints, and custom inference profile ARNs. OMO does not run a separate Bedrock login flow during install.
+
 ##### GitHub Copilot (Fallback Provider)
 
 GitHub Copilot is supported as a **fallback provider** when native providers are unavailable. Priority is agent-specific. Common install-time defaults when Copilot is the best available provider:


### PR DESCRIPTION
Closes #3803.

OpenCode already exposes Amazon Bedrock. The OMO gap was discoverability during install: users need to configure Bedrock in OpenCode first, then reference Bedrock model IDs in OMO routing.

This adds a Bedrock section to the OpenCode provider setup with:
- `opencode.json` provider options
- `AWS_PROFILE` / `AWS_REGION` launch example
- OMO agent model-routing examples
- link to the upstream OpenCode Bedrock provider guide

Checks:
- `rg -n 'Amazon Bedrock|amazon-bedrock|AWS_PROFILE|Bedrock provider guide' docs/guide/installation.md`
- `git diff --check`
- tmux docs lookup transcript with cleanup receipt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Amazon Bedrock setup section to the install guide to clarify that Bedrock is configured in OpenCode and then referenced in OMO routing (addresses #3803). Includes `opencode.json` provider options, `AWS_PROFILE`/`AWS_REGION` launch syntax, OMO model examples using the `amazon-bedrock` prefix, a link to the provider guide, and a note that OMO has no separate Bedrock login.

<sup>Written for commit 0e678608855544bd7cb71a7d0de67914c8bdfbbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

