### PR TITLE
fix(team-core): expand leading ~ in team_mode.base_dir

### DIFF
--- a/packages/team-core/src/team-registry/paths.test.ts
+++ b/packages/team-core/src/team-registry/paths.test.ts
@@ -51,6 +51,30 @@ describe("paths", () => {
     expect(resolvedBaseDir).toBe("/tmp/test-abc")
   })
 
+  test("resolveBaseDir expands a leading ~ in base_dir to the home directory", () => {
+    // given — regression for #5331: raw "~/.omo" must not reach mkdir unexpanded
+    const config = TeamModeConfigSchema.parse({ base_dir: "~/.omo" })
+
+    // when
+    const resolvedBaseDir = resolveBaseDir(config)
+
+    // then
+    expect(resolvedBaseDir).toBe(path.join(homedir(), ".omo"))
+    expect(resolvedBaseDir).not.toBe("~/.omo")
+  })
+
+  test("resolveBaseDir expands a leading ~ for an arbitrary base_dir path", () => {
+    // given
+    const config = TeamModeConfigSchema.parse({ base_dir: "~/some/custom/team-root" })
+
+    // when
+    const resolvedBaseDir = resolveBaseDir(config)
+
+    // then
+    expect(resolvedBaseDir).toBe(path.join(homedir(), "some/custom/team-root"))
+    expect(resolvedBaseDir.startsWith("~")).toBe(false)
+  })
+
   test("#given team runtime ids contain traversal #when runtime paths are built #then they are rejected before escaping base dir", () => {
     // given
     const baseDir = "/tmp/omo-contained"

--- a/packages/team-core/src/team-registry/paths.ts
+++ b/packages/team-core/src/team-registry/paths.ts
@@ -66,7 +66,8 @@ function resolveContainedPath(baseDir: string, pathSegments: readonly string[]):
 }
 
 export function resolveBaseDir(config: TeamModeConfig): string {
-  return config.base_dir ?? path.join(homedir(), ".omo")
+  const resolved = config.base_dir ?? path.join(homedir(), ".omo")
+  return resolved.startsWith("~") ? path.join(homedir(), resolved.slice(1)) : resolved
 }
 
 export function getTeamSpecPath(


### PR DESCRIPTION
## Summary

Fixes #5331.

`resolveBaseDir()` in `packages/team-core/src/team-registry/paths.ts` returned `config.base_dir` verbatim. When `team_mode.base_dir` is set to the literal string `"~/.omo"` (a natural value, since the docs describe `~/.omo` as the default location), the raw string reached `mkdir("~/.omo", { recursive: true })` and Node/Bun treated `~` as a literal directory name. Result: a real directory named `~` was created in the cwd, and `$HOME/.omo` was never written.

This pollutes every directory opencode is launched in with a junk `~` folder.

## Root cause

3-link chain:

1. Config: `~/.config/opencode/oh-my-openagent.jsonc` sets `"team_mode": { "enabled": true, "base_dir": "~/.omo" }`.
2. Code: `resolveBaseDir(config) = config.base_dir ?? path.join(homedir(), ".omo")`. Because `base_dir` is set, the `homedir()` fallback is never reached, so the literal `"~/.omo"` is returned.
3. Exec: `ensureBaseDirs("~/.omo")` calls `mkdir("~/.omo", { recursive: true })`. With no shell in the path there is no tilde expansion, so a literal `~` directory is created.

## Fix

Expand a leading `~` via `homedir()` before returning from `resolveBaseDir()`. Covers both the config-supplied and the default path:

```ts
export function resolveBaseDir(config: TeamModeConfig): string {
  const resolved = config.base_dir ?? path.join(homedir(), ".omo")
  return resolved.startsWith("~") ? path.join(homedir(), resolved.slice(1)) : resolved
}
```

## Verification

- strace before fix: `mkdir("~/.omo") = -1 ENOENT` then `mkdir("~") = 0` then `mkdir("~/.omo/teams"|"runtime"|"worktrees") = 0`.
- After the fix, `opencode run "hi"` in a fresh dir produces no literal `~`, and `$HOME/.omo/{runtime,teams,worktrees}` is created in the correct location.
- `--pure` run (plugins disabled) already produced an empty dir, confirming the culprit is the plugin and not opencode core.

## Tests

Added two regression tests in `packages/team-core/src/team-registry/paths.test.ts` (given/when/then):

- `resolveBaseDir` expands `base_dir: "~/.omo"` to `path.join(homedir(), ".omo")`.
- `resolveBaseDir` expands an arbitrary `~/some/custom/team-root`.

Suite results:

- `bun test packages/team-core/`: 144 pass, 1 skip, 0 fail.
- `bun test packages/omo-opencode/src/features/team-mode/`: 297 pass, 1 skip, 0 fail.

## Notes

- This is the same bug class as opencode core #32223 and #23695 (tilde not expanded in path arguments / plugin config).
- Scope is intentionally minimal: the single shared `resolveBaseDir()` used by all team-mode path resolution, so every consumer (mailbox, tasks, runtime state, worktrees, team specs) benefits from one fix.
- Targets `dev` per the contribution policy; merge-commit preferred.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand a leading `~` in `team_mode.base_dir` to the user home so we don’t create a literal `~` directory and team data goes under `$HOME/.omo`. Fixes #5331.

- **Bug Fixes**
  - Update `resolveBaseDir()` to map paths starting with `~` using `homedir()`.
  - Add regression tests for `"~/.omo"` and `"~/some/custom/team-root"`.

<sup>Written for commit 9172a02a35fe7645d70adc353671637a0a3c4542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

