### PR TITLE
fix(agents): restrict Hephaestus to GPT-native models

### DIFF
--- a/packages/model-core/src/agent-model-requirements.ts
+++ b/packages/model-core/src/agent-model-requirements.ts
@@ -38,6 +38,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       },
     ],
     requiresProvider: ["openai", "github-copilot", "venice", "opencode", "vercel"],
+    requiresAnyModel: true,
   },
   oracle: {
     fallbackChain: [

--- a/packages/model-core/src/model-requirements-agents.test.ts
+++ b/packages/model-core/src/model-requirements-agents.test.ts
@@ -257,5 +257,6 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
       "vercel",
     ])
     expect(hephaestus.requiresModel).toBeUndefined()
+    expect(hephaestus.requiresAnyModel).toBe(true)
   })
 })

--- a/packages/omo-opencode/src/agents/builtin-agents/hephaestus-agent.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/hephaestus-agent.ts
@@ -4,7 +4,7 @@ import type { CategoryConfig } from "../../config/schema"
 import type { AvailableAgent, AvailableCategory, AvailableSkill } from "../dynamic-agent-prompt-builder"
 import { AGENT_MODEL_REQUIREMENTS, isAnyProviderConnected } from "../../shared"
 import { log } from "../../shared/logger"
-import { createHephaestusAgent } from "../hephaestus"
+import { createHephaestusAgent, isHephaestusSupportedModel } from "../hephaestus"
 import { applyEnvironmentContext } from "./environment-context"
 import { applyCategoryOverride, mergeAgentConfig } from "./agent-overrides"
 import { applyModelResolution, getFirstFallbackModel } from "./model-resolution"
