### PR TITLE
fix(monitor): deliver idle output injection reliably

### DIFF
--- a/docs/reference/monitor.md
+++ b/docs/reference/monitor.md
@@ -118,7 +118,7 @@ Monitor supports two output injection modes.
 | Mode | Default | Behavior |
 |------|---------|----------|
 | `idle` | yes | Buffers output and flushes only when the parent session is idle, at safe turn boundaries. It does not interrupt an active turn. |
-| `live_safe` | no | Requires `monitor.live_mode_enabled: true`. Flushes on the next tick after each batch, but still defers while the session is active. It is only a little more responsive than `idle`. |
+| `live_safe` | no | Requires `monitor.live_mode_enabled: true`. Flushes on the next tick after each batch, but still defers while the session is active. In the current implementation this matches `idle` behavior. |
 
 Use `idle` unless the agent needs quicker feedback and you accept more frequent internal output injections.
 

--- a/src/features/monitor/injection-route.test.ts
+++ b/src/features/monitor/injection-route.test.ts
@@ -186,7 +186,7 @@ describe("MonitorOutputInjector injection route", () => {
       // then
       expect(harness.calls).toHaveLength(1)
       expect(harness.calls[0]?.source).toBe("monitor-output:mon_route:batch-1")
-      expect(harness.scheduledFlushes).toHaveLength(1)
+      expect(harness.scheduledFlushes).toHaveLength(2)
       expect(harness.injector.getPendingBatches(record.id)).toEqual([])
     })
   })
@@ -274,7 +274,25 @@ describe("MonitorOutputInjector injection route", () => {
 
       // then
       expect(harness.calls.map((call) => call.source)).toEqual(["monitor-output:mon_route:batch-5"])
+      expect(harness.scheduledFlushes).toHaveLength(2)
+      expect(harness.injector.getPendingBatches(record.id)).toEqual([])
+    })
+  })
+
+  describe("#given idle-mode output arrives with no explicit flush trigger", () => {
+    test("#when queueBatch runs for an idle-mode record #then it schedules a flush that delivers exactly once without any session.idle", async () => {
+      // given
+      const record = createRecord({ mode: "idle" })
+      const batch = createBatch(6)
+      const harness = createHarness({ active: false })
+
+      // when: only queueBatch runs - no explicit flushMonitor, no session.idle event
+      harness.injector.queueBatch(record, batch)
+
+      // then: the queue itself scheduled a flush, and running it delivers exactly once
       expect(harness.scheduledFlushes).toHaveLength(1)
+      await harness.scheduledFlushes[0]?.operation()
+      expect(harness.calls.map((call) => call.source)).toEqual(["monitor-output:mon_route:batch-6"])
       expect(harness.injector.getPendingBatches(record.id)).toEqual([])
     })
   })

--- a/src/features/monitor/manager.test.ts
+++ b/src/features/monitor/manager.test.ts
@@ -175,6 +175,12 @@ function createCounters(): MonitorCounters {
   }
 }
 
+async function drainMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 afterEach(() => {
   subagentSessions.clear()
   resetProcessCleanupForTesting()
@@ -330,6 +336,87 @@ describe("MonitorManager", () => {
       expect(manager).toBeInstanceOf(MonitorManager)
       expect(registerManagerForCleanup).toHaveBeenCalledTimes(1)
       expect(manager.getOutput("missing", { stream: "all" })).toEqual({ lines: [], counters: createCounters() })
+    })
+  })
+
+  describe("#given a monitor whose process exits", () => {
+    function createExitHarness() {
+      let resolveExit!: (result: { code: number | null; signal: string | null }) => void
+      let rejectExit!: (error: unknown) => void
+      const exited = new Promise<{ code: number | null; signal: string | null }>((resolve, reject) => {
+        resolveExit = resolve
+        rejectExit = reject
+      })
+      const flushed: string[] = []
+      const scheduler = createFakeScheduler()
+      const manager = new MonitorManager({
+        pluginContext: unsafeTestValue({ client: {}, directory: "/repo" }),
+        config: {
+          max_monitors_per_session: 3,
+          max_runtime_ms: 60_000,
+          batch_max_lines: 3,
+          batch_max_bytes: 1024,
+          flush_interval_ms: 1000,
+          ring_max_lines: 20,
+          line_max_bytes: 1024,
+          pattern_max_length: 512,
+        },
+        deps: {
+          randomId: () => "mon_exit",
+          spawnMonitoredProcess() {
+            return {
+              kill() {},
+              exited,
+              stdout: createEmptyStream(),
+              stderr: createEmptyStream(),
+            }
+          },
+          createInjector() {
+            return {
+              queueBatch() {},
+              async flushMonitor(monitorId: string) {
+                flushed.push(monitorId)
+              },
+              requeueMonitor() {},
+            }
+          },
+          scheduler: {
+            setTimer: scheduler.setTimer,
+            clearTimer: scheduler.clearTimer,
+            now: () => 0,
+          },
+          registerManagerForCleanup: () => {},
+          unregisterManagerForCleanup: () => {},
+          log: () => {},
+        },
+      })
+      return { manager, resolveExit, rejectExit, flushed }
+    }
+
+    test("#when the process exits naturally #then the manager flushes the injector for final delivery", async () => {
+      // given
+      const { manager, resolveExit, flushed } = createExitHarness()
+      const record = await startMonitor(manager, "exiting-cmd", "s1")
+
+      // when
+      resolveExit({ code: 0, signal: null })
+      await drainMicrotasks()
+
+      // then
+      expect(flushed).toContain(record.id)
+    })
+
+    test("#when the process exit rejects #then the manager still flushes the injector for final delivery", async () => {
+      // given
+      const { manager, rejectExit, flushed } = createExitHarness()
+      const record = await startMonitor(manager, "failing-cmd", "s1")
+
+      // when
+      rejectExit(new Error("spawn failure"))
+      await drainMicrotasks()
+
+      // then
+      expect(flushed).toContain(record.id)
     })
   })
 })

