### PR TITLE
docs(known-issues): add OpenCode cache recovery

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,16 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #4863 — OpenCode 1.16.x starts with only build/plan agents after install
+
+- **Affects**: OpenCode 1.16.x with oh-my-openagent 4.7.x.
+- **Symptom**: After installing oh-my-openagent, the OpenCode agent list only shows the built-in build/plan agents. `bunx oh-my-openagent doctor` can still report `System OK`, so this looks like a successful install even though the OMO agents are not visible.
+- **Workaround**: Stop OpenCode, clear the OpenCode and OMO cache directories, then reinstall:
+
+  ```sh
+  rm -rf ~/.cache/opencode/ ~/.cache/oh-my-openagent/ ~/.cache/oh-my-opencode/
+  bunx oh-my-openagent install
+  ```
+
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4863.


### PR DESCRIPTION
## Summary
- document the OpenCode 1.16.x symptom from #4863 where only build/plan agents appear after install
- add the cache reset and reinstall workaround from the issue thread

## Verification
- rg -n "#4863|~/.cache/opencode|bunx oh-my-openagent install|only shows the built-in build/plan agents" docs/reference/known-issues.md
- git diff --check
- tmux QA transcript: /mnt/c/Users/Han/.omo/evidence/task-36-opencode-cache-recovery-tmux.txt

Closes #4863

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a known-issues entry for OpenCode 1.16.x (#4863) where only build/plan agents appear after installing `oh-my-openagent`. Documents a quick fix: stop OpenCode, clear `~/.cache/opencode`, `~/.cache/oh-my-openagent`, `~/.cache/oh-my-opencode`, then run `bunx oh-my-openagent install`.

<sup>Written for commit 8bf130d60903beff9263ec33ea126ebb01c60a16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

