### PR TITLE
fix(ulw-loop): sync README, type criteriaCoverage, and harden the verification gate

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/CHANGELOG.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- README now documents the implemented CLI (all `omo ulw-loop` subcommands), both the `UserPromptSubmit` and `PreToolUse` hook channels, and the aggregate-plugin layout (the component does not ship its own `.codex-plugin/plugin.json`), replacing the stale "Wave 1 is scaffold only" description.
+- `criteriaCoverage` is now a typed member of `UlwLoopQualityGate` (new `UlwLoopCriteriaCoverage` interface); `validateQualityGate` builds it directly instead of through an `Object.assign` cast.
+
+### Added
+- Smoke-test assertions that pin the README to the implemented CLI subcommands and hook channels, plus a typed `criteriaCoverage` regression in `types.test.ts`.
+
 ## [0.1.0] - unreleased
 
 - Initial scaffold of codex-ulw-loop plugin.

--- a/packages/omo-codex/plugin/components/ulw-loop/README.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/README.md
@@ -1,38 +1,41 @@
+---
+
 # codex-ulw-loop
 
 [![ci](https://img.shields.io/badge/ci-pending-lightgrey.svg)](#) [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Codex plugin scaffold for durable repo-native multi-goal orchestration with embedded success criteria and observable evidence audit.
+Codex plugin component for durable repo-native multi-goal orchestration with embedded success criteria and observable evidence audit. State lives under `.omo/ulw-loop/` and is mutated only through the `omo ulw-loop` CLI; never hand-edit the goal store.
 
-## Behavior
+## CLI
+
+Every subcommand below is implemented. Pass `--json` to any subcommand for machine-readable output, and `--session-id <id>` (or the `OMO_ULW_LOOP_SESSION_ID` env var) to scope state to a parallel session.
 
 | Subcommand | Purpose |
 |------------|---------|
-| `omo ulw-loop create-goals` | Create repo-native goals from a brief and seed criteria. |
-| `omo ulw-loop record-evidence` | Record observable evidence for the active criterion. |
-| `omo ulw-loop criteria` | Inspect or revise goal success criteria. |
-| `omo ulw-loop complete-goals` | Complete eligible goals after criteria pass. |
-| `omo ulw-loop checkpoint` | Refuse completion until criteria and evidence gates pass. |
-| `omo ulw-loop steer` | Apply steering updates to the plan. |
-| `omo ulw-loop status` | Report active goal, criteria, and evidence state. |
+| `omo ulw-loop create-goals` | Create repo-native goals and seed success criteria from a brief (`--brief`, `--brief-file`, `--from-stdin`, or positional text). |
+| `omo ulw-loop status` | Report the active goal, success criteria, and evidence state. |
+| `omo ulw-loop complete-goals` | Start or resume the next eligible goal, or report aggregate completion / a blocked-decision handoff. |
+| `omo ulw-loop add-goal` | Append a goal (`--title`, `--objective`) to the active plan. |
+| `omo ulw-loop criteria` | Inspect a goal's success criteria (`--goal-id`). |
+| `omo ulw-loop record-evidence` | Record observable evidence for one criterion (`--goal-id`, `--criterion-id`, `--status` of `pass`/`fail`/`blocked`, `--evidence`). |
+| `omo ulw-loop checkpoint` | Gate a goal transition (`--goal-id`, `--status`, `--evidence`); final completion requires `--codex-goal-json` and a passing `--quality-gate-json`. |
+| `omo ulw-loop steer` | Apply a steering mutation proposal to the plan. |
+| `omo ulw-loop record-review-blockers` | Mark a goal `review_blocked` from final-review findings and add a follow-up goal. |
+| `omo ulw-loop help` | Print CLI usage. |
 
-Wave 1 is scaffold only. Command behavior lands in later waves.
+The quality gate parsed by `checkpoint` validates `aiSlopCleaner`, `verification`, `codeReview`, and `criteriaCoverage` (see `UlwLoopQualityGate` in `src/domain-types.ts`).
 
 ## Codex Plugin
 
-The plugin ships:
+This directory is a component of the aggregate `@sisyphuslabs/omo-codex-plugin` root. Plugin discovery (`.codex-plugin/plugin.json`) is owned by that aggregate root, not by this component. The component ships:
 
-- `.codex-plugin/plugin.json` for Codex plugin discovery.
-- `hooks/hooks.json` for the `UserPromptSubmit` hook.
-- `skills/ulw-loop/` as the future skill directory.
+- `hooks/hooks.json` registering two hooks:
+  - `UserPromptSubmit` → `node "${PLUGIN_ROOT}/dist/cli.js" hook user-prompt-submit` (checks ulw-loop steering).
+  - `PreToolUse` matching `^create_goal$` → `node "${PLUGIN_ROOT}/dist/cli.js" hook pre-tool-use` (enforces the unlimited ulw-loop goal budget).
+- `skills/ulw-loop/` — the `ulw-loop` skill (`SKILL.md`, `agents/openai.yaml`, `references/full-workflow.md`).
+- `bin.omo-ulw-loop` → `dist/cli.js` for standalone CLI invocation.
 
-The hook command is:
-
-```bash
-node "${PLUGIN_ROOT}/dist/cli.js" hook user-prompt-submit
-```
-
-No MCP server or Codex tool is exposed in this scaffold.
+This component ships a CLI, a skill, and hooks. It does not expose an MCP server.
 
 ## Local Development
 
@@ -43,6 +46,8 @@ npm run typecheck
 npm run check
 npm pack --dry-run
 ```
+
+`npm test` runs Vitest, `npm run typecheck` runs `tsc --noEmit`, and `npm run check` runs typecheck + Biome + build.
 
 ## Local Codex Installation
 
@@ -63,7 +68,7 @@ enabled = true
 
 ## Privacy
 
-This plugin runs locally. The scaffold does not call a network service by itself.
+This component runs locally and does not call a network service by itself.
 
 ## License
 
@@ -72,3 +77,4 @@ This plugin runs locally. The scaffold does not call a network service by itself
 ## Related
 
 - [lazycodex](https://github.com/code-yeongyu/lazycodex) - Sisyphus Labs Codex marketplace repository.
+- [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) - the monorepo this component is developed in.

--- a/packages/omo-codex/plugin/components/ulw-loop/biome.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/packages/omo-codex/plugin/components/ulw-loop/src/codex-goal-instruction.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/codex-goal-instruction.ts
@@ -105,7 +105,7 @@ function finalSection(plan: UlwLoopPlan, goal: UlwLoopItem, isFinal: boolean, ag
 	const checkpointCommand = `omo ulw-loop checkpoint${option} --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh complete get_goal JSON or path>" --quality-gate-json "<quality gate JSON or path>"`;
 	return joinLines([
 		"Final story — run mandatory quality gate before update_goal:",
-		"- Run ai-slop-cleaner on changed files even when it is a no-op, rerun verification, then run the code review (multi_agent_v1.spawn_agent(agent_type=\"codex-ultrawork-reviewer\", fork_context=false, ...); fall back to agent_type=\"worker\" with a scoped reviewer assignment if unavailable).",
+		'- Run ai-slop-cleaner on changed files even when it is a no-op, rerun verification, then run the code review (multi_agent_v1.spawn_agent(agent_type="codex-ultrawork-reviewer", fork_context=false, ...); fall back to agent_type="worker" with a scoped reviewer assignment if unavailable).',
 		"- If the final review is not APPROVE with architect status CLEAR, do not call update_goal. Record blocker work first:",
 		`  ${blockerCommand}`,
 		aggregate

--- a/packages/omo-codex/plugin/components/ulw-loop/src/domain-types.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/domain-types.ts
@@ -69,10 +69,17 @@ export interface UlwLoopPlan {
 	goals: UlwLoopItem[];
 }
 
+export interface UlwLoopCriteriaCoverage {
+	totalCriteria: number;
+	passCount: number;
+	adversarialClassesCovered: string[];
+}
+
 export interface UlwLoopQualityGate {
 	aiSlopCleaner: { status: "passed"; evidence: string };
 	verification: { status: "passed"; commands: string[]; evidence: string };
 	codeReview: { recommendation: "APPROVE"; architectStatus: "CLEAR"; evidence: string };
+	criteriaCoverage: UlwLoopCriteriaCoverage;
 }
 
 export interface UlwLoopLedgerEntry {

--- a/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate.ts
@@ -129,8 +129,8 @@ export function validateQualityGate(input: unknown): UlwLoopQualityGate {
 		aiSlopCleaner: { status: "passed", evidence: cleanerEvidence },
 		verification: { status: "passed", commands, evidence: verificationEvidence },
 		codeReview: { recommendation, architectStatus, evidence: reviewEvidence },
+		criteriaCoverage: { totalCriteria, passCount, adversarialClassesCovered: covered },
 	};
-	Object.assign(result, { criteriaCoverage: { totalCriteria, passCount, adversarialClassesCovered: covered } });
 	return result;
 }
 

--- a/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { ULW_LOOP_SUBCOMMANDS } from "../src/cli-commands.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -198,5 +199,38 @@ describe("source LOC budget", () => {
 			}).length;
 			expect(pure, `${file} pure LOC`).toBeLessThanOrEqual(250);
 		}
+	});
+});
+
+describe("README ↔ implementation contract", () => {
+	it("#given the README #when subcommands are inspected #then every implemented CLI subcommand is documented", async () => {
+		const readme = await readText("README.md");
+
+		for (const subcommand of ULW_LOOP_SUBCOMMANDS) {
+			expect(readme, `README documents \`omo ulw-loop ${subcommand}\``).toContain(`omo ulw-loop ${subcommand}`);
+		}
+	});
+
+	it("#given the README #when stale scaffold language is checked #then it is absent", async () => {
+		const readme = await readText("README.md");
+
+		expect(readme).not.toMatch(/scaffold only/i);
+		expect(readme).not.toMatch(/Wave 1/i);
+		expect(readme).not.toMatch(/lands in later waves/i);
+	});
+
+	it("#given the README #when hooks are described #then both hook channels are documented", async () => {
+		const readme = await readText("README.md");
+
+		expect(readme).toContain("UserPromptSubmit");
+		expect(readme).toContain("user-prompt-submit");
+		expect(readme).toContain("PreToolUse");
+		expect(readme).toContain("pre-tool-use");
+	});
+
+	it("#given the README #when the quality gate is described #then criteriaCoverage is named", async () => {
+		const readme = await readText("README.md");
+
+		expect(readme).toContain("criteriaCoverage");
 	});
 });

