### PR TITLE
fix(codex): stamp codegraph MCP path during bootstrap

### DIFF
--- a/packages/omo-codex/plugin/test/bootstrap-setup.test.mjs
+++ b/packages/omo-codex/plugin/test/bootstrap-setup.test.mjs
@@ -127,6 +127,37 @@ test("#given a completed first run #when the worker setup runs again #then confi
 	});
 });
 
+test("#given a package-relative CodeGraph MCP path #when worker setup runs #then the path is stamped absolute", async () => {
+	await withSetupFixture(async (fixture) => {
+		await writeFile(
+			join(fixture.pluginRoot, ".mcp.json"),
+			`${JSON.stringify(
+				{
+					mcpServers: {
+						codegraph: {
+							args: ["components/codegraph/dist/serve.js"],
+							command: "node",
+							cwd: ".",
+							required: false,
+						},
+						git_bash: { args: ["serve"], command: "node", env: {} },
+					},
+				},
+				null,
+				"\t",
+			)}\n`,
+		);
+
+		await runWorkerSetup(setupOptions(fixture));
+
+		const manifest = JSON.parse(await readFile(join(fixture.pluginRoot, ".mcp.json"), "utf8"));
+		assert.deepEqual(manifest.mcpServers.codegraph.args, [
+			join(fixture.pluginRoot, "components", "codegraph", "dist", "serve.js"),
+		]);
+		assert.equal(manifest.mcpServers.codegraph.cwd, ".");
+	});
+});
+
 test("#given bootstrap-managed staging #when agents are linked #then nothing is persisted under PLUGIN_ROOT", async () => {
 	await withSetupFixture(async (fixture) => {
 		await runWorkerSetup(setupOptions(fixture));

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -13230,28 +13230,42 @@ function readVersionManifest(path2) {
 import { readFile as readFile17, writeFile as writeFile10 } from "node:fs/promises";
 import { join as join30 } from "node:path";
 var GIT_BASH_ENV_KEY2 = "OMO_CODEX_GIT_BASH_PATH";
+var CODEGRAPH_RELATIVE_ARGS = new Set(["components/codegraph/dist/serve.js", "./components/codegraph/dist/serve.js"]);
 async function stampGitBashMcpEnv(input) {
-  if (input.platform !== "win32")
-    return false;
-  const rawOverride = input.env?.[GIT_BASH_ENV_KEY2];
-  const override = typeof rawOverride === "string" ? rawOverride.trim() : "";
-  if (override === "")
-    return false;
   const manifestPath = join30(input.pluginRoot, ".mcp.json");
   if (!await fileExistsStrict(manifestPath))
     return false;
   const parsed = JSON.parse(await readFile17(manifestPath, "utf8"));
   if (!isPlainRecord(parsed) || !isPlainRecord(parsed["mcpServers"]))
     return false;
-  const gitBashServer = parsed["mcpServers"]["git_bash"];
-  if (!isPlainRecord(gitBashServer))
+  let changed = stampCodegraphMcpPath(parsed["mcpServers"], input.pluginRoot);
+  if (input.platform === "win32") {
+    const rawOverride = input.env?.[GIT_BASH_ENV_KEY2];
+    const override = typeof rawOverride === "string" ? rawOverride.trim() : "";
+    const gitBashServer = parsed["mcpServers"]["git_bash"];
+    if (override !== "" && isPlainRecord(gitBashServer)) {
+      const serverEnv = isPlainRecord(gitBashServer["env"]) ? gitBashServer["env"] : {};
+      if (serverEnv[GIT_BASH_ENV_KEY2] !== override) {
+        gitBashServer["env"] = { ...serverEnv, [GIT_BASH_ENV_KEY2]: override };
+        changed = true;
+      }
+    }
+  }
+  if (!changed)
     return false;
-  const serverEnv = isPlainRecord(gitBashServer["env"]) ? gitBashServer["env"] : {};
-  if (serverEnv[GIT_BASH_ENV_KEY2] === override)
-    return false;
-  gitBashServer["env"] = { ...serverEnv, [GIT_BASH_ENV_KEY2]: override };
   await writeFile10(manifestPath, `${JSON.stringify(parsed, null, "\t")}
 `);
+  return true;
+}
+function stampCodegraphMcpPath(mcpServers, pluginRoot) {
+  const codegraphServer = mcpServers["codegraph"];
+  if (!isPlainRecord(codegraphServer) || !Array.isArray(codegraphServer["args"]))
+    return false;
+  const args = codegraphServer["args"];
+  const entrypoint = args[0];
+  if (typeof entrypoint !== "string" || !CODEGRAPH_RELATIVE_ARGS.has(entrypoint))
+    return false;
+  codegraphServer["args"] = [join30(pluginRoot, "components", "codegraph", "dist", "serve.js"), ...args.slice(1)];
   return true;
 }
 // packages/omo-codex/src/install/codex-hook-targets.ts

--- a/packages/omo-codex/scripts/install-git-bash-mcp-env.test.mjs
+++ b/packages/omo-codex/scripts/install-git-bash-mcp-env.test.mjs
@@ -62,6 +62,30 @@ test("#given a non-Windows install #when stamping #then the manifest stays byte-
 	assert.equal(await readFile(join(pluginRoot, ".mcp.json"), "utf8"), MANIFEST);
 });
 
+test("#given a package-relative CodeGraph MCP path #when stamping on non-Windows #then codegraph server arg becomes absolute", async (t) => {
+	const pluginRoot = await mkdtemp(join(tmpdir(), "git-bash-mcp-env-"));
+	t.after(() => rm(pluginRoot, { recursive: true, force: true }));
+	await writeFile(
+		join(pluginRoot, ".mcp.json"),
+		`${JSON.stringify(
+			{
+				mcpServers: {
+					codegraph: { args: ["components/codegraph/dist/serve.js"], command: "node" },
+					git_bash: { command: "node", args: ["../../git-bash-mcp/dist/cli.js", "mcp"] },
+				},
+			},
+			null,
+			"\t",
+		)}\n`,
+	);
+
+	const changed = await stampGitBashMcpEnv({ pluginRoot, env: {}, platform: "darwin" });
+
+	assert.equal(changed, true);
+	const parsed = JSON.parse(await readFile(join(pluginRoot, ".mcp.json"), "utf8"));
+	assert.deepEqual(parsed.mcpServers.codegraph.args, [join(pluginRoot, "components", "codegraph", "dist", "serve.js")]);
+});
+
 test("#given the override already stamped #when stamping again #then nothing changes", async (t) => {
 	const pluginRoot = await createPluginRoot();
 	t.after(() => rm(pluginRoot, { recursive: true, force: true }));

--- a/packages/omo-codex/src/install/codex-git-bash-mcp-env.ts
+++ b/packages/omo-codex/src/install/codex-git-bash-mcp-env.ts
@@ -4,29 +4,47 @@ import { fileExistsStrict, isPlainRecord } from "./codex-cache-fs"
 import type { CodexInstallPlatform } from "./types"
 
 const GIT_BASH_ENV_KEY = "OMO_CODEX_GIT_BASH_PATH"
+const CODEGRAPH_RELATIVE_ARGS = new Set(["components/codegraph/dist/serve.js", "./components/codegraph/dist/serve.js"])
 
 export async function stampGitBashMcpEnv(input: {
   readonly pluginRoot: string
   readonly env?: NodeJS.ProcessEnv
   readonly platform?: CodexInstallPlatform
 }): Promise<boolean> {
-  if (input.platform !== "win32") return false
-  const rawOverride = input.env?.[GIT_BASH_ENV_KEY]
-  const override = typeof rawOverride === "string" ? rawOverride.trim() : ""
-  if (override === "") return false
-
   const manifestPath = join(input.pluginRoot, ".mcp.json")
   if (!(await fileExistsStrict(manifestPath))) return false
   const parsed: unknown = JSON.parse(await readFile(manifestPath, "utf8"))
   if (!isPlainRecord(parsed) || !isPlainRecord(parsed["mcpServers"])) return false
 
-  const gitBashServer = parsed["mcpServers"]["git_bash"]
-  if (!isPlainRecord(gitBashServer)) return false
+  let changed = stampCodegraphMcpPath(parsed["mcpServers"], input.pluginRoot)
 
-  const serverEnv = isPlainRecord(gitBashServer["env"]) ? gitBashServer["env"] : {}
-  if (serverEnv[GIT_BASH_ENV_KEY] === override) return false
+  if (input.platform === "win32") {
+    const rawOverride = input.env?.[GIT_BASH_ENV_KEY]
+    const override = typeof rawOverride === "string" ? rawOverride.trim() : ""
+    const gitBashServer = parsed["mcpServers"]["git_bash"]
 
-  gitBashServer["env"] = { ...serverEnv, [GIT_BASH_ENV_KEY]: override }
+    if (override !== "" && isPlainRecord(gitBashServer)) {
+      const serverEnv = isPlainRecord(gitBashServer["env"]) ? gitBashServer["env"] : {}
+      if (serverEnv[GIT_BASH_ENV_KEY] !== override) {
+        gitBashServer["env"] = { ...serverEnv, [GIT_BASH_ENV_KEY]: override }
+        changed = true
+      }
+    }
+  }
+
+  if (!changed) return false
   await writeFile(manifestPath, `${JSON.stringify(parsed, null, "\t")}\n`)
+  return true
+}
+
+function stampCodegraphMcpPath(mcpServers: Record<string, unknown>, pluginRoot: string): boolean {
+  const codegraphServer = mcpServers["codegraph"]
+  if (!isPlainRecord(codegraphServer) || !Array.isArray(codegraphServer["args"])) return false
+
+  const args = codegraphServer["args"]
+  const entrypoint = args[0]
+  if (typeof entrypoint !== "string" || !CODEGRAPH_RELATIVE_ARGS.has(entrypoint)) return false
+
+  codegraphServer["args"] = [join(pluginRoot, "components", "codegraph", "dist", "serve.js"), ...args.slice(1)]
   return true
 }


### PR DESCRIPTION
## Summary
Fixes the CodeGraph MCP bootstrap path stamping reported in code-yeongyu/lazycodex#56. The bootstrap manifest stamping step now rewrites the known package-relative CodeGraph MCP entrypoint to an absolute path under the installed plugin root, so Codex no longer resolves it relative to the user workspace.

The existing Windows Git Bash override behavior is preserved: `git_bash.env.OMO_CODEX_GIT_BASH_PATH` is still stamped only on Windows when a non-empty override is present.

## Changes
- Stamp `mcpServers.codegraph.args[0]` from `components/codegraph/dist/serve.js` or `./components/codegraph/dist/serve.js` to `${pluginRoot}/components/codegraph/dist/serve.js`.
- Keep the existing Git Bash MCP env stamping behavior and idempotent no-change return value.
- Add installer-helper and bootstrap-worker regression coverage for package-relative CodeGraph MCP paths.
- Regenerate the Codex installer bundle used by the published local installer path.

## Verification
**RED:** `node --test packages/omo-codex/scripts/install-git-bash-mcp-env.test.mjs` failed before the fix on the new CodeGraph path test with `false !== true`.

**Automated:**
- `node --test packages/omo-codex/scripts/install-git-bash-mcp-env.test.mjs` passed: 6/6.
- `node --test packages/omo-codex/plugin/test/bootstrap-setup.test.mjs` passed: 11/11.
- `node --check packages/omo-codex/scripts/install-dist/install-local.mjs` passed.
- `node --check packages/omo-codex/plugin/components/bootstrap/dist/cli.js` passed after local build.
- `bun run test:codex` passed: 337/337.

**Manual QA / real surface:**
- Isolated temp plugin root with package-relative CodeGraph MCP arg was passed through the real bootstrap setup path. Observed `stampedArg` absolute and under plugin root; launching `node <stampedArg>` from a different cwd exited 0 with `moduleNotFound: false`; temp root cleanup confirmed.
- `bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test` passed with isolated `CODEX_HOME`; real `~/.codex/config.toml` unchanged.
- `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` passed: real Codex app-server turn completed and plugin hooks fired for `sessionStart`, `userPromptSubmit`, and `stop`; real `~/.codex/config.toml` unchanged.

Evidence is also mirrored locally under `.omo/evidence/20260618-lazycodex-issues/issue-56/`.

Fixes code-yeongyu/lazycodex#56


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CodeGraph MCP bootstrap path resolution by rewriting package-relative entrypoints to an absolute path under the plugin root. Prevents Codex from resolving CodeGraph relative to the user workspace. Fixes code-yeongyu/lazycodex#56.

- **Bug Fixes**
  - Stamp `mcpServers.codegraph.args[0]` from `components/codegraph/dist/serve.js` or `./components/codegraph/dist/serve.js` to `${pluginRoot}/components/codegraph/dist/serve.js` during bootstrap.
  - Preserve Windows-only stamping of `git_bash.env.OMO_CODEX_GIT_BASH_PATH` when a non-empty override is present; no-op otherwise.
  - Add regression tests for installer-helper and bootstrap worker; regenerate the local installer bundle.

<sup>Written for commit cb36172f3cc51f07316cb8d7c6268f85e520e740. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

