### PR TITLE
fix(ulw-loop): emit JSON errors on stdout in --json mode

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/src/cli-commands.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/cli-commands.ts
@@ -2,7 +2,7 @@
 import { readFile } from "node:fs/promises";
 import { type CheckpointUlwLoopArgs, checkpointUlwLoop } from "./checkpoint.js";
 import { hasFlag, parseCodexGoalJson, parseRecordEvidenceArgs, positionalText, readStdin, readValue } from "./cli-arg-parser.js";
-import { blockedDecisionHandoff, normalizeCodexGoalMode, printJson, printStatus, ULW_LOOP_HELP } from "./cli-output.js";
+import { blockedDecisionHandoff, normalizeCodexGoalMode, printJson, printJsonError, printStatus, ULW_LOOP_HELP } from "./cli-output.js";
 import { parseSteeringProposal, printSteerResult } from "./cli-steering.js";
 import { buildCodexGoalInstruction } from "./codex-goal-instruction.js";
 import { recordEvidence } from "./evidence.js";
@@ -32,7 +32,10 @@ export async function ulwLoopCommand(argv: readonly string[]): Promise<number> {
 	const json = hasFlag(rest, "--json");
 	const scope = commandScope(rest);
 	try {
-		if (!isUlwLoopSubcommand(command)) { process.stdout.write(`${ULW_LOOP_HELP}\n`); return 1; }
+		if (!isUlwLoopSubcommand(command)) {
+			if (json) { printJsonError(new UlwLoopError(`Unknown ulw-loop subcommand: ${command}.`, "ULW_LOOP_SUBCOMMAND_UNKNOWN", { details: { command } })); return 1; }
+			process.stdout.write(`${ULW_LOOP_HELP}\n`); return 1;
+		}
 		switch (command) {
 			case "help": process.stdout.write(`${ULW_LOOP_HELP}\n`); return 0;
 			case "create-goals": return await createGoals(repoRoot, rest, json, scope);
@@ -47,6 +50,7 @@ export async function ulwLoopCommand(argv: readonly string[]): Promise<number> {
 			default: return unhandledSubcommand(command);
 		}
 	} catch (error) {
+		if (json) { printJsonError(error); return 1; }
 		if (error instanceof UlwLoopError) process.stderr.write(`[ulw-loop] ${error.message}\n`);
 		else if (error instanceof Error) process.stderr.write(`[ulw-loop] unexpected: ${error.message}\n`);
 		else process.stderr.write("[ulw-loop] unknown error\n");

--- a/packages/omo-codex/plugin/components/ulw-loop/src/cli-output.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/cli-output.ts
@@ -20,6 +20,25 @@ export function printJson(value: unknown): void {
 	process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
 
+export function printJsonError(error: unknown): void {
+	if (error instanceof UlwLoopError) {
+		printJson({
+			ok: false,
+			error: {
+				code: error.code,
+				message: error.message,
+				...(error.details === undefined ? {} : { details: error.details }),
+			},
+		});
+		return;
+	}
+	if (error instanceof Error) {
+		printJson({ ok: false, error: { code: "ULW_LOOP_UNEXPECTED", message: error.message } });
+		return;
+	}
+	printJson({ ok: false, error: { code: "ULW_LOOP_UNKNOWN", message: "unknown error" } });
+}
+
 function criteriaCounts(goal: UlwLoopItem): CriteriaCounts {
 	let pass = 0;
 	for (const criterion of goal.successCriteria) if (criterion.status === "pass") pass += 1;

--- a/packages/omo-codex/plugin/components/ulw-loop/test/cli-commands.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/cli-commands.test.ts
@@ -394,4 +394,10 @@ describe("ulwLoopCommand error handling", () => {
 		expect(await ulwLoopCommand(["status"])).toBe(1);
 		expect(err.join("")).toContain("[ulw-loop]");
 	});
+
+	it("#given no --json #when an error occurs #then writes only to stderr and leaves stdout empty", async () => {
+		expect(await ulwLoopCommand(["status"])).toBe(1);
+		expect(out.join("")).toBe("");
+		expect(err.join("")).toContain("[ulw-loop]");
+	});
 });

--- a/packages/omo-codex/plugin/components/ulw-loop/test/cli-json-errors.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/cli-json-errors.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ulwLoopCommand } from "../src/cli-commands.ts";
+
+let testDir: string;
+let out: string[];
+let err: string[];
+let originalCodexSessionId: string | undefined;
+let originalCodexThreadId: string | undefined;
+let originalOmoSessionId: string | undefined;
+
+beforeEach(async () => {
+	testDir = await mkdtemp(join(tmpdir(), "ug-cli-json-err-"));
+	out = [];
+	err = [];
+	originalCodexSessionId = process.env["CODEX_SESSION_ID"];
+	originalCodexThreadId = process.env["CODEX_THREAD_ID"];
+	originalOmoSessionId = process.env["OMO_ULW_LOOP_SESSION_ID"];
+	delete process.env["CODEX_SESSION_ID"];
+	delete process.env["CODEX_THREAD_ID"];
+	delete process.env["OMO_ULW_LOOP_SESSION_ID"];
+	vi.spyOn(process, "cwd").mockReturnValue(testDir);
+	vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array): boolean => {
+		out.push(chunk.toString());
+		return true;
+	});
+	vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array): boolean => {
+		err.push(chunk.toString());
+		return true;
+	});
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	if (originalCodexSessionId === undefined) delete process.env["CODEX_SESSION_ID"];
+	else process.env["CODEX_SESSION_ID"] = originalCodexSessionId;
+	if (originalCodexThreadId === undefined) delete process.env["CODEX_THREAD_ID"];
+	else process.env["CODEX_THREAD_ID"] = originalCodexThreadId;
+	if (originalOmoSessionId === undefined) delete process.env["OMO_ULW_LOOP_SESSION_ID"];
+	else process.env["OMO_ULW_LOOP_SESSION_ID"] = originalOmoSessionId;
+	await rm(testDir, { recursive: true, force: true });
+});
+
+function stdoutJson(): Record<string, unknown> {
+	return JSON.parse(out.join(""));
+}
+
+describe("ulwLoopCommand --json error contract", () => {
+	it("#given no plan #when status --json #then emits JSON error on stdout, nothing on stderr, exit 1", async () => {
+		const code = await ulwLoopCommand(["status", "--json"]);
+
+		expect(code).toBe(1);
+		expect(err.join("")).toBe("");
+		expect(stdoutJson()).toMatchObject({
+			ok: false,
+			error: { code: "ULW_LOOP_PLAN_MISSING", message: expect.stringContaining("No ulw-loop plan") },
+		});
+	});
+
+	it("#given no plan #when complete-goals --json #then emits JSON error on stdout, exit 1", async () => {
+		const code = await ulwLoopCommand(["complete-goals", "--json"]);
+
+		expect(code).toBe(1);
+		expect(err.join("")).toBe("");
+		expect(stdoutJson()).toMatchObject({ ok: false, error: { code: "ULW_LOOP_PLAN_MISSING" } });
+	});
+
+	it("#given an unknown subcommand #when --json #then emits a JSON error (not help text), exit 1", async () => {
+		const code = await ulwLoopCommand(["wat", "--json"]);
+
+		expect(code).toBe(1);
+		expect(out.join("")).not.toContain("Usage:");
+		expect(stdoutJson()).toMatchObject({ ok: false, error: { code: expect.any(String) } });
+	});
+
+	it("#given a malformed required flag #when --json #then surfaces the UlwLoopError code with details on stdout", async () => {
+		const code = await ulwLoopCommand(["criteria", "--json"]);
+
+		expect(code).toBe(1);
+		expect(err.join("")).toBe("");
+		expect(stdoutJson()).toMatchObject({
+			ok: false,
+			error: { code: "ULW_LOOP_ARGUMENT_MISSING", details: { flag: "--goal-id" } },
+		});
+	});
+});


