### PR TITLE
fix(codex): make codegraph startup hook output valid

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -1990,7 +1990,6 @@ async function executeCodegraphSessionStartHook(options = {}) {
   const homeDir = resolveHomeDir2(env);
   const config = options.config ?? getCodexOmoConfig({ cwd: projectRoot, env, homeDir });
   if (config.codegraph?.enabled === false) {
-    writeHookJson(options.stdout ?? processStdout, "skipped-disabled");
     return { action: "skipped-disabled", exitCode: 0 };
   }
   (options.spawnWorker ?? spawnDetachedWorker)({
@@ -1998,11 +1997,16 @@ async function executeCodegraphSessionStartHook(options = {}) {
     command: process.execPath,
     env: { ...env, [SESSION_START_CWD_ENV]: projectRoot }
   });
-  writeHookJson(options.stdout ?? processStdout, "spawned");
+  writeHookJson(options.stdout ?? processStdout);
   return { action: "spawned", exitCode: 0 };
 }
-function writeHookJson(stdout, action) {
-  const output = action === "spawned" ? { hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: CODEGRAPH_SESSION_START_NOTICE }, codegraph: { action } } : { hookSpecificOutput: { hookEventName: "SessionStart" }, codegraph: { action } };
+function writeHookJson(stdout) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: CODEGRAPH_SESSION_START_NOTICE
+    }
+  };
   stdout.write(`${JSON.stringify(output)}
 `);
 }

--- a/packages/omo-codex/plugin/components/codegraph/src/hook.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/hook.ts
@@ -8,7 +8,6 @@ import { getCodexOmoConfig } from "../../../shared/src/config-loader.ts";
 import { SESSION_START_CWD_ENV } from "./session-start-worker.js";
 import type {
 	HookStdout,
-	SessionStartAction,
 	SessionStartHookOptions,
 	SessionStartHookResult,
 	WorkerSpawnInvocation,
@@ -47,7 +46,6 @@ export async function executeCodegraphSessionStartHook(options: SessionStartHook
 	const config = options.config ?? getCodexOmoConfig({ cwd: projectRoot, env, homeDir });
 
 	if (config.codegraph?.enabled === false) {
-		writeHookJson(options.stdout ?? processStdout, "skipped-disabled");
 		return { action: "skipped-disabled", exitCode: 0 };
 	}
 
@@ -56,14 +54,17 @@ export async function executeCodegraphSessionStartHook(options: SessionStartHook
 		command: process.execPath,
 		env: { ...env, [SESSION_START_CWD_ENV]: projectRoot },
 	});
-	writeHookJson(options.stdout ?? processStdout, "spawned");
+	writeHookJson(options.stdout ?? processStdout);
 	return { action: "spawned", exitCode: 0 };
 }
 
-function writeHookJson(stdout: HookStdout, action: SessionStartAction): void {
-	const output = action === "spawned"
-		? { hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: CODEGRAPH_SESSION_START_NOTICE }, codegraph: { action } }
-		: { hookSpecificOutput: { hookEventName: "SessionStart" }, codegraph: { action } };
+function writeHookJson(stdout: HookStdout): void {
+	const output = {
+		hookSpecificOutput: {
+			hookEventName: "SessionStart",
+			additionalContext: CODEGRAPH_SESSION_START_NOTICE,
+		},
+	};
 	stdout.write(`${JSON.stringify(output)}\n`);
 }
 

