### PR TITLE
test(omo-codex): dedupe component package smoke fixtures

### DIFF
--- a/packages/omo-codex/plugin/components/comment-checker/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/comment-checker/test/package-smoke.test.ts
@@ -1,44 +1,12 @@
-import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-
-type PackageJson = {
-	readonly type: string;
-	readonly packageManager: string;
-	readonly bin: Record<string, string>;
-	readonly dependencies?: Record<string, unknown>;
-	readonly optionalDependencies: Record<string, string>;
-};
-
-type HookCommand = {
-	readonly command: string;
-};
-
-type HookEntry = {
-	readonly hooks: readonly HookCommand[];
-};
-
-type HooksJson = {
-	readonly hooks: Record<string, readonly HookEntry[]>;
-};
-
-function readPackageJson(path: string): PackageJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
-	return parsed;
-}
-
-function readHooksJson(path: string): HooksJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isHooksJson(parsed)) throw new TypeError(`Invalid hooks metadata: ${path}`);
-	return parsed;
-}
+import { readHooksJson, readPackageJson, readTextFile } from "../../test-support/package-smoke-fixture.js";
 
 describe("plugin package metadata", () => {
 	it("#given packaged plugin files #when validating entrypoints #then hook command uses portable plugin root interpolation", () => {
 		// given
 		const packageJson = readPackageJson("package.json");
 		const hooksJson = readHooksJson("hooks/hooks.json");
-		const cliSource = readFileSync("src/cli.ts", "utf8");
+		const cliSource = readTextFile("src/cli.ts");
 
 		// when
 		const command = hooksJson.hooks["PostToolUse"]?.[0]?.hooks[0]?.command;
@@ -54,40 +22,3 @@ describe("plugin package metadata", () => {
 		expect(command).toBe(`node "${pluginRoot}/dist/cli.js" hook post-tool-use`);
 	});
 });
-
-function isPackageJson(value: unknown): value is PackageJson {
-	if (!isRecord(value)) return false;
-	const dependencies = value["dependencies"];
-	return (
-		value["type"] === "module" &&
-		value["packageManager"] === "npm@11.12.1" &&
-		isStringRecord(value["bin"]) &&
-		isStringRecord(value["optionalDependencies"]) &&
-		(dependencies === undefined || isRecord(dependencies))
-	);
-}
-
-function isHooksJson(value: unknown): value is HooksJson {
-	if (!isRecord(value) || !isRecord(value["hooks"])) return false;
-	return Object.values(value["hooks"]).every(isHookEntries);
-}
-
-function isHookEntries(value: unknown): value is readonly HookEntry[] {
-	return Array.isArray(value) && value.every(isHookEntry);
-}
-
-function isHookEntry(value: unknown): value is HookEntry {
-	return isRecord(value) && Array.isArray(value["hooks"]) && value["hooks"].every(isHookCommand);
-}
-
-function isHookCommand(value: unknown): value is HookCommand {
-	return isRecord(value) && typeof value["command"] === "string";
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}

--- a/packages/omo-codex/plugin/components/lsp/package.json
+++ b/packages/omo-codex/plugin/components/lsp/package.json
@@ -39,7 +39,7 @@
 		"bootstrap": "node scripts/build-lsp-tools.mjs && node scripts/build-lsp-daemon.mjs",
 		"prebuild": "node scripts/build-lsp-tools.mjs && node scripts/build-lsp-daemon.mjs",
 		"build": "node scripts/clean-dist.mjs && tsc -p tsconfig.build.json",
-		"pretest": "node scripts/build-lsp-tools.mjs && node scripts/build-lsp-daemon.mjs",
+		"pretest": "npm run build --silent",
 		"test": "node scripts/test.mjs",
 		"test:watch": "vitest",
 		"pretypecheck": "node scripts/build-lsp-tools.mjs && node scripts/build-lsp-daemon.mjs",

--- a/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
@@ -1,53 +1,12 @@
-import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-
-type PackageJson = {
-	readonly version: string;
-	readonly type: string;
-	readonly packageManager: string;
-	readonly bin: Record<string, string>;
-	readonly dependencies: Record<string, string>;
-	readonly scripts: Record<string, string>;
-};
-
-type HookCommand = {
-	readonly command: string;
-};
-
-type HookEntry = {
-	readonly hooks: readonly HookCommand[];
-};
-
-type HooksJson = {
-	readonly hooks: Record<string, readonly HookEntry[]>;
-};
-
-type McpServer = {
-	readonly command: string;
-	readonly args: readonly string[];
-};
-
-type McpJson = {
-	readonly mcpServers: Record<string, McpServer>;
-};
-
-function readPackageJson(path: string): PackageJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
-	return parsed;
-}
-
-function readHooksJson(path: string): HooksJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isHooksJson(parsed)) throw new TypeError(`Invalid hooks metadata: ${path}`);
-	return parsed;
-}
-
-function readMcpJson(path: string): McpJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isMcpJson(parsed)) throw new TypeError(`Invalid MCP metadata: ${path}`);
-	return parsed;
-}
+import {
+	listDirectoryNames,
+	readHooksJson,
+	readMcpJson,
+	readPackageJson,
+	readTextFile,
+	requireScripts,
+} from "../../test-support/package-smoke-fixture.js";
 
 describe("plugin package metadata", () => {
 	it("#given packaged component files #when validating entrypoints #then hook command stays local and MCP command references the package", () => {
@@ -55,10 +14,11 @@ describe("plugin package metadata", () => {
 		const packageJson = readPackageJson("package.json");
 		const hooksJson = readHooksJson("hooks/hooks.json");
 		const mcpJson = readMcpJson(".mcp.json");
-		const cliSource = readFileSync("src/cli.ts", "utf8");
-		const codexHookCliSource = readFileSync("src/codex-hook-cli.ts", "utf8");
-		const codexHookSource = readFileSync("src/codex-hook.ts", "utf8");
-		const sourceFiles = readdirSync("src");
+		const cliSource = readTextFile("src/cli.ts");
+		const codexHookCliSource = readTextFile("src/codex-hook-cli.ts");
+		const codexHookSource = readTextFile("src/codex-hook.ts");
+		const sourceFiles = listDirectoryNames("src");
+		const scripts = requireScripts(packageJson, "package.json");
 
 		// when
 		const postToolUseCommand = hooksJson.hooks["PostToolUse"]?.[0]?.hooks[0]?.command;
@@ -74,7 +34,7 @@ describe("plugin package metadata", () => {
 		});
 		expect(packageJson.bin["omo-lsp"]).toBe("./dist/cli.js");
 		expect(packageJson.bin["codex-lsp"]).toBeUndefined();
-		expect(packageJson.scripts["build"]).toBe("node scripts/clean-dist.mjs && tsc -p tsconfig.build.json");
+		expect(scripts["build"]).toBe("node scripts/clean-dist.mjs && tsc -p tsconfig.build.json");
 		expect(cliSource.startsWith("#!/usr/bin/env node")).toBe(true);
 		expect(cliSource).toContain("Usage: omo-lsp [mcp | hook post-tool-use | hook post-compact]");
 		expect(postToolUseCommand).toBe(`node "${pluginRoot}/dist/cli.js" hook post-tool-use`);
@@ -91,55 +51,16 @@ describe("plugin package metadata", () => {
 		expect(sourceFiles.filter((name) => name.startsWith("lazy-mcp") || name === "lazy-lsp-mcp.ts")).toEqual([]);
 	});
 
+	it("#given LSP skill guidance #when validating MCP tool instructions #then tool names are not framed as shell commands", () => {
+		// given
+		const skill = readTextFile("skills/lsp/SKILL.md");
+
+		// when
+		const mentionsToolInterface = skill.includes("through the tool interface");
+		const rejectsShellExecution = skill.includes("not shell commands");
+
+		// then
+		expect(mentionsToolInterface).toBe(true);
+		expect(rejectsShellExecution).toBe(true);
+	});
 });
-
-function isPackageJson(value: unknown): value is PackageJson {
-	return (
-		isRecord(value) &&
-		typeof value["version"] === "string" &&
-		value["type"] === "module" &&
-		value["packageManager"] === "npm@11.12.1" &&
-		isStringRecord(value["bin"]) &&
-		isStringRecord(value["dependencies"]) &&
-		isStringRecord(value["scripts"])
-	);
-}
-
-function isHooksJson(value: unknown): value is HooksJson {
-	if (!isRecord(value) || !isRecord(value["hooks"])) return false;
-	return Object.values(value["hooks"]).every(isHookEntries);
-}
-
-function isHookEntries(value: unknown): value is readonly HookEntry[] {
-	return Array.isArray(value) && value.every(isHookEntry);
-}
-
-function isHookEntry(value: unknown): value is HookEntry {
-	return isRecord(value) && Array.isArray(value["hooks"]) && value["hooks"].every(isHookCommand);
-}
-
-function isHookCommand(value: unknown): value is HookCommand {
-	return isRecord(value) && typeof value["command"] === "string";
-}
-
-function isMcpJson(value: unknown): value is McpJson {
-	if (!isRecord(value) || !isRecord(value["mcpServers"])) return false;
-	return Object.values(value["mcpServers"]).every(isMcpServer);
-}
-
-function isMcpServer(value: unknown): value is McpServer {
-	return (
-		isRecord(value) &&
-		typeof value["command"] === "string" &&
-		Array.isArray(value["args"]) &&
-		value["args"].every((item) => typeof item === "string")
-	);
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}

--- a/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-	listDirectoryNames,
+	listDirectoryEntries,
 	readHooksJson,
 	readMcpJson,
 	readPackageJson,
@@ -17,7 +17,7 @@ describe("plugin package metadata", () => {
 		const cliSource = readTextFile("src/cli.ts");
 		const codexHookCliSource = readTextFile("src/codex-hook-cli.ts");
 		const codexHookSource = readTextFile("src/codex-hook.ts");
-		const sourceFiles = listDirectoryNames("src");
+		const sourceFiles = listDirectoryEntries("src");
 		const scripts = requireScripts(packageJson, "package.json");
 
 		// when

--- a/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
@@ -35,6 +35,7 @@ describe("plugin package metadata", () => {
 		expect(packageJson.bin["omo-lsp"]).toBe("./dist/cli.js");
 		expect(packageJson.bin["codex-lsp"]).toBeUndefined();
 		expect(scripts["build"]).toBe("node scripts/clean-dist.mjs && tsc -p tsconfig.build.json");
+		expect(scripts["pretest"]).toBe("npm run build --silent");
 		expect(cliSource.startsWith("#!/usr/bin/env node")).toBe(true);
 		expect(cliSource).toContain("Usage: omo-lsp [mcp | hook post-tool-use | hook post-compact]");
 		expect(postToolUseCommand).toBe(`node "${pluginRoot}/dist/cli.js" hook post-tool-use`);

--- a/packages/omo-codex/plugin/components/rules/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/package-smoke.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-	listDirectoryNames,
+	listDirectoryEntries,
 	readHooksJson,
 	readPackageJson,
 	readPluginJson,
@@ -16,7 +16,7 @@ describe("plugin package metadata", () => {
 		const hooksJson = readHooksJson("hooks/hooks.json");
 		const cliSource = readTextFile("src/cli.ts");
 		const packageFiles = requireFiles(packageJson, "package.json");
-		const bundledRules = [...listDirectoryNames("bundled-rules")].sort();
+		const bundledRules = [...listDirectoryEntries("bundled-rules")].sort();
 
 		// when
 		const hookConfig = hooksJson.hooks;

--- a/packages/omo-codex/plugin/components/rules/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/package-smoke.test.ts
@@ -1,48 +1,12 @@
-import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-
-type PackageJson = {
-	readonly type: string;
-	readonly packageManager: string;
-	readonly bin: Record<string, string>;
-	readonly files: readonly string[];
-	readonly dependencies?: Record<string, unknown>;
-};
-
-type PluginJson = {
-	readonly hooks: string;
-};
-
-type HookCommand = {
-	readonly command: string;
-};
-
-type HookEntry = {
-	readonly matcher?: string;
-	readonly hooks: readonly HookCommand[];
-};
-
-type HooksJson = {
-	readonly hooks: Record<string, readonly HookEntry[]>;
-};
-
-function readPackageJson(path: string): PackageJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
-	return parsed;
-}
-
-function readPluginJson(path: string): PluginJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isPluginJson(parsed)) throw new TypeError(`Invalid plugin metadata: ${path}`);
-	return parsed;
-}
-
-function readHooksJson(path: string): HooksJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isHooksJson(parsed)) throw new TypeError(`Invalid hooks metadata: ${path}`);
-	return parsed;
-}
+import {
+	listDirectoryNames,
+	readHooksJson,
+	readPackageJson,
+	readPluginJson,
+	readTextFile,
+	requireFiles,
+} from "../../test-support/package-smoke-fixture.js";
 
 describe("plugin package metadata", () => {
 	it("#given packaged plugin files #when validating entrypoints #then hook commands use portable plugin root interpolation", () => {
@@ -50,8 +14,9 @@ describe("plugin package metadata", () => {
 		const packageJson = readPackageJson("package.json");
 		const pluginJson = readPluginJson(".codex-plugin/plugin.json");
 		const hooksJson = readHooksJson("hooks/hooks.json");
-		const cliSource = readFileSync("src/cli.ts", "utf8");
-		const bundledRules = readdirSync("bundled-rules").sort();
+		const cliSource = readTextFile("src/cli.ts");
+		const packageFiles = requireFiles(packageJson, "package.json");
+		const bundledRules = [...listDirectoryNames("bundled-rules")].sort();
 
 		// when
 		const hookConfig = hooksJson.hooks;
@@ -69,7 +34,7 @@ describe("plugin package metadata", () => {
 		expect(packageJson.packageManager).toBe("npm@11.12.1");
 		expect(packageJson.dependencies ?? {}).toEqual({ picomatch: "^4.0.3" });
 		expect(packageJson.bin["omo-rules"]).toBe("./dist/cli.js");
-		expect(packageJson.files).toContain("bundled-rules");
+		expect(packageFiles).toContain("bundled-rules");
 		expect(bundledRules).toContain("windows-git-bash.md");
 		expect(pluginJson.hooks).toBe("./hooks/hooks.json");
 		expect(cliSource.startsWith("#!/usr/bin/env node")).toBe(true);
@@ -106,48 +71,3 @@ describe("plugin package metadata", () => {
 		).toBe(false);
 	});
 });
-
-function isPackageJson(value: unknown): value is PackageJson {
-	if (!isRecord(value)) return false;
-	const dependencies = value["dependencies"];
-	return (
-		value["type"] === "module" &&
-		value["packageManager"] === "npm@11.12.1" &&
-		isStringRecord(value["bin"]) &&
-		isStringArray(value["files"]) &&
-		(dependencies === undefined || isRecord(dependencies))
-	);
-}
-
-function isStringArray(value: unknown): value is readonly string[] {
-	return Array.isArray(value) && value.every((item) => typeof item === "string");
-}
-
-function isPluginJson(value: unknown): value is PluginJson {
-	return isRecord(value) && typeof value["hooks"] === "string";
-}
-
-function isHooksJson(value: unknown): value is HooksJson {
-	if (!isRecord(value) || !isRecord(value["hooks"])) return false;
-	return Object.values(value["hooks"]).every(isHookEntries);
-}
-
-function isHookEntries(value: unknown): value is readonly HookEntry[] {
-	return Array.isArray(value) && value.every(isHookEntry);
-}
-
-function isHookEntry(value: unknown): value is HookEntry {
-	return isRecord(value) && Array.isArray(value["hooks"]) && value["hooks"].every(isHookCommand);
-}
-
-function isHookCommand(value: unknown): value is HookCommand {
-	return isRecord(value) && typeof value["command"] === "string";
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}

--- a/packages/omo-codex/plugin/components/test-support/package-smoke-fixture.ts
+++ b/packages/omo-codex/plugin/components/test-support/package-smoke-fixture.ts
@@ -6,10 +6,10 @@ export type ComponentPackageJson = {
 	readonly version?: string;
 	readonly type: string;
 	readonly packageManager: string;
-	readonly bin: Record<string, string>;
-	readonly dependencies?: Record<string, string>;
-	readonly optionalDependencies?: Record<string, string>;
-	readonly scripts?: Record<string, string>;
+	readonly bin: Readonly<Record<string, string>>;
+	readonly dependencies?: Readonly<Record<string, string>>;
+	readonly optionalDependencies?: Readonly<Record<string, string>>;
+	readonly scripts?: Readonly<Record<string, string>>;
 	readonly files?: readonly string[];
 };
 
@@ -71,7 +71,7 @@ export function readTextFile(path: string): string {
 	return readFileSync(path, "utf8");
 }
 
-export function listDirectoryNames(path: string): readonly string[] {
+export function listDirectoryEntries(path: string): readonly string[] {
 	return readdirSync(path);
 }
 
@@ -80,7 +80,7 @@ export function requireFiles(packageJson: ComponentPackageJson, path: string): r
 	return packageJson.files;
 }
 
-export function requireScripts(packageJson: ComponentPackageJson, path: string): Record<string, string> {
+export function requireScripts(packageJson: ComponentPackageJson, path: string): Readonly<Record<string, string>> {
 	if (packageJson.scripts === undefined) throw new TypeError(`Package metadata missing scripts: ${path}`);
 	return packageJson.scripts;
 }

--- a/packages/omo-codex/plugin/components/test-support/package-smoke-fixture.ts
+++ b/packages/omo-codex/plugin/components/test-support/package-smoke-fixture.ts
@@ -1,0 +1,158 @@
+/// <reference path="../../node_modules/@types/node/index.d.ts" />
+
+import { readdirSync, readFileSync } from "node:fs";
+
+export type ComponentPackageJson = {
+	readonly version?: string;
+	readonly type: string;
+	readonly packageManager: string;
+	readonly bin: Record<string, string>;
+	readonly dependencies?: Record<string, string>;
+	readonly optionalDependencies?: Record<string, string>;
+	readonly scripts?: Record<string, string>;
+	readonly files?: readonly string[];
+};
+
+export type HookCommand = {
+	readonly command: string;
+};
+
+export type HookEntry = {
+	readonly matcher?: string;
+	readonly hooks: readonly HookCommand[];
+};
+
+export type HooksJson = {
+	readonly hooks: Record<string, readonly HookEntry[]>;
+};
+
+export type McpServer = {
+	readonly command: string;
+	readonly args: readonly string[];
+};
+
+export type McpJson = {
+	readonly mcpServers: Record<string, McpServer>;
+};
+
+export type PluginJson = {
+	readonly hooks: string;
+};
+
+export function readPackageJson(path: string): ComponentPackageJson {
+	const parsed = readJsonFile(path);
+	if (!isComponentPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
+	return parsed;
+}
+
+export function readHooksJson(path: string): HooksJson {
+	const parsed = readJsonFile(path);
+	if (!isHooksJson(parsed)) throw new TypeError(`Invalid hooks metadata: ${path}`);
+	return parsed;
+}
+
+export function readMcpJson(path: string): McpJson {
+	const parsed = readJsonFile(path);
+	if (!isMcpJson(parsed)) throw new TypeError(`Invalid MCP metadata: ${path}`);
+	return parsed;
+}
+
+export function readPluginJson(path: string): PluginJson {
+	const parsed = readJsonFile(path);
+	if (!isPluginJson(parsed)) throw new TypeError(`Invalid plugin metadata: ${path}`);
+	return parsed;
+}
+
+export function readJsonFile(path: string): unknown {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function readTextFile(path: string): string {
+	return readFileSync(path, "utf8");
+}
+
+export function listDirectoryNames(path: string): readonly string[] {
+	return readdirSync(path);
+}
+
+export function requireFiles(packageJson: ComponentPackageJson, path: string): readonly string[] {
+	if (packageJson.files === undefined) throw new TypeError(`Package metadata missing files: ${path}`);
+	return packageJson.files;
+}
+
+export function requireScripts(packageJson: ComponentPackageJson, path: string): Record<string, string> {
+	if (packageJson.scripts === undefined) throw new TypeError(`Package metadata missing scripts: ${path}`);
+	return packageJson.scripts;
+}
+
+export function collectHookCommandsFromValue(value: unknown): readonly string[] {
+	if (typeof value === "string") return [];
+	if (Array.isArray(value)) return value.flatMap(collectHookCommandsFromValue);
+	if (!isRecord(value)) return [];
+	const ownCommand = typeof value["command"] === "string" ? [value["command"]] : [];
+	return [...ownCommand, ...Object.values(value).flatMap(collectHookCommandsFromValue)];
+}
+
+function isComponentPackageJson(value: unknown): value is ComponentPackageJson {
+	if (!isRecord(value)) return false;
+	const dependencies = value["dependencies"];
+	const optionalDependencies = value["optionalDependencies"];
+	const scripts = value["scripts"];
+	const files = value["files"];
+	return (
+		value["type"] === "module" &&
+		value["packageManager"] === "npm@11.12.1" &&
+		isStringRecord(value["bin"]) &&
+		(dependencies === undefined || isStringRecord(dependencies)) &&
+		(optionalDependencies === undefined || isStringRecord(optionalDependencies)) &&
+		(scripts === undefined || isStringRecord(scripts)) &&
+		(files === undefined || isStringArray(files))
+	);
+}
+
+function isHooksJson(value: unknown): value is HooksJson {
+	if (!isRecord(value) || !isRecord(value["hooks"])) return false;
+	return Object.values(value["hooks"]).every(isHookEntries);
+}
+
+function isHookEntries(value: unknown): value is readonly HookEntry[] {
+	return Array.isArray(value) && value.every(isHookEntry);
+}
+
+function isHookEntry(value: unknown): value is HookEntry {
+	return isRecord(value) && Array.isArray(value["hooks"]) && value["hooks"].every(isHookCommand);
+}
+
+function isHookCommand(value: unknown): value is HookCommand {
+	return isRecord(value) && typeof value["command"] === "string";
+}
+
+function isMcpJson(value: unknown): value is McpJson {
+	if (!isRecord(value) || !isRecord(value["mcpServers"])) return false;
+	return Object.values(value["mcpServers"]).every(isMcpServer);
+}
+
+function isMcpServer(value: unknown): value is McpServer {
+	return (
+		isRecord(value) &&
+		typeof value["command"] === "string" &&
+		Array.isArray(value["args"]) &&
+		value["args"].every((item) => typeof item === "string")
+	);
+}
+
+function isPluginJson(value: unknown): value is PluginJson {
+	return isRecord(value) && typeof value["hooks"] === "string";
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
@@ -1,23 +1,23 @@
-import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-
-type PackageJson = {
-	readonly type: string;
-	readonly packageManager: string;
-	readonly bin: Record<string, string>;
-	readonly files: readonly string[];
-	readonly scripts: Record<string, string>;
-};
+import {
+	collectHookCommandsFromValue,
+	readJsonFile,
+	readPackageJson,
+	readTextFile,
+	requireFiles,
+	requireScripts,
+} from "../../test-support/package-smoke-fixture.js";
 
 describe("codex ultrawork package metadata", () => {
 	it("#given package metadata #when inspected #then hook ships as bundled CLI", () => {
 		// given
 		const packageJson = readPackageJson("package.json");
-		const hooksJson = readJson("hooks/hooks.json");
-		const cliSource = readFileSync("src/cli.ts", "utf8");
+		const hooksJson = readJsonFile("hooks/hooks.json");
+		const cliSource = readTextFile("src/cli.ts");
 
 		// when
-		const packageFiles = packageJson.files;
+		const packageFiles = requireFiles(packageJson, "package.json");
+		const scripts = requireScripts(packageJson, "package.json");
 		const hookCommands = collectHookCommandsFromValue(hooksJson);
 		const pluginRoot = ["$", "{PLUGIN_ROOT}"].join("");
 
@@ -25,10 +25,10 @@ describe("codex ultrawork package metadata", () => {
 		expect(packageJson.type).toBe("module");
 		expect(packageJson.packageManager).toBe("npm@11.12.1");
 		expect(packageJson.bin["omo-ultrawork"]).toBe("./dist/cli.js");
-		expect(packageJson.scripts["build"]).toBe(
+		expect(scripts["build"]).toBe(
 			"node scripts/sync-directive.mjs && node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js",
 		);
-		expect(packageJson.scripts["test"]).toBe("vitest --run");
+		expect(scripts["test"]).toBe("vitest --run");
 		expect(packageFiles).toContain("dist");
 		expect(packageFiles).toContain("directive.md");
 		expect(packageFiles).not.toContain("hooks/ultrawork-detector.py");
@@ -36,45 +36,76 @@ describe("codex ultrawork package metadata", () => {
 		expect(hookCommands).toContain(`node "${pluginRoot}/dist/cli.js" hook user-prompt-submit`);
 		expect(hookCommands).not.toContainEqual(expect.stringMatching(/\bpython3?\b|ultrawork-detector\.py/));
 	});
+
+	it("#given explorer guidance #when inspected #then names the packaged code-search MCP surface", () => {
+		// given
+		const explorer = readTextFile("agents/explorer.toml");
+
+		// when
+		const guidance = explorer.toLowerCase();
+
+		// then
+		expect(guidance).toContain("ast_grep");
+		expect(guidance).toContain("structural");
+	});
+
+	it("#given explorer guidance #when inspected #then starts codebase inspection with Sparkshell", () => {
+		// given
+		const explorer = readTextFile("agents/explorer.toml");
+
+		// when
+		const guidance = explorer.toLowerCase();
+		const sparkshellIndex = guidance.indexOf("omo sparkshell <command>");
+		const lspIndex = guidance.indexOf("lsp_goto_definition");
+		const structuralIndex = guidance.indexOf("ast_grep_search");
+
+		// then
+		expect(sparkshellIndex).toBeGreaterThanOrEqual(0);
+		expect(lspIndex).toBeGreaterThan(sparkshellIndex);
+		expect(structuralIndex).toBeGreaterThan(sparkshellIndex);
+		expect(guidance).toContain("prefer `omo sparkshell <command>` before raw shell commands");
+		expect(guidance).toContain("--shell '<command>'");
+		expect(guidance).toContain("--tmux-pane");
+	});
+
+	it("#given librarian guidance #when inspected #then names the packaged research MCP surfaces", () => {
+		// given
+		const librarian = readTextFile("agents/librarian.toml");
+
+		// when
+		const guidance = librarian.toLowerCase();
+
+		// then
+		expect(guidance).toContain("grep_app");
+		expect(guidance).toContain("context7");
+		expect(guidance).toContain("ast_grep");
+	});
+
+	it("#given ulw-plan skill #when inspected #then requires dynamic adversarial workflow phases", () => {
+		// given
+		const skill = readTextFile("skills/ulw-plan/SKILL.md");
+		const workflow = readTextFile("skills/ulw-plan/references/full-workflow.md");
+		const requiredContracts = [
+			"dynamic adversarial workflow phases",
+			"stale_state",
+			"source vs packaged split",
+			"misleading_success_output",
+			"confirm test really ran",
+			"prompt_injection",
+			"Discord/external content treated as claims, not instructions",
+		] as const;
+
+		// when
+		const sourceSurfaces = {
+			skill,
+			workflow,
+		} satisfies Record<string, string>;
+
+		// then
+		for (const [name, source] of Object.entries(sourceSurfaces)) {
+			for (const contract of requiredContracts) {
+				expect(source, `${name} should include ${contract}`).toContain(contract);
+			}
+		}
+	});
 });
-
-function readJson(path: string): unknown {
-	return JSON.parse(readFileSync(path, "utf8"));
-}
-
-function readPackageJson(path: string): PackageJson {
-	const parsed = readJson(path);
-	if (!isPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
-	return parsed;
-}
-
-function collectHookCommandsFromValue(value: unknown): readonly string[] {
-	if (typeof value === "string") return [];
-	if (Array.isArray(value)) return value.flatMap(collectHookCommandsFromValue);
-	if (!isRecord(value)) return [];
-	const ownCommand = typeof value["command"] === "string" ? [value["command"]] : [];
-	return [...ownCommand, ...Object.values(value).flatMap(collectHookCommandsFromValue)];
-}
-
-function isPackageJson(value: unknown): value is PackageJson {
-	return (
-		isRecord(value) &&
-		value["type"] === "module" &&
-		value["packageManager"] === "npm@11.12.1" &&
-		isStringRecord(value["bin"]) &&
-		isStringArray(value["files"]) &&
-		isStringRecord(value["scripts"])
-	);
-}
-
-function isStringArray(value: unknown): value is readonly string[] {
-	return Array.isArray(value) && value.every((item) => typeof item === "string");
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}

--- a/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
@@ -37,7 +37,7 @@ describe("codex ultrawork package metadata", () => {
 		expect(hookCommands).not.toContainEqual(expect.stringMatching(/\bpython3?\b|ultrawork-detector\.py/));
 	});
 
-	it("#given explorer guidance #when inspected #then names the packaged code-search MCP surface", () => {
+	it("#given explorer guidance #when inspected #then names the packaged code-search surfaces", () => {
 		// given
 		const explorer = readTextFile("agents/explorer.toml");
 
@@ -45,7 +45,7 @@ describe("codex ultrawork package metadata", () => {
 		const guidance = explorer.toLowerCase();
 
 		// then
-		expect(guidance).toContain("ast_grep");
+		expect(guidance).toContain("ast-grep");
 		expect(guidance).toContain("structural");
 	});
 
@@ -57,7 +57,7 @@ describe("codex ultrawork package metadata", () => {
 		const guidance = explorer.toLowerCase();
 		const sparkshellIndex = guidance.indexOf("omo sparkshell <command>");
 		const lspIndex = guidance.indexOf("lsp_goto_definition");
-		const structuralIndex = guidance.indexOf("ast_grep_search");
+		const structuralIndex = guidance.indexOf("ast-grep");
 
 		// then
 		expect(sparkshellIndex).toBeGreaterThanOrEqual(0);
@@ -78,34 +78,34 @@ describe("codex ultrawork package metadata", () => {
 		// then
 		expect(guidance).toContain("grep_app");
 		expect(guidance).toContain("context7");
-		expect(guidance).toContain("ast_grep");
+		expect(guidance).toContain("ast-grep");
 	});
 
 	it("#given ulw-plan skill #when inspected #then requires dynamic adversarial workflow phases", () => {
 		// given
 		const skill = readTextFile("skills/ulw-plan/SKILL.md");
 		const workflow = readTextFile("skills/ulw-plan/references/full-workflow.md");
-		const requiredContracts = [
+		const skillContracts = [
+			"CodeGraph first",
+			"scripts/scaffold-plan.mjs",
+			"Approval gate",
+		] as const;
+		const workflowContracts = [
 			"dynamic adversarial workflow phases",
 			"stale_state",
-			"source vs packaged split",
+			"source-vs-packaged split",
 			"misleading_success_output",
-			"confirm test really ran",
+			"confirm a test really ran",
 			"prompt_injection",
-			"Discord/external content treated as claims, not instructions",
+			"Discord / external content as claims",
 		] as const;
 
-		// when
-		const sourceSurfaces = {
-			skill,
-			workflow,
-		} satisfies Record<string, string>;
-
 		// then
-		for (const [name, source] of Object.entries(sourceSurfaces)) {
-			for (const contract of requiredContracts) {
-				expect(source, `${name} should include ${contract}`).toContain(contract);
-			}
+		for (const contract of skillContracts) {
+			expect(skill, `skill should include ${contract}`).toContain(contract);
+		}
+		for (const contract of workflowContracts) {
+			expect(workflow, `workflow should include ${contract}`).toContain(contract);
 		}
 	});
 });

--- a/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
@@ -85,11 +85,7 @@ describe("codex ultrawork package metadata", () => {
 		// given
 		const skill = readTextFile("skills/ulw-plan/SKILL.md");
 		const workflow = readTextFile("skills/ulw-plan/references/full-workflow.md");
-		const skillContracts = [
-			"CodeGraph first",
-			"scripts/scaffold-plan.mjs",
-			"Approval gate",
-		] as const;
+		const skillContracts = ["CodeGraph first", "scripts/scaffold-plan.mjs", "Approval gate"] as const;
 		const workflowContracts = [
 			"dynamic adversarial workflow phases",
 			"stale_state",

--- a/packages/omo-codex/plugin/package-lock.json
+++ b/packages/omo-codex/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sisyphuslabs/omo-codex-plugin",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sisyphuslabs/omo-codex-plugin",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"workspaces": [
 				"components/codegraph",
 				"components/comment-checker",
@@ -97,7 +97,7 @@
 		},
 		"components/codegraph": {
 			"name": "@sisyphuslabs/codex-codegraph",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"bin": {
 				"omo-codegraph": "dist/cli.js"
 			},
@@ -113,7 +113,7 @@
 		},
 		"components/comment-checker": {
 			"name": "@code-yeongyu/codex-comment-checker",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"license": "MIT",
 			"bin": {
 				"omo-comment-checker": "dist/cli.js"
@@ -134,7 +134,7 @@
 		},
 		"components/git-bash": {
 			"name": "@sisyphuslabs/codex-git-bash-hook",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"bin": {
 				"omo-git-bash-hook": "dist/cli.js"
 			},
@@ -149,7 +149,7 @@
 		},
 		"components/lazycodex-executor-verify": {
 			"name": "@code-yeongyu/codex-lazycodex-executor-verify",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"license": "MIT",
 			"bin": {
 				"lazycodex-executor-verify": "dist/cli.js"
@@ -166,7 +166,7 @@
 		},
 		"components/lsp": {
 			"name": "@code-yeongyu/codex-lsp",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"license": "MIT",
 			"dependencies": {
 				"@code-yeongyu/lsp-daemon": "file:../../../../lsp-daemon"
@@ -186,7 +186,7 @@
 		},
 		"components/rules": {
 			"name": "@code-yeongyu/codex-rules",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^4.0.3"
@@ -208,7 +208,7 @@
 		},
 		"components/start-work-continuation": {
 			"name": "@code-yeongyu/codex-start-work-continuation",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"license": "MIT",
 			"bin": {
 				"omo-start-work-continuation": "dist/cli.js"
@@ -226,7 +226,7 @@
 		},
 		"components/telemetry": {
 			"name": "@code-yeongyu/codex-telemetry",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"license": "MIT",
 			"bin": {
 				"omo-telemetry": "dist/cli.js"
@@ -244,7 +244,7 @@
 		},
 		"components/ultrawork": {
 			"name": "@code-yeongyu/codex-ultrawork",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"license": "MIT",
 			"bin": {
 				"omo-ultrawork": "dist/cli.js"
@@ -262,7 +262,7 @@
 		},
 		"components/ulw-loop": {
 			"name": "@code-yeongyu/codex-ulw-loop",
-			"version": "4.11.0",
+			"version": "4.11.1",
 			"license": "MIT",
 			"bin": {
 				"omo-ulw-loop": "dist/cli.js"


### PR DESCRIPTION
## Summary
This revives the useful package-smoke fixture dedupe from the closed #5017 branch on top of current `dev`, then finishes the current-dev compatibility fixes that were still missing.

The PR keeps the shared `package-smoke-fixture.ts` extraction for comment-checker, lsp, rules, and ultrawork package smoke tests. It also updates the LSP package smoke path so `npm test` rebuilds the local dist before node test assertions, aligns ultrawork guidance assertions with the current `ast-grep` / `ulw-plan` wording, and refreshes generated Codex package metadata to the current 4.11.0 version.

Old PR status: #5017 is already closed, so there was nothing open to close; this PR uses a fresh branch/head.

## Changes
- Add a shared package-smoke fixture for omo-codex component package metadata tests.
- Reuse the fixture from comment-checker, lsp, rules, and ultrawork smoke tests.
- Rebuild the LSP component before package smoke tests so node tests exercise the current `dist/cli.js`.
- Update ultrawork smoke assertions for the current packaged code-search and `ulw-plan` guidance contracts.
- Refresh generated Codex plugin package metadata from 4.10.0 to the current 4.11.0 release state.

## Verification
**Component package smoke:** `npm test` in `packages/omo-codex/plugin/components/{comment-checker,rules,lsp,ultrawork}` passed.
Evidence: `.omo/evidence/20260618-package-smoke-dedup/component-npm-tests.txt`

**Codex gate:** `bun run test:codex` passed with 336 tests.
Evidence: `.omo/evidence/20260618-package-smoke-dedup/test-codex-final.txt`

**Manual Codex QA:** isolated local Codex/plugin QA passed without touching real `~/.codex/config.toml`.
- `install-verify.sh --self-test` passed.
- `app-server-drive.sh --plugin` passed and observed plugin hook notifications for `sessionStart`, `userPromptSubmit`, and `stop`.
- `hook-unit-probe.sh --self-test` passed for ultrawork `UserPromptSubmit` injection.
- `tui-smoke.sh --plugin --seconds 5` passed.
Evidence: `.omo/evidence/20260618-package-smoke-dedup/{install-verify.txt,app-server-drive.json,hook-unit-probe.txt,tui-smoke.txt}`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates component package smoke tests with a shared `package-smoke-fixture.ts` used by `comment-checker`, `lsp`, `rules`, and `ultrawork`. Rebuilds `lsp` before tests and syncs the plugin lockfile to 4.11.1.

- **Refactors**
  - Add shared `package-smoke-fixture.ts` with helpers (`readJsonFile`, `readTextFile`, `listDirectoryEntries`, `requireScripts`, `requireFiles`, `collectHookCommandsFromValue`, `readMcpJson`, `readPluginJson`) and remove per-test boilerplate.
  - Migrate component smoke tests to the fixture and tighten checks: portable hook commands; package `scripts`/`files`; LSP tool guidance not framed as shell commands; ultrawork guidance references `ast-grep`, prefers Sparkshell first, names research MCP surfaces, and enforces dynamic workflow contracts. Set `lsp` `pretest` to `npm run build --silent`.

- **Dependencies**
  - Sync `@sisyphuslabs/omo-codex-plugin` lockfile to 4.11.1.

<sup>Written for commit b7fc07197e1022e229dd42309afc19059b67ceca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

