### PR TITLE
fix: allow opted-in non-GPT Hephaestus registration

### DIFF
--- a/packages/omo-opencode/src/agents/builtin-agents/hephaestus-agent.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/hephaestus-agent.ts
@@ -44,6 +44,10 @@ export function maybeCreateHephaestusConfig(input: {
   const hephaestusOverride = agentOverrides["hephaestus"]
   const hephaestusRequirement = AGENT_MODEL_REQUIREMENTS["hephaestus"]
   const hasHephaestusExplicitConfig = hephaestusOverride !== undefined
+  const allowNonGptModel = hephaestusOverride?.allow_non_gpt_model === true
+
+  const isUnsupportedHephaestusModel = (model: string | undefined) =>
+    !allowNonGptModel && !isHephaestusSupportedModel(model)
 
   const hasRequiredProvider =
     !hephaestusRequirement?.requiresProvider ||
@@ -79,7 +83,7 @@ export function maybeCreateHephaestusConfig(input: {
   }
   const { model: hephaestusModel, variant: hephaestusResolvedVariant } = hephaestusResolution
 
-  if (!isHephaestusSupportedModel(hephaestusModel)) {
+  if (isUnsupportedHephaestusModel(hephaestusModel)) {
     log("[agent-registration] Agent skipped: unsupported Hephaestus model", {
       agent: "hephaestus",
       configuredModel: hephaestusModel,
@@ -93,7 +97,8 @@ export function maybeCreateHephaestusConfig(input: {
     undefined,
     availableSkills,
     availableCategories,
-    useTaskSystem
+    useTaskSystem,
+    allowNonGptModel
   )
 
   hephaestusConfig = { ...hephaestusConfig, variant: hephaestusResolvedVariant ?? "medium" }
@@ -101,7 +106,7 @@ export function maybeCreateHephaestusConfig(input: {
   const hepOverrideCategory = (hephaestusOverride as Record<string, unknown> | undefined)?.category as string | undefined
   if (hepOverrideCategory) {
     hephaestusConfig = applyCategoryOverride(hephaestusConfig, hepOverrideCategory, mergedCategories)
-    if (!isHephaestusSupportedModel(hephaestusConfig.model)) {
+    if (isUnsupportedHephaestusModel(hephaestusConfig.model)) {
       log("[agent-registration] Agent skipped: unsupported Hephaestus category model", {
         agent: "hephaestus",
         configuredModel: hephaestusConfig.model,
@@ -114,7 +119,7 @@ export function maybeCreateHephaestusConfig(input: {
 
   if (hephaestusOverride) {
     hephaestusConfig = mergeAgentConfig(hephaestusConfig, hephaestusOverride, directory)
-    if (!isHephaestusSupportedModel(hephaestusConfig.model)) {
+    if (isUnsupportedHephaestusModel(hephaestusConfig.model)) {
       log("[agent-registration] Agent skipped: unsupported Hephaestus override model", {
         agent: "hephaestus",
         configuredModel: hephaestusConfig.model,

--- a/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
@@ -375,6 +375,41 @@ describe("maybeCreateHephaestusConfig apply_patch permission", () => {
     });
   });
 
+  describe("#given non-GPT model with explicit Hephaestus opt-out", () => {
+    test("#when config is created #then Hephaestus is registered", () => {
+      // given
+      const agentOverrides: AgentOverrides = {
+        hephaestus: {
+          model: "anthropic/claude-opus-4-7",
+          allow_non_gpt_model: true,
+          permission: {
+            apply_patch: "allow",
+          } as Record<string, "allow">,
+        },
+      };
+      const mergedCategories: Record<string, CategoryConfig> = {};
+
+      // when
+      const config = maybeCreateHephaestusConfig({
+        disabledAgents: [],
+        agentOverrides,
+        availableModels: new Set(["anthropic/claude-opus-4-7"]),
+        systemDefaultModel: "anthropic/claude-opus-4-7",
+        isFirstRunNoCache: false,
+        availableAgents: [],
+        availableSkills: [],
+        availableCategories: [],
+        mergedCategories,
+        useTaskSystem: false,
+      });
+
+      // then
+      expect(config).toBeDefined();
+      expect(config?.model).toBe("anthropic/claude-opus-4-7");
+      expect(config?.permission).toHaveProperty("apply_patch", "allow");
+    });
+  });
+
   describe("#given generic GPT model with user override allowing apply_patch", () => {
     test("#when config is created #then Hephaestus is not registered", () => {
       // given

--- a/packages/omo-opencode/src/agents/hephaestus/agent.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.ts
@@ -69,6 +69,7 @@ export interface HephaestusContext {
   availableSkills?: AvailableSkill[];
   availableCategories?: AvailableCategory[];
   useTaskSystem?: boolean;
+  allowUnsupportedModel?: boolean;
 }
 
 export function getHephaestusPrompt(
@@ -86,7 +87,9 @@ function buildDynamicHephaestusPrompt(ctx?: HephaestusContext): string {
   const useTaskSystem = ctx?.useTaskSystem ?? false;
   const model = ctx?.model;
 
-  const source = getHephaestusPromptSource(model);
+  const source = ctx?.allowUnsupportedModel && !isHephaestusSupportedModel(model)
+    ? "gpt"
+    : getHephaestusPromptSource(model);
 
   let basePrompt: string;
   switch (source) {
@@ -135,6 +138,7 @@ export function createHephaestusAgent(
   availableSkills?: AvailableSkill[],
   availableCategories?: AvailableCategory[],
   useTaskSystem = false,
+  allowUnsupportedModel = false,
 ): AgentConfig {
   const tools = availableToolNames ? categorizeTools(availableToolNames) : [];
 
@@ -145,6 +149,7 @@ export function createHephaestusAgent(
     availableSkills,
     availableCategories,
     useTaskSystem,
+    allowUnsupportedModel,
   });
 
   return {


### PR DESCRIPTION
## Summary

- Lets `agents.hephaestus.allow_non_gpt_model: true` bypass Hephaestus registration-time model checks.
- Passes the opt-in through to Hephaestus prompt construction, where unsupported models use the generic GPT prompt instead of throwing.
- Keeps the default behavior unchanged: without the explicit opt-in, non-GPT Hephaestus models are still skipped/rejected.

## Test Plan

- [x] `npx --yes bun@1.3.14 test packages/omo-opencode/src/agents/hephaestus/agent.test.ts`
- [x] `npx --yes bun@1.3.14 run typecheck:packages`

Related question: #5399


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Hephaestus to register with non-GPT models when opted in via `agents.hephaestus.allow_non_gpt_model: true`, falling back to the generic GPT prompt instead of rejecting. Default behavior stays the same; without the flag, unsupported models are skipped.

- **Bug Fixes**
  - Gate model support checks behind the opt-in during registration.
  - Plumb `allowUnsupportedModel` to prompt construction; use GPT prompt for unsupported models.
  - Add test to verify non-GPT registration with the flag and preserve `apply_patch` permission.

<sup>Written for commit 954afdac22ec50a00b568d696f43a017ea6b9340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

