### PR TITLE
fix(skills-loader): infer resolvedPath for builtin skills so Base directory shows actual skill path

### DIFF
--- a/packages/skills-loader-core/src/features/builtin-skills/skill-file-loader.test.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skill-file-loader.test.ts
@@ -7,7 +7,6 @@ import { parseFrontmatter } from "@oh-my-opencode/utils"
 import { createBuiltinSkills } from "./skills"
 import {
   createSharedSkillTemplateLoader,
-  getBuiltinSkillSourceDir,
   getSharedSkillSourceDir,
   loadSharedSkillTemplate,
 } from "./skill-file-loader"
@@ -75,18 +74,15 @@ describe("shared builtin skill file loader", () => {
     expect(loader("layout")).toBe("Layout body")
   })
 
-  test("#given builtin skills with reference files #when source dirs are resolved #then relative references have a stable base", () => {
+  test("#given shared skill with reference files #when source dir is resolved #then relative references have a stable base", () => {
     // given
     const sharedSourceDir = getSharedSkillSourceDir("debugging")
-    const builtinSourceDir = getBuiltinSkillSourceDir("dev-browser")
 
     // when
     const debuggingReferencePath = join(sharedSourceDir, "references", "runtimes", "node.md")
-    const devBrowserReferencePath = join(builtinSourceDir, "references", "installation.md")
 
     // then
     expect(existsSync(debuggingReferencePath)).toBe(true)
-    expect(existsSync(devBrowserReferencePath)).toBe(true)
   })
 
   test("#given a missing shared skill file #when loading the template #then the loader fails fast", () => {

--- a/packages/skills-loader-core/src/features/builtin-skills/skill-file-loader.test.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skill-file-loader.test.ts
@@ -1,16 +1,22 @@
 /// <reference path="../../../../../bun-test.d.ts" />
 
 import { describe, expect, test } from "bun:test"
-import { normalize } from "node:path"
+import { existsSync } from "node:fs"
+import { join, normalize } from "node:path"
 import { parseFrontmatter } from "@oh-my-opencode/utils"
 import { createBuiltinSkills } from "./skills"
-import { createSharedSkillTemplateLoader, loadSharedSkillTemplate } from "./skill-file-loader"
+import {
+  createSharedSkillTemplateLoader,
+  getBuiltinSkillSourceDir,
+  getSharedSkillSourceDir,
+  loadSharedSkillTemplate,
+} from "./skill-file-loader"
 
 declare const Bun: {
   file(path: string): { text(): Promise<string> }
 }
 
-const SHARED_BUILTIN_SKILLS = ["remove-ai-slops", "review-work", "frontend", "init-deep", "debugging"] as const
+const SHARED_BUILTIN_SKILLS = ["remove-ai-slops", "review-work", "frontend", "init-deep", "debugging", "visual-qa"] as const
 
 describe("shared builtin skill file loader", () => {
   test("#given extracted shared skill files #when builtin skills are created #then templates load from SKILL.md bodies", async () => {
@@ -67,6 +73,20 @@ describe("shared builtin skill file loader", () => {
 
     // then
     expect(loader("layout")).toBe("Layout body")
+  })
+
+  test("#given builtin skills with reference files #when source dirs are resolved #then relative references have a stable base", () => {
+    // given
+    const sharedSourceDir = getSharedSkillSourceDir("debugging")
+    const builtinSourceDir = getBuiltinSkillSourceDir("dev-browser")
+
+    // when
+    const debuggingReferencePath = join(sharedSourceDir, "references", "runtimes", "node.md")
+    const devBrowserReferencePath = join(builtinSourceDir, "references", "installation.md")
+
+    // then
+    expect(existsSync(debuggingReferencePath)).toBe(true)
+    expect(existsSync(devBrowserReferencePath)).toBe(true)
   })
 
   test("#given a missing shared skill file #when loading the template #then the loader fails fast", () => {

--- a/packages/skills-loader-core/src/features/builtin-skills/skill-file-loader.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skill-file-loader.ts
@@ -1,9 +1,21 @@
-import { readFileSync } from "node:fs"
-import { join } from "node:path"
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { sharedSkillsRootPath } from "@oh-my-opencode/shared-skills"
 import { parseFrontmatter } from "@oh-my-opencode/utils"
 
 type SkillFileReader = (path: string, encoding: "utf8") => string
+
+export function getSharedSkillSourceDir(skillName: string): string {
+	return join(sharedSkillsRootPath(), skillName)
+}
+
+export function getBuiltinSkillSourceDir(skillName: string): string {
+	const moduleDir = dirname(fileURLToPath(import.meta.url))
+	const sourceDir = join(moduleDir, skillName)
+	if (moduleDir.endsWith(join("src", "features", "builtin-skills")) || existsSync(sourceDir)) return sourceDir
+	return join(dirname(sharedSkillsRootPath()), "builtin-skills", skillName)
+}
 
 export function createSharedSkillTemplateLoader(
 	readFile: SkillFileReader = readFileSync,

--- a/packages/skills-loader-core/src/features/builtin-skills/skill-file-loader.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skill-file-loader.ts
@@ -1,6 +1,5 @@
-import { existsSync, readFileSync } from "node:fs"
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { sharedSkillsRootPath } from "@oh-my-opencode/shared-skills"
 import { parseFrontmatter } from "@oh-my-opencode/utils"
 
@@ -8,13 +7,6 @@ type SkillFileReader = (path: string, encoding: "utf8") => string
 
 export function getSharedSkillSourceDir(skillName: string): string {
 	return join(sharedSkillsRootPath(), skillName)
-}
-
-export function getBuiltinSkillSourceDir(skillName: string): string {
-	const moduleDir = dirname(fileURLToPath(import.meta.url))
-	const sourceDir = join(moduleDir, skillName)
-	if (moduleDir.endsWith(join("src", "features", "builtin-skills")) || existsSync(sourceDir)) return sourceDir
-	return join(dirname(sharedSkillsRootPath()), "builtin-skills", skillName)
 }
 
 export function createSharedSkillTemplateLoader(

--- a/packages/skills-loader-core/src/features/builtin-skills/types.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/types.ts
@@ -4,6 +4,7 @@ export interface BuiltinSkill {
   name: string
   description: string
   template: string
+  sourceDir?: string
   license?: string
   compatibility?: string
   metadata?: Record<string, unknown>

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/merger.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/merger.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test"
+import { createBuiltinSkills } from "../builtin-skills/skills"
+import { getBuiltinSkillSourceDir, getSharedSkillSourceDir } from "../builtin-skills/skill-file-loader"
 import type { BuiltinSkill } from "../builtin-skills/types"
 import type { CommandDefinition } from "@oh-my-opencode/claude-code-compat-core/claude-code-command-loader/types"
 import { mergeSkills } from "./merger"
@@ -51,5 +53,47 @@ describe("mergeSkills", () => {
     expect(merged).toHaveLength(1)
     expect(merged[0]?.scope).toBe("user")
     expect(merged[0]?.definition.description).toBe("user skill")
+  })
+
+  it("populates resolvedPath for shared-skills-backed builtin skills", () => {
+    // given
+    const builtinSkills = createBuiltinSkills()
+
+    // when
+    const merged = mergeSkills(builtinSkills, undefined, [], [], [], [], [])
+    const debugging = merged.find((s) => s.name === "debugging")
+    const frontend = merged.find((s) => s.name === "frontend")
+    const visualQa = merged.find((s) => s.name === "visual-qa")
+
+    // then
+    expect(debugging?.resolvedPath).toBe(getSharedSkillSourceDir("debugging"))
+    expect(frontend?.resolvedPath).toBe(getSharedSkillSourceDir("frontend"))
+    expect(visualQa?.resolvedPath).toBe(getSharedSkillSourceDir("visual-qa"))
+  })
+
+  it("populates resolvedPath for builtin-skills-backed skills", () => {
+    // given
+    const builtinSkills = createBuiltinSkills({ browserProvider: "dev-browser" })
+
+    // when
+    const merged = mergeSkills(builtinSkills, undefined, [], [], [], [], [])
+    const devBrowser = merged.find((s) => s.name === "dev-browser")
+
+    // then
+    expect(devBrowser?.resolvedPath).toBe(getBuiltinSkillSourceDir("dev-browser"))
+  })
+
+  it("prefers explicit sourceDir over inferred path", () => {
+    // given
+    const explicitDir = "/custom/skill/dir"
+    const builtinSkills: BuiltinSkill[] = [
+      { name: "custom-skill", description: "custom", template: "t", sourceDir: explicitDir },
+    ]
+
+    // when
+    const merged = mergeSkills(builtinSkills, undefined, [], [], [], [], [])
+
+    // then
+    expect(merged[0]?.resolvedPath).toBe(explicitDir)
   })
 })

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/merger.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/merger.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { createBuiltinSkills } from "../builtin-skills/skills"
-import { getBuiltinSkillSourceDir, getSharedSkillSourceDir } from "../builtin-skills/skill-file-loader"
+import { getSharedSkillSourceDir } from "../builtin-skills/skill-file-loader"
 import type { BuiltinSkill } from "../builtin-skills/types"
 import type { CommandDefinition } from "@oh-my-opencode/claude-code-compat-core/claude-code-command-loader/types"
 import { mergeSkills } from "./merger"
@@ -71,7 +71,7 @@ describe("mergeSkills", () => {
     expect(visualQa?.resolvedPath).toBe(getSharedSkillSourceDir("visual-qa"))
   })
 
-  it("populates resolvedPath for builtin-skills-backed skills", () => {
+  it("leaves resolvedPath undefined for non-shared builtin skills", () => {
     // given
     const builtinSkills = createBuiltinSkills({ browserProvider: "dev-browser" })
 
@@ -80,7 +80,7 @@ describe("mergeSkills", () => {
     const devBrowser = merged.find((s) => s.name === "dev-browser")
 
     // then
-    expect(devBrowser?.resolvedPath).toBe(getBuiltinSkillSourceDir("dev-browser"))
+    expect(devBrowser?.resolvedPath).toBeUndefined()
   })
 
   it("prefers explicit sourceDir over inferred path", () => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/merger/builtin-skill-converter.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/merger/builtin-skill-converter.ts
@@ -1,6 +1,19 @@
+import { existsSync } from "node:fs"
+import { join } from "node:path"
 import type { BuiltinSkill } from "../../builtin-skills/types"
+import { getSharedSkillSourceDir, getBuiltinSkillSourceDir } from "../../builtin-skills/skill-file-loader"
 import type { CommandDefinition } from "@oh-my-opencode/claude-code-compat-core/claude-code-command-loader/types"
 import type { LoadedSkill } from "../types"
+
+function inferBuiltinSourceDir(name: string): string | undefined {
+  const sharedDir = getSharedSkillSourceDir(name)
+  if (existsSync(join(sharedDir, "SKILL.md"))) return sharedDir
+
+  const builtinDir = getBuiltinSkillSourceDir(name)
+  if (existsSync(builtinDir)) return builtinDir
+
+  return undefined
+}
 
 export function builtinToLoadedSkill(builtin: BuiltinSkill): LoadedSkill {
   const definition: CommandDefinition = {
@@ -17,6 +30,7 @@ export function builtinToLoadedSkill(builtin: BuiltinSkill): LoadedSkill {
     name: builtin.name,
     definition,
     scope: "builtin",
+    resolvedPath: builtin.sourceDir ?? inferBuiltinSourceDir(builtin.name),
     license: builtin.license,
     compatibility: builtin.compatibility,
     metadata: builtin.metadata as Record<string, string> | undefined,

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/merger/builtin-skill-converter.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/merger/builtin-skill-converter.ts
@@ -1,16 +1,13 @@
 import { existsSync } from "node:fs"
 import { join } from "node:path"
 import type { BuiltinSkill } from "../../builtin-skills/types"
-import { getSharedSkillSourceDir, getBuiltinSkillSourceDir } from "../../builtin-skills/skill-file-loader"
+import { getSharedSkillSourceDir } from "../../builtin-skills/skill-file-loader"
 import type { CommandDefinition } from "@oh-my-opencode/claude-code-compat-core/claude-code-command-loader/types"
 import type { LoadedSkill } from "../types"
 
 function inferBuiltinSourceDir(name: string): string | undefined {
   const sharedDir = getSharedSkillSourceDir(name)
   if (existsSync(join(sharedDir, "SKILL.md"))) return sharedDir
-
-  const builtinDir = getBuiltinSkillSourceDir(name)
-  if (existsSync(builtinDir)) return builtinDir
 
   return undefined
 }


### PR DESCRIPTION
## Summary

Closes #5444

* Fixed built-in skills such as `debugging`, `frontend`, and `visual-qa` so that they display the correct **Base directory** in the `skill` tool output
* Implemented centralized path inference in `builtinToLoadedSkill()` — no changes are required to individual skill definitions
* Added optional `sourceDir` override support for cases where automatic inference is not sufficient
* Build verified

## Changes

* **`types.ts`**: Added an optional `sourceDir?: string` field to the `BuiltinSkill` interface
* **`skill-file-loader.ts`**: Exported helper function `getSharedSkillSourceDir()`
* **`builtin-skill-converter.ts`**: Added `inferBuiltinSourceDir()`, which automatically resolves the skill source directory by checking `shared-skills`
* **Tests**: Covered `resolvedPath` assignment in the merger tests, and source directory resolution in the skill-file-loader tests

### Important Design Decision: Minimal Centralized Change

This fix was intentionally kept as small and centralized as possible:

* ✅ **No changes to individual skill definitions** — `debugging.ts`, `frontend.ts`, `visual-qa.ts`, etc. remain unchanged
* ✅ **Automatic path inference** — `builtinToLoadedSkill()` resolves paths centrally via `inferBuiltinSourceDir()`
* ✅ **Backward compatible** — existing skills continue to work without modification
* ✅ **Extensible** — skills can optionally specify `sourceDir` for custom paths

The total change set is about 80 lines across 5 files: 3 source files and 2 test files.

### How It Works

```typescript
// builtin-skill-converter.ts
function inferBuiltinSourceDir(name: string): string | undefined {
  // Check shared-skills/skills/<name>/SKILL.md
  const sharedDir = getSharedSkillSourceDir(name)
  if (existsSync(join(sharedDir, "SKILL.md"))) return sharedDir

  // No physical directory, such as inline-only skills like Playwright MCP
  return undefined
}

export function builtinToLoadedSkill(builtin: BuiltinSkill): LoadedSkill {
  return {
    // ...
    resolvedPath: builtin.sourceDir ?? inferBuiltinSourceDir(builtin.name),
  }
}
```

### Behavior

| Case                                                                        | `resolvedPath` value                        |
| --------------------------------------------------------------------------- | ------------------------------------------- |
| Skills in `shared-skills`, such as `debugging`, `frontend`, and `visual-qa` | `shared-skills/skills/<name>/`              |
| Inline-only skills without resources, such as Playwright MCP or dev-browser | `undefined` → falls back to `process.cwd()` |
| Skills with an explicit `sourceDir`                                         | The specified path                          |

|                                     Before                                    |                                      After                                      |
| :---------------------------------------------------------------------------: | :-----------------------------------------------------------------------------: |
|                  `**Base directory**: E:\<my-workspace-dir>`                  |                `**Base directory**: E:\...\dist\skills\debugging`               |
| The `debugging` skill displayed `cwd`, and `references` could not be resolved | The `debugging` skill displays its actual path, and `references` are accessible |

## Testing

```bash
# Type check
bun run typecheck

# Run affected tests
bun test packages/skills-loader-core/src/features/builtin-skills/skill-file-loader.test.ts
bun test packages/skills-loader-core/src/features/opencode-skill-loader/merger.test.ts

# Full test suite
bun test
```

### Test Results

* ✅ 9 new/existing tests passed in the affected files
* ✅ 211/212 tests passed in the full `skills-loader-core` suite

  * The one failing test is an existing, unrelated Windows symlink permission issue
* ✅ Type check passed with no errors

### Manual Testing

Verified with a local build on Windows 11, non-WSL:

| Skill       | Before                          | After                                         |
| ----------- | ------------------------------- | --------------------------------------------- |
| `debugging` | `E:\<my-workspace-dir>` (`cwd`) | `E:\...\dist\skills\debugging` ✅              |
| `frontend`  | `E:\<my-workspace-dir>` (`cwd`) | `E:\...\dist\skills\frontend` ✅               |
| `visual-qa` | `E:\<my-workspace-dir>` (`cwd`) | `E:\...\dist\skills\visual-qa` ✅              |
| `ast-grep`  | `E:\...\dist\skills\ast-grep` ✅ | `E:\...\dist\skills\ast-grep` ✅ No regression |
| `refactor`  | `E:\...\dist\skills\refactor` ✅ | `E:\...\dist\skills\refactor` ✅ No regression |

### Testing Limitations

**This PR has only been tested on Windows 11, non-WSL.** The fix should be platform-independent because it uses `node:fs` and `node:path`, but I would appreciate confirmation from anyone who can test it on Linux-based environments.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes built-in skills showing the workspace cwd as the Base directory. We now infer `resolvedPath` so the Base directory points to the actual shared skill path, which restores reference resolution.

- **Bug Fixes**
  - Centralized path inference in `builtinToLoadedSkill()` using `inferBuiltinSourceDir()`; only checks `shared-skills/skills/<name>/SKILL.md`.
  - Removed `getBuiltinSkillSourceDir()` (builtin-skills resources are not shipped); exported `getSharedSkillSourceDir()` for stable reference paths.
  - Added optional `sourceDir` on `BuiltinSkill` to override inference when needed.
  - Updated tests to verify `resolvedPath` for shared skills (`debugging`, `frontend`, `visual-qa`), keep it undefined for non-shared builtins, prefer explicit `sourceDir`, and confirm reference files resolve from `getSharedSkillSourceDir()`.

<sup>Written for commit 5bdb5dbd009ac9922c0dfbb053604f9a93d839f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



