### PR TITLE
fix(codegraph): select safe node runtime before bootstrap

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -1,22 +1,22 @@
 #!/usr/bin/env node
 
-// src/cli.ts
+// components/codegraph/src/cli.ts
 import { realpathSync as realpathSync3 } from "node:fs";
-import { basename as basename4, resolve as resolve4 } from "node:path";
+import { basename as basename5, resolve as resolve4 } from "node:path";
 import { stderr as processStderr3 } from "node:process";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
-// src/hook.ts
+// components/codegraph/src/hook.ts
 import { spawn } from "node:child_process";
 import { homedir as homedir7 } from "node:os";
 import { cwd as processCwd2, env as processEnv2, stdin as processStdin, stdout as processStdout } from "node:process";
 import { fileURLToPath } from "node:url";
 
-// ../../../../utils/src/omo-config/loader.ts
+// ../../utils/src/omo-config/loader.ts
 import { existsSync as existsSync2, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 
-// ../../../../utils/src/deep-merge.ts
+// ../../utils/src/deep-merge.ts
 var DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 function isUnsafeObjectKey(key) {
   return DANGEROUS_KEYS.has(key);
@@ -25,7 +25,7 @@ function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value) && Object.prototype.toString.call(value) === "[object Object]";
 }
 
-// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/scanner.js
+// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/scanner.js
 function createScanner(text, ignoreTrivia = false) {
   const len = text.length;
   let pos = 0, value = "", tokenOffset = 0, token = 16, lineNumber = 0, lineStartOffset = 0, tokenLineStartOffset = 0, prevTokenLineStartOffset = 0, scanError = 0;
@@ -440,7 +440,7 @@ var CharacterCodes;
   CharacterCodes2[CharacterCodes2["tab"] = 9] = "tab";
 })(CharacterCodes || (CharacterCodes = {}));
 
-// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/string-intern.js
+// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/string-intern.js
 var cachedSpaces = new Array(20).fill(0).map((_, index) => {
   return " ".repeat(index);
 });
@@ -474,7 +474,7 @@ var cachedBreakLinesWithSpaces = {
   }
 };
 
-// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/parser.js
+// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/parser.js
 var ParseOptions;
 (function(ParseOptions2) {
   ParseOptions2.DEFAULT = {
@@ -777,7 +777,7 @@ function visit(text, visitor, options = ParseOptions.DEFAULT) {
   return true;
 }
 
-// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/main.js
+// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/main.js
 var ScanError;
 (function(ScanError2) {
   ScanError2[ScanError2["None"] = 0] = "None";
@@ -866,7 +866,7 @@ function printParseErrorCode(code) {
   return "<unknown ParseErrorCode>";
 }
 
-// ../../../../utils/src/jsonc-parser.ts
+// ../../utils/src/jsonc-parser.ts
 var pluginConfigFileDetectionCache = new Map;
 function stripBom(content) {
   return content.charCodeAt(0) === 65279 ? content.slice(1) : content;
@@ -887,7 +887,7 @@ function parseJsoncSafe(content) {
   };
 }
 
-// ../../../../utils/src/omo-config.ts
+// ../../utils/src/omo-config.ts
 var HARNESS_IDS = ["codex", "opencode", "omo"];
 var SETTING_HARNESS_SUPPORT = {
   "codegraph.auto_provision": HARNESS_IDS,
@@ -897,7 +897,7 @@ var SETTING_HARNESS_SUPPORT = {
   "codegraph.watch_debounce_ms": ["opencode", "omo"]
 };
 
-// ../../../../utils/src/omo-config/env-overrides.ts
+// ../../utils/src/omo-config/env-overrides.ts
 var CODEGRAPH_ENV_KEYS = [
   ["auto_provision", "AUTO_PROVISION", "boolean"],
   ["enabled", "ENABLED", "boolean"],
@@ -969,7 +969,7 @@ function buildEnvOverrides(harness, env, warnings, merge) {
   return config;
 }
 
-// ../../../../utils/src/omo-config/resolve.ts
+// ../../utils/src/omo-config/resolve.ts
 import { existsSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 function containsPath(parent, child) {
@@ -1012,7 +1012,7 @@ function toMissingSource(candidate) {
   };
 }
 
-// ../../../../utils/src/omo-config/loader.ts
+// ../../utils/src/omo-config/loader.ts
 var BUILT_IN_DEFAULTS = {
   codegraph: {
     auto_provision: true,
@@ -1235,7 +1235,7 @@ function loadOmoConfig(options) {
   return { config, sources, warnings };
 }
 
-// ../../shared/src/config-loader.ts
+// shared/src/config-loader.ts
 function getCodexOmoConfig(options = {}) {
   const result = loadOmoConfig({
     ...options.cwd === undefined ? {} : { cwd: options.cwd },
@@ -1250,14 +1250,14 @@ function getCodexOmoConfig(options = {}) {
   };
 }
 
-// src/session-start-worker.ts
+// components/codegraph/src/session-start-worker.ts
 import { execFile as execFile2 } from "node:child_process";
 import { appendFileSync as appendFileSync2, existsSync as existsSync6, mkdirSync as mkdirSync2 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { extname, join as join7 } from "node:path";
 import { cwd as processCwd, env as processEnv, stderr as processStderr } from "node:process";
 
-// ../../../../utils/src/codegraph/env.ts
+// ../../utils/src/codegraph/env.ts
 import { homedir as homedir2 } from "node:os";
 import { join as join2 } from "node:path";
 var CODEGRAPH_INSTALL_DIR_ENV = "CODEGRAPH_INSTALL_DIR";
@@ -1274,10 +1274,11 @@ function buildCodegraphEnv(options = {}) {
   };
 }
 
-// ../../../../utils/src/codegraph/node-support.ts
+// ../../utils/src/codegraph/node-support.ts
 var CODEGRAPH_MIN_NODE_MAJOR = 20;
 var CODEGRAPH_BLOCKED_NODE_MAJOR = 25;
 var CODEGRAPH_UNSAFE_NODE_ENV = "CODEGRAPH_ALLOW_UNSAFE_NODE";
+var CODEGRAPH_NODE_BIN_ENV = "CODEGRAPH_NODE_BIN";
 function evaluateCodegraphNodeSupport(options = {}) {
   const nodeVersion = options.nodeVersion ?? process.versions.node;
   const env = options.env ?? process.env;
@@ -1302,7 +1303,7 @@ function parseNodeMajor(version) {
   return Number.isNaN(major) ? 0 : major;
 }
 
-// ../../../../utils/src/codegraph/provision.ts
+// ../../utils/src/codegraph/provision.ts
 import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { chmod, mkdir, readdir, readFile, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
@@ -1311,7 +1312,7 @@ import { homedir as homedir3, hostname } from "node:os";
 import { basename, join as join3 } from "node:path";
 import { promisify } from "node:util";
 
-// ../../../../utils/src/codegraph/manifest.ts
+// ../../utils/src/codegraph/manifest.ts
 var CODEGRAPH_PROVISION_MANIFEST = {
   assets: {
     "darwin-arm64": {
@@ -1348,7 +1349,7 @@ var CODEGRAPH_PROVISION_MANIFEST = {
   version: "1.0.1"
 };
 
-// ../../../../utils/src/codegraph/provision.ts
+// ../../utils/src/codegraph/provision.ts
 var DEFAULT_LOCK_WAIT_MS = 5000;
 var DEFAULT_LOCK_STALE_MS = 120000;
 var DEFAULT_DOWNLOAD_TIMEOUT_MS = 60000;
@@ -1521,13 +1522,14 @@ async function ensureCodegraphProvisioned(options) {
   }
 }
 
-// ../../../../utils/src/codegraph/resolve.ts
+// ../../utils/src/codegraph/resolve.ts
 import { existsSync as existsSync4 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
-import { dirname as dirname2, join as join5 } from "node:path";
+import { spawnSync } from "node:child_process";
+import { basename as basename2, dirname as dirname2, join as join5 } from "node:path";
 import { createRequire } from "node:module";
 
-// ../../../../utils/src/runtime/which.ts
+// ../../utils/src/runtime/which.ts
 import { accessSync, constants } from "node:fs";
 import { delimiter, join as join4 } from "node:path";
 var runtime = globalThis;
@@ -1592,16 +1594,72 @@ function bunWhich(commandName) {
   return null;
 }
 
-// ../../../../utils/src/codegraph/resolve.ts
+// ../../utils/src/codegraph/resolve.ts
 var CODEGRAPH_PACKAGE = "@colbymchenry/codegraph";
 var CODEGRAPH_ENV_BIN = "OMO_CODEGRAPH_BIN";
 var CODEGRAPH_LEGACY_ENV_BIN = "CODEGRAPH_BIN";
+var CODEGRAPH_NODE_CANDIDATES = ["node24", "node22", "node20", "node"];
 var requireFromHere = createRequire(import.meta.url);
 function defaultRequireResolve(specifier) {
   return requireFromHere.resolve(specifier);
 }
-function defaultNodeRuntime() {
-  return process.execPath || null;
+function defaultNodeVersion(nodePath) {
+  if (nodePath === process.execPath && isNodeExecutableName(nodePath))
+    return process.versions.node;
+  try {
+    const result = spawnSync(nodePath, ["--version"], {
+      encoding: "utf8",
+      timeout: 2000,
+      windowsHide: true
+    });
+    if (result.error !== undefined || result.status !== 0)
+      return null;
+    const version = `${result.stdout}
+${result.stderr}`.trim().split(/\s+/)[0];
+    return version === undefined || version.length === 0 ? null : version;
+  } catch (error) {
+    if (error instanceof Error)
+      return null;
+    throw error;
+  }
+}
+function isNodeExecutableName(filePath) {
+  const executable = basename2(filePath).toLowerCase();
+  return executable === "node" || executable === "node.exe" || /^node\d+(\.exe)?$/.test(executable);
+}
+function looksLikePath(command) {
+  return command.includes("/") || command.includes("\\") || /^[a-zA-Z]:/.test(command);
+}
+function resolveConfiguredNodeRuntime(configured, fileExists, which) {
+  if (looksLikePath(configured))
+    return fileExists(configured) ? configured : null;
+  return which(configured);
+}
+function supportsCodegraphNodeRuntime(nodePath, env, nodeVersion) {
+  const version = nodeVersion(nodePath);
+  if (version === null)
+    return false;
+  return evaluateCodegraphNodeSupport({ env, nodeVersion: version }).supported;
+}
+function defaultNodeRuntime(env, fileExists, which, nodeVersion) {
+  const configured = env[CODEGRAPH_NODE_BIN_ENV]?.trim();
+  if (configured !== undefined && configured.length > 0) {
+    const resolved = resolveConfiguredNodeRuntime(configured, fileExists, which);
+    return resolved !== null && supportsCodegraphNodeRuntime(resolved, env, nodeVersion) ? resolved : null;
+  }
+  const candidates = [
+    ...isNodeExecutableName(process.execPath) ? [process.execPath] : [],
+    ...CODEGRAPH_NODE_CANDIDATES.map((commandName) => which(commandName)).filter((candidate) => candidate !== null)
+  ];
+  const seen = new Set;
+  for (const candidate of candidates) {
+    if (seen.has(candidate))
+      continue;
+    seen.add(candidate);
+    if (supportsCodegraphNodeRuntime(candidate, env, nodeVersion))
+      return candidate;
+  }
+  return null;
 }
 function defaultProvisionedBin(homeDir, fileExists) {
   const binaryName = process.platform === "win32" ? "codegraph.cmd" : "codegraph";
@@ -1636,7 +1694,8 @@ function resolveCodegraphCommand(options = {}) {
   if (configuredBin !== undefined && configuredBin.length > 0) {
     return { argsPrefix: [], command: configuredBin, exists: fileExists(configuredBin), source: "env" };
   }
-  const nodeRuntime = options.nodeRuntime ?? defaultNodeRuntime;
+  const which = options.which ?? bunWhich;
+  const nodeRuntime = options.nodeRuntime ?? (() => defaultNodeRuntime(env, fileExists, which, options.nodeVersion ?? defaultNodeVersion));
   const bundled = resolveBundledShim(options.requireResolve ?? defaultRequireResolve, fileExists);
   const runtime2 = nodeRuntime();
   if (bundled !== null && runtime2 !== null) {
@@ -1646,7 +1705,7 @@ function resolveCodegraphCommand(options = {}) {
   if (provisioned !== null && fileExists(provisioned)) {
     return { argsPrefix: [], command: provisioned, exists: true, source: "provisioned" };
   }
-  const pathCommand = (options.which ?? bunWhich)("codegraph");
+  const pathCommand = which("codegraph");
   return {
     argsPrefix: [],
     command: pathCommand ?? "codegraph",
@@ -1655,7 +1714,7 @@ function resolveCodegraphCommand(options = {}) {
   };
 }
 
-// ../../../../utils/src/codegraph/workspace.ts
+// ../../utils/src/codegraph/workspace.ts
 import { createHash as createHash2 } from "node:crypto";
 import {
   appendFileSync,
@@ -1670,7 +1729,7 @@ import {
   symlinkSync
 } from "node:fs";
 import { homedir as homedir5 } from "node:os";
-import { basename as basename2, join as join6, resolve as resolve2 } from "node:path";
+import { basename as basename3, join as join6, resolve as resolve2 } from "node:path";
 function sanitizeBase(value) {
   const sanitized = value.replace(/[^A-Za-z0-9._-]/g, "-").replace(/-+/g, "-");
   return sanitized.length > 0 ? sanitized : "workspace";
@@ -1681,7 +1740,7 @@ function codegraphDataRoot(homeDir) {
 function workspaceStorageName(workspace) {
   const resolved = resolve2(workspace);
   const hash = createHash2("sha256").update(resolved).digest("hex").slice(0, 16);
-  return `${sanitizeBase(basename2(resolved))}-${hash}`;
+  return `${sanitizeBase(basename3(resolved))}-${hash}`;
 }
 function fallbackResult(dataRoot, projectLink, reason) {
   return { dataDir: projectLink, dataRoot, linked: false, mode: "in-place-fallback", projectLink, reason };
@@ -1751,7 +1810,7 @@ function ensureCodegraphGitignored(workspace) {
   }
 }
 
-// src/session-start-worker.ts
+// components/codegraph/src/session-start-worker.ts
 var SESSION_START_CWD_ENV = "OMO_CODEGRAPH_SESSION_START_CWD";
 var CODEGRAPH_VERSION = "1.0.1";
 var COMMAND_TIMEOUT_MS = 60000;
@@ -1772,16 +1831,17 @@ async function runCodegraphSessionStartWorker(options = {}) {
   if (config.codegraph?.enabled === false) {
     return finish("skipped-disabled", { projectRoot }, logOutcome);
   }
-  if (!evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion }).supported) {
-    return finish("skipped-unsupported-node", { projectRoot }, logOutcome);
-  }
-  return runBootstrap(projectRoot, config.codegraph ?? {}, env, homeDir, { ...defaultDeps, ...options.deps }, logOutcome);
+  const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
+  return runBootstrap(projectRoot, config.codegraph ?? {}, env, homeDir, nodeSupport, { ...defaultDeps, ...options.deps }, logOutcome);
 }
-async function runBootstrap(projectRoot, config, env, homeDir, deps, logOutcome) {
+async function runBootstrap(projectRoot, config, env, homeDir, nodeSupport, deps, logOutcome) {
   try {
-    const command = await resolveOrProvisionCommand(deps, config, env, homeDir);
+    const command = await resolveOrProvisionCommand(deps, config, env, homeDir, nodeSupport);
     if (command.kind === "unavailable") {
       return finish("skipped-unavailable", { error: command.error, projectRoot, source: command.source }, logOutcome);
+    }
+    if (command.kind === "unsupported-node") {
+      return finish("skipped-unsupported-node", { projectRoot }, logOutcome);
     }
     deps.prepareWorkspace(projectRoot, { homeDir });
     deps.ensureGitignored(projectRoot);
@@ -1801,10 +1861,16 @@ function finish(action, detail, logOutcome) {
   safeLogOutcome(logOutcome, { ...detail, action });
   return { action };
 }
-async function resolveOrProvisionCommand(deps, config, env, homeDir) {
+async function resolveOrProvisionCommand(deps, config, env, homeDir, nodeSupport) {
   const resolved = deps.resolveCommand({ env, homeDir, provisioned: () => provisionedBinFromInstallDir(config.install_dir) });
-  if (resolved.exists)
+  if (resolved.exists) {
+    if (resolved.source !== "bundled" && resolved.source !== "env" && !nodeSupport.supported) {
+      return { kind: "unsupported-node" };
+    }
     return { kind: "resolved", resolution: resolved };
+  }
+  if (!nodeSupport.supported)
+    return { kind: "unsupported-node" };
   if (config.auto_provision === false)
     return { error: "codegraph binary unavailable and auto_provision is disabled", kind: "unavailable", source: resolved.source };
   const installDir = config.install_dir ?? join7(homeDir, ".omo", "codegraph");
@@ -1912,7 +1978,7 @@ function isRecord2(value) {
   return typeof value === "object" && value !== null;
 }
 
-// src/hook.ts
+// components/codegraph/src/hook.ts
 var CODEGRAPH_SESSION_START_NOTICE = "LazyCodex CodeGraph bootstrap scheduled in background";
 async function runCodegraphSessionStartHook(options = {}) {
   return (await executeCodegraphSessionStartHook(options)).exitCode;
@@ -1979,11 +2045,11 @@ function defaultWorkerCliPath() {
   return fileURLToPath(import.meta.url);
 }
 
-// src/serve.ts
+// components/codegraph/src/serve.ts
 import { spawn as spawn2 } from "node:child_process";
 import { existsSync as existsSync7, realpathSync as realpathSync2 } from "node:fs";
 import { homedir as homedir8 } from "node:os";
-import { basename as basename3, extname as extname2, join as join8, resolve as resolve3 } from "node:path";
+import { basename as basename4, extname as extname2, join as join8, resolve as resolve3 } from "node:path";
 import {
   cwd as processCwd3,
   env as processEnv3,
@@ -2017,7 +2083,7 @@ async function runCodegraphServe(options = {}) {
     return 1;
   }
   const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
-  if (!nodeSupport.supported) {
+  if (resolution.source !== "bundled" && resolution.source !== "env" && !nodeSupport.supported) {
     (options.stderr ?? processStderr2).write(buildCodegraphNodeSkipHint(nodeSupport));
     return 1;
   }
@@ -2035,11 +2101,11 @@ async function runCodegraphServe(options = {}) {
 function shouldSkipResolvedCommand(resolution, commandExists) {
   if (resolution.source !== "env")
     return false;
-  if (!looksLikePath(resolution.command))
+  if (!looksLikePath2(resolution.command))
     return false;
   return !commandExists(resolution.command);
 }
-function looksLikePath(command) {
+function looksLikePath2(command) {
   return command.includes("/") || command.includes("\\");
 }
 function codegraphEnvForConfig(config, homeDir, buildEnv) {
@@ -2092,13 +2158,13 @@ function isDirectInvocation(argvPath) {
   if (argvPath === undefined)
     return false;
   const modulePath = fileURLToPath2(import.meta.url);
-  const moduleName = basename3(modulePath);
+  const moduleName = basename4(modulePath);
   if (moduleName !== "serve.js" && moduleName !== "serve.ts")
     return false;
   return realpathSync2(resolve3(argvPath)) === realpathSync2(modulePath);
 }
 
-// src/cli.ts
+// components/codegraph/src/cli.ts
 async function runCodegraphCli(options = {}) {
   const argv = options.argv ?? process.argv;
   const command = argv[2];
@@ -2129,7 +2195,7 @@ function isDirectInvocation2(argvPath) {
   if (argvPath === undefined)
     return false;
   const modulePath = fileURLToPath3(import.meta.url);
-  const moduleName = basename4(modulePath);
+  const moduleName = basename5(modulePath);
   if (moduleName !== "cli.js" && moduleName !== "cli.ts")
     return false;
   return realpathSync3(resolve4(argvPath)) === realpathSync3(modulePath);

--- a/packages/omo-codex/plugin/components/codegraph/dist/serve.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/serve.js
@@ -4,7 +4,7 @@
 import { spawn } from "node:child_process";
 import { existsSync as existsSync4, realpathSync } from "node:fs";
 import { homedir as homedir4 } from "node:os";
-import { basename, extname, join as join5, resolve as resolve2 } from "node:path";
+import { basename as basename2, extname, join as join5, resolve as resolve2 } from "node:path";
 import {
   cwd as processCwd,
   env as processEnv,
@@ -34,6 +34,7 @@ function buildCodegraphEnv(options = {}) {
 var CODEGRAPH_MIN_NODE_MAJOR = 20;
 var CODEGRAPH_BLOCKED_NODE_MAJOR = 25;
 var CODEGRAPH_UNSAFE_NODE_ENV = "CODEGRAPH_ALLOW_UNSAFE_NODE";
+var CODEGRAPH_NODE_BIN_ENV = "CODEGRAPH_NODE_BIN";
 function evaluateCodegraphNodeSupport(options = {}) {
   const nodeVersion = options.nodeVersion ?? process.versions.node;
   const env = options.env ?? process.env;
@@ -61,7 +62,8 @@ function parseNodeMajor(version) {
 // ../../../../utils/src/codegraph/resolve.ts
 import { existsSync } from "node:fs";
 import { homedir as homedir2 } from "node:os";
-import { dirname, join as join3 } from "node:path";
+import { spawnSync } from "node:child_process";
+import { basename, dirname, join as join3 } from "node:path";
 import { createRequire } from "node:module";
 
 // ../../../../utils/src/runtime/which.ts
@@ -133,12 +135,68 @@ function bunWhich(commandName) {
 var CODEGRAPH_PACKAGE = "@colbymchenry/codegraph";
 var CODEGRAPH_ENV_BIN = "OMO_CODEGRAPH_BIN";
 var CODEGRAPH_LEGACY_ENV_BIN = "CODEGRAPH_BIN";
+var CODEGRAPH_NODE_CANDIDATES = ["node24", "node22", "node20", "node"];
 var requireFromHere = createRequire(import.meta.url);
 function defaultRequireResolve(specifier) {
   return requireFromHere.resolve(specifier);
 }
-function defaultNodeRuntime() {
-  return process.execPath || null;
+function defaultNodeVersion(nodePath) {
+  if (nodePath === process.execPath && isNodeExecutableName(nodePath))
+    return process.versions.node;
+  try {
+    const result = spawnSync(nodePath, ["--version"], {
+      encoding: "utf8",
+      timeout: 2000,
+      windowsHide: true
+    });
+    if (result.error !== undefined || result.status !== 0)
+      return null;
+    const version = `${result.stdout}
+${result.stderr}`.trim().split(/\s+/)[0];
+    return version === undefined || version.length === 0 ? null : version;
+  } catch (error) {
+    if (error instanceof Error)
+      return null;
+    throw error;
+  }
+}
+function isNodeExecutableName(filePath) {
+  const executable = basename(filePath).toLowerCase();
+  return executable === "node" || executable === "node.exe" || /^node\d+(\.exe)?$/.test(executable);
+}
+function looksLikePath(command) {
+  return command.includes("/") || command.includes("\\") || /^[a-zA-Z]:/.test(command);
+}
+function resolveConfiguredNodeRuntime(configured, fileExists, which) {
+  if (looksLikePath(configured))
+    return fileExists(configured) ? configured : null;
+  return which(configured);
+}
+function supportsCodegraphNodeRuntime(nodePath, env, nodeVersion) {
+  const version = nodeVersion(nodePath);
+  if (version === null)
+    return false;
+  return evaluateCodegraphNodeSupport({ env, nodeVersion: version }).supported;
+}
+function defaultNodeRuntime(env, fileExists, which, nodeVersion) {
+  const configured = env[CODEGRAPH_NODE_BIN_ENV]?.trim();
+  if (configured !== undefined && configured.length > 0) {
+    const resolved = resolveConfiguredNodeRuntime(configured, fileExists, which);
+    return resolved !== null && supportsCodegraphNodeRuntime(resolved, env, nodeVersion) ? resolved : null;
+  }
+  const candidates = [
+    ...isNodeExecutableName(process.execPath) ? [process.execPath] : [],
+    ...CODEGRAPH_NODE_CANDIDATES.map((commandName) => which(commandName)).filter((candidate) => candidate !== null)
+  ];
+  const seen = new Set;
+  for (const candidate of candidates) {
+    if (seen.has(candidate))
+      continue;
+    seen.add(candidate);
+    if (supportsCodegraphNodeRuntime(candidate, env, nodeVersion))
+      return candidate;
+  }
+  return null;
 }
 function defaultProvisionedBin(homeDir, fileExists) {
   const binaryName = process.platform === "win32" ? "codegraph.cmd" : "codegraph";
@@ -173,7 +231,8 @@ function resolveCodegraphCommand(options = {}) {
   if (configuredBin !== undefined && configuredBin.length > 0) {
     return { argsPrefix: [], command: configuredBin, exists: fileExists(configuredBin), source: "env" };
   }
-  const nodeRuntime = options.nodeRuntime ?? defaultNodeRuntime;
+  const which = options.which ?? bunWhich;
+  const nodeRuntime = options.nodeRuntime ?? (() => defaultNodeRuntime(env, fileExists, which, options.nodeVersion ?? defaultNodeVersion));
   const bundled = resolveBundledShim(options.requireResolve ?? defaultRequireResolve, fileExists);
   const runtime2 = nodeRuntime();
   if (bundled !== null && runtime2 !== null) {
@@ -183,7 +242,7 @@ function resolveCodegraphCommand(options = {}) {
   if (provisioned !== null && fileExists(provisioned)) {
     return { argsPrefix: [], command: provisioned, exists: true, source: "provisioned" };
   }
-  const pathCommand = (options.which ?? bunWhich)("codegraph");
+  const pathCommand = which("codegraph");
   return {
     argsPrefix: [],
     command: pathCommand ?? "codegraph",
@@ -1457,7 +1516,7 @@ async function runCodegraphServe(options = {}) {
     return 1;
   }
   const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
-  if (!nodeSupport.supported) {
+  if (resolution.source !== "bundled" && resolution.source !== "env" && !nodeSupport.supported) {
     (options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
     return 1;
   }
@@ -1475,11 +1534,11 @@ async function runCodegraphServe(options = {}) {
 function shouldSkipResolvedCommand(resolution, commandExists) {
   if (resolution.source !== "env")
     return false;
-  if (!looksLikePath(resolution.command))
+  if (!looksLikePath2(resolution.command))
     return false;
   return !commandExists(resolution.command);
 }
-function looksLikePath(command) {
+function looksLikePath2(command) {
   return command.includes("/") || command.includes("\\");
 }
 function codegraphEnvForConfig(config, homeDir, buildEnv) {
@@ -1532,7 +1591,7 @@ function isDirectInvocation(argvPath) {
   if (argvPath === undefined)
     return false;
   const modulePath = fileURLToPath(import.meta.url);
-  const moduleName = basename(modulePath);
+  const moduleName = basename2(modulePath);
   if (moduleName !== "serve.js" && moduleName !== "serve.ts")
     return false;
   return realpathSync(resolve2(argvPath)) === realpathSync(modulePath);

--- a/packages/omo-codex/plugin/components/codegraph/src/serve.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/serve.ts
@@ -88,7 +88,7 @@ export async function runCodegraphServe(options: RunCodegraphServeOptions = {}):
 	}
 
 	const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
-	if (!nodeSupport.supported) {
+	if (resolution.source !== "bundled" && resolution.source !== "env" && !nodeSupport.supported) {
 		(options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
 		return 1;
 	}

--- a/packages/omo-codex/plugin/components/codegraph/src/session-start-worker.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/session-start-worker.ts
@@ -6,7 +6,7 @@ import { cwd as processCwd, env as processEnv, stderr as processStderr } from "n
 
 import { getCodexOmoConfig } from "../../../shared/src/config-loader.ts";
 import { buildCodegraphEnv } from "../../../../../utils/src/codegraph/env.ts";
-import { evaluateCodegraphNodeSupport } from "../../../../../utils/src/codegraph/node-support.ts";
+import { evaluateCodegraphNodeSupport, type CodegraphNodeSupport } from "../../../../../utils/src/codegraph/node-support.ts";
 import { ensureCodegraphProvisioned } from "../../../../../utils/src/codegraph/provision.ts";
 import {
 	resolveCodegraphCommand,
@@ -47,11 +47,8 @@ export async function runCodegraphSessionStartWorker(options: SessionStartWorker
 		return finish("skipped-disabled", { projectRoot }, logOutcome);
 	}
 
-	if (!evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion }).supported) {
-		return finish("skipped-unsupported-node", { projectRoot }, logOutcome);
-	}
-
-	return runBootstrap(projectRoot, config.codegraph ?? {}, env, homeDir, { ...defaultDeps, ...options.deps }, logOutcome);
+	const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
+	return runBootstrap(projectRoot, config.codegraph ?? {}, env, homeDir, nodeSupport, { ...defaultDeps, ...options.deps }, logOutcome);
 }
 
 async function runBootstrap(
@@ -59,13 +56,17 @@ async function runBootstrap(
 	config: CodegraphConfig,
 	env: Record<string, string | undefined>,
 	homeDir: string,
+	nodeSupport: CodegraphNodeSupport,
 	deps: CodegraphSessionStartDeps,
 	logOutcome: (outcome: CodegraphSessionStartOutcome) => void,
 ): Promise<{ readonly action: WorkerAction }> {
 	try {
-		const command = await resolveOrProvisionCommand(deps, config, env, homeDir);
+		const command = await resolveOrProvisionCommand(deps, config, env, homeDir, nodeSupport);
 		if (command.kind === "unavailable") {
 			return finish("skipped-unavailable", { error: command.error, projectRoot, source: command.source }, logOutcome);
+		}
+		if (command.kind === "unsupported-node") {
+			return finish("skipped-unsupported-node", { projectRoot }, logOutcome);
 		}
 
 		deps.prepareWorkspace(projectRoot, { homeDir });
@@ -90,11 +91,24 @@ function finish(action: WorkerAction, detail: Omit<CodegraphSessionStartOutcome,
 
 type ResolutionResult =
 	| { readonly kind: "resolved"; readonly resolution: CodegraphCommandResolution }
+	| { readonly kind: "unsupported-node" }
 	| { readonly error: string; readonly kind: "unavailable"; readonly projectRoot?: string; readonly source: CodegraphCommandResolution["source"] };
 
-async function resolveOrProvisionCommand(deps: CodegraphSessionStartDeps, config: CodegraphConfig, env: Record<string, string | undefined>, homeDir: string): Promise<ResolutionResult> {
+async function resolveOrProvisionCommand(
+	deps: CodegraphSessionStartDeps,
+	config: CodegraphConfig,
+	env: Record<string, string | undefined>,
+	homeDir: string,
+	nodeSupport: CodegraphNodeSupport,
+): Promise<ResolutionResult> {
 	const resolved = deps.resolveCommand({ env, homeDir, provisioned: () => provisionedBinFromInstallDir(config.install_dir) });
-	if (resolved.exists) return { kind: "resolved", resolution: resolved };
+	if (resolved.exists) {
+		if (resolved.source !== "bundled" && resolved.source !== "env" && !nodeSupport.supported) {
+			return { kind: "unsupported-node" };
+		}
+		return { kind: "resolved", resolution: resolved };
+	}
+	if (!nodeSupport.supported) return { kind: "unsupported-node" };
 	if (config.auto_provision === false) return { error: "codegraph binary unavailable and auto_provision is disabled", kind: "unavailable", source: resolved.source };
 
 	const installDir = config.install_dir ?? join(homeDir, ".omo", "codegraph");

--- a/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
@@ -197,7 +197,7 @@ describe("CodeGraph SessionStart hook", () => {
 		}
 	});
 
-	it("#given an unsupported local Node #when worker runs #then it skips codegraph without resolving or provisioning", async () => {
+	it("#given an unsupported local Node and a PATH CodeGraph command #when worker runs #then it skips without touching the workspace", async () => {
 		// given
 		const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-node-"));
 		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-node-home-"));
@@ -212,10 +212,13 @@ describe("CodeGraph SessionStart hook", () => {
 				logOutcome: (outcome) => outcomes.push(outcome),
 				deps: {
 					resolveCommand: () => {
-						throw new Error("resolveCommand should not run on unsupported Node");
+						return { argsPrefix: [], command: "/usr/local/bin/codegraph", exists: true, source: "path" };
 					},
 					ensureProvisioned: () => {
 						throw new Error("ensureProvisioned should not run on unsupported Node");
+					},
+					prepareWorkspace: () => {
+						throw new Error("prepareWorkspace should not run on unsupported Node");
 					},
 					runCommand: () => {
 						throw new Error("runCommand should not run on unsupported Node");
@@ -227,6 +230,54 @@ describe("CodeGraph SessionStart hook", () => {
 			expect(result).toEqual({ action: "skipped-unsupported-node" });
 			expect(existsSync(join(workspace, ".codegraph"))).toBe(false);
 			expect(outcomes).toEqual([{ action: "skipped-unsupported-node", projectRoot: workspace }]);
+		} finally {
+			rmSync(workspace, { recursive: true, force: true });
+			rmSync(homeDir, { recursive: true, force: true });
+		}
+	});
+
+	it("#given an unsupported local Node but bundled CodeGraph resolves through CODEGRAPH_NODE_BIN #when worker runs #then it bootstraps with the compatible runtime", async () => {
+		// given
+		const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-compatible-node-"));
+		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-compatible-node-home-"));
+		const nodeBin = "/opt/node22/bin/node";
+		const calls: Array<{ readonly args: readonly string[]; readonly command: string }> = [];
+		const outcomes: unknown[] = [];
+
+		try {
+			// when
+			const result = await runCodegraphSessionStartWorker({
+				cwd: workspace,
+				env: { CODEGRAPH_NODE_BIN: nodeBin, HOME: homeDir },
+				nodeVersion: "26.3.0",
+				logOutcome: (outcome) => outcomes.push(outcome),
+				deps: {
+					ensureGitignored: () => true,
+					ensureProvisioned: () => {
+						throw new Error("provisioning should not run when bundled CodeGraph resolved");
+					},
+					prepareWorkspace: () => ({
+						dataDir: join(homeDir, ".omo/codegraph/projects/test"),
+						dataRoot: join(homeDir, ".omo/codegraph"),
+						linked: true,
+						mode: "global-linked",
+						projectLink: join(workspace, ".codegraph"),
+					}),
+					resolveCommand: () => ({ argsPrefix: ["codegraph.js"], command: nodeBin, exists: true, source: "bundled" }),
+					runCommand: (_projectRoot, command, args) => {
+						calls.push({ args, command });
+						return Promise.resolve({ exitCode: 0, stdout: calls.length === 1 ? '{"initialized":false}' : "", timedOut: false });
+					},
+				},
+			});
+
+			// then
+			expect(result).toEqual({ action: "initialized" });
+			expect(calls).toEqual([
+				{ args: ["codegraph.js", "status", "--json"], command: nodeBin },
+				{ args: ["codegraph.js", "init"], command: nodeBin },
+			]);
+			expect(outcomes).toEqual([{ action: "initialized", exitCode: 0, projectRoot: workspace, source: "bundled", timedOut: false }]);
 		} finally {
 			rmSync(workspace, { recursive: true, force: true });
 			rmSync(homeDir, { recursive: true, force: true });

--- a/packages/omo-codex/plugin/components/codegraph/test/serve.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve.test.ts
@@ -134,6 +134,53 @@ describe("runCodegraphServe", () => {
 		expect(spawned).toEqual(["node"]);
 	});
 
+	it("#given an unsupported local Node but CODEGRAPH_NODE_BIN resolves a bundled shim with Node 22 #when serving MCP #then it spawns the compatible runtime", async () => {
+		// given
+		const spawned: Array<{ readonly args: readonly string[]; readonly command: string }> = [];
+		const nodeBin = "/opt/node22/bin/node";
+
+		// when
+		const exitCode = await runCodegraphServe({
+			env: { CODEGRAPH_NODE_BIN: nodeBin },
+			nodeVersion: "26.3.0",
+			buildEnv: () => ({}),
+			resolve: () => ({ argsPrefix: ["codegraph.js"], command: nodeBin, exists: true, source: "bundled" }),
+			runProcess: (command: string, args: readonly string[]) => {
+				spawned.push({ args, command });
+				return Promise.resolve(0);
+			},
+			stderr: { write: () => undefined },
+		});
+
+		// then
+		expect(exitCode).toBe(0);
+		expect(spawned).toEqual([{ args: ["codegraph.js", "serve", "--mcp"], command: nodeBin }]);
+	});
+
+	it("#given OMO_CODEGRAPH_BIN points at an explicit command #when local Node is unsupported #then serve trusts the configured command", async () => {
+		// given
+		const commandPath = "/opt/codegraph-node22/bin/codegraph";
+		const spawned: Array<{ readonly args: readonly string[]; readonly command: string }> = [];
+
+		// when
+		const exitCode = await runCodegraphServe({
+			env: { OMO_CODEGRAPH_BIN: commandPath },
+			nodeVersion: "26.3.0",
+			buildEnv: () => ({}),
+			commandExists: (candidate) => candidate === commandPath,
+			resolve: () => ({ argsPrefix: [], command: commandPath, exists: true, source: "env" }),
+			runProcess: (command: string, args: readonly string[]) => {
+				spawned.push({ args, command });
+				return Promise.resolve(0);
+			},
+			stderr: { write: () => undefined },
+		});
+
+		// then
+		expect(exitCode).toBe(0);
+		expect(spawned).toEqual([{ args: ["serve", "--mcp"], command: commandPath }]);
+	});
+
 	it("#given OMO_CODEGRAPH_BIN points at a missing path #when serving MCP #then exits before spawn", async () => {
 		// given
 		const stderr: string[] = [];

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/codegraph-bootstrap.test.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/codegraph-bootstrap.test.ts
@@ -44,6 +44,7 @@ function createDeps(events: string[], overrides: Partial<CodegraphBootstrapDeps>
       if (args[0] === "status") return { exitCode: 0, stdout: "not initialized", timedOut: false }
       return { exitCode: 0, stdout: "", timedOut: false }
     },
+    nodeSupport: () => ({ major: 22, override: false, supported: true }),
     schedule: (task) => {
       events.push("scheduled")
       void task()
@@ -199,6 +200,87 @@ describe("createCodegraphBootstrapHook", () => {
     expect(events.some((event) => event.startsWith("run:"))).toBe(false)
     expect(events.some((event) => event.startsWith("prepare:"))).toBe(false)
     expect(events.some((event) => event.startsWith("gitignore:"))).toBe(false)
+  })
+
+  test("#given a PATH CodeGraph binary but the host Node is unsupported #when background work runs #then it leaves the project untouched", async () => {
+    // given
+    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-node-"))
+    const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-node-home-"))
+    const events: string[] = []
+    const hook = createCodegraphBootstrapHook(
+      { directory: workspace },
+      { auto_provision: false, enabled: true },
+      {
+        log: (message) => {
+          events.push(`log:${message}`)
+        },
+        nodeSupport: () => ({ major: 26, override: false, reason: "too-new", supported: false }),
+        prepareWorkspace: (projectRoot) => prepareCodegraphWorkspace(projectRoot, { homeDir }),
+        resolveCommand: () => ({ argsPrefix: [], command: "/usr/local/bin/codegraph", exists: true, source: "path" }),
+        runCommand: async () => {
+          throw new Error("codegraph command should not run")
+        },
+        schedule: (task) => {
+          void task()
+        },
+      },
+    )
+
+    try {
+      // when
+      hook.event({ event: { type: "session.created", properties: { worktree: workspace } } })
+      await waitForBackground()
+
+      // then
+      expect(events).toContain("log:[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap")
+      expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
+      expect(existsSync(join(workspace, ".git", "info", "exclude"))).toBe(false)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+      rmSync(homeDir, { recursive: true, force: true })
+    }
+  })
+
+  test("#given CodeGraph is missing and auto provision is enabled on unsupported Node #when background work runs #then it does not provision or mutate the project", async () => {
+    // given
+    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-provision-"))
+    const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-provision-home-"))
+    const events: string[] = []
+    const hook = createCodegraphBootstrapHook(
+      { directory: workspace },
+      { auto_provision: true, enabled: true },
+      {
+        ensureProvisioned: async () => {
+          throw new Error("codegraph provisioning should not run")
+        },
+        log: (message) => {
+          events.push(`log:${message}`)
+        },
+        nodeSupport: () => ({ major: 26, override: false, reason: "too-new", supported: false }),
+        prepareWorkspace: (projectRoot) => prepareCodegraphWorkspace(projectRoot, { homeDir }),
+        resolveCommand: () => ({ argsPrefix: [], command: "codegraph", exists: false, source: "path" }),
+        runCommand: async () => {
+          throw new Error("codegraph command should not run")
+        },
+        schedule: (task) => {
+          void task()
+        },
+      },
+    )
+
+    try {
+      // when
+      hook.event({ event: { type: "session.created", properties: { worktree: workspace } } })
+      await waitForBackground()
+
+      // then
+      expect(events).toContain("log:[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap")
+      expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
+      expect(existsSync(join(workspace, ".git", "info", "exclude"))).toBe(false)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+      rmSync(homeDir, { recursive: true, force: true })
+    }
   })
 
   test("#given CodeGraph is unavailable and auto provisioning is disabled #when background work runs #then it leaves the project untouched", async () => {

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
@@ -8,8 +8,10 @@ import {
   ensureCodegraphProvisioned,
   prepareCodegraphWorkspace,
   resolveCodegraphCommand,
+  resolveCodegraphNodeSupport,
   type BuildCodegraphEnvOptions,
   type CodegraphCommandResolution,
+  type CodegraphNodeSupport,
   type CodegraphProvisionResult,
   type CodegraphWorkspacePreparation,
   type PrepareCodegraphWorkspaceOptions,
@@ -43,6 +45,7 @@ export interface CodegraphBootstrapDeps {
     readonly version: "1.0.1"
   }) => Promise<CodegraphProvisionResult>
   readonly log: (message: string, data?: Record<string, unknown>) => void
+  readonly nodeSupport: () => CodegraphNodeSupport
   readonly prepareWorkspace: (
     projectRoot: string,
     options?: PrepareCodegraphWorkspaceOptions,
@@ -102,6 +105,15 @@ async function resolveOrProvisionCommand(
   const resolved = resolveInitialCommand(deps, config)
   if (resolved.exists) return resolved
   if (config.auto_provision === false) return null
+  const nodeSupport = deps.nodeSupport()
+  if (!nodeSupport.supported) {
+    deps.log("[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap", {
+      major: nodeSupport.major,
+      reason: nodeSupport.reason,
+      source: resolved.source,
+    })
+    return null
+  }
 
   const installDir = config.install_dir ?? defaultInstallDir()
   const provisioned = await deps.ensureProvisioned({
@@ -129,6 +141,15 @@ async function runBootstrap(
     const command = await resolveOrProvisionCommand(deps, config)
     if (command === null) {
       deps.log("[codegraph-bootstrap] CodeGraph unavailable; skipping bootstrap", { projectRoot })
+      return
+    }
+    const nodeSupport = deps.nodeSupport()
+    if (command.source !== "bundled" && command.source !== "env" && !nodeSupport.supported) {
+      deps.log("[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap", {
+        major: nodeSupport.major,
+        projectRoot,
+        reason: nodeSupport.reason,
+      })
       return
     }
 
@@ -168,6 +189,7 @@ const defaultDeps: CodegraphBootstrapDeps = {
   ensureGitignored: ensureCodegraphGitignored,
   ensureProvisioned: ensureCodegraphProvisioned,
   log,
+  nodeSupport: resolveCodegraphNodeSupport,
   prepareWorkspace: prepareCodegraphWorkspace,
   resolveCommand: resolveCodegraphCommand,
   runCommand: runCodegraphCommand,

--- a/packages/omo-opencode/src/mcp/codegraph.test.ts
+++ b/packages/omo-opencode/src/mcp/codegraph.test.ts
@@ -10,14 +10,17 @@ describe("createCodegraphMcpConfig", () => {
   it("returns a local MCP command that launches codegraph serve --mcp when the binary is present", () => {
     // given
     const codegraphPath = "/opt/omo/codegraph/bin/codegraph"
+    const nodePath = "/opt/node22/bin/node"
 
     // when
     const config = createCodegraphMcpConfig({
       cwd: "/workspace/project",
       config: { enabled: true },
+      env: {},
       fileExists: () => false,
       homeDir: "/tmp/omo-codegraph-test-home",
-      resolveExecutable: createResolver({ codegraph: codegraphPath }),
+      nodeVersionForExecutable: (candidate) => (candidate === nodePath ? "22.14.0" : "26.3.0"),
+      resolveExecutable: createResolver({ codegraph: codegraphPath, node: nodePath }),
     })
 
     // then
@@ -65,6 +68,75 @@ describe("createCodegraphMcpConfig", () => {
     expect(config.enabled).toBe(false)
   })
 
+  it("#given only a PATH CodeGraph binary and an unsupported host Node #when creating the MCP config #then it stays disabled", () => {
+    // given
+    const codegraphPath = "/usr/local/bin/codegraph"
+    const nodePath = "/opt/node26/bin/node"
+
+    // when
+    const config = createCodegraphMcpConfig({
+      cwd: "/workspace/project",
+      config: { enabled: true },
+      env: {},
+      fileExists: () => false,
+      homeDir: "/tmp/omo-codegraph-test-home",
+      nodeVersionForExecutable: (candidate) => (candidate === nodePath ? "26.3.0" : "0.0.0"),
+      requireResolve: () => {
+        throw new Error("bundled package absent")
+      },
+      resolveExecutable: createResolver({ codegraph: codegraphPath, node: nodePath }),
+    })
+
+    // then
+    expect(config.command).toEqual([codegraphPath, "serve", "--mcp"])
+    expect(config.enabled).toBe(false)
+  })
+
+  it("#given OMO_CODEGRAPH_BIN points at an explicit command #when host Node is unsupported #then the MCP stays enabled", () => {
+    // given
+    const codegraphPath = "/opt/codegraph-node22/bin/codegraph"
+
+    // when
+    const config = createCodegraphMcpConfig({
+      cwd: "/workspace/project",
+      config: { enabled: true },
+      env: { OMO_CODEGRAPH_BIN: codegraphPath },
+      fileExists: (filePath) => filePath === codegraphPath,
+      homeDir: "/tmp/omo-codegraph-test-home",
+      nodeVersionForExecutable: () => "26.3.0",
+      resolveExecutable: createResolver({}),
+    })
+
+    // then
+    expect(config.command).toEqual([codegraphPath, "serve", "--mcp"])
+    expect(config.enabled).toBe(true)
+  })
+
+  it("#given a bundled CodeGraph shim and CODEGRAPH_NODE_BIN points at Node 22 #when creating the MCP config #then it enables the compatible command", () => {
+    // given
+    const packageJson = join("/bundle", "node_modules", "@colbymchenry", "codegraph", "package.json")
+    const shim = join("/bundle", "node_modules", "@colbymchenry", "codegraph", "bin", "codegraph.js")
+    const nodeBin = "/opt/node22/bin/node"
+
+    // when
+    const config = createCodegraphMcpConfig({
+      cwd: "/workspace/project",
+      config: { enabled: true },
+      env: { CODEGRAPH_NODE_BIN: nodeBin },
+      fileExists: (filePath) => filePath === shim || filePath === nodeBin,
+      homeDir: "/tmp/omo-codegraph-test-home",
+      nodeVersionForExecutable: (candidate) => (candidate === nodeBin ? "22.22.3" : "26.3.0"),
+      requireResolve: () => packageJson,
+      resolveExecutable: createResolver({}),
+    })
+
+    // then
+    expect(config).toMatchObject({
+      command: [nodeBin, shim, "serve", "--mcp"],
+      enabled: true,
+      type: "local",
+    })
+  })
   it("forces telemetry off in the MCP environment", () => {
     // given
     const codegraphPath = "/opt/omo/codegraph/bin/codegraph"
@@ -87,17 +159,20 @@ describe("createCodegraphMcpConfig", () => {
     // given
     const installDir = "/custom/codegraph"
     const provisionedPath = join(installDir, "bin", process.platform === "win32" ? "codegraph.cmd" : "codegraph")
+    const nodePath = "/opt/node22/bin/node"
 
     // when
     const config = createCodegraphMcpConfig({
       cwd: "/workspace/project",
       config: { enabled: true, install_dir: installDir },
+      env: {},
       fileExists: (filePath) => filePath === provisionedPath,
       homeDir: "/tmp/omo-codegraph-test-home",
+      nodeVersionForExecutable: (candidate) => (candidate === nodePath ? "22.14.0" : "26.3.0"),
       requireResolve: () => {
         throw new Error("bundled package absent")
       },
-      resolveExecutable: createResolver({}),
+      resolveExecutable: createResolver({ node: nodePath }),
     })
 
     // then

--- a/packages/omo-opencode/src/mcp/codegraph.ts
+++ b/packages/omo-opencode/src/mcp/codegraph.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
 import { join } from "node:path"
-import { buildCodegraphEnv, resolveCodegraphCommand } from "@oh-my-opencode/utils"
+import { buildCodegraphEnv, resolveCodegraphCommand, resolveCodegraphNodeSupport } from "@oh-my-opencode/utils"
 import type { ResolveCodegraphCommandOptions } from "@oh-my-opencode/utils"
 import type { CodegraphConfig } from "../config/schema/codegraph"
 import type { LocalMcpConfig } from "./lsp"
@@ -12,6 +12,7 @@ export type CodegraphMcpConfigOptions = {
   readonly env?: ResolveCodegraphCommandOptions["env"]
   readonly fileExists?: ResolveCodegraphCommandOptions["fileExists"]
   readonly homeDir?: string
+  readonly nodeVersionForExecutable?: ResolveCodegraphCommandOptions["nodeVersion"]
   readonly provisioned?: ResolveCodegraphCommandOptions["provisioned"]
   readonly requireResolve?: ResolveCodegraphCommandOptions["requireResolve"]
   readonly resolveExecutable?: RuntimeExecutableResolver
@@ -20,13 +21,6 @@ export type CodegraphMcpConfigOptions = {
 function createWhichResolver(resolveExecutable: RuntimeExecutableResolver): (commandName: string) => string | null {
   return (commandName: string): string | null => {
     const resolved = resolveExecutable(commandName)
-    return resolved.available ? resolved.command : null
-  }
-}
-
-function createNodeRuntimeResolver(resolveExecutable: RuntimeExecutableResolver): () => string | null {
-  return (): string | null => {
-    const resolved = resolveExecutable("node")
     return resolved.available ? resolved.command : null
   }
 }
@@ -46,22 +40,32 @@ function codegraphEnvForConfig(config: Partial<CodegraphConfig> | undefined, hom
 }
 
 export function createCodegraphMcpConfig(options: CodegraphMcpConfigOptions = {}): LocalMcpConfig {
+  const env = options.env ?? process.env
   const resolveExecutable = options.resolveExecutable ?? resolveRuntimeExecutable
+  const which = createWhichResolver(resolveExecutable)
   const fileExists = options.fileExists ?? existsSync
   const resolvedCommand = resolveCodegraphCommand({
-    env: options.env,
+    env,
     fileExists,
     homeDir: options.homeDir,
-    nodeRuntime: createNodeRuntimeResolver(resolveExecutable),
+    nodeVersion: options.nodeVersionForExecutable,
     provisioned: options.provisioned ?? (() => provisionedBinFromInstallDir(options.config?.install_dir, fileExists)),
     requireResolve: options.requireResolve,
-    which: createWhichResolver(resolveExecutable),
+    which,
   })
+  const nodeSupport = resolveCodegraphNodeSupport({
+    env,
+    fileExists,
+    nodeVersion: options.nodeVersionForExecutable,
+    which,
+  })
+  const enabled =
+    resolvedCommand.exists && (resolvedCommand.source === "bundled" || resolvedCommand.source === "env" || nodeSupport.supported)
 
   return {
     type: "local",
     command: [resolvedCommand.command, ...resolvedCommand.argsPrefix, "serve", "--mcp"],
-    enabled: resolvedCommand.exists,
+    enabled,
     environment: codegraphEnvForConfig(options.config, options.homeDir),
   }
 }

--- a/packages/utils/src/codegraph-resolve.test.ts
+++ b/packages/utils/src/codegraph-resolve.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { join } from "node:path"
 
-import { resolveCodegraphCommand } from "./codegraph/resolve"
+import { resolveCodegraphCommand, resolveCodegraphNodeRuntime, resolveCodegraphNodeSupport } from "./codegraph/resolve"
 
 describe("resolveCodegraphCommand", () => {
   it("prefers OMO_CODEGRAPH_BIN over bundled, provisioned, and PATH tiers", () => {
@@ -92,6 +92,105 @@ describe("resolveCodegraphCommand", () => {
       exists: true,
       source: "bundled",
     })
+  })
+
+  it("#given CODEGRAPH_NODE_BIN points at Node 22 #when resolving a bundled package under a too-new host #then it uses the compatible runtime", () => {
+    // given
+    const packageRoot = join("/bundle", "node_modules", "@colbymchenry", "codegraph")
+    const bundledShim = join(packageRoot, "bin", "codegraph.js")
+    const packageJson = join(packageRoot, "package.json")
+    const nodeBin = "/opt/node22/bin/node"
+
+    // when
+    const result = resolveCodegraphCommand({
+      env: { CODEGRAPH_NODE_BIN: nodeBin },
+      fileExists: (filePath: string) => filePath === bundledShim || filePath === nodeBin,
+      nodeVersion: (candidate: string) => (candidate === nodeBin ? "v22.22.3" : "v26.3.0"),
+      provisioned: () => null,
+      requireResolve: () => packageJson,
+      which: () => null,
+    })
+
+    // then
+    expect(result).toEqual({
+      argsPrefix: [bundledShim],
+      command: nodeBin,
+      exists: true,
+      source: "bundled",
+    })
+  })
+
+  it("#given the host Node is too new #when Node 22 is on PATH #then bundled CodeGraph uses that compatible runtime", () => {
+    // given
+    const packageRoot = join("/bundle", "node_modules", "@colbymchenry", "codegraph")
+    const bundledShim = join(packageRoot, "npm-shim.js")
+    const packageJson = join(packageRoot, "package.json")
+    const node22 = "/usr/local/bin/node22"
+
+    // when
+    const result = resolveCodegraphCommand({
+      fileExists: (filePath: string) => filePath === bundledShim || filePath === node22,
+      nodeVersion: (candidate: string) => (candidate === node22 ? "22.14.0" : "26.3.0"),
+      provisioned: () => null,
+      requireResolve: () => packageJson,
+      which: (commandName: string) => (commandName === "node22" ? node22 : null),
+    })
+
+    // then
+    expect(result).toEqual({
+      argsPrefix: [bundledShim],
+      command: node22,
+      exists: true,
+      source: "bundled",
+    })
+  })
+
+  it("#given Node 22 is on PATH #when resolving CodeGraph Node support #then it reports supported", () => {
+    // given
+    const node22 = "/usr/local/bin/node22"
+
+    // when
+    const runtime = resolveCodegraphNodeRuntime({
+      nodeVersion: (candidate: string) => (candidate === node22 ? "v22.14.0" : "v26.0.0"),
+      which: (commandName: string) => (commandName === "node22" ? node22 : null),
+    })
+    const support = resolveCodegraphNodeSupport({
+      nodeVersion: (candidate: string) => (candidate === node22 ? "v22.14.0" : "v26.0.0"),
+      which: (commandName: string) => (commandName === "node22" ? node22 : null),
+    })
+
+    // then
+    expect(runtime).toBe(node22)
+    expect(support).toEqual({ major: 22, override: false, supported: true })
+  })
+
+  it("#given only Node 26 is on PATH #when resolving CodeGraph Node support #then it reports unsupported", () => {
+    // given
+    const node = "/usr/local/bin/node"
+
+    // when
+    const support = resolveCodegraphNodeSupport({
+      nodeVersion: (candidate: string) => (candidate === node ? "v26.0.0" : "v0.0.0"),
+      which: (commandName: string) => (commandName === "node" ? node : null),
+    })
+
+    // then
+    expect(support).toEqual({ major: 0, override: false, reason: "too-old", supported: false })
+  })
+
+  it("#given CODEGRAPH_NODE_BIN is a command name #when it resolves to Node 22 #then that runtime is selected", () => {
+    // given
+    const node22 = "/opt/homebrew/bin/node22"
+
+    // when
+    const runtime = resolveCodegraphNodeRuntime({
+      env: { CODEGRAPH_NODE_BIN: "node22" },
+      nodeVersion: (candidate: string) => (candidate === node22 ? "22.17.1" : "26.0.0"),
+      which: (commandName: string) => (commandName === "node22" ? node22 : null),
+    })
+
+    // then
+    expect(runtime).toBe(node22)
   })
 
   it("uses provisioned binaries before PATH", () => {

--- a/packages/utils/src/codegraph/node-support.ts
+++ b/packages/utils/src/codegraph/node-support.ts
@@ -1,6 +1,7 @@
 export const CODEGRAPH_MIN_NODE_MAJOR = 20
 export const CODEGRAPH_BLOCKED_NODE_MAJOR = 25
 export const CODEGRAPH_UNSAFE_NODE_ENV = "CODEGRAPH_ALLOW_UNSAFE_NODE"
+export const CODEGRAPH_NODE_BIN_ENV = "CODEGRAPH_NODE_BIN"
 
 export type CodegraphNodeUnsupportedReason = "too-new" | "too-old"
 

--- a/packages/utils/src/codegraph/resolve.ts
+++ b/packages/utils/src/codegraph/resolve.ts
@@ -1,9 +1,11 @@
 import { existsSync } from "node:fs"
 import { homedir } from "node:os"
-import { dirname, join } from "node:path"
+import { spawnSync } from "node:child_process"
+import { basename, dirname, join } from "node:path"
 import { createRequire } from "node:module"
 
 import { bunWhich } from "../runtime/which"
+import { CODEGRAPH_NODE_BIN_ENV, evaluateCodegraphNodeSupport, type CodegraphNodeSupport } from "./node-support"
 
 export type CodegraphCommandSource = "bundled" | "env" | "path" | "provisioned"
 
@@ -19,22 +21,123 @@ export interface ResolveCodegraphCommandOptions {
   readonly fileExists?: (filePath: string) => boolean
   readonly homeDir?: string
   readonly nodeRuntime?: () => string | null
+  readonly nodeVersion?: (nodePath: string) => string | null
   readonly provisioned?: () => string | null
   readonly requireResolve?: (specifier: string) => string
+  readonly which?: (commandName: string) => string | null
+}
+
+export interface ResolveCodegraphNodeSupportOptions {
+  readonly env?: Record<string, string | undefined>
+  readonly fileExists?: (filePath: string) => boolean
+  readonly nodeVersion?: (nodePath: string) => string | null
   readonly which?: (commandName: string) => string | null
 }
 
 const CODEGRAPH_PACKAGE = "@colbymchenry/codegraph"
 const CODEGRAPH_ENV_BIN = "OMO_CODEGRAPH_BIN"
 const CODEGRAPH_LEGACY_ENV_BIN = "CODEGRAPH_BIN"
+const CODEGRAPH_NODE_CANDIDATES = ["node24", "node22", "node20", "node"] as const
 const requireFromHere = createRequire(import.meta.url)
 
 function defaultRequireResolve(specifier: string): string {
   return requireFromHere.resolve(specifier)
 }
 
-function defaultNodeRuntime(): string | null {
-  return process.execPath || null
+function defaultNodeVersion(nodePath: string): string | null {
+  if (nodePath === process.execPath && isNodeExecutableName(nodePath)) return process.versions.node
+
+  try {
+    const result = spawnSync(nodePath, ["--version"], {
+      encoding: "utf8",
+      timeout: 2_000,
+      windowsHide: true,
+    })
+    if (result.error !== undefined || result.status !== 0) return null
+    const version = `${result.stdout}\n${result.stderr}`.trim().split(/\s+/)[0]
+    return version === undefined || version.length === 0 ? null : version
+  } catch (error) {
+    if (error instanceof Error) return null
+    throw error
+  }
+}
+
+function isNodeExecutableName(filePath: string): boolean {
+  const executable = basename(filePath).toLowerCase()
+  return executable === "node" || executable === "node.exe" || /^node\d+(\.exe)?$/.test(executable)
+}
+
+function looksLikePath(command: string): boolean {
+  return command.includes("/") || command.includes("\\") || /^[a-zA-Z]:/.test(command)
+}
+
+function resolveConfiguredNodeRuntime(
+  configured: string,
+  fileExists: (filePath: string) => boolean,
+  which: (commandName: string) => string | null,
+): string | null {
+  if (looksLikePath(configured)) return fileExists(configured) ? configured : null
+  return which(configured)
+}
+
+function supportsCodegraphNodeRuntime(
+  nodePath: string,
+  env: Record<string, string | undefined>,
+  nodeVersion: (nodePath: string) => string | null,
+): boolean {
+  const version = nodeVersion(nodePath)
+  if (version === null) return false
+  return evaluateCodegraphNodeSupport({ env, nodeVersion: version }).supported
+}
+
+function defaultNodeRuntime(
+  env: Record<string, string | undefined>,
+  fileExists: (filePath: string) => boolean,
+  which: (commandName: string) => string | null,
+  nodeVersion: (nodePath: string) => string | null,
+): string | null {
+  const configured = env[CODEGRAPH_NODE_BIN_ENV]?.trim()
+  if (configured !== undefined && configured.length > 0) {
+    const resolved = resolveConfiguredNodeRuntime(configured, fileExists, which)
+    return resolved !== null && supportsCodegraphNodeRuntime(resolved, env, nodeVersion) ? resolved : null
+  }
+
+  const candidates = [
+    ...(isNodeExecutableName(process.execPath) ? [process.execPath] : []),
+    ...CODEGRAPH_NODE_CANDIDATES.map((commandName) => which(commandName)).filter((candidate) => candidate !== null),
+  ]
+  const seen = new Set<string>()
+  for (const candidate of candidates) {
+    if (seen.has(candidate)) continue
+    seen.add(candidate)
+    if (supportsCodegraphNodeRuntime(candidate, env, nodeVersion)) return candidate
+  }
+  return null
+}
+
+export function resolveCodegraphNodeRuntime(
+  options: ResolveCodegraphNodeSupportOptions = {},
+): string | null {
+  const env = options.env ?? process.env
+  return defaultNodeRuntime(
+    env,
+    options.fileExists ?? existsSync,
+    options.which ?? bunWhich,
+    options.nodeVersion ?? defaultNodeVersion,
+  )
+}
+
+export function resolveCodegraphNodeSupport(
+  options: ResolveCodegraphNodeSupportOptions = {},
+): CodegraphNodeSupport {
+  const env = options.env ?? process.env
+  const nodeVersion = options.nodeVersion ?? defaultNodeVersion
+  const runtime = resolveCodegraphNodeRuntime({ ...options, env, nodeVersion })
+  if (runtime === null) {
+    return evaluateCodegraphNodeSupport({ env, nodeVersion: "0.0.0" })
+  }
+
+  return evaluateCodegraphNodeSupport({ env, nodeVersion: nodeVersion(runtime) ?? "0.0.0" })
 }
 
 function defaultProvisionedBin(homeDir: string, fileExists: (filePath: string) => boolean): string | null {
@@ -74,7 +177,9 @@ export function resolveCodegraphCommand(
     return { argsPrefix: [], command: configuredBin, exists: fileExists(configuredBin), source: "env" }
   }
 
-  const nodeRuntime = options.nodeRuntime ?? defaultNodeRuntime
+  const which = options.which ?? bunWhich
+  const nodeRuntime =
+    options.nodeRuntime ?? (() => defaultNodeRuntime(env, fileExists, which, options.nodeVersion ?? defaultNodeVersion))
   const bundled = resolveBundledShim(options.requireResolve ?? defaultRequireResolve, fileExists)
   const runtime = nodeRuntime()
   if (bundled !== null && runtime !== null) {
@@ -87,7 +192,7 @@ export function resolveCodegraphCommand(
     return { argsPrefix: [], command: provisioned, exists: true, source: "provisioned" }
   }
 
-  const pathCommand = (options.which ?? bunWhich)("codegraph")
+  const pathCommand = which("codegraph")
   return {
     argsPrefix: [],
     command: pathCommand ?? "codegraph",


### PR DESCRIPTION
## Summary
- Resolve bundled CodeGraph through an explicit compatible Node runtime (`CODEGRAPH_NODE_BIN`, `node24`, `node22`, `node20`, then `node`) instead of trusting the host process runtime.
- Disable OpenCode PATH/provisioned CodeGraph MCP and bootstrap paths when no compatible external Node is available, while preserving explicit `OMO_CODEGRAPH_BIN` / `CODEGRAPH_BIN` overrides.
- Align Codex CodeGraph serve/session-start behavior and regenerate the component bundle.

## QA Evidence
Evidence directory: `.omo/evidence/20260617-codegraph-node-runtime/`

- `bun run build` passed.
- `bun run typecheck` passed.
- `bun test` passed: 10028 pass / 2 skip / 0 fail.
- `bun run test:codex` passed: 336 pass / 0 fail.
- Targeted guard tests passed:
  - `opencode-mcp-node-runtime-guard-tests.txt`
  - `targeted-root-tests.txt`
  - `codex-codegraph-component-test.txt`
- OpenCode real harness proof:
  - `opencode-codegraph-real-harness.txt`: isolated `session.created` path skipped unsupported CodeGraph before provisioning/workspace mutation; no `.codegraph`, no `.git/info/exclude`, no provisioned files; real DB count unchanged.
  - `opencode-mcp-path-codegraph-node26-harness.txt`: isolated OpenCode `/config` with PATH `codegraph` and only fake Node v26 returned `mcp.codegraph.enabled:false`; fake codegraph was not spawned; real DB count unchanged.
- Codex real harness proof:
  - `codex-app-server-drive-plugin.txt` passed with isolated `CODEX_HOME` and real `~/.codex/config.toml` unchanged.
  - `codex-hook-unit-probe.txt` passed.
- `no-suppression-audit.txt`: `NO_SUPPRESSIONS_FOUND`.
- Final ultrawork reviewer: APPROVED.

## Notes
- This was driven from OpenCode session investigation for `ses_12c35ce96ffe6yQEAwYJvUJ00N` on `mengmotamac`.
- Explicit user-provided CodeGraph binaries remain trusted because they may be wrappers that manage their own runtime.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Select a compatible Node runtime for CodeGraph before bootstrap and serving to avoid failures on unsupported hosts. Prefer an explicit Node (`CODEGRAPH_NODE_BIN`, then `node24`/`node22`/`node20`/`node`) and skip PATH/provisioned CodeGraph when no compatible runtime is available; still honor explicit `OMO_CODEGRAPH_BIN`/`CODEGRAPH_BIN`.

- **Bug Fixes**
  - Bundled `@colbymchenry/codegraph` now runs under a verified compatible Node (version checked via `--version`).
  - OpenCode bootstrap and Codex serve/session-start skip on unsupported Node unless using bundled or env-provided commands.
  - MCP stays disabled on unsupported Node for PATH/provisioned commands; remains enabled for bundled or explicit env overrides.

- **Refactors**
  - Added `resolveCodegraphNodeRuntime` and `resolveCodegraphNodeSupport` in `@oh-my-opencode/utils` and wired both Codex and OpenCode to the shared resolver.

<sup>Written for commit 377c66aeb671e3027e680f6d814cbec6f79a3709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

