### PR TITLE
feat(model-core): support provider1|provider2/name pipe syntax in model and fallback_models fields

### DIFF
--- a/packages/model-core/src/fallback-chain-from-models.ts
+++ b/packages/model-core/src/fallback-chain-from-models.ts
@@ -1,3 +1,4 @@
+import { splitProvidersAndModel, parseVariantFromModelID } from "./model-string-parser"
 import type { FallbackEntry } from "./model-requirements"
 import type { FallbackModelObject } from "./fallback-model-object"
 import { normalizeFallbackModels } from "./model-resolver"
@@ -40,13 +41,14 @@ export function parseFallbackModelEntry(
   const trimmed = model.trim()
   if (!trimmed) return undefined
 
-  const parts = trimmed.split("/")
-  const providerID =
-    parts.length >= 2 ? parts[0].trim() : (contextProviderID?.trim() || defaultProviderID)
-  const rawModelID = parts.length >= 2 ? parts.slice(1).join("/").trim() : trimmed
+  const { providers, modelID } = splitProvidersAndModel(trimmed)
+  const providerID = providers.length > 0
+    ? providers[0]
+    : (contextProviderID?.trim() || defaultProviderID)
+  const rawModelID = modelID || trimmed
   if (!providerID || !rawModelID) return undefined
 
-  const parsed = parseVariantFromModel(rawModelID)
+  const parsed = parseVariantFromModelID(rawModelID)
   if (!parsed.modelID) return undefined
 
   return {
@@ -72,9 +74,8 @@ export function parseFallbackModelObjectEntry(
     top_p: obj.top_p,
     maxTokens: obj.maxTokens,
     thinking: obj.thinking,
-  }
 }
-
+}
 /**
  * Find the most specific FallbackEntry whose `provider/model` is a prefix of
  * the resolved `provider/modelID`.  Longest match wins so that e.g.
@@ -115,13 +116,35 @@ export function buildFallbackChainFromModels(
   if (!normalized || normalized.length === 0) return undefined
 
   const parsed = normalized
-    .map((entry) => {
+    .flatMap((entry) => {
       if (typeof entry === "string") {
-        return parseFallbackModelEntry(entry, contextProviderID, defaultProviderID)
+        const { providers, modelID } = splitProvidersAndModel(entry)
+        if (providers.length > 1) {
+          const parsedVariant = parseVariantFromModelID(modelID)
+          if (!parsedVariant.modelID) return []
+          return providers.map((p) =>
+            ({ providers: [p], model: parsedVariant.modelID, variant: parsedVariant.variant } as FallbackEntry)
+          )
+        }
+        return parseFallbackModelEntry(entry, contextProviderID, defaultProviderID) || []
       }
-      return parseFallbackModelObjectEntry(entry, contextProviderID, defaultProviderID)
+      const { providers, modelID } = splitProvidersAndModel(entry.model)
+      if (providers.length > 1) {
+        const parsedVariant = parseVariantFromModelID(modelID)
+        if (!parsedVariant.modelID) return []
+        return providers.map((p) => ({
+          providers: [p],
+          model: parsedVariant.modelID,
+          variant: entry.variant ?? parsedVariant.variant,
+          reasoningEffort: entry.reasoningEffort,
+          temperature: entry.temperature,
+          top_p: entry.top_p,
+          maxTokens: entry.maxTokens,
+          thinking: entry.thinking,
+        } as FallbackEntry))
+      }
+      return parseFallbackModelObjectEntry(entry, contextProviderID, defaultProviderID) || []
     })
-    .filter((entry): entry is FallbackEntry => entry !== undefined)
 
   if (parsed.length === 0) return undefined
   return parsed

--- a/packages/model-core/src/model-format-normalizer.ts
+++ b/packages/model-core/src/model-format-normalizer.ts
@@ -1,3 +1,5 @@
+import { splitProvidersAndModel } from "./model-string-parser"
+
 export function normalizeModelFormat(
   model: string | { providerID: string; modelID: string } | null | undefined
 ): { providerID: string; modelID: string } | undefined {
@@ -10,9 +12,9 @@ export function normalizeModelFormat(
   }
 
   if (typeof model === "string") {
-    const parts = model.split("/")
-    if (parts.length >= 2) {
-      return { providerID: parts[0], modelID: parts.slice(1).join("/") }
+    const { providers, modelID } = splitProvidersAndModel(model)
+    if (providers.length > 0 && modelID) {
+      return { providerID: providers[0], modelID }
     }
   }
 

--- a/packages/model-core/src/model-resolution-pipeline.ts
+++ b/packages/model-core/src/model-resolution-pipeline.ts
@@ -1,3 +1,5 @@
+import { splitProvidersAndModel } from "./model-string-parser"
+
 import { fuzzyMatchModel } from "./model-availability"
 import type { FallbackEntry } from "./model-requirements"
 import { transformModelForProvider } from "./provider-model-id-transform"
@@ -88,23 +90,28 @@ export function resolveModelPipeline(
 
   const normalizedUiModel = normalizeModel(intent?.uiSelectedModel)
   if (normalizedUiModel) {
-    log("Model resolved via UI selection", { model: normalizedUiModel })
-    return { model: normalizedUiModel, provenance: "override" }
+    const { providers: uiProviders, modelID: uiModelID } = splitProvidersAndModel(normalizedUiModel)
+    const normalizedModel = uiProviders.length > 0 && uiModelID ? `${uiProviders[0]}/${uiModelID}` : normalizedUiModel
+    log("Model resolved via UI selection", { model: normalizedModel })
+    return { model: normalizedModel, provenance: "override" }
   }
 
   const normalizedUserModel = normalizeModel(intent?.userModel)
   if (normalizedUserModel) {
-    log("Model resolved via config override", { model: normalizedUserModel })
-    return { model: normalizedUserModel, provenance: "override" }
+    const { providers: userProviders, modelID: userModelID } = splitProvidersAndModel(normalizedUserModel)
+    const normalizedModel = userProviders.length > 0 && userModelID ? `${userProviders[0]}/${userModelID}` : normalizedUserModel
+    log("Model resolved via config override", { model: normalizedModel })
+    return { model: normalizedModel, provenance: "override" }
   }
 
   const normalizedCategoryDefault = normalizeModel(intent?.categoryDefaultModel)
   if (normalizedCategoryDefault) {
     attempted.push(normalizedCategoryDefault)
     if (availableModels.size > 0) {
-      const parts = normalizedCategoryDefault.split("/")
-      const providerHint = parts.length >= 2 ? [parts[0]] : undefined
-      const match = deps.fuzzyMatchModel(normalizedCategoryDefault, availableModels, providerHint)
+      const { providers: catProviders, modelID: catModelID } = splitProvidersAndModel(normalizedCategoryDefault)
+      const fusedModel = catProviders.length > 0 && catModelID ? `${catProviders[0]}/${catModelID}` : normalizedCategoryDefault
+      const providerHint = catProviders.length > 0 ? [catProviders[0]] : undefined
+      const match = deps.fuzzyMatchModel(fusedModel, availableModels, providerHint)
       if (match) {
         log("Model resolved via category default (fuzzy matched)", {
           original: normalizedCategoryDefault,
@@ -120,12 +127,11 @@ export function resolveModelPipeline(
         })
         return { model: normalizedCategoryDefault, provenance: "category-default", attempted }
       }
-      const parts = normalizedCategoryDefault.split("/")
-      if (parts.length >= 2) {
-        const provider = parts[0]
-        if (connectedProviders.includes(provider)) {
-          const modelName = parts.slice(1).join("/")
-          const transformedModel = `${provider}/${deps.transformModelForProvider(provider, modelName)}`
+      const { providers: catProviders, modelID: catModelID } = splitProvidersAndModel(normalizedCategoryDefault)
+      if (catProviders.length > 0 && catModelID) {
+        const matchedProvider = catProviders.find(p => connectedProviders.includes(p))
+        if (matchedProvider) {
+          const transformedModel = `${matchedProvider}/${deps.transformModelForProvider(matchedProvider, catModelID)}`
           log("Model resolved via category default (connected provider)", {
             model: transformedModel,
             original: normalizedCategoryDefault,
@@ -149,12 +155,11 @@ export function resolveModelPipeline(
       if (connectedSet !== null) {
         for (const model of userFallbackModels) {
           attempted.push(model)
-          const parts = model.split("/")
-          if (parts.length >= 2) {
-            const provider = parts[0]
-            if (connectedSet.has(provider)) {
-              const modelName = parts.slice(1).join("/")
-              const transformedModel = `${provider}/${deps.transformModelForProvider(provider, modelName)}`
+          const { providers: fbProviders, modelID: fbModelID } = splitProvidersAndModel(model)
+          if (fbProviders.length > 0 && fbModelID) {
+            const matchedProvider = fbProviders.find(p => connectedSet.has(p))
+            if (matchedProvider) {
+              const transformedModel = `${matchedProvider}/${deps.transformModelForProvider(matchedProvider, fbModelID)}`
               log("Model resolved via user fallback_models (connected provider)", { model: transformedModel, original: model })
               return { model: transformedModel, provenance: "provider-fallback", attempted }
             }
@@ -165,9 +170,10 @@ export function resolveModelPipeline(
     } else {
       for (const model of userFallbackModels) {
         attempted.push(model)
-        const parts = model.split("/")
-        const providerHint = parts.length >= 2 ? [parts[0]] : undefined
-        const match = deps.fuzzyMatchModel(model, availableModels, providerHint)
+        const { providers: fbProviders, modelID: fbModelID } = splitProvidersAndModel(model)
+        const providerHint = fbProviders.length > 0 ? [fbProviders[0]] : undefined
+        const fusedModel = fbProviders.length > 0 && fbModelID ? `${fbProviders[0]}/${fbModelID}` : model
+        const match = deps.fuzzyMatchModel(fusedModel, availableModels, providerHint)
         if (match) {
           log("Model resolved via user fallback_models (availability confirmed)", { model: model, match })
           return { model: match, provenance: "provider-fallback", attempted }

--- a/packages/model-core/src/model-string-parser.test.ts
+++ b/packages/model-core/src/model-string-parser.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "bun:test"
+import { parseModelString, parseVariantFromModelID, splitProvidersAndModel } from "./model-string-parser"
+
+describe("splitProvidersAndModel", () => {
+  it("splits provider1|provider2/name format", () => {
+    const result = splitProvidersAndModel("cpa|opencode-go/kimi-k2.6")
+    expect(result).toEqual({ providers: ["cpa", "opencode-go"], modelID: "kimi-k2.6" })
+  })
+
+  it("splits single provider/model format", () => {
+    const result = splitProvidersAndModel("cpa/kimi-k2.6")
+    expect(result).toEqual({ providers: ["cpa"], modelID: "kimi-k2.6" })
+  })
+
+  it("handles provider|model with slashes in model", () => {
+    const result = splitProvidersAndModel("anthropic|cpa/claude-opus-4-8")
+    expect(result).toEqual({ providers: ["anthropic", "cpa"], modelID: "claude-opus-4-8" })
+  })
+
+  it("handles model without provider or slash", () => {
+    const result = splitProvidersAndModel("kimi-k2.6")
+    expect(result).toEqual({ providers: [], modelID: "kimi-k2.6" })
+  })
+
+  it("handles three providers", () => {
+    const result = splitProvidersAndModel("cpa|opencode-go|zai/kimi-k2.6")
+    expect(result).toEqual({ providers: ["cpa", "opencode-go", "zai"], modelID: "kimi-k2.6" })
+  })
+
+  it("returns empty arrays for empty string", () => {
+    const result = splitProvidersAndModel("")
+    expect(result).toEqual({ providers: [], modelID: "" })
+  })
+
+  it("handles trailing slash gracefully", () => {
+    const result = splitProvidersAndModel("cpa|opencode-go/")
+    expect(result).toEqual({ providers: ["cpa", "opencode-go"], modelID: "" })
+  })
+})
+
+describe("parseModelString with pipe syntax", () => {
+  it("extracts first provider from pipe syntax", () => {
+    const result = parseModelString("cpa|opencode-go/kimi-k2.6")
+    expect(result).toEqual({ providerID: "cpa", modelID: "kimi-k2.6" })
+  })
+
+  it("extracts variant from pipe syntax", () => {
+    const result = parseModelString("cpa|opencode-go/kimi-k2.6 high")
+    expect(result).toEqual({ providerID: "cpa", modelID: "kimi-k2.6", variant: "high" })
+  })
+
+  it("standard provider/model still works", () => {
+    const result = parseModelString("openai/gpt-5.4")
+    expect(result).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+  })
+})

--- a/packages/model-core/src/model-string-parser.ts
+++ b/packages/model-core/src/model-string-parser.ts
@@ -45,23 +45,44 @@ export function parseModelString(
   const trimmedModel = model.trim()
   if (!trimmedModel) return undefined
 
-  const separatorIndex = trimmedModel.indexOf("/")
-  if (separatorIndex === -1) {
-    return undefined
-  }
+  const { providers, modelID } = splitProvidersAndModel(model)
+  if (providers.length === 0) return undefined
+  if (!modelID) return undefined
 
-  const providerID = trimmedModel.slice(0, separatorIndex).trim()
-  const rawModelID = trimmedModel.slice(separatorIndex + 1).trim()
-  if (!providerID || !rawModelID) {
-    return undefined
-  }
+  const parsedModel = parseVariantFromModelID(modelID)
+  if (!parsedModel.modelID) return undefined
 
-  const parsedModel = parseVariantFromModelID(rawModelID)
-  if (!parsedModel.modelID) {
-    return undefined
-  }
-
+  const providerID = providers[0]
   return parsedModel.variant
     ? { providerID, modelID: parsedModel.modelID, variant: parsedModel.variant }
     : { providerID, modelID: parsedModel.modelID }
+}
+
+/**
+ * Split a model string into providers and model ID.
+ * Supports pipe syntax: `"cpa|opencode-go/kimi-k2.6"` → providers: [`cpa`, `opencode-go`], modelID: `kimi-k2.6`
+ * Falls back to existing format: `"cpa/kimi-k2.6"` → providers: [`cpa`], modelID: `kimi-k2.6`
+ * No slash: `"model-name"` → providers: [], modelID: `model-name`
+ */
+export function splitProvidersAndModel(
+  s: string,
+): { providers: string[]; modelID: string } {
+  const trimmed = s.trim()
+  if (!trimmed) return { providers: [], modelID: "" }
+
+  const hasPipe = trimmed.includes("|")
+  const slashIndex = hasPipe ? trimmed.lastIndexOf("/") : trimmed.indexOf("/")
+
+
+  if (slashIndex === -1) {
+    return { providers: [], modelID: trimmed }
+  }
+
+  const providersPart = trimmed.slice(0, slashIndex)
+  const modelID = trimmed.slice(slashIndex + 1).trim()
+  const providers = hasPipe
+    ? providersPart.split("|").map(p => p.trim()).filter(Boolean)
+    : [providersPart.trim()].filter(Boolean)
+
+  return { providers, modelID }
 }

