### PR TITLE
fix(omo-opencode): cache resolved config agents

### DIFF
--- a/packages/omo-opencode/src/plugin-handlers/config-handler-cache.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler-cache.test.ts
@@ -1,0 +1,214 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import type { OhMyOpenCodeConfig } from "../config"
+import * as agents from "../agents"
+import * as commandLoader from "../features/claude-code-command-loader"
+import { isAgentRegistered } from "../features/claude-code-session-state"
+import * as builtinCommands from "../features/builtin-commands"
+import * as skillLoader from "../features/opencode-skill-loader"
+import * as agentLoader from "../features/claude-code-agent-loader"
+import * as mcpLoader from "../features/claude-code-mcp-loader"
+import * as pluginLoader from "../features/claude-code-plugin-loader"
+import * as mcpModule from "../mcp"
+import * as shared from "../shared"
+import { getAgentListDisplayName } from "../shared/agent-display-names"
+import { installAgentSortShim, setAgentSortOrder } from "../shared/agent-sort-shim"
+import * as configDir from "../shared/opencode-config-dir"
+import * as permissionCompat from "../shared/permission-compat"
+import * as modelResolver from "../shared/model-resolver"
+import * as configErrors from "../shared/config-errors"
+import { unsafeTestValue } from "../../../../test-support/unsafe-test-value"
+
+let createConfigHandler: (typeof import("./config-handler"))["createConfigHandler"]
+
+async function importFreshConfigHandlerModule(): Promise<typeof import("./config-handler")> {
+  return import(`./config-handler?test=${Date.now()}-${Math.random()}`)
+}
+
+function createPluginConfig(overrides: Partial<OhMyOpenCodeConfig> = {}): OhMyOpenCodeConfig {
+  return {
+    git_master: {
+      commit_footer: true,
+      include_co_authored_by: true,
+      git_env_prefix: "GIT_MASTER=1",
+    },
+    ...overrides,
+  }
+}
+
+beforeEach(async () => {
+  mock.restore()
+  configErrors.clearConfigLoadErrors()
+
+  spyOn(agents, unsafeTestValue("createBuiltinAgents")).mockResolvedValue({
+    sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+    oracle: { name: "oracle", prompt: "test", mode: "subagent" },
+  })
+
+  spyOn(commandLoader, unsafeTestValue("loadUserCommands")).mockResolvedValue({})
+  spyOn(commandLoader, unsafeTestValue("loadProjectCommands")).mockResolvedValue({})
+  spyOn(commandLoader, unsafeTestValue("loadOpencodeGlobalCommands")).mockResolvedValue({})
+  spyOn(commandLoader, unsafeTestValue("loadOpencodeProjectCommands")).mockResolvedValue({})
+  spyOn(builtinCommands, unsafeTestValue("loadBuiltinCommands")).mockReturnValue({})
+  spyOn(skillLoader, unsafeTestValue("loadUserSkills")).mockResolvedValue({})
+  spyOn(skillLoader, unsafeTestValue("loadProjectSkills")).mockResolvedValue({})
+  spyOn(skillLoader, unsafeTestValue("loadOpencodeGlobalSkills")).mockResolvedValue({})
+  spyOn(skillLoader, unsafeTestValue("loadOpencodeProjectSkills")).mockResolvedValue({})
+  spyOn(skillLoader, unsafeTestValue("discoverUserClaudeSkills")).mockResolvedValue([])
+  spyOn(skillLoader, unsafeTestValue("discoverProjectClaudeSkills")).mockResolvedValue([])
+  spyOn(skillLoader, unsafeTestValue("discoverOpencodeGlobalSkills")).mockResolvedValue([])
+  spyOn(skillLoader, unsafeTestValue("discoverOpencodeProjectSkills")).mockResolvedValue([])
+  spyOn(agentLoader, unsafeTestValue("loadUserAgents")).mockReturnValue({})
+  spyOn(agentLoader, unsafeTestValue("loadProjectAgents")).mockReturnValue({})
+  spyOn(agentLoader, unsafeTestValue("loadOpencodeGlobalAgents")).mockReturnValue({})
+  spyOn(agentLoader, unsafeTestValue("loadOpencodeProjectAgents")).mockReturnValue({})
+  spyOn(mcpLoader, unsafeTestValue("loadMcpConfigs")).mockResolvedValue({ servers: {}, loadedServers: [] })
+  spyOn(mcpLoader, "setAdditionalAllowedMcpEnvVars").mockImplementation(() => {})
+  spyOn(pluginLoader, unsafeTestValue("loadAllPluginComponents")).mockResolvedValue({
+    commands: {},
+    skills: {},
+    agents: {},
+    mcpServers: {},
+    hooksConfigs: [],
+    plugins: [],
+    errors: [],
+  })
+  spyOn(mcpModule, unsafeTestValue("createBuiltinMcps")).mockReturnValue({})
+  spyOn(shared, unsafeTestValue("log")).mockImplementation(() => {})
+  spyOn(shared, unsafeTestValue("fetchAvailableModels")).mockResolvedValue(new Set(["anthropic/claude-opus-4-7"]))
+  spyOn(shared, unsafeTestValue("readConnectedProvidersCache")).mockReturnValue(null)
+  spyOn(configDir, unsafeTestValue("getOpenCodeConfigPaths")).mockReturnValue({
+    configDir: "/tmp/.config/opencode",
+    configJson: "/tmp/.config/opencode/opencode.json",
+    configJsonc: "/tmp/.config/opencode/opencode.jsonc",
+    packageJson: "/tmp/.config/opencode/package.json",
+    omoConfig: "/tmp/.config/opencode/oh-my-opencode.jsonc",
+  })
+  spyOn(permissionCompat, unsafeTestValue("migrateAgentConfig")).mockImplementation((config: Record<string, unknown>) => config)
+
+  spyOn(modelResolver, unsafeTestValue("resolveModelWithFallback")).mockReturnValue({
+    model: "anthropic/claude-opus-4-7",
+    source: "provider-fallback",
+  })
+  ;({ createConfigHandler } = await importFreshConfigHandlerModule())
+})
+
+afterEach(() => {
+  setAgentSortOrder(undefined)
+  configErrors.clearConfigLoadErrors()
+  mock.restore()
+})
+
+describe("Config handler hot path caching", () => {
+  test("reuses the resolved agent roster for repeated config hook invocations with the same model", async () => {
+    // #given
+    const pluginConfig = createPluginConfig({
+      agents: Object.fromEntries(
+        Array.from({ length: 12 }, (_, index) => [
+          `agent-${index}`,
+          {
+            model: `provider/model-${index}`,
+            fallback_models: [`provider/fallback-${index}`],
+          },
+        ]),
+      ),
+      categories: Object.fromEntries(
+        Array.from({ length: 10 }, (_, index) => [
+          `category-${index}`,
+          {
+            model: `provider/category-model-${index}`,
+            fallback_models: [`provider/category-fallback-${index}`],
+          },
+        ]),
+      ),
+    })
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
+    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
+
+    // #then
+    expect(unsafeTestValue(agents.createBuiltinAgents).mock.calls).toHaveLength(1)
+    expect(isAgentRegistered(getAgentListDisplayName("sisyphus"))).toBe(true)
+  })
+
+  test("re-resolves the agent roster when host skill paths change", async () => {
+    // #given
+    const pluginConfig = createPluginConfig({})
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler({
+      model: "anthropic/claude-opus-4-7",
+      agent: {},
+      skills: { paths: ["/tmp/first-sibling-plugin-skills"] },
+    })
+    await handler({
+      model: "anthropic/claude-opus-4-7",
+      agent: {},
+      skills: { paths: ["/tmp/second-sibling-plugin-skills"] },
+    })
+
+    // #then
+    expect(unsafeTestValue(agents.createBuiltinAgents).mock.calls).toHaveLength(2)
+  })
+
+  test("preserves agent_order on cache hits when default_agent is only a fallback", async () => {
+    // #given
+    installAgentSortShim()
+    const pluginConfig = createPluginConfig({
+      agent_order: ["hephaestus", "sisyphus", "prometheus", "atlas"],
+    })
+    setAgentSortOrder(pluginConfig.agent_order)
+    const createBuiltinAgentsMock = unsafeTestValue<{
+      mockResolvedValue: (value: Record<string, unknown>) => void
+    }>(agents.createBuiltinAgents)
+    createBuiltinAgentsMock.mockResolvedValue({
+      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+      hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
+      atlas: { name: "atlas", prompt: "test", mode: "primary" },
+    })
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
+    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
+    const sortedNames = [
+      { name: getAgentListDisplayName("atlas") },
+      { name: getAgentListDisplayName("sisyphus") },
+      { name: getAgentListDisplayName("prometheus") },
+      { name: getAgentListDisplayName("hephaestus") },
+    ].toSorted((left, right) => left.name.localeCompare(right.name)).map((agent) => agent.name)
+
+    // #then
+    expect(sortedNames).toEqual([
+      getAgentListDisplayName("hephaestus"),
+      getAgentListDisplayName("sisyphus"),
+      getAgentListDisplayName("prometheus"),
+      getAgentListDisplayName("atlas"),
+    ])
+  })
+})

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
@@ -17,6 +17,7 @@ import * as mcpLoader from "../features/claude-code-mcp-loader"
 import * as pluginLoader from "../features/claude-code-plugin-loader"
 import * as mcpModule from "../mcp"
 import * as shared from "../shared"
