### PR TITLE
fix(omo-codex): use file URL for dynamic import in scaffold-plan test (fixes Windows CI)

### DIFF
--- a/packages/omo-codex/plugin/test/scaffold-plan.test.mjs
+++ b/packages/omo-codex/plugin/test/scaffold-plan.test.mjs
@@ -3,15 +3,18 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const scriptPath = join(root, "skills", "ulw-plan", "scripts", "scaffold-plan.mjs");
+// On Windows an absolute path like "C:\..." is not a valid ESM specifier (the
+// drive letter is read as a URL protocol), so convert it to a file:// URL.
+const scriptUrl = pathToFileURL(scriptPath).href;
 const workflowPath = join(root, "skills", "ulw-plan", "references", "full-workflow.md");
 
 test("#given the scaffold script and the workflow reference #when compared #then every plan header the script emits is documented in full-workflow.md (no drift)", async () => {
 	// given
-	const { PLAN_SECTION_HEADERS } = await import(scriptPath);
+	const { PLAN_SECTION_HEADERS } = await import(scriptUrl);
 	const workflow = await readFile(workflowPath, "utf8");
 
 	// then — the script is the single source of the plan shape; the reference must document the same headers
@@ -23,7 +26,7 @@ test("#given the scaffold script and the workflow reference #when compared #then
 
 test("#given buildPlanSkeleton #when intent is unclear #then the human TL;DR leads the plan and surfaces the decisions veto block", async () => {
 	// given
-	const { buildPlanSkeleton, PLAN_SECTION_HEADERS } = await import(scriptPath);
+	const { buildPlanSkeleton, PLAN_SECTION_HEADERS } = await import(scriptUrl);
 	const plan = buildPlanSkeleton("demo", "unclear");
 
 	// then — the human-readable summary is on top, above the AI detail
@@ -36,7 +39,7 @@ test("#given buildPlanSkeleton #when intent is unclear #then the human TL;DR lea
 
 test("#given buildPlanSkeleton #when intent is clear #then it surfaces a decisions-to-sanity-check block instead", async () => {
 	// given
-	const { buildPlanSkeleton } = await import(scriptPath);
+	const { buildPlanSkeleton } = await import(scriptUrl);
 	const plan = buildPlanSkeleton("demo", "clear");
 
 	// then
@@ -46,7 +49,7 @@ test("#given buildPlanSkeleton #when intent is clear #then it surfaces a decisio
 
 test("#given resolveSafeOmoPath #when the target escapes .omo or the workspace #then it is refused (the script never escapes .omo)", async () => {
 	// given
-	const { resolveSafeOmoPath } = await import(scriptPath);
+	const { resolveSafeOmoPath } = await import(scriptUrl);
 	const cwd = "/tmp/ws";
 
 	// then — the prometheus-md-only hook gates Write/Edit but not Bash, so the script self-guards its own writes
@@ -59,7 +62,7 @@ test("#given resolveSafeOmoPath #when the target escapes .omo or the workspace #
 
 test("#given parseArgs #when the slug is missing or unsafe #then it throws, and valid flags parse", async () => {
 	// given
-	const { parseArgs } = await import(scriptPath);
+	const { parseArgs } = await import(scriptUrl);
 
 	// then
 	assert.throws(() => parseArgs(["node", "s"]));
@@ -77,7 +80,7 @@ test("#given parseArgs #when the slug is missing or unsafe #then it throws, and 
 
 test("#given an already-scaffolded plan #when the script is re-run plain #then it is a no-op that preserves appended todos (resume-safe, no crash, no clobber)", async () => {
 	// given
-	const { scaffold } = await import(scriptPath);
+	const { scaffold } = await import(scriptUrl);
 	const dir = await mkdtemp(join(tmpdir(), "ulwp-"));
 	try {
 		await scaffold(dir, { slug: "demo", intent: "unclear" });
@@ -104,7 +107,7 @@ test("#given an already-scaffolded plan #when the script is re-run plain #then i
 
 test("#given a hand-edited plan #when --reset is used #then it refuses without --force and overwrites with --force", async () => {
 	// given
-	const { scaffold } = await import(scriptPath);
+	const { scaffold } = await import(scriptUrl);
 	const dir = await mkdtemp(join(tmpdir(), "ulwp-"));
 	try {
 		await scaffold(dir, { slug: "demo", intent: "clear" });


### PR DESCRIPTION
## Summary
`codex-compatibility (windows-latest)` is red because `packages/omo-codex/plugin/test/scaffold-plan.test.mjs` imports the script under test via a raw absolute path:

```js
const scriptPath = join(root, "skills", "ulw-plan", "scripts", "scaffold-plan.mjs");
const { ... } = await import(scriptPath);
```

On Windows that path starts with a drive letter (`C:\...`, `D:\...` on the runners), and the ESM loader reads the drive letter as a URL protocol, so the dynamic import is rejected:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: ... On Windows, absolute paths must be
valid file:// URLs. Received protocol 'c:'
```

All 7 tests in the file fail for this reason. The failure is environment-specific (Windows only) and unrelated to any product code.

## Fix
Convert the path with `pathToFileURL()` before importing, so the specifier is a valid `file://` URL on every platform:

```js
import { fileURLToPath, pathToFileURL } from "node:url";
const scriptUrl = pathToFileURL(scriptPath).href;
const { ... } = await import(scriptUrl);
```

## Verification
Reproduced and fixed on a real Windows 11 machine with `node --test`:
- before: `tests 7 / pass 0 / fail 7` (all `ERR_UNSUPPORTED_ESM_URL_SCHEME`, `protocol 'c:'`)
- after:  `tests 7 / pass 7 / fail 0`

Only the test file changed; no product code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing Windows CI by importing the scaffold script via a file URL instead of a raw absolute path in packages/omo-codex/plugin/test/scaffold-plan.test.mjs. The test now uses pathToFileURL() so the ESM loader accepts the specifier on Windows; only the test file changed.

<sup>Written for commit 98ed8e67c4335c879c07b118c5ddec397da106c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

