### PR TITLE
feat(dev-env): cross-harness dev environment + CONTRIBUTING accuracy fixes

### DIFF
--- a/.agents/skills/codex-qa/SKILL.md
+++ b/.agents/skills/codex-qa/SKILL.md
@@ -12,7 +12,7 @@ an isolated `CODEX_HOME` + a local mock model means no real API call and the rea
 that asserts its scenario against the live machine, so the scripts are both the
 QA tools and their own regression checks.
 
-Verified against `codex-cli 0.139.0` (node, jq, tmux, bun on macOS). Confirm with
+Verified against `codex-cli 0.140.0` (node, jq, tmux, bun on macOS). Confirm with
 `codex --version`; check a flag with `codex <cmd> --help`.
 
 ## Golden rules (read before running anything)
@@ -41,6 +41,12 @@ Verified against `codex-cli 0.139.0` (node, jq, tmux, bun on macOS). Confirm wit
 cd <this-skill-dir>                        # .agents/skills/codex-qa
 bash scripts/lib/common.sh --self-check    # confirm deps + isolation harness
 ```
+
+**Docker is the default QA surface.** Run this QA inside a disposable container
+that has the latest codex and a copy of your config, with the host `~/.codex`
+untouched: `script/agent/qa-docker.sh` (see [references/docker-qa.md](references/docker-qa.md)).
+The local scripts below are the fallback for when Docker is unavailable or on
+Windows.
 
 ## Router: pick your case
 

--- a/.agents/skills/codex-qa/references/docker-qa.md
+++ b/.agents/skills/codex-qa/references/docker-qa.md
@@ -1,0 +1,57 @@
+# Docker QA (default path)
+
+Run Codex QA inside a DISPOSABLE container so the real `~/.codex` is never
+touched and you always test against the latest codex. The container is the
+sandbox: latest released codex (and opencode) are baked in, a COPY of your
+config is loaded, and the container is removed on exit (`docker run --rm`). This
+is the DEFAULT; fall back to running the scripts locally (see SKILL.md) only
+when Docker is unavailable or on Windows.
+
+## Run
+
+From the repo root:
+
+```bash
+# smoke: prove the container has the latest codex
+script/agent/qa-docker.sh bash -lc 'codex --version'
+
+# drive the app-server / hook probes inside the container
+script/agent/qa-docker.sh bash .claude/skills/codex-qa/scripts/app-server-drive.sh --self-test
+script/agent/qa-docker.sh bash .claude/skills/codex-qa/scripts/hook-unit-probe.sh --self-test
+script/agent/qa-docker.sh bash .claude/skills/codex-qa/scripts/install-verify.sh --self-test
+
+# remove the QA images when done
+script/agent/qa-docker.sh --clean
+```
+
+`qa-docker.sh` builds `omo-dev` (from `.devcontainer/Dockerfile`) then `omo-qa`
+(from `.devcontainer/qa.Dockerfile`, which adds the latest `@openai/codex` +
+`opencode-ai` npm packages plus `sqlite3 jq curl rsync`).
+
+## Isolation still applies inside
+
+The codex-qa scripts already isolate via an mktemp `CODEX_HOME` and a local mock
+model (no real API call). In Docker that runs inside a throwaway container too,
+so there are two layers: the scripts never touch the mounted real `~/.codex`,
+and the container is discarded on exit. `qa-docker.sh` mounts `~/.codex`
+READ-ONLY at `/mnt/host/codex`; the entrypoint copies it into the container's
+writable home for any case that wants the real config. The host `~/.codex`
+(including `config.toml`) is never written.
+
+## Credentials
+
+codex-qa uses a mock model, so no real key is needed for the first-party hook
+proof. For runs that do need auth, provide it at run time only: a gitignored
+`.env` / `.env.local`, Codespaces secrets, or the devcontainer `remoteEnv`
+passthrough - never baked into the image.
+
+## Fallback: local / Windows
+
+`qa-docker.sh` exits 3 with guidance when Docker is unavailable or on Windows;
+run the scripts directly on the host there (they isolate via mktemp
+`CODEX_HOME`). Windows has no Docker QA path here by design.
+
+## Cleanup
+
+Each run auto-removes its container (`--rm`). The `omo-dev` / `omo-qa` images
+persist for fast re-runs; drop them with `script/agent/qa-docker.sh --clean`.

--- a/.agents/skills/codex-qa/references/docker-qa.md
+++ b/.agents/skills/codex-qa/references/docker-qa.md
@@ -7,26 +7,31 @@ config is loaded, and the container is removed on exit (`docker run --rm`). This
 is the DEFAULT; fall back to running the scripts locally (see SKILL.md) only
 when Docker is unavailable or on Windows.
 
-## Run
+## Use it
 
-From the repo root:
+`qa-docker.sh` brings up a disposable box (builds `omo-dev` then `omo-qa` on
+first use, reused after) and drops you into it. From the repo root:
 
 ```bash
-# smoke: prove the container has the latest codex
-script/agent/qa-docker.sh bash -lc 'codex --version'
+# drive codex via the FIRST-PARTY app-server (no acp): a real turn in the box
+script/agent/qa-docker.sh codex
 
-# drive the app-server / hook probes inside the container
-script/agent/qa-docker.sh bash .claude/skills/codex-qa/scripts/app-server-drive.sh --self-test
-script/agent/qa-docker.sh bash .claude/skills/codex-qa/scripts/hook-unit-probe.sh --self-test
-script/agent/qa-docker.sh bash .claude/skills/codex-qa/scripts/install-verify.sh --self-test
+# fallback: the interactive codex TUI in the box (uses your mounted config)
+script/agent/qa-docker.sh codex --tui
 
-# remove the QA images when done
-script/agent/qa-docker.sh --clean
+# a shell inside the box: codex (and opencode) are on PATH
+script/agent/qa-docker.sh
+script/agent/qa-docker.sh shell
+
+# one-off command, or a codex-qa self-test inside the box:
+script/agent/qa-docker.sh exec codex --version
+script/agent/qa-docker.sh exec bash .claude/skills/codex-qa/scripts/tui-smoke.sh --self-test
+
+script/agent/qa-docker.sh --clean   # remove the QA images
 ```
 
-`qa-docker.sh` builds `omo-dev` (from `.devcontainer/Dockerfile`) then `omo-qa`
-(from `.devcontainer/qa.Dockerfile`, which adds the latest `@openai/codex` +
-`opencode-ai` npm packages plus `sqlite3 jq curl rsync`).
+`omo-qa` is `omo-dev` (`.devcontainer/Dockerfile`) plus the latest `@openai/codex`
+and `opencode-ai` npm packages and `sqlite3 jq curl rsync`.
 
 ## Isolation still applies inside
 

--- a/.agents/skills/opencode-qa/SKILL.md
+++ b/.agents/skills/opencode-qa/SKILL.md
@@ -10,7 +10,7 @@ helper script and a deep reference. Every script ships a `--self-test` that
 asserts its scenario against the live machine, so the scripts are both the QA
 tools and their own regression checks.
 
-Verified against opencode v1.15.13 (bun 1.3.12, macOS). Confirm the installed
+Verified against opencode v1.17.7 (bun 1.3.12, macOS). Confirm the installed
 version with `opencode --version`; the surface is stable but always sanity
 check a flag with `opencode <cmd> --help`.
 
@@ -38,6 +38,12 @@ directory (or with their absolute path):
 cd <this-skill-dir>                        # .agents/skills/opencode-qa
 bash scripts/lib/common.sh --self-check    # confirm the harness + deps
 ```
+
+**Docker is the default QA surface.** Run QA inside a disposable container that
+has the latest opencode and a copy of your config, with the host untouched:
+`script/agent/qa-docker.sh` (see [references/docker-qa.md](references/docker-qa.md)).
+The local scripts below are the fallback for when Docker is unavailable or on
+Windows.
 
 `common.sh` provides the shared harness (DB path, SQL escaping, isolated XDG
 sandbox, free port, server start/stop, and an EXIT-trap cleanup). It requires
@@ -193,3 +199,4 @@ isolated sandbox and clean up on exit.
 - `references/tui-tmux.md` - tmux recipe, isolation, TUI control API
 - `references/testing-harness.md` - how opencode tests itself (bun test)
 - `references/sdk.md` - the @opencode-ai/sdk client (reference only)
+- `references/docker-qa.md` - run QA in a disposable Docker container (default; local is the fallback)

--- a/.agents/skills/opencode-qa/references/docker-qa.md
+++ b/.agents/skills/opencode-qa/references/docker-qa.md
@@ -1,0 +1,69 @@
+# Docker QA (default path)
+
+Run opencode QA inside a DISPOSABLE container so the host is never touched and
+you always test against the latest opencode. The container itself is the
+sandbox: latest released opencode + codex are baked in, a COPY of your local
+config is loaded, and the container is removed on exit (`docker run --rm`). This
+is the DEFAULT; fall back to running the scripts locally (see SKILL.md) only
+when Docker is unavailable or on Windows.
+
+## Run
+
+From the repo root:
+
+```bash
+# smoke: prove the container has the latest opencode + codex
+script/agent/qa-docker.sh
+
+# run any opencode-qa script inside the container
+script/agent/qa-docker.sh bash .agents/skills/opencode-qa/scripts/server-smoke.sh --self-test
+script/agent/qa-docker.sh bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test
+
+# skip the config copy (fastest, for pure version / CLI checks)
+script/agent/qa-docker.sh --no-config bash -lc 'opencode --version'
+
+# remove the QA images when done
+script/agent/qa-docker.sh --clean
+```
+
+`qa-docker.sh` builds two images on first use and reuses them after: `omo-dev`
+(from `.devcontainer/Dockerfile`) and `omo-qa` (from `.devcontainer/qa.Dockerfile`,
+which adds the latest `opencode-ai` + `@openai/codex` npm packages plus
+`sqlite3 jq curl rsync`). Pin versions with `--build-arg OMO_OPENCODE_VERSION=...`
+on the qa.Dockerfile if you need a specific release.
+
+## Why the container is the sandbox
+
+The local scripts isolate by pointing `XDG_*` at temp dirs so they never
+pollute the real `~/.local/share/opencode/opencode.db`. In Docker the whole
+container is throwaway, so isolation is structural: your host DB and config are
+never written. `qa-docker.sh` mounts `~/.config/opencode` (and `~/.codex`)
+READ-ONLY at `/mnt/host/*`; the entrypoint copies them into the container's
+writable home (heavy caches excluded) so QA runs against a COPY.
+
+## Credentials
+
+Secrets are never baked into the image. Provide them at run time only:
+
+- a gitignored `.env` or `.env.local` at the repo root (auto-sourced by
+  `script/agent/setup.sh` and `script/agent/qa-sandbox.sh`),
+- GitHub Codespaces secrets, or
+- the devcontainer `remoteEnv` passthrough.
+
+The host config is mounted read-only, so auth that already lives in
+`~/.config/opencode` rides along without copying secrets into any image layer.
+
+Fish caveat: if your shell sets `OPENCODE_CONFIG_DIR` (for example a
+`profiles/today` override), export it before calling `qa-docker.sh` so the
+container resolves the same profile (the runner forwards it with `-e`).
+
+## Fallback: local / Windows
+
+`qa-docker.sh` exits 3 with guidance when Docker is unavailable or on Windows.
+There, run the scripts directly on the host (the rest of this skill); they
+isolate via temp `XDG_*`. Windows has no Docker QA path here by design.
+
+## Cleanup
+
+Each run auto-removes its container (`--rm`). The `omo-dev` / `omo-qa` images
+persist for fast re-runs; drop them with `script/agent/qa-docker.sh --clean`.

--- a/.agents/skills/opencode-qa/references/docker-qa.md
+++ b/.agents/skills/opencode-qa/references/docker-qa.md
@@ -7,30 +7,33 @@ config is loaded, and the container is removed on exit (`docker run --rm`). This
 is the DEFAULT; fall back to running the scripts locally (see SKILL.md) only
 when Docker is unavailable or on Windows.
 
-## Run
+## Use it
 
-From the repo root:
+`qa-docker.sh` brings up a disposable box (builds `omo-dev` then `omo-qa` on
+first use, reused after) and either drops you into it or serves opencode to
+your host. From the repo root:
 
 ```bash
-# smoke: prove the container has the latest opencode + codex
+# a shell inside the box: just type `opencode ...` or `codex ...`
 script/agent/qa-docker.sh
+script/agent/qa-docker.sh shell
 
-# run any opencode-qa script inside the container
-script/agent/qa-docker.sh bash .agents/skills/opencode-qa/scripts/server-smoke.sh --self-test
-script/agent/qa-docker.sh bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test
+# serve opencode's HTTP API to the host, then drive it from OUTSIDE:
+script/agent/qa-docker.sh serve 4096               # terminal 1 (Ctrl-C stops + removes)
+curl http://127.0.0.1:4096/global/health           # host -> {"healthy":true,"version":"1.17.7"}
+opencode run "hi" --attach http://127.0.0.1:4096   # a real turn against the box
 
-# skip the config copy (fastest, for pure version / CLI checks)
-script/agent/qa-docker.sh --no-config bash -lc 'opencode --version'
+# one-off command, or a skill's own self-test, inside:
+script/agent/qa-docker.sh exec opencode --version
+script/agent/qa-docker.sh exec bash .agents/skills/opencode-qa/scripts/server-smoke.sh --self-test
 
-# remove the QA images when done
-script/agent/qa-docker.sh --clean
+script/agent/qa-docker.sh --no-config exec opencode --version   # skip the config copy
+script/agent/qa-docker.sh --clean                               # remove the QA images
 ```
 
