### PR TITLE
fix(publish): stage split Codex hook manifests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -719,7 +719,7 @@ jobs:
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add package.json packages/oh-my-opencode-*/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/hooks.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
+          git add package.json packages/oh-my-opencode-*/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
           git diff --cached --quiet || git commit -m "release: v${VERSION}"
 
       - name: Create release tag

--- a/script/lazycodex-marketplace-validation.pin.test.ts
+++ b/script/lazycodex-marketplace-validation.pin.test.ts
@@ -9,20 +9,6 @@ async function writePluginMcpManifest(pluginRoot: string, manifest: unknown): Pr
   await writeFile(join(pluginRoot, ".mcp.json"), `${JSON.stringify(manifest, null, 2)}\n`)
 }
 
-async function expectRejectsWith(promise: Promise<void>, expectedMessage: string): Promise<void> {
-  let validationError: unknown
-  try {
-    await promise
-  } catch (error) {
-    validationError = error
-  }
-  if (!(validationError instanceof Error)) {
-    expect(validationError).toBeInstanceOf(Error)
-    return
-  }
-  expect(validationError.message).toContain(expectedMessage)
-}
-
 describe("lazycodex marketplace validation guards", () => {
   test("#given a root per-hook manifest references a missing command #when validating the plugin bundle #then the target is rejected", async () => {
     // given
@@ -55,7 +41,7 @@ describe("lazycodex marketplace validation guards", () => {
       const validated = validateLazycodexPluginBundle(pluginRoot)
 
       // then
-      await expectRejectsWith(validated, "missing hook command target")
+      await expect(validated).rejects.toThrow("missing hook command target")
     } finally {
       await rm(pluginRoot, { recursive: true, force: true })
     }
@@ -71,7 +57,7 @@ describe("lazycodex marketplace validation guards", () => {
       const validated = validateLazycodexPluginBundle(pluginRoot)
 
       // then
-      await expectRejectsWith(validated, "mcpServers must be object")
+      await expect(validated).rejects.toThrow("mcpServers must be object")
     } finally {
       await rm(pluginRoot, { recursive: true, force: true })
     }
@@ -87,7 +73,7 @@ describe("lazycodex marketplace validation guards", () => {
       const validated = validateLazycodexPluginBundle(pluginRoot)
 
       // then
-      await expectRejectsWith(validated, "invalid MCP manifest")
+      await expect(validated).rejects.toThrow("invalid MCP manifest")
     } finally {
       await rm(pluginRoot, { recursive: true, force: true })
     }

--- a/script/lazycodex-marketplace-validation.pin.test.ts
+++ b/script/lazycodex-marketplace-validation.pin.test.ts
@@ -9,7 +9,58 @@ async function writePluginMcpManifest(pluginRoot: string, manifest: unknown): Pr
   await writeFile(join(pluginRoot, ".mcp.json"), `${JSON.stringify(manifest, null, 2)}\n`)
 }
 
+async function expectRejectsWith(promise: Promise<void>, expectedMessage: string): Promise<void> {
+  let validationError: unknown
+  try {
+    await promise
+  } catch (error) {
+    validationError = error
+  }
+  if (!(validationError instanceof Error)) {
+    expect(validationError).toBeInstanceOf(Error)
+    return
+  }
+  expect(validationError.message).toContain(expectedMessage)
+}
+
 describe("lazycodex marketplace validation guards", () => {
+  test("#given a root per-hook manifest references a missing command #when validating the plugin bundle #then the target is rejected", async () => {
+    // given
+    const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-root-hook-manifest-"))
+    await mkdir(join(pluginRoot, "hooks"), { recursive: true })
+    await writeFile(
+      join(pluginRoot, "hooks", "user-prompt-submit-loading-project-rules.json"),
+      `${JSON.stringify(
+        {
+          hooks: {
+            UserPromptSubmit: [
+              {
+                hooks: [
+                  {
+                    type: "command",
+                    command: "${PLUGIN_ROOT}/missing-target.js",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    try {
+      // when
+      const validated = validateLazycodexPluginBundle(pluginRoot)
+
+      // then
+      await expectRejectsWith(validated, "missing hook command target")
+    } finally {
+      await rm(pluginRoot, { recursive: true, force: true })
+    }
+  })
+
   test("#given an array mcpServers manifest #when validating the plugin bundle #then the manifest is rejected", async () => {
     // given
     const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-array-manifest-"))
@@ -20,7 +71,7 @@ describe("lazycodex marketplace validation guards", () => {
       const validated = validateLazycodexPluginBundle(pluginRoot)
 
       // then
-      await expect(validated).rejects.toThrow("mcpServers must be object")
+      await expectRejectsWith(validated, "mcpServers must be object")
     } finally {
       await rm(pluginRoot, { recursive: true, force: true })
     }
@@ -36,7 +87,7 @@ describe("lazycodex marketplace validation guards", () => {
       const validated = validateLazycodexPluginBundle(pluginRoot)
 
       // then
-      await expect(validated).rejects.toThrow("invalid MCP manifest")
+      await expectRejectsWith(validated, "invalid MCP manifest")
     } finally {
       await rm(pluginRoot, { recursive: true, force: true })
     }

--- a/script/lazycodex-marketplace-validation.ts
+++ b/script/lazycodex-marketplace-validation.ts
@@ -1,5 +1,5 @@
 import { readFile, readdir, stat } from "node:fs/promises"
-import { dirname, join, resolve, sep } from "node:path"
+import { basename, dirname, join, resolve, sep } from "node:path"
 import { isPlainRecord } from "@oh-my-opencode/utils"
 
 export async function validateLazycodexPluginBundle(pluginRoot: string): Promise<void> {
@@ -64,8 +64,26 @@ async function validatePluginHookCommands(pluginRoot: string, issues: string[]):
 }
 
 async function findHookManifestPaths(root: string): Promise<string[]> {
-  const paths = await findManifestPaths(root, "hooks.json")
-  return paths.filter((path) => dirname(path).endsWith(`${sep}hooks`))
+  const entries = await readdir(root, { withFileTypes: true })
+  const paths: string[] = []
+
+  if (basename(root) === "hooks") {
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith(".json")) {
+        paths.push(join(root, entry.name))
+      }
+    }
+    return paths
+  }
+
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === ".git") continue
+    if (entry.isDirectory()) {
+      paths.push(...(await findHookManifestPaths(join(root, entry.name))))
+    }
+  }
+
+  return paths
 }
 
 async function findManifestPaths(root: string, manifestName: string): Promise<string[]> {


### PR DESCRIPTION
## Summary
Fixes the Codex publish workflow after root hook manifests were split from a deleted aggregate `packages/omo-codex/plugin/hooks/hooks.json` into per-hook files under `packages/omo-codex/plugin/hooks/*.json`.

The release version-bump commit now stages the split root hook manifests, and the LazyCodex marketplace validator now scans every JSON manifest directly inside hook directories so root per-hook manifests are validated alongside component `hooks/hooks.json` manifests.

## Changes
- Update `.github/workflows/publish.yml` to stage `packages/omo-codex/plugin/hooks/*.json` during the release version commit.
- Extend `script/lazycodex-marketplace-validation.ts` hook discovery to include direct `.json` files under any `hooks/` directory.
- Add a pin test proving a broken root per-hook manifest command using `${PLUGIN_ROOT}` is rejected.

## Verification
**Release blocker proof:**
- Baseline stale pathspec failed with exit 128: `.omo/evidence/20260619-publish-hook-manifests/baseline-stale-git-add-pathspec.txt`
- Fixed workflow pathspec passed with exit 0: `.omo/evidence/20260619-publish-hook-manifests/git-add-pathspec.txt`

**Automated:**
- `bun test script/lazycodex-marketplace-validation.pin.test.ts` ✅ (`3 pass`)
- `bun run typecheck:script` ✅
- `bun run typecheck` ✅ after normal frozen install repaired cold-worktree links
- `bun run build` ✅
- `bun run test:codex` ✅ (`349 pass`, `0 fail`)

**Manual QA / real harness:**
- Codex isolated common self-check ✅
- Codex isolated install verification ✅ (`~/.codex/config.toml` unchanged)
- Codex app-server plugin drive ✅ (`hook/started` + `hook/completed`; `sessionStart`, `userPromptSubmit`, `stop`; mock turn completed)
- Codex tmux TUI smoke ✅
- OpenCode common self-check ✅
- OpenCode server smoke ✅
- OpenCode SSE hook probe ✅
- OpenCode tmux TUI smoke ✅ (real DB session count unchanged)

Evidence directory: `.omo/evidence/20260619-publish-hook-manifests/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Codex publish by staging split per-hook manifests and updating validation to scan JSON files inside each `hooks/` folder. This ensures root hook manifests are committed and broken command targets are caught.

- **Bug Fixes**
  - Update `.github/workflows/publish.yml` to `git add` `packages/omo-codex/plugin/hooks/*.json`.
  - Extend `script/lazycodex-marketplace-validation.ts` to discover JSON manifests directly under any `hooks/` directory.
  - Add a pin test that rejects a root per-hook manifest referencing a missing `${PLUGIN_ROOT}` command.

<sup>Written for commit 9b451acc2dea2fa61bbbda29297d87c41cae0ab0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

