### PR TITLE
docs(skills): make atomic PRs + parallel multi-PR work first-class in work-with-pr

### DIFF
--- a/.agents/skills/work-with-pr/SKILL.md
+++ b/.agents/skills/work-with-pr/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: work-with-pr
-description: "Full PR lifecycle in an isolated git worktree: implement via the ulw-loop skill with mandatory evidence-bound manual QA → detailed English PR → verification loop (CI + review-work reviewers + Cubic, where Cubic is skipped only when its quota is exhausted) → merge by default → worktree cleanup. Unbounded loop: any failing gate sends you back to fix-and-re-QA inside the worktree. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
+description: "Full PR lifecycle in an isolated git worktree: implement via the ulw-loop skill with mandatory evidence-bound manual QA → detailed English PR → verification loop (CI + review-work reviewers + Cubic, where Cubic is skipped only when its quota is exhausted) → merge by default → worktree cleanup. Decomposes one task into the smallest atomic, independently-mergeable PRs and builds the independent ones concurrently via a worktree per PR driven by parallel subagents or a team. Unbounded loop: any failing gate sends you back to fix-and-re-QA inside the worktree. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'split into atomic PRs', 'parallel PRs', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
 ---
 
 # Work With PR — Full PR Lifecycle
 
 You are executing a complete PR lifecycle: from isolated worktree setup, through `ulw-loop`-driven implementation with evidence-bound manual QA, PR creation, and an unbounded verification loop until the PR is merged. The loop has three gates — CI, review-work, and Cubic — and a failing gate sends you back into the worktree to fix and re-QA. You keep cycling until every active gate passes at once.
 
+**The unit of delivery is the smallest PR that compiles, passes, and stands on its own — not "one task, one PR."** A single task routinely splits into several atomic PRs; the lifecycle below describes ONE of them, so apply it to each, and build the independent ones concurrently (Phase 0).
+
 <architecture>
 
 ```
-Phase 0: Setup         → Branch + worktree in sibling directory
+Phase 0: Setup         → Split into atomic PRs, then branch + worktree per PR (parallel when independent)
 Phase 1: Implement     → Drive the work through the ulw-loop skill:
                          evidence-bound manual QA per success criterion, atomic commits
 Phase 2: PR Creation   → Push, create a detailed English PR targeting dev
@@ -28,11 +30,21 @@ Phase 4: Merge         → Merge by default, then worktree cleanup
 
 ## Phase 0: Setup
 
-Create an isolated worktree so the user's main working directory stays clean. This matters because the user may have uncommitted work, and checking out a branch would destroy it.
+Create an isolated worktree so the user's main working directory stays clean — the user may have uncommitted work, and a branch checkout would destroy it. Isolation also makes parallelism cheap: one worktree per PR, so several build at once without colliding.
 
 <setup>
 
-### 1. Resolve repository context
+### 1. Decide the PR split
+
+Before creating anything, decompose the task into the smallest atomic PRs that each compile, pass, and deliver one reviewable slice. Prefer more small PRs over one large one — a 200-line PR gets a real review; a 2000-line PR gets a rubber stamp. Sequence by dependency: independent slices branch off the base and run in parallel; dependent slices stack, each branched off the previous.
+
+Building more than one independent PR concurrently is the recommended default, not an exotic option:
+- **Subagents** — dispatch one background subagent per PR, each owning its own worktree, branch, and the full Phase 0→4 lifecycle.
+- **Team** — for larger fan-outs, form a team (`team_mode`) and assign one member per PR.
+
+When the work is large enough to need a plan (`ulw-plan`), this decomposition is not optional polish: the plan MUST encode the atomic PRs, their dependency order, and which run in parallel as first-class structure.
+
+### 2. Resolve repository context
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
@@ -40,7 +52,7 @@ REPO_NAME=$(basename "$PWD")
 BASE_BRANCH="dev"  # CI blocks PRs to master
 ```
 