-`qa-docker.sh` builds two images on first use and reuses them after: `omo-dev`
-(from `.devcontainer/Dockerfile`) and `omo-qa` (from `.devcontainer/qa.Dockerfile`,
-which adds the latest `opencode-ai` + `@openai/codex` npm packages plus
-`sqlite3 jq curl rsync`). Pin versions with `--build-arg OMO_OPENCODE_VERSION=...`
-on the qa.Dockerfile if you need a specific release.
+`omo-qa` is `omo-dev` (`.devcontainer/Dockerfile`) plus the latest `opencode-ai`
+and `@openai/codex` npm packages and `sqlite3 jq curl rsync`. Pin with
+`--build-arg OMO_OPENCODE_VERSION=...` on the qa.Dockerfile for a specific release.
 
 ## Why the container is the sandbox
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/script/agent/setup.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/script/agent/cleanup.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Codex App local-environment setup script (committable). Codex runs this at the
+# project root when it creates a new worktree at the start of a thread. It just
+# delegates to the shared cross-harness bootstrap so every harness stays in sync.
+#
+# Codex Cloud setup is a web-UI field (paste the same commands there); the Codex
+# CLI reads AGENTS.md only and has no setup-script hook.
+set -euo pipefail
+exec bash "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/script/agent/setup.sh"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "bash script/agent/setup.sh"
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# Dev container image for oh-my-openagent.
+# Node 24 (npm builds the vendored lsp-tools-mcp / lsp-daemon / git-bash-mcp +
+# codex plugin) + Bun 1.3.12 (the workspace runtime, pinned to CI) + tmux
+# (interactive_bash + team-mode). git ships with the base image.
+FROM mcr.microsoft.com/devcontainers/javascript-node:24-bookworm
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends tmux \
+ && rm -rf /var/lib/apt/lists/*
+
+# Pin Bun to match CI (oven-sh/setup-bun bun-version: 1.3.12).
+ENV BUN_INSTALL=/usr/local
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.12" \
+ && bun --version
+
+USER node

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,62 @@
+# Dev container guide
+
+This dev container backs GitHub Codespaces, VS Code Dev Containers, and plain
+Docker (via [`script/agent/docker-dev.sh`](../script/agent/docker-dev.sh)). It
+builds [`Dockerfile`](./Dockerfile) (Node 24 + Bun 1.3.12 + tmux) and runs
+[`script/agent/setup.sh`](../script/agent/setup.sh) on create. This guide covers
+getting your credentials and per-harness config INTO the container so OpenCode,
+Codex, and Claude Code all work inside it.
+
+## Provider credentials (required)
+
+`setup.sh` and [`script/agent/qa-sandbox.sh`](../script/agent/qa-sandbox.sh)
+auto-source a repo-root `.env`. Inside the container, create it once:
+
+```bash
+cp .env.example .env
+$EDITOR .env   # set ANTHROPIC_API_KEY / OPENAI_API_KEY
+```
+
+Alternatives:
+
+- **GitHub Codespaces**: add `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` as
+  Codespaces secrets (repo Settings, Secrets, Codespaces). They are injected as
+  environment variables automatically.
+- **Local Dev Containers**: `devcontainer.json` forwards them from your host
+  shell via `"remoteEnv": { "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}", ... }`.
+  Export them in your host shell before opening the container.
+
+## Harness config (optional, to drive the agents inside the container)
+
+To use OpenCode / Codex / Claude Code from inside the container with your
+existing auth and settings, bind-mount the host config dirs. Add a `mounts`
+entry to [`devcontainer.json`](./devcontainer.json) (it supports JSONC):
+
+```jsonc
+"mounts": [
+  // OpenCode config + auth
+  "source=${localEnv:HOME}/.config/opencode,target=/home/node/.config/opencode,type=bind,consistency=cached",
+  // Codex CLI config + auth
+  "source=${localEnv:HOME}/.codex,target=/home/node/.codex,type=bind,consistency=cached",
+  // Claude Code config + auth
+  "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached"
+]
+```
+
+Notes:
+
+- The container user is `node` (home `/home/node`), so target those paths.
+- Bind mounts are read-write; the container can change your host config. Mount
+  only what you need, or copy the files in instead if you want isolation.
+- Codespaces has no host filesystem to mount; re-authenticate inside the
+  container, or copy the needed files via a `postCreateCommand`.
+- For QA that must NOT touch any real config, `source script/agent/qa-sandbox.sh`
+  points `XDG_*` and `CODEX_HOME` at a throwaway temp dir instead.
+
+## Maintenance
+
+If the image, the bootstrap, or the injected config changes, update
+[`Dockerfile`](./Dockerfile), [`script/agent/setup.sh`](../script/agent/setup.sh),
+this README, and the "Development Environment" sections of the root
+[`AGENTS.md`](../AGENTS.md) and [`CONTRIBUTING.md`](../CONTRIBUTING.md) together.
+See the maintenance directive in `AGENTS.md`.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "oh-my-openagent",
+  "build": { "dockerfile": "Dockerfile" },
+  "postCreateCommand": "OMO_AGENT_FORCE_BUILD=1 bash script/agent/setup.sh",
+  "remoteEnv": {
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+    "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["oven.bun-vscode", "biomejs.biome"]
+    }
+  }
+}

--- a/.devcontainer/qa-entrypoint.sh
+++ b/.devcontainer/qa-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Disposable-container QA entrypoint. Copies the read-only host config mounts
+# into writable home dirs so QA runs against a COPY (the host config is never
+# written), excluding heavy caches, then exec's the QA command. The container is
+# the sandbox and is discarded on exit (docker run --rm), so the host is never
+# touched.
+set -euo pipefail
+
+excludes=(--exclude=cache/ --exclude=.cache/ --exclude=__pycache__/ --exclude=.ruff_cache/ --exclude=node_modules/ --exclude='*.log')
+
+if [ -d /mnt/host/opencode-config ]; then
+  mkdir -p "$HOME/.config/opencode"
+  rsync -a "${excludes[@]}" /mnt/host/opencode-config/ "$HOME/.config/opencode/" 2>/dev/null || true
+fi
+if [ -d /mnt/host/codex ]; then
+  mkdir -p "$HOME/.codex"
+  rsync -a "${excludes[@]}" /mnt/host/codex/ "$HOME/.codex/" 2>/dev/null || true
+fi
+
+exec "$@"

--- a/.devcontainer/qa.Dockerfile
+++ b/.devcontainer/qa.Dockerfile
@@ -1,0 +1,26 @@
+# QA image for the opencode-qa / codex-qa skills.
+# Layered ON TOP of the devcontainer dev image (omo-dev) so the dev and QA
+# environments share one base, plus the LATEST released opencode + codex CLIs
+# and the QA toolchain (sqlite3, jq, curl, rsync). Build order (omo-dev first,
+# then omo-qa) is handled by script/agent/qa-docker.sh.
+FROM omo-dev
+
+USER root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends sqlite3 jq curl rsync ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Latest released opencode + codex. Both npm packages ship prebuilt binaries, so
+# there is no source build (matching "use the latest version" without a slow
+# codex-rs compile). Pin by passing OMO_OPENCODE_VERSION / OMO_CODEX_VERSION.
+ARG OMO_OPENCODE_VERSION=latest
+ARG OMO_CODEX_VERSION=latest
+RUN npm install -g "opencode-ai@${OMO_OPENCODE_VERSION}" "@openai/codex@${OMO_CODEX_VERSION}" \
+ && opencode --version \
+ && codex --version
+
+COPY .devcontainer/qa-entrypoint.sh /usr/local/bin/qa-entrypoint.sh
+RUN chmod +x /usr/local/bin/qa-entrypoint.sh
+
+USER node
+ENTRYPOINT ["/usr/local/bin/qa-entrypoint.sh"]

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# oh-my-openagent dev/QA credentials and config.
+#
+# Copy this file to .env (gitignored) ONCE and fill in the values you need:
+#   cp .env.example .env
+#
+# script/agent/setup.sh and script/agent/qa-sandbox.sh auto-source .env, so you
+# set your keys a single time on this machine and are never prompted again.
+# Only the providers you actually QA against are required.
+
+# Provider API keys. Uncomment and fill in only the providers you QA against.
+# A commented key keeps any value already in your shell or Codespaces secrets;
+# an empty uncommented value would override it with an empty string.
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+# GEMINI_API_KEY=
+
+# Optional: password for `opencode serve` based QA (see the opencode-qa skill).
+# OPENCODE_SERVER_PASSWORD=
+
+# Optional: force `bun run build` even when dist/index.js already exists.
+# OMO_AGENT_FORCE_BUILD=1

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ plans/
 .claude/*
 !.claude/skills
 !.claude/commands
+!.claude/settings.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **HOLD THE FUCK UP. THIS ENTIRE GODDAMN CODEBASE IS BEING RIPPED APART AND REBUILT RIGHT NOW. A MASSIVE MULTI-HARNESS AGENT OS REFACTOR IS IN PROGRESS — WE ARE RESTRUCTURING EVERYTHING TO SUPPORT MULTIPLE AGENT HARNESSES (OPENCODE, CODEX, PI, AND OTHERS). DO NOT TRUST THE STRUCTURE BELOW AS STABLE. READ THE [ROADMAP](./ROADMAP.md) BEFORE YOU TOUCH ANYTHING OR SO HELP ME GOD.**
 
-**Generated:** 2026-06-16 | **Commit:** 6d4928684 | **Branch:** dev | **Release:** v4.10.0
+**Generated:** 2026-06-17 | **Commit:** 437922bc0 | **Branch:** dev | **Release:** v4.10.0
 
 ## STOP. QA IS MANDATORY. NON-NEGOTIABLE. EVERY SINGLE TIME YOU TOUCH AN OPENCODE- OR CODEX-CONNECTED COMPONENT.
 
@@ -53,7 +53,7 @@ OpenCode plugin (npm: `oh-my-opencode`, dual-published as `oh-my-openagent` duri
 
 ```
 oh-my-opencode/                      # workspace root (no root src/ — it moved into packages/omo-opencode)
-├── packages/                        # 39 sibling pkgs, layered: Core → MCP → Skills → Adapters → Platform/Web. See packages/AGENTS.md
+├── packages/                        # 37 sibling pkgs, layered: Core → MCP → Skills → Adapters → Platform/Web. See packages/AGENTS.md
 │   ├── omo-opencode/                # ★ THE OpenCode plugin adapter (formerly root src/). Build entry: src/index.ts
 │   │   └── src/                     # plugin source and OpenCode-facing adapter shims. Full breakdown → packages/omo-opencode/src/AGENTS.md
 │   │       ├── index.ts             # Plugin entry; thin wrapper re-exporting createPluginModule() from src/testing/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,24 @@ bunx oh-my-opencode run <message> # Non-interactive session (auto-completes when
 bunx oh-my-opencode mcp-oauth login <server-url>  # Tier-3 MCP OAuth (PKCE + DCR)
 ```
 
+## DEVELOPMENT ENVIRONMENT
+
+Cross-harness, one-command dev setup. The **single source of truth** is [`script/agent/setup.sh`](script/agent/setup.sh): it verifies the toolchain (bun/node/git, warns if tmux is missing), runs `bun install`, and runs `bun run build` only when `dist/index.js` is missing or `OMO_AGENT_FORCE_BUILD=1` (cheap to re-run). [`script/agent/cleanup.sh`](script/agent/cleanup.sh) removes regenerable transients by default and takes `--deep` to also drop `dist/`, vendored `packages/*/dist/`, and `node_modules/`. Every harness below delegates to those two scripts, so there is exactly one place to maintain. Claude Code reads [`CLAUDE.md`](CLAUDE.md) (a symlink to this AGENTS.md) and OpenCode reads this file, so every harness shares one infra.
+
+| Harness | Committed wiring | Runs |
+|---------|------------------|------|
+| GitHub Codespaces / VS Code Dev Containers | [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) + [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile) (Node 24 + Bun 1.3.12 + tmux) | `postCreateCommand` runs `setup.sh` on container create |
+| Plain Docker | [`script/agent/docker-dev.sh`](script/agent/docker-dev.sh) | builds the same Dockerfile, opens a shell |
+| Cursor cloud agents | [`.cursor/environment.json`](.cursor/environment.json) | `install` runs `setup.sh` on environment creation |
+| Claude Code | [`.claude/settings.json`](.claude/settings.json) | `SessionStart` runs `setup.sh`, `SessionEnd` runs `cleanup.sh` |
+| Codex App (local environments) | [`.codex/setup.sh`](.codex/setup.sh) | committable setup script Codex runs at project root on worktree creation |
+| Codex Cloud / Codex CLI | no committable hook | Cloud: paste the `setup.sh` commands into the web-UI Setup script field. CLI: AGENTS.md only. |
+| OpenCode (this plugin's own harness) | root [`AGENTS.md`](AGENTS.md) + [`CLAUDE.md`](CLAUDE.md) symlink | no worktree hook; run `script/agent/setup.sh` (Claude Code auto-runs it via `.claude/settings.json`) |
+
+**Credentials and isolation.** [`.env.example`](.env.example) is the committed injection point: copy it to `.env` (gitignored) ONCE and fill in keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, optionally `OPENCODE_SERVER_PASSWORD`). `setup.sh` and `qa-sandbox.sh` auto-source `.env`, so credentials are set once per machine and never prompted again. For QA, `source` [`script/agent/qa-sandbox.sh`](script/agent/qa-sandbox.sh): it exports an isolated, throwaway environment (its own `XDG_DATA_HOME`/`XDG_CONFIG_HOME`/`XDG_CACHE_HOME`/`XDG_STATE_HOME` and a fresh `CODEX_HOME` under a `mktemp` dir, plus `OPENCODE_DISABLE_AUTOUPDATE`/`OPENCODE_DISABLE_MODELS_FETCH`) so QA NEVER reads or writes the host's real `~/.config/opencode` or `~/.codex`. Mirrors the `opencode-qa` and `codex-qa` skill conventions. For containerized environments, [`.devcontainer/README.md`](.devcontainer/README.md) documents how to inject provider credentials and your `~/.codex`, `~/.claude`, and `~/.config/opencode` config into the container.
+
+**MAINTENANCE - KEEP THIS IN SYNC.** `script/agent/setup.sh` and `script/agent/cleanup.sh` are the contract. Whenever a setup dependency or configuration is added, breaks, or changes (a new build step, a pinned tool version in the Dockerfile, a new env var or credential, a new harness wiring file), you MUST, in the SAME change, update: this section; the matching "Development Environment" / "Credentials & Isolation" sections in [`CONTRIBUTING.md`](CONTRIBUTING.md); [`.devcontainer/README.md`](.devcontainer/README.md) if container config injection changed; and the matching skill (`opencode-qa` for the OpenCode side, `codex-qa` for the Codex side) whose isolation conventions `qa-sandbox.sh` mirrors. Keep `script/agent-env.test.ts`, `script/agent-harness-wiring.test.ts`, and `script/agents-md-dev-env.test.ts` green. `CLAUDE.md` is a symlink to this file, so the Claude side stays in sync automatically. The scripts, the docs, and the skills must never drift out of sync.
+
 ## CI/CD
 
 | Workflow | Trigger | Purpose |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,13 @@ First off, thanks for taking the time to contribute! This document provides guid
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
+- [Language Policy](#language-policy)
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Development Setup](#development-setup)
   - [Testing Your Changes Locally](#testing-your-changes-locally)
+- [Development Environment](#development-environment)
+- [Credentials & Isolation](#credentials--isolation)
 - [Project Structure](#project-structure)
 - [Development Workflow](#development-workflow)
   - [Build Commands](#build-commands)
@@ -18,7 +21,9 @@ First off, thanks for taking the time to contribute! This document provides guid
   - [Adding a New Hook](#adding-a-new-hook)
   - [Adding a New Tool](#adding-a-new-tool)
   - [Adding a New MCP Server](#adding-a-new-mcp-server)
+- [QA Discipline](#qa-discipline)
 - [Pull Request Process](#pull-request-process)
+  - [PR Checklist](#pr-checklist)
 - [Publishing](#publishing)
 - [Getting Help](#getting-help)
 
@@ -55,8 +60,10 @@ If English isn't your first language, don't worry! We value your contributions r
 
 ### Prerequisites
 
-- **Bun** (latest version) - The only supported package manager
-- **TypeScript** - Strict mode for type checking and declarations
+- **Bun** 1.3.12 (CI-pinned) - The only package manager for the workspace itself
+- **Node** 24 - Required for vendored packages (lsp-tools-mcp, lsp-daemon, git-bash-mcp) and the Codex plugin build via npm
+- **git** - Version control
+- **tmux** (optional) - Enables the `interactive_bash` tool and Team Mode visualization
 
 ### Development Setup
 
@@ -84,45 +91,119 @@ After making changes, you can test your local build in OpenCode:
 
 2. **Update your OpenCode config** (`~/.config/opencode/opencode.json` or `opencode.jsonc`):
 
-   ```json
-   {
-     "plugin": ["file://./oh-my-opencode/dist/index.js"]
-   }
-   ```
-
-   For example, if your config is in the parent directory of `oh-my-opencode`:
+   Built dist (after `bun run build`):
 
    ```json
    {
-     "plugin": ["file://./oh-my-opencode/dist/index.js"]
+     "plugin": ["file:///absolute/path/to/oh-my-openagent/dist/index.js"]
    }
    ```
 
-   > **Note**: Remove `"oh-my-opencode"` from the plugin array if it exists, to avoid conflicts with the npm version.
+   Source mode (no build needed):
+
+   ```json
+   {
+     "plugin": ["file:///absolute/path/to/oh-my-openagent/packages/omo-opencode/src/index.ts"]
+   }
+   ```
+
+   The path must be **absolute** and contain a recognizable project name plus `(src|dist)/index.(ts|js)`. A relative `file://./...` path will not be detected by the installer.
+
+   > **Note**: Remove `"oh-my-openagent"` or `"oh-my-opencode"` from the plugin array if they exist, to avoid conflicts with the npm version.
 
 3. **Restart OpenCode** to load the changes.
 
 4. **Verify** the plugin is loaded by checking for OmO agent availability or startup messages.
 
