### PR TITLE
docs(work-with-pr): default to auto-merge; wait until actually merged

### DIFF
--- a/.agents/skills/work-with-pr/SKILL.md
+++ b/.agents/skills/work-with-pr/SKILL.md
@@ -21,7 +21,7 @@ Phase 3: Verify Loop   → Unbounded iteration; a failing gate routes back to Ph
   ├─ Gate B: review-work → 5-agent parallel review (the reviewer subagents)
   └─ Gate C: Cubic      → cubic-dev-ai[bot] "No issues found"
                          (SKIPPED, not failed, when Cubic's quota is exhausted)
-Phase 4: Merge         → Merge by default, then worktree cleanup
+Phase 4: Merge         → Auto-merge by default; wait until actually merged, then worktree cleanup
 ```
 
 </architecture>
@@ -293,14 +293,28 @@ Once all active gates pass (Cubic may be SKIPPED on quota):
 
 <merge_cleanup>
 
-### Merge the PR
+### Merge the PR (auto-merge by default)
 
-Merging is the default — do it unless the user explicitly told you not to. If they opted out, skip this step and report the green, ready-to-merge PR, but STILL run the cleanup below: the worktree is removed either way.
+Enabling auto-merge is the default - do it unless the user explicitly told you not to merge. Auto-merge hands the merge to GitHub, which lands the PR the moment every required gate is green, so you never sit and babysit checks. It does NOT bypass the gates: if a gate fails, GitHub will not merge, which routes you back to Phase 1 to fix and re-QA like any other failing gate.
 
 ```bash
-# This repository requires merge commits. Never use --squash or --rebase here.
-gh pr merge "$PR_NUMBER" --merge --delete-branch
+# This repository requires merge commits. Never use --squash or --rebase.
+# --auto arms auto-merge: GitHub merges as soon as all required checks pass.
+gh pr merge "$PR_NUMBER" --merge --auto --delete-branch
+# If the repo has not enabled the auto-merge feature, --auto errors; once the gates
+# are green, fall back to a direct merge: gh pr merge "$PR_NUMBER" --merge --delete-branch
 ```
+
+Then WAIT until the merge has actually completed before you report done or clean up - never walk away while the PR is still merging:
+
+```bash
+# Block until the PR is actually MERGED (auto-merge lands once all required checks pass)
+until [ "$(gh pr view "$PR_NUMBER" --json state -q .state)" = "MERGED" ]; do
+  gh pr checks "$PR_NUMBER" --watch --fail-fast >/dev/null 2>&1 || true   # spend the interval on the checks
+done
+```
+
+If the user opted out of merging, skip the merge but STILL run the cleanup below: the worktree is removed either way.
 
 ### Sync .omo state back to main repo
 

--- a/.opencode/skills/work-with-pr/SKILL.md
+++ b/.opencode/skills/work-with-pr/SKILL.md
@@ -21,7 +21,7 @@ Phase 3: Verify Loop   → Unbounded iteration; a failing gate routes back to Ph
   ├─ Gate B: review-work → 5-agent parallel review (the reviewer subagents)
   └─ Gate C: Cubic      → cubic-dev-ai[bot] "No issues found"
                          (SKIPPED, not failed, when Cubic's quota is exhausted)
-Phase 4: Merge         → Merge by default, then worktree cleanup
+Phase 4: Merge         → Auto-merge by default; wait until actually merged, then worktree cleanup
 ```
 
 </architecture>
@@ -293,14 +293,28 @@ Once all active gates pass (Cubic may be SKIPPED on quota):
 
 <merge_cleanup>
 
-### Merge the PR
+### Merge the PR (auto-merge by default)
 
-Merging is the default — do it unless the user explicitly told you not to. If they opted out, skip this step and report the green, ready-to-merge PR, but STILL run the cleanup below: the worktree is removed either way.
+Enabling auto-merge is the default - do it unless the user explicitly told you not to merge. Auto-merge hands the merge to GitHub, which lands the PR the moment every required gate is green, so you never sit and babysit checks. It does NOT bypass the gates: if a gate fails, GitHub will not merge, which routes you back to Phase 1 to fix and re-QA like any other failing gate.
 
 ```bash
-# This repository requires merge commits. Never use --squash or --rebase here.
-gh pr merge "$PR_NUMBER" --merge --delete-branch
+# This repository requires merge commits. Never use --squash or --rebase.
+# --auto arms auto-merge: GitHub merges as soon as all required checks pass.
+gh pr merge "$PR_NUMBER" --merge --auto --delete-branch
+# If the repo has not enabled the auto-merge feature, --auto errors; once the gates
+# are green, fall back to a direct merge: gh pr merge "$PR_NUMBER" --merge --delete-branch
 ```
+
+Then WAIT until the merge has actually completed before you report done or clean up - never walk away while the PR is still merging:
+
+```bash
+# Block until the PR is actually MERGED (auto-merge lands once all required checks pass)
+until [ "$(gh pr view "$PR_NUMBER" --json state -q .state)" = "MERGED" ]; do
+  gh pr checks "$PR_NUMBER" --watch --fail-fast >/dev/null 2>&1 || true   # spend the interval on the checks
+done
+```
+
+If the user opted out of merging, skip the merge but STILL run the cleanup below: the worktree is removed either way.
 
 ### Sync .omo state back to main repo
 


### PR DESCRIPTION
## Summary

In the `work-with-pr` skill, make **auto-merge the default** (unless the user opts out) and require **waiting until the PR is actually merged** before declaring done or cleaning up - so the agent stops babysitting CI.

## Changes

- Phase 4 "Merge the PR" now defaults to `gh pr merge "$PR_NUMBER" --merge --auto --delete-branch` (auto-merge), with a direct-merge fallback when the repo has not enabled auto-merge.
- Adds an explicit wait loop that blocks until `gh pr view --json state` reports `MERGED` before cleanup.
- Clarifies auto-merge does NOT bypass gates: a failing gate still blocks the merge and routes back to Phase 1.
- Updated the architecture diagram line accordingly.
- Both `.agents/skills/work-with-pr/SKILL.md` and `.opencode/skills/work-with-pr/SKILL.md` updated byte-identically (shared-skill no-drift rule).

## Verification

- `.agents` and `.opencode` copies are byte-identical (`diff -q`).
- The `project-skill-tool-references` contract assertions are untouched (`commits through git-master`, `category="unspecified-high"` still present); CI runs the test.
- No new em/en dashes in the added lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the `work-with-pr` skill to use GitHub auto-merge and wait until the PR is actually MERGED before reporting done or cleaning up. This avoids babysitting CI and prevents premature cleanup.

- **New Features**
  - Default to `gh pr merge --merge --auto --delete-branch`, with a direct-merge fallback when auto-merge is unavailable.
  - Block until `gh pr view --json state` returns `MERGED`; watch checks during the wait.
  - Clarified gates still enforce merges; updated the architecture line and synced `.agents`/`.opencode` copies.

<sup>Written for commit 815fa4a36767e26e463ce2ae9709ab6a9ed452d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