--- a/packages/omo-opencode/src/cli/run/model-resolver.test.ts
+++ b/packages/omo-opencode/src/cli/run/model-resolver.test.ts
@@ -80,4 +80,25 @@ describe("resolveRunModel", () => {
     // then
     expect(resolve).toThrow()
   })
+  it("given pipe syntax 'cpa|opencode-go/kimi-k2.6', when resolved, then returns first provider", () => {
+    // given
+    const modelString = "cpa|opencode-go/kimi-k2.6"
+
+    // when
+    const result = resolveRunModel(modelString)
+
+    // then
+    expect(result).toEqual({ providerID: "cpa", modelID: "kimi-k2.6" })
+  })
+
+  it("given pipe syntax with nested slashes 'anthropic|cpa/claude-opus-4-8', when resolved, then returns first provider and full modelID", () => {
+    // given
+    const modelString = "anthropic|cpa/claude-opus-4-8"
+
+    // when
+    const result = resolveRunModel(modelString)
+
+    // then
+    expect(result).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-8" })
+  })
 })

--- a/packages/omo-opencode/src/cli/run/model-resolver.ts
+++ b/packages/omo-opencode/src/cli/run/model-resolver.ts
@@ -1,3 +1,5 @@
+import { splitProvidersAndModel } from "../../shared/model-string-parser"
+
 export function resolveRunModel(
   modelString?: string
 ): { providerID: string; modelID: string } | undefined {
@@ -10,20 +12,10 @@ export function resolveRunModel(
     throw new Error("Model string cannot be empty")
   }
 
-  const parts = trimmed.split("/")
-  if (parts.length < 2) {
-    throw new Error("Model string must be in 'provider/model' format")
+  const { providers, modelID } = splitProvidersAndModel(trimmed)
+  if (providers.length === 0 || !modelID) {
+    throw new Error("Model string must be in 'provider/model' or 'provider1|provider2/name' format")
   }
 
-  const providerID = parts[0]
-  if (providerID.length === 0) {
-    throw new Error("Provider cannot be empty")
-  }
-
-  const modelID = parts.slice(1).join("/")
-  if (modelID.length === 0) {
-    throw new Error("Model ID cannot be empty")
-  }
-
-  return { providerID, modelID }
+  return { providerID: providers[0], modelID }
 }

--- a/packages/omo-opencode/src/hooks/shared/compaction-model-resolver.ts
+++ b/packages/omo-opencode/src/hooks/shared/compaction-model-resolver.ts
@@ -1,3 +1,5 @@
+import { splitProvidersAndModel } from "../../shared/model-string-parser"
+
 import type { OhMyOpenCodeConfig } from "../../config"
 import { getSessionAgent } from "../../features/claude-code-session-state"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
@@ -21,14 +23,13 @@ export function resolveCompactionModel(
   if (!compactionConfig?.model) {
     return { providerID: originalProviderID, modelID: originalModelID }
   }
-
-  const modelParts = compactionConfig.model.split("/")
-  if (modelParts.length < 2) {
+  const { providers, modelID } = splitProvidersAndModel(compactionConfig.model)
+  if (providers.length === 0 || !modelID) {
     return { providerID: originalProviderID, modelID: originalModelID }
   }
 
   return {
-    providerID: modelParts[0],
-    modelID: modelParts.slice(1).join("/"),
+    providerID: providers[0],
+    modelID,
   }
 }

--- a/packages/omo-opencode/src/plugin-handlers/prometheus-agent-config-builder.ts
+++ b/packages/omo-opencode/src/plugin-handlers/prometheus-agent-config-builder.ts
@@ -1,3 +1,5 @@
+import { splitProvidersAndModel } from "../shared/model-string-parser"
+
 import type { CategoryConfig } from "../config/schema";
 import { PROMETHEUS_PERMISSION, getPrometheusPrompt } from "../agents/prometheus";
 import { resolvePromptAppend } from "../agents/builtin-agents/resolve-file-uri";
@@ -31,11 +33,10 @@ function isModelInFallbackChain(
   if (!model || !fallbackChain || fallbackChain.length === 0) {
     return false;
   }
+  const { modelID } = splitProvidersAndModel(model || "")
+  if (!modelID) return false;
 
-  const modelParts = model.split("/");
-  const modelName = modelParts.length >= 2 ? modelParts.slice(1).join("/") : model;
-
-  return fallbackChain.some((entry) => entry.model === modelName);
+  return fallbackChain.some((entry) => entry.model === modelID);
 }
 
 export async function buildPrometheusAgentConfig(params: {

--- a/packages/omo-opencode/src/plugin/ultrawork-model-override.ts
+++ b/packages/omo-opencode/src/plugin/ultrawork-model-override.ts
@@ -1,3 +1,5 @@
+import { splitProvidersAndModel } from "../shared/model-string-parser"
+
 import type { OhMyOpenCodeConfig } from "../config"
 import type { AgentOverrides } from "../config/schema/agent-overrides"
 import { getSessionAgent } from "../features/claude-code-session-state"
@@ -83,13 +85,12 @@ export function resolveUltraworkOverride(
   if (!ultraworkConfig.model) {
     return { variant: ultraworkConfig.variant }
   }
-
-  const modelParts = ultraworkConfig.model.split("/")
-  if (modelParts.length < 2) return null
+  const { providers, modelID } = splitProvidersAndModel(ultraworkConfig.model)
+  if (providers.length === 0 || !modelID) return null
 
   return {
-    providerID: modelParts[0],
-    modelID: modelParts.slice(1).join("/"),
+    providerID: providers[0],
+    modelID,
     variant: ultraworkConfig.variant,
   }
 }

--- a/packages/omo-opencode/src/shared/fallback-chain-from-models.test.ts
+++ b/packages/omo-opencode/src/shared/fallback-chain-from-models.test.ts
@@ -456,4 +456,79 @@ describe("parseFallbackModelEntry: non-string input (issue #4145)", () => {
       },
     ])
   })
+
+})
+describe("buildFallbackChainFromModels with pipe syntax", () => {
+  it("expands cpa|opencode-go/kimi-k2.6 to two entries", () => {
+    const result = buildFallbackChainFromModels(
+      ["cpa|opencode-go/kimi-k2.6"],
+      undefined,
+    )
+    expect(result).toEqual([
+      { providers: ["cpa"], model: "kimi-k2.6" },
+      { providers: ["opencode-go"], model: "kimi-k2.6" },
+    ])
+  })
+
+  it("expands object entry with pipe syntax in model field", () => {
+    const result = buildFallbackChainFromModels(
+      [{ model: "cpa|opencode-go/kimi-k2.6", variant: "medium", reasoningEffort: "high" }],
+      undefined,
+    )
+    expect(result).toEqual([
+      { providers: ["cpa"], model: "kimi-k2.6", variant: "medium", reasoningEffort: "high" },
+      { providers: ["opencode-go"], model: "kimi-k2.6", variant: "medium", reasoningEffort: "high" },
+    ])
+  })
+
+  it("mixed array of pipe and standard entries", () => {
+    const result = buildFallbackChainFromModels(
+      [
+        "cpa|opencode-go/kimi-k2.6",
+        "google/gemini-3-flash",
+        { model: "cpa/glm-5", variant: "low" },
+      ],
+      undefined,
+    )
+    expect(result).toEqual([
+      { providers: ["cpa"], model: "kimi-k2.6" },
+      { providers: ["opencode-go"], model: "kimi-k2.6" },
+      { providers: ["google"], model: "gemini-3-flash" },
+      { providers: ["cpa"], model: "glm-5", variant: "low" },
+    ])
+  })
+
+  it("standard provider/model still works alongside pipe entries", () => {
+    const result = buildFallbackChainFromModels(
+      ["cpa/kimi-k2.5", "opencode-go/big-pickle"],
+      undefined,
+    )
+    expect(result).toEqual([
+      { providers: ["cpa"], model: "kimi-k2.5" },
+      { providers: ["opencode-go"], model: "big-pickle" },
+    ])
+  })
+
+  it("object entry parses inline variant from pipe-syntax model", () => {
+    const result = buildFallbackChainFromModels(
+      [{ model: "cpa|opencode-go/kimi-k2.6 high" }],
+      undefined,
+    )
+    expect(result).toEqual([
+      { providers: ["cpa"], model: "kimi-k2.6", variant: "high" },
+      { providers: ["opencode-go"], model: "kimi-k2.6", variant: "high" },
+    ])
+  })
+})
+
+describe("parseFallbackModelEntry with pipe syntax", () => {
+  it("uses first provider from pipe syntax", () => {
+    const result = parseFallbackModelEntry("cpa|opencode-go/kimi-k2.6", undefined)
+    expect(result).toEqual({ providers: ["cpa"], model: "kimi-k2.6" })
+  })
+
+  it("parses variant from pipe-syntax model", () => {
+    const result = parseFallbackModelEntry("cpa|opencode-go/kimi-k2.6 high", undefined)
+    expect(result).toEqual({ providers: ["cpa"], model: "kimi-k2.6", variant: "high" })
+  })
 })

