### PR TITLE
fix(publish): gate npm publish on release state merge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -329,9 +329,143 @@ jobs:
             echo "Check the requested version format, bump input, or npm metadata lookup."
           } >> "$GITHUB_STEP_SUMMARY"
 
+  prepare-release-state:
+    runs-on: ubuntu-latest
+    needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata]
+    if: >-
+      always() &&
+      github.repository == 'code-yeongyu/oh-my-openagent' &&
+      needs.test.result == 'success' &&
+      needs.typecheck.result == 'success' &&
+      needs.codex-compatibility.result == 'success' &&
+      needs.preflight-trust.result == 'success' &&
+      needs.release-metadata.result == 'success'
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      pull-requests: write
+    outputs:
+      release_sha: ${{ steps.prepare.outputs.release_sha }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - run: git fetch --force --tags
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Prepare and merge release state before publishing
+        id: prepare
+        env:
+          VERSION: ${{ needs.release-metadata.outputs.version }}
+          RELEASE_REF: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          BASE_REF="${RELEASE_REF:-dev}"
+          RELEASE_BRANCH="release/v${VERSION}-source-state"
+
+          git fetch origin "${BASE_REF}" --tags
+
+          if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+            RELEASE_SHA="$(git rev-list --max-count=1 "refs/tags/v${VERSION}")"
+            echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "Release tag v${VERSION} already exists locally at ${RELEASE_SHA}"
+            exit 0
+          fi
+
+          RELEASE_SHA="$(git rev-list --max-count=1 --grep="^release: v${VERSION}$" "origin/${BASE_REF}" 2>/dev/null || true)"
+          if [ -n "$RELEASE_SHA" ]; then
+            echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "Release commit already exists on origin/${BASE_REF}: ${RELEASE_SHA}"
+            exit 0
+          fi
+
+          git checkout -B "$RELEASE_BRANCH" "origin/${BASE_REF}"
+
+          CURRENT_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$CURRENT_VERSION" = "$VERSION" ]; then
+            RELEASE_SHA="$(git rev-parse HEAD)"
+            echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "origin/${BASE_REF} is already stamped as v${VERSION}: ${RELEASE_SHA}"
+            exit 0
+          fi
+
+          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+
+          for platform in darwin-arm64 darwin-x64 darwin-x64-baseline linux-x64 linux-x64-baseline linux-arm64 linux-x64-musl linux-x64-musl-baseline linux-arm64-musl windows-x64 windows-x64-baseline windows-arm64; do
+            package_dir="packages/oh-my-opencode-${platform}"
+            jq --arg v "$VERSION" '.version = $v' "${package_dir}/package.json" > tmp.json
+            mv tmp.json "${package_dir}/package.json"
+          done
+
+          jq --arg v "$VERSION" '.optionalDependencies = (.optionalDependencies | to_entries | map(.value = $v) | from_entries)' package.json > tmp.json && mv tmp.json package.json
+
+          node packages/omo-codex/plugin/scripts/sync-version.mjs
+          node packages/omo-codex/plugin/scripts/sync-hook-status-messages.mjs
+          bun install --lockfile-only
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add package.json packages/oh-my-opencode-*/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
+          git diff --cached --quiet || git commit -m "release: v${VERSION}"
+          git push --force-with-lease origin "HEAD:${RELEASE_BRANCH}"
+
+          PR_NUMBER="$(gh pr list --head "$RELEASE_BRANCH" --base "$BASE_REF" --state open --json number --jq '.[0].number // empty')"
+          if [ -z "$PR_NUMBER" ]; then
+            PR_URL="$(gh pr create --base "$BASE_REF" --head "$RELEASE_BRANCH" --title "release: v${VERSION}" --body "Automated release-state PR for v${VERSION}. This must merge before npm publication starts so protected-branch push failures cannot create a half-published release.")"
+            PR_NUMBER="${PR_URL##*/}"
+          fi
+
+          gh pr merge "$PR_NUMBER" --merge --auto --delete-branch=false
+
+          for attempt in $(seq 1 120); do
+            PR_STATE="$(gh pr view "$PR_NUMBER" --json state --jq '.state')"
+            if [ "$PR_STATE" = "MERGED" ]; then
+              RELEASE_SHA="$(gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid')"
+              echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+              echo "Release-state PR #${PR_NUMBER} merged at ${RELEASE_SHA}"
+              exit 0
+            fi
+
+            FAILURES="$(gh pr view "$PR_NUMBER" --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT")] | length')"
+            if [ "$FAILURES" != "0" ]; then
+              echo "::error::Release-state PR #${PR_NUMBER} has failing required checks; refusing to publish npm packages."
+              gh pr view "$PR_NUMBER" --json url,statusCheckRollup --jq '{url, statusCheckRollup}'
+              exit 1
+            fi
+
+            echo "Waiting for release-state PR #${PR_NUMBER} to merge (attempt ${attempt}/120)"
+            sleep 30
+          done
+
+          echo "::error::Timed out waiting for release-state PR #${PR_NUMBER} to merge; refusing to publish npm packages."
+          exit 1
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        env:
+          JOB_SUMMARY_TITLE: Release source-state gate
+          JOB_SUMMARY_STATUS: ${{ job.status }}
+          JOB_SUMMARY_DETAILS: |
+            - Ensures the `release: v${{ needs.release-metadata.outputs.version }}` source-state commit exists on the release branch before npm publish starts.
+            - Creates and auto-merges a release-state PR when source manifests need stamping.
+            - Refuses to publish packages if protected-branch rules or required checks prevent that PR from merging.
+          JOB_SUMMARY_NEXT: If this fails, merge the release-state PR or fix its checks before rerunning publish.
+        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
+
   publish-main:
     runs-on: ubuntu-latest
