### PR TITLE
feat(codex): add teammode skill

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: teammode
+description: Codex-only team orchestration with durable team state and coordinated thread cleanup
+---
+
+# Teammode
+
+Use this skill when the user asks Codex to create, coordinate, inspect, archive,
+or delete a team of Codex threads. This is a Codex-only workflow. It is inspired
+by the lifecycle concerns in Yeachan-Heo/oh-my-codex team skill, but it does not
+copy that runtime model or depend on an external terminal runner.
+
+## Core Model
+
+A team is the parent object. Threads and subagents are members of that team, not
+the other way around. Store the team record under:
+
+```text
+.omo/teams/{session_id}/team.json
+.omo/teams/{session_id}/notepad.md
+.omo/teams/{session_id}/events.jsonl
+```
+
+`{session_id}` is the leader Codex session id when available. If the current
+session id is not exposed, use a stable timestamp slug and record the fallback
+in `events.jsonl`.
+
+The `team.json` shape is:
+
+```json
+{
+  "schemaVersion": 1,
+  "sessionId": "{session_id}",
+  "teamName": "Team Name",
+  "activeTeam": true,
+  "archived": false,
+  "leader": {
+    "threadId": "leader-thread-id",
+    "role": "leader",
+    "title": "[team name] {session name}"
+  },
+  "members": [
+    {
+      "id": "A",
+      "threadId": "member-thread-id",
+      "role": "release analyst",
+      "status": "active",
+      "title": "[team name] {session name}"
+    }
+  ]
+}
+```
+
+Keep `notepad.md` for leader memory, peer digests, decisions, and cleanup notes.
+Append every create, broadcast, status, archive, and delete action to
+`events.jsonl`.
+
+## Team Creation
+
+1. Choose a short team name and a session name before creating members.
+2. Every team-created thread title must use this exact shape:
+   `[team name] {session name}`.
+3. Write `team.json` before sending work to members.
+4. Create durable member threads with `codex_app.create_thread` when available.
+   Use `codex_app.set_thread_title` immediately after creation if the title did
+   not land during creation.
+5. For short in-turn helper lanes, `multi_agent_v1.spawn_agent` is acceptable,
+   but durable teams should prefer Codex thread tools so the team remains visible
+   as a set of archived or active threads.
+
+Member prompts must be self-contained and English-only. Include:
+
+- team name and leader thread id
+- the member's explicit role and owned scope
+- the exact deliverable and verification expectation
+- the team state directory path
+- instructions to send `WORKING: <role> - <phase>` during long work
+- instructions to send a concise final report to the leader
+- instructions that all member-to-member and member-to-leader communication is
+  English-only
+
+## Communication
+
+The leader owns coordination. Members own their assigned lane and report risks
+that affect other lanes.
+
+Use `codex_app.send_message_to_thread` for leader-to-member messages and
+broadcasts. Use `codex_app.read_thread` to inspect recent member status before
+reassigning or summarizing. Broadcast peer digests when one member finds context
+that changes another member's assumptions.
+
+Cadence:
+
+- Require frequent status updates for long tasks, usually every 30-60 seconds of
+  active work or at each phase boundary.
+- Members acknowledge handoffs with understood scope, affected files or topics,
+  owner, and next action.
+- The leader records status snapshots in `notepad.md` and `events.jsonl`.
+- The leader waits for every required member final report before claiming the
+  team is complete.
+
+For bounded in-turn helper work, use:
+
+```json
+{
+  "tool": "multi_agent_v1.spawn_agent",
+  "arguments": {
+    "fork_context": false,
+    "message": "TASK: act as a focused teammate. DELIVERABLE: ... SCOPE: ... VERIFY: ... Communicate in English only."
+  }
+}
+```
+
+Wait with `multi_agent_v1.wait_agent` and close finished helper agents with
+`multi_agent_v1.close_agent`. Record helper ids in `team.json` only when they
+materially contributed to the team result.
+
+For helper agents that may take longer than one wait cycle, require both
+progress markers: `WORKING: <task> - <current phase>` before long work and
+`BLOCKED: <reason>` only when the helper cannot progress. A
+`multi_agent_v1.wait_agent` timeout only means no new mailbox update arrived.
+Treat a running helper as alive. Fallback only when the helper is completed
+without the deliverable, ack-only after follow-up, explicitly `BLOCKED:`, or no
+longer running.
+
+## Archive
+
+Archiving a team closes or archives every member before the team is marked
+archived.
+
+1. Send a final archive notice to every active member thread with
+   `codex_app.send_message_to_thread`.
+2. Inspect each member with `codex_app.read_thread` and copy useful final notes
+   into `notepad.md`.
+3. Archive every member thread with `codex_app.set_thread_archived`.
+4. Close any helper subagents with `multi_agent_v1.close_agent`.
+5. Set `activeTeam` to `false`, set `archived` to `true`, and append the archive
+   receipt to `events.jsonl`.
+
+If a thread archive tool is unavailable, record the failed archive attempt and
+the member thread ids in `events.jsonl` and surface that limitation to the user.
+Do not pretend the member was archived.
+
+## Delete
+
+Delete is stronger than archive.
+
+1. Archive first when `archived` is not already `true`.
+2. Confirm there are no active member threads left unhandled.
+3. Remove `.omo/teams/{session_id}` only after the archive receipts and useful
+   notes have been preserved or explicitly deemed disposable by the user.
+4. Report which team directory was removed and which threads were archived.
+
+Never delete team state while member threads are still active unless the user
+explicitly requested an abort and you recorded the abort in `events.jsonl`.
+
+## Stop Rules
+
+- Stop and ask before deleting a non-archived team if any member is still active.
+- Stop if the user asks for private or non-English member communication; team
+  member communication remains English-only.
+- Stop if thread tooling is unavailable and the requested operation depends on
+  creating, reading, sending to, or archiving actual Codex threads.

