### PR TITLE
fix(background-agent): release stale unknown parent wake deferrals

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-deferral.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-deferral.test.ts
@@ -7,61 +7,8 @@ import { ParentWakeNotifier } from "./parent-wake-notifier"
 
 type ParentWakeClient = ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
 
-describe("ParentWakeNotifier — assistant history deferral", () => {
-  test("#given parent session messages cannot be inspected #when checking parent wake history #then parent wake stays deferred", async () => {
-    // given
-    const client = unsafeTestValue<ParentWakeClient>({
-      session: {
-        messages: async () => {
-          throw new Error("message endpoint failed")
-        },
-        status: async () => ({ data: { "parent-message-error": { type: "idle" } } }),
-        promptAsync: async () => {
-          return { data: {} }
-        },
-      },
-    })
-    const notifier = new ParentWakeNotifier(
-      {
-        client,
-        directory: "/tmp/test-omo",
-        enqueueNotificationForParent: async (_sessionID, operation) => {
-          await operation()
-        },
-      },
-      {
-        pendingRetryMs: 1_000,
-        acceptedMessageSkewMs: 5_000,
-        toolCallDeferMaxMs: 5_000,
-        failureRequeueWindowMs: 5_000,
-        userMessageInProgressWindowMs: 2_000,
-      },
-    )
-    notifier.queuePendingParentWake(
-      "parent-message-error",
-      "task complete",
-      { agent: "sisyphus" },
-      true,
-    )
-    const pendingWake = notifier.getPendingParentWakes().get("parent-message-error")
-    expect(pendingWake).toBeDefined()
-    if (!pendingWake) {
-      throw new Error("Missing pending parent wake")
-    }
-
-    try {
-      // when
-      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-message-error", pendingWake)
-
-      // then
-      expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
-    } finally {
-      notifier.shutdown()
-      releaseAllPromptAsyncReservationsForTesting()
-    }
-  })
-
-  test("#given old assistant turn has recent running tool activity #when checking parent wake history #then stale tool escape stays deferred", async () => {
+describe("ParentWakeNotifier — assistant text history deferral", () => {
+  test("#given stale unknown-finish assistant text has no pending tool call #when checking parent wake history #then parent wake stops deferring", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -72,21 +19,14 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
             {
               info: {
                 role: "assistant",
-                finish: "tool-calls",
-                time: { created: 80_000 },
+                finish: "unknown",
+                time: { created: 90_000 },
               },
-              parts: [
-                {
-                  type: "tool",
-                  tool: "bash",
-                  time: { start: 99_000, end: 99_500 },
-                  state: { status: "running" },
-                },
-              ],
+              parts: [{ type: "text", text: "still streaming" }],
             },
           ],
         }),
-        status: async () => ({ data: { "parent-fresh-tool-activity": { type: "idle" } } }),
+        status: async () => ({ data: { "parent-stale-text": { type: "idle" } } }),
         promptAsync: async () => {
           return { data: {} }
         },
@@ -109,12 +49,12 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
       },
     )
     notifier.queuePendingParentWake(
-      "parent-fresh-tool-activity",
+      "parent-stale-text",
       "task complete",
       { agent: "sisyphus" },
       true,
     )
-    const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-tool-activity")
+    const pendingWake = notifier.getPendingParentWakes().get("parent-stale-text")
     expect(pendingWake).toBeDefined()
     if (!pendingWake) {
       throw new Error("Missing pending parent wake")
@@ -123,7 +63,73 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
 
     try {
       // when
-      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-fresh-tool-activity", pendingWake)
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-stale-text", pendingWake)
+
+      // then
+      expect(decision).toEqual({ defer: false, skipPromptGateToolStateCheck: true })
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given fresh unfinished assistant text has no pending tool call #when checking parent wake history #then parent wake continues deferring", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: {
+                role: "assistant",
+                finish: "unknown",
+                time: { created: 99_000 },
+              },
+              parts: [{ type: "text", text: "still streaming" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-fresh-text": { type: "idle" } } }),
+        promptAsync: async () => {
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-fresh-text",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+    const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-text")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 98_000
+
+    try {
+      // when
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-fresh-text", pendingWake)
 
       // then
       expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
@@ -134,10 +140,11 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
     }
   })
 
-  test("#given old assistant turn has recent state-level tool activity #when checking parent wake history #then stale tool escape stays deferred", async () => {
+  test("#given stale deferral but fresh unfinished assistant text #when flushing parent wake #then wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
+    let promptAsyncCallCount = 0
     const client = unsafeTestValue<ParentWakeClient>({
       session: {
         messages: async () => ({
@@ -145,21 +152,16 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
             {
               info: {
                 role: "assistant",
-                finish: "tool-calls",
-                time: { created: 80_000 },
+                finish: "unknown",
+                time: { created: 99_000 },
               },
-              parts: [
-                {
-                  type: "tool",
-                  tool: "bash",
-                  state: { status: "running", time: { updated: 99_500 } },
-                },
-              ],
+              parts: [{ type: "text", text: "still streaming" }],
             },
           ],
         }),
-        status: async () => ({ data: { "parent-fresh-tool-state-activity": { type: "idle" } } }),
+        status: async () => ({ data: { "parent-fresh-text-flush": { type: "idle" } } }),
         promptAsync: async () => {
+          promptAsyncCallCount += 1
           return { data: {} }
         },
       },
@@ -181,12 +183,12 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
       },
     )
     notifier.queuePendingParentWake(
-      "parent-fresh-tool-state-activity",
+      "parent-fresh-text-flush",
       "task complete",
       { agent: "sisyphus" },
       true,
     )
-    const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-tool-state-activity")
+    const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-text-flush")
     expect(pendingWake).toBeDefined()
     if (!pendingWake) {
       throw new Error("Missing pending parent wake")
@@ -195,13 +197,11 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
 
     try {
       // when
-      const decision = await notifier["shouldDeferParentWakeForSessionHistory"](
-        "parent-fresh-tool-state-activity",
-        pendingWake,
-      )
+      await notifier.flushPendingParentWake("parent-fresh-text-flush")
 
       // then
-      expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
+      expect(promptAsyncCallCount).toBe(1)
+      expect(notifier.getPendingParentWakes().has("parent-fresh-text-flush")).toBe(true)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-race.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-race.test.ts
@@ -1,0 +1,97 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { ParentWakeNotifier } from "./parent-wake-notifier"
+
+type ParentWakeClient = ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
+
+type PromptAsyncCall = {
+  readonly body: { readonly noReply?: boolean }
+}
+
+describe("ParentWakeNotifier — assistant text dispatch race", () => {
+  test("#given stale text becomes fresh assistant activity before dispatch #when flushing parent wake #then wake is recorded without forking a reply", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    let messageReadCount = 0
+    const promptAsyncCalls: PromptAsyncCall[] = []
+    const staleAssistantMessages = [
+      {
+        info: {
+          role: "assistant",
+          finish: "unknown",
+          time: { created: 90_000 },
+        },
+        parts: [{ type: "text", text: "old streamed text" }],
+      },
+    ]
+    const freshAssistantMessages = [
+      {
+        info: {
+          role: "assistant",
+          finish: "unknown",
+          time: { created: 99_000 },
+        },
+        parts: [{ type: "text", text: "new streamed text" }],
+      },
+    ]
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => {
+          messageReadCount += 1
+          return { data: messageReadCount === 1 ? staleAssistantMessages : freshAssistantMessages }
+        },
+        status: async () => ({ data: { "parent-stale-then-fresh-text": { type: "idle" } } }),
+        promptAsync: async (call: PromptAsyncCall) => {
+          promptAsyncCalls.push(call)
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-stale-then-fresh-text",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+    const pendingWake = notifier.getPendingParentWakes().get("parent-stale-then-fresh-text")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 90_000
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-stale-then-fresh-text")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-stale-then-fresh-text")).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -109,6 +109,27 @@ export class ParentWakeFlushRunner {
       return
     }
 
+    const finalToolWaitDecision = await this.confirmParentWakeStillSafeForReply(
+      sessionID,
+      latestWake,
+      toolWaitDecision,
+    )
+    if (finalToolWaitDecision.defer) {
+      if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
+        return
+      }
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry,
+        toolWaitDecision: { ...finalToolWaitDecision, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+        retainPendingWake: latestWake.shouldReply,
+      })
+      log("[background-agent] Recorded admit-only parent wake because parent session history became unsafe:", {
+        sessionID,
+      })
+      return
+    }
+
     const dispatchedWake = this.deps.dispatchedTracker.getWake(sessionID)
     if (dispatchedWake && isRedundantParentWake(latestWake, dispatchedWake)) {
       this.deps.pendingQueue.deleteWake(sessionID)
@@ -118,7 +139,7 @@ export class ParentWakeFlushRunner {
 
     await this.sendParentWakePrompt(sessionID, latestWake, {
       emptyAssistantTurnRetry,
-      toolWaitDecision,
+      toolWaitDecision: finalToolWaitDecision,
     })
   }
 
@@ -224,6 +245,17 @@ export class ParentWakeFlushRunner {
     sessionID: string,
     wake: PendingParentWake,
   ): Promise<ToolWaitDeferralDecision> {
+    return this.deps.sessionInspector.shouldDeferForHistory(sessionID, wake)
+  }
+
+  private async confirmParentWakeStillSafeForReply(
+    sessionID: string,
+    wake: PendingParentWake,
+    decision: ToolWaitDeferralDecision,
+  ): Promise<ToolWaitDeferralDecision> {
+    if (!decision.skipPromptGateToolStateCheck) {
+      return decision
+    }
     return this.deps.sessionInspector.shouldDeferForHistory(sessionID, wake)
   }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-history-state.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-history-state.ts
@@ -1,6 +1,7 @@
 import {
   messageCompleted,
   messageFinish,
+  messageHasSubstantiveAssistantOutput,
   messageHasUnresolvedTool,
   messageHasWaitingTool,
   messageIsSyntheticOrInternalUser,
@@ -8,7 +9,7 @@ import {
 } from "../../shared/prompt-async-gate/prompt-message-state"
 import { isEmptyNoProgressAssistantTurnInfo } from "./empty-assistant-turn"
 import { isRecord } from "./error-classifier"
-import { getParentWakeMessageCreatedAt } from "./parent-wake-message-activity"
+import { getParentWakeMessageActivityAt, getParentWakeMessageCreatedAt } from "./parent-wake-message-activity"
 import type { PendingParentWake } from "./parent-wake-dedupe"
 
 export function latestAssistantTurnIsCompletedEmptyNoProgress(messages: readonly unknown[]): boolean {
@@ -67,6 +68,28 @@ export function latestAssistantTurnHasFreshToolActivity(
   return false
 }
 
+export function latestAssistantTurnHasStaleUnknownSubstantiveOutput(
+  messages: readonly unknown[],
+  now: number,
+  maxAgeMs: number,
+): boolean {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    const role = messageRole(message)
+    if (role === "assistant") {
+      const finish = messageFinish(message)
+      return (finish === undefined || finish === "unknown")
+        && !messageCompleted(message)
+        && messageHasSubstantiveAssistantOutput(message)
+        && !messageHasFreshActivity(message, now, maxAgeMs)
+    }
+    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
+      return false
+    }
+  }
+  return false
+}
+
 export function createEmptyAssistantTurnRetryDedupeKey(wake: PendingParentWake): string {
   return [
     "background-agent-parent-wake-empty-retry",
@@ -85,6 +108,14 @@ function partHasFreshToolActivity(part: unknown, now: number, maxAgeMs: number):
     now,
     maxAgeMs,
   )
+}
+
+function messageHasFreshActivity(message: unknown, now: number, maxAgeMs: number): boolean {
+  if (!isRecord(message)) {
+    return false
+  }
+  const activityAt = getParentWakeMessageActivityAt(message)
+  return activityAt !== undefined && now - activityAt <= maxAgeMs
 }
 
 function timeHasFreshActivity(time: unknown, now: number, maxAgeMs: number): boolean {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
@@ -5,59 +5,13 @@ import {
 } from "../../shared/prompt-async-gate/pending-tool-turn"
 import {
   latestAssistantTurnHasFreshToolActivity,
+  latestAssistantTurnHasStaleUnknownSubstantiveOutput,
   latestAssistantTurnHasToolBlock,
   latestAssistantTurnIsCompletedEmptyNoProgress,
 } from "./parent-wake-history-state"
 import type { PendingParentWake } from "./parent-wake-dedupe"
 import { getParentWakeMessageCreatedAt } from "./parent-wake-message-activity"
-
-export type ParentWakeSessionMessage = {
-  readonly info?: {
-    readonly role?: string
-    readonly finish?: string
-    readonly error?: unknown
-    readonly time?: {
-      readonly created?: unknown
-      readonly updated?: unknown
-      readonly completed?: unknown
-      readonly start?: unknown
-      readonly end?: unknown
-    }
-  }
-  readonly role?: string
-  readonly finish?: string
-  readonly error?: unknown
-  readonly time?: {
-    readonly created?: unknown
-    readonly updated?: unknown
-    readonly completed?: unknown
-    readonly start?: unknown
-    readonly end?: unknown
-  }
-  readonly parts?: readonly {
-    readonly type?: string
-    readonly text?: string
-    readonly synthetic?: boolean
-    readonly content?: unknown
-    readonly time?: {
-      readonly created?: unknown
-      readonly updated?: unknown
-      readonly completed?: unknown
-      readonly start?: unknown
-      readonly end?: unknown
-    }
-    readonly state?: {
-      readonly status?: unknown
-      readonly time?: {
-        readonly created?: unknown
-        readonly updated?: unknown
-        readonly completed?: unknown
-        readonly start?: unknown
-        readonly end?: unknown
-      }
-    }
-  }[]
-}
+import type { ParentWakeSessionMessage } from "./parent-wake-session-message"
 
 export type ToolWaitDeferralDecision = {
   readonly defer: boolean
@@ -159,6 +113,15 @@ export function getParentWakeSessionHistoryDeferralDecision(input: {
     // and resumed by the idle/consumption machinery (ses_14a3ab27bffe incident).
     log("[background-agent] Holding parent wake during stale tool-call deferral:", { sessionID: input.sessionID })
     return { defer: true, skipPromptGateToolStateCheck: true }
+  }
+  if (
+    now - input.wake.toolCallDeferralStartedAt >= input.toolCallDeferMaxMs
+    && latestAssistantTurnHasStaleUnknownSubstantiveOutput(messages, now, input.toolCallDeferMaxMs)
+  ) {
+    log("[background-agent] Retrying parent wake after stale unknown-finish assistant output:", {
+      sessionID: input.sessionID,
+    })
+    return { defer: false, skipPromptGateToolStateCheck: true }
   }
   log("[background-agent] Deferred parent wake because latest assistant turn blocks internal prompts:", {
     sessionID: input.sessionID,

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-session-inspector.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-session-inspector.ts
@@ -3,13 +3,13 @@ import { isPromptMessageInspectionAborted } from "../../shared/prompt-async-gate
 import type { PromptMessagesQuery } from "../../shared/prompt-async-gate/types"
 import { getErrorText } from "./error-classifier"
 import type { PendingParentWake } from "./parent-wake-dedupe"
+import type { ParentWakeSessionMessage } from "./parent-wake-session-message"
 import {
   getParentWakeSessionHistoryDeferralDecision,
   hasAssistantOrToolOutputAfterParentWake,
   hasAssistantOutputAfterParentWakeAdmission,
   hasRecordedParentWakePromptMessage,
   parentWakeUserMessageIsInProgress,
-  type ParentWakeSessionMessage,
   type ToolWaitDeferralDecision,
 } from "./parent-wake-session-history"
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-session-message.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-session-message.ts
@@ -1,0 +1,47 @@
+export type ParentWakeSessionMessage = {
+  readonly info?: {
+    readonly role?: string
+    readonly finish?: string
+    readonly error?: unknown
+    readonly time?: {
+      readonly created?: unknown
+      readonly updated?: unknown
+      readonly completed?: unknown
+      readonly start?: unknown
+      readonly end?: unknown
+    }
+  }
+  readonly role?: string
+  readonly finish?: string
+  readonly error?: unknown
+  readonly time?: {
+    readonly created?: unknown
+    readonly updated?: unknown
+    readonly completed?: unknown
+    readonly start?: unknown
+    readonly end?: unknown
+  }
+  readonly parts?: readonly {
+    readonly type?: string
+    readonly text?: string
+    readonly synthetic?: boolean
+    readonly content?: unknown
+    readonly time?: {
+      readonly created?: unknown
+      readonly updated?: unknown
+      readonly completed?: unknown
+      readonly start?: unknown
+      readonly end?: unknown
+    }
+    readonly state?: {
+      readonly status?: unknown
+      readonly time?: {
+        readonly created?: unknown
+        readonly updated?: unknown
+        readonly completed?: unknown
+        readonly start?: unknown
+        readonly end?: unknown
+      }
+    }
+  }[]
+}

--- a/packages/omo-opencode/src/shared/live-server-route-probe.test.ts
+++ b/packages/omo-opencode/src/shared/live-server-route-probe.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import {
+  _setFetchImplementationForTesting,
+  initLiveServerRoute,
+  resetLiveServerRouteForTesting,
+  resolveDispatchClient,
+} from "./live-server-route"
+
+describe("live-server-route probe endpoint", () => {
+  afterEach(() => {
+    resetLiveServerRouteForTesting()
+  })
+
+  test("#given live server route is registered #when availability is probed #then the stable health endpoint is used", async () => {
+    //#given
+    const fetchedUrls: string[] = []
+    const fakeFetch: typeof fetch = async (input) => {
+      fetchedUrls.push(String(input))
+      return new Response(JSON.stringify({ healthy: true }), { status: 200 })
+    }
+    const inProcessClient = { marker: "in-process" }
+    _setFetchImplementationForTesting(fakeFetch)
+    initLiveServerRoute({
+      serverUrl: new URL("http://127.0.0.1:4096"),
+      directory: "/tmp/live-probe",
+      inProcessClient,
+    })
+
+    //#when
+    await resolveDispatchClient(inProcessClient, "ses_probe_endpoint")
+
+    //#then
+    expect(fetchedUrls).toEqual(["http://127.0.0.1:4096/global/health"])
+  })
+})

--- a/packages/omo-opencode/src/shared/live-server-route.ts
+++ b/packages/omo-opencode/src/shared/live-server-route.ts
@@ -88,7 +88,7 @@ async function probe(registration: RouteRegistration): Promise<boolean> {
     return false
   }
 
-  const probeUrl = new URL("/session", registration.serverUrl)
+  const probeUrl = new URL("/global/health", registration.serverUrl)
   const authHeader = getServerBasicAuthHeader()
   const headers: Record<string, string> = authHeader ? { Authorization: authHeader } : {}
 
@@ -128,13 +128,18 @@ async function probe(registration: RouteRegistration): Promise<boolean> {
   }
 }
 
-function hasFreshProbe(registration: RouteRegistration): boolean {
-  return registration.available !== undefined && Date.now() - registration.probeTimestamp < PROBE_TTL_MS
+function getFreshProbeAvailability(registration: RouteRegistration): boolean | undefined {
+  const available = registration.available
+  if (available === undefined || Date.now() - registration.probeTimestamp >= PROBE_TTL_MS) {
+    return undefined
+  }
+  return available
 }
 
 async function resolveAvailability(registration: RouteRegistration): Promise<boolean> {
-  if (hasFreshProbe(registration)) {
-    return registration.available!
+  const freshAvailability = getFreshProbeAvailability(registration)
+  if (freshAvailability !== undefined) {
+    return freshAvailability
   }
 
   if (!registration.inFlightProbe) {
@@ -177,11 +182,12 @@ export function tryResolveDispatchClientSync(client: unknown, sessionID: string)
     return { client, route: "in-process", reason: "unavailable" }
   }
 
-  if (!hasFreshProbe(registration)) {
+  const freshAvailability = getFreshProbeAvailability(registration)
+  if (freshAvailability === undefined) {
     return undefined
   }
 
-  if (!registration.available) {
+  if (!freshAvailability) {
     return { client, route: "in-process", reason: "unavailable" }
   }
 
@@ -199,7 +205,10 @@ export async function resolveDispatchClient(client: unknown, sessionID: string):
     return syncResult
   }
 
-  const registration = registrations.get(client)!
+  const registration = registrations.get(client)
+  if (!registration) {
+    return { client, route: "in-process", reason: "identity" }
+  }
   const isAvailable = await resolveAvailability(registration)
   if (!isAvailable) {
     return { client, route: "in-process", reason: "unavailable" }


### PR DESCRIPTION
## Summary
Fixes #5401 by letting parent wake stop history-deferring once the latest assistant turn is a stale unknown-finish turn with substantive assistant output and no fresh activity. Fresh streaming/active tool states still defer, and reply dispatch now rechecks history immediately before forking a reply so a stale-to-fresh race is admitted without creating a new parent turn.

This also fixes live parent-wake routing availability checks to probe the stable `/global/health` endpoint. The OpenCode serve QA now proves parent wakes route through the live listener instead of falling back to the unsafe in-process client path.

## Changes
- Added stale unknown-finish substantive-output detection to parent wake history state.
- Updated parent wake flushing to re-read history before reply dispatch when the earlier decision skipped the prompt-gate tool-state check.
- Added a stale-to-fresh assistant text race regression proving the wake is recorded as `noReply` and retained rather than forking a reply.
- Changed live-route probing from `/session` to `/global/health` and removed non-null assertions in the touched route module.
- Added focused live-route probe coverage for the health endpoint.

## Verification
- Red/green proof: `.omo/evidence/20260619-issue-5401-parent-wake/red-green.log`
- Race red proof: `.omo/evidence/20260619-issue-5401-parent-wake/security-race-red.log`
- Race green proof: `.omo/evidence/20260619-issue-5401-parent-wake/security-race-green.log`
- Live-route red proof: `.omo/evidence/20260619-issue-5401-parent-wake/live-route-health-probe-red.log`
- Final focused route + parent-wake tests: `.omo/evidence/20260619-issue-5401-parent-wake/final-targeted-green.log` (39 pass, 0 fail)
- Typecheck: `.omo/evidence/20260619-issue-5401-parent-wake/final-typecheck.log`
- Build: `.omo/evidence/20260619-issue-5401-parent-wake/final-build.log`
- Full root test suite: `.omo/evidence/20260619-issue-5401-parent-wake/final-bun-test.log` (10039 pass, 2 skip, 0 fail)
- TypeScript no-excuse audit: `.omo/evidence/20260619-issue-5401-parent-wake/final-no-excuse.log` (no violations in 5 files)
- LOC receipt: `.omo/evidence/20260619-issue-5401-parent-wake/final-loc.log`
- OpenCode QA self-check: `.omo/evidence/20260619-issue-5401-parent-wake/final-opencode-qa-self-check.log`
- OpenCode serve wake-split QA: `.omo/evidence/20260619-issue-5401-parent-wake/final-opencode-qa.log` plus `.omo/evidence/20260619-issue-5401-parent-wake/serve-wake-split-final-fixed/` (`RESULT=FIXED children=1 stops=1 plugin_inits=1`, route provenance shows `dispatch via live listener`, fake LLM reached `branch=wake`, real DB unchanged 5737 before/after)

## Related Issues
Closes #5401
