### PR TITLE
docs(known-issues): note OpenCode startup hang

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,10 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #5050: OpenCode can hang during startup before the plugin runs
+
+- **Affects**: OpenCode 1.16.2 startup with external plugins and cold package caches.
+- **Symptom**: `opencode --pure` starts, but normal `opencode` clears the terminal and stalls after `service=plugin path=oh-my-openagent@latest loading plugin`.
+- **Workaround**: If the hang happens before `/tmp/oh-my-opencode.log` gets a plugin entry, avoid the npm resolver path by using an absolute `file://` plugin path or by pre-populating the OpenCode package cache. If logs point to a malformed or locked `opencode.db`, back up and remove `~/.local/share/opencode/opencode.db*`; OpenCode recreates it on next start, but local session history is lost.
+- **Status**: Open. The npm resolver timeout belongs upstream in OpenCode; tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5050.


### PR DESCRIPTION
## Summary
- document the #5050 startup hang where `opencode --pure` works but plugin startup stalls
- add the cache/path and `opencode.db` recovery notes from the issue thread

## Verification
- rg -n '#5050:|OpenCode can hang|--pure|oh-my-openagent@latest|opencode\\.db|file://|package cache' docs/reference/known-issues.md
- git diff --check
- tmux QA transcript: /mnt/c/Users/Han/.omo/evidence/task-38-opencode-startup-hang-tmux.txt

Closes #5050


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Known Issues entry for #5050: OpenCode can hang during startup—`opencode --pure` works, but `opencode` stalls while loading `oh-my-openagent@latest`.
Includes symptoms, workarounds (use a `file://` plugin path or pre-populate the package cache; reset `opencode.db` if corrupt), and a link to the tracking issue.

<sup>Written for commit 85233554f4a6cf4448595821e8d4cc17d3c59412. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