+import { installAgentSortShim, setAgentSortOrder } from "../shared/agent-sort-shim"
 import * as configDir from "../shared/opencode-config-dir"
 import * as permissionCompat from "../shared/permission-compat"
 import * as modelResolver from "../shared/model-resolver"
@@ -138,6 +139,7 @@ afterEach(() => {
   ;(unsafeTestValue(permissionCompat.migrateAgentConfig))?.mockRestore?.()
   ;(unsafeTestValue(modelResolver.resolveModelWithFallback))?.mockRestore?.()
   ;(unsafeTestValue(agentPriorityOrder.reorderAgentsByPriority))?.mockRestore?.()
+  setAgentSortOrder(undefined)
   configErrors.clearConfigLoadErrors()
   mock.restore()
 })
@@ -241,6 +243,77 @@ describe("Config handler hot path caching", () => {
     // #then
     expect(unsafeTestValue(agents.createBuiltinAgents).mock.calls).toHaveLength(1)
     expect(isAgentRegistered(getAgentListDisplayName("sisyphus"))).toBe(true)
+  })
+
+  test("re-resolves the agent roster when host skill paths change", async () => {
+    // #given
+    const pluginConfig = createPluginConfig({})
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler({
+      model: "anthropic/claude-opus-4-7",
+      agent: {},
+      skills: { paths: ["/tmp/first-sibling-plugin-skills"] },
+    })
+    await handler({
+      model: "anthropic/claude-opus-4-7",
+      agent: {},
+      skills: { paths: ["/tmp/second-sibling-plugin-skills"] },
+    })
+
+    // #then
+    expect(unsafeTestValue(agents.createBuiltinAgents).mock.calls).toHaveLength(2)
+  })
+
+  test("preserves agent_order on cache hits when default_agent is only a fallback", async () => {
+    // #given
+    installAgentSortShim()
+    const pluginConfig = createPluginConfig({
+      agent_order: ["hephaestus", "sisyphus", "prometheus", "atlas"],
+    })
+    setAgentSortOrder(pluginConfig.agent_order)
+    const createBuiltinAgentsMock = unsafeTestValue<{
+      mockResolvedValue: (value: Record<string, unknown>) => void
+    }>(agents.createBuiltinAgents)
+    createBuiltinAgentsMock.mockResolvedValue({
+      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+      hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
+      atlas: { name: "atlas", prompt: "test", mode: "primary" },
+    })
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
+    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
+    const sortedNames = [
+      { name: getAgentListDisplayName("atlas") },
+      { name: getAgentListDisplayName("sisyphus") },
+      { name: getAgentListDisplayName("prometheus") },
+      { name: getAgentListDisplayName("hephaestus") },
+    ].toSorted((left, right) => left.name.localeCompare(right.name)).map((agent) => agent.name)
+
+    // #then
+    expect(sortedNames).toEqual([
+      getAgentListDisplayName("hephaestus"),
+      getAgentListDisplayName("sisyphus"),
+      getAgentListDisplayName("prometheus"),
+      getAgentListDisplayName("atlas"),
+    ])
   })
 })
 

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
@@ -9,7 +9,6 @@ import { resolveCategoryConfig } from "./category-config-resolver"
 import * as agents from "../agents"
 import * as sisyphusJunior from "../agents/sisyphus-junior"
 import * as commandLoader from "../features/claude-code-command-loader"
