### PR TITLE
fix(init-deep): drive real LSP + codegraph tools instead of a non-existent API

### DIFF
--- a/packages/omo-codex/plugin/skills/init-deep/SKILL.md
+++ b/packages/omo-codex/plugin/skills/init-deep/SKILL.md
@@ -38,7 +38,7 @@ Generate hierarchical AGENTS.md files. Root + complexity-scored subdirectories.
 
 1. **Discovery + Analysis** (concurrent)
    - Fire background explore agents immediately
-   - Main session: bash structure + LSP codemap + read existing AGENTS.md
+   - Main session: bash structure + LSP/codegraph code map + read existing AGENTS.md
 2. **Score & Decide** - Determine AGENTS.md locations from merged findings
 3. **Generate** - Root first, then subdirs in parallel
 4. **Review** - Deduplicate, trim, validate
@@ -47,7 +47,7 @@ Generate hierarchical AGENTS.md files. Root + complexity-scored subdirectories.
 **TodoWrite ALL phases. Mark in_progress → completed in real-time.**
 ```
 TodoWrite([
-  { id: "discovery", content: "Fire explore agents + LSP codemap + read existing", status: "pending", priority: "high" },
+  { id: "discovery", content: "Fire explore agents + LSP/codegraph map + read existing", status: "pending", priority: "high" },
   { id: "scoring", content: "Score directories, determine locations", status: "pending", priority: "high" },
   { id: "generate", content: "Generate AGENTS.md files (root + subdirs)", status: "pending", priority: "high" },
   { id: "review", content: "Deduplicate, validate, trim", status: "pending", priority: "medium" }
@@ -63,16 +63,16 @@ TodoWrite([
 
 ### Fire Background Explore Agents IMMEDIATELY
 
-Don't wait-these run async while main session works.
+Don't wait-these run async while main session works. **Equip every agent with the code graph**: any task touching structure, entry points, dependencies, or hotspots MUST query `codegraph_*` (explore/search/callers/callees/impact) and `lsp_symbols` when present, and ground its claims in that data instead of guessing from conventions. Richer real-graph context per agent = a more accurate project map.
 
 ```
 // Fire all at once, collect results later
-task(subagent_type="explore", load_skills=[], description="Explore project structure", run_in_background=true, prompt="Project structure: PREDICT standard patterns for detected language → REPORT deviations only")
-task(subagent_type="explore", load_skills=[], description="Find entry points", run_in_background=true, prompt="Entry points: FIND main files → REPORT non-standard organization")
+task(subagent_type="explore", load_skills=[], description="Explore project structure", run_in_background=true, prompt="Project structure: map real layout via codegraph_explore/codegraph_files → REPORT deviations from standard patterns")
+task(subagent_type="explore", load_skills=[], description="Find entry points", run_in_background=true, prompt="Entry points: FIND main files, trace reach via codegraph_callees + lsp_symbols → REPORT non-standard organization")
 task(subagent_type="explore", load_skills=[], description="Find conventions", run_in_background=true, prompt="Conventions: FIND config files (.eslintrc, pyproject.toml, .editorconfig) → REPORT project-specific rules")
 task(subagent_type="explore", load_skills=[], description="Find anti-patterns", run_in_background=true, prompt="Anti-patterns: FIND 'DO NOT', 'NEVER', 'ALWAYS', 'DEPRECATED' comments → LIST forbidden patterns")
 task(subagent_type="explore", load_skills=[], description="Explore build/CI", run_in_background=true, prompt="Build/CI: FIND .github/workflows, Makefile → REPORT non-standard patterns")
-task(subagent_type="explore", load_skills=[], description="Find test patterns", run_in_background=true, prompt="Test patterns: FIND test configs, test structure → REPORT unique conventions")
+task(subagent_type="explore", load_skills=[], description="Find test patterns", run_in_background=true, prompt="Test patterns: FIND test configs/structure; codegraph_callers on core modules to see what is covered → REPORT unique conventions")
 ```
 
 <dynamic-agents>
@@ -134,24 +134,19 @@ For each existing file found:
 
 If `--create-new`: Read all existing first (preserve context) → then delete all → regenerate.
 
-#### 3. LSP Codemap (if available)
-```
-LspServers()  # Check availability
+#### 3. Code Map - drive LSP AND codegraph (do NOT skip)
 
