### PR TITLE
fix(codex): prefer Node support hint for CodeGraph

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -2085,11 +2085,15 @@ async function runCodegraphServe(options = {}) {
     provisioned: () => provisionedBinFromInstallDir2(codegraphConfig.install_dir)
   };
   const resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
+  const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
   if (!resolution.exists || shouldSkipResolvedCommand(resolution, options.commandExists ?? existsSync7)) {
+    if (resolution.source === "path" && !nodeSupport.supported) {
+      (options.stderr ?? processStderr2).write(buildCodegraphNodeSkipHint(nodeSupport));
+      return 1;
+    }
     (options.stderr ?? processStderr2).write(CODEGRAPH_SKIP_HINT);
     return 1;
   }
-  const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
   if (codegraphCommandRequiresSupportedLocalNode(resolution) && !nodeSupport.supported) {
     (options.stderr ?? processStderr2).write(buildCodegraphNodeSkipHint(nodeSupport));
     return 1;

--- a/packages/omo-codex/plugin/components/codegraph/dist/serve.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/serve.js
@@ -1514,11 +1514,15 @@ async function runCodegraphServe(options = {}) {
     provisioned: () => provisionedBinFromInstallDir(codegraphConfig.install_dir)
   };
   const resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
+  const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
   if (!resolution.exists || shouldSkipResolvedCommand(resolution, options.commandExists ?? existsSync4)) {
+    if (resolution.source === "path" && !nodeSupport.supported) {
+      (options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
+      return 1;
+    }
     (options.stderr ?? processStderr).write(CODEGRAPH_SKIP_HINT);
     return 1;
   }
-  const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
   if (codegraphCommandRequiresSupportedLocalNode(resolution) && !nodeSupport.supported) {
     (options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
     return 1;

--- a/packages/omo-codex/plugin/components/codegraph/src/serve.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/serve.ts
@@ -83,12 +83,16 @@ export async function runCodegraphServe(options: RunCodegraphServeOptions = {}):
 		provisioned: () => provisionedBinFromInstallDir(codegraphConfig.install_dir),
 	} satisfies ResolveCodegraphCommandOptions;
 	const resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
+	const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
 	if (!resolution.exists || shouldSkipResolvedCommand(resolution, options.commandExists ?? existsSync)) {
+		if (resolution.source === "path" && !nodeSupport.supported) {
+			(options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
+			return 1;
+		}
 		(options.stderr ?? processStderr).write(CODEGRAPH_SKIP_HINT);
 		return 1;
 	}
 
-	const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
 	if (codegraphCommandRequiresSupportedLocalNode(resolution) && !nodeSupport.supported) {
 		(options.stderr ?? processStderr).write(buildCodegraphNodeSkipHint(nodeSupport));
 		return 1;

--- a/packages/omo-codex/plugin/components/codegraph/test/serve-node-support.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve-node-support.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+
+import { CODEGRAPH_UNSAFE_NODE_ENV } from "../../../../../utils/src/codegraph/node-support.ts";
+import { runCodegraphServe } from "../src/serve.ts";
+
+describe("runCodegraphServe node support", () => {
+	it("#given Node is too new and no command resolves #when serving MCP #then the unsupported-node hint wins", async () => {
+		// given
+		const stderr: string[] = [];
+		const spawned: string[] = [];
+
+		// when
+		const exitCode = await runCodegraphServe({
+			env: { PATH: "/bin" },
+			nodeVersion: "26.3.0",
+			buildEnv: () => ({}),
+			resolve: () => ({ argsPrefix: [], command: "codegraph", exists: false, source: "path" }),
+			runProcess: (command: string) => {
+				spawned.push(command);
+				return Promise.resolve(0);
+			},
+			stderr: { write: (chunk: string) => stderr.push(chunk) },
+		});
+
+		// then
+		expect(exitCode).toBe(1);
+		expect(spawned).toEqual([]);
+		expect(stderr).toHaveLength(1);
+		expect(stderr[0]).toContain("CodeGraph MCP skipped");
+		expect(stderr[0]).toContain("Node 26 is unsupported");
+		expect(stderr[0]).toContain(CODEGRAPH_UNSAFE_NODE_ENV);
+	});
+});


### PR DESCRIPTION
## Summary
Fixes the Discord report where the Codex CodeGraph MCP wrapper could show the generic missing-binary hint on Node 26 when no `codegraph` command was discoverable. The wrapper now evaluates local Node support before the PATH missing-binary branch, so unsupported Node versions get the actionable Node downgrade/override guidance. Explicit `OMO_CODEGRAPH_BIN` missing-path overrides still report the missing binary.

## Changes
- Move CodeGraph Node support evaluation before the unresolved-command branch in `runCodegraphServe()`.
- Emit the unsupported-Node skip hint for auto-discovered PATH resolution when Node is unsupported.
- Add a focused failing-first test for the Node 26/no-command case.
- Refresh generated CodeGraph wrapper bundles.

## Verification
**Automated:**
- `bun test packages/omo-codex/plugin/components/codegraph/test/serve-node-support.test.ts` ✅ (`.omo/evidence/20260619-codegraph-node26/green-serve-node-support.txt`)
- Existing CodeGraph serve regression suite ✅ (`.omo/evidence/20260619-codegraph-node26/green-serve-regression.txt`)
- `bun run test:codex` ✅ (`.omo/evidence/20260619-codegraph-node26/test-codex.txt`)
- `bun test` ✅ (`.omo/evidence/20260619-codegraph-node26/bun-test.txt`)
- `bun run typecheck` ✅ (`.omo/evidence/20260619-codegraph-node26/typecheck.txt`)
- `bun run build` ✅ (`.omo/evidence/20260619-codegraph-node26/build.txt`)
- no-excuse audit on changed TS files ✅ (`.omo/evidence/20260619-codegraph-node26/no-excuse.txt`)

**Manual QA:**
- Node v26, isolated HOME, empty PATH, built wrapper exits 1 with `Node 26 is unsupported` and no generic missing-binary hint ✅ (`.omo/evidence/20260619-codegraph-node26/manual-node26-unsupported.txt`)
- Node v26, isolated HOME/PATH, explicit missing `OMO_CODEGRAPH_BIN`, built wrapper exits 1 with missing-binary hint and no unsupported-Node hint ✅ (`.omo/evidence/20260619-codegraph-node26/manual-explicit-missing-override.txt`)
- Codex QA common self-check, isolated install verification, and live app-server plugin hook proof all passed with real `~/.codex/config.toml` unchanged ✅ (`.omo/evidence/20260619-codegraph-node26/codex-common-self-check.txt`, `codex-install-verify-worktree.txt`, `codex-app-server-plugin-worktree-rerun.txt`)

## Related
- Discord: https://discord.com/channels/1452487457085063218/1490539106797621259/1517398227236814930

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CodeGraph MCP serve behavior to show the unsupported Node hint on Node 26+ when no `codegraph` command is found. Users now see clear Node downgrade/override guidance instead of a generic missing-binary message.

- **Bug Fixes**
  - Evaluate Node support before the missing-binary branch in `runCodegraphServe()`.
  - Preserve missing-binary errors when `OMO_CODEGRAPH_BIN` is set but not found.
  - Add a test for Node 26 with no command; refresh built wrappers.

<sup>Written for commit fa1af8689fa64aa154035d1353f7ed8dd7c9acd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

