### PR TITLE
chore: land v4.11.0 release state

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,18 +53,18 @@
         "typescript": "^6.0.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.10.0",
-        "oh-my-opencode-darwin-x64": "4.10.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.10.0",
-        "oh-my-opencode-linux-arm64": "4.10.0",
-        "oh-my-opencode-linux-arm64-musl": "4.10.0",
-        "oh-my-opencode-linux-x64": "4.10.0",
-        "oh-my-opencode-linux-x64-baseline": "4.10.0",
-        "oh-my-opencode-linux-x64-musl": "4.10.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.10.0",
-        "oh-my-opencode-windows-arm64": "4.10.0",
-        "oh-my-opencode-windows-x64": "4.10.0",
-        "oh-my-opencode-windows-x64-baseline": "4.10.0",
+        "oh-my-opencode-darwin-arm64": "4.11.0",
+        "oh-my-opencode-darwin-x64": "4.11.0",
+        "oh-my-opencode-darwin-x64-baseline": "4.11.0",
+        "oh-my-opencode-linux-arm64": "4.11.0",
+        "oh-my-opencode-linux-arm64-musl": "4.11.0",
+        "oh-my-opencode-linux-x64": "4.11.0",
+        "oh-my-opencode-linux-x64-baseline": "4.11.0",
+        "oh-my-opencode-linux-x64-musl": "4.11.0",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.11.0",
+        "oh-my-opencode-windows-arm64": "4.11.0",
+        "oh-my-opencode-windows-x64": "4.11.0",
+        "oh-my-opencode-windows-x64-baseline": "4.11.0",
       },
     },
     "packages/agents-md-core": {
@@ -154,7 +154,7 @@
     },
     "packages/omo-codex": {
       "name": "@oh-my-opencode/omo-codex",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "dependencies": {
         "@oh-my-opencode/utils": "workspace:*",
       },
@@ -683,29 +683,29 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.10.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Oj9zhQYRpcjPkuhzXBS7BOST1wNfbaIHA8Wz+hdWWpSwtEgMU33Tv4hZPEK9097m1fy5eoOZQ7RIF7u6bdHFIw=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.11.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-FiTdlGzsQZdxYcI1XJAPsXtf1VBwB0IwX9MZHgIlydtwK7v1cC49UXKf5s0lQJcIIfkAKQMzg520EtmUJcfQyA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.10.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-cWKZUwilUGsSFlZLIVsiACkQ69oY0qCLBTLDi1TUAc1PyqrHiZim8Y+qWbbGmkMyAWrahUkILIvb1PotKbq0NA=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.11.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-PeKNAuCftCbkdfEvqSviD9IBd/NZrHy6NvpVwILTkRpuaTyFltc2iV5XsE3ibEEUHUbVkzNFNEJj5XRi3ppzrw=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.10.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-szmEaKoHqGk9Z006o5TrBJl1swlI+JgHrLG6cx1mBfiuB0DnGTAmw0/I7WqQcx4/L0jxUxPDXH5GOfZQedK9xQ=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.11.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-F8bp8L84+mm1Cx2gjReMbJ6bUb0EXED4wtWeQkXYsPoB55yNaP77aLba2AUeOCFWrUgd1hsl44MDXKdEbQyNYA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.10.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-A9D8/LaAqOEgqMTUstM8+qoSTMxOOTwHIwUaR0TDTbf+kJeQQvbPNcsAgaqj1wUWN7vJrY5ryq6l+NRDiwJWxA=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.11.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0SSijE6ZT4gUlc82ZiEzUvBgor+7dcA95EKGaKv/e52D7YiEfE9oY+Tr0KirWKYKVLi7IQl5wbmK/CcFC1nAyQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.10.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-rFlWaOCqxrBZ6y66VWQG97sFJu4KwmVMyhIWTDG1aMygUmjTDzwGcONLOI3jV3l1ohylP5LRSSjFbGAgS2zT1Q=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.11.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-OboeaV/kCvSrNUhLrk5qRuc10bm2lSWcBj5MPl0Cwc1np69E35JYfoEH4FnZCd6UzV8NbZhOqMbWTEzeDOkdAg=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4gdvY8kSC1h/8Hl6FbSMeTFR7PK/alUTyaGNinEQPdkAGXON4l/jmVQlZ4ZA1JdkG4I3zEj8heHh/fNKiWQnHQ=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-cjPAz2Mln3w/jf38PeD2JLpR/ll7eK7QQC0aNWKa84PwuJoa5m+L9szAog85nPcmxXDM63zm+Kygq/FmQuEZlw=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-hKIQl8pmQ4ZKFrr0+CTCgNtTCRWDcgfGFpuRKcDRL6g0mpeZZQ+j8kO7gup2honlP00OBKnkXplXavpsZsgFrQ=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MFLS3SarQluhZkiRjBX1xzVXZlknu7oJeM1u+yA508/k+8dwiT0mib39HCeMGnNxaDKFvQ3cjNP9lHgCAGwGlA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-uU1FzU2XJJ21rPVR4VXdi+oRqo4HVAFcfaa4zr/MElpAL0THPfVtK/hkg6dydN7ZXkJBBDXqdIApQoO0FMRCjA=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-PFduNtyxBI4FXwaR9LE4fgtdqt4+b737mDsUej2ACPIsa25yYtbraD2ImpF5h3yI42JFKKoWhig5GlrOhzM7wQ=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-8RD6RPi7FjLsppk6xmA2fryygSt8bTTq9rI5DUSZa9cfXqm7VXeZutq5KdIywqxdNdEmwyK5SE1YYBE0nBt7bA=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1kMo0fFjkouRBKCNogdr8j3gd3qg7xsgOOIAE5AldW4CtS8TbrJb/yRgvhw9me33emIVQOFuQlSFutOt2FcQVg=="],
 
-    "oh-my-opencode-windows-arm64": ["oh-my-opencode-windows-arm64@4.10.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-sZhiWE4PFrjfDZZXSPHHZxPAKxmO6LeRM6QkfjRJQDlHAgRmEqd2/c+vfVRYtkM2rVevabifT03IGuhyyF10Pw=="],
+    "oh-my-opencode-windows-arm64": ["oh-my-opencode-windows-arm64@4.11.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-KQLHvDA0VJjgZ690Eo5D/K0qvkFVK6Iga4mAF0aP2jN3Xme9RY4IB4SGw6kvmNSXDabMnH32jvO+P6wveaoGBw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.10.0", "", { "os": "win32", "cpu": "x64" }, "sha512-SVDKp/kMqDwdGKn1ntWtejt7PCIbjvz7C23gFcIAcD5Svy8Sq8NWBgOLDWvMtq38Hw5zS5h4rsNo433CchA7ew=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.11.0", "", { "os": "win32", "cpu": "x64" }, "sha512-UzFeqQd52Cv06wQcHrJ9v96tN+6WToZiBmsq1FNNwBXPPDVJDmh5grUpFVMPbtoBoe3dOjfGXwtJUW1CLtjdMQ=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.10.0", "", { "os": "win32", "cpu": "x64" }, "sha512-c2p8hZDyU0JJPKlXXpSedsZU/XSiazvSGi4hgTZGpiBtniE78VBHOovCK7wX69HbHzfQ11fdmrdOCLsS7XNcWg=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.11.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5q47VBEk+Tjpry5Cs2JjEwJt5sgqXDdKZaySC3+PxcvR30vh7yAY2hxX0AZRtuWOABQUuNV0N3Dpj2Sxn76ZmA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "The Best AI Agent Harness - Batteries-Included OpenCode Plugin with Multi-Model Orchestration, Parallel Background Agents, and Crafted LSP/AST Tools",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -170,18 +170,18 @@
     "typescript": "^6.0.3"
   },
   "optionalDependencies": {
-    "oh-my-opencode-darwin-arm64": "4.10.0",
-    "oh-my-opencode-darwin-x64": "4.10.0",
-    "oh-my-opencode-darwin-x64-baseline": "4.10.0",
-    "oh-my-opencode-linux-arm64": "4.10.0",
-    "oh-my-opencode-linux-arm64-musl": "4.10.0",
-    "oh-my-opencode-linux-x64": "4.10.0",
-    "oh-my-opencode-linux-x64-baseline": "4.10.0",
-    "oh-my-opencode-linux-x64-musl": "4.10.0",
-    "oh-my-opencode-linux-x64-musl-baseline": "4.10.0",
-    "oh-my-opencode-windows-arm64": "4.10.0",
-    "oh-my-opencode-windows-x64": "4.10.0",
-    "oh-my-opencode-windows-x64-baseline": "4.10.0"
+    "oh-my-opencode-darwin-arm64": "4.11.0",
+    "oh-my-opencode-darwin-x64": "4.11.0",
+    "oh-my-opencode-darwin-x64-baseline": "4.11.0",
+    "oh-my-opencode-linux-arm64": "4.11.0",
+    "oh-my-opencode-linux-arm64-musl": "4.11.0",
+    "oh-my-opencode-linux-x64": "4.11.0",
+    "oh-my-opencode-linux-x64-baseline": "4.11.0",
+    "oh-my-opencode-linux-x64-musl": "4.11.0",
+    "oh-my-opencode-linux-x64-musl-baseline": "4.11.0",
+    "oh-my-opencode-windows-arm64": "4.11.0",
+    "oh-my-opencode-windows-x64": "4.11.0",
+    "oh-my-opencode-windows-x64-baseline": "4.11.0"
   },
   "overrides": {
     "hono": "^4.12.18",

--- a/packages/oh-my-opencode-darwin-arm64/package.json
+++ b/packages/oh-my-opencode-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-arm64",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (darwin-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-darwin-x64-baseline/package.json
+++ b/packages/oh-my-opencode-darwin-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-x64-baseline",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (darwin-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-darwin-x64/package.json
+++ b/packages/oh-my-opencode-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-x64",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (darwin-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-arm64-musl/package.json
+++ b/packages/oh-my-opencode-linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-arm64-musl",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (linux-arm64-musl)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-arm64/package.json
+++ b/packages/oh-my-opencode-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-arm64",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (linux-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64-baseline/package.json
+++ b/packages/oh-my-opencode-linux-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-baseline",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64-musl-baseline/package.json
+++ b/packages/oh-my-opencode-linux-x64-musl-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-musl-baseline",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-musl-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64-musl/package.json
+++ b/packages/oh-my-opencode-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-musl",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-musl)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64/package.json
+++ b/packages/oh-my-opencode-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-windows-arm64/package.json
+++ b/packages/oh-my-opencode-windows-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-arm64",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (windows-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-windows-x64-baseline/package.json
+++ b/packages/oh-my-opencode-windows-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-x64-baseline",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (windows-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-windows-x64/package.json
+++ b/packages/oh-my-opencode-windows-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-x64",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Platform-specific binary for oh-my-opencode (windows-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/omo-codex/package.json
+++ b/packages/omo-codex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oh-my-opencode/omo-codex",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"type": "module",
 	"private": true,
 	"description": "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",

--- a/packages/omo-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/omo-codex/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "omo",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "One Codex plugin namespace for Yeongyu's local Codex components.",
 	"author": {
 		"name": "Yeongyu Kim",

--- a/packages/omo-codex/plugin/components/bootstrap/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/bootstrap/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"command": "node \"${PLUGIN_ROOT}/components/bootstrap/dist/cli.js\" hook session-start",
 						"commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\bootstrap.ps1\"",
 						"timeout": 30,
-						"statusMessage": "LazyCodex(4.10.0): Checking Bootstrap Provisioning"
+						"statusMessage": "LazyCodex(4.11.0): Checking Bootstrap Provisioning"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/bootstrap/package.json
+++ b/packages/omo-codex/plugin/components/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-bootstrap",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex SessionStart bootstrap component that provisions LazyCodex runtime dependencies from a detached worker.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/codegraph/package.json
+++ b/packages/omo-codex/plugin/components/codegraph/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-codegraph",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex plugin MCP wrapper for CodeGraph.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/comment-checker/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/comment-checker/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-tool-use",
 						"timeout": 30,
-						"statusMessage": "LazyCodex(4.10.0): Checking Comments"
+						"statusMessage": "LazyCodex(4.11.0): Checking Comments"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/comment-checker/package.json
+++ b/packages/omo-codex/plugin/components/comment-checker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-comment-checker",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex plugin that runs comment-checker after edit-like PostToolUse hooks.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/git-bash/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/git-bash/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook pre-tool-use",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Recommending Git Bash MCP"
+						"statusMessage": "LazyCodex(4.11.0): Recommending Git Bash MCP"
 					}
 				]
 			}
