### PR TITLE
fix(codex-start-work): align boulder reader parity

### DIFF
--- a/packages/omo-codex/plugin/components/start-work-continuation/src/boulder-reader.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/src/boulder-reader.ts
@@ -23,6 +23,7 @@ type BoulderWork = {
 type BoulderState = {
 	readonly works: readonly BoulderWork[];
 	readonly mirrorWork: BoulderWork | null;
+	readonly hasWorksMap: boolean;
 };
 
 export type ContinuationState = {
@@ -117,7 +118,8 @@ function parseBoulderState(value: unknown): BoulderState | null {
 
 	const works: BoulderWork[] = [];
 	const worksValue = value["works"];
-	if (isRecord(worksValue)) {
+	const hasWorksMap = isRecord(worksValue);
+	if (hasWorksMap) {
 		for (const workValue of Object.values(worksValue)) {
 			const work = parseBoulderWork(workValue);
 			if (work !== null) works.push(work);
@@ -126,7 +128,7 @@ function parseBoulderState(value: unknown): BoulderState | null {
 
 	const mirrorWork = parseBoulderWork(value);
 	if (works.length === 0 && mirrorWork === null) return null;
-	return { works, mirrorWork };
+	return { works, mirrorWork, hasWorksMap };
 }
 
 function parseBoulderWork(value: unknown): BoulderWork | null {
@@ -168,6 +170,7 @@ function getWorkForSession(state: BoulderState, normalizedSessionId: string): Bo
 	}
 
 	if (newestWork !== null) return newestWork;
+	if (state.hasWorksMap) return null;
 	if (state.mirrorWork?.sessionIds.includes(normalizedSessionId) === true) return state.mirrorWork;
 	return null;
 }

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
@@ -164,6 +164,38 @@ describe("start-work boulder state reader", () => {
 		// then
 		expect(state).toBeNull();
 	});
+
+	it("#given works omit the codex session but stale mirror matches #when state is read #then continuation is absent", () => {
+		// given
+		const workspace = createWorkspace({
+			boulderJson: JSON.stringify({
+				schema_version: 2,
+				active_work_id: "work_1",
+				works: {
+					work_1: {
+						work_id: "work_1",
+						active_plan: ".omo/plans/plan.md",
+						plan_name: "current-work",
+						status: "active",
+						started_at: "2026-06-13T00:00:00.000Z",
+						session_ids: ["opencode:sess_other"],
+					},
+				},
+				active_plan: ".omo/plans/plan.md",
+				plan_name: "stale-mirror",
+				status: "active",
+				started_at: "2026-06-12T00:00:00.000Z",
+				session_ids: ["codex:sess_abc"],
+			}),
+			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n",
+		});
+
+		// when
+		const state = readContinuationState(workspace, "sess_abc");
+
+		// then
+		expect(state).toBeNull();
+	});
 });
 
 type WorkspaceInput = {


### PR DESCRIPTION
## Summary
Fixes the Codex start-work continuation reader so modern Boulder `works` maps are authoritative. When a modern map exists but the current session is absent, the reader no longer falls back to a stale legacy mirror and resumes unrelated work.

## Changes
- Track whether `.omo/boulder.json` contained a modern `works` map.
- Use the legacy mirror fallback only for legacy-only state files.
- Add regression coverage for the stale mirror mismatch.

## Verification
**Automated:**
- RED regression after installing local test deps -> `.omo/evidence/20260619-publish-blocker-fixes/boulder-reader/red-after-install.txt`
- Focused GREEN boulder-reader tests -> `.omo/evidence/20260619-publish-blocker-fixes/boulder-reader/green.txt`

**Manual QA:**
- Manual data fixture with modern `works` plus stale mirror produced empty hook stdout for the unrelated session -> `.omo/evidence/20260619-publish-blocker-fixes/boulder-reader/manual-data.txt`
- Dependency grep confirms no direct runtime dependency on `@oh-my-opencode/boulder-state` was introduced -> `.omo/evidence/20260619-publish-blocker-fixes/boulder-reader/dependency-grep.txt`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Codex start-work continuation reader to use the modern Boulder `works` map as the source of truth. Stops falling back to the legacy mirror when a modern map exists, preventing resumes for unrelated sessions.

- **Bug Fixes**
  - Parse and store `hasWorksMap` when reading Boulder state.
  - If `works` exists but has no match for the session, return no continuation; only use the legacy mirror for legacy-only files.
  - Added a regression test covering the stale mirror mismatch.

<sup>Written for commit cc48c8ff946d8b398687cc84195812cd8cd735fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

