### PR TITLE
docs(known-issues): note team quiescence workaround

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,10 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #4990 — Team-mode lead can stall after full quiescence
+
+- **Affects**: Team-mode workflows where the lead and all members become idle with no unread messages or pending tasks.
+- **Symptom**: The team looks finished, but the lead does not start the next turn until the user sends a manual nudge such as `are you done?`. After that nudge, the lead can call `team_status` and continue.
+- **Workaround**: Before assuming the team is stuck, send one short manual nudge and ask the lead to run `team_status` plus `team_task_list`. For long multi-round runs, prefer explicit `team_task_*` state over ad-hoc message counting so the lead has a deterministic completion signal.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4990.


### PR DESCRIPTION
## Summary

- Add #4990 to `docs/reference/known-issues.md`
- Document the team-mode full-quiescence stall symptom
- Include the current workaround: one manual nudge plus `team_status` / `team_task_list`, with explicit `team_task_*` state for long runs

## Verification

- `rg -n "#4990|full quiescence|manual nudge|team_task" docs/reference/known-issues.md`
- `git diff --check`
- tmux readback: `/mnt/c/Users/Han/.omo/evidence/task-44-team-quiescence-tmux.txt`

Fixes #4990.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new known issue to docs/reference/known-issues.md for team-mode stalling after full quiescence, aligned with #4990. Includes a simple workaround: send a short manual nudge, then run `team_status` and `team_task_list`; for long runs, use explicit `team_task_*` state to provide a clear completion signal.

<sup>Written for commit 545488a58b3accfab840460a8a3f9495f205f5ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