@@ -20,7 +20,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-compact",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Resetting Git Bash MCP Reminder"
+						"statusMessage": "LazyCodex(4.11.0): Resetting Git Bash MCP Reminder"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/git-bash/package.json
+++ b/packages/omo-codex/plugin/components/git-bash/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-git-bash-hook",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex hook component that reminds Windows sessions to prefer the OMO git_bash MCP.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/lazycodex-executor-verify/dist/cli.js\" hook subagent-stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Verifying LazyCodex Executor Evidence"
+						"statusMessage": "LazyCodex(4.11.0): Verifying LazyCodex Executor Evidence"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/package.json
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-lazycodex-executor-verify",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex SubagentStop evidence verifier for LazyCodex executor completions.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/lsp/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/lsp/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-tool-use",
 						"timeout": 60,
-						"statusMessage": "LazyCodex(4.10.0): Checking LSP Diagnostics"
+						"statusMessage": "LazyCodex(4.11.0): Checking LSP Diagnostics"
 					}
 				]
 			}
@@ -21,7 +21,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-compact",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Resetting LSP Diagnostics Cache"
+						"statusMessage": "LazyCodex(4.11.0): Resetting LSP Diagnostics Cache"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/lsp/package.json
+++ b/packages/omo-codex/plugin/components/lsp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-lsp",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex plugin that exposes Language Server Protocol tools and post-edit diagnostics.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/rules/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/rules/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook session-start",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Loading Project Rules"
+						"statusMessage": "LazyCodex(4.11.0): Loading Project Rules"
 					}
 				]
 			}
