### PR TITLE
fix(sisyphus): reconcile file-edit guidance to runtime model family (#5297)

### DIFF
--- a/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-family.test.ts
+++ b/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-family.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test"
+
+import { createSystemTransformHandler } from "./system-transform"
+import {
+  GPT_APPLY_PATCH_GUIDANCE,
+  GPT_FILE_EDIT_GUIDANCE,
+} from "../agents/gpt-apply-patch-guard"
+import { createSisyphusAgent } from "../agents/sisyphus"
+
+const GPT_MODEL = { id: "gpt-5.5", providerID: "openai" }
+const NON_GPT_MODEL = { id: "qwen3.7-plus", providerID: "opencode-go" }
+
+function runHandler(
+  system: string[],
+  model: { id: string; providerID: string },
+): Promise<string[]> {
+  const handler = createSystemTransformHandler(undefined, undefined, {})
+  const output = { system }
+  return handler({ sessionID: "s", model }, output).then(() => output.system)
+}
+
+describe("Sisyphus runtime prompt family reconciliation (#5297)", () => {
+  test("#given GPT apply_patch guidance baked #when runtime model is non-GPT #then guidance is rewritten to be tool-agnostic", async () => {
+    // given: configured GPT model baked the apply_patch-only guidance
+    const baked = [`Step 4. ${GPT_APPLY_PATCH_GUIDANCE}`]
+
+    // when: user switched to a non-GPT model in the TUI
+    const result = await runHandler(baked, NON_GPT_MODEL)
+
+    // then: the prompt no longer forces apply_patch
+    const joined = result.join("\n")
+    expect(joined).not.toContain(GPT_APPLY_PATCH_GUIDANCE)
+    expect(joined).toContain(GPT_FILE_EDIT_GUIDANCE)
+  })
+
+  test("#given non-GPT file-edit guidance baked #when runtime model is GPT #then guidance is upgraded to apply_patch", async () => {
+    // given: configured non-GPT model baked the tool-agnostic guidance
+    const baked = [`Step 4. ${GPT_FILE_EDIT_GUIDANCE}`]
+
+    // when: user switched to a GPT model in the TUI
+    const result = await runHandler(baked, GPT_MODEL)
+
+    // then: GPT gets its apply_patch-specific guidance back
+    const joined = result.join("\n")
+    expect(joined).toContain(GPT_APPLY_PATCH_GUIDANCE)
+    expect(joined).not.toContain(GPT_FILE_EDIT_GUIDANCE)
+  })
+
+  test("#given GPT guidance baked #when runtime model is also GPT #then guidance is left unchanged", async () => {
+    const baked = [`Step 4. ${GPT_APPLY_PATCH_GUIDANCE}`]
+    const result = await runHandler(baked, GPT_MODEL)
+    expect(result.join("\n")).toContain(GPT_APPLY_PATCH_GUIDANCE)
+  })
+
+  test("#given no runtime model #when system transform runs #then guidance is untouched", async () => {
+    const baked = [`Step 4. ${GPT_APPLY_PATCH_GUIDANCE}`]
+    const handler = createSystemTransformHandler(undefined, undefined, {})
+    const output = { system: [...baked] }
+    await handler(
+      { sessionID: "s", model: undefined as unknown as { id: string; providerID: string } },
+      output,
+    )
+    expect(output.system).toEqual(baked)
+  })
+
+  test("#given a real GPT-configured Sisyphus prompt #when run on a non-GPT model #then apply_patch is not forced (config-to-runtime mismatch)", async () => {
+    // given: this is the path issue #5258 tests missed — the prompt is actually
+    // *built* for a GPT model (as it would be from oh-my-openagent.jsonc), then
+    // assembled and passed through the runtime hook with a different model.
+    const gptAgent = createSisyphusAgent("openai/gpt-5.5", [], [], [], [])
+    expect(gptAgent.prompt).toContain(GPT_APPLY_PATCH_GUIDANCE)
+
+    // when: the runtime model selected in the TUI is non-GPT
+    const result = await runHandler([gptAgent.prompt ?? ""], NON_GPT_MODEL)
+
+    // then: the final system prompt no longer instructs apply_patch usage
+    expect(result.join("\n")).not.toContain(GPT_APPLY_PATCH_GUIDANCE)
+  })
+})

--- a/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-family.test.ts
+++ b/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-family.test.ts
@@ -33,8 +33,12 @@ describe("Sisyphus runtime prompt family reconciliation (#5297)", () => {
     expect(joined).toContain(GPT_FILE_EDIT_GUIDANCE)
   })
 
-  test("#given non-GPT file-edit guidance baked #when runtime model is GPT #then guidance is upgraded to apply_patch", async () => {
-    // given: configured non-GPT model baked the tool-agnostic guidance
+  test("#given the tool-agnostic guidance string is present #when runtime model is GPT #then the helper rewrites it to apply_patch", async () => {
+    // NOTE: this exercises the reverse-direction helper behavior on a synthetic
+    // input. The real non-GPT Sisyphus prompt does not bake GPT_FILE_EDIT_GUIDANCE
+    // (it carries no file-edit guidance line at all), so this is not a proof of a
+    // real config-to-runtime reverse path - only that the swap is correct when
+    // such a string does appear (e.g. in the sisyphus-junior / hephaestus GPT prompts).
     const baked = [`Step 4. ${GPT_FILE_EDIT_GUIDANCE}`]
 
     // when: user switched to a GPT model in the TUI
@@ -64,7 +68,7 @@ describe("Sisyphus runtime prompt family reconciliation (#5297)", () => {
   })
 
   test("#given a real GPT-configured Sisyphus prompt #when run on a non-GPT model #then apply_patch is not forced (config-to-runtime mismatch)", async () => {
-    // given: this is the path issue #5258 tests missed — the prompt is actually
+    // given: this is the path issue #5258 tests missed. The prompt is actually
     // *built* for a GPT model (as it would be from oh-my-openagent.jsonc), then
     // assembled and passed through the runtime hook with a different model.
     const gptAgent = createSisyphusAgent("openai/gpt-5.5", [], [], [], [])

--- a/packages/omo-opencode/src/plugin/system-transform.ts
+++ b/packages/omo-opencode/src/plugin/system-transform.ts
@@ -1,10 +1,45 @@
 import type { DefaultModeConfig } from "../config/schema/default-mode"
 import {
+  GPT_APPLY_PATCH_GUIDANCE,
+  GPT_FILE_EDIT_GUIDANCE,
+} from "../agents/gpt-apply-patch-guard"
+import { isGptModel } from "../agents/types"
+import {
   getSparkShellRuntimeAwareness,
   hasSparkShellRuntimeAwareness,
 } from "../shared/sparkshell-awareness"
 
 const ULTRAWORK_MODE_TAG = "<ultrawork-mode>"
+
+/**
+ * The Sisyphus prompt body (incl. the file-edit guidance) is baked into the
+ * agent config at registration time, based on the *configured* model in
+ * `oh-my-openagent.jsonc`. When the user switches to a different model family in
+ * the TUI, that baked guidance no longer matches the runtime model — e.g. a
+ * GPT-configured agent run on a non-GPT model still says "Use `apply_patch`",
+ * even though `apply_patch` is not exposed (issue #5297).
+ *
+ * The system-transform hook is the only per-request seam that knows the model
+ * actually selected at runtime, so reconcile the file-edit guidance here to
+ * match the runtime family rather than the configured one.
+ */
+function reconcileFileEditGuidance(
+  system: string[],
+  modelID: string | undefined,
+): void {
+  if (!modelID) return
+
+  const [from, to] = isGptModel(modelID)
+    ? [GPT_FILE_EDIT_GUIDANCE, GPT_APPLY_PATCH_GUIDANCE]
+    : [GPT_APPLY_PATCH_GUIDANCE, GPT_FILE_EDIT_GUIDANCE]
+
+  for (let i = 0; i < system.length; i++) {
+    const part = system[i]
+    if (part.includes(from)) {
+      system[i] = part.split(from).join(to)
+    }
+  }
+}
 
 export function createSystemTransformHandler(
   defaultMode?: DefaultModeConfig,
@@ -15,6 +50,8 @@ export function createSystemTransformHandler(
   output: { system: string[] },
 ) => Promise<void> {
   return async (input, output): Promise<void> => {
+    reconcileFileEditGuidance(output.system, input.model?.id)
+
     const sparkshellAwareness = getSparkShellRuntimeAwareness(env)
     if (
       sparkshellAwareness.length > 0 &&

--- a/packages/omo-opencode/src/plugin/system-transform.ts
+++ b/packages/omo-opencode/src/plugin/system-transform.ts
@@ -15,7 +15,7 @@ const ULTRAWORK_MODE_TAG = "<ultrawork-mode>"
  * The Sisyphus prompt body (incl. the file-edit guidance) is baked into the
  * agent config at registration time, based on the *configured* model in
  * `oh-my-openagent.jsonc`. When the user switches to a different model family in
- * the TUI, that baked guidance no longer matches the runtime model — e.g. a
+ * the TUI, that baked guidance no longer matches the runtime model, e.g. a
  * GPT-configured agent run on a non-GPT model still says "Use `apply_patch`",
  * even though `apply_patch` is not exposed (issue #5297).
  *


### PR DESCRIPTION
## Summary
Fixes #5297. The Sisyphus model-family prompt (GPT vs non-GPT) was chosen from the model configured in `oh-my-openagent.jsonc` and baked into the agent config at registration time. When a user switches models in the TUI at runtime, the baked guidance no longer matches — e.g. a GPT-configured Sisyphus run on a non-GPT model still instructs "Use `apply_patch`", even though `apply_patch` isn't exposed.

## Fix
The `experimental.chat.system.transform` hook is the only per-request seam that knows the runtime-selected model, so reconcile the file-edit guidance there to match the runtime family instead of the configured one:
- runtime non-GPT + baked `GPT_APPLY_PATCH_GUIDANCE` → tool-agnostic `GPT_FILE_EDIT_GUIDANCE`
- runtime GPT + baked tool-agnostic guidance → `GPT_APPLY_PATCH_GUIDANCE`
- matching family / no runtime model → unchanged

## Why not change agent registration
In `builtin-agents/sisyphus-agent.ts` the resolved `model` also drives the *actual run model*, permission, and thinking config — not just the prompt family. Making the UI-selected model win there would regress the intended "explicit config model wins" behavior. Reconciling at the runtime seam also covers the configured-base case (no mismatch → no change), so no registration change is needed.

## Tests
Added `packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-family.test.ts`, including the config→runtime mismatch path that #5258's tests missed: a prompt actually built for GPT via `createSisyphusAgent("openai/gpt-5.5", …)`, then assembled and passed through the runtime hook with a non-GPT model, asserting `apply_patch` is no longer forced.

Verification:
- new tests: 5 pass
- `plugin/` suite: 279 pass, 0 fail
- `tsgo --noEmit -p packages/omo-opencode/tsconfig.json`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Sisyphus file-edit guidance with the runtime-selected model family so prompts don’t instruct the wrong tool after TUI model switches. Fixes #5297.

- **Bug Fixes**
  - Reconcile guidance in `experimental.chat.system.transform` using the runtime model ID.
  - Non-GPT runtime rewrites `GPT_APPLY_PATCH_GUIDANCE` to `GPT_FILE_EDIT_GUIDANCE`; GPT runtime rewrites the reverse; unchanged if matching or no runtime model.
  - Added tests for config↔runtime mismatch, no-runtime-model case, and reverse-direction helper on synthetic input; also removed em dashes in comments and renamed the reverse-case test for clarity.

<sup>Written for commit f03718daae2daad8a3a5a9750f66412f7b9757eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


