### PR TITLE
release: v4.11.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,18 +53,18 @@
         "typescript": "^6.0.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.11.0",
-        "oh-my-opencode-darwin-x64": "4.11.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.11.0",
-        "oh-my-opencode-linux-arm64": "4.11.0",
-        "oh-my-opencode-linux-arm64-musl": "4.11.0",
-        "oh-my-opencode-linux-x64": "4.11.0",
-        "oh-my-opencode-linux-x64-baseline": "4.11.0",
-        "oh-my-opencode-linux-x64-musl": "4.11.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.11.0",
-        "oh-my-opencode-windows-arm64": "4.11.0",
-        "oh-my-opencode-windows-x64": "4.11.0",
-        "oh-my-opencode-windows-x64-baseline": "4.11.0",
+        "oh-my-opencode-darwin-arm64": "4.11.1",
+        "oh-my-opencode-darwin-x64": "4.11.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.11.1",
+        "oh-my-opencode-linux-arm64": "4.11.1",
+        "oh-my-opencode-linux-arm64-musl": "4.11.1",
+        "oh-my-opencode-linux-x64": "4.11.1",
+        "oh-my-opencode-linux-x64-baseline": "4.11.1",
+        "oh-my-opencode-linux-x64-musl": "4.11.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.11.1",
+        "oh-my-opencode-windows-arm64": "4.11.1",
+        "oh-my-opencode-windows-x64": "4.11.1",
+        "oh-my-opencode-windows-x64-baseline": "4.11.1",
       },
     },
     "packages/agents-md-core": {
@@ -154,7 +154,7 @@
     },
     "packages/omo-codex": {
       "name": "@oh-my-opencode/omo-codex",
-      "version": "4.11.0",
+      "version": "4.11.1",
       "dependencies": {
         "@oh-my-opencode/utils": "workspace:*",
       },
@@ -683,29 +683,29 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.11.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-FiTdlGzsQZdxYcI1XJAPsXtf1VBwB0IwX9MZHgIlydtwK7v1cC49UXKf5s0lQJcIIfkAKQMzg520EtmUJcfQyA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.11.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ol+/1A0yO/Y7Kd7Z1i6ZHUdnexerCV1CqPTpbj9FTz3m4aJ4c3/J2srjtcMV50E6Xbob/gAkNHqJNxT7HBlPYQ=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.11.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-PeKNAuCftCbkdfEvqSviD9IBd/NZrHy6NvpVwILTkRpuaTyFltc2iV5XsE3ibEEUHUbVkzNFNEJj5XRi3ppzrw=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.11.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-ezXSdHtvBPyz8HU2CecfWQeR7BBAUEfGBRuP4e5kmm/98G9Cfk8wAyTOpUI6DUwavzkIxxQzPgdeMvSr8PSrwA=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.11.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-F8bp8L84+mm1Cx2gjReMbJ6bUb0EXED4wtWeQkXYsPoB55yNaP77aLba2AUeOCFWrUgd1hsl44MDXKdEbQyNYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.11.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-cwsZYnJvTDEuGux+rEA+xUuA1yAx70hLcY3Mjl0uQacLg5K+bpWHaqbtYs2AiQqSocy1S/NgnH91i+tGxxdEQw=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.11.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0SSijE6ZT4gUlc82ZiEzUvBgor+7dcA95EKGaKv/e52D7YiEfE9oY+Tr0KirWKYKVLi7IQl5wbmK/CcFC1nAyQ=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-pBtVlvndAQDq0rdFbQ2CPQOJtcTQ//aVHtxXZmj3+LdDXCS6pmNuMUnstG0E4+ODDF32G14TA2uN+CCNkbzEjA=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.11.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-OboeaV/kCvSrNUhLrk5qRuc10bm2lSWcBj5MPl0Cwc1np69E35JYfoEH4FnZCd6UzV8NbZhOqMbWTEzeDOkdAg=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-fp8ou2Lym3tMGyAstEQ3H8tbrYAy4D+EqxbhHzW7+YhzKjIitdWclByFBBtEi1YVwMr9V0heyTaBKAwHRHXHfw=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-cjPAz2Mln3w/jf38PeD2JLpR/ll7eK7QQC0aNWKa84PwuJoa5m+L9szAog85nPcmxXDM63zm+Kygq/FmQuEZlw=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-8EKN6WgSA7hvKdCXeFM9sSIguegWaWpg5NNeLB0xzEejXHNgUi+vjaaGq3IsO6W/CJ6IZ/w0itV5sH/tPmzfyg=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MFLS3SarQluhZkiRjBX1xzVXZlknu7oJeM1u+yA508/k+8dwiT0mib39HCeMGnNxaDKFvQ3cjNP9lHgCAGwGlA=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-zY1E/SFwgCo+rNnMoPHlWzAn8MeBpulKjzraC76D51mecY7D5kNk8WIbwsvHaWLjs1K+o193eRVD2Hj9vuqp2A=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-PFduNtyxBI4FXwaR9LE4fgtdqt4+b737mDsUej2ACPIsa25yYtbraD2ImpF5h3yI42JFKKoWhig5GlrOhzM7wQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-JBbexeaI9wp0ccj97HdGHTUCxtAK+iurYGOFy3/l01wuHTBwrESnQI6nkVoJbjrql3XBo0jqjypHQk/pyV2VJQ=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1kMo0fFjkouRBKCNogdr8j3gd3qg7xsgOOIAE5AldW4CtS8TbrJb/yRgvhw9me33emIVQOFuQlSFutOt2FcQVg=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-CtyKGXEyyDMUSzzbG5++MWRSYghxFZGpaMDdSE6TxHz1Pt4boFIq1J2AnKuLVXqM3XwBms2UMoxbK+wDK/LX+A=="],
 
-    "oh-my-opencode-windows-arm64": ["oh-my-opencode-windows-arm64@4.11.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-KQLHvDA0VJjgZ690Eo5D/K0qvkFVK6Iga4mAF0aP2jN3Xme9RY4IB4SGw6kvmNSXDabMnH32jvO+P6wveaoGBw=="],
+    "oh-my-opencode-windows-arm64": ["oh-my-opencode-windows-arm64@4.11.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-8eYNfESwPyYWzI+4LFsVE/gm1XB3FyrhjYWwqxHKO431M8YJ7h97bwiktJXVDO//i93j9SA4QKDG9/gybz/bEg=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.11.0", "", { "os": "win32", "cpu": "x64" }, "sha512-UzFeqQd52Cv06wQcHrJ9v96tN+6WToZiBmsq1FNNwBXPPDVJDmh5grUpFVMPbtoBoe3dOjfGXwtJUW1CLtjdMQ=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-zNQtyGnlZPU2GemNGGM0DQUL6/sTkJRq9Xf3ugARVXpLBEMvxMQsKnJt1Mg6bIF4GgTKngzf6Mt25lgE9qwZRQ=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.11.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5q47VBEk+Tjpry5Cs2JjEwJt5sgqXDdKZaySC3+PxcvR30vh7yAY2hxX0AZRtuWOABQUuNV0N3Dpj2Sxn76ZmA=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-YDfTnUvLlTEkL23HLm++DAzCjoKgrzp0RV8eoM5tcQc+9doeIYI8xRc+3/L8dte9zdO6BNCEdfMSFw2ZdmEzSg=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "The Best AI Agent Harness - Batteries-Included OpenCode Plugin with Multi-Model Orchestration, Parallel Background Agents, and Crafted LSP/AST Tools",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -170,18 +170,18 @@
     "typescript": "^6.0.3"
   },
   "optionalDependencies": {
-    "oh-my-opencode-darwin-arm64": "4.11.0",
-    "oh-my-opencode-darwin-x64": "4.11.0",
-    "oh-my-opencode-darwin-x64-baseline": "4.11.0",
-    "oh-my-opencode-linux-arm64": "4.11.0",
-    "oh-my-opencode-linux-arm64-musl": "4.11.0",
-    "oh-my-opencode-linux-x64": "4.11.0",
-    "oh-my-opencode-linux-x64-baseline": "4.11.0",
-    "oh-my-opencode-linux-x64-musl": "4.11.0",
-    "oh-my-opencode-linux-x64-musl-baseline": "4.11.0",
-    "oh-my-opencode-windows-arm64": "4.11.0",
-    "oh-my-opencode-windows-x64": "4.11.0",
-    "oh-my-opencode-windows-x64-baseline": "4.11.0"
+    "oh-my-opencode-darwin-arm64": "4.11.1",
+    "oh-my-opencode-darwin-x64": "4.11.1",
+    "oh-my-opencode-darwin-x64-baseline": "4.11.1",
+    "oh-my-opencode-linux-arm64": "4.11.1",
+    "oh-my-opencode-linux-arm64-musl": "4.11.1",
+    "oh-my-opencode-linux-x64": "4.11.1",
+    "oh-my-opencode-linux-x64-baseline": "4.11.1",
+    "oh-my-opencode-linux-x64-musl": "4.11.1",
+    "oh-my-opencode-linux-x64-musl-baseline": "4.11.1",
+    "oh-my-opencode-windows-arm64": "4.11.1",
+    "oh-my-opencode-windows-x64": "4.11.1",
+    "oh-my-opencode-windows-x64-baseline": "4.11.1"
   },
   "overrides": {
     "hono": "^4.12.18",

--- a/packages/oh-my-opencode-darwin-arm64/package.json
+++ b/packages/oh-my-opencode-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-arm64",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (darwin-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-darwin-x64-baseline/package.json
+++ b/packages/oh-my-opencode-darwin-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-x64-baseline",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (darwin-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-darwin-x64/package.json
+++ b/packages/oh-my-opencode-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-x64",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (darwin-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-arm64-musl/package.json
+++ b/packages/oh-my-opencode-linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-arm64-musl",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-arm64-musl)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-arm64/package.json
+++ b/packages/oh-my-opencode-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-arm64",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64-baseline/package.json
+++ b/packages/oh-my-opencode-linux-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-baseline",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64-musl-baseline/package.json
+++ b/packages/oh-my-opencode-linux-x64-musl-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-musl-baseline",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-musl-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64-musl/package.json
+++ b/packages/oh-my-opencode-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-musl",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-musl)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64/package.json
+++ b/packages/oh-my-opencode-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-windows-arm64/package.json
+++ b/packages/oh-my-opencode-windows-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-arm64",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (windows-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-windows-x64-baseline/package.json
+++ b/packages/oh-my-opencode-windows-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-x64-baseline",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (windows-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-windows-x64/package.json
+++ b/packages/oh-my-opencode-windows-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-x64",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Platform-specific binary for oh-my-opencode (windows-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/omo-codex/package.json
+++ b/packages/omo-codex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oh-my-opencode/omo-codex",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"type": "module",
 	"private": true,
 	"description": "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",

--- a/packages/omo-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/omo-codex/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "omo",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "One Codex plugin namespace for Yeongyu's local Codex components.",
 	"author": {
 		"name": "Yeongyu Kim",

--- a/packages/omo-codex/plugin/components/bootstrap/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/bootstrap/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"command": "node \"${PLUGIN_ROOT}/components/bootstrap/dist/cli.js\" hook session-start",
 						"commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\bootstrap.ps1\"",
 						"timeout": 30,
-						"statusMessage": "LazyCodex(4.11.0): Checking Bootstrap Provisioning"
+						"statusMessage": "LazyCodex(4.11.1): Checking Bootstrap Provisioning"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/bootstrap/package.json
+++ b/packages/omo-codex/plugin/components/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-bootstrap",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex SessionStart bootstrap component that provisions LazyCodex runtime dependencies from a detached worker.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/codegraph/package.json
+++ b/packages/omo-codex/plugin/components/codegraph/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-codegraph",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex plugin MCP wrapper for CodeGraph.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/comment-checker/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/comment-checker/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-tool-use",
 						"timeout": 30,
-						"statusMessage": "LazyCodex(4.11.0): Checking Comments"
+						"statusMessage": "LazyCodex(4.11.1): Checking Comments"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/comment-checker/package.json
+++ b/packages/omo-codex/plugin/components/comment-checker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-comment-checker",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex plugin that runs comment-checker after edit-like PostToolUse hooks.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/git-bash/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/git-bash/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook pre-tool-use",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Recommending Git Bash MCP"
+						"statusMessage": "LazyCodex(4.11.1): Recommending Git Bash MCP"
 					}
 				]
 			}
