### PR TITLE
feat(team-mode): add per-member allowedPaths edit gate for inline members

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
@@ -102,6 +102,12 @@ function buildMemberPrompt(
 ): string {
   const promptLines = [`Team: ${spec.name}`, `TeamRunId: ${teamRunId}`, `Member: ${member.name}`]
   if (worktreePath) promptLines.push(`Worktree: ${worktreePath}`)
+  if (member.allowedPaths && member.allowedPaths.length > 0 && !worktreePath) {
+    promptLines.push(
+      `AllowedPaths (glob): ${member.allowedPaths.join(", ")}`,
+      "You may ONLY edit files matching these patterns. Do NOT modify, revert (git restore/checkout), or delete files outside your assignment — other members own those files and your edits will be hard-blocked by the edit tool.",
+    )
+  }
   if (member.prompt) promptLines.push(member.prompt)
   promptLines.push(buildTeammateCommunicationAddendum(config))
   return promptLines.join("\n")

--- a/packages/omo-opencode/src/features/team-mode/tools/lifecycle-create-tool.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/lifecycle-create-tool.ts
@@ -28,6 +28,7 @@ const TeamCreateInlineMemberToolSchema = tool.schema.object({
   loadSkills: tool.schema.array(tool.schema.string()).optional().describe("Optional skills to load for this member."),
   role: tool.schema.string().optional().describe("Optional natural-language role used to build a prompt when prompt is omitted."),
   description: tool.schema.string().optional().describe("Optional natural-language description used to build a prompt when prompt is omitted."),
+  allowedPaths: tool.schema.array(tool.schema.string()).optional().describe("Optional glob allow-list (picomatch). Inline members (no worktree) are hard-gated to these paths on the edit tool; worktree members bypass it."),
 })
 
 const TeamCreateInlineSpecToolSchema = tool.schema.union([

--- a/packages/omo-opencode/src/hooks/team-tool-gating/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/team-tool-gating/hook.test.ts
@@ -49,6 +49,18 @@ function createRuntimeState(): RuntimeState {
   }
 }
 
+function createRuntimeStateWithMemberBoundary(
+  memberName: string,
+  boundary: { allowedPaths?: string[]; worktreePath?: string },
+): RuntimeState {
+  return {
+    ...createRuntimeState(),
+    members: createRuntimeState().members.map((member) =>
+      member.name === memberName ? { ...member, ...boundary } : member,
+    ),
+  }
+}
+
 async function seedTeams(baseDir: string, ...runtimeStates: RuntimeState[]): Promise<void> {
   const config = TeamModeConfigSchema.parse({ base_dir: baseDir, enabled: true })
   await Promise.all(runtimeStates.map(async (runtimeState) => {
@@ -285,5 +297,96 @@ describe("createTeamToolGating", () => {
 
     // then
     await expect(result).rejects.toThrow("denied: not a participant of team 11111111-1111-4111-8111-111111111111")
+  })
+
+  test("allows an inline member to edit a file inside its allowedPaths", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))
+    temporaryDirectories.push(baseDir)
+    await seedTeams(baseDir, createRuntimeStateWithMemberBoundary("m1", { allowedPaths: ["src/ui/**"] }))
+
+    // when
+    const result = runHook("edit", "member-session-1", { filePath: "src/ui/Button.tsx" }, undefined, baseDir)
+
+    // then
+    await expect(result).resolves.toBeUndefined()
+  })
+
+  test("rejects an inline member editing a file outside its allowedPaths", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))
+    temporaryDirectories.push(baseDir)
+    await seedTeams(baseDir, createRuntimeStateWithMemberBoundary("m1", { allowedPaths: ["src/ui/**"] }))
+
+    // when
+    const result = runHook("edit", "member-session-1", { filePath: "src/api/handler.ts" }, undefined, baseDir)
+
+    // then
+    await expect(result).rejects.toThrow(/outside member m1's allowedPaths/)
+  })
+
+  test("allows an inline member to edit any file when allowedPaths is unset", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))
+    temporaryDirectories.push(baseDir)
+    await seedTeams(baseDir, createRuntimeState())
+
+    // when
+    const result = runHook("edit", "member-session-1", { filePath: "src/anywhere/handler.ts" }, undefined, baseDir)
+
+    // then
+    await expect(result).resolves.toBeUndefined()
+  })
+
+  test("bypasses the allow-list gate for a worktree member even with allowedPaths set", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))
+    temporaryDirectories.push(baseDir)
+    await seedTeams(baseDir, createRuntimeStateWithMemberBoundary("m1", { allowedPaths: ["src/ui/**"], worktreePath: "/tmp/worktree-m1" }))
+
+    // when
+    const result = runHook("edit", "member-session-1", { filePath: "src/api/handler.ts" }, undefined, baseDir)
+
+    // then
+    await expect(result).resolves.toBeUndefined()
+  })
+
+  test("allows the lead to edit any file (allowedPaths is member-only)", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))
+    temporaryDirectories.push(baseDir)
+    await seedTeams(baseDir, createRuntimeStateWithMemberBoundary("m1", { allowedPaths: ["src/ui/**"] }))
+
+    // when
+    const result = runHook("edit", "lead-session", { filePath: "src/api/handler.ts" }, undefined, baseDir)
+
+    // then
+    await expect(result).resolves.toBeUndefined()
+  })
+
+  test("allows a non-team session to edit without team gating", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))
+    temporaryDirectories.push(baseDir)
+    await seedTeams(baseDir, createRuntimeStateWithMemberBoundary("m1", { allowedPaths: ["src/ui/**"] }))
+
+    // when
+    const result = runHook("edit", "non-team-session", { filePath: "src/api/handler.ts" }, undefined, baseDir)
+
+    // then
+    await expect(result).resolves.toBeUndefined()
+  })
+
+  test("rejects an inline member editing via a cwd-escaping path", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))
+    temporaryDirectories.push(baseDir)
+    await seedTeams(baseDir, createRuntimeStateWithMemberBoundary("m1", { allowedPaths: ["src/ui/**"] }))
+
+    // when
+    const result = runHook("edit", "member-session-1", { filePath: "../outside-repo/secret.ts" }, undefined, baseDir)
+
+    // then
+    await expect(result).rejects.toThrow(/outside member m1's allowedPaths/)
   })
 })

