### PR TITLE
test(omo-opencode): relax background output poll timing

### DIFF
--- a/packages/omo-opencode/src/tools/background-task/create-background-output.polling-interval.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/create-background-output.polling-interval.test.ts
@@ -38,6 +38,8 @@ const client: BackgroundOutputClient = {
   },
 }
 
+const LEGACY_BACKGROUND_OUTPUT_POLL_INTERVAL_MS = 1000
+
 describe("background_output blocking poll interval", () => {
   test("#given a short blocking timeout and a task that completes on retry #when fetching output #then it does not sleep for the legacy one second interval", async () => {
     // given
@@ -64,7 +66,7 @@ describe("background_output blocking poll interval", () => {
     }, mockContext)
 
     // then
-    expect(Date.now() - startedAt).toBeLessThan(200)
+    expect(Date.now() - startedAt).toBeLessThan(LEGACY_BACKGROUND_OUTPUT_POLL_INTERVAL_MS)
     expect(pollCount).toBeGreaterThanOrEqual(3)
     expect(output).toContain("completed result")
   })


### PR DESCRIPTION
## Summary
Fixes the Windows-only CI failure in the `background_output blocking poll interval` test. The implementation already polls quickly; the test was asserting a brittle `<200ms` wall-clock ceiling and failed on Windows at 219ms even though it still avoided the legacy one-second sleep.

## Changes
- Replaces the hardcoded 200ms assertion with a named legacy one-second boundary.
- Keeps the regression meaningful: the test still fails if `background_output` sleeps for the legacy 1000ms interval before retrying.

## Verification
**RED:** GitHub Actions CI run `27808775016` failed on `test (windows-latest)` with the focused test taking 219ms against the old `<200ms` ceiling. Artifact: `.omo/evidence/20260619-ci-test-fix/ci-failed-run-27808775016.log`.

**GREEN / automated:**
- `bun test packages/omo-opencode/src/tools/background-task/create-background-output.polling-interval.test.ts` passed.
- `bun run typecheck` passed.
- `bun test` passed: 10051 pass, 2 skip, 0 fail.

**Manual QA / OpenCode surface:**
- `.agents/skills/opencode-qa/scripts/lib/common.sh --self-check` passed.
- `.agents/skills/opencode-qa/scripts/tui-smoke.sh --self-test` passed and proved tmux cleanup plus real DB session count unchanged.
- `.agents/skills/opencode-qa/scripts/server-smoke.sh` passed and proved isolated server health/auth behavior.

Evidence directory: `.omo/evidence/20260619-ci-test-fix/`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky Windows CI test by relaxing the polling time assertion to below the legacy 1s interval, avoiding false failures. Adds a named constant for the legacy poll interval to keep the test meaningful.

- **Bug Fixes**
  - Replace brittle <200ms check with `LEGACY_BACKGROUND_OUTPUT_POLL_INTERVAL_MS` (1000ms).
  - Test still fails if `background_output` sleeps for the legacy 1s interval before retrying.

<sup>Written for commit bbed9447efd54d3611274ef5671825414c3a36c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

