### PR TITLE
fix(start-work): pass bare session id to SDK session.messages

### DIFF
--- a/packages/omo-opencode/src/hooks/start-work/start-work-hook.test.ts
+++ b/packages/omo-opencode/src/hooks/start-work/start-work-hook.test.ts
@@ -55,4 +55,31 @@ You are starting a Sisyphus work session.
     // then
     expect(state?.session_ids).toEqual(["opencode:raw-sess"])
   })
+
+  test("#given raw chat session id #when locating the recent session plan #then the SDK receives the bare ses id (#5285)", async () => {
+    // given
+    writeFileSync(join(testDir, ".omo", "plans", "work.md"), "# Work\n- [ ] First task\n")
+    const sessionMessageIds: string[] = []
+    const hook = createStartWorkHook(unsafeTestValue<Parameters<typeof createStartWorkHook>[0]>({
+      directory: testDir,
+      client: {
+        session: {
+          messages: async (args: { path: { id: string } }) => {
+            sessionMessageIds.push(args.path.id)
+            return { data: [] }
+          },
+        },
+      },
+    }))
+    const output = {
+      parts: [{ type: "text", text: createStartWorkPrompt() }],
+    }
+
+    // when
+    await hook["chat.message"]({ sessionID: "raw-sess" }, output)
+
+    // then
+    expect(sessionMessageIds).toContain("raw-sess")
+    expect(sessionMessageIds).not.toContain("opencode:raw-sess")
+  })
 })

--- a/packages/omo-opencode/src/hooks/start-work/start-work-hook.ts
+++ b/packages/omo-opencode/src/hooks/start-work/start-work-hook.ts
@@ -94,7 +94,8 @@ export function createStartWorkHook(ctx: PluginInput) {
       : await findRecentSessionPlanPath({
           client: ctx.client,
           directory: ctx.directory,
-          sessionID: sessionId,
+          // SDK session.messages needs the bare ses_ id, not the opencode:-prefixed storage id (#5285)
+          sessionID: input.sessionID,
           availablePlans: findPrometheusPlans(ctx.directory),
         })
 


### PR DESCRIPTION
## Summary
- Fixes #5285: the start-work hook passed the `opencode:`-prefixed session id to `client.session.messages()`, which the OpenCode SDK rejects, so the recent-session plan lookup silently failed.
- Only the SDK call is changed to use the bare `input.sessionID`; the prefixed id is intentionally kept for boulder storage and `$SESSION_ID` substitution.
- Adds a regression test that asserts the SDK receives the bare `ses_` id (fails without the one-line change).

## Context
In `processStartWork` (`packages/omo-opencode/src/hooks/start-work/start-work-hook.ts`), `normalizeSessionId(input.sessionID, "opencode")` turns a raw `ses_xxx` into `opencode:ses_xxx`. That prefixed `sessionId` was then handed to `findRecentSessionPlanPath`, which calls `client.session.messages({ path: { id: input.sessionID } })`.

The OpenCode SDK validates that session ids start with `ses`, so `opencode:ses_xxx` (URL-encoded to `opencode%3Ases_xxx`) fails with `Expected a string starting with 'ses'`. `findRecentSessionPlanPath` catches the error and returns `null`, so `/start-work` silently fails to bind the recent session's Prometheus plan.

## What changed
- `start-work-hook.ts`: pass the bare `input.sessionID` (not the prefixed `sessionId`) to `findRecentSessionPlanPath` -> `client.session.messages`. The prefixed `sessionId` is still used for `readBoulderState`/storage and `$SESSION_ID` text replacement.

## Why this is standalone
- Not covered by any open PR (searched `start-work`/`session messages`).
- Intentionally a single-call fix; it does not touch the boulder storage id format or `$SESSION_ID` substitution, which correctly require the prefixed id.
- A short inline comment marks the SDK-contract reason so a future "consistency" edit does not reintroduce the prefix.

## Verification
- `bun test packages/omo-opencode/src/hooks/start-work/start-work-hook.test.ts packages/omo-opencode/src/hooks/start-work/session-plan-affinity.test.ts` -> 4 pass, 0 fail
- Regression proof: reverting only the `start-work-hook.ts` change makes the new test fail (the SDK receives `opencode:raw-sess` instead of `raw-sess`).
- `tsgo --noEmit -p packages/omo-opencode/tsconfig.json` -> exit 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes start-work by sending the bare session id to the SDK, restoring recent-session plan lookup and preventing silent failures. Fixes #5285.

- Bug Fixes
  - Pass bare `input.sessionID` to `client.session.messages`; keep the `opencode:`-prefixed id for storage and `$SESSION_ID` substitution.
  - Add a regression test to ensure the SDK receives the bare id (e.g., `raw-sess`), not the `opencode:`-prefixed value.

<sup>Written for commit 4425f17d49a9439dc30225d198d7d87100b51c0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