@@ -20,7 +20,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-compact",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Resetting Git Bash MCP Reminder"
+						"statusMessage": "LazyCodex(4.11.1): Resetting Git Bash MCP Reminder"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/git-bash/package.json
+++ b/packages/omo-codex/plugin/components/git-bash/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-git-bash-hook",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex hook component that reminds Windows sessions to prefer the OMO git_bash MCP.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/lazycodex-executor-verify/dist/cli.js\" hook subagent-stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Verifying LazyCodex Executor Evidence"
+						"statusMessage": "LazyCodex(4.11.1): Verifying LazyCodex Executor Evidence"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/package.json
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-lazycodex-executor-verify",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex SubagentStop evidence verifier for LazyCodex executor completions.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/lsp/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/lsp/hooks/hooks.json
@@ -8,7 +8,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-tool-use",
 						"timeout": 60,
-						"statusMessage": "LazyCodex(4.11.0): Checking LSP Diagnostics"
+						"statusMessage": "LazyCodex(4.11.1): Checking LSP Diagnostics"
 					}
 				]
 			}
@@ -21,7 +21,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-compact",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Resetting LSP Diagnostics Cache"
+						"statusMessage": "LazyCodex(4.11.1): Resetting LSP Diagnostics Cache"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/lsp/package.json
+++ b/packages/omo-codex/plugin/components/lsp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-lsp",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex plugin that exposes Language Server Protocol tools and post-edit diagnostics.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/rules/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/rules/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook session-start",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Loading Project Rules"
+						"statusMessage": "LazyCodex(4.11.1): Loading Project Rules"
 					}
 				]
 			}