-# Entry points (parallel)
-LspDocumentSymbols(filePath="src/index.ts")
-LspDocumentSymbols(filePath="main.py")
+Highest-signal source for the CODE MAP and the Symbol/Export/Reference scoring rows. Complementary, not alternatives - run BOTH when present, alongside the explore agents.
 
-# Key symbols (parallel)
-LspWorkspaceSymbols(filePath=".", query="class")
-LspWorkspaceSymbols(filePath=".", query="interface")
-LspWorkspaceSymbols(filePath=".", query="function")
+**LSP** - check `lsp_status`; model-facing names are `lsp_status`/`lsp_symbols`/`lsp_find_references`/`lsp_goto_definition` (some harnesses drop the `lsp_` prefix):
+- `lsp_symbols` scope="document" on each entry point -> file outline.
+- `lsp_symbols` scope="workspace", query by kind (class/interface/function) -> symbol inventory.
+- `lsp_find_references` on top exports (line/character from the symbols result) -> reference centrality.
 
-# Centrality for top exports
-LspFindReferences(filePath="...", line=X, character=Y)
-```
+**codegraph** - when `codegraph_*` tools exist (check `codegraph_status`); a first-class peer to LSP, NOT a last resort:
+- `codegraph_explore` -> overview; `codegraph_callers`/`codegraph_callees`/`codegraph_impact` -> centrality + blast radius for the scoring matrix; `codegraph_search`/`codegraph_files` -> symbol/file inventory.
 
-**LSP Fallback**: If unavailable, use `codegraph_explore` first when codegraph_* tools exist; otherwise rely on explore agents + the ast-grep skill (`sg` CLI).
+Only if NEITHER exists: explore agents + the ast-grep skill (`sg`), and mark centrality unmeasured in the CODE MAP.
 
 ### Collect Background Results
 
@@ -160,7 +155,7 @@ LspFindReferences(filePath="...", line=X, character=Y)
 for each background task ID (`bg_...`): background_output(task_id="bg_...")
 ```
 
-**Merge: bash + LSP + existing + explore findings. Mark "discovery" as completed.**
+**Merge: bash + LSP/codegraph + existing + explore findings. Mark "discovery" as completed.**
 
 ---
 
@@ -177,9 +172,9 @@ for each background task ID (`bg_...`): background_output(task_id="bg_...")
 | Code ratio | 2x | >70% | bash |
 | Unique patterns | 1x | Has own config | explore |
 | Module boundary | 2x | Has index.ts/__init__.py | bash |
-| Symbol density | 2x | >30 symbols | LSP |
-| Export count | 2x | >10 exports | LSP |
-| Reference centrality | 3x | >20 refs | LSP |
+| Symbol density | 2x | >30 symbols | LSP/cg |
+| Export count | 2x | >10 exports | LSP/cg |
+| Reference centrality | 3x | >20 refs | LSP/cg |
 
 ### Decision Rules
 
@@ -236,7 +231,7 @@ NEVER use Write to overwrite an existing file. ALWAYS check existence first via 
 |------|----------|-------|
 
 ## CODE MAP
-{From LSP - skip if unavailable or project <10 files}
+{From LSP/codegraph - skip only if neither exists or project <10 files}
 
 | Symbol | Type | Location | Refs | Role |
 |--------|------|----------|------|------|
@@ -319,7 +314,7 @@ Hierarchy:
 ## Anti-Patterns
 
 - **Static agent count**: MUST vary agents based on project size/depth
-- **Sequential execution**: MUST parallel (explore + LSP concurrent)
+- **Sequential execution**: MUST parallel (explore + LSP + codegraph concurrent)
 - **Ignoring existing**: ALWAYS read existing first, even with --create-new
 - **Over-documenting**: Not every dir needs AGENTS.md
 - **Redundancy**: Child never repeats parent

--- a/packages/shared-skills/skills/init-deep/SKILL.md
+++ b/packages/shared-skills/skills/init-deep/SKILL.md
@@ -20,7 +20,7 @@ Generate hierarchical AGENTS.md files. Root + complexity-scored subdirectories.
 
 1. **Discovery + Analysis** (concurrent)
    - Fire background explore agents immediately
