### PR TITLE
fix(omo-opencode): mark completed sync handbacks

### DIFF
--- a/packages/omo-opencode/src/tools/delegate-task/sync-continuation.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-continuation.test.ts
@@ -480,6 +480,139 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
     expect(result).toContain("Result")
   })
 
+  test("marks and aborts resumed sync session after successful handback", async () => {
+    //#given - a resumed sync continuation completes successfully
+    const { handedBackSyncSessions } = require("../../features/claude-code-session-state")
+    handedBackSyncSessions.clear()
+    const abortCalls: Array<{ path: { id: string } }> = []
+    const mockClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+            {
+              info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "end_turn" },
+              parts: [{ type: "text", text: "Response" }],
+            },
+            { info: { id: "msg_003", role: "user", time: { created: 3000 } } },
+            {
+              info: { id: "msg_004", role: "assistant", time: { created: 4000 }, finish: "end_turn" },
+              parts: [{ type: "text", text: "New response" }],
+            },
+          ],
+        }),
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async (input: { path: { id: string } }) => {
+          abortCalls.push(input)
+          return {}
+        },
+        status: async () => ({
+          data: { ses_test: { type: "idle" } },
+        }),
+      },
+    }
+
+    const { executeSyncContinuation } = require("./sync-continuation")
+
+    const deps = {
+      pollSyncSession: async () => null,
+      fetchSyncResult: async () => ({ ok: true as const, textContent: "Result" }),
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-123",
+      metadata: () => {},
+    }
+
+    const mockExecutorCtx = {
+      client: mockClient,
+    }
+
+    const args = {
+      task_id: "ses_test_12345678",
+      prompt: "test prompt",
+      description: "test task",
+      load_skills: [],
+      run_in_background: false,
+    }
+
+    //#when - executeSyncContinuation hands the completed result back to the parent
+    const result = await executeSyncContinuation(args, mockCtx, mockExecutorCtx, { sessionID: "parent-session", messageID: "parent-message" }, deps)
+
+    //#then - todo-continuation wake paths can identify and stop the handed-back child
+    expect(result).toContain("Task continued and completed")
+    expect(handedBackSyncSessions.has("ses_test_12345678")).toBe(true)
+    expect(abortCalls).toEqual([{ path: { id: "ses_test_12345678" } }])
+
+    handedBackSyncSessions.clear()
+  })
+
+  test("does not mark or abort resumed sync session when handback fails", async () => {
+    //#given - a resumed sync continuation returns a poll error instead of a handback result
+    const { handedBackSyncSessions } = require("../../features/claude-code-session-state")
+    handedBackSyncSessions.clear()
+    const abortCalls: Array<{ path: { id: string } }> = []
+    const mockClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+            {
+              info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "end_turn" },
+              parts: [{ type: "text", text: "Response" }],
+            },
+          ],
+        }),
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async (input: { path: { id: string } }) => {
+          abortCalls.push(input)
+          return {}
+        },
+        status: async () => ({
+          data: { ses_test: { type: "idle" } },
+        }),
+      },
+    }
+
+    const { executeSyncContinuation } = require("./sync-continuation")
+
+    const deps = {
+      pollSyncSession: async () => "Task failed before handback",
+      fetchSyncResult: async () => ({ ok: true as const, textContent: "Result" }),
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-123",
+      metadata: () => {},
+    }
+
+    const mockExecutorCtx = {
+      client: mockClient,
+    }
+
+    const args = {
+      task_id: "ses_test_87654321",
+      prompt: "test prompt",
+      description: "test task",
+      load_skills: [],
+      run_in_background: false,
+    }
+
+    //#when - executeSyncContinuation cannot hand a result back to the parent
+    const result = await executeSyncContinuation(args, mockCtx, mockExecutorCtx, { sessionID: "parent-session", messageID: "parent-message" }, deps)
+
+    //#then - todo-continuation wake paths are not told to ignore a still-unreturned child
+    expect(result).toBe("Task failed before handback")
+    expect(handedBackSyncSessions.has("ses_test_87654321")).toBe(false)
+    expect(abortCalls).toEqual([])
+
+    handedBackSyncSessions.clear()
+  })
+
   test("removes toast when abort happens", async () => {
     //#given - create a context with abort signal
     const controller = new AbortController()

--- a/packages/omo-opencode/src/tools/delegate-task/sync-continuation.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-continuation.ts
@@ -1,6 +1,7 @@
 import type { DelegateTaskArgs, ToolContextWithMetadata } from "./types"
 import type { ExecutorContext, ParentContext, SessionMessage } from "./executor-types"
 import { isPlanFamily } from "./constants"
+import { handedBackSyncSessions } from "../../features/claude-code-session-state"
 import { publishToolMetadata } from "../../features/tool-metadata-store"
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
@@ -14,6 +15,7 @@ import { buildTaskPrompt } from "./prompt-builder"
 import { buildTaskMetadataBlock } from "../../features/tool-metadata-store/task-metadata-contract"
 import { getTaskID } from "./task-id"
 import { resolveMetadataModel } from "./resolve-metadata-model"
+import { log } from "../../shared/logger"
 
 type ResumeModel = { providerID: string; modelID: string }
 
@@ -119,6 +121,7 @@ export async function executeSyncContinuation(
   let resumeModel: ResumeModel | undefined
   let resumeVariant: string | undefined
   let anchorMessageCount: number | undefined
+  let handedBackToParent = false
 
   try {
     const resumeContext = await resolveResumeContext(client, continuationID)
@@ -203,6 +206,7 @@ export async function executeSyncContinuation(
         }
 
         const duration = formatDuration(startTime)
+        handedBackToParent = true
 
         return `Task continued and completed in ${duration}.
 
@@ -226,6 +230,7 @@ ${buildTaskMetadataBlock({
       }
 
      const duration = formatDuration(startTime)
+     handedBackToParent = true
 
      return `Task continued and completed in ${duration}.
 
@@ -242,6 +247,14 @@ ${buildTaskMetadataBlock({
    } finally {
      if (toastManager) {
        toastManager.removeTask(taskId)
+     }
+     if (handedBackToParent) {
+       handedBackSyncSessions.add(continuationID)
+       if (typeof client.session.abort === "function") {
+         void client.session.abort({ path: { id: continuationID } }).catch((error: unknown) => {
+           log(`[task] Failed to abort completed sync continuation session:`, error)
+         })
+       }
      }
    }
 }


### PR DESCRIPTION
## Summary
Fixes the resumed sync-continuation handback path so completed child sessions are marked as handed back and best-effort aborted after the result has been returned to the parent. This prevents later todo-continuation wake paths from re-awakening a child session that already completed and handed its result back.

## Changes
- Mark resumed sync continuation sessions in `handedBackSyncSessions` only after a successful handback result is prepared.
- Best-effort abort the completed child session after handback so it cannot keep receiving continuation prompts.
- Add regression coverage for both successful handback and failed handback paths.

## Testing
- RED: `.omo/evidence/20260614-fix-5089-sync-continuation/red.log`
- GREEN: `.omo/evidence/20260614-fix-5089-sync-continuation/green-after-handback-guard.log`
- Local regression: `.omo/evidence/20260614-fix-5089-sync-continuation/local-regression.log`
- `bun run typecheck`: `.omo/evidence/20260614-fix-5089-sync-continuation/typecheck.log`
- `bun run build`: `.omo/evidence/20260614-fix-5089-sync-continuation/build-after-handback-guard.log`
- Manual handback CLI proof: `.omo/evidence/20260614-fix-5089-sync-continuation/manual-sync-handback-cli.log`
  - observed completed handback, `handedBackSyncSessions.has(...) === true`, and child `session.abort` call
- Isolated OpenCode QA: `.omo/evidence/20260614-fix-5089-sync-continuation/opencode-agent-list-isolated-qa.log`
  - local `dist/index.js` plugin loaded via isolated `HOME`/XDG dirs
  - real opencode DB session count unchanged

## Related Issues
Refs #5089