@@ -19,7 +19,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Loading Project Rules"
+						"statusMessage": "LazyCodex(4.11.1): Loading Project Rules"
 					}
 				]
 			}
@@ -32,7 +32,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-tool-use",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Matching Project Rules"
+						"statusMessage": "LazyCodex(4.11.1): Matching Project Rules"
 					}
 				]
 			}
@@ -45,7 +45,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-compact",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Resetting Project Rule Cache"
+						"statusMessage": "LazyCodex(4.11.1): Resetting Project Rule Cache"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/rules/package.json
+++ b/packages/omo-codex/plugin/components/rules/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-rules",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex plugin that injects project rule files into model context through lifecycle hooks.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/start-work-continuation/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/start-work-continuation/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/start-work-continuation/dist/cli.js\" hook stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Checking Start-Work Continuation"
+						"statusMessage": "LazyCodex(4.11.1): Checking Start-Work Continuation"
 					}
 				]
 			}
@@ -19,7 +19,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/start-work-continuation/dist/cli.js\" hook subagent-stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Checking Start-Work Continuation"
+						"statusMessage": "LazyCodex(4.11.1): Checking Start-Work Continuation"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/start-work-continuation/package.json
+++ b/packages/omo-codex/plugin/components/start-work-continuation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-start-work-continuation",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex Stop hook continuation injector for omo-codex start-work plans.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/telemetry/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/telemetry/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook session-start",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Recording Session Telemetry"
+						"statusMessage": "LazyCodex(4.11.1): Recording Session Telemetry"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/telemetry/package.json
+++ b/packages/omo-codex/plugin/components/telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-telemetry",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex plugin component that emits omo-codex anonymous daily-active telemetry on SessionStart.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/ultrawork/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/ultrawork/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Checking Ultrawork Trigger"
+						"statusMessage": "LazyCodex(4.11.1): Checking Ultrawork Trigger"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/ultrawork/package.json
+++ b/packages/omo-codex/plugin/components/ultrawork/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-ultrawork",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex plugin that injects the ultrawork orchestration directive and ships LazyCodex planning, review, QA, and gate agent roles.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/ulw-loop/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Checking Ulw-Loop Steering"
+						"statusMessage": "LazyCodex(4.11.1): Checking Ulw-Loop Steering"
 					}
 				]
 			}