@@ -19,7 +19,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Loading Project Rules"
+						"statusMessage": "LazyCodex(4.11.0): Loading Project Rules"
 					}
 				]
 			}
@@ -32,7 +32,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-tool-use",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Matching Project Rules"
+						"statusMessage": "LazyCodex(4.11.0): Matching Project Rules"
 					}
 				]
 			}
@@ -45,7 +45,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-compact",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Resetting Project Rule Cache"
+						"statusMessage": "LazyCodex(4.11.0): Resetting Project Rule Cache"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/rules/package.json
+++ b/packages/omo-codex/plugin/components/rules/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-rules",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex plugin that injects project rule files into model context through lifecycle hooks.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/start-work-continuation/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/start-work-continuation/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/start-work-continuation/dist/cli.js\" hook stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Checking Start-Work Continuation"
+						"statusMessage": "LazyCodex(4.11.0): Checking Start-Work Continuation"
 					}
 				]
 			}
@@ -19,7 +19,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/start-work-continuation/dist/cli.js\" hook subagent-stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Checking Start-Work Continuation"
+						"statusMessage": "LazyCodex(4.11.0): Checking Start-Work Continuation"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/start-work-continuation/package.json
+++ b/packages/omo-codex/plugin/components/start-work-continuation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-start-work-continuation",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex Stop hook continuation injector for omo-codex start-work plans.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/telemetry/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/telemetry/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook session-start",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Recording Session Telemetry"
+						"statusMessage": "LazyCodex(4.11.0): Recording Session Telemetry"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/telemetry/package.json
+++ b/packages/omo-codex/plugin/components/telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-telemetry",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex plugin component that emits omo-codex anonymous daily-active telemetry on SessionStart.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/ultrawork/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/ultrawork/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Checking Ultrawork Trigger"
+						"statusMessage": "LazyCodex(4.11.0): Checking Ultrawork Trigger"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/ultrawork/package.json
+++ b/packages/omo-codex/plugin/components/ultrawork/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-ultrawork",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex plugin that injects the ultrawork orchestration directive and ships LazyCodex planning, review, QA, and gate agent roles.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/ulw-loop/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Checking Ulw-Loop Steering"
+						"statusMessage": "LazyCodex(4.11.0): Checking Ulw-Loop Steering"
 					}
 				]
 			}
