### PR TITLE
fix(opencode): retry plugin component load failures

### DIFF
--- a/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
@@ -1408,6 +1408,54 @@ describe("config-handler plugin loading error boundary (#1559)", () => {
     })
   })
 
+  test("retries plugin component loading after an empty fallback failure", async () => {
+    //#given
+    ;(unsafeTestValue(pluginLoader.loadAllPluginComponents)).mockRestore?.()
+    let attempts = 0
+    spyOn(pluginLoader, unsafeTestValue("loadAllPluginComponents")).mockImplementation(async () => {
+      attempts += 1
+      if (attempts === 1) {
+        throw new Error("transient")
+      }
+      return {
+        commands: { "retry-cmd": { name: "retry-cmd", description: "test", template: "test" } },
+        skills: {},
+        agents: {},
+        mcpServers: {},
+        hooksConfigs: [],
+        plugins: [{ name: "retry-plugin", version: "1.0.0", scope: "project", installPath: "/tmp/retry-plugin", pluginKey: "retry-plugin" }],
+        errors: [],
+      }
+    })
+    const pluginConfig = createPluginConfig({})
+    const { createConfigHandler: createFreshConfigHandler } = await importFreshConfigHandlerModule()
+    const handler = createFreshConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+    const firstConfig: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-7",
+      agent: {},
+    }
+    const secondConfig: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-7",
+      agent: {},
+    }
+
+    //#when
+    await handler(firstConfig)
+    await handler(secondConfig)
+
+    //#then
+    expect(attempts).toBe(2)
+    expect((firstConfig.command as Record<string, unknown>)["retry-cmd"]).toBeUndefined()
+    expect((secondConfig.command as Record<string, unknown>)["retry-cmd"]).toBeDefined()
+  })
+
   test("passes through plugin data on successful load (identity test)", async () => {
     //#given
     ;(unsafeTestValue(pluginLoader.loadAllPluginComponents)).mockRestore?.()

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
@@ -1420,7 +1420,14 @@ describe("config-handler plugin loading error boundary (#1559)", () => {
       return {
         commands: { "retry-cmd": { name: "retry-cmd", description: "test", template: "test" } },
         skills: {},
-        agents: {},
+        agents: {
+          "retry-agent": {
+            name: "retry-agent",
+            description: "Recovered plugin agent",
+            prompt: "Plugin agent recovered after retry",
+            mode: "subagent",
+          },
+        },
         mcpServers: {},
         hooksConfigs: [],
         plugins: [{ name: "retry-plugin", version: "1.0.0", scope: "project", installPath: "/tmp/retry-plugin", pluginKey: "retry-plugin" }],
@@ -1454,6 +1461,8 @@ describe("config-handler plugin loading error boundary (#1559)", () => {
     expect(attempts).toBe(2)
     expect((firstConfig.command as Record<string, unknown>)["retry-cmd"]).toBeUndefined()
     expect((secondConfig.command as Record<string, unknown>)["retry-cmd"]).toBeDefined()
+    expect((firstConfig.agent as Record<string, unknown>)["retry-agent"]).toBeUndefined()
+    expect((secondConfig.agent as Record<string, unknown>)["retry-agent"]).toBeDefined()
   })
 
   test("passes through plugin data on successful load (identity test)", async () => {

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.ts
@@ -105,6 +105,9 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
 
     pluginComponentsPromise ??= loadPluginComponents({ pluginConfig });
     const pluginComponents = await pluginComponentsPromise;
+    if (pluginComponents.retryableLoadFailure) {
+      pluginComponentsPromise = undefined;
+    }
 
     applyHookConfig({ pluginComponents });
 

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.ts
@@ -105,7 +105,8 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
 
     pluginComponentsPromise ??= loadPluginComponents({ pluginConfig });
     const pluginComponents = await pluginComponentsPromise;
-    if (pluginComponents.retryableLoadFailure) {
+    const pluginComponentsLoadFailed = pluginComponents.retryableLoadFailure === true;
+    if (pluginComponentsLoadFailed) {
       pluginComponentsPromise = undefined;
     }
 
@@ -113,7 +114,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
 
     const agentCacheKey = createAgentConfigCacheKey(config);
     let agentResult: Record<string, unknown>;
-    if (agentConfigSnapshot?.cacheKey === agentCacheKey) {
+    if (!pluginComponentsLoadFailed && agentConfigSnapshot?.cacheKey === agentCacheKey) {
       config.agent = cloneAgentConfig(agentConfigSnapshot.agents);
       if (agentConfigSnapshot.defaultAgent !== undefined) {
         config.default_agent = agentConfigSnapshot.defaultAgent;
@@ -132,12 +133,14 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
         ctx,
         pluginComponents,
       });
-      agentConfigSnapshot = {
-        cacheKey: agentCacheKey,
-        configuredDefaultAgent,
-        defaultAgent: config.default_agent,
-        agents: cloneAgentConfig(agentResult),
-      };
+      agentConfigSnapshot = pluginComponentsLoadFailed
+        ? undefined
+        : {
+            cacheKey: agentCacheKey,
+            configuredDefaultAgent,
+            defaultAgent: config.default_agent,
+            agents: cloneAgentConfig(agentResult),
+          };
     }
 
     applyToolConfig({ config, pluginConfig, agentResult });

--- a/packages/omo-opencode/src/plugin-handlers/plugin-components-loader.ts
+++ b/packages/omo-opencode/src/plugin-handlers/plugin-components-loader.ts
@@ -11,6 +11,7 @@ export type PluginComponents = {
   hooksConfigs: PluginHooksConfig[];
   plugins: Array<{ name: string; version: string }>;
   errors: Array<{ pluginKey: string; installPath: string; error: string }>;
+  retryableLoadFailure?: true;
 };
 
 const EMPTY_PLUGIN_COMPONENTS: PluginComponents = {
@@ -67,6 +68,6 @@ export async function loadPluginComponents(params: {
     const errorMessage = error instanceof Error ? error.message : String(error);
     log("[config-handler] Plugin loading failed", { error: errorMessage });
     addConfigLoadError({ path: "plugin-loading", error: errorMessage });
-    return EMPTY_PLUGIN_COMPONENTS;
+    return { ...EMPTY_PLUGIN_COMPONENTS, retryableLoadFailure: true };
   }
 }


### PR DESCRIPTION
## Summary
Fixes a pre-publish release blocker where the config handler cached plugin component loading at the promise level even when the loader returned an empty fallback after a transient failure or timeout.

The loader now marks caught empty fallbacks as retryable, and the config handler clears the cached promise after observing that marker so the next config hook can retry and recover plugin commands/skills/agents/MCPs/hooks without requiring an OpenCode restart.

## Changes
- Add a retryable fallback marker to `PluginComponents` when plugin loading catches an error/timeout.
- Drop the cached plugin-components promise after retryable fallback results.
- Add regression coverage proving a first failing load does not poison later successful plugin component discovery.

## Verification
**Automated**
- `bun install --frozen-lockfile` ✅
- `bun test packages/omo-opencode/src/plugin-handlers/config-handler.test.ts --test-name-pattern "retries plugin component loading"` ✅ (`.omo/evidence/20260619-opencode-plugin-components-retry/focused-retry-test.txt`)
- `bun test packages/omo-opencode/src/plugin-handlers/config-handler.test.ts packages/omo-opencode/src/plugin-handlers/config-handler-cache.test.ts` ✅ (`.omo/evidence/20260619-opencode-plugin-components-retry/plugin-handler-tests.txt`)
- `bun run typecheck` ✅ (`.omo/evidence/20260619-opencode-plugin-components-retry/typecheck.txt`)
- `git diff --check` ✅

**Manual QA / real OpenCode isolation**
- OpenCode QA common harness self-check ✅
- OpenCode isolated server smoke (`/global/health`, `/doc`, auth 401) ✅
- OpenCode SSE event stream delivered `server.connected` ✅
- OpenCode TUI tmux smoke rendered and accepted input ✅
- Real OpenCode DB session count stayed unchanged: 5737 before/after ✅

Evidence: `.omo/evidence/20260619-opencode-plugin-components-retry/opencode-qa/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where transient plugin component load failures cached an empty fallback and blocked recovery. We now mark retryable failures, drop the cached promise, and avoid caching fallback agent config so the next run retries and restores plugin data without restarting OpenCode.

- **Bug Fixes**
  - Add `retryableLoadFailure` to `PluginComponents` on caught failures and clear the cached load promise.
  - Skip reuse and storage of `agentConfigSnapshot` when a retryable failure is detected (no caching of fallback plugin agents).
  - Add a regression test proving a failed first load is retried and recovered on the next config run.

<sup>Written for commit 5b368609ee2bc945a5a1334c9b4f37a3ef6ba450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