@@ -20,7 +20,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook pre-tool-use",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Enforcing Unlimited Ulw-Loop Budget"
+						"statusMessage": "LazyCodex(4.11.1): Enforcing Unlimited Ulw-Loop Budget"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/components/ulw-loop/package.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-ulw-loop",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Codex plugin: durable repo-native multi-goal orchestration with embedded success criteria and observable evidence audit.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/hooks/hooks.json
+++ b/packages/omo-codex/plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/rules/dist/cli.js\" hook session-start",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Loading Project Rules"
+						"statusMessage": "LazyCodex(4.11.1): Loading Project Rules"
 					}
 				]
 			},
@@ -17,7 +17,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/telemetry/dist/cli.js\" hook session-start",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Recording Session Telemetry"
+						"statusMessage": "LazyCodex(4.11.1): Recording Session Telemetry"
 					}
 				]
 			},
@@ -28,7 +28,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/scripts/auto-update.mjs\" hook session-start",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Checking Auto Update"
+						"statusMessage": "LazyCodex(4.11.1): Checking Auto Update"
 					}
 				]
 			},
@@ -39,7 +39,7 @@
 						"command": "node \"${PLUGIN_ROOT}/components/bootstrap/dist/cli.js\" hook session-start",
 						"commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\bootstrap.ps1\"",
 						"timeout": 30,