-import { isAgentRegistered } from "../features/claude-code-session-state"
 import * as builtinCommands from "../features/builtin-commands"
 import * as skillLoader from "../features/opencode-skill-loader"
 import * as agentLoader from "../features/claude-code-agent-loader"
@@ -17,7 +16,6 @@ import * as mcpLoader from "../features/claude-code-mcp-loader"
 import * as pluginLoader from "../features/claude-code-plugin-loader"
 import * as mcpModule from "../mcp"
 import * as shared from "../shared"
-import { installAgentSortShim, setAgentSortOrder } from "../shared/agent-sort-shim"
 import * as configDir from "../shared/opencode-config-dir"
 import * as permissionCompat from "../shared/permission-compat"
 import * as modelResolver from "../shared/model-resolver"
@@ -139,7 +137,6 @@ afterEach(() => {
   ;(unsafeTestValue(permissionCompat.migrateAgentConfig))?.mockRestore?.()
   ;(unsafeTestValue(modelResolver.resolveModelWithFallback))?.mockRestore?.()
   ;(unsafeTestValue(agentPriorityOrder.reorderAgentsByPriority))?.mockRestore?.()
-  setAgentSortOrder(undefined)
   configErrors.clearConfigLoadErrors()
   mock.restore()
 })
@@ -201,119 +198,6 @@ describe("Sisyphus-Junior model inheritance", () => {
     expect(agentConfig[getAgentDisplayName("sisyphus-junior")]?.model).toBe(
       "openai/gpt-5.5"
     )
-  })
-})
-
-describe("Config handler hot path caching", () => {
-  test("reuses the resolved agent roster for repeated config hook invocations with the same model", async () => {
-    // #given
-    const pluginConfig = createPluginConfig({
-      agents: Object.fromEntries(
-        Array.from({ length: 12 }, (_, index) => [
-          `agent-${index}`,
-          {
-            model: `provider/model-${index}`,
-            fallback_models: [`provider/fallback-${index}`],
-          },
-        ]),
-      ),
-      categories: Object.fromEntries(
-        Array.from({ length: 10 }, (_, index) => [
-          `category-${index}`,
-          {
-            model: `provider/category-model-${index}`,
-            fallback_models: [`provider/category-fallback-${index}`],
-          },
-        ]),
-      ),
-    })
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
-
-    // #when
-    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
-    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
-
-    // #then
-    expect(unsafeTestValue(agents.createBuiltinAgents).mock.calls).toHaveLength(1)
-    expect(isAgentRegistered(getAgentListDisplayName("sisyphus"))).toBe(true)
-  })
-
-  test("re-resolves the agent roster when host skill paths change", async () => {
-    // #given
-    const pluginConfig = createPluginConfig({})
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
-
-    // #when
-    await handler({
-      model: "anthropic/claude-opus-4-7",
-      agent: {},
-      skills: { paths: ["/tmp/first-sibling-plugin-skills"] },
-    })
-    await handler({
-      model: "anthropic/claude-opus-4-7",
-      agent: {},
-      skills: { paths: ["/tmp/second-sibling-plugin-skills"] },
-    })
-
-    // #then
-    expect(unsafeTestValue(agents.createBuiltinAgents).mock.calls).toHaveLength(2)
-  })
-
-  test("preserves agent_order on cache hits when default_agent is only a fallback", async () => {
-    // #given
-    installAgentSortShim()
-    const pluginConfig = createPluginConfig({
-      agent_order: ["hephaestus", "sisyphus", "prometheus", "atlas"],
-    })
-    setAgentSortOrder(pluginConfig.agent_order)
-    const createBuiltinAgentsMock = unsafeTestValue<{
-      mockResolvedValue: (value: Record<string, unknown>) => void
-    }>(agents.createBuiltinAgents)
-    createBuiltinAgentsMock.mockResolvedValue({
-      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
-      hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
-      atlas: { name: "atlas", prompt: "test", mode: "primary" },
-    })
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
-
-    // #when
-    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
-    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
-    const sortedNames = [
-      { name: getAgentListDisplayName("atlas") },
-      { name: getAgentListDisplayName("sisyphus") },
-      { name: getAgentListDisplayName("prometheus") },
-      { name: getAgentListDisplayName("hephaestus") },
-    ].toSorted((left, right) => left.name.localeCompare(right.name)).map((agent) => agent.name)
-
-    // #then
-    expect(sortedNames).toEqual([
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("sisyphus"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("atlas"),
-    ])
   })
 })
 

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
@@ -9,6 +9,7 @@ import { resolveCategoryConfig } from "./category-config-resolver"
 import * as agents from "../agents"
 import * as sisyphusJunior from "../agents/sisyphus-junior"
 import * as commandLoader from "../features/claude-code-command-loader"
+import { isAgentRegistered } from "../features/claude-code-session-state"
 import * as builtinCommands from "../features/builtin-commands"
 import * as skillLoader from "../features/opencode-skill-loader"
 import * as agentLoader from "../features/claude-code-agent-loader"
@@ -198,6 +199,48 @@ describe("Sisyphus-Junior model inheritance", () => {
     expect(agentConfig[getAgentDisplayName("sisyphus-junior")]?.model).toBe(
       "openai/gpt-5.5"
     )
+  })
+})
+
+describe("Config handler hot path caching", () => {
+  test("reuses the resolved agent roster for repeated config hook invocations with the same model", async () => {
+    // #given
+    const pluginConfig = createPluginConfig({
+      agents: Object.fromEntries(
+        Array.from({ length: 12 }, (_, index) => [
+          `agent-${index}`,
+          {
+            model: `provider/model-${index}`,
+            fallback_models: [`provider/fallback-${index}`],
+          },
+        ]),
+      ),
+      categories: Object.fromEntries(
+        Array.from({ length: 10 }, (_, index) => [
+          `category-${index}`,
+          {
+            model: `provider/category-model-${index}`,
+            fallback_models: [`provider/category-fallback-${index}`],
+          },
+        ]),
+      ),
+    })
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
+    await handler({ model: "anthropic/claude-opus-4-7", agent: {} })
+
+    // #then
+    expect(unsafeTestValue(agents.createBuiltinAgents).mock.calls).toHaveLength(1)
+    expect(isAgentRegistered(getAgentListDisplayName("sisyphus"))).toBe(true)
   })
 })
 

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.ts
@@ -16,6 +16,7 @@ import {
   registerAgentName,
 } from "../features/claude-code-session-state";
 import { setDefaultAgentForSort } from "../shared/agent-sort-shim";
