### PR TITLE
fix(programming-skill): restore hard LOC gate

### DIFF
--- a/packages/shared-skills/skills/programming/SKILL.md
+++ b/packages/shared-skills/skills/programming/SKILL.md
@@ -184,7 +184,7 @@ A `tsconfig.json` with `"strict": true` alone is **not** strict. The reference e
 
 ## CODE SMELLS — AUTOMATIC REVIEW TRIGGERS
 
-**A code smell is not a hard block — it is a signal that your design NEEDS a second look.** When any smell below fires, STOP. Re-examine the code. Decide whether `/refactor` is warranted. Either fix the smell or justify carrying it with a SPECIFIC reason — "it's fine" is not a justification.
+Most smells below are design review triggers: STOP, re-examine the code, and either fix the smell or justify carrying it with a SPECIFIC reason. **The 250 pure LOC ceiling is stricter: >250 is a DEFECT. Refactor before adding lines except for rare SIZE_OK or pure-data-table exceptions.**
 
 Full rationale, measurement methods, workaround detection, and split examples: **[`references/code-smells.md`](references/code-smells.md)**.
 
@@ -243,7 +243,7 @@ bun run scripts/typescript/check-no-excuse-rules.ts <changed paths>
 |---|---|---|
 | ≤ 200 | Healthy | continue |
 | 200 - 250 | **Warning band** | State that fact and propose a split if the next edit will add lines. |
-| > 250 | **Code smell detected** | Re-examine the file. Load `/refactor` if splitting is warranted. Justify with a SPECIFIC reason if carrying the smell. |
+| > 250 | **DEFECT** | Do NOT commit new lines to this file. Refactor now: split the touched unit before adding lines, except for rare SIZE_OK or pure-data-table exceptions. |
 
 ### Step 3 — architectural self-review (always, even at 80 LOC)
 


### PR DESCRIPTION
## Summary
Restores the release-blocking hard 250 pure LOC policy in the shared `programming` skill's main `SKILL.md` body.

The previous release diff moved detailed guidance into `references/code-smells.md` but left the main skill saying smells were "not a hard block" and downgraded `> 250` to a generic code smell. This PR keeps the broader smell review language for other smells while making the 250 pure LOC gate visible and unambiguous in the main skill.

## Changes
- Removes the softened "not a hard block" wording from the main code-smells section.
- Restores `> 250` in the post-write review table to `DEFECT` with `Do NOT commit` / `Refactor now` semantics.
- Leaves `packages/shared-skills/skills/programming/references/code-smells.md` unchanged because it already preserved the hard-gate behavior.

## Verification
Evidence directory in the isolated worktree: `.omo/evidence/20260618-programming-skill-loc-policy/`

RED evidence captured before editing:
- `.omo/evidence/20260618-programming-skill-loc-policy/red-review-report.txt`
- `.omo/evidence/20260618-programming-skill-loc-policy/red-current-policy-mismatch.txt`
- `.omo/evidence/20260618-programming-skill-loc-policy/red-release-diff.txt`

Commands run:
- `git diff --check` PASS (`verify-git-diff-check.txt`)
- Targeted policy text check PASS: no `not a hard block` remains in the CODE SMELLS section; `> 250` row is `DEFECT` and says `Refactor now` (`verify-policy-text-checks.txt`)
- `bun test packages/omo-opencode/src/shared-skills-package.test.ts` PASS after workspace dependency install: 2 pass, 0 fail (`verify-shared-skills-package-test-after-install.txt`)
- `git diff --check HEAD~1..HEAD` PASS (`post-commit-verify.txt`)

Note: first attempt to run the shared-skills package test before `bun install` failed with missing workspace module `@oh-my-opencode/rules-engine`; retained as `verify-shared-skills-package-test.txt`. After `bun install`, the same test passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the hard 250 pure LOC gate in the `programming` skill’s `SKILL.md`, making >250 a release-blocking DEFECT with “Refactor now” guidance. Removes the “not a hard block” smell language while keeping detailed guidance in `references/code-smells.md`.

<sup>Written for commit 86ed9ebd5be6f90c3072de52169f8cf342ef6eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

