### PR TITLE
fix(codex): emit schema-only codegraph session-start JSON

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -2002,7 +2002,7 @@ async function executeCodegraphSessionStartHook(options = {}) {
   return { action: "spawned", exitCode: 0 };
 }
 function writeHookJson(stdout, action) {
-  const output = action === "spawned" ? { hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: CODEGRAPH_SESSION_START_NOTICE }, codegraph: { action } } : { hookSpecificOutput: { hookEventName: "SessionStart" }, codegraph: { action } };
+  const output = action === "spawned" ? { hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: CODEGRAPH_SESSION_START_NOTICE } } : { hookSpecificOutput: { hookEventName: "SessionStart" } };
   stdout.write(`${JSON.stringify(output)}
 `);
 }

--- a/packages/omo-codex/plugin/components/codegraph/src/hook.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/hook.ts
@@ -62,8 +62,8 @@ export async function executeCodegraphSessionStartHook(options: SessionStartHook
 
 function writeHookJson(stdout: HookStdout, action: SessionStartAction): void {
 	const output = action === "spawned"
-		? { hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: CODEGRAPH_SESSION_START_NOTICE }, codegraph: { action } }
-		: { hookSpecificOutput: { hookEventName: "SessionStart" }, codegraph: { action } };
+		? { hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: CODEGRAPH_SESSION_START_NOTICE } }
+		: { hookSpecificOutput: { hookEventName: "SessionStart" } };
 	stdout.write(`${JSON.stringify(output)}\n`);
 }
 

