### PR TITLE
fix: behavior-preserving robustness fixes from pre-publish review

### DIFF
--- a/packages/omo-codex/scripts/atomic-write.test.mjs
+++ b/packages/omo-codex/scripts/atomic-write.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { lstat, mkdir, mkdtemp, readFile, readdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { isRetriableRenameError, writeFileAtomic } from "./install/atomic-write.mjs";
+
+test("#given a fresh target path #when writeFileAtomic writes content #then the file holds exactly that content with no temp residue", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-atomic-write-fresh-"));
+	const target = join(root, "config.toml");
+
+	// when
+	await writeFileAtomic(target, "alpha = 1\n");
+
+	// then
+	assert.equal(await readFile(target, "utf8"), "alpha = 1\n");
+	assert.deepEqual(await readdir(root), ["config.toml"]);
+});
+
+test("#given an existing file #when writeFileAtomic overwrites it #then the content is replaced with no temp residue", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-atomic-write-replace-"));
+	const target = join(root, "config.toml");
+	await writeFile(target, "old = true\n");
+
+	// when
+	await writeFileAtomic(target, "new = true\n");
+
+	// then
+	assert.equal(await readFile(target, "utf8"), "new = true\n");
+	const residue = (await readdir(root)).filter((entry) => entry.startsWith(".tmp-"));
+	assert.deepEqual(residue, []);
+});
+
+test("#given the rename target cannot be replaced #when writeFileAtomic fails #then the original is untouched and the temp file is cleaned up", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-atomic-write-fail-"));
+	const target = join(root, "config.toml");
+	await mkdir(target);
+	await writeFile(join(target, "sentinel"), "keep\n");
+
+	// when
+	await assert.rejects(writeFileAtomic(target, "should not land\n"));
+
+	// then
+	assert.equal(await readFile(join(target, "sentinel"), "utf8"), "keep\n");
+	const residue = (await readdir(root)).filter((entry) => entry.startsWith(".tmp-"));
+	assert.deepEqual(residue, []);
+});
+
+test("#given the target is a symlink #when writeFileAtomic writes #then it writes through to the link target and preserves the symlink", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-atomic-write-symlink-"));
+	const realTarget = join(root, "actual.toml");
+	const link = join(root, "config.toml");
+	await writeFile(realTarget, "old = true\n");
+	await symlink(realTarget, link);
+
+	// when
+	await writeFileAtomic(link, "new = true\n");
+
+	// then
+	assert.equal(await readFile(realTarget, "utf8"), "new = true\n");
+	assert.equal((await lstat(link)).isSymbolicLink(), true);
+	const residue = (await readdir(root)).filter((entry) => entry.startsWith(".tmp-"));
+	assert.deepEqual(residue, []);
+});
+
+test("#given various rename errors #when classifying retriability #then only Windows file-lock codes are retriable", () => {
+	// given
+	const busy = Object.assign(new Error("busy"), { code: "EBUSY" });
+	const perm = Object.assign(new Error("perm"), { code: "EPERM" });
+	const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+
+	// when / then
+	assert.equal(isRetriableRenameError(busy), true);
+	assert.equal(isRetriableRenameError(perm), true);
+	assert.equal(isRetriableRenameError(missing), false);
+	assert.equal(isRetriableRenameError("not an error"), false);
+});