+## Development Environment
+
+The cross-harness one-command bootstrap is the single source of truth for all development environments.
+
+- **`script/agent/setup.sh`** verifies Bun, Node, and git, warns if tmux is missing, runs `bun install`, and builds when `dist/index.js` is missing or `OMO_AGENT_FORCE_BUILD=1` is set.
+- **`script/agent/cleanup.sh`** removes regenerable transients by default. Pass `--deep` to also drop `dist/` and `node_modules/`.
+
+All harnesses delegate to these scripts:
+
+| Harness | Wiring |
+| ------- | ------ |
+| GitHub Codespaces / VS Code Dev Containers | `.devcontainer/devcontainer.json` runs `postCreateCommand: script/agent/setup.sh` on `.devcontainer/Dockerfile` (Node 24 + Bun 1.3.12 + tmux) |
+| Plain Docker | `script/agent/docker-dev.sh` builds the Dockerfile and opens a shell |
+| Cursor cloud agents | `.cursor/environment.json` `install` runs setup on environment creation |
+| Claude Code | `.claude/settings.json` `SessionStart` hook runs setup; `SessionEnd` hook runs cleanup |
+| Codex App (local environments) | `.codex/setup.sh` runs at project root on worktree creation |
+| OpenCode (this plugin's own harness) | reads `AGENTS.md` + `CLAUDE.md` (a symlink); run `script/agent/setup.sh` directly |
+
+The single source of truth is `script/agent/setup.sh`. Maintenance means editing that one script and the pinned Dockerfile versions.
+
+## Credentials & Isolation
+
+`.env.example` is the committed injection point. Copy it to `.env` (gitignored) once and fill in your keys:
+
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+- `OPENCODE_SERVER_PASSWORD` (optional)
+
+Both `setup.sh` and `qa-sandbox.sh` auto-source `.env`, so credentials are set once per machine and never prompted again.
+
+For QA isolation, run:
+
+```bash
+source script/agent/qa-sandbox.sh
+```
+
+This exports an isolated, throwaway environment with its own `XDG_*` directories and a fresh `CODEX_HOME` under a `mktemp` directory. It also sets `OPENCODE_DISABLE_AUTOUPDATE=1` and `OPENCODE_DISABLE_MODELS_FETCH=1`. QA never reads or writes the host's real `~/.config/opencode` or `~/.codex`. This mirrors the conventions used by the `opencode-qa` and `codex-qa` skills.
+
+For containerized environments (Codespaces, Dev Containers, Docker), see [`.devcontainer/README.md`](.devcontainer/README.md). It documents injecting provider credentials (via `.env`, Codespaces secrets, or `remoteEnv`) and bind-mounting your `~/.codex`, `~/.claude`, and `~/.config/opencode` config into the container so OpenCode, Codex, and Claude Code all work inside it.
+
 ## Project Structure
+
+The repository is a monorepo with layered packages under `packages/`.
 
 ```
 oh-my-opencode/
-├── packages/omo-opencode/src/
-│   ├── index.ts         # Plugin entry (V1 PluginModule, default export)
-│   ├── plugin-config.ts # JSONC multi-level config (Zod v4)
-│   ├── agents/          # 11 agents (Sisyphus, Hephaestus, Oracle, Librarian, Explore, Atlas, Prometheus, Metis, Momus, Multimodal-Looker, Sisyphus-Junior)
-│   ├── hooks/           # 54 base lifecycle hooks (61 with Team Mode) across 58 dirs
-│   ├── tools/           # 20-39 tools across 16 directories (config-gated)
-│   ├── mcp/             # 3 built-in remote MCPs (websearch, context7, grep_app)
-│   ├── features/        # 20 feature modules (background-agent, skill-loader, tmux, MCP-OAuth, boulder-state, etc.)
-│   ├── config/          # Zod v4 schema system
-│   ├── shared/          # Cross-cutting utilities
-│   ├── cli/             # CLI: install, run, doctor, mcp-oauth (Commander.js)
-│   ├── plugin/          # 10 OpenCode hook handlers + 52 hook composition
-│   └── plugin-handlers/ # 6-phase config loading pipeline
-└── dist/                # Build output (ESM + .d.ts)
+├── packages/
+│   ├── omo-opencode/          # OpenCode Ultimate edition adapter and build entry
+│   │   └── src/
+│   │       ├── index.ts         # Thin wrapper default-exporting PluginModule via createPluginModule()
+│   │       ├── plugin-config.ts # JSONC multi-level config (Zod v4)
+│   │       ├── agents/          # agent factories (Sisyphus, Hephaestus, Oracle, ...)
+│   │       ├── hooks/           # lifecycle hooks, 5-tier composition (see AGENTS.md for current counts)
+│   │       ├── tools/           # native tool dirs, config-gated (LSP via MCP, ast-grep via skill)
+│   │       ├── mcp/             # built-in MCPs: remote (websearch, context7, grep_app) + local stdio (lsp, codegraph)
+│   │       ├── features/        # feature modules (background-agent, skill-loader, tmux, MCP-OAuth, boulder-state, monitor, ...)
+│   │       ├── config/          # Zod v4 schema system
+│   │       ├── shared/          # Cross-cutting utilities
+│   │       ├── cli/             # CLI: install, run, doctor, mcp-oauth, boulder, sparkshell, ulw-loop (Commander.js)
+│   │       ├── plugin/          # OpenCode hook handlers + 5-tier hook composition
+│   │       └── plugin-handlers/ # 6-phase config loading pipeline
+│   ├── omo-codex/               # Codex Light edition / lazycodex
+│   ├── utils/                   # Core package
+│   ├── model-core/              # Core package
+│   ├── prompts-core/            # Core package
+│   ├── rules-engine/            # Core package
+│   ├── agents-md-core/          # Core package
+│   ├── comment-checker-core/    # Core package
+│   ├── hashline-core/           # Core package
+│   ├── boulder-state/           # Core package
+│   ├── telemetry-core/          # Core package
+│   ├── lsp-core/                # Core package
+│   ├── mcp-stdio-core/          # Core package
+│   ├── tmux-core/               # Core package
+│   ├── claude-code-compat-core/ # Core package
+│   ├── skills-loader-core/      # Core package
+│   ├── mcp-client-core/         # Core package
+│   ├── openclaw-core/           # Core package
+│   ├── team-core/               # Core package
+│   ├── delegate-core/           # Core package
+│   ├── lsp-tools-mcp/           # MCP package
+│   ├── lsp-daemon/              # MCP package
+│   ├── git-bash-mcp/            # MCP package
+│   ├── shared-skills/           # Cross-harness SKILL.md bundle
+│   └── web/                     # Marketing site (Next.js 15 + Cloudflare Workers)
+└── dist/                        # Build output (ESM + .d.ts)
 ```
+
+The multi-harness refactor is in progress. See `ROADMAP.md` for the current state.
 
 ## Development Workflow
 
@@ -143,7 +224,15 @@ bun run clean && bun run build
 
 # Build schema only (after modifying packages/omo-opencode/src/config/schema/)
 bun run build:schema
+
+# Run the root Bun test suite
+bun test
+
+# Run the Codex Light compatibility suite
+bun run test:codex
 ```
+
+Tests are co-located as `*.test.ts` files and follow a given/when/then style.
 
 ### Code Style & Conventions
 
@@ -153,8 +242,8 @@ bun run build:schema
 | Types            | Use `bun-types`, not `@types/node`                                        |
 | Directory Naming | kebab-case (`ast-grep/`, `claude-code-hooks/`)                            |
 | File Operations  | Never use bash commands (mkdir/touch/rm) for file creation in code        |
-| Tool Structure   | Each tool: `index.ts`, `types.ts`, `constants.ts`, `tools.ts`, `utils.ts` |
-| Hook Pattern     | `createXXXHook(input: PluginInput)` function naming                       |
+| Tool Structure   | `index.ts` (barrel), `types.ts`, `constants.ts`, and concern-split implementation files named after what they do. Generic catch-all dump modules are banned (see `.omo/rules/file-size-architectural-smell.md`). |
+| Hook Pattern     | `createXXXHook(deps)` function naming                                     |
 | Exports          | Barrel pattern (`export * from "./module"` in index.ts)                   |
 
 **Anti-Patterns (Do Not Do)**:
@@ -171,38 +260,44 @@ bun run build:schema
 ### Adding a New Agent
 
 1. Create a new `.ts` file in `packages/omo-opencode/src/agents/`
-2. Define the agent configuration following existing patterns
-3. Add to `builtinAgents` in `packages/omo-opencode/src/agents/index.ts`
-4. Update `packages/omo-opencode/src/agents/types.ts` if needed
-5. Run `bun run build:schema` to update the JSON schema
+2. Export a factory `createXyzAgent(model): AgentConfig` where `AgentConfig` is imported from `@opencode-ai/sdk`
+3. Set the static `.mode` property on the factory to `"primary"`, `"subagent"`, or `"all"`
+4. Add the factory to the `agentSources` record in `packages/omo-opencode/src/agents/builtin-agents.ts`
+5. Add the new name to the `BuiltinAgentName` union in `packages/omo-opencode/src/agents/types.ts` AND to `BuiltinAgentNameSchema` (plus `OverridableAgentNameSchema` if it should be user-overridable) in `packages/omo-opencode/src/config/schema/agent-names.ts`. The schema enum is what `build:schema` emits, so updating only `types.ts` will not change the published JSON schema.
+6. Run `bun run build:schema` to regenerate the JSON schema
+7. Special agents (Sisyphus, Hephaestus, Atlas, Prometheus) have dedicated wiring under `packages/omo-opencode/src/agents/builtin-agents/`; a plain subagent only needs the `agentSources` entry from step 4
 
 ```typescript
 // packages/omo-opencode/src/agents/my-agent.ts
-import type { AgentConfig } from "./types";
+import type { AgentConfig } from "@opencode-ai/sdk";
 
-export const myAgent: AgentConfig = {
-  name: "my-agent",
-  model: "anthropic/claude-opus-4-7",
-  description: "Description of what this agent does",
-  prompt: `Your agent's system prompt here`,
-  temperature: 0.1,
-  // ... other config
-};
+export function createMyAgent(model: string): AgentConfig {
+  return {
+    name: "my-agent",
+    model,
+    description: "Description of what this agent does",
+    prompt: `Your agent's system prompt here`,
+    temperature: 0.1,
+    // ... other config
+  };
+}
+
+createMyAgent.mode = "subagent" as const;
 ```
 
 ### Adding a New Hook
 
 1. Create a new directory in `packages/omo-opencode/src/hooks/` (kebab-case)
-2. Implement `createXXXHook()` function returning event handlers
-3. Export from `packages/omo-opencode/src/hooks/index.ts`
+2. Implement `createXyzHook(deps)` returning an object keyed by OpenCode hook names (for example `"tool.execute.before"`, `"chat.message"`, `"event"`) whose values are `(input, output) => void` handlers
+3. Re-export from `packages/omo-opencode/src/hooks/index.ts`
+4. Wire the hook into the matching tier composer in `packages/omo-opencode/src/plugin/hooks/create-*-hooks.ts` (Session / ToolGuard / Transform / Continuation / Skill) via `safeHook()`
+5. Add the hook name to `HookNameSchema` in `packages/omo-opencode/src/config/schema/hooks.ts`
 
 ```typescript
 // packages/omo-opencode/src/hooks/my-hook/index.ts
-import type { PluginInput } from "@opencode-ai/plugin";
-
-export function createMyHook(input: PluginInput) {
+export function createMyHook(deps: { logger: Logger }) {
   return {
-    onSessionStart: async () => {
+    "chat.message": async (input: ChatMessageInput, output: ChatMessageOutput) => {
       // Hook logic here
     },
   };
@@ -211,19 +306,24 @@ export function createMyHook(input: PluginInput) {
 
 ### Adding a New Tool
 
-1. Create a new directory in `packages/omo-opencode/src/tools/` with required files:
-   - `index.ts` - Main exports
-   - `types.ts` - TypeScript interfaces
-   - `constants.ts` - Constants and tool descriptions
-   - `tools.ts` - Tool implementations
-   - `utils.ts` - Helper functions
-2. Add to `builtinTools` in `packages/omo-opencode/src/tools/index.ts`
+1. Create a new directory in `packages/omo-opencode/src/tools/<name>/`
+2. Export a factory `createXyzTool(ctx): ToolDefinition` built with `tool({...})` from `@opencode-ai/plugin`
+3. Register the factory in the `ToolRegistryFactories` type and `defaultToolRegistryFactories` record in `packages/omo-opencode/src/plugin/tool-registry-factories.ts`
+4. Wire it into `createCoreTools()` in `tool-registry-core-tools.ts` for always-on tools, or a gated record in `tool-registry-gated-tools.ts` spread in `packages/omo-opencode/src/plugin/tool-registry.ts`
+5. Export from `packages/omo-opencode/src/tools/index.ts`
 
 ### Adding a New MCP Server
 
-1. Create configuration in `packages/omo-opencode/src/mcp/`
-2. Add to `packages/omo-opencode/src/mcp/index.ts`
-3. Document in README if it requires external setup
+1. Create a config factory in `packages/omo-opencode/src/mcp/<name>.ts` returning a `RemoteMcpConfig` (type `"remote"`, url) or `LocalMcpConfig` (type `"local"`, command)
+2. Register it inside `createBuiltinMcps()` in `packages/omo-opencode/src/mcp/index.ts`
+3. Add the MCP name to `McpNameSchema` in `packages/omo-opencode/src/mcp/types.ts`
+4. Document in README if it requires external setup
+
+## QA Discipline
+
+Any change to `packages/omo-opencode` (the OpenCode side) must be QA'd with the `opencode-qa` skill. Any change to `packages/omo-codex` (the Codex Light side) must be QA'd with the `codex-qa` skill. Record QA evidence under `.omo/evidence/<date>-<slug>/`.
+
+"It typechecks" or "`bun test` is green" is not QA. You must drive the real harness and record the observed behavior.
 
 ## Pull Request Process
 
@@ -233,6 +333,8 @@ export function createMyHook(input: PluginInput) {
    ```bash
    bun run typecheck  # Ensure no type errors
    bun run build      # Ensure build succeeds
+   bun test           # Run the root test suite
+   bun run test:codex # Run the Codex Light compatibility suite
    ```
 4. **Test in OpenCode** using the local build method described above
 5. **Commit** with clear, descriptive messages:
@@ -246,7 +348,10 @@ export function createMyHook(input: PluginInput) {
 - [ ] Code follows project conventions
 - [ ] `bun run typecheck` passes
 - [ ] `bun run build` succeeds
+- [ ] `bun test` passes
+- [ ] `bun run test:codex` passes (if Codex-side changed)
 - [ ] Tested locally with OpenCode
+- [ ] QA evidence recorded under `.omo/evidence/` (if harness-connected changes)
 - [ ] Updated documentation if needed (README, AGENTS.md)
 - [ ] No version changes in `package.json`
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/ — Monorepo Packages
 
-**Generated:** 2026-06-16
+**Generated:** 2026-06-17
 
 ## OVERVIEW
 
@@ -14,7 +14,7 @@
 | **MCP packages** | 3 | `lsp-tools-mcp`, `git-bash-mcp`, `lsp-daemon` |
 | **Core packages** | 18 | `utils`, `model-core`, `prompts-core`, `rules-engine` (was `rules-core`), `agents-md-core`, `comment-checker-core`, `hashline-core`, `boulder-state`, `telemetry-core`, `lsp-core`, `mcp-stdio-core`, `tmux-core`, `claude-code-compat-core`, `skills-loader-core`, `mcp-client-core`, `openclaw-core`, `team-core`, `delegate-core` |
 | **Adapters** | 2 | `omo-opencode` (OpenCode Ultimate edition; the former root `src/`, build entry for the main npm dist) + `omo-codex` (Codex CLI Light edition; npm/bin alias `lazycodex`; Codex marketplace `sisyphuslabs` / plugin `omo`). See [`packages/omo-opencode/src/AGENTS.md`](omo-opencode/src/AGENTS.md), [`packages/omo-codex/AGENTS.md`](omo-codex/AGENTS.md) |
-| **Skills** | 1 | `shared-skills` (cross-harness SKILL.md bundle shared between OMO and Codex; shipped via root `files` array) |
+| **Skills** | 1 | [`shared-skills`](shared-skills/AGENTS.md) (cross-harness SKILL.md bundle shared between OMO and Codex; shipped via root `files` array) |
 | **Web** | 1 | `web` |
 
 ## PLATFORM BINARIES (12)
@@ -30,31 +30,33 @@ Each contains only a `bin/<binary>` and a `package.json`. Built by [`script/buil
 | Package | Layout | Purpose |
 |---------|--------|---------|
 | `lsp-tools-mcp/` | Vendored standalone project (`.github/`, `CHANGELOG.md`, `LICENSE`, `src/`, `test/`, `biome.json`, `vitest.config.ts`) | Serves `lsp_diagnostics`, `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols`, `lsp_prepare_rename`, `lsp_rename`, `lsp_status` tools via stdio MCP. Registered as tier-1 MCP `lsp` in [`packages/omo-opencode/src/mcp/`](omo-opencode/src/mcp/AGENTS.md). Node-targeted, built with `npm` + vitest, and consumes `lsp-core` + `mcp-stdio-core`. |
-| `git-bash-mcp/` | Internal package (`src/`, `dist/`, `tsconfig.json`) | stdio MCP serving the Windows-only `git_bash` tool for the Codex edition. Tier-1 MCP. |
+| [`git-bash-mcp/`](git-bash-mcp/AGENTS.md) | Internal package (`src/`, `dist/`, `tsconfig.json`) | stdio MCP serving the Windows-only `git_bash` tool for the Codex edition (Bun-targeted, unlike the other two). Tier-1 MCP. |
 | `lsp-daemon/` | Vendored standalone project (`src/`, `test/`, `scripts/`, `biome.json`, `package-lock.json`) | Shared per-user LSP **daemon** over a unix socket (Windows named pipe) + a stdio MCP **proxy** + a tool client, consuming `lsp-core` + `mcp-stdio-core`. Lets multiple Codex sessions share one warm LSP process. Bin `omo-lsp-daemon`. Node-targeted (`npm` + vitest). See [`packages/lsp-daemon/AGENTS.md`](lsp-daemon/AGENTS.md). |
 
 ## CORE PACKAGES
 
+Every Core package now ships its own AGENTS.md (linked below).
+
 | Package | Layout | Purpose |
 |---------|--------|---------|
-| `utils/` | `src/`, `tsconfig.json` | Shared utilities: deep-merge, snake-case, frontmatter, file-utils, etc. |
-| `model-core/` | `src/`, `tsconfig.json` | Model resolution pipeline with ProviderCache dependency injection. |
-| `prompts-core/` | `src/`, `prompts/`, `test/`, `tsconfig.json` | Harness-neutral markdown prompt loading, model-variant routing, and bundled mode prompts for search/analyze/team/hyperplan. |
-| `rules-engine/` | `src/`, `tsconfig.json` | Rule discovery + matching engine (renamed from `rules-core`). |
-| `agents-md-core/` | `src/`, `tsconfig.json` | AGENTS.md walk-up discovery and injection logic. |
-| `comment-checker-core/` | `src/`, `tsconfig.json` | apply-patch parser and binary runner with injectable spawn. |
-| `hashline-core/` | `src/`, `tsconfig.json` | Hashline edit primitives and diff helpers shared by adapter shims. |
-| `boulder-state/` | `src/`, `tsconfig.json` | Work tracking state machine with split storage. |
-| `telemetry-core/` | `src/`, `tsconfig.json` | Harness-neutral telemetry primitives and PostHog wrappers. |
-| `lsp-core/` | `src/`, `tsconfig.json` | Harness-neutral LSP engine, request context, tool definitions, and MCP entry helpers. |
-| `mcp-stdio-core/` | `src/`, `tsconfig.json` | Shared JSON-RPC stdio framing and dispatch primitives for MCP servers. |
-| `tmux-core/` | `src/`, `tsconfig.json` | Harness-neutral tmux session, pane, layout, and runner primitives. |
-| `claude-code-compat-core/` | `src/`, `tsconfig.json` | Claude Code compatibility loaders for plugins, MCPs, commands, and agents. |
-| `skills-loader-core/` | `src/`, `tsconfig.json` | Skill loading, builtin skill, runtime skill, and skill matching primitives. |
-| `mcp-client-core/` | `src/`, `tsconfig.json` | MCP client lifecycle, skill-embedded MCP manager, and OAuth primitives. |
-| `openclaw-core/` | `src/`, `tsconfig.json` | OpenClaw gateway, reply-listener daemon, session registry, and tmux injection primitives. |
-| `team-core/` | `src/`, `tsconfig.json` | Team-mode registry, mailbox, tasklist, state, worktree, and tmux layout domain primitives. |
-| `delegate-core/` | `src/`, `tsconfig.json` | Delegate task selection and retry primitives. |
+| [`utils/`](utils/AGENTS.md) | `src/`, `tsconfig.json` | Shared utilities: deep-merge, snake-case, frontmatter, file-utils, etc. |
+| [`model-core/`](model-core/AGENTS.md) | `src/`, `tsconfig.json` | Model resolution pipeline with ProviderCache dependency injection. |
+| [`prompts-core/`](prompts-core/AGENTS.md) | `src/`, `prompts/`, `test/`, `tsconfig.json` | Harness-neutral markdown prompt loading, model-variant routing, and bundled mode prompts for search/analyze/team/hyperplan. |
+| [`rules-engine/`](rules-engine/AGENTS.md) | `src/`, `tsconfig.json` | Rule discovery + matching engine (renamed from `rules-core`). |
+| [`agents-md-core/`](agents-md-core/AGENTS.md) | `src/`, `tsconfig.json` | AGENTS.md walk-up discovery and injection logic. |
+| [`comment-checker-core/`](comment-checker-core/AGENTS.md) | `src/`, `tsconfig.json` | apply-patch parser and binary runner with injectable spawn. |
+| [`hashline-core/`](hashline-core/AGENTS.md) | `src/`, `tsconfig.json` | Hashline edit primitives and diff helpers shared by adapter shims. |
+| [`boulder-state/`](boulder-state/AGENTS.md) | `src/`, `tsconfig.json` | Work tracking state machine with split storage. |
+| [`telemetry-core/`](telemetry-core/AGENTS.md) | `src/`, `tsconfig.json` | Harness-neutral telemetry primitives and PostHog wrappers. |
+| [`lsp-core/`](lsp-core/AGENTS.md) | `src/`, `tsconfig.json` | Harness-neutral LSP engine, request context, tool definitions, and MCP entry helpers. |
+| [`mcp-stdio-core/`](mcp-stdio-core/AGENTS.md) | `src/`, `tsconfig.json` | Shared JSON-RPC stdio framing and dispatch primitives for MCP servers. |
+| [`tmux-core/`](tmux-core/AGENTS.md) | `src/`, `tsconfig.json` | Harness-neutral tmux session, pane, layout, and runner primitives. |
+| [`claude-code-compat-core/`](claude-code-compat-core/AGENTS.md) | `src/`, `tsconfig.json` | Claude Code compatibility loaders for plugins, MCPs, commands, and agents. |
+| [`skills-loader-core/`](skills-loader-core/AGENTS.md) | `src/`, `tsconfig.json` | Skill loading, builtin skill, runtime skill, and skill matching primitives. |
+| [`mcp-client-core/`](mcp-client-core/AGENTS.md) | `src/`, `tsconfig.json` | MCP client lifecycle, skill-embedded MCP manager, and OAuth primitives. |
+| [`openclaw-core/`](openclaw-core/AGENTS.md) | `src/`, `tsconfig.json` | OpenClaw gateway, reply-listener daemon, session registry, and tmux injection primitives. |
+| [`team-core/`](team-core/AGENTS.md) | `src/`, `tsconfig.json` | Team-mode registry, mailbox, tasklist, state, worktree, and tmux layout domain primitives. |
+| [`delegate-core/`](delegate-core/AGENTS.md) | `src/`, `tsconfig.json` | Delegate task selection and retry primitives. |
 
 ## WEB
 

--- a/packages/agents-md-core/AGENTS.md
+++ b/packages/agents-md-core/AGENTS.md
@@ -1,0 +1,29 @@
+# agents-md-core — AGENTS.md Discovery + Injection (Core)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+Harness-neutral logic for walking a file path UP its directory tree, discovering nearby `AGENTS.md` files, truncating their content, and formatting them as a `[Directory Context: ...]` block for injection into the session. Discovery itself is delegated to [`rules-engine`](../rules-engine/AGENTS.md) (`findAgentsMdUp`, `AgentsMdCache`); this package owns path resolution, formatting, and the per-session injected-paths cache. Package: `@oh-my-opencode/agents-md-core`.
+
+## PUBLIC API (`src/index.ts`)
+
+| Export | Source | Role |
+|--------|--------|------|
+| `AGENTS_FILENAME` | `constants.ts` | re-exported from `rules-engine` (value `"AGENTS.md"`) |
+| `resolveFilePath(rootDir, path)` | `finder.ts` | resolve + `realpathSync` validate path is inside `rootDir`; `null` if escapes |
+| `formatAgentsMdContextBlock({agentsPath, content, truncated})` | `formatter.ts` | wrap content in directory-context block + optional truncation notice |
+| `getSessionCache({sessionCaches, sessionID, storage})` | `injection-cache.ts` | per-session `Set<string>` of already-injected dirs, backed by storage |
+| `processFilePathForAgentsInjection(...)` | `injector.ts` | orchestrator: resolve → `findAgentsMdUp` → read → truncate → format → cache |
+| types | `types.ts` | `AgentsMdTruncator`, `AgentsMdContextOutput`, `AgentsMdInjectedPathsStorage`, `TruncationResult` |
+
+## DEPENDENCIES & CONSUMERS
+
+- **Depends on:** `@oh-my-opencode/rules-engine` only.
+- **Consumed by** (OpenCode edition only; no Codex consumer): `omo-opencode/src/hooks/directory-agents-injector/{finder,injector}.ts` (re-export) and `hooks/hephaestus-agents-md-injector/hook.ts` (`formatAgentsMdContextBlock`).
+
+## NOTES
+
+- **Path-traversal guard is a security invariant.** `resolveFilePath` canonicalizes via `realpathSync` and returns `null` when the resolved path is outside `rootDirectory`.
+- **Truncator + storage are injected** (`AgentsMdTruncator`, `AgentsMdInjectedPathsStorage`) — this package never implements truncation strategy or persistence itself.
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/packages/boulder-state/AGENTS.md
+++ b/packages/boulder-state/AGENTS.md
@@ -1,0 +1,34 @@
+# boulder-state — Work-Tracking State Machine (Core)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+Tracks the active work plan (the "boulder") across sessions, worktrees, and subagent task delegations. State persists in `<worktree-root>/.omo/boulder.json` (`schema_version: 2`). Zero npm dependencies — pure functional state machine over JSON. Package: `@oh-my-opencode/boulder-state`.
+
+## STATE MODEL
+
+Every `BoulderState` carries `active_work_id` + a `works` map. The root-level fields (`active_plan`, `plan_name`, `status`, `session_ids`, `task_sessions`, …) are a **mirror** of the currently active work. `selectMirrorWork()` picks the active work (by id, else most-recently-updated); `projectWorkToMirror()` copies it to root; `writeBoulderState()` syncs root → work entry before serialization. Legacy single-work states with no `works` map auto-upgrade via `getBoulderWorks()`.
+
+## PUBLIC API (`src/index.ts`)
+
+| Area | Functions |
+|------|-----------|
+| **Read** (`storage/read-state.ts`) | `readBoulderState`, `getBoulderWorks`, `getActiveWorks`, `getWorkById/ByPlanName/ForSession`, `getWorkResumeOptions`, `getTaskSessionState` |
+| **Write** (`storage/write-state.ts`) | `writeBoulderState`, `clearBoulderState`, `createBoulderState`, `addBoulderWork`, `completeBoulder`, `selectActiveWork`, `generateWorkId` |
+| **Sessions/tasks** (`storage/{session,task}.ts`) | `appendSessionId(ForWork)`, `upsertTaskSessionState(ForWork)`, `startTaskTimer`, `endTaskTimer` |
+| **Plans** (`plan-checklist.ts`, `top-level-task.ts`, `storage/plan-progress.ts`) | `getPlanChecklist`, `parsePlanChecklist`, `readCurrentTopLevelTask`, `findPrometheusPlans`, `getPlanProgress`, `getPlanName` |
+| **Paths** (`storage/path.ts`) | `getBoulderFilePath`, `resolveBoulderPlanPath(ForWork)` |
+
+## CONSUMERS
+
+- **omo-opencode** (`workspace:*`): `features/boulder-state/*` re-exports; hooks `atlas`, `ralph-loop`, `start-work`, `todo-continuation-enforcer`; CLI `boulder` command.
+- **omo-codex** (`file:` dep): `plugin/components/start-work-continuation/boulder-reader.ts`.
+
+## NOTES
+
+- **Prototype-pollution guard:** `RESERVED_KEYS = {__proto__, prototype, constructor}` — task upserts reject matching keys.
+- **Session IDs are normalized** with an `opencode:` / `codex:` prefix (`normalizeSessionId`).
+- **`writeBoulderState` self-creates `.omo/.gitignore`** (`*`, `!/rules/`) on first `mkdir`.
+- **Plan parsing** recognizes only `## TODOs` and `## Final Verification Wave` sections; counts numbered `1.`/`F1.` items, skips indented checkboxes.
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/packages/comment-checker-core/AGENTS.md
+++ b/packages/comment-checker-core/AGENTS.md
@@ -1,0 +1,31 @@
+# comment-checker-core — apply-patch Parser + Checker Runner (Core)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+Two responsibilities: (1) parse LLM apply-patch edits into structured `CheckerEdit[]`, and (2) run the external `@code-yeongyu/comment-checker` binary to detect AI-slop comments in changed code. Spawn is dependency-injected (not `child_process.spawn`) so both editions can drive the same core. Package: `@oh-my-opencode/comment-checker-core`.
+
+## PUBLIC API (`src/index.ts`)
+
+| Export | Source | Role |
+|--------|--------|------|
+| `parseApplyPatchRequests(patch)` | `apply-patch-edits.ts` | parse `*** Add/Update/Delete File:` + `*** Move to:` protocol with `@@` context + `+`/`-` markers |
+| `extractApplyPatchEdits(details, args?)` | `apply-patch-edits.ts` | high-level extractor (patch text OR metadata files) |
+| `getApplyPatchMetadataFiles(details)` | `apply-patch-edits.ts` | read files from nested `details.files` / `result.files` / `metadata.files` |
+| `resolveCommentCheckerBinary(input)` | `runner.ts` | locate binary via `createRequire(@code-yeongyu/comment-checker)` |
+| `runCommentChecker(input, options)` | `runner.ts` | pipe `HookInput` JSON to stdin, read stdout/stderr, return `CheckResult` |
+| types (17) | `types.ts` | `CheckerEdit`, `HookInput`, `CheckResult`, `SpawnFn`/`SpawnProcess`/`SpawnSignal`, `ApplyPatchFileMetadata`, … |
+
+## DEPENDENCIES & CONSUMERS
+
+- **Depends on:** `@oh-my-opencode/utils` (`isRecord` from `utils/record-type-guard`).
+- **Consumed by BOTH editions:** `omo-opencode/src/hooks/comment-checker/{hook,types,cli}.ts` and `omo-codex/plugin/components/comment-checker/src/{core,core-values,apply-patch,request-extractor}.ts`.
+
+## NOTES
+
+- **Exit-code contract:** `0` = clean, `2` = has comments; any other code / error / timeout silently returns `{hasComments: false, message: ""}`.
+- **Spawn timeouts:** default 30s, 1s kill grace, SIGTERM→SIGKILL escalation.
+- **`SpawnProcess` is an injected interface** — `stdin.write/end`, `ReadableStream<Uint8Array>` stdout/stderr, `exited: Promise<number>` — never the Node `ChildProcess` type directly.
+- **`HookInput` mirrors OpenCode's `tool.execute.before` input schema** exactly, so the same parser serves the Codex `PreToolUse`/`PostToolUse` adapters.
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/packages/delegate-core/AGENTS.md
+++ b/packages/delegate-core/AGENTS.md
@@ -1,0 +1,35 @@
+# delegate-core — Delegate Model Selection + Retry Guidance (Core)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+Two harness-neutral primitives for the `task`/delegate tool: (1) resolve which model a category/agent delegation should run on, with a multi-step fallback chain; (2) detect common `task()` invocation errors and build corrective retry guidance. Purely functional — zero state, zero IO, all deps injected. Package: `@oh-my-opencode/delegate-core`.
+
+## PUBLIC API (`src/index.ts` barrel)
+
+| Module | Key exports |
+|--------|-------------|
+| `model-selection.ts` | `resolveModelForDelegateTask(input, deps)`; types `DelegateFallbackEntry`, `DelegateModelResolutionInput/Result/Deps` |
+| `retry-patterns.ts` | `detectDelegateTaskError(output)`, `DELEGATE_TASK_ERROR_PATTERNS` (9 entries) |
+| `retry-guidance.ts` | `buildRetryGuidance(errorInfo)` — fix hint + available options + example call |
+
+### Resolution order (`resolveModelForDelegateTask`)
+
+1. user model override (promote first reachable `userFallbackModels` if unreachable) → 2. **skip sentinel** if caches cold (`{skipped: true}`) → 3. category default model (user-set returned as-is, else fuzzy-matched) → 4. user `fallback_models` array → 5. hardcoded `fallbackChain` (per-entry providers, exact-then-fuzzy) → 6. system default → 7. `undefined`.
+
+### Recognized error patterns (9)
+
+`missing_run_in_background`, `missing_load_skills`, `mutual_exclusion`, `missing_category_or_agent`, `unknown_category`, `empty_agent`, `unknown_agent`, `primary_agent`, `unknown_skills`.
+
+## DEPENDENCIES & CONSUMERS
+
+- **Depends on:** `@oh-my-opencode/model-core` (`fuzzyMatchModel`, `normalizeModel`, `parseModelString`, `parseVariantFromModelID`, `transformModelForProvider`).
+- **Consumed by** (OpenCode edition only; no Codex consumer): `omo-opencode/src/tools/delegate-task/model-selection.ts` (wires cache + logger deps) and `hooks/delegate-task-retry/{patterns,guidance}.ts` (re-export).
+
+## NOTES
+
+- **Cold-cache `skipped` sentinel:** when `availableModels` AND `connectedProviders` caches are both empty, resolution defers — caller waits for the model cache rather than picking wrong.
+- **`-high` models** are matched on their base model exactly, never fuzzy-downgraded to a non-high variant.
+- **Variant propagation:** a matched `DelegateFallbackEntry`'s variant flows through to the result.
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/packages/git-bash-mcp/AGENTS.md
+++ b/packages/git-bash-mcp/AGENTS.md
@@ -1,0 +1,30 @@
+# git-bash-mcp — Windows Git Bash stdio MCP (MCP layer)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+Internal **Bun-targeted** MCP-layer package (`@oh-my-opencode/git-bash-mcp`, private). Serves the Windows-only `git_bash` tool family for the Codex edition: resolve Git Bash's `bash.exe` and run shell commands through it. Consumes [`mcp-stdio-core`](../mcp-stdio-core/AGENTS.md) for JSON-RPC framing and [`utils`](../utils/AGENTS.md) for the bash resolver. NOT registered by the OpenCode edition (it has tmux-based `interactive_bash`). Package server name `git_bash`.
+
+## TOOLS SERVED
+
+- `which_bash` — resolve the `bash.exe` path; returns `{found, path, source, candidates}`. Cross-platform.
+- `diagnose` — report whether Git Bash execution is available; returns `{platform, enabled, status, resolution}`. Cross-platform.
+- `run` — **Windows-only.** Run a command via `bash.exe -lc`. Params `command` (required), `timeout` (≤30 min), `workdir`, `description`. Registered only when `platform === "win32" && canRunGitBash()`; otherwise omitted from `tools/list`.
+
+## KEY FILES
+
+| File | Role |
+|------|------|
+| `cli.ts` | Bin `omo-git-bash`. `mcp` subcommand → `runMcpStdioServer()` |
+| `mcp.ts` | `handleGitBashMcpRequest()` + tool registration over `runJsonRpcStdioServer` |
+| `runner.ts` | `runGitBashCommand()` — spawns `bash.exe -lc`, temp-fd output capture, timeout kill |
+| `git-bash-resolver.ts` | re-exports `resolveGitBash(ForCurrentProcess)` from `@oh-my-opencode/utils/runtime` |
+
+## NOTES
+
+- **Bun-targeted (NOT npm+vitest like `lsp-tools-mcp`/`lsp-daemon`).** Build: `bun build src/cli.ts --outdir dist --target node --format esm` (root: `bun run build:git-bash-mcp`). Tests via `bun:test`. No biome, no `engines.node`.
+- **Codex-only consumption:** `omo-codex/plugin/.mcp.json` declares it; `script/sync-lazycodex-marketplace.ts` copies `dist/` → `<plugin>/components/git-bash-mcp/dist/` and rewrites the `.mcp.json` path. Root `files` ships `packages/git-bash-mcp/dist`.
+- **Temp-fd output capture** (`mkdtempSync` + `openSync` + `rmSync`) avoids Windows pipe-buffer deadlocks.
+- **Timeout env chain:** `OMO_CODEX_GIT_BASH_TIMEOUT_MS` → `OMO_CODEX_EXEC_COMMAND_TIMEOUT_MS` → `CODEX_EXEC_COMMAND_TIMEOUT_MS` → `EXEC_COMMAND_TIMEOUT_MS` → 120_000 default (max 30 min).
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/packages/hashline-core/AGENTS.md
+++ b/packages/hashline-core/AGENTS.md
@@ -1,0 +1,32 @@
+# hashline-core — Hash-Anchored Edit Primitives (Core)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+The engine behind the Hashline edit tool (inspired by [oh-my-pi](https://github.com/can1357/oh-my-pi)). Tags every line with a `LINE#HASH|` content hash, validates edit refs against current content (rejecting stale lines), then applies structured `replace`/`append`/`prepend` edits with autocorrection, deduplication, and unified-diff generation. Package: `@oh-my-opencode/hashline-core`.
+
+## PUBLIC API (`src/index.ts`, ~26 fns + 7 types) — by area
+
+| Area | Files | Key exports |
+|------|-------|-------------|
+| **Hash compute** | `hash-computation.ts`, `xxhash32.ts`, `constants.ts` | `computeLineHash`, `computeLegacyLineHash`, `formatHashLine(s)`, `streamHashLinesFrom{Utf8,Lines}`, `NIBBLE_STR`, `HASHLINE_DICT` |
+| **Validation** | `validation.ts` | `parseLineRef`, `validateLineRef(s)`, `normalizeLineRef`, `HashlineMismatchError` |
+| **Apply** | `edit-operations.ts`, `edit-operation-primitives.ts` | `applyHashlineEdits`, `applyHashlineEditsWithReport`, `apply{SetLine,ReplaceLines,InsertAfter,InsertBefore,Append,Prepend}` |
+| **Normalize/dedup/order** | `normalize-edits.ts`, `edit-deduplication.ts`, `edit-ordering.ts` | `normalizeHashlineEdits`, `dedupeEdits`, `detectOverlappingRanges` |
+| **Autocorrect** | `autocorrect-replacement-lines.ts`, `edit-text-normalization.ts` | `autocorrectReplacementLines`, prefix/indent/echo strippers |
+| **Diff/display** | `diff-utils.ts`, `hashline-edit-diff.ts` | `toHashlineContent`, `generateUnifiedDiff`, `countLineDiffs`, `generateHashlineDiff` |
+| **Canonicalize/chunk** | `file-text-canonicalization.ts`, `hashline-chunk-formatter.ts` | `canonicalizeFileText`/`restoreFileText` (BOM + LF/CRLF), `createHashlineChunkFormatter` (200 lines / 64 KB) |
+
+## DEPENDENCIES & CONSUMERS
+
+- **Depends on:** `diff` (^9) — for `createTwoFilesPatch` in `generateUnifiedDiff` only. Otherwise self-contained.
+- **Consumed by:** the ~15 thin re-export shims under `omo-opencode/src/tools/hashline-edit/`. NOT consumed by the Codex edition (Light has no hashline).
+
+## NOTES
+
+- **"Option 2" hashing:** no npm xxhash dependency. `xxhash32.ts` prefers native `Bun.hash.xxHash32()` at call time and falls back to a pure-JS impl, so it runs under Bun and Node.
+- **Legacy hash compatibility:** validation accepts both `computeLineHash` (trimEnd + strip `\r`) and `computeLegacyLineHash` (strip ALL whitespace) — old stored hashes still validate.
+- **Seed rule:** content lines seed `0`; whitespace-only lines seed `lineNumber` (distinct hash per position).
+- **`normalizeHashlineEdits` rejects unknown ops** with `"Legacy format was removed; use op/pos/end/lines."` — the discriminated union is `replace | append | prepend` only.
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/packages/mcp-stdio-core/AGENTS.md
+++ b/packages/mcp-stdio-core/AGENTS.md
@@ -1,0 +1,31 @@
+# mcp-stdio-core — JSON-RPC stdio Framing + Dispatch (Core)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+The lowest-level core package: JSON-RPC 2.0 transport over stdio (line-mode and Content-Length framed), an event-loop server with idle timeout, response builders, and an `isPlainRecord` guard. Zero runtime/peer dependencies — imports nothing from the workspace, consumed by every MCP-layer package. Package: `@oh-my-opencode/mcp-stdio-core`.
+
+## KEY FILES (5 source, all flat in `src/`)
+
+| File | Subpath export | Role |
+|------|----------------|------|
+| `types.ts` | `./types` | `JsonRpcId/Error/Result/Response`, `McpToolDescriptor`, `TextContent`, `McpLifecycleLog` |
+| `record.ts` | `./record` | `isPlainRecord(value)` type guard |
+| `responses.ts` | `./responses` | `successResponse`, `errorResponse`, `jsonRpcId`, `messageFromError` |
+| `server.ts` | `./server` | `runJsonRpcStdioServer(config)` — async-generator loop, idle timeout, `McpRequestHandler` |
+| `transport.ts` | `./transport` | `readStdioJsonRpcMessages` (async gen), `writeStdioJsonRpcResponse`, dual framing |
+
+## CONSUMERS
+
+- `lsp-core/src/mcp.ts` (primary) — LSP MCP server.
+- `git-bash-mcp/src/mcp.ts` — Git Bash MCP server.
+- `lsp-daemon/src/proxy.ts` — stdio MCP proxy (also imports the `./record` subpath).
+
+## NOTES
+
+- **Two framing modes:** `"line"` (`\n`-delimited) and `"framed"` (`Content-Length:` header per MCP spec); auto-detected by scanning the buffer prefix for `content-length:`.
+- **Idle timeout uses `timer.unref()`** — the timeout never keeps the process alive.
+- **Handler contract:** return `undefined` to skip silently; `onHandlerError` catches exceptions; `parseErrorResponse` customizes JSON parse errors.
+- **Keep zero dependencies.** `.js` suffix on relative imports (ESM). This is the floor of the package layering — it must stay leaf.
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/packages/prompts-core/AGENTS.md
+++ b/packages/prompts-core/AGENTS.md
@@ -1,0 +1,34 @@
+# prompts-core — Markdown Prompt Loading + Variant Routing (Core)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+Owns all static markdown prompt content (`prompts/` tree), bundles it at build time via Bun's `.md` text loader (never read from disk at runtime), and exports it as `VariantTable` records plus typed `loadPrompt`/`loadPromptSync` (frontmatter parse + runtime placeholder injection) and `resolveVariant` (model → variant). Harness-neutral: zero OpenCode SDK coupling, enforced by an audit test. Package: `@oh-my-opencode/prompts-core`.
+
+## PROMPT TREE (`prompts/`)
+
+| Family | Variants |
+|--------|----------|
+| `ultrawork/` | `default`, `gpt`, `gemini`, `planner`, `codex` (5) |
+| `atlas/` | `default`, `gpt`, `gemini`, `kimi`, `kimi-k2-7`, `opus-4-7` (6) |
+| `prometheus/` | `default` only (no model routing) |
+| `mode/` | `hyperplan`, `team` |
+
+## PUBLIC API (`src/index.ts`)
+
+- **Constants:** `ULTRAWORK_{DEFAULT,GPT,GEMINI,PLANNER}_PROMPT`, `CODEX_ULTRAWORK_PROMPT`, `HYPERPLAN_MODE_PROMPT`, `TEAM_MODE_PROMPT`; `VariantTable`s `ultraworkPromptVariants`, `codexUltraworkPromptVariants`, `atlasPromptVariants`, `prometheusPromptVariants`.
+- **Functions:** `resolveVariant(input)` (uses `model-core` matchers), `loadPrompt`/`loadPromptSync` (bundled sync or filesystem async).
+- **Types/errors:** `ModelVariant` (11 literals), `PromptSource`, `LoadedPrompt`, `VariantTable`; `PromptFileNotFoundError`, `PromptPathTraversalError`.
+
+## DEPENDENCIES & CONSUMERS
+
+- **Peer deps:** `@oh-my-opencode/model-core` (`isGptModel`, `isGeminiModel`, `isKimiK2Model`, …), `@oh-my-opencode/utils` (`parseFrontmatter`).
+- **Consumers:** `omo-opencode/src/hooks/keyword-detector/{ultrawork,hyperplan,team}/*.ts` (thin re-export shims), `agents/atlas/agent.ts`, `agents/prometheus/system-prompt.ts`; `omo-codex` resolves `prompts-core/prompts/ultrawork/codex.md` directly (secondary export path).
+
+## NOTES
+
+- **Edit prompt bodies in `prompts/*.md`, NOT the `.ts` loaders.** The `-prompts.ts` files just import + wrap the markdown.
+- **No `@opencode-ai/*` imports** — enforced by `test/opencode-coupling-audit.test.ts`.
+- **`codex.md` is exported via a secondary package path** (`./prompts/ultrawork/codex.md`) for the Light edition; prometheus stays single-variant (no per-model files).
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/packages/shared-skills/AGENTS.md
+++ b/packages/shared-skills/AGENTS.md
@@ -1,0 +1,38 @@
+# shared-skills — Cross-Harness SKILL.md Bundle (Skills)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+Hand-authored, cross-harness skill bundle shared between the OpenCode and Codex editions. Pure data — no logic, no transform inside the package. The only code is `index.mjs`, which exports `sharedSkillsRootPath()` returning the absolute path to `skills/`. Package: `@oh-my-opencode/shared-skills` (`files`: `index.mjs`, `index.d.ts`, `skills`).
+
+## SKILLS (17 under `skills/<name>/`)
+
+`programming`, `debugging`, `frontend`, `visual-qa`, `ast-grep`, `git-master`, `refactor`, `review-work`, `start-work`, `ulw-plan`, `ultraresearch`, `init-deep`, `remove-ai-slops`, `lsp-setup` (shared) + `lcx-report-bug`, `lcx-contribute-bug-fix`, `lcx-doctor` (Codex-only, `lcx-` prefix).
+
+Per-skill layout: `SKILL.md` (YAML frontmatter `name:` + single-line `description:` with triggers) + optional `references/` (the real content; SKILL.md is a router/index) + optional `scripts/` + optional `agents/openai.yaml` (5 skills carry the Codex agent role declaration).
+
+## PIPELINE
+
+```
+skills/ (source)
+  ├─ build:shared-skills-assets (root) → cp -R skills dist/skills          # literal copy, no transform
+  ├─ skills-loader-core → loadSkillsFromDir(sharedSkillsRootPath(), scope:"shared")   # OpenCode runtime
+  └─ omo-codex/plugin/scripts/sync-skills.mjs → plugin/skills/             # copy + adaptSkillForCodex()
+        (inserts Codex Harness Tool Compatibility sections; overlays start-work/review-work;
+         filters out *.test.* ) → ships to ~/.codex/.../skills/
+```
+
+## CONSUMERS
+
+- `skills-loader-core` (`workspace:*`) — default `skillsRootPath` for builtin/shared skill loading.
+- `omo-opencode/src/cli/install-ast-grep-sg.ts` — finds the ast-grep skill dir for binary install.
+- `omo-codex/plugin` (`file:` dep) — `sync-skills.mjs` is the only transformer.
+
+## NOTES
+
+- **No generator builds the skills** — they are authored by hand; the build step is a plain `cp -R`.
+- **Test files (`*.test.ts/.mjs`) are excluded** when Codex copies skills.
+- **`lcx-` prefix = Codex-only** (no OpenCode counterpart). Frontmatter has NO `location:` field (unlike `.agents/skills/`).
+- **Packaging is pinned** by `omo-opencode/src/shared-skills-package.test.ts` (workspace inclusion + `files` entries + every skill parses).
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/packages/telemetry-core/AGENTS.md
+++ b/packages/telemetry-core/AGENTS.md
@@ -1,0 +1,35 @@
+# telemetry-core — Daily-Active Telemetry Primitives (Core)
+
+**Generated:** 2026-06-17
+
+## OVERVIEW
+
+Harness-neutral PostHog telemetry: env-gated opt-out, SHA256-hashed machine id, once-per-UTC-day capture dedup, and JSONL diagnostics. No product-specific strings live here — each consumer passes a `TelemetryProductConfig` (event name, cache dir, machine-id prefix, env prefix). Package: `@oh-my-opencode/telemetry-core`.
+
+## PUBLIC API (`src/index.ts` barrel)
+
+| Module | Key exports |
+|--------|-------------|
+| `record-daily-active.ts` | `recordDailyActive(input)` — orchestrator: enabled? → client → dedup → `trackActive` → flush → shutdown |
+| `posthog-client.ts` | `createTelemetryClient`, `isTelemetryClientEnabled`, `createDefaultPostHogTransport` |
+| `activity-state.ts` | `getDailyActiveCaptureState`, `resolveTelemetryStateDir`, `getTelemetryActivityStateFilePath` |
+| `env.ts` | `shouldDisableTelemetry`, `getTelemetryApiKey/Host`, `hasTelemetryApiKey` |
+| `machine-id.ts` | `getTelemetryDistinctId`, `getDefaultTelemetryOsProvider` |
+| `diagnostics.ts` | `writeTelemetryDiagnostic`, `cleanupTelemetryDiagnostics` |
+| `constants.ts` | `DEFAULT_POSTHOG_HOST`, `DEFAULT_POSTHOG_API_KEY` |
+| `types.ts` | `TelemetryProductConfig`, `TelemetryClient`, `TelemetryTransport(Factory)`, `TelemetryOsProvider`, … |
+
+## DEPENDENCIES & CONSUMERS
+
+- **Depends on:** `@oh-my-opencode/utils` (`writeFileAtomically`, `resolveXdgDataDir`) + `posthog-node` (^5).
+- **Consumed by BOTH editions:** `omo-opencode/src/shared/posthog*.ts`; `omo-codex/src/telemetry/*` and `omo-codex/plugin/components/telemetry/*`.
+
+## NOTES
+
+- **At most once per UTC day per machine.** `getDailyActiveCaptureState` compares last-active UTC day in the state file; same day → `captureDaily: false`, nothing sent.
+- **`$process_person_profile: false`** hardcoded on every capture — no PostHog person profiles.
+- **Distinct id = `sha256(prefix + hostname)`** — never the raw hostname.
+- **Opt-out env matrix:** `${PREFIX}_DISABLE_POSTHOG` (truthy `1/true/yes`) OR `${PREFIX}_SEND_ANONYMOUS_TELEMETRY` (opt-out `0/false/no/yes`); global `OMO_` prefix also checked.
+- **NO_OP_CLIENT** returned when disabled or transport init fails (`enabled: false`, all methods no-op). Transport + OS provider are injectable for tests.
+- **Diagnostics** JSONL: 7-day retention, 256 KB cap, cleanup on every write.
+- Parent: [`packages/AGENTS.md`](../AGENTS.md).

--- a/script/agent-env.test.ts
+++ b/script/agent-env.test.ts
@@ -20,7 +20,9 @@ describe("agent dev-environment scripts", () => {
     test("#given the shared bootstrap #when inspected #then it is an executable strict bash script", () => {
       // given / when / then
       expect(existsSync(setup), "script/agent/setup.sh must exist").toBe(true)
-      expect(isExecutable(setup), "setup.sh must be executable").toBe(true)
+      if (process.platform !== "win32") {
+        expect(isExecutable(setup), "setup.sh must be executable").toBe(true)
+      }
       const body = read(setup)
       expect(body.startsWith("#!/usr/bin/env bash")).toBe(true)
       expect(body).toContain("set -euo pipefail")
@@ -49,7 +51,9 @@ describe("agent dev-environment scripts", () => {
     test("#given the teardown #when inspected #then it is an executable strict bash script with a --deep mode", () => {
       // given / when / then
       expect(existsSync(cleanup), "script/agent/cleanup.sh must exist").toBe(true)
-      expect(isExecutable(cleanup), "cleanup.sh must be executable").toBe(true)
+      if (process.platform !== "win32") {
+        expect(isExecutable(cleanup), "cleanup.sh must be executable").toBe(true)
+      }
       const body = read(cleanup)
       expect(body.startsWith("#!/usr/bin/env bash")).toBe(true)
       expect(body).toContain("set -euo pipefail")

--- a/script/agent-env.test.ts
+++ b/script/agent-env.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, readFileSync, statSync } from "node:fs"
+import { join } from "node:path"
+
+const AGENT_DIR = join(import.meta.dir, "agent")
+const REPO_ROOT = join(import.meta.dir, "..")
+
+function read(path: string): string {
+  return readFileSync(path, "utf8")
+}
+
+function isExecutable(path: string): boolean {
+  return (statSync(path).mode & 0o111) !== 0
+}
+
+describe("agent dev-environment scripts", () => {
+  describe("setup.sh", () => {
+    const setup = join(AGENT_DIR, "setup.sh")
+
+    test("#given the shared bootstrap #when inspected #then it is an executable strict bash script", () => {
+      // given / when / then
+      expect(existsSync(setup), "script/agent/setup.sh must exist").toBe(true)
+      expect(isExecutable(setup), "setup.sh must be executable").toBe(true)
+      const body = read(setup)
+      expect(body.startsWith("#!/usr/bin/env bash")).toBe(true)
+      expect(body).toContain("set -euo pipefail")
+    })
+
+    test("#given the bootstrap #when it runs #then it verifies tools, installs, and conditionally builds", () => {
+      // given
+      const body = read(join(AGENT_DIR, "setup.sh"))
+
+      // then
+      expect(body).toContain("command -v") // tool presence check
+      expect(body).toContain("bun node git") // required toolchain verified
+      expect(body).toContain("tmux") // non-fatal warning path
+      expect(body).toContain("bun install")
+      expect(body).toContain("bun run build")
+      expect(body).toContain("OMO_AGENT_FORCE_BUILD") // idempotent skip-build guard
+      expect(body).toContain(".env") // credential sourcing
+      expect(body).toContain("--ignore-scripts")
+      expect(body).toContain("1.3.12")
+    })
+  })
+
+  describe("cleanup.sh", () => {
+    const cleanup = join(AGENT_DIR, "cleanup.sh")
+
+    test("#given the teardown #when inspected #then it is an executable strict bash script with a --deep mode", () => {
+      // given / when / then
+      expect(existsSync(cleanup), "script/agent/cleanup.sh must exist").toBe(true)
+      expect(isExecutable(cleanup), "cleanup.sh must be executable").toBe(true)
+      const body = read(cleanup)
+      expect(body.startsWith("#!/usr/bin/env bash")).toBe(true)
+      expect(body).toContain("set -euo pipefail")
+      expect(body).toContain("--deep")
+    })
+
+    test("#given the teardown #when inspected for safety #then it guards repo root and never nukes source or host", () => {
+      // given
+      const body = read(join(AGENT_DIR, "cleanup.sh"))
+
+      // then
+      expect(body).toContain("oh-my-openagent") // package-name repo-root guard
+      const dangerous = ["rm -rf /", "rm -rf ~", "rm -rf $HOME", "rm -rf src", "rm -rf packages"]
+      for (const pattern of dangerous) {
+        expect(body, `cleanup must never contain '${pattern}'`).not.toContain(pattern)
+      }
+    })
+  })
+
+  describe("qa-sandbox.sh", () => {
+    const sandbox = join(AGENT_DIR, "qa-sandbox.sh")
+
+    test("#given the QA isolation helper #when inspected #then it isolates XDG + CODEX_HOME and injects creds", () => {
+      // given / when / then
+      expect(existsSync(sandbox), "script/agent/qa-sandbox.sh must exist").toBe(true)
+      const body = read(sandbox)
+      expect(body.startsWith("#!/usr/bin/env bash")).toBe(true)
+      expect(body).toContain("mktemp")
+      for (const xdg of ["XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME"]) {
+        expect(body, `must isolate ${xdg}`).toContain(xdg)
+      }
+      expect(body).toContain("CODEX_HOME")
+      expect(body).toContain("OPENCODE_DISABLE_AUTOUPDATE")
+      expect(body).toContain("OPENCODE_DISABLE_MODELS_FETCH")
+      expect(body).toContain(".env") // creds injection, set once
+      expect(body).toContain(":-$0")
+    })
+  })
+
+  describe(".env.example", () => {
+    test("#given the credential template #when inspected #then it documents the injection points without real secrets", () => {
+      // given
+      const example = join(REPO_ROOT, ".env.example")
+
+      // when / then
+      expect(existsSync(example), ".env.example must exist (committed injection point)").toBe(true)
+      const body = read(example)
+      expect(body).toContain("ANTHROPIC_API_KEY")
+      expect(body).toContain("OPENAI_API_KEY")
+      expect(body).toContain("#") // documented with comments
+      expect(body).toContain("# ANTHROPIC_API_KEY")
+    })
+  })
+})

--- a/script/agent-harness-wiring.test.ts
+++ b/script/agent-harness-wiring.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const REPO_ROOT = join(import.meta.dir, "..")
+const AGENT_DIR = join(import.meta.dir, "agent")
+
+function read(path: string): string {
+  return readFileSync(path, "utf8")
+}
+
+function parsesAsJson(raw: string): boolean {
+  try {
+    JSON.parse(raw)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe("cross-harness env wiring", () => {
+  test("#given Cursor cloud agents #when reading .cursor/environment.json #then install delegates to the shared setup script", () => {
+    // given
+    const path = join(REPO_ROOT, ".cursor", "environment.json")
+
+    // when / then
+    expect(existsSync(path), ".cursor/environment.json must exist").toBe(true)
+    const raw = read(path)
+    expect(parsesAsJson(raw), ".cursor/environment.json must be valid JSON").toBe(true)
+    expect(raw).toContain("script/agent/setup.sh")
+  })
+
+  test("#given Claude Code #when reading .claude/settings.json #then SessionStart runs setup and SessionEnd runs cleanup", () => {
+    // given
+    const path = join(REPO_ROOT, ".claude", "settings.json")
+
+    // when / then
+    expect(existsSync(path), ".claude/settings.json must exist").toBe(true)
+    const raw = read(path)
+    expect(parsesAsJson(raw), ".claude/settings.json must be valid JSON").toBe(true)
+    expect(raw).toContain("SessionStart")
+    expect(raw).toContain("SessionEnd")
+    expect(raw).toContain("script/agent/setup.sh")
+    expect(raw).toContain("script/agent/cleanup.sh")
+  })
+
+  test("#given Codex App local environments #when reading .codex/setup.sh #then it delegates to the shared setup script", () => {
+    // given
+    const path = join(REPO_ROOT, ".codex", "setup.sh")
+
+    // when / then
+    expect(existsSync(path), ".codex/setup.sh must exist (committable Codex App setup)").toBe(true)
+    const raw = read(path)
+    expect(raw.startsWith("#!/usr/bin/env bash")).toBe(true)
+    expect(raw).toContain("script/agent/setup.sh")
+  })
+
+  test("#given Codespaces + Dev Containers #when reading .devcontainer/devcontainer.json #then it builds the Dockerfile and runs setup on create", () => {
+    // given
+    const path = join(REPO_ROOT, ".devcontainer", "devcontainer.json")
+
+    // when / then
+    expect(existsSync(path), ".devcontainer/devcontainer.json must exist").toBe(true)
+    const raw = read(path)
+    expect(parsesAsJson(raw), "devcontainer.json must be strict JSON").toBe(true)
+    expect(raw).toContain("postCreateCommand")
+    expect(raw).toContain("script/agent/setup.sh")
+    expect(raw).toContain("Dockerfile")
+  })
+
+  test("#given the devcontainer image #when reading .devcontainer/Dockerfile #then it pins node 24 + bun + tmux", () => {
+    // given
+    const path = join(REPO_ROOT, ".devcontainer", "Dockerfile")
+
+    // when / then
+    expect(existsSync(path), ".devcontainer/Dockerfile must exist").toBe(true)
+    const raw = read(path)
+    expect(raw).toContain("FROM mcr.microsoft.com/devcontainers/javascript-node")
+    expect(raw).toContain("bun")
+    expect(raw).toContain("tmux")
+  })
+
+  test("#given plain Docker users #when reading script/agent/docker-dev.sh #then it builds from the devcontainer Dockerfile", () => {
+    // given
+    const path = join(AGENT_DIR, "docker-dev.sh")
+
+    // when / then
+    expect(existsSync(path), "script/agent/docker-dev.sh must exist").toBe(true)
+    const raw = read(path)
+    expect(raw.startsWith("#!/usr/bin/env bash")).toBe(true)
+    expect(raw).toContain(".devcontainer/Dockerfile")
+  })
+
+  test("#given a containerized harness #when reading .devcontainer/devcontainer.json #then host provider creds pass through via remoteEnv", () => {
+    // given
+    const path = join(REPO_ROOT, ".devcontainer", "devcontainer.json")
+
+    // when / then
+    const raw = read(path)
+    expect(raw).toContain("remoteEnv")
+    expect(raw).toContain("ANTHROPIC_API_KEY")
+    expect(raw).toContain("OPENAI_API_KEY")
+    expect(raw).toContain("${localEnv:")
+  })
+
+  test("#given a devcontainer user #when reading .devcontainer/README.md #then it guides injecting creds + Codex/Claude/OpenCode config", () => {
+    // given
+    const path = join(REPO_ROOT, ".devcontainer", "README.md")
+
+    // when / then
+    expect(existsSync(path), ".devcontainer/README.md must exist").toBe(true)
+    const raw = read(path)
+    expect(raw).toContain("ANTHROPIC_API_KEY")
+    expect(raw).toContain(".codex")
+    expect(raw).toContain(".claude")
+    expect(raw).toContain(".config/opencode")
+  })
+
+  test("#given the Claude wiring #when reading .gitignore #then .claude/settings.json is force-tracked", () => {
+    // given
+    const raw = read(join(REPO_ROOT, ".gitignore"))
+
+    // then
+    expect(raw).toContain("!.claude/settings.json")
+  })
+})

--- a/script/agent-harness-wiring.test.ts
+++ b/script/agent-harness-wiring.test.ts
@@ -124,3 +124,53 @@ describe("cross-harness env wiring", () => {
     expect(raw).toContain("!.claude/settings.json")
   })
 })
+
+describe("Docker QA harness", () => {
+  test("#given the QA image #when reading .devcontainer/qa.Dockerfile #then it layers latest opencode + codex on the dev image", () => {
+    // given
+    const path = join(REPO_ROOT, ".devcontainer", "qa.Dockerfile")
+
+    // then
+    expect(existsSync(path), ".devcontainer/qa.Dockerfile must exist").toBe(true)
+    const raw = read(path)
+    expect(raw).toContain("FROM omo-dev")
+    expect(raw).toContain("opencode-ai")
+    expect(raw).toContain("@openai/codex")
+  })
+
+  test("#given the QA entrypoint #when reading .devcontainer/qa-entrypoint.sh #then it copies host config from a read-only mount", () => {
+    // given
+    const path = join(REPO_ROOT, ".devcontainer", "qa-entrypoint.sh")
+
+    // then
+    expect(existsSync(path), ".devcontainer/qa-entrypoint.sh must exist").toBe(true)
+    const raw = read(path)
+    expect(raw.startsWith("#!/usr/bin/env bash")).toBe(true)
+    expect(raw).toContain("/mnt/host")
+    expect(raw).toContain("rsync")
+  })
+
+  test("#given the runner #when reading script/agent/qa-docker.sh #then it is disposable with local + Windows fallback", () => {
+    // given
+    const path = join(AGENT_DIR, "qa-docker.sh")
+
+    // then
+    expect(existsSync(path), "script/agent/qa-docker.sh must exist").toBe(true)
+    const raw = read(path)
+    expect(raw).toContain("docker run --rm")
+    expect(raw.toLowerCase()).toContain("windows")
+    expect(raw).toContain(".devcontainer/qa.Dockerfile")
+  })
+
+  test("#given both QA skills #when looking for the docker-qa reference #then each documents the Docker path", () => {
+    // given
+    const oc = join(REPO_ROOT, ".agents", "skills", "opencode-qa", "references", "docker-qa.md")
+    const cx = join(REPO_ROOT, ".claude", "skills", "codex-qa", "references", "docker-qa.md")
+
+    // then
+    expect(existsSync(oc), "opencode-qa needs references/docker-qa.md").toBe(true)
+    expect(existsSync(cx), "codex-qa needs references/docker-qa.md").toBe(true)
+    expect(read(oc)).toContain("qa-docker.sh")
+    expect(read(cx)).toContain("qa-docker.sh")
+  })
+})

--- a/script/agent-harness-wiring.test.ts
+++ b/script/agent-harness-wiring.test.ts
@@ -160,6 +160,10 @@ describe("Docker QA harness", () => {
     expect(raw).toContain("docker run --rm")
     expect(raw.toLowerCase()).toContain("windows")
     expect(raw).toContain(".devcontainer/qa.Dockerfile")
+    expect(raw).toContain("serve")
+    expect(raw).toContain("codex")
+    expect(raw).toContain("app-server")
+    expect(raw).toContain("--tui")
   })
 
   test("#given both QA skills #when looking for the docker-qa reference #then each documents the Docker path", () => {

--- a/script/agent/cleanup.sh
+++ b/script/agent/cleanup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Cross-harness teardown for oh-my-openagent dev environments.
+#
+# Default: remove only regenerable transient artifacts (build-info, OS junk).
+# It NEVER touches source, node_modules, dist, or anything outside the repo.
+# Pass --deep to also drop build outputs and dependencies for a full reset
+# (regenerate with script/agent/setup.sh).
+#
+# Wired into Claude Code (.claude/settings.json SessionEnd). Codex and Cursor
+# have no committable teardown hook, so run this manually there if you want it.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+log() { printf '[cleanup] %s\n' "$*"; }
+
+# Safety guard: refuse to run unless we are at the oh-my-openagent repo root.
+if ! grep -q '"oh-my-openagent"' "$REPO_ROOT/package.json" 2>/dev/null; then
+  log "ERROR: refusing to run - $REPO_ROOT is not the oh-my-openagent repo root"
+  exit 1
+fi
+
+deep=0
+for arg in "$@"; do
+  case "$arg" in
+    --deep) deep=1 ;;
+    -h | --help)
+      log "usage: cleanup.sh [--deep]   (--deep also removes dist + node_modules)"
+      exit 0
+      ;;
+    *)
+      log "unknown argument: $arg (try --help)"
+      exit 2
+      ;;
+  esac
+done
+
+# Always-safe: regenerable transient files only, never inside node_modules/.git.
+find "$REPO_ROOT" -name '*.tsbuildinfo' -type f \
+  -not -path '*/node_modules/*' -not -path '*/.git/*' -delete 2>/dev/null || true
+find "$REPO_ROOT" -name '.DS_Store' -type f \
+  -not -path '*/node_modules/*' -not -path '*/.git/*' -delete 2>/dev/null || true
+log "removed transient build-info and OS artifacts"
+
+if [ "$deep" -eq 1 ]; then
+  log "--deep: removing build outputs and dependencies (rerun script/agent/setup.sh to restore)"
+  rm -rf "$REPO_ROOT/dist"
+  rm -rf "$REPO_ROOT"/packages/*/dist
+  rm -rf "$REPO_ROOT/node_modules"
+fi
+
+log "done."

--- a/script/agent/docker-dev.sh
+++ b/script/agent/docker-dev.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Plain-Docker dev shell using the SAME image as GitHub Codespaces and VS Code
+# Dev Containers (.devcontainer/Dockerfile). Builds the image, then drops you
+# into a bash shell with the repo mounted. The first thing to run inside is
+# usually: bash script/agent/setup.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+IMAGE="${OMO_DEV_IMAGE:-omo-dev}"
+WORKDIR="/workspaces/oh-my-openagent"
+
+echo "[docker-dev] building $IMAGE from .devcontainer/Dockerfile"
+docker build -t "$IMAGE" -f .devcontainer/Dockerfile .
+
+echo "[docker-dev] starting shell ($IMAGE) with repo mounted at $WORKDIR"
+exec docker run --rm -it -v "$REPO_ROOT:$WORKDIR" -w "$WORKDIR" "$IMAGE" bash

--- a/script/agent/qa-docker.sh
+++ b/script/agent/qa-docker.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Run opencode-qa / codex-qa inside a DISPOSABLE Docker container that has the
+# latest released opencode + codex and a COPY of your local config, so QA never
+# touches the host. This is the DEFAULT QA path; it falls back to local QA when
+# Docker is unavailable, and Windows always uses local (see the docker-qa.md
+# reference in each QA skill).
+#
+#   script/agent/qa-docker.sh                                   # smoke: opencode + codex versions
+#   script/agent/qa-docker.sh bash .agents/skills/opencode-qa/scripts/server-smoke.sh --self-test
+#   script/agent/qa-docker.sh --no-config bash -lc 'opencode --version'
+#   script/agent/qa-docker.sh --clean                           # remove the QA images
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+cd "$REPO_ROOT"
+log() { printf '[qa-docker] %s\n' "$*"; }
+
+# Windows: no Docker QA path here - the QA skills run directly on the host.
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  *NT* | MINGW* | MSYS* | CYGWIN*)
+    log "Windows detected: run the QA skill scripts locally instead (see references/docker-qa.md)."
+    exit 3
+    ;;
+esac
+
+# No Docker: fall back to local QA (the unavoidable second-best).
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+  log "Docker unavailable: fall back to local QA - 'cd <skill-dir> && bash scripts/<script>.sh' (see references/docker-qa.md)."
+  exit 3
+fi
+
+dev_image="omo-dev"
+qa_image="omo-qa"
+
+if [ "${1:-}" = "--clean" ]; then
+  docker rmi -f "$qa_image" "$dev_image" >/dev/null 2>&1 || true
+  log "removed QA images ($qa_image, $dev_image)."
+  exit 0
+fi
+
+mount_config=1
+if [ "${1:-}" = "--no-config" ]; then
+  mount_config=0
+  shift
+fi
+
+docker image inspect "$dev_image" >/dev/null 2>&1 || {
+  log "building $dev_image from .devcontainer/Dockerfile (one-time)"
+  docker build -t "$dev_image" -f .devcontainer/Dockerfile .
+}
+docker image inspect "$qa_image" >/dev/null 2>&1 || {
+  log "building $qa_image with latest opencode + codex + QA tools (one-time)"
+  docker build -t "$qa_image" -f .devcontainer/qa.Dockerfile .
+}
+
+if [ "$#" -eq 0 ]; then
+  set -- bash -lc 'opencode --version && codex --version'
+fi
+
+config_mounts=()
+if [ "$mount_config" -eq 1 ]; then
+  [ -d "$HOME/.config/opencode" ] && config_mounts+=(-v "$HOME/.config/opencode:/mnt/host/opencode-config:ro")
+  [ -d "$HOME/.codex" ] && config_mounts+=(-v "$HOME/.codex:/mnt/host/codex:ro")
+fi
+
+log "running QA in a disposable container (--rm); host config mounted read-only, copied into the container"
+exec docker run --rm -i \
+  -v "$REPO_ROOT:/workspaces/oh-my-openagent" \
+  "${config_mounts[@]}" \
+  -e "OPENCODE_CONFIG_DIR=${OPENCODE_CONFIG_DIR:-}" \
+  -w /workspaces/oh-my-openagent \
+  "$qa_image" "$@"

--- a/script/agent/qa-docker.sh
+++ b/script/agent/qa-docker.sh
@@ -1,21 +1,25 @@
 #!/usr/bin/env bash
-# Run opencode-qa / codex-qa inside a DISPOSABLE Docker container that has the
-# latest released opencode + codex and a COPY of your local config, so QA never
-# touches the host. This is the DEFAULT QA path; it falls back to local QA when
-# Docker is unavailable, and Windows always uses local (see the docker-qa.md
-# reference in each QA skill).
+# Bring up a DISPOSABLE, isolated dev/QA box that has the latest opencode + codex
+# and a COPY of your local config, then just USE it: a shell inside, a one-off
+# command, or opencode's HTTP server published to your host. The host is never
+# touched (config mounted read-only, copied into the container; --rm on exit).
+# Default QA path; Windows and Docker-less hosts use the local skill scripts
+# (see references/docker-qa.md in each QA skill).
 #
-#   script/agent/qa-docker.sh                                   # smoke: opencode + codex versions
-#   script/agent/qa-docker.sh bash .agents/skills/opencode-qa/scripts/server-smoke.sh --self-test
-#   script/agent/qa-docker.sh --no-config bash -lc 'opencode --version'
-#   script/agent/qa-docker.sh --clean                           # remove the QA images
+#   script/agent/qa-docker.sh                 # shell in the box (type 'opencode ...' / 'codex ...')
+#   script/agent/qa-docker.sh shell           # same
+#   script/agent/qa-docker.sh serve [PORT]    # opencode serve -> http://127.0.0.1:PORT (default 4096)
+#   script/agent/qa-docker.sh codex [--tui]   # drive codex via the first-party app-server, or --tui fallback
+#   script/agent/qa-docker.sh exec <cmd...>   # run one command inside, then exit
+#   script/agent/qa-docker.sh --no-config ... # do not copy host config in
+#   script/agent/qa-docker.sh --clean         # remove the QA images
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
 cd "$REPO_ROOT"
 log() { printf '[qa-docker] %s\n' "$*"; }
 
-# Windows: no Docker QA path here - the QA skills run directly on the host.
+# Windows: no Docker QA path here; the QA skills run directly on the host.
 case "$(uname -s 2>/dev/null || echo unknown)" in
   *NT* | MINGW* | MSYS* | CYGWIN*)
     log "Windows detected: run the QA skill scripts locally instead (see references/docker-qa.md)."
@@ -23,9 +27,8 @@ case "$(uname -s 2>/dev/null || echo unknown)" in
     ;;
 esac
 
-# No Docker: fall back to local QA (the unavoidable second-best).
 if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
-  log "Docker unavailable: fall back to local QA - 'cd <skill-dir> && bash scripts/<script>.sh' (see references/docker-qa.md)."
+  log "Docker unavailable: run the QA skill scripts locally (see references/docker-qa.md)."
   exit 3
 fi
 
@@ -49,13 +52,9 @@ docker image inspect "$dev_image" >/dev/null 2>&1 || {
   docker build -t "$dev_image" -f .devcontainer/Dockerfile .
 }
 docker image inspect "$qa_image" >/dev/null 2>&1 || {
-  log "building $qa_image with latest opencode + codex + QA tools (one-time)"
+  log "building $qa_image with latest opencode + codex (one-time)"
   docker build -t "$qa_image" -f .devcontainer/qa.Dockerfile .
 }
-
-if [ "$#" -eq 0 ]; then
-  set -- bash -lc 'opencode --version && codex --version'
-fi
 
 config_mounts=()
 if [ "$mount_config" -eq 1 ]; then
@@ -63,10 +62,50 @@ if [ "$mount_config" -eq 1 ]; then
   [ -d "$HOME/.codex" ] && config_mounts+=(-v "$HOME/.codex:/mnt/host/codex:ro")
 fi
 
-log "running QA in a disposable container (--rm); host config mounted read-only, copied into the container"
-exec docker run --rm -i \
-  -v "$REPO_ROOT:/workspaces/oh-my-openagent" \
-  "${config_mounts[@]}" \
-  -e "OPENCODE_CONFIG_DIR=${OPENCODE_CONFIG_DIR:-}" \
-  -w /workspaces/oh-my-openagent \
-  "$qa_image" "$@"
+# Allocate a tty only when we have one (so CI / background use still works).
+tty_flags=(-i)
+[ -t 0 ] && [ -t 1 ] && tty_flags=(-it)
+
+docker_run() {
+  exec docker run --rm "${tty_flags[@]}" \
+    -v "$REPO_ROOT:/workspaces/oh-my-openagent" \
+    "${config_mounts[@]}" \
+    -e "OPENCODE_CONFIG_DIR=${OPENCODE_CONFIG_DIR:-}" \
+    -w /workspaces/oh-my-openagent \
+    "$@"
+}
+
+mode="${1:-shell}"
+case "$mode" in
+  shell)
+    log "shell in a disposable container; opencode + codex are on PATH. Ctrl-D to exit + remove."
+    docker_run "$qa_image" bash
+    ;;
+  serve)
+    shift
+    port="${1:-4096}"
+    log "opencode serve at http://127.0.0.1:${port} (reach it from the host). Ctrl-C to stop + remove."
+    docker_run -p "127.0.0.1:${port}:${port}" "$qa_image" bash -lc "opencode serve --hostname 0.0.0.0 --port ${port}"
+    ;;
+  codex)
+    shift
+    if [ "${1:-}" = "--tui" ]; then
+      log "codex TUI (fallback) in the box - interactive; uses your mounted config."
+      docker_run "$qa_image" bash -lc "exec codex"
+    else
+      log "codex via the first-party app-server (no acp): driving a real turn in the box."
+      docker_run "$qa_image" bash -lc "bash .agents/skills/codex-qa/scripts/app-server-drive.sh --self-test"
+    fi
+    ;;
+  exec)
+    shift
+    [ "$#" -gt 0 ] || {
+      log "exec needs a command, e.g. 'qa-docker.sh exec opencode --version'"
+      exit 2
+    }
+    docker_run "$qa_image" "$@"
+    ;;
+  *)
+    docker_run "$qa_image" "$@"
+    ;;
+esac

--- a/script/agent/qa-sandbox.sh
+++ b/script/agent/qa-sandbox.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# QA isolation helper. SOURCE this file (do not execute it) to export a
+# throwaway OpenCode + Codex environment so QA never reads or writes your real
+# host config:
+#
+#   source script/agent/qa-sandbox.sh
+#
+# It mirrors the opencode-qa (oqa_mk_isolated_xdg) and codex-qa (isolated
+# CODEX_HOME) skill conventions: every path lands under a fresh mktemp dir, so
+# the running machine's ~/.config/opencode and ~/.codex are untouched. Remove
+# the sandbox afterwards with: rm -rf "$OMO_QA_ROOT"
+#
+# Intentionally does NOT set -e: sourcing must not change the caller's shell.
+
+OMO_QA_ROOT="$(mktemp -d -t omo-qa-sandbox.XXXXXX)"
+export OMO_QA_ROOT
+
+# OpenCode: isolated XDG dirs (never the host ~/.config or ~/.local/share).
+export XDG_DATA_HOME="$OMO_QA_ROOT/data"
+export XDG_CONFIG_HOME="$OMO_QA_ROOT/config"
+export XDG_CACHE_HOME="$OMO_QA_ROOT/cache"
+export XDG_STATE_HOME="$OMO_QA_ROOT/state"
+mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME"
+export OPENCODE_DISABLE_AUTOUPDATE=1
+export OPENCODE_DISABLE_MODELS_FETCH=1
+
+# Codex: isolated CODEX_HOME (must exist before codex runs, or it hard-errors).
+export CODEX_HOME="$OMO_QA_ROOT/codex"
+mkdir -p "$CODEX_HOME"
+
+# Credentials, set once: inject keys from the gitignored .env (see .env.example).
+# ${BASH_SOURCE[0]:-$0} resolves this file under both bash and zsh (sourced $0).
+_omo_self="${BASH_SOURCE[0]:-$0}"
+_omo_repo_root="$(cd "$(dirname "$_omo_self")/../.." && pwd)"
+if [ -f "$_omo_repo_root/.env" ]; then
+  case "$-" in *a*) _omo_had_allexport=1 ;; *) _omo_had_allexport=0 ;; esac
+  set -a
+  # shellcheck disable=SC1091
+  . "$_omo_repo_root/.env"
+  [ "$_omo_had_allexport" = "1" ] || set +a
+  unset _omo_had_allexport
+fi
+unset _omo_self _omo_repo_root
+
+printf '[qa-sandbox] isolated env ready under %s\n' "$OMO_QA_ROOT"
+printf '[qa-sandbox]   XDG_CONFIG_HOME=%s\n' "$XDG_CONFIG_HOME"
+printf '[qa-sandbox]   CODEX_HOME=%s\n' "$CODEX_HOME"
+printf '[qa-sandbox] host ~/.config/opencode and ~/.codex are untouched. Clean up: rm -rf "%s"\n' "$OMO_QA_ROOT"