-    needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, publish-platform]
+    needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]
     if: >-
       always() &&
       github.repository == 'code-yeongyu/oh-my-openagent' &&
@@ -340,6 +474,7 @@ jobs:
       needs.codex-compatibility.result == 'success' &&
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success' &&
+      needs.prepare-release-state.result == 'success' &&
       (inputs.skip_platform == true || needs.publish-platform.result == 'success')
     steps:
       - uses: actions/checkout@v5
@@ -622,7 +757,7 @@ jobs:
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   publish-platform:
-    needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata]
+    needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state]
     if: >-
       always() &&
       github.repository == 'code-yeongyu/oh-my-openagent' &&
@@ -631,7 +766,8 @@ jobs:
       needs.typecheck.result == 'success' &&
       needs.codex-compatibility.result == 'success' &&
       needs.preflight-trust.result == 'success' &&
-      needs.release-metadata.result == 'success'
+      needs.release-metadata.result == 'success' &&
+      needs.prepare-release-state.result == 'success'
     uses: ./.github/workflows/publish-platform.yml
     with:
       version: ${{ needs.release-metadata.outputs.version }}

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -31,7 +31,16 @@ const workflowExpectations = [
   { path: ".github/workflows/publish-platform.yml", jobs: ["build", "publish"] },
   {
     path: ".github/workflows/publish.yml",
-    jobs: ["test", "typecheck", "codex-compatibility", "preflight-trust", "release-metadata", "publish-main", "release"],
+    jobs: [
+      "test",
+      "typecheck",
+      "codex-compatibility",
+      "preflight-trust",
+      "release-metadata",
+      "prepare-release-state",
+      "publish-main",
+      "release",
+    ],
   },
   { path: ".github/workflows/refresh-model-capabilities.yml", jobs: ["refresh"] },
   { path: ".github/workflows/sisyphus-agent.yml", jobs: ["agent"] },

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -122,10 +122,14 @@ describe("test workflows", () => {
         codexCompatibilityJob.indexOf("name: Run Codex compatibility tests")
     const runsCodexCommand = codexCompatibilityJob.includes("run: bun run test:codex")
     const publishMainNeedsCodex =
-      workflow.includes("needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, publish-platform]") &&
+      workflow.includes(
+        "needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
+      ) &&
       workflow.includes("needs.codex-compatibility.result == 'success'")
     const publishPlatformNeedsCodex =
-      workflow.includes("needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata]") &&
+      workflow.includes(
+        "needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state]",
+      ) &&
       workflow.includes("needs.codex-compatibility.result == 'success'")
 
     // #then
@@ -296,7 +300,9 @@ describe("test workflows", () => {
     const computesVersionOnce = (workflow.match(/id: version/g) ?? []).length === 1
     const platformUsesMetadata = workflow.includes("version: ${{ needs.release-metadata.outputs.version }}") &&
       workflow.includes("dist_tag: ${{ needs.release-metadata.outputs.dist_tag }}")
-    const mainWaitsForPlatform = workflow.includes("needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, publish-platform]") &&
+    const mainWaitsForPlatform = workflow.includes(
+      "needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
+    ) &&
       workflow.includes("inputs.skip_platform == true || needs.publish-platform.result == 'success'")
     const releaseUsesMetadata = workflow.includes("VERSION: ${{ needs.release-metadata.outputs.version }}")
     const wrappersVerifyPlatformPackages = workflow.includes("name: Verify platform packages are published") &&
@@ -504,7 +510,7 @@ describe("test workflows", () => {
     expect(publishIds, "PLATFORM_PACKAGE_IDS must match build-binaries PLATFORMS exactly").toEqual(
       buildBinariesPlatforms,
     )
-    expect(publishYmlLists.length, "publish.yml must enumerate platforms in 2 PLATFORMS arrays + 2 version-bump loops").toBe(4)
+    expect(publishYmlLists.length, "publish.yml must enumerate platforms in 2 PLATFORMS arrays + 3 version-bump loops").toBe(5)
     for (const publishYmlList of publishYmlLists) {
       expect(publishYmlList, "every publish.yml platform list must match build-binaries PLATFORMS exactly").toEqual(
         buildBinariesPlatforms,


### PR DESCRIPTION
Prevents a repeat of the v4.12.0 half-published failure by moving release-source stamping ahead of npm publication. The publish workflow now creates and waits for a protected-branch release-state PR before any package publish starts; if checks or branch protection block that PR, the workflow fails safely before touching npm.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates npm publish on a merged release-state PR to prevent half-published releases. Moves source stamping ahead of publication and blocks publishing if branch protection or checks fail.

- **Bug Fixes**
  - Added `prepare-release-state` job to stamp versions, open a protected "release: vX.Y.Z" PR, and wait for it to merge before any publish starts.
  - Made `publish-main` and `publish-platform` depend on `prepare-release-state`; they only run after the release-state PR merges.
  - Fail early if required checks fail or the PR can’t merge; no npm publish occurs.
  - Tightened tests to cover the gate: updated `script/ci-job-summary-workflow.test.ts` and `script/publish-workflow.test.ts` to expect the new job, enforce `needs` wiring, and validate platform list enumeration.

<sup>Written for commit eae7cffc1b84f66a146688f4222aa8a295513b6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