--- a/packages/omo-codex/scripts/install/atomic-write.mjs
+++ b/packages/omo-codex/scripts/install/atomic-write.mjs
@@ -1,0 +1,59 @@
+import { lstat, readlink, realpath, rename, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+
+const RENAME_RETRY_DELAYS_MS = [10, 25, 50];
+const RETRIABLE_RENAME_CODES = new Set(["EPERM", "EBUSY"]);
+
+export function isRetriableRenameError(error) {
+	if (!(error instanceof Error)) return false;
+	return RETRIABLE_RENAME_CODES.has(Reflect.get(error, "code"));
+}
+
+export async function writeFileAtomic(targetPath, data) {
+	const writeTarget = await resolveSymlinkTarget(targetPath);
+	const temporaryPath = join(
+		dirname(writeTarget),
+		`.tmp-${basename(writeTarget)}-${process.pid}-${Date.now()}`,
+	);
+	await writeFile(temporaryPath, data);
+	try {
+		await renameWithRetry(temporaryPath, writeTarget);
+	} catch (renameError) {
+		await unlink(temporaryPath).catch(() => {});
+		throw renameError;
+	}
+}
+
+async function resolveSymlinkTarget(targetPath) {
+	let linkStats;
+	try {
+		linkStats = await lstat(targetPath);
+	} catch {
+		return targetPath;
+	}
+	if (!linkStats.isSymbolicLink()) return targetPath;
+	try {
+		return await realpath(targetPath);
+	} catch {
+		const linkValue = await readlink(targetPath);
+		return isAbsolute(linkValue) ? linkValue : resolve(dirname(targetPath), linkValue);
+	}
+}
+
+async function renameWithRetry(fromPath, toPath) {
+	for (let attempt = 0; ; attempt += 1) {
+		try {
+			await rename(fromPath, toPath);
+			return;
+		} catch (renameError) {
+			if (!isRetriableRenameError(renameError) || attempt >= RENAME_RETRY_DELAYS_MS.length) {
+				throw renameError;
+			}
+			await delay(RENAME_RETRY_DELAYS_MS[attempt]);
+		}
+	}
+}
+
+function delay(milliseconds) {
+	return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/packages/omo-codex/scripts/install/config.mjs
+++ b/packages/omo-codex/scripts/install/config.mjs
@@ -1,5 +1,7 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
+
+import { writeFileAtomic } from "./atomic-write.mjs";
 
 import { ensureCodexMultiAgentV2Config } from "./multi-agent-v2-config.mjs";
 import { readCodexModelCatalog } from "./model-catalog.mjs";
@@ -70,7 +72,7 @@ export async function updateCodexConfig({
 		config = ensureAgentConfig(config, agentConfig);
 	}
 
-	await writeFile(configPath, config.trimEnd() + "\n");
+	await writeFileAtomic(configPath, config.trimEnd() + "\n");
 }
 
 function legacyMarketplaceNames(marketplaceName) {

--- a/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.test.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { prepareLookAtInput } from "./look-at-input-preparer"
+
+describe("prepareLookAtInput JSON file handling", () => {
+  test("#given an existing JSON file #when preparing input #then returns a text part containing the file content", () => {
+    //#given
+    const dir = mkdtempSync(join(tmpdir(), "look-at-json-ok-"))
+    const jsonPath = join(dir, "data.json")
+    writeFileSync(jsonPath, '{"hello":"world"}')
+
+    try {
+      //#when
+      const result = prepareLookAtInput({ file_path: jsonPath, goal: "inspect" })
+
+      //#then
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.inputParts).toHaveLength(1)
+      const part = result.value.inputParts[0]
+      expect(part?.type).toBe("text")
+      if (part?.type !== "text") return
+      expect(part.text).toContain("Attached JSON file (data.json)")
+      expect(part.text).toContain('{"hello":"world"}')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("#given a missing JSON file #when preparing input #then returns ok:false with a File not found error instead of throwing", () => {
+    //#given
+    const missingPath = join(tmpdir(), "look-at-json-missing-3f9c2a1b9d.json")
+
+    //#when
+    const result = prepareLookAtInput({ file_path: missingPath, goal: "inspect" })
+
+    //#then
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe(`Error: File not found: ${missingPath}`)
+  })
+
+  test("#given a JSON path that is actually a directory #when preparing input #then returns ok:false instead of throwing", () => {
+    //#given
+    const dir = mkdtempSync(join(tmpdir(), "look-at-json-dir-"))
+    const jsonDir = join(dir, "weird.json")
+    mkdirSync(jsonDir)
+
+    try {
+      //#when
+      const result = prepareLookAtInput({ file_path: jsonDir, goal: "inspect" })
+
+      //#then
+      expect(result.ok).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.ts
@@ -57,11 +57,34 @@ function getTemporaryConversionPath(error: unknown): string | null {
   return null
 }
 
-function createJsonTextPart(filePath: string): LookAtTextPart {
-  const fileContent = readFileSync(filePath, "utf-8")
+type ReadJsonTextPartResult =
+  | { ok: true; value: LookAtTextPart }
+  | { ok: false; error: string }
+
+function readJsonTextPart(filePath: string): ReadJsonTextPartResult {
+  let fileContent: string
+  try {
+    fileContent = readFileSync(filePath, "utf-8")
+  } catch (error) {
+    const code = error instanceof Error ? Reflect.get(error, "code") : undefined
+    if (code === "ENOENT") {
+      return { ok: false, error: `Error: File not found: ${filePath}` }
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    return { ok: false, error: `Error: Failed to read JSON file ${filePath}: ${message}` }
+  }
   return {
-    type: "text",
-    text: `Attached JSON file (${basename(filePath)}):\n\n${fileContent}`,
+    ok: true,
+    value: {
+      type: "text",
+      text: `Attached JSON file (${basename(filePath)}):\n\n${fileContent}`,
+    },
+  }
+}
+
+function cleanupTempFiles(tempFiles: readonly string[]): void {
+  for (const temporaryFile of tempFiles) {
+    cleanupConvertedImage(temporaryFile)
   }
 }
 
@@ -86,7 +109,12 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
     let tempConversionPath: string | null = null
 
     if (mimeType === "application/json") {
-      inputParts.push(createJsonTextPart(filePath))
+      const jsonPart = readJsonTextPart(filePath)
+      if (!jsonPart.ok) {
+        cleanupTempFiles(tempFilesToCleanup)
+        return { ok: false, error: jsonPart.error }
+      }
+      inputParts.push(jsonPart.value)
       continue
     }
 
@@ -104,6 +132,7 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
           tempConversionPath = failedConversionPath
         }
         log(`[look_at] Conversion failed: ${conversionError}`)
+        cleanupTempFiles(tempFilesToCleanup)
         return {
           ok: false,
           error: `Error: Failed to convert image format. ${conversionError}`,
@@ -139,6 +168,7 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
         log("[look_at] Base64 conversion successful")
       } catch (conversionError) {
         log(`[look_at] Base64 conversion failed: ${conversionError}`)
+        cleanupTempFiles(tempFilesToCleanup)
         return {
           ok: false,
           error: `Error: Failed to convert Base64 image format. ${conversionError}`,
@@ -166,9 +196,7 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
       inputParts,
       sourceDescription,
       cleanup() {
-        for (const temporaryFile of tempFilesToCleanup) {
-          cleanupConvertedImage(temporaryFile)
-        }
+        cleanupTempFiles(tempFilesToCleanup)
       },
     },
   }

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -431,4 +431,33 @@ describe("test workflows", () => {
     }
   })
 
+  test("matches the canonical platform set in optionalDependencies and on-disk platform packages", () => {
+    // #given
+    const rootManifest: { optionalDependencies?: Record<string, string> } = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    )
+    const buildBinariesPlatforms = PLATFORMS.map((entry) => entry.platform).sort()
+    const platformPrefix = "oh-my-opencode-"
+
+    const optionalDependencyPlatforms = Object.keys(rootManifest.optionalDependencies ?? {})
+      .filter((name) => name.startsWith(platformPrefix))
+      .map((name) => name.slice(platformPrefix.length))
+      .sort()
+
+    const onDiskPlatforms = readdirSync(new URL("../packages/", import.meta.url))
+      .filter((name) => name.startsWith(platformPrefix))
+      .map((name) => name.slice(platformPrefix.length))
+      .sort()
+
+    // #when / #then
+    expect(
+      optionalDependencyPlatforms,
+      "root optionalDependencies must list every canonical platform package",
+    ).toEqual(buildBinariesPlatforms)
+    expect(
+      onDiskPlatforms,
+      "packages/ must contain a directory for every canonical platform package",
+    ).toEqual(buildBinariesPlatforms)
+  })
+
 })


### PR DESCRIPTION
## Summary
Three behavior-preserving robustness fixes surfaced by the pre-publish review. Every happy-path behavior is unchanged; only failure-mode edges are closed.

## Changes
1. **fix(codex): atomic `config.toml` write** — `updateCodexConfig` rewrote `config.toml` in place from a *detached* bootstrap worker, so a torn or killed write (sleep, OOM, Windows 30s hook kill) could truncate the user's Codex config. New `writeFileAtomic` writes to a sibling temp + atomic `fs.rename` — symlink write-through preserved, with an EPERM/EBUSY retry for Windows file locks.
2. **fix(look-at): missing JSON file no longer throws** — the JSON branch's `readFileSync` threw outside `prepareLookAtInput`'s `{ok:false}` contract and skipped temp-file cleanup. Now routed through the same `File not found` contract other file types already use, and temp files are cleaned up on every early return.
3. **test(release): platform-set drift guard** — assert root `optionalDependencies` and on-disk `packages/oh-my-opencode-*` dirs match the canonical `build-binaries` PLATFORMS set (closes the two previously-unguarded enumeration surfaces).

## Tests / QA
- atomic-write 5/5 · look-at 89/89 · config 23/23 · publish-workflow 20/20
- tsgo typecheck (omo-opencode + script): clean
- Real isolated `CODEX_HOME` install: fresh / idempotent re-install / **symlink write-through preserved** / 0 tmp residue
- look_at runtime contract probe: existing JSON → text part; missing JSON → `{ok:false}` File-not-found, no throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens failure paths without changing behavior. Adds atomic writes for Codex `config.toml`, consistent `{ok:false}` handling for missing JSON in `look_at`, and a release guard to keep platform packages in sync.

- **Bug Fixes**
  - `omo-codex`: write `config.toml` atomically via `writeFileAtomic` (temp file + atomic rename). Preserves symlink write-through, retries on Windows `EPERM`/`EBUSY`, and cleans up temps on failure.
  - `omo-opencode` `look_at`: missing JSON file no longer throws; returns `{ok:false}` with “File not found” and cleans temp files on every early return.
  - Release workflow: add a drift guard test to ensure `optionalDependencies` and `packages/oh-my-opencode-*` match the canonical `PLATFORMS` set.

<sup>Written for commit 82e65bc2455a4ddb743e6266ca73675b610b6d7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