-						"statusMessage": "LazyCodex(4.11.0): Checking Bootstrap Provisioning"
+						"statusMessage": "LazyCodex(4.11.1): Checking Bootstrap Provisioning"
 					}
 				]
 			},
@@ -49,7 +49,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/codegraph/dist/cli.js\" hook session-start",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Checking Codegraph Bootstrap"
+						"statusMessage": "LazyCodex(4.11.1): Checking Codegraph Bootstrap"
 					}
 				]
 			}
@@ -61,7 +61,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/rules/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Loading Project Rules"
+						"statusMessage": "LazyCodex(4.11.1): Loading Project Rules"
 					}
 				]
 			},
@@ -71,7 +71,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/ultrawork/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Checking Ultrawork Trigger"
+						"statusMessage": "LazyCodex(4.11.1): Checking Ultrawork Trigger"
 					}
 				]
 			},
@@ -81,7 +81,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/ulw-loop/dist/cli.js\" hook user-prompt-submit",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Checking Ulw-Loop Steering"
+						"statusMessage": "LazyCodex(4.11.1): Checking Ulw-Loop Steering"
 					}
 				]
 			}
@@ -94,7 +94,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/git-bash/dist/cli.js\" hook pre-tool-use",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Recommending Git Bash MCP"
+						"statusMessage": "LazyCodex(4.11.1): Recommending Git Bash MCP"
 					}
 				]
 			},
@@ -105,7 +105,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/ulw-loop/dist/cli.js\" hook pre-tool-use",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Enforcing Unlimited Goal Budget"
+						"statusMessage": "LazyCodex(4.11.1): Enforcing Unlimited Goal Budget"
 					}
 				]
 			}
@@ -118,13 +118,13 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/comment-checker/dist/cli.js\" hook post-tool-use",
 						"timeout": 30,
-						"statusMessage": "LazyCodex(4.11.0): Checking Comments"
+						"statusMessage": "LazyCodex(4.11.1): Checking Comments"
 					},
 					{
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/lsp/dist/cli.js\" hook post-tool-use",
 						"timeout": 60,
-						"statusMessage": "LazyCodex(4.11.0): Checking LSP Diagnostics"
+						"statusMessage": "LazyCodex(4.11.1): Checking LSP Diagnostics"
 					}
 				]
 			},
@@ -135,7 +135,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/rules/dist/cli.js\" hook post-tool-use",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Matching Project Rules"
+						"statusMessage": "LazyCodex(4.11.1): Matching Project Rules"
 					}
 				]
 			}
@@ -148,7 +148,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/git-bash/dist/cli.js\" hook post-compact",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Resetting Git Bash MCP Reminder"
+						"statusMessage": "LazyCodex(4.11.1): Resetting Git Bash MCP Reminder"
 					}
 				]
 			},