--- a/packages/omo-codex/plugin/components/ulw-loop/test/types.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-
+import { validateQualityGate } from "../src/quality-gate.ts";
+import type { UlwLoopCriteriaCoverage } from "../src/types.ts";
 import {
 	iso,
 	ULW_LOOP_BRIEF,
@@ -74,6 +75,28 @@ describe("iso()", () => {
 			const s = iso();
 
 			expect(s).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+		});
+	});
+});
+
+describe("UlwLoopQualityGate.criteriaCoverage", () => {
+	const VALID_GATE = {
+		aiSlopCleaner: { status: "passed", evidence: "no slop after cleaner run" },
+		verification: { status: "passed", commands: ["npm test"], evidence: "all tests pass" },
+		codeReview: { recommendation: "APPROVE", architectStatus: "CLEAR", evidence: "ship it" },
+		criteriaCoverage: { totalCriteria: 2, passCount: 2, adversarialClassesCovered: ["malformed_input"] },
+	};
+
+	describe("when a validated gate is inspected", () => {
+		it("then criteriaCoverage is a typed member of the quality gate, not a bolted-on cast", () => {
+			// when
+			const gate = validateQualityGate(VALID_GATE);
+
+			// then — a typed read locks the interface field; reverting it fails `tsc --noEmit`.
+			const coverage: UlwLoopCriteriaCoverage = gate.criteriaCoverage;
+			expect(coverage.totalCriteria).toBe(2);
+			expect(coverage.passCount).toBe(2);
+			expect(coverage.adversarialClassesCovered).toContain("malformed_input");
 		});
 	});
 });


