### PR TITLE
docs(known-issues): note Desktop runtime skill workaround

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,20 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #5025 — OpenCode Desktop loads the plugin but only shows native modes
+
+- **Affects**: OpenCode Desktop on Windows with `oh-my-openagent@4.7.5`.
+- **Symptom**: The Desktop plugin list shows `oh-my-openagent` as loaded, but the UI only exposes the native `build` and `plan` modes. The OpenCode log may include `Runtime skill source server requires Bun.serve failed to load plugin`.
+- **Workaround**: Disable the runtime security skills that start the Bun-backed skill source server, then restart OpenCode Desktop:
+
+  ```json
+  {
+    "disabled_skills": [
+      "security-research",
+      "security-review"
+    ]
+  }
+  ```
+
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5025.


### PR DESCRIPTION
## Summary

- Add #5025 to `docs/reference/known-issues.md`
- Document the OpenCode Desktop partial-load symptom where only `build` and `plan` show up
- Include the current workaround: disable `security-research` and `security-review`, then restart Desktop

## Verification

- `rg -n "#5025|Runtime skill source server requires Bun\\.serve|security-research|security-review" docs/reference/known-issues.md`
- `git diff --check`
- tmux readback: `/mnt/c/Users/Han/.omo/evidence/task-42-desktop-runtime-skills-tmux.txt`

Fixes #5025.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a known issue entry (#5025) for OpenCode Desktop where the plugin appears loaded but only `build` and `plan` show, and documents a workaround: disable `security-research` and `security-review` and restart Desktop. This helps Windows users on `oh-my-openagent@4.7.5` restore full plugin modes and links to the tracking issue.

<sup>Written for commit e868cd3fbe117084b4d2e02842f3092a226268ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

