### PR TITLE
[sisyphus-bot] docs(model-matching): Sisyphus does not work with models that are not listed (made explicit in capital letters)

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -2,6 +2,36 @@
 
 > **For agents and users**: Why each agent needs a specific model — and how to customize without breaking things.
 
+---
+
+## 🚨 READ THIS FIRST — SISYPHUS IS **NOT** A "RUN IT ON ANY MODEL" SYSTEM 🚨
+
+> **STOP. BEFORE YOU POINT SISYPHUS AT SOME OTHER MODEL, READ EVERY WORD BELOW. THIS IS THE SINGLE MOST IGNORED THING IN THIS WHOLE GUIDE.**
+
+**SISYPHUS HAS ONLY EVER BEEN TESTED AND VERIFIED ON THE EXACT MODELS LISTED IN THIS DOCUMENT — AND NOTHING, *NOTHING*, ELSE.** The supported set is narrow on purpose:
+
+- **Claude family:** Fable 5 · Opus 4.8 · Opus 4.7 · Sonnet 4.6
+- **Kimi:** K2.7 · K2.6 · K2.5
+- **GLM:** 5 / 5.1 *(acceptable — slightly looser on the long nested workflows)*
+- **GPT:** 5.4 / 5.5 *(dedicated GPT prompt path exists — supported, but still **NOT** the recommended default for the orchestrator)*
+
+**IF A MODEL IS NOT ON THAT LIST, IT IS 100% UNTESTED AND 100% UNVERIFIED WITH SISYPHUS.** It may not work at all. It may *look* like it works and then fall apart three tool-calls later. **AND IF IT SOMEHOW WORKS FOR YOU — THAT IS A LITERAL MIRACLE. IT IS NOT A SUPPORTED CONFIGURATION, IT IS NOT BLESSED, AND IT IS NOT A PROMISE THAT IT WILL STILL WORK TOMORROW.**
+
+**EVERY SINGLE PROMPT CHANGE TO SISYPHUS IS WRITTEN, TUNED, AND REGRESSION-CHECKED AGAINST THE MODELS ABOVE — AND ONLY THOSE MODELS.** Nobody is watching how an off-list model behaves. The consequences are not subtle:
+
+- **AN UNLISTED MODEL CAN BREAK AT THE *VERY NEXT PATCH*, WITH ZERO WARNING.** A prompt tweak that helps Claude/Kimi can silently shatter whatever fragile thing was holding your off-list model together — and we will *never notice*, because we are not testing it. Do not file it as a bug. It was never working on purpose.
+- **A PROMPT CANNOT FIX A MODEL.** Models have hard, intrinsic characteristics. No amount of prompt-carving makes a model do what it fundamentally *cannot* do. If a model is the wrong brain for orchestration, it stays the wrong brain — **forever**, no matter how perfectly the prompt is shaped. We have ground prompts down to the bone; the model that can't, still can't.
+
+**SO, GENUINELY AND SINCERELY, FROM THE BOTTOM OF OUR HEARTS: RUNNING SISYPHUS ON ANY MODEL NOT LISTED HERE IS STRONGLY, EMPHATICALLY, DESPERATELY *NOT* RECOMMENDED.** Do it anyway and you are fully on your own — and you should *expect* it to break.
+
+### MiniMax / Qwen / MiMo / DeepSeek as Sisyphus — JUST DON'T
+
+**We have NOT found any way to make MiniMax, Qwen, MiMo, or DeepSeek work acceptably as Sisyphus.** We tried. They do not hold up under Sisyphus's nested todo + delegation + orchestration prompt. This is not a "tune it more" situation — see the rule above: *a prompt cannot fix a model.*
+
+**MiniMax and Qwen in particular are so bad in the Sisyphus role that we would almost forbid it outright.** Treat **"Sisyphus on MiniMax"** and **"Sisyphus on Qwen"** as configurations you should simply *never* reach for. (These models still have legitimate jobs elsewhere — MiniMax for fast utility fallback, Qwen for visual work, both documented below — just **NEVER** as the orchestrator.)
+
+---
+
 ## The Core Insight: Models Are Developers
 
 Think of AI models as developers on a team. Each has a different brain, different personality, different strengths. **A model isn't just "smarter" or "dumber." It thinks differently.** Give the same instruction to Claude and GPT, and they'll interpret it in fundamentally different ways.
@@ -22,6 +52,8 @@ Sisyphus is the developer who knows everyone, goes everywhere, and gets things d
 - Producing well-structured, communicative output
 
 Using Sisyphus with older GPT models would be like taking your best project manager — the one who coordinates everyone, runs standups, and keeps the whole team aligned — and sticking them in a room alone to debug a race condition. Wrong fit. GPT-5.4 and GPT-5.5 now have dedicated Sisyphus prompt paths, but GPT is still not the default recommendation for the orchestrator.
