### PR TITLE
test(qa): fail release probes on hidden hook regressions

### DIFF
--- a/.agents/skills/codex-qa/scripts/lib/app-server-client.mjs
+++ b/.agents/skills/codex-qa/scripts/lib/app-server-client.mjs
@@ -19,99 +19,139 @@
 //                 turn/completed.
 //   CODEX_BIN     codex binary (default "codex"; PATH lookup, no shell function).
 //
-// Prints a JSON summary to stdout. Exit 0 iff the turn completed AND every
-// EXPECT_HOOK fired with status "completed".
+// Prints a JSON summary to stdout. Exit 0 iff the turn completed, every
+// EXPECT_HOOK fired with status "completed", and no hook completed failed.
 import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
-const CODEX_BIN = process.env.CODEX_BIN || "codex";
-const MOCK_PORT = process.env.MOCK_PORT;
-const PROMPT = process.env.PROMPT || "say hello";
-const CWD = process.env.QA_CWD || process.cwd();
-const DEADLINE_MS = Number(process.env.DEADLINE_MS || 60000);
-const EXPECT = (process.env.EXPECT_HOOK || "").split(",").map((s) => s.trim()).filter(Boolean);
-
-if (!MOCK_PORT) {
-  console.error("app-server-client: MOCK_PORT is required (start lib/mock-model.mjs first)");
-  process.exit(2);
+export function parseExpectedHooks(value) {
+  return (value || "").split(",").map((s) => s.trim()).filter(Boolean);
 }
 
-// Config overrides force codex onto the local mock provider, never the real one.
-const overrides = [
-  `model="mock-model"`,
-  `model_provider="mock_provider"`,
-  `model_providers.mock_provider.name="codex-qa mock"`,
-  `model_providers.mock_provider.base_url="http://127.0.0.1:${MOCK_PORT}/v1"`,
-  `model_providers.mock_provider.wire_api="responses"`,
-  `model_providers.mock_provider.request_max_retries=0`,
-  `model_providers.mock_provider.stream_max_retries=0`,
-  `approval_policy="never"`,
-  `sandbox_mode="read-only"`,
-];
-const args = overrides.flatMap((o) => ["-c", o]).concat("app-server");
-
-const child = spawn(CODEX_BIN, args, { stdio: ["pipe", "pipe", "pipe"], env: process.env });
-let stderr = "";
-child.stderr.on("data", (c) => (stderr += c));
-
-const hooks = [];
-let assistantText = null;
-let threadId = null;
-let turnId = null;
-let turnStatus = null;
-let buf = "";
-let finished = false;
-
-const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
-
-function finish() {
-  if (finished) return;
-  finished = true;
-  try { child.kill("SIGTERM"); } catch {}
-  const completed = new Set(hooks.filter((h) => h.method === "hook/completed" && h.status === "completed").map((h) => h.eventName));
-  const missing = EXPECT.filter((e) => !completed.has(e));
-  const ok = turnStatus === "completed" && missing.length === 0;
-  console.log(JSON.stringify({ ok, turnStatus, assistantText, threadId, turnId, expectHook: EXPECT, missingHooks: missing, hooks, stderrTail: stderr.split("\n").slice(-10).join("\n") }, null, 2));
-  process.exit(ok ? 0 : 1);
+export function summarizeRun({ turnStatus, assistantText, threadId, turnId, expectHook, hooks, stderr }) {
+  const completed = new Set(
+    hooks
+      .filter((h) => h.method === "hook/completed" && h.status === "completed")
+      .map((h) => h.eventName),
+  );
+  const missingHooks = expectHook.filter((eventName) => !completed.has(eventName));
+  const failedHooks = hooks.filter((h) => h.method === "hook/completed" && h.status !== "completed");
+  const ok = turnStatus === "completed" && missingHooks.length === 0 && failedHooks.length === 0;
+  return {
+    ok,
+    turnStatus,
+    assistantText,
+    threadId,
+    turnId,
+    expectHook,
+    missingHooks,
+    failedHooks,
+    hooks,
+    stderrTail: stderr.split("\n").slice(-10).join("\n"),
+  };
 }
 
-function handle(msg) {
-  if (msg.id === 1 && msg.result) {
-    send({ method: "initialized" });
-    send({ id: 2, method: "thread/start", params: { cwd: CWD } });
-  } else if (msg.id === 2 && msg.result) {
-    threadId = msg.result.thread?.id;
-    send({ id: 3, method: "turn/start", params: { threadId, input: [{ type: "text", text: PROMPT }] } });
-  } else if (msg.id === 3 && msg.result) {
-    turnId = msg.result.turn?.id;
-  } else if (msg.method === "hook/started" || msg.method === "hook/completed") {
-    const run = msg.params?.run || {};
-    hooks.push({ method: msg.method, eventName: run.eventName, status: run.status, source: run.source ?? run.pluginId });
-  } else if (msg.method === "item/completed") {
-    const item = msg.params?.item;
-    if (item?.type === "agentMessage" && typeof item.text === "string") assistantText = item.text;
-  } else if (msg.method === "turn/completed") {
-    turnStatus = msg.params?.turn?.status;
-    finish();
+function main() {
+  const CODEX_BIN = process.env.CODEX_BIN || "codex";
+  const MOCK_PORT = process.env.MOCK_PORT;
+  const PROMPT = process.env.PROMPT || "say hello";
+  const CWD = process.env.QA_CWD || process.cwd();
+  const DEADLINE_MS = Number(process.env.DEADLINE_MS || 60000);
+  const EXPECT = parseExpectedHooks(process.env.EXPECT_HOOK || "");
+
+  if (!MOCK_PORT) {
+    console.error("app-server-client: MOCK_PORT is required (start lib/mock-model.mjs first)");
+    process.exit(2);
   }
+
+  // Config overrides force codex onto the local mock provider, never the real one.
+  const overrides = [
+    `model="mock-model"`,
+    `model_provider="mock_provider"`,
+    `model_providers.mock_provider.name="codex-qa mock"`,
+    `model_providers.mock_provider.base_url="http://127.0.0.1:${MOCK_PORT}/v1"`,
+    `model_providers.mock_provider.wire_api="responses"`,
+    `model_providers.mock_provider.request_max_retries=0`,
+    `model_providers.mock_provider.stream_max_retries=0`,
+    `approval_policy="never"`,
+    `sandbox_mode="read-only"`,
+  ];
+  const args = overrides.flatMap((o) => ["-c", o]).concat("app-server");
+
+  const child = spawn(CODEX_BIN, args, { stdio: ["pipe", "pipe", "pipe"], env: process.env });
+  let stderr = "";
+  child.stderr.on("data", (c) => (stderr += c));
+
+  const hooks = [];
+  let assistantText = null;
+  let threadId = null;
+  let turnId = null;
+  let turnStatus = null;
+  let buf = "";
+  let finished = false;
+
+  const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+
+  function finish() {
+    if (finished) return;
+    finished = true;
+    try { child.kill("SIGTERM"); } catch {}
+    const summary = summarizeRun({ turnStatus, assistantText, threadId, turnId, expectHook: EXPECT, hooks, stderr });
+    console.log(JSON.stringify(summary, null, 2));
+    process.exit(summary.ok ? 0 : 1);
+  }
+
+  function handle(msg) {
+    if (msg.id === 1 && msg.result) {
+      send({ method: "initialized" });
+      send({ id: 2, method: "thread/start", params: { cwd: CWD } });
+    } else if (msg.id === 2 && msg.result) {
+      threadId = msg.result.thread?.id;
+      send({ id: 3, method: "turn/start", params: { threadId, input: [{ type: "text", text: PROMPT }] } });
+    } else if (msg.id === 3 && msg.result) {
+      turnId = msg.result.turn?.id;
+    } else if (msg.method === "hook/started" || msg.method === "hook/completed") {
+      const run = msg.params?.run || {};
+      hooks.push({
+        method: msg.method,
+        eventName: run.eventName,
+        status: run.status,
+        source: run.source ?? run.pluginId,
+        pluginId: run.pluginId,
+        hookName: run.hookName ?? run.name,
+        runId: run.id,
+      });
+    } else if (msg.method === "item/completed") {
+      const item = msg.params?.item;
+      if (item?.type === "agentMessage" && typeof item.text === "string") assistantText = item.text;
+    } else if (msg.method === "turn/completed") {
+      turnStatus = msg.params?.turn?.status;
+      finish();
+    }
+  }
+
+  child.stdout.on("data", (chunk) => {
+    buf += chunk;
+    let nl;
+    while ((nl = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (!line) continue;
+      let msg;
+      try { msg = JSON.parse(line); } catch { continue; }
+      handle(msg);
+    }
+  });
+  child.on("exit", (code) => {
+    if (finished) return;
+    console.log(JSON.stringify({ ok: false, exitCode: code, turnStatus, hooks, stderrTail: stderr.split("\n").slice(-15).join("\n") }, null, 2));
+    process.exit(1);
+  });
+
+  send({ id: 1, method: "initialize", params: { clientInfo: { name: "codex-qa", version: "0.1.0" }, capabilities: { experimentalApi: true, requestAttestation: false } } });
+  setTimeout(() => { stderr += "\n[driver] deadline reached\n"; finish(); }, DEADLINE_MS);
 }
 
-child.stdout.on("data", (chunk) => {
-  buf += chunk;
-  let nl;
-  while ((nl = buf.indexOf("\n")) >= 0) {
-    const line = buf.slice(0, nl).trim();
-    buf = buf.slice(nl + 1);
-    if (!line) continue;
-    let msg;
-    try { msg = JSON.parse(line); } catch { continue; }
-    handle(msg);
-  }
-});
-child.on("exit", (code) => {
-  if (finished) return;
-  console.log(JSON.stringify({ ok: false, exitCode: code, turnStatus, hooks, stderrTail: stderr.split("\n").slice(-15).join("\n") }, null, 2));
-  process.exit(1);
-});
-
-send({ id: 1, method: "initialize", params: { clientInfo: { name: "codex-qa", version: "0.1.0" }, capabilities: { experimentalApi: true, requestAttestation: false } } });
-setTimeout(() => { stderr += "\n[driver] deadline reached\n"; finish(); }, DEADLINE_MS);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/.agents/skills/codex-qa/scripts/lib/app-server-client.test.js
+++ b/.agents/skills/codex-qa/scripts/lib/app-server-client.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { parseExpectedHooks, summarizeRun } from "./app-server-client.mjs";
+
+describe("app-server-client summary", () => {
+  it("#given a completed expected event also has a failed hook run #when summarized #then the QA run fails", () => {
+    const summary = summarizeRun({
+      turnStatus: "completed",
+      assistantText: "ok",
+      threadId: "thread",
+      turnId: "turn",
+      expectHook: ["sessionStart", "userPromptSubmit"],
+      hooks: [
+        { method: "hook/completed", eventName: "sessionStart", status: "completed", source: "plugin" },
+        { method: "hook/completed", eventName: "userPromptSubmit", status: "completed", source: "plugin" },
+        { method: "hook/completed", eventName: "userPromptSubmit", status: "failed", source: "plugin" },
+      ],
+      stderr: "",
+    });
+
+    expect(summary.ok).toBe(false);
+    expect(summary.missingHooks).toEqual([]);
+    expect(summary.failedHooks).toEqual([
+      { method: "hook/completed", eventName: "userPromptSubmit", status: "failed", source: "plugin" },
+    ]);
+  });
+
+  it("#given all expected hooks complete #when summarized #then the QA run passes", () => {
+    const summary = summarizeRun({
+      turnStatus: "completed",
+      assistantText: "ok",
+      threadId: "thread",
+      turnId: "turn",
+      expectHook: ["sessionStart", "userPromptSubmit"],
+      hooks: [
+        { method: "hook/completed", eventName: "sessionStart", status: "completed", source: "plugin" },
+        { method: "hook/completed", eventName: "userPromptSubmit", status: "completed", source: "plugin" },
+      ],
+      stderr: "",
+    });
+
+    expect(summary.ok).toBe(true);
+    expect(summary.failedHooks).toEqual([]);
+  });
+
+  it("#given a comma-separated expectation #when parsed #then whitespace and empties are ignored", () => {
+    expect(parseExpectedHooks(" sessionStart, ,userPromptSubmit ")).toEqual(["sessionStart", "userPromptSubmit"]);
+  });
+});

--- a/.agents/skills/opencode-qa/scripts/serve-wake-split-probe.sh
+++ b/.agents/skills/opencode-qa/scripts/serve-wake-split-probe.sh
@@ -8,7 +8,8 @@
 #
 # Two assertion modes:
 #   --expect reproduced   exit 0 if terminal_stops>1 OR child_task_sessions>1 OR mechanism arm true
-#   --expect fixed        exit 0 if terminal_stops==1, child_task_sessions==1, and fixed branch counts hold
+#   --expect fixed        exit 0 if terminal_stops==1, child_task_sessions==1, fixed branch counts hold,
+#                         and the wake dispatch used the live listener for this probe session
 #
 # Usage:
 #   serve-wake-split-probe.sh [--expect reproduced|fixed] [--evidence-dir DIR]
@@ -362,6 +363,15 @@ swsp_detect_wake_during_parent() {
   fi
 }
 
+swsp_has_session_live_dispatch() {
+  local route_prov="$1"
+  local session_id="$2"
+  [ -n "$session_id" ] || return 1
+  printf '%s\n' "$route_prov" \
+    | grep -F "dispatch via live listener" \
+    | grep -F "\"sessionID\":\"${session_id}\"" >/dev/null 2>&1
+}
+
 # Verify branch-count guard: all required branches fired.
 # Returns 0 if OK, 1 if any required branch missing (also sets RESULT=HARNESS_ERROR).
 swsp_check_branch_counts() {
@@ -377,12 +387,7 @@ swsp_check_branch_counts() {
 
   swsp_info "branch counts: parent-tool-call=$ptc parent-hold=$pc child=$cc wake=$wc"
 
-  local wake_required=0
-  if [ "$mode" = "reproduced" ]; then
-    wake_required=1
-  fi
-
-  if [ "$ptc" -lt 1 ] || [ "$pc" -lt 1 ] || [ "$cc" -lt 1 ] || { [ "$wake_required" -eq 1 ] && [ "$wc" -lt 1 ]; }; then
+  if [ "$ptc" -lt 1 ] || [ "$pc" -lt 1 ] || [ "$cc" -lt 1 ]; then
     printf 'RESULT=HARNESS_ERROR branch_counts parent-tool-call=%s parent-hold=%s child=%s wake=%s\n' \
       "$ptc" "$pc" "$cc" "$wc"
     return 1
@@ -449,6 +454,32 @@ swsp_self_test() {
       swsp_log "FAIL: omo config merge wrong: _probe='$probe_val' explore_model='$explore_model'"
       fails=$((fails+1))
     fi
+  fi
+
+  local route_fixture
+  route_fixture='[2026-06-19T00:00:00.000Z] [live-server-route] dispatch via live listener {"sessionID":"ses_other","source":"background-agent-parent-wake"}
+[2026-06-19T00:00:01.000Z] [live-server-route] dispatch via live listener {"sessionID":"ses_probe","source":"background-agent-parent-wake"}'
+  if swsp_has_session_live_dispatch "$route_fixture" "ses_probe" \
+    && ! swsp_has_session_live_dispatch "$route_fixture" "ses_missing"; then
+    swsp_info "PASS: live dispatch detection is scoped to the probe session"
+  else
+    swsp_log "FAIL: live dispatch detection accepted an unrelated session"
+    fails=$((fails+1))
+  fi
+
+  local branch_log
+  branch_log="$(mktemp -t swsp-branch-log.XXXXXX)"
+  OQA_TMPDIRS+=("$branch_log")
+  {
+    printf '[2026-06-19T00:00:00.000Z] branch=parent-tool-call\n'
+    printf '[2026-06-19T00:00:01.000Z] branch=parent-hold\n'
+    printf '[2026-06-19T00:00:02.000Z] branch=child\n'
+  } >"$branch_log"
+  if swsp_check_branch_counts "$branch_log" reproduced >/dev/null 2>&1; then
+    swsp_info "PASS: reproduced branch guard accepts mechanism-only evidence"
+  else
+    swsp_log "FAIL: reproduced branch guard still requires wake branch"
+    fails=$((fails+1))
   fi
 
   swsp_stop_fake_llm
@@ -632,11 +663,14 @@ swsp_run_probe() {
   printf '%s\n' "$plugin_inits" >"$evidence_dir/plugin-init-count.txt"
 
   # Step 9: Route provenance
-  local route_prov=""
+  local route_prov_all="" route_prov=""
   if [ -f "$omo_log" ]; then
-    route_prov="$(tail -c "+$((omo_log_offset + 1))" "$omo_log" 2>/dev/null \
+    route_prov_all="$(tail -c "+$((omo_log_offset + 1))" "$omo_log" 2>/dev/null \
       | grep -E "live-server-route" || true)"
+    route_prov="$(printf '%s\n' "$route_prov_all" \
+      | awk -v dir="$OQA_PROJ" -v sid="\"sessionID\":\"${ses_id}\"" 'index($0, dir) || index($0, sid)' || true)"
   fi
+  printf '%s\n' "$route_prov_all" >"$evidence_dir/route-provenance-all.log"
   printf '%s\n' "$route_prov" >"$evidence_dir/route-provenance.log"
   swsp_info "route-provenance lines: $(printf '%s' "$route_prov" | wc -l | tr -d ' ')"
 
@@ -690,7 +724,7 @@ swsp_run_probe() {
   # Arm 2: Mechanism signal (wake dispatched during parent turn + in-process path)
   # in-process path: no live-server-route dispatch line for this wake
   local has_live_dispatch=false
-  if printf '%s' "$route_prov" | grep -q "dispatch via live listener" 2>/dev/null; then
+  if swsp_has_session_live_dispatch "$route_prov" "$ses_id"; then
     has_live_dispatch=true
   fi
   if [ "$wake_during_parent" = "true" ] && [ "$has_live_dispatch" = "false" ]; then
@@ -704,7 +738,8 @@ swsp_run_probe() {
     && [ "${ptc:-0}" -eq 1 ] \
     && [ "${pc:-0}" -eq 1 ] \
     && [ "${cc:-0}" -eq 1 ] \
-    && [ "${wc:-0}" -eq 0 ] 2>/dev/null; then
+    && [ "${wc:-0}" -eq 0 ] \
+    && [ "$has_live_dispatch" = "true" ] 2>/dev/null; then
     result="FIXED"
   fi
 


### PR DESCRIPTION
## Summary
- Make the Codex app-server QA driver fail when any completed plugin hook reports a non-completed status, even if another hook for the same event succeeded.
- Add a focused regression for the previous false-green userPromptSubmit case.
- Tighten the OpenCode wake split probe so fixed mode requires session-scoped live-listener dispatch and reproduced mode can accept mechanism-only evidence without a wake branch.

## Verification
- `bun install` ✅
- `bun test ./.agents/skills/codex-qa/scripts/lib/app-server-client.test.js` ✅
- `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` ✅, evidence: `.omo/evidence/20260619-codex-qa-hook-false-green/codex-app-server-drive-plugin-strict.txt`
- `bash .agents/skills/opencode-qa/scripts/serve-wake-split-probe.sh --self-test` ✅, evidence: `.omo/evidence/20260619-codex-qa-hook-false-green/opencode-wake-split-self-test-rerun.txt`
- `bash .agents/skills/opencode-qa/scripts/serve-wake-split-probe.sh --expect fixed --evidence-dir .omo/evidence/20260619-codex-qa-hook-false-green/opencode-wake-split-rerun` ✅
- `bun run build` ✅, evidence: `.omo/evidence/20260619-codex-qa-hook-false-green/build-rerun.txt`
- `bun run typecheck` ✅
- `bun test` ✅
- `bun run test:codex` ✅, evidence: `.omo/evidence/20260619-codex-qa-hook-false-green/test-codex-rerun.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Codex app-server QA fail on hidden plugin hook regressions and tighten the OpenCode wake split probe to prevent false greens. Adds a targeted test for the previous `userPromptSubmit` case and session-scoped live-dispatch checks.

- **Bug Fixes**
  - Codex QA driver now fails if any `hook/completed` has a non-`completed` status; adds `failedHooks` in the summary and exposes `parseExpectedHooks`/`summarizeRun` for tests.
  - Adds a focused test ensuring the `userPromptSubmit` regression is caught.
  - Wake split probe: in fixed mode, require session-scoped “dispatch via live listener”; in reproduced mode, accept mechanism-only evidence (no wake branch). Filters route provenance by session and saves full/filtered logs.

<sup>Written for commit 8bc5a40c85ee13681d7958e60d242ecdc62e554a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