+import { getConfiguredDefaultAgent } from "./agent-config-assembly";
 
 export { resolveCategoryConfig } from "./category-config-resolver";
 
@@ -40,6 +41,7 @@ export interface ConfigHandlerDeps {
 
 type AgentConfigSnapshot = {
   readonly cacheKey: string;
+  readonly configuredDefaultAgent: string | undefined;
   readonly defaultAgent: unknown;
   readonly agents: Record<string, unknown>;
 }
@@ -67,14 +69,16 @@ function createAgentConfigCacheKey(config: Record<string, unknown>): string {
     agent: config.agent,
     default_agent: config.default_agent,
     model: config.model,
+    skills: config.skills,
   })
 }
 
 function replayAgentConfigSideEffects(params: {
   agentResult: Record<string, unknown>;
+  configuredDefaultAgent: string | undefined;
   defaultAgent: unknown;
 }): void {
-  if (typeof params.defaultAgent === "string") {
+  if (params.configuredDefaultAgent && typeof params.defaultAgent === "string") {
     setDefaultAgentForSort(params.defaultAgent)
   }
   clearRegisteredAgentNames()
@@ -114,9 +118,11 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       agentResult = config.agent as Record<string, unknown>;
       replayAgentConfigSideEffects({
         agentResult,
+        configuredDefaultAgent: agentConfigSnapshot.configuredDefaultAgent,
         defaultAgent: config.default_agent,
       })
     } else {
+      const configuredDefaultAgent = getConfiguredDefaultAgent(config);
       agentResult = await applyAgentConfig({
         config,
         pluginConfig,
@@ -125,6 +131,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       });
       agentConfigSnapshot = {
         cacheKey: agentCacheKey,
+        configuredDefaultAgent,
         defaultAgent: config.default_agent,
         agents: cloneAgentConfig(agentResult),
       };

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.ts
@@ -11,6 +11,11 @@ import { applyProviderConfig } from "./provider-config-handler";
 import { loadPluginComponents } from "./plugin-components-loader";
 import { applyToolConfig } from "./tool-config-handler";
 import { clearFormatterCache } from "../tools/hashline-edit/formatter-trigger"
+import {
+  clearRegisteredAgentNames,
+  registerAgentName,
+} from "../features/claude-code-session-state";
+import { setDefaultAgentForSort } from "../shared/agent-sort-shim";
 
 export { resolveCategoryConfig } from "./category-config-resolver";
 
@@ -33,8 +38,55 @@ export interface ConfigHandlerDeps {
   runtimeSkillSourceUrl?: string;
 }
 
+type AgentConfigSnapshot = {
+  readonly cacheKey: string;
+  readonly defaultAgent: unknown;
+  readonly agents: Record<string, unknown>;
+}
+
+function cloneConfigValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(cloneConfigValue)
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, cloneConfigValue(entry)]),
+    )
+  }
+
+  return value
+}
+
+function cloneAgentConfig(agents: Record<string, unknown>): Record<string, unknown> {
+  return cloneConfigValue(agents) as Record<string, unknown>
+}
+
+function createAgentConfigCacheKey(config: Record<string, unknown>): string {
+  return JSON.stringify({
+    agent: config.agent,
+    default_agent: config.default_agent,
+    model: config.model,
+  })
+}
+
+function replayAgentConfigSideEffects(params: {
+  agentResult: Record<string, unknown>;
+  defaultAgent: unknown;
+}): void {
+  if (typeof params.defaultAgent === "string") {
+    setDefaultAgentForSort(params.defaultAgent)
+  }
+  clearRegisteredAgentNames()
+  for (const name of Object.keys(params.agentResult)) {
+    registerAgentName(name)
+  }
+}
+
 export function createConfigHandler(deps: ConfigHandlerDeps) {
   const { ctx, pluginConfig, modelCacheState, runtimeSkillSourceUrl } = deps;
+  let pluginComponentsPromise: ReturnType<typeof loadPluginComponents> | undefined;
+  let agentConfigSnapshot: AgentConfigSnapshot | undefined;
 
   return async (config: Record<string, unknown>) => {
     const formatterConfig = config.formatter;
@@ -47,16 +99,36 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     });
     clearFormatterCache()
 