-### 2. Create branch
+### 3. Create branch
 
 If user provides a branch name, use it. Otherwise, derive from the task:
 
@@ -51,7 +63,7 @@ git fetch origin "$BASE_BRANCH"
 git branch "$BRANCH_NAME" "origin/$BASE_BRANCH"
 ```
 
-### 3. Create worktree
+### 4. Create worktree
 
 Place worktrees as siblings to the repo — not inside it. This avoids git nested repo issues and keeps the working tree clean.
 
@@ -61,7 +73,7 @@ mkdir -p "$(dirname "$WORKTREE_PATH")"
 git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
 ```
 
-### 4. Set working context
+### 5. Set working context
 
 All subsequent work happens inside the worktree. Install dependencies if needed:
 
@@ -85,7 +97,7 @@ Drive all implementation through the `ulw-loop` skill (your harness's native ult
 
 ### Scope discipline
 
-For bug fixes, stay minimal: fix the bug, add a test, prove it, stop. Do not refactor surrounding code, add config options, or "improve" things that aren't broken — the verification loop catches regressions, and scope creep makes failures harder to isolate.
+Within each PR, stay minimal: deliver its one slice, add the test, prove it, stop. Do not refactor surrounding code, add config options, or "improve" things that aren't broken — that work belongs in its own PR, and scope creep makes failures harder to isolate.
 
 ### Commit strategy
 
@@ -367,5 +379,6 @@ git rebase "origin/$BASE_BRANCH"
 | Fixing unrelated code during verification loop | Scope creep causes new failures | HIGH |
 | Deleting worktree on failure | User loses ability to inspect/resume | HIGH |
 | Ignoring Cubic false positives without justification | Cubic issues should be evaluated, not blindly dismissed | MEDIUM |
+| Bundling independent slices into one big PR | Atomic review dies — a 2000-line PR gets rubber-stamped, regressions hide, and one bad slice blocks all the others | HIGH |
 | Giant single commits | Harder to isolate failures, violates git-master principles | MEDIUM |
 | Not running local checks before push | Wastes CI time on obvious failures | MEDIUM |

--- a/.opencode/skills/work-with-pr/SKILL.md
+++ b/.opencode/skills/work-with-pr/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: work-with-pr
-description: "Full PR lifecycle in an isolated git worktree: implement via the ulw-loop skill with mandatory evidence-bound manual QA → detailed English PR → verification loop (CI + review-work reviewers + Cubic, where Cubic is skipped only when its quota is exhausted) → merge by default → worktree cleanup. Unbounded loop: any failing gate sends you back to fix-and-re-QA inside the worktree. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
+description: "Full PR lifecycle in an isolated git worktree: implement via the ulw-loop skill with mandatory evidence-bound manual QA → detailed English PR → verification loop (CI + review-work reviewers + Cubic, where Cubic is skipped only when its quota is exhausted) → merge by default → worktree cleanup. Decomposes one task into the smallest atomic, independently-mergeable PRs and builds the independent ones concurrently via a worktree per PR driven by parallel subagents or a team. Unbounded loop: any failing gate sends you back to fix-and-re-QA inside the worktree. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'split into atomic PRs', 'parallel PRs', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
 ---
 
 # Work With PR — Full PR Lifecycle
 
 You are executing a complete PR lifecycle: from isolated worktree setup, through `ulw-loop`-driven implementation with evidence-bound manual QA, PR creation, and an unbounded verification loop until the PR is merged. The loop has three gates — CI, review-work, and Cubic — and a failing gate sends you back into the worktree to fix and re-QA. You keep cycling until every active gate passes at once.
 
+**The unit of delivery is the smallest PR that compiles, passes, and stands on its own — not "one task, one PR."** A single task routinely splits into several atomic PRs; the lifecycle below describes ONE of them, so apply it to each, and build the independent ones concurrently (Phase 0).
+
 <architecture>
 
 ```
-Phase 0: Setup         → Branch + worktree in sibling directory
+Phase 0: Setup         → Split into atomic PRs, then branch + worktree per PR (parallel when independent)
 Phase 1: Implement     → Drive the work through the ulw-loop skill:
                          evidence-bound manual QA per success criterion, atomic commits
 Phase 2: PR Creation   → Push, create a detailed English PR targeting dev
@@ -28,11 +30,21 @@ Phase 4: Merge         → Merge by default, then worktree cleanup
 
 ## Phase 0: Setup
 
-Create an isolated worktree so the user's main working directory stays clean. This matters because the user may have uncommitted work, and checking out a branch would destroy it.
+Create an isolated worktree so the user's main working directory stays clean — the user may have uncommitted work, and a branch checkout would destroy it. Isolation also makes parallelism cheap: one worktree per PR, so several build at once without colliding.
 
 <setup>
 
-### 1. Resolve repository context
+### 1. Decide the PR split
+
+Before creating anything, decompose the task into the smallest atomic PRs that each compile, pass, and deliver one reviewable slice. Prefer more small PRs over one large one — a 200-line PR gets a real review; a 2000-line PR gets a rubber stamp. Sequence by dependency: independent slices branch off the base and run in parallel; dependent slices stack, each branched off the previous.
+
+Building more than one independent PR concurrently is the recommended default, not an exotic option:
+- **Subagents** — dispatch one background subagent per PR, each owning its own worktree, branch, and the full Phase 0→4 lifecycle.
+- **Team** — for larger fan-outs, form a team (`team_mode`) and assign one member per PR.
+
+When the work is large enough to need a plan (`ulw-plan`), this decomposition is not optional polish: the plan MUST encode the atomic PRs, their dependency order, and which run in parallel as first-class structure.
+
+### 2. Resolve repository context
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
@@ -40,7 +52,7 @@ REPO_NAME=$(basename "$PWD")
 BASE_BRANCH="dev"  # CI blocks PRs to master
 ```
 
-### 2. Create branch
+### 3. Create branch
 
 If user provides a branch name, use it. Otherwise, derive from the task:
 
@@ -51,7 +63,7 @@ git fetch origin "$BASE_BRANCH"
 git branch "$BRANCH_NAME" "origin/$BASE_BRANCH"
 ```
 
-### 3. Create worktree
+### 4. Create worktree
 
 Place worktrees as siblings to the repo — not inside it. This avoids git nested repo issues and keeps the working tree clean.
 
@@ -61,7 +73,7 @@ mkdir -p "$(dirname "$WORKTREE_PATH")"
 git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
 ```
 
-### 4. Set working context
+### 5. Set working context
 
 All subsequent work happens inside the worktree. Install dependencies if needed:
 
@@ -85,7 +97,7 @@ Drive all implementation through the `ulw-loop` skill (your harness's native ult
 
 ### Scope discipline
 
-For bug fixes, stay minimal: fix the bug, add a test, prove it, stop. Do not refactor surrounding code, add config options, or "improve" things that aren't broken — the verification loop catches regressions, and scope creep makes failures harder to isolate.
+Within each PR, stay minimal: deliver its one slice, add the test, prove it, stop. Do not refactor surrounding code, add config options, or "improve" things that aren't broken — that work belongs in its own PR, and scope creep makes failures harder to isolate.
 
 ### Commit strategy
 
@@ -367,5 +379,6 @@ git rebase "origin/$BASE_BRANCH"
 | Fixing unrelated code during verification loop | Scope creep causes new failures | HIGH |
 | Deleting worktree on failure | User loses ability to inspect/resume | HIGH |
 | Ignoring Cubic false positives without justification | Cubic issues should be evaluated, not blindly dismissed | MEDIUM |
+| Bundling independent slices into one big PR | Atomic review dies — a 2000-line PR gets rubber-stamped, regressions hide, and one bad slice blocks all the others | HIGH |
 | Giant single commits | Harder to isolate failures, violates git-master principles | MEDIUM |
 | Not running local checks before push | Wastes CI time on obvious failures | MEDIUM |


### PR DESCRIPTION
## Summary

The `work-with-pr` skill silently assumed "one task = one PR" and described a single linear worktree. This rewrites it so the skill teaches, as a built-in part of the workflow, that the unit of delivery is the **smallest PR that compiles, passes, and stands on its own**, that one task routinely splits into several atomic PRs, and that building independent PRs concurrently (a worktree per PR, driven by subagents or a team) is the recommended default. `ulw-plan` is now required to encode this decomposition.

Edits were made at the source via prompt-engineering (category C, integrated as if always there), not patched on at the bottom. Both the `.agents/` and `.opencode/` copies are kept byte-identical so the `opencode-skill-loader` dedup never picks a stale variant.

## Changes

- **Intro** — states the atomic-PR mental model once; clarifies the lifecycle applies to each PR.
- **Architecture map** — Phase 0 line now reads "Split into atomic PRs, then branch + worktree per PR (parallel when independent)".
- **Phase 0** — new first step **"1. Decide the PR split"**: smallest-atomic-PR decomposition, a sizing heuristic (a 200-line PR gets a real review; a 2000-line PR gets a rubber stamp), dependency sequencing (independent slices parallel, dependent slices stack), the two parallel mechanisms (one background **subagent** per PR / a **team** member per PR), and the **`ulw-plan` mandate** to encode the PR decomposition as first-class plan structure. Remaining steps renumbered 2..5.
- **Phase 1 scope discipline** — reframed from "For bug fixes" to "Within each PR" (token-neutral; broadened and linked to the atomic framing).
- **Anti-patterns** — added "Bundling independent slices into one big PR" (HIGH), beside the commit-level row.
- **description frontmatter** — reflects atomic/parallel decomposition; adds triggers `'split into atomic PRs'`, `'parallel PRs'` (903 chars, < 1024, no Hangul).

## Verification

**Automated:** `project-skill-tool-references.test.ts` (both `skills-loader-core` and `omo-opencode` copies) reads the real `work-with-pr` SKILL.md and asserts the commit guidance still delegates through `git-master` with `category="unspecified-high"` and contains no fabricated `task(category=...)` calls — re-ran **4 pass / 0 fail** against the edited skill.

**Manual QA (real surface = how the loader parses the file):** frontmatter parses as valid YAML (`name`, `description`); all section tags balanced; Phase 0 numbering sequential 1..5; anti-patterns table all 3-column; all new-guidance anchors present; `.agents/` and `.opencode/` copies byte-identical. Evidence + the exact command output live under `.omo/evidence/20260617-work-with-pr-atomic-pr/` (gitignored, kept locally).

This is a prose/prompt-only change to a project-scope skill markdown; no code path changed, so there is no RED→GREEN unit to add. The loader's parse + content contract is the real surface and is proven above.

## Related Issues

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make atomic PRs and parallel multi-PR work first-class in the `work-with-pr` skill. The doc now teaches splitting a task into the smallest independently mergeable PRs and running independent ones in parallel, with `ulw-plan` required to encode the split.

- **New Features**
  - Phase 0 now starts with “Decide the PR split”: sizing heuristic, dependency sequencing, and parallel execution via subagents or team; `ulw-plan` must capture the PR graph.
  - Architecture map updated to “Split into atomic PRs, then branch + worktree per PR (parallel when independent)”.
  - Scope discipline reframed to “within each PR”; added anti-pattern for bundling independent slices; steps renumbered.
  - Frontmatter updated with atomic/parallel wording and triggers; `.agents/` and `.opencode/` copies kept byte-identical; tests confirm loader parsing and delegation through `git-master`.

<sup>Written for commit 81db3c645940166cb28699287f9b08cfdb69d7f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