@@ -159,7 +159,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/rules/dist/cli.js\" hook post-compact",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Resetting Project Rule Cache"
+						"statusMessage": "LazyCodex(4.11.1): Resetting Project Rule Cache"
 					}
 				]
 			},
@@ -170,7 +170,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/lsp/dist/cli.js\" hook post-compact",
 						"timeout": 5,
-						"statusMessage": "LazyCodex(4.11.0): Resetting LSP Diagnostics Cache"
+						"statusMessage": "LazyCodex(4.11.1): Resetting LSP Diagnostics Cache"
 					}
 				]
 			}
@@ -182,7 +182,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/start-work-continuation/dist/cli.js\" hook stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Checking Start-Work Continuation"
+						"statusMessage": "LazyCodex(4.11.1): Checking Start-Work Continuation"
 					}
 				]
 			}
@@ -194,7 +194,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/start-work-continuation/dist/cli.js\" hook subagent-stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Checking Start-Work Continuation"
+						"statusMessage": "LazyCodex(4.11.1): Checking Start-Work Continuation"
 					}
 				]
 			},
@@ -205,7 +205,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/lazycodex-executor-verify/dist/cli.js\" hook subagent-stop",
 						"timeout": 10,
-						"statusMessage": "LazyCodex(4.11.0): Verifying LazyCodex Executor Evidence"
+						"statusMessage": "LazyCodex(4.11.1): Verifying LazyCodex Executor Evidence"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/package.json
+++ b/packages/omo-codex/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/omo-codex-plugin",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "Aggregate Codex plugin root for OMO components.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5907,7 +5907,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.11.0",
+    version: "4.11.1",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",


### PR DESCRIPTION
## Summary
Recovery PR for the v4.11.1 release state after the publish workflow successfully published npm packages but failed to push the release commit directly to protected `dev`.

The failed workflow run: https://github.com/code-yeongyu/oh-my-openagent/actions/runs/27742745649

## What happened
- `publish-main` succeeded.
- npm packages are already published as 4.11.1.
- Platform package publish jobs succeeded.
- The workflow failed only at `Push release state` because protected `dev` rejected direct push from the workflow token with required checks enforced.

## Changes
- Stamps root/package optional dependency versions to 4.11.1.
- Stamps platform package manifests to 4.11.1.
- Stamps OMO Codex package/plugin/component manifests to 4.11.1.
- Stamps LazyCodex hook status messages to 4.11.1.
- Updates `bun.lock` from the release version bump.
- Updates the generated Codex installer bundle embedded package version to 4.11.1.

## Verification
- `git diff --check` - pass
- Version consistency check confirms root, OMO Codex, plugin, and Codex plugin metadata are 4.11.1, and optionalDependencies all resolve to 4.11.1
- `bun test script/publish-workflow.test.ts script/publish-lazycodex-workflow.test.ts` - 27 pass after `bun install`
- npm verification already shows 4.11.1 for `oh-my-opencode`, `oh-my-openagent`, `lazycodex-ai`, and checked platform packages

Evidence directory: `.omo/evidence/20260618-release-state-v4111/`

## Follow-up after merge
After this PR merges, create/push tag `v4.11.1`, create/update the GitHub release notes, verify npm/platform/LazyCodex surfaces, and post the release announcement.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers the v4.11.1 release state on the protected `dev` branch after npm packages were published but the workflow couldn’t push the release commit. Aligns all manifests, hooks, and the installer to 4.11.1 to match published artifacts.

- **Dependencies**
  - Bump root `oh-my-opencode` to 4.11.1 and set all platform optionalDependencies `oh-my-opencode-*` to 4.11.1.
  - Bump `@oh-my-opencode/omo-codex` and all Codex plugin/component packages to 4.11.1; update LazyCodex hook status messages to 4.11.1.
  - Update `bun.lock` and the Codex installer bundle to embed 4.11.1.

- **Migration**
  - After merge: push tag `v4.11.1` and create/update the GitHub release notes.
  - Verify npm/platform/LazyCodex surfaces show 4.11.1.

<sup>Written for commit bba99cb8141a4ccf1a4794ecbd6064345f44fe22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