--- a/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
@@ -37,12 +37,12 @@ describe("CodeGraph SessionStart hook", () => {
 			expect(exitCode).toBe(0);
 			expect(spawned).toHaveLength(1);
 			const parsed = JSON.parse(stdout.join(""));
+			expect(Object.keys(parsed)).toEqual(["hookSpecificOutput"]);
 			expect(parsed).toEqual({
 				hookSpecificOutput: {
 					hookEventName: "SessionStart",
 					additionalContext: "LazyCodex CodeGraph bootstrap scheduled in background",
 				},
-				codegraph: { action: "spawned" },
 			});
 		} finally {
 			rmSync(homeDir, { recursive: true, force: true });
@@ -68,7 +68,6 @@ describe("CodeGraph SessionStart hook", () => {
 		expect(spawned).toEqual([]);
 		expect(JSON.parse(stdout.join(""))).toEqual({
 			hookSpecificOutput: { hookEventName: "SessionStart" },
-			codegraph: { action: "skipped-disabled" },
 		});
 	});
 
@@ -97,7 +96,7 @@ describe("CodeGraph SessionStart hook", () => {
 			// then
 			expect(result).toEqual({ action: "skipped-disabled", exitCode: 0 });
 			expect(spawned).toEqual([]);
-			expect(JSON.parse(stdout.join("")).codegraph).toEqual({ action: "skipped-disabled" });
+			expect(JSON.parse(stdout.join(""))).toEqual({ hookSpecificOutput: { hookEventName: "SessionStart" } });
 		} finally {
 			rmSync(homeDir, { recursive: true, force: true });
 			rmSync(workspace, { recursive: true, force: true });
@@ -128,7 +127,7 @@ describe("CodeGraph SessionStart hook", () => {
 			// then
 			expect(result).toEqual({ action: "skipped-disabled", exitCode: 0 });
 			expect(spawned).toEqual([]);
-			expect(JSON.parse(stdout.join("")).codegraph).toEqual({ action: "skipped-disabled" });
+			expect(JSON.parse(stdout.join(""))).toEqual({ hookSpecificOutput: { hookEventName: "SessionStart" } });
 		} finally {
 			rmSync(homeDir, { recursive: true, force: true });
 			rmSync(workspace, { recursive: true, force: true });
@@ -191,7 +190,12 @@ describe("CodeGraph SessionStart hook", () => {
 					},
 				},
 			]);
-			expect(JSON.parse(stdout.join("")).codegraph).toEqual({ action: "spawned" });
+			expect(JSON.parse(stdout.join(""))).toEqual({
+				hookSpecificOutput: {
+					hookEventName: "SessionStart",
+					additionalContext: "LazyCodex CodeGraph bootstrap scheduled in background",
+				},
+			});
 		} finally {
 			rmSync(workspace, { recursive: true, force: true });
 		}
@@ -531,7 +535,7 @@ describe("CodeGraph SessionStart hook", () => {
 		// then
 		expect(result.exitCode).toBe(0);
 		expect(spawned).toEqual([]);
-		expect(JSON.parse(stdout.join("")).codegraph).toEqual({ action: "skipped-disabled" });
+		expect(JSON.parse(stdout.join(""))).toEqual({ hookSpecificOutput: { hookEventName: "SessionStart" } });
 	});
 
 	it("#given plugin hook config #when inspected #then CodeGraph is registered after bootstrap SessionStart", () => {


### PR DESCRIPTION
## Summary
Fixes the Codex CodeGraph `SessionStart` hook stdout shape so Codex receives only the schema-supported top-level `hookSpecificOutput` object. The hook still starts the detached CodeGraph bootstrap worker when enabled and still surfaces the bootstrap notice through `additionalContext`.

Codex 0.140 rejects extra top-level hook stdout metadata, so the previous `codegraph: { action }` field could make `SessionStart` fail before a turn starts. This PR removes only that non-schema metadata and tightens the focused tests around the stdout contract.

## Changes
- Remove the extra top-level `codegraph` metadata from CodeGraph `SessionStart` hook stdout.
- Keep the spawned-worker `additionalContext` notice intact.
- Update focused CodeGraph hook tests to assert the stdout object contains only `hookSpecificOutput` for spawned, disabled, config override, and malformed-input paths.
- Rebuild the shipped CodeGraph component CLI bundle.

## Verification
**RED:** `.omo/evidence/20260618-codegraph-sessionstart-json-pr/red-test.txt`
- Focused hook test failed against the old implementation because stdout included the extra top-level `codegraph` key.

**Automated GREEN:**
- `bun test test/hook.test.ts` from `packages/omo-codex/plugin/components/codegraph` -> 16 pass (`.omo/evidence/20260618-codegraph-sessionstart-json-pr/focused-green-test.txt`)
- `bun run typecheck` from `packages/omo-codex/plugin/components/codegraph` -> passed (`.omo/evidence/20260618-codegraph-sessionstart-json-pr/typecheck.txt`)
- `bun run build` from `packages/omo-codex/plugin/components/codegraph` -> passed (`.omo/evidence/20260618-codegraph-sessionstart-json-pr/component-build.txt`)
- `bun run test:codex` -> 336 pass, 0 fail (`.omo/evidence/20260618-codegraph-sessionstart-json-pr/test-codex.txt`)

**Manual QA / real surface:**
- Runtime CLI surface: `node packages/omo-codex/plugin/components/codegraph/dist/cli.js hook session-start` emitted JSON whose only top-level key is `hookSpecificOutput`, preserving the CodeGraph bootstrap notice (`.omo/evidence/20260618-codegraph-sessionstart-json-pr/runtime-cli-schema.txt`).
- Isolated Codex app-server surface: `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` passed, proved `sessionStart`, `userPromptSubmit`, and `stop` hooks fired, and confirmed real `~/.codex/config.toml` unchanged (`.omo/evidence/20260618-codegraph-sessionstart-json-pr/codex-qa-app-server-plugin.json`).
- `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check` passed (`.omo/evidence/20260618-codegraph-sessionstart-json-pr/codex-qa-common-self-check.txt`).

Cleanup receipts are included in the evidence files. No tmux/browser/container state was left running by the scoped runtime CLI check.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit schema-only JSON from the CodeGraph SessionStart hook so Codex 0.140 accepts the output. The background bootstrap still runs when enabled, and its notice is preserved via `additionalContext`.

- **Bug Fixes**
  - Removed the top-level `codegraph` metadata; stdout now only includes `hookSpecificOutput`.
  - Preserved the spawned-worker bootstrap notice in `additionalContext`.
  - Tightened hook tests to assert schema-only JSON across spawned, disabled, config-override, and malformed-input paths.
  - Rebuilt the CodeGraph component CLI bundle.

<sup>Written for commit 99d816c44c20471bff782ea6ae5e593bcfea204f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