--- a/script/agent/setup.sh
+++ b/script/agent/setup.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Cross-harness dev-environment bootstrap for oh-my-openagent.
+#
+# Single source of truth for setting up a working tree so an agent (or human)
+# can build and QA the plugin. Wired into Codex App (.codex/setup.sh), Cursor
+# (.cursor/environment.json install), Claude Code (.claude/settings.json
+# SessionStart), and the devcontainer (postCreateCommand). Idempotent and safe
+# to re-run: it skips the (slow) build when dist/index.js already exists unless
+# OMO_AGENT_FORCE_BUILD=1.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+log() { printf '[setup] %s\n' "$*"; }
+
+# Credentials, set once: source the gitignored .env if present so keys are
+# never prompted for again on this machine. See .env.example.
+if [ -f "$REPO_ROOT/.env" ]; then
+  log "loading credentials from .env"
+  set -a
+  # shellcheck disable=SC1091
+  . "$REPO_ROOT/.env"
+  set +a
+fi
+
+# Required toolchain.
+missing=0
+for tool in bun node git; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    log "ERROR: required tool '$tool' not found on PATH"
+    missing=1
+  fi
+done
+if [ "$missing" -ne 0 ]; then
+  log "install the missing tools and re-run. See CONTRIBUTING.md (Prerequisites)."
+  exit 1
+fi
+
+# Optional toolchain (non-fatal).
+if ! command -v tmux >/dev/null 2>&1; then
+  log "WARN: tmux not found - interactive_bash and team-mode will be unavailable"
+fi
+
+log "bun $(bun --version) / node $(node --version) / $(git --version)"
+
+# Warn (do not fail) when the local toolchain drifts from the CI-pinned versions.
+expected_bun="1.3.12"
+expected_node_major="24"
+bun_version="$(bun --version 2>/dev/null || echo unknown)"
+node_major="$(node --version 2>/dev/null | sed -E 's/^v?([0-9]+).*/\1/')"
+[ "$bun_version" = "$expected_bun" ] || log "WARN: Bun $bun_version differs from CI-pinned $expected_bun (see .devcontainer/Dockerfile)"
+[ "$node_major" = "$expected_node_major" ] || log "WARN: Node major $node_major differs from CI-pinned $expected_node_major"
+
+# --ignore-scripts: the root package.json 'prepare' runs 'bun run build'; skip it
+# here so the explicit, guarded build below stays idempotent.
+log "installing dependencies (bun install --ignore-scripts)"
+bun install --ignore-scripts
+
+if [ ! -f "$REPO_ROOT/dist/index.js" ] || [ "${OMO_AGENT_FORCE_BUILD:-0}" = "1" ]; then
+  log "building plugin (dist/index.js missing or OMO_AGENT_FORCE_BUILD=1)"
+  bun run build
+else
+  log "dist/index.js present - skipping build (set OMO_AGENT_FORCE_BUILD=1 to force a rebuild)"
+fi
+
+log "ready. Run 'bun test' to verify, or 'source script/agent/qa-sandbox.sh' for isolated QA."

