### PR TITLE
fix(codex): preserve marketplace auto-update boundary

### DIFF
--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -22,8 +22,10 @@ const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_RETRY_INTERVAL_MS = 30 * 60 * 1_000;
 const DEFAULT_UPDATE_COMMAND = "npx";
 const DEFAULT_UPDATE_ARGS = ["--yes", "lazycodex-ai@latest", "install", "--no-tui", "--codex-autonomous"];
+const MARKETPLACE_FLOW_NOTICE =
+	"[LazyCodex] Auto-update skipped: this LazyCodex install is managed by the Codex plugin marketplace, so the npx self-update was not started. Tell the user to upgrade with `codex plugin marketplace upgrade sisyphuslabs`, and that Codex will require hook re-approval after the upgrade.";
 
-export function resolveAutoUpdatePlan({ env = process.env, now = Date.now(), lastCheckedAt, lastAttemptedAt, lastStatus } = {}) {
+export function resolveAutoUpdatePlan({ env = process.env, now = Date.now(), lastCheckedAt, lastAttemptedAt, lastStatus, installFlow } = {}) {
 	if (env.LAZYCODEX_AUTO_UPDATE_DISABLED === "1" || env.OMO_CODEX_AUTO_UPDATE_DISABLED === "1") {
 		return { shouldRun: false, reason: "disabled" };
 	}
@@ -37,6 +39,9 @@ export function resolveAutoUpdatePlan({ env = process.env, now = Date.now(), las
 	if (!successStatus && typeof lastAttemptedAt === "number" && retryIntervalMs > 0 && now - lastAttemptedAt < retryIntervalMs) {
 		return { shouldRun: false, reason: "retry-throttled" };
 	}
+
+	const flow = installFlow ?? detectAutoUpdateInstallFlow(env).flow;
+	if (flow === "marketplace") return { shouldRun: false, reason: "marketplace-flow" };
 
 	const currentVersion = resolveCurrentVersion(env);
 	const latestVersion = resolveLatestVersion(env);
@@ -111,8 +116,15 @@ export async function runAutoUpdateCheck({ env = process.env, now = Date.now() }
 		lastCheckedAt: state.lastCheckedAt,
 		lastAttemptedAt: state.lastAttemptedAt,
 		lastStatus: state.lastStatus,
+		installFlow: installFlow.flow,
 	});
 	if (!plan.shouldRun) {
+		if (plan.reason === "marketplace-flow") {
+			await appendUpdateLog(env, now, "skipped", { kind: "marketplace-flow" });
+			await writeState(statePath, { ...state, lastCheckedAt: now, lastStatus: "success" });
+			notices.push(MARKETPLACE_FLOW_NOTICE);
+			return { started: false, reason: plan.reason, notices };
+		}
 		await appendUpdateLog(env, now, "skipped", { reason: plan.reason });
 		if (plan.reason === "up-to-date") {
 			await writeState(statePath, { ...state, lastCheckedAt: now, lastStatus: "success" });

--- a/packages/omo-codex/plugin/test/auto-update.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update.test.mjs
@@ -302,41 +302,29 @@ function marketplaceCheckEnv(root, pluginRoot, spawnLogPath, extra = {}) {
 	});
 }
 
-test("#given marketplace plugin root without install snapshot #when running check #then runs the same auto-update flow", async () => {
+test("#given marketplace plugin root without install snapshot #when running check #then skips npx update with marketplace-flow log and upgrade notice", async () => {
 	const { root, pluginRoot } = await makeStorePluginRoot("lazycodex-auto-update-marketplace-");
 	const spawnLogPath = join(root, "spawn.log");
 	const env = marketplaceCheckEnv(root, pluginRoot, spawnLogPath);
 
 	const result = await runAutoUpdateCheck({ env, now: 123_456 });
 
-	assert.equal(result.started, true);
-	assert.equal(result.status, 0);
+	assert.equal(result.started, false);
+	assert.equal(result.reason, "marketplace-flow");
 	assert.equal(result.notices.length, 1);
-	assert.match(result.notices[0], /Auto-update started in the background/);
-	assert.doesNotMatch(result.notices[0], /marketplace upgrade/);
-	assert.equal(await readFile(spawnLogPath, "utf8"), "ok");
+	assert.match(result.notices[0], /codex plugin marketplace upgrade sisyphuslabs/);
+	assert.match(result.notices[0], /hook re-approval/);
+	await assert.rejects(readFile(spawnLogPath, "utf8"), { code: "ENOENT" });
 	const state = JSON.parse(await readFile(env.LAZYCODEX_AUTO_UPDATE_STATE_PATH, "utf8"));
 	assert.equal(state.lastCheckedAt, 123_456);
 	assert.equal(state.lastStatus, "success");
+	assert.notEqual(state.lastStatus, "started");
 	const logEntries = (await readFile(env.LAZYCODEX_AUTO_UPDATE_LOG_PATH, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
 	assert.deepEqual(logEntries, [
 		{
 			timestamp: "1970-01-01T00:02:03.456Z",
-			event: "started",
-			command: process.execPath,
-			args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(spawnLogPath)}, "ok")`],
-		},
-		{
-			timestamp: "1970-01-01T00:02:03.456Z",
-			event: "finished",
-			status: 0,
-		},
-		{
-			timestamp: "1970-01-01T00:02:03.456Z",
-			event: "notified",
-			kind: "update-started",
-			fromVersion: "1.0.0",
-			toVersion: "1.0.1",
+			event: "skipped",
+			kind: "marketplace-flow",
 		},
 	]);
 });
@@ -367,7 +355,7 @@ test("#given marketplace skip already recorded #when next session is within inte
 	const first = await runAutoUpdateCheck({ env, now: 123_456 });
 	const second = await runAutoUpdateCheck({ env, now: 123_457 });
 
-	assert.equal(first.started, true);
+	assert.equal(first.reason, "marketplace-flow");
 	assert.equal(first.notices.length, 1);
 	assert.equal(second.started, false);
 	assert.equal(second.reason, "throttled");


### PR DESCRIPTION
## Summary
Restores the release-blocking trust boundary for marketplace-managed LazyCodex installs. Marketplace installs must not self-update through `npx lazycodex-ai@latest install` from a SessionStart background hook, because marketplace upgrades are the path that preserves Codex's hook re-approval ceremony.

## Changes
- Restores marketplace install-flow gating in the auto-update plan.
- Restores the marketplace upgrade notice telling users to run `codex plugin marketplace upgrade sisyphuslabs`.
- Pins tests so marketplace roots skip npm self-update, do not spawn the updater, log `marketplace-flow`, and throttle repeated notices.

## Verification
- `node --test packages/omo-codex/plugin/test/auto-update.test.mjs` - 24 pass
- `git diff --check` - pass
- Text evidence confirms `marketplace-flow`, marketplace upgrade notice, and hook re-approval wording.

Evidence directory: `.omo/evidence/20260618-codex-marketplace-auto-update/`

## Release Gate
Addresses Codex release-gate blocker: marketplace auto-update bypassed marketplace upgrade/re-approval flow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the marketplace trust boundary for LazyCodex auto-updates by blocking self-updates on marketplace-managed installs. Users are guided to upgrade via the Codex marketplace so hook re-approval is preserved.

- **Bug Fixes**
  - Detect marketplace installs and skip `npx --yes lazycodex-ai@latest install`, returning `marketplace-flow`.
  - Add notice prompting `codex plugin marketplace upgrade sisyphuslabs` and clarifying hook re-approval; throttle repeated notices.
  - Log a `marketplace-flow` skip and mark state as success without spawning the updater.
  - Update tests to expect skip behavior, notice content, and no `npx` spawn.

<sup>Written for commit d11ac81f7dd761acefce7f31d81335fad86ba83a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