### PR DESCRIPTION
## What

Hardening pass on the `ulw-loop` Codex component (`packages/omo-codex/plugin/components/ulw-loop`). Component-scoped only.

### 1. `fix`: `criteriaCoverage` type gap
`validateQualityGate()` returns `UlwLoopQualityGate`, but the interface omitted `criteriaCoverage`, so the validator had to bolt the field on with `Object.assign(result, { criteriaCoverage })` and consumers couldn't read it type-safely.

- Add a `UlwLoopCriteriaCoverage` interface and make `criteriaCoverage` a required member of `UlwLoopQualityGate` (a validated gate always has it — `validateQualityGate` throws otherwise).
- Build the field directly and drop the `Object.assign` cast.
- Add a typed regression in `types.test.ts` that reads `gate.criteriaCoverage` through the interface, so dropping the field again fails `tsc --noEmit`.

### 2. `docs`: README out of sync with the implementation
The README still described a scaffold and contradicted the component's own tests:

- "Wave 1 is scaffold only. Command behavior lands in later waves." — every subcommand is implemented (v4.x).
- Subcommand table was incomplete (missing `add-goal`, `record-review-blockers`, `help`).
- Claimed the component ships `.codex-plugin/plugin.json`, but `package-smoke.test.ts` asserts that file is **absent** (discovery is owned by the aggregate `@sisyphuslabs/omo-codex-plugin` root).
- Only documented the `UserPromptSubmit` hook; the `PreToolUse` `^create_goal$` budget guard was undocumented.