--- a/packages/omo-opencode/src/hooks/team-tool-gating/hook.ts
+++ b/packages/omo-opencode/src/hooks/team-tool-gating/hook.ts
@@ -1,4 +1,6 @@
 import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import picomatch from "picomatch"
+import path from "node:path"
 
 import type { TeamModeConfig } from "../../config/schema/team-mode"
 import { lookupTeamSession } from "../../features/team-mode/team-session-registry"
@@ -78,7 +80,7 @@ function isTargetMember(participant: TeamParticipant, teamRunId: string | undefi
     && participant.memberName === memberName
 }
 
-export function createTeamToolGating(_ctx: PluginInput, config: TeamModeConfig | undefined): Hooks {
+export function createTeamToolGating(ctx: PluginInput, config: TeamModeConfig | undefined): Hooks {
   return {
     "tool.execute.before": async (
       input: { tool: string; sessionID: string; callID: string },
@@ -89,6 +91,12 @@ export function createTeamToolGating(_ctx: PluginInput, config: TeamModeConfig |
       }
 
       const toolName = input.tool
+
+      if (toolName === "edit") {
+        await enforceEditAllowedPaths(input.sessionID, output.args, ctx, config)
+        return
+      }
+
       if (!toolName.startsWith("team_") && toolName !== "delegate-task") {
         return
       }
@@ -145,5 +153,59 @@ export function createTeamToolGating(_ctx: PluginInput, config: TeamModeConfig |
         )
       }
     },
+  }
+}
+
+type MemberFileBoundary = {
+  worktreePath?: string
+  allowedPaths?: string[]
+}
+
+async function resolveMemberFileBoundary(
+  teamRunId: string,
+  memberName: string,
+  config: TeamModeConfig,
+): Promise<MemberFileBoundary | undefined> {
+  const runtimeState = await loadRuntimeState(teamRunId, config)
+  if (!ACTIVE_RUNTIME_STATUSES.has(runtimeState.status)) return undefined
+  const member = runtimeState.members.find((entry) => entry.name === memberName)
+  if (!member) return undefined
+  return { worktreePath: member.worktreePath, allowedPaths: member.allowedPaths }
+}
+
+// Resolves filePath against cwd, rejects cwd-escaping paths (../ or absolute outside cwd),
+// then matches the cwd-relative path against the glob allow-list via picomatch.
+function isEditPathAllowed(allowedPaths: string[], filePath: string, cwd: string): boolean {
+  const resolved = path.resolve(cwd, filePath)
+  const relative = path.relative(cwd, resolved)
+  if (relative === "") return false
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return false
+  return picomatch.isMatch(relative, allowedPaths, { dot: true })
+}
+
+async function enforceEditAllowedPaths(
+  sessionID: string,
+  args: Record<string, unknown>,
+  ctx: PluginInput,
+  config: TeamModeConfig,
+): Promise<void> {
+  const participant = await resolveParticipant(sessionID, config)
+  if (participant.role !== "member") return
+
+  const boundary = await resolveMemberFileBoundary(participant.teamRunId, participant.memberName, config)
+  if (!boundary) return
+  // Worktree members are filesystem-isolated; skip the gate.
+  if (boundary.worktreePath) return
+  // No allow-list set = unrestricted (backward compatible).
+  if (!boundary.allowedPaths || boundary.allowedPaths.length === 0) return
+
+  const filePath = getStringArg(args, "filePath")
+  if (!filePath) {
+    throw new Error(`edit denied: member ${participant.memberName} has allowedPaths set but no filePath was provided`)
+  }
+  if (!isEditPathAllowed(boundary.allowedPaths, filePath, ctx.directory)) {
+    throw new Error(
+      `edit denied: "${filePath}" is outside member ${participant.memberName}'s allowedPaths [${boundary.allowedPaths.join(", ")}]`,
+    )
   }
 }

