### PR TITLE
fix(team-mode): expand leading tilde in resolveBaseDir (#5331)

### DIFF
--- a/src/features/team-mode/team-registry/paths.test.ts
+++ b/src/features/team-mode/team-registry/paths.test.ts
@@ -54,6 +54,28 @@ describe("paths", () => {
     expect(resolvedBaseDir).toBe("/tmp/test-abc")
   })
 
+  test("resolveBaseDir expands leading tilde to homedir (#5331)", () => {
+    // given - user wrote the natural docs value "~/.omo" expecting shell expansion
+    const config = TeamModeConfigSchema.parse({ base_dir: "~/.omo" })
+
+    // when
+    const resolvedBaseDir = resolveBaseDir(config)
+
+    // then - should be $HOME/.omo, NOT a literal "~" dir in cwd
+    expect(resolvedBaseDir).toBe(path.join(homedir(), ".omo"))
+  })
+
+  test("resolveBaseDir expands tilde with subpath (#5331)", () => {
+    // given - tilde in the middle of a path is left alone; only the leading ~ is expanded
+    const config = TeamModeConfigSchema.parse({ base_dir: "~/.omo/teams" })
+
+    // when
+    const resolvedBaseDir = resolveBaseDir(config)
+
+    // then
+    expect(resolvedBaseDir).toBe(path.join(homedir(), ".omo", "teams"))
+  })
+
   test("discoverTeamSpecs prefers project scope", async () => {
     // given
     const rootDirectory = await createTemporaryRoot()

--- a/src/features/team-mode/team-registry/paths.ts
+++ b/src/features/team-mode/team-registry/paths.ts
@@ -19,8 +19,14 @@ function getTeamDirectory(baseDir: string, teamName: string, scope: "user" | "pr
   return path.join(baseDir, "teams", teamName)
 }
 
+function expandLeadingTilde(input: string): string {
+  if (input === "~") return homedir()
+  if (input.startsWith(`~${path.sep}`)) return path.join(homedir(), input.slice(2))
+  return input
+}
+
 export function resolveBaseDir(config: TeamModeConfig): string {
-  return config.base_dir ?? path.join(homedir(), ".omo")
+  return expandLeadingTilde(config.base_dir ?? path.join(homedir(), ".omo"))
 }
 
 export function getTeamSpecPath(


### PR DESCRIPTION
## Problem

When users set `team_mode.base_dir = "~/.omo"` in their config, the raw tilde-prefixed string was passed straight to `mkdir`, creating a **literal `~` directory in the current working directory** instead of expanding `~` to the user's home directory.

This polluted every directory opencode was launched in with a stray `~` folder and silently landed team-mode state in the wrong place.

## Root Cause

`resolveBaseDir()` in `src/features/team-mode/team-registry/paths.ts` returns `config.base_dir` as-is when set. Shell-style tilde expansion never happens because Node.js APIs (path.join, fs.mkdir) don't expand `~`.

```ts
// Before
export function resolveBaseDir(config: TeamModeConfig): string {
  return config.base_dir ?? path.join(homedir(), ".omo")
}
```

## Fix

Added a small `expandLeadingTilde()` helper that handles the two tilde forms:
- `~`         → `$HOME`
- `~/...`     → `$HOME/...`
- anything else is left untouched (so `/tmp/foo`, `./local`, and a stray `foo~/bar` are unaffected).

```ts
function expandLeadingTilde(input: string): string {
  if (input === "~") return homedir()
  if (input.startsWith(`~${path.sep}`)) return path.join(homedir(), input.slice(2))
  return input
}

export function resolveBaseDir(config: TeamModeConfig): string {
  return expandLeadingTilde(config.base_dir ?? path.join(homedir(), ".omo"))
}
```

`path.sep` is used so this also handles Windows `~\\foo` correctly.

## TDD Evidence

**RED** — added 2 new tests in `paths.test.ts`:
- `base_dir: "~/.omo"` resolves to `path.join(homedir(), ".omo")`
- `base_dir: "~/.omo/teams"` resolves to `path.join(homedir(), ".omo", "teams")`

Both failed before the fix with the literal tilde string returned.

**GREEN** — apply `expandLeadingTilde()` in `resolveBaseDir`; all 7 `paths` tests pass, 262 team-mode tests pass.

**SURFACE** — change is contained to `resolveBaseDir()`; no other function in the team-mode module is affected.

## Constraints Checklist

- [x] No `as any` / `@ts-ignore` / `@ts-expect-error`
- [x] No test deletions
- [x] No new dependencies
- [x] TDD: red test written first
- [x] No `unwrap()` / `expect()` shortcuts in test bodies
- [x] No `setTimeout` / `sleep` in tests
- [x] Subscribed before triggering (no race conditions)
- [x] BDD test style (`// given`, `// when`, `// then`)

Closes #5331

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands leading tilde in `team_mode.base_dir` to the user’s home directory to prevent creating a literal `~` folder and store team‑mode state in the right place. Handles `~` and `~/…` on all platforms (fixes #5331).

- **Bug Fixes**
  - Added `expandLeadingTilde()` and applied it in `resolveBaseDir`; non-leading tildes and other paths remain unchanged.
  - Added tests for `~/.omo` and `~/.omo/teams`.

<sup>Written for commit 17a5856d5862563fbd72f54a206f79cf3ca20301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

