### PR TITLE
docs(known-issues): note plan agent workaround

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,10 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #4710: `@plan` may stay in Sisyphus instead of switching to Prometheus
+
+- **Affects**: Current OpenCode/Ultimate planning flow.
+- **Symptom**: Typing `@plan` from Sisyphus can leave the request in Sisyphus instead of handing it to Prometheus.
+- **Workaround**: Switch to Prometheus first with the Tab agent selector or `/agent`, ask for the plan there, then run `/start-work` after approval.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4710.


### PR DESCRIPTION
## Summary
- document the #4710 symptom where `@plan` may stay in Sisyphus instead of switching to Prometheus
- add the explicit Prometheus workaround: use Tab or `/agent`, then run `/start-work` after approval

## Verification
- rg -n '#4710:|@plan may stay|Tab agent selector|/agent|/start-work' docs/reference/known-issues.md
- git diff --check
- tmux QA transcript: /mnt/c/Users/Han/.omo/evidence/task-37-plan-agent-workaround-tmux.txt

Closes #4710


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a known-issues entry for #4710 where `@plan` may remain in Sisyphus instead of switching to Prometheus, and document a workaround. Switch to Prometheus via the Tab agent selector or `/agent`, request the plan there, then run `/start-work` after approval.

<sup>Written for commit 4cbf176e4902dcd15d27f4aa321b8d0da959c0e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

