### PR TITLE
fix(ulw-loop): make complete-goals resume idempotent, stop ledger spam

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/src/plan-crud.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/plan-crud.ts
@@ -101,7 +101,7 @@ export async function startNextUlwLoop(repoRoot: string, args: { retryFailed?: b
 		const now = iso();
 		if (plan.aggregateCompletion?.status === "complete") return { done: true, plan };
 		const existing = plan.goals.find((goal) => goal.status === "in_progress" && isScheduleEligible(goal));
-		if (existing) { await appendLedger(repoRoot, { at: now, kind: "goal_resumed", goalId: existing.id, status: existing.status, message: "Resuming active ulw-loop" }, scope); return { plan, goal: existing, resumed: true }; }
+		if (existing) return { plan, goal: existing, resumed: true };
 		let next = plan.goals.find((goal) => goal.status === "pending" && isScheduleEligible(goal));
 		if (!next && args.retryFailed) {
 			next = plan.goals.find((goal) => goal.status === "failed" && !goal.nonRetriable && isScheduleEligible(goal));

--- a/packages/omo-codex/plugin/components/ulw-loop/test/cli-complete-goals.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/cli-complete-goals.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ulwLoopCommand } from "../src/cli-commands.ts";
+import { ulwLoopLedgerPath } from "../src/paths.ts";
 
 let testDir: string;
 let out: string[];
@@ -31,6 +32,14 @@ function stdoutJson(): Record<string, unknown> {
 	return JSON.parse(out.join(""));
 }
 
+async function ledgerKinds(): Promise<string[]> {
+	const raw = await readFile(ulwLoopLedgerPath(testDir), "utf8");
+	return raw
+		.split(/\r?\n/)
+		.filter(Boolean)
+		.map((line) => (JSON.parse(line) as { kind: string }).kind);
+}
+
 async function createPlan(): Promise<void> {
 	expect(await ulwLoopCommand(["create-goals", "--brief", "- Goal A\n- Goal B", "--json"])).toBe(0);
 	resetOutput();
@@ -48,5 +57,21 @@ describe("ulwLoopCommand complete-goals", () => {
 			instruction: { json: { objective: expect.any(String) } },
 		});
 		expect(JSON.stringify(stdoutJson())).not.toContain('"status":"active"');
+	});
+
+	it("#given an in-progress goal #when complete-goals is called again #then it resumes without appending to the ledger", async () => {
+		// given
+		await createPlan();
+		expect(await ulwLoopCommand(["complete-goals", "--json"])).toBe(0);
+		expect(stdoutJson()).toMatchObject({ ok: true, resumed: false, goal: { status: "in_progress" } });
+		expect(await ledgerKinds()).toEqual(["plan_created", "goal_started"]);
+		resetOutput();
+
+		// when
+		expect(await ulwLoopCommand(["complete-goals", "--json"])).toBe(0);
+
+		// then
+		expect(stdoutJson()).toMatchObject({ ok: true, resumed: true, goal: { status: "in_progress" } });
+		expect(await ledgerKinds()).toEqual(["plan_created", "goal_started"]);
 	});
 });


### PR DESCRIPTION
## Summary
`omo ulw-loop complete-goals` is the agent's repeated "what's next?" read/handoff call during an active run. When a goal was already `in_progress`, `startNextUlwLoop` appended a `goal_resumed` entry to `ledger.jsonl` on **every** such call — despite no state change — spamming the append-only audit log. Nothing reads the `goal_resumed` kind back (only the constants allow-list references it), so the writes were pure cost: an unbounded, noisy ledger and a non-idempotent read path.

## Changes
- `plan-crud.ts`: drop the `appendLedger(goal_resumed)` call from the resume branch of `startNextUlwLoop`. Resuming an active goal is now idempotent — it returns the existing goal with `resumed: true` (unchanged output) and does not touch the ledger. Real state transitions (`goal_started`, `goal_retried`) still record.
- `cli-complete-goals.test.ts`: regression test asserting that a second `complete-goals` resumes (`resumed: true`, goal stays `in_progress`) while the ledger kinds stay exactly `["plan_created", "goal_started"]`.

## Testing
- `vitest --run` → **294 passed** (21 files); RED→GREEN verified (reverting the source makes the new test fail on the extra `goal_resumed` entry).
- `tsc --noEmit` ✅ · `biome check` ✅ · `tsc -p tsconfig.build.json` ✅

## Related
Reimplements the fix from #5259 (thanks @cosmosjeon for spotting it) under a clean branch with our own regression test, so it lands with full CI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop ledger spam by making the `complete-goals` resume path idempotent. We no longer append `goal_resumed` to `ledger.jsonl` when a goal is already `in_progress`; output stays the same and real transitions still record.

- **Bug Fixes**
  - Removed `appendLedger("goal_resumed")` from the resume branch in `startNextUlwLoop`, so repeated `complete-goals` calls return the current goal with `resumed: true` without writing to the ledger. Real transitions (`goal_started`, `goal_retried`) still append.
  - Added a regression test ensuring a second `complete-goals` call resumes and the ledger kinds remain exactly `["plan_created", "goal_started"]`.

<sup>Written for commit 1c18d1e461501bc78161c65f0e2f47c9f7e461be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