@@ -20,7 +20,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook pre-tool-use",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Enforcing Unlimited Ulw-Loop Budget"
+						"statusMessage": "LazyCodex(4.11.0): Enforcing Unlimited Ulw-Loop Budget"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/ulw-loop/package.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-ulw-loop",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Codex plugin: durable repo-native multi-goal orchestration with embedded success criteria and observable evidence audit.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/hooks/hooks.json
+++ b/packages/omo-codex/plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/rules/dist/cli.js\" hook session-start",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Loading Project Rules"
+						"statusMessage": "LazyCodex(4.11.0): Loading Project Rules"
 					}
 				]
 			},
@@ -17,7 +17,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/telemetry/dist/cli.js\" hook session-start",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Recording Session Telemetry"
+						"statusMessage": "LazyCodex(4.11.0): Recording Session Telemetry"
 					}
 				]
 			},
@@ -28,7 +28,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/scripts/auto-update.mjs\" hook session-start",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Checking Auto Update"
+						"statusMessage": "LazyCodex(4.11.0): Checking Auto Update"
 					}
 				]
 			},
@@ -39,7 +39,7 @@
 						"command": "node \"${PLUGIN_ROOT}/components/bootstrap/dist/cli.js\" hook session-start",
 						"commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\bootstrap.ps1\"",
 						"timeout": 30,
