### PR TITLE
fix(codex): guard teammode delete symlink paths

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -157,8 +157,7 @@ const handlers = {
 
 	async delete(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const dir = resolveTeamDir(cwd, sessionId);
-		const team = await readTeam(dir);
+		const { dir, team } = await loadTeam(cwd, sessionId);
 		const active = team.members.filter((m) => m.status !== "archived");
 		if (flags.force !== true && (team.status !== "archived" || active.length > 0)) {
 			throw new Error(

--- a/packages/omo-codex/plugin/test/teammode-safety.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-safety.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -130,6 +130,50 @@ test("#given team dir is swapped to a symlink #when status reads team state #the
 
 		assert.notEqual(result.status, 0);
 		assert.match(result.stderr, /path component is a symlink|team dir is a symlink/);
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+test("#given teams root is a symlink #when delete runs #then outside team state stays untouched", (t) => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-delete-root-symlink-"));
+	try {
+		const outsideTeams = join(tempRoot, "outside-teams");
+		const outsideTeamDir = join(outsideTeams, "escape");
+		mkdirSync(outsideTeamDir, { recursive: true });
+		writeFileSync(
+			join(outsideTeamDir, "team.json"),
+			`${JSON.stringify(
+				{
+					schemaVersion: 2,
+					teamId: "outside-team",
+					teamName: "Outside",
+					sessionName: "Escape",
+					leader: { kind: "main-session", sessionId: "escape" },
+					status: "archived",
+					members: [],
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		mkdirSync(join(tempRoot, ".omo"), { recursive: true });
+		try {
+			symlinkSync(outsideTeams, join(tempRoot, ".omo", "teams"), "dir");
+		} catch (error) {
+			if (error?.code === "EPERM" || error?.code === "EACCES" || error?.code === "EINVAL") {
+				t.skip(`symlink unavailable on this filesystem: ${error.code}`);
+				return;
+			}
+			throw error;
+		}
+
+		const result = runTeamRaw(tempRoot, "delete", "--team", "escape", "--force");
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /path component is a symlink/);
+		assert.equal(existsSync(outsideTeamDir), true);
+		assert.equal(JSON.parse(readFileSync(join(outsideTeamDir, "team.json"), "utf8")).teamId, "outside-team");
 	} finally {
 		rmSync(tempRoot, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary
Fixes a pre-publish review blocker where the Codex teammode `delete` command used `resolveTeamDir()` directly, bypassing the trusted/symlink-guarded `loadTeam()` path used by the rest of the controller. This prevents a symlinked `.omo/teams` root from redirecting `delete --force` to outside team state.

## Changes
- Route `team.mjs delete` through `loadTeam()` / `assertSafeTeamDir()` before reading or removing team state.
- Add a regression where `.omo/teams` is swapped to a directory symlink and `delete --force` must refuse while preserving the outside directory.

## Verification
**Automated:** `bun run build` passed, `bun run typecheck` passed, `bun run test:codex` passed, `node --test packages/omo-codex/plugin/test/teammode-safety.test.mjs` passed.

**Manual QA / harness:** `.omo/evidence/20260619-teammode-delete-symlink/codex-install-verify.txt` passed, `.omo/evidence/20260619-teammode-delete-symlink/codex-app-server-drive-plugin.txt` passed, `.omo/evidence/20260619-teammode-delete-symlink/codex-tui-smoke.txt` passed.

Diagnostic pre-setup failures are preserved in the same evidence directory with `*-failed.txt` names; reruns after `bun install` and `bun run build` are green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened teammode delete in `omo-codex` to guard symlinked paths and prevent deletes outside team state. `delete --force` now refuses when `.omo/teams` is a directory symlink and preserves external files.

- **Bug Fixes**
  - Route `team.mjs delete` through `loadTeam()` and `assertSafeTeamDir()` before accessing team state.
  - Add regression test to ensure symlinked `.omo/teams` blocks delete and keeps the outside team dir untouched.

<sup>Written for commit eb62bc3fefb368888588b55e0b5675e3a5e6cfb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

