### PR TITLE
ci: bump all workflow actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
 
@@ -54,7 +54,7 @@ jobs:
         run: npm ci && npm run build
         working-directory: packages/lsp-tools-mcp
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -80,9 +80,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
 
@@ -94,7 +94,7 @@ jobs:
         run: npm ci && npm run build
         working-directory: packages/lsp-tools-mcp
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -119,9 +119,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
 
@@ -133,7 +133,7 @@ jobs:
         run: npm ci && npm run build
         working-directory: packages/lsp-tools-mcp
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
 
@@ -190,7 +190,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -202,7 +202,7 @@ jobs:
         run: npm ci && npm run build
         working-directory: packages/lsp-tools-mcp
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -245,7 +245,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check stored CLA signatures
         id: cla_state
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const signaturePath = "signatures/cla.json";

--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         platform: [darwin-arm64, darwin-x64, darwin-x64-baseline, linux-x64, linux-x64-baseline, linux-arm64, linux-x64-musl, linux-x64-musl-baseline, linux-arm64-musl, windows-x64, windows-x64-baseline, windows-arm64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build launcher
         if: steps.check.outputs.skip != 'true'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload artifact
         if: steps.check.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binary-${{ matrix.platform }}
           path: |
@@ -247,7 +247,7 @@ jobs:
       - name: Download artifact
         id: download
         if: steps.check.outputs.skip_all != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: binary-${{ matrix.platform }}
           path: .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,9 +39,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
 
@@ -66,9 +66,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
 
@@ -93,9 +93,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
 
@@ -261,7 +261,7 @@ jobs:
       needs.release-metadata.result == 'success' &&
       (inputs.skip_platform == true || needs.publish-platform.result == 'success')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -553,7 +553,7 @@ jobs:
       needs.publish-main.result == 'success' &&
       (inputs.skip_platform == true || needs.publish-platform.result == 'success')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -665,7 +665,7 @@ jobs:
 
       - name: Checkout LazyCodex marketplace
         if: needs.release-metadata.outputs.dist_tag == ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: code-yeongyu/lazycodex
           path: lazycodex-marketplace

--- a/.github/workflows/refresh-model-capabilities.yml
+++ b/.github/workflows/refresh-model-capabilities.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'code-yeongyu/oh-my-openagent'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -30,7 +30,7 @@ jobs:
         run: bun run test:model-capabilities
 
       - name: Create refresh pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: refresh model capabilities snapshot"
           title: "chore: refresh model capabilities snapshot"

--- a/.github/workflows/sisyphus-agent.yml
+++ b/.github/workflows/sisyphus-agent.yml
@@ -62,7 +62,7 @@ jobs:
           bun-version: "1.3.12"
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -25,7 +25,7 @@ jobs:
       run:
         working-directory: packages/web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -35,7 +35,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Restore Next.js build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/web/.next/cache
           key: ${{ runner.os }}-web-next-${{ hashFiles('packages/web/bun.lock', 'packages/web/package.json', 'packages/web/next.config.ts', 'packages/web/open-next.config.ts', 'packages/web/postcss.config.mjs') }}-${{ hashFiles('packages/web/app/**', 'packages/web/components/**', 'packages/web/lib/**', 'packages/web/messages/**', 'packages/web/i18n/**', 'docs/**') }}

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -48,7 +48,7 @@ jobs:
           NEXT_TELEMETRY_DISABLED: "1"
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## What

GitHub is deprecating Node.js 20 action runtimes (forced to Node 24 starting 2026-06-16, removed 2026-09-16). CI was emitting deprecation warnings for `actions/checkout`, `actions/cache`, and `actions/setup-node`. This bumps every Node.js-based action used across all workflows to a Node 24 capable major.

## Changes (all `.github/workflows/`)

GitHub-maintained:
- `actions/checkout@v4` -> `@v5` (node24)
- `actions/setup-node@v4` -> `@v6` (node24)
- `actions/cache@v4` -> `@v5` (node24)
- `actions/github-script@v7` -> `@v8` (node24)
- `actions/upload-artifact@v4` -> `@v6` (node24)
- `actions/download-artifact@v4` -> `@v7` (node24)

Third-party:
- `nick-fields/retry@v3` -> `@v4` (node24)
- `peter-evans/create-pull-request@v7` -> `@v8` (node24)
- `cloudflare/wrangler-action@v3` -> `@v4` (node24)

Already node24 (unchanged): `oven-sh/setup-bun@v2`.

## Known remaining

- `contributor-assistant/github-action@v2.6.1` (cla.yml) is **still on Node.js 20** because its latest release (v2.6.1) has no Node 24 runtime yet. There is no safe version bump available; left as-is and to be revisited when upstream ships a Node 24 release.

## Compatibility verification

- Confirmed the target major of each action declares `using: node24` by reading its `action.yml`.
- Verified no breaking input/behavior changes for our usages:
  - `github-script@v8`: script uses only `github`/`context`/`core` globals (still provided).
  - `upload-artifact@v6` / `download-artifact@v7`: only `name`/`path`/`retention-days`/`if-no-files-found` used; all retained; v4 artifact backend readable by v7.
  - `nick-fields/retry@v4`: `timeout_minutes`/`max_attempts`/`retry_wait_seconds`/`shell`/`command` all retained.
  - `create-pull-request@v8`: `commit-message`/`title`/`body`/`branch`/`delete-branch`/`labels` all retained.
  - `wrangler-action@v4`: uses project-local wrangler; `packages/web` already pins `wrangler@^4.93.0`; inputs `apiToken`/`accountId`/`workingDirectory`/`command` retained.
- `actionlint .github/workflows/*.yml`: clean.

Scope: workflow YAML only; no opencode/codex plugin code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps all GitHub Actions in our workflows to Node.js 24–compatible majors to remove deprecation warnings and stay ahead of GitHub’s Node 20 sunset. Workflow YAML only; no app code changes.

- **Dependencies**
  - Updated: `actions/checkout@v5`, `actions/setup-node@v6`, `actions/cache@v5`, `actions/github-script@v8`, `actions/upload-artifact@v6`, `actions/download-artifact@v7`.
  - Updated: `nick-fields/retry@v4`, `peter-evans/create-pull-request@v8`, `cloudflare/wrangler-action@v4`. Unchanged: `oven-sh/setup-bun@v2`.
  - Known gap: `contributor-assistant/github-action@v2.6.1` still on Node 20; waiting for an upstream Node 24 release.
  - Checked for breaking changes in our inputs; none found. `actionlint` passes.

<sup>Written for commit 6d2df5b44235394eb974c56d6b2f80862985bd3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