--- a/packages/team-core/src/team-state-store/store.ts
+++ b/packages/team-core/src/team-state-store/store.ts
@@ -141,6 +141,7 @@ export async function createRuntimeState(
       status: "pending",
       color: member.color,
       worktreePath: member.worktreePath,
+      allowedPaths: member.allowedPaths,
       lastInjectedTurnMarker: undefined,
       pendingInjectedMessageIds: [],
     })),

--- a/packages/team-core/src/types.ts
+++ b/packages/team-core/src/types.ts
@@ -27,6 +27,9 @@ const MemberBaseSchema = z.object({
   name: z.string().min(1).regex(/^[a-z0-9-]+$/),
   cwd: z.string().optional(),
   worktreePath: z.string().optional(),
+  // Glob allow-list (picomatch). Inline members are hard-gated to these paths on the `edit` tool
+  // via team-tool-gating; worktree members bypass it (filesystem-isolated). Unset = unrestricted.
+  allowedPaths: z.array(z.string().min(1)).optional(),
   subscriptions: z.array(z.string()).optional(),
   backendType: z.enum(["in-process", "tmux"]).default("in-process"),
   color: z.string().optional(),
@@ -143,6 +146,7 @@ const RuntimeStateMemberSchema = z.object({
   status: z.enum(["pending", "running", "idle", "errored", "completed", "shutdown_approved"]),
   color: z.string().optional(),
   worktreePath: z.string().optional(),
+  allowedPaths: z.array(z.string()).optional(),
   lastInjectedTurnMarker: z.string().optional(),
   pendingInjectedMessageIds: z.array(z.string()).default([]),
 }).strict()


### PR DESCRIPTION
Closes #5333

## Problem

In **Team Mode inline mode** (no worktree), all member agents share the same working directory with no filesystem isolation. Today, `team-tool-gating` only inspects `team_*` tools — the `edit` and `bash` tools are never checked. So a member can freely mutate any file, including files owned by another member's assignment.

The lead's `git diff --stat` verification only catches **additive** scope creep; it does **not** catch destructive reverts (`git restore`/`checkout`) that silently wipe another member's uncommitted edits. This is the exact failure mode hit in real parallel team runs and relates to #2494 and #3599.

## Solution

Add an optional **per-member `allowedPaths` glob allow-list** to `TeamSpec` members. When set on an **inline** member (no `worktreePath`), the `team-tool-gating` hook hard-gates the `edit` tool: any `filePath` outside the allow-list is rejected before execution. Worktree members bypass the gate (already filesystem-isolated); unset means unrestricted (fully backward compatible).

```yamlc
members:
  - name: frontend-worker
    category: visual-engineering
    allowedPaths: ["src/ui/**", "src/components/**"]
    prompt: "..."
  - name: backend-worker
    category: quick
    allowedPaths: ["src/api/**", "src/db/**"]
    prompt: "..."
```

**Path matching:** glob via `picomatch`, paths normalized with `path.resolve(cwd, filePath)`. Paths that escape cwd (absolute outside cwd, or `../` traversal) are always rejected.

**Soft layer:** `buildMemberPrompt` injects the member's allowed paths plus an explicit warning not to modify/revert files outside its assignment, so well-behaved models self-correct before hitting the hard gate.

## Files Changed

| File | Change |
|------|--------|
| `packages/team-core/src/types.ts` | `allowedPaths` on `MemberBaseSchema` + `RuntimeStateMemberSchema` |
| `packages/team-core/src/team-state-store/store.ts` | Copy `allowedPaths` from spec member → runtime member |
| `packages/omo-opencode/.../team-runtime/create.ts` | `buildMemberPrompt` injects allowed paths + warning (inline only) |
| `packages/omo-opencode/.../hooks/team-tool-gating/hook.ts` | `edit` path enforcement: picomatch match + cwd-escape rejection |
| `packages/omo-opencode/.../tools/lifecycle-create-tool.ts` | Expose `allowedPaths` on inline member tool schema |
| `packages/omo-opencode/.../hooks/team-tool-gating/hook.test.ts` | 7 new tests covering allow/deny/bypass/cwd-escape/lead/neither |

+178 / −1 across 6 files.

## Explicitly out of scope

- **`bash` command parsing** — intentionally NOT done in this PR. Shell parsing is a rabbit hole that gives a false sense of security. The `edit` hard gate covers the primary mutation path cleanly; the prompt warning covers the destructive-git case. `bash` interception can be a follow-up if needed.
- **Activating the existing team-level `teamAllowedPaths`** — it is currently declared on `TeamSpec` and surfaced on the `team_create` tool but nothing enforces it (dead field). Intersection semantics (team ∩ member) are deferred to a follow-up to keep this PR focused on the per-member partition that actually solves the incident. Flagged here for transparency.

## Verification

- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test` for `team-tool-gating` (21), `team-core` types/store/registry (64), `team-runtime/create` (14) — all pass ✅

## Checklist

- [x] Forked from `dev`, branch `feat/team-inline-file-protection`
- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] Tests added and passing
- [x] No `as any` / `@ts-ignore`
- [x] Backward compatible (optional field, opt-in)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-member allowedPaths allow-list for inline team members and hard-gates the `edit` tool to those paths, preventing cross-member edits and destructive reverts in shared workspaces. Addresses #5333 by enforcing file boundaries without breaking existing teams.

- **New Features**
  - Adds optional `allowedPaths` to `TeamSpec` members; enforced by `team-tool-gating` for `edit` when inline (no worktree).
  - Uses `picomatch` to match cwd-relative paths; rejects any path that escapes the repo.
  - Worktree members bypass the gate; unset `allowedPaths` means no restriction; leads are unaffected.
  - Injects allowed paths and a warning into `buildMemberPrompt` for inline members.
  - Propagates `allowedPaths` to runtime state and the inline member tool schema; adds tests for allow/deny/bypass and cwd-escape cases.

<sup>Written for commit 1d721bc1614e7ac92136795e31f8520e08fe1f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

