### PR TITLE
fix(codex-installer): sync packaged skills during cache install

### DIFF
--- a/packages/omo-codex/plugin/package-lock.json
+++ b/packages/omo-codex/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sisyphuslabs/omo-codex-plugin",
-	"version": "4.11.1",
+	"version": "4.12.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sisyphuslabs/omo-codex-plugin",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"workspaces": [
 				"components/codegraph",
 				"components/comment-checker",
@@ -92,7 +92,7 @@
 		},
 		"components/codegraph": {
 			"name": "@sisyphuslabs/codex-codegraph",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"bin": {
 				"omo-codegraph": "dist/cli.js"
 			},
@@ -108,7 +108,7 @@
 		},
 		"components/comment-checker": {
 			"name": "@code-yeongyu/codex-comment-checker",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"license": "MIT",
 			"bin": {
 				"omo-comment-checker": "dist/cli.js"
@@ -129,7 +129,7 @@
 		},
 		"components/git-bash": {
 			"name": "@sisyphuslabs/codex-git-bash-hook",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"bin": {
 				"omo-git-bash-hook": "dist/cli.js"
 			},
@@ -144,7 +144,7 @@
 		},
 		"components/lazycodex-executor-verify": {
 			"name": "@code-yeongyu/codex-lazycodex-executor-verify",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"license": "MIT",
 			"bin": {
 				"lazycodex-executor-verify": "dist/cli.js"
@@ -161,7 +161,7 @@
 		},
 		"components/lsp": {
 			"name": "@code-yeongyu/codex-lsp",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@code-yeongyu/lsp-daemon": "file:../../../../lsp-daemon"
@@ -181,7 +181,7 @@
 		},
 		"components/rules": {
 			"name": "@code-yeongyu/codex-rules",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^4.0.3"
@@ -203,7 +203,7 @@
 		},
 		"components/start-work-continuation": {
 			"name": "@code-yeongyu/codex-start-work-continuation",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"license": "MIT",
 			"bin": {
 				"omo-start-work-continuation": "dist/cli.js"
@@ -220,7 +220,7 @@
 		},
 		"components/telemetry": {
 			"name": "@code-yeongyu/codex-telemetry",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"license": "MIT",
 			"bin": {
 				"omo-telemetry": "dist/cli.js"
@@ -238,7 +238,7 @@
 		},
 		"components/ultrawork": {
 			"name": "@code-yeongyu/codex-ultrawork",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"license": "MIT",
 			"bin": {
 				"omo-ultrawork": "dist/cli.js"
@@ -256,7 +256,7 @@
 		},
 		"components/ulw-loop": {
 			"name": "@code-yeongyu/codex-ulw-loop",
-			"version": "4.11.1",
+			"version": "4.12.0",
 			"license": "MIT",
 			"bin": {
 				"omo-ulw-loop": "dist/cli.js"

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5907,7 +5907,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.11.1",
+    version: "4.12.0",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -7139,6 +7139,8 @@ async function installCachedPlugin(input) {
     await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath);
     await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath });
     await maybeRunNpmInstall(tempPath, input.runCommand, ["ci", "--omit=dev"]);
+    if (input.buildSource === false)
+      await maybeRunNpmSyncSkills(tempPath, input.runCommand);
     await rewriteCachedMcpManifest(tempPath, input.sourcePath);
     await rewriteCachedManifestRoot(tempPath, tempPath, targetPath);
     await assertHookCommandTargets(tempPath);
@@ -7164,6 +7166,17 @@ async function maybeRunNpmBuild(cwd, runCommand) {
   if (!isPlainRecord(scripts) || typeof scripts.build !== "string")
     return;
   await runCommand("npm", ["run", "build"], { cwd });
+}
+async function maybeRunNpmSyncSkills(cwd, runCommand) {
+  if (!await fileExistsStrict(join9(cwd, "package.json")))
+    return;
+  const packageJson = JSON.parse(await readFile7(join9(cwd, "package.json"), "utf8"));
+  if (!isPlainRecord(packageJson))
+    return;
+  const scripts = packageJson.scripts;
+  if (!isPlainRecord(scripts) || typeof scripts["sync:skills"] !== "string")
+    return;
+  await runCommand("npm", ["run", "sync:skills"], { cwd });
 }
 function createTempSiblingPath(targetPath) {
   return join9(dirname3(targetPath), `.tmp-${basename2(targetPath)}-${process.pid}-${Date.now()}`);

--- a/packages/omo-codex/src/install/codex-cache-install.test.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.test.ts
@@ -77,4 +77,44 @@ describe("codex-cache install", () => {
     expect(await readFile(join(cacheRoot, "package.json"), "utf8")).toBe(JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }))
     expect(await readdir(join(codexHome, "plugins", "cache", "debug", "omo"))).toEqual(["0.1.0"])
   })
+
+  test("#given packaged plugin has stale aggregate skills #when caching plugin #then syncs skills after production dependencies install", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-skills-"))
+    const codexHome = join(root, "codex-home")
+    const sourceRoot = join(root, "plugin")
+    const commands: string[] = []
+    await mkdir(join(sourceRoot, "scripts"), { recursive: true })
+    await mkdir(join(sourceRoot, "skills", "ulw-plan"), { recursive: true })
+    await writeFile(join(sourceRoot, "skills", "ulw-plan", "SKILL.md"), "---\nname: ulw-plan\n---\n")
+    await writeFile(
+      join(sourceRoot, "package.json"),
+      JSON.stringify({
+        name: "@scope/omo",
+        version: "0.1.0",
+        scripts: { "sync:skills": "node scripts/sync-skills.mjs" },
+      }),
+    )
+
+    // when
+    const installed = await installCachedPlugin({
+      buildSource: false,
+      codexHome,
+      marketplaceName: "debug",
+      name: "omo",
+      sourcePath: sourceRoot,
+      version: "0.1.0",
+      runCommand: async (command, args, options) => {
+        commands.push(`${command} ${args.join(" ")}`)
+        if (command === "npm" && args.join(" ") === "run sync:skills") {
+          await mkdir(join(options.cwd, "skills", "ultraresearch"), { recursive: true })
+          await writeFile(join(options.cwd, "skills", "ultraresearch", "SKILL.md"), "---\nname: ultraresearch\n---\n")
+        }
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm ci --omit=dev", "npm run sync:skills"])
+    expect(await readFile(join(installed.path, "skills", "ultraresearch", "SKILL.md"), "utf8")).toContain("name: ultraresearch")
+  })
 })

--- a/packages/omo-codex/src/install/codex-cache-install.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.ts
@@ -32,6 +32,7 @@ export async function installCachedPlugin(input: {
     await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath)
     await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath })
     await maybeRunNpmInstall(tempPath, input.runCommand, ["ci", "--omit=dev"])
+    if (input.buildSource === false) await maybeRunNpmSyncSkills(tempPath, input.runCommand)
     await rewriteCachedMcpManifest(tempPath, input.sourcePath)
     await rewriteCachedManifestRoot(tempPath, tempPath, targetPath)
     await assertHookCommandTargets(tempPath)
@@ -55,6 +56,15 @@ async function maybeRunNpmBuild(cwd: string, runCommand: RunCommand): Promise<vo
   const scripts = packageJson.scripts
   if (!isPlainRecord(scripts) || typeof scripts.build !== "string") return
   await runCommand("npm", ["run", "build"], { cwd })
+}
+
+async function maybeRunNpmSyncSkills(cwd: string, runCommand: RunCommand): Promise<void> {
+  if (!(await fileExistsStrict(join(cwd, "package.json")))) return
+  const packageJson: unknown = JSON.parse(await readFile(join(cwd, "package.json"), "utf8"))
+  if (!isPlainRecord(packageJson)) return
+  const scripts = packageJson.scripts
+  if (!isPlainRecord(scripts) || typeof scripts["sync:skills"] !== "string") return
+  await runCommand("npm", ["run", "sync:skills"], { cwd })
 }
 
 function createTempSiblingPath(targetPath: string): string {


### PR DESCRIPTION
## Summary
- Investigated Discord report `1517743293331537940`: `ultraresearch` source still exists, but the packaged Codex cache path could install a stale aggregate `plugin/skills` tree that no longer contained it.
- Fixed packaged-mode Codex cache installs to run `npm run sync:skills` after production dependency install when the package exposes that script and `buildSource=false`.
- Added a stale-packaged-aggregate regression test and regenerated the bundled installer entrypoint.

## Evidence
- Discord report captured: `.omo/evidence/20260620-restore-ultraresearch/discord-report.json`
- Failing-first proof: `.omo/evidence/20260620-restore-ultraresearch/red-packaged-skill-list.txt`, `.omo/evidence/20260620-restore-ultraresearch/red-packaged-sync-test.txt`
- Focused green proof: `.omo/evidence/20260620-restore-ultraresearch/green-packaged-sync-test.txt`, `.omo/evidence/20260620-restore-ultraresearch/green-sync-skills-test.txt`
- Real packaged-mode cache proof: `.omo/evidence/20260620-restore-ultraresearch/packaged-mode-cache-proof.txt`
- Codex harness QA: `.omo/evidence/20260620-restore-ultraresearch/codex-qa-install-verify-worktree.txt`, `.omo/evidence/20260620-restore-ultraresearch/codex-qa-ultraresearch-cache-proof.txt`
- Full local gate: `.omo/evidence/20260620-restore-ultraresearch/prepush-typecheck-test-build.txt`

## Verification
- `bun test packages/omo-codex/src/install/codex-cache-install.test.ts packages/omo-codex/src/install/install-codex.test.ts`
- `node --test packages/omo-codex/plugin/test/sync-skills.test.mjs`
- `bun run test:codex`
- `REPO_ROOT=/Users/yeongyu/local-workspaces/omo-wt/fix/restore-ultraresearch-skill bash /Users/yeongyu/local-workspaces/omo/.agents/skills/codex-qa/scripts/install-verify.sh --self-test --keep`
- `bun run typecheck`
- `bun test`
- `bun run build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes packaged-mode Codex cache installs by syncing the aggregated skills tree so stale packages don’t drop skills like ultraresearch. When caching a plugin with `buildSource=false`, we now run `npm run sync:skills` after production deps if the script exists.

- **Bug Fixes**
  - Run `npm run sync:skills` after `npm ci --omit=dev` during cached plugin install; added a regression test to verify command order and that `ultraresearch` is restored.

- **Dependencies**
  - Bumped `@sisyphuslabs/omo-codex-plugin` lockfile and bundled version refs to 4.12.0.

<sup>Written for commit a6924001960e490f920c3f4f341d5ca0a2c412db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

