### PR TITLE
fix(keyword-detector): skip mode injection on internal-initiator wake messages

### DIFF
--- a/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
@@ -8,8 +8,10 @@ import {
 } from "../../features/claude-code-session-state"
 import type { ContextCollector } from "../../features/context-injector"
 import {
+  hasInternalInitiatorMarker,
   isRealUserTextPart,
   isSyntheticOrInternalOnlyTextParts,
+  isTextPartLike,
   log,
 } from "../../shared"
 import {
@@ -69,6 +71,11 @@ export function createKeywordDetectorHook(
     ): Promise<void> => {
       if (isSyntheticOrInternalOnlyTextParts(output.parts)) {
         log(`[keyword-detector] Skipping synthetic/internal text message`, { sessionID: input.sessionID })
+        return
+      }
+
+      if ((output.parts ?? []).some((part) => isTextPartLike(part) && hasInternalInitiatorMarker(part.text))) {
+        log(`[keyword-detector] Skipping internal-initiator wake message`, { sessionID: input.sessionID })
         return
       }
 

--- a/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
@@ -86,6 +86,28 @@ describe("keyword-detector message transform", () => {
     expect(text).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
   })
 
+  test("should skip keyword injection when any part carries the internal-initiator marker", async () => {
+    // given - an OMO-internal wake whose parts mix a marker part with a real-looking user part
+    const collector = new ContextCollector()
+    const sessionID = "internal-wake-mixed-parts"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [
+        { type: "text", text: OMO_INTERNAL_INITIATOR_MARKER },
+        { type: "text", text: "ultrawork fix the flaky suite" },
+      ],
+    }
+
+    // when - keyword detection runs on the mixed internal wake
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - no mode prompt is injected and both parts stay untouched
+    expect(output.parts[0].text).toBe(OMO_INTERNAL_INITIATOR_MARKER)
+    expect(output.parts[1].text).toBe("ultrawork fix the flaky suite")
+  })
+
   test("should leave search wording as plain user text", async () => {
     // given - mock getMainSessionID to return our session (isolate from global state)
     const collector = new ContextCollector()


### PR DESCRIPTION
## Summary

`keyword-detector`'s `chat.message` handler injected mode prompts (e.g. `[analyze-mode]`, ultrawork) into OMO-internal wake messages emitted on background-task completion. Those wakes are tagged with `<!-- OMO_INTERNAL_INITIATOR -->`, but the existing guard `isSyntheticOrInternalOnlyTextParts` only skips when **every** text part is synthetic/internal. A wake that mixes a real-looking content part with a separate marker part slips through, so the agent re-runs mode setup instead of immediately collecting results and continuing.

## Fix

Add a second early return in the `chat.message` handler: skip keyword detection when **any** text part carries the internal-initiator marker, reusing the existing `hasInternalInitiatorMarker` helper.

```ts
if ((output.parts ?? []).some((part) => isTextPartLike(part) && hasInternalInitiatorMarker(part.text))) {
  log(`[keyword-detector] Skipping internal-initiator wake message`, { sessionID: input.sessionID })
  return
}
```

This matches the approach suggested in the issue, using the typed `isTextPartLike` guard from the shared barrel instead of `any` casts.

## Tests

- Added a regression test: an internal wake whose parts mix a marker part with a real-looking ultrawork part must receive no mode injection.
- Verified it **fails without** the guard (the detector injects the full `<ultrawork-mode>` prompt into the user part) and **passes with** it.
- `bun test packages/omo-opencode/src/hooks/keyword-detector/index.test.ts` -> 48 pass / 0 fail.
- `tsgo --noEmit -p packages/omo-opencode/tsconfig.json` -> 0 errors.

Fixes #5326

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `keyword-detector` from injecting mode prompts into OMO internal wake messages by skipping detection when any part contains the internal-initiator marker, fixing #5326. This stops wasted turns where the agent re-enters mode setup and lets it continue processing results.

- **Bug Fixes**
  - Added an early return in `chat.message` to skip when any text part has `<!-- OMO_INTERNAL_INITIATOR -->` using `hasInternalInitiatorMarker` with `isTextPartLike`.
  - Ensures mixed internal wakes (marker + real-looking content) are left unchanged (no `[analyze-mode]`/ultrawork injection).
  - Added a regression test for the mixed-parts case.

<sup>Written for commit 5cfd66054831a4eb84004263339a3dc8202eb8bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

