### PR TITLE
docs(known-issues): note Ralph Loop log spam

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,10 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #5105: Ralph Loop can flood logs while child subagents are active
+
+- **Affects**: Sessions with an active Ralph Loop and background child subagents.
+- **Symptom**: `/tmp/oh-my-opencode.log` repeats `promptAsync reservation release skipped for different source` while child subagents emit message events.
+- **Workaround**: If you are not using Ralph Loop in that workspace, add `"disabled_hooks": ["ralph-loop"]` to `oh-my-openagent.jsonc`. If a loop is already active, run `/cancel-ralph` before disabling the hook.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5105.


### PR DESCRIPTION
## Summary
- document the #5105 Ralph Loop log-spam symptom
- add the `/cancel-ralph` and `disabled_hooks: ["ralph-loop"]` containment path

## Verification
- rg -n '#5105:|Ralph Loop can flood|promptAsync reservation release skipped|disabled_hooks.*ralph-loop|cancel-ralph' docs/reference/known-issues.md docs/reference/configuration.md docs/reference/features.md docs/guide/installation.md
- git diff --check
- tmux QA transcript: /mnt/c/Users/Han/.omo/evidence/task-41-ralph-loop-log-spam-tmux.txt

Closes #5105


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the Ralph Loop log spam known issue (#5105) and how to contain it. Adds a Known Issues entry with steps to run `/cancel-ralph` and disable the hook in `oh-my-openagent.jsonc` (`"disabled_hooks": ["ralph-loop"]`) to stop repeated “promptAsync reservation release skipped for different source” logs.

<sup>Written for commit f761239cf97e4ec2d2804775b9931c0c0fe4cb44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

