### PR TITLE
fix(codex): normalize codegraph mcp path before bootstrap

### DIFF
--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -6979,6 +6979,7 @@ async function collectPackageJsonPaths(directory, root, paths) {
 // packages/omo-codex/src/install/codex-cache-mcp-manifest.ts
 import { readFile as readFile5, writeFile as writeFile3 } from "node:fs/promises";
 import { join as join7, sep as sep3 } from "node:path";
+var CODEGRAPH_RELATIVE_ARGS = new Set(["components/codegraph/dist/serve.js", "./components/codegraph/dist/serve.js"]);
 async function rewriteCachedMcpManifest(pluginRoot, sourceRoot = pluginRoot) {
   const manifestPath = join7(pluginRoot, ".mcp.json");
   if (!await fileExistsStrict(manifestPath))
@@ -7004,6 +7005,8 @@ async function rewriteCachedMcpManifest(pluginRoot, sourceRoot = pluginRoot) {
       const bundledMcpRuntimeArg = resolveBundledMcpRuntimeArg(pluginRoot, arg);
       if (bundledMcpRuntimeArg !== null)
         return bundledMcpRuntimeArg;
+      if (CODEGRAPH_RELATIVE_ARGS.has(arg))
+        return join7(pluginRoot, "components", "codegraph", "dist", "serve.js");
       if (arg.startsWith("./") || arg.startsWith("../"))
         return resolveCachedRuntimePath(pluginRoot, sourceRoot, arg);
       return arg;
@@ -13230,7 +13233,7 @@ function readVersionManifest(path2) {
 import { readFile as readFile17, writeFile as writeFile10 } from "node:fs/promises";
 import { join as join30 } from "node:path";
 var GIT_BASH_ENV_KEY2 = "OMO_CODEX_GIT_BASH_PATH";
-var CODEGRAPH_RELATIVE_ARGS = new Set(["components/codegraph/dist/serve.js", "./components/codegraph/dist/serve.js"]);
+var CODEGRAPH_RELATIVE_ARGS2 = new Set(["components/codegraph/dist/serve.js", "./components/codegraph/dist/serve.js"]);
 async function stampGitBashMcpEnv(input) {
   const manifestPath = join30(input.pluginRoot, ".mcp.json");
   if (!await fileExistsStrict(manifestPath))
@@ -13263,7 +13266,7 @@ function stampCodegraphMcpPath(mcpServers, pluginRoot) {
     return false;
   const args = codegraphServer["args"];
   const entrypoint = args[0];
-  if (typeof entrypoint !== "string" || !CODEGRAPH_RELATIVE_ARGS.has(entrypoint))
+  if (typeof entrypoint !== "string" || !CODEGRAPH_RELATIVE_ARGS2.has(entrypoint))
     return false;
   codegraphServer["args"] = [join30(pluginRoot, "components", "codegraph", "dist", "serve.js"), ...args.slice(1)];
   return true;

--- a/packages/omo-codex/scripts/install-mcp-runtime.test.mjs
+++ b/packages/omo-codex/scripts/install-mcp-runtime.test.mjs
@@ -104,6 +104,42 @@ test("#given plugin-local MCP runtime #when installing cached plugin #then manif
 	assert.deepEqual(cachedMcp.mcpServers.omo.args, [join(result.path, "dist", "cli.js")]);
 });
 
+test("#given CodeGraph MCP runtime in plugin cache #when installing cached plugin #then manifest points at cached plugin before bootstrap", async () => {
+	const repoRoot = await makeTempDir();
+	const codexHome = await makeTempDir();
+	const sourceRoot = join(repoRoot, "packages", "omo-codex", "plugin");
+
+	await writeJson(join(sourceRoot, "package.json"), {
+		name: "@example/omo",
+		version: "0.1.0",
+	});
+	await writeJson(join(sourceRoot, ".mcp.json"), {
+		mcpServers: {
+			codegraph: {
+				command: "node",
+				args: ["components/codegraph/dist/serve.js"],
+				cwd: ".",
+				required: false,
+			},
+		},
+	});
+	await writeJson(join(sourceRoot, "components", "codegraph", "dist", "serve.js"), { executable: true });
+
+	const result = await installCachedPlugin({
+		codexHome,
+		marketplaceName: "sisyphuslabs",
+		name: "omo",
+		runCommand: async () => {},
+		sourcePath: sourceRoot,
+		version: "0.1.0",
+	});
+
+	const cachedMcp = JSON.parse(await readFile(join(result.path, ".mcp.json"), "utf8"));
+
+	assert.deepEqual(cachedMcp.mcpServers.codegraph.args, [join(result.path, "components", "codegraph", "dist", "serve.js")]);
+	assert.equal(Object.hasOwn(cachedMcp.mcpServers.codegraph, "cwd"), false);
+});
+
 test("#given external MCP package not in the generated bundled runtime set #when installing cached plugin #then manifest args point at source", async () => {
 	const repoRoot = await makeTempDir();
 	const codexHome = await makeTempDir();

--- a/packages/omo-codex/src/install/codex-cache-mcp-manifest.ts
+++ b/packages/omo-codex/src/install/codex-cache-mcp-manifest.ts
@@ -4,6 +4,8 @@ import { resolveBundledMcpRuntimeArg } from "./codex-cache-bundled-mcps"
 import { fileExistsStrict, isPlainRecord } from "./codex-cache-fs"
 import { resolveCachedRuntimePath } from "./codex-cache-paths"
 
+const CODEGRAPH_RELATIVE_ARGS = new Set(["components/codegraph/dist/serve.js", "./components/codegraph/dist/serve.js"])
+
 export async function rewriteCachedMcpManifest(pluginRoot: string, sourceRoot = pluginRoot): Promise<void> {
   const manifestPath = join(pluginRoot, ".mcp.json")
   if (!(await fileExistsStrict(manifestPath))) return
@@ -23,6 +25,7 @@ export async function rewriteCachedMcpManifest(pluginRoot: string, sourceRoot = 
       if (typeof arg !== "string") return arg
       const bundledMcpRuntimeArg = resolveBundledMcpRuntimeArg(pluginRoot, arg)
       if (bundledMcpRuntimeArg !== null) return bundledMcpRuntimeArg
+      if (CODEGRAPH_RELATIVE_ARGS.has(arg)) return join(pluginRoot, "components", "codegraph", "dist", "serve.js")
       if (arg.startsWith("./") || arg.startsWith("../")) return resolveCachedRuntimePath(pluginRoot, sourceRoot, arg)
       return arg
     })

--- a/packages/omo-codex/src/install/codex-cache.test.ts
+++ b/packages/omo-codex/src/install/codex-cache.test.ts
@@ -28,6 +28,34 @@ describe("codex-cache", () => {
     expect(rewritten.mcpServers.lsp.args[0]).toBe(join(root, "./components/lsp/dist/cli.js"))
   })
 
+  test("#given cached CodeGraph manifest uses bare package-relative entrypoint #when rewriting before bootstrap #then entrypoint becomes absolute under plugin root", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-codegraph-"))
+    await writeFile(
+      join(root, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          codegraph: {
+            command: "node",
+            args: ["components/codegraph/dist/serve.js"],
+            cwd: ".",
+            required: false,
+          },
+        },
+      }),
+    )
+
+    // when
+    await rewriteCachedMcpManifest(root)
+
+    // then
+    const rewritten = JSON.parse(await readFile(join(root, ".mcp.json"), "utf8")) as {
+      mcpServers: { codegraph: { cwd?: string; args: string[] } }
+    }
+    expect(rewritten.mcpServers.codegraph.cwd).toBeUndefined()
+    expect(rewritten.mcpServers.codegraph.args).toEqual([join(root, "components", "codegraph", "dist", "serve.js")])
+  })
+
   test("rewrites bundled mcp manifest args that point outside the plugin cache into bundled cache paths", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-"))


### PR DESCRIPTION
## Summary
Fixes the release-blocking CodeGraph MCP path regression by normalizing bare package-relative CodeGraph entrypoints during cached plugin install, before bootstrap or the first live Codex session can load MCP config.

## Changes
- Rewrites `components/codegraph/dist/serve.js` and `./components/codegraph/dist/serve.js` to an absolute path under the plugin cache in `rewriteCachedMcpManifest`.
- Adds install/cache tests proving the CodeGraph entrypoint is absolute and `cwd` is removed before bootstrap.
- Updates the generated local installer bundle so published install paths match source.

## Verification
- `bun test packages/omo-codex/src/install/codex-cache.test.ts` - 17 pass
- `node --test packages/omo-codex/scripts/install-git-bash-mcp-env.test.mjs` - 6 pass
- `node --test packages/omo-codex/scripts/install-mcp-runtime.test.mjs` - 5 pass
- `git diff --check` - pass
- Text evidence confirms CodeGraph bare-relative args are handled in the cache manifest rewrite path.

Evidence directory: `.omo/evidence/20260618-codex-codegraph-mcp-prebootstrap/`

## Release Gate
Addresses Codex release-gate blocker: CodeGraph MCP path normalization was happening after install/bootstrap, leaving a first-session stale manifest window.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes the CodeGraph MCP entrypoint during cached plugin install so the pre-bootstrap manifest uses an absolute path and no cwd. Fixes the first-session stale manifest regression.

- **Bug Fixes**
  - Rewrites bare `components/codegraph/dist/serve.js` and `./components/codegraph/dist/serve.js` args to an absolute path under the plugin cache in `rewriteCachedMcpManifest`.
  - Removes `cwd` from the CodeGraph server in the cached `.mcp.json`.
  - Updates the local installer bundle to keep published paths aligned with source and adds tests covering manifest rewrite and install-time behavior.

<sup>Written for commit 72fda247eaeaee0373572dd56f3aa0bc84b2f590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