-   - Main session: bash structure + LSP codemap + read existing AGENTS.md
+   - Main session: bash structure + LSP/codegraph code map + read existing AGENTS.md
 2. **Score & Decide** - Determine AGENTS.md locations from merged findings
 3. **Generate** - Root first, then subdirs in parallel
 4. **Review** - Deduplicate, trim, validate
@@ -29,7 +29,7 @@ Generate hierarchical AGENTS.md files. Root + complexity-scored subdirectories.
 **TodoWrite ALL phases. Mark in_progress → completed in real-time.**
 ```
 TodoWrite([
-  { id: "discovery", content: "Fire explore agents + LSP codemap + read existing", status: "pending", priority: "high" },
+  { id: "discovery", content: "Fire explore agents + LSP/codegraph map + read existing", status: "pending", priority: "high" },
   { id: "scoring", content: "Score directories, determine locations", status: "pending", priority: "high" },
   { id: "generate", content: "Generate AGENTS.md files (root + subdirs)", status: "pending", priority: "high" },
   { id: "review", content: "Deduplicate, validate, trim", status: "pending", priority: "medium" }
@@ -45,16 +45,16 @@ TodoWrite([
 
 ### Fire Background Explore Agents IMMEDIATELY
 
-Don't wait-these run async while main session works.
+Don't wait-these run async while main session works. **Equip every agent with the code graph**: any task touching structure, entry points, dependencies, or hotspots MUST query `codegraph_*` (explore/search/callers/callees/impact) and `lsp_symbols` when present, and ground its claims in that data instead of guessing from conventions. Richer real-graph context per agent = a more accurate project map.
 
 ```
 // Fire all at once, collect results later
-task(subagent_type="explore", load_skills=[], description="Explore project structure", run_in_background=true, prompt="Project structure: PREDICT standard patterns for detected language → REPORT deviations only")
-task(subagent_type="explore", load_skills=[], description="Find entry points", run_in_background=true, prompt="Entry points: FIND main files → REPORT non-standard organization")
+task(subagent_type="explore", load_skills=[], description="Explore project structure", run_in_background=true, prompt="Project structure: map real layout via codegraph_explore/codegraph_files → REPORT deviations from standard patterns")
+task(subagent_type="explore", load_skills=[], description="Find entry points", run_in_background=true, prompt="Entry points: FIND main files, trace reach via codegraph_callees + lsp_symbols → REPORT non-standard organization")
 task(subagent_type="explore", load_skills=[], description="Find conventions", run_in_background=true, prompt="Conventions: FIND config files (.eslintrc, pyproject.toml, .editorconfig) → REPORT project-specific rules")
 task(subagent_type="explore", load_skills=[], description="Find anti-patterns", run_in_background=true, prompt="Anti-patterns: FIND 'DO NOT', 'NEVER', 'ALWAYS', 'DEPRECATED' comments → LIST forbidden patterns")
 task(subagent_type="explore", load_skills=[], description="Explore build/CI", run_in_background=true, prompt="Build/CI: FIND .github/workflows, Makefile → REPORT non-standard patterns")
-task(subagent_type="explore", load_skills=[], description="Find test patterns", run_in_background=true, prompt="Test patterns: FIND test configs, test structure → REPORT unique conventions")
+task(subagent_type="explore", load_skills=[], description="Find test patterns", run_in_background=true, prompt="Test patterns: FIND test configs/structure; codegraph_callers on core modules to see what is covered → REPORT unique conventions")
 ```
 
 <dynamic-agents>
@@ -116,24 +116,19 @@ For each existing file found:
 
 If `--create-new`: Read all existing first (preserve context) → then delete all → regenerate.
 
-#### 3. LSP Codemap (if available)
-```
-LspServers()  # Check availability
+#### 3. Code Map - drive LSP AND codegraph (do NOT skip)
 
-# Entry points (parallel)
-LspDocumentSymbols(filePath="src/index.ts")
-LspDocumentSymbols(filePath="main.py")
+Highest-signal source for the CODE MAP and the Symbol/Export/Reference scoring rows. Complementary, not alternatives - run BOTH when present, alongside the explore agents.
 
-# Key symbols (parallel)
-LspWorkspaceSymbols(filePath=".", query="class")
-LspWorkspaceSymbols(filePath=".", query="interface")
-LspWorkspaceSymbols(filePath=".", query="function")
+**LSP** - check `lsp_status`; model-facing names are `lsp_status`/`lsp_symbols`/`lsp_find_references`/`lsp_goto_definition` (some harnesses drop the `lsp_` prefix):
+- `lsp_symbols` scope="document" on each entry point -> file outline.
+- `lsp_symbols` scope="workspace", query by kind (class/interface/function) -> symbol inventory.
+- `lsp_find_references` on top exports (line/character from the symbols result) -> reference centrality.
 
