### PR TITLE
fix(codex): run teammode team.mjs correctly through a symlinked install

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -17,8 +17,9 @@
 //   node "<skill-root>/scripts/team.mjs" guide        --team <id>
 
 import { randomUUID } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { rm, writeFile } from "node:fs/promises";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { buildGuide, buildMemberPrompt } from "./team-guide.mjs";
 import {
 	addMember,
@@ -191,7 +192,20 @@ async function main() {
 	await handler(process.cwd(), parseFlags(rest));
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Symlink-robust main-module check: a symlinked install invokes this file through a symlink
+// path while node resolves import.meta.url to the realpath, so compare the resolved real paths
+// (falling back to the literal url comparison if a path cannot be resolved).
+function isInvokedAsScript() {
+	const entry = process.argv[1];
+	if (!entry) return false;
+	try {
+		return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(entry);
+	} catch {
+		return import.meta.url === pathToFileURL(entry).href;
+	}
+}
+
+if (isInvokedAsScript()) {
 	await main().catch((error) => {
 		process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
 		process.exit(1);

--- a/packages/omo-codex/plugin/test/teammode-cli.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-cli.test.mjs
@@ -238,3 +238,30 @@ test("#given a symlinked .omo/teams #when init runs #then it refuses before writ
 		await rm(outside, { recursive: true, force: true });
 	}
 });
+
+test("#given team.mjs invoked through a symlinked scripts dir #when init runs #then the main guard still fires", async (t) => {
+	// given --- mirror a symlinked install: the skills dir is a symlink to the repo, so the
+	// script is invoked through a symlink path while node resolves its module url to the realpath.
+	if (!(await canCreateSymlink())) {
+		t.skip("symbolic links are unavailable in this environment");
+		return;
+	}
+	const dir = await mkTmp();
+	try {
+		const linkedScripts = join(dir, "linked-scripts");
+		await symlink(join(root, "skills", "teammode", "scripts"), linkedScripts, "dir");
+
+		// when --- run the script through the symlink path
+		const res = spawnSync(
+			process.execPath,
+			[join(linkedScripts, "team.mjs"), "init", "--name", "Crew", "--session-name", "s", "--session", "demo"],
+			{ cwd: dir, encoding: "utf8" },
+		);
+
+		// then --- main() runs (the guard matches by realpath, not the literal argv path)
+		assert.equal(res.status, 0, res.stderr);
+		assert.match(res.stdout, /created:/, "the script executes when invoked via a symlinked scripts dir");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

Follow-up to #5417. The teammode controller `team.mjs` silently did nothing when invoked through a symlink (it exited 0 with no output). This breaks a dev setup that symlinks the cached Codex skills dir to the repo so skill changes are live without reinstalling.

## Root cause

The main-module guard was `import.meta.url === pathToFileURL(process.argv[1]).href`. node resolves `import.meta.url` to the **realpath**, but `process.argv[1]` stays the literal **symlink** path. When the script is reached through a symlinked scripts dir, the two never match, `main()` never runs, and the CLI is a no-op that still exits 0.

## Fix

Compare resolved real paths: `realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1])`, falling back to the original url comparison if a path cannot be resolved. Works for both a normal (copied) install and a symlinked one.

## Verification

**Automated:** `bun run test:codex` -> **363/363 pass**, EXIT=0 (+1 new test). A new test (`teammode-cli.test.mjs`) symlinks the scripts dir and invokes `team.mjs` through it, asserting it produces output; it fails on the old guard and passes on the fix.

**Manual QA** (`.omo/evidence/20260619-codex-teammode-symlink/`): symlinked the scripts dir and ran `team.mjs init`/`status` through the symlink - now prints `created:` + the team status (previously silent). This is the exact failure mode hit in a symlinked local install.

## Related

Follow-up to #5417 / #5416 (teammode).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes teammode controller `team.mjs` so it runs correctly when invoked through a symlinked install. Updates the main-module guard to be symlink-safe and adds a test to prevent regressions.

- **Bug Fixes**
  - Main-module check now compares resolved real paths (`realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1])`) with a fallback to the URL comparison.
  - Added CLI test that runs `team.mjs` via a symlinked scripts dir and verifies it produces output.

<sup>Written for commit eb032169185655ecc75c531e35e5a59ee7061bfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

