### PR TITLE
Fix Windows dev-env script audit

### DIFF
--- a/script/agent-env.test.ts
+++ b/script/agent-env.test.ts
@@ -1,16 +1,28 @@
 import { describe, expect, test } from "bun:test"
-import { existsSync, readFileSync, statSync } from "node:fs"
+import { execFileSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 
 const AGENT_DIR = join(import.meta.dir, "agent")
 const REPO_ROOT = join(import.meta.dir, "..")
+const SETUP_SCRIPT = "script/agent/setup.sh"
+const CLEANUP_SCRIPT = "script/agent/cleanup.sh"
 
 function read(path: string): string {
   return readFileSync(path, "utf8")
 }
 
-function isExecutable(path: string): boolean {
-  return (statSync(path).mode & 0o111) !== 0
+function gitFileMode(path: string): string {
+  const output = execFileSync("git", ["ls-files", "--stage", "--", path], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  })
+  const [mode] = output.trim().split(/\s+/, 1)
+  return mode ?? ""
+}
+
+function isExecutableInGitIndex(path: string): boolean {
+  return gitFileMode(path) === "100755"
 }
 
 describe("agent dev-environment scripts", () => {
@@ -20,7 +32,7 @@ describe("agent dev-environment scripts", () => {
     test("#given the shared bootstrap #when inspected #then it is an executable strict bash script", () => {
       // given / when / then
       expect(existsSync(setup), "script/agent/setup.sh must exist").toBe(true)
-      expect(isExecutable(setup), "setup.sh must be executable").toBe(true)
+      expect(isExecutableInGitIndex(SETUP_SCRIPT), "setup.sh must be executable").toBe(true)
       const body = read(setup)
       expect(body.startsWith("#!/usr/bin/env bash")).toBe(true)
       expect(body).toContain("set -euo pipefail")
@@ -49,7 +61,7 @@ describe("agent dev-environment scripts", () => {
     test("#given the teardown #when inspected #then it is an executable strict bash script with a --deep mode", () => {
       // given / when / then
       expect(existsSync(cleanup), "script/agent/cleanup.sh must exist").toBe(true)
-      expect(isExecutable(cleanup), "cleanup.sh must be executable").toBe(true)
+      expect(isExecutableInGitIndex(CLEANUP_SCRIPT), "cleanup.sh must be executable").toBe(true)
       const body = read(cleanup)
       expect(body.startsWith("#!/usr/bin/env bash")).toBe(true)
       expect(body).toContain("set -euo pipefail")


### PR DESCRIPTION
## Summary
Fixes the Windows CI failure on PR #5354 by checking the Git index mode for committed shell scripts instead of relying on host filesystem executable bits. Windows runners do not expose POSIX execute bits through Node `fs.stat` the same way Unix hosts do, while Git correctly tracks the scripts as `100755`.

## Changes
- Replaces `statSync(path).mode & 0o111` with `git ls-files --stage` checks in `script/agent-env.test.ts`.
- Keeps the executable-bit audit intact for `script/agent/setup.sh` and `script/agent/cleanup.sh`.

## Verification
- `bun test script/agent-env.test.ts` ✅
- `bun run typecheck:script` ✅
- LSP diagnostics for `script/agent-env.test.ts` ✅

## Notes
Local full `bun test` was attempted; the patched test passed, but the run still fails on two unrelated `claude-code-agent-loader` tests that read this machine's default OpenCode agents. Those failures reproduce in isolation and are outside this PR's scope.

Related: code-yeongyu/oh-my-openagent#5354

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows CI by checking shell script executability via the Git index instead of filesystem mode. Ensures `script/agent/setup.sh` and `script/agent/cleanup.sh` are enforced as `100755` on Windows runners.

- **Bug Fixes**
  - Replaced `fs.stat` execute-bit check with `git ls-files --stage` in `script/agent-env.test.ts` to read index mode (`100755`).
  - Kept existence and strict bash header checks for both scripts.

<sup>Written for commit c52acbe8de7ea2688cb4e0d270e1674d5d943ebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

