### PR TITLE
fix: clear release gate blockers

### DIFF
--- a/.agents/skills/codex-qa/scripts/lib/app-server-client.mjs
+++ b/.agents/skills/codex-qa/scripts/lib/app-server-client.mjs
@@ -95,7 +95,12 @@ function main() {
   function finish() {
     if (finished) return;
     finished = true;
-    try { child.kill("SIGTERM"); } catch {}
+    try {
+      child.kill("SIGTERM");
+    } catch (error) {
+      const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+      stderr += `\n[driver] failed to terminate app-server: ${message}\n`;
+    }
     const summary = summarizeRun({ turnStatus, assistantText, threadId, turnId, expectHook: EXPECT, hooks, stderr });
     console.log(JSON.stringify(summary, null, 2));
     process.exit(summary.ok ? 0 : 1);
@@ -138,7 +143,12 @@ function main() {
       buf = buf.slice(nl + 1);
       if (!line) continue;
       let msg;
-      try { msg = JSON.parse(line); } catch { continue; }
+      try {
+        msg = JSON.parse(line);
+      } catch (error) {
+        if (error instanceof SyntaxError) continue;
+        throw error;
+      }
       handle(msg);
     }
   });

--- a/packages/omo-codex/plugin/test/teammode-safety-fixture.mjs
+++ b/packages/omo-codex/plugin/test/teammode-safety-fixture.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { root } from "./aggregate-plugin-fixture.mjs";
+
+const teamScript = join(root, "components", "teammode", "skills", "teammode", "scripts", "team.mjs");
+
+export function createTeamRoot(prefix) {
+	return mkdtempSync(join(tmpdir(), prefix));
+}
+
+export function cleanupTeamRoot(tempRoot) {
+	rmSync(tempRoot, { recursive: true, force: true });
+}
+
+export function teamDir(tempRoot, sessionId) {
+	return join(tempRoot, ".omo", "teams", sessionId);
+}
+
+export function teamJsonPath(tempRoot, sessionId) {
+	return join(teamDir(tempRoot, sessionId), "team.json");
+}
+
+export function readTeamJson(tempRoot, sessionId) {
+	return JSON.parse(readFileSync(teamJsonPath(tempRoot, sessionId), "utf8"));
+}
+
+export function runTeam(cwd, ...args) {
+	const result = runTeamRaw(cwd, ...args);
+	assert.equal(result.status, 0, `team.mjs ${args.join(" ")} failed: ${result.stderr}`);
+	return result;
+}
+
+export function runTeamRaw(cwd, ...args) {
+	return spawnSync(process.execPath, [teamScript, ...args], {
+		cwd,
+		encoding: "utf8",
+		timeout: 10_000,
+	});
+}
+
+export function symlinkOrSkip(t, target, path, type) {
+	try {
+		symlinkSync(target, path, type);
+		return true;
+	} catch (error) {
+		if (isUnavailableSymlinkError(error)) {
+			t.skip(`symlink unavailable on this filesystem: ${error.code}`);
+			return false;
+		}
+		throw error;
+	}
+}
+
+function isUnavailableSymlinkError(error) {
+	return error?.code === "EPERM" || error?.code === "EACCES" || error?.code === "EINVAL";
+}
+
+export function createArchivedOutsideTeam(tempRoot, sessionId) {
+	const outsideTeams = join(tempRoot, "outside-teams");
+	const outsideTeamDir = join(outsideTeams, sessionId);
+	mkdirSync(outsideTeamDir, { recursive: true });
+	writeFileSync(
+		join(outsideTeamDir, "team.json"),
+		`${JSON.stringify(
+			{
+				schemaVersion: 2,
+				teamId: "outside-team",
+				teamName: "Outside",
+				sessionName: "Escape",
+				leader: { kind: "main-session", sessionId },
+				status: "archived",
+				members: [],
+			},
+			null,
+			2,
+		)}\n`,
+	);
+	return { outsideTeams, outsideTeamDir };
+}
+
+export function assertOutsideTeamIntact(outsideTeamDir) {
+	assert.equal(existsSync(outsideTeamDir), true);
+	assert.equal(JSON.parse(readFileSync(join(outsideTeamDir, "team.json"), "utf8")).teamId, "outside-team");
+}

