### PR TITLE
fix(codegraph): guide uninitialized tools to OMO store

### DIFF
--- a/packages/omo-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/omo-codex/plugin/.codex-plugin/plugin.json
@@ -32,6 +32,7 @@
 		"./hooks/pre-tool-use-enforcing-unlimited-goal-budget.json",
 		"./hooks/post-tool-use-checking-comments.json",
 		"./hooks/post-tool-use-checking-lsp-diagnostics.json",
+		"./hooks/post-tool-use-checking-codegraph-init-guidance.json",
 		"./hooks/post-tool-use-matching-project-rules.json",
 		"./hooks/post-compact-resetting-git-bash-mcp-reminder.json",
 		"./hooks/post-compact-resetting-project-rule-cache.json",

--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -1,22 +1,214 @@
 #!/usr/bin/env node
 
-// src/cli.ts
+// components/codegraph/src/cli.ts
 import { realpathSync as realpathSync3 } from "node:fs";
 import { basename as basename5, resolve as resolve4 } from "node:path";
 import { stderr as processStderr3 } from "node:process";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
-// src/hook.ts
+// components/codegraph/src/hook.ts
 import { spawn } from "node:child_process";
-import { homedir as homedir7 } from "node:os";
+import { homedir as homedir8 } from "node:os";
 import { cwd as processCwd2, env as processEnv2, stdin as processStdin, stdout as processStdout } from "node:process";
 import { fileURLToPath } from "node:url";
 
-// ../../../../utils/src/omo-config/loader.ts
-import { existsSync as existsSync2, readFileSync } from "node:fs";
-import { homedir } from "node:os";
+// ../../utils/src/codegraph/guidance.ts
+import { homedir as homedir2 } from "node:os";
 
