### PR TITLE
fix(agents): route gpt-5.3-codex as native Sisyphus

### DIFF
--- a/packages/omo-opencode/src/agents/types.test.ts
+++ b/packages/omo-opencode/src/agents/types.test.ts
@@ -22,6 +22,7 @@ describe("isGptNativeSisyphusModel", () => {
   test("allows with various providers and suffixes", () => {
     expect(isGptNativeSisyphusModel("github-copilot/gpt-5.4")).toBe(true);
     expect(isGptNativeSisyphusModel("venice/gpt-5-4")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.3-codex")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.4-codex")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.5-mini")).toBe(true);
   });

--- a/packages/omo-opencode/src/agents/types.ts
+++ b/packages/omo-opencode/src/agents/types.ts
@@ -119,7 +119,7 @@ function extractModelName(model: string): string {
   return model.includes("/") ? (model.split("/").pop() ?? model) : model;
 }
 
-const GPT_NATIVE_SISYPHUS_RE = /gpt-5[.-](?:[4-9]|\d{2,})/i;
+const GPT_NATIVE_SISYPHUS_RE = /gpt-5[.-](?:(?:3[.-])?codex|[4-9]|\d{2,})/i;
 
 export function isGptNativeSisyphusModel(model: string): boolean {
   const modelName = extractModelName(model).toLowerCase();


### PR DESCRIPTION
## Summary
Fixes a release-blocking regression where `openai/gpt-5.3-codex` was not treated as a GPT-native Sisyphus model, so it missed the GPT-native prompt path and reasoning-effort behavior.

The matcher now allows the special `gpt-5.3-codex` family while still rejecting ordinary `gpt-5.0`, `gpt-5.1`, and `gpt-5.3` models.

## Changes
- Adds a regression assertion for `openai/gpt-5.3-codex` in `isGptNativeSisyphusModel`.
- Updates the GPT-native Sisyphus regex to include `gpt-5.3-codex` and existing `gpt-5.4+` variants.

## Verification
**Automated**
- `bun test packages/omo-opencode/src/agents/types.test.ts packages/omo-opencode/src/agents/sisyphus-agent-factory.test.ts` - 36 pass
- `bun test packages/model-core/src/model-availability.test.ts packages/omo-opencode/src/hooks/keyword-detector/ultrawork/ultrawork-source-routing.test.ts` - 4 pass
- `bun run typecheck:packages` - pass
- `git diff --check` - pass

**Manual QA / Evidence**
- Red test evidence: `.omo/evidence/20260618-gpt53-codex-sisyphus/red-types-test.txt`
- Green agent tests: `.omo/evidence/20260618-gpt53-codex-sisyphus/green-agent-tests.txt`
- Related routing tests: `.omo/evidence/20260618-gpt53-codex-sisyphus/green-related-tests.txt`
- tmux routing proof: `.omo/evidence/20260618-gpt53-codex-sisyphus/tmux-qa-agent-routing.txt`
- OpenCode TUI smoke: `.omo/evidence/20260618-gpt53-codex-sisyphus/opencode-qa-tui-smoke.txt` (`real DB untouched`, session count unchanged)
- Typecheck output: `.omo/evidence/20260618-gpt53-codex-sisyphus/typecheck-packages.txt`

## Related Issues
- Fixes #5368


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `openai/gpt-5.3-codex` through the GPT-native Sisyphus path to restore native prompts and reasoning-effort. Keeps rejection of plain `gpt-5.0/5.1/5.3`.

- **Bug Fixes**
  - Expanded GPT-native Sisyphus regex to include `gpt-5.3-codex` alongside existing `gpt-5.4+` variants.
  - Added a unit test to assert `openai/gpt-5.3-codex` is allowed.

<sup>Written for commit a83ae1306d815771c6c9d41457798c13a27b888b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

