### PR TITLE
fix(codex): resolve lazycodex issues 59 and 60

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -1595,6 +1595,9 @@ function bunWhich(commandName) {
 }
 
 // ../../utils/src/codegraph/resolve.ts
+function codegraphCommandRequiresSupportedLocalNode(resolution) {
+  return resolution.source !== "bundled" && resolution.source !== "env" && resolution.source !== "provisioned";
+}
 var CODEGRAPH_PACKAGE = "@colbymchenry/codegraph";
 var CODEGRAPH_ENV_BIN = "OMO_CODEGRAPH_BIN";
 var CODEGRAPH_LEGACY_ENV_BIN = "CODEGRAPH_BIN";
@@ -1864,7 +1867,7 @@ function finish(action, detail, logOutcome) {
 async function resolveOrProvisionCommand(deps, config, env, homeDir, nodeSupport) {
   const resolved = deps.resolveCommand({ env, homeDir, provisioned: () => provisionedBinFromInstallDir(config.install_dir) });
   if (resolved.exists) {
-    if (resolved.source !== "bundled" && resolved.source !== "env" && !nodeSupport.supported) {
+    if (codegraphCommandRequiresSupportedLocalNode(resolved) && !nodeSupport.supported) {
       return { kind: "unsupported-node" };
     }
     return { kind: "resolved", resolution: resolved };
@@ -2087,7 +2090,7 @@ async function runCodegraphServe(options = {}) {
     return 1;
   }
   const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
-  if (resolution.source !== "bundled" && resolution.source !== "env" && !nodeSupport.supported) {
+  if (codegraphCommandRequiresSupportedLocalNode(resolution) && !nodeSupport.supported) {
     (options.stderr ?? processStderr2).write(buildCodegraphNodeSkipHint(nodeSupport));
     return 1;
   }

--- a/packages/omo-codex/plugin/components/codegraph/dist/serve.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/serve.js
@@ -132,6 +132,9 @@ function bunWhich(commandName) {
 }
 
 // ../../../../utils/src/codegraph/resolve.ts
+function codegraphCommandRequiresSupportedLocalNode(resolution) {
+  return resolution.source !== "bundled" && resolution.source !== "env" && resolution.source !== "provisioned";
+}
 var CODEGRAPH_PACKAGE = "@colbymchenry/codegraph";
 var CODEGRAPH_ENV_BIN = "OMO_CODEGRAPH_BIN";
 var CODEGRAPH_LEGACY_ENV_BIN = "CODEGRAPH_BIN";
@@ -1516,7 +1519,7 @@ async function runCodegraphServe(options = {}) {
     return 1;
   }
   const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
-  if (resolution.source !== "bundled" && resolution.source !== "env" && !nodeSupport.supported) {
+  if (codegraphCommandRequiresSupportedLocalNode(resolution) && !nodeSupport.supported) {
     (options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
     return 1;
   }

--- a/packages/omo-codex/plugin/components/codegraph/src/serve.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/serve.ts
@@ -17,6 +17,7 @@ import {
 	evaluateCodegraphNodeSupport,
 } from "../../../../../utils/src/codegraph/node-support.ts";
 import {
+	codegraphCommandRequiresSupportedLocalNode,
 	resolveCodegraphCommand,
 	type CodegraphCommandResolution,
 	type ResolveCodegraphCommandOptions,
@@ -88,7 +89,7 @@ export async function runCodegraphServe(options: RunCodegraphServeOptions = {}):
 	}
 
 	const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
-	if (resolution.source !== "bundled" && resolution.source !== "env" && !nodeSupport.supported) {
+	if (codegraphCommandRequiresSupportedLocalNode(resolution) && !nodeSupport.supported) {
 		(options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
 		return 1;
 	}

--- a/packages/omo-codex/plugin/components/codegraph/src/session-start-worker.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/session-start-worker.ts
@@ -9,6 +9,7 @@ import { buildCodegraphEnv } from "../../../../../utils/src/codegraph/env.ts";
 import { evaluateCodegraphNodeSupport, type CodegraphNodeSupport } from "../../../../../utils/src/codegraph/node-support.ts";
 import { ensureCodegraphProvisioned } from "../../../../../utils/src/codegraph/provision.ts";
 import {
+	codegraphCommandRequiresSupportedLocalNode,
 	resolveCodegraphCommand,
 	type CodegraphCommandResolution,
 } from "../../../../../utils/src/codegraph/resolve.ts";
@@ -103,7 +104,7 @@ async function resolveOrProvisionCommand(
 ): Promise<ResolutionResult> {
 	const resolved = deps.resolveCommand({ env, homeDir, provisioned: () => provisionedBinFromInstallDir(config.install_dir) });
 	if (resolved.exists) {
-		if (resolved.source !== "bundled" && resolved.source !== "env" && !nodeSupport.supported) {
+		if (codegraphCommandRequiresSupportedLocalNode(resolved) && !nodeSupport.supported) {
 			return { kind: "unsupported-node" };
 		}
 		return { kind: "resolved", resolution: resolved };

--- a/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../src/hook.ts";
 
 const pluginRoot = resolve(fileURLToPath(new URL("../../..", import.meta.url)));
-const hooksConfigPath = resolve(pluginRoot, "hooks/hooks.json");
+const pluginConfigPath = resolve(pluginRoot, ".codex-plugin/plugin.json");
 
 describe("CodeGraph SessionStart hook", () => {
 	it("#given hook session-start cli args #when invoked with empty JSON input #then it emits valid JSON and exits zero", async () => {
@@ -537,18 +537,18 @@ describe("CodeGraph SessionStart hook", () => {
 
 	it("#given plugin hook config #when inspected #then CodeGraph is registered after bootstrap SessionStart", () => {
 		// given
-		const hooksConfig = JSON.parse(readFileSync(hooksConfigPath, "utf8"));
+		const pluginConfig: unknown = JSON.parse(readFileSync(pluginConfigPath, "utf8"));
 
 		// when
-		const sessionStartHooks = hooksConfig.hooks.SessionStart;
-		const commands = sessionStartHooks.map((entry: { readonly hooks: readonly [{ readonly command: string }] }) => {
-			return entry.hooks[0].command;
-		});
+		const hookPaths =
+			typeof pluginConfig === "object" && pluginConfig !== null && "hooks" in pluginConfig && Array.isArray(pluginConfig.hooks)
+				? pluginConfig.hooks.filter((hookPath): hookPath is string => typeof hookPath === "string")
+				: [];
 
 		// then
-		expect(commands).toContain('node "${PLUGIN_ROOT}/components/codegraph/dist/cli.js" hook session-start');
-		expect(commands.indexOf('node "${PLUGIN_ROOT}/components/bootstrap/dist/cli.js" hook session-start')).toBeLessThan(
-			commands.indexOf('node "${PLUGIN_ROOT}/components/codegraph/dist/cli.js" hook session-start'),
+		expect(hookPaths).toContain("./hooks/session-start-checking-codegraph-bootstrap.json");
+		expect(hookPaths.indexOf("./hooks/session-start-checking-bootstrap-provisioning.json")).toBeLessThan(
+			hookPaths.indexOf("./hooks/session-start-checking-codegraph-bootstrap.json"),
 		);
 	});
 });

--- a/packages/omo-codex/plugin/components/codegraph/test/provisioned-node-guard.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/provisioned-node-guard.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runCodegraphSessionStartWorker } from "../src/hook.ts";
+import { runCodegraphServe } from "../src/serve.ts";
+
+describe("CodeGraph provisioned launcher Node guard", () => {
+	it("#given provisioned CodeGraph binary #when serve runs under unsupported local Node #then it trusts the launcher", async () => {
+		// given
+		const commandPath = "/home/test/.omo/codegraph/bin/codegraph";
+		const spawned: Array<{ readonly args: readonly string[]; readonly command: string }> = [];
+
+		// when
+		const exitCode = await runCodegraphServe({
+			env: {},
+			nodeVersion: "26.3.0",
+			buildEnv: () => ({}),
+			resolve: () => ({ argsPrefix: [], command: commandPath, exists: true, source: "provisioned" }),
+			runProcess: (command, args) => {
+				spawned.push({ args, command });
+				return Promise.resolve(0);
+			},
+			stderr: { write: () => undefined },
+		});
+
+		// then
+		expect(exitCode).toBe(0);
+		expect(spawned).toEqual([{ args: ["serve", "--mcp"], command: commandPath }]);
+	});
+
+	it("#given provisioned CodeGraph exists #when SessionStart worker runs under unsupported local Node #then it bootstraps through the launcher", async () => {
+		// given
+		const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-node25-"));
+		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-node25-home-"));
+		const installDir = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-node25-install-"));
+		const binPath = join(installDir, "bin", "codegraph");
+		const calls: Array<{ readonly args: readonly string[]; readonly command: string }> = [];
+		const outcomes: unknown[] = [];
+
+		try {
+			mkdirSync(join(installDir, "bin"), { recursive: true });
+			writeFileSync(binPath, "");
+
+			// when
+			const result = await runCodegraphSessionStartWorker({
+				config: { codegraph: { enabled: true, install_dir: installDir }, sources: [], warnings: [] },
+				nodeVersion: "26.3.0",
+				cwd: workspace,
+				env: { HOME: homeDir },
+				logOutcome: (outcome) => outcomes.push(outcome),
+				deps: {
+					ensureGitignored: () => true,
+					ensureProvisioned: () => {
+						throw new Error("provisioning should not run when install_dir binary exists");
+					},
+					prepareWorkspace: () => ({
+						dataDir: join(homeDir, ".omo/codegraph/projects/test"),
+						dataRoot: join(homeDir, ".omo/codegraph"),
+						linked: true,
+						mode: "global-linked",
+						projectLink: join(workspace, ".codegraph"),
+					}),
+					resolveCommand: (options) => {
+						const provisioned = options?.provisioned?.() ?? null;
+						return {
+							argsPrefix: [],
+							command: provisioned ?? "missing-codegraph",
+							exists: provisioned !== null,
+							source: provisioned === null ? "path" : "provisioned",
+						};
+					},
+					runCommand: (_projectRoot, command, args) => {
+						calls.push({ args, command });
+						return Promise.resolve({ exitCode: 0, stdout: calls.length === 1 ? '{"initialized":false}' : "", timedOut: false });
+					},
+				},
+			});
+
+			// then
+			expect(result).toEqual({ action: "initialized" });
+			expect(calls).toEqual([
+				{ args: ["status", "--json"], command: binPath },
+				{ args: ["init"], command: binPath },
+			]);
+			expect(outcomes).toEqual([{ action: "initialized", exitCode: 0, projectRoot: workspace, source: "provisioned", timedOut: false }]);
+		} finally {
+			rmSync(workspace, { recursive: true, force: true });
+			rmSync(homeDir, { recursive: true, force: true });
+			rmSync(installDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/omo-codex/plugin/components/start-work-continuation/package.json
+++ b/packages/omo-codex/plugin/components/start-work-continuation/package.json
@@ -42,7 +42,6 @@
 		"NOTICE"
 	],
 	"devDependencies": {
-		"@oh-my-opencode/boulder-state": "file:../../../../boulder-state",
 		"@biomejs/biome": "2.4.16",
 		"@types/node": "^25.9.3",
 		"typescript": "^6.0.3",

--- a/packages/omo-codex/plugin/components/start-work-continuation/src/boulder-reader.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/src/boulder-reader.ts
@@ -1,14 +1,29 @@
-import { join } from "node:path";
-import type { BoulderWorkStatus, PlanChecklist } from "@oh-my-opencode/boulder-state";
-import {
-	getBoulderFilePath,
-	getPlanChecklist,
-	getWorkForSession,
-	normalizeSessionId,
-	resolveBoulderPlanPathForWork,
-} from "@oh-my-opencode/boulder-state";
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
-export type { PlanChecklist };
+export type PlanChecklist = {
+	readonly completed: number;
+	readonly remaining: number;
+	readonly total: number;
+	readonly nextTaskLabel: string | null;
+};
+
+type BoulderWorkStatus = "active" | "paused" | "completed" | "abandoned";
+
+type BoulderWork = {
+	readonly activePlan: string;
+	readonly planName: string;
+	readonly status?: BoulderWorkStatus;
+	readonly startedAt?: string;
+	readonly updatedAt?: string;
+	readonly sessionIds: readonly string[];
+	readonly worktreePath?: string;
+};
+
+type BoulderState = {
+	readonly works: readonly BoulderWork[];
+	readonly mirrorWork: BoulderWork | null;
+};
 
 export type ContinuationState = {
 	readonly planName: string;
@@ -19,22 +34,216 @@ export type ContinuationState = {
 	readonly checklist: PlanChecklist;
 };
 
+const TODO_HEADING = "TODOs";
+const FINAL_VERIFICATION_HEADING = "Final Verification Wave";
+const CHECKBOX_PREFIX_LENGTH = "- [ ] ".length;
+const SESSION_ID_PREFIX_PATTERN = /^(codex|opencode):/;
+
 export function readContinuationState(cwd: string, sessionId: string): ContinuationState | null {
-	const work = getWorkForSession(cwd, normalizeSessionId(sessionId, "codex"));
+	const boulderPath = getBoulderFilePath(cwd);
+	const boulderState = readBoulderState(boulderPath);
+	if (boulderState === null) return null;
+
+	const work = getWorkForSession(boulderState, normalizeSessionId(sessionId, "codex"));
 	if (work === null || !isContinuableStatus(work.status)) return null;
+
 	const planPath = resolveBoulderPlanPathForWork(cwd, work);
 	const checklist = getPlanChecklist(planPath);
 	if (checklist.remaining === 0) return null;
+
 	return {
-		planName: work.plan_name,
+		planName: work.planName,
 		planPath,
-		boulderPath: getBoulderFilePath(cwd),
+		boulderPath,
 		ledgerPath: join(cwd, ".omo", "start-work", "ledger.jsonl"),
-		worktreePath: work.worktree_path ?? null,
+		worktreePath: work.worktreePath ?? null,
 		checklist,
 	};
 }
 
+export function getPlanChecklist(planPath: string): PlanChecklist {
+	if (!existsSync(planPath)) return emptyChecklist();
+
+	try {
+		return parsePlanChecklist(readFileSync(planPath, "utf8"));
+	} catch (error) {
+		if (error instanceof Error) return emptyChecklist();
+		throw error;
+	}
+}
+
+function parsePlanChecklist(markdown: string): PlanChecklist {
+	const lines = markdown.split(/\r?\n/);
+	const hasCountedSections = lines.some((line) => isCountedHeading(parseLevelTwoHeading(line)));
+	let completed = 0;
+	let remaining = 0;
+	let nextTaskLabel: string | null = null;
+	let isCountedSection = !hasCountedSections;
+
+	for (const line of lines) {
+		const heading = parseLevelTwoHeading(line);
+		if (heading !== null) {
+			isCountedSection = isCountedHeading(heading);
+			continue;
+		}
+		if (!isCountedSection) continue;
+
+		const checkbox = parseTopLevelCheckbox(line);
+		if (checkbox === null) continue;
+
+		if (checkbox.checked) {
+			completed += 1;
+		} else {
+			remaining += 1;
+			nextTaskLabel = nextTaskLabel ?? checkbox.label;
+		}
+	}
+
+	return { completed, remaining, total: completed + remaining, nextTaskLabel };
+}
+
+function readBoulderState(path: string): BoulderState | null {
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+		return parseBoulderState(parsed);
+	} catch (error) {
+		if (error instanceof Error) return null;
+		throw error;
+	}
+}
+
+function parseBoulderState(value: unknown): BoulderState | null {
+	if (!isRecord(value)) return null;
+
+	const works: BoulderWork[] = [];
+	const worksValue = value["works"];
+	if (isRecord(worksValue)) {
+		for (const workValue of Object.values(worksValue)) {
+			const work = parseBoulderWork(workValue);
+			if (work !== null) works.push(work);
+		}
+	}
+
+	const mirrorWork = parseBoulderWork(value);
+	if (works.length === 0 && mirrorWork === null) return null;
+	return { works, mirrorWork };
+}
+
+function parseBoulderWork(value: unknown): BoulderWork | null {
+	if (!isRecord(value)) return null;
+
+	const activePlan = value["active_plan"];
+	const planName = value["plan_name"];
+	if (typeof activePlan !== "string") return null;
+
+	const status = parseBoulderWorkStatus(value["status"]);
+	const sessionIds = parseSessionIds(value["session_ids"]);
+	const worktreePath = value["worktree_path"];
+	const startedAt = value["started_at"];
+	const updatedAt = value["updated_at"];
+
+	return {
+		activePlan,
+		planName: typeof planName === "string" ? planName : activePlan,
+		sessionIds,
+		...(status === undefined ? {} : { status }),
+		...(typeof startedAt === "string" ? { startedAt } : {}),
+		...(typeof updatedAt === "string" ? { updatedAt } : {}),
+		...(typeof worktreePath === "string" ? { worktreePath } : {}),
+	};
+}
+
+function getWorkForSession(state: BoulderState, normalizedSessionId: string): BoulderWork | null {
+	let newestWork: BoulderWork | null = null;
+	let newestWorkMs = 0;
+
+	for (const work of state.works) {
+		if (!work.sessionIds.includes(normalizedSessionId)) continue;
+
+		const workMs = parseIsoToMs(work.updatedAt ?? work.startedAt) ?? 0;
+		if (newestWork === null || workMs > newestWorkMs) {
+			newestWork = work;
+			newestWorkMs = workMs;
+		}
+	}
+
+	if (newestWork !== null) return newestWork;
+	if (state.mirrorWork?.sessionIds.includes(normalizedSessionId) === true) return state.mirrorWork;
+	return null;
+}
+
+function resolveBoulderPlanPathForWork(cwd: string, work: BoulderWork): string {
+	const absolutePlanPath = resolveTrackedPath(cwd, work.activePlan);
+	const worktreePath = work.worktreePath?.trim();
+	if (worktreePath === undefined || worktreePath.length === 0) return absolutePlanPath;
+
+	const relativePlanPath = relative(resolve(cwd), absolutePlanPath);
+	if (relativePlanPath.length === 0 || relativePlanPath.startsWith("..") || isAbsolute(relativePlanPath)) {
+		return absolutePlanPath;
+	}
+
+	const worktreePlanPath = resolve(resolveTrackedPath(cwd, worktreePath), relativePlanPath);
+	return existsSync(worktreePlanPath) ? worktreePlanPath : absolutePlanPath;
+}
+
+function resolveTrackedPath(baseDirectory: string, trackedPath: string): string {
+	return isAbsolute(trackedPath) ? resolve(trackedPath) : resolve(baseDirectory, trackedPath);
+}
+
+function parseTopLevelCheckbox(line: string): { readonly checked: boolean; readonly label: string } | null {
+	if (line.startsWith("- [ ] ")) return { checked: false, label: line.slice(CHECKBOX_PREFIX_LENGTH) };
+	if (line.startsWith("- [x] ") || line.startsWith("- [X] ")) {
+		return { checked: true, label: line.slice(CHECKBOX_PREFIX_LENGTH) };
+	}
+	return null;
+}
+
+function parseLevelTwoHeading(line: string): string | null {
+	if (!line.startsWith("## ")) return null;
+	return line.slice("## ".length).trim();
+}
+
+function isCountedHeading(heading: string | null): boolean {
+	return heading === TODO_HEADING || heading === FINAL_VERIFICATION_HEADING;
+}
+
+function parseBoulderWorkStatus(value: unknown): BoulderWorkStatus | undefined {
+	if (value === "active" || value === "paused" || value === "completed" || value === "abandoned") return value;
+	return undefined;
+}
+
+function parseSessionIds(value: unknown): readonly string[] {
+	if (!Array.isArray(value)) return [];
+	const sessionIds: string[] = [];
+	for (const item of value) {
+		if (typeof item === "string") sessionIds.push(normalizeSessionId(item));
+	}
+	return sessionIds;
+}
+
+function normalizeSessionId(sessionId: string, platform: "codex" | "opencode" = "opencode"): string {
+	if (SESSION_ID_PREFIX_PATTERN.test(sessionId)) return sessionId;
+	return `${platform}:${sessionId}`;
+}
+
+function parseIsoToMs(value: string | undefined): number | null {
+	if (value === undefined) return null;
+	const parsed = Date.parse(value);
+	return Number.isNaN(parsed) ? null : parsed;
+}
+
 function isContinuableStatus(status: BoulderWorkStatus | undefined): boolean {
 	return status === "active" || status === "paused";
+}
+
+function getBoulderFilePath(cwd: string): string {
+	return join(cwd, ".omo", "boulder.json");
+}
+
+function emptyChecklist(): PlanChecklist {
+	return { completed: 0, remaining: 0, total: 0, nextTaskLabel: null };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
@@ -1,9 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getPlanChecklist } from "@oh-my-opencode/boulder-state";
 import { afterEach, describe, expect, it } from "vitest";
-import { readContinuationState } from "../src/boulder-reader.js";
+import { getPlanChecklist, readContinuationState } from "../src/boulder-reader.js";
 
 const cleanupRoots: string[] = [];
 
@@ -109,6 +108,21 @@ describe("start-work boulder state reader", () => {
 		expect(state).toBeNull();
 	});
 
+	it("#given paused codex work with remaining checklist #when state is read #then continuation is present", () => {
+		// given
+		const workspace = createWorkspace({
+			boulderJson: createBoulderJson({ status: "paused", sessionIds: ["codex:sess_abc"] }),
+			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n",
+		});
+
+		// when
+		const state = readContinuationState(workspace, "sess_abc");
+
+		// then
+		expect(state?.planName).toBe("launch-plan");
+		expect(state?.checklist).toEqual({ completed: 0, remaining: 1, total: 1, nextTaskLabel: "First" });
+	});
+
 	it("#given no remaining top-level checklist items #when state is read #then continuation is absent", () => {
 		// given
 		const workspace = createWorkspace({
@@ -127,6 +141,20 @@ describe("start-work boulder state reader", () => {
 		// given
 		const workspace = createWorkspace({
 			boulderJson: "{",
+			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n",
+		});
+
+		// when
+		const state = readContinuationState(workspace, "sess_abc");
+
+		// then
+		expect(state).toBeNull();
+	});
+
+	it("#given bare boulder session id #when codex state is read #then continuation is absent", () => {
+		// given
+		const workspace = createWorkspace({
+			boulderJson: createBoulderJson({ status: "active", sessionIds: ["sess_abc"] }),
 			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n",
 		});
 

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/cli.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/cli.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execPath } from "node:process";
@@ -23,7 +23,11 @@ describe("start-work continuation CLI", () => {
 		// then
 		if (result.error !== undefined) throw result.error;
 		expect(result.status).toBe(0);
-		expect(result.stdout).toContain('"decision":"block"');
+		const output = parseStopHookOutput(result.stdout);
+		expect(output.decision).toBe("block");
+		expect(output.reason).toContain("Remaining top-level checkboxes: `2` of `3`");
+		expect(output.reason).toContain("Next incomplete task: `Task one`");
+		expect(output.reason).toContain("Your session id in boulder.json: `codex:s1`");
 	});
 
 	it("#given valid SubagentStop stdin #when CLI runs #then stdout contains block JSON", () => {
@@ -80,6 +84,18 @@ describe("start-work continuation CLI", () => {
 		expect(result.status).toBe(0);
 		expect(result.stdout).toBe("");
 	});
+
+	it("#given built CLI bundle #when inspected #then it does not depend on the monorepo boulder package", () => {
+		// given
+		const cliPath = join(process.cwd(), "dist", "cli.js");
+
+		// when
+		const source = readFileSync(cliPath, "utf8");
+
+		// then
+		expect(source).not.toContain("@oh-my-opencode/boulder-state");
+		expect(source).not.toContain("../../boulder-state");
+	});
 });
 
 function runCli(subcommand: "stop" | "subagent-stop", input: string) {
@@ -90,7 +106,7 @@ function createWorkspace(sessionIds: readonly string[]): string {
 	const root = mkdtempSync(join(tmpdir(), "codex-continuation-cli-"));
 	cleanupRoots.push(root);
 	mkdirSync(join(root, ".omo", "plans"), { recursive: true });
-	writeFileSync(join(root, ".omo", "plans", "plan.md"), "## TODOs\n\n- [ ] Task one\n");
+	writeFileSync(join(root, ".omo", "plans", "plan.md"), "## TODOs\n\n- [ ] Task one\n- [x] Done\n- [ ] Task two\n");
 	const work = {
 		work_id: "w1",
 		active_plan: ".omo/plans/plan.md",
@@ -121,4 +137,19 @@ function makePayload(
 		stop_hook_active: stopHookActive,
 		last_assistant_message: "done",
 	};
+}
+
+type ParsedStopHookOutput = {
+	readonly decision: unknown;
+	readonly reason: string;
+};
+
+function parseStopHookOutput(stdout: string): ParsedStopHookOutput {
+	const parsed: unknown = JSON.parse(stdout);
+	if (!isRecord(parsed) || typeof parsed["reason"] !== "string") throw new Error("CLI did not emit Stop hook JSON");
+	return { decision: parsed["decision"], reason: parsed["reason"] };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/omo-codex/plugin/package-lock.json
+++ b/packages/omo-codex/plugin/package-lock.json
@@ -23,11 +23,6 @@
 				"@oh-my-opencode/shared-skills": "file:../../shared-skills"
 			}
 		},
-		"../../boulder-state": {
-			"name": "@oh-my-opencode/boulder-state",
-			"version": "0.1.0",
-			"dev": true
-		},
 		"../../comment-checker-core": {
 			"name": "@oh-my-opencode/comment-checker-core",
 			"version": "0.1.0",
@@ -215,7 +210,6 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.4.16",
-				"@oh-my-opencode/boulder-state": "file:../../../../boulder-state",
 				"@types/node": "^25.9.3",
 				"typescript": "^6.0.3",
 				"vitest": "^4.1.8"
@@ -561,10 +555,6 @@
 				"@emnapi/core": "^1.7.1",
 				"@emnapi/runtime": "^1.7.1"
 			}
-		},
-		"node_modules/@oh-my-opencode/boulder-state": {
-			"resolved": "../../boulder-state",
-			"link": true
 		},
 		"node_modules/@oh-my-opencode/comment-checker-core": {
 			"resolved": "../../comment-checker-core",

--- a/packages/utils/src/codegraph/resolve.ts
+++ b/packages/utils/src/codegraph/resolve.ts
@@ -16,6 +16,12 @@ export interface CodegraphCommandResolution {
   readonly source: CodegraphCommandSource
 }
 
+export function codegraphCommandRequiresSupportedLocalNode(
+  resolution: CodegraphCommandResolution,
+): boolean {
+  return resolution.source !== "bundled" && resolution.source !== "env" && resolution.source !== "provisioned"
+}
+
 export interface ResolveCodegraphCommandOptions {
   readonly env?: Record<string, string | undefined>
   readonly fileExists?: (filePath: string) => boolean


### PR DESCRIPTION
## Summary
- trust provisioned CodeGraph launchers under unsupported wrapper Node versions while keeping PATH-discovered commands guarded
- make start-work-continuation self-contained so the Stop hook CLI can be bundled without the monorepo-only Boulder dependency

## Verification
- bun run test:codex: 342 pass
- CodeGraph component tests: 31 pass
- start-work-continuation tests: 28 pass
- bundled CLI contract: 7 pass
- package layout: 6 pass

## Evidence
- .omo/evidence/20260619-codegraph-node25/
- .omo/evidence/20260619-start-work-stop-cli/

Fixes code-yeongyu/lazycodex#59
Fixes code-yeongyu/lazycodex#60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow CodeGraph to run when launched via a provisioned binary even if the local Node version is unsupported, and make the Start Work Stop hook CLI self-contained so it bundles outside the monorepo. Fixes code-yeongyu/lazycodex#59 and code-yeongyu/lazycodex#60.

- Bug Fixes
  - CodeGraph (serve + SessionStart worker): skip Node-version guard for commands resolved as provisioned; keep guard for PATH-discovered commands; centralized the check via codegraphCommandRequiresSupportedLocalNode (affects `@colbymchenry/codegraph` launcher behavior).
  - Start-work-continuation: removed dependency on `@oh-my-opencode/boulder-state` and inlined a minimal Boulder reader; CLI bundle no longer references monorepo packages and now reports remaining checklist counts, next task, and normalized session id in the stop reason.

<sup>Written for commit 9eaa5c04fac18d51e4b3d165421c86ecd48bfd6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

