### PR TITLE
fix(codex-auto-update): update marketplace installs

### DIFF
--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -22,10 +22,8 @@ const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_RETRY_INTERVAL_MS = 30 * 60 * 1_000;
 const DEFAULT_UPDATE_COMMAND = "npx";
 const DEFAULT_UPDATE_ARGS = ["--yes", "lazycodex-ai@latest", "install", "--no-tui", "--codex-autonomous"];
-const MARKETPLACE_FLOW_NOTICE =
-	"[LazyCodex] Auto-update skipped: this LazyCodex install is managed by the Codex plugin marketplace, so the npx self-update was not started. Tell the user to upgrade with `codex plugin marketplace upgrade sisyphuslabs`, and that Codex will ask them to re-approve hooks after the upgrade.";
 
-export function resolveAutoUpdatePlan({ env = process.env, now = Date.now(), lastCheckedAt, lastAttemptedAt, lastStatus, installFlow } = {}) {
+export function resolveAutoUpdatePlan({ env = process.env, now = Date.now(), lastCheckedAt, lastAttemptedAt, lastStatus } = {}) {
 	if (env.LAZYCODEX_AUTO_UPDATE_DISABLED === "1" || env.OMO_CODEX_AUTO_UPDATE_DISABLED === "1") {
 		return { shouldRun: false, reason: "disabled" };
 	}
@@ -39,9 +37,6 @@ export function resolveAutoUpdatePlan({ env = process.env, now = Date.now(), las
 	if (!successStatus && typeof lastAttemptedAt === "number" && retryIntervalMs > 0 && now - lastAttemptedAt < retryIntervalMs) {
 		return { shouldRun: false, reason: "retry-throttled" };
 	}
-
-	const flow = installFlow ?? detectAutoUpdateInstallFlow(env).flow;
-	if (flow === "marketplace") return { shouldRun: false, reason: "marketplace-flow" };
 
 	const currentVersion = resolveCurrentVersion(env);
 	const latestVersion = resolveLatestVersion(env);
@@ -116,15 +111,8 @@ export async function runAutoUpdateCheck({ env = process.env, now = Date.now() }
 		lastCheckedAt: state.lastCheckedAt,
 		lastAttemptedAt: state.lastAttemptedAt,
 		lastStatus: state.lastStatus,
-		installFlow: installFlow.flow,
 	});
 	if (!plan.shouldRun) {
-		if (plan.reason === "marketplace-flow") {
-			await appendUpdateLog(env, now, "skipped", { kind: "marketplace-flow" });
-			await writeState(statePath, { ...state, lastCheckedAt: now, lastStatus: "success" });
-			notices.push(MARKETPLACE_FLOW_NOTICE);
-			return { started: false, reason: plan.reason, notices };
-		}
 		await appendUpdateLog(env, now, "skipped", { reason: plan.reason });
 		if (plan.reason === "up-to-date") {
 			await writeState(statePath, { ...state, lastCheckedAt: now, lastStatus: "success" });

--- a/packages/omo-codex/plugin/test/auto-update.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update.test.mjs
@@ -302,29 +302,41 @@ function marketplaceCheckEnv(root, pluginRoot, spawnLogPath, extra = {}) {
 	});
 }
 
-test("#given marketplace plugin root without install snapshot #when running check #then skips npx update with marketplace-flow log and upgrade notice", async () => {
+test("#given marketplace plugin root without install snapshot #when running check #then runs the same auto-update flow", async () => {
 	const { root, pluginRoot } = await makeStorePluginRoot("lazycodex-auto-update-marketplace-");
 	const spawnLogPath = join(root, "spawn.log");
 	const env = marketplaceCheckEnv(root, pluginRoot, spawnLogPath);
 
 	const result = await runAutoUpdateCheck({ env, now: 123_456 });
 
-	assert.equal(result.started, false);
-	assert.equal(result.reason, "marketplace-flow");
+	assert.equal(result.started, true);
+	assert.equal(result.status, 0);
 	assert.equal(result.notices.length, 1);
-	assert.match(result.notices[0], /codex plugin marketplace upgrade sisyphuslabs/);
-	assert.match(result.notices[0], /re-approve/);
-	await assert.rejects(readFile(spawnLogPath, "utf8"), { code: "ENOENT" });
+	assert.match(result.notices[0], /Auto-update started in the background/);
+	assert.doesNotMatch(result.notices[0], /marketplace upgrade/);
+	assert.equal(await readFile(spawnLogPath, "utf8"), "ok");
 	const state = JSON.parse(await readFile(env.LAZYCODEX_AUTO_UPDATE_STATE_PATH, "utf8"));
 	assert.equal(state.lastCheckedAt, 123_456);
 	assert.equal(state.lastStatus, "success");
-	assert.notEqual(state.lastStatus, "started");
 	const logEntries = (await readFile(env.LAZYCODEX_AUTO_UPDATE_LOG_PATH, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
 	assert.deepEqual(logEntries, [
 		{
 			timestamp: "1970-01-01T00:02:03.456Z",
-			event: "skipped",
-			kind: "marketplace-flow",
+			event: "started",
+			command: process.execPath,
+			args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(spawnLogPath)}, "ok")`],
+		},
+		{
+			timestamp: "1970-01-01T00:02:03.456Z",
+			event: "finished",
+			status: 0,
+		},
+		{
+			timestamp: "1970-01-01T00:02:03.456Z",
+			event: "notified",
+			kind: "update-started",
+			fromVersion: "1.0.0",
+			toVersion: "1.0.1",
 		},
 	]);
 });
@@ -355,7 +367,7 @@ test("#given marketplace skip already recorded #when next session is within inte
 	const first = await runAutoUpdateCheck({ env, now: 123_456 });
 	const second = await runAutoUpdateCheck({ env, now: 123_457 });
 
-	assert.equal(first.reason, "marketplace-flow");
+	assert.equal(first.started, true);
 	assert.equal(first.notices.length, 1);
 	assert.equal(second.started, false);
 	assert.equal(second.reason, "throttled");


### PR DESCRIPTION
## Summary
- let marketplace/native-cache LazyCodex installs use the same auto-update path as npx-local installs
- remove the marketplace-flow skip notice path
- update auto-update tests to prove marketplace roots run the update command and throttle subsequent checks

## Verification
- node --test packages/omo-codex/plugin/test/auto-update.test.mjs
- bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test
- bun run test:codex
- codex-ultrawork-reviewer APPROVE / architectStatus CLEAR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable auto-update for marketplace/native-cache LazyCodex installs using the same path as `npx` local installs. Removed the marketplace skip path and notice; tests now verify update execution, logging, and throttling.

- **Bug Fixes**
  - Removed the marketplace-flow gate and notice; marketplace roots now run the update command.
  - Simplified plan resolution by dropping the `installFlow` parameter and the marketplace check.
  - Updated tests to assert start/finish/notified logs, success status, and throttled subsequent checks.

<sup>Written for commit 910965490e047a279c2ee1bf99daa9bbf644fc1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