--- a/packages/omo-opencode/src/shared/model-string-parser.ts
+++ b/packages/omo-opencode/src/shared/model-string-parser.ts
@@ -1,1 +1,1 @@
-export { parseVariantFromModelID, parseModelString } from "@oh-my-opencode/model-core"
+export { parseVariantFromModelID, parseModelString, splitProvidersAndModel } from "@oh-my-opencode/model-core"


### PR DESCRIPTION
## Summary

Adds `|` (pipe) syntax to model strings, allowing multiple providers for the same model in a compact single entry. Example: `"cpa|opencode-go/kimi-k2.6"` expands to two fallback entries — `cpa/kimi-k2.6` and `opencode-go/kimi-k2.6`. This dramatically reduces fallback_models config verbosity when using multiple budget providers.

## Changes

- **`model-string-parser.ts`**: New `splitProvidersAndModel()` utility — split on last `/` for providers+model, split providers on `|`. Updated `parseModelString()` to use it.
- **`fallback-chain-from-models.ts`**: `buildFallbackChainFromModels()` expands pipe entries into multiple `FallbackEntry` entries. Object entries preserve variant/temperature/etc across all expanded entries. Inline variants parsed from pipe model strings.
- **`model-resolution-pipeline.ts`**: Normalizes pipe syntax in `userModel`, `uiSelectedModel`, `categoryDefaultModel`, and `userFallbackModels`. Fuzzy matches use first provider from pipe list.
- **`model-format-normalizer.ts`**: `normalizeModelFormat()` extracts first provider from pipe syntax.
- **Adapter shims** (`model-resolver.ts`, `ultrawork-model-override.ts`, `compaction-model-resolver.ts`, `prometheus-agent-config-builder.ts`): all accept pipe syntax.
- **Tests**: New `model-string-parser.test.ts`, pipe tests added to `fallback-chain-from-models.test.ts` and `model-resolver.test.ts`.

