### PR TITLE
fix(omo-opencode): preserve provider cache snapshots

### DIFF
--- a/packages/omo-opencode/src/shared/connected-providers-cache.test.ts
+++ b/packages/omo-opencode/src/shared/connected-providers-cache.test.ts
@@ -156,6 +156,74 @@ describe("updateConnectedProvidersCache", () => {
 		}
 	})
 
+	test("removes stale providers when a complete refresh confirms they are disconnected", async () => {
+		const { createConnectedProvidersCacheStore } = await importFreshConnectedProvidersCacheModule()
+		const { testCacheStore, fakeUserCacheRoot } = createTestCacheContext(createConnectedProvidersCacheStore)
+
+		try {
+			//#given - a previous complete provider snapshot includes two connected providers
+			await testCacheStore.updateConnectedProvidersCache({
+				provider: {
+					list: async () => ({
+						data: {
+							connected: ["google", "anthropic"],
+							all: [
+								{
+									id: "google",
+									models: {
+										"gemini-3.1-pro": { id: "gemini-3.1-pro" },
+									},
+								},
+								{
+									id: "anthropic",
+									models: {
+										"claude-opus-4-7": { id: "claude-opus-4-7" },
+									},
+								},
+							],
+						},
+					}),
+				},
+			})
+
+			//#when - a later full provider list still knows anthropic but no longer marks it connected
+			await testCacheStore.updateConnectedProvidersCache({
+				provider: {
+					list: async () => ({
+						data: {
+							connected: ["google"],
+							all: [
+								{
+									id: "google",
+									models: {
+										"gemini-3.1-pro": { id: "gemini-3.1-pro" },
+									},
+								},
+								{
+									id: "anthropic",
+									models: {
+										"claude-opus-4-7": { id: "claude-opus-4-7" },
+									},
+								},
+							],
+						},
+					}),
+				},
+			})
+
+			//#then - disconnected providers are not kept eligible for model fallback
+			expect(testCacheStore.readConnectedProvidersCache()).toEqual(["google"])
+			expect(testCacheStore.readProviderModelsCache()).toMatchObject({
+				connected: ["google"],
+				models: {
+					google: [{ id: "gemini-3.1-pro" }],
+				},
+			})
+		} finally {
+			cleanupTestCacheContext(fakeUserCacheRoot)
+		}
+	})
+
 	test("writes empty models when provider has no models", async () => {
 		const { createConnectedProvidersCacheStore } = await importFreshConnectedProvidersCacheModule()
 		const { testCacheStore, fakeUserCacheRoot } = createTestCacheContext(createConnectedProvidersCacheStore)
@@ -187,6 +255,59 @@ describe("updateConnectedProvidersCache", () => {
 			const cache = testCacheStore.readProviderModelsCache()
 			expect(cache).not.toBeNull()
 			expect(cache!.models).toEqual({})
+		} finally {
+			cleanupTestCacheContext(fakeUserCacheRoot)
+		}
+	})
+
+	test("clears stale models when a connected provider explicitly reports no models", async () => {
+		const { createConnectedProvidersCacheStore } = await importFreshConnectedProvidersCacheModule()
+		const { testCacheStore, fakeUserCacheRoot } = createTestCacheContext(createConnectedProvidersCacheStore)
+
+		try {
+			//#given - a previous provider snapshot includes model metadata for a connected provider
+			await testCacheStore.updateConnectedProvidersCache({
+				provider: {
+					list: async () => ({
+						data: {
+							connected: ["openai"],
+							all: [
+								{
+									id: "openai",
+									models: {
+										"gpt-5.5": { id: "gpt-5.5" },
+									},
+								},
+							],
+						},
+					}),
+				},
+			})
+
+			//#when - a later authoritative refresh reports the provider with an empty model list
+			await testCacheStore.updateConnectedProvidersCache({
+				provider: {
+					list: async () => ({
+						data: {
+							connected: ["openai"],
+							all: [
+								{
+									id: "openai",
+									models: {},
+								},
+							],
+						},
+					}),
+				},
+			})
+
+			//#then - old models are not restored into the connected provider's cache entry
+			expect(testCacheStore.readProviderModelsCache()).toMatchObject({
+				connected: ["openai"],
+				models: {
+					openai: [],
+				},
+			})
 		} finally {
 			cleanupTestCacheContext(fakeUserCacheRoot)
 		}

--- a/packages/omo-opencode/src/shared/connected-providers-cache.test.ts
+++ b/packages/omo-opencode/src/shared/connected-providers-cache.test.ts
@@ -93,6 +93,69 @@ describe("updateConnectedProvidersCache", () => {
 		}
 	})
 
+	test("preserves last-good providers and models when a refresh returns a narrower partial list", async () => {
+		const { createConnectedProvidersCacheStore } = await importFreshConnectedProvidersCacheModule()
+		const { testCacheStore, fakeUserCacheRoot } = createTestCacheContext(createConnectedProvidersCacheStore)
+
+		try {
+			//#given - a previous complete provider snapshot includes the Sisyphus fallback provider
+			await testCacheStore.updateConnectedProvidersCache({
+				provider: {
+					list: async () => ({
+						data: {
+							connected: ["google", "anthropic"],
+							all: [
+								{
+									id: "google",
+									models: {
+										"gemini-3.1-pro": { id: "gemini-3.1-pro" },
+									},
+								},
+								{
+									id: "anthropic",
+									models: {
+										"claude-opus-4-7": { id: "claude-opus-4-7" },
+									},
+								},
+							],
+						},
+					}),
+				},
+			})
+
+			//#when - a transient cold-start refresh only reports one connected provider
+			await testCacheStore.updateConnectedProvidersCache({
+				provider: {
+					list: async () => ({
+						data: {
+							connected: ["google"],
+							all: [
+								{
+									id: "google",
+									models: {
+										"gemini-3.1-pro": { id: "gemini-3.1-pro" },
+									},
+								},
+							],
+						},
+					}),
+				},
+			})
+
+			//#then - the partial refresh does not poison the model gate cache
+			expect(testCacheStore.readConnectedProvidersCache()).toEqual(["google", "anthropic"])
+			expect(testCacheStore.readProviderModelsCache()).toMatchObject({
+				connected: ["google", "anthropic"],
+				models: {
+					google: [{ id: "gemini-3.1-pro" }],
+					anthropic: [{ id: "claude-opus-4-7" }],
+				},
+			})
+		} finally {
+			cleanupTestCacheContext(fakeUserCacheRoot)
+		}
+	})
+
 	test("writes empty models when provider has no models", async () => {
 		const { createConnectedProvidersCacheStore } = await importFreshConnectedProvidersCacheModule()
 		const { testCacheStore, fakeUserCacheRoot } = createTestCacheContext(createConnectedProvidersCacheStore)

--- a/packages/omo-opencode/src/shared/connected-providers-cache.test.ts
+++ b/packages/omo-opencode/src/shared/connected-providers-cache.test.ts
@@ -224,6 +224,52 @@ describe("updateConnectedProvidersCache", () => {
 		}
 	})
 
+	test("clears connected providers when a complete refresh reports none connected", async () => {
+		const { createConnectedProvidersCacheStore } = await importFreshConnectedProvidersCacheModule()
+		const { testCacheStore, fakeUserCacheRoot } = createTestCacheContext(createConnectedProvidersCacheStore)
+
+		try {
+			//#given - a previous complete provider snapshot includes connected providers
+			await testCacheStore.updateConnectedProvidersCache({
+				provider: {
+					list: async () => ({
+						data: {
+							connected: ["google", "anthropic"],
+							all: [
+								{ id: "google", models: { "gemini-3.1-pro": { id: "gemini-3.1-pro" } } },
+								{ id: "anthropic", models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
+							],
+						},
+					}),
+				},
+			})
+
+			//#when - a full provider list confirms neither provider is connected
+			await testCacheStore.updateConnectedProvidersCache({
+				provider: {
+					list: async () => ({
+						data: {
+							connected: [],
+							all: [
+								{ id: "google", models: { "gemini-3.1-pro": { id: "gemini-3.1-pro" } } },
+								{ id: "anthropic", models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
+							],
+						},
+					}),
+				},
+			})
+
+			//#then - all disconnected providers are evicted from fallback reachability
+			expect(testCacheStore.readConnectedProvidersCache()).toEqual([])
+			expect(testCacheStore.readProviderModelsCache()).toMatchObject({
+				connected: [],
+				models: {},
+			})
+		} finally {
+			cleanupTestCacheContext(fakeUserCacheRoot)
+		}
+	})
+
 	test("writes empty models when provider has no models", async () => {
 		const { createConnectedProvidersCacheStore } = await importFreshConnectedProvidersCacheModule()
 		const { testCacheStore, fakeUserCacheRoot } = createTestCacheContext(createConnectedProvidersCacheStore)

--- a/packages/omo-opencode/src/shared/connected-providers-cache.ts
+++ b/packages/omo-opencode/src/shared/connected-providers-cache.ts
@@ -47,7 +47,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null
 }
 
-function mergeConnectedProviders(previous: string[] | null | undefined, fetched: string[]): string[] {
+function mergeConnectedProviders(
+	previous: string[] | null | undefined,
+	fetched: string[],
+	reportedProviderIDs: Set<string>,
+): string[] {
 	if (!previous || previous.length === 0) {
 		return fetched
 	}
@@ -62,18 +66,27 @@ function mergeConnectedProviders(previous: string[] | null | undefined, fetched:
 		return fetched
 	}
 
-	return Array.from(new Set([...previous, ...fetched]))
+	const fetchedSetWithConfirmedDisconnects = new Set(fetched)
+	for (const provider of previous) {
+		if (!reportedProviderIDs.has(provider)) {
+			fetchedSetWithConfirmedDisconnects.add(provider)
+		}
+	}
+	return Array.from(fetchedSetWithConfirmedDisconnects)
 }
 
 function mergeProviderModels(
 	previous: Record<string, string[] | ModelMetadata[]> | undefined,
 	fetched: Record<string, ModelMetadata[]>,
 	connected: string[],
+	reportedModelProviderIDs: Set<string>,
 ): Record<string, string[] | ModelMetadata[]> {
 	const merged: Record<string, string[] | ModelMetadata[]> = {}
 	for (const provider of connected) {
 		if (fetched[provider]) {
 			merged[provider] = fetched[provider]
+		} else if (reportedModelProviderIDs.has(provider) && previous?.[provider]) {
+			merged[provider] = []
 		} else if (previous?.[provider]) {
 			merged[provider] = previous[provider]
 		}
@@ -159,7 +172,9 @@ export function createConnectedProvidersCacheStore(
 			const previousProviderModels = readProviderModelsCache()
 			const result = await client.provider.list()
 			const fetchedConnected = result.data?.connected ?? []
-			const connected = mergeConnectedProviders(previousConnected ?? previousProviderModels?.connected, fetchedConnected)
+			const allProviders = result.data?.all ?? []
+			const reportedProviderIDs = new Set(allProviders.map((provider) => provider.id))
+			const connected = mergeConnectedProviders(previousConnected ?? previousProviderModels?.connected, fetchedConnected, reportedProviderIDs)
 			log("[connected-providers-cache] Fetched connected providers", {
 				count: fetchedConnected.length,
 				providers: fetchedConnected,
@@ -168,10 +183,11 @@ export function createConnectedProvidersCacheStore(
 			writeConnectedProvidersCache(connected)
 
 			const modelsByProvider: Record<string, ModelMetadata[]> = {}
-			const allProviders = result.data?.all ?? []
+			const reportedModelProviderIDs = new Set<string>()
 
 			for (const provider of allProviders) {
 				if (provider.models) {
+					reportedModelProviderIDs.add(provider.id)
 					const modelMetadata = Object.entries(provider.models).map(([modelID, rawMetadata]) => {
 						if (!isRecord(rawMetadata)) {
 							return { id: modelID }
@@ -191,7 +207,7 @@ export function createConnectedProvidersCacheStore(
 					}
 				}
 			}
-			const mergedModelsByProvider = mergeProviderModels(previousProviderModels?.models, modelsByProvider, connected)
+			const mergedModelsByProvider = mergeProviderModels(previousProviderModels?.models, modelsByProvider, connected, reportedModelProviderIDs)
 
 			log("[connected-providers-cache] Extracted models from provider list", {
 				providerCount: Object.keys(mergedModelsByProvider).length,

--- a/packages/omo-opencode/src/shared/connected-providers-cache.ts
+++ b/packages/omo-opencode/src/shared/connected-providers-cache.ts
@@ -47,6 +47,40 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null
 }
 
+function mergeConnectedProviders(previous: string[] | null | undefined, fetched: string[]): string[] {
+	if (!previous || previous.length === 0) {
+		return fetched
+	}
+
+	if (fetched.length === 0) {
+		return previous
+	}
+
+	const fetchedSet = new Set(fetched)
+	const droppedPreviousProvider = previous.some((provider) => !fetchedSet.has(provider))
+	if (!droppedPreviousProvider) {
+		return fetched
+	}
+
+	return Array.from(new Set([...previous, ...fetched]))
+}
+
+function mergeProviderModels(
+	previous: Record<string, string[] | ModelMetadata[]> | undefined,
+	fetched: Record<string, ModelMetadata[]>,
+	connected: string[],
+): Record<string, string[] | ModelMetadata[]> {
+	const merged: Record<string, string[] | ModelMetadata[]> = {}
+	for (const provider of connected) {
+		if (fetched[provider]) {
+			merged[provider] = fetched[provider]
+		} else if (previous?.[provider]) {
+			merged[provider] = previous[provider]
+		}
+	}
+	return merged
+}
+
 export function createConnectedProvidersCacheStore(
 	getCacheDir: () => string = dataPath.getOmoOpenCodeCacheDir
 ) {
@@ -121,11 +155,14 @@ export function createConnectedProvidersCacheStore(
 		}
 
 		try {
+			const previousConnected = readConnectedProvidersCache()
+			const previousProviderModels = readProviderModelsCache()
 			const result = await client.provider.list()
-			const connected = result.data?.connected ?? []
+			const fetchedConnected = result.data?.connected ?? []
+			const connected = mergeConnectedProviders(previousConnected ?? previousProviderModels?.connected, fetchedConnected)
 			log("[connected-providers-cache] Fetched connected providers", {
-				count: connected.length,
-				providers: connected,
+				count: fetchedConnected.length,
+				providers: fetchedConnected,
 			})
 
 			writeConnectedProvidersCache(connected)
@@ -154,14 +191,15 @@ export function createConnectedProvidersCacheStore(
 					}
 				}
 			}
+			const mergedModelsByProvider = mergeProviderModels(previousProviderModels?.models, modelsByProvider, connected)
 
 			log("[connected-providers-cache] Extracted models from provider list", {
-				providerCount: Object.keys(modelsByProvider).length,
-				totalModels: Object.values(modelsByProvider).reduce((sum, ids) => sum + ids.length, 0),
+				providerCount: Object.keys(mergedModelsByProvider).length,
+				totalModels: Object.values(mergedModelsByProvider).reduce((sum, ids) => sum + ids.length, 0),
 			})
 
 			writeProviderModelsCache({
-				models: modelsByProvider,
+				models: mergedModelsByProvider,
 				connected,
 			})
 		} catch (err) {

--- a/packages/omo-opencode/src/shared/connected-providers-cache.ts
+++ b/packages/omo-opencode/src/shared/connected-providers-cache.ts
@@ -56,7 +56,7 @@ function mergeConnectedProviders(
 		return fetched
 	}
 
-	if (fetched.length === 0) {
+	if (fetched.length === 0 && reportedProviderIDs.size === 0) {
 		return previous
 	}
 

--- a/packages/omo-opencode/src/shared/model-availability.test.ts
+++ b/packages/omo-opencode/src/shared/model-availability.test.ts
@@ -269,6 +269,18 @@ describe("fuzzyMatchModel", () => {
 		expect(result).toBe("github-copilot/claude-sonnet-5.1")
 	})
 
+	it("should normalize dash and dot version separators for non-Claude model families", () => {
+		const available = new Set([
+			"kimi-for-coding/kimi-k2-6",
+			"zai-coding-plan/glm-4.6",
+			"openai/gpt-5-4",
+		])
+
+		expect(fuzzyMatchModel("kimi-k2.6", available, ["kimi-for-coding"])).toBe("kimi-for-coding/kimi-k2-6")
+		expect(fuzzyMatchModel("glm-4-6", available, ["zai-coding-plan"])).toBe("zai-coding-plan/glm-4.6")
+		expect(fuzzyMatchModel("gpt-5.4", available, ["openai"])).toBe("openai/gpt-5-4")
+	})
+
 	// given available models from multiple providers
 	// when providers filter is specified
 	// then only search models from specified providers

--- a/packages/omo-opencode/src/shared/model-availability.ts
+++ b/packages/omo-opencode/src/shared/model-availability.ts
@@ -13,6 +13,8 @@ function normalizeModelName(name: string): string {
 	return name
 		.toLowerCase()
 		.replace(/claude-(opus|sonnet|haiku)-(\d+)[.-](\d+)/g, "claude-$1-$2.$3")
+		.replace(/kimi-k2[.-](\d+)/g, "kimi-k2.$1")
+		.replace(/\b(glm|gpt)-(\d+)[.-](\d+)/g, "$1-$2.$3")
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes an agent-visibility failure mode where a transient narrow `provider.list()` refresh can poison the connected-provider/model cache and hide configured core agents such as Sisyphus. Also broadens model fuzzy matching so future Kimi/GLM/GPT dash-vs-dot version spellings resolve consistently.

## Changes
- Preserve the last-good connected provider snapshot when a refresh is empty or omits previously connected providers from the reported provider universe.
- Evict confirmed stale providers when a full provider list still reports the provider but no longer marks it connected.
- Clear all connected providers when a full provider list reports none connected.
- Clear stale model lists when a connected provider explicitly reports an empty model map.
- Normalize future non-Claude model version separators for Kimi K2, GLM, and GPT families.

## Testing
- RED: `.omo/evidence/20260614-fix-3456-provider-cache/red.log`
- RED stale-provider review fix: `.omo/evidence/20260614-fix-3456-provider-cache/red-stale-provider-eviction.log`
- RED stale-model review fix: `.omo/evidence/20260614-fix-3456-provider-cache/red-stale-model-eviction.log`
- RED disconnect-all review fix: `.omo/evidence/20260614-fix-3456-provider-cache/red-disconnect-all-eviction.log`
- GREEN: `.omo/evidence/20260614-fix-3456-provider-cache/green-after-disconnect-all-fix.log`
- Local regression: `.omo/evidence/20260614-fix-3456-provider-cache/local-regression-after-disconnect-all-fix.log`
- `bun run typecheck`: `.omo/evidence/20260614-fix-3456-provider-cache/typecheck-after-disconnect-all-fix.log`
- `bun run build`: `.omo/evidence/20260614-fix-3456-provider-cache/build-after-disconnect-all-fix.log`
- Manual provider-cache CLI proof: `.omo/evidence/20260614-fix-3456-provider-cache/manual-provider-cache-cli.log`
  - transient partial refresh preserves `google,anthropic`
  - confirmed full disconnect reduces connected providers to `google`
  - confirmed disconnect-all reduces connected providers to `[]`
  - explicit empty models clears stale model list to `google: []`
- Isolated OpenCode QA: `.omo/evidence/20260614-fix-3456-provider-cache/opencode-agent-list-isolated-qa.log`
  - local `dist/index.js` plugin loaded via isolated `HOME`/XDG dirs
  - Sisyphus/Hephaestus/Prometheus present in `opencode agent list`
  - real opencode DB session count unchanged

## Related Issues
Fixes #3456