### PR DESCRIPTION
## Problem

`omo ulw-loop <sub> --json` emitted **nothing on stdout** for any error path. Errors were written as plain text to **stderr** (exit 1), and the invalid-subcommand branch wrote the help text to stdout. A machine consumer running the documented post-compaction recovery call

```sh
omo ulw-loop status --json 2>/dev/null
```

(stderr suppressed) therefore saw empty output and could not distinguish *"no plan exists"* from *"the binary crashed"* from *"wrong directory"*.

### Real-world trigger
A live Codex run (cwd `…/apitopia`) executed `omo ulw-loop complete-goals --json 2>/dev/null || true` and `omo ulw-loop status --json 2>/dev/null || true`, got `(no output)`, and concluded *"ULW CLI exited without output in this shell, so I couldn't record additional checkpoints."* Reproduced before the fix:

```
$ omo ulw-loop status --json   # no plan present
exit=1 ; STDOUT empty ; STDERR="[ulw-loop] No ulw-loop plan found at .omo/ulw-loop/goals.json. ..."
```

## Fix

- `cli-output.ts`: add `printJsonError(error)` → prints `{ ok: false, error: { code, message, details? } }` to **stdout**.
- `cli-commands.ts`: the `catch` block and the unknown-subcommand branch route through `printJsonError` when `--json` is set; exit code stays `1`.
- **Non-`--json` behavior is unchanged** — errors still go to stderr as plain text.

