### PR TITLE
fix(codex): enforce teammode composition invariants

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -68,6 +68,31 @@ function memberById(team, id) {
 	return found;
 }
 
+function normalizedFocus(focus) {
+	return focus.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function assertUniqueMemberFocus(team) {
+	const seen = new Map();
+	for (const member of team.members) {
+		const key = normalizedFocus(member.focus ?? "");
+		const previous = seen.get(key);
+		if (previous) {
+			throw new Error(`member focus "${member.focus}" duplicates "${previous.focus}" (no two members may own the same thing)`);
+		}
+		seen.set(key, member);
+	}
+}
+
+function assertTeamReadyForThreadBinding(team) {
+	if (isUnderstaffed(team)) {
+		throw new Error(
+			`cannot bind member threads until the team has at least ${MIN_MEMBERS} distinct members; current count is ${team.members.length}`,
+		);
+	}
+	assertUniqueMemberFocus(team);
+}
+
 export function addMember(team, { id, focus, lens, deliverable = "", branch = null }) {
 	if (!id?.trim()) throw new Error("member id is required");
 	if (!focus?.trim()) throw new Error("member focus is required - a concrete part, ownership area, or perspective");
@@ -75,6 +100,8 @@ export function addMember(team, { id, focus, lens, deliverable = "", branch = nu
 	const memberId = id.trim();
 	const memberFocus = focus.trim();
 	if (team.members.some((m) => m.id === memberId)) throw new Error(`member id "${memberId}" already exists (duplicate)`);
+	const duplicate = team.members.find((m) => normalizedFocus(m.focus) === normalizedFocus(memberFocus));
+	if (duplicate) throw new Error(`member focus "${memberFocus}" duplicates "${duplicate.focus}" (no two members may own the same thing)`);
 	team.members.push({
 		id: memberId,
 		focus: memberFocus,
@@ -91,6 +118,7 @@ export function addMember(team, { id, focus, lens, deliverable = "", branch = nu
 
 export function bindThread(team, { id, threadId, cwd = null, worktreePath = null }) {
 	if (!threadId?.trim()) throw new Error("thread id is required");
+	assertTeamReadyForThreadBinding(team);
 	const m = memberById(team, id);
 	m.threadId = threadId.trim();
 	m.status = "active";
@@ -121,6 +149,7 @@ export function validateTeam(team) {
 	if (!team.teamId || !team.teamName) throw new Error("invalid team: teamId and teamName are required");
 	if (team.leader?.kind !== "main-session") throw new Error("invalid team: leader.kind must be main-session");
 	if (!Array.isArray(team.members)) throw new Error("invalid team: members must be an array");
+	assertUniqueMemberFocus(team);
 	return team;
 }
 

--- a/packages/omo-codex/plugin/test/teammode-safety.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-safety.test.mjs
@@ -84,6 +84,103 @@ test("#given member A exists #when add-member receives A with trailing space #th
 	}
 });
 
+test("#given member focus already exists #when add-member receives same focus with different spacing and case #then state is not partially mutated", () => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-duplicate-focus-"));
+	try {
+		runTeam(tempRoot, "init", "--name", "DuplicateFocus", "--session-name", "Members", "--session", "safe-duplicate-focus");
+		runTeam(
+			tempRoot,
+			"add-member",
+			"--team",
+			"safe-duplicate-focus",
+			"--id",
+			"A",
+			"--focus",
+			"Plugin Hook Packaging",
+			"--lens",
+			"ownership",
+			"--deliverable",
+			"first",
+		);
+
+		const result = runTeamRaw(
+			tempRoot,
+			"add-member",
+			"--team",
+			"safe-duplicate-focus",
+			"--id",
+			"B",
+			"--focus",
+			" plugin   hook packaging ",
+			"--lens",
+			"area",
+			"--deliverable",
+			"second",
+		);
+		const team = JSON.parse(readFileSync(join(tempRoot, ".omo", "teams", "safe-duplicate-focus", "team.json"), "utf8"));
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /member focus "plugin   hook packaging" duplicates "Plugin Hook Packaging"/);
+		assert.deepEqual(
+			team.members.map((member) => member.id),
+			["A"],
+		);
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+test("#given only one member exists #when bind-thread runs #then member is not activated", () => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-understaffed-bind-"));
+	try {
+		runTeam(tempRoot, "init", "--name", "Understaffed", "--session-name", "Members", "--session", "safe-understaffed");
+		runTeam(
+			tempRoot,
+			"add-member",
+			"--team",
+			"safe-understaffed",
+			"--id",
+			"A",
+			"--focus",
+			"installer",
+			"--lens",
+			"area",
+			"--deliverable",
+			"first",
+		);
+
+		const result = runTeamRaw(tempRoot, "bind-thread", "--team", "safe-understaffed", "--id", "A", "--thread", "thread-a");
+		let team = JSON.parse(readFileSync(join(tempRoot, ".omo", "teams", "safe-understaffed", "team.json"), "utf8"));
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /at least 2 distinct members/);
+		assert.equal(team.members[0].threadId, null);
+		assert.equal(team.members[0].status, "pending");
+
+		runTeam(
+			tempRoot,
+			"add-member",
+			"--team",
+			"safe-understaffed",
+			"--id",
+			"B",
+			"--focus",
+			"runtime qa",
+			"--lens",
+			"perspective",
+			"--deliverable",
+			"second",
+		);
+		runTeam(tempRoot, "bind-thread", "--team", "safe-understaffed", "--id", "A", "--thread", "thread-a");
+		team = JSON.parse(readFileSync(join(tempRoot, ".omo", "teams", "safe-understaffed", "team.json"), "utf8"));
+
+		assert.equal(team.members[0].threadId, "thread-a");
+		assert.equal(team.members[0].status, "active");
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
 test("#given persisted paths are mutated outside trusted team dir #when guide is regenerated #then outside file stays untouched", () => {
 	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-mutated-paths-"));
 	try {


### PR DESCRIPTION
## Summary
Fixes the Codex teammode release blocker found in pre-publish review: team state could accept overlapping member ownership and bind a one-member team even though the skill contract requires two or more distinct slices.

The state model now rejects duplicate normalized `focus` values, validates persisted state for duplicate ownership, and refuses `bind-thread` until the team has at least two distinct members.

## Changes
- Add normalized member-focus uniqueness checks in `team-state.mjs`.
- Gate `bindThread()` with a minimum two-member readiness check before mutating member state.
- Add regression coverage for duplicate focus rejection and one-member bind rejection, including no-partial-mutation assertions.

## Verification
**Automated**
- `node --test packages/omo-codex/plugin/test/teammode-safety.test.mjs` ✅
- `bun install --frozen-lockfile` ✅
- `bun run test:codex` ✅ after install (`.omo/evidence/20260619-codex-teammode-composition/test-codex-after-install.txt`)
- `bun run typecheck` ✅ (`.omo/evidence/20260619-codex-teammode-composition/typecheck.txt`)
- `git diff --check` ✅

**Manual QA / real Codex isolation**
- Isolated local Codex install: `.omo/evidence/20260619-codex-teammode-composition/codex-qa/01-install-verify-self-test.txt` ✅
- Live Codex app-server hook proof: `.omo/evidence/20260619-codex-teammode-composition/codex-qa/02-app-server-drive-plugin.txt` ✅
- Codex TUI smoke: `.omo/evidence/20260619-codex-teammode-composition/codex-qa/03-tui-smoke-self-test.txt` ✅
- Installed plugin cache teammode probe: `.omo/evidence/20260619-codex-teammode-composition/codex-qa/04-installed-teammode-composition.txt` ✅
  - duplicate normalized focus is rejected
  - failed duplicate add leaves member count at 1
  - one-member `bind-thread` is rejected and leaves member pending
  - two-member `bind-thread` succeeds
  - real `~/.codex/config.toml` checksum unchanged


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a release blocker in Codex team mode: prevents duplicate member ownership and blocks thread binding with only one member. This enforces safe team composition and avoids partial state writes.

- **Bug Fixes**
  - Reject duplicate member focus (normalized for case/whitespace) in `omo-codex` team state.
  - Validate persisted teams for duplicate focus on load.
  - Gate `bindThread()` until there are at least two distinct members; no partial mutation on failure.
  - Added regression tests for duplicate focus and one-member bind.

<sup>Written for commit 4dd556dceabd8e91c870c1b9362a0c4a870abca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