-						"statusMessage": "LazyCodex(4.10.0): Checking Bootstrap Provisioning"
+						"statusMessage": "LazyCodex(4.11.0): Checking Bootstrap Provisioning"
 					}
 				]
 			},
@@ -49,7 +49,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/codegraph/dist/cli.js\" hook session-start",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Checking Codegraph Bootstrap"
+						"statusMessage": "LazyCodex(4.11.0): Checking Codegraph Bootstrap"
 					}
 				]
 			}
@@ -61,7 +61,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/rules/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Loading Project Rules"
+						"statusMessage": "LazyCodex(4.11.0): Loading Project Rules"
 					}
 				]
 			},
@@ -71,7 +71,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/ultrawork/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Checking Ultrawork Trigger"
+						"statusMessage": "LazyCodex(4.11.0): Checking Ultrawork Trigger"
 					}
 				]
 			},
@@ -81,7 +81,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/ulw-loop/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Checking Ulw-Loop Steering"
+						"statusMessage": "LazyCodex(4.11.0): Checking Ulw-Loop Steering"
 					}
 				]
 			}
@@ -94,7 +94,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/git-bash/dist/cli.js\" hook pre-tool-use",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Recommending Git Bash MCP"
+						"statusMessage": "LazyCodex(4.11.0): Recommending Git Bash MCP"
 					}
 				]
 			},
@@ -105,7 +105,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/ulw-loop/dist/cli.js\" hook pre-tool-use",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Enforcing Unlimited Goal Budget"
+						"statusMessage": "LazyCodex(4.11.0): Enforcing Unlimited Goal Budget"
 					}
 				]
 			}
