### PR TITLE
feat(visual-qa): agent-browser fallback + clone-coding dual verification

### DIFF
--- a/packages/shared-skills/skills/visual-qa/SKILL.md
+++ b/packages/shared-skills/skills/visual-qa/SKILL.md
@@ -27,7 +27,7 @@ If the change touches both, run both capture tracks and feed both into the passe
 ### Web
 
 1. Capture a REFERENCE image: the user's mock/target, or a known-good baseline. Save as PNG.
-2. Capture the ACTUAL rendered screenshot at the same viewport size using the project's browser tooling (the playwright, agent-browser, or dev-browser skill). Save as PNG.
+2. Capture the ACTUAL rendered screenshot at the same viewport size using the project's browser tooling (the playwright, agent-browser, or dev-browser skill). Save as PNG. If none is configured or available, install [agent-browser](https://github.com/vercel-labs/agent-browser) (`bun add -g agent-browser && agent-browser install`) and capture with it — see `$SKILL_DIR/references/agent-browser-setup.md` for the full setup, including how to shoot a fixed-viewport screenshot.
 3. Run the diff and keep the JSON:
 
 ```
@@ -178,6 +178,22 @@ Completion gate: do not declare the UI done until both passes are satisfied, OR 
 ## Completion gate
 [Satisfied, or the exact remaining gaps and who accepted them]
 ```
+
+## Step 5 - Clone-coding mode (when the task was a clone or design port)
+
+Run this step IN ADDITION to Steps 1-4, but ONLY when the original user task was a clone or design port: "clone this site", "move this Figma design to code", "rebuild this screen", "make it look exactly like X". For these tasks the normal dual-oracle is necessary but NOT sufficient. After it returns, run the following TWO additional MANDATORY verifications and LOOP until BOTH pass.
+
+1. Pixel-perfect design-compare subagent (visual oracle). Dispatch a focused, read-only design-compare reviewer (recommend `gpt-5.5` with medium reasoning). It must crop/zoom BOTH the reference (the target / Figma export / source-site screenshot) and the ACTUAL screenshot into matching regions and read them **pixel-by-pixel** - header, nav, each card, spacing, type ramp, color tokens - not at a glance. Anchor every claim with the bundled tool:
+
+```
+bun "$SKILL_DIR/scripts/cli.ts" image-diff <reference.png> <actual.png>
+```
+
+   It judges whether layout geometry, spacing, design tokens (color, type, radius, shadow), and the design itself are identical to the target, region by region. Anything off by more than rounding is a finding.
+
+2. Code-level design-system fidelity (code oracle). Call the code-quality reviewer named EXACTLY `lazycodex-clone-fidelity-reviewer` (spawn it by that agent name). It verifies the implementation is a RIGOROUS design-system build - a real component tree, real design tokens, reused primitives - and is NOT a pasted image, a screenshot or background-image substitute, or a hardcoded one-off that merely looks right in one screenshot. If that named reviewer is not installed in this harness, fall back to an inline rigorous code review against the SAME criteria.
+
+RULE (mandatory, non-negotiable): the clone is NOT done until BOTH the pixel-compare AND the `lazycodex-clone-fidelity-reviewer` (or its inline fallback) confirm that the **layer structure, the design system, and the design itself** are strictly identical to the target. If EITHER fails, it is a MANDATORY retry: re-implement the gaps and re-run BOTH verifications from the top. Repeat the retry loop until both pass on the same revision. Never declare a clone complete on a single pass, on visual-only evidence, or on code-only evidence - both oracles must confirm on the same build.
 
 ## Reference evidence is not the verdict
 

