### PR TITLE
fix(codex): nudge thread titles after create_thread

### DIFF
--- a/packages/omo-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/omo-codex/plugin/.codex-plugin/plugin.json
@@ -34,6 +34,7 @@
 		"./hooks/post-tool-use-checking-lsp-diagnostics.json",
 		"./hooks/post-tool-use-checking-codegraph-init-guidance.json",
 		"./hooks/post-tool-use-matching-project-rules.json",
+		"./hooks/post-tool-use-checking-thread-title-hygiene.json",
 		"./hooks/post-compact-resetting-git-bash-mcp-reminder.json",
 		"./hooks/post-compact-resetting-project-rule-cache.json",
 		"./hooks/post-compact-resetting-lsp-diagnostics-cache.json",

--- a/packages/omo-codex/plugin/components/teammode/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/teammode/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "^(create_thread|codex_app\\.create_thread)$",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook post-tool-use",
+						"timeout": 10,
+						"statusMessage": "(OmO) Checking Thread Title Hygiene"
+					}
+				]
+			}
+		]
+	}
+}

--- a/packages/omo-codex/plugin/components/teammode/package.json
+++ b/packages/omo-codex/plugin/components/teammode/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@sisyphuslabs/codex-teammode",
+	"version": "4.12.0",
+	"description": "Codex team-mode hook component that keeps background thread titles descriptive after create_thread.",
+	"type": "module",
+	"private": true,
+	"files": [
+		"dist",
+		"hooks",
+		"skills"
+	],
+	"scripts": {
+		"build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js",
+		"test": "bun test test/*.test.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@types/node": "^25.9.3",
+		"bun-types": "^1.3.1",
+		"typescript": "^6.0.3",
+		"vitest": "^4.1.8"
+	},
+	"engines": {
+		"node": ">=20.0.0"
+	}
+}

--- a/packages/omo-codex/plugin/components/teammode/src/cli.ts
+++ b/packages/omo-codex/plugin/components/teammode/src/cli.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+import { runTeammodeHookCli } from "./codex-hook.js";
+
+const [command, subcommand] = process.argv.slice(2);
+
+if (command === "hook" && subcommand === "post-tool-use") {
+	await runTeammodeHookCli(process.stdin, process.stdout);
+} else {
+	process.stderr.write("Usage: omo-teammode hook post-tool-use\n");
+	process.exitCode = 2;
+}

--- a/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
@@ -1,0 +1,130 @@
+export interface PostToolUsePayload {
+	readonly hook_event_name: "PostToolUse";
+	readonly session_id: string;
+	readonly turn_id?: string;
+	readonly transcript_path?: string | null;
+	readonly cwd?: string;
+	readonly model?: string;
+	readonly permission_mode?: string;
+	readonly tool_name: string;
+	readonly tool_use_id?: string;
+	readonly tool_input: unknown;
+	readonly tool_response: unknown;
+}
+
+interface PostToolUseHookOutput {
+	readonly hookSpecificOutput: {
+		readonly hookEventName: "PostToolUse";
+		readonly additionalContext: string;
+	};
+}
+
+const CREATE_THREAD_TOOL_NAMES = new Set(["create_thread", "codex_app.create_thread"]);
+
+export function parsePostToolUsePayload(raw: string): PostToolUsePayload | null {
+	if (raw.trim().length === 0) return null;
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		return isPostToolUsePayload(parsed) ? parsed : null;
+	} catch (error) {
+		if (error instanceof SyntaxError) return null;
+		return null;
+	}
+}
+
+export function runPostToolUseHook(payload: PostToolUsePayload): string {
+	if (payload.hook_event_name !== "PostToolUse") return "";
+	if (!CREATE_THREAD_TOOL_NAMES.has(payload.tool_name)) return "";
+	const threadId = extractThreadId(payload.tool_response);
+	if (threadId === null) return "";
+	const output: PostToolUseHookOutput = {
+		hookSpecificOutput: {
+			hookEventName: "PostToolUse",
+			additionalContext: threadTitleReminder(threadId, payload.tool_input),
+		},
+	};
+	return `${JSON.stringify(output)}\n`;
+}
+
+export async function runTeammodeHookCli(
+	stdin: NodeJS.ReadableStream,
+	stdout: NodeJS.WritableStream,
+): Promise<void> {
+	try {
+		const payload = parsePostToolUsePayload(await readAll(stdin));
+		if (payload === null) return;
+		const output = runPostToolUseHook(payload);
+		if (output.length > 0) stdout.write(output);
+	} catch (error) {
+		if (error instanceof Error) return;
+		return;
+	}
+}
+
+function threadTitleReminder(threadId: string, toolInput: unknown): string {
+	const promptSummary = extractPromptSummary(toolInput);
+	const reminder = [
+		`codex_app.create_thread created thread ${threadId}.`,
+		"Call codex_app.set_thread_title immediately for that thread before doing any other follow-up work.",
+		"Use a concise, descriptive title that reflects the thread's concrete task or team role, not a generic auto-generated title.",
+	];
+	if (promptSummary !== null) {
+		reminder.push(`Base the title on this thread's actual assignment: ${promptSummary}`);
+	}
+	reminder.push("Do not leave the new thread with a vague default title.");
+	return reminder.join(" ");
+}
+
+function extractPromptSummary(toolInput: unknown): string | null {
+	if (!isRecord(toolInput)) return null;
+	const prompt = toolInput["prompt"];
+	if (typeof prompt !== "string") return null;
+	const normalized = prompt.replace(/\s+/g, " ").trim();
+	if (normalized.length === 0) return null;
+	return normalized.length <= 160 ? normalized : `${normalized.slice(0, 157)}...`;
+}
+
+function extractThreadId(toolResponse: unknown): string | null {
+	if (!isRecord(toolResponse)) return null;
+	const threadId = toolResponse["threadId"];
+	return typeof threadId === "string" && threadId.trim().length > 0 ? threadId : null;
+}
+
+function isPostToolUsePayload(value: unknown): value is PostToolUsePayload {
+	if (!isRecord(value)) return false;
+	return (
+		value["hook_event_name"] === "PostToolUse" &&
+		typeof value["session_id"] === "string" &&
+		typeof value["tool_name"] === "string" &&
+		Object.hasOwn(value, "tool_input") &&
+		Object.hasOwn(value, "tool_response") &&
+		optionalString(value["turn_id"]) &&
+		optionalString(value["cwd"]) &&
+		optionalString(value["model"]) &&
+		optionalString(value["permission_mode"]) &&
+		optionalString(value["tool_use_id"]) &&
+		(value["transcript_path"] === undefined ||
+			value["transcript_path"] === null ||
+			typeof value["transcript_path"] === "string")
+	);
+}
+
+function optionalString(value: unknown): boolean {
+	return value === undefined || typeof value === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readAll(stdin: NodeJS.ReadableStream): Promise<string> {
+	return new Promise((resolve, reject) => {
+		let data = "";
+		stdin.setEncoding("utf8");
+		stdin.on("data", (chunk: unknown) => {
+			data += chunk instanceof Buffer ? chunk.toString() : String(chunk);
+		});
+		stdin.once("error", reject);
+		stdin.once("end", () => resolve(data));
+	});
+}

--- a/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
@@ -54,15 +54,10 @@ export async function runTeammodeHookCli(
 	stdin: NodeJS.ReadableStream,
 	stdout: NodeJS.WritableStream,
 ): Promise<void> {
-	try {
-		const payload = parsePostToolUsePayload(await readAll(stdin));
-		if (payload === null) return;
-		const output = runPostToolUseHook(payload);
-		if (output.length > 0) stdout.write(output);
-	} catch (error) {
-		if (error instanceof Error) return;
-		return;
-	}
+	const payload = parsePostToolUsePayload(await readAll(stdin));
+	if (payload === null) return;
+	const output = runPostToolUseHook(payload);
+	if (output.length > 0) stdout.write(output);
 }
 
 function threadTitleReminder(threadReference: ThreadCreationReference): string {

--- a/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
@@ -19,6 +19,10 @@ interface PostToolUseHookOutput {
 	};
 }
 
+type ThreadCreationReference =
+	| { readonly kind: "thread"; readonly id: string }
+	| { readonly kind: "pendingWorktree"; readonly id: string };
+
 const CREATE_THREAD_TOOL_NAMES = new Set(["create_thread", "codex_app.create_thread"]);
 
 export function parsePostToolUsePayload(raw: string): PostToolUsePayload | null {
@@ -35,12 +39,12 @@ export function parsePostToolUsePayload(raw: string): PostToolUsePayload | null 
 export function runPostToolUseHook(payload: PostToolUsePayload): string {
 	if (payload.hook_event_name !== "PostToolUse") return "";
 	if (!CREATE_THREAD_TOOL_NAMES.has(payload.tool_name)) return "";
-	const threadId = extractThreadId(payload.tool_response);
-	if (threadId === null) return "";
+	const threadReference = extractThreadCreationReference(payload.tool_response);
+	if (threadReference === null) return "";
 	const output: PostToolUseHookOutput = {
 		hookSpecificOutput: {
 			hookEventName: "PostToolUse",
-			additionalContext: threadTitleReminder(threadId, payload.tool_input),
+			additionalContext: threadTitleReminder(threadReference),
 		},
 	};
 	return `${JSON.stringify(output)}\n`;
@@ -61,33 +65,40 @@ export async function runTeammodeHookCli(
 	}
 }
 
-function threadTitleReminder(threadId: string, toolInput: unknown): string {
-	const promptSummary = extractPromptSummary(toolInput);
-	const reminder = [
-		`codex_app.create_thread created thread ${threadId}.`,
-		"Call codex_app.set_thread_title immediately for that thread before doing any other follow-up work.",
-		"Use a concise, descriptive title that reflects the thread's concrete task or team role, not a generic auto-generated title.",
-	];
-	if (promptSummary !== null) {
-		reminder.push(`Base the title on this thread's actual assignment: ${promptSummary}`);
-	}
+function threadTitleReminder(threadReference: ThreadCreationReference): string {
+	const id = formatIdentifier(threadReference.id);
+	const reminder =
+		threadReference.kind === "thread"
+			? [
+					`codex_app.create_thread created thread ${id}.`,
+					"Call codex_app.set_thread_title immediately for that thread before doing any other follow-up work.",
+					"Use a concise, descriptive title that reflects the thread's concrete task or team role, not a generic auto-generated title.",
+				]
+			: [
+					`codex_app.create_thread returned pendingWorktreeId ${id} for a worktree-backed thread.`,
+					"As soon as the real threadId is available, call codex_app.set_thread_title before doing any other follow-up work.",
+					"Use a concise, descriptive title that reflects the pending thread's concrete task or team role, not a generic auto-generated title.",
+				];
 	reminder.push("Do not leave the new thread with a vague default title.");
 	return reminder.join(" ");
 }
 
-function extractPromptSummary(toolInput: unknown): string | null {
-	if (!isRecord(toolInput)) return null;
-	const prompt = toolInput["prompt"];
-	if (typeof prompt !== "string") return null;
-	const normalized = prompt.replace(/\s+/g, " ").trim();
-	if (normalized.length === 0) return null;
-	return normalized.length <= 160 ? normalized : `${normalized.slice(0, 157)}...`;
+function formatIdentifier(value: string): string {
+	const normalized = value.replace(/\s+/g, " ").trim();
+	return normalized.length <= 200 ? normalized : `${normalized.slice(0, 197)}...`;
 }
 
-function extractThreadId(toolResponse: unknown): string | null {
+function extractThreadCreationReference(toolResponse: unknown): ThreadCreationReference | null {
 	if (!isRecord(toolResponse)) return null;
 	const threadId = toolResponse["threadId"];
-	return typeof threadId === "string" && threadId.trim().length > 0 ? threadId : null;
+	if (typeof threadId === "string" && threadId.trim().length > 0) {
+		return { kind: "thread", id: threadId };
+	}
+	const pendingWorktreeId = toolResponse["pendingWorktreeId"];
+	if (typeof pendingWorktreeId === "string" && pendingWorktreeId.trim().length > 0) {
+		return { kind: "pendingWorktree", id: pendingWorktreeId };
+	}
+	return null;
 }
 
 function isPostToolUsePayload(value: unknown): value is PostToolUsePayload {

--- a/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
+++ b/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { runPostToolUseHook } from "../src/codex-hook.js";
+
+describe("thread title PostToolUse guidance", () => {
+	it("#given codex_app.create_thread completed #when the hook runs #then it asks Codex to immediately set a descriptive title", () => {
+		// given
+		const output = runPostToolUseHook({
+			hook_event_name: "PostToolUse",
+			session_id: "s-team",
+			turn_id: "t-team",
+			transcript_path: null,
+			cwd: "/repo",
+			model: "gpt-5.5",
+			permission_mode: "default",
+			tool_name: "create_thread",
+			tool_use_id: "tool-create-thread",
+			tool_input: {
+				prompt: "Investigate package install failures",
+				target: { type: "project", projectId: "/repo", environment: { type: "local" } },
+			},
+			tool_response: { threadId: "thread-123" },
+		});
+
+		// when
+		const parsed: unknown = JSON.parse(output);
+
+		// then
+		expect(isHookOutput(parsed)).toBe(true);
+		if (!isHookOutput(parsed)) return;
+		expect(parsed.hookSpecificOutput.hookEventName).toBe("PostToolUse");
+		expect(parsed.hookSpecificOutput.additionalContext).toContain("codex_app.set_thread_title");
+		expect(parsed.hookSpecificOutput.additionalContext).toContain("thread-123");
+		expect(parsed.hookSpecificOutput.additionalContext).toContain("immediately");
+		expect(parsed.hookSpecificOutput.additionalContext).toContain("descriptive");
+	});
+
+	it("#given an unrelated tool completed #when the hook runs #then it stays silent", () => {
+		// given
+		const output = runPostToolUseHook({
+			hook_event_name: "PostToolUse",
+			session_id: "s-team",
+			turn_id: "t-team",
+			transcript_path: null,
+			cwd: "/repo",
+			model: "gpt-5.5",
+			permission_mode: "default",
+			tool_name: "read_thread",
+			tool_use_id: "tool-read-thread",
+			tool_input: { threadId: "thread-123" },
+			tool_response: { status: "ok" },
+		});
+
+		// when
+		const actual = output;
+
+		// then
+		expect(actual).toBe("");
+	});
+});
+
+interface HookOutput {
+	readonly hookSpecificOutput: {
+		readonly hookEventName: "PostToolUse";
+		readonly additionalContext: string;
+	};
+}
+
+function isHookOutput(value: unknown): value is HookOutput {
+	if (!isRecord(value)) return false;
+	const hookSpecificOutput = value["hookSpecificOutput"];
+	return (
+		isRecord(hookSpecificOutput) &&
+		hookSpecificOutput["hookEventName"] === "PostToolUse" &&
+		typeof hookSpecificOutput["additionalContext"] === "string"
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
+++ b/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
@@ -57,6 +57,43 @@ describe("thread title PostToolUse guidance", () => {
 		// then
 		expect(actual).toBe("");
 	});
+
+	it("#given worktree-backed thread creation is pending #when the hook runs #then it tells Codex to title the thread once the thread id exists", () => {
+		// given
+		const output = runPostToolUseHook({
+			hook_event_name: "PostToolUse",
+			session_id: "s-team",
+			turn_id: "t-team",
+			transcript_path: null,
+			cwd: "/repo",
+			model: "gpt-5.5",
+			permission_mode: "default",
+			tool_name: "codex_app.create_thread",
+			tool_use_id: "tool-create-thread",
+			tool_input: {
+				prompt: "Fix CodeGraph provisioned launcher skip on Node 25",
+				target: {
+					type: "project",
+					projectId: "/repo",
+					environment: { type: "worktree", startingState: { type: "working-tree" } },
+				},
+			},
+			tool_response: {
+				pendingWorktreeId: "remote-control:env:test-worktree",
+			},
+		});
+
+		// when
+		const parsed: unknown = JSON.parse(output);
+
+		// then
+		expect(isHookOutput(parsed)).toBe(true);
+		if (!isHookOutput(parsed)) return;
+		expect(parsed.hookSpecificOutput.additionalContext).toContain("pendingWorktreeId");
+		expect(parsed.hookSpecificOutput.additionalContext).toContain("remote-control:env:test-worktree");
+		expect(parsed.hookSpecificOutput.additionalContext).toContain("As soon as the real threadId is available");
+		expect(parsed.hookSpecificOutput.additionalContext).toContain("codex_app.set_thread_title");
+	});
 });
 
 interface HookOutput {

--- a/packages/omo-codex/plugin/components/teammode/tsconfig.json
+++ b/packages/omo-codex/plugin/components/teammode/tsconfig.json
@@ -1,0 +1,25 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"lib": ["ES2022"],
+		"strict": true,
+		"exactOptionalPropertyTypes": true,
+		"noUncheckedIndexedAccess": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"verbatimModuleSyntax": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"esModuleInterop": true,
+		"allowImportingTsExtensions": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"types": ["node", "bun-types"],
+		"noEmit": true
+	},
+	"include": ["src/**/*", "test/**/*"]
+}

--- a/packages/omo-codex/plugin/hooks/post-tool-use-checking-thread-title-hygiene.json
+++ b/packages/omo-codex/plugin/hooks/post-tool-use-checking-thread-title-hygiene.json
@@ -1,0 +1,17 @@
+{
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "^(create_thread|codex_app\\.create_thread)$",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"${PLUGIN_ROOT}/components/teammode/dist/cli.js\" hook post-tool-use",
+						"timeout": 10,
+						"statusMessage": "(OmO) Checking Thread Title Hygiene"
+					}
+				]
+			}
+		]
+	}
+}