@@ -118,13 +118,13 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/comment-checker/dist/cli.js\" hook post-tool-use",
 						"timeout": 30,
-						"statusMessage": "LazyCodex(4.10.0): Checking Comments"
+						"statusMessage": "LazyCodex(4.11.0): Checking Comments"
 					},
 					{
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/lsp/dist/cli.js\" hook post-tool-use",
 						"timeout": 60,
-						"statusMessage": "LazyCodex(4.10.0): Checking LSP Diagnostics"
+						"statusMessage": "LazyCodex(4.11.0): Checking LSP Diagnostics"
 					}
 				]
 			},
@@ -135,7 +135,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/rules/dist/cli.js\" hook post-tool-use",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Matching Project Rules"
+						"statusMessage": "LazyCodex(4.11.0): Matching Project Rules"
 					}
 				]
 			}
@@ -148,7 +148,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/git-bash/dist/cli.js\" hook post-compact",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Resetting Git Bash MCP Reminder"
+						"statusMessage": "LazyCodex(4.11.0): Resetting Git Bash MCP Reminder"
 					}
 				]
 			},
@@ -159,7 +159,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/rules/dist/cli.js\" hook post-compact",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Resetting Project Rule Cache"
+						"statusMessage": "LazyCodex(4.11.0): Resetting Project Rule Cache"
 					}
 				]
 			},
@@ -170,7 +170,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/lsp/dist/cli.js\" hook post-compact",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.10.0): Resetting LSP Diagnostics Cache"
+						"statusMessage": "LazyCodex(4.11.0): Resetting LSP Diagnostics Cache"
 					}
 				]
 			}
@@ -182,7 +182,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/start-work-continuation/dist/cli.js\" hook stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Checking Start-Work Continuation"
+						"statusMessage": "LazyCodex(4.11.0): Checking Start-Work Continuation"
 					}
 				]
 			}
@@ -194,7 +194,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/start-work-continuation/dist/cli.js\" hook subagent-stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Checking Start-Work Continuation"
+						"statusMessage": "LazyCodex(4.11.0): Checking Start-Work Continuation"
 					}
 				]
 			},
@@ -205,7 +205,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/lazycodex-executor-verify/dist/cli.js\" hook subagent-stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.10.0): Verifying LazyCodex Executor Evidence"
+						"statusMessage": "LazyCodex(4.11.0): Verifying LazyCodex Executor Evidence"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/package.json
+++ b/packages/omo-codex/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/omo-codex-plugin",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Aggregate Codex plugin root for OMO components.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",


### PR DESCRIPTION
## Summary
- land the v4.11.0 release-state commit through protected dev after publish workflow direct push was rejected by branch rules
- sync root/package optional dependency versions, platform package versions, and Codex plugin metadata to 4.11.0

## Evidence
- Failed recovery workflow: https://github.com/code-yeongyu/oh-my-openagent/actions/runs/27681447014
- Failure cause: GH013 branch protection rejected direct workflow push to dev because required checks are expected
- npm packages already published: oh-my-opencode@4.11.0, oh-my-openagent@4.11.0, lazycodex-ai@4.11.0

This PR lets required checks validate the release-state commit before merge, then the release workflow can detect `release: v4.11.0` on dev and finish tag/release/lazycodex steps idempotently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the v4.11.0 release state to `dev` so required checks can run, letting the release workflow complete. Aligns all `oh-my-opencode` packages and Codex plugin versions/messages to 4.11.0.

- **Dependencies**
  - Bumped root `oh-my-opencode` to 4.11.0 and synced `optionalDependencies` for all `oh-my-opencode-<platform>` binaries to 4.11.0.
  - Updated all platform package versions to 4.11.0.
  - Updated `@oh-my-opencode/omo-codex` and all plugin component packages to 4.11.0.
  - Updated Codex hook status messages to "LazyCodex(4.11.0)".
  - Refreshed `bun.lock`.

<sup>Written for commit e6a50ed62f774922762711430a444215b6d611b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

