### PR TITLE
fix(omo-codex): provision CodeGraph during MCP serve

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -1,22 +1,22 @@
 #!/usr/bin/env node
 
-// components/codegraph/src/cli.ts
+// src/cli.ts
 import { realpathSync as realpathSync3 } from "node:fs";
 import { basename as basename5, resolve as resolve4 } from "node:path";
 import { stderr as processStderr3 } from "node:process";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
-// components/codegraph/src/hook.ts
+// src/hook.ts
 import { spawn } from "node:child_process";
 import { homedir as homedir7 } from "node:os";
 import { cwd as processCwd2, env as processEnv2, stdin as processStdin, stdout as processStdout } from "node:process";
 import { fileURLToPath } from "node:url";
 
-// ../../utils/src/omo-config/loader.ts
+// ../../../../utils/src/omo-config/loader.ts
 import { existsSync as existsSync2, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 
-// ../../utils/src/deep-merge.ts
+// ../../../../utils/src/deep-merge.ts
 var DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 function isUnsafeObjectKey(key) {
   return DANGEROUS_KEYS.has(key);
@@ -25,7 +25,7 @@ function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value) && Object.prototype.toString.call(value) === "[object Object]";
 }
 
-// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/scanner.js
+// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/scanner.js
 function createScanner(text, ignoreTrivia = false) {
   const len = text.length;
   let pos = 0, value = "", tokenOffset = 0, token = 16, lineNumber = 0, lineStartOffset = 0, tokenLineStartOffset = 0, prevTokenLineStartOffset = 0, scanError = 0;
@@ -440,7 +440,7 @@ var CharacterCodes;
   CharacterCodes2[CharacterCodes2["tab"] = 9] = "tab";
 })(CharacterCodes || (CharacterCodes = {}));
 
-// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/string-intern.js
+// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/string-intern.js
 var cachedSpaces = new Array(20).fill(0).map((_, index) => {
   return " ".repeat(index);
 });
@@ -474,7 +474,7 @@ var cachedBreakLinesWithSpaces = {
   }
 };
 
-// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/parser.js
+// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/parser.js
 var ParseOptions;
 (function(ParseOptions2) {
   ParseOptions2.DEFAULT = {
@@ -777,7 +777,7 @@ function visit(text, visitor, options = ParseOptions.DEFAULT) {
   return true;
 }
 
-// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/main.js
+// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/main.js
 var ScanError;
 (function(ScanError2) {
   ScanError2[ScanError2["None"] = 0] = "None";
@@ -866,7 +866,7 @@ function printParseErrorCode(code) {
   return "<unknown ParseErrorCode>";
 }
 
-// ../../utils/src/jsonc-parser.ts
+// ../../../../utils/src/jsonc-parser.ts
 var pluginConfigFileDetectionCache = new Map;
 function stripBom(content) {
   return content.charCodeAt(0) === 65279 ? content.slice(1) : content;
@@ -887,7 +887,7 @@ function parseJsoncSafe(content) {
   };
 }
 
-// ../../utils/src/omo-config.ts
+// ../../../../utils/src/omo-config.ts
 var HARNESS_IDS = ["codex", "opencode", "omo"];
 var SETTING_HARNESS_SUPPORT = {
   "codegraph.auto_provision": HARNESS_IDS,
@@ -897,7 +897,7 @@ var SETTING_HARNESS_SUPPORT = {
   "codegraph.watch_debounce_ms": ["opencode", "omo"]
 };
 
-// ../../utils/src/omo-config/env-overrides.ts
+// ../../../../utils/src/omo-config/env-overrides.ts
 var CODEGRAPH_ENV_KEYS = [
   ["auto_provision", "AUTO_PROVISION", "boolean"],
   ["enabled", "ENABLED", "boolean"],
@@ -969,7 +969,7 @@ function buildEnvOverrides(harness, env, warnings, merge) {
   return config;
 }
 
-// ../../utils/src/omo-config/resolve.ts
+// ../../../../utils/src/omo-config/resolve.ts
 import { existsSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 function containsPath(parent, child) {
@@ -1012,7 +1012,7 @@ function toMissingSource(candidate) {
   };
 }
 
-// ../../utils/src/omo-config/loader.ts
+// ../../../../utils/src/omo-config/loader.ts
 var BUILT_IN_DEFAULTS = {
   codegraph: {
     auto_provision: true,
@@ -1235,7 +1235,7 @@ function loadOmoConfig(options) {
   return { config, sources, warnings };
 }
 
-// shared/src/config-loader.ts
+// ../../shared/src/config-loader.ts
 function getCodexOmoConfig(options = {}) {
   const result = loadOmoConfig({
     ...options.cwd === undefined ? {} : { cwd: options.cwd },
@@ -1250,14 +1250,14 @@ function getCodexOmoConfig(options = {}) {
   };
 }
 
-// components/codegraph/src/session-start-worker.ts
+// src/session-start-worker.ts
 import { execFile as execFile2 } from "node:child_process";
 import { appendFileSync as appendFileSync2, existsSync as existsSync6, mkdirSync as mkdirSync2 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { extname, join as join7 } from "node:path";
 import { cwd as processCwd, env as processEnv, stderr as processStderr } from "node:process";
 
-// ../../utils/src/codegraph/env.ts
+// ../../../../utils/src/codegraph/env.ts
 import { homedir as homedir2 } from "node:os";
 import { join as join2 } from "node:path";
 var CODEGRAPH_INSTALL_DIR_ENV = "CODEGRAPH_INSTALL_DIR";
@@ -1274,7 +1274,7 @@ function buildCodegraphEnv(options = {}) {
   };
 }
 
-// ../../utils/src/codegraph/node-support.ts
+// ../../../../utils/src/codegraph/node-support.ts
 var CODEGRAPH_MIN_NODE_MAJOR = 20;
 var CODEGRAPH_BLOCKED_NODE_MAJOR = 25;
 var CODEGRAPH_UNSAFE_NODE_ENV = "CODEGRAPH_ALLOW_UNSAFE_NODE";
@@ -1303,7 +1303,7 @@ function parseNodeMajor(version) {
   return Number.isNaN(major) ? 0 : major;
 }
 
-// ../../utils/src/codegraph/provision.ts
+// ../../../../utils/src/codegraph/provision.ts
 import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { chmod, mkdir, readdir, readFile, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
@@ -1312,7 +1312,7 @@ import { homedir as homedir3, hostname } from "node:os";
 import { basename, join as join3 } from "node:path";
 import { promisify } from "node:util";
 
-// ../../utils/src/codegraph/manifest.ts
+// ../../../../utils/src/codegraph/manifest.ts
 var CODEGRAPH_PROVISION_MANIFEST = {
   assets: {
     "darwin-arm64": {
@@ -1349,7 +1349,7 @@ var CODEGRAPH_PROVISION_MANIFEST = {
   version: "1.0.1"
 };
 
-// ../../utils/src/codegraph/provision.ts
+// ../../../../utils/src/codegraph/provision.ts
 var DEFAULT_LOCK_WAIT_MS = 5000;
 var DEFAULT_LOCK_STALE_MS = 120000;
 var DEFAULT_DOWNLOAD_TIMEOUT_MS = 60000;
@@ -1522,14 +1522,14 @@ async function ensureCodegraphProvisioned(options) {
   }
 }
 
-// ../../utils/src/codegraph/resolve.ts
+// ../../../../utils/src/codegraph/resolve.ts
 import { existsSync as existsSync4 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { spawnSync } from "node:child_process";
 import { basename as basename2, dirname as dirname2, join as join5 } from "node:path";
 import { createRequire } from "node:module";
 
-// ../../utils/src/runtime/which.ts
+// ../../../../utils/src/runtime/which.ts
 import { accessSync, constants } from "node:fs";
 import { delimiter, join as join4 } from "node:path";
 var runtime = globalThis;
@@ -1594,7 +1594,7 @@ function bunWhich(commandName) {
   return null;
 }
 
-// ../../utils/src/codegraph/resolve.ts
+// ../../../../utils/src/codegraph/resolve.ts
 function codegraphCommandRequiresSupportedLocalNode(resolution) {
   return resolution.source !== "bundled" && resolution.source !== "env" && resolution.source !== "provisioned";
 }
@@ -1717,7 +1717,7 @@ function resolveCodegraphCommand(options = {}) {
   };
 }
 
-// ../../utils/src/codegraph/workspace.ts
+// ../../../../utils/src/codegraph/workspace.ts
 import { createHash as createHash2 } from "node:crypto";
 import {
   appendFileSync,
@@ -1813,7 +1813,7 @@ function ensureCodegraphGitignored(workspace) {
   }
 }
 
-// components/codegraph/src/session-start-worker.ts
+// src/session-start-worker.ts
 var SESSION_START_CWD_ENV = "OMO_CODEGRAPH_SESSION_START_CWD";
 var CODEGRAPH_VERSION = "1.0.1";
 var COMMAND_TIMEOUT_MS = 60000;
@@ -1981,7 +1981,7 @@ function isRecord2(value) {
   return typeof value === "object" && value !== null;
 }
 
-// components/codegraph/src/hook.ts
+// src/hook.ts
 var CODEGRAPH_SESSION_START_NOTICE = "LazyCodex CodeGraph bootstrap scheduled in background";
 async function runCodegraphSessionStartHook(options = {}) {
   return (await executeCodegraphSessionStartHook(options)).exitCode;
@@ -2052,7 +2052,7 @@ function defaultWorkerCliPath() {
   return fileURLToPath(import.meta.url);
 }
 
-// components/codegraph/src/serve.ts
+// src/serve.ts
 import { spawn as spawn2 } from "node:child_process";
 import { existsSync as existsSync7, realpathSync as realpathSync2 } from "node:fs";
 import { homedir as homedir8 } from "node:os";
@@ -2068,6 +2068,7 @@ var CODEGRAPH_SKIP_HINT = `CodeGraph MCP skipped: codegraph binary not found. In
 `;
 var CODEGRAPH_DISABLED_HINT = `CodeGraph MCP skipped: disabled by OMO SOT config. Set [codex].codegraph.enabled=true to enable it.
 `;
+var CODEGRAPH_VERSION2 = "1.0.1";
 var WINDOWS_CMD_EXTENSIONS2 = new Set([".bat", ".cmd"]);
 var WINDOWS_NODE_SCRIPT_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
 async function runCodegraphServe(options = {}) {
@@ -2084,15 +2085,24 @@ async function runCodegraphServe(options = {}) {
     homeDir,
     provisioned: () => provisionedBinFromInstallDir2(codegraphConfig.install_dir)
   };
-  const resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
+  let resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
   const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
   if (!resolution.exists || shouldSkipResolvedCommand(resolution, options.commandExists ?? existsSync7)) {
     if (resolution.source === "path" && !nodeSupport.supported) {
       (options.stderr ?? processStderr2).write(buildCodegraphNodeSkipHint(nodeSupport));
       return 1;
     }
-    (options.stderr ?? processStderr2).write(CODEGRAPH_SKIP_HINT);
-    return 1;
+    const provisioned = await provisionMissingCodegraph({
+      config: codegraphConfig,
+      ensureProvisioned: options.ensureProvisioned ?? ensureCodegraphProvisioned,
+      homeDir,
+      resolution
+    });
+    if (provisioned === null) {
+      (options.stderr ?? processStderr2).write(CODEGRAPH_SKIP_HINT);
+      return 1;
+    }
+    resolution = provisioned;
   }
   if (codegraphCommandRequiresSupportedLocalNode(resolution) && !nodeSupport.supported) {
     (options.stderr ?? processStderr2).write(buildCodegraphNodeSkipHint(nodeSupport));
@@ -2108,6 +2118,21 @@ async function runCodegraphServe(options = {}) {
     env: mergedEnv,
     stdio: "inherit"
   });
+}
+async function provisionMissingCodegraph(options) {
+  if (options.resolution.source === "env")
+    return null;
+  if (options.config.auto_provision === false)
+    return null;
+  const installDir = options.config.install_dir ?? join8(options.homeDir, ".omo", "codegraph");
+  const result = await options.ensureProvisioned({
+    installDir,
+    lockDir: join8(installDir, ".locks"),
+    version: CODEGRAPH_VERSION2
+  });
+  if (!result.provisioned || result.binPath === undefined)
+    return null;
+  return { argsPrefix: [], command: result.binPath, exists: true, source: "provisioned" };
 }
 function shouldSkipResolvedCommand(resolution, commandExists) {
   if (resolution.source !== "env")
@@ -2175,7 +2200,7 @@ function isDirectInvocation(argvPath) {
   return realpathSync2(resolve3(argvPath)) === realpathSync2(modulePath);
 }
 
-// components/codegraph/src/cli.ts
+// src/cli.ts
 async function runCodegraphCli(options = {}) {
   const argv = options.argv ?? process.argv;
   const command = argv[2];

--- a/packages/omo-codex/plugin/components/codegraph/dist/serve.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/serve.js
@@ -2,9 +2,9 @@
 
 // src/serve.ts
 import { spawn } from "node:child_process";
-import { existsSync as existsSync4, realpathSync } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { basename as basename2, extname, join as join5, resolve as resolve2 } from "node:path";
+import { existsSync as existsSync5, realpathSync } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { basename as basename3, extname, join as join6, resolve as resolve2 } from "node:path";
 import {
   cwd as processCwd,
   env as processEnv,
@@ -59,16 +59,235 @@ function parseNodeMajor(version) {
   return Number.isNaN(major) ? 0 : major;
 }
 
-// ../../../../utils/src/codegraph/resolve.ts
+// ../../../../utils/src/codegraph/provision.ts
+import { createHash, randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { chmod, mkdir, readdir, readFile, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { homedir as homedir2 } from "node:os";
+import { homedir as homedir2, hostname } from "node:os";
+import { basename, join as join2 } from "node:path";
+import { promisify } from "node:util";
+
+// ../../../../utils/src/codegraph/manifest.ts
+var CODEGRAPH_PROVISION_MANIFEST = {
+  assets: {
+    "darwin-arm64": {
+      executableName: "codegraph",
+      sha256: "95bb27bf6382b69659e158e0c04d71cc394778951e1317d582be7807e7866908",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-darwin-arm64.tar.gz"
+    },
+    "darwin-x64": {
+      executableName: "codegraph",
+      sha256: "3311cc1d1f0f0ad742709b6a43d8a9187b1ef0af0dd30e0b58008dc673e29478",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-darwin-x64.tar.gz"
+    },
+    "linux-arm64": {
+      executableName: "codegraph",
+      sha256: "e16f612bc96c2ebccd04574cbed500c9939147c80666ad6bb024398dff7992ae",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-linux-arm64.tar.gz"
+    },
+    "linux-x64": {
+      executableName: "codegraph",
+      sha256: "d45a068f44596a85c7ba7d0ef924eaf7103fbbf3cafbeb668127daff60a52228",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-linux-x64.tar.gz"
+    },
+    "win32-arm64": {
+      executableName: "codegraph.cmd",
+      sha256: "8d57ced73b24d35f758f2ede2318e80e1d7241987f37a999e3d80edb6fddf961",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.0.1.tgz"
+    },
+    "win32-x64": {
+      executableName: "codegraph.cmd",
+      sha256: "52607fe73b05e741fd1087da2ceca9d3c8f565e36bf1a7070600bdbdf3931e32",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.0.1.tgz"
+    }
+  },
+  version: "1.0.1"
+};
+
+// ../../../../utils/src/codegraph/provision.ts
+var DEFAULT_LOCK_WAIT_MS = 5000;
+var DEFAULT_LOCK_STALE_MS = 120000;
+var DEFAULT_DOWNLOAD_TIMEOUT_MS = 60000;
+var execFileAsync = promisify(execFile);
+function platformKey() {
+  return `${process.platform}-${process.arch}`;
+}
+function markerPath(installDir, version) {
+  return join2(installDir, ".provisioned", `codegraph-${version}.json`);
+}
+function defaultInstallDir() {
+  return join2(homedir2(), ".omo", "codegraph");
+}
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+function isErrnoException(error) {
+  return error instanceof Error && "code" in error;
+}
+async function removeEmptyDirectory(path) {
+  try {
+    await rmdir(path);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT")
+      return;
+    if (isErrnoException(error) && error.code === "ENOTEMPTY")
+      return;
+    throw error;
+  }
+}
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+async function defaultDownloader(asset, timeoutMs = DEFAULT_DOWNLOAD_TIMEOUT_MS) {
+  const response = await fetch(asset.url, { signal: AbortSignal.timeout(timeoutMs) });
+  if (!response.ok)
+    throw new Error(`download failed with HTTP ${response.status}`);
+  return new Uint8Array(await response.arrayBuffer());
+}
+function forcedBadChecksumOptions(options) {
+  if (options.forceBadChecksum !== true)
+    return null;
+  const key = options.platformKey ?? platformKey();
+  return {
+    downloader: async () => new TextEncoder().encode("checksum mismatch"),
+    installDir: options.installDir ?? join2(options.lockDir, "codegraph-force-bad-checksum"),
+    manifest: {
+      assets: {
+        [key]: { executableName: process.platform === "win32" ? "codegraph.cmd" : "codegraph", sha256: "0000", url: "memory://bad" }
+      },
+      version: options.version
+    },
+    platformKey: key
+  };
+}
+async function readMarker(path) {
+  if (!existsSync(path))
+    return null;
+  try {
+    const raw = JSON.parse(await readFile(path, "utf8"));
+    if (typeof raw === "object" && raw !== null && "binPath" in raw) {
+      const value = raw.binPath;
+      return typeof value === "string" && existsSync(value) ? value : null;
+    }
+    return null;
+  } catch (error) {
+    if (error instanceof Error)
+      return null;
+    throw error;
+  }
+}
+async function acquireLock(lockPath, waitMs, staleMs) {
+  const startedAt = Date.now();
+  await mkdir(join2(lockPath, ".."), { recursive: true });
+  while (Date.now() - startedAt <= waitMs) {
+    try {
+      await mkdir(lockPath);
+      return () => rm(lockPath, { force: true, recursive: true });
+    } catch (error) {
+      if (!isErrnoException(error) || error.code !== "EEXIST")
+        throw error;
+      const lockStat = await stat(lockPath).catch(() => null);
+      if (lockStat !== null && Date.now() - lockStat.mtimeMs > staleMs) {
+        await rm(lockPath, { force: true, recursive: true });
+        continue;
+      }
+      await sleep(25);
+    }
+  }
+  return null;
+}
+async function extractTarGz(archivePath, destinationDir) {
+  await execFileAsync("tar", ["-xzf", archivePath, "-C", destinationDir]);
+}
+async function installExtractedBundle(extractDir, installDir, executableName) {
+  const roots = await readdir(extractDir);
+  if (roots.length !== 1)
+    throw new Error(`CodeGraph archive should contain one root directory, found ${roots.length}`);
+  const bundleDir = join2(extractDir, roots[0] ?? "");
+  const bundleEntries = await readdir(bundleDir);
+  await mkdir(installDir, { recursive: true });
+  for (const entry of bundleEntries) {
+    await rm(join2(installDir, entry), { force: true, recursive: true });
+    await rename(join2(bundleDir, entry), join2(installDir, entry));
+  }
+  const destination = join2(installDir, "bin", executableName);
+  if (!existsSync(destination))
+    throw new Error(`CodeGraph archive did not contain bin/${executableName}`);
+  await chmod(destination, 493);
+  return destination;
+}
+async function installAsset(layout) {
+  const { asset, downloader, installDir, version } = layout;
+  const stagingDir = join2(installDir, ".staging", randomUUID());
+  const archivePath = join2(stagingDir, basename(asset.url));
+  const extractDir = join2(stagingDir, "extract");
+  try {
+    await mkdir(extractDir, { recursive: true });
+    const bytes = await downloader(asset);
+    const actualChecksum = sha256(bytes);
+    if (actualChecksum !== asset.sha256) {
+      throw new Error(`checksum mismatch for ${basename(asset.url)}: expected ${asset.sha256}, got ${actualChecksum}`);
+    }
+    if (!asset.url.endsWith(".tar.gz") && !asset.url.endsWith(".tgz")) {
+      throw new Error(`unsupported CodeGraph archive type for ${basename(asset.url)}`);
+    }
+    await writeFile(archivePath, bytes);
+    await extractTarGz(archivePath, extractDir);
+    const destination = await installExtractedBundle(extractDir, installDir, asset.executableName);
+    await mkdir(join2(installDir, ".provisioned"), { recursive: true });
+    await writeFile(markerPath(installDir, version), `${JSON.stringify({ binPath: destination, version })}
+`);
+    return destination;
+  } finally {
+    await rm(stagingDir, { force: true, recursive: true });
+    await removeEmptyDirectory(join2(installDir, ".staging"));
+  }
+}
+async function ensureCodegraphProvisioned(options) {
+  const forced = forcedBadChecksumOptions(options);
+  const installDir = forced?.installDir ?? options.installDir ?? defaultInstallDir();
+  const manifest = forced?.manifest ?? options.manifest ?? CODEGRAPH_PROVISION_MANIFEST;
+  const activePlatformKey = forced?.platformKey ?? options.platformKey ?? platformKey();
+  const downloader = forced?.downloader ?? options.downloader ?? ((asset) => defaultDownloader(asset, options.downloadTimeoutMs));
+  const marker = markerPath(installDir, options.version);
+  const existing = await readMarker(marker);
+  if (existing !== null)
+    return { binPath: existing, provisioned: true };
+  const lockPath = join2(options.lockDir, `codegraph-${hostname()}.lock`);
+  const release = await acquireLock(lockPath, options.lockWaitMs ?? DEFAULT_LOCK_WAIT_MS, options.lockStaleMs ?? DEFAULT_LOCK_STALE_MS);
+  if (release === null)
+    return { error: "timed out waiting for codegraph provisioning lock", provisioned: false };
+  try {
+    const lockedExisting = await readMarker(marker);
+    if (lockedExisting !== null)
+      return { binPath: lockedExisting, provisioned: true };
+    if (manifest.version !== options.version) {
+      return { error: `manifest version ${manifest.version} does not match requested ${options.version}`, provisioned: false };
+    }
+    const asset = manifest.assets[activePlatformKey];
+    if (asset === undefined) {
+      return { error: `no CodeGraph ${options.version} asset for ${activePlatformKey}`, provisioned: false };
+    }
+    const binPath = await installAsset({ asset, downloader, installDir, version: options.version });
+    return { binPath, provisioned: true };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error), provisioned: false };
+  } finally {
+    await release();
+  }
+}
+
+// ../../../../utils/src/codegraph/resolve.ts
+import { existsSync as existsSync2 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
 import { spawnSync } from "node:child_process";
-import { basename, dirname, join as join3 } from "node:path";
+import { basename as basename2, dirname, join as join4 } from "node:path";
 import { createRequire } from "node:module";
 
 // ../../../../utils/src/runtime/which.ts
 import { accessSync, constants } from "node:fs";
-import { delimiter, join as join2 } from "node:path";
+import { delimiter, join as join3 } from "node:path";
 var runtime = globalThis;
 function isUnsafeCommandName(commandName) {
   if (commandName.includes("/") || commandName.includes("\\"))
@@ -123,7 +342,7 @@ function bunWhich(commandName) {
     return null;
   for (const pathEntry of pathEntries) {
     for (const candidateName of candidateNames) {
-      const candidatePath = join2(pathEntry, candidateName);
+      const candidatePath = join3(pathEntry, candidateName);
       if (isExecutable(candidatePath))
         return candidatePath;
     }
@@ -164,7 +383,7 @@ ${result.stderr}`.trim().split(/\s+/)[0];
   }
 }
 function isNodeExecutableName(filePath) {
-  const executable = basename(filePath).toLowerCase();
+  const executable = basename2(filePath).toLowerCase();
   return executable === "node" || executable === "node.exe" || /^node\d+(\.exe)?$/.test(executable);
 }
 function looksLikePath(command) {
@@ -204,8 +423,8 @@ function defaultNodeRuntime(env, fileExists, which, nodeVersion) {
 function defaultProvisionedBin(homeDir, fileExists) {
   const binaryName = process.platform === "win32" ? "codegraph.cmd" : "codegraph";
   const candidates = [
-    join3(homeDir, ".omo", "codegraph", "bin", binaryName),
-    join3(homeDir, ".omo", "codegraph", "node-servers", "node_modules", ".bin", binaryName)
+    join4(homeDir, ".omo", "codegraph", "bin", binaryName),
+    join4(homeDir, ".omo", "codegraph", "node-servers", "node_modules", ".bin", binaryName)
   ];
   return candidates.find((candidate) => fileExists(candidate)) ?? null;
 }
@@ -213,7 +432,7 @@ function resolveBundledShim(requireResolve, fileExists) {
   try {
     const packageJson = requireResolve(`${CODEGRAPH_PACKAGE}/package.json`);
     const packageRoot = dirname(packageJson);
-    const candidates = [join3(packageRoot, "bin", "codegraph.js"), join3(packageRoot, "npm-shim.js")];
+    const candidates = [join4(packageRoot, "bin", "codegraph.js"), join4(packageRoot, "npm-shim.js")];
     return candidates.find((candidate) => fileExists(candidate)) ?? null;
   } catch (error) {
     if (error instanceof Error)
@@ -229,7 +448,7 @@ function resolveBundledShim(requireResolve, fileExists) {
 }
 function resolveCodegraphCommand(options = {}) {
   const env = options.env ?? process.env;
-  const fileExists = options.fileExists ?? existsSync;
+  const fileExists = options.fileExists ?? existsSync2;
   const configuredBin = env[CODEGRAPH_ENV_BIN]?.trim() || env[CODEGRAPH_LEGACY_ENV_BIN]?.trim();
   if (configuredBin !== undefined && configuredBin.length > 0) {
     return { argsPrefix: [], command: configuredBin, exists: fileExists(configuredBin), source: "env" };
@@ -241,7 +460,7 @@ function resolveCodegraphCommand(options = {}) {
   if (bundled !== null && runtime2 !== null) {
     return { argsPrefix: [bundled], command: runtime2, exists: true, source: "bundled" };
   }
-  const provisioned = options.provisioned?.() ?? defaultProvisionedBin(options.homeDir ?? homedir2(), fileExists);
+  const provisioned = options.provisioned?.() ?? defaultProvisionedBin(options.homeDir ?? homedir3(), fileExists);
   if (provisioned !== null && fileExists(provisioned)) {
     return { argsPrefix: [], command: provisioned, exists: true, source: "provisioned" };
   }
@@ -255,8 +474,8 @@ function resolveCodegraphCommand(options = {}) {
 }
 
 // ../../../../utils/src/omo-config/loader.ts
-import { existsSync as existsSync3, readFileSync } from "node:fs";
-import { homedir as homedir3 } from "node:os";
+import { existsSync as existsSync4, readFileSync } from "node:fs";
+import { homedir as homedir4 } from "node:os";
 
 // ../../../../utils/src/deep-merge.ts
 var DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -1212,8 +1431,8 @@ function buildEnvOverrides(harness, env, warnings, merge) {
 }
 
 // ../../../../utils/src/omo-config/resolve.ts
-import { existsSync as existsSync2 } from "node:fs";
-import { dirname as dirname2, isAbsolute, join as join4, relative, resolve } from "node:path";
+import { existsSync as existsSync3 } from "node:fs";
+import { dirname as dirname2, isAbsolute, join as join5, relative, resolve } from "node:path";
 function containsPath(parent, child) {
   const pathToChild = relative(parent, child);
   return pathToChild === "" || !pathToChild.startsWith("..") && !isAbsolute(pathToChild);
@@ -1226,8 +1445,8 @@ function findProjectConfigPathsNearestFirst(cwd, homeDir) {
   while (true) {
     if (stopBeforeDir !== null && currentDir === stopBeforeDir)
       break;
-    const configPath = join4(currentDir, ".omo", "config.jsonc");
-    if (existsSync2(configPath)) {
+    const configPath = join5(currentDir, ".omo", "config.jsonc");
+    if (existsSync3(configPath)) {
       paths.push(configPath);
     }
     const parentDir = dirname2(currentDir);
@@ -1238,7 +1457,7 @@ function findProjectConfigPathsNearestFirst(cwd, homeDir) {
   return paths;
 }
 function resolveOmoConfigPaths(options) {
-  const globalPath = join4(resolve(options.homeDir), ".omo", "config.jsonc");
+  const globalPath = join5(resolve(options.homeDir), ".omo", "config.jsonc");
   const projectPathsFarthestFirst = findProjectConfigPathsNearestFirst(options.cwd, options.homeDir).reverse();
   return [
     { path: globalPath, scope: "global" },
@@ -1449,13 +1668,13 @@ function validateHarnessApplicability(config, harness) {
 }
 function loadOmoConfig(options) {
   const cwd = options.cwd ?? process.cwd();
-  const homeDir = options.homeDir ?? process.env["HOME"] ?? process.env["USERPROFILE"] ?? homedir3();
+  const homeDir = options.homeDir ?? process.env["HOME"] ?? process.env["USERPROFILE"] ?? homedir4();
   const env = options.env ?? process.env;
   let config = BUILT_IN_DEFAULTS;
   const sources = [];
   const warnings = [];
   for (const candidate of resolveOmoConfigPaths({ cwd, homeDir })) {
-    if (!existsSync3(candidate.path)) {
+    if (!existsSync4(candidate.path)) {
       if (candidate.scope === "global") {
         sources.push(toMissingSource(candidate));
       }
@@ -1497,11 +1716,12 @@ var CODEGRAPH_SKIP_HINT = `CodeGraph MCP skipped: codegraph binary not found. In
 `;
 var CODEGRAPH_DISABLED_HINT = `CodeGraph MCP skipped: disabled by OMO SOT config. Set [codex].codegraph.enabled=true to enable it.
 `;
+var CODEGRAPH_VERSION = "1.0.1";
 var WINDOWS_CMD_EXTENSIONS = new Set([".bat", ".cmd"]);
 var WINDOWS_NODE_SCRIPT_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
 async function runCodegraphServe(options = {}) {
   const env = options.env ?? processEnv;
-  const homeDir = options.homeDir ?? homedir4();
+  const homeDir = options.homeDir ?? homedir5();
   const config = options.config ?? getCodexOmoConfig({ cwd: options.cwd ?? processCwd(), env, homeDir });
   const codegraphConfig = config.codegraph ?? {};
   if (codegraphConfig.enabled === false) {
@@ -1513,15 +1733,24 @@ async function runCodegraphServe(options = {}) {
     homeDir,
     provisioned: () => provisionedBinFromInstallDir(codegraphConfig.install_dir)
   };
-  const resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
+  let resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
   const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
-  if (!resolution.exists || shouldSkipResolvedCommand(resolution, options.commandExists ?? existsSync4)) {
+  if (!resolution.exists || shouldSkipResolvedCommand(resolution, options.commandExists ?? existsSync5)) {
     if (resolution.source === "path" && !nodeSupport.supported) {
       (options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
       return 1;
     }
-    (options.stderr ?? processStderr).write(CODEGRAPH_SKIP_HINT);
-    return 1;
+    const provisioned = await provisionMissingCodegraph({
+      config: codegraphConfig,
+      ensureProvisioned: options.ensureProvisioned ?? ensureCodegraphProvisioned,
+      homeDir,
+      resolution
+    });
+    if (provisioned === null) {
+      (options.stderr ?? processStderr).write(CODEGRAPH_SKIP_HINT);
+      return 1;
+    }
+    resolution = provisioned;
   }
   if (codegraphCommandRequiresSupportedLocalNode(resolution) && !nodeSupport.supported) {
     (options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
@@ -1537,6 +1766,21 @@ async function runCodegraphServe(options = {}) {
     env: mergedEnv,
     stdio: "inherit"
   });
+}
+async function provisionMissingCodegraph(options) {
+  if (options.resolution.source === "env")
+    return null;
+  if (options.config.auto_provision === false)
+    return null;
+  const installDir = options.config.install_dir ?? join6(options.homeDir, ".omo", "codegraph");
+  const result = await options.ensureProvisioned({
+    installDir,
+    lockDir: join6(installDir, ".locks"),
+    version: CODEGRAPH_VERSION
+  });
+  if (!result.provisioned || result.binPath === undefined)
+    return null;
+  return { argsPrefix: [], command: result.binPath, exists: true, source: "provisioned" };
 }
 function shouldSkipResolvedCommand(resolution, commandExists) {
   if (resolution.source !== "env")
@@ -1555,8 +1799,8 @@ function codegraphEnvForConfig(config, homeDir, buildEnv) {
 function provisionedBinFromInstallDir(installDir) {
   if (installDir === undefined)
     return null;
-  const candidate = join5(installDir, "bin", process.platform === "win32" ? "codegraph.cmd" : "codegraph");
-  return existsSync4(candidate) ? candidate : null;
+  const candidate = join6(installDir, "bin", process.platform === "win32" ? "codegraph.cmd" : "codegraph");
+  return existsSync5(candidate) ? candidate : null;
 }
 async function runCodegraphServeCli() {
   process.exitCode = await runCodegraphServe();
@@ -1598,7 +1842,7 @@ function isDirectInvocation(argvPath) {
   if (argvPath === undefined)
     return false;
   const modulePath = fileURLToPath(import.meta.url);
-  const moduleName = basename2(modulePath);
+  const moduleName = basename3(modulePath);
   if (moduleName !== "serve.js" && moduleName !== "serve.ts")
     return false;
   return realpathSync(resolve2(argvPath)) === realpathSync(modulePath);

--- a/packages/omo-codex/plugin/components/codegraph/src/serve.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/serve.ts
@@ -17,6 +17,10 @@ import {
 	evaluateCodegraphNodeSupport,
 } from "../../../../../utils/src/codegraph/node-support.ts";
 import {
+	ensureCodegraphProvisioned,
+	type EnsureCodegraphProvisionedOptions,
+} from "../../../../../utils/src/codegraph/provision.ts";
+import {
 	codegraphCommandRequiresSupportedLocalNode,
 	resolveCodegraphCommand,
 	type CodegraphCommandResolution,
@@ -37,6 +41,9 @@ export type CodegraphServeProcessRunner = (
 	args: readonly string[],
 	options: CodegraphServeProcessOptions,
 ) => Promise<number>;
+export type CodegraphProvisioner = (
+	options: EnsureCodegraphProvisionedOptions,
+) => ReturnType<typeof ensureCodegraphProvisioned>;
 
 export interface ServeProcessInvocation {
 	readonly args: readonly string[];
@@ -58,12 +65,14 @@ export interface RunCodegraphServeOptions {
 	readonly resolve?: (options: ResolveCodegraphCommandOptions) => ReturnType<typeof resolveCodegraphCommand>;
 	readonly runProcess?: CodegraphServeProcessRunner;
 	readonly stderr?: CodegraphServeStderr;
+	readonly ensureProvisioned?: CodegraphProvisioner;
 }
 
 const CODEGRAPH_SKIP_HINT =
 	"CodeGraph MCP skipped: codegraph binary not found. Install CodeGraph or set OMO_CODEGRAPH_BIN.\n";
 const CODEGRAPH_DISABLED_HINT =
 	"CodeGraph MCP skipped: disabled by OMO SOT config. Set [codex].codegraph.enabled=true to enable it.\n";
+const CODEGRAPH_VERSION = "1.0.1";
 const WINDOWS_CMD_EXTENSIONS = new Set([".bat", ".cmd"]);
 const WINDOWS_NODE_SCRIPT_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
 
@@ -82,15 +91,24 @@ export async function runCodegraphServe(options: RunCodegraphServeOptions = {}):
 		homeDir,
 		provisioned: () => provisionedBinFromInstallDir(codegraphConfig.install_dir),
 	} satisfies ResolveCodegraphCommandOptions;
-	const resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
+	let resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
 	const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
 	if (!resolution.exists || shouldSkipResolvedCommand(resolution, options.commandExists ?? existsSync)) {
 		if (resolution.source === "path" && !nodeSupport.supported) {
 			(options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
 			return 1;
 		}
-		(options.stderr ?? processStderr).write(CODEGRAPH_SKIP_HINT);
-		return 1;
+		const provisioned = await provisionMissingCodegraph({
+			config: codegraphConfig,
+			ensureProvisioned: options.ensureProvisioned ?? ensureCodegraphProvisioned,
+			homeDir,
+			resolution,
+		});
+		if (provisioned === null) {
+			(options.stderr ?? processStderr).write(CODEGRAPH_SKIP_HINT);
+			return 1;
+		}
+		resolution = provisioned;
 	}
 
 	if (codegraphCommandRequiresSupportedLocalNode(resolution) && !nodeSupport.supported) {
@@ -108,6 +126,25 @@ export async function runCodegraphServe(options: RunCodegraphServeOptions = {}):
 		env: mergedEnv,
 		stdio: "inherit",
 	});
+}
+
+async function provisionMissingCodegraph(options: {
+	readonly config: CodegraphConfig;
+	readonly ensureProvisioned: CodegraphProvisioner;
+	readonly homeDir: string;
+	readonly resolution: CodegraphCommandResolution;
+}): Promise<CodegraphCommandResolution | null> {
+	if (options.resolution.source === "env") return null;
+	if (options.config.auto_provision === false) return null;
+
+	const installDir = options.config.install_dir ?? join(options.homeDir, ".omo", "codegraph");
+	const result = await options.ensureProvisioned({
+		installDir,
+		lockDir: join(installDir, ".locks"),
+		version: CODEGRAPH_VERSION,
+	});
+	if (!result.provisioned || result.binPath === undefined) return null;
+	return { argsPrefix: [], command: result.binPath, exists: true, source: "provisioned" };
 }
 
 function shouldSkipResolvedCommand(

--- a/packages/omo-codex/plugin/components/codegraph/test/provisioned-node-guard.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/provisioned-node-guard.test.ts
@@ -35,7 +35,7 @@ describe("CodeGraph provisioned launcher Node guard", () => {
 		const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-node25-"));
 		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-node25-home-"));
 		const installDir = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-node25-install-"));
-		const binPath = join(installDir, "bin", "codegraph");
+		const binPath = join(installDir, "bin", process.platform === "win32" ? "codegraph.cmd" : "codegraph");
 		const calls: Array<{ readonly args: readonly string[]; readonly command: string }> = [];
 		const outcomes: unknown[] = [];
 

--- a/packages/omo-codex/plugin/components/codegraph/test/serve-provision.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve-provision.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+import { runCodegraphServe } from "../src/serve.ts";
+
+describe("runCodegraphServe provisioning", () => {
+	it("#given CodeGraph is unresolved #when serving MCP #then provisions CodeGraph before spawning", async () => {
+		// given
+		const binPath = join("/tmp/home/.omo/codegraph", "bin", "codegraph");
+		const calls: Array<{
+			readonly args: readonly string[];
+			readonly command: string;
+			readonly env: Record<string, string | undefined>;
+		}> = [];
+		const stderr: string[] = [];
+
+		// when
+		const exitCode = await runCodegraphServe({
+			config: { codegraph: { enabled: true }, sources: [], warnings: [] },
+			env: { PATH: "/bin" },
+			homeDir: "/tmp/home",
+			nodeVersion: "22.14.0",
+			buildEnv: () => ({}),
+			resolve: () => ({ argsPrefix: [], command: "codegraph", exists: false, source: "path" }),
+			ensureProvisioned: (options) =>
+				Promise.resolve({
+					binPath: join(options.installDir ?? "/tmp/home/.omo/codegraph", "bin", "codegraph"),
+					provisioned: true,
+				}),
+			runProcess: (command, args, options) => {
+				calls.push({ args, command, env: options.env });
+				return Promise.resolve(0);
+			},
+			stderr: { write: (chunk: string) => stderr.push(chunk) },
+		});
+
+		// then
+		expect(exitCode).toBe(0);
+		expect(stderr).toEqual([]);
+		expect(calls).toEqual([
+			{
+				args: ["serve", "--mcp"],
+				command: binPath,
+				env: { PATH: "/bin" },
+			},
+		]);
+	});
+});

--- a/packages/omo-codex/plugin/components/codegraph/test/serve.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve.test.ts
@@ -17,6 +17,7 @@ describe("runCodegraphServe", () => {
 
 		// when
 		const exitCode = await runCodegraphServe({
+			config: { codegraph: { auto_provision: false, enabled: true }, sources: [], warnings: [] },
 			env: { PATH: "/bin" },
 			buildEnv: () => ({}),
 			resolve: () => ({ argsPrefix: [], command: "codegraph", exists: false, source: "path" }),


### PR DESCRIPTION
## Summary
- Refs #5382 and code-yeongyu/lazycodex#56.
- Rebased after #5418 and narrowed the PR to the supported-runtime CodeGraph MCP serve-time provisioning race.
- When CodeGraph command resolution is missing and `auto_provision` is still enabled, `serve.ts` now calls the existing provisioner and starts the returned provisioned launcher.
- #5418 behavior is preserved: unsupported Node with no command still shows the Node support hint; explicit bad `OMO_CODEGRAPH_BIN` and `auto_provision: false` still keep the existing skip behavior.

## Why this still matters after #5418
#5418 fixed the Discord-reported UX path where unsupported Node 26 plus no discovered command showed the generic missing-binary hint. This PR keeps that behavior intact.

The remaining path is different: on a supported runtime, Codex can start the CodeGraph MCP before background SessionStart bootstrap finishes provisioning the binary. In that state, `serve.ts` can resolve no command even though auto-provision is enabled. This PR lets the MCP wrapper provision immediately and continue to `serve --mcp` instead of exiting before MCP `initialize`.

## Scope
- `packages/omo-codex/plugin/components/codegraph/src/serve.ts`: provision only the missing non-env command path, then spawn the provisioned launcher.
- `packages/omo-codex/plugin/components/codegraph/test/serve-provision.test.ts`: cover supported-runtime provision-before-spawn behavior.
- `packages/omo-codex/plugin/components/codegraph/test/serve.test.ts`: keep the old skip expectation pinned to `auto_provision: false`.
- `packages/omo-codex/plugin/components/codegraph/test/provisioned-node-guard.test.ts`: make the #5415 Windows fixture use `codegraph.cmd`.
- `packages/omo-codex/plugin/components/codegraph/dist/{serve.js,cli.js}`: regenerated component bundle.

## Verification
- `bun run build` in `packages/omo-codex/plugin/components/codegraph`
- `bun run typecheck` in `packages/omo-codex/plugin/components/codegraph`
- `bun test test` in `packages/omo-codex/plugin/components/codegraph` -> 33 pass, 0 fail
- Built `dist/serve.js` probe: unresolved `codegraph` plus injected provisioner spawned the provisioned launcher with `serve --mcp` and returned exit code 0.
