### PR TITLE
fix(opencode): block placeholder sleep waits after delegation

### DIFF
--- a/packages/omo-opencode/src/plugin-interface.ts
+++ b/packages/omo-opencode/src/plugin-interface.ts
@@ -93,6 +93,7 @@ export function createPluginInterface(args: {
     "tool.execute.before": createToolExecuteBeforeHandler({
       ctx,
       hooks,
+      backgroundManager: managers.backgroundManager,
     }),
 
     "tool.execute.after": createToolExecuteAfterHandler({

--- a/packages/omo-opencode/src/plugin/tool-execute-before-background-wait.test.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-before-background-wait.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+
+import { createToolExecuteBeforeHandler } from "./tool-execute-before"
+
+function createTestContext() {
+  return {
+    client: {
+      session: {
+        messages: async () => ({ data: [] }),
+      },
+    },
+  }
+}
+
+describe("createToolExecuteBeforeHandler background wait guard", () => {
+  test("blocks placeholder sleep waits while background children are still active", async () => {
+    //#given
+    const backgroundManager = {
+      hasActiveChildTasks: (sessionID: string) => sessionID === "ses_parent",
+    }
+    const handler = createToolExecuteBeforeHandler({
+      ctx: createTestContext(),
+      hooks: {},
+      backgroundManager,
+    })
+    const output = {
+      args: {
+        command: "# Placeholder wait\nsleep 1",
+      } as Record<string, unknown>,
+    }
+
+    //#when
+    const run = handler({ tool: "bash", sessionID: "ses_parent", callID: "call_wait" }, output)
+
+    //#then
+    await expect(run).rejects.toThrow("Background task wait is already managed")
+  })
+
+  test("allows sleep commands when the session has no active background children", async () => {
+    //#given
+    const backgroundManager = {
+      hasActiveChildTasks: () => false,
+    }
+    const handler = createToolExecuteBeforeHandler({
+      ctx: createTestContext(),
+      hooks: {},
+      backgroundManager,
+    })
+    const output = {
+      args: {
+        command: "sleep 1",
+      } as Record<string, unknown>,
+    }
+
+    //#when
+    const run = handler({ tool: "bash", sessionID: "ses_parent", callID: "call_sleep" }, output)
+
+    //#then
+    await expect(run).resolves.toBeUndefined()
+  })
+
+  test("allows non-wait bash commands while background children are active", async () => {
+    //#given
+    const backgroundManager = {
+      hasActiveChildTasks: () => true,
+    }
+    const handler = createToolExecuteBeforeHandler({
+      ctx: createTestContext(),
+      hooks: {},
+      backgroundManager,
+    })
+    const output = {
+      args: {
+        command: "sleep 1 && echo ready",
+      } as Record<string, unknown>,
+    }
+
+    //#when
+    const run = handler({ tool: "bash", sessionID: "ses_parent", callID: "call_work" }, output)
+
+    //#then
+    await expect(run).resolves.toBeUndefined()
+  })
+})

--- a/packages/omo-opencode/src/plugin/tool-execute-before-background-wait.test.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-before-background-wait.test.ts
@@ -40,6 +40,7 @@ describe("createToolExecuteBeforeHandler background wait guard", () => {
     //#given
     const backgroundManager = {
       hasActiveChildTasks: () => false,
+      hasPendingParentWake: () => false,
     }
     const handler = createToolExecuteBeforeHandler({
       ctx: createTestContext(),
@@ -59,10 +60,35 @@ describe("createToolExecuteBeforeHandler background wait guard", () => {
     await expect(run).resolves.toBeUndefined()
   })
 
+  test("blocks placeholder sleep waits while a parent wake is pending", async () => {
+    //#given
+    const backgroundManager = {
+      hasActiveChildTasks: () => false,
+      hasPendingParentWake: (sessionID: string) => sessionID === "ses_parent",
+    }
+    const handler = createToolExecuteBeforeHandler({
+      ctx: createTestContext(),
+      hooks: {},
+      backgroundManager,
+    })
+    const output = {
+      args: {
+        command: "# Placeholder wait\nsleep 1",
+      } as Record<string, unknown>,
+    }
+
+    //#when
+    const run = handler({ tool: "bash", sessionID: "ses_parent", callID: "call_wake" }, output)
+
+    //#then
+    await expect(run).rejects.toThrow("Background task wait is already managed")
+  })
+
   test("allows non-wait bash commands while background children are active", async () => {
     //#given
     const backgroundManager = {
       hasActiveChildTasks: () => true,
+      hasPendingParentWake: () => false,
     }
     const handler = createToolExecuteBeforeHandler({
       ctx: createTestContext(),

--- a/packages/omo-opencode/src/plugin/tool-execute-before.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-before.ts
@@ -11,6 +11,23 @@ import { ULTRAWORK_VERIFICATION_PROMISE } from "../hooks/ralph-loop/constants"
 import { readState, writeState } from "../hooks/ralph-loop/storage"
 
 import type { CreatedHooks } from "../create-hooks"
+import type { BackgroundManager } from "../features/background-agent"
+
+const BACKGROUND_WAIT_BLOCK_MESSAGE = [
+  "Background task wait is already managed by the plugin.",
+  "End this response now and wait for the <system-reminder> completion notification.",
+  "After that reminder arrives, call background_output with the task_id from the launch result.",
+].join(" ")
+
+function isPureSleepCommand(command: string): boolean {
+  const commandLines = command
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+
+  return commandLines.length > 0
+    && commandLines.every((line) => /^sleep\s+\d+(?:\.\d+)?[smhd]?\s*$/i.test(line))
+}
 
 function getLoopCommandArguments(args: Record<string, unknown>, command: "ralph-loop" | "ulw-loop"): string {
   const rawUserMessage = typeof args.user_message === "string" ? args.user_message.trim() : ""
@@ -25,11 +42,12 @@ function getLoopCommandArguments(args: Record<string, unknown>, command: "ralph-
 export function createToolExecuteBeforeHandler(args: {
   ctx: PluginContext
   hooks: CreatedHooks
+  backgroundManager?: Pick<BackgroundManager, "hasActiveChildTasks">
 }): (
   input: { tool: string; sessionID: string; callID: string },
   output: { args: Record<string, unknown> },
 ) => Promise<void> {
-  const { ctx, hooks } = args
+  const { ctx, hooks, backgroundManager } = args
 
   function buildUltraworkOracleVerificationPrompt(prompt: string, originalTask: string, verificationAttemptId: string): string {
     const verificationPrompt = [
@@ -72,6 +90,13 @@ export function createToolExecuteBeforeHandler(args: {
           sessionID: input.sessionID,
           callID: input.callID,
         })
+      }
+
+      if (
+        isPureSleepCommand(output.args.command)
+        && backgroundManager?.hasActiveChildTasks(input.sessionID) === true
+      ) {
+        throw new Error(BACKGROUND_WAIT_BLOCK_MESSAGE)
       }
     }
 

--- a/packages/omo-opencode/src/plugin/tool-execute-before.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-before.ts
@@ -42,7 +42,7 @@ function getLoopCommandArguments(args: Record<string, unknown>, command: "ralph-
 export function createToolExecuteBeforeHandler(args: {
   ctx: PluginContext
   hooks: CreatedHooks
-  backgroundManager?: Pick<BackgroundManager, "hasActiveChildTasks">
+  backgroundManager?: Pick<BackgroundManager, "hasActiveChildTasks" | "hasPendingParentWake">
 }): (
   input: { tool: string; sessionID: string; callID: string },
   output: { args: Record<string, unknown> },
@@ -94,7 +94,10 @@ export function createToolExecuteBeforeHandler(args: {
 
       if (
         isPureSleepCommand(output.args.command)
-        && backgroundManager?.hasActiveChildTasks(input.sessionID) === true
+        && (
+          backgroundManager?.hasActiveChildTasks(input.sessionID) === true
+          || backgroundManager?.hasPendingParentWake(input.sessionID) === true
+        )
       ) {
         throw new Error(BACKGROUND_WAIT_BLOCK_MESSAGE)
       }


### PR DESCRIPTION
## Summary

Fixes #5391 by adding a runtime `tool.execute.before` guard for the exact loop pattern reported by users: a parent session with active background child tasks trying to run a pure placeholder wait command such as `# Placeholder wait\nsleep 1`.

The guard is intentionally narrow. It only applies to `bash`, only when the effective command is comments/blank lines plus simple `sleep <duration>` lines, and only while `BackgroundManager.hasActiveChildTasks(sessionID)` is true. Mixed shell commands that do real work, and sessions without active child tasks, continue to run.

## Changes

- Pass `managers.backgroundManager` into the `tool.execute.before` handler.
- Reject pure placeholder `sleep` bash waits while background child tasks are active, with an actionable instruction to yield until the `<system-reminder>` arrives.
- Add focused regression coverage for:
  - blocking `# Placeholder wait\nsleep 1` with an active child task;
  - allowing `sleep 1` when no child is active;
  - allowing useful commands that contain `sleep`, such as `sleep 1 && echo ready`.

## Verification

Automated:
- `bun test packages/omo-opencode/src/plugin/tool-execute-before-background-wait.test.ts`
- `bun test packages/omo-opencode/src/plugin/tool-execute-before.test.ts packages/omo-opencode/src/plugin/tool-execute-before-background-wait.test.ts packages/omo-opencode/src/plugin/tool-execute-before-mcp-prefix.test.ts packages/omo-opencode/src/plugin/tool-execute-before-session-notification.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-opencode/src/plugin/tool-execute-before.ts packages/omo-opencode/src/plugin/tool-execute-before-background-wait.test.ts packages/omo-opencode/src/plugin-interface.ts`

Failing-first proof:
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/red-proof/red-proof.log`
- The new regression test fails on clean `origin/dev` with `Expected promise that rejects / Received promise that resolved`.

OpenCode QA:
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/opencode-qa.md`
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/opencode-sleep-guard-real-harness.log`
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/opencode-sleep-guard-run.ndjson`
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/opencode-common-self-check.log`
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/opencode-sse-self-test.log`

Manual QA observed with isolated XDG/OpenCode state:
- Real `opencode run --format json` loaded the local plugin and fake OpenAI Responses server.
- Fake model drove a background `task`, a delayed child, and then the parent pure `# Placeholder wait\nsleep 1` bash tool call.
- The real bash tool event returned the new guard error.
- Parent completed afterward without executing the sleep.
- Live OpenCode DB session count stayed unchanged: `5737 -> 5737`.
- Cleanup logged: fake server killed and isolated sandbox removed.

## Related Issues

Closes #5391.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents placeholder bash sleep loops after delegation by blocking pure `sleep` commands when background work is still in flight or a parent wake is pending. Adds a narrow `tool.execute.before` guard in `omo-opencode`; fixes #5391.

- **Bug Fixes**
  - Block pure placeholder waits (comments/blank lines + `sleep <duration>`) in `bash` when `BackgroundManager.hasActiveChildTasks(sessionID)` or `hasPendingParentWake(sessionID)` is true; return guidance to wait for `<system-reminder>` then call `background_output`.
  - Pass `backgroundManager` into `tool.execute.before`.
  - Allow normal `sleep` with no children and commands that do real work; add focused tests including the pending-wake case.

<sup>Written for commit ab5e8aebce7f068e712e56f9c4c83ef1f06df91e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Follow-up Verification for Pending Parent Wake

Addressed review-work code-quality blocker by also blocking pure placeholder sleeps while `BackgroundManager.hasPendingParentWake(sessionID)` is true.

Additional evidence:
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/followup-pending-wake/red-pending-wake.log` — pending-wake regression failed before the production fix.
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/followup-pending-wake/focused-pending-wake-green.log` — focused regression passed after the fix.
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/followup-pending-wake/targeted-hook-tests.log` — related hook tests passed.
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/followup-pending-wake/typecheck.log` — typecheck passed.
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/followup-pending-wake/build.log` — build passed.
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/followup-pending-wake/no-excuse.log` — TypeScript no-excuse checker passed.
- `.omo/evidence/20260619-issue-5391-sisyphus-sleep-loop/followup-pending-wake/opencode-sleep-guard-real-harness.log` — isolated real OpenCode harness passed at clean HEAD `ab5e8aebc`; live DB count unchanged `5737 -> 5737`.