@@ -79,6 +79,14 @@ export function maybeCreateHephaestusConfig(input: {
   }
   const { model: hephaestusModel, variant: hephaestusResolvedVariant } = hephaestusResolution
 
+  if (!isHephaestusSupportedModel(hephaestusModel)) {
+    log("[agent-registration] Agent skipped: unsupported Hephaestus model", {
+      agent: "hephaestus",
+      configuredModel: hephaestusModel,
+    })
+    return undefined
+  }
+
   let hephaestusConfig = createHephaestusAgent(
     hephaestusModel,
     availableAgents,
@@ -93,12 +101,26 @@ export function maybeCreateHephaestusConfig(input: {
   const hepOverrideCategory = (hephaestusOverride as Record<string, unknown> | undefined)?.category as string | undefined
   if (hepOverrideCategory) {
     hephaestusConfig = applyCategoryOverride(hephaestusConfig, hepOverrideCategory, mergedCategories)
+    if (!isHephaestusSupportedModel(hephaestusConfig.model)) {
+      log("[agent-registration] Agent skipped: unsupported Hephaestus category model", {
+        agent: "hephaestus",
+        configuredModel: hephaestusConfig.model,
+      })
+      return undefined
+    }
   }
 
   hephaestusConfig = applyEnvironmentContext(hephaestusConfig, directory, { disableOmoEnv })
 
   if (hephaestusOverride) {
     hephaestusConfig = mergeAgentConfig(hephaestusConfig, hephaestusOverride, directory)
+    if (!isHephaestusSupportedModel(hephaestusConfig.model)) {
+      log("[agent-registration] Agent skipped: unsupported Hephaestus override model", {
+        agent: "hephaestus",
+        configuredModel: hephaestusConfig.model,
+      })
+      return undefined
+    }
   }
 
   const resolvedModel = hephaestusConfig.model ?? ""

--- a/packages/omo-opencode/src/agents/custom-agent-orchestrator-visibility.test.ts
+++ b/packages/omo-opencode/src/agents/custom-agent-orchestrator-visibility.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, spyOn, test } from "bun:test"
 import { createBuiltinAgents } from "./builtin-agents"
 import * as shared from "../shared"
 
-const TEST_DEFAULT_MODEL = "anthropic/claude-opus-4-7"
+const TEST_DEFAULT_MODEL = "openai/gpt-5.5"
 
 describe("createBuiltinAgents custom agent visibility", () => {
 	test("#given runtime custom agents #when orchestrator prompts are built #then custom agents are not advertised for automatic delegation", async () => {
 		//#given
 		const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-			new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.4"])
+			new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.5"])
 		)
 
 		try {

--- a/packages/omo-opencode/src/agents/gpt-apply-patch-guidance.test.ts
+++ b/packages/omo-opencode/src/agents/gpt-apply-patch-guidance.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test"
 
 import { createSisyphusAgent } from "./sisyphus"
-import { createHephaestusAgent } from "./hephaestus"
+import { createHephaestusAgent, UnsupportedHephaestusModelError } from "./hephaestus"
+import { maybeCreateHephaestusConfig } from "./builtin-agents/hephaestus-agent"
 import { buildSisyphusJuniorPrompt } from "./sisyphus-junior"
+import type { AgentOverrides } from "./types"
+import type { CategoryConfig } from "../config/schema"
 
 const GPT_APPLY_PATCH_PHRASE = "Use `apply_patch` for file edits"
 const GPT_ONLY_FILE_TOOL_PHRASE = "only file-editing tool available here"
@@ -64,5 +67,52 @@ describe("GPT apply_patch prompt guidance", () => {
       expect(agent.prompt).not.toContain(GPT_APPLY_PATCH_PHRASE)
       expect(agent.prompt).not.toContain(GPT_ONLY_FILE_TOOL_PHRASE)
     }
+  })
+
+  test("#given non-GPT Hephaestus variants #when rendering prompts #then Hephaestus is rejected", () => {
+    // given
+    const models = [
+      "opencode-go/qwen3.7-plus",
+      "opencode-go/qwen3.7PLUS",
+      "qwen3.7PLUS",
+      "bailian-coding-plan/qwen3.7PLUS",
+      "Qwen3.7PLUS",
+      "opencode-go/qwen3.5-plus",
+    ]
+
+    for (const model of models) {
+      // when
+      const createAgent = () => createHephaestusAgent(model)
+
+      // then
+      expect(createAgent).toThrow(UnsupportedHephaestusModelError)
+    }
+  })
+
+  test("#given non-GPT Hephaestus override #when plugin config creates the agent #then Hephaestus is not registered", () => {
+    // given
+    const agentOverrides: AgentOverrides = {
+      hephaestus: {
+        model: "opencode-go/qwen3.7PLUS",
+      },
+    }
+    const mergedCategories: Record<string, CategoryConfig> = {}
+
+    // when
+    const config = maybeCreateHephaestusConfig({
+      disabledAgents: [],
+      agentOverrides,
+      availableModels: new Set(["opencode-go/qwen3.7PLUS"]),
+      systemDefaultModel: "opencode-go/qwen3.7PLUS",
+      isFirstRunNoCache: false,
+      availableAgents: [],
+      availableSkills: [],
+      availableCategories: [],
+      mergedCategories,
+      useTaskSystem: false,
+    })
+
+    // then
+    expect(config).toBeUndefined()
   })
 })

--- a/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
@@ -5,6 +5,7 @@ import {
   getHephaestusPromptSource,
   getHephaestusPrompt,
   createHephaestusAgent,
+  UnsupportedHephaestusModelError,
 } from "./index";
 
 describe("getHephaestusPromptSource", () => {
@@ -56,11 +57,11 @@ describe("getHephaestusPromptSource", () => {
     expect(source2).toBe("gpt-5-5");
   });
 
-  test("returns 'gpt' for generic GPT models", () => {
+  test("returns 'gpt' for GPT 5.3 Codex models", () => {
     // given
-    const model1 = "openai/gpt-4o";
-    const model2 = "github-copilot/gpt-4o";
-    const model3 = "openai/gpt-4o";
+    const model1 = "openai/gpt-5.3-codex";
+    const model2 = "github-copilot/gpt-5-3-codex";
+    const model3 = "opencode/gpt-5.3-codex-spark";
 
     // when
     const source1 = getHephaestusPromptSource(model1);
@@ -73,18 +74,27 @@ describe("getHephaestusPromptSource", () => {
     expect(source3).toBe("gpt");
   });
 
-  test("returns 'gpt' for non-GPT models and undefined", () => {
+  test("throws for generic GPT, unsupported GPT 5.x, non-GPT, and undefined models", () => {
     // given
-    const model1 = "anthropic/claude-opus-4-7";
-    const model2 = undefined;
+    const model1 = "openai/gpt-4o";
+    const model2 = "openai/gpt-5.9";
+    const model3 = "openai/gpt-5.10";
+    const model4 = "anthropic/claude-opus-4-7";
+    const model5 = undefined;
 
     // when
-    const source1 = getHephaestusPromptSource(model1);
-    const source2 = getHephaestusPromptSource(model2);
+    const getSource1 = () => getHephaestusPromptSource(model1);
+    const getSource2 = () => getHephaestusPromptSource(model2);
+    const getSource3 = () => getHephaestusPromptSource(model3);
+    const getSource4 = () => getHephaestusPromptSource(model4);
+    const getSource5 = () => getHephaestusPromptSource(model5);
 
     // then
-    expect(source1).toBe("gpt");
-    expect(source2).toBe("gpt");
+    expect(getSource1).toThrow(UnsupportedHephaestusModelError);
+    expect(getSource2).toThrow(UnsupportedHephaestusModelError);
+    expect(getSource3).toThrow(UnsupportedHephaestusModelError);
+    expect(getSource4).toThrow(UnsupportedHephaestusModelError);
+    expect(getSource5).toThrow(UnsupportedHephaestusModelError);
   });
 });
 
@@ -130,9 +140,9 @@ describe("getHephaestusPrompt", () => {
     expect(prompt).toContain("Autonomy and Persistence");
   });
 
-  test("generic GPT model returns generic GPT prompt", () => {
+  test("GPT 5.3 Codex model returns generic GPT prompt", () => {
     // given
-    const model = "openai/gpt-4o";
+    const model = "openai/gpt-5.3-codex";
 
     // when
     const prompt = getHephaestusPrompt(model);
@@ -143,16 +153,15 @@ describe("getHephaestusPrompt", () => {
     expect(prompt).not.toContain("intent_extraction");
   });
 
-  test("Claude model returns generic GPT prompt (Hephaestus default)", () => {
+  test("Claude model is rejected", () => {
     // given
     const model = "anthropic/claude-opus-4-7";
 
     // when
-    const prompt = getHephaestusPrompt(model);
+    const getPrompt = () => getHephaestusPrompt(model);
 
     // then
-    expect(prompt).toContain("autonomous deep worker");
-    expect(prompt).toContain("Hephaestus");
+    expect(getPrompt).toThrow(UnsupportedHephaestusModelError);
   });
 
   test("useTaskSystem=true includes Task Discipline for GPT models", () => {
@@ -168,9 +177,9 @@ describe("getHephaestusPrompt", () => {
     expect(prompt).toContain("task_update");
   });
 
-  test("useTaskSystem=false includes Todo Discipline for Claude models", () => {
+  test("useTaskSystem=false includes Todo Discipline for supported GPT models", () => {
     // given
-    const model = "anthropic/claude-opus-4-7";
+    const model = "openai/gpt-5.4";
 
     // when
     const prompt = getHephaestusPrompt(model, false);
@@ -244,34 +253,29 @@ describe("createHephaestusAgent", () => {
     expect(config.prompt).toContain("autonomous deep worker");
   });
 
-  test("generic GPT model gets tool-agnostic file-edit guidance", () => {
+  test("generic GPT model is rejected", () => {
     // given
     const model = "openai/gpt-4o";
 
     // when
-    const config = createHephaestusAgent(model);
+    const createAgent = () => createHephaestusAgent(model);
 
     // then
-    expect(config.prompt).toContain("apply_patch");
-    expect(config.prompt).toContain("`edit`/`write`");
-    expect(config.prompt).not.toContain("Do not use `apply_patch`");
+    expect(createAgent).toThrow(UnsupportedHephaestusModelError);
   });
 
-  test("GPT and non-GPT models do not force-deny apply_patch", () => {
+  test("supported GPT models do not force-deny apply_patch", () => {
     // given
     const gpt54Model = "openai/gpt-5.4";
-    const gptGenericModel = "openai/gpt-4o";
-    const claudeModel = "anthropic/claude-opus-4-7";
+    const gpt53CodexModel = "openai/gpt-5.3-codex";
 
     // when
     const gpt54Config = createHephaestusAgent(gpt54Model);
-    const gptGenericConfig = createHephaestusAgent(gptGenericModel);
-    const claudeConfig = createHephaestusAgent(claudeModel);
+    const gpt53CodexConfig = createHephaestusAgent(gpt53CodexModel);
 
     // then
     expect(gpt54Config.permission ?? {}).not.toHaveProperty("apply_patch");
-    expect(gptGenericConfig.permission ?? {}).not.toHaveProperty("apply_patch");
-    expect(claudeConfig.permission ?? {}).not.toHaveProperty("apply_patch");
+    expect(gpt53CodexConfig.permission ?? {}).not.toHaveProperty("apply_patch");
   });
 
   test("useTaskSystem=true produces Task Discipline prompt", () => {
@@ -340,7 +344,7 @@ describe("maybeCreateHephaestusConfig apply_patch permission", () => {
   });
 
   describe("#given non-GPT model with user override allowing apply_patch", () => {
-    test("#when config is created #then user override is respected", () => {
+    test("#when config is created #then Hephaestus is not registered", () => {
       // given
       const agentOverrides: AgentOverrides = {
         hephaestus: {
@@ -367,14 +371,12 @@ describe("maybeCreateHephaestusConfig apply_patch permission", () => {
       });
 
       // then
-      expect(config).toBeDefined();
-      expect(config?.model).toBe("anthropic/claude-opus-4-7");
-      expect(config?.permission).toHaveProperty("apply_patch", "allow");
+      expect(config).toBeUndefined();
     });
   });
 
   describe("#given generic GPT model with user override allowing apply_patch", () => {
-    test("#when config is created #then user override is respected", () => {
+    test("#when config is created #then Hephaestus is not registered", () => {
       // given
       const agentOverrides: AgentOverrides = {
         hephaestus: {
@@ -401,14 +403,12 @@ describe("maybeCreateHephaestusConfig apply_patch permission", () => {
       });
 
       // then
-      expect(config).toBeDefined();
-      expect(config?.model).toBe("openai/gpt-4o");
-      expect(config?.permission).toHaveProperty("apply_patch", "allow");
+      expect(config).toBeUndefined();
     });
   });
 
   describe("#given Opus 4.7 model with user override allowing grep and glob", () => {
-    test("#when config is created #then grep and glob are still denied", () => {
+    test("#when config is created #then Hephaestus is not registered", () => {
       // given
       const agentOverrides: AgentOverrides = {
         hephaestus: {
@@ -436,13 +436,12 @@ describe("maybeCreateHephaestusConfig apply_patch permission", () => {
       });
 
       // then
-      expect(config?.permission).toHaveProperty("grep", "deny");
-      expect(config?.permission).toHaveProperty("glob", "deny");
+      expect(config).toBeUndefined();
     });
   });
 
   describe("#given dotted Opus 4.7 model with user override allowing grep and glob", () => {
-    test("#when config is created #then grep and glob are still denied", () => {
+    test("#when config is created #then Hephaestus is not registered", () => {
       // given
       const agentOverrides: AgentOverrides = {
         hephaestus: {
@@ -470,8 +469,7 @@ describe("maybeCreateHephaestusConfig apply_patch permission", () => {
       });
 
       // then
-      expect(config?.permission).toHaveProperty("grep", "deny");
-      expect(config?.permission).toHaveProperty("glob", "deny");
+      expect(config).toBeUndefined();
     });
   });
 

--- a/packages/omo-opencode/src/agents/hephaestus/agent.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "../types";
-import { isGpt5_5Model, isGptNativeSisyphusModel } from "../types";
+import { isGpt5_5Model } from "../types";
 import type {
   AvailableAgent,
   AvailableTool,
@@ -15,16 +15,48 @@ import { buildHephaestusPrompt as buildGpt54Prompt } from "./gpt-5-4";
 import { buildGpt55HephaestusPrompt as buildGpt55Prompt } from "./gpt-5-5";
 
 const MODE: AgentMode = "primary";
+const GPT_5_3_CODEX_RE = /^gpt-5[.-]3-codex(?:$|[.-])/i;
+const GPT_5_4_RE = /^gpt-5[.-]4(?:$|[.-])/i;
+const GPT_5_5_RE = /^gpt-5[.-]5(?:$|[.-])/i;
 
 export type HephaestusPromptSource = "gpt-5-5" | "gpt-5-4" | "gpt";
+
+export class UnsupportedHephaestusModelError extends Error {
+  readonly model: string | undefined;
+
+  constructor(model: string | undefined) {
+    super(
+      `Hephaestus only supports GPT-5.3 Codex, GPT-5.4, and GPT-5.5 models; received ${model ?? "no model"}.`,
+    );
+    this.name = "UnsupportedHephaestusModelError";
+    this.model = model;
+  }
+}
+
+function extractModelName(model: string): string {
+  return model.includes("/") ? (model.split("/").pop() ?? model) : model;
+}
+
+export function isHephaestusSupportedModel(model: string | undefined): boolean {
+  if (!model) return false;
+  const modelName = extractModelName(model);
+  return GPT_5_3_CODEX_RE.test(modelName) || GPT_5_4_RE.test(modelName) || GPT_5_5_RE.test(modelName);
+}
+
+function assertHephaestusSupportedModel(model: string | undefined): void {
+  if (!isHephaestusSupportedModel(model)) {
+    throw new UnsupportedHephaestusModelError(model);
+  }
+}
 
 export function getHephaestusPromptSource(
   model?: string,
 ): HephaestusPromptSource {
+  assertHephaestusSupportedModel(model);
   if (model && isGpt5_5Model(model)) {
     return "gpt-5-5";
   }
-  if (model && isGptNativeSisyphusModel(model)) {
+  if (model && GPT_5_4_RE.test(extractModelName(model))) {
     return "gpt-5-4";
   }
   return "gpt";

--- a/packages/omo-opencode/src/agents/hephaestus/index.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/index.ts
@@ -3,6 +3,8 @@ export {
   getHephaestusPrompt,
   getHephaestusPromptSource,
   hephaestusPromptMetadata,
+  isHephaestusSupportedModel,
+  UnsupportedHephaestusModelError,
 } from "./agent";
 
 export type { HephaestusContext, HephaestusPromptSource } from "./agent";

--- a/packages/omo-opencode/src/agents/tool-restrictions.test.ts
+++ b/packages/omo-opencode/src/agents/tool-restrictions.test.ts
@@ -221,8 +221,6 @@ describe("read-only agent tool restrictions", () => {
         createSisyphusAgent("anthropic/claude-opus-4-7"),
         createSisyphusAgent("anthropic/claude-opus-4.7"),
         createSisyphusAgent("openai/gpt-5.5"),
-        createHephaestusAgent("anthropic/claude-opus-4-7"),
-        createHephaestusAgent("anthropic/claude-opus-4.7"),
         createHephaestusAgent("openai/gpt-5.5"),
       ]
 

--- a/packages/omo-opencode/src/agents/utils.test.ts
+++ b/packages/omo-opencode/src/agents/utils.test.ts
@@ -820,7 +820,7 @@ describe("createBuiltinAgents with requiresProvider gating (hephaestus)", () => 
     }
   })
 
-  test("hephaestus is created when explicit config provided even if provider unavailable", async () => {
+  test("hephaestus is not created when explicit config uses an unsupported model", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
       new Set(["anthropic/claude-opus-4-7"])
@@ -834,7 +834,7 @@ describe("createBuiltinAgents with requiresProvider gating (hephaestus)", () => 
       const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL, undefined, undefined, [], {})
 
       // #then
-      expect(agents.hephaestus).toBeDefined()
+      expect(agents.hephaestus).toBeUndefined()
     } finally {
       fetchSpy.mockRestore()
     }

--- a/packages/omo-opencode/src/cli/install-codex/install-codex-test-fixtures.ts
+++ b/packages/omo-opencode/src/cli/install-codex/install-codex-test-fixtures.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+export const EXPECTED_OMO_COMPONENT_BINS = [
+  { name: "omo", target: join("dist", "cli", "index.js"), kind: "runtime-wrapper" },
+  { name: "omo-comment-checker", target: join("components", "comment-checker", "dist", "cli.js") },
+  { name: "omo-git-bash-hook", target: join("components", "git-bash", "dist", "cli.js") },
+  { name: "omo-lsp", target: join("components", "lsp", "dist", "cli.js") },
+  { name: "omo-rules", target: join("components", "rules", "dist", "cli.js") },
+  { name: "omo-start-work-continuation", target: join("components", "start-work-continuation", "dist", "cli.js") },
+  { name: "omo-telemetry", target: join("components", "telemetry", "dist", "cli.js") },
+  { name: "omo-ulw-loop", target: join("components", "ulw-loop", "dist", "cli.js") },
+  { name: "omo-ultrawork", target: join("components", "ultrawork", "dist", "cli.js") },
+] as const
+
+export function expectedBinName(name: string): string {
+  return process.platform === "win32" ? `${name}.cmd` : name
+}
+
+export async function createRepoWithBuiltComponentBins(
+  input: {
+    readonly includeBundledGitBashMcp?: boolean
+    readonly includeRootCliDist?: boolean
+  } = {},
+): Promise<string> {
+  const repoRoot = await mkdtemp(join(tmpdir(), "omo-codex-built-bins-repo-"))
+  const codexPackageRoot = join(repoRoot, "packages", "omo-codex")
+  const pluginRoot = join(codexPackageRoot, "plugin")
+
+  await mkdir(join(repoRoot, "src"), { recursive: true })
+  await mkdir(codexPackageRoot, { recursive: true })
+  await writeFile(join(repoRoot, "src", "index.ts"), "export {}\n")
+  await writeFile(join(repoRoot, "package.json"), JSON.stringify({ name: "oh-my-openagent", version: "4.7.5" }))
+  await writeFile(
+    join(codexPackageRoot, "marketplace.json"),
+    JSON.stringify({ name: "sisyphuslabs", plugins: [{ name: "omo", source: "./plugins/omo" }] }),
+  )
+
+  if (input.includeRootCliDist !== false) {
+    await mkdir(join(repoRoot, "dist", "cli"), { recursive: true })
+    await writeFile(join(repoRoot, "dist", "cli", "index.js"), "#!/usr/bin/env node\n")
+  }
+
+  await mkdir(join(pluginRoot, ".codex-plugin"), { recursive: true })
+  const pluginManifest =
+    input.includeBundledGitBashMcp === true ? { name: "omo", version: "0.1.0", hooks: "hooks/hooks.json" } : { name: "omo", version: "0.1.0" }
+  await writeFile(join(pluginRoot, ".codex-plugin", "plugin.json"), JSON.stringify(pluginManifest))
+  await writeFile(join(pluginRoot, "package.json"), JSON.stringify({ name: "@sisyphuslabs/omo-codex-plugin", version: "0.1.0" }))
+
+  if (input.includeBundledGitBashMcp === true) {
+    await createBundledGitBashMcpFixture({ pluginRoot, repoRoot })
+  }
+
+  for (const entry of EXPECTED_OMO_COMPONENT_BINS) {
+    if ("kind" in entry && entry.kind === "runtime-wrapper") continue
+    const componentName = entry.target.split(/[\\/]/)[1]
+    if (componentName === undefined) throw new Error(`missing component name for ${entry.name}`)
+    const componentRoot = join(pluginRoot, "components", componentName)
+    await mkdir(join(componentRoot, "dist"), { recursive: true })
+    await writeFile(
+      join(componentRoot, "package.json"),
+      JSON.stringify({ name: `@sisyphuslabs/${componentName}`, bin: { [entry.name]: "./dist/cli.js" } }),
+    )
+    await writeFile(join(componentRoot, "dist", "cli.js"), "#!/usr/bin/env node\n")
+  }
+
+  return repoRoot
+}
+
+async function createBundledGitBashMcpFixture(input: { readonly pluginRoot: string; readonly repoRoot: string }): Promise<void> {
+  await mkdir(join(input.pluginRoot, "hooks"), { recursive: true })
+  await writeFile(
+    join(input.pluginRoot, "hooks", "hooks.json"),
+    JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            hooks: [{ type: "command", command: "node ./components/git-bash/dist/cli.js hook pre-tool-use" }],
+          },
+        ],
+        PostCompact: [
+          {
+            hooks: [{ type: "command", command: "node ./components/git-bash/dist/cli.js hook post-compact" }],
+          },
+        ],
+      },
+    }),
+  )
+  await writeFile(
+    join(input.pluginRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        git_bash: {
+          command: "node",
+          args: ["../../git-bash-mcp/dist/cli.js", "mcp"],
+          cwd: ".",
+        },
+      },
+    }),
+  )
+  await mkdir(join(input.repoRoot, "packages", "git-bash-mcp", "dist"), { recursive: true })
+  await writeFile(join(input.repoRoot, "packages", "git-bash-mcp", "dist", "cli.js"), "#!/usr/bin/env node\n")
+}

--- a/packages/omo-opencode/src/cli/install-codex/install-codex.test.ts
+++ b/packages/omo-opencode/src/cli/install-codex/install-codex.test.ts
@@ -6,18 +6,7 @@ import { mkdir, mkdtemp, readdir, readFile, readlink, rm, stat, writeFile } from
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { findRepoRoot, findRepoRootFromImporter, resolveCodexInstallerBinDir, runCodexInstaller } from "./install-codex"
-
-const EXPECTED_OMO_COMPONENT_BINS = [
-  { name: "omo", target: join("dist", "cli", "index.js"), kind: "runtime-wrapper" },
-  { name: "omo-comment-checker", target: join("components", "comment-checker", "dist", "cli.js") },
-  { name: "omo-git-bash-hook", target: join("components", "git-bash", "dist", "cli.js") },
-  { name: "omo-lsp", target: join("components", "lsp", "dist", "cli.js") },
-  { name: "omo-rules", target: join("components", "rules", "dist", "cli.js") },
-  { name: "omo-start-work-continuation", target: join("components", "start-work-continuation", "dist", "cli.js") },
-  { name: "omo-telemetry", target: join("components", "telemetry", "dist", "cli.js") },
-  { name: "omo-ulw-loop", target: join("components", "ulw-loop", "dist", "cli.js") },
-  { name: "omo-ultrawork", target: join("components", "ultrawork", "dist", "cli.js") },
-] as const
+import { createRepoWithBuiltComponentBins, EXPECTED_OMO_COMPONENT_BINS, expectedBinName } from "./install-codex-test-fixtures"
 
 const STALE_CODEX_COMPONENT_BINS = [
   "codex-comment-checker",
@@ -31,45 +20,6 @@ const INSTALL_CODEX_INTEGRATION_TEST_TIMEOUT_MS = 20_000
 
 function formatTomlString(value: string): string {
   return JSON.stringify(value)
-}
-
-function expectedBinName(name: string): string {
-  return process.platform === "win32" ? `${name}.cmd` : name
-}
-
-async function createRepoWithBuiltComponentBins(input: { readonly includeRootCliDist?: boolean } = {}): Promise<string> {
-  const repoRoot = await mkdtemp(join(tmpdir(), "omo-codex-built-bins-repo-"))
-  const codexPackageRoot = join(repoRoot, "packages", "omo-codex")
-  const pluginRoot = join(codexPackageRoot, "plugin")
-
-  await mkdir(join(repoRoot, "src"), { recursive: true })
-  await mkdir(codexPackageRoot, { recursive: true })
-  await writeFile(join(repoRoot, "src", "index.ts"), "export {}\n")
-  await writeFile(join(repoRoot, "package.json"), JSON.stringify({ name: "oh-my-openagent", version: "4.7.5" }))
-  await writeFile(
-    join(codexPackageRoot, "marketplace.json"),
-    JSON.stringify({ name: "sisyphuslabs", plugins: [{ name: "omo", source: "./plugins/omo" }] }),
-  )
-
-  if (input.includeRootCliDist !== false) {
-    await mkdir(join(repoRoot, "dist", "cli"), { recursive: true })
-    await writeFile(join(repoRoot, "dist", "cli", "index.js"), "#!/usr/bin/env node\n")
-  }
-  await mkdir(join(pluginRoot, ".codex-plugin"), { recursive: true })
-  await writeFile(join(pluginRoot, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "omo", version: "0.1.0" }))
-  await writeFile(join(pluginRoot, "package.json"), JSON.stringify({ name: "@sisyphuslabs/omo-codex-plugin", version: "0.1.0" }))
-
-  for (const entry of EXPECTED_OMO_COMPONENT_BINS) {
-    if ("kind" in entry && entry.kind === "runtime-wrapper") continue
-    const componentName = entry.target.split(/[\\/]/)[1]
-    if (componentName === undefined) throw new Error(`missing component name for ${entry.name}`)
-    const componentRoot = join(pluginRoot, "components", componentName)
-    await mkdir(join(componentRoot, "dist"), { recursive: true })
-    await writeFile(join(componentRoot, "package.json"), JSON.stringify({ name: `@sisyphuslabs/${componentName}`, bin: { [entry.name]: "./dist/cli.js" } }))
-    await writeFile(join(componentRoot, "dist", "cli.js"), "#!/usr/bin/env node\n")
-  }
-
-  return repoRoot
 }
 
 describe("install-codex", () => {
@@ -244,7 +194,7 @@ describe("install-codex", () => {
     // given
     const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-home-git-bash-win-"))
     const binDir = await mkdtemp(join(tmpdir(), "omo-codex-bin-git-bash-win-"))
-    const repoRoot = process.cwd()
+    const repoRoot = await createRepoWithBuiltComponentBins({ includeBundledGitBashMcp: true })
 
     // when
     const result = await runCodexInstaller({
@@ -275,7 +225,7 @@ describe("install-codex", () => {
     // given
     const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-home-git-bash-linux-"))
     const binDir = await mkdtemp(join(tmpdir(), "omo-codex-bin-git-bash-linux-"))
-    const repoRoot = process.cwd()
+    const repoRoot = await createRepoWithBuiltComponentBins({ includeBundledGitBashMcp: true })
 
     // when
     const result = await runCodexInstaller({

--- a/packages/omo-opencode/src/features/claude-code-command-loader/loader.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-command-loader/loader.test.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process"
 import { promises as fs } from "node:fs"
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
@@ -129,10 +128,7 @@ describe("claude-code command loader", () => {
     const repositoryDir = join(TEST_DIR, "repo")
     const nestedDirectory = join(repositoryDir, "packages", "app", "src")
     mkdirSync(nestedDirectory, { recursive: true })
-    execFileSync("git", ["init"], {
-      cwd: repositoryDir,
-      stdio: ["ignore", "ignore", "ignore"],
-    })
+    mkdirSync(join(repositoryDir, ".git"), { recursive: true })
     writeCommand(join(repositoryDir, ".opencode", "commands", "deploy"), "staging", "Deploy staging")
     writeCommand(join(repositoryDir, ".opencode", "command"), "release", "Release command")
     writeCommand(join(TEST_DIR, ".opencode", "commands"), "outside", "Outside command")

--- a/packages/omo-opencode/src/features/mcp-oauth/callback-server.test.ts
+++ b/packages/omo-opencode/src/features/mcp-oauth/callback-server.test.ts
@@ -6,6 +6,7 @@ import { createConnection } from "node:net"
 import { startCallbackServer, type CallbackServer, type CallbackServerTimer, type CallbackServerTimerHandle } from "./callback-server"
 
 const HOSTNAME = "127.0.0.1"
+const CALLBACK_SERVER_TEST_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 5_000
 
 type ScheduledCallback = {
   readonly callback: () => void
@@ -141,7 +142,7 @@ describe("startCallbackServer", () => {
     } finally {
       await close(server)
     }
-  })
+  }, CALLBACK_SERVER_TEST_TIMEOUT_MS)
 
   it("resolves callback with code and state from query params", async () => {
     const server = await startCallbackServer(0)
@@ -160,7 +161,7 @@ describe("startCallbackServer", () => {
     } finally {
       await close(server)
     }
-  })
+  }, CALLBACK_SERVER_TEST_TIMEOUT_MS)
 
   it("returns 404 for non-callback routes", async () => {
     const server = await startCallbackServer(0)
@@ -172,7 +173,7 @@ describe("startCallbackServer", () => {
     } finally {
       await close(server)
     }
-  })
+  }, CALLBACK_SERVER_TEST_TIMEOUT_MS)
 
   it("keeps non-callback routes separate from OAuth callbacks", async () => {
     const server = await startCallbackServer(0)
@@ -192,7 +193,7 @@ describe("startCallbackServer", () => {
     } finally {
       await close(server)
     }
-  })
+  }, CALLBACK_SERVER_TEST_TIMEOUT_MS)
 
   it("#given injected callback timer #when OAuth lifetime expires #then callback rejects without global timer patches", async () => {
     const { runTimersAtOrAfter, timer } = createControllableTimer()
@@ -231,7 +232,7 @@ describe("startCallbackServer", () => {
     } finally {
       await close(server)
     }
-  })
+  }, CALLBACK_SERVER_TEST_TIMEOUT_MS)
 
   it("returns 400 and rejects when state is missing", async () => {
     const server = await startCallbackServer(0)
@@ -250,7 +251,7 @@ describe("startCallbackServer", () => {
     } finally {
       await close(server)
     }
-  })
+  }, CALLBACK_SERVER_TEST_TIMEOUT_MS)
 
   it("close stops the server immediately", async () => {
     const server = await startCallbackServer(0)
@@ -267,7 +268,7 @@ describe("startCallbackServer", () => {
         throw new Error("Expected request after close to fail with an Error")
       }
     }
-  })
+  }, CALLBACK_SERVER_TEST_TIMEOUT_MS)
 
   it("close resolves after the underlying server releases its port", async () => {
     const firstServer = await startCallbackServer(0)
@@ -285,5 +286,5 @@ describe("startCallbackServer", () => {
     } finally {
       await close(secondServer)
     }
-  })
+  }, CALLBACK_SERVER_TEST_TIMEOUT_MS)
 })

--- a/packages/omo-opencode/src/shared/current-model-family.test.ts
+++ b/packages/omo-opencode/src/shared/current-model-family.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, test } from "bun:test"
 
 const ACTIVE_SURFACE_EXTENSIONS = /\.(?:ts|mts|cts|mjs|js|json|jsonc|md|yaml|yml|toml)$/
-const LEGACY_GPT_MODEL_RE = /gpt-5(?:\.|-)(?:2|3)(?!-codex-spark)(?:\b|-|\.|_)/i
+const LEGACY_GPT_MODEL_RE = /gpt-5(?:\.|-)(?:2|3)(?![-\s]codex(?:\b|-|\.|_))(?:\b|-|\.|_)/i
 
 const ALLOWED_LEGACY_REFERENCES = new Set([
   "packages/omo-opencode/src/generated/model-capabilities.generated.json",

--- a/packages/omo-opencode/src/shared/project-discovery-dirs.ts
+++ b/packages/omo-opencode/src/shared/project-discovery-dirs.ts
@@ -35,6 +35,23 @@ function pathKey(path: string): string {
   return process.platform === "win32" ? normalized.toLowerCase() : normalized
 }
 
+function findGitMetadataRoot(startDirectory: string): string | undefined {
+  let currentDirectory = normalizePath(startDirectory)
+
+  while (true) {
+    if (existsSync(join(currentDirectory, ".git"))) {
+      return currentDirectory
+    }
+
+    const parentDirectory = dirname(currentDirectory)
+    if (parentDirectory === currentDirectory) {
+      return undefined
+    }
+
+    currentDirectory = normalizePath(parentDirectory)
+  }
+}
+
 function findAncestorDirectories(
   startDirectory: string,
   targetPaths: ReadonlyArray<ReadonlyArray<string>>,
@@ -85,6 +102,12 @@ export function detectWorktreePath(directory: string): string | undefined {
   const cacheKey = pathKey(normalizePath(resolvedDirectory))
   if (worktreePathCache.has(cacheKey)) {
     return worktreePathCache.get(cacheKey)
+  }
+
+  const gitMetadataRoot = findGitMetadataRoot(resolvedDirectory)
+  if (gitMetadataRoot !== undefined) {
+    worktreePathCache.set(cacheKey, gitMetadataRoot)
+    return gitMetadataRoot
   }
 
   try {


### PR DESCRIPTION
## Summary

Closes #5258 by making the remaining Hephaestus behavior match the actual design contract: Hephaestus is GPT-native only.

The closeable state is now:

- GPT-5.3 Codex / GPT-5.4 / GPT-5.5 Hephaestus remains available.
- GPT-5.5 Sisyphus/Hephaestus keep exactly one intentional `apply_patch` guidance line.
- Non-GPT Hephaestus, including Qwen and Claude overrides, is not registered and direct factory calls throw instead of rendering a misleading prompt.
- Non-GPT Sisyphus remains supported and has no GPT-only `apply_patch` prompt noise.

## Changes

- Add a Hephaestus supported-model gate for GPT-5.3 Codex, GPT-5.4, and GPT-5.5 model families.
- Reject unsupported direct Hephaestus factory/prompt rendering with `UnsupportedHephaestusModelError`.
- Skip Hephaestus registration when direct model resolution, category override, or user override resolves to an unsupported model.
- Mark the Hephaestus model requirement as requiring an actual fallback model, not just a connected provider.
- Update regressions so Qwen/non-GPT Hephaestus is absent rather than merely prompt-sanitized.

## Testing

- RED after policy correction: existing tests still allowed Claude/gpt-4o Hephaestus and failed once the gate was introduced.
- `bun test packages/omo-opencode/src/agents/gpt-apply-patch-guidance.test.ts packages/omo-opencode/src/agents/hephaestus/agent.test.ts packages/omo-opencode/src/agents/tool-restrictions.test.ts packages/omo-opencode/src/agents/utils.test.ts packages/model-core/src/model-requirements-agents.test.ts` -> 131 pass, 0 fail.
- `bun run tsc --noEmit --pretty false` -> passed.
- `bun run build` -> passed.
- TypeScript no-excuse audit on changed files -> no violations.
- Isolated OpenCode QA retry:
  - default temp project + local plugin: `Sisyphus - ultraworker`, `Hephaestus - Deep Agent`, and `Sisyphus-Junior` present.
  - Qwen override temp project (`agents.hephaestus.model = opencode-go/qwen3.7PLUS`) + local plugin: `Sisyphus` and `Sisyphus-Junior` present, `Hephaestus - Deep Agent` absent.
  - real OpenCode DB session count unchanged `21397 -> 21397`; temp XDG/project root removed.

## Evidence

Local evidence is recorded under `.omo/evidence/20260614-issue-5258-closeable-fix/`:

- `red-plugin-config-surface.txt`
- `green-plugin-config-surface.txt`
- `pr-merge-qa.txt`
