### PR TITLE
fix(sisyphus): determine prompt family by runtime model, not configured model (#5297)

### DIFF
--- a/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.ts
@@ -9,6 +9,7 @@ import { applyOverrides } from "./agent-overrides"
 import { applyModelResolution, getFirstFallbackModel } from "./model-resolution"
 import { createSisyphusAgent } from "../sisyphus"
 import { applyFrontierToolSchemaPermission } from "../frontier-tool-schema-guard"
+import { setSisyphusRuntimePromptContext } from "../sisyphus-runtime-prompt-reconciler"
 
 export function maybeCreateSisyphusConfig(input: {
   disabledAgents: string[]
@@ -104,6 +105,27 @@ export function maybeCreateSisyphusConfig(input: {
 
   sisyphusConfig = applyEnvironmentContext(sisyphusConfig, directory, {
     disableOmoEnv,
+  })
+
+  // The body above is baked from the *configured* model. If the user switches to
+  // a different model family in the TUI, the system-transform hook rebuilds the
+  // prompt for the runtime model using this captured pipeline (issue #5297/#5316).
+  setSisyphusRuntimePromptContext({
+    configuredModel: sisyphusModel,
+    bakedPrompt: sisyphusConfig.prompt ?? "",
+    rebuildPromptForModel: (runtimeModel: string): string => {
+      let rebuilt = createSisyphusAgent(
+        runtimeModel,
+        availableAgents,
+        undefined,
+        availableSkills,
+        availableCategories,
+        useTaskSystem
+      )
+      rebuilt = applyOverrides(rebuilt, sisyphusOverride, mergedCategories, directory)
+      rebuilt = applyEnvironmentContext(rebuilt, directory, { disableOmoEnv })
+      return rebuilt.prompt ?? ""
+    },
   })
 
   return sisyphusConfig

--- a/packages/omo-opencode/src/agents/sisyphus-agent-factory.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-agent-factory.ts
@@ -34,6 +34,36 @@ import {
 
 const MODE: AgentMode = "primary";
 
+/**
+ * Identifies which prompt body `createSisyphusAgent` bakes for a given model.
+ * The whole Sisyphus prompt is model-family-specific and selected here, so this
+ * is the single source of truth shared with the runtime reconciler: when the TUI
+ * runtime model resolves to a different family than the configured one, the baked
+ * body is the wrong family and must be rebuilt (issue #5297/#5316).
+ */
+export type SisyphusPromptFamily =
+  | "kimi-k2-7"
+  | "kimi-k2-6"
+  | "gpt-5-5"
+  | "gpt-5-4"
+  | "claude-fable-5"
+  | "claude-opus-4-8"
+  | "claude-opus-4-7"
+  | "glm-5-2"
+  | "fallback";
+
+export function resolveSisyphusPromptFamily(model: string): SisyphusPromptFamily {
+  if (isKimiK27Model(model)) return "kimi-k2-7";
+  if (isKimiK2Model(model)) return "kimi-k2-6";
+  if (isGpt5_5Model(model)) return "gpt-5-5";
+  if (isGptNativeSisyphusModel(model)) return "gpt-5-4";
+  if (isClaudeFable5Model(model)) return "claude-fable-5";
+  if (isClaudeOpus48Model(model)) return "claude-opus-4-8";
+  if (isClaudeOpus47Model(model)) return "claude-opus-4-7";
+  if (isGlmModel(model)) return "glm-5-2";
+  return "fallback";
+}
+
 export function createSisyphusAgent(
   model: string,
   availableAgents?: AvailableAgent[],
@@ -47,83 +77,68 @@ export function createSisyphusAgent(
   const categories = availableCategories ?? [];
   const agents = availableAgents ?? [];
 
-  if (isKimiK27Model(model)) {
-    return buildGptSisyphusAgentConfig(
-      MODE,
-      model,
-      buildKimiK27SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
-    );
+  switch (resolveSisyphusPromptFamily(model)) {
+    case "kimi-k2-7":
+      return buildGptSisyphusAgentConfig(
+        MODE,
+        model,
+        buildKimiK27SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "kimi-k2-6":
+      return buildGptSisyphusAgentConfig(
+        MODE,
+        model,
+        buildKimiK26SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "gpt-5-5":
+      return buildGptSisyphusAgentConfig(
+        MODE,
+        model,
+        buildGpt55SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "gpt-5-4":
+      return buildGptSisyphusAgentConfig(
+        MODE,
+        model,
+        buildGpt54SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "claude-fable-5":
+      return buildClaudeSisyphusAgentConfig(
+        MODE,
+        model,
+        buildClaudeFable5SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "claude-opus-4-8":
+      return buildClaudeSisyphusAgentConfig(
+        MODE,
+        model,
+        buildClaudeOpus48SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "claude-opus-4-7":
+      return buildClaudeSisyphusAgentConfig(
+        MODE,
+        model,
+        buildClaudeOpus47SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "glm-5-2":
+      return buildGlmSisyphusAgentConfig(
+        MODE,
+        model,
+        buildGlm52SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "fallback": {
+      const prompt = buildFallbackSisyphusPrompt(
+        model,
+        agents,
+        tools,
+        skills,
+        categories,
+        useTaskSystem,
+      );
+      return isGptModel(model)
+        ? buildGptSisyphusAgentConfig(MODE, model, prompt)
+        : buildClaudeSisyphusAgentConfig(MODE, model, prompt);
+    }
   }
-
-  if (isKimiK2Model(model)) {
-    return buildGptSisyphusAgentConfig(
-      MODE,
-      model,
-      buildKimiK26SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
-    );
-  }
-
-  if (isGpt5_5Model(model)) {
-    return buildGptSisyphusAgentConfig(
-      MODE,
-      model,
-      buildGpt55SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
-    );
-  }
-
-  if (isGptNativeSisyphusModel(model)) {
-    return buildGptSisyphusAgentConfig(
-      MODE,
-      model,
-      buildGpt54SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
-    );
-  }
-
-  if (isClaudeFable5Model(model)) {
-    return buildClaudeSisyphusAgentConfig(
-      MODE,
-      model,
-      buildClaudeFable5SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
-    );
-  }
-
-  if (isClaudeOpus48Model(model)) {
-    return buildClaudeSisyphusAgentConfig(
-      MODE,
-      model,
-      buildClaudeOpus48SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
-    );
-  }
-
-  if (isClaudeOpus47Model(model)) {
-    return buildClaudeSisyphusAgentConfig(
-      MODE,
-      model,
-      buildClaudeOpus47SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
-    );
-  }
-
-  if (isGlmModel(model)) {
-    return buildGlmSisyphusAgentConfig(
-      MODE,
-      model,
-      buildGlm52SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
-    );
-  }
-
-  const prompt = buildFallbackSisyphusPrompt(
-    model,
-    agents,
-    tools,
-    skills,
-    categories,
-    useTaskSystem,
-  );
-
-  if (isGptModel(model)) {
-    return buildGptSisyphusAgentConfig(MODE, model, prompt);
-  }
-
-  return buildClaudeSisyphusAgentConfig(MODE, model, prompt);
 }
 createSisyphusAgent.mode = MODE;

--- a/packages/omo-opencode/src/agents/sisyphus-runtime-prompt-reconciler.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-runtime-prompt-reconciler.ts
@@ -1,0 +1,71 @@
+import { resolveSisyphusPromptFamily } from "./sisyphus-agent-factory";
+
+/**
+ * Context captured at Sisyphus registration so the per-request system-transform
+ * hook can rebuild the prompt for the model actually selected at runtime.
+ *
+ * - `bakedPrompt` is the exact prompt string registered (body + overrides + env),
+ *   used to locate the entry to replace in the runtime system array.
+ * - `rebuildPromptForModel` re-runs the same registration pipeline with a
+ *   different model, so overrides / prompt_append / env context are preserved.
+ */
+export type SisyphusRuntimePromptContext = {
+  configuredModel: string;
+  bakedPrompt: string;
+  rebuildPromptForModel: (runtimeModel: string) => string;
+};
+
+let context: SisyphusRuntimePromptContext | undefined;
+
+export function setSisyphusRuntimePromptContext(ctx: SisyphusRuntimePromptContext): void {
+  context = ctx;
+}
+
+export function clearSisyphusRuntimePromptContext(): void {
+  context = undefined;
+}
+
+/**
+ * The Sisyphus prompt body is baked at registration from the *configured* model
+ * in `oh-my-openagent.jsonc`. When the user switches to a different model family
+ * in the TUI, the entire baked body is the wrong family for the runtime model
+ * (issue #5297/#5316): a GPT-configured agent run on a non-GPT model still
+ * carries the whole GPT-5.5 body, not just one apply_patch line.
+ *
+ * The system-transform hook is the only per-request seam that knows the runtime
+ * model, so rebuild the whole prompt for the runtime family and swap it in here
+ * rather than patching individual family-specific lines (which can never convert
+ * a GPT body into a non-GPT one).
+ *
+ * Returns true if a swap was performed.
+ */
+export function reconcileSisyphusRuntimePrompt(
+  system: string[],
+  runtimeModel: string | undefined,
+): boolean {
+  if (!runtimeModel || !context) return false
+
+  // Same family => the baked body already matches the runtime model; leave it.
+  if (
+    resolveSisyphusPromptFamily(runtimeModel) ===
+    resolveSisyphusPromptFamily(context.configuredModel)
+  ) {
+    return false
+  }
+
+  const rebuilt = context.rebuildPromptForModel(runtimeModel)
+  if (rebuilt === context.bakedPrompt) return false
+
+  // Substring replace rather than exact-equality: opencode core may concatenate
+  // the agent prompt with other system text in a single array entry, so match
+  // the baked body wherever it appears.
+  let swapped = false
+  for (let i = 0; i < system.length; i++) {
+    const part = system[i]
+    if (part.includes(context.bakedPrompt)) {
+      system[i] = part.split(context.bakedPrompt).join(rebuilt)
+      swapped = true
+    }
+  }
+  return swapped
+}

--- a/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-reconciler.test.ts
+++ b/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-reconciler.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { createSystemTransformHandler } from "./system-transform"
+import { GPT_APPLY_PATCH_GUIDANCE } from "../agents/gpt-apply-patch-guard"
+import { createSisyphusAgent } from "../agents/sisyphus"
+import {
+  clearSisyphusRuntimePromptContext,
+  reconcileSisyphusRuntimePrompt,
+  setSisyphusRuntimePromptContext,
+} from "../agents/sisyphus-runtime-prompt-reconciler"
+
+const GPT_MODEL = "openai/gpt-5.5"
+const NON_GPT_MODEL = "opencode-go/qwen3.7-plus"
+
+// Mirror what maybeCreateSisyphusConfig captures at registration: the baked GPT
+// prompt plus a rebuild closure that re-runs the factory for a different model.
+function registerGptSisyphus(): string {
+  const baked = createSisyphusAgent(GPT_MODEL, [], [], [], []).prompt ?? ""
+  setSisyphusRuntimePromptContext({
+    configuredModel: GPT_MODEL,
+    bakedPrompt: baked,
+    rebuildPromptForModel: (model) => createSisyphusAgent(model, [], [], [], []).prompt ?? "",
+  })
+  return baked
+}
+
+afterEach(() => {
+  clearSisyphusRuntimePromptContext()
+})
+
+describe("Sisyphus runtime prompt family reconciliation (#5297/#5316)", () => {
+  test("#given a GPT-configured Sisyphus body #when run on a non-GPT model #then the WHOLE body is rebuilt, not just the apply_patch line", () => {
+    const baked = registerGptSisyphus()
+    // sanity: the baked body really is the GPT-5.5 family body
+    expect(baked).toContain("based on GPT-5.5")
+    expect(baked).toContain(GPT_APPLY_PATCH_GUIDANCE)
+
+    const system = [baked]
+    const swapped = reconcileSisyphusRuntimePrompt(system, NON_GPT_MODEL)
+
+    expect(swapped).toBe(true)
+    // The GPT identity and the GPT-only apply_patch guidance are both gone...
+    expect(system[0]).not.toContain("based on GPT-5.5")
+    expect(system[0]).not.toContain(GPT_APPLY_PATCH_GUIDANCE)
+    // ...and the entry is exactly what registration would have baked for qwen.
+    expect(system[0]).toBe(createSisyphusAgent(NON_GPT_MODEL, [], [], [], []).prompt)
+  })
+
+  test("#given the baked body concatenated with other system text #when run on a non-GPT model #then only the body portion is rebuilt", () => {
+    const baked = registerGptSisyphus()
+    // opencode may join the agent prompt with surrounding system text in one entry
+    const system = [`<context>\n${baked}\n</context>`]
+
+    const swapped = reconcileSisyphusRuntimePrompt(system, NON_GPT_MODEL)
+
+    expect(swapped).toBe(true)
+    expect(system[0]).toContain("<context>")
+    expect(system[0]).toContain("</context>")
+    expect(system[0]).not.toContain("based on GPT-5.5")
+    expect(system[0]).not.toContain(GPT_APPLY_PATCH_GUIDANCE)
+  })
+
+  test("#given a GPT-configured body #when run on the same GPT family #then the body is left untouched", () => {
+    const baked = registerGptSisyphus()
+    const system = [baked]
+    const swapped = reconcileSisyphusRuntimePrompt(system, GPT_MODEL)
+    expect(swapped).toBe(false)
+    expect(system[0]).toBe(baked)
+  })
+
+  test("#given no registered Sisyphus context #when reconcile runs #then it is a no-op", () => {
+    const system = ["unrelated system prompt"]
+    expect(reconcileSisyphusRuntimePrompt(system, NON_GPT_MODEL)).toBe(false)
+    expect(system).toEqual(["unrelated system prompt"])
+  })
+
+  test("#given a non-Sisyphus session #when reconcile runs #then nothing matches and nothing changes", () => {
+    registerGptSisyphus()
+    const system = ["some other agent's prompt with no Sisyphus body"]
+    expect(reconcileSisyphusRuntimePrompt(system, NON_GPT_MODEL)).toBe(false)
+    expect(system).toEqual(["some other agent's prompt with no Sisyphus body"])
+  })
+
+  test("#given the full system-transform handler #when runtime model is non-GPT #then the GPT body is reconciled end-to-end", async () => {
+    const baked = registerGptSisyphus()
+    const handler = createSystemTransformHandler(undefined, undefined, {})
+    const output = { system: [baked] }
+
+    await handler(
+      { sessionID: "s", model: { id: NON_GPT_MODEL, providerID: "opencode-go" } },
+      output,
+    )
+
+    expect(output.system[0]).not.toContain("based on GPT-5.5")
+    expect(output.system[0]).not.toContain(GPT_APPLY_PATCH_GUIDANCE)
+  })
+})

--- a/packages/omo-opencode/src/plugin/system-transform.ts
+++ b/packages/omo-opencode/src/plugin/system-transform.ts
@@ -1,4 +1,5 @@
 import type { DefaultModeConfig } from "../config/schema/default-mode"
+import { reconcileSisyphusRuntimePrompt } from "../agents/sisyphus-runtime-prompt-reconciler"
 import {
   getSparkShellRuntimeAwareness,
   hasSparkShellRuntimeAwareness,
@@ -15,6 +16,12 @@ export function createSystemTransformHandler(
   output: { system: string[] },
 ) => Promise<void> {
   return async (input, output): Promise<void> => {
+    // The Sisyphus prompt body is model-family-specific and baked at registration
+    // from the *configured* model in oh-my-openagent.jsonc. This per-request hook
+    // is the only seam that knows the model actually selected at runtime, so
+    // rebuild the whole body for the runtime model family here (issue #5297).
+    reconcileSisyphusRuntimePrompt(output.system, input.model?.id)
+
     const sparkshellAwareness = getSparkShellRuntimeAwareness(env)
     if (
       sparkshellAwareness.length > 0 &&


### PR DESCRIPTION
Proper replacement for the reverted #5316 (reverted on dev as `Revert "Merge pull request #5316"`), resolving #5297. The issue author verified the runtime behavior in the comments below.

## Problem

The Sisyphus prompt body is model-family-specific and chosen once at registration from the *configured* model in `oh-my-openagent.jsonc`. When the user switches to a different family in the TUI, the entire baked body is the wrong family for the runtime model: a GPT-configured agent run on a non-GPT model still carries the whole GPT-5.5 body, not just the one `apply_patch` line.

#5316 rewrote only the single `GPT_APPLY_PATCH_GUIDANCE` string in the `chat.system.transform` hook, and its test only asserted that one line, so the rest of the GPT-only body kept leaking through (matching the screenshot in the review comment on #5316). It was reverted on dev.

## Fix

Rebuild the whole body at the only per-request seam that knows the runtime model (`experimental.chat.system.transform`):

- Capture the registration pipeline as a rebuild closure (preserving overrides / `prompt_append` / env context).
- In the hook, rebuild the prompt for the runtime model family and swap it in when it differs from the configured family. No per-line string patching, so it cannot leak family-specific lines the way the reverted approach did.
- `resolveSisyphusPromptFamily()` is extracted as the single source of truth shared by the factory and the reconciler, so the two can never drift.
- Substring replacement, robust to core concatenating the agent prompt with other system text.

## Tests

New tests reproduce the configured-vs-runtime mismatch end-to-end (a GPT-configured body run on a non-GPT model) and assert the GPT identity (`based on GPT-5.5`) and the `apply_patch` guidance are both gone, and that the result matches what registration would bake for the runtime model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)