### PR TITLE
feat: per-call model + reasoning override with list_models discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ pluginModule.server(input, options)   # serverPlugin() in packages/omo-opencode/
 
 ## TOOL CATALOG (config-gated)
 
-**Always on (12 registry tools):** `grep`, `glob`, `session_list`, `session_read`, `session_search`, `session_info`, `background_output`, `background_cancel`, `call_omo_agent`, `task` (delegate), `skill`, `skill_mcp`.
+**Always on (13 registry tools):** `grep`, `glob`, `session_list`, `session_read`, `session_search`, `session_info`, `background_output`, `background_cancel`, `call_omo_agent`, `task` (delegate), `skill`, `skill_mcp`, `list_models`.
 
 > Note: the 8 LSP aliases (`lsp_status`, `lsp_diagnostics`, `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols`, `lsp_prepare_rename`, `lsp_rename`, `lsp_install_decision`) are NOT registry registrations — they are served by the built-in `lsp` MCP via `packages/lsp-tools-mcp`. Structural search and rewrite is provided by the `ast-grep` skill using `sg`.
 

--- a/docs/guide/team-mode.md
+++ b/docs/guide/team-mode.md
@@ -72,6 +72,17 @@ When both scopes define the same team name, project scope wins.
 - **`kind: "subagent_type"`** — direct agent (atlas, sisyphus, sisyphus-junior, hephaestus). `prompt` optional.
 - **`kind: "category"`** — routed through `sisyphus-junior` with the chosen category model. `prompt` REQUIRED.
 