--- a/src/features/monitor/manager.ts
+++ b/src/features/monitor/manager.ts
@@ -396,16 +396,27 @@ export class MonitorManager implements MonitorManagerContract {
       state.batcher.flushNow()
       state.batcher.destroy()
       state.pipeline.stop()
-      this.clearScheduledFlush(state.record.id)
+      void state.injector.flushMonitor(state.record.id).catch((flushError) => {
+        this.logger("[monitor] Failed to flush monitor output after process exit", {
+          monitorId: state.record.id,
+          error: flushError,
+        })
+      })
     }).catch((error) => {
       if (state.record.status === "stopped") {
         return
       }
 
       state.record.status = "failed"
+      state.batcher.flushNow()
       state.batcher.destroy()
       state.pipeline.stop()
-      this.clearScheduledFlush(state.record.id)
+      void state.injector.flushMonitor(state.record.id).catch((flushError) => {
+        this.logger("[monitor] Failed to flush monitor output after process failure", {
+          monitorId: state.record.id,
+          error: flushError,
+        })
+      })
       this.logger("[monitor] monitored process failed", { monitorId: state.record.id, error })
     })
   }

--- a/src/features/monitor/output-injector.ts
+++ b/src/features/monitor/output-injector.ts
@@ -88,9 +88,7 @@ export class MonitorOutputInjector {
       this.pendingOutputs.set(record.id, { record, batches: [batch] })
     }
 
-    if (record.mode === "live_safe") {
-      this.scheduleFlush(record.id, 0)
-    }
+    this.scheduleFlush(record.id, 0)
   }
 
   getPendingBatches(monitorId: string): OutputBatch[] {


### PR DESCRIPTION
## What

Fixes the Monitor feature's headline behavior — idle-mode auto-injection of the `[OMO MONITOR OUTPUT]` envelope — which never fired in real interactive use.

> **Base branch is `feat/monitor-tool`** (the monitor feature itself), so this PR is scoped to **only the idle-injection fix**. The monitor feature predates the current `dev` multi-harness refactor and is not yet ported to the new package layout, so it cannot land on `dev` as-is.

## Root cause

`session.idle` is edge-triggered once at turn end, but monitor output is batched **asynchronously after** that edge. Idle-mode `queueBatch` scheduled no flush (only `live_safe` did), and process exit cancelled the only pending retry via `clearScheduledFlush`. Result: across entire real sessions there were **zero** `[OMO MONITOR OUTPUT]` envelopes and zero `monitor-output:` dispatches.

## Fix

- `output-injector.ts` `queueBatch`: schedule a flush for **all** modes (level-triggered). The `isSessionActive` gate in `flushMonitor` still guarantees idle-only delivery, so active turns are never interrupted.
- `manager.ts` `observeProcessExit` (normal + failure paths): perform a final `flushMonitor` instead of `clearScheduledFlush`, so buffered matched output is delivered, not dropped, on exit.
- Injection still routes exclusively through the gated `dispatchInternalPrompt` (`queueBehavior: "defer"`, nonzero `postDispatchHoldMs`, `checkStatus`/`checkToolState`).

## Verification

- **review-work** (5 parallel reviewers — goal & constraint, hands-on QA, code quality, security, context mining): **all PASS**, zero blocking issues.
- New RED→GREEN regression tests: idle `queueBatch` schedules a flush without an explicit `session.idle`; process exit (normal + failure) flushes the injector.
- `bun test src/features/monitor src/tools/monitor src/shared/prompt-async-route-audit.test.ts` → **104 pass / 0 fail**; `lsp_diagnostics` clean; `bun run build` exit 0.
- **Live**: a real `opencode` TUI now shows the `[OMO MONITOR OUTPUT]` envelope arriving mid-conversation (the exact scenario that produced zero envelopes before the fix); active-turn safety and no-orphan-process behavior independently confirmed by the QA reviewer.

## Changed files

- `src/features/monitor/output-injector.ts`
- `src/features/monitor/manager.ts`
- `src/features/monitor/injection-route.test.ts`
- `src/features/monitor/manager.test.ts`
- `docs/reference/monitor.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes idle-mode monitor output injection so `[OMO MONITOR OUTPUT]` envelopes are delivered reliably without interrupting active turns. Also ensures a final flush on process exit so buffered output isn’t lost.

- **Bug Fixes**
  - `queueBatch` now schedules a flush for all modes; the `flushMonitor` idle gate still prevents active-turn injection.
  - On process exit (success or failure), call `flushMonitor` for final delivery instead of clearing the timer.
  - Added regression tests; docs clarify `live_safe` currently matches `idle`.

<sup>Written for commit cf3e95009a2a275604e13d359a0712b4d1045bf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