This makes the `--json` contract total: every outcome (success *and* error) yields one parseable JSON object on stdout.

## Tests (RED → GREEN)

- **NEW** `test/cli-json-errors.test.ts`: `status --json` / `complete-goals --json` with no plan → `{ok:false,error:{code:"ULW_LOOP_PLAN_MISSING"}}` on stdout, stderr empty, exit 1; unknown subcommand `--json` → JSON error (not help); malformed required flag → `ULW_LOOP_ARGUMENT_MISSING` with `details.flag` on stdout.
- `test/cli-commands.test.ts`: regression assertion that the non-`--json` error path leaves stdout empty.
- Full suite: **22 files / 299 tests pass**, `tsc --noEmit` clean, biome clean.

## Manual QA (real compiled `dist/cli.js`, driven under tmux with `2>/dev/null`)

| Scenario | Result |
|---|---|
| `status --json` (no plan) | `{"ok":false,"error":{"code":"ULW_LOOP_PLAN_MISSING"}}` · exit 1 · JSON-parse OK |
| `complete-goals --json` (no plan) | `{"ok":false,"error":{"code":"ULW_LOOP_PLAN_MISSING"}}` · exit 1 · JSON-parse OK |
| `wat --json` (unknown sub) | `{"ok":false,"error":{"code":"ULW_LOOP_SUBCOMMAND_UNKNOWN"}}` · exit 1 · no help text |
| `status` (no `--json`) regression | stdout empty · exit 1 (error on stderr) |
| `status --json` **with** a plan | `{"ok":true,…}` · exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit JSON errors to stdout in `--json` mode for `omo ulw-loop` so machine consumers always get a parseable result. Unknown subcommands now return a JSON error; exit codes are unchanged.

- **Bug Fixes**
  - Added `printJsonError` to output `{ ok: false, error: { code, message, details? } }` on stdout in `--json` mode.
  - Routed caught errors and unknown subcommands through `printJsonError` when `--json` is set; exit remains `1`. Non-`--json` behavior stays on stderr.
  - Added tests for `status`, `complete-goals`, unknown subcommand, and missing flags; plus a regression test confirming non-`--json` keeps stdout empty.

<sup>Written for commit 022c5f3edc1d29eddf3afa6b965f507876cd1a61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