+## Per-member model override
+
+Any member may pin its own model and reasoning, gated to connected/available models. A malformed or unavailable model fails team creation loudly (rather than silently spawning a default). Omit to use the category/subagent default.
+
+- **`model`** (string, optional) — `"provider/model"` or `"provider/model variant"`, e.g. `"openai/gpt-5.5"` or `"openai/gpt-5.5 xhigh"`.
+- **`reasoning_effort`** (string, optional) — `minimal` / `low` / `medium` / `high` / `xhigh` / `max`; takes precedence over a variant embedded in `model`.
+
+```json
+{ "kind": "subagent_type", "name": "scout", "subagent_type": "sisyphus", "model": "openai/gpt-5.5", "reasoning_effort": "xhigh" }
+```
+
 ## Eligible agents
 
 - **Eligible:** `sisyphus`, `atlas`, `sisyphus-junior`.

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -174,6 +174,32 @@ task({
 });
 ```
 
+### Per-Call Model Override
+
+The orchestrator can pin the model (and reasoning) for an individual delegation at its own discretion, instead of relying only on the configured per-agent / per-category default. The override is **gated to connected/available models** — unknown models are rejected before any subagent spawns — and the agent/category fallback chain is preserved for runtime recovery.
+
+Available on `task` (both `subagent_type` and `category`) and on `call_omo_agent`:
+
+- **`model`** (string) — `"provider/model"` or `"provider/model variant"`, e.g. `"openai/gpt-5.5"` or `"openai/gpt-5.5 xhigh"`.
+- **`reasoning_effort`** (string) — `minimal` / `low` / `medium` / `high` / `xhigh` / `max`; takes precedence over a variant embedded in `model`.
+
+```typescript
+task({
+  subagent_type: "librarian",
+  model: "openai/gpt-5.5",
+  reasoning_effort: "xhigh",
+  run_in_background: true,
+  description: "API contract",
+  prompt: "Find the request/response schema for ...",
+});
+```
+
+Omit `model` to keep the configured default. Team members can pin a model the same way — see [Team Mode](../guide/team-mode.md#per-member-model-override).
+
+### `list_models` Tool
+
+`list_models` returns the models currently connected to the session — grouped by provider, as `provider/model` ids you can pass verbatim to `model` — plus the valid `reasoning_effort` vocabulary. It accepts an optional `provider` filter. Call it before passing a per-call model override so you pick a model that exists (unknown models are rejected).
+
 ### Custom Categories
 
 You can define custom categories in your plugin config file. During the rename transition, both `oh-my-openagent.json[c]` and legacy `oh-my-opencode.json[c]` basenames are recognized.

--- a/packages/delegate-core/src/index.ts
+++ b/packages/delegate-core/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./model-selection"
+export * from "./requested-model"
 export * from "./retry-guidance"
 export * from "./retry-patterns"

--- a/packages/delegate-core/src/requested-model.test.ts
+++ b/packages/delegate-core/src/requested-model.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+import { parseModelString } from "@oh-my-opencode/model-core"
+import { fuzzyMatchModel } from "@oh-my-opencode/model-core"
+import { resolveRequestedModelOverride, type RequestedModelDeps } from "./requested-model"
+
+function depsWith(available: string[]): RequestedModelDeps {
+  return {
+    availableModels: new Set(available),
+    parseModelString,
+    fuzzyMatchModel,
+  }
+}
+
+describe("resolveRequestedModelOverride", () => {
+  test("#given no model #then kind none (config defaults apply)", () => {
+    // when
+    const result = resolveRequestedModelOverride({}, depsWith(["openai/gpt-5.5"]))
+    // then
+    expect(result.kind).toBe("none")
+  })
+
+  test("#given blank model string #then kind none", () => {
+    const result = resolveRequestedModelOverride({ model: "   " }, depsWith(["openai/gpt-5.5"]))
+    expect(result.kind).toBe("none")
+  })
+
+  test("#given malformed model #then error", () => {
+    // when
+    const result = resolveRequestedModelOverride({ model: "not-a-model" }, depsWith(["openai/gpt-5.5"]))
+    // then
+    expect(result.kind).toBe("error")
+    if (result.kind === "error") {
+      expect(result.message).toContain("provider/model")
+    }
+  })
+
+  test("#given model not among connected providers #then error rejects it (gate)", () => {
+    // when
+    const result = resolveRequestedModelOverride(
+      { model: "openai/ghost-999" },
+      depsWith(["openai/gpt-5.5", "anthropic/claude-opus-4-8"]),
+    )
+    // then
+    expect(result.kind).toBe("error")
+    if (result.kind === "error") {
+      expect(result.message).toContain("not available")
+    }
+  })
+
+  test("#given available model #then resolved with canonical provider/model (gated)", () => {
+    // when
+    const result = resolveRequestedModelOverride(
+      { model: "openai/gpt-5.5" },
+      depsWith(["openai/gpt-5.5", "anthropic/claude-opus-4-8"]),
+    )
+    // then
+    expect(result.kind).toBe("resolved")
+    if (result.kind === "resolved") {
+      expect(result.model.providerID).toBe("openai")
+      expect(result.model.modelID).toBe("gpt-5.5")
+      expect(result.model.variant).toBeUndefined()
+      expect(result.matched).toBe("openai/gpt-5.5")
+    }
+  })
+
+  test("#given variant in model string #then variant carried", () => {
+    // when
+    const result = resolveRequestedModelOverride(
+      { model: "openai/gpt-5.5 xhigh" },
+      depsWith(["openai/gpt-5.5"]),
+    )
+    // then
+    expect(result.kind).toBe("resolved")
+    if (result.kind === "resolved") {
+      expect(result.model.modelID).toBe("gpt-5.5")
+      expect(result.model.variant).toBe("xhigh")
+    }
+  })
+
+  test("#given explicit reasoningEffort #then it overrides parsed variant", () => {
+    // when
+    const result = resolveRequestedModelOverride(
+      { model: "openai/gpt-5.5 high", reasoningEffort: "xhigh" },
+      depsWith(["openai/gpt-5.5"]),
+    )
+    // then
+    expect(result.kind).toBe("resolved")
+    if (result.kind === "resolved") {
+      expect(result.model.variant).toBe("xhigh")
+    }
+  })
+
+  test("#given cold cache (no available models) #then resolved passthrough (cannot verify, do not block first call)", () => {
+    // when
+    const result = resolveRequestedModelOverride({ model: "openai/gpt-5.5 medium" }, depsWith([]))
+    // then
+    expect(result.kind).toBe("resolved")
+    if (result.kind === "resolved") {
+      expect(result.model.providerID).toBe("openai")
+      expect(result.model.modelID).toBe("gpt-5.5")
+      expect(result.model.variant).toBe("medium")
+    }
+  })
+})

--- a/packages/delegate-core/src/requested-model.ts
+++ b/packages/delegate-core/src/requested-model.ts
@@ -1,0 +1,89 @@
+// Per-call model override requested by the orchestrating agent at delegation time.
+// Pure + dependency-injected (no IO): parses a "provider/model[ variant]" string,
+// applies an explicit reasoning/variant override, and gates the result against the
+// set of connected/available models. Config defaults still apply when no model is
+// requested (kind: "none").
+
+export type RequestedModelInput = {
+  readonly model?: string
+  readonly reasoningEffort?: string
+}
+
+export type RequestedModelConfig = {
+  readonly providerID: string
+  readonly modelID: string
+  readonly variant?: string
+}
+
+export type RequestedModelResolution =
+  | { readonly kind: "none" }
+  | { readonly kind: "resolved"; readonly model: RequestedModelConfig; readonly matched: string }
+  | { readonly kind: "error"; readonly message: string }
+
+export type RequestedModelDeps = {
+  readonly availableModels: ReadonlySet<string>
+  readonly parseModelString: (
+    model: string,
+  ) => { providerID: string; modelID: string; variant?: string } | undefined
+  readonly fuzzyMatchModel: (
+    target: string,
+    available: Set<string>,
+    providers?: string[],
+  ) => string | null
+}
+
+const MAX_SAMPLE = 8
+
+function sampleAvailable(available: ReadonlySet<string>): string {
+  return Array.from(available).sort().slice(0, MAX_SAMPLE).join(", ")
+}
+
+export function resolveRequestedModelOverride(
+  input: RequestedModelInput,
+  deps: RequestedModelDeps,
+): RequestedModelResolution {
+  const requested = input.model?.trim()
+  if (!requested) {
+    return { kind: "none" }
+  }
+
+  const parsed = deps.parseModelString(requested)
+  if (!parsed) {
+    return {
+      kind: "error",
+      message: `Invalid model "${requested}". Expected "provider/model" (optionally "provider/model variant"), e.g. "openai/gpt-5.5" or "openai/gpt-5.5 xhigh".`,
+    }
+  }
+
+  const explicitReasoning = input.reasoningEffort?.trim()
+  const variant = explicitReasoning && explicitReasoning.length > 0 ? explicitReasoning : parsed.variant
+  const full = `${parsed.providerID}/${parsed.modelID}`
+
+  // Cold cache: we genuinely cannot verify availability. Do not block the first
+  // delegation — pass the parsed model through and let runtime resolution handle it.
+  if (deps.availableModels.size === 0) {
+    return {
+      kind: "resolved",
+      matched: full,
+      model: variant ? { ...parsed, variant } : { providerID: parsed.providerID, modelID: parsed.modelID },
+    }
+  }
+
+  const matched = deps.fuzzyMatchModel(full, new Set(deps.availableModels), [parsed.providerID])
+  if (!matched) {
+    return {
+      kind: "error",
+      message: `Model "${full}" is not available among connected providers. Available models include: ${sampleAvailable(deps.availableModels)}.`,
+    }
+  }
+
+  const separatorIndex = matched.indexOf("/")
+  const providerID = separatorIndex === -1 ? parsed.providerID : matched.slice(0, separatorIndex)
+  const modelID = separatorIndex === -1 ? matched : matched.slice(separatorIndex + 1)
+
+  return {
+    kind: "resolved",
+    matched,
+    model: variant ? { providerID, modelID, variant } : { providerID, modelID },
+  }
+}

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/resolve-member.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/resolve-member.ts
@@ -8,6 +8,30 @@ import {
   resolveCategoryExecution,
   resolveSubagentExecution,
 } from "./resolve-member-dependencies"
+import { resolveRequestedModelOverride } from "@oh-my-opencode/delegate-core"
+import { parseModelString } from "../../../shared"
+import { fuzzyMatchModel } from "../../../shared/model-availability"
+import { getAvailableModelsForDelegateTask } from "../../../tools/delegate-task/available-models"
+
+// Optional per-member model override declared on the team member spec, gated to
+// connected/available models. Throws (surfaced as TeamMemberResolutionError) when
+// the declared model is malformed or unavailable, so a bad spec fails team creation
+// loudly instead of silently spawning the configured default.
+async function resolveMemberModelOverride(
+  member: Member,
+  ctx: ExecutorContext,
+): Promise<DelegatedModelConfig | undefined> {
+  if (!member.model) return undefined
+  const availableModels = await getAvailableModelsForDelegateTask(ctx.client)
+  const override = resolveRequestedModelOverride(
+    { model: member.model, reasoningEffort: member.reasoning_effort },
+    { availableModels, parseModelString, fuzzyMatchModel },
+  )
+  if (override.kind === "error") {
+    throw new Error(`model override: ${override.message}`)
+  }
+  return override.kind === "resolved" ? override.model : undefined
+}
 
 export class TeamMemberResolutionError extends Error {
   constructor(public readonly memberName: string, public readonly cause: Error) {
@@ -66,6 +90,8 @@ export async function resolveMember(
   parentAgent?: string,
 ): Promise<ResolvedMember> {
   try {
+    const memberModelOverride = await resolveMemberModelOverride(member, ctx)
+
     if (member.kind === "category") {
       const execution = await resolveCategoryExecution(
         {
@@ -82,16 +108,17 @@ export async function resolveMember(
         throw new Error(execution.error)
       }
 
+      const categoryModel = memberModelOverride ?? execution.categoryModel
       return {
         memberName: member.name,
         agentToUse: execution.agentToUse,
-        model: execution.categoryModel,
+        model: categoryModel,
         fallbackChain: execution.fallbackChain,
         systemContent: resolveSystemContent({
           agentToUse: execution.agentToUse,
           categoryPromptAppend: execution.categoryPromptAppend,
           maxPromptTokens: execution.maxPromptTokens,
-          model: execution.categoryModel,
+          model: categoryModel,
         }),
       }
     }
@@ -114,14 +141,15 @@ export async function resolveMember(
       throw new Error(execution.error)
     }
 
+    const subagentModel = memberModelOverride ?? execution.categoryModel
     return {
       memberName: member.name,
       agentToUse: execution.agentToUse,
-      model: execution.categoryModel,
+      model: subagentModel,
       fallbackChain: execution.fallbackChain,
       systemContent: resolveSystemContent({
         agentToUse: execution.agentToUse,
-        model: execution.categoryModel,
+        model: subagentModel,
       }),
     }
   } catch (error) {

--- a/packages/omo-opencode/src/features/team-mode/tools/lifecycle-create-tool.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/lifecycle-create-tool.ts
@@ -28,6 +28,8 @@ const TeamCreateInlineMemberToolSchema = tool.schema.object({
   loadSkills: tool.schema.array(tool.schema.string()).optional().describe("Optional skills to load for this member."),
   role: tool.schema.string().optional().describe("Optional natural-language role used to build a prompt when prompt is omitted."),
   description: tool.schema.string().optional().describe("Optional natural-language description used to build a prompt when prompt is omitted."),
+  model: tool.schema.string().optional().describe("Optional. Override THIS member's model, e.g. \"openai/gpt-5.5\" or \"xai/grok-composer-2.5-fast\" (optionally \"provider/model variant\"). Gated to connected/available models — call list_models to see them. Omit to use the category/subagent default."),
+  reasoning_effort: tool.schema.string().optional().describe("Optional. Reasoning/variant for THIS member (minimal|low|medium|high|xhigh|max); takes precedence over a variant embedded in model."),
 })
 
 const TeamCreateInlineSpecToolSchema = tool.schema.union([

--- a/packages/omo-opencode/src/features/team-mode/tools/lifecycle-inline-member-model.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/lifecycle-inline-member-model.test.ts
@@ -1,0 +1,70 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { parseInlineTeamSpec } from "./lifecycle-inline-spec"
+
+type MemberWithModel = { name: string; model?: string; reasoning_effort?: string }
+
+function findMember(spec: { members: ReadonlyArray<unknown> }, name: string): MemberWithModel | undefined {
+  return (spec.members as MemberWithModel[]).find((m) => m.name === name)
+}
+
+describe("team_create inline member model override", () => {
+  test("#given an inline member object with model + reasoning_effort #then they survive the parse chain", () => {
+    // when
+    const spec = parseInlineTeamSpec({
+      name: "probe-team",
+      leadAgentId: "lead",
+      members: [
+        { kind: "subagent_type", name: "lead", subagent_type: "sisyphus" },
+        { kind: "subagent_type", name: "scout", subagent_type: "sisyphus", model: "xai/grok-composer-2.5-fast", reasoning_effort: "xhigh" },
+      ],
+    })
+    // then
+    const scout = findMember(spec, "scout")
+    expect(scout?.model).toBe("xai/grok-composer-2.5-fast")
+    expect(scout?.reasoning_effort).toBe("xhigh")
+  })
+
+  test("#given a category member with model variant string #then it survives", () => {
+    // when
+    const spec = parseInlineTeamSpec({
+      name: "probe-team",
+      leadAgentId: "lead",
+      members: [
+        { kind: "subagent_type", name: "lead", subagent_type: "sisyphus" },
+        { kind: "category", name: "worker", category: "quick", prompt: "do the assigned work", model: "openai/gpt-5.5 xhigh" },
+      ],
+    })
+    // then
+    expect(findMember(spec, "worker")?.model).toBe("openai/gpt-5.5 xhigh")
+  })
+
+  test("#given a stringified inline_spec with member model #then it survives (JSON-string path)", () => {
+    // when
+    const spec = parseInlineTeamSpec(JSON.stringify({
+      name: "probe-team",
+      leadAgentId: "lead",
+      members: [
+        { kind: "subagent_type", name: "lead", subagent_type: "sisyphus" },
+        { kind: "subagent_type", name: "scout", subagent_type: "sisyphus", model: "openai/gpt-5.4-fast" },
+      ],
+    }))
+    // then
+    expect(findMember(spec, "scout")?.model).toBe("openai/gpt-5.4-fast")
+  })
+
+  test("#given a member without model #then no model is set (configured default preserved)", () => {
+    // when
+    const spec = parseInlineTeamSpec({
+      name: "probe-team",
+      leadAgentId: "lead",
+      members: [
+        { kind: "subagent_type", name: "lead", subagent_type: "sisyphus" },
+        { kind: "subagent_type", name: "scout", subagent_type: "sisyphus" },
+      ],
+    })
+    // then
+    expect(findMember(spec, "scout")?.model).toBeUndefined()
+  })
+})

--- a/packages/omo-opencode/src/plugin/tool-registry-core-tools.test.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-core-tools.test.ts
@@ -24,6 +24,7 @@ function createFactories(createSkillTool: (options: SkillLoadOptions) => typeof 
     createSkillTool,
     createGrepTools: () => ({}),
     createGlobTools: () => ({}),
+    createListModelsTools: () => ({}),
     createSessionManagerTools: () => ({}),
     createDelegateTask: () => fakeTool,
     discoverCommandsSync: () => [],

--- a/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
@@ -124,6 +124,7 @@ export function createCoreTools(args: {
   const tools: ToolsRecord = {
     ...factories.createGrepTools(ctx),
     ...factories.createGlobTools(ctx),
+    ...factories.createListModelsTools(ctx),
     ...factories.createSessionManagerTools(ctx),
     ...backgroundTools,
     call_omo_agent: callOmoAgent,

--- a/packages/omo-opencode/src/plugin/tool-registry-factories.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-factories.ts
@@ -20,6 +20,7 @@ import {
   createGlobTools,
   createGrepTools,
   createHashlineEditTool,
+  createListModelsTools,
   createLookAt,
   createMonitorTools,
   createSessionManagerTools,
@@ -42,6 +43,7 @@ export type ToolRegistryFactories = {
   createSkillTool: typeof createSkillTool
   createGrepTools: typeof createGrepTools
   createGlobTools: typeof createGlobTools
+  createListModelsTools: typeof createListModelsTools
   createSessionManagerTools: typeof createSessionManagerTools
   createDelegateTask: typeof createDelegateTask
   discoverCommandsSync: typeof discoverCommandsSync
@@ -74,6 +76,7 @@ export const defaultToolRegistryFactories: ToolRegistryFactories = {
   createSkillTool,
   createGrepTools,
   createGlobTools,
+  createListModelsTools,
   createSessionManagerTools,
   createDelegateTask,
   discoverCommandsSync,

--- a/packages/omo-opencode/src/tools/call-omo-agent/tools.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/tools.ts
@@ -13,6 +13,9 @@ import { buildFallbackChainFromModels } from "../../shared/fallback-chain-from-m
 import { log } from "../../shared"
 import { CONFIG_BASENAME } from "../../shared/plugin-identity"
 import { parseModelString } from "../../shared"
+import { fuzzyMatchModel } from "../../shared/model-availability"
+import { getAvailableModelsForDelegateTask } from "../delegate-task/available-models"
+import { resolveRequestedModelOverride } from "@oh-my-opencode/delegate-core"
 import { executeBackground } from "./background-executor"
 import { executeSync } from "./sync-executor"
 import { resolveCallableAgents } from "./agent-resolver"
@@ -147,6 +150,14 @@ export function createCallOmoAgent(
         .string()
         .describe("Existing Task session to continue")
         .optional(),
+      model: tool.schema
+        .string()
+        .describe("Optional. Override the model for THIS call at your discretion. Format \"provider/model\" or \"provider/model variant\" (e.g. \"openai/gpt-5.5 xhigh\"). Must be a connected/available model or the call is rejected — call `list_models` first to see connected models and valid reasoning values. Omit to use the agent's configured default.")
+        .optional(),
+      reasoning_effort: tool.schema
+        .string()
+        .describe("Optional. Reasoning/variant for THIS call (e.g. \"low\", \"medium\", \"high\", \"xhigh\", \"max\"). Takes precedence over a variant embedded in `model`.")
+        .optional(),
     },
     async execute(args: CallOmoAgentArgs, toolContext) {
       const toolCtx = toolContext as ToolContextWithMetadata;
@@ -178,11 +189,32 @@ export function createCallOmoAgent(
         return `Error: Agent "${normalizedAgent}" is disabled via disabled_agents configuration. Remove it from disabled_agents in your ${CONFIG_BASENAME}.json to use it.`
       }
 
-      const { model: resolvedModel, fallbackChain } = resolveModelAndFallbackChain({
+      const { model: configResolvedModel, fallbackChain } = resolveModelAndFallbackChain({
         subagentType: args.subagent_type,
         agentOverrides,
         userCategories,
       })
+
+      // Orchestrator per-call model override (gated to connected/available models).
+      let resolvedModel = configResolvedModel
+      if (args.model) {
+        const availableModels = await getAvailableModelsForDelegateTask(ctx.client)
+        const override = resolveRequestedModelOverride(
+          { model: args.model, reasoningEffort: args.reasoning_effort },
+          { availableModels, parseModelString, fuzzyMatchModel },
+        )
+        if (override.kind === "error") {
+          return `Invalid model override: ${override.message}`
+        }
+        if (override.kind === "resolved") {
+          resolvedModel = override.model
+          log("[call_omo_agent] orchestrator model override accepted", {
+            requested: args.model,
+            matched: override.matched,
+            variant: override.model.variant,
+          })
+        }
+      }
 
       if (args.run_in_background) {
         if (args.session_id) {

--- a/packages/omo-opencode/src/tools/call-omo-agent/types.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/types.ts
@@ -8,6 +8,10 @@ export interface CallOmoAgentArgs {
   subagent_type: string
   run_in_background: boolean
   session_id?: string
+  /** Orchestrator per-call model override, e.g. "openai/gpt-5.5" or "openai/gpt-5.5 xhigh". Gated to connected models. */
+  model?: string
+  /** Orchestrator per-call reasoning/variant override (e.g. "xhigh"); precedence over a variant inside `model`. */
+  reasoning_effort?: string
 }
 
 export interface CallOmoAgentSyncResult {

--- a/packages/omo-opencode/src/tools/delegate-task/model-override-integration.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/model-override-integration.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test"
+import { createDelegateTask } from "./tools"
+
+type CapturedBody = { model?: { providerID?: string; modelID?: string }; variant?: string }
+
+const AVAILABLE = new Set(["openai/gpt-5.5", "anthropic/claude-opus-4-7"])
+
+type CapturedLaunch = { agent?: string; model?: { providerID?: string; modelID?: string; variant?: string } }
+
+function makeHarness(availableModelsOverride?: Set<string>) {
+  let promptBody: CapturedBody = {}
+  let promptCalled = false
+  let launchInput: CapturedLaunch | undefined
+  const promptMock = async (input: { body: CapturedBody }) => {
+    promptCalled = true
+    promptBody = input.body
+    return { data: {} }
+  }
+  const client = {
+    app: {
+      agents: async () => ({
+        data: [
+          { name: "librarian", mode: "subagent" },
+          { name: "explore", mode: "subagent" },
+          { name: "sisyphus-junior", mode: "subagent" },
+        ],
+      }),
+    },
+    config: { get: async () => ({ data: { model: "anthropic/claude-opus-4-7" } }) },
+    model: { list: async () => [] },
+    session: {
+      get: async () => ({ data: { directory: "/project" } }),
+      create: async () => ({ data: { id: "ses_test" } }),
+      prompt: promptMock,
+      promptAsync: promptMock,
+      messages: async () => ({
+        data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "done" }] }],
+      }),
+      status: async () => ({ data: { ses_test: { type: "idle" } } }),
+    },
+  }
+  const mockManager = {
+    launch: async (input: CapturedLaunch) => {
+      launchInput = input
+      return { id: "bg_test", description: "x", agent: input.agent ?? "", status: "pending" }
+    },
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tool = createDelegateTask({ manager: mockManager, client, availableModelsOverride } as any)
+  const toolContext = {
+    sessionID: "parent",
+    messageID: "msg",
+    agent: "sisyphus",
+    abort: new AbortController().signal,
+  }
+  // Effective model = sync prompt body (category/sisyphus-junior path) OR background launch (research subagents are forced background).
+  const effectiveModel = (): { providerID?: string; modelID?: string } | undefined =>
+    promptBody.model ?? (launchInput?.model ? { providerID: launchInput.model.providerID, modelID: launchInput.model.modelID } : undefined)
+  const effectiveVariant = (): string | undefined => promptBody.variant ?? launchInput?.model?.variant
+  return {
+    tool,
+    toolContext,
+    getBody: () => promptBody,
+    wasPromptCalled: () => promptCalled,
+    getLaunch: () => launchInput,
+    effectiveModel,
+    effectiveVariant,
+  }
+}
+
+describe("delegate-task orchestrator model override (tool boundary)", () => {
+  test("S1 #given subagent_type + model #then the spawned session runs on the chosen model", async () => {
+    // given
+    const h = makeHarness(AVAILABLE)
+    // when
+    await h.tool.execute(
+      { description: "x", prompt: "p", subagent_type: "librarian", run_in_background: false, load_skills: [], model: "openai/gpt-5.5" },
+      h.toolContext,
+    )
+    // then (librarian is forced background -> assert via launch input)
+    expect(h.effectiveModel()).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+  }, { timeout: 20000 })
+
+  test("S2 #given reasoning_effort #then it is applied as the session variant", async () => {
+    // given
+    const h = makeHarness(AVAILABLE)
+    // when
+    await h.tool.execute(
+      { description: "x", prompt: "p", subagent_type: "librarian", run_in_background: false, load_skills: [], model: "openai/gpt-5.5", reasoning_effort: "xhigh" },
+      h.toolContext,
+    )
+    // then
+    expect(h.effectiveModel()).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+    expect(h.effectiveVariant()).toBe("xhigh")
+  }, { timeout: 20000 })
+
+  test("S3 #given an unavailable model #then the call is rejected and NOTHING is spawned (gate)", async () => {
+    // given
+    const h = makeHarness(AVAILABLE)
+    // when
+    const result = await h.tool.execute(
+      { description: "x", prompt: "p", subagent_type: "librarian", run_in_background: false, load_skills: [], model: "openai/ghost-999" },
+      h.toolContext,
+    )
+    // then
+    expect(String(result)).toContain("not available")
+    expect(h.wasPromptCalled()).toBe(false)
+    expect(h.getLaunch()).toBeUndefined()
+  }, { timeout: 20000 })
+
+  test("S5 #given category + model variant string #then the junior runs the chosen model + variant", async () => {
+    // given
+    const h = makeHarness(AVAILABLE)
+    // when
+    await h.tool.execute(
+      { description: "x", prompt: "p", category: "quick", run_in_background: false, load_skills: [], model: "openai/gpt-5.5 xhigh" },
+      h.toolContext,
+    )
+    // then
+    expect(h.effectiveModel()).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+    expect(h.effectiveVariant()).toBe("xhigh")
+  }, { timeout: 20000 })
+
+  test("S4 #given no model arg #then the override is skipped and the chosen model is NOT forced", async () => {
+    // given - regression: omitting model must leave the configured/default path untouched
+    const h = makeHarness(AVAILABLE)
+    // when
+    await h.tool.execute(
+      { description: "x", prompt: "p", subagent_type: "librarian", run_in_background: false, load_skills: [] },
+      h.toolContext,
+    )
+    // then - librarian default chain is gpt-5.4-mini family, never the override target
+    expect(h.effectiveModel()?.modelID).not.toBe("gpt-5.5")
+  }, { timeout: 20000 })
+})

--- a/packages/omo-opencode/src/tools/delegate-task/tool-argument-preparation.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tool-argument-preparation.ts
@@ -83,6 +83,10 @@ export async function prepareDelegateTaskArgs(args: Record<string, unknown>, ctx
 
   const taskID = typeof args.task_id === "string" ? args.task_id : undefined
   const command = typeof args.command === "string" ? args.command : undefined
+  const model = typeof args.model === "string" && args.model.trim() !== "" ? args.model : undefined
+  const reasoningEffort = typeof args.reasoning_effort === "string" && args.reasoning_effort.trim() !== ""
+    ? args.reasoning_effort
+    : undefined
 
 
   return {
@@ -96,5 +100,7 @@ export async function prepareDelegateTaskArgs(args: Record<string, unknown>, ctx
     task_id: taskID,
     command,
     load_skills: normalizedLoadSkills,
+    model,
+    reasoning_effort: reasoningEffort,
   }
 }

--- a/packages/omo-opencode/src/tools/delegate-task/tools.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.ts
@@ -15,6 +15,10 @@ import {
 } from "./executor"
 import { prepareDelegateTaskArgs } from "./tool-argument-preparation"
 import { createDelegateTaskPresentation } from "./tool-description"
+import { getAvailableModelsForDelegateTask } from "./available-models"
+import { resolveRequestedModelOverride } from "@oh-my-opencode/delegate-core"
+import { parseModelString } from "../../shared"
+import { fuzzyMatchModel } from "../../shared/model-availability"
 import type { AvailableSkill } from "../../agents/dynamic-agent-prompt-builder"
 import { mergeNativeSkillInfos, type NativeSkillEntry } from "../skill/native-skills"
 import type { SkillInfo } from "../skill/types"
@@ -76,6 +80,14 @@ const delegateTaskArgsSchema = {
     .optional()
     .describe("Continuation session id (`ses_...`) from task metadata; not a background task id (`bg_...`)."),
   command: tool.schema.string().optional().describe("The command that triggered this task"),
+  model: tool.schema
+    .string()
+    .optional()
+    .describe("Optional. Override the model for THIS delegation, at your discretion. Format \"provider/model\" or \"provider/model variant\" (e.g. \"openai/gpt-5.5\", \"openai/gpt-5.5 xhigh\"). Must be a connected/available model or the call is rejected — call `list_models` first to see connected models and valid reasoning values. Omit to use the configured default for the agent/category."),
+  reasoning_effort: tool.schema
+    .string()
+    .optional()
+    .describe("Optional. Reasoning/variant for THIS delegation (e.g. \"low\", \"medium\", \"high\", \"xhigh\", \"max\"). Takes precedence over a variant embedded in `model`. Only meaningful together with `model`."),
 }
 
 export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefinition {
@@ -144,6 +156,31 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
         ? `${parentContext.model.providerID}/${parentContext.model.modelID}`
         : undefined
 
+      // Orchestrator per-call model override (gated to connected/available models).
+      // Rejected synchronously before any session is spawned when the model is
+      // malformed or unavailable; otherwise it replaces the configured default while
+      // the agent/category fallback chain is preserved for runtime recovery.
+      let requestedOverride: DelegatedModelConfig | undefined
+      if (delegateTaskArgs.model) {
+        const availableModels = options.availableModelsOverride
+          ?? await getAvailableModelsForDelegateTask(options.client)
+        const override = resolveRequestedModelOverride(
+          { model: delegateTaskArgs.model, reasoningEffort: delegateTaskArgs.reasoning_effort },
+          { availableModels, parseModelString, fuzzyMatchModel },
+        )
+        if (override.kind === "error") {
+          return `Invalid model override: ${override.message}`
+        }
+        if (override.kind === "resolved") {
+          requestedOverride = override.model
+          log("[task] orchestrator model override accepted", {
+            requested: delegateTaskArgs.model,
+            matched: override.matched,
+            variant: override.model.variant,
+          })
+        }
+      }
+
       let agentToUse: string
       let categoryModel: DelegatedModelConfig | undefined
       let categoryPromptAppend: string | undefined
@@ -179,7 +216,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
           willForceBackground: isUnstableAgent && isRunInBackgroundExplicitlyFalse,
         })
 
-        if (isUnstableAgent && isRunInBackgroundExplicitlyFalse) {
+        if (!requestedOverride && isUnstableAgent && isRunInBackgroundExplicitlyFalse) {
           const systemContent = buildSystemContent({
             skillContent,
             skillContents,
@@ -201,6 +238,12 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
         agentToUse = resolution.agentToUse
         categoryModel = resolution.categoryModel
         fallbackChain = resolution.fallbackChain
+      }
+
+      if (requestedOverride) {
+        categoryModel = requestedOverride
+        actualModel = `${requestedOverride.providerID}/${requestedOverride.modelID}`
+        modelInfo = { model: actualModel, type: "user-defined", source: "override" }
       }
 
       const systemContent = buildSystemContent({

--- a/packages/omo-opencode/src/tools/delegate-task/types.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/types.ts
@@ -62,6 +62,10 @@ export interface DelegateTaskArgs {
   task_id?: string
   command?: string
   load_skills: string[]
+  /** Orchestrator per-call model override, e.g. "openai/gpt-5.5" or "openai/gpt-5.5 xhigh". Gated to connected models. */
+  model?: string
+  /** Orchestrator per-call reasoning/variant override (e.g. "xhigh"); takes precedence over a variant inside `model`. */
+  reasoning_effort?: string
 }
 
 export interface ToolContextWithMetadata {

--- a/packages/omo-opencode/src/tools/index.ts
+++ b/packages/omo-opencode/src/tools/index.ts
@@ -1,5 +1,6 @@
 export { createGrepTools } from "./grep"
 export { createGlobTools } from "./glob"
+export { createListModelsTools } from "./list-models"
 export { createSkillTool } from "./skill"
 export { discoverCommandsSync } from "./slashcommand"
 export { createSessionManagerTools } from "./session-manager"

--- a/packages/omo-opencode/src/tools/list-models/index.ts
+++ b/packages/omo-opencode/src/tools/list-models/index.ts
@@ -1,0 +1,1 @@
+export { createListModelsTools, buildListModelsOutput, formatModelList, REASONING_VALUES } from "./tools"

--- a/packages/omo-opencode/src/tools/list-models/list-models.test.ts
+++ b/packages/omo-opencode/src/tools/list-models/list-models.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import { buildListModelsOutput, formatModelList, REASONING_VALUES } from "./tools"
+
+describe("list_models formatting", () => {
+  test("#given connected models #then grouped by provider, sorted, verbatim ids", () => {
+    // when
+    const out = formatModelList(new Set(["openai/gpt-5.5", "anthropic/claude-opus-4-8", "openai/gpt-5.4-mini"]))
+    // then
+    expect(out).toContain("anthropic:")
+    expect(out).toContain("  - anthropic/claude-opus-4-8")
+    expect(out).toContain("openai:")
+    expect(out).toContain("  - openai/gpt-5.4-mini")
+    expect(out).toContain("  - openai/gpt-5.5")
+    // anthropic sorts before openai
+    expect(out.indexOf("anthropic:")).toBeLessThan(out.indexOf("openai:"))
+  })
+
+  test("#given provider filter #then only that provider is listed", () => {
+    // when
+    const out = formatModelList(new Set(["openai/gpt-5.5", "anthropic/claude-opus-4-8"]), "openai")
+    // then
+    expect(out).toContain("openai/gpt-5.5")
+    expect(out).not.toContain("anthropic")
+  })
+
+  test("#given empty set #then cold-cache guidance (not an error)", () => {
+    // when
+    const out = formatModelList(new Set())
+    // then
+    expect(out.toLowerCase()).toContain("cold cache")
+  })
+
+  test("#given provider filter with no matches #then helpful message", () => {
+    // when
+    const out = formatModelList(new Set(["openai/gpt-5.5"]), "ghost")
+    // then
+    expect(out).toContain('provider "ghost"')
+  })
+
+  test("#then full output includes reasoning vocabulary + usage examples", () => {
+    // when
+    const out = buildListModelsOutput(new Set(["openai/gpt-5.5"]))
+    // then
+    for (const v of REASONING_VALUES) expect(out).toContain(v)
+    expect(out).toContain("reasoning_effort")
+    expect(out).toContain('task(subagent_type="librarian"')
+    expect(out).toContain("call_omo_agent(")
+    expect(out).toContain("Unknown models are rejected")
+  })
+})

--- a/packages/omo-opencode/src/tools/list-models/tools.ts
+++ b/packages/omo-opencode/src/tools/list-models/tools.ts
@@ -1,0 +1,77 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import { getAvailableModelsForDelegateTask } from "../delegate-task/available-models"
+
+// The reasoning/variant vocabulary accepted by `reasoning_effort` (and embedded
+// `model "<variant>"`). Values are normalized per-model at resolution time —
+// unsupported ones are downgraded or dropped, never hard-failed.
+export const REASONING_VALUES = ["minimal", "low", "medium", "high", "xhigh", "max"] as const
+
+export function formatModelList(models: ReadonlySet<string>, providerFilter?: string): string {
+  if (models.size === 0) {
+    return "(no connected models detected yet — cold cache. You may still pass a \"provider/model\" you know is connected; it is accepted on a cold cache and validated once the model list warms up.)"
+  }
+  const byProvider = new Map<string, string[]>()
+  const filter = providerFilter?.trim().toLowerCase()
+  for (const full of models) {
+    const idx = full.indexOf("/")
+    const provider = idx === -1 ? full : full.slice(0, idx)
+    const modelId = idx === -1 ? full : full.slice(idx + 1)
+    if (filter && provider.toLowerCase() !== filter) continue
+    const arr = byProvider.get(provider) ?? []
+    arr.push(modelId)
+    byProvider.set(provider, arr)
+  }
+  if (byProvider.size === 0) {
+    return `(no connected models for provider "${providerFilter}". Omit the provider filter to see all.)`
+  }
+  const lines: string[] = []
+  for (const provider of [...byProvider.keys()].sort()) {
+    lines.push(`${provider}:`)
+    for (const modelId of byProvider.get(provider)!.sort()) {
+      lines.push(`  - ${provider}/${modelId}`)
+    }
+  }
+  return lines.join("\n")
+}
+
+export function buildListModelsOutput(models: ReadonlySet<string>, providerFilter?: string): string {
+  return [
+    "# Available models — pass any of these verbatim as `model`",
+    formatModelList(models, providerFilter),
+    "",
+    "# Reasoning / variant values for `reasoning_effort`",
+    `${REASONING_VALUES.join(", ")} (auto-normalized per model; unsupported values are downgraded or dropped).`,
+    "",
+    "# How to use",
+    'task(subagent_type="librarian", model="<provider/model>", reasoning_effort="<value>", run_in_background=true, description="...", prompt="...")',
+    'call_omo_agent(subagent_type="explore", model="<provider/model>", reasoning_effort="<value>", run_in_background=true, description="...", prompt="...")',
+    "Omit `model` to use the configured default for that agent/category. Unknown models are rejected.",
+  ].join("\n")
+}
+
+export function createListModelsTools(ctx: PluginInput): Record<string, ToolDefinition> {
+  const list_models: ToolDefinition = tool({
+    description:
+      "List the models currently connected/available to this OpenCode session (grouped by provider), plus the valid " +
+      "reasoning/variant values. Call this BEFORE passing a per-call `model` (and `reasoning_effort`) to `task`, " +
+      "`call_omo_agent`, or a team member, so you choose a model that actually exists — unknown models are rejected. " +
+      "Returns provider/model ids you can pass verbatim.",
+    args: {
+      provider: tool.schema
+        .string()
+        .optional()
+        .describe('Optional provider id to filter by (e.g. "openai", "anthropic", "google"). Omit to list every connected provider.'),
+    },
+    execute: async (args) => {
+      try {
+        const models = await getAvailableModelsForDelegateTask(ctx.client)
+        return buildListModelsOutput(models, args.provider)
+      } catch (e) {
+        return `Error listing models: ${e instanceof Error ? e.message : String(e)}`
+      }
+    },
+  })
+
+  return { list_models }
+}

--- a/packages/team-core/src/member-model-override.test.ts
+++ b/packages/team-core/src/member-model-override.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { MemberSchema } from "./types"
+
+describe("declared team member per-call model override", () => {
+  test("#given subagent member with model + reasoning_effort #then parses and carries both", () => {
+    // when
+    const result = MemberSchema.safeParse({
+      kind: "subagent_type",
+      name: "scout",
+      subagent_type: "sisyphus",
+      model: "openai/gpt-5.5",
+      reasoning_effort: "xhigh",
+    })
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const data = result.data as { model?: string; reasoning_effort?: string }
+      expect(data.model).toBe("openai/gpt-5.5")
+      expect(data.reasoning_effort).toBe("xhigh")
+    }
+  })
+
+  test("#given category member with model variant string #then parses", () => {
+    // when
+    const result = MemberSchema.safeParse({
+      kind: "category",
+      name: "writer",
+      category: "writing",
+      prompt: "Write release notes",
+      model: "openai/gpt-5.5 xhigh",
+    })
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const data = result.data as { model?: string }
+      expect(data.model).toBe("openai/gpt-5.5 xhigh")
+    }
+  })
+
+  test("#given member without model #then still parses (configured default preserved)", () => {
+    // when
+    const result = MemberSchema.safeParse({
+      kind: "subagent_type",
+      name: "scout",
+      subagent_type: "sisyphus",
+    })
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const data = result.data as { model?: string }
+      expect(data.model).toBeUndefined()
+    }
+  })
+
+  test("#given unknown extra field #then rejected (strict schema preserved)", () => {
+    // when
+    const result = MemberSchema.safeParse({
+      kind: "subagent_type",
+      name: "scout",
+      subagent_type: "sisyphus",
+      bogus_field: "nope",
+    })
+    // then
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/team-core/src/types.ts
+++ b/packages/team-core/src/types.ts
@@ -31,6 +31,12 @@ const MemberBaseSchema = z.object({
   backendType: z.enum(["in-process", "tmux"]).default("in-process"),
   color: z.string().optional(),
   isActive: z.boolean().default(true),
+  // Optional per-member model override chosen by the lead/orchestrator at team
+  // definition time, e.g. "openai/gpt-5.5" or "openai/gpt-5.5 xhigh". Gated to
+  // connected/available models when the member is resolved. Omit to use the
+  // category/subagent configured default.
+  model: z.string().optional(),
+  reasoning_effort: z.string().optional(),
 }).strict()
 
 export const CategoryMemberSchema = MemberBaseSchema.extend({


### PR DESCRIPTION
## Summary

- Lets the orchestrator pick a model (and reasoning/variant) **per delegation** — on `task` (both `subagent_type` and `category`), `call_omo_agent`, and team members — gated to connected/available models, with the configured default **and fallback chain preserved** when omitted.
- Adds a `list_models` tool so the agent can discover connected `provider/model` ids and the valid reasoning vocabulary before overriding.
- Fixes `team_create` inline members to actually accept `model` / `reasoning_effort` (the tool schema previously stripped them).

## Changes

- **`@oh-my-opencode/delegate-core`** — new pure, dependency-injected helper `resolveRequestedModelOverride()`: parses `provider/model[ variant]`, lets `reasoning_effort` override the embedded variant, gates via `fuzzyMatchModel`, with cold-cache passthrough so the first call isn't blocked.
- **`task` + `call_omo_agent`** — new optional `model` / `reasoning_effort` args; the override replaces the resolved model at top precedence while preserving the agent/category `fallbackChain`.
- **`team-core` `MemberBaseSchema`** — optional `model` / `reasoning_effort` (schema stays `.strict()`); and `team_create`'s inline-member tool schema now advertises both fields so the framework no longer strips them.
- **`list_models`** — new always-on tool: connected `provider/model` ids grouped by provider plus the reasoning vocabulary; pointer seeded into the `model` arg descriptions. Registered via the standard factory → `tool-registry-factories` → `createCoreTools()` → `tools/index.ts` path.
- **Docs** — `docs/reference/features.md` (per-call override + `list_models`) and `docs/guide/team-mode.md` (per-member override).

## Testing

```bash
bun run typecheck   # 0 errors (tsgo, all packages)
bun test            # green locally; CI passes on ubuntu/macos/windows
```

- `delegate-core` helper — 8 (parse / gate / variant / reasoning precedence / cold cache)
- delegate-task tool-boundary integration — 5 (asserts the real `session.prompt`/`launch` body carries model, reasoning, gate-reject + no-spawn, default-preserved, category)
- team member schema — 4; `team_create` inline-member model — 4; `list_models` formatting — 5
- **Manual QA on the real OpenCode harness:** `list_models` returns the connected set; `task(model="openai/gpt-5.5", reasoning_effort="high")` and `task(model="xai/grok-composer-2.5-fast")` each launch on exactly that model/provider; an invalid id (`openai/ghost-999`) fails at the gate/provider and the preserved fallback chain recovers it. Plugin load verified in an isolated XDG sandbox (`Built tool registry … totalTools 26, teamModeEnabled true`, 25→26 = `list_models` registered).

## Related Issues

None — standalone feature. Three design questions for maintainers:

1. **Opt-in gating?** On by default (the gate is the safety). Happy to add a `delegate_task.allow_runtime_model` config flag if you'd prefer it gated, given the caution in `docs/guide/agent-model-matching.md`.
2. **Cold-cache passthrough** in `requested-model.ts` is the one gate relaxation (first-call safety); stricter behavior is a one-liner.
3. **`reasoning_effort`** accepts any string (normalized downstream per model); could be enum-validated.