README now documents every `omo ulw-loop` subcommand, both hook channels, the aggregate-plugin ownership, and the validated quality-gate shape (incl. `criteriaCoverage`). The shared `npx lazycodex-ai install` / `omo/0.1.0` install boilerplate is left matching the sibling component READMEs.

### 3. `test`: README ↔ implementation contract (smoke test)
New `package-smoke.test.ts` assertions lock the docs to the code: every `ULW_LOOP_SUBCOMMANDS` entry is documented, stale scaffold language stays absent, both hook channels are described, and `criteriaCoverage` is named.

### 4. `chore`: make the component's `npm run check` gate runnable green
`package.json` declared `@biomejs/biome` `2.4.16` while `biome.json`'s `$schema` and one source string still reflected `2.4.15`, leaving `npm run check` (typecheck + Biome + build) red. Bumped the schema URL and applied Biome's deterministic format (one double→single quote string in `codex-goal-instruction.ts`, semantically identical).

## Verification
Run in `packages/omo-codex/plugin/components/ulw-loop`:

- `npm test` → 304 passing (22 files)
- `npm run check` → `tsc --noEmit` + `biome check .` + `tsc -p tsconfig.build.json` all green

## Notes / out of scope
- The component's Vitest suite currently isn't wired into any CI job (`bunfig.toml` ignores `packages/omo-codex/plugin/**` and `test:codex` runs an explicit opencode file list). Wiring it in is a CI-level change left as a follow-up.
- The `omo/0.1.0` install path is shared boilerplate across all component READMEs / `MARKETPLACE.md` / `install-marketplace-cache.test.mjs`; normalizing it repo-wide is out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `ulw-loop` by adding `UlwLoopCriteriaCoverage` and making `criteriaCoverage` a required member of `UlwLoopQualityGate`; `validateQualityGate` now builds it directly. Updated README to match the implemented `omo ulw-loop` CLI and both hooks, added smoke/types tests to prevent drift, and aligned `@biomejs/biome` schema to 2.4.16 so `npm run check` passes.

<sup>Written for commit 3384790b6078c4d57b1ae29093b946fadaf281c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

