### PR TITLE
fix(codex): harden teammode guide writes and member IDs

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -169,13 +169,30 @@ export async function teamExists(dir) {
 	return (await lstatOrNull(join(dir, "team.json"))) !== null;
 }
 
-export async function writeTeamAtomic(team) {
+async function persistedFileTarget(team, pathKey, fileName) {
 	validateTeam(team);
-	const target = team.paths.team;
+	if (!team.paths?.dir || !team.paths?.[pathKey]) throw new Error(`invalid team: paths.${pathKey} is required`);
+	const dir = resolve(team.paths.dir);
+	const target = resolve(team.paths[pathKey]);
+	if (target !== resolve(dir, fileName)) throw new Error(`refused: ${fileName} persist target escapes team dir: ${team.paths[pathKey]}`);
 	const st = await lstatOrNull(target);
-	if (st?.isSymbolicLink()) throw new Error(`refused: team.json is a symlink: ${target}`);
-	const tmp = `${target}.tmp-${process.pid}`;
-	await writeFile(tmp, `${JSON.stringify(team, null, 2)}\n`, "utf8");
+	if (st?.isSymbolicLink()) throw new Error(`refused: ${fileName} is a symlink: ${target}`);
+	if (st && !st.isFile()) throw new Error(`refused: ${fileName} is not a file: ${target}`);
+	return target;
+}
+
+async function writePersistedFileAtomic(team, pathKey, fileName, content) {
+	const target = await persistedFileTarget(team, pathKey, fileName);
+	const tmp = `${target}.tmp-${process.pid}-${randomUUID()}`;
+	await writeFile(tmp, content, { encoding: "utf8", flag: "wx" });
 	await rename(tmp, target);
 	return team;
+}
+
+export async function writeTeamAtomic(team) {
+	return writePersistedFileAtomic(team, "team", "team.json", `${JSON.stringify(team, null, 2)}\n`);
+}
+
+export async function writeGuideAtomic(team, content) {
+	return writePersistedFileAtomic(team, "guide", "guide.md", content);
 }

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -153,6 +153,15 @@ async function mkdirNoSymlink(dir, stopAt) {
 	await mkdir(dir);
 }
 
+async function assertNoSymlinkComponents(dir, stopAt) {
+	if (dir === stopAt) return;
+	const rel = relative(stopAt, dir);
+	if (rel.startsWith("..") || isAbsolute(rel)) throw new Error(`refused: path escapes ${stopAt}: ${dir}`);
+	await assertNoSymlinkComponents(dirname(dir), stopAt);
+	const st = await lstatOrNull(dir);
+	if (st?.isSymbolicLink()) throw new Error(`refused: path component is a symlink: ${dir}`);
+}
+
 export async function ensureTeamDir(cwd, sessionId) {
 	const workspaceRoot = resolve(cwd);
 	const teamsRoot = resolve(cwd, ".omo", "teams");
@@ -160,6 +169,15 @@ export async function ensureTeamDir(cwd, sessionId) {
 	await mkdirNoSymlink(teamsRoot, workspaceRoot);
 	await mkdirNoSymlink(dir, teamsRoot);
 	await mkdirNoSymlink(join(dir, "artifacts"), dir);
+	return dir;
+}
+
+export async function assertSafeTeamDir(cwd, sessionId) {
+	const workspaceRoot = resolve(cwd);
+	const teamsRoot = resolve(cwd, ".omo", "teams");
+	const dir = resolveTeamDir(cwd, sessionId);
+	await assertNoSymlinkComponents(teamsRoot, workspaceRoot);
+	await assertNoSymlinkComponents(dir, teamsRoot);
 	return dir;
 }
 
@@ -171,30 +189,33 @@ export async function teamExists(dir) {
 	return (await lstatOrNull(join(dir, "team.json"))) !== null;
 }
 
-async function persistedFileTarget(team, pathKey, fileName) {
+async function persistedFileTarget(team, pathKey, fileName, expectedDir) {
 	validateTeam(team);
 	if (!team.paths?.dir || !team.paths?.[pathKey]) throw new Error(`invalid team: paths.${pathKey} is required`);
-	const dir = resolve(team.paths.dir);
+	const dir = resolve(expectedDir);
+	if (resolve(team.paths.dir) !== dir) throw new Error(`refused: persisted team dir does not match trusted team dir: ${team.paths.dir}`);
 	const target = resolve(team.paths[pathKey]);
 	if (target !== resolve(dir, fileName)) throw new Error(`refused: ${fileName} persist target escapes team dir: ${team.paths[pathKey]}`);
+	const dirStat = await lstatOrNull(dir);
+	if (dirStat?.isSymbolicLink()) throw new Error(`refused: team dir is a symlink: ${dir}`);
 	const st = await lstatOrNull(target);
 	if (st?.isSymbolicLink()) throw new Error(`refused: ${fileName} is a symlink: ${target}`);
 	if (st && !st.isFile()) throw new Error(`refused: ${fileName} is not a file: ${target}`);
 	return target;
 }
 
-async function writePersistedFileAtomic(team, pathKey, fileName, content) {
-	const target = await persistedFileTarget(team, pathKey, fileName);
+async function writePersistedFileAtomic(team, pathKey, fileName, content, expectedDir) {
+	const target = await persistedFileTarget(team, pathKey, fileName, expectedDir);
 	const tmp = `${target}.tmp-${process.pid}-${randomUUID()}`;
 	await writeFile(tmp, content, { encoding: "utf8", flag: "wx" });
 	await rename(tmp, target);
 	return team;
 }
 
-export async function writeTeamAtomic(team) {
-	return writePersistedFileAtomic(team, "team", "team.json", `${JSON.stringify(team, null, 2)}\n`);
+export async function writeTeamAtomic(team, expectedDir) {
+	return writePersistedFileAtomic(team, "team", "team.json", `${JSON.stringify(team, null, 2)}\n`, expectedDir);
 }
 
-export async function writeGuideAtomic(team, content) {
-	return writePersistedFileAtomic(team, "guide", "guide.md", content);
+export async function writeGuideAtomic(team, content, expectedDir) {
+	return writePersistedFileAtomic(team, "guide", "guide.md", content, expectedDir);
 }

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -72,10 +72,12 @@ export function addMember(team, { id, focus, lens, deliverable = "", branch = nu
 	if (!id?.trim()) throw new Error("member id is required");
 	if (!focus?.trim()) throw new Error("member focus is required - a concrete part, ownership area, or perspective");
 	if (!LENSES.includes(lens)) throw new Error(`invalid lens "${lens}" - use one of: ${LENSES.join(", ")}`);
-	if (team.members.some((m) => m.id === id)) throw new Error(`member id "${id}" already exists (duplicate)`);
+	const memberId = id.trim();
+	const memberFocus = focus.trim();
+	if (team.members.some((m) => m.id === memberId)) throw new Error(`member id "${memberId}" already exists (duplicate)`);
 	team.members.push({
-		id: id.trim(),
-		focus: focus.trim(),
+		id: memberId,
+		focus: memberFocus,
 		lens,
 		deliverable: deliverable.trim(),
 		threadId: null,
@@ -84,7 +86,7 @@ export function addMember(team, { id, focus, lens, deliverable = "", branch = nu
 		worktree: { path: null, branch: branch ?? null },
 		status: "pending",
 	});
-	return touch(team, "add-member", `member ${id.trim()} (${lens}): ${focus.trim()}`);
+	return touch(team, "add-member", `member ${memberId} (${lens}): ${memberFocus}`);
 }
 
 export function bindThread(team, { id, threadId, cwd = null, worktreePath = null }) {

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -18,7 +18,7 @@
 
 import { randomUUID } from "node:crypto";
 import { realpathSync } from "node:fs";
-import { rm, writeFile } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { buildGuide, buildMemberPrompt } from "./team-guide.mjs";
 import {
@@ -33,6 +33,7 @@ import {
 	resolveTeamDir,
 	setMemberStatus,
 	teamExists,
+	writeGuideAtomic,
 	writeTeamAtomic,
 } from "./team-state.mjs";
 
@@ -64,7 +65,7 @@ function requireFlag(flags, name) {
 
 async function persist(team) {
 	await writeTeamAtomic(team);
-	await writeFile(team.paths.guide, buildGuide(team), "utf8");
+	await writeGuideAtomic(team, buildGuide(team));
 }
 
 const handlers = {
@@ -178,7 +179,7 @@ const handlers = {
 	async guide(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
 		const team = await readTeam(resolveTeamDir(cwd, sessionId));
-		await writeFile(team.paths.guide, buildGuide(team), "utf8");
+		await writeGuideAtomic(team, buildGuide(team));
 		process.stdout.write(`${team.paths.guide}\n`);
 	},
 };

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -95,15 +95,16 @@ const handlers = {
 	async "add-member"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
 		const team = await readTeam(resolveTeamDir(cwd, sessionId));
+		const memberId = requireFlag(flags, "id").trim();
 		addMember(team, {
-			id: requireFlag(flags, "id"),
+			id: memberId,
 			focus: requireFlag(flags, "focus"),
 			lens: requireFlag(flags, "lens"),
 			deliverable: typeof flags.deliverable === "string" ? flags.deliverable : "",
 			branch: typeof flags.branch === "string" ? flags.branch : null,
 		});
 		await persist(team);
-		process.stdout.write(`added member ${flags.id} to team ${sessionId}.\n\nSend this as the new thread's first message (title it "${team.threadTitleConvention}"):\n---\n${buildMemberPrompt(team, flags.id)}\n---\n`);
+		process.stdout.write(`added member ${memberId} to team ${sessionId}.\n\nSend this as the new thread's first message (title it "${team.threadTitleConvention}"):\n---\n${buildMemberPrompt(team, memberId)}\n---\n`);
 	},
 
 	async "bind-thread"(cwd, flags) {

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -24,6 +24,7 @@ import { buildGuide, buildMemberPrompt } from "./team-guide.mjs";
 import {
 	addMember,
 	archive,
+	assertSafeTeamDir,
 	bindThread,
 	buildTeam,
 	ensureTeamDir,
@@ -63,9 +64,14 @@ function requireFlag(flags, name) {
 	return value;
 }
 
-async function persist(team) {
-	await writeTeamAtomic(team);
-	await writeGuideAtomic(team, buildGuide(team));
+async function loadTeam(cwd, sessionId) {
+	const dir = await assertSafeTeamDir(cwd, sessionId);
+	return { dir, team: await readTeam(dir) };
+}
+
+async function persist(team, dir) {
+	await writeTeamAtomic(team, dir);
+	await writeGuideAtomic(team, buildGuide(team), dir);
 }
 
 const handlers = {
@@ -86,7 +92,7 @@ const handlers = {
 			worktreeEnabled: flags.worktree === true,
 			baseBranch: typeof flags["base-branch"] === "string" ? flags["base-branch"] : "dev",
 		});
-		await persist(team);
+		await persist(team, dir);
 		process.stdout.write(`created: ${dir}\n`);
 		process.stdout.write(`team.json + guide.md written; artifacts/ ready. session id: ${sessionId}\n`);
 		process.stdout.write(`next: add-member --team ${sessionId} --id A --focus "<part/ownership/perspective>" --lens area|ownership|perspective --deliverable "<...>"\n`);
@@ -94,7 +100,7 @@ const handlers = {
 
 	async "add-member"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const team = await readTeam(resolveTeamDir(cwd, sessionId));
+		const { dir, team } = await loadTeam(cwd, sessionId);
 		const memberId = requireFlag(flags, "id").trim();
 		addMember(team, {
 			id: memberId,
@@ -103,49 +109,49 @@ const handlers = {
 			deliverable: typeof flags.deliverable === "string" ? flags.deliverable : "",
 			branch: typeof flags.branch === "string" ? flags.branch : null,
 		});
-		await persist(team);
+		await persist(team, dir);
 		process.stdout.write(`added member ${memberId} to team ${sessionId}.\n\nSend this as the new thread's first message (title it "${team.threadTitleConvention}"):\n---\n${buildMemberPrompt(team, memberId)}\n---\n`);
 	},
 
 	async "bind-thread"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const team = await readTeam(resolveTeamDir(cwd, sessionId));
+		const { dir, team } = await loadTeam(cwd, sessionId);
 		bindThread(team, {
 			id: requireFlag(flags, "id"),
 			threadId: requireFlag(flags, "thread"),
 			cwd: typeof flags.cwd === "string" ? flags.cwd : null,
 			worktreePath: typeof flags["worktree-path"] === "string" ? flags["worktree-path"] : null,
 		});
-		await persist(team);
+		await persist(team, dir);
 		process.stdout.write(`bound member ${flags.id} to thread ${flags.thread}.\n`);
 	},
 
 	async "member-prompt"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const team = await readTeam(resolveTeamDir(cwd, sessionId));
+		const { team } = await loadTeam(cwd, sessionId);
 		process.stdout.write(`${buildMemberPrompt(team, requireFlag(flags, "id"))}\n`);
 	},
 
 	async "set-status"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const team = await readTeam(resolveTeamDir(cwd, sessionId));
+		const { dir, team } = await loadTeam(cwd, sessionId);
 		setMemberStatus(team, {
 			id: requireFlag(flags, "id"),
 			status: requireFlag(flags, "status"),
 			note: typeof flags.note === "string" ? flags.note : "",
 		});
-		await persist(team);
+		await persist(team, dir);
 		process.stdout.write(`member ${flags.id} -> ${flags.status}\n`);
 	},
 
 	async archive(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const team = await readTeam(resolveTeamDir(cwd, sessionId));
+		const { dir, team } = await loadTeam(cwd, sessionId);
 		archive(team, {
 			id: typeof flags.id === "string" ? flags.id : null,
 			note: typeof flags.note === "string" ? flags.note : "",
 		});
-		await persist(team);
+		await persist(team, dir);
 		process.stdout.write(flags.id ? `archived member ${flags.id}\n` : `archived team ${sessionId} and closed all members\n`);
 	},
 
@@ -165,7 +171,7 @@ const handlers = {
 
 	async status(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const team = await readTeam(resolveTeamDir(cwd, sessionId));
+		const { team } = await loadTeam(cwd, sessionId);
 		process.stdout.write(`Team ${team.teamName} [${team.status}] - leader: main session - ${team.members.length} member(s)\n`);
 		for (const m of team.members) {
 			process.stdout.write(`  ${m.id} (${m.lens}) ${m.focus} -> ${m.deliverable || "(no deliverable)"} [${m.status}]${m.threadId ? ` thread=${m.threadId}` : ""}${m.cwd ? ` cwd=${m.cwd}` : ""}\n`);
@@ -179,8 +185,8 @@ const handlers = {
 
 	async guide(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const team = await readTeam(resolveTeamDir(cwd, sessionId));
-		await writeGuideAtomic(team, buildGuide(team));
+		const { dir, team } = await loadTeam(cwd, sessionId);
+		await writeGuideAtomic(team, buildGuide(team), dir);
 		process.stdout.write(`${team.paths.guide}\n`);
 	},
 };

--- a/packages/omo-codex/plugin/test/teammode-safety.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-safety.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -79,6 +79,57 @@ test("#given member A exists #when add-member receives A with trailing space #th
 			team.members.map((member) => member.id),
 			["A"],
 		);
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+test("#given persisted paths are mutated outside trusted team dir #when guide is regenerated #then outside file stays untouched", () => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-mutated-paths-"));
+	try {
+		runTeam(tempRoot, "init", "--name", "Mutated", "--session-name", "Paths", "--session", "safe-mutated");
+		const teamPath = join(tempRoot, ".omo", "teams", "safe-mutated", "team.json");
+		const outsideDir = join(tempRoot, "outside");
+		const outsideGuide = join(outsideDir, "guide.md");
+		mkdirSync(outsideDir);
+		writeFileSync(outsideGuide, "ORIGINAL_OUTSIDE\n");
+		const team = JSON.parse(readFileSync(teamPath, "utf8"));
+		team.paths.dir = outsideDir;
+		team.paths.guide = outsideGuide;
+		writeFileSync(teamPath, `${JSON.stringify(team, null, 2)}\n`);
+
+		const result = runTeamRaw(tempRoot, "guide", "--team", "safe-mutated");
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /persisted team dir does not match trusted team dir/);
+		assert.equal(readFileSync(outsideGuide, "utf8"), "ORIGINAL_OUTSIDE\n");
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+test("#given team dir is swapped to a symlink #when status reads team state #then command refuses the symlink", (t) => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-dir-symlink-"));
+	try {
+		runTeam(tempRoot, "init", "--name", "SymlinkDir", "--session-name", "Paths", "--session", "safe-dir");
+		const teamDir = join(tempRoot, ".omo", "teams", "safe-dir");
+		const outsideDir = join(tempRoot, "outside-team-dir");
+		mkdirSync(outsideDir);
+		rmSync(teamDir, { recursive: true, force: true });
+		try {
+			symlinkSync(outsideDir, teamDir, "dir");
+		} catch (error) {
+			if (error?.code === "EPERM" || error?.code === "EACCES" || error?.code === "EINVAL") {
+				t.skip(`symlink unavailable on this filesystem: ${error.code}`);
+				return;
+			}
+			throw error;
+		}
+
+		const result = runTeamRaw(tempRoot, "status", "--team", "safe-dir");
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /path component is a symlink|team dir is a symlink/);
 	} finally {
 		rmSync(tempRoot, { recursive: true, force: true });
 	}

--- a/packages/omo-codex/plugin/test/teammode-safety.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-safety.test.mjs
@@ -38,6 +38,52 @@ test("#given guide.md is a symlink #when guide is regenerated #then the outside 
 	}
 });
 
+test("#given member A exists #when add-member receives A with trailing space #then state is not partially mutated", () => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-duplicate-"));
+	try {
+		runTeam(tempRoot, "init", "--name", "Duplicate", "--session-name", "Members", "--session", "safe-duplicate");
+		runTeam(
+			tempRoot,
+			"add-member",
+			"--team",
+			"safe-duplicate",
+			"--id",
+			"A",
+			"--focus",
+			"alpha",
+			"--lens",
+			"area",
+			"--deliverable",
+			"first",
+		);
+
+		const result = runTeamRaw(
+			tempRoot,
+			"add-member",
+			"--team",
+			"safe-duplicate",
+			"--id",
+			"A ",
+			"--focus",
+			"beta",
+			"--lens",
+			"ownership",
+			"--deliverable",
+			"second",
+		);
+		const team = JSON.parse(readFileSync(join(tempRoot, ".omo", "teams", "safe-duplicate", "team.json"), "utf8"));
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /member id "A" already exists/);
+		assert.deepEqual(
+			team.members.map((member) => member.id),
+			["A"],
+		);
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
 function runTeam(cwd, ...args) {
 	const result = runTeamRaw(cwd, ...args);
 	assert.equal(result.status, 0, `team.mjs ${args.join(" ")} failed: ${result.stderr}`);

--- a/packages/omo-codex/plugin/test/teammode-safety.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-safety.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { root } from "./aggregate-plugin-fixture.mjs";
+
+const teamScript = join(root, "components", "teammode", "skills", "teammode", "scripts", "team.mjs");
+
+test("#given guide.md is a symlink #when guide is regenerated #then the outside target stays untouched", (t) => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-guide-"));
+	try {
+		runTeam(tempRoot, "init", "--name", "Symlink", "--session-name", "Escape", "--session", "safe-guide");
+		const teamDir = join(tempRoot, ".omo", "teams", "safe-guide");
+		const guidePath = join(teamDir, "guide.md");
+		const outsidePath = join(tempRoot, "outside-guide-target.md");
+		writeFileSync(outsidePath, "ORIGINAL_OUTSIDE\n");
+		unlinkSync(guidePath);
+		try {
+			symlinkSync(outsidePath, guidePath);
+		} catch (error) {
+			if (error?.code === "EPERM" || error?.code === "EACCES" || error?.code === "EINVAL") {
+				t.skip(`symlink unavailable on this filesystem: ${error.code}`);
+				return;
+			}
+			throw error;
+		}
+
+		const result = runTeamRaw(tempRoot, "guide", "--team", "safe-guide");
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /guide\.md is a symlink|persist target escapes/);
+		assert.equal(readFileSync(outsidePath, "utf8"), "ORIGINAL_OUTSIDE\n");
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+function runTeam(cwd, ...args) {
+	const result = runTeamRaw(cwd, ...args);
+	assert.equal(result.status, 0, `team.mjs ${args.join(" ")} failed: ${result.stderr}`);
+	return result;
+}
+
+function runTeamRaw(cwd, ...args) {
+	return spawnSync(process.execPath, [teamScript, ...args], {
+		cwd,
+		encoding: "utf8",
+		timeout: 10_000,
+	});
+}


### PR DESCRIPTION
## Summary
Fixes two Codex teammode release blockers: guide writes could follow a symlink outside the team directory, and member IDs were checked before trimming, allowing `A` and `A ` to coexist. The component now refuses symlink/escape targets for persisted team files and normalizes member IDs before duplicate checks and storage.

## Changes
- Add guarded atomic team guide writes that reject symlink and path escape targets.
- Trim member IDs before duplicate validation and persistence.
- Add focused teammode safety coverage for guide symlink protection and trimmed duplicate rejection.

## Verification
**Automated:**
- Focused teammode safety tests -> `.omo/evidence/20260619-publish-blocker-fixes/teammode/focused-final-tests.txt`
- `bun run test:codex` -> `.omo/evidence/20260619-publish-blocker-fixes/teammode/test-codex.txt`

**Manual QA:**
- CLI symlink scenario left the external target unchanged and rejected duplicate `A ` with one persisted member -> `.omo/evidence/20260619-publish-blocker-fixes/teammode/manual-cli.txt`
- Component/generated skill scripts were synced and compared -> `.omo/evidence/20260619-publish-blocker-fixes/teammode/sync-skills-generated-receipt.txt`
- Isolated Codex install verification passed and real `~/.codex/config.toml` shasum stayed unchanged -> `.omo/evidence/20260619-publish-blocker-fixes/teammode/codex-install-verify-final.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Codex teammode persistence and member handling. We now trust only the resolved team dir and block symlinked or escaping paths; member IDs are trimmed before validation to prevent duplicates like "A" vs "A ".

- **Bug Fixes**
  - Atomic writes for `team.json` and `guide.md`; refuse symlinked team dirs/files, non-file replacements, and persisted paths that don’t match the trusted team dir.
  - Trim member IDs (and focus) before duplicate checks and storage; CLI output and prompts use the trimmed ID.
  - Added tests for guide symlink protection, mutated persisted paths, team-dir symlink rejection, and trimmed duplicate rejection.

<sup>Written for commit fe327c3d79a6bd3f7654d1d54861491a9b63e395. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