--- a/packages/omo-codex/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-skills.mjs
@@ -12,6 +12,7 @@ const skillSources = [
 	["comment-checker", "components/comment-checker/skills/comment-checker"],
 	["lsp", "components/lsp/skills/lsp"],
 	["rules", "components/rules/skills/rules"],
+	["teammode", "components/teammode/skills/teammode"],
 	["ulw-loop", "components/ulw-loop/skills/ulw-loop"],
 	["ulw-plan", "components/ultrawork/skills/ulw-plan"],
 ];

--- a/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
@@ -22,6 +22,7 @@ export const expectedSkills = [
 	"review-work",
 	"rules",
 	"start-work",
+	"teammode",
 	"ultraresearch",
 	"ulw-loop",
 	"ulw-plan",
@@ -32,6 +33,7 @@ export const componentSkillSources = [
 	["comment-checker", "components/comment-checker/skills/comment-checker"],
 	["lsp", "components/lsp/skills/lsp"],
 	["rules", "components/rules/skills/rules"],
+	["teammode", "components/teammode/skills/teammode"],
 	["ulw-loop", "components/ulw-loop/skills/ulw-loop"],
 	["ulw-plan", "components/ultrawork/skills/ulw-plan"],
 ];

--- a/packages/omo-codex/plugin/test/teammode-skill-contract.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-skill-contract.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const requiredContracts = [
+	["frontmatter name", /^---\r?\nname: teammode\r?\n/m],
+	["Codex-only scope", /Codex-only/i],
+	["team state root", /\.omo\/teams\/\{session_id\}/],
+	["leader state field", /"leader"/],
+	["members state field", /"members"/],
+	["active team state field", /"activeTeam"/],
+	["team name state field", /"teamName"/],
+	["archived state field", /"archived"/],
+	["member threads state field", /"threadId"/],
+	["team thread title format", /\[team name\] \{session name\}/i],
+	["English-only member communication", /English-only|English only/i],
+	["frequent status updates", /frequent/i],
+	["clear member roles", /clear role|explicit role/i],
+	["team thread creation", /codex_app\.create_thread/],
+	["thread message broadcast", /codex_app\.send_message_to_thread/],
+	["thread status inspection", /codex_app\.read_thread/],
+	["thread title update", /codex_app\.set_thread_title/],
+	["thread archival", /codex_app\.set_thread_archived/],
+	["native subagent fallback", /multi_agent_v1\.spawn_agent/],
+	["native subagent waiting", /multi_agent_v1\.wait_agent/],
+	["native subagent cleanup", /multi_agent_v1\.close_agent/],
+	["archive closes members", /archive[\s\S]*member[\s\S]*(?:close|archive)/i],
+	["delete removes team state", /delete[\s\S]*\.omo\/teams\/\{session_id\}/i],
+	["upstream inspiration is attributed", /inspired\s+by[\s\S]*oh-my-codex/i],
+];
+
+const bannedRuntimePatterns = [
+	["OMX command runtime", /\bomx\s+team\b/i],
+	["OMX team state", /\.omx\/state\/team/i],
+	["generic OMX runtime", /\bOMX\b/],
+	["OpenCode team tool create", /team_create\(/],
+	["OpenCode team tool send", /team_send_message\(/],
+	["OpenCode team tool delete", /team_delete\(/],
+	["tmux runtime", /\btmux\b/i],
+	["pane runtime", /\bpane\b/i],
+];
+
+async function readSkill(path) {
+	return readFile(path, "utf8");
+}
+
+function assertTeamModeContract(content, label) {
+	for (const [name, pattern] of requiredContracts) {
+		assert.match(content, pattern, `${label} missing contract: ${name}`);
+	}
+	for (const [name, pattern] of bannedRuntimePatterns) {
+		assert.doesNotMatch(content, pattern, `${label} leaked banned runtime: ${name}`);
+	}
+}
+
+test("#given Codex teammode source skill #when inspected #then it defines the native team contract", async () => {
+	const content = await readSkill(join(root, "components", "teammode", "skills", "teammode", "SKILL.md"));
+
+	assertTeamModeContract(content, "source teammode skill");
+});
+
+test("#given generated Codex teammode skill #when inspected #then it preserves the team contract and metadata", async () => {
+	const skillRoot = join(root, "skills", "teammode");
+	const content = await readSkill(join(skillRoot, "SKILL.md"));
+	const metadata = await readSkill(join(skillRoot, "agents", "openai.yaml"));
+
+	assertTeamModeContract(content, "generated teammode skill");
+	assert.match(metadata, /display_name: "\(OmO\) teammode"/);
+});


### PR DESCRIPTION
## Summary
Adds a Codex-only `teammode` skill to LazyCodex so Codex can coordinate a named team of threads with durable `.omo/teams/{session_id}` state, explicit leader/member roles, English-only teammate communication, and archive/delete lifecycle guidance.

The skill is packaged through the existing component-local skill sync pipeline rather than adding a new runtime component, hook, MCP, or workspace.

## Changes
- Added `packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md` as the source-of-truth teammode skill.
- Registered `teammode` in the Codex plugin skill sync source list and expected skill inventory.
- Added contract tests covering source and generated skill content, display metadata, Codex-native thread/subagent tooling, `.omo/teams/{session_id}` state, `[team name] {session name}` thread titles, English-only communication, archive/delete rules, and banned OMX/OpenCode runtime leakage.

## Verification
**Automated:**
- `node --test packages/omo-codex/plugin/test/teammode-skill-contract.test.mjs` ✅
- `node --test packages/omo-codex/plugin/test/teammode-skill-contract.test.mjs packages/omo-codex/plugin/test/sync-skills.test.mjs packages/omo-codex/plugin/test/aggregate-skills.test.mjs` ✅
- `npm --prefix packages/omo-codex/plugin run build` ✅
- `npm --prefix packages/omo-codex/plugin test` ✅ (219 tests)
- `bun run test:codex` ✅ (344 tests)

**Codex QA / manual evidence:**
- `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check` ✅
- `bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test` ✅
- `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` ✅, observed `sessionStart`, `userPromptSubmit`, and `stop` hooks
- Isolated `CODEX_HOME` install payload inspection confirmed `skills/teammode/SKILL.md` and `(OmO) teammode` metadata ✅

Evidence directory: `.omo/evidence/20260619-codex-teammode-skill/`
- `manual-qa-matrix.md`
- `handoff-notepad.md`
- `executor-code-review.md`
- `code-reviewer-report.md`
- `test-codex.txt`
- `codex-qa-app-server-plugin.json`

Final gate reviewer: APPROVE.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Codex-only `teammode` skill to coordinate named teams of threads with durable `.omo/teams/{session_id}` state, explicit leader/member roles, English-only communication, and archive/delete lifecycle. Integrated via the existing Codex plugin skill sync; no new runtime component.

- **New Features**
  - Added `packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md` as the skill source.
  - Registered `teammode` in the skill sync and expected skill list.
  - Included contract tests covering skill content/metadata, Codex thread tools, state shape, thread title format, English-only comms, archive/delete rules, and bans on OMX/OpenCode runtime leakage.

<sup>Written for commit 72221159364da0a4249877e153b1c93c3a6108f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