-    const pluginComponents = await loadPluginComponents({ pluginConfig });
+    pluginComponentsPromise ??= loadPluginComponents({ pluginConfig });
+    const pluginComponents = await pluginComponentsPromise;
 
     applyHookConfig({ pluginComponents });
 
-    const agentResult = await applyAgentConfig({
-      config,
-      pluginConfig,
-      ctx,
-      pluginComponents,
-    });
+    const agentCacheKey = createAgentConfigCacheKey(config);
+    let agentResult: Record<string, unknown>;
+    if (agentConfigSnapshot?.cacheKey === agentCacheKey) {
+      config.agent = cloneAgentConfig(agentConfigSnapshot.agents);
+      if (agentConfigSnapshot.defaultAgent !== undefined) {
+        config.default_agent = agentConfigSnapshot.defaultAgent;
+      }
+      agentResult = config.agent as Record<string, unknown>;
+      replayAgentConfigSideEffects({
+        agentResult,
+        defaultAgent: config.default_agent,
+      })
+    } else {
+      agentResult = await applyAgentConfig({
+        config,
+        pluginConfig,
+        ctx,
+        pluginComponents,
+      });
+      agentConfigSnapshot = {
+        cacheKey: agentCacheKey,
+        defaultAgent: config.default_agent,
+        agents: cloneAgentConfig(agentResult),
+      };
+    }
 
     applyToolConfig({ config, pluginConfig, agentResult });
     await applyMcpConfig({ config, pluginConfig, ctx, pluginComponents });