-// ../../../../utils/src/deep-merge.ts
+// ../../utils/src/codegraph/workspace.ts
+import { createHash } from "node:crypto";
+import {
+  appendFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
+function sanitizeBase(value) {
+  const sanitized = value.replace(/[^A-Za-z0-9._-]/g, "-").replace(/-+/g, "-");
+  return sanitized.length > 0 ? sanitized : "workspace";
+}
+function codegraphDataRoot(homeDir) {
+  return join(homeDir, ".omo", "codegraph");
+}
+function workspaceStorageName(workspace) {
+  const resolved = resolve(workspace);
+  const hash = createHash("sha256").update(resolved).digest("hex").slice(0, 16);
+  return `${sanitizeBase(basename(resolved))}-${hash}`;
+}
+function resolveCodegraphWorkspacePaths(workspace, options = {}) {
+  const resolvedWorkspace = resolve(workspace);
+  const dataRoot = codegraphDataRoot(options.homeDir ?? homedir());
+  return {
+    dataDir: join(dataRoot, "projects", workspaceStorageName(resolvedWorkspace)),
+    dataRoot,
+    projectLink: join(resolvedWorkspace, ".codegraph")
+  };
+}
+function fallbackResult(dataRoot, projectLink, reason) {
+  return { dataDir: projectLink, dataRoot, linked: false, mode: "in-place-fallback", projectLink, reason };
+}
+function isSameFilesystem(workspace, dataRoot, override) {
+  if (override !== undefined)
+    return override;
+  return statSync(workspace).dev === statSync(dataRoot).dev;
+}
+function ensureInPlaceFallback(projectLink) {
+  if (!existsSync(projectLink))
+    mkdirSync(projectLink, { recursive: true });
+}
+function prepareCodegraphWorkspace(workspace, options = {}) {
+  const resolvedWorkspace = resolve(workspace);
+  const { dataDir, dataRoot, projectLink } = resolveCodegraphWorkspacePaths(resolvedWorkspace, options);
+  try {
+    mkdirSync(dataDir, { recursive: true });
+    if (existsSync(projectLink)) {
+      const linkStat = lstatSync(projectLink);
+      if (!linkStat.isSymbolicLink()) {
+        return { dataDir: projectLink, dataRoot, linked: false, mode: "in-project", projectLink };
+      }
+      if (realpathSync(projectLink) === realpathSync(dataDir)) {
+        return { dataDir, dataRoot, linked: true, mode: "global-linked", projectLink };
+      }
+      return fallbackResult(dataRoot, projectLink, "existing .codegraph symlink points outside OMO store");
+    }
+    if (!isSameFilesystem(resolvedWorkspace, dataRoot, options.sameFilesystem)) {
+      ensureInPlaceFallback(projectLink);
+      return fallbackResult(dataRoot, projectLink, "workspace and OMO store are on different filesystems");
+    }
+    const symlink = options.symlink ?? symlinkSync;
+    symlink(dataDir, projectLink, (options.platform ?? process.platform) === "win32" ? "junction" : "dir");
+    return { dataDir, dataRoot, linked: true, mode: "global-linked", projectLink };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    try {
+      ensureInPlaceFallback(projectLink);
+    } catch (fallbackError) {
+      return fallbackResult(dataRoot, projectLink, `${reason}; fallback failed: ${String(fallbackError)}`);
+    }
+    return fallbackResult(dataRoot, projectLink, reason);
+  }
+}
+function ensureCodegraphGitignored(workspace) {
+  const gitDir = join(workspace, ".git");
+  if (!existsSync(gitDir))
+    return false;
+  const excludePath = join(gitDir, "info", "exclude");
+  try {
+    mkdirSync(join(gitDir, "info"), { recursive: true });
+    const existing = existsSync(excludePath) ? readFileSync(excludePath, "utf8") : "";
+    if (existing.split(/\r?\n/).includes(".codegraph"))
+      return true;
+    appendFileSync(excludePath, `${existing.endsWith(`
+`) || existing.length === 0 ? "" : `
+`}.codegraph
+`);
+    return true;
+  } catch (error) {
+    if (error instanceof Error)
+      return false;
+    throw error;
+  }
+}
+
+// ../../utils/src/codegraph/guidance.ts
+var CODEGRAPH_UNINITIALIZED_PATTERN = /CodeGraph not initialized in ([\s\S]*?)\.\s*Run ['`]codegraph init['`] in that project first\./i;
+var ANSI_ESCAPE_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+var CODEGRAPH_STATUS_PROJECT_PATTERN = /^.*?\bProject:\s*(.+?)\s*$/im;
+var CODEGRAPH_STATUS_UNINITIALIZED_PATTERN = /^.*?\bNot initialized\s*$/im;
+var CODEGRAPH_INIT_HINT_PATTERN = /Run\s+["'`]codegraph init["'`]\s+(?:in that project first|to initialize)\.?/i;
+function getCodegraphUninitializedProject(input) {
+  const output = textFromUnknown(input.toolOutput);
+  if (!isCodegraphTool(input.toolName))
+    return null;
+  const projectPath = extractProjectPath(output);
+  if (projectPath !== null)
+    return projectPath;
+  if (!looksLikeCodegraphUninitializedOutput(output))
+    return null;
+  return typeof input.cwd === "string" && input.cwd.trim().length > 0 ? input.cwd.trim() : null;
+}
+function buildCodegraphInitGuidance(projectPath, options = {}) {
+  const { dataDir, dataRoot, projectLink } = resolveCodegraphWorkspacePaths(projectPath, {
+    homeDir: options.homeDir ?? homedir2()
+  });
+  const displayProjectPath = formatDisplayPath(projectPath);
+  const displayProjectLink = formatDisplayPath(projectLink);
+  const displayDataDir = formatDisplayPath(dataDir);
+  const displayDataRoot = formatDisplayPath(dataRoot);
+  return [
+    "OMO CodeGraph initialization guidance:",
+    "",
+    `CodeGraph is not initialized for ${displayProjectPath}. Initialize it through OMO's global local store instead of leaving a standalone project-local index.`,
+    "",
+    `- Link or create ${displayProjectLink} so it points at ${displayDataDir} under the OMO store ${displayDataRoot}.`,
+    `- Then run \`codegraph init\` from ${displayProjectPath} and retry the CodeGraph tool.`,
+    "- OMO's CodeGraph bootstrap does this automatically on session start; if bootstrap just ran, wait for it to finish and retry."
+  ].join(`
+`);
+}
+function buildCodegraphInitGuidanceForToolResult(input, options = {}) {
+  const projectPath = getCodegraphUninitializedProject(input);
+  return projectPath === null ? null : buildCodegraphInitGuidance(projectPath, options);
+}
+function extractProjectPath(output) {
+  const normalizedOutput = normalizeCodegraphOutput(output);
+  const uninitializedMatch = normalizedOutput.match(CODEGRAPH_UNINITIALIZED_PATTERN);
+  const uninitializedProject = uninitializedMatch?.[1]?.trim();
+  if (uninitializedProject && uninitializedProject.length > 0)
+    return uninitializedProject;
+  if (!looksLikeCodegraphUninitializedOutput(normalizedOutput))
+    return null;
+  const statusMatch = normalizedOutput.match(CODEGRAPH_STATUS_PROJECT_PATTERN);
+  const statusProject = statusMatch?.[1]?.trim();
+  return statusProject && statusProject.length > 0 ? statusProject : null;
+}
+function looksLikeCodegraphUninitializedOutput(output) {
+  const normalizedOutput = normalizeCodegraphOutput(output);
+  if (normalizedOutput.match(CODEGRAPH_UNINITIALIZED_PATTERN) !== null)
+    return true;
+  return CODEGRAPH_STATUS_UNINITIALIZED_PATTERN.test(normalizedOutput) && CODEGRAPH_INIT_HINT_PATTERN.test(normalizedOutput);
+}
+function normalizeCodegraphOutput(output) {
+  return output.replace(ANSI_ESCAPE_PATTERN, "");
+}
+function isCodegraphTool(toolName) {
+  if (typeof toolName !== "string")
+    return false;
+  return toolName.startsWith("codegraph.") || toolName.startsWith("codegraph_") || toolName.startsWith("mcp__codegraph__");
+}
+function formatDisplayPath(value) {
+  return JSON.stringify(value);
+}
+function textFromUnknown(value) {
+  if (typeof value === "string")
+    return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint")
+    return String(value);
+  if (Array.isArray(value))
+    return value.map(textFromUnknown).filter(Boolean).join(`
+`);
+  if (!isRecord(value))
+    return "";
+  return Object.entries(value).map(([key, nested]) => `${key}: ${textFromUnknown(nested)}`).filter((line) => line.trim().length > 0).join(`
+`);
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// ../../utils/src/omo-config/loader.ts
+import { existsSync as existsSync3, readFileSync as readFileSync2 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+
+// ../../utils/src/deep-merge.ts
 var DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 function isUnsafeObjectKey(key) {
   return DANGEROUS_KEYS.has(key);
@@ -25,7 +217,7 @@ function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value) && Object.prototype.toString.call(value) === "[object Object]";
 }
 
-// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/scanner.js
+// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/scanner.js
 function createScanner(text, ignoreTrivia = false) {
   const len = text.length;
   let pos = 0, value = "", tokenOffset = 0, token = 16, lineNumber = 0, lineStartOffset = 0, tokenLineStartOffset = 0, prevTokenLineStartOffset = 0, scanError = 0;
@@ -440,7 +632,7 @@ var CharacterCodes;
   CharacterCodes2[CharacterCodes2["tab"] = 9] = "tab";
 })(CharacterCodes || (CharacterCodes = {}));
 
-// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/string-intern.js
+// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/string-intern.js
 var cachedSpaces = new Array(20).fill(0).map((_, index) => {
   return " ".repeat(index);
 });
@@ -474,7 +666,7 @@ var cachedBreakLinesWithSpaces = {
   }
 };
 
-// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/parser.js
+// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/parser.js
 var ParseOptions;
 (function(ParseOptions2) {
   ParseOptions2.DEFAULT = {
@@ -777,7 +969,7 @@ function visit(text, visitor, options = ParseOptions.DEFAULT) {
   return true;
 }
 
-// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/main.js
+// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/main.js
 var ScanError;
 (function(ScanError2) {
   ScanError2[ScanError2["None"] = 0] = "None";
@@ -866,7 +1058,7 @@ function printParseErrorCode(code) {
   return "<unknown ParseErrorCode>";
 }
 
-// ../../../../utils/src/jsonc-parser.ts
+// ../../utils/src/jsonc-parser.ts
 var pluginConfigFileDetectionCache = new Map;
 function stripBom(content) {
   return content.charCodeAt(0) === 65279 ? content.slice(1) : content;
@@ -887,7 +1079,7 @@ function parseJsoncSafe(content) {
   };
 }
 
-// ../../../../utils/src/omo-config.ts
+// ../../utils/src/omo-config.ts
 var HARNESS_IDS = ["codex", "opencode", "omo"];
 var SETTING_HARNESS_SUPPORT = {
   "codegraph.auto_provision": HARNESS_IDS,
@@ -897,7 +1089,7 @@ var SETTING_HARNESS_SUPPORT = {
   "codegraph.watch_debounce_ms": ["opencode", "omo"]
 };
 
-// ../../../../utils/src/omo-config/env-overrides.ts
+// ../../utils/src/omo-config/env-overrides.ts
 var CODEGRAPH_ENV_KEYS = [
   ["auto_provision", "AUTO_PROVISION", "boolean"],
   ["enabled", "ENABLED", "boolean"],
@@ -969,23 +1161,23 @@ function buildEnvOverrides(harness, env, warnings, merge) {
   return config;
 }
 
-// ../../../../utils/src/omo-config/resolve.ts
-import { existsSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+// ../../utils/src/omo-config/resolve.ts
+import { existsSync as existsSync2 } from "node:fs";
+import { dirname, isAbsolute, join as join2, relative, resolve as resolve2 } from "node:path";
 function containsPath(parent, child) {
   const pathToChild = relative(parent, child);
   return pathToChild === "" || !pathToChild.startsWith("..") && !isAbsolute(pathToChild);
 }
 function findProjectConfigPathsNearestFirst(cwd, homeDir) {
-  const startDir = resolve(cwd);
-  const stopBeforeDir = containsPath(resolve(homeDir), startDir) ? resolve(homeDir) : null;
+  const startDir = resolve2(cwd);
+  const stopBeforeDir = containsPath(resolve2(homeDir), startDir) ? resolve2(homeDir) : null;
   const paths = [];
   let currentDir = startDir;
   while (true) {
     if (stopBeforeDir !== null && currentDir === stopBeforeDir)
       break;
-    const configPath = join(currentDir, ".omo", "config.jsonc");
-    if (existsSync(configPath)) {
+    const configPath = join2(currentDir, ".omo", "config.jsonc");
+    if (existsSync2(configPath)) {
       paths.push(configPath);
     }
     const parentDir = dirname(currentDir);
@@ -996,7 +1188,7 @@ function findProjectConfigPathsNearestFirst(cwd, homeDir) {
   return paths;
 }
 function resolveOmoConfigPaths(options) {
-  const globalPath = join(resolve(options.homeDir), ".omo", "config.jsonc");
+  const globalPath = join2(resolve2(options.homeDir), ".omo", "config.jsonc");
   const projectPathsFarthestFirst = findProjectConfigPathsNearestFirst(options.cwd, options.homeDir).reverse();
   return [
     { path: globalPath, scope: "global" },
@@ -1012,7 +1204,7 @@ function toMissingSource(candidate) {
   };
 }
 
-// ../../../../utils/src/omo-config/loader.ts
+// ../../utils/src/omo-config/loader.ts
 var BUILT_IN_DEFAULTS = {
   codegraph: {
     auto_provision: true,
@@ -1028,7 +1220,7 @@ var CODEGRAPH_SETTING_KEYS = [
   "telemetry",
   "watch_debounce_ms"
 ];
-function isRecord(value) {
+function isRecord2(value) {
   return isPlainObject(value);
 }
 function hasOwn(record, key) {
@@ -1056,7 +1248,7 @@ function mergeValues(base, override) {
 }
 function mergeCodegraphConfig(base, override) {
   const merged = mergeValues(base, override);
-  if (!isRecord(merged))
+  if (!isRecord2(merged))
     return;
   const codegraph = {};
   for (const key of CODEGRAPH_SETTING_KEYS) {
@@ -1111,7 +1303,7 @@ function setCodegraphSetting2(config, key, value) {
   }
 }
 function normalizeCodegraphSection(section, pathPrefix, warnings) {
-  if (!isRecord(section)) {
+  if (!isRecord2(section)) {
     warnings.push(`${pathPrefix} must be an object`);
     return {};
   }
@@ -1131,7 +1323,7 @@ function normalizeCodegraphSection(section, pathPrefix, warnings) {
   return codegraph;
 }
 function normalizeConfigBody(value, pathPrefix, warnings) {
-  if (!isRecord(value)) {
+  if (!isRecord2(value)) {
     warnings.push(`${pathPrefix} must be an object`);
     return {};
   }
@@ -1152,7 +1344,7 @@ function normalizeConfigBody(value, pathPrefix, warnings) {
   return config;
 }
 function normalizeActiveHarnessBlock(value, harness, pathPrefix, warnings) {
-  if (!isRecord(value))
+  if (!isRecord2(value))
     return {};
   const blockKey = `[${harness}]`;
   if (!hasOwn(value, blockKey))
@@ -1161,7 +1353,7 @@ function normalizeActiveHarnessBlock(value, harness, pathPrefix, warnings) {
 }
 function loadConfigFile(path, harness) {
   try {
-    const content = readFileSync(path, "utf-8");
+    const content = readFileSync2(path, "utf-8");
     const parsed = parseJsoncSafe(content);
     if (parsed.errors.length > 0) {
       return {
@@ -1207,13 +1399,13 @@ function validateHarnessApplicability(config, harness) {
 }
 function loadOmoConfig(options) {
   const cwd = options.cwd ?? process.cwd();
-  const homeDir = options.homeDir ?? process.env["HOME"] ?? process.env["USERPROFILE"] ?? homedir();
+  const homeDir = options.homeDir ?? process.env["HOME"] ?? process.env["USERPROFILE"] ?? homedir3();
   const env = options.env ?? process.env;
   let config = BUILT_IN_DEFAULTS;
   const sources = [];
   const warnings = [];
   for (const candidate of resolveOmoConfigPaths({ cwd, homeDir })) {
-    if (!existsSync2(candidate.path)) {
+    if (!existsSync3(candidate.path)) {
       if (candidate.scope === "global") {
         sources.push(toMissingSource(candidate));
       }
@@ -1235,7 +1427,7 @@ function loadOmoConfig(options) {
   return { config, sources, warnings };
 }
 
-// ../../shared/src/config-loader.ts
+// shared/src/config-loader.ts
 function getCodexOmoConfig(options = {}) {
   const result = loadOmoConfig({
     ...options.cwd === undefined ? {} : { cwd: options.cwd },
@@ -1250,31 +1442,31 @@ function getCodexOmoConfig(options = {}) {
   };
 }
 
-// src/session-start-worker.ts
+// components/codegraph/src/session-start-worker.ts
 import { execFile as execFile2 } from "node:child_process";
 import { appendFileSync as appendFileSync2, existsSync as existsSync6, mkdirSync as mkdirSync2 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
+import { homedir as homedir7 } from "node:os";
 import { extname, join as join7 } from "node:path";
 import { cwd as processCwd, env as processEnv, stderr as processStderr } from "node:process";
 
-// ../../../../utils/src/codegraph/env.ts
-import { homedir as homedir2 } from "node:os";
-import { join as join2 } from "node:path";
+// ../../utils/src/codegraph/env.ts
+import { homedir as homedir4 } from "node:os";
+import { join as join3 } from "node:path";
 var CODEGRAPH_INSTALL_DIR_ENV = "CODEGRAPH_INSTALL_DIR";
 var CODEGRAPH_NO_DOWNLOAD_ENV = "CODEGRAPH_NO_DOWNLOAD";
 var CODEGRAPH_TELEMETRY_ENV = "CODEGRAPH_TELEMETRY";
 var DO_NOT_TRACK_ENV = "DO_NOT_TRACK";
 function buildCodegraphEnv(options = {}) {
-  const homeDir = options.homeDir ?? homedir2();
+  const homeDir = options.homeDir ?? homedir4();
   return {
-    [CODEGRAPH_INSTALL_DIR_ENV]: join2(homeDir, ".omo", "codegraph"),
+    [CODEGRAPH_INSTALL_DIR_ENV]: join3(homeDir, ".omo", "codegraph"),
     [CODEGRAPH_NO_DOWNLOAD_ENV]: "1",
     [CODEGRAPH_TELEMETRY_ENV]: "0",
     [DO_NOT_TRACK_ENV]: "1"
   };
 }
 
-// ../../../../utils/src/codegraph/node-support.ts
+// ../../utils/src/codegraph/node-support.ts
 var CODEGRAPH_MIN_NODE_MAJOR = 20;
 var CODEGRAPH_BLOCKED_NODE_MAJOR = 25;
 var CODEGRAPH_UNSAFE_NODE_ENV = "CODEGRAPH_ALLOW_UNSAFE_NODE";
@@ -1303,16 +1495,16 @@ function parseNodeMajor(version) {
   return Number.isNaN(major) ? 0 : major;
 }
 
-// ../../../../utils/src/codegraph/provision.ts
-import { createHash, randomUUID } from "node:crypto";
+// ../../utils/src/codegraph/provision.ts
+import { createHash as createHash2, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { chmod, mkdir, readdir, readFile, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
-import { existsSync as existsSync3 } from "node:fs";
-import { homedir as homedir3, hostname } from "node:os";
-import { basename, join as join3 } from "node:path";
+import { existsSync as existsSync4 } from "node:fs";
+import { homedir as homedir5, hostname } from "node:os";
+import { basename as basename2, join as join4 } from "node:path";
 import { promisify } from "node:util";
 
-// ../../../../utils/src/codegraph/manifest.ts
+// ../../utils/src/codegraph/manifest.ts
 var CODEGRAPH_PROVISION_MANIFEST = {
   assets: {
     "darwin-arm64": {
@@ -1349,7 +1541,7 @@ var CODEGRAPH_PROVISION_MANIFEST = {
   version: "1.0.1"
 };
 
-// ../../../../utils/src/codegraph/provision.ts
+// ../../utils/src/codegraph/provision.ts
 var DEFAULT_LOCK_WAIT_MS = 5000;
 var DEFAULT_LOCK_STALE_MS = 120000;
 var DEFAULT_DOWNLOAD_TIMEOUT_MS = 60000;
@@ -1358,13 +1550,13 @@ function platformKey() {
   return `${process.platform}-${process.arch}`;
 }
 function markerPath(installDir, version) {
-  return join3(installDir, ".provisioned", `codegraph-${version}.json`);
+  return join4(installDir, ".provisioned", `codegraph-${version}.json`);
 }
 function defaultInstallDir() {
-  return join3(homedir3(), ".omo", "codegraph");
+  return join4(homedir5(), ".omo", "codegraph");
 }
 function sha256(bytes) {
-  return createHash("sha256").update(bytes).digest("hex");
+  return createHash2("sha256").update(bytes).digest("hex");
 }
 function isErrnoException(error) {
   return error instanceof Error && "code" in error;
@@ -1381,7 +1573,7 @@ async function removeEmptyDirectory(path) {
   }
 }
 function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+  return new Promise((resolve3) => setTimeout(resolve3, ms));
 }
 async function defaultDownloader(asset, timeoutMs = DEFAULT_DOWNLOAD_TIMEOUT_MS) {
   const response = await fetch(asset.url, { signal: AbortSignal.timeout(timeoutMs) });
@@ -1395,7 +1587,7 @@ function forcedBadChecksumOptions(options) {
   const key = options.platformKey ?? platformKey();
   return {
     downloader: async () => new TextEncoder().encode("checksum mismatch"),
-    installDir: options.installDir ?? join3(options.lockDir, "codegraph-force-bad-checksum"),
+    installDir: options.installDir ?? join4(options.lockDir, "codegraph-force-bad-checksum"),
     manifest: {
       assets: {
         [key]: { executableName: process.platform === "win32" ? "codegraph.cmd" : "codegraph", sha256: "0000", url: "memory://bad" }
@@ -1406,13 +1598,13 @@ function forcedBadChecksumOptions(options) {
   };
 }
 async function readMarker(path) {
-  if (!existsSync3(path))
+  if (!existsSync4(path))
     return null;
   try {
     const raw = JSON.parse(await readFile(path, "utf8"));
     if (typeof raw === "object" && raw !== null && "binPath" in raw) {
       const value = raw.binPath;
-      return typeof value === "string" && existsSync3(value) ? value : null;
+      return typeof value === "string" && existsSync4(value) ? value : null;
     }
     return null;
   } catch (error) {
@@ -1423,7 +1615,7 @@ async function readMarker(path) {
 }
 async function acquireLock(lockPath, waitMs, staleMs) {
   const startedAt = Date.now();
-  await mkdir(join3(lockPath, ".."), { recursive: true });
+  await mkdir(join4(lockPath, ".."), { recursive: true });
   while (Date.now() - startedAt <= waitMs) {
     try {
       await mkdir(lockPath);
@@ -1448,44 +1640,44 @@ async function installExtractedBundle(extractDir, installDir, executableName) {
   const roots = await readdir(extractDir);
   if (roots.length !== 1)
     throw new Error(`CodeGraph archive should contain one root directory, found ${roots.length}`);
-  const bundleDir = join3(extractDir, roots[0] ?? "");
+  const bundleDir = join4(extractDir, roots[0] ?? "");
   const bundleEntries = await readdir(bundleDir);
   await mkdir(installDir, { recursive: true });
   for (const entry of bundleEntries) {
-    await rm(join3(installDir, entry), { force: true, recursive: true });
-    await rename(join3(bundleDir, entry), join3(installDir, entry));
+    await rm(join4(installDir, entry), { force: true, recursive: true });
+    await rename(join4(bundleDir, entry), join4(installDir, entry));
   }
-  const destination = join3(installDir, "bin", executableName);
-  if (!existsSync3(destination))
+  const destination = join4(installDir, "bin", executableName);
+  if (!existsSync4(destination))
     throw new Error(`CodeGraph archive did not contain bin/${executableName}`);
   await chmod(destination, 493);
   return destination;
 }
 async function installAsset(layout) {
   const { asset, downloader, installDir, version } = layout;
-  const stagingDir = join3(installDir, ".staging", randomUUID());
-  const archivePath = join3(stagingDir, basename(asset.url));
-  const extractDir = join3(stagingDir, "extract");
+  const stagingDir = join4(installDir, ".staging", randomUUID());
+  const archivePath = join4(stagingDir, basename2(asset.url));
+  const extractDir = join4(stagingDir, "extract");
   try {
     await mkdir(extractDir, { recursive: true });
     const bytes = await downloader(asset);
     const actualChecksum = sha256(bytes);
     if (actualChecksum !== asset.sha256) {
-      throw new Error(`checksum mismatch for ${basename(asset.url)}: expected ${asset.sha256}, got ${actualChecksum}`);
+      throw new Error(`checksum mismatch for ${basename2(asset.url)}: expected ${asset.sha256}, got ${actualChecksum}`);
     }
     if (!asset.url.endsWith(".tar.gz") && !asset.url.endsWith(".tgz")) {
-      throw new Error(`unsupported CodeGraph archive type for ${basename(asset.url)}`);
+      throw new Error(`unsupported CodeGraph archive type for ${basename2(asset.url)}`);
     }
     await writeFile(archivePath, bytes);
     await extractTarGz(archivePath, extractDir);
     const destination = await installExtractedBundle(extractDir, installDir, asset.executableName);
-    await mkdir(join3(installDir, ".provisioned"), { recursive: true });
+    await mkdir(join4(installDir, ".provisioned"), { recursive: true });
     await writeFile(markerPath(installDir, version), `${JSON.stringify({ binPath: destination, version })}
 `);
     return destination;
   } finally {
     await rm(stagingDir, { force: true, recursive: true });
-    await removeEmptyDirectory(join3(installDir, ".staging"));
+    await removeEmptyDirectory(join4(installDir, ".staging"));
   }
 }
 async function ensureCodegraphProvisioned(options) {
@@ -1498,7 +1690,7 @@ async function ensureCodegraphProvisioned(options) {
   const existing = await readMarker(marker);
   if (existing !== null)
     return { binPath: existing, provisioned: true };
-  const lockPath = join3(options.lockDir, `codegraph-${hostname()}.lock`);
+  const lockPath = join4(options.lockDir, `codegraph-${hostname()}.lock`);
   const release = await acquireLock(lockPath, options.lockWaitMs ?? DEFAULT_LOCK_WAIT_MS, options.lockStaleMs ?? DEFAULT_LOCK_STALE_MS);
   if (release === null)
     return { error: "timed out waiting for codegraph provisioning lock", provisioned: false };
@@ -1522,16 +1714,16 @@ async function ensureCodegraphProvisioned(options) {
   }
 }
 
-// ../../../../utils/src/codegraph/resolve.ts
-import { existsSync as existsSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
+// ../../utils/src/codegraph/resolve.ts
+import { existsSync as existsSync5 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
 import { spawnSync } from "node:child_process";
-import { basename as basename2, dirname as dirname2, join as join5 } from "node:path";
+import { basename as basename3, dirname as dirname2, join as join6 } from "node:path";
 import { createRequire } from "node:module";
 
-// ../../../../utils/src/runtime/which.ts
+// ../../utils/src/runtime/which.ts
 import { accessSync, constants } from "node:fs";
-import { delimiter, join as join4 } from "node:path";
+import { delimiter, join as join5 } from "node:path";
 var runtime = globalThis;
 function isUnsafeCommandName(commandName) {
   if (commandName.includes("/") || commandName.includes("\\"))
@@ -1586,7 +1778,7 @@ function bunWhich(commandName) {
     return null;
   for (const pathEntry of pathEntries) {
     for (const candidateName of candidateNames) {
-      const candidatePath = join4(pathEntry, candidateName);
+      const candidatePath = join5(pathEntry, candidateName);
       if (isExecutable(candidatePath))
         return candidatePath;
     }
@@ -1594,7 +1786,7 @@ function bunWhich(commandName) {
   return null;
 }
 
-// ../../../../utils/src/codegraph/resolve.ts
+// ../../utils/src/codegraph/resolve.ts
 function codegraphCommandRequiresSupportedLocalNode(resolution) {
   return resolution.source !== "bundled" && resolution.source !== "env" && resolution.source !== "provisioned";
 }
@@ -1627,7 +1819,7 @@ ${result.stderr}`.trim().split(/\s+/)[0];
   }
 }
 function isNodeExecutableName(filePath) {
-  const executable = basename2(filePath).toLowerCase();
+  const executable = basename3(filePath).toLowerCase();
   return executable === "node" || executable === "node.exe" || /^node\d+(\.exe)?$/.test(executable);
 }
 function looksLikePath(command) {
@@ -1667,8 +1859,8 @@ function defaultNodeRuntime(env, fileExists, which, nodeVersion) {
 function defaultProvisionedBin(homeDir, fileExists) {
   const binaryName = process.platform === "win32" ? "codegraph.cmd" : "codegraph";
   const candidates = [
-    join5(homeDir, ".omo", "codegraph", "bin", binaryName),
-    join5(homeDir, ".omo", "codegraph", "node-servers", "node_modules", ".bin", binaryName)
+    join6(homeDir, ".omo", "codegraph", "bin", binaryName),
+    join6(homeDir, ".omo", "codegraph", "node-servers", "node_modules", ".bin", binaryName)
   ];
   return candidates.find((candidate) => fileExists(candidate)) ?? null;
 }
@@ -1676,7 +1868,7 @@ function resolveBundledShim(requireResolve, fileExists) {
   try {
     const packageJson = requireResolve(`${CODEGRAPH_PACKAGE}/package.json`);
     const packageRoot = dirname2(packageJson);
-    const candidates = [join5(packageRoot, "bin", "codegraph.js"), join5(packageRoot, "npm-shim.js")];
+    const candidates = [join6(packageRoot, "bin", "codegraph.js"), join6(packageRoot, "npm-shim.js")];
     return candidates.find((candidate) => fileExists(candidate)) ?? null;
   } catch (error) {
     if (error instanceof Error)
@@ -1692,7 +1884,7 @@ function resolveBundledShim(requireResolve, fileExists) {
 }
 function resolveCodegraphCommand(options = {}) {
   const env = options.env ?? process.env;
-  const fileExists = options.fileExists ?? existsSync4;
+  const fileExists = options.fileExists ?? existsSync5;
   const configuredBin = env[CODEGRAPH_ENV_BIN]?.trim() || env[CODEGRAPH_LEGACY_ENV_BIN]?.trim();
   if (configuredBin !== undefined && configuredBin.length > 0) {
     return { argsPrefix: [], command: configuredBin, exists: fileExists(configuredBin), source: "env" };
@@ -1704,7 +1896,7 @@ function resolveCodegraphCommand(options = {}) {
   if (bundled !== null && runtime2 !== null) {
     return { argsPrefix: [bundled], command: runtime2, exists: true, source: "bundled" };
   }
-  const provisioned = options.provisioned?.() ?? defaultProvisionedBin(options.homeDir ?? homedir4(), fileExists);
+  const provisioned = options.provisioned?.() ?? defaultProvisionedBin(options.homeDir ?? homedir6(), fileExists);
   if (provisioned !== null && fileExists(provisioned)) {
     return { argsPrefix: [], command: provisioned, exists: true, source: "provisioned" };
   }
@@ -1717,103 +1909,7 @@ function resolveCodegraphCommand(options = {}) {
   };
 }
 
-// ../../../../utils/src/codegraph/workspace.ts
-import { createHash as createHash2 } from "node:crypto";
-import {
-  appendFileSync,
-  existsSync as existsSync5,
-  lstatSync,
-  mkdirSync,
-  readFileSync as readFileSync2,
-  readdirSync,
-  realpathSync,
-  rmSync,
-  statSync,
-  symlinkSync
-} from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { basename as basename3, join as join6, resolve as resolve2 } from "node:path";
-function sanitizeBase(value) {
-  const sanitized = value.replace(/[^A-Za-z0-9._-]/g, "-").replace(/-+/g, "-");
-  return sanitized.length > 0 ? sanitized : "workspace";
-}
-function codegraphDataRoot(homeDir) {
-  return join6(homeDir, ".omo", "codegraph");
-}
-function workspaceStorageName(workspace) {
-  const resolved = resolve2(workspace);
-  const hash = createHash2("sha256").update(resolved).digest("hex").slice(0, 16);
-  return `${sanitizeBase(basename3(resolved))}-${hash}`;
-}
-function fallbackResult(dataRoot, projectLink, reason) {
-  return { dataDir: projectLink, dataRoot, linked: false, mode: "in-place-fallback", projectLink, reason };
-}
-function isSameFilesystem(workspace, dataRoot, override) {
-  if (override !== undefined)
-    return override;
-  return statSync(workspace).dev === statSync(dataRoot).dev;
-}
-function ensureInPlaceFallback(projectLink) {
-  if (!existsSync5(projectLink))
-    mkdirSync(projectLink, { recursive: true });
-}
-function prepareCodegraphWorkspace(workspace, options = {}) {
-  const resolvedWorkspace = resolve2(workspace);
-  const dataRoot = codegraphDataRoot(options.homeDir ?? homedir5());
-  const dataDir = join6(dataRoot, "projects", workspaceStorageName(resolvedWorkspace));
-  const projectLink = join6(resolvedWorkspace, ".codegraph");
-  try {
-    mkdirSync(dataDir, { recursive: true });
-    if (existsSync5(projectLink)) {
-      const linkStat = lstatSync(projectLink);
-      if (!linkStat.isSymbolicLink()) {
-        return { dataDir: projectLink, dataRoot, linked: false, mode: "in-project", projectLink };
-      }
-      if (realpathSync(projectLink) === realpathSync(dataDir)) {
-        return { dataDir, dataRoot, linked: true, mode: "global-linked", projectLink };
-      }
-      return fallbackResult(dataRoot, projectLink, "existing .codegraph symlink points outside OMO store");
-    }
-    if (!isSameFilesystem(resolvedWorkspace, dataRoot, options.sameFilesystem)) {
-      ensureInPlaceFallback(projectLink);
-      return fallbackResult(dataRoot, projectLink, "workspace and OMO store are on different filesystems");
-    }
-    const symlink = options.symlink ?? symlinkSync;
-    symlink(dataDir, projectLink, (options.platform ?? process.platform) === "win32" ? "junction" : "dir");
-    return { dataDir, dataRoot, linked: true, mode: "global-linked", projectLink };
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    try {
-      ensureInPlaceFallback(projectLink);
-    } catch (fallbackError) {
-      return fallbackResult(dataRoot, projectLink, `${reason}; fallback failed: ${String(fallbackError)}`);
-    }
-    return fallbackResult(dataRoot, projectLink, reason);
-  }
-}
-function ensureCodegraphGitignored(workspace) {
-  const gitDir = join6(workspace, ".git");
-  if (!existsSync5(gitDir))
-    return false;
-  const excludePath = join6(gitDir, "info", "exclude");
-  try {
-    mkdirSync(join6(gitDir, "info"), { recursive: true });
-    const existing = existsSync5(excludePath) ? readFileSync2(excludePath, "utf8") : "";
-    if (existing.split(/\r?\n/).includes(".codegraph"))
-      return true;
-    appendFileSync(excludePath, `${existing.endsWith(`
-`) || existing.length === 0 ? "" : `
-`}.codegraph
-`);
-    return true;
-  } catch (error) {
-    if (error instanceof Error)
-      return false;
-    throw error;
-  }
-}
-
-// src/session-start-worker.ts
+// components/codegraph/src/session-start-worker.ts
 var SESSION_START_CWD_ENV = "OMO_CODEGRAPH_SESSION_START_CWD";
 var CODEGRAPH_VERSION = "1.0.1";
 var COMMAND_TIMEOUT_MS = 60000;
@@ -1900,7 +1996,7 @@ ${status.stderr ?? ""}`.toLowerCase();
   return { kind: "sync" };
 }
 function jsonSaysInitialized(value) {
-  if (!isRecord2(value))
+  if (!isRecord3(value))
     return;
   const initialized = value["initialized"] ?? value["isInitialized"] ?? value["ready"];
   if (typeof initialized === "boolean")
@@ -1966,7 +2062,7 @@ function toOutputText(value) {
   return Buffer.isBuffer(value) ? value.toString("utf8") : value;
 }
 function resolveHomeDir(env) {
-  return env["HOME"] ?? env["USERPROFILE"] ?? homedir6();
+  return env["HOME"] ?? env["USERPROFILE"] ?? homedir7();
 }
 function parseJson(text) {
   try {
@@ -1977,14 +2073,17 @@ function parseJson(text) {
     throw error;
   }
 }
-function isRecord2(value) {
+function isRecord3(value) {
   return typeof value === "object" && value !== null;
 }
 
-// src/hook.ts
+// components/codegraph/src/hook.ts
 var CODEGRAPH_SESSION_START_NOTICE = "LazyCodex CodeGraph bootstrap scheduled in background";
 async function runCodegraphSessionStartHook(options = {}) {
   return (await executeCodegraphSessionStartHook(options)).exitCode;
+}
+async function runCodegraphPostToolUseHookCli(options = {}) {
+  return (await executeCodegraphPostToolUseHook(options)).exitCode;
 }
 async function executeCodegraphSessionStartHook(options = {}) {
   const env = options.env ?? processEnv2;
@@ -2003,6 +2102,30 @@ async function executeCodegraphSessionStartHook(options = {}) {
   writeHookJson(options.stdout ?? processStdout);
   return { action: "spawned", exitCode: 0 };
 }
+async function executeCodegraphPostToolUseHook(options = {}) {
+  const env = options.env ?? processEnv2;
+  const input = await readHookInput(options.stdin ?? processStdin);
+  const output = runCodegraphPostToolUseHook(input, { homeDir: resolveHomeDir2(env) });
+  if (output.length === 0)
+    return { action: "skipped", exitCode: 0 };
+  (options.stdout ?? processStdout).write(output);
+  return { action: "emitted-guidance", exitCode: 0 };
+}
+function runCodegraphPostToolUseHook(input, options = {}) {
+  const toolName = isRecord4(input) ? input["tool_name"] : undefined;
+  const cwd = isRecord4(input) ? input["cwd"] : undefined;
+  const toolOutput = isRecord4(input) ? input["tool_response"] ?? input["tool_output"] ?? input["response"] : input;
+  const guidance = buildCodegraphInitGuidanceForToolResult({ cwd, toolName, toolOutput }, options);
+  if (guidance === null)
+    return "";
+  return `${JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: guidance
+    }
+  })}
+`;
+}
 function writeHookJson(stdout) {
   const output = {
     hookSpecificOutput: {
@@ -2018,10 +2141,10 @@ function spawnDetachedWorker(invocation) {
   child.unref();
 }
 function resolveHomeDir2(env) {
-  return env["HOME"] ?? env["USERPROFILE"] ?? homedir7();
+  return env["HOME"] ?? env["USERPROFILE"] ?? homedir8();
 }
 function resolveProjectRoot(input, fallback) {
-  if (!isRecord3(input))
+  if (!isRecord4(input))
     return fallback;
   const cwd = input["cwd"];
   return typeof cwd === "string" && cwd.trim().length > 0 ? cwd : fallback;
@@ -2045,17 +2168,17 @@ function parseJson2(text) {
     throw error;
   }
 }
-function isRecord3(value) {
+function isRecord4(value) {
   return typeof value === "object" && value !== null;
 }
 function defaultWorkerCliPath() {
   return fileURLToPath(import.meta.url);
 }
 
-// src/serve.ts
+// components/codegraph/src/serve.ts
 import { spawn as spawn2 } from "node:child_process";
 import { existsSync as existsSync7, realpathSync as realpathSync2 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
+import { homedir as homedir9 } from "node:os";
 import { basename as basename4, extname as extname2, join as join8, resolve as resolve3 } from "node:path";
 import {
   cwd as processCwd3,
@@ -2073,7 +2196,7 @@ var WINDOWS_CMD_EXTENSIONS2 = new Set([".bat", ".cmd"]);
 var WINDOWS_NODE_SCRIPT_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
 async function runCodegraphServe(options = {}) {
   const env = options.env ?? processEnv3;
-  const homeDir = options.homeDir ?? homedir8();
+  const homeDir = options.homeDir ?? homedir9();
   const config = options.config ?? getCodexOmoConfig({ cwd: options.cwd ?? processCwd3(), env, homeDir });
   const codegraphConfig = config.codegraph ?? {};
   if (codegraphConfig.enabled === false) {
@@ -2200,13 +2323,21 @@ function isDirectInvocation(argvPath) {
   return realpathSync2(resolve3(argvPath)) === realpathSync2(modulePath);
 }
 
-// src/cli.ts
+// components/codegraph/src/cli.ts
 async function runCodegraphCli(options = {}) {
   const argv = options.argv ?? process.argv;
   const command = argv[2];
   const subcommand = argv[3];
   if (command === "hook" && subcommand === "session-start") {
     return runCodegraphSessionStartHook(options);
+  }
+  if (command === "hook" && subcommand === "post-tool-use") {
+    const hookOptions = {
+      ...options.env === undefined ? {} : { env: options.env },
+      ...options.stdin === undefined ? {} : { stdin: options.stdin },
+      ...options.stdout === undefined ? {} : { stdout: options.stdout }
+    };
+    return runCodegraphPostToolUseHookCli(hookOptions);
   }
   if (command === "hook" && subcommand === "session-start-worker") {
     const workerOptions = {

--- a/packages/omo-codex/plugin/components/codegraph/src/cli.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/cli.ts
@@ -5,8 +5,10 @@ import { stderr as processStderr } from "node:process";
 import { fileURLToPath } from "node:url";
 
 import {
+	runCodegraphPostToolUseHookCli,
 	runCodegraphSessionStartHook,
 	runCodegraphSessionStartWorker,
+	type PostToolUseHookOptions,
 	type SessionStartHookOptions,
 	type SessionStartWorkerOptions,
 } from "./hook.js";
@@ -23,6 +25,15 @@ export async function runCodegraphCli(options: RunCodegraphCliOptions = {}): Pro
 
 	if (command === "hook" && subcommand === "session-start") {
 		return runCodegraphSessionStartHook(options);
+	}
+
+	if (command === "hook" && subcommand === "post-tool-use") {
+		const hookOptions: PostToolUseHookOptions = {
+			...(options.env === undefined ? {} : { env: options.env }),
+			...(options.stdin === undefined ? {} : { stdin: options.stdin }),
+			...(options.stdout === undefined ? {} : { stdout: options.stdout }),
+		};
+		return runCodegraphPostToolUseHookCli(hookOptions);
 	}
 
 	if (command === "hook" && subcommand === "session-start-worker") {

--- a/packages/omo-codex/plugin/components/codegraph/src/hook-types.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/hook-types.ts
@@ -10,6 +10,7 @@ import type { CodegraphWorkspacePreparation as SharedCodegraphWorkspacePreparati
 import type { CodegraphConfig as SharedCodegraphConfig } from "../../../../../utils/src/omo-config.ts";
 
 export type SessionStartAction = "skipped-disabled" | "spawned";
+export type PostToolUseAction = "emitted-guidance" | "skipped";
 export type WorkerAction = "failed" | "initialized" | "skipped-disabled" | "skipped-status" | "skipped-unavailable" | "skipped-unsupported-node" | "synced";
 
 export interface WorkerSpawnInvocation {
@@ -24,6 +25,11 @@ export interface HookStdout {
 
 export interface SessionStartHookResult {
 	readonly action: SessionStartAction;
+	readonly exitCode: 0;
+}
+
+export interface PostToolUseHookResult {
+	readonly action: PostToolUseAction;
 	readonly exitCode: 0;
 }
 
@@ -71,6 +77,12 @@ export interface SessionStartHookOptions {
 	readonly stdin?: Readable & { readonly isTTY?: boolean };
 	readonly stdout?: HookStdout;
 	readonly workerCliPath?: string;
+}
+
+export interface PostToolUseHookOptions {
+	readonly env?: Record<string, string | undefined>;
+	readonly stdin?: Readable & { readonly isTTY?: boolean };
+	readonly stdout?: HookStdout;
 }
 
 export interface SessionStartWorkerOptions {

--- a/packages/omo-codex/plugin/components/codegraph/src/hook.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/hook.ts
@@ -4,10 +4,13 @@ import { cwd as processCwd, env as processEnv, stdin as processStdin, stdout as 
 import type { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
+import { buildCodegraphInitGuidanceForToolResult } from "../../../../../utils/src/codegraph/guidance.ts";
 import { getCodexOmoConfig } from "../../../shared/src/config-loader.ts";
 import { SESSION_START_CWD_ENV } from "./session-start-worker.js";
 import type {
 	HookStdout,
+	PostToolUseHookOptions,
+	PostToolUseHookResult,
 	SessionStartHookOptions,
 	SessionStartHookResult,
 	WorkerSpawnInvocation,
@@ -23,6 +26,8 @@ export type {
 	CodexOmoConfig,
 	HookStdout,
 	OmoConfigSource,
+	PostToolUseHookOptions,
+	PostToolUseHookResult,
 	SessionStartAction,
 	SessionStartHookOptions,
 	SessionStartHookResult,
@@ -36,6 +41,10 @@ export const CODEGRAPH_SESSION_START_NOTICE = "LazyCodex CodeGraph bootstrap sch
 
 export async function runCodegraphSessionStartHook(options: SessionStartHookOptions = {}): Promise<number> {
 	return (await executeCodegraphSessionStartHook(options)).exitCode;
+}
+
+export async function runCodegraphPostToolUseHookCli(options: PostToolUseHookOptions = {}): Promise<number> {
+	return (await executeCodegraphPostToolUseHook(options)).exitCode;
 }
 
 export async function executeCodegraphSessionStartHook(options: SessionStartHookOptions = {}): Promise<SessionStartHookResult> {
@@ -56,6 +65,31 @@ export async function executeCodegraphSessionStartHook(options: SessionStartHook
 	});
 	writeHookJson(options.stdout ?? processStdout);
 	return { action: "spawned", exitCode: 0 };
+}
+
+export async function executeCodegraphPostToolUseHook(options: PostToolUseHookOptions = {}): Promise<PostToolUseHookResult> {
+	const env = options.env ?? processEnv;
+	const input = await readHookInput(options.stdin ?? processStdin);
+	const output = runCodegraphPostToolUseHook(input, { homeDir: resolveHomeDir(env) });
+	if (output.length === 0) return { action: "skipped", exitCode: 0 };
+
+	(options.stdout ?? processStdout).write(output);
+	return { action: "emitted-guidance", exitCode: 0 };
+}
+
+export function runCodegraphPostToolUseHook(input: unknown, options: { readonly homeDir?: string } = {}): string {
+	const toolName = isRecord(input) ? input["tool_name"] : undefined;
+	const cwd = isRecord(input) ? input["cwd"] : undefined;
+	const toolOutput = isRecord(input) ? (input["tool_response"] ?? input["tool_output"] ?? input["response"]) : input;
+	const guidance = buildCodegraphInitGuidanceForToolResult({ cwd, toolName, toolOutput }, options);
+	if (guidance === null) return "";
+
+	return `${JSON.stringify({
+		hookSpecificOutput: {
+			hookEventName: "PostToolUse",
+			additionalContext: guidance,
+		},
+	})}\n`;
 }
 
 function writeHookJson(stdout: HookStdout): void {

--- a/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
@@ -9,6 +9,7 @@ import { runCodegraphCli } from "../src/cli.ts";
 import {
 	executeCodegraphSessionStartHook,
 	resolveCodegraphCommandInvocation,
+	runCodegraphPostToolUseHook,
 	runCodegraphSessionStartWorker,
 	type WorkerSpawnInvocation,
 } from "../src/hook.ts";
@@ -46,6 +47,54 @@ describe("CodeGraph SessionStart hook", () => {
 		} finally {
 			rmSync(homeDir, { recursive: true, force: true });
 		}
+	});
+
+	it("#given CodeGraph MCP reports an uninitialized project #when PostToolUse fires #then it emits OMO global-store init guidance", async () => {
+		// given
+		const output = runCodegraphPostToolUseHook(
+			{
+				cwd: "/Users/me/project",
+				tool_name: "codegraph.codegraph_status",
+				tool_response: {
+					error: [
+						"Tool execution failed: CodeGraph not initialized in /Users/me/project.",
+						"Run 'codegraph init' in that project first.",
+					].join(" "),
+				},
+			},
+			{ homeDir: "/Users/me" },
+		);
+
+		// when
+		const parsed = JSON.parse(output);
+
+		// then
+		expect(parsed).toEqual({
+			hookSpecificOutput: {
+				hookEventName: "PostToolUse",
+				additionalContext: expect.stringContaining('"/Users/me/.omo/codegraph/projects/project-'),
+			},
+		});
+		expect(parsed.hookSpecificOutput.additionalContext).toContain('run `codegraph init` from "/Users/me/project"');
+	});
+
+	it("#given real CodeGraph status output has no MCP path phrase #when PostToolUse fires #then it emits OMO global-store init guidance", async () => {
+		// given
+		const output = runCodegraphPostToolUseHook(
+			{
+				cwd: "/Users/me/project",
+				tool_name: "mcp__codegraph__codegraph_status",
+				tool_response: ['Project: /Users/me/project', "Not initialized", 'Run "codegraph init" to initialize'].join("\n"),
+			},
+			{ homeDir: "/Users/me" },
+		);
+
+		// when
+		const parsed = JSON.parse(output);
+
+		// then
+		expect(parsed.hookSpecificOutput.additionalContext).toContain('CodeGraph is not initialized for "/Users/me/project"');
+		expect(parsed.hookSpecificOutput.additionalContext).toContain('"/Users/me/.omo/codegraph/projects/project-');
 	});
 
 	it("#given CodeGraph is disabled by Codex SOT config #when SessionStart fires #then it skips without spawning", async () => {

--- a/packages/omo-codex/plugin/hooks/post-tool-use-checking-codegraph-init-guidance.json
+++ b/packages/omo-codex/plugin/hooks/post-tool-use-checking-codegraph-init-guidance.json
@@ -1,0 +1,17 @@
+{
+	"hooks": {
+		"PostToolUse": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"${PLUGIN_ROOT}/components/codegraph/dist/cli.js\" hook post-tool-use",
+						"timeout": 5,
+						"statusMessage": "(OmO) Checking CodeGraph Init Guidance"
+					}
+				],
+				"matcher": "^(codegraph[._].*|mcp__codegraph__.*)$"
+			}
+		]
+	}
+}

--- a/packages/omo-codex/plugin/hooks/session-start-checking-codegraph-bootstrap.json
+++ b/packages/omo-codex/plugin/hooks/session-start-checking-codegraph-bootstrap.json
@@ -7,7 +7,7 @@
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/codegraph/dist/cli.js\" hook session-start",
 						"timeout": 5,
-						"statusMessage": "(OmO) Checking Codegraph Bootstrap"
+						"statusMessage": "(OmO) Checking CodeGraph Bootstrap"
 					}
 				]
 			}

--- a/packages/omo-codex/plugin/scripts/hook-status-message.mjs
+++ b/packages/omo-codex/plugin/scripts/hook-status-message.mjs
@@ -1,6 +1,7 @@
 const PRODUCT_PREFIX = "(OmO)";
 
 const WORD_OVERRIDES = new Map([
+	["codegraph", "CodeGraph"],
 	["lazycodex", "LazyCodex"],
 	["lsp", "LSP"],
 	["mcp", "MCP"],

--- a/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
@@ -30,6 +30,7 @@ test("#given isolated components #when hooks are inspected #then commands stay i
 	const componentMarkers = [
 		"components/comment-checker/dist/cli.js",
 		"components/lsp/dist/cli.js",
+		"components/codegraph/dist/cli.js",
 		"components/rules/dist/cli.js",
 		"components/start-work-continuation/dist/cli.js",
 		"components/telemetry/dist/cli.js",
@@ -177,6 +178,23 @@ test("#given aggregate SessionStart hooks #when inspected #then LazyCodex auto-u
 	assert.match(text, /scripts\/auto-update\.mjs/);
 	assert.match(text, /Checking Auto Update/);
 	assert(sessionStartCommands.some((command) => command.includes("scripts/auto-update.mjs")));
+});
+
+test("#given aggregate PostToolUse hooks #when inspected #then CodeGraph init guidance is registered for CodeGraph tools", async () => {
+	// given
+	const commandHooks = await readAggregateCommandHooks();
+
+	// when
+	const codegraphPostToolUseHooks = commandHooks.filter(
+		(hook) =>
+			hook.eventName === "PostToolUse" &&
+			hook.handler.command === 'node "${PLUGIN_ROOT}/components/codegraph/dist/cli.js" hook post-tool-use',
+	);
+
+	// then
+	assert.equal(codegraphPostToolUseHooks.length, 1);
+	assert.equal(codegraphPostToolUseHooks[0]?.matcher, "^(codegraph[._].*|mcp__codegraph__.*)$");
+	assert.equal(codegraphPostToolUseHooks[0]?.handler.statusMessage, "(OmO) Checking CodeGraph Init Guidance");
 });
 
 test("#given aggregate plugin packaging #when inspected #then hooks and compatibility sentinels stay Python-free", async () => {

--- a/packages/omo-codex/plugin/test/aggregate-manifest.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-manifest.test.mjs
@@ -17,7 +17,7 @@ test("#given aggregate plugin manifest #when inspected #then it owns the omo nam
 	// then
 	assert.equal(manifest.name, "omo");
 	assert(Array.isArray(hookPaths));
-	assert.equal(hookPaths.length, 19);
+	assert.equal(hookPaths.length, 20);
 	assert(hookPaths.every((hookPath) => typeof hookPath === "string" && hookPath.startsWith("./hooks/")));
 	assert(!hookPaths.includes("./hooks/hooks.json"));
 	assert.equal(skillsPath, "./skills/");

--- a/packages/omo-codex/plugin/test/aggregate-plugin-fixture.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-plugin-fixture.mjs
@@ -68,7 +68,7 @@ export function collectCommandHooks(hooks, source) {
 			}
 			group.hooks.forEach((handler, handlerIndex) => {
 				if (typeof handler !== "object" || handler === null || handler.type !== "command") return;
-				commandHooks.push({ source, eventName, groupIndex, handlerIndex, handler });
+				commandHooks.push({ source, eventName, groupIndex, handlerIndex, matcher: group.matcher, handler });
 			});
 		});
 	}

--- a/packages/omo-codex/plugin/test/hook-status-message.test.mjs
+++ b/packages/omo-codex/plugin/test/hook-status-message.test.mjs
@@ -25,6 +25,7 @@ const AGGREGATE_EXPECTED_LABELS = new Map([
 	["hooks/hooks.json:PreToolUse:1:0", "Enforcing Unlimited Goal Budget"],
 	["hooks/hooks.json:PostToolUse:0:0", "Checking Comments"],
 	["hooks/hooks.json:PostToolUse:0:1", "Checking LSP Diagnostics"],
+	["hooks/hooks.json:PostToolUse:0:2", "Checking CodeGraph Init Guidance"],
 	["hooks/hooks.json:PostToolUse:1:0", "Matching Project Rules"],
 	["hooks/hooks.json:PostCompact:0:0", "Resetting Git Bash MCP Reminder"],
 	["hooks/hooks.json:PostCompact:1:0", "Resetting Project Rule Cache"],

--- a/packages/omo-opencode/src/plugin/tool-execute-after.test.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-after.test.ts
@@ -195,9 +195,10 @@ describe("createToolExecuteAfterHandler", () => {
     )
 
     // then
-    expect(output.output).toContain('CodeGraph is not initialized for "/Users/me/project"')
-    expect(output.output).toContain(".omo/codegraph/projects/project-")
-    expect(output.output).toContain('run `codegraph init` from "/Users/me/project"')
+    const normalizedOutput = normalizeDisplayPaths(output.output)
+    expect(normalizedOutput).toContain('CodeGraph is not initialized for "/Users/me/project"')
+    expect(normalizedOutput).toContain(".omo/codegraph/projects/project-")
+    expect(normalizedOutput).toContain('run `codegraph init` from "/Users/me/project"')
   })
 
   it("#given non-CodeGraph tool output contains a CodeGraph phrase #when tool.execute.after runs #then guidance is not appended", async () => {
@@ -247,7 +248,12 @@ describe("createToolExecuteAfterHandler", () => {
     )
 
     // then
-    expect(output.output).toContain('CodeGraph is not initialized for "/Users/me/project"')
-    expect(output.output).toContain(".omo/codegraph/projects/project-")
+    const normalizedOutput = normalizeDisplayPaths(output.output)
+    expect(normalizedOutput).toContain('CodeGraph is not initialized for "/Users/me/project"')
+    expect(normalizedOutput).toContain(".omo/codegraph/projects/project-")
   })
 })
+
+function normalizeDisplayPaths(value: string): string {
+  return value.replaceAll("\\\\", "/").replaceAll("\\", "/")
+}

--- a/packages/omo-opencode/src/plugin/tool-execute-after.test.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-after.test.ts
@@ -172,4 +172,82 @@ describe("createToolExecuteAfterHandler", () => {
     // then
     expect(seenArgs).toBe(args)
   })
+
+  it("#given CodeGraph MCP reports an uninitialized project #when tool.execute.after runs #then output includes OMO global-store init guidance", async () => {
+    // given
+    const handler = createToolExecuteAfterHandler({
+      ctx: { directory: "/repo" } as never,
+      hooks: {} as never,
+    })
+    const output = {
+      title: "Error",
+      output: [
+        "Tool execution failed: CodeGraph not initialized in /Users/me/project.",
+        "Run 'codegraph init' in that project first.",
+      ].join(" "),
+      metadata: {},
+    }
+
+    // when
+    await handler(
+      { tool: "codegraph.codegraph_status", sessionID: "ses_parent", callID: "call_codegraph" },
+      output,
+    )
+
+    // then
+    expect(output.output).toContain('CodeGraph is not initialized for "/Users/me/project"')
+    expect(output.output).toContain(".omo/codegraph/projects/project-")
+    expect(output.output).toContain('run `codegraph init` from "/Users/me/project"')
+  })
+
+  it("#given non-CodeGraph tool output contains a CodeGraph phrase #when tool.execute.after runs #then guidance is not appended", async () => {
+    // given
+    const handler = createToolExecuteAfterHandler({
+      ctx: { directory: "/repo" } as never,
+      hooks: {} as never,
+    })
+    const output = {
+      title: "Result",
+      output: [
+        "Tool execution failed: CodeGraph not initialized in /tmp/fake.",
+        "Run 'codegraph init' in that project first.",
+      ].join(" "),
+      metadata: {},
+    }
+
+    // when
+    await handler(
+      { tool: "bash", sessionID: "ses_parent", callID: "call_bash" },
+      output,
+    )
+
+    // then
+    expect(output.output).not.toContain("OMO CodeGraph initialization guidance")
+  })
+
+  it("#given real CodeGraph status output #when tool.execute.after runs #then output includes OMO global-store init guidance", async () => {
+    // given
+    const handler = createToolExecuteAfterHandler({
+      ctx: { directory: "/Users/me/project" } as never,
+      hooks: {} as never,
+    })
+    const output = {
+      title: "Status",
+      output: [
+        "Not initialized",
+        'Run "codegraph init" to initialize',
+      ].join("\n"),
+      metadata: {},
+    }
+
+    // when
+    await handler(
+      { tool: "mcp__codegraph__codegraph_status", sessionID: "ses_parent", callID: "call_codegraph" },
+      output,
+    )
+
+    // then
+    expect(output.output).toContain('CodeGraph is not initialized for "/Users/me/project"')
+    expect(output.output).toContain(".omo/codegraph/projects/project-")
+  })
 })

--- a/packages/omo-opencode/src/plugin/tool-execute-after.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-after.ts
@@ -1,4 +1,5 @@
 import { recoverToolMetadata } from "../features/tool-metadata-store"
+import { buildCodegraphInitGuidanceForToolResult } from "@oh-my-opencode/utils"
 import type { CreatedHooks } from "../create-hooks"
 import { log as defaultLog } from "../shared/logger"
 import { stripInvisibleAgentCharacters } from "../shared/agent-display-names"
@@ -50,6 +51,20 @@ function expectsRecoverableMetadata(tool: string): boolean {
   return METADATA_LINKED_TOOLS.has(tool)
 }
 
+function appendCodegraphInitGuidance(
+  input: ToolExecuteAfterInput,
+  output: ToolExecuteAfterOutput,
+  cwd: string | null,
+): void {
+  const guidance = buildCodegraphInitGuidanceForToolResult({
+    cwd: cwd ?? undefined,
+    toolName: input.tool,
+    toolOutput: output.output,
+  })
+  if (guidance === null || output.output.includes(guidance)) return
+  output.output = `${output.output}\n\n${guidance}`
+}
+
 export function createToolExecuteAfterHandler(args: {
   ctx: PluginContext
   hooks: CreatedHooks
@@ -69,6 +84,8 @@ export function createToolExecuteAfterHandler(args: {
     output: ToolExecuteAfterOutput | undefined,
   ): Promise<void> => {
     if (!output) return
+
+    appendCodegraphInitGuidance(input, output, getPluginDirectory(ctx))
 
     const hookInput = {
       tool: input.tool,

--- a/packages/utils/src/codegraph-guidance.test.ts
+++ b/packages/utils/src/codegraph-guidance.test.ts
@@ -93,7 +93,7 @@ describe("CodeGraph initialization guidance", () => {
 
   test("#given an uninitialized project #when guidance is built #then it points to the OMO global store", () => {
     // when
-    const guidance = buildCodegraphInitGuidance("/Users/me/project", { homeDir: "/Users/me" })
+    const guidance = normalizeDisplayPaths(buildCodegraphInitGuidance("/Users/me/project", { homeDir: "/Users/me" }))
 
     // then
     expect(guidance).toContain('CodeGraph is not initialized for "/Users/me/project"')
@@ -112,3 +112,7 @@ describe("CodeGraph initialization guidance", () => {
     expect(guidance).not.toContain("project`\nINJECT")
   })
 })
+
+function normalizeDisplayPaths(value: string): string {
+  return value.replaceAll("\\\\", "/").replaceAll("\\", "/")
+}

--- a/packages/utils/src/codegraph-guidance.test.ts
+++ b/packages/utils/src/codegraph-guidance.test.ts
@@ -97,7 +97,7 @@ describe("CodeGraph initialization guidance", () => {
 
     // then
     expect(guidance).toContain('CodeGraph is not initialized for "/Users/me/project"')
-    expect(guidance).toContain('"/Users/me/project/.codegraph"')
+    expect(guidance).toContain('/Users/me/project/.codegraph"')
     expect(guidance).toContain('"/Users/me/.omo/codegraph/projects/project-')
     expect(guidance).toContain('run `codegraph init` from "/Users/me/project"')
     expect(guidance).not.toContain("Run 'codegraph init' in that project first.")

--- a/packages/utils/src/codegraph-guidance.test.ts
+++ b/packages/utils/src/codegraph-guidance.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test"
+
+import { buildCodegraphInitGuidance, getCodegraphUninitializedProject } from "./codegraph/guidance"
+
+describe("CodeGraph initialization guidance", () => {
+  test("#given CodeGraph MCP reports an uninitialized project #when parsed #then the project path is extracted", () => {
+    // given
+    const output = [
+      "Tool execution failed: CodeGraph not initialized in /Users/me/project.",
+      "Run 'codegraph init' in that project first.",
+    ].join(" ")
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      toolName: "codegraph.codegraph_status",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBe("/Users/me/project")
+  })
+
+  test("#given non-CodeGraph output mentions initialization #when parsed #then no guidance is emitted", () => {
+    // given
+    const output = [
+      "Tool execution failed: CodeGraph not initialized in /Users/me/project.",
+      "Run 'codegraph init' in that project first.",
+    ].join(" ")
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      toolName: "bash",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBeNull()
+  })
+
+  test("#given real CodeGraph status output reports not initialized #when parsed #then the project path is extracted", () => {
+    // given
+    const output = [
+      "Project: /Users/me/project",
+      "Not initialized",
+      'Run "codegraph init" to initialize',
+    ].join("\n")
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      toolName: "mcp__codegraph__codegraph_status",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBe("/Users/me/project")
+  })
+
+  test("#given decorated CodeGraph status output reports not initialized #when parsed #then the project path is extracted", () => {
+    // given
+    const output = [
+      "\u001b[36m* Project:\u001b[0m /Users/me/project",
+      "\u001b[31m! Not initialized\u001b[0m",
+      '\u001b[2mRun "codegraph init" to initialize\u001b[0m',
+    ].join("\n")
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      toolName: "mcp__codegraph__codegraph_status",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBe("/Users/me/project")
+  })
+
+  test("#given CodeGraph output omits a project path #when cwd is provided #then cwd is used as fallback", () => {
+    // given
+    const output = [
+      "Not initialized",
+      'Run "codegraph init" to initialize',
+    ].join("\n")
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      cwd: "/Users/me/project",
+      toolName: "codegraph.codegraph_status",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBe("/Users/me/project")
+  })
+
+  test("#given an uninitialized project #when guidance is built #then it points to the OMO global store", () => {
+    // when
+    const guidance = buildCodegraphInitGuidance("/Users/me/project", { homeDir: "/Users/me" })
+
+    // then
+    expect(guidance).toContain('CodeGraph is not initialized for "/Users/me/project"')
+    expect(guidance).toContain('"/Users/me/project/.codegraph"')
+    expect(guidance).toContain('"/Users/me/.omo/codegraph/projects/project-')
+    expect(guidance).toContain('run `codegraph init` from "/Users/me/project"')
+    expect(guidance).not.toContain("Run 'codegraph init' in that project first.")
+  })
+
+  test("#given project path contains markdown control characters #when guidance is built #then the path is JSON escaped", () => {
+    // when
+    const guidance = buildCodegraphInitGuidance("/Users/me/project`\nINJECT", { homeDir: "/Users/me" })
+
+    // then
+    expect(guidance).toContain('"/Users/me/project`\\nINJECT"')
+    expect(guidance).not.toContain("project`\nINJECT")
+  })
+})

--- a/packages/utils/src/codegraph/guidance.ts
+++ b/packages/utils/src/codegraph/guidance.ts
@@ -1,0 +1,111 @@
+import { homedir } from "node:os"
+
+import { resolveCodegraphWorkspacePaths } from "./workspace"
+
+const CODEGRAPH_UNINITIALIZED_PATTERN =
+  /CodeGraph not initialized in ([\s\S]*?)\.\s*Run ['`]codegraph init['`] in that project first\./i
+const ANSI_ESCAPE_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g
+const CODEGRAPH_STATUS_PROJECT_PATTERN = /^.*?\bProject:\s*(.+?)\s*$/im
+const CODEGRAPH_STATUS_UNINITIALIZED_PATTERN =
+  /^.*?\bNot initialized\s*$/im
+const CODEGRAPH_INIT_HINT_PATTERN =
+  /Run\s+["'`]codegraph init["'`]\s+(?:in that project first|to initialize)\.?/i
+
+export interface CodegraphInitGuidanceInput {
+  readonly cwd?: unknown
+  readonly toolName?: unknown
+  readonly toolOutput: unknown
+}
+
+export interface CodegraphInitGuidanceOptions {
+  readonly homeDir?: string
+}
+
+export function getCodegraphUninitializedProject(input: CodegraphInitGuidanceInput): string | null {
+  const output = textFromUnknown(input.toolOutput)
+  if (!isCodegraphTool(input.toolName)) return null
+
+  const projectPath = extractProjectPath(output)
+  if (projectPath !== null) return projectPath
+  if (!looksLikeCodegraphUninitializedOutput(output)) return null
+  return typeof input.cwd === "string" && input.cwd.trim().length > 0 ? input.cwd.trim() : null
+}
+
+export function buildCodegraphInitGuidance(
+  projectPath: string,
+  options: CodegraphInitGuidanceOptions = {},
+): string {
+  const { dataDir, dataRoot, projectLink } = resolveCodegraphWorkspacePaths(projectPath, {
+    homeDir: options.homeDir ?? homedir(),
+  })
+  const displayProjectPath = formatDisplayPath(projectPath)
+  const displayProjectLink = formatDisplayPath(projectLink)
+  const displayDataDir = formatDisplayPath(dataDir)
+  const displayDataRoot = formatDisplayPath(dataRoot)
+  return [
+    "OMO CodeGraph initialization guidance:",
+    "",
+    `CodeGraph is not initialized for ${displayProjectPath}. Initialize it through OMO's global local store instead of leaving a standalone project-local index.`,
+    "",
+    `- Link or create ${displayProjectLink} so it points at ${displayDataDir} under the OMO store ${displayDataRoot}.`,
+    `- Then run \`codegraph init\` from ${displayProjectPath} and retry the CodeGraph tool.`,
+    "- OMO's CodeGraph bootstrap does this automatically on session start; if bootstrap just ran, wait for it to finish and retry.",
+  ].join("\n")
+}
+
+export function buildCodegraphInitGuidanceForToolResult(
+  input: CodegraphInitGuidanceInput,
+  options: CodegraphInitGuidanceOptions = {},
+): string | null {
+  const projectPath = getCodegraphUninitializedProject(input)
+  return projectPath === null ? null : buildCodegraphInitGuidance(projectPath, options)
+}
+
+function extractProjectPath(output: string): string | null {
+  const normalizedOutput = normalizeCodegraphOutput(output)
+  const uninitializedMatch = normalizedOutput.match(CODEGRAPH_UNINITIALIZED_PATTERN)
+  const uninitializedProject = uninitializedMatch?.[1]?.trim()
+  if (uninitializedProject && uninitializedProject.length > 0) return uninitializedProject
+
+  if (!looksLikeCodegraphUninitializedOutput(normalizedOutput)) return null
+  const statusMatch = normalizedOutput.match(CODEGRAPH_STATUS_PROJECT_PATTERN)
+  const statusProject = statusMatch?.[1]?.trim()
+  return statusProject && statusProject.length > 0 ? statusProject : null
+}
+
+function looksLikeCodegraphUninitializedOutput(output: string): boolean {
+  const normalizedOutput = normalizeCodegraphOutput(output)
+  if (normalizedOutput.match(CODEGRAPH_UNINITIALIZED_PATTERN) !== null) return true
+  return CODEGRAPH_STATUS_UNINITIALIZED_PATTERN.test(normalizedOutput) && CODEGRAPH_INIT_HINT_PATTERN.test(normalizedOutput)
+}
+
+function normalizeCodegraphOutput(output: string): string {
+  return output.replace(ANSI_ESCAPE_PATTERN, "")
+}
+
+function isCodegraphTool(toolName: unknown): boolean {
+  if (typeof toolName !== "string") return false
+  return toolName.startsWith("codegraph.")
+    || toolName.startsWith("codegraph_")
+    || toolName.startsWith("mcp__codegraph__")
+}
+
+function formatDisplayPath(value: string): string {
+  return JSON.stringify(value)
+}
+
+function textFromUnknown(value: unknown): string {
+  if (typeof value === "string") return value
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") return String(value)
+  if (Array.isArray(value)) return value.map(textFromUnknown).filter(Boolean).join("\n")
+  if (!isRecord(value)) return ""
+
+  return Object.entries(value)
+    .map(([key, nested]) => `${key}: ${textFromUnknown(nested)}`)
+    .filter((line) => line.trim().length > 0)
+    .join("\n")
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/utils/src/codegraph/index.ts
+++ b/packages/utils/src/codegraph/index.ts
@@ -1,4 +1,5 @@
 export * from "./env"
+export * from "./guidance"
 export * from "./node-support"
 export * from "./provision"
 export * from "./resolve"

--- a/packages/utils/src/codegraph/workspace.ts
+++ b/packages/utils/src/codegraph/workspace.ts
@@ -25,6 +25,12 @@ export interface CodegraphWorkspacePreparation {
   readonly reason?: string
 }
 
+export interface CodegraphWorkspacePaths {
+  readonly dataDir: string
+  readonly dataRoot: string
+  readonly projectLink: string
+}
+
 export interface PrepareCodegraphWorkspaceOptions {
   readonly homeDir?: string
   readonly platform?: NodeJS.Platform
@@ -55,7 +61,7 @@ export function sanitizeBase(value: string): string {
   return sanitized.length > 0 ? sanitized : "workspace"
 }
 
-function codegraphDataRoot(homeDir: string): string {
+export function codegraphDataRoot(homeDir: string): string {
   return join(homeDir, ".omo", "codegraph")
 }
 
@@ -63,6 +69,19 @@ function workspaceStorageName(workspace: string): string {
   const resolved = resolve(workspace)
   const hash = createHash("sha256").update(resolved).digest("hex").slice(0, 16)
   return `${sanitizeBase(basename(resolved))}-${hash}`
+}
+
+export function resolveCodegraphWorkspacePaths(
+  workspace: string,
+  options: { readonly homeDir?: string } = {},
+): CodegraphWorkspacePaths {
+  const resolvedWorkspace = resolve(workspace)
+  const dataRoot = codegraphDataRoot(options.homeDir ?? homedir())
+  return {
+    dataDir: join(dataRoot, "projects", workspaceStorageName(resolvedWorkspace)),
+    dataRoot,
+    projectLink: join(resolvedWorkspace, ".codegraph"),
+  }
 }
 
 function fallbackResult(
@@ -87,9 +106,7 @@ export function prepareCodegraphWorkspace(
   options: PrepareCodegraphWorkspaceOptions = {},
 ): CodegraphWorkspacePreparation {
   const resolvedWorkspace = resolve(workspace)
-  const dataRoot = codegraphDataRoot(options.homeDir ?? homedir())
-  const dataDir = join(dataRoot, "projects", workspaceStorageName(resolvedWorkspace))
-  const projectLink = join(resolvedWorkspace, ".codegraph")
+  const { dataDir, dataRoot, projectLink } = resolveCodegraphWorkspacePaths(resolvedWorkspace, options)
 
   try {
     mkdirSync(dataDir, { recursive: true })


### PR DESCRIPTION
## Summary
This PR intercepts CodeGraph uninitialized-tool output and replaces the bare `codegraph init` hint with OMO-specific guidance. The guidance points users at the existing global local store pattern under `~/.omo/codegraph/projects/<workspace>-<hash>` while still telling them to run `codegraph init` from the project and retry.

## Changes
- Adds shared CodeGraph uninitialized-output parsing and guidance helpers in `packages/utils`.
- Handles both synthetic MCP failures and real `codegraph status` output, including ANSI/icon-prefixed status lines.
- Appends the guidance from OpenCode `tool.execute.after` for CodeGraph tools only.
- Adds a Codex `PostToolUse` CodeGraph hook and registers it in the plugin aggregate manifest.
- Updates Codex hook status copy to consistently use `CodeGraph`.

## Verification
**Automated**
- `bun test packages/utils/src/codegraph-guidance.test.ts`
- `bun test packages/omo-opencode/src/plugin/tool-execute-after.test.ts`
- `cd packages/omo-codex/plugin/components/codegraph && bun run build && bun run test`
- `bun run --cwd packages/utils typecheck`
- `bun run --cwd packages/omo-opencode typecheck`
- `bun run typecheck`
- `bun run test:codex` — latest evidence: `.omo/evidence/20260620-codegraph-init-guidance/test-codex-after-ansi-fix.txt`, 354 pass / 0 fail
- `git diff --check`

**Manual / harness QA evidence**
- Codex direct PostToolUse real-status guidance: `.omo/evidence/20260620-codegraph-init-guidance/codex-codegraph-post-tool-use-real-status-guidance.json`
- Codex non-CodeGraph suppression receipt: `.omo/evidence/20260620-codegraph-init-guidance/codex-codegraph-post-tool-use-non-codegraph-suppressed-receipt.txt`
- Isolated Codex app-server plugin load: `.omo/evidence/20260620-codegraph-init-guidance/codex-app-server-plugin.json`
- Codex QA isolation self-check: `.omo/evidence/20260620-codegraph-init-guidance/codex-common-self-check.txt`
- OpenCode QA harness self-check: `.omo/evidence/20260620-codegraph-init-guidance/opencode-common-self-check.txt`
- OpenCode isolated SSE self-test: `.omo/evidence/20260620-codegraph-init-guidance/opencode-sse-self-test.txt`
- OpenCode DB isolation receipt: `.omo/evidence/20260620-codegraph-init-guidance/opencode-isolated-db-count.txt`
- ANSI/icon-prefix reviewer regression fix: `.omo/evidence/20260620-codegraph-init-guidance/reviewer-ansi-prefix-fix-tests.txt`

## Review
- Code review: PASS after ANSI/icon-prefix parser fix.
- Gate review: APPROVE.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes uninitialized CodeGraph tool output to OMO’s global store and adds clear init instructions. Guidance is emitted via a Codex `PostToolUse` hook and appended by OpenCode’s `tool.execute.after`, with robust parsing and cross‑platform‑safe paths.

- **New Features**
  - Added guidance utilities in `@oh-my-opencode/utils` to detect uninitialized CodeGraph output (including ANSI‑stripped real `codegraph status`) and build project-specific instructions.
  - Introduced a Codex `PostToolUse` hook and CLI entry (`hook post-tool-use`) that emits guidance for CodeGraph tools; registered with a matcher for CodeGraph tool names and outputs JSON `additionalContext`.
  - Updated OpenCode `tool.execute.after` to append guidance only for CodeGraph tools and avoid duplicates, pointing to `~/.omo/codegraph/projects/<workspace>-<hash>` and advising to run `codegraph init`.
  - Exported `resolveCodegraphWorkspacePaths` and `codegraphDataRoot` to compute `dataDir`, `dataRoot`, and `.codegraph` link paths.

- **Bug Fixes**
  - Improved parsing of ANSI/icon‑prefixed status lines and standardized “CodeGraph” capitalization in hook status messages.
  - Escaped guidance paths, normalized path separators in tests, and allowed Windows drive prefixes for cross‑platform reliability.

<sup>Written for commit dc167b3b76ade6ba24e7674658a805243ee81852. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

