### PR TITLE
docs(known-issues): note LSP install prompt

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,10 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #5260: Background tasks can wait on an LSP install decision
+
+- **Affects**: Background tasks that call LSP tools when the language server is not installed.
+- **Symptom**: The task reports that it is stuck on `lsp_install_decision` and waits for an install prompt instead of continuing without LSP.
+- **Workaround**: Record a `declined` install decision for the missing server with `lsp_install_decision`; future LSP calls collapse to a one-line warning. To share that decision across sessions, set `LSP_TOOLS_MCP_INSTALL_DECISIONS` to a stable decisions-file path.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5260.


### PR DESCRIPTION
## Summary
- document the #5260 background-task symptom around `lsp_install_decision`
- point users to the `declined` decision workaround and the shared decisions-file env var

## Verification
- rg -n '#5260:|lsp_install_decision|declined|LSP_TOOLS_MCP_INSTALL_DECISIONS|one-line warning' docs/reference/known-issues.md docs/reference/configuration.md
- git diff --check
- tmux QA transcript: /mnt/c/Users/Han/.omo/evidence/task-39-lsp-install-decision-tmux.txt

Closes #5260


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the #5260 known issue where background tasks can block on an LSP install prompt (`lsp_install_decision`) instead of running. Adds a workaround: record a `declined` decision and use `LSP_TOOLS_MCP_INSTALL_DECISIONS` to share the decisions file across sessions.

<sup>Written for commit 8e2d8bb91265422f40593c2bfd671f3c6fcf4115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

