### PR TITLE
docs(known-issues): note simple task loop

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,10 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #5120: Sisyphus can loop on simple tasks
+
+- **Affects**: OpenCode 1.17.0 with oh-my-openagent 4.8.1.
+- **Symptom**: A trivial prompt such as `output hello world` can repeat the plan-style status block instead of answering directly.
+- **Workaround**: For one-off trivial prompts, run `opencode --pure` or temporarily disable the plugin for that session.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5120.


### PR DESCRIPTION
## Summary
- document the #5120 simple-task loop symptom for Sisyphus
- add the one-off `opencode --pure` / session-disable workaround from the issue

## Verification
- rg -n '#5120:|Sisyphus can loop|output hello world|opencode --pure|temporarily disable' docs/reference/known-issues.md
- git diff --check
- tmux QA transcript: /mnt/c/Users/Han/.omo/evidence/task-40-simple-task-loop-tmux.txt

Closes #5120


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a known-issues entry for Sisyphus where simple prompts (e.g., “output hello world”) loop the plan block on OpenCode 1.17.0 with `oh-my-openagent` 4.8.1. Includes a workaround to run `opencode --pure` or temporarily disable the plugin, and links to #5120.

<sup>Written for commit 93ee8d6d1d432d50ad54b4774d985e4e3595a3ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