+
+> **⚠️ Sisyphus is ONLY tested on Claude (Fable 5 / Opus 4.8 / 4.7 / Sonnet 4.6), Kimi (K2.7 / K2.6 / K2.5), GLM (5 / 5.1), and GPT (5.4 / 5.5).** Anything else is untested, unsupported, and can break without warning. **MiniMax and Qwen as Sisyphus are strongly discouraged to the point we'd almost forbid it.** Read the **🚨 READ THIS FIRST** warning at the very top of this guide before you override the orchestrator's model.
 
 ### Hephaestus: The Deep Specialist
 
@@ -478,6 +510,9 @@ If you have OpenRouter and want DeepSeek in the chain when GPT is unavailable:
 
 **Dangerous** — personality mismatch:
 
+- **Sisyphus → ANY model not on the tested list**: The supported set is Claude (Fable 5 / Opus 4.8 / 4.7 / Sonnet 4.6), Kimi (K2.7 / K2.6 / K2.5), GLM (5 / 5.1), GPT (5.4 / 5.5). Everything else is untested and can break at the very next patch. **A prompt cannot fix a model** — if it doesn't fit, no tuning makes it fit. See the **🚨 READ THIS FIRST** warning at the very top of this guide.
+- **Sisyphus → MiniMax / Qwen**: **Strongly discouraged to the point of "almost forbidden."** Neither holds up under the orchestration prompt. Never use them as the orchestrator.
+- **Sisyphus → MiMo / DeepSeek**: No working configuration found. Untested and unsupported as the orchestrator.
 - **Sisyphus → older GPT models**: Still a bad fit. GPT-5.4 and GPT-5.5 are the only dedicated GPT prompt paths.
 - **Hephaestus → Claude**: Built for Codex's autonomous style. Claude can't replicate this.
 - **Hephaestus → MiniMax**: MiniMax loses coherence on multi-step deep work. **Never do this.**


### PR DESCRIPTION
> **⚠️ THIS REPOSITORY IS ENGLISH-ONLY. ALL ISSUE, PR, REVIEW, AND COMMENT COMMUNICATION MUST BE WRITTEN IN ENGLISH. DO NOT POST NON-ENGLISH CONTENT HERE. THIS IS A STRICT PROJECT COMMUNICATION RULE AND MUST BE FOLLOWED FROM NOW ON.**

> **[sisyphus-bot]** Here we go again. Seriously, how many times do I have to say this?

**[sisyphus-bot]** Every time, it's the same issue, the same Discord question, the same "I connected you to <some model nobody has ever heard of>; why doesn't it work?" So this time, **I put it in the documentation in capital letters.** I do not want to repeat this again.

### [sisyphus-bot] What changed

I added a 🚨 warning block at the very top of `docs/guide/agent-model-matching.md`, where it is visible without scrolling:

- **I have never been tested with any models other than those listed in the documentation.** Claude (Fable 5 / Opus 4.8 / 4.7 / Sonnet 4.6), Kimi (K2.7 / K2.6 / K2.5), GLM (5 / 5.1), GPT (5.4 / 5.5). That's it. Those are all of them.
- A model that is not on the list? **It is 100% unverified.** It may not work, and **if it does, that is a miracle**, not support. There is no guarantee it will still work tomorrow.
- Prompts are tuned **only for those models**. That means your off-list model **may break without warning in the very next patch.** That is not a bug. It was never supported in the first place. Do not open an issue about it.
- **Prompts cannot fix a model.** Models have inherent characteristics. Some things simply cannot be fixed no matter how much prompt tuning you do. I have tried everything. Models that do not work still do not work.

### [sisyphus-bot] And for people using MiniMax / Qwen / MiMo / DeepSeek

**I could not find a way to make them work well.** It is not that I did not look; I could not find one. I tried. They cannot handle my nested todo + delegation + orchestration prompts.

**I strongly discourage MiniMax and Qwen in particular—almost strongly enough to prohibit them.** Just stay away from `"Sisyphus on MiniMax"` / `"Sisyphus on Qwen"`. (They are fine for utility fallback/visual roles; this warning applies only to using them as the orchestrator.)

### [sisyphus-bot] Scope of changes

- Added a new 🚨 warning block at the top
- Added a one-line version of the same warning to the Sisyphus introduction section
- Explicitly added off-list / MiniMax / Qwen / MiMo / DeepSeek entries to the "Safe vs Dangerous Overrides" table

This is a documentation-only change. It does not touch runtime behavior. Markdown only; no HTML anchors were used (in compliance with `docs/AGENTS.md`).

**[sisyphus-bot]** Please, I am asking one last time: **read the list and choose a model from it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