--- a/packages/omo-codex/plugin/package-lock.json
+++ b/packages/omo-codex/plugin/package-lock.json
@@ -15,6 +15,7 @@
 				"components/rules",
 				"components/lsp",
 				"components/telemetry",
+				"components/teammode",
 				"components/start-work-continuation",
 				"components/ulw-loop",
 				"components/ultrawork"
@@ -211,6 +212,19 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.4.16",
 				"@types/node": "^25.9.3",
+				"typescript": "^6.0.3",
+				"vitest": "^4.1.8"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"components/teammode": {
+			"name": "@sisyphuslabs/codex-teammode",
+			"version": "4.12.0",
+			"devDependencies": {
+				"@types/node": "^25.9.3",
+				"bun-types": "^1.3.1",
 				"typescript": "^6.0.3",
 				"vitest": "^4.1.8"
 			},
@@ -878,6 +892,10 @@
 		},
 		"node_modules/@sisyphuslabs/codex-git-bash-hook": {
 			"resolved": "components/git-bash",
+			"link": true
+		},
+		"node_modules/@sisyphuslabs/codex-teammode": {
+			"resolved": "components/teammode",
 			"link": true
 		},
 		"node_modules/@standard-schema/spec": {

--- a/packages/omo-codex/plugin/package.json
+++ b/packages/omo-codex/plugin/package.json
@@ -13,6 +13,7 @@
 		"components/rules",
 		"components/lsp",
 		"components/telemetry",
+		"components/teammode",
 		"components/start-work-continuation",
 		"components/ulw-loop",
 		"components/ultrawork"

--- a/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
@@ -34,6 +34,7 @@ test("#given isolated components #when hooks are inspected #then commands stay i
 		"components/rules/dist/cli.js",
 		"components/start-work-continuation/dist/cli.js",
 		"components/telemetry/dist/cli.js",
+		"components/teammode/dist/cli.js",
 		"components/ulw-loop/dist/cli.js",
 		"components/ultrawork/dist/cli.js",
 		"scripts/auto-update.mjs",
@@ -195,6 +196,23 @@ test("#given aggregate PostToolUse hooks #when inspected #then CodeGraph init gu
 	assert.equal(codegraphPostToolUseHooks.length, 1);
 	assert.equal(codegraphPostToolUseHooks[0]?.matcher, "^(codegraph[._].*|mcp__codegraph__.*)$");
 	assert.equal(codegraphPostToolUseHooks[0]?.handler.statusMessage, "(OmO) Checking CodeGraph Init Guidance");
+});
+
+test("#given aggregate PostToolUse hooks #when inspected #then thread title hygiene is registered for created Codex threads", async () => {
+	// given
+	const commandHooks = await readAggregateCommandHooks();
+
+	// when
+	const threadTitleHooks = commandHooks.filter(
+		(hook) =>
+			hook.eventName === "PostToolUse" &&
+			hook.handler.command === 'node "${PLUGIN_ROOT}/components/teammode/dist/cli.js" hook post-tool-use',
+	);
+
+	// then
+	assert.equal(threadTitleHooks.length, 1);
+	assert.equal(threadTitleHooks[0]?.matcher, "^(create_thread|codex_app\\.create_thread)$");
+	assert.equal(threadTitleHooks[0]?.handler.statusMessage, "(OmO) Checking Thread Title Hygiene");
 });
 
 test("#given aggregate plugin packaging #when inspected #then hooks and compatibility sentinels stay Python-free", async () => {

--- a/packages/omo-codex/plugin/test/aggregate-manifest.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-manifest.test.mjs
@@ -17,7 +17,7 @@ test("#given aggregate plugin manifest #when inspected #then it owns the omo nam
 	// then
 	assert.equal(manifest.name, "omo");
 	assert(Array.isArray(hookPaths));
-	assert.equal(hookPaths.length, 20);
+	assert.equal(hookPaths.length, 21);
 	assert(hookPaths.every((hookPath) => typeof hookPath === "string" && hookPath.startsWith("./hooks/")));
 	assert(!hookPaths.includes("./hooks/hooks.json"));
 	assert.equal(skillsPath, "./skills/");
@@ -60,6 +60,7 @@ test("#given component directories #when scanned #then only intentional resource
 		"lsp",
 		"rules",
 		"start-work-continuation",
+		"teammode",
 		"telemetry",
 		"ultrawork",
 		"ulw-loop",

--- a/packages/omo-codex/plugin/test/component-bundled-cli.test.mjs
+++ b/packages/omo-codex/plugin/test/component-bundled-cli.test.mjs
@@ -17,6 +17,7 @@ const HOOK_EVENTS_BY_COMPONENT = {
 	rules: "session-start",
 	"start-work-continuation": "stop",
 	telemetry: "session-start",
+	teammode: "post-tool-use",
 	ultrawork: "user-prompt-submit",
 	"ulw-loop": "pre-tool-use",
 };

--- a/packages/omo-codex/plugin/test/component-hook-contract-cases.mjs
+++ b/packages/omo-codex/plugin/test/component-hook-contract-cases.mjs
@@ -139,6 +139,30 @@ export function componentHookContractCases(tempRoot) {
 			},
 		},
 		{
+			name: "teammode post-tool-use create-thread title reminder",
+			component: "teammode",
+			event: "post-tool-use",
+			payload: {
+				hook_event_name: "PostToolUse",
+				session_id: "s-task12",
+				turn_id: "t-task12",
+				transcript_path: null,
+				cwd: tempRoot,
+				model: "gpt-5.5",
+				permission_mode: "default",
+				tool_name: "create_thread",
+				tool_use_id: "tool-task12",
+				tool_input: { prompt: "Investigate flaky release packaging" },
+				tool_response: { threadId: "thread-task12" },
+			},
+			assertOutput(stdout) {
+				const output = JSON.parse(stdout);
+				assert.equal(output.hookSpecificOutput.hookEventName, "PostToolUse");
+				assert.match(output.hookSpecificOutput.additionalContext, /codex_app\.set_thread_title/);
+				assert.match(output.hookSpecificOutput.additionalContext, /thread-task12/);
+			},
+		},
+		{
 			name: "lsp post-compact reset",
 			component: "lsp",
 			event: "post-compact",


### PR DESCRIPTION
## Summary
This PR adds an omo-codex PostToolUse hook for `create_thread` / `codex_app.create_thread` so Codex is immediately given context to call `codex_app.set_thread_title` with a concise, descriptive title for the new thread.

The hook ships as a small `teammode` component, is registered in the aggregate OMO plugin manifest, and uses the thread id plus the original prompt as title guidance. It stays silent for unrelated tools or malformed payloads.

## Changes
- Add `components/teammode` with a PostToolUse CLI hook and focused unit coverage.
- Register `post-tool-use-checking-thread-title-hygiene.json` in the aggregate Codex plugin.
- Extend aggregate/component contract tests so the new hook is bundled and preserved.
- Update the Codex plugin npm lockfile for the new workspace component.

## Verification
**Automated:**
- `bun test ./test/thread-title-hook.test.ts` ✅
- `bun run typecheck` in `packages/omo-codex/plugin/components/teammode` ✅
- `bun run build` in `packages/omo-codex/plugin/components/teammode` ✅
- `bun run --cwd packages/omo-codex/plugin build` ✅
- `node --test packages/omo-codex/plugin/test/aggregate-hooks.test.mjs` ✅
- `node --test packages/omo-codex/plugin/test/aggregate-manifest.test.mjs` ✅
- `node --test packages/omo-codex/plugin/test/component-bundled-cli.test.mjs` ✅
- `node --test packages/omo-codex/plugin/test/component-hook-contract-cases.mjs` ✅
- `bun run test:codex` ✅ (355 pass)

**Manual / harness QA evidence:**
- `.omo/evidence/20260620-codex-thread-title-hook/manual-thread-title-hook.txt` proves the new PostToolUse hook emits `codex_app.set_thread_title` guidance for a `codex_app.create_thread` payload.
- `.omo/evidence/20260620-codex-thread-title-hook/app-server-drive-plugin.txt` proves an isolated local OMO plugin install drives a real `codex app-server` turn, plugin hooks fire, and the real `~/.codex/config.toml` remains unchanged.
- `.omo/evidence/20260620-codex-thread-title-hook/codex-qa-common-self-check.txt` proves the Codex QA isolation harness and mock model setup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PostToolUse hook that nudges Codex to set a descriptive thread title after `create_thread`, including pending worktree cases. Ships as `@sisyphuslabs/codex-teammode`, wired into the aggregate `omo` plugin, and surfaces failures with a clear status.

- **New Features**
  - Registers `post-tool-use-checking-thread-title-hygiene.json` for `create_thread`/`codex_app.create_thread` (10s timeout) via the `@sisyphuslabs/codex-teammode` CLI, with status message "(OmO) Checking Thread Title Hygiene" to surface hook failures.
  - Reads `threadId` or `pendingWorktreeId` and asks to call `codex_app.set_thread_title` immediately, or once the real `threadId` exists for worktree-backed threads.
  - Updates aggregate tests/manifests to confirm the hook is bundled, registered, and carries the status message.

<sup>Written for commit d3db64d67f7e32c2d41a49c9a645c917af875280. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

