### PR TITLE
docs(known-issues): note Codex subagent wait workaround

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,10 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #5021 — Codex planner or reviewer subagents can appear stuck
+
+- **Affects**: LazyCodex / OMO Codex planner and reviewer flows that use native Codex subagents.
+- **Symptom**: A parent session can receive repeated `wait_agent` timeouts while a planner or reviewer subagent remains `running`. Follow-up prompts may not recover the run, and the session can look stuck until the child agent is closed or respawned.
+- **Workaround**: Use short wait cycles, send one targeted follow-up that asks the child to return a result or `BLOCKED`, then record the child as inconclusive before closing or respawning it. Do not treat repeated wait timeouts as proof that the child finished.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5021.


### PR DESCRIPTION
## Summary

- Add #5021 to `docs/reference/known-issues.md`
- Document the LazyCodex / OMO Codex planner and reviewer subagent wait symptom
- Include the safe workaround: bounded waits, one targeted follow-up, then record inconclusive state before closing or respawning

## Verification

- `rg -n "#5021|wait_agent|planner or reviewer|inconclusive" docs/reference/known-issues.md`
- `git diff --check`
- tmux readback: `/mnt/c/Users/Han/.omo/evidence/task-43-codex-subagent-wait-tmux.txt`

Fixes #5021.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented known issue #5021: Codex planner/reviewer subagents can appear stuck with repeated `wait_agent` timeouts. Added scope (LazyCodex/OMO Codex), symptoms, and a safe workaround: short wait cycles, one targeted follow-up, then mark as inconclusive before closing or respawning.

<sup>Written for commit 26addfedfec9e141a3363475ac5ebe510b98b3b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