-# Centrality for top exports
-LspFindReferences(filePath="...", line=X, character=Y)
-```
+**codegraph** - when `codegraph_*` tools exist (check `codegraph_status`); a first-class peer to LSP, NOT a last resort:
+- `codegraph_explore` -> overview; `codegraph_callers`/`codegraph_callees`/`codegraph_impact` -> centrality + blast radius for the scoring matrix; `codegraph_search`/`codegraph_files` -> symbol/file inventory.
 
-**LSP Fallback**: If unavailable, use `codegraph_explore` first when codegraph_* tools exist; otherwise rely on explore agents + the ast-grep skill (`sg` CLI).
+Only if NEITHER exists: explore agents + the ast-grep skill (`sg`), and mark centrality unmeasured in the CODE MAP.
 
 ### Collect Background Results
 
@@ -142,7 +137,7 @@ LspFindReferences(filePath="...", line=X, character=Y)
 for each background task ID (`bg_...`): background_output(task_id="bg_...")
 ```
 
-**Merge: bash + LSP + existing + explore findings. Mark "discovery" as completed.**
+**Merge: bash + LSP/codegraph + existing + explore findings. Mark "discovery" as completed.**
 
 ---
 
@@ -159,9 +154,9 @@ for each background task ID (`bg_...`): background_output(task_id="bg_...")
 | Code ratio | 2x | >70% | bash |
 | Unique patterns | 1x | Has own config | explore |
 | Module boundary | 2x | Has index.ts/__init__.py | bash |
-| Symbol density | 2x | >30 symbols | LSP |
-| Export count | 2x | >10 exports | LSP |
-| Reference centrality | 3x | >20 refs | LSP |
+| Symbol density | 2x | >30 symbols | LSP/cg |
+| Export count | 2x | >10 exports | LSP/cg |
+| Reference centrality | 3x | >20 refs | LSP/cg |
 
 ### Decision Rules
 
@@ -218,7 +213,7 @@ NEVER use Write to overwrite an existing file. ALWAYS check existence first via 
 |------|----------|-------|
 
 ## CODE MAP
-{From LSP - skip if unavailable or project <10 files}
+{From LSP/codegraph - skip only if neither exists or project <10 files}
 
 | Symbol | Type | Location | Refs | Role |
 |--------|------|----------|------|------|
@@ -301,7 +296,7 @@ Hierarchy:
 ## Anti-Patterns
 
 - **Static agent count**: MUST vary agents based on project size/depth
-- **Sequential execution**: MUST parallel (explore + LSP concurrent)
+- **Sequential execution**: MUST parallel (explore + LSP + codegraph concurrent)
 - **Ignoring existing**: ALWAYS read existing first, even with --create-new
 - **Over-documenting**: Not every dir needs AGENTS.md
 - **Redundancy**: Child never repeats parent


### PR DESCRIPTION
## Why

`/init-deep` is supposed to build the hierarchical `AGENTS.md` project map from rich code-intelligence context. In practice it never touched LSP and only mentioned codegraph as an afterthought, so the map was built from convention-guessing.

Diagnosed with the `prompt-engineering` skill (verified against source), the root cause is a **Category A defect — wrong information**: the skill instructed the model to call tools that do not exist.

```
LspServers()              LspDocumentSymbols(...)
LspWorkspaceSymbols(...)  LspFindReferences(...)
```

The real tool surface (pinned in `packages/lsp-tools-mcp/test/tool-surface.test.ts`, served by the `lsp` MCP) is `status` / `symbols` (with a required `scope`) / `find_references` / `goto_definition` / ... (callable as `lsp_*` in OpenCode). A model reading CamelCase pseudo-functions absent from its tool list treats the whole block as illustrative and skips LSP entirely. On top of that, codegraph was buried as a fallback-of-a-fallback (only `codegraph_explore` named), and the Phase-1 explore agents were told to "PREDICT standard patterns" with zero graph grounding.

## What changed