--- a/script/agents-md-dev-env.test.ts
+++ b/script/agents-md-dev-env.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const AGENTS_PATH = join(import.meta.dir, "..", "AGENTS.md")
+
+function readAgents(): string {
+  return readFileSync(AGENTS_PATH, "utf8")
+}
+
+describe("AGENTS.md dev-environment documentation", () => {
+  test("#given root AGENTS.md #when scanned #then it documents the shared setup/cleanup scripts and every harness wiring", () => {
+    // given
+    const content = readAgents()
+
+    // then
+    const required: ReadonlyArray<readonly [token: string, why: string]> = [
+      ["script/agent/setup.sh", "shared bootstrap"],
+      ["script/agent/cleanup.sh", "shared teardown"],
+      ["script/agent/qa-sandbox.sh", "isolated QA helper"],
+      [".env.example", "credential injection point"],
+      [".devcontainer", "Codespaces + Dev Containers wiring"],
+      [".cursor/environment.json", "Cursor wiring"],
+      [".claude/settings.json", "Claude Code wiring"],
+      [".codex/setup.sh", "Codex App wiring"],
+    ]
+    for (const [token, why] of required) {
+      expect(content, `AGENTS.md must document ${why} (${token})`).toContain(token)
+    }
+  })
+
+  test("#given the dev-environment section #when scanned #then it names a single source of truth and a keep-in-sync maintenance directive", () => {
+    // given
+    const content = readAgents()
+    const lower = content.toLowerCase()
+
+    // then
+    expect(content).toContain("single source of truth") // setup.sh is canonical
+    expect(lower).toContain("in sync") // update docs when the scripts change
+  })
+
+  test("#given the maintenance directive #when scanned #then it requires updating the matching QA skill and shares the infra with the Claude side", () => {
+    // given
+    const content = readAgents()
+    const lower = content.toLowerCase()
+
+    // then
+    expect(lower).toContain("and the matching skill")
+    expect(content).toContain("CLAUDE.md")
+  })
+})
+
+describe("CLAUDE.md (shared with the Claude side)", () => {
+  test("#given the Claude entry doc #when read #then it carries the same AGENTS.md dev-environment infra", () => {
+    // given
+    const claudePath = join(import.meta.dir, "..", "CLAUDE.md")
+
+    // when / then
+    expect(existsSync(claudePath), "CLAUDE.md must exist so Claude Code shares the infra").toBe(true)
+    const content = readFileSync(claudePath, "utf8")
+    expect(content).toContain("DEVELOPMENT ENVIRONMENT")
+    expect(content).toContain("script/agent/setup.sh")
+  })
+})