--- a/packages/shared-skills/skills/visual-qa/references/agent-browser-setup.md
+++ b/packages/shared-skills/skills/visual-qa/references/agent-browser-setup.md
@@ -1,0 +1,44 @@
+# agent-browser setup (Web capture fallback)
+
+Use this when the project has **no** browser tooling configured or available for the Web
+capture path in Step 2 (no playwright / dev-browser skill, no usable headless browser).
+[agent-browser](https://github.com/vercel-labs/agent-browser) is a standalone CLI that
+drives a real Chromium and can screenshot a page at a fixed viewport — exactly what the
+`image-diff` evidence step needs.
+
+Repo: https://github.com/vercel-labs/agent-browser
+
+## Install
+
+```
+bun add -g agent-browser && agent-browser install
+```
+
+`bun add -g agent-browser` installs the CLI globally; `agent-browser install` downloads the
+managed browser it drives. (Equivalent with npm: `npm install -g agent-browser && agent-browser install`.)
+
+Confirm it is ready and discover the current flags:
+
+```
+agent-browser --help
+```
+
+## Capture a screenshot at a fixed viewport
+
+Set the viewport first, then screenshot — this guarantees the ACTUAL capture matches the
+REFERENCE viewport so `image-diff` compares like-for-like:
+
+```
+agent-browser set viewport 1280 720      # width height (add a third arg, e.g. 2, for retina scale)
+agent-browser screenshot actual.png      # add --full for full-page, --screenshot-dir ./shots for a custom dir
+```
+
+Then feed the PNG into the diff exactly as in Step 2:
+
+```
+bun "$SKILL_DIR/scripts/cli.ts" image-diff <reference.png> actual.png
+```
+
+Match the viewport numbers to whatever the reference/mock was captured at; mismatched
+dimensions make `dimensionsMatch` false and inflate `diffRatio`. Run `agent-browser --help`
+for the full command set (navigation, batch, annotate, format/quality flags).

--- a/packages/shared-skills/skills/visual-qa/scripts/skill-prompt-contract.test.ts
+++ b/packages/shared-skills/skills/visual-qa/scripts/skill-prompt-contract.test.ts
@@ -5,6 +5,15 @@ import { dirname, join } from "node:path"
 const repoRoot = findRepoRoot(import.meta.dir)
 const sharedSkillPath = join(repoRoot, "packages", "shared-skills", "skills", "visual-qa", "SKILL.md")
 const codexSkillPath = join(repoRoot, "packages", "omo-codex", "plugin", "skills", "visual-qa", "SKILL.md")
+const referencesPath = join(
+	repoRoot,
+	"packages",
+	"shared-skills",
+	"skills",
+	"visual-qa",
+	"references",
+	"agent-browser-setup.md",
+)
 
 type PromptFixture = {
 	readonly label: string
@@ -79,6 +88,40 @@ describe("visual-qa skill prompt contract", () => {
 			expect(lowerCheckBlock, fixture.label).toContain("reused primitives")
 			expect(lowerCheckBlock, fixture.label).toContain("blocking")
 			expect(outputBlock, fixture.label).toContain("BLOCKING:")
+		}
+	})
+
+	test("#given the Web capture path #when no browser tooling is configured #then it falls back to agent-browser", () => {
+		for (const fixture of fixtures()) {
+			const web = sectionBetween(fixture.text, "### Web", "### TUI")
+
+			expect(web, fixture.label).toContain("agent-browser")
+			expect(fixture.text, fixture.label).toContain("bun add -g agent-browser")
+			expect(fixture.text, fixture.label).toContain("https://github.com/vercel-labs/agent-browser")
+			expect(fixture.text, fixture.label).toContain("references/agent-browser-setup.md")
+		}
+	})
+
+	test("#given the agent-browser fallback #when documenting setup #then a references doc lists install, link, and help", () => {
+		expect(existsSync(referencesPath)).toBe(true)
+		const doc = readFileSync(referencesPath, "utf8")
+
+		expect(doc).toContain("bun add -g agent-browser")
+		expect(doc).toContain("agent-browser install")
+		expect(doc).toContain("https://github.com/vercel-labs/agent-browser")
+		expect(doc).toContain("agent-browser --help")
+	})
+
+	test("#given a clone/design-port task #when in clone-coding mode #then dual pixel + code-fidelity verification loops until both pass", () => {
+		for (const fixture of fixtures()) {
+			const cloneMode = sectionBetween(fixture.text, "## Step 5", "## Reference evidence is not the verdict")
+			const lowerCloneMode = cloneMode.toLowerCase()
+
+			expect(lowerCloneMode, fixture.label).toContain("clone")
+			expect(cloneMode, fixture.label).toContain("pixel-by-pixel")
+			expect(cloneMode, fixture.label).toContain("image-diff")
+			expect(cloneMode, fixture.label).toContain("lazycodex-clone-fidelity-reviewer")
+			expect(lowerCloneMode, fixture.label).toContain("retry")
 		}
 	})
 })


