### PR TITLE
fix(team-mode): avoid cancelling approved running tasks

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team-bg-cancel.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team-bg-cancel.test.ts
@@ -32,7 +32,7 @@ describe("deleteTeam cancels only this team's background tasks", () => {
     }))
   })
 
-  test("uses leadSessionId as the getTasksByParentSession key", async () => {
+  test("uses leadSessionId as the getTasksByParentSession key when force deleting", async () => {
     // given
     const fixture = await createFixture()
     temporaryDirectories.push(fixture.baseDir)
@@ -55,7 +55,7 @@ describe("deleteTeam cancels only this team's background tasks", () => {
     } satisfies DeleteTeamBackgroundManager
 
     // when
-    await deleteTeam(fixture.teamRunId, fixture.config, undefined, bgMgr)
+    await deleteTeam(fixture.teamRunId, fixture.config, undefined, bgMgr, { force: true })
 
     // then
     expect(getTasksByParentSessionMock).toHaveBeenCalledTimes(1)
@@ -98,7 +98,38 @@ describe("deleteTeam cancels only this team's background tasks", () => {
     expect(cancelTaskMock).not.toHaveBeenCalled()
   })
 
-  test("leaves unrelated sibling tasks on the same lead session alive", async () => {
+  test("does not cancel active background tasks after shutdown approval without force", async () => {
+    // given
+    const fixture = await createFixture()
+    temporaryDirectories.push(fixture.baseDir)
+    await updateMemberStatuses(fixture.teamRunId, fixture.config, {
+      "member-a": "shutdown_approved",
+      "member-b": "shutdown_approved",
+    })
+    const getTasksByParentSessionMock = mock(() => [
+      createBackgroundTask({ id: "team-task-a", sessionId: "session-a", parentMessageId: `team-create:${fixture.teamRunId}:member-a` }),
+    ])
+    const cancelTaskMock = mock(async (_taskId: string, _options?: Parameters<DeleteTeamBackgroundManager["cancelTask"]>[1]) => true)
+    const bgMgr = {
+      getTasksByParentSession: getTasksByParentSessionMock,
+      cancelTask: cancelTaskMock,
+    } satisfies DeleteTeamBackgroundManager
+
+    // when
+    let errorMessage = ""
+    try {
+      await deleteTeam(fixture.teamRunId, fixture.config, undefined, bgMgr)
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error)
+    }
+
+    // then
+    expect(errorMessage).toBe("members still active")
+    expect(getTasksByParentSessionMock).toHaveBeenCalledTimes(1)
+    expect(cancelTaskMock).not.toHaveBeenCalled()
+  })
+
+  test("leaves unrelated sibling tasks on the same lead session alive when force deleting", async () => {
     // given
     const fixture = await createFixture()
     temporaryDirectories.push(fixture.baseDir)
@@ -120,7 +151,7 @@ describe("deleteTeam cancels only this team's background tasks", () => {
     } satisfies DeleteTeamBackgroundManager
 
     // when
-    await deleteTeam(fixture.teamRunId, fixture.config, undefined, bgMgr)
+    await deleteTeam(fixture.teamRunId, fixture.config, undefined, bgMgr, { force: true })
 
     // then
     expect(cancelTaskMock).toHaveBeenCalledTimes(1)

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/delete-team.ts
@@ -46,8 +46,20 @@ const FORCE_COMPLETABLE_MEMBER_STATUSES = new Set<RuntimeState["members"][number
 
 const FORCE_BYPASS_DELETING_STATUSES = new Set<RuntimeState["status"]>(["creating", "orphaned"])
 
+const ACTIVE_BACKGROUND_TASK_STATUSES = new Set(["pending", "running"])
 function ignoreStaleTeamSessionSweepFailure(error: unknown): void {
   if (error instanceof Error) return
+}
+
+function getTeamBackgroundTasks(
+  bgMgr: DeleteTeamBackgroundManager,
+  runtimeState: RuntimeState,
+): ReturnType<DeleteTeamBackgroundManager["getTasksByParentSession"]> {
+  if (!runtimeState.leadSessionId) return []
+
+  const teamMessageMarkerPrefix = `team-create:${runtimeState.teamRunId}:`
+  return bgMgr.getTasksByParentSession(runtimeState.leadSessionId)
+    .filter((task) => task.teamRunId === runtimeState.teamRunId || task.parentMessageId?.startsWith(teamMessageMarkerPrefix))
 }
 
 export async function deleteTeam(
@@ -65,15 +77,40 @@ export async function deleteTeam(
     throw new Error("members still active")
   }
 
-  if (bgMgr && runtimeState.leadSessionId) {
-    const teamMessageMarkerPrefix = `team-create:${teamRunId}:`
-    const teamTasks = bgMgr.getTasksByParentSession(runtimeState.leadSessionId)
-      .filter((task) => task.teamRunId === teamRunId || task.parentMessageId?.startsWith(teamMessageMarkerPrefix))
+  const deletableTeamStatuses = options?.force === true
+    ? FORCE_DELETABLE_TEAM_STATUSES
+    : DELETABLE_TEAM_STATUSES
+  if (!deletableTeamStatuses.has(runtimeState.status)) {
+    throw new Error(`team cannot be deleted from '${runtimeState.status}'`)
+  }
+
+  if (bgMgr) {
+    const teamTasks = getTeamBackgroundTasks(bgMgr, runtimeState)
+    if (options?.force !== true && teamTasks.some((task) => task.status !== undefined && ACTIVE_BACKGROUND_TASK_STATUSES.has(task.status))) {
+      throw new Error("members still active")
+    }
+
+    if (options?.force !== true) {
+      return await deleteTeamResources(teamRunId, config, runtimeState, tmuxMgr, options, deps)
+    }
+
     await Promise.all(teamTasks.map((task) => bgMgr.cancelTask(task.id, {
       source: "team-mode-delete",
       reason: `delete team ${teamRunId}`,
     })))
   }
+
+  return await deleteTeamResources(teamRunId, config, runtimeState, tmuxMgr, options, deps)
+}
+
+async function deleteTeamResources(
+  teamRunId: string,
+  config: TeamModeConfig,
+  runtimeState: RuntimeState,
+  tmuxMgr?: TmuxSessionManager,
+  options?: { force?: boolean },
+  deps: DeleteTeamDeps = defaultDeleteTeamDeps,
+): Promise<{ removedWorktrees: string[]; removedLayout: boolean }> {
 
   if (options?.force === true) {
     await transitionRuntimeState(teamRunId, (currentRuntimeState) => ({


### PR DESCRIPTION
## Summary
- prevent non-force team_delete from cancelling team background tasks that are still pending/running after shutdown approval
- keep force=true delete behavior as the explicit task-cancelling path
- add a regression test for shutdown_approved members with an active background task

## Verification
- bun test packages/omo-opencode/src/features/team-mode/team-runtime/delete-team-bg-cancel.test.ts packages/omo-opencode/src/features/team-mode/team-runtime/shutdown.test.ts --bail
- bun run typecheck
- manual deleteTeam driver: shutdown_approved + running background task rejects with "members still active" and cancelTask is not called

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Non-force team deletion no longer cancels running or pending background tasks after shutdown approval. Force delete remains the only path that cancels tasks.

- **Bug Fixes**
  - Non-force `deleteTeam`: if any team task is `pending` or `running`, throw "members still active" and do not call `cancelTask`.
  - Force `deleteTeam`: cancel only this team's tasks using `leadSessionId` and the `team-create:<teamRunId>:` marker before deleting resources.
  - Added early validation for allowed deletable team statuses.

- **Tests**
  - Added regression test for `shutdown_approved` members with an active background task (expects rejection and no cancellations).
  - Updated tests to pass `{ force: true }` when cancellation is intended and clarified test names.

<sup>Written for commit cb5c832b49263ccb298cc10f695284bb19c08177. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