--- a/script/contributing-accuracy.test.ts
+++ b/script/contributing-accuracy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const CONTRIBUTING_PATH = join(import.meta.dir, "..", "CONTRIBUTING.md")
+
+function readContributing(): string {
+  return readFileSync(CONTRIBUTING_PATH, "utf8")
+}
+
+describe("CONTRIBUTING.md accuracy", () => {
+  test("#given the contributor guide #when scanned for known-wrong tokens #then no stale defect survives", () => {
+    // given
+    const content = readContributing()
+
+    // when
+    // static scan of the rendered guide
+
+    // then
+    const forbidden: ReadonlyArray<readonly [token: string, defect: string]> = [
+      ["oh-my-opencode/dist/index.js", "D1 broken local plugin path (wrong clone dir + wrong relative root)"],
+      ["utils.ts", "D8/D13 prescribes a catch-all file the repo explicitly bans"],
+      ["builtinTools", "D14 wrong tool registration entrypoint"],
+      ["builtinAgents", "D9 wrong agent registration entrypoint"],
+      ["onSessionStart", "D11/D12 invented hook handler shape"],
+    ]
+    for (const [token, defect] of forbidden) {
+      expect(content, `must not document ${defect}`).not.toContain(token)
+    }
+  })
+
+  test("#given the contributor guide #when scanned for the real registration entrypoints #then current symbols are documented", () => {
+    // given
+    const content = readContributing()
+
+    // then
+    const required: ReadonlyArray<readonly [token: string, why: string]> = [
+      ["agentSources", "D9 real agent registry in agents/builtin-agents.ts"],
+      ["@opencode-ai/sdk", "D9 real AgentConfig source"],
+      ["tool-registry-factories", "D13 real tool registry layer"],
+      ["createBuiltinMcps", "D15 real MCP registry function"],
+      ["HookNameSchema", "D11 hook enable/disable registration"],
+      ["file:///", "D1 absolute local plugin path form the installer accepts"],
+    ]
+    for (const [token, why] of required) {
+      expect(content, `must document ${why}`).toContain(token)
+    }
+  })
+
+  test("#given the contributor guide #when scanned for testing + QA discipline #then bun test, codex suite, and evidence rules are present", () => {
+    // given
+    const content = readContributing()
+
+    // then
+    expect(content).toContain("bun test")
+    expect(content).toContain("test:codex")
+    expect(content).toContain(".omo/evidence")
+    expect(content).toContain("opencode-qa")
+    expect(content).toContain("codex-qa")
+  })
+
+  test("#given the contributor guide #when scanned for the dev-environment sections #then cross-harness setup, credentials, and isolation are documented", () => {
+    // given
+    const content = readContributing()
+    const lower = content.toLowerCase()
+
+    // then
+    expect(content).toContain("Development Environment")
+    expect(content).toContain("script/agent/setup.sh")
+    expect(content).toContain("script/agent/cleanup.sh")
+    expect(content).toContain(".env.example")
+    expect(lower).toContain("credential")
+    expect(lower).toContain("isolat")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes every verified inaccuracy in `CONTRIBUTING.md` and adds a deterministic, cross-harness developer environment: one shared `script/agent/setup.sh` + `cleanup.sh` that GitHub Codespaces, Dev Containers, Docker, Cursor, Claude Code, and Codex App all delegate to, plus a `qa-sandbox.sh` that isolates QA from the host. No `packages/*/src/` runtime code is touched - this is docs + dev tooling only.

## CONTRIBUTING.md accuracy (D1-D20)

Verified against the live codebase and canonical `AGENTS.md`:

- **D1** Local plugin path was wrong and duplicated. Replaced with the two correct ABSOLUTE forms (`file:///.../dist/index.js`, `file:///.../packages/omo-opencode/src/index.ts`); the installer's `isSourceOmoPluginEntry` regex rejects relative `file://./` paths.
- **D2** `index.ts` is a thin 18-line wrapper delegating to `createPluginModule()` (dropped "V1").
- **D3-D7** Corrected counts: 53 base hooks (60 with Team Mode), 13 native tool dirs, 5 built-in MCPs (3 remote + lsp + codegraph), 22 feature modules, 14 OpenCode hook handlers (removed the meaningless "52 hook composition").
- **D8** Removed the per-tool `utils.ts` prescription (a banned catch-all that contradicted the repo's own rules); documented the real tool layout.
- **D9** "Adding a New Agent": real factory pattern, `AgentConfig` from `@opencode-ai/sdk`, registration in the `agentSources` record + `BuiltinAgentName` union.
- **D11/D12** "Adding a New Hook": real hook-name-keyed handler shape, tier composer wiring via `safeHook()`, `HookNameSchema` registration (removed the invented `onSessionStart` example).
- **D13/D14** "Adding a New Tool": `tool({...})` factory, registration via `tool-registry-factories.ts` (removed the `builtinTools`/`utils.ts` claims).
- **D15** "Adding a New MCP": `createBuiltinMcps()` + `McpNameSchema`.
- **D16** Added `bun test` and `bun run test:codex` to Build Commands and the PR checklist.
- **D17** New QA Discipline section (opencode-qa / codex-qa skills, evidence under `.omo/evidence/`).
- **D18** Project Structure now reflects the monorepo layering (18 Core + 3 MCP + 2 adapters + shared-skills + web + platform binaries) and the ROADMAP.
- **D19** Prerequisites: Bun 1.3.12, Node 24, git, optional tmux.
- **D20** CLI list: install, run, doctor, mcp-oauth, boulder, sparkshell, ulw-loop.

## Cross-harness dev environment

- `script/agent/setup.sh` - idempotent bootstrap (verify bun/node/git, warn on missing tmux, `bun install`, build only when `dist/index.js` is missing or `OMO_AGENT_FORCE_BUILD=1`).
- `script/agent/cleanup.sh` - safe by default (regenerable transients only, repo-root guarded); `--deep` also drops dist + vendored dist + node_modules.
- `script/agent/qa-sandbox.sh` - sourceable; isolates `XDG_*` + `CODEX_HOME` under a `mktemp` dir so QA never touches the host config.
- `script/agent/docker-dev.sh` - plain-Docker shell using the same image.
- Wiring (all delegate to the shared scripts): `.cursor/environment.json`, `.claude/settings.json` (SessionStart/SessionEnd), `.codex/setup.sh`, `.devcontainer/devcontainer.json` + `Dockerfile` (Node 24 + Bun 1.3.12 + tmux, powering Codespaces + Dev Containers).

## Credentials, isolation, sharing

- `.env.example` is the committed injection point; copy to `.env` (gitignored) once, sourced by setup + qa-sandbox, never re-prompted.
- `.devcontainer/README.md` documents injecting provider creds (env / Codespaces secrets / `remoteEnv`) and bind-mounting `~/.codex`, `~/.claude`, `~/.config/opencode` into the container.
- `CLAUDE.md` is a symlink to `AGENTS.md` so Claude Code shares the same infra; OpenCode reads `AGENTS.md` directly.
- New `## DEVELOPMENT ENVIRONMENT` section in `AGENTS.md` with a MAINTENANCE directive: when a setup dependency/config changes or breaks, update the script, the docs, `.devcontainer/README.md`, AND the matching `opencode-qa` / `codex-qa` skill - keep them in sync.

## Tests + QA (TDD, evidence under .omo/evidence/20260617-contributing-dx/)

- 4 new test files (given/when/then), RED first (16 fail) then GREEN (22 pass).
- Manual QA on real surfaces: fresh-clone `setup.sh` built `dist/index.js` (4.9 MB); `cleanup.sh` default safe + `--deep` verified; `docker build` succeeded; `qa-sandbox.sh` proved host `~/.config/opencode` and `~/.codex` untouched (66/66, 85/85); set-once `.env` sourced with no prompt.
- `typecheck:script` exit 0; script audit suite green.

## Scope

Docs + `script/agent/*` + `.cursor` + `.claude` + `.codex` + `.devcontainer` + `.env.example` + `CLAUDE.md` + co-located tests. No `packages/*/src/` runtime change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single, cross-harness dev environment and a disposable Docker QA path with new shell/serve/codex modes, plus CONTRIBUTING accuracy fixes and per-package docs. No runtime code changes.

- **New Features**
  - Shared scripts: `script/agent/setup.sh` (verifies bun/node/git; idempotent build via `OMO_AGENT_FORCE_BUILD`), `script/agent/cleanup.sh` (`--deep`), `script/agent/qa-sandbox.sh` (isolated XDG + `CODEX_HOME`).
  - Docker QA (default): `script/agent/qa-docker.sh` builds `omo-dev` and `omo-qa` (`.devcontainer/qa.Dockerfile` with latest `opencode-ai` + `@openai/codex` and `sqlite3 jq curl rsync`), then:
    - shell inside the box, `serve [PORT]` to expose `opencode` HTTP API, `codex` via first‑party app-server or `--tui`, and `exec <cmd...>`; supports `--no-config`/`--clean`; falls back to local on Windows/no Docker.
    - `.devcontainer/qa-entrypoint.sh` copies host config from read‑only mounts into the container and excludes caches.
  - Harness wiring: `.claude/settings.json` (SessionStart/End → setup/cleanup), `.cursor/environment.json`, `.codex/setup.sh`, `.devcontainer/{Dockerfile,devcontainer.json,README.md}`, `script/agent/docker-dev.sh`, `.env.example`.
  - QA docs: mark Docker as the default path and add `references/docker-qa.md` to both QA skills; version bumps (`codex-cli 0.140.0`, `opencode v1.17.7`).
  - Docs/tests: per‑package `AGENTS.md` added across core/MCP/skills; root/package hubs refreshed; audit tests cover scripts, wiring, docs, and the Docker QA harness.

- **Bug Fixes**
  - `CONTRIBUTING.md`: correct local plugin paths, real registries and schemas, updated prereqs (Bun 1.3.12, Node 24), build/test commands (`bun test`, `bun run test:codex`), QA discipline, and current project structure.
  - `AGENTS.md` and `packages/AGENTS.md`: add Development Environment section, publish per‑package `AGENTS.md`, refresh counts/links.
  - CI tests: guard script exec‑bit assertions on Windows to keep the suite green.

<sup>Written for commit 31772aaa44da9da311e58ee2a70e07a8cec978be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