### PR DESCRIPTION
## Summary

Two TDD-first enhancements to the shared skill `packages/shared-skills/skills/visual-qa/SKILL.md`.

### Feature 2 — agent-browser fallback for the Web capture path
- Step 2 → Web keeps its existing capture sentence **verbatim** and **appends** a fallback: when the project has no browser tooling configured/available, install [agent-browser](https://github.com/vercel-labs/agent-browser) via `bun add -g agent-browser && agent-browser install` and capture with it.
- New file `references/agent-browser-setup.md` (new `references/` dir parallel to `scripts/`) documenting install, repo link, `agent-browser --help`, and a fixed-viewport screenshot recipe that feeds back into the `image-diff` step. Referenced from SKILL.md via `$SKILL_DIR/references/agent-browser-setup.md`. Commands verified against the upstream README.

### Feature 3a — clone-coding dual verification (mandatory)
- New `## Step 5 - Clone-coding mode (when the task was a clone or design port)`, triggered **only** on clone/design-port tasks ("clone this site", "move this Figma design to code", "make it look exactly like X").
- After the normal dual-oracle, runs **two MANDATORY verifications and loops until BOTH pass**:
  1. **Pixel-perfect design-compare subagent** (recommend `gpt-5.5`, medium reasoning) — crops/zooms reference + actual into regions, reads them **pixel-by-pixel**, anchored by `bun "$SKILL_DIR/scripts/cli.ts" image-diff <reference.png> <actual.png>`.
  2. **Code-level design-system fidelity** — spawns the agent named exactly `lazycodex-clone-fidelity-reviewer` (inline rigorous review as fallback if not installed).
- Rule stated forcefully: the clone is NOT done until BOTH confirm the layer structure, design system, and the design itself are strictly identical; either failure is a MANDATORY retry. Never complete on a single pass or on visual-only OR code-only evidence.

## TDD
1. Extended `scripts/skill-prompt-contract.test.ts` first → **RED** (3 new tests fail).
2. Implemented SKILL.md edits + references file → **GREEN** (5/5).
3. All pre-existing Pass A / Pass B assertions kept intact; full scripts suite **42/42**.

```
bun test packages/shared-skills/skills/visual-qa/scripts/skill-prompt-contract.test.ts   # 5 pass / 0 fail
bun test packages/shared-skills/skills/visual-qa/scripts/                                  # 42 pass / 0 fail
```

## QA evidence
Full RED/GREEN output and printouts of the new sections + references file: `qa-evidence-visual-qa.md` (worktree/repo root of this branch).

Note: the build-generated codex copy `packages/omo-codex/plugin/skills/visual-qa/SKILL.md` is absent in this branch; the contract test treats it as optional, so no action taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Web capture fallback using `agent-browser` and a clone-coding mode with dual verification that retries until both checks pass. Updates `SKILL.md`, adds `references/agent-browser-setup.md`, and extends prompt-contract tests to enforce the new behavior.

- **New Features**
  - Web capture: fallback to `agent-browser` when no browser tooling is available; adds `references/agent-browser-setup.md` with install (`bun add -g agent-browser && agent-browser install`), `agent-browser --help`, and fixed-viewport screenshots.
  - Clone-coding mode: for clone/design-port tasks only; requires pixel-compare (via `image-diff`) and `lazycodex-clone-fidelity-reviewer` code checks; loops until both pass.

- **Migration**
  - If your project lacks browser tooling, install `agent-browser` with `bun add -g agent-browser && agent-browser install` and follow `packages/shared-skills/skills/visual-qa/references/agent-browser-setup.md`.

<sup>Written for commit 643b2ddf275f5f8b50751c493416e0126d435c57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

