### PR TITLE
test: optimize local and CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -242,8 +242,41 @@ jobs:
       - name: Verify dist bundle tests
         run: bun test packages/omo-opencode/src/shared/dist-bundle-bun-globals.test.ts packages/omo-opencode/src/shared/dist-bundle-prompt-content.test.ts
 
+  auto-commit-schema:
+    runs-on: ubuntu-latest
+    needs: [test, typecheck, codex-compatibility, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12"
+
+      - name: Build vendored lsp-tools-mcp package
+        run: npm ci && npm run build
+        working-directory: packages/lsp-tools-mcp
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build vendored lsp-daemon package
+        run: npm ci && npm run build
+        working-directory: packages/lsp-daemon
+
+      - name: Build
+        run: bun run build
+
       - name: Auto-commit schema changes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           if git diff --quiet assets/oh-my-opencode.schema.json; then
             echo "No schema changes to commit"
@@ -257,7 +290,7 @@ jobs:
 
   draft-release:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [test, typecheck, codex-compatibility, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
+          cache: npm
+          cache-dependency-path: |
+            packages/lsp-tools-mcp/package-lock.json
+            packages/lsp-daemon/package-lock.json
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -103,6 +107,10 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
+          cache: npm
+          cache-dependency-path: |
+            packages/lsp-tools-mcp/package-lock.json
+            packages/lsp-daemon/package-lock.json
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -142,6 +150,10 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
+          cache: npm
+          cache-dependency-path: |
+            packages/lsp-tools-mcp/package-lock.json
+            packages/lsp-daemon/package-lock.json
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -211,6 +223,11 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-vendored-${{ hashFiles('packages/lsp-tools-mcp/package-lock.json', 'packages/lsp-daemon/package-lock.json') }}
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [test, typecheck, codex-compatibility]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
-          cache: npm
-          cache-dependency-path: |
-            packages/lsp-tools-mcp/package-lock.json
-            packages/lsp-daemon/package-lock.json
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -107,10 +103,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
-          cache: npm
-          cache-dependency-path: |
-            packages/lsp-tools-mcp/package-lock.json
-            packages/lsp-daemon/package-lock.json
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -150,10 +142,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
-          cache: npm
-          cache-dependency-path: |
-            packages/lsp-tools-mcp/package-lock.json
-            packages/lsp-daemon/package-lock.json
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -223,11 +211,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/cache@v5
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-vendored-${{ hashFiles('packages/lsp-tools-mcp/package-lock.json', 'packages/lsp-daemon/package-lock.json') }}
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-vendored-${{ hashFiles('packages/lsp-tools-mcp/package-lock.json', 'packages/lsp-daemon/package-lock.json') }}

--- a/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
@@ -29,7 +29,9 @@ type SessionMessageForTest = {
 
 type FakeTimers = {
   getDelay: (timer: ReturnType<typeof setTimeout>) => number | undefined
-  run: (timer: ReturnType<typeof setTimeout>) => void
+  run: (timer: ReturnType<typeof setTimeout>) => Promise<void>
+  advanceBy: (ms: number) => Promise<void>
+  runNext: () => Promise<boolean>
   restore: () => void
 }
 
@@ -82,6 +84,10 @@ function createManager(
   manager: BackgroundManager
   promptAsyncCalls: PromptAsyncCall[]
 } {
+  if (enableParentSessionNotifications && !fakeTimers) {
+    fakeTimers = installFakeTimers()
+  }
+
   const promptAsyncCalls: PromptAsyncCall[] = []
   const client = {
     session: {
@@ -117,8 +123,11 @@ function createManager(
 function installFakeTimers(): FakeTimers {
   const originalSetTimeout = globalThis.setTimeout
   const originalClearTimeout = globalThis.clearTimeout
-  const callbacks = new Map<ReturnType<typeof setTimeout>, () => void>()
+  const originalDateNow = Date.now
+  const callbacks = new Map<ReturnType<typeof setTimeout>, () => void | Promise<void>>()
   const delays = new Map<ReturnType<typeof setTimeout>, number>()
+  const dueTimes = new Map<ReturnType<typeof setTimeout>, number>()
+  let now = Date.now()
 
   globalThis.setTimeout = ((handler: Parameters<typeof setTimeout>[0], delay?: number, ...args: unknown[]): ReturnType<typeof setTimeout> => {
     if (typeof handler !== "function") {
@@ -129,33 +138,66 @@ function installFakeTimers(): FakeTimers {
     originalClearTimeout(timer)
     const callback = handler as (...callbackArgs: Array<unknown>) => void
     callbacks.set(timer, () => callback(...args))
-    delays.set(timer, delay ?? 0)
+    const normalizedDelay = Math.max(0, delay ?? 0)
+    delays.set(timer, normalizedDelay)
+    dueTimes.set(timer, now + normalizedDelay)
     return timer
   }) as typeof setTimeout
 
   globalThis.clearTimeout = ((timer: ReturnType<typeof setTimeout>): void => {
     callbacks.delete(timer)
     delays.delete(timer)
+    dueTimes.delete(timer)
   }) as typeof clearTimeout
+  Date.now = () => now
 
   return {
     getDelay(timer) {
       return delays.get(timer)
     },
-    run(timer) {
+    async run(timer) {
       const callback = callbacks.get(timer)
       if (!callback) {
         throw new Error(`Timer not found: ${String(timer)}`)
       }
 
+      now = dueTimes.get(timer) ?? now
       callbacks.delete(timer)
       delays.delete(timer)
-      callback()
+      dueTimes.delete(timer)
+      await callback()
+      await flushMicrotasks()
+    },
+    async advanceBy(ms) {
+      const target = now + ms
+      while (true) {
+        const nextTimer = nextTimerDueBefore(target)
+        if (!nextTimer) break
+        await this.run(nextTimer)
+      }
+      now = target
+      await flushMicrotasks()
+    },
+    async runNext() {
+      const nextTimer = nextTimerDueBefore(Number.POSITIVE_INFINITY)
+      if (!nextTimer) {
+        await flushMicrotasks()
+        return false
+      }
+      await this.run(nextTimer)
+      return true
     },
     restore() {
       globalThis.setTimeout = originalSetTimeout
       globalThis.clearTimeout = originalClearTimeout
+      Date.now = originalDateNow
     },
+  }
+
+  function nextTimerDueBefore(target: number): ReturnType<typeof setTimeout> | undefined {
+    return [...dueTimes.entries()]
+      .filter(([, dueAt]) => dueAt <= target)
+      .sort((left, right) => left[1] - right[1])[0]?.[0]
   }
 }
 
@@ -178,6 +220,13 @@ function getPendingParentWakes(manager: BackgroundManager): Map<string, PendingP
   return parentWakeNotifier.getPendingParentWakes()
 }
 
+function getPendingParentWakeTimers(manager: BackgroundManager): Map<string, ReturnType<typeof setTimeout>> {
+  const parentWakeNotifier = Reflect.get(manager, "parentWakeNotifier") as {
+    getPendingParentWakeTimers: () => Map<string, ReturnType<typeof setTimeout>>
+  }
+  return parentWakeNotifier.getPendingParentWakeTimers()
+}
+
 function getCompletionTimers(manager: BackgroundManager): Map<string, ReturnType<typeof setTimeout>> {
   return Reflect.get(manager, "completionTimers") as Map<string, ReturnType<typeof setTimeout>>
 }
@@ -187,30 +236,55 @@ async function notifyParentSessionForTest(manager: BackgroundManager, task: Back
   return notifyParentSession.call(manager, task)
 }
 
-async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
-  const startedAt = Date.now()
-  while (!predicate()) {
-    if (Date.now() - startedAt >= timeoutMs) {
-      return
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10))
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve()
   }
 }
 
-function waitForDeferredWake(promptAsyncCalls: PromptAsyncCall[]): Promise<void> {
-  return waitUntil(() => promptAsyncCalls.length > 0, 600)
+async function flushParentWake(manager: BackgroundManager, sessionID = "parent-1"): Promise<void> {
+  if (!fakeTimers) {
+    throw new Error("Fake timers must be installed before flushing parent wakes")
+  }
+
+  const pendingTimer = getPendingParentWakeTimers(manager).get(sessionID)
+  if (pendingTimer) {
+    await fakeTimers.run(pendingTimer)
+  } else {
+    const flushPendingParentWake = Reflect.get(manager, "flushPendingParentWake") as (id: string) => Promise<void>
+    void flushPendingParentWake.call(manager, sessionID)
+    await flushMicrotasks()
+  }
+
+  await fakeTimers.advanceBy(151)
 }
 
-function waitForDeferredWakeRetry(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 1_180))
+async function waitForDeferredWake(manager: BackgroundManager, promptAsyncCalls: PromptAsyncCall[]): Promise<void> {
+  if (!fakeTimers) {
+    throw new Error("Fake timers must be installed before waiting for parent wakes")
+  }
+
+  for (let attempts = 0; attempts < 12 && promptAsyncCalls.length === 0; attempts += 1) {
+    await flushParentWake(manager)
+    if (promptAsyncCalls.length > 0) break
+    await fakeTimers.runNext()
+  }
 }
 
-function waitForRequeuedParentWake(manager: BackgroundManager, sessionID: string): Promise<void> {
-  return waitUntil(() => (getPendingParentWakes(manager).get(sessionID)?.notifications.length ?? 0) > 0, 600)
+async function waitForRequeuedParentWake(manager: BackgroundManager, sessionID: string): Promise<void> {
+  if (!fakeTimers) {
+    throw new Error("Fake timers must be installed before waiting for parent wakes")
+  }
+
+  for (let attempts = 0; attempts < 12 && (getPendingParentWakes(manager).get(sessionID)?.notifications.length ?? 0) === 0; attempts += 1) {
+    await flushParentWake(manager, sessionID)
+    if ((getPendingParentWakes(manager).get(sessionID)?.notifications.length ?? 0) > 0) break
+    await fakeTimers.runNext()
+  }
 }
 
-function waitForCoalescedFlush(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 400))
+function waitForCoalescedFlush(manager: BackgroundManager, promptAsyncCalls: PromptAsyncCall[]): Promise<void> {
+  return waitForDeferredWake(manager, promptAsyncCalls)
 }
 
 function getRequiredTimer(manager: BackgroundManager, taskID: string): ReturnType<typeof setTimeout> {
@@ -242,7 +316,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await notifyParentSessionForTest(manager, taskA)
       const taskATimer = getRequiredTimer(manager, taskA.id)
       expect(fakeTimers.getDelay(taskATimer)).toBe(TASK_CLEANUP_DELAY_MS)
-      fakeTimers.run(taskATimer)
+      await fakeTimers.run(taskATimer)
 
       // then
       expect(fakeTimers.getDelay(taskATimer)).toBeUndefined()
@@ -259,7 +333,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await notifyParentSessionForTest(manager, taskC)
       const rescheduledTaskATimer = getRequiredTimer(manager, taskA.id)
       expect(fakeTimers.getDelay(rescheduledTaskATimer)).toBe(TASK_CLEANUP_DELAY_MS)
-      fakeTimers.run(rescheduledTaskATimer)
+      await fakeTimers.run(rescheduledTaskATimer)
 
       // then
       expect(getTasks(manager).has(taskA.id)).toBe(false)
@@ -283,7 +357,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
 
       // when
       await notifyParentSessionForTest(manager, taskB)
-      await waitForCoalescedFlush()
+      await waitForCoalescedFlush(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -322,7 +396,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       for (const task of tasks) {
         await notifyParentSessionForTest(manager, task)
       }
-      await waitForCoalescedFlush()
+      await waitForCoalescedFlush(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -379,7 +453,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       // when
       sessionStatuses["parent-1"] = { type: "idle" }
       manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
-      await waitForDeferredWake(promptAsyncCalls)
+      await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -415,7 +489,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       // when
       sessionStatuses["parent-1"] = { type: "idle" }
       manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
-      await waitForDeferredWake(promptAsyncCalls)
+      await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -463,7 +537,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await notifyParentSessionForTest(manager, task)
       sessionStatuses["parent-1"] = { type: "idle" }
       manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
-      await waitForDeferredWake(promptAsyncCalls)
+      await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -505,7 +579,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       try {
         // when
         await notifyParentSessionForTest(manager, task)
-        await waitForCoalescedFlush()
+        await waitForCoalescedFlush(manager, promptAsyncCalls)
 
         // then
         expect(promptAsyncCalls).toHaveLength(1)
@@ -551,7 +625,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       try {
         // when
         await notifyParentSessionForTest(manager, task)
-        await waitForCoalescedFlush()
+        await waitForCoalescedFlush(manager, promptAsyncCalls)
 
         // then
         expect(promptAsyncCalls).toHaveLength(1)
@@ -603,7 +677,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
 
       // when
       manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
-      await waitForDeferredWake(promptAsyncCalls)
+      await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -654,7 +728,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
 
       // when
       manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
-      await waitForDeferredWake(promptAsyncCalls)
+      await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -696,7 +770,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       try {
         // when
         await notifyParentSessionForTest(manager, task)
-        await waitForCoalescedFlush()
+        await waitForCoalescedFlush(manager, promptAsyncCalls)
 
         // then
         expect(promptAsyncCalls).toHaveLength(1)
@@ -718,7 +792,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
 
       // when
       await notifyParentSessionForTest(manager, task)
-      await waitForCoalescedFlush()
+      await waitForCoalescedFlush(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -742,7 +816,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       // when
       sessionStatuses["parent-1"] = { type: "idle" }
       manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
-      await waitForDeferredWake(promptAsyncCalls)
+      await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -766,7 +840,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       // when
       await notifyParentSessionForTest(manager, task)
       sessionStatuses["parent-1"] = { type: "idle" }
-      await waitForDeferredWakeRetry()
+      await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
@@ -795,7 +869,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await notifyParentSessionForTest(manager, task)
       sessionStatuses["parent-1"] = { type: "idle" }
       manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
-      await waitForDeferredWake(promptAsyncCalls)
+      await waitForDeferredWake(manager, promptAsyncCalls)
       await waitForRequeuedParentWake(manager, "parent-1")
 
       // then
@@ -823,7 +897,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
 
       // when
       expect(fakeTimers.getDelay(cleanupTimer)).toBe(TASK_CLEANUP_DELAY_MS)
-      fakeTimers.run(cleanupTimer)
+      await fakeTimers.run(cleanupTimer)
 
       // then
       expect(getCompletionTimers(manager).has(task.id)).toBe(false)

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test"
 
-import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
+import { DEFAULT_PROMPT_QUEUE_RETRY_MS, releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
 import { setPromptReservation } from "../../shared/prompt-async-gate/reservations"
 import { createAutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
+import { installRuntimeFallbackTestClock, restoreRuntimeFallbackTestClock } from "./test-timeout-clock.test-support"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 
 function createContext(promptCalls: { count: number }): RuntimeFallbackPluginInput {
@@ -67,28 +68,16 @@ function reserveSession(sessionID: string, holdMs: number): void {
   })
 }
 
-function createPromptCallSignal(): {
-  readonly notify: () => void
-  readonly wait: () => Promise<void>
-} {
-  let notify: () => void = () => {}
-  const observed = new Promise<void>((resolve) => {
-    notify = resolve
-  })
-  return {
-    notify,
-    wait: () => Promise.race([
-      observed,
-      new Promise<void>((_, reject) => {
-        setTimeout(() => reject(new Error("Timed out waiting for queued fallback prompt dispatch")), 1500)
-      }),
-    ]),
+async function flushPromptGateMicrotasks(): Promise<void> {
+  for (let index = 0; index < 5; index += 1) {
+    await Promise.resolve()
   }
 }
 
 describe("createAutoRetryDispatcher reserved-session retry (#5109)", () => {
   afterEach(() => {
     releaseAllPromptAsyncReservationsForTesting()
+    restoreRuntimeFallbackTestClock()
   })
 
   test("#given a stale promptAsync reservation that releases shortly after #when auto retry runs #then the fallback dispatch is retried instead of silently abandoned", async () => {
@@ -101,9 +90,13 @@ describe("createAutoRetryDispatcher reserved-session retry (#5109)", () => {
     state.pendingFallbackModel = "openai/gpt-5.4"
     deps.sessionStates.set(sessionID, state)
     reserveSession(sessionID, 250)
+    const clock = installRuntimeFallbackTestClock()
 
     // when
-    await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.error")
+    const retryPromise = helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.error")
+    await flushPromptGateMicrotasks()
+    await clock.advanceBy(500)
+    await retryPromise
 
     // then
     expect(promptCalls.count).toBe(1)
@@ -125,9 +118,13 @@ describe("createAutoRetryDispatcher reserved-session retry (#5109)", () => {
     state.pendingFallbackModel = "openai/gpt-5.4"
     deps.sessionStates.set(sessionID, state)
     reserveSession(sessionID, 250)
+    const clock = installRuntimeFallbackTestClock()
 
     // when
-    await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.error")
+    const retryPromise = helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.error")
+    await flushPromptGateMicrotasks()
+    await clock.advanceBy(500)
+    await retryPromise
 
     // then
     expect(promptCalls.count).toBe(1)
@@ -141,7 +138,6 @@ describe("createAutoRetryDispatcher reserved-session retry (#5109)", () => {
     const deps = createDeps(promptCalls)
     const sessionID = "session-active-assistant-then-unblocked"
     let assistantIsActive = true
-    const promptCallSignal = createPromptCallSignal()
     deps.ctx.client.session.messages = async () => ({
       data: assistantIsActive
         ? [
@@ -167,19 +163,21 @@ describe("createAutoRetryDispatcher reserved-session retry (#5109)", () => {
     })
     deps.ctx.client.session.promptAsync = async () => {
       promptCalls.count += 1
-      promptCallSignal.notify()
       return {}
     }
     const helpers = createAutoRetryHelpers(deps)
     const state = createFallbackState("anthropic/claude-opus-4-7")
     state.pendingFallbackModel = "openai/gpt-5.4"
     deps.sessionStates.set(sessionID, state)
+    const clock = installRuntimeFallbackTestClock()
 
     // when
     await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.error")
     expect(promptCalls.count).toBe(0)
     assistantIsActive = false
-    await promptCallSignal.wait()
+    await flushPromptGateMicrotasks()
+    await clock.advanceBy(DEFAULT_PROMPT_QUEUE_RETRY_MS)
+    await flushPromptGateMicrotasks()
 
     // then
     expect(promptCalls.count).toBe(1)

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -4,19 +4,75 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { createFirstPromptWatchdog, observeEventForWatchdog, type FirstPromptWatchdog } from "./first-prompt-watchdog"
 
-// Real timers are unavoidable here (bun:test has no built-in fake-timer API),
-// so margins are sized generously to survive a loaded CI runner. Specifically:
-//   - SAFE_WAIT_BEFORE_FIRE_MS must be << WATCHDOG_MS so the cancel call lands
-//     before the timer fires even with significant scheduler delay
-//     (margin: WATCHDOG_MS - SAFE_WAIT_BEFORE_FIRE_MS >= 60ms here).
-//   - SAFE_WAIT_AFTER_FIRE_MS must be >> WATCHDOG_MS so we conclusively
-//     observe whether the timer fired (margin: ~2.5x WATCHDOG_MS).
 const WATCHDOG_MS = 100
 const SAFE_WAIT_BEFORE_FIRE_MS = 40
 const SAFE_WAIT_AFTER_FIRE_MS = 250
 
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+type FakeTimers = {
+  advanceBy: (ms: number) => Promise<void>
+  restore: () => void
+}
+
+function installFakeTimers(): FakeTimers {
+  const originalSetTimeout = globalThis.setTimeout
+  const originalClearTimeout = globalThis.clearTimeout
+  const originalDateNow = Date.now
+  const callbacks = new Map<ReturnType<typeof setTimeout>, () => void | Promise<void>>()
+  const dueTimes = new Map<ReturnType<typeof setTimeout>, number>()
+  let now = Date.now()
+
+  globalThis.setTimeout = ((handler: Parameters<typeof setTimeout>[0], delay?: number, ...args: unknown[]): ReturnType<typeof setTimeout> => {
+    if (typeof handler !== "function") {
+      throw new Error("String timer handlers are not supported in tests")
+    }
+
+    const timer = originalSetTimeout(() => {}, 0)
+    originalClearTimeout(timer)
+    callbacks.set(timer, () => handler(...args))
+    dueTimes.set(timer, now + Math.max(0, delay ?? 0))
+    return timer
+  }) as typeof setTimeout
+
+  globalThis.clearTimeout = ((timer: ReturnType<typeof setTimeout>): void => {
+    callbacks.delete(timer)
+    dueTimes.delete(timer)
+  }) as typeof clearTimeout
+  Date.now = () => now
+
+  return {
+    async advanceBy(ms) {
+      const target = now + ms
+      while (true) {
+        const nextTimer = nextTimerDueBefore(target)
+        if (!nextTimer) break
+        now = dueTimes.get(nextTimer) ?? now
+        const callback = callbacks.get(nextTimer)
+        callbacks.delete(nextTimer)
+        dueTimes.delete(nextTimer)
+        await callback?.()
+        await flushMicrotasks()
+      }
+      now = target
+      await flushMicrotasks()
+    },
+    restore() {
+      globalThis.setTimeout = originalSetTimeout
+      globalThis.clearTimeout = originalClearTimeout
+      Date.now = originalDateNow
+    },
+  }
+
+  function nextTimerDueBefore(target: number): ReturnType<typeof setTimeout> | undefined {
+    return [...dueTimes.entries()]
+      .filter(([, dueAt]) => dueAt <= target)
+      .sort((left, right) => left[1] - right[1])[0]?.[0]
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve()
+  }
 }
 
 function createContext(): RuntimeFallbackPluginInput {
@@ -96,11 +152,23 @@ const PLUGIN_CONFIG_WITH_FALLBACK = {
 }
 
 describe("first-prompt-watchdog", () => {
+  let fakeTimers: FakeTimers | undefined
+
+  function getFakeTimers(): FakeTimers {
+    if (!fakeTimers) {
+      throw new Error("Fake timers must be installed before advancing watchdog time")
+    }
+    return fakeTimers
+  }
+
   beforeEach(() => {
     subagentSessions.clear()
+    fakeTimers = installFakeTimers()
   })
 
   afterEach(() => {
+    fakeTimers?.restore()
+    fakeTimers = undefined
     subagentSessions.clear()
   })
 
@@ -115,7 +183,7 @@ describe("first-prompt-watchdog", () => {
 
     // when
     watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
-    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
 
     // then
     expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
@@ -138,9 +206,9 @@ describe("first-prompt-watchdog", () => {
 
     // when
     watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
-    await wait(SAFE_WAIT_BEFORE_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_BEFORE_FIRE_MS)
     watchdog.onAssistantProgress(sessionID)
-    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
 
     // then
     expect(calls.abort).toEqual([])
@@ -160,7 +228,7 @@ describe("first-prompt-watchdog", () => {
 
     // when
     watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
-    await wait(SAFE_WAIT_BEFORE_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_BEFORE_FIRE_MS)
     observeEventForWatchdog(
       {
         type: "message.part.updated",
@@ -176,7 +244,7 @@ describe("first-prompt-watchdog", () => {
       },
       watchdog,
     )
-    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
 
     // then
     expect(calls.abort).toEqual([])
@@ -196,7 +264,7 @@ describe("first-prompt-watchdog", () => {
 
     // when
     watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
-    await wait(SAFE_WAIT_BEFORE_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_BEFORE_FIRE_MS)
     observeEventForWatchdog(
       {
         type: "message.part.delta",
@@ -204,7 +272,7 @@ describe("first-prompt-watchdog", () => {
       },
       watchdog,
     )
-    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
 
     // then
     expect(calls.abort).toEqual([])
@@ -224,7 +292,7 @@ describe("first-prompt-watchdog", () => {
 
     // when
     watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
-    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
 
     // then
     expect(calls.abort).toEqual([])
@@ -244,9 +312,9 @@ describe("first-prompt-watchdog", () => {
 
     // when
     watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
-    await wait(SAFE_WAIT_BEFORE_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_BEFORE_FIRE_MS)
     watchdog.onSessionTerminal(sessionID)
-    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
 
     // then
     expect(calls.abort).toEqual([])
@@ -266,7 +334,7 @@ describe("first-prompt-watchdog", () => {
 
     // when
     watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
-    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
 
     // then
     expect(calls.abort).toEqual([])

--- a/packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts
@@ -16,6 +16,10 @@ import {
   releaseAllPromptAsyncReservationsForTesting,
   releasePromptAsyncReservation,
 } from "../shared/prompt-async-gate"
+import {
+  installRuntimeFallbackTestClock,
+  restoreRuntimeFallbackTestClock,
+} from "./test-timeout-clock.test-support"
 import type { RuntimeFallbackPluginInput } from "./types"
 
 type RuntimeFallbackModule = typeof import("./hook")
@@ -48,6 +52,7 @@ describe("runtime-fallback", () => {
   })
 
   afterEach(() => {
+    restoreRuntimeFallbackTestClock()
     SessionCategoryRegistry.clear()
     resetClaudeCodeSessionState()
     clearAllDelegatedChildSessionBootstrap()
@@ -347,6 +352,7 @@ describe("runtime-fallback", () => {
     })
 
     test("should continue fallback chain when fallback model is not found", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
         pluginConfig: createMockPluginConfigWithCategoryFallback([
@@ -380,6 +386,7 @@ describe("runtime-fallback", () => {
           },
         },
       })
+      await clock.advanceBy(2_001)
 
       await hook.event({
         event: {
@@ -405,6 +412,7 @@ describe("runtime-fallback", () => {
     })
 
     test("should continue fallback chain when ProviderModelNotFoundError occurs", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
         pluginConfig: createMockPluginConfigWithCategoryFallback([
@@ -435,6 +443,7 @@ describe("runtime-fallback", () => {
           },
         },
       })
+      await clock.advanceBy(2_001)
 
       await hook.event({
         event: {
@@ -1522,6 +1531,7 @@ describe("runtime-fallback", () => {
     })
 
     test("should advance fallback after session timeout when Copilot retry emits no retryable events", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
       const abortCalls: Array<{ path?: { id?: string } }> = []
 
@@ -1582,7 +1592,10 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      for (let flushes = 0; flushes < 20 && retriedModels.length === 0; flushes += 1) {
+        await Promise.resolve()
+      }
+      await clock.advanceBy(50)
 
       expect(retriedModels).toContain("github-copilot/claude-opus-4.7")
       expect(retriedModels).toContain("openai/gpt-5.4")
@@ -1593,6 +1606,7 @@ describe("runtime-fallback", () => {
     })
 
     test("should keep session timeout active after chat.message model override", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
 
       const hook = createRuntimeFallbackHook(
@@ -1660,13 +1674,14 @@ describe("runtime-fallback", () => {
         output
       )
 
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      await clock.advanceBy(50)
 
       expect(retriedModels).toContain("github-copilot/claude-opus-4.7")
       expect(retriedModels).toContain("openai/gpt-5.4")
     })
 
     test("should abort in-flight fallback request before advancing on timeout", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
       const abortCalls: Array<{ path?: { id?: string } }> = []
       const never = new Promise<never>(() => {})
@@ -1733,7 +1748,10 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      for (let flushes = 0; flushes < 20 && retriedModels.length === 0; flushes += 1) {
+        await Promise.resolve()
+      }
+      await clock.advanceBy(50)
 
       expect(abortCalls.some((call) => call.path?.id === sessionID)).toBe(true)
       expect(retriedModels).toContain("github-copilot/claude-opus-4.7")
@@ -1743,6 +1761,7 @@ describe("runtime-fallback", () => {
     })
 
     test("should not advance fallback after session.stop cancels timeout-driven retry", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
 
       const hook = createRuntimeFallbackHook(
@@ -1807,12 +1826,13 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      await clock.advanceBy(50)
 
       expect(retriedModels).toHaveLength(1)
     })
 
     test("should not advance fallback timeout after completed subagent clears eligibility", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
       const abortCalls: Array<{ path?: { id?: string } }> = []
 
@@ -1877,7 +1897,7 @@ describe("runtime-fallback", () => {
       expect(retriedModels).toEqual(["github-copilot/claude-opus-4.7"])
 
       subagentSessions.delete(sessionID)
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      await clock.advanceBy(50)
 
       expect(retriedModels).toEqual(["github-copilot/claude-opus-4.7"])
       expect(abortCalls).toEqual([])
@@ -1886,6 +1906,7 @@ describe("runtime-fallback", () => {
     })
 
     test("should not trigger second fallback after successful assistant reply", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
       const mockMessages = [
         { info: { role: "user" }, parts: [{ type: "text", text: "test" }] },
@@ -1978,12 +1999,13 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      await clock.advanceBy(50)
 
       expect(retriedModels).toEqual(["github-copilot/claude-opus-4.7"])
     })
 
     test("should not clear fallback timeout on assistant non-error update with Copilot retry signal", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
 
       const hook = createRuntimeFallbackHook(
@@ -2054,12 +2076,13 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 60))
+      await clock.advanceBy(60)
 
       expect(retriedModels).toContain("openai/gpt-5.5")
     })
 
     test("should not clear fallback timeout on assistant non-error update with OpenAI retry signal", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
 
       const hook = createRuntimeFallbackHook(
@@ -2129,12 +2152,13 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 60))
+      await clock.advanceBy(60)
 
       expect(retriedModels).toContain("anthropic/claude-opus-4-7")
     })
 
     test("should not clear fallback timeout on assistant non-error update without user-visible content", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
 
       const hook = createRuntimeFallbackHook(
@@ -2205,12 +2229,13 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 60))
+      await clock.advanceBy(60)
 
       expect(retriedModels).toContain("openai/gpt-5.5")
     })
 
     test("should not clear fallback timeout from info.message alone without persisted assistant text", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
 
       const hook = createRuntimeFallbackHook(
@@ -2281,12 +2306,13 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 60))
+      await clock.advanceBy(60)
 
       expect(retriedModels).toContain("openai/gpt-5.5")
     })
 
     test("should keep timeout armed when session.idle fires before fallback result", async () => {
+      const clock = installRuntimeFallbackTestClock()
       const retriedModels: string[] = []
 
       const hook = createRuntimeFallbackHook(
@@ -2351,7 +2377,7 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await new Promise((resolve) => setTimeout(resolve, 60))
+      await clock.advanceBy(60)
 
       expect(retriedModels).toContain("openai/gpt-5.5")
     })
@@ -2994,6 +3020,7 @@ describe("runtime-fallback", () => {
     })
 
     test("consecutive session.errors advance chain normally when retry completes between them", async () => {
+      const clock = installRuntimeFallbackTestClock()
       //#given
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
@@ -3028,12 +3055,14 @@ describe("runtime-fallback", () => {
         },
       })
 
-      await hook.event({
+      const secondErrorPromise = hook.event({
         event: {
           type: "session.error",
           properties: { sessionID, model: "provider-a/model-a", error: { statusCode: 429, message: "Rate limit again" } },
         },
       })
+      await clock.advanceBy(3_000)
+      await secondErrorPromise
 
       //#then - both should advance the chain (no skip)
       const fallbackLogs = logCalls.filter((call) => call.msg.includes("Preparing fallback"))
@@ -3242,6 +3271,7 @@ describe("runtime-fallback", () => {
     })
 
     test("pendingFallbackModel advances chain on subsequent error even when persisted", async () => {
+      const clock = installRuntimeFallbackTestClock()
       //#given
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
@@ -3285,13 +3315,15 @@ describe("runtime-fallback", () => {
       await hook.event({ event: { type: "session.idle", properties: { sessionID } } })
 
       //#when - second error fires after retry completed (retryInFlight cleared)
-      await hook.event({
+      const secondErrorPromise = hook.event({
         event: {
           type: "session.error",
           // model matches pendingFallbackModel so the awaiting-fallback gate lets this through
           properties: { sessionID, model: "provider-a/model-a", error: { statusCode: 429, message: "Rate limit again" } },
         },
       })
+      await clock.advanceBy(3_000)
+      await secondErrorPromise
 
       //#then - chain advances normally (not skipped), consistent with consecutive errors test
       const fallbackLogs = logCalls.filter((call) => call.msg.includes("Preparing fallback"))

--- a/packages/omo-opencode/src/hooks/runtime-fallback/test-timeout-clock.test-support.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/test-timeout-clock.test-support.ts
@@ -1,0 +1,104 @@
+type TestTimerID = number & ReturnType<typeof setTimeout>
+type TestTimerCallback = (...args: unknown[]) => void | Promise<void>
+
+type CapturedTimer = {
+  readonly id: TestTimerID
+  readonly callback: TestTimerCallback
+  readonly args: readonly unknown[]
+  active: boolean
+  dueAt: number
+}
+
+type OriginalClock = {
+  readonly setTimeout: typeof globalThis.setTimeout
+  readonly clearTimeout: typeof globalThis.clearTimeout
+  readonly dateNow: typeof Date.now
+}
+
+export type RuntimeFallbackTestClock = {
+  readonly advanceBy: (ms: number) => Promise<void>
+  readonly restore: () => void
+}
+
+let activeClock: RuntimeFallbackTestClock | undefined
+
+export function installRuntimeFallbackTestClock(startAt = Date.now()): RuntimeFallbackTestClock {
+  restoreRuntimeFallbackTestClock()
+
+  const original: OriginalClock = {
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout,
+    dateNow: Date.now,
+  }
+  const timers: CapturedTimer[] = []
+  let now = startAt
+  let nextTimerID = 1
+  let restored = false
+
+  const fakeSetTimeout = ((callback: Parameters<typeof setTimeout>[0], delay?: number, ...args: unknown[]) => {
+    if (typeof callback !== "function") {
+      return original.setTimeout(callback, delay, ...args)
+    }
+
+    const id = nextTimerID as TestTimerID
+    nextTimerID += 1
+    timers.push({
+      id,
+      callback: callback as TestTimerCallback,
+      args,
+      active: true,
+      dueAt: now + Math.max(0, delay ?? 0),
+    })
+    return id
+  }) as typeof globalThis.setTimeout
+
+  const fakeClearTimeout = ((id?: Parameters<typeof clearTimeout>[0]) => {
+    const timer = timers.find((candidate) => candidate.id === id)
+    if (timer) {
+      timer.active = false
+      return
+    }
+    original.clearTimeout(id)
+  }) as typeof globalThis.clearTimeout
+
+  globalThis.setTimeout = fakeSetTimeout
+  globalThis.clearTimeout = fakeClearTimeout
+  Date.now = () => now
+
+  const clock: RuntimeFallbackTestClock = {
+    advanceBy: async (ms: number) => {
+      const target = now + ms
+      while (true) {
+        const timer = timers
+          .filter((candidate) => candidate.active && candidate.dueAt <= target)
+          .sort((left, right) => left.dueAt - right.dueAt)[0]
+        if (!timer) break
+
+        now = timer.dueAt
+        timer.active = false
+        await timer.callback(...timer.args)
+        await Promise.resolve()
+      }
+      now = target
+      await Promise.resolve()
+    },
+    restore: () => {
+      if (restored) return
+      restored = true
+      globalThis.setTimeout = original.setTimeout
+      globalThis.clearTimeout = original.clearTimeout
+      Date.now = original.dateNow
+      if (activeClock === clock) {
+        activeClock = undefined
+      }
+    },
+  }
+
+  activeClock = clock
+  return clock
+}
+
+export function restoreRuntimeFallbackTestClock(): void {
+  activeClock?.restore()
+  activeClock = undefined
+}

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/opencode-overload-continuation.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/opencode-overload-continuation.test.ts
@@ -1,3 +1,7 @@
+/// <reference types="bun-types" />
+
+import type { PluginInput } from "@opencode-ai/plugin"
+import { createOpencodeClient } from "@opencode-ai/sdk"
 import { describe, expect, test } from "bun:test"
 
 import { _resetForTesting, setMainSession } from "../../features/claude-code-session-state"
@@ -13,34 +17,40 @@ type PromptInput = {
   body: { parts: Array<{ text: string }> }
 }
 
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
+type TimerCallback = (...args: unknown[]) => void
+type FakeTimerID = number & ReturnType<typeof setTimeout> & ReturnType<typeof setInterval>
 
-function createPluginInput(promptCalls: PromptCall[]): Parameters<typeof createTodoContinuationEnforcer>[0] {
+function createPluginInput(promptCalls: PromptCall[]): PluginInput {
+  const directory = "/tmp/opencode-overload-continuation-test"
+  const client = createOpencodeClient({ directory })
+  Reflect.set(client.session, "todo", async () => ({
+    data: [
+      { id: "1", content: "Keep working", status: "pending", priority: "high" },
+    ],
+  }))
+  Reflect.set(client.session, "messages", async () => ({ data: [] }))
+  Reflect.set(client.session, "promptAsync", async (input: PromptInput) => {
+    promptCalls.push({
+      sessionID: input.path.id,
+      text: input.body.parts[0]?.text ?? "",
+    })
+    return {}
+  })
+  Reflect.set(client.tui, "showToast", async () => ({}))
+
   return {
-    directory: "/tmp/opencode-overload-continuation-test",
-    client: {
-      session: {
-        todo: async () => ({
-          data: [
-            { id: "1", content: "Keep working", status: "pending", priority: "high" },
-          ],
-        }),
-        messages: async () => ({ data: [] }),
-        promptAsync: async (input: PromptInput) => {
-          promptCalls.push({
-            sessionID: input.path.id,
-            text: input.body.parts[0]?.text ?? "",
-          })
-          return {}
-        },
-      },
-      tui: {
-        showToast: async () => ({}),
-      },
+    client,
+    project: {
+      id: "opencode-overload-continuation-test",
+      worktree: directory,
+      time: { created: Date.now() },
     },
-  } as Parameters<typeof createTodoContinuationEnforcer>[0]
+    directory,
+    worktree: directory,
+    experimental_workspace: { register: () => {} },
+    serverUrl: new URL("http://localhost"),
+    $: {} as PluginInput["$"],
+  }
 }
 
 describe("todo-continuation-enforcer OpenCode overload errors", () => {
@@ -53,36 +63,74 @@ describe("todo-continuation-enforcer OpenCode overload errors", () => {
       _resetForTesting()
       setMainSession(sessionID)
       const hook = createTodoContinuationEnforcer(createPluginInput(promptCalls))
+      const original = {
+        setTimeout: globalThis.setTimeout,
+        clearTimeout: globalThis.clearTimeout,
+        setInterval: globalThis.setInterval,
+        clearInterval: globalThis.clearInterval,
+      }
+      const scheduledTimeouts: Array<{ delay: number; callback: TimerCallback; args: unknown[] }> = []
+      const fakeSetTimeout = (handler: TimerHandler, delay?: number, ...callbackArgs: unknown[]) => {
+        if (typeof handler !== "function") {
+          return original.setTimeout(handler, delay, ...callbackArgs)
+        }
+        const callback: TimerCallback = (...timerArgs) => {
+          handler(...timerArgs)
+        }
+        scheduledTimeouts.push({
+          delay: typeof delay === "number" && Number.isFinite(delay) ? delay : 0,
+          callback,
+          args: callbackArgs,
+        })
+        return scheduledTimeouts.length as FakeTimerID
+      }
+      Reflect.set(globalThis, "setTimeout", fakeSetTimeout)
+      Reflect.set(globalThis, "clearTimeout", () => {})
+      Reflect.set(globalThis, "setInterval", () => (scheduledTimeouts.length + 1) as FakeTimerID)
+      Reflect.set(globalThis, "clearInterval", () => {})
 
-      await hook.handler({
-        event: { type: "session.idle", properties: { sessionID } },
-      })
+      try {
+        await hook.handler({
+          event: { type: "session.idle", properties: { sessionID } },
+        })
 
-      // when
-      await hook.handler({
-        event: {
-          type: "session.error",
-          properties: {
-            sessionID,
-            error: {
-              type: "error",
-              sequence_number: 2,
+        // when
+        await hook.handler({
+          event: {
+            type: "session.error",
+            properties: {
+              sessionID,
               error: {
-                type: "service_unavailable_error",
-                code: "server_is_overloaded",
-                message: "Our servers are currently overloaded. Please try again later.",
-                param: null,
+                type: "error",
+                sequence_number: 2,
+                error: {
+                  type: "service_unavailable_error",
+                  code: "server_is_overloaded",
+                  message: "Our servers are currently overloaded. Please try again later.",
+                  param: null,
+                },
               },
             },
           },
-        },
-      })
-      await wait(2500)
+        })
+        const countdownTimer = scheduledTimeouts.find((timer) => timer.delay === 2000)
+        expect(countdownTimer).toBeDefined()
+        countdownTimer?.callback(...countdownTimer.args)
+        for (let index = 0; index < 25; index++) {
+          await Promise.resolve()
+        }
 
-      // then
-      expect(promptCalls).toHaveLength(1)
-      expect(promptCalls[0]?.sessionID).toBe(sessionID)
-      expect(promptCalls[0]?.text).toContain("TODO CONTINUATION")
+        // then
+        expect(promptCalls).toHaveLength(1)
+        expect(promptCalls[0]?.sessionID).toBe(sessionID)
+        expect(promptCalls[0]?.text).toContain("TODO CONTINUATION")
+      } finally {
+        Reflect.set(globalThis, "setTimeout", original.setTimeout)
+        Reflect.set(globalThis, "clearTimeout", original.clearTimeout)
+        Reflect.set(globalThis, "setInterval", original.setInterval)
+        Reflect.set(globalThis, "clearInterval", original.clearInterval)
+        _resetForTesting()
+      }
     },
     { timeout: 10000 },
   )

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -21,8 +21,7 @@ interface FakeTimers {
 }
 
 function createFakeTimers(): FakeTimers {
-  const FAKE_MIN_DELAY_MS = 500
-  const REAL_MAX_DELAY_MS = 5000
+  const REAL_MAX_DELAY_MS = 60_000
   const originalNow = Date.now()
   let clockNow = originalNow
   let timerNow = 0
@@ -69,9 +68,6 @@ function createFakeTimers(): FakeTimers {
 
   globalThis.setTimeout = ((callback: TimerCallback, delay?: number, ...args: unknown[]) => {
     const normalized = normalizeDelay(delay)
-    if (normalized < FAKE_MIN_DELAY_MS) {
-      return original.setTimeout(callback, delay, ...args)
-    }
     if (normalized >= REAL_MAX_DELAY_MS) {
       return original.setTimeout(callback, delay, ...args)
     }
@@ -80,9 +76,6 @@ function createFakeTimers(): FakeTimers {
 
   globalThis.setInterval = ((callback: TimerCallback, delay?: number, ...args: unknown[]) => {
     const interval = normalizeDelay(delay)
-    if (interval < FAKE_MIN_DELAY_MS) {
-      return original.setInterval(callback, delay, ...args)
-    }
     if (interval >= REAL_MAX_DELAY_MS) {
       return original.setInterval(callback, delay, ...args)
     }
@@ -154,8 +147,6 @@ function createFakeTimers(): FakeTimers {
 
   return { advanceBy, restore }
 }
-
-const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
 describe("todo-continuation-enforcer", () => {
   let promptCalls: Array<{ sessionID: string; agent?: string; model?: { providerID?: string; modelID?: string }; text: string }>
@@ -286,7 +277,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should inject continuation when idle with incomplete todos", async () => {
-    fakeTimers.restore()
     // given - main session with incomplete todos
     const sessionID = "main-123"
     setMainSession(sessionID)
@@ -301,18 +291,17 @@ describe("todo-continuation-enforcer", () => {
     })
 
     // then - countdown toast shown
-    await wait(50)
+    await fakeTimers.advanceBy(50, true)
     expect(toastCalls.length).toBeGreaterThanOrEqual(1)
     expect(toastCalls[0].title).toBe("Todo Continuation")
 
     // then - after countdown, continuation injected
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
     expect(promptCalls.length).toBe(1)
     expect(promptCalls[0].text).toContain("TODO CONTINUATION")
   }, { timeout: 15000 })
 
   test("should inject continuation when idle event carries session id in info", async () => {
-    fakeTimers.restore()
     // given - OpenCode session events can nest the session id under info
     const sessionID = "main-info-idle"
     setMainSession(sessionID)
@@ -325,7 +314,7 @@ describe("todo-continuation-enforcer", () => {
     })
 
     // then - continuation is still injected for that session
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
     expect(promptCalls).toHaveLength(1)
     expect(promptCalls[0].sessionID).toBe(sessionID)
     expect(promptCalls[0].text).toContain("TODO CONTINUATION")
@@ -400,7 +389,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should inject for any session with incomplete todos", async () => {
-    fakeTimers.restore()
     //#given — any session, not necessarily main session
     const otherSession = "other-session"
 
@@ -412,13 +400,12 @@ describe("todo-continuation-enforcer", () => {
     })
 
     //#then — continuation injected regardless of session type
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
     expect(promptCalls.length).toBe(1)
     expect(promptCalls[0].sessionID).toBe(otherSession)
   }, { timeout: 15000 })
 
   test("should inject for background task session (subagent)", async () => {
-    fakeTimers.restore()
     // given - main session set, background task session registered
     setMainSession("main-session")
     const bgTaskSession = "bg-task-session"
@@ -432,7 +419,7 @@ describe("todo-continuation-enforcer", () => {
     })
 
     // then - continuation injected for background task session
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
     expect(promptCalls.length).toBe(1)
     expect(promptCalls[0].sessionID).toBe(bgTaskSession)
   }, { timeout: 15000 })
@@ -466,7 +453,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should ignore user message within grace period", async () => {
-    fakeTimers.restore()
     // given - session starting countdown
     const sessionID = "main-grace"
     setMainSession(sessionID)
@@ -488,7 +474,7 @@ describe("todo-continuation-enforcer", () => {
 
      // then - countdown should continue (message was ignored)
     // wait past 2s countdown and verify injection happens
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
     expect(promptCalls).toHaveLength(1)
   }, { timeout: 15000 })
 
@@ -692,7 +678,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should inject after recovery complete", async () => {
-    fakeTimers.restore()
     // given - session was in recovery, now complete
     const sessionID = "main-recovery-done"
     setMainSession(sessionID)
@@ -708,7 +693,7 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(3000)
+    await fakeTimers.advanceBy(3000, true)
 
     // then - continuation injected
     expect(promptCalls.length).toBe(1)
@@ -1182,7 +1167,6 @@ describe("todo-continuation-enforcer", () => {
 
 
   test("should NOT skip for non-abort errors even if immediately before idle", async () => {
-    fakeTimers.restore()
     // given - session with incomplete todos
     const sessionID = "main-noabort-error"
     setMainSession(sessionID)
@@ -1205,7 +1189,7 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     // then - continuation injected (non-abort errors don't block)
     expect(promptCalls.length).toBe(1)
@@ -1238,7 +1222,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should inject when last assistant message has no error", async () => {
-    fakeTimers.restore()
     // given - session where last assistant message completed normally
     const sessionID = "main-api-no-error"
     setMainSession(sessionID)
@@ -1255,14 +1238,13 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     // then - continuation injected (no abort)
     expect(promptCalls.length).toBe(1)
   }, { timeout: 15000 })
 
   test("should inject when last message is from user (not assistant)", async () => {
-    fakeTimers.restore()
     // given - session where last message is from user
     const sessionID = "main-api-user-last"
     setMainSession(sessionID)
@@ -1279,7 +1261,7 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     // then - continuation injected (last message is user, not aborted assistant)
     expect(promptCalls.length).toBe(1)
@@ -1369,7 +1351,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should keep skipping after cancel even when the abort window is stale", async () => {
-    fakeTimers.restore()
     // given - session with incomplete todos and old abort timestamp
     const sessionID = "main-stale-abort"
     setMainSession(sessionID)
@@ -1389,19 +1370,18 @@ describe("todo-continuation-enforcer", () => {
     })
 
     // when - wait >3s then idle fires
-    await wait(3100)
+    await fakeTimers.advanceBy(3100, true)
 
     await hook.handler({
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(3000)
+    await fakeTimers.advanceBy(3000, true)
 
     expect(promptCalls).toHaveLength(0)
   }, { timeout: 15000 })
 
   test("should clear abort flag on user message activity", async () => {
-    fakeTimers.restore()
     // given - session with abort detected
     const sessionID = "main-clear-on-user"
     setMainSession(sessionID)
@@ -1421,7 +1401,7 @@ describe("todo-continuation-enforcer", () => {
     })
 
     // when - user sends new message (clears abort flag)
-    await wait(600)
+    await fakeTimers.advanceBy(600, true)
     await hook.handler({
       event: {
         type: "message.updated",
@@ -1434,14 +1414,13 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     // then - continuation injected (abort flag was cleared by user activity)
     expect(promptCalls.length).toBeGreaterThan(0)
   }, { timeout: 15000 })
 
   test("should reset failure state and keep skipping after a cancelled run", async () => {
-    fakeTimers.restore()
     const sessionID = "main-reset-after-cancel"
     setMainSession(sessionID)
     mockMessages = [
@@ -1455,7 +1434,7 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
     expect(promptCalls.length).toBeGreaterThan(0)
 
     promptCalls.length = 0
@@ -1467,19 +1446,18 @@ describe("todo-continuation-enforcer", () => {
       },
     })
 
-    await wait(3100)
+    await fakeTimers.advanceBy(3100, true)
 
     await hook.handler({
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     expect(promptCalls).toHaveLength(0)
   }, { timeout: 15000 })
 
   test("should clear abort flag on assistant message activity", async () => {
-    fakeTimers.restore()
     // given - session with abort detected
     const sessionID = "main-clear-on-assistant"
     setMainSession(sessionID)
@@ -1511,14 +1489,13 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     // then - continuation injected (abort flag was cleared by assistant activity)
     expect(promptCalls.length).toBeGreaterThan(0)
   }, { timeout: 15000 })
 
   test("should clear abort flag on tool execution", async () => {
-    fakeTimers.restore()
     // given - session with abort detected
     const sessionID = "main-clear-on-tool"
     setMainSession(sessionID)
@@ -1550,7 +1527,7 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     // then - continuation injected (abort flag was cleared by tool execution)
     expect(promptCalls.length).toBeGreaterThan(0)
@@ -1609,7 +1586,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should pass model property in prompt call (undefined when no message context)", async () => {
-    fakeTimers.restore()
     // given - session with incomplete todos, no prior message context available
     const sessionID = "main-model-preserve"
     setMainSession(sessionID)
@@ -1623,7 +1599,7 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     // then - prompt call made, model is undefined when no context (expected behavior)
     expect(promptCalls.length).toBe(1)
@@ -1909,7 +1885,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should inject when agent info is undefined but skipAgents is empty", async () => {
-    fakeTimers.restore()
     // given - session with no agent info but skipAgents is empty
     const sessionID = "main-no-agent-no-skip"
     setMainSession(sessionID)
@@ -1959,7 +1934,7 @@ describe("todo-continuation-enforcer", () => {
        event: { type: "session.idle", properties: { sessionID } },
      })
 
-     await wait(2500)
+     await fakeTimers.advanceBy(2500, true)
 
     // then - continuation injected (no agents to skip)
     expect(promptCalls.length).toBe(1)
@@ -2011,7 +1986,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should inject when isContinuationStopped returns false", async () => {
-    fakeTimers.restore()
     // given - session with continuation not stopped
     const sessionID = "main-not-stopped"
     setMainSession(sessionID)
@@ -2025,7 +1999,7 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     // then - continuation injected (stopped flag is false)
     expect(promptCalls.length).toBe(1)
@@ -2055,7 +2029,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should reset consecutiveFailures after user-initiated abort and resume after fresh activity [regression #2984]", async () => {
-    fakeTimers.restore()
     const sessionID = "main-abort-recovery"
     setMainSession(sessionID)
     const mockInput = createMockPluginInput()
@@ -2083,7 +2056,7 @@ describe("todo-continuation-enforcer", () => {
     const hook = createTodoContinuationEnforcer(mockInput, {})
 
     await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
     expect(promptCallCount).toBe(1)
 
     await hook.handler({
@@ -2094,9 +2067,9 @@ describe("todo-continuation-enforcer", () => {
     })
 
     shouldFail = false
-    await wait(9000)
+    await fakeTimers.advanceBy(9000, true)
     await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
     expect(promptCallCount).toBe(1)
 
     await hook.handler({
@@ -2107,7 +2080,7 @@ describe("todo-continuation-enforcer", () => {
     })
 
     await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     expect(promptCallCount).toBe(2)
     expect(promptCalls).toHaveLength(1)
@@ -2254,7 +2227,6 @@ describe("todo-continuation-enforcer", () => {
   }, { timeout: 30000 })
 
   test("should clear token limit flag when user sends new message after recovery", async () => {
-    fakeTimers.restore()
     // given - session that hit token limit
     const sessionID = "main-token-limit-recovery"
     setMainSession(sessionID)
@@ -2289,7 +2261,7 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(2500)
+    await fakeTimers.advanceBy(2500, true)
 
     // then - continuation injected (token limit flag cleared by user activity)
     expect(promptCalls.length).toBe(1)

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -37,6 +37,10 @@ function sliceWorkflowSection(workflow: string, startMarker: string, endMarker: 
   return workflow.slice(start, end)
 }
 
+function normalizeWorkflowText(workflow: string): string {
+  return workflow.replace(/\r\n/g, "\n")
+}
+
 function expectBunSetupBeforeLspToolsBuild(workflowSection: string, label: string): void {
   const bunSetupIndex = workflowSection.indexOf("uses: oven-sh/setup-bun@v2")
   const lspBuildIndex = workflowSection.indexOf("name: Build vendored lsp-tools-mcp package")
@@ -141,7 +145,7 @@ describe("test workflows", () => {
 
   test("runs codex compatibility checks on every supported os without serializing build", () => {
     // #given
-    const workflow = readFileSync(ciWorkflowPath, "utf8")
+    const workflow = normalizeWorkflowText(readFileSync(ciWorkflowPath, "utf8"))
     const codexCompatibilityJob = sliceWorkflowSection(workflow, "  codex-compatibility:", "  lazycodex-published-smoke:")
     const buildJob = sliceWorkflowSection(workflow, "  build:", "  draft-release:")
 

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -37,6 +37,14 @@ function sliceWorkflowSection(workflow: string, startMarker: string, endMarker: 
   return workflow.slice(start, end)
 }
 
+function sliceWorkflowSectionToEnd(workflow: string, startMarker: string): string {
+  const start = workflow.indexOf(startMarker)
+  if (start < 0) {
+    throw new Error(`missing workflow section starting at ${startMarker}`)
+  }
+  return workflow.slice(start)
+}
+
 function normalizeWorkflowText(workflow: string): string {
   return workflow.replace(/\r\n/g, "\n")
 }
@@ -147,21 +155,27 @@ describe("test workflows", () => {
     // #given
     const workflow = normalizeWorkflowText(readFileSync(ciWorkflowPath, "utf8"))
     const codexCompatibilityJob = sliceWorkflowSection(workflow, "  codex-compatibility:", "  lazycodex-published-smoke:")
-    const buildJob = sliceWorkflowSection(workflow, "  build:", "  draft-release:")
+    const buildJob = sliceWorkflowSection(workflow, "  build:", "  auto-commit-schema:")
+    const autoCommitSchemaJob = sliceWorkflowSection(workflow, "  auto-commit-schema:", "  draft-release:")
+    const draftReleaseJob = sliceWorkflowSectionToEnd(workflow, "  draft-release:")
 
     // #when
     const hasCodexMatrixJob = workflow.includes("codex-compatibility:")
     const hasSupportedOsMatrix = codexCompatibilityJob.includes("os: [ubuntu-latest, macos-latest, windows-latest]")
     const hasCodexCommand = workflow.includes("run: bun run test:codex")
     const buildWaitsForChecks = buildJob.includes("needs:")
-    const draftReleaseWaitsForBuild = workflow.includes("  draft-release:\n    runs-on: ubuntu-latest\n    needs: [build]")
+    const buildHasWritePermission = buildJob.includes("contents: write")
+    const writeGateNeedsAllChecks = autoCommitSchemaJob.includes("needs: [test, typecheck, codex-compatibility, build]")
+    const draftReleaseNeedsAllChecks = draftReleaseJob.includes("needs: [test, typecheck, codex-compatibility, build]")
 
     // #then
     expect(hasCodexMatrixJob, "CI must expose a Codex compatibility matrix job").toBe(true)
     expect(hasSupportedOsMatrix, "CI Codex compatibility must cover supported OSes").toBe(true)
     expect(hasCodexCommand, "Codex compatibility job must run the shared Codex test script").toBe(true)
     expect(buildWaitsForChecks, "Build has no artifact dependency on test/typecheck/codex and must not serialize CI").toBe(false)
-    expect(draftReleaseWaitsForBuild, "Draft release must still wait for the build artifact gate").toBe(true)
+    expect(buildHasWritePermission, "Parallel build must stay read-only; write actions belong behind the all-check gate").toBe(false)
+    expect(writeGateNeedsAllChecks, "Schema auto-commit must wait for all root checks and build").toBe(true)
+    expect(draftReleaseNeedsAllChecks, "Draft release must wait for all root checks and build").toBe(true)
   })
 
   test("prepares lsp-tools-mcp before Codex compatibility tests", () => {

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -139,19 +139,25 @@ describe("test workflows", () => {
     expect(hasMatrixRunner, "CI root checks must run on the selected matrix OS").toBe(true)
   })
 
-  test("runs codex compatibility checks on every supported os", () => {
+  test("runs codex compatibility checks on every supported os without serializing build", () => {
     // #given
     const workflow = readFileSync(ciWorkflowPath, "utf8")
+    const codexCompatibilityJob = sliceWorkflowSection(workflow, "  codex-compatibility:", "  lazycodex-published-smoke:")
+    const buildJob = sliceWorkflowSection(workflow, "  build:", "  draft-release:")
 
     // #when
     const hasCodexMatrixJob = workflow.includes("codex-compatibility:")
+    const hasSupportedOsMatrix = codexCompatibilityJob.includes("os: [ubuntu-latest, macos-latest, windows-latest]")
     const hasCodexCommand = workflow.includes("run: bun run test:codex")
-    const buildNeedsCodexMatrix = workflow.includes("needs: [test, typecheck, codex-compatibility]")
+    const buildWaitsForChecks = buildJob.includes("needs:")
+    const draftReleaseWaitsForBuild = workflow.includes("  draft-release:\n    runs-on: ubuntu-latest\n    needs: [build]")
 
     // #then
     expect(hasCodexMatrixJob, "CI must expose a Codex compatibility matrix job").toBe(true)
+    expect(hasSupportedOsMatrix, "CI Codex compatibility must cover supported OSes").toBe(true)
     expect(hasCodexCommand, "Codex compatibility job must run the shared Codex test script").toBe(true)
-    expect(buildNeedsCodexMatrix, "Build must wait for Codex compatibility checks").toBe(true)
+    expect(buildWaitsForChecks, "Build has no artifact dependency on test/typecheck/codex and must not serialize CI").toBe(false)
+    expect(draftReleaseWaitsForBuild, "Draft release must still wait for the build artifact gate").toBe(true)
   })
 
   test("prepares lsp-tools-mcp before Codex compatibility tests", () => {

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -164,7 +164,7 @@ describe("test workflows", () => {
     const hasSupportedOsMatrix = codexCompatibilityJob.includes("os: [ubuntu-latest, macos-latest, windows-latest]")
     const hasCodexCommand = workflow.includes("run: bun run test:codex")
     const buildWaitsForChecks = buildJob.includes("needs:")
-    const buildHasWritePermission = buildJob.includes("contents: write")
+    const buildHasReadOnlyContentsPermission = buildJob.includes("permissions:\n      contents: read")
     const writeGateNeedsAllChecks = autoCommitSchemaJob.includes("needs: [test, typecheck, codex-compatibility, build]")
     const draftReleaseNeedsAllChecks = draftReleaseJob.includes("needs: [test, typecheck, codex-compatibility, build]")
 
@@ -173,7 +173,7 @@ describe("test workflows", () => {
     expect(hasSupportedOsMatrix, "CI Codex compatibility must cover supported OSes").toBe(true)
     expect(hasCodexCommand, "Codex compatibility job must run the shared Codex test script").toBe(true)
     expect(buildWaitsForChecks, "Build has no artifact dependency on test/typecheck/codex and must not serialize CI").toBe(false)
-    expect(buildHasWritePermission, "Parallel build must stay read-only; write actions belong behind the all-check gate").toBe(false)
+    expect(buildHasReadOnlyContentsPermission, "Parallel build must explicitly stay read-only; write actions belong behind the all-check gate").toBe(true)
     expect(writeGateNeedsAllChecks, "Schema auto-commit must wait for all root checks and build").toBe(true)
     expect(draftReleaseNeedsAllChecks, "Draft release must wait for all root checks and build").toBe(true)
   })


### PR DESCRIPTION
## Summary

This PR optimizes the regular local `bun test` runtime and the GitHub CI wall-clock path without sharding, splitting, retries, or skipping the full test gate.

Local wins come from replacing real wall-clock sleeps in slow OpenCode tests with deterministic test-local timer advancement while preserving the same production behavior assertions. CI wins come from letting `build` run in parallel with `test`, `typecheck`, and `codex-compatibility`; write-capable release/schema jobs remain gated on all required checks.

## Final Performance Result

Local full-suite timing:
- Baseline: `/usr/bin/time -p bun test` = 9983 pass, 2 skipped, 0 fail, 23440 expect() calls, 9985 tests across 1206 files, real 218.33s.
- Final post-rebase run: `/usr/bin/time -p bun test` = 9991 pass, 2 skipped, 0 fail, 23453 expect() calls, 9993 tests across 1207 files, real 124.47s.
- Latest after the write-gate and read-permission reviewer fixes: `/usr/bin/time -p bun test` = 9991 pass, 2 skipped, 0 fail, 23457 expect() calls, 9993 tests across 1207 files, real 129.13s.
- Best final verification run after the write-gate fix: real 123.88s with the same 9993 tests across 1207 files.
- Net local change using the latest full-suite run: 89.20s faster, about 40.9% wall-clock reduction, while covering 8 more tests and 1 more file than the baseline.

CI timing:
- Current dev baseline run `27668356968` completed green in about 8m38s.
- Final green PR run `27671548193` completed green on commit `da0386b29`.
- Final PR CI job times: root `bun test` macOS 2m45s, Ubuntu 2m59s, Windows 6m04s; `build` 1m09s; Codex compatibility macOS 1m16s, Ubuntu 1m33s, Windows 3m58s.
- The final CI optimization is workflow shape, not npm download caching: build runs in parallel with test/typecheck/codex-compatibility instead of waiting behind the slowest test lane.
- The npm cache wiring was removed because PR run `27669152384` showed added setup/cache overhead and no overall CI improvement.

## Changes

Local test runtime:
- Virtualized slow countdown/wait behavior in `todo-continuation-enforcer` tests.
- Virtualized runtime-fallback retry/watchdog/auto-retry timers.
- Virtualized background-agent parent wake cleanup timers.
- Kept assertions over the same observable behavior; no meaningful test coverage was deleted.

CI runtime and safety:
- Kept root CI test/typecheck/Codex checks as regular matrix jobs on Ubuntu, macOS, and Windows.
- Kept root CI test command as plain `bun test`.
- Let `build` run independently so it no longer serializes behind the slowest test lane.
- Made `build` explicitly read-only with `permissions: contents: read`.
- Moved schema auto-commit into `auto-commit-schema`, gated on `test`, `typecheck`, `codex-compatibility`, and `build`.
- Made `draft-release` depend on `test`, `typecheck`, `codex-compatibility`, and `build` directly.
- Added workflow assertions so release/write paths cannot regress to build-only gating or an implicitly write-capable build job.

Windows fix:
- Added CRLF normalization for workflow assertions.
- Evidence shows the CRLF simulation failed before normalization and `script/publish-workflow.test.ts` passed afterward.

## Verification

Local automated verification:
- `bun test script/publish-workflow.test.ts`: 21 pass.
- YAML lint for `.github/workflows/ci.yml`: pass.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml`: pass with no findings.
- `bun run typecheck:script`: pass.
- TypeScript no-excuse scan for `script/publish-workflow.test.ts`: pass.
- `git diff --check`: pass.
- `/usr/bin/time -p bun test`: 9991 pass, 2 skipped, 0 fail, real 129.13s latest full-suite run.

OpenCode QA receipts:
- OpenCode QA harness self-check: pass.
- OpenCode isolated tmux TUI smoke: pass.
- Real DB session count stayed unchanged on accepted TUI smoke evidence.

CI verification:
- Final green PR run: `27671548193`, all substantive checks successful.
- `draft-release` and `auto-commit-schema` correctly skipped for PR context after waiting on their required checks.

Reviewer verification:
- Focused final reviewer PASS on commit `da0386b29`: build has no `needs`, build has `permissions: contents: read`, write/release jobs wait on all checks, root test remains plain `bun test`, and no workaround additions were found.

## Evidence

Evidence files are local and gitignored by repo policy, under `.omo/evidence/20260617-test-ci-performance/`.

Key artifacts:
- `local-bun-test-baseline-1.log`
- `local-bun-test-after-rebase-1.log`
- `local-bun-test-after-write-gate-fix.log`
- `local-bun-test-after-read-permission-assertion.log`
- `ci-dev-current-run-27668356968.json`
- `ci-pr-run-27671548193-final.json`
- `ci-pr-run-27671548193-jobs.tsv`
- `ci-pr-checks-after-read-permission-assertion-final.txt`
- `windows-crlf-workflow-red-proof.log`
- `workflow-test-after-crlf-normalization.log`
- `workflow-test-after-write-gate-fix.log`
- `workflow-test-after-read-permission-assertion.log`
- `ci-yaml-lint-after-write-gate-fix.log`
- `actionlint-after-read-permission-assertion.log`
- `typecheck-script-after-read-permission-assertion.log`
- `no-excuse-after-read-permission-assertion.log`
- `runtime-fallback-*-after-*.log`
- `background-agent-*-after-*.log`
- `opencode-qa-*.log`
- `cubic-bounded-wait-after-da0386b29.log`
