### PR TITLE
fix(task): route plan directly and fix generic direct-subagent hang

### DIFF
--- a/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
@@ -37,6 +37,7 @@ export function createCoreTools(args: {
     manager: managers.backgroundManager,
     client: ctx.client,
     directory: ctx.directory,
+    pluginContext: ctx,
     userCategories: pluginConfig.categories,
     agentOverrides: pluginConfig.agents,
     gitMasterConfig: pluginConfig.git_master,

--- a/packages/omo-opencode/src/tools/call-omo-agent/agent-resolver.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/agent-resolver.ts
@@ -9,8 +9,9 @@ export function clearCallableAgentsCache(): void {
  * Resolves the set of callable agent names for call_omo_agent.
  *
  * This tool is deliberately narrower than delegate-task: it may only launch
- * the research lookup agents used by worker-style agents while they continue
- * local work. Dynamic agents and other built-ins must go through task().
+ * research lookup agents and the plan agent direct path used to avoid wrapping
+ * plan in delegate-task's sync poller. Dynamic agents and other built-ins must
+ * go through task().
  */
 export async function resolveCallableAgents(
   _client?: PluginInput["client"],

--- a/packages/omo-opencode/src/tools/call-omo-agent/agent-restriction.test.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/agent-restriction.test.ts
@@ -69,7 +69,7 @@ describe("call_omo_agent restricted agent set", () => {
 
     //#then
     expect(result).toContain("Invalid agent type")
-    expect(result).toContain("Only explore, librarian are allowed")
+    expect(result).toContain("Only explore, librarian, plan are allowed")
     expect(launch).not.toHaveBeenCalled()
   })
 
@@ -92,8 +92,30 @@ describe("call_omo_agent restricted agent set", () => {
 
     //#then
     expect(result).toContain("Invalid agent type")
-    expect(result).toContain("Only explore, librarian are allowed")
+    expect(result).toContain("Only explore, librarian, plan are allowed")
     expect(launch).not.toHaveBeenCalled()
+  })
+
+
+  test("#when caller requests plan #then call_omo_agent launches it through the direct path", async () => {
+    //#given
+    clearCallableAgentsCache()
+    const pluginInput = createPluginInput([
+      { name: "explore", mode: "subagent" },
+      { name: "librarian", mode: "subagent" },
+      { name: "plan", mode: "subagent" },
+    ])
+    const { manager, launch } = createBackgroundManager()
+    const toolDefinition = createCallOmoAgent(pluginInput, manager)
+
+    //#when
+    await toolDefinition.execute(
+      { description: "Plan", prompt: "Plan work", subagent_type: "plan", run_in_background: true },
+      toolContext,
+    )
+
+    //#then
+    expect(launch).toHaveBeenCalledTimes(1)
   })
 
   test("#when caller requests explore or librarian #then call_omo_agent still launches them", async () => {

--- a/packages/omo-opencode/src/tools/call-omo-agent/constants.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/constants.ts
@@ -1,9 +1,10 @@
 export const ALLOWED_AGENTS = [
   "explore",
   "librarian",
+  "plan",
 ] as const
 
-export const CALL_OMO_AGENT_DESCRIPTION = `Spawn explore/librarian agent. run_in_background REQUIRED (true=async with task_id, false=sync).
+export const CALL_OMO_AGENT_DESCRIPTION = `Spawn explore/librarian/plan agent. run_in_background REQUIRED (true=async with task_id, false=sync).
 
 Allowed agents:
 {agents}

--- a/packages/omo-opencode/src/tools/call-omo-agent/tools.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/tools.ts
@@ -122,7 +122,7 @@ export function createCallOmoAgent(
       subagent_type: tool.schema
         .string()
         .describe(
-          "The agent to invoke. Only explore and librarian are allowed.",
+          "The agent to invoke. Only explore, librarian, and plan are allowed.",
         ),
       run_in_background: tool.schema
         .boolean()

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.status-fallback.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.status-fallback.test.ts
@@ -5,6 +5,21 @@ import { pollSyncSession } from "./sync-session-poller"
 import { __resetTimingConfig, __setTimingConfig } from "./timing"
 import type { OpencodeClient, ToolContextWithMetadata } from "./types"
 
+async function withMockedDateNow(stepMs: number, run: () => Promise<void>) {
+  const originalDateNow = Date.now
+  let now = 0
+  Date.now = () => {
+    const current = now
+    now += stepMs
+    return current
+  }
+  try {
+    await run()
+  } finally {
+    Date.now = originalDateNow
+  }
+}
+
 const toolContext: ToolContextWithMetadata = {
   sessionID: "ses_parent",
   messageID: "msg_parent",
@@ -48,4 +63,46 @@ describe("pollSyncSession status fallback", () => {
     // then
     expect(result).toBeNull()
   })
+
+  test("#given status remains running but assistant text exists #when polling #then messages complete the sync task", async () => {
+    // given
+    __setTimingConfig({
+      POLL_INTERVAL_MS: 1,
+      MAX_POLL_TIME_MS: 50,
+    })
+    let messageCallCount = 0
+    const client = unsafeTestValue<OpencodeClient>({
+      session: {
+        status: async () => ({ data: { ses_stale_running: { type: "running" } } }),
+        messages: async () => {
+          messageCallCount++
+          return {
+            data: [
+              { info: { id: "msg_001", role: "user", time: { created: 1 } } },
+              {
+                info: { id: "msg_002", role: "assistant", time: { created: 2 } },
+                parts: [{ type: "text", text: "done" }],
+              },
+            ],
+          }
+        },
+        abort: async () => ({ data: {} }),
+      },
+    })
+
+    await withMockedDateNow(6_000, async () => {
+      // when
+      const result = await pollSyncSession(toolContext, client, {
+        sessionID: "ses_stale_running",
+        agentToUse: "explore",
+        toastManager: null,
+        taskId: undefined,
+      }, 30_000)
+
+      // then
+      expect(result).toBeNull()
+      expect(messageCallCount).toBeGreaterThan(0)
+    })
+  })
+
 })

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
@@ -9,6 +9,7 @@ const NON_TERMINAL_FINISH_REASONS = new Set(["tool-calls", "unknown"])
 const PENDING_TOOL_PART_TYPES = new Set(["tool", "tool_use", "tool-call"])
 const ACTIVE_SESSION_STATUSES = new Set(["busy", "retry", "running"])
 const CHILD_WAKE_GRACE_MS = 5_000
+const ACTIVE_STATUS_MESSAGE_CHECK_GRACE_MS = 5_000
 
 function wait(milliseconds: number): Promise<void> {
   const sharedBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)
@@ -100,6 +101,7 @@ export async function pollSyncSession(
   const childWakeGraceMs = input.childWakeGraceMs ?? CHILD_WAKE_GRACE_MS
   let childWaitAssistantId: string | undefined
   let childWaitStartedAt = 0
+  let activeStatusStartedAt = 0
   const shouldWaitForChildTasks = (currentAssistantId: string | undefined): boolean => {
     if (input.hasActiveChildBackgroundTasks?.(input.sessionID)) {
       childWaitAssistantId = currentAssistantId
@@ -179,9 +181,15 @@ export async function pollSyncSession(
       })
     }
 
-    if (isActiveSessionStatus(sessionStatus)) {
-      inactiveStart = Date.now()
-      continue
+    const activeStatus = isActiveSessionStatus(sessionStatus)
+    if (activeStatus) {
+      activeStatusStartedAt ||= Date.now()
+      if (Date.now() - activeStatusStartedAt < ACTIVE_STATUS_MESSAGE_CHECK_GRACE_MS) {
+        inactiveStart = Date.now()
+        continue
+      }
+    } else {
+      activeStatusStartedAt = 0
     }
 
     let messages: SessionMessage[]
@@ -245,8 +253,13 @@ export async function pollSyncSession(
       log("[task] Poll complete - assistant text detected (fallback)", {
         sessionID: input.sessionID,
         pollCount,
+        sessionStatus: sessionStatus?.type ?? "not_in_status",
       })
       break
+    }
+
+    if (activeStatus) {
+      inactiveStart = Date.now()
     }
   }
 

--- a/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
@@ -380,6 +380,81 @@ describe("sisyphus-task", () => {
     })
   })
 
+
+  describe("plan direct routing", () => {
+    test("#given sync plan task #when executed #then it routes through call_omo_agent instead of delegate sync wrapper", async () => {
+      //#given
+      const { createDelegateTask } = require("./tools")
+      const launch = mock(() => Promise.resolve({
+        id: "plan-task-id",
+        sessionId: "ses-plan",
+        description: "Plan work",
+        agent: "plan",
+        status: "pending",
+      }))
+      const mockManager = {
+        launch,
+        getTask: mock(() => ({ status: "pending", sessionId: "ses-plan" })),
+        reserveSubagentSpawn: mock(() => Promise.resolve({
+          spawnContext: { rootSessionID: "root", parentDepth: 0, childDepth: 1 },
+          descendantCount: 1,
+          commit: mock(() => 1),
+          rollback: mock(() => undefined),
+        })),
+      }
+      const mockClient = {
+        app: { agents: async () => ({ data: [] }) },
+        config: { get: async () => ({}) },
+        provider: { list: async () => ({ data: { connected: ["openai"] } }) },
+        model: { list: async () => ({ data: [{ provider: "openai", id: "gpt-5.5" }] }) },
+        session: {
+          create: mock(async () => ({ data: { id: "ses-sync-wrapper" } })),
+          get: async () => ({ data: { id: "parent-session", directory: "/tmp" } }),
+          prompt: async () => ({ data: {} }),
+          promptAsync: async () => ({ data: {} }),
+          messages: async () => ({ data: [{
+            info: { role: "assistant", time: { created: 1 } },
+            parts: [{ type: "text", text: "PLAN_OK" }],
+          }] }),
+          status: async () => ({ data: {} }),
+        },
+      }
+      const pluginContext = {
+        client: mockClient,
+        directory: "/tmp",
+      }
+      const tool = createDelegateTask({
+        manager: mockManager,
+        client: mockClient,
+        directory: "/tmp",
+        pluginContext,
+        connectedProvidersOverride: TEST_CONNECTED_PROVIDERS,
+        availableModelsOverride: createTestAvailableModels(),
+      })
+
+      //#when
+      const result = await tool.execute({
+        description: "Plan work",
+        prompt: "Plan the work",
+        subagent_type: "plan",
+        run_in_background: false,
+        load_skills: [],
+      }, {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "sisyphus",
+        abort: new AbortController().signal,
+      })
+
+      //#then
+      expect(result).toContain("session_id: ses-sync-wrapper")
+      expect(result).not.toContain("Task completed")
+      expect(launch).not.toHaveBeenCalled()
+      expect(mockManager.reserveSubagentSpawn).toHaveBeenCalledTimes(1)
+      expect(mockClient.session.create).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe("load_skills parsing", () => {
     test("parses valid JSON string into array before validation", async () => {
       //#given
@@ -3924,7 +3999,20 @@ describe("sisyphus-task", () => {
          config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
          session: { get: async () => ({ data: { directory: "/project" } }), create: async () => ({ data: { id: "s" } }), prompt: async () => ({ data: {} }), promptAsync: async () => ({ data: {} }), messages: async () => ({ data: [] }), status: async () => ({ data: {} }) },
        }
-       const tool = createDelegateTask({ manager: { launch: async () => ({}) }, client: mockClient })
+       const tool = createDelegateTask({
+         manager: {
+           launch: async () => ({}),
+           reserveSubagentSpawn: async () => ({
+             spawnContext: { rootSessionID: "root", parentDepth: 0, childDepth: 1 },
+             descendantCount: 1,
+             commit: () => 1,
+             rollback: () => undefined,
+           }),
+         },
+         client: mockClient,
+         directory: "/project",
+         pluginContext: { client: mockClient, directory: "/project" },
+       })
       
       //#when
       const result = await tool.execute(
@@ -4012,7 +4100,20 @@ describe("sisyphus-task", () => {
            status: async () => ({ data: { "ses_ok": { type: "idle" } } }),
          },
        }
-       const tool = createDelegateTask({ manager: { launch: async () => ({}) }, client: mockClient })
+       const tool = createDelegateTask({
+         manager: {
+           launch: async () => ({}),
+           reserveSubagentSpawn: async () => ({
+             spawnContext: { rootSessionID: "root", parentDepth: 0, childDepth: 1 },
+             descendantCount: 1,
+             commit: () => 1,
+             rollback: () => undefined,
+           }),
+         },
+         client: mockClient,
+         directory: "/project",
+         pluginContext: { client: mockClient, directory: "/project" },
+       })
       
       //#when
       const result = await tool.execute(
@@ -4022,7 +4123,7 @@ describe("sisyphus-task", () => {
       
       //#then
       expect(result).not.toContain("plan-family")
-      expect(result).toContain("Plan created")
+      expect(result).toContain("session_id: ses_ok")
     }, { timeout: 20000 })
   })
 
@@ -4418,59 +4519,56 @@ describe("sisyphus-task", () => {
   })
 
   describe("subagent task permission", () => {
-    test("plan subagent should have task permission enabled", async () => {
-      //#given - sisyphus delegates to plan agent
+    test("plan subagent uses direct call_omo_agent route instead of delegate task permission path", async () => {
+      //#given
       const { createDelegateTask } = require("./tools")
-      let promptBody: CapturedPromptBody = {}
-      
-       const mockManager = { launch: async () => ({}) }
-       
-       const promptMock = async (input: CapturedPromptInput) => {
-         promptBody = input.body
-         return { data: {} }
-       }
-       
-       const mockClient = {
-         app: { agents: async () => ({ data: [{ name: "plan", mode: "subagent" }] }) },
-         config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
-         session: {
-           get: async () => ({ data: { directory: "/project" } }),
-           create: async () => ({ data: { id: "ses_plan_delegate" } }),
-           prompt: promptMock,
-           promptAsync: promptMock,
-           messages: async () => ({
-             data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Plan created" }] }]
-           }),
-           status: async () => ({ data: { "ses_plan_delegate": { type: "idle" } } }),
-         },
-       }
-       
-       const tool = createDelegateTask({
-         manager: mockManager,
-         client: mockClient,
-       })
-      
-      const toolContext = {
-        sessionID: "parent-session",
-        messageID: "parent-message",
-        agent: "sisyphus",
-        abort: new AbortController().signal,
+      const mockClient = {
+        app: { agents: async () => ({ data: [{ name: "plan", mode: "subagent" }] }) },
+        config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
+        session: {
+          get: async () => ({ data: { directory: "/project" } }),
+          create: async () => ({ data: { id: "ses_plan_delegate" } }),
+          prompt: async () => ({ data: {} }),
+          promptAsync: async () => ({ data: {} }),
+          messages: async () => ({ data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Plan created" }] }] }),
+          status: async () => ({ data: { "ses_plan_delegate": { type: "idle" } } }),
+        },
       }
-      
-      //#when - sisyphus delegates to plan
-      await tool.execute(
+      const tool = createDelegateTask({
+        manager: {
+          launch: async () => ({}),
+          reserveSubagentSpawn: async () => ({
+            spawnContext: { rootSessionID: "root", parentDepth: 0, childDepth: 1 },
+            descendantCount: 1,
+            commit: () => 1,
+            rollback: () => undefined,
+          }),
+        },
+        client: mockClient,
+        directory: "/project",
+        pluginContext: { client: mockClient, directory: "/project" },
+      })
+
+      //#when
+      const result = await tool.execute(
         {
-          description: "Test plan task permission",
+          description: "Test plan direct route",
           prompt: "Create a plan",
           subagent_type: "plan",
           run_in_background: false,
           load_skills: [],
         },
-        toolContext
+        {
+          sessionID: "parent-session",
+          messageID: "parent-message",
+          agent: "sisyphus",
+          abort: new AbortController().signal,
+        }
       )
-      
-      //#then - plan agent should have task permission
-      expect(promptBody.tools.task).toBe(true)
+
+      //#then
+      expect(result).toContain("session_id: ses_plan_delegate")
+      expect(result).not.toContain("Task completed")
     }, { timeout: 20000 })
 
     test("prometheus primary agent should not be callable via task", async () => {

--- a/packages/omo-opencode/src/tools/delegate-task/tools.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.ts
@@ -16,6 +16,8 @@ import {
 import { prepareDelegateTaskArgs } from "./tool-argument-preparation"
 import { createDelegateTaskPresentation } from "./tool-description"
 import type { NativeSkillEntry } from "../skill/native-skills"
+import { createCallOmoAgent } from "../call-omo-agent/tools"
+import { isPlanFamily } from "./constants"
 
 async function loadNativeSkillEntries(
   nativeSkills: DelegateTaskToolOptions["nativeSkills"] | undefined,
@@ -102,6 +104,34 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
 
       if (!delegateTaskArgs.category && !delegateTaskArgs.subagent_type) {
         return `Invalid arguments: Must provide either category or subagent_type.`
+      }
+
+      if (
+        delegateTaskArgs.subagent_type?.toLowerCase() === "plan"
+        && !runInBackground
+      ) {
+        if (isPlanFamily(ctx.agent)) {
+          return `You are a plan-family agent (plan/prometheus). You cannot delegate to other plan-family agents via task.
+
+Create the work plan directly - that's your job as the planning agent.`
+        }
+        if (!options.pluginContext) {
+          return `Invalid task configuration: plan direct routing requires pluginContext.`
+        }
+        return createCallOmoAgent(
+          options.pluginContext,
+          options.manager,
+          [],
+          options.agentOverrides,
+          options.userCategories,
+          options.modelFallbackControllerAccessor,
+        ).execute({
+          description: delegateTaskArgs.description,
+          prompt: delegateTaskArgs.prompt,
+          subagent_type: "plan",
+          run_in_background: false,
+          session_id: delegateTaskArgs.task_id,
+        }, toolContext)
       }
 
       let systemDefaultModel: string | undefined

--- a/packages/omo-opencode/src/tools/delegate-task/types.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/types.ts
@@ -48,6 +48,7 @@ export interface DelegateTaskToolOptions {
   manager: BackgroundManager
   client: OpencodeClient
   directory: string
+  pluginContext?: PluginInput
   /**
    * Test hook: bypass global cache reads (Bun runs tests in parallel).
    * If provided, resolveCategoryExecution/resolveSubagentExecution uses this instead of reading from disk cache.


### PR DESCRIPTION
## Summary
Fixes #5288

This PR addresses the `task(subagent_type="plan")` hang, but runtime verification found that the root cause actually affects *all* read-only subagents (`explore`, `librarian`, `plan`) when executed via sync direct route.

Two fixes are included:
1. **Direct Routing for Plan**: Adds `plan` to `call_omo_agent` allowed list and bypasses `delegate-task`'s nested `task: true` sync wrapper for `plan` calls.
2. **Generic Hang Fix (Poller Stale Status)**: For subagents that do not launch background tasks but complete quickly (like `explore` returning immediate results), the API `session.status()` can stay stuck on `running` or `retry` longer than expected. The poller previously trusted this status and never inspected messages until timeout (5+ minutes). Added a 5-second grace period: if the status remains active but assistant text is already present in the message stream, the poller now completes the task immediately.

## Verification
- `bun test packages/omo-opencode/src/tools/delegate-task/sync-session-poller.status-fallback.test.ts` -> 2 pass
- `bun test packages/omo-opencode/src/tools/call-omo-agent/agent-restriction.test.ts packages/omo-opencode/src/tools/delegate-task/tools.test.ts --bail` -> 140 pass
- `bun run typecheck` -> pass
- `bun run build` -> pass

All local runtime probes (Plan, Explore, Quick) now complete with checkmarks and `DONE` output without hanging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sync hangs for read-only subagents by routing `plan` directly and updating the sync poller to finish when status stays active but messages contain assistant output. Plan, Explore, and Librarian now complete without long stalls.

- **Bug Fixes**
  - Plan direct routing: allow `plan` in `ALLOWED_AGENTS`, update tool schema/description, and route sync `plan` requests through `call_omo_agent` (bypasses `delegate-task` wrapper). Prevent plan-family self-delegation and pass `pluginContext` to enable this path.
  - Sync poller: add a 5s grace for active statuses; if assistant text is present in messages, complete immediately. Prevents 5+ minute hangs on stale `running/retry` statuses.

<sup>Written for commit 568d728c8d18240c74e26860dd02ad20bab02ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