--- a/packages/omo-codex/plugin/test/teammode-safety.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-safety.test.mjs
@@ -1,32 +1,30 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
-import { root } from "./aggregate-plugin-fixture.mjs";
-
-const teamScript = join(root, "components", "teammode", "skills", "teammode", "scripts", "team.mjs");
+import {
+	assertOutsideTeamIntact,
+	cleanupTeamRoot,
+	createArchivedOutsideTeam,
+	createTeamRoot,
+	readTeamJson,
+	runTeam,
+	runTeamRaw,
+	symlinkOrSkip,
+	teamDir,
+	teamJsonPath,
+} from "./teammode-safety-fixture.mjs";
 
 test("#given guide.md is a symlink #when guide is regenerated #then the outside target stays untouched", (t) => {
-	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-guide-"));
+	const tempRoot = createTeamRoot("omo-codex-teammode-guide-");
 	try {
 		runTeam(tempRoot, "init", "--name", "Symlink", "--session-name", "Escape", "--session", "safe-guide");
-		const teamDir = join(tempRoot, ".omo", "teams", "safe-guide");
-		const guidePath = join(teamDir, "guide.md");
+		const guidePath = join(teamDir(tempRoot, "safe-guide"), "guide.md");
 		const outsidePath = join(tempRoot, "outside-guide-target.md");
 		writeFileSync(outsidePath, "ORIGINAL_OUTSIDE\n");
 		unlinkSync(guidePath);
-		try {
-			symlinkSync(outsidePath, guidePath);
-		} catch (error) {
-			if (error?.code === "EPERM" || error?.code === "EACCES" || error?.code === "EINVAL") {
-				t.skip(`symlink unavailable on this filesystem: ${error.code}`);
-				return;
-			}
-			throw error;
-		}
+		if (!symlinkOrSkip(t, outsidePath, guidePath)) return;
 
 		const result = runTeamRaw(tempRoot, "guide", "--team", "safe-guide");
 
@@ -34,12 +32,12 @@ test("#given guide.md is a symlink #when guide is regenerated #then the outside 
 		assert.match(result.stderr, /guide\.md is a symlink|persist target escapes/);
 		assert.equal(readFileSync(outsidePath, "utf8"), "ORIGINAL_OUTSIDE\n");
 	} finally {
-		rmSync(tempRoot, { recursive: true, force: true });
+		cleanupTeamRoot(tempRoot);
 	}
 });
 
 test("#given member A exists #when add-member receives A with trailing space #then state is not partially mutated", () => {
-	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-duplicate-"));
+	const tempRoot = createTeamRoot("omo-codex-teammode-duplicate-");
 	try {
 		runTeam(tempRoot, "init", "--name", "Duplicate", "--session-name", "Members", "--session", "safe-duplicate");
 		runTeam(
@@ -71,7 +69,7 @@ test("#given member A exists #when add-member receives A with trailing space #th
 			"--deliverable",
 			"second",
 		);
-		const team = JSON.parse(readFileSync(join(tempRoot, ".omo", "teams", "safe-duplicate", "team.json"), "utf8"));
+		const team = readTeamJson(tempRoot, "safe-duplicate");
 
 		assert.notEqual(result.status, 0);
 		assert.match(result.stderr, /member id "A" already exists/);
@@ -80,12 +78,12 @@ test("#given member A exists #when add-member receives A with trailing space #th
 			["A"],
 		);
 	} finally {
-		rmSync(tempRoot, { recursive: true, force: true });
+		cleanupTeamRoot(tempRoot);
 	}
 });
 
 test("#given member focus already exists #when add-member receives same focus with different spacing and case #then state is not partially mutated", () => {
-	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-duplicate-focus-"));
+	const tempRoot = createTeamRoot("omo-codex-teammode-duplicate-focus-");
 	try {
 		runTeam(tempRoot, "init", "--name", "DuplicateFocus", "--session-name", "Members", "--session", "safe-duplicate-focus");
 		runTeam(
@@ -117,7 +115,7 @@ test("#given member focus already exists #when add-member receives same focus wi
 			"--deliverable",
 			"second",
 		);
-		const team = JSON.parse(readFileSync(join(tempRoot, ".omo", "teams", "safe-duplicate-focus", "team.json"), "utf8"));
+		const team = readTeamJson(tempRoot, "safe-duplicate-focus");
 
 		assert.notEqual(result.status, 0);
 		assert.match(result.stderr, /member focus "plugin   hook packaging" duplicates "Plugin Hook Packaging"/);
@@ -126,12 +124,12 @@ test("#given member focus already exists #when add-member receives same focus wi
 			["A"],
 		);
 	} finally {
-		rmSync(tempRoot, { recursive: true, force: true });
+		cleanupTeamRoot(tempRoot);
 	}
 });
 
 test("#given only one member exists #when bind-thread runs #then member is not activated", () => {
-	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-understaffed-bind-"));
+	const tempRoot = createTeamRoot("omo-codex-teammode-understaffed-bind-");
 	try {
 		runTeam(tempRoot, "init", "--name", "Understaffed", "--session-name", "Members", "--session", "safe-understaffed");
 		runTeam(
@@ -150,7 +148,7 @@ test("#given only one member exists #when bind-thread runs #then member is not a
 		);
 
 		const result = runTeamRaw(tempRoot, "bind-thread", "--team", "safe-understaffed", "--id", "A", "--thread", "thread-a");
-		let team = JSON.parse(readFileSync(join(tempRoot, ".omo", "teams", "safe-understaffed", "team.json"), "utf8"));
+		let team = readTeamJson(tempRoot, "safe-understaffed");
 
 		assert.notEqual(result.status, 0);
 		assert.match(result.stderr, /at least 2 distinct members/);
@@ -172,20 +170,20 @@ test("#given only one member exists #when bind-thread runs #then member is not a
 			"second",
 		);
 		runTeam(tempRoot, "bind-thread", "--team", "safe-understaffed", "--id", "A", "--thread", "thread-a");
-		team = JSON.parse(readFileSync(join(tempRoot, ".omo", "teams", "safe-understaffed", "team.json"), "utf8"));
+		team = readTeamJson(tempRoot, "safe-understaffed");
 
 		assert.equal(team.members[0].threadId, "thread-a");
 		assert.equal(team.members[0].status, "active");
 	} finally {
-		rmSync(tempRoot, { recursive: true, force: true });
+		cleanupTeamRoot(tempRoot);
 	}
 });
 
 test("#given persisted paths are mutated outside trusted team dir #when guide is regenerated #then outside file stays untouched", () => {
-	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-mutated-paths-"));
+	const tempRoot = createTeamRoot("omo-codex-teammode-mutated-paths-");
 	try {
 		runTeam(tempRoot, "init", "--name", "Mutated", "--session-name", "Paths", "--session", "safe-mutated");
-		const teamPath = join(tempRoot, ".omo", "teams", "safe-mutated", "team.json");
+		const teamPath = teamJsonPath(tempRoot, "safe-mutated");
 		const outsideDir = join(tempRoot, "outside");
 		const outsideGuide = join(outsideDir, "guide.md");
 		mkdirSync(outsideDir);
@@ -201,91 +199,42 @@ test("#given persisted paths are mutated outside trusted team dir #when guide is
 		assert.match(result.stderr, /persisted team dir does not match trusted team dir/);
 		assert.equal(readFileSync(outsideGuide, "utf8"), "ORIGINAL_OUTSIDE\n");
 	} finally {
-		rmSync(tempRoot, { recursive: true, force: true });
+		cleanupTeamRoot(tempRoot);
 	}
 });
 
 test("#given team dir is swapped to a symlink #when status reads team state #then command refuses the symlink", (t) => {
-	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-dir-symlink-"));
+	const tempRoot = createTeamRoot("omo-codex-teammode-dir-symlink-");
 	try {
 		runTeam(tempRoot, "init", "--name", "SymlinkDir", "--session-name", "Paths", "--session", "safe-dir");
-		const teamDir = join(tempRoot, ".omo", "teams", "safe-dir");
+		const targetTeamDir = teamDir(tempRoot, "safe-dir");
 		const outsideDir = join(tempRoot, "outside-team-dir");
 		mkdirSync(outsideDir);
-		rmSync(teamDir, { recursive: true, force: true });
-		try {
-			symlinkSync(outsideDir, teamDir, "dir");
-		} catch (error) {
-			if (error?.code === "EPERM" || error?.code === "EACCES" || error?.code === "EINVAL") {
-				t.skip(`symlink unavailable on this filesystem: ${error.code}`);
-				return;
-			}
-			throw error;
-		}
+		rmSync(targetTeamDir, { recursive: true, force: true });
+		if (!symlinkOrSkip(t, outsideDir, targetTeamDir, "dir")) return;
 
 		const result = runTeamRaw(tempRoot, "status", "--team", "safe-dir");
 
 		assert.notEqual(result.status, 0);
 		assert.match(result.stderr, /path component is a symlink|team dir is a symlink/);
 	} finally {
-		rmSync(tempRoot, { recursive: true, force: true });
+		cleanupTeamRoot(tempRoot);
 	}
 });
 
 test("#given teams root is a symlink #when delete runs #then outside team state stays untouched", (t) => {
-	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-teammode-delete-root-symlink-"));
+	const tempRoot = createTeamRoot("omo-codex-teammode-delete-root-symlink-");
 	try {
-		const outsideTeams = join(tempRoot, "outside-teams");
-		const outsideTeamDir = join(outsideTeams, "escape");
-		mkdirSync(outsideTeamDir, { recursive: true });
-		writeFileSync(
-			join(outsideTeamDir, "team.json"),
-			`${JSON.stringify(
-				{
-					schemaVersion: 2,
-					teamId: "outside-team",
-					teamName: "Outside",
-					sessionName: "Escape",
-					leader: { kind: "main-session", sessionId: "escape" },
-					status: "archived",
-					members: [],
-				},
-				null,
-				2,
-			)}\n`,
-		);
+		const { outsideTeams, outsideTeamDir } = createArchivedOutsideTeam(tempRoot, "escape");
 		mkdirSync(join(tempRoot, ".omo"), { recursive: true });
-		try {
-			symlinkSync(outsideTeams, join(tempRoot, ".omo", "teams"), "dir");
-		} catch (error) {
-			if (error?.code === "EPERM" || error?.code === "EACCES" || error?.code === "EINVAL") {
-				t.skip(`symlink unavailable on this filesystem: ${error.code}`);
-				return;
-			}
-			throw error;
-		}
+		if (!symlinkOrSkip(t, outsideTeams, join(tempRoot, ".omo", "teams"), "dir")) return;
 
 		const result = runTeamRaw(tempRoot, "delete", "--team", "escape", "--force");
 
 		assert.notEqual(result.status, 0);
 		assert.match(result.stderr, /path component is a symlink/);
-		assert.equal(existsSync(outsideTeamDir), true);
-		assert.equal(JSON.parse(readFileSync(join(outsideTeamDir, "team.json"), "utf8")).teamId, "outside-team");
+		assertOutsideTeamIntact(outsideTeamDir);
 	} finally {
-		rmSync(tempRoot, { recursive: true, force: true });
+		cleanupTeamRoot(tempRoot);
 	}
 });
-
-function runTeam(cwd, ...args) {
-	const result = runTeamRaw(cwd, ...args);
-	assert.equal(result.status, 0, `team.mjs ${args.join(" ")} failed: ${result.stderr}`);
-	return result;
-}
-
-function runTeamRaw(cwd, ...args) {
-	return spawnSync(process.execPath, [teamScript, ...args], {
-		cwd,
-		encoding: "utf8",
-		timeout: 10_000,
-	});
-}

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -7058,7 +7058,7 @@ async function rewriteCachedManifestRoot(pluginRoot, fromRoot, toRoot) {
 // packages/omo-codex/src/install/codex-hook-targets.ts
 import { readFile as readFile6 } from "node:fs/promises";
 import { join as join8, sep as sep4 } from "node:path";
-var PLUGIN_ROOT_TARGET_PATTERN = /\$\{PLUGIN_ROOT\}\/([^"']+)/g;
+var PLUGIN_ROOT_TARGET_PATTERN = /\$\{PLUGIN_ROOT\}[\\/]+([^"']+)/g;
 async function findMissingHookCommandTargets(pluginRoot) {
   const commands = [];
   for (const manifestPath of await hookManifestPaths(pluginRoot)) {
@@ -7074,7 +7074,7 @@ async function findMissingHookCommandTargets(pluginRoot) {
       const targetSuffix = match[1];
       if (targetSuffix === undefined)
         continue;
-      const target = join8(pluginRoot, ...targetSuffix.split("/"));
+      const target = join8(pluginRoot, ...targetSuffix.split(/[\\/]+/));
       if (seen.has(target))
         continue;
       seen.add(target);
@@ -7119,6 +7119,8 @@ function collectCommands(value, commands) {
     return;
   if (value["type"] === "command" && typeof value["command"] === "string")
     commands.push(value["command"]);
+  if (value["type"] === "command" && typeof value["commandWindows"] === "string")
+    commands.push(value["commandWindows"]);
   for (const entry of Object.values(value))
     collectCommands(entry, commands);
 }

--- a/packages/omo-codex/scripts/install-hook-targets.test.mjs
+++ b/packages/omo-codex/scripts/install-hook-targets.test.mjs
@@ -84,6 +84,39 @@ async function createPluginRootWithHookArray({ withGitBashDist }) {
 	return pluginRoot;
 }
 
+async function createPluginRootWithWindowsHook({ withBootstrapScript }) {
+	const pluginRoot = await mkdtemp(join(tmpdir(), "hook-targets-windows-"));
+	await mkdir(join(pluginRoot, "hooks"), { recursive: true });
+	await writeFile(
+		join(pluginRoot, "hooks", "hooks.json"),
+		JSON.stringify(
+			{
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									commandWindows:
+										'powershell -NoProfile -ExecutionPolicy Bypass -File "${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\bootstrap.ps1"',
+								},
+							],
+						},
+					],
+				},
+			},
+			null,
+			"\t",
+		),
+	);
+	if (withBootstrapScript) {
+		const target = join(pluginRoot, "components", "bootstrap", "scripts", "bootstrap.ps1");
+		await mkdir(dirname(target), { recursive: true });
+		await writeFile(target, "");
+	}
+	return pluginRoot;
+}
+
 test("#given a hook command target missing from the payload #when scanning #then exactly that path is reported", async (t) => {
 	const pluginRoot = await createPluginRoot({ withGitBashDist: false });
 	t.after(() => rm(pluginRoot, { recursive: true, force: true }));
@@ -91,6 +124,22 @@ test("#given a hook command target missing from the payload #when scanning #then
 	const missing = await findMissingHookCommandTargets(pluginRoot);
 
 	assert.deepEqual(missing, [join(pluginRoot, "components/git-bash/dist/cli.js")]);
+});
+
+test("#given a Windows hook command target missing from the payload #when scanning #then the backslash path is reported", async (t) => {
+	const pluginRoot = await createPluginRootWithWindowsHook({ withBootstrapScript: false });
+	t.after(() => rm(pluginRoot, { recursive: true, force: true }));
+
+	const missing = await findMissingHookCommandTargets(pluginRoot);
+
+	assert.deepEqual(missing, [join(pluginRoot, "components", "bootstrap", "scripts", "bootstrap.ps1")]);
+});
+
+test("#given a Windows hook command target exists in the payload #when scanning #then nothing is missing", async (t) => {
+	const pluginRoot = await createPluginRootWithWindowsHook({ withBootstrapScript: true });
+	t.after(() => rm(pluginRoot, { recursive: true, force: true }));
+
+	assert.deepEqual(await findMissingHookCommandTargets(pluginRoot), []);
 });
 
 test("#given a complete payload #when scanning #then nothing is missing", async (t) => {

--- a/packages/omo-codex/src/install/codex-hook-targets.ts
+++ b/packages/omo-codex/src/install/codex-hook-targets.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises"
 import { join, sep } from "node:path"
 import { fileExistsStrict, isPlainRecord } from "./codex-cache-fs"
 
-const PLUGIN_ROOT_TARGET_PATTERN = /\$\{PLUGIN_ROOT\}\/([^"']+)/g
+const PLUGIN_ROOT_TARGET_PATTERN = /\$\{PLUGIN_ROOT\}[\\/]+([^"']+)/g
 
 export async function findMissingHookCommandTargets(pluginRoot: string): Promise<readonly string[]> {
   const commands: string[] = []
@@ -18,7 +18,7 @@ export async function findMissingHookCommandTargets(pluginRoot: string): Promise
     for (const match of command.matchAll(PLUGIN_ROOT_TARGET_PATTERN)) {
       const targetSuffix = match[1]
       if (targetSuffix === undefined) continue
-      const target = join(pluginRoot, ...targetSuffix.split("/"))
+      const target = join(pluginRoot, ...targetSuffix.split(/[\\/]+/))
       if (seen.has(target)) continue
       seen.add(target)
       if (!(await fileExistsStrict(target))) missing.push(target)
@@ -64,5 +64,6 @@ function collectCommands(value: unknown, commands: string[]): void {
   }
   if (!isPlainRecord(value)) return
   if (value["type"] === "command" && typeof value["command"] === "string") commands.push(value["command"])
+  if (value["type"] === "command" && typeof value["commandWindows"] === "string") commands.push(value["commandWindows"])
   for (const entry of Object.values(value)) collectCommands(entry, commands)
 }

--- a/packages/omo-opencode/src/plugin-handlers/config-handler-formatter.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler-formatter.test.ts
@@ -5,6 +5,7 @@ import * as agentConfigHandler from "./agent-config-handler"
 import * as commandConfigHandler from "./command-config-handler"
 import * as mcpConfigHandler from "./mcp-config-handler"
 import * as pluginComponentsLoader from "./plugin-components-loader"
+import type { PluginComponents } from "./plugin-components-loader"
 import * as providerConfigHandler from "./provider-config-handler"
 import * as shared from "../shared"
 import * as toolConfigHandler from "./tool-config-handler"
@@ -30,6 +31,23 @@ function createPluginConfig(overrides: Partial<OhMyOpenCodeConfig> = {}): OhMyOp
       git_env_prefix: "GIT_MASTER=1",
     },
     ...overrides,
+  }
+}
+
+function createPluginComponentsWithCommand(): PluginComponents {
+  return {
+    commands: {
+      pluginCommand: {
+        agent: "sisyphus",
+        description: "from plugin",
+      },
+    },
+    skills: {},
+    agents: {},
+    mcpServers: {},
+    hooksConfigs: [],
+    plugins: [{ name: "fixture", version: "1.0.0" }],
+    errors: [],
   }
 }
 
@@ -135,5 +153,35 @@ describe("createConfigHandler formatter pass-through", () => {
 
     // then
     expect(config.formatter).toBe(false)
+  })
+
+  test("loads fresh plugin components for each config invocation so command mutation does not leak", async () => {
+    // given
+    const observedAgents: unknown[] = []
+    loadPluginComponentsSpy.mockImplementation(async () => createPluginComponentsWithCommand())
+    applyCommandConfigSpy.mockImplementation(async ({ pluginComponents }) => {
+      const command = pluginComponents.commands.pluginCommand
+      if (typeof command !== "object" || command === null || !("agent" in command)) {
+        throw new Error("plugin command fixture is missing an agent")
+      }
+      observedAgents.push(command.agent)
+      command.agent = "poisoned-by-first-config"
+    })
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig: createPluginConfig(),
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // when
+    await handler({})
+    await handler({})
+
+    // then
+    expect(observedAgents).toEqual(["sisyphus", "sisyphus"])
+    expect(loadPluginComponentsSpy).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.ts
@@ -89,7 +89,6 @@ function replayAgentConfigSideEffects(params: {
 
 export function createConfigHandler(deps: ConfigHandlerDeps) {
   const { ctx, pluginConfig, modelCacheState, runtimeSkillSourceUrl } = deps;
-  let pluginComponentsPromise: ReturnType<typeof loadPluginComponents> | undefined;
   let agentConfigSnapshot: AgentConfigSnapshot | undefined;
 
   return async (config: Record<string, unknown>) => {
@@ -103,12 +102,8 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     });
     clearFormatterCache()
 
-    pluginComponentsPromise ??= loadPluginComponents({ pluginConfig });
-    const pluginComponents = await pluginComponentsPromise;
+    const pluginComponents = await loadPluginComponents({ pluginConfig });
     const pluginComponentsLoadFailed = pluginComponents.retryableLoadFailure === true;
-    if (pluginComponentsLoadFailed) {
-      pluginComponentsPromise = undefined;
-    }
 
     applyHookConfig({ pluginComponents });
 

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.internal-wake.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.internal-wake.test.ts
@@ -69,6 +69,42 @@ describe("pollSyncSession internal all-complete wakes", () => {
     expect(result).toBeNull()
   })
 
+  test("#given terminal assistant error followed by internal all-complete wake #when polling #then the error is returned", async () => {
+    // given
+    __setTimingConfig({
+      POLL_INTERVAL_MS: 1,
+      MAX_POLL_TIME_MS: 50,
+    })
+    const client = createClientForMessages([
+      { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+      {
+        info: {
+          id: "msg_002",
+          role: "assistant",
+          time: { created: 2000 },
+          finish: "stop",
+          error: { message: "child failed after stale output" },
+        },
+        parts: [{ type: "text", text: "old deliverable" }],
+      },
+      {
+        info: { id: "msg_003", role: "user", time: { created: 3000 } },
+        parts: [{ type: "text", text: internalAllCompleteWake }],
+      },
+    ])
+
+    // when
+    const result = await pollSyncSession(toolContext, client, {
+      sessionID: "ses_test",
+      agentToUse: "sisyphus",
+      toastManager: null,
+      taskId: undefined,
+    }, 50)
+
+    // then
+    expect(result).toBe("child failed after stale output")
+  })
+
   test("#given terminal assistant turn followed by ordinary user turn #when polling #then the sync task remains incomplete", async () => {
     // given
     __setTimingConfig({

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
@@ -1,15 +1,14 @@
 import type { ToolContextWithMetadata, OpencodeClient } from "./types"
 import type { SessionMessage } from "./executor-types"
 import { getDefaultSyncPollTimeoutMs, getTimingConfig } from "./timing"
+import { getTerminalSessionError, isSessionComplete } from "./sync-session-turns"
 import { log } from "../../shared/logger"
-import { isTerminalNoReplyUserMessage, normalizeSDKResponse } from "../../shared"
-import { extractErrorMessage } from "../../features/background-agent/error-classifier"
+import { normalizeSDKResponse } from "../../shared"
+
+export { isSessionComplete } from "./sync-session-turns"
 
 const ACTIVE_SESSION_STATUSES = new Set(["busy", "retry", "running"])
 const CHILD_WAKE_GRACE_MS = 5_000
-const NON_TERMINAL_FINISH_REASONS = new Set(["tool-calls", "unknown"])
-const PENDING_TOOL_PART_TYPES = new Set(["tool", "tool_use", "tool-call"])
-const ALL_BACKGROUND_TASKS_COMPLETE_MARKER = "[ALL BACKGROUND TASKS COMPLETE]"
 
 function wait(milliseconds: number): Promise<void> {
   const sharedBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)
@@ -31,37 +30,6 @@ function isActiveSessionStatus(status: { type: string } | undefined): boolean {
   return status !== undefined && ACTIVE_SESSION_STATUSES.has(status.type)
 }
 
-function getTextParts(message: SessionMessage): string {
-  return (message.parts ?? [])
-    .filter((part) => part.type === "text")
-    .map((part) => part.text ?? "")
-    .join("\n")
-}
-
-function isInternalAllCompleteWake(message: SessionMessage): boolean {
-  return isTerminalNoReplyUserMessage(message) && getTextParts(message).includes(ALL_BACKGROUND_TASKS_COMPLETE_MARKER)
-}
-
-export function isSessionComplete(messages: SessionMessage[]): boolean {
-  let lastRelevantUser: SessionMessage | undefined
-  let lastAssistant: SessionMessage | undefined
-
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
-    if (!lastAssistant && msg.info?.role === "assistant") lastAssistant = msg
-    if (!lastRelevantUser && msg.info?.role === "user" && !isInternalAllCompleteWake(msg)) {
-      lastRelevantUser = msg
-    }
-    if (lastRelevantUser && lastAssistant) break
-  }
-
-  if (!lastAssistant?.info?.finish) return false
-  if (NON_TERMINAL_FINISH_REASONS.has(lastAssistant.info.finish)) return false
-  if (lastAssistant.parts?.some((part) => part.type && PENDING_TOOL_PART_TYPES.has(part.type))) return false
-  if (!lastRelevantUser?.info?.id || !lastAssistant?.info?.id) return false
-  return lastRelevantUser.info.id < lastAssistant.info.id
-}
-
 async function fetchSessionMessages(
   client: OpencodeClient,
   sessionID: string
@@ -69,20 +37,6 @@ async function fetchSessionMessages(
   const messagesResult = await client.session.messages({ path: { id: sessionID } })
   const rawData = (messagesResult as { data?: unknown })?.data ?? messagesResult
   return Array.isArray(rawData) ? (rawData as SessionMessage[]) : []
-}
-
-function getTerminalSessionError(messages: SessionMessage[]): string | null {
-  const lastAssistant = [...messages].reverse().find((msg) => msg.info?.role === "assistant")
-  const lastUser = [...messages].reverse().find((msg) => msg.info?.role === "user")
-  if (lastUser?.info?.id && lastAssistant?.info?.id && lastAssistant.info.id <= lastUser.info.id) {
-    return null
-  }
-  if (!lastAssistant?.info || !("error" in lastAssistant.info)) {
-    return null
-  }
-
-  const errorMessage = extractErrorMessage((lastAssistant.info as { error?: unknown }).error)
-  return errorMessage && errorMessage.length > 0 ? errorMessage : "Session error"
 }
 
 const DEFAULT_MAX_ASSISTANT_TURNS = 300

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-turns.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-turns.ts
@@ -1,0 +1,63 @@
+import type { SessionMessage } from "./executor-types"
+import { isTerminalNoReplyUserMessage } from "../../shared"
+import { extractErrorMessage } from "../../features/background-agent/error-classifier"
+
+const NON_TERMINAL_FINISH_REASONS = new Set(["tool-calls", "unknown"])
+const PENDING_TOOL_PART_TYPES = new Set(["tool", "tool_use", "tool-call"])
+const ALL_BACKGROUND_TASKS_COMPLETE_MARKER = "[ALL BACKGROUND TASKS COMPLETE]"
+
+type LastSessionTurns = {
+  readonly lastAssistant: SessionMessage | undefined
+  readonly lastRelevantUser: SessionMessage | undefined
+}
+
+function getTextParts(message: SessionMessage): string {
+  return (message.parts ?? [])
+    .filter((part) => part.type === "text")
+    .map((part) => part.text ?? "")
+    .join("\n")
+}
+
+function isInternalAllCompleteWake(message: SessionMessage): boolean {
+  return isTerminalNoReplyUserMessage(message) && getTextParts(message).includes(ALL_BACKGROUND_TASKS_COMPLETE_MARKER)
+}
+
+function getLastSessionTurns(messages: readonly SessionMessage[]): LastSessionTurns {
+  let lastRelevantUser: SessionMessage | undefined
+  let lastAssistant: SessionMessage | undefined
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg === undefined) continue
+    if (!lastAssistant && msg.info?.role === "assistant") lastAssistant = msg
+    if (!lastRelevantUser && msg.info?.role === "user" && !isInternalAllCompleteWake(msg)) {
+      lastRelevantUser = msg
+    }
+    if (lastRelevantUser && lastAssistant) break
+  }
+
+  return { lastAssistant, lastRelevantUser }
+}
+
+export function isSessionComplete(messages: readonly SessionMessage[]): boolean {
+  const { lastAssistant, lastRelevantUser } = getLastSessionTurns(messages)
+
+  if (!lastAssistant?.info?.finish) return false
+  if (NON_TERMINAL_FINISH_REASONS.has(lastAssistant.info.finish)) return false
+  if (lastAssistant.parts?.some((part) => part.type && PENDING_TOOL_PART_TYPES.has(part.type))) return false
+  if (!lastRelevantUser?.info?.id || !lastAssistant?.info?.id) return false
+  return lastRelevantUser.info.id < lastAssistant.info.id
+}
+
+export function getTerminalSessionError(messages: readonly SessionMessage[]): string | null {
+  const { lastAssistant, lastRelevantUser } = getLastSessionTurns(messages)
+  if (lastRelevantUser?.info?.id && lastAssistant?.info?.id && lastAssistant.info.id <= lastRelevantUser.info.id) {
+    return null
+  }
+  if (!lastAssistant?.info || !("error" in lastAssistant.info)) {
+    return null
+  }
+
+  const errorMessage = extractErrorMessage(lastAssistant.info.error)
+  return errorMessage && errorMessage.length > 0 ? errorMessage : "Session error"
+}


### PR DESCRIPTION
## Summary

Clears the release-gate blockers found during pre-publish review across Codex QA, Codex installer validation, and OpenCode runtime/config handling.

The PR keeps the fixes split into focused commits and includes fresh automated plus real harness QA evidence under `.omo/evidence/20260619-fix-release-blockers/` in the worktree.

## Changes

- Codex QA app-server driver now reports SIGTERM cleanup failures instead of swallowing them, and only ignores JSON parse `SyntaxError` while streaming notifications.
- Codex teammode safety tests now use a dedicated fixture module so touched test files stay under the 250 pure-LOC ceiling.
- Codex installer hook-target validation now scans `commandWindows` and supports `${PLUGIN_ROOT}` paths with Windows backslash separators; regenerated `install-local.mjs` included.
- OpenCode config handler now loads fresh plugin component clones for every config invocation, preventing command remap mutation from poisoning later hooks.
- OpenCode sync-session poller now shares terminal-turn analysis between completion and terminal-error detection, so an internal all-complete noReply wake cannot hide a terminal assistant error.

## Verification

Automated evidence captured in `.omo/evidence/20260619-fix-release-blockers/`:

- `git diff --check` ✅ (`git-diff-check.txt`)
- `bun run typecheck` ✅ (`typecheck.txt`)
- `bun run build` ✅ (`build.txt`)
- `bun run test:codex` ✅ (`test-codex.txt`, 353 node tests in final segment)
- `bun test` ✅ (`bun-test.txt`, 10056 pass / 2 skip / 0 fail)
- LOC/no-excuse scans ✅ (`loc-report.txt`, `no-excuse-scan.txt`)

Focused checks:

- `bun test packages/omo-opencode/src/tools/delegate-task/sync-session-poller.internal-wake.test.ts packages/omo-opencode/src/tools/delegate-task/sync-session-poller.test.ts` ✅
- `bun test packages/omo-opencode/src/plugin-handlers/config-handler-formatter.test.ts packages/omo-opencode/src/plugin-handlers/config-handler-cache.test.ts` ✅
- `bun run build:codex-install && node --test packages/omo-codex/scripts/install-hook-targets.test.mjs` ✅
- `node --test packages/omo-codex/plugin/test/teammode-safety.test.mjs` ✅

Manual QA evidence:

- Codex isolated QA (`codex-qa/`): common self-check, install verify, hook-unit probe, live `codex app-server --plugin` drive, TUI smoke; real `~/.codex/config.toml` unchanged.
- OpenCode isolated QA (`opencode-qa/`): common self-check, server smoke, SSE probe, TUI smoke, wake-split fixed probe; live DB session count stayed `5737 -> 5737`.

## Release note

This clears known code blockers, but publishing still needs the normal release version bump path because npm already has `4.11.1` published.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pre-publish blockers across `codex-qa`, `omo-codex` installer, and `omo-opencode` runtime. Improves shutdown reporting, Windows hook target validation, config isolation, and session error surfacing.

- **Bug Fixes**
  - `codex-qa` app-server client: report SIGTERM cleanup failures; only ignore JSON parse `SyntaxError` when streaming.
  - Installer validation: scan `commandWindows` and support `${PLUGIN_ROOT}` with backslashes; updates reflected in `install-local.mjs`.
  - `omo-opencode` config handler: load fresh plugin components per config call to prevent command mutation leaks.
  - Sync-session poller: unified turn analysis and returns terminal assistant errors even after internal all-complete wakes.

- **Refactors**
  - Split `teammode-safety` test helpers into `teammode-safety-fixture.mjs` to keep tests small and reusable; added Windows hook path tests.
  - Extracted turn analysis into `sync-session-turns.ts` for reuse by the poller.

<sup>Written for commit 837a433861f76fba783c1164a66e0877e07724f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