All edits are in the canonical `packages/shared-skills/skills/init-deep/SKILL.md` (the Codex plugin copy is regenerated by `sync-skills.mjs`):

- **Real tool names.** Replace the four non-existent CamelCase calls with `lsp_status`, `lsp_symbols` (with `scope="document"|"workspace"`), `lsp_find_references`, `lsp_goto_definition`. The skill notes some harnesses drop the `lsp_` prefix, covering both the OpenCode-prefixed and raw-MCP unprefixed surfaces.
- **Active, not optional.** Reframe LSP and codegraph from "(if available)" / "fallback" into the **primary** code-map source, driven **alongside** the explore agents — complementary, not alternatives.
- **codegraph as a first-class peer.** Name the tools that map to the skill's own scoring rows (Symbol density / Export count / Reference centrality): `codegraph_explore`, `codegraph_callers`/`codegraph_callees`/`codegraph_impact`, `codegraph_search`/`codegraph_files`.
- **Graph-grounded explore agents.** Phase-1 explore agents that touch structure / entry points / dependencies / hotspots are told to ground findings in `codegraph_*` and `lsp_symbols` instead of guessing from conventions, so the project map is built from maximum real context.
- **Internal consistency.** Workflow line, todo content, scoring-matrix source column, CODE MAP note, and the parallelism anti-pattern updated so codegraph is first-class throughout.

Net length is roughly neutral (the rewritten code-map section is shorter than the fake-call block it replaces); no patch-on-top, no fake names remain.

## QA (evidence under `.omo/evidence/20260618-init-deep-lsp-codegraph/`)

Shared-skills reaches BOTH editions, so both `opencode-qa` and `codex-qa` were exercised in isolated sandboxes.

- **Real harness tool surface:** `tools/list` on the actual `lsp` MCP returns the real names (`status`/`symbols`/`find_references`/...); the fake names are **entirely absent** — confirming the diagnosis and that the new names are the valid ones.
- **Runtime skill delivery + contract:** 27 governing tests pass, including `skill-file-loader.test.ts` (runs the real `loadSharedSkillTemplate("init-deep")` and asserts the edited body is what the skill system delivers) and the byte-equivalence test.
- **Static:** 0 fake names, 21 real `lsp_*`/`codegraph_*` references in both the canonical and synced Codex copies; both pass the skill validator.
- **Codex gate:** `bun run test:codex` → 336 pass / 0 fail.
- **Isolation:** real OpenCode DB session count unchanged (21542 -> 21542); isolated XDG/HOME/CODEX_HOME; real `~/.codex` untouched.
- **Known limitation (honest):** a full live `opencode run` observing the model emit the calls could not complete in the isolated sandbox — proven to be a provider-connectivity constraint, not this change: a bare no-plugin run also hangs, and the sandbox `.env` key returns HTTP 401 against the real Anthropic endpoint (it is a gateway key whose base-URL config the isolation deliberately strips). The fix is prompt text; its correctness is established by the tool-surface + loader + static evidence above.

## Risk / non-goals

- Does **not** implement codegraph auto-bootstrap/indexing (separate planned work). The skill checks `codegraph_status` and uses codegraph only when its tools are present; on Codex (codegraph not yet wired) the model finds no `codegraph_*` tools and proceeds with LSP + explore — graceful, no error.
- Output `AGENTS.md` stays telegraphic; "maximum context" applies to the analysis feeding the map, not to verbose output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the real LSP MCP tools and make codegraph a first-class input in `init-deep`, so `AGENTS.md` is built from actual code intelligence instead of guessed conventions.

- **Bug Fixes**
  - Replace fake LSP calls with `lsp_status`, `lsp_symbols` (with `scope`), `lsp_find_references`, `lsp_goto_definition`.
  - Treat LSP and codegraph as primary sources; add explicit `codegraph_explore`, `codegraph_callers`/`codegraph_callees`/`codegraph_impact`, `codegraph_search`/`codegraph_files`.
  - Ground explore agents in `codegraph_*` and `lsp_symbols`; fall back to `sg` only if neither exists.
  - Align scoring matrix source tags, CODE MAP notes, and parallelism guidance; update both `packages/shared-skills/skills/init-deep/SKILL.md` and `packages/omo-codex/plugin/skills/init-deep/SKILL.md`.

<sup>Written for commit 28eab54775bd5b19751f3512d04b73cd1b445e5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

