### PR TITLE
fix(codex): handle Bun-global LazyCodex trust

### DIFF
--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -13145,10 +13145,24 @@ function buildDelegatedOmoInvocation(parsed) {
 import { spawn as spawn4, spawnSync as spawnSync2 } from "node:child_process";
 import { readFileSync as readFileSync3 } from "node:fs";
 import { dirname as dirname8, join as join29 } from "node:path";
+import { createInterface as createInterface2 } from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 var DEFAULT_UPDATE_COMMAND = "npx";
 var DEFAULT_UPDATE_ARGS = ["--yes", "lazycodex-ai@latest", "install", "--no-tui", "--codex-autonomous"];
+var BUN_UPDATE_COMMAND = "bun";
+var BUN_GLOBAL_UPDATE_ARGS = ["update", "-g", "lazycodex-ai@latest"];
+var BUN_GLOBAL_UNTRUSTED_ARGS = ["pm", "-g", "untrusted"];
+var BUN_GLOBAL_TRUST_ARGS = ["pm", "-g", "trust"];
 var INSTALLED_VERSION_FILE = "lazycodex-install.json";
+var KNOWN_LAZYCODEX_BUN_TRUST_PACKAGES = new Set([
+  "@ast-grep/cli",
+  "@code-yeongyu/comment-checker",
+  "@sisyphuslabs/omo-codex-plugin",
+  "lazycodex-ai",
+  "oh-my-openagent",
+  "oh-my-opencode"
+]);
+var KNOWN_LAZYCODEX_BUN_TRUST_PREFIXES = ["@oh-my-opencode/", "oh-my-openagent-", "oh-my-opencode-"];
 async function runLazyCodexManualUpdate(input = {}) {
   const env3 = input.env ?? process.env;
   const log2 = input.log ?? console.log;
@@ -13159,7 +13173,9 @@ async function runLazyCodexManualUpdate(input = {}) {
     currentVersion,
     latestVersion,
     command: resolveCommand2(env3),
-    args: resolveArgs(env3)
+    args: resolveArgs(env3),
+    env: env3,
+    invokedPath: input.invokedPath ?? process.argv[1]
   });
   if (!plan.shouldUpdate) {
     const printableVersion = currentVersion ?? "unknown";
@@ -13171,6 +13187,14 @@ async function runLazyCodexManualUpdate(input = {}) {
     return 0;
   }
   await commandRunner(plan.command, plan.args, { cwd: process.cwd(), env: env3 });
+  if (plan.postUpdate === "bun-global-trust") {
+    await handleBunGlobalTrust({
+      env: env3,
+      log: log2,
+      commandRunner,
+      isInteractive: input.isInteractive ?? (process.stdin.isTTY === true && process.stdout.isTTY === true)
+    });
+  }
   return 0;
 }
 function resolveLazyCodexUpdatePlan(input = {}) {
@@ -13182,7 +13206,10 @@ function resolveLazyCodexUpdatePlan(input = {}) {
     return { shouldUpdate: false, reason: "unknown-latest" };
   if (compareVersions(latest, current) <= 0)
     return { shouldUpdate: false, reason: "up-to-date" };
-  return { shouldUpdate: true, command: input.command ?? DEFAULT_UPDATE_COMMAND, args: input.args ?? DEFAULT_UPDATE_ARGS };
+  if (isBunGlobalEntrypoint(input.invokedPath, input.env ?? process.env)) {
+    return { shouldUpdate: true, command: BUN_UPDATE_COMMAND, args: BUN_GLOBAL_UPDATE_ARGS, postUpdate: "bun-global-trust" };
+  }
+  return { shouldUpdate: true, command: input.command ?? DEFAULT_UPDATE_COMMAND, args: input.args ?? DEFAULT_UPDATE_ARGS, postUpdate: "none" };
 }
 function resolveCommand2(env3) {
   return env3.LAZYCODEX_AUTO_UPDATE_COMMAND?.trim() || DEFAULT_UPDATE_COMMAND;
@@ -13214,6 +13241,70 @@ function resolveLatestVersion(env3) {
     return;
   const version2 = result.stdout.trim();
   return version2.length > 0 ? version2 : undefined;
+}
+async function handleBunGlobalTrust(input) {
+  const packageNames = resolveKnownBunGlobalUntrustedPackages(input.env);
+  if (packageNames.length === 0)
+    return;
+  const trustArgs = [...BUN_GLOBAL_TRUST_ARGS, ...packageNames];
+  const trustCommand = [BUN_UPDATE_COMMAND, ...trustArgs].join(" ");
+  if (!input.isInteractive) {
+    input.log(`Bun blocked LazyCodex-related postinstall scripts. Run this command to trust them:
+${trustCommand}`);
+    return;
+  }
+  if (await confirmBunGlobalTrust(packageNames)) {
+    await input.commandRunner(BUN_UPDATE_COMMAND, trustArgs, { cwd: process.cwd(), env: input.env });
+    return;
+  }
+  input.log(`Skipped Bun postinstall trust. To run it later:
+${trustCommand}`);
+}
+function resolveKnownBunGlobalUntrustedPackages(env3) {
+  const result = spawnSync2(BUN_UPDATE_COMMAND, BUN_GLOBAL_UNTRUSTED_ARGS, {
+    encoding: "utf8",
+    env: env3,
+    stdio: ["ignore", "pipe", "ignore"]
+  });
+  if (result.status !== 0)
+    return [];
+  const names = [];
+  for (const match of result.stdout.matchAll(/^\.\/node_modules\/((?:@[^/\s]+\/)?[^\s]+)\s+@/gm)) {
+    const packageName = match[1];
+    if (packageName !== undefined && isKnownLazyCodexBunTrustPackage(packageName) && !names.includes(packageName)) {
+      names.push(packageName);
+    }
+  }
+  return names;
+}
+async function confirmBunGlobalTrust(packageNames) {
+  const prompt = `Trust Bun postinstall scripts for ${packageNames.join(", ")}? [y/N] `;
+  const readline = createInterface2({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await readline.question(prompt)).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  } finally {
+    readline.close();
+  }
+}
+function isKnownLazyCodexBunTrustPackage(packageName) {
+  return KNOWN_LAZYCODEX_BUN_TRUST_PACKAGES.has(packageName) || KNOWN_LAZYCODEX_BUN_TRUST_PREFIXES.some((prefix) => packageName.startsWith(prefix));
+}
+function isBunGlobalEntrypoint(invokedPath, env3) {
+  if (typeof invokedPath !== "string" || invokedPath.trim().length === 0)
+    return false;
+  const normalizedPath = normalizePathForPrefix(invokedPath);
+  return resolveBunGlobalNodeModulesRoots(env3).some((root) => normalizedPath.startsWith(root));
+}
+function resolveBunGlobalNodeModulesRoots(env3) {
+  return [
+    env3.BUN_INSTALL?.trim() ? join29(env3.BUN_INSTALL.trim(), "install", "global", "node_modules") : undefined,
+    env3.HOME?.trim() ? join29(env3.HOME.trim(), ".bun", "install", "global", "node_modules") : undefined
+  ].flatMap((root) => root === undefined ? [] : [normalizePathForPrefix(root)]);
+}
+function normalizePathForPrefix(path2) {
+  const normalized = path2.replaceAll("\\", "/").replace(/\/+$/, "");
+  return normalized.endsWith("/node_modules") ? `${normalized}/` : normalized;
 }
 function defaultRunCommandForManualUpdate(command, args, options) {
   return new Promise((resolve11, reject) => {
@@ -13431,7 +13522,7 @@ async function runLazyCodexInstallLocalCli(input) {
       input.log(`Installed ${result2.installed.length} plugin(s) from ${result2.marketplaceName}.`);
       return 0;
     }
-    return runLazyCodexManualUpdate({ env: input.env, dryRun: parsed.dryRun, log: input.log });
+    return runLazyCodexManualUpdate({ env: input.env, dryRun: parsed.dryRun, log: input.log, invokedPath: input.invokedPath });
   }
   const repoRoot = parsed.repoRoot ? resolve11(parsed.repoRoot) : input.defaultRepoRoot;
   const result = await installMarketplaceLocally({

--- a/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
+++ b/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -148,6 +148,69 @@ test("#given stale lazycodex version #when running update dry-run #then prints t
 	assert.equal(output, "npx --yes lazycodex-ai@latest install --no-tui --codex-autonomous");
 });
 
+test("#given bun global lazycodex wrapper #when running update dry-run #then prints bun global update command", { skip: process.platform === "win32" }, () => {
+	// given
+	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
+	const tempHome = mkdtempSync(join(tmpdir(), "lazycodex-bun-global-dry-run-"));
+	const binPath = createBunGlobalLazyCodexSymlink(tempHome, scriptPath);
+
+	try {
+		// when
+		const output = execFileSync(process.execPath, [binPath, "--dry-run", "update"], {
+			encoding: "utf8",
+			env: {
+				...process.env,
+				HOME: tempHome,
+				LAZYCODEX_CURRENT_VERSION: "1.0.0",
+				LAZYCODEX_LATEST_VERSION: "1.0.1",
+			},
+		}).trim();
+
+		// then
+		assert.equal(output, "bun update -g lazycodex-ai@latest");
+	} finally {
+		rmSync(tempHome, { recursive: true, force: true });
+	}
+});
+
+test("#given bun global lazycodex wrapper and untrusted known scripts #when update runs noninteractively #then prints manual scoped trust command", { skip: process.platform === "win32" }, () => {
+	// given
+	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
+	const tempHome = mkdtempSync(join(tmpdir(), "lazycodex-bun-global-trust-"));
+	const tempBin = mkdtempSync(join(tmpdir(), "lazycodex-bun-bin-"));
+	const commandLogPath = join(tempHome, "commands.log");
+	const binPath = createBunGlobalLazyCodexSymlink(tempHome, scriptPath);
+	writeFakeBunCommand(tempBin);
+	writeFakeNpxCommand(tempBin);
+
+	try {
+		// when
+		const output = execFileSync(process.execPath, [binPath, "update"], {
+			encoding: "utf8",
+			env: {
+				...process.env,
+				HOME: tempHome,
+				LAZYCODEX_CURRENT_VERSION: "1.0.0",
+				LAZYCODEX_LATEST_VERSION: "1.0.1",
+				LAZYCODEX_TEST_COMMAND_LOG: commandLogPath,
+				PATH: `${tempBin}:${process.env.PATH ?? ""}`,
+			},
+		});
+		const commandLog = readFileSync(commandLogPath, "utf8");
+
+		// then
+		assert.match(commandLog, /^bun update -g lazycodex-ai@latest$/m);
+		assert.match(commandLog, /^bun pm -g untrusted$/m);
+		assert.doesNotMatch(commandLog, /^bun pm -g trust/m);
+		assert.doesNotMatch(commandLog, /^npx /m);
+		assert.match(output, /bun pm -g trust oh-my-openagent @code-yeongyu\/comment-checker/);
+		assert.doesNotMatch(output, /left-pad/);
+	} finally {
+		rmSync(tempHome, { recursive: true, force: true });
+		rmSync(tempBin, { recursive: true, force: true });
+	}
+});
+
 test("#given current lazycodex version #when running update dry-run #then reports already current", () => {
 	// given
 	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
@@ -165,6 +228,51 @@ test("#given current lazycodex version #when running update dry-run #then report
 	// then
 	assert.equal(output, "lazycodex-ai 1.0.1 is already up to date.");
 });
+
+function createBunGlobalLazyCodexSymlink(homeDir, scriptPath) {
+	const packageBinDir = join(homeDir, ".bun", "install", "global", "node_modules", "lazycodex-ai", "bin");
+	mkdirSync(packageBinDir, { recursive: true });
+	const binPath = join(packageBinDir, "lazycodex-ai");
+	symlinkSync(scriptPath, binPath);
+	return binPath;
+}
+
+function writeExecutable(path, source) {
+	writeFileSync(path, source);
+	chmodSync(path, 0o755);
+}
+
+function writeFakeBunCommand(binDir) {
+	writeExecutable(
+		join(binDir, "bun"),
+		`#!/bin/sh
+printf '%s\\n' "bun $*" >> "$LAZYCODEX_TEST_COMMAND_LOG"
+if [ "$1" = "pm" ] && [ "$2" = "-g" ] && [ "$3" = "untrusted" ]; then
+  cat <<'EOF'
+./node_modules/oh-my-openagent @4.9.2
+ » [postinstall]: node postinstall.mjs
+
+./node_modules/left-pad @1.0.0
+ » [postinstall]: node postinstall.js
+
+./node_modules/@code-yeongyu/comment-checker @0.8.0
+ » [postinstall]: node postinstall.js
+EOF
+fi
+exit 0
+`,
+	);
+}
+
+function writeFakeNpxCommand(binDir) {
+	writeExecutable(
+		join(binDir, "npx"),
+		`#!/bin/sh
+printf '%s\\n' "npx $*" >> "$LAZYCODEX_TEST_COMMAND_LOG"
+exit 0
+`,
+	);
+}
 
 test("#given dry-run ulw-loop #when running the Node installer entrypoint #then prints delegated ulw-loop command", () => {
 	// given

--- a/packages/omo-codex/scripts/install-local.mjs
+++ b/packages/omo-codex/scripts/install-local.mjs
@@ -70,6 +70,7 @@ if (isEntrypointInvocation(process.argv[1] ?? "")) {
 			argv: process.argv.slice(2),
 			defaultRepoRoot: resolveDefaultRepoRoot(),
 			entrypointPath,
+			invokedPath: process.argv[1] ?? "",
 			cwd: process.cwd(),
 			env: process.env,
 			log: console.log,

--- a/packages/omo-codex/src/install/install-local-cli.ts
+++ b/packages/omo-codex/src/install/install-local-cli.ts
@@ -35,6 +35,7 @@ export async function runLazyCodexInstallLocalCli(input: {
   readonly argv: readonly string[]
   readonly defaultRepoRoot: string
   readonly entrypointPath: string
+  readonly invokedPath?: string
   readonly cwd: string
   readonly env: NodeJS.ProcessEnv
   readonly log: (line: string) => void
@@ -68,7 +69,7 @@ export async function runLazyCodexInstallLocalCli(input: {
       input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`)
       return 0
     }
-    return runLazyCodexManualUpdate({ env: input.env, dryRun: parsed.dryRun, log: input.log })
+    return runLazyCodexManualUpdate({ env: input.env, dryRun: parsed.dryRun, log: input.log, invokedPath: input.invokedPath })
   }
 
   const repoRoot = parsed.repoRoot ? resolve(parsed.repoRoot) : input.defaultRepoRoot

--- a/packages/omo-codex/src/install/lazycodex-manual-update.ts
+++ b/packages/omo-codex/src/install/lazycodex-manual-update.ts
@@ -1,12 +1,26 @@
 import { spawn, spawnSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
+import { createInterface } from "node:readline/promises"
 import { fileURLToPath } from "node:url"
 import type { RunCommand } from "./types"
 
 const DEFAULT_UPDATE_COMMAND = "npx"
 const DEFAULT_UPDATE_ARGS = ["--yes", "lazycodex-ai@latest", "install", "--no-tui", "--codex-autonomous"] as const
+const BUN_UPDATE_COMMAND = "bun"
+const BUN_GLOBAL_UPDATE_ARGS = ["update", "-g", "lazycodex-ai@latest"] as const
+const BUN_GLOBAL_UNTRUSTED_ARGS = ["pm", "-g", "untrusted"] as const
+const BUN_GLOBAL_TRUST_ARGS = ["pm", "-g", "trust"] as const
 const INSTALLED_VERSION_FILE = "lazycodex-install.json"
+const KNOWN_LAZYCODEX_BUN_TRUST_PACKAGES = new Set([
+  "@ast-grep/cli",
+  "@code-yeongyu/comment-checker",
+  "@sisyphuslabs/omo-codex-plugin",
+  "lazycodex-ai",
+  "oh-my-openagent",
+  "oh-my-opencode",
+])
+const KNOWN_LAZYCODEX_BUN_TRUST_PREFIXES = ["@oh-my-opencode/", "oh-my-openagent-", "oh-my-opencode-"] as const
 
 type Version = {
   readonly major: number
@@ -17,13 +31,15 @@ type Version = {
 
 type LazyCodexUpdatePlan =
   | { readonly shouldUpdate: false; readonly reason: "unknown-current" | "unknown-latest" | "up-to-date" }
-  | { readonly shouldUpdate: true; readonly command: string; readonly args: readonly string[] }
+  | { readonly shouldUpdate: true; readonly command: string; readonly args: readonly string[]; readonly postUpdate: "bun-global-trust" | "none" }
 
 export async function runLazyCodexManualUpdate(input: {
   readonly env?: NodeJS.ProcessEnv
   readonly dryRun?: boolean
   readonly log?: (line: string) => void
   readonly runCommand?: RunCommand
+  readonly invokedPath?: string
+  readonly isInteractive?: boolean
 } = {}): Promise<number> {
   const env = input.env ?? process.env
   const log = input.log ?? console.log
@@ -35,6 +51,8 @@ export async function runLazyCodexManualUpdate(input: {
     latestVersion,
     command: resolveCommand(env),
     args: resolveArgs(env),
+    env,
+    invokedPath: input.invokedPath ?? process.argv[1],
   })
   if (!plan.shouldUpdate) {
     const printableVersion = currentVersion ?? "unknown"
@@ -48,6 +66,14 @@ export async function runLazyCodexManualUpdate(input: {
     return 0
   }
   await commandRunner(plan.command, plan.args, { cwd: process.cwd(), env })
+  if (plan.postUpdate === "bun-global-trust") {
+    await handleBunGlobalTrust({
+      env,
+      log,
+      commandRunner,
+      isInteractive: input.isInteractive ?? (process.stdin.isTTY === true && process.stdout.isTTY === true),
+    })
+  }
   return 0
 }
 
@@ -56,13 +82,18 @@ function resolveLazyCodexUpdatePlan(input: {
   readonly latestVersion?: string
   readonly command?: string
   readonly args?: readonly string[]
+  readonly env?: NodeJS.ProcessEnv
+  readonly invokedPath?: string
 } = {}): LazyCodexUpdatePlan {
   const current = parseVersion(input.currentVersion)
   if (current === null) return { shouldUpdate: false, reason: "unknown-current" }
   const latest = parseVersion(input.latestVersion)
   if (latest === null) return { shouldUpdate: false, reason: "unknown-latest" }
   if (compareVersions(latest, current) <= 0) return { shouldUpdate: false, reason: "up-to-date" }
-  return { shouldUpdate: true, command: input.command ?? DEFAULT_UPDATE_COMMAND, args: input.args ?? DEFAULT_UPDATE_ARGS }
+  if (isBunGlobalEntrypoint(input.invokedPath, input.env ?? process.env)) {
+    return { shouldUpdate: true, command: BUN_UPDATE_COMMAND, args: BUN_GLOBAL_UPDATE_ARGS, postUpdate: "bun-global-trust" }
+  }
+  return { shouldUpdate: true, command: input.command ?? DEFAULT_UPDATE_COMMAND, args: input.args ?? DEFAULT_UPDATE_ARGS, postUpdate: "none" }
 }
 
 function resolveCommand(env: NodeJS.ProcessEnv): string {
@@ -99,6 +130,80 @@ function resolveLatestVersion(env: NodeJS.ProcessEnv): string | undefined {
   if (result.status !== 0) return undefined
   const version = result.stdout.trim()
   return version.length > 0 ? version : undefined
+}
+
+async function handleBunGlobalTrust(input: {
+  readonly env: NodeJS.ProcessEnv
+  readonly log: (line: string) => void
+  readonly commandRunner: RunCommand
+  readonly isInteractive: boolean
+}): Promise<void> {
+  const packageNames = resolveKnownBunGlobalUntrustedPackages(input.env)
+  if (packageNames.length === 0) return
+
+  const trustArgs = [...BUN_GLOBAL_TRUST_ARGS, ...packageNames]
+  const trustCommand = [BUN_UPDATE_COMMAND, ...trustArgs].join(" ")
+  if (!input.isInteractive) {
+    input.log(`Bun blocked LazyCodex-related postinstall scripts. Run this command to trust them:\n${trustCommand}`)
+    return
+  }
+
+  if (await confirmBunGlobalTrust(packageNames)) {
+    await input.commandRunner(BUN_UPDATE_COMMAND, trustArgs, { cwd: process.cwd(), env: input.env })
+    return
+  }
+  input.log(`Skipped Bun postinstall trust. To run it later:\n${trustCommand}`)
+}
+
+function resolveKnownBunGlobalUntrustedPackages(env: NodeJS.ProcessEnv): readonly string[] {
+  const result = spawnSync(BUN_UPDATE_COMMAND, BUN_GLOBAL_UNTRUSTED_ARGS, {
+    encoding: "utf8",
+    env,
+    stdio: ["ignore", "pipe", "ignore"],
+  })
+  if (result.status !== 0) return []
+  const names: string[] = []
+  for (const match of result.stdout.matchAll(/^\.\/node_modules\/((?:@[^/\s]+\/)?[^\s]+)\s+@/gm)) {
+    const packageName = match[1]
+    if (packageName !== undefined && isKnownLazyCodexBunTrustPackage(packageName) && !names.includes(packageName)) {
+      names.push(packageName)
+    }
+  }
+  return names
+}
+
+async function confirmBunGlobalTrust(packageNames: readonly string[]): Promise<boolean> {
+  const prompt = `Trust Bun postinstall scripts for ${packageNames.join(", ")}? [y/N] `
+  const readline = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const answer = (await readline.question(prompt)).trim().toLowerCase()
+    return answer === "y" || answer === "yes"
+  } finally {
+    readline.close()
+  }
+}
+
+function isKnownLazyCodexBunTrustPackage(packageName: string): boolean {
+  return KNOWN_LAZYCODEX_BUN_TRUST_PACKAGES.has(packageName) ||
+    KNOWN_LAZYCODEX_BUN_TRUST_PREFIXES.some((prefix) => packageName.startsWith(prefix))
+}
+
+function isBunGlobalEntrypoint(invokedPath: string | undefined, env: NodeJS.ProcessEnv): boolean {
+  if (typeof invokedPath !== "string" || invokedPath.trim().length === 0) return false
+  const normalizedPath = normalizePathForPrefix(invokedPath)
+  return resolveBunGlobalNodeModulesRoots(env).some((root) => normalizedPath.startsWith(root))
+}
+
+function resolveBunGlobalNodeModulesRoots(env: NodeJS.ProcessEnv): readonly string[] {
+  return [
+    env.BUN_INSTALL?.trim() ? join(env.BUN_INSTALL.trim(), "install", "global", "node_modules") : undefined,
+    env.HOME?.trim() ? join(env.HOME.trim(), ".bun", "install", "global", "node_modules") : undefined,
+  ].flatMap((root) => root === undefined ? [] : [normalizePathForPrefix(root)])
+}
+
+function normalizePathForPrefix(path: string): string {
+  const normalized = path.replaceAll("\\", "/").replace(/\/+$/, "")
+  return normalized.endsWith("/node_modules") ? `${normalized}/` : normalized
 }
 
 function defaultRunCommandForManualUpdate(command: string, args: readonly string[], options: { readonly cwd: string; readonly env?: NodeJS.ProcessEnv }): Promise<void> {


### PR DESCRIPTION
## Summary
Fixes #5183 by making the LazyCodex manual updater recognize Bun-global installs. When the invoked LazyCodex wrapper is under Bun's global `node_modules`, the updater now uses `bun update -g lazycodex-ai@latest`, inspects `bun pm -g untrusted`, and handles blocked postinstall scripts with a conservative allowlist.

Interactive terminals get a `y/N` prompt before running `bun pm -g trust` for known LazyCodex/OMO packages only. Noninteractive runs print the exact manual scoped trust command and never run trust automatically.

## Changes
- Detect Bun-global LazyCodex wrapper paths from `HOME` / `BUN_INSTALL` global install roots.
- Preserve the existing `npx --yes lazycodex-ai@latest install --no-tui --codex-autonomous` path for non-Bun installs.
- Parse Bun untrusted output and allow only known LazyCodex/OMO packages.
- Add generated-entrypoint tests for Bun-global update command selection and noninteractive scoped manual trust output.
- Rebuild the generated `packages/omo-codex/scripts/install-dist/install-local.mjs` bundle.

## Verification
**Failing-first proof**
- `.omo/evidence/20260619-issue-5183-bun-global-trust-red-entrypoint.txt` captured the pre-fix failure: Bun-global update still printed the `npx` command and never inspected Bun trust state.

**Automated**
- `bun run build:codex-install` ✅ (`.omo/evidence/20260619-issue-5183-post-loc-build-codex-install.txt`)
- `tsgo --noEmit -p packages/omo-codex/tsconfig.json` ✅ (`.omo/evidence/20260619-issue-5183-post-loc-omo-codex-typecheck.txt`)
- `node --test packages/omo-codex/scripts/install-local-entrypoint.test.mjs` ✅ (`.omo/evidence/20260619-issue-5183-post-loc-entrypoint.txt`)
- `node --test packages/omo-codex/scripts/install-generated-bundle.test.mjs` ✅ (`.omo/evidence/20260619-issue-5183-post-loc-generated-bundle.txt`)
- `bun run typecheck` ✅ (`.omo/evidence/20260619-issue-5183-typecheck.txt`)
- `bun run test:codex` ✅ 344 passed (`.omo/evidence/20260619-issue-5183-post-loc-test-codex.txt`)
- static no-`--all` trust audit ✅ (`.omo/evidence/20260619-issue-5183-no-trust-all.txt`)
- pure LOC check ✅ `lazycodex-manual-update.ts` is 249 pure LOC (`.omo/evidence/20260619-issue-5183-post-loc-check.txt`)

**Manual QA / Codex QA**
- tmux fake-Bun interactive updater proof ✅ (`.omo/evidence/20260619-issue-5183-bun-global-trust/interactive-trust-pane.txt`, `interactive-trust-commands.txt`, `interactive-trust-cleanup.txt`)
- codex-qa common isolation self-check ✅ (`.omo/evidence/20260619-issue-5183-codex-qa-common-self-check.txt`)
- codex-qa isolated install verification ✅ (`.omo/evidence/20260619-issue-5183-codex-qa-install-verify.txt`)
- codex-qa app-server live hook proof ✅ (`.omo/evidence/20260619-issue-5183-codex-qa-app-server-plugin.json`)

## Notes
- During QA, running two Codex plugin builds concurrently caused a transient JSON read failure in `sync-hook-status-messages.mjs`; serial reruns passed. The final evidence artifacts use serial Codex QA.
- Plan: `.omo/plans/issue-5183-bun-global-trust.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bun-global updates for `lazycodex-ai` by detecting global wrappers, using Bun’s global update flow, and safely handling Bun trust prompts. Resolves incorrect `npx` guidance and ensures clear, scoped trust instructions.

- **Bug Fixes**
  - Detect Bun-global wrapper via `BUN_INSTALL`/`HOME` and use `bun update -g lazycodex-ai@latest` instead of `npx ...`.
  - After update, inspect `bun pm -g untrusted` and allow trust only for known LazyCodex/OMO packages (e.g. `lazycodex-ai`, `oh-my-openagent`, `@code-yeongyu/comment-checker`, `@oh-my-opencode/*`).
  - Interactive: prompt `y/N` before running `bun pm -g trust ...`. Noninteractive: never trust automatically; print the exact command to run.
  - Pass `invokedPath` through the CLI so global detection works from the wrapper.
  - Added tests for Bun-global dry-run and noninteractive trust output; rebuilt the generated installer bundle.

<sup>Written for commit 4095df8e6dd488a558b2d7d269fe2375cbc29f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