### PR DESCRIPTION
## Summary
Fixes #5397 by caching the finalized OpenCode agent roster inside the config hook for repeated invocations with the same host agent/default-agent/model input. This avoids rebuilding the full built-in agent/category graph on the hot config path when users configure many agents and categories.

The cache stores a finalized snapshot, clones it on reuse before per-call tool permission mutation, and replays the same runtime registration side effects that the normal finalizer path performs.

## Changes
- Cache resolved plugin components and finalized agent config inside `createConfigHandler`.
- Clone cached agent config on reuse so `applyToolConfig` can mutate permissions without corrupting the snapshot.
- Replay agent registration/default-sort side effects on cache hits.
- Add a regression test with 12 configured agents and 10 configured categories proving repeated config hook invocations build the roster once and keep the agent registry populated.

## Verification
**Failing-first proof**
- RED: `.omo/evidence/20260619-fix-5397-agent-config-hot-path/red-final-config-cache.txt` showed the new test failing with `Expected length: 1 / Received length: 2` before the production fix.
- GREEN: `.omo/evidence/20260619-fix-5397-agent-config-hot-path/green-final-config-cache.txt` and `.omo/evidence/20260619-fix-5397-agent-config-hot-path/config-handler-test-final.txt` passed after the fix.

**Automated**
- `bun test packages/omo-opencode/src/plugin-handlers/config-handler.test.ts` -> 52 pass, 0 fail (`config-handler-test-final.txt`).
- `bun test packages/omo-opencode/src/plugin-handlers/agent-config-handler.test.ts packages/omo-opencode/src/plugin-handlers/agent-config-finalizer.test.ts` -> 29 pass, 0 fail (`adjacent-agent-config-tests.txt`).
- `tsgo --noEmit -p packages/omo-opencode/tsconfig.json` -> passed (`typecheck-omo-opencode-final.txt`).
- `bun run typecheck` -> passed (`typecheck-root.txt`).
- `bun test` -> 10038 pass, 2 skip, 0 fail (`bun-test-root-final.txt`).
- `bun run build` -> passed (`build-root-final-2.txt`).
- `git diff --check` -> passed (`git-diff-check-final.txt`).

