### PR TITLE
ci: auto-close master-targeting PRs with a friendly notice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,26 +11,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Block PRs targeting master branch
+  # Block PRs targeting master branch (comment + auto-close, then fail the check)
   block-master-pr:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
     steps:
       - name: Check PR target branch
         env:
           BASE_REF: ${{ github.base_ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [ "$BASE_REF" = "master" ]; then
-            echo "::error::PRs to master branch are not allowed. Please target the 'dev' branch instead."
-            echo ""
-            echo "PULL REQUESTS TO MASTER ARE BLOCKED"
-            echo ""
-            echo "All PRs must target the 'dev' branch."
-            echo "Please close this PR and create a new one targeting 'dev'."
-            exit 1
-          else
+          if [ "$BASE_REF" != "master" ]; then
             echo "PR targets '${BASE_REF}' branch - OK"
+            exit 0
           fi
+
+          echo "::error::PRs to master branch are not allowed. Please target the 'dev' branch instead."
+
+          gh pr comment "$PR_URL" --body "$(cat <<EOF
+          Hi @${PR_AUTHOR}, thanks for the contribution!
+
+          This repository does not accept pull requests that target the \`master\` branch, so this PR is being closed automatically.
+
+          **What to do instead:**
+          1. Re-target (or recreate) this PR against the \`dev\` branch.
+          2. All changes land on \`dev\` first; \`master\` is updated only by the release workflow.
+
+          No worries, nothing is lost. Just open a new PR against \`dev\` and we'll take it from there. Thanks again!
+          EOF
+          )"
+
+          gh pr close "$PR_URL"
+
+          echo "PR was auto-closed because it targeted 'master'."
+          exit 1
 
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What

When a pull request targets the `master` branch, the `block-master-pr` CI job previously only failed the check with an error message. Contributors had to read CI logs and manually close/recreate the PR.

This change makes the job, under the `github-actions` identity:

1. Post a friendly comment explaining the policy and how to re-target onto `dev`.
2. Auto-close the PR.
3. Still fail the check (preserves the existing required-status-check gate on `master`).

PRs targeting `dev` (or anything other than `master`) are unaffected and pass immediately.

## Why

`master` is updated only by the release workflow; all contributions land on `dev` first. Auto-closing with a clear, kind notice removes friction and avoids stale master-targeting PRs lingering.

## Details

- Added `permissions: pull-requests: write` to the job (needed for `gh pr comment` / `gh pr close`).
- Uses `GH_TOKEN: secrets.GITHUB_TOKEN` with `gh` CLI.
- Non-master targets short-circuit with `exit 0`.

## Verification

- `python3` YAML parse of `ci.yml` succeeds; rendered `run` script is correct.
- `bash -n` on the rendered script: syntax OK.
- `actionlint .github/workflows/ci.yml`: OK.

Scope: only `.github/workflows/ci.yml` (no opencode/codex plugin code touched).

## Related

Companion to the new GitHub ruleset "Require passing CI on dev" (added at the repo settings level) which requires the CI test/typecheck/codex-compatibility/build checks to pass before merging into `dev`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-closes PRs that target the `master` branch and posts a friendly comment with next steps, while still failing the required check. PRs targeting `dev` or other branches pass immediately.

- New Features
  - For `master` targets: post guidance comment, auto-close the PR, then fail the check to preserve the gate.
  - Added `permissions: pull-requests: write`; use `GH_TOKEN` with the `gh` CLI.
  - Non-`master` targets short-circuit with `exit 0`. Scope: `.github/workflows/ci.yml` only.

<sup>Written for commit a46192e532ea6c3efbc458028f6a078a30177a1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