## Verification

**Automated:** `bun run typecheck` ✅ · `bun run build` ✅
**Manual:** All key parsing scenarios tested via `bun --eval` (pipe strings, fallback chain expansion, variant parsing, pipeline resolution)

## Related Issues

Closes #5323

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for pipe syntax in model strings like "provider1|provider2/name" to reduce config noise. Pipe entries expand into multiple fallbacks; overrides use the first provider, while defaults/fallbacks pick any connected provider from the list. Closes #5323.

- New Features
  - Added `splitProvidersAndModel()` and used it across parsing, normalization, resolution, CLI, and plugins.
  - `buildFallbackChainFromModels()` expands pipe entries (strings and objects), preserves options, and parses inline variants.
  - Resolution pipeline normalizes pipe syntax for `userModel`, `uiSelectedModel`, `categoryDefaultModel`, and `fallback_models`; fuzzy matches hint with the first provider; defaults/fallbacks choose a connected provider from the list.
  - `normalizeModelFormat()` and `parseModelString()` extract the first provider from pipe syntax.
  - CLI and plugins accept pipe syntax (`model-resolver`, `compaction-model-resolver`, `ultrawork-model-override`, `prometheus-agent-config-builder` compares by parsed modelID).
  - Added tests for parser, fallback expansion, resolution, and CLI.

<sup>Written for commit 8184de0d687a92ef5b880009d49513e1d15664d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