**OpenCode QA**
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check` -> passed (`opencode-common-self-check.txt`).
- `bash .agents/skills/opencode-qa/scripts/server-smoke.sh` -> passed (`opencode-server-smoke.txt`).
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test` -> passed (`opencode-sse-self-test.txt`).
- Local plugin `/config` smoke loaded this worktree via `file://...`, used the issue's many-agent/many-category config, called `/config` twice, observed 12 resolved agents, and proved the live OpenCode DB session count stayed unchanged at 5737 -> 5737 (`opencode-local-plugin-config-smoke-final.txt`, `opencode-local-plugin-config-1.json`, `opencode-local-plugin-config-2.json`, `opencode-local-plugin-server.log`).

## Related Issues
Closes #5397.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches the finalized OpenCode agent roster in `omo-opencode`’s config handler to avoid rebuilding on repeated calls with the same inputs. Fixes #5397 and removes a hot-path rebuild while keeping agent registration and sorting correct.

- **Performance**
  - Cache plugin components and finalized agent config inside `createConfigHandler`, keyed by `model`, `default_agent`, host `agent`, and `skills`.
  - On cache hit, deep-clone the roster before `applyToolConfig`, replay agent-name registration, and restore default-agent sort only when a configured default exists.
  - Invalidate the cache when skill paths change to pick up new sibling plugin skills; added focused tests for reuse, skill-path invalidation, and `agent_order` preservation.

<sup>Written for commit ef426b1274d847518235700cb789f2704a47bc4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