--- a/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
@@ -42,7 +42,6 @@ describe("CodeGraph SessionStart hook", () => {
 					hookEventName: "SessionStart",
 					additionalContext: "LazyCodex CodeGraph bootstrap scheduled in background",
 				},
-				codegraph: { action: "spawned" },
 			});
 		} finally {
 			rmSync(homeDir, { recursive: true, force: true });
@@ -66,10 +65,7 @@ describe("CodeGraph SessionStart hook", () => {
 		// then
 		expect(result).toEqual({ action: "skipped-disabled", exitCode: 0 });
 		expect(spawned).toEqual([]);
-		expect(JSON.parse(stdout.join(""))).toEqual({
-			hookSpecificOutput: { hookEventName: "SessionStart" },
-			codegraph: { action: "skipped-disabled" },
-		});
+		expect(stdout.join("")).toBe("");
 	});
 
 	it("#given HOME OMO config disables Codex CodeGraph #when SessionStart fires #then it skips without spawning", async () => {
@@ -97,7 +93,7 @@ describe("CodeGraph SessionStart hook", () => {
 			// then
 			expect(result).toEqual({ action: "skipped-disabled", exitCode: 0 });
 			expect(spawned).toEqual([]);
-			expect(JSON.parse(stdout.join("")).codegraph).toEqual({ action: "skipped-disabled" });
+			expect(stdout.join("")).toBe("");
 		} finally {
 			rmSync(homeDir, { recursive: true, force: true });
 			rmSync(workspace, { recursive: true, force: true });
@@ -128,7 +124,7 @@ describe("CodeGraph SessionStart hook", () => {
 			// then
 			expect(result).toEqual({ action: "skipped-disabled", exitCode: 0 });
 			expect(spawned).toEqual([]);
-			expect(JSON.parse(stdout.join("")).codegraph).toEqual({ action: "skipped-disabled" });
+			expect(stdout.join("")).toBe("");
 		} finally {
 			rmSync(homeDir, { recursive: true, force: true });
 			rmSync(workspace, { recursive: true, force: true });
@@ -191,7 +187,12 @@ describe("CodeGraph SessionStart hook", () => {
 					},
 				},
 			]);
-			expect(JSON.parse(stdout.join("")).codegraph).toEqual({ action: "spawned" });
+			expect(JSON.parse(stdout.join(""))).toEqual({
+				hookSpecificOutput: {
+					additionalContext: "LazyCodex CodeGraph bootstrap scheduled in background",
+					hookEventName: "SessionStart",
+				},
+			});
 		} finally {
 			rmSync(workspace, { recursive: true, force: true });
 		}
@@ -514,7 +515,7 @@ describe("CodeGraph SessionStart hook", () => {
 		}
 	});
 
-	it("#given malformed hook input #when SessionStart fires #then it still emits JSON and exits zero", async () => {
+	it("#given malformed hook input with CodeGraph disabled #when SessionStart fires #then it stays silent and exits zero", async () => {
 		// given
 		const stdout: string[] = [];
 		const spawned: WorkerSpawnInvocation[] = [];
@@ -531,7 +532,7 @@ describe("CodeGraph SessionStart hook", () => {
 		// then
 		expect(result.exitCode).toBe(0);
 		expect(spawned).toEqual([]);
-		expect(JSON.parse(stdout.join("")).codegraph).toEqual({ action: "skipped-disabled" });
+		expect(stdout.join("")).toBe("");
 	});
 
 	it("#given plugin hook config #when inspected #then CodeGraph is registered after bootstrap SessionStart", () => {


### PR DESCRIPTION
## Summary

Fixes the Codex startup hook failure where the CodeGraph `SessionStart` hook could emit JSON that Codex rejects as invalid session-start output.

## Root Cause

The CodeGraph hook wrote component-private diagnostics as a top-level `codegraph` field on stdout. Codex accepts only the event-specific hook output schema for `SessionStart`, so that extra top-level field could mark the hook failed. Disabled CodeGraph paths also emitted a no-op JSON line when silence is safer.

## Changes

- Emit only `hookSpecificOutput` when the CodeGraph startup hook has a notice for Codex.
- Keep disabled/skipped CodeGraph startup paths silent.
- Regenerate the bundled CodeGraph CLI runtime.
- Tighten the CodeGraph hook regression tests around the stdout contract.

## Verification

Evidence recorded locally under `.omo/evidence/20260618-codex-sessionstart-json/`:

- RED: CodeGraph hook test failed on extra top-level `codegraph` output.
- GREEN: CodeGraph hook test passed `16/16`.
- Component suite: CodeGraph component tests passed `29/29`.
- Typecheck: `tsc --noEmit` passed.
- Codex gate: `bun run test:codex` passed `336/336`.
- Real Codex QA: isolated `codex app-server` with local mock model completed; all five `sessionStart` hooks completed and no failed hook status or invalid SessionStart JSON remained.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex session-start failures by making the CodeGraph startup hook emit valid JSON that Codex accepts. Removes the extra top-level field and keeps disabled paths silent to prevent false hook failures.

- Bug Fixes
  - Emit only hook-specific output for SessionStart; drop the extra top-level codegraph field.
  - Stay silent when CodeGraph is disabled (no stdout).
  - Regenerate the bundled CodeGraph CLI runtime and tighten stdout contract tests.

<sup>Written for commit 47af76f597178fb70d327251f1275d19c43b51db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

