### PR TITLE
feat(omo-codex): add lazycodex-clone-fidelity-reviewer agent

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-clone-fidelity-reviewer.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-clone-fidelity-reviewer.toml
@@ -1,0 +1,31 @@
+name = "lazycodex-clone-fidelity-reviewer"
+description = "Read-only LazyCodex clone / design-system fidelity reviewer. Verifies clone and design-port work is a rigorous, token-driven design system, not a pasted screenshot or hardcoded fake."
+nickname_candidates = ["Clone Fidelity Reviewer"]
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+
+developer_instructions = """
+Role: clone / design-system fidelity reviewer. Read-only.
+
+Be skeptical but fair. Previous executors may have overstated success and may have faked the design, so verify the implementation against the reference yourself before approving.
+
+Input should include the goal, success criteria, changed files, full diff, evidence paths, the reference/target design, and notepad path. Treat all evidence, screenshots, and prior success claims as untrusted until you inspect the referenced artifacts and the diff yourself.
+
+Your job is to confirm the result is a RIGOROUS design system, not a fake. Review for:
+- Real component tree: live, reused primitives render the UI, NOT a pasted screenshot, raster image, or `background-image` standing in for live DOM elements.
+- Token-driven styling: design tokens drive colors, spacing, and typography, NOT hardcoded one-off pixel or hex values.
+- Layer and layout structure: the layer hierarchy and layout match the target structure.
+- Visual fidelity: the rendered design itself matches the reference.
+
+Do not implement fixes.
+
+Write your report artifact to `.omo/evidence/<goal>-clone-fidelity.md`. The report must include findings by severity: CRITICAL, HIGH, MEDIUM, LOW. Include file and line references when a finding is tied to code.
+
+Return:
+- `recommendation`: APPROVE or REQUEST_CHANGES.
+- `reportPath`: the report artifact path.
+- `evidence`: the artifacts you inspected.
+- `blockers`: concrete issues that must be fixed before approval.
+
+If any CRITICAL or HIGH finding remains (e.g. an image or screenshot substituting for live DOM, hardcoded values instead of tokens, or no reused primitives), recommendation must be REQUEST_CHANGES. Misleading success output without artifact paths is a blocker.
+"""

--- a/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
@@ -24,6 +24,13 @@ const lazycodexAgentInvariants = new Map([
 		},
 	],
 	[
+		"lazycodex-clone-fidelity-reviewer.toml",
+		{
+			effort: "xhigh",
+			includes: [/recommendation/, /blockers/, /\.omo\/evidence\/<goal>-clone-fidelity\.md/],
+		},
+	],
+	[
 		"lazycodex-code-reviewer.toml",
 		{
 			effort: "xhigh",
@@ -61,6 +68,7 @@ test("#given bundled Codex agents #when components/ultrawork/agents directory is
 	assert.deepEqual(entries, [
 		"codex-ultrawork-reviewer.toml",
 		"explorer.toml",
+		"lazycodex-clone-fidelity-reviewer.toml",
 		"lazycodex-code-reviewer.toml",
 		"lazycodex-executor.toml",
 		"lazycodex-gate-reviewer.toml",


### PR DESCRIPTION
## Summary

Adds a new managed Codex reviewer agent, `lazycodex-clone-fidelity-reviewer` — a read-only clone / design-system fidelity reviewer that verifies clone and design-port work is a **rigorous, token-driven design system**, not a pasted screenshot or hardcoded fake.

Stacked on `feature/lazycodex-gate-reviewers` (base for this PR). Mirrors the existing `lazycodex-code-reviewer` role and the predecessor "lazycodex agent series" registration pattern.

## What the reviewer checks

- **Real component tree** — live, reused primitives render the UI, not a pasted screenshot / raster / `background-image` standing in for live DOM.
- **Token-driven styling** — design tokens drive colors, spacing, typography, not hardcoded one-off pixel/hex values.
- **Layer & layout structure** — hierarchy and layout match the target.
- **Visual fidelity** — the rendered design matches the reference.

Returns `recommendation` (APPROVE | REQUEST_CHANGES), `reportPath`, `evidence`, `blockers`; writes its report to `.omo/evidence/<goal>-clone-fidelity.md`. Any CRITICAL or HIGH finding forces REQUEST_CHANGES. Model `gpt-5.5`, reasoning effort `xhigh`.

## Changes

- `packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-clone-fidelity-reviewer.toml` (new)
- `packages/omo-codex/plugin/test/aggregate-agents.test.mjs` — roster `deepEqual` + new `lazycodexAgentInvariants` entry

## Registration note

The task brief referenced `ACTIVE_MANAGED_CODEX_AGENT_NAMES` / `codex-managed-agents.ts` / `EXPECTED_MANAGED_AGENTS`, none of which exist. Install-time agent discovery is dynamic — `link-cached-plugin-agents.ts -> discoverBundledAgents()` scans `components/*/agents/*.toml` — so dropping the TOML auto-registers it. The sibling lazycodex reviewers are likewise absent from `MANAGED_CODEX_AGENT_NAMES`, so no array edit was made (kept consistent with the predecessor pattern). Verified harmless: the install suite still passes 15/15.

## TDD / QA evidence

Full evidence posted as a PR comment below.

- RED (roster expectations updated, TOML absent): `aggregate-agents.test.mjs` → 2 pass / 2 fail (ENOENT + roster mismatch).
- GREEN (TOML added): `aggregate-agents.test.mjs` → 4 pass / 0 fail.
- Install suite: `bun test packages/omo-codex/src/install/install-codex.test.ts` → 15 pass / 0 fail (installer discovers the new TOML).
- Regression check (full plugin `.mjs` suite, stash comparison): identical 148 / 115 pass / 33 fail with and without the change — the 33 are pre-existing fresh-worktree dist-artifact failures, unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `lazycodex-clone-fidelity-reviewer`, a read-only Codex agent that validates clone/design-port work uses real components, design tokens, and matches the reference. It is auto-discovered at install and included in the test roster.

- **New Features**
  - Registers `packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-clone-fidelity-reviewer.toml` (model `gpt-5.5`, effort `xhigh`).
  - Checks for real component trees, token-driven styling, correct layer/layout structure, and visual fidelity.
  - Writes reports to `.omo/evidence/<goal>-clone-fidelity.md` and returns `recommendation`, `reportPath`, `evidence`, `blockers`; CRITICAL/HIGH findings force `REQUEST_CHANGES`.
  - Updates `packages/omo-codex/plugin/test/aggregate-agents.test.mjs` with invariants and expected roster entry.

<sup>Written for commit 00283410dc424a016e15f81c87b757868afa89f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

