### PR TITLE
fix(telemetry): bypass posthog module caching for robust testing

### DIFF
--- a/packages/omo-codex/src/telemetry/cross-package-equivalence.test.ts
+++ b/packages/omo-codex/src/telemetry/cross-package-equivalence.test.ts
@@ -29,6 +29,7 @@ function getObjectProperty(value: unknown, key: string): unknown {
 function collectFiles(root: string, relativePrefix = ""): string[] {
   const files: string[] = []
   for (const entry of readdirSync(join(root, relativePrefix), { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue
     const relativePath = join(relativePrefix, entry.name)
     const fullPath = join(root, relativePath)
     if (entry.isDirectory()) {
@@ -43,7 +44,7 @@ function collectFiles(root: string, relativePrefix = ""): string[] {
 describe("omo-codex telemetry single-source guard", () => {
   describe("#given the omo-codex package tree", () => {
     it("#when sync-copy references are searched #then no telemetry sync script or build hook remains", () => {
-      const files = collectFiles(CODEX_ROOT).filter((file) => !file.includes("node_modules/"))
+      const files = collectFiles(CODEX_ROOT)
       const offenders: string[] = []
 
       for (const file of files) {

--- a/packages/omo-codex/src/telemetry/posthog-diagnostics.test.ts
+++ b/packages/omo-codex/src/telemetry/posthog-diagnostics.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -31,6 +31,7 @@ function clearTelemetryEnv(): void {
 
 function createDataHomePath(): string {
   const tempPath = mkdtempSync(join(tmpdir(), "omo-codex-posthog-diagnostics-"))
+  mkdirSync(join(tempPath, CACHE_DIR_NAME), { recursive: true })
   tempPaths.push(tempPath)
   return tempPath
 }
@@ -39,41 +40,35 @@ function getDiagnosticsFilePath(dataHomePath: string): string {
   return join(dataHomePath, CACHE_DIR_NAME, "telemetry-diagnostics.jsonl")
 }
 
-function mockPostHogCaptureFailure(): void {
-  mock.module("posthog-node", () => ({
-    PostHog: class {
-      capture(): void {
-        throw new Error("capture failed")
-      }
-
-      async shutdown(): Promise<void> {}
+function mockPostHogCaptureFailure(posthog: PostHogModule): void {
+  posthog.__setTransportFactoryForTesting(() => ({
+    capture: () => {
+      throw new Error("capture failed")
     },
+    flush: async () => {},
+    shutdown: async () => {},
   }))
 }
 
-function mockPostHogCaptureSymbolFailure(): void {
+function mockPostHogCaptureSymbolFailure(posthog: PostHogModule): void {
   const failure = Symbol("capture failed")
-  mock.module("posthog-node", () => ({
-    PostHog: class {
-      capture(): void {
-        throw failure
-      }
-
-      async shutdown(): Promise<void> {}
+  posthog.__setTransportFactoryForTesting(() => ({
+    capture: () => {
+      throw failure
     },
+    flush: async () => {},
+    shutdown: async () => {},
   }))
 }
 
-function mockPostHogShutdownFailure(capturedMessages: CapturedPostHogMessage[]): void {
-  mock.module("posthog-node", () => ({
-    PostHog: class {
-      capture(message: CapturedPostHogMessage): void {
-        capturedMessages.push(message)
-      }
-
-      async shutdown(): Promise<void> {
-        throw new Error("shutdown failed")
-      }
+function mockPostHogShutdownFailure(posthog: PostHogModule, capturedMessages: CapturedPostHogMessage[]): void {
+  posthog.__setTransportFactoryForTesting(() => ({
+    capture: (message: any) => {
+      capturedMessages.push(message)
+    },
+    flush: async () => {},
+    shutdown: async () => {
+      throw new Error("shutdown failed")
     },
   }))
 }
@@ -92,6 +87,7 @@ describe("omo-codex posthog telemetry diagnostics", () => {
     } else {
       process.env.XDG_DATA_HOME = originalXdgDataHome
     }
+    delete process.env.XDG_STATE_HOME
     for (const tempPath of tempPaths.splice(0)) {
       rmSync(tempPath, { recursive: true, force: true })
     }
@@ -101,9 +97,10 @@ describe("omo-codex posthog telemetry diagnostics", () => {
     // given
     const dataHomePath = createDataHomePath()
     process.env.XDG_DATA_HOME = dataHomePath
+    process.env.XDG_STATE_HOME = dataHomePath
     process.env.POSTHOG_API_KEY = "test-api-key"
-    mockPostHogCaptureFailure()
     const posthog = await importPostHogModule()
+    mockPostHogCaptureFailure(posthog)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -120,9 +117,10 @@ describe("omo-codex posthog telemetry diagnostics", () => {
     // given
     const dataHomePath = createDataHomePath()
     process.env.XDG_DATA_HOME = dataHomePath
+    process.env.XDG_STATE_HOME = dataHomePath
     process.env.POSTHOG_API_KEY = "test-api-key"
-    mockPostHogCaptureSymbolFailure()
     const posthog = await importPostHogModule()
+    mockPostHogCaptureSymbolFailure(posthog)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -141,9 +139,10 @@ describe("omo-codex posthog telemetry diagnostics", () => {
     const dataHomePath = createDataHomePath()
     const capturedMessages: CapturedPostHogMessage[] = []
     process.env.XDG_DATA_HOME = dataHomePath
+    process.env.XDG_STATE_HOME = dataHomePath
     process.env.POSTHOG_API_KEY = "test-api-key"
-    mockPostHogShutdownFailure(capturedMessages)
     const posthog = await importPostHogModule()
+    mockPostHogShutdownFailure(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when

--- a/packages/omo-codex/src/telemetry/posthog.test.ts
+++ b/packages/omo-codex/src/telemetry/posthog.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-import { readFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { DEFAULT_POSTHOG_API_KEY as TELEMETRY_CORE_DEFAULT_POSTHOG_API_KEY } from "@oh-my-opencode/telemetry-core"
+
+import { CACHE_DIR_NAME } from "./product-identity"
 
 type CapturedPostHogMessage = {
   readonly distinctId: string
@@ -15,6 +18,16 @@ async function importPostHogModule(): Promise<PostHogModule> {
   return import(`./posthog?test=${Date.now()}-${Math.random()}`)
 }
 
+const originalXdgDataHome = process.env.XDG_DATA_HOME
+const tempPaths: string[] = []
+
+function createDataHomePath(): string {
+  const tempPath = mkdtempSync(join(tmpdir(), "omo-codex-posthog-"))
+  mkdirSync(join(tempPath, CACHE_DIR_NAME), { recursive: true })
+  tempPaths.push(tempPath)
+  return tempPath
+}
+
 function clearTelemetryEnv(): void {
   delete process.env.OMO_DISABLE_POSTHOG
   delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
@@ -24,15 +37,13 @@ function clearTelemetryEnv(): void {
   delete process.env.POSTHOG_HOST
 }
 
-function mockPostHogNode(capturedMessages: CapturedPostHogMessage[]): void {
-  mock.module("posthog-node", () => ({
-    PostHog: class {
-      capture(message: CapturedPostHogMessage): void {
-        capturedMessages.push(message)
-      }
-
-      async shutdown(): Promise<void> {}
+function mockPostHogNode(posthog: PostHogModule, capturedMessages: CapturedPostHogMessage[]): void {
+  posthog.__setTransportFactoryForTesting(() => ({
+    capture: (message: any) => {
+      capturedMessages.push(message)
     },
+    flush: async () => {},
+    shutdown: async () => {},
   }))
 }
 
@@ -56,20 +67,32 @@ describe("omo-codex posthog telemetry", () => {
   beforeEach(() => {
     mock.restore()
     clearTelemetryEnv()
+    process.env.XDG_DATA_HOME = createDataHomePath()
+    process.env.XDG_STATE_HOME = process.env.XDG_DATA_HOME
   })
 
   afterEach(() => {
     mock.restore()
     clearTelemetryEnv()
+    if (originalXdgDataHome === undefined) {
+      delete process.env.XDG_DATA_HOME
+    } else {
+      process.env.XDG_DATA_HOME = originalXdgDataHome
+    }
+    delete process.env.XDG_STATE_HOME
+    for (const tempPath of tempPaths.splice(0)) {
+      rmSync(tempPath, { recursive: true, force: true })
+    }
   })
 
   it("matrix row 1 disabled when OMO_DISABLE_POSTHOG=1", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
     process.env.POSTHOG_API_KEY = "test-api-key"
     setMatrix("1", undefined, undefined, undefined)
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -82,10 +105,11 @@ describe("omo-codex posthog telemetry", () => {
   it("matrix row 2 disabled when OMO_SEND_ANONYMOUS_TELEMETRY=0", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
+
     process.env.POSTHOG_API_KEY = "test-api-key"
     setMatrix(undefined, "0", undefined, undefined)
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -98,10 +122,11 @@ describe("omo-codex posthog telemetry", () => {
   it("matrix row 3 disabled when OMO_CODEX_DISABLE_POSTHOG=1", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
+
     process.env.POSTHOG_API_KEY = "test-api-key"
     setMatrix(undefined, undefined, "1", undefined)
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -114,10 +139,11 @@ describe("omo-codex posthog telemetry", () => {
   it("matrix row 4 disabled when OMO_CODEX_SEND_ANONYMOUS_TELEMETRY=0", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
+
     process.env.POSTHOG_API_KEY = "test-api-key"
     setMatrix(undefined, undefined, undefined, "0")
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -130,10 +156,11 @@ describe("omo-codex posthog telemetry", () => {
   it("matrix row 5 enabled when all vars unset", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
+
     process.env.POSTHOG_API_KEY = "test-api-key"
     setMatrix(undefined, undefined, undefined, undefined)
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -146,9 +173,10 @@ describe("omo-codex posthog telemetry", () => {
   it("captures omo_codex_daily_active with omo-codex platform", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
+
     process.env.POSTHOG_API_KEY = "test-api-key"
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -162,9 +190,10 @@ describe("omo-codex posthog telemetry", () => {
   it("does not capture on same day", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
+
     process.env.POSTHOG_API_KEY = "test-api-key"
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: false }))
 
     // when
@@ -177,9 +206,10 @@ describe("omo-codex posthog telemetry", () => {
   it("createInstallPostHog sets source=install", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
+
     process.env.POSTHOG_API_KEY = "test-api-key"
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -192,9 +222,10 @@ describe("omo-codex posthog telemetry", () => {
   it("createCliPostHog sets source=cli", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
+
     process.env.POSTHOG_API_KEY = "test-api-key"
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when
@@ -207,9 +238,10 @@ describe("omo-codex posthog telemetry", () => {
   it("returns no-op when POSTHOG_API_KEY override is empty", async () => {
     // given
     const capturedMessages: CapturedPostHogMessage[] = []
-    mockPostHogNode(capturedMessages)
+
     process.env.POSTHOG_API_KEY = " "
     const posthog = await importPostHogModule()
+    mockPostHogNode(posthog, capturedMessages)
     posthog.__setActivityStateProviderForTesting(() => ({ dayUTC: "2026-05-25", captureDaily: true }))
 
     // when

--- a/packages/omo-codex/src/telemetry/posthog.ts
+++ b/packages/omo-codex/src/telemetry/posthog.ts
@@ -42,6 +42,7 @@ type CreatePostHogClientOptions = {
 
 let osProviderOverride: TelemetryOsProvider | null = null
 let activityStateProviderOverride: ActivityStateProvider | null = null
+let transportFactoryOverride: TelemetryTransportFactory | null = null
 
 const NO_OP_POSTHOG: PostHogClient = {
   trackActive: () => undefined,
@@ -78,7 +79,7 @@ function createPostHogClient(
     osProvider: options.osProvider ?? resolveOsProvider(),
     product: createCodexTelemetryProductConfig(),
     source,
-    transportFactory: options.transportFactory,
+    transportFactory: options.transportFactory ?? transportFactoryOverride ?? undefined,
   })
 
   if (!client.enabled) {
@@ -149,4 +150,12 @@ export function __setActivityStateProviderForTesting(provider: ActivityStateProv
 
 export function __resetActivityStateProviderForTesting(): void {
   activityStateProviderOverride = null
+}
+
+export function __setTransportFactoryForTesting(factory: TelemetryTransportFactory): void {
+  transportFactoryOverride = factory
+}
+
+export function __resetTransportFactoryForTesting(): void {
+  transportFactoryOverride = null
 }


### PR DESCRIPTION
Fixes flaky telemetry tests that failed to mock posthog-node due to module cache invalidation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes telemetry tests by bypassing `posthog-node` module caching and adding a test-only transport injection, fixing Windows flakiness. Improves test determinism with temp XDG dirs and minor harness tweaks.

- **Bug Fixes**
  - Added `__setTransportFactoryForTesting`/reset in `posthog.ts` and used it in tests to simulate capture/shutdown paths instead of mocking `posthog-node`.
  - Dynamically import `./posthog` with a cache-busting query to avoid stale module state between tests.
  - Create and use temp `XDG_DATA_HOME`/`XDG_STATE_HOME` directories during tests, ensure `CACHE_DIR_NAME` exists, and clean up after.
  - Skip `node_modules` in the telemetry tree scan to prevent false positives.

<sup>Written for commit 23f9602fdf251bfbffe1cf3dfc68ad28647c2fef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

