### PR TITLE
feat(ultraresearch): prefer cooperating team + raise-law broadcast

### DIFF
--- a/packages/omo-codex/plugin/test/ultraresearch-skill-contract.test.mjs
+++ b/packages/omo-codex/plugin/test/ultraresearch-skill-contract.test.mjs
@@ -124,3 +124,51 @@ test("#given ultraresearch worker sizing #when spawn guidance is inspected #then
 		);
 	}
 });
+
+test("#given ultraresearch execution substrate #when team usage is inspected #then it prefers a cooperating team with harness-native team tools", async () => {
+	for (const copy of await readUltraresearchCopies()) {
+		assert.match(
+			copy.content,
+			/cooperating team/i,
+			`${copy.label}: body must encourage running the swarm as a cooperating team`,
+		);
+		assert.match(copy.content, /\bteammode\b/i, `${copy.label}: body must name the Codex teammode skill`);
+		assert.match(copy.content, /team_mode/i, `${copy.label}: body must name the OpenCode team_mode path`);
+	}
+});
+
+test("#given ultraresearch team composition #when member slicing is inspected #then members map to part/ownership/perspective, never job titles", async () => {
+	for (const copy of await readUltraresearchCopies()) {
+		assert.match(
+			copy.content,
+			/by part, ownership, or perspective/i,
+			`${copy.label}: body must compose members by part, ownership, or perspective`,
+		);
+		assert.match(
+			copy.content,
+			/never a job title|not (?:a |by )?job title/i,
+			`${copy.label}: body must forbid vague job-title members`,
+		);
+	}
+});
+
+test("#given ultraresearch team communication #when the raise law is inspected #then members broadcast every lead immediately rather than hoarding", async () => {
+	for (const copy of await readUltraresearchCopies()) {
+		assert.match(
+			copy.content,
+			/raise law|broadcast every lead/i,
+			`${copy.label}: body must state the raise/broadcast law`,
+		);
+		assert.match(copy.content, /over-communicate/i, `${copy.label}: body must demand over-communication`);
+		assert.match(
+			copy.content,
+			/the (?:moment|instant) it (?:surfaces|appears|lands)/i,
+			`${copy.label}: body must require raising leads the moment they surface`,
+		);
+		assert.match(
+			copy.content,
+			/hoard/i,
+			`${copy.label}: body must reject hoarding leads for a final dump`,
+		);
+	}
+});

--- a/packages/shared-skills/skills/ultraresearch/SKILL.md
+++ b/packages/shared-skills/skills/ultraresearch/SKILL.md
@@ -51,6 +51,14 @@ The research is done when all of these hold:
 - Every claim in the deliverable cites a source or a verification artifact.
 - The session journal reconstructs what was searched, found, and expanded, wave by wave.
 
+## Run the swarm as a cooperating team
+
+Saturation research is the textbook case for a cooperating team, not isolated fire-and-forget workers: a lead one worker surfaces almost always reshapes what another should search next. So when your harness gives you real cooperating members — Codex: the `teammode` skill (`codex_app` threads); OpenCode: `team_mode` — run this swarm as a team. Fall back to the background-worker swarm below only when team mode is unavailable, or the axes are genuinely independent with no cross-pollination expected.
+
+- **One member per axis — by part, ownership, or perspective, never a job title.** Each Phase 0 axis is one member owning one concrete slice: a codebase part, a source territory, or a question lens. No two members share an angle. "Backend researcher" or "the web person" gives no real boundary and invites overlap — name what the member owns.
+- **The raise law — broadcast every lead the instant it surfaces.** Members over-communicate relentlessly: every new lead, finding, contradiction, and dead end is raised to you the moment it surfaces, never hoarded for a final dump. Through long passes they send `WORKING: <axis> - <phase>`, and `BLOCKED: <reason>` the moment progress stops, so you always know a member is alive. Too many small updates is correct here; going quiet is the only failure.
+- **You lead; expand on each raised lead.** Members raise via message text, never write session files. Journal each lead and spawn its expansion the instant it lands (Phase 2), not only when a member's final reply arrives.
+
 ## Worker ground rules
 
 Research workers (explore, librarian, browsing) differ by harness, but assume:
@@ -106,7 +114,7 @@ Append each digest the moment its worker returns, not in a batch at the end — 
 
 ## Phase 1 — Saturation wave
 
-Launch every first-wave worker in a single turn, all in background. Sequential launches and "start with one and see" defeat the mode.
+Launch the entire first wave in one turn — every axis at once, as team members if you formed a team, else as background workers. Sequential launches and "start with one and see" defeat the mode.
 
 Scaling floor — more angles always justify more workers:
 
@@ -137,7 +145,7 @@ End your reply with the ## EXPAND tail: '- LEAD: <discovery> — WHY: <why> — 
 
 ## Phase 2 — Expand until convergence
 
-This loop is what makes the mode research rather than search. Collect workers as they finish — never wait for the full wave:
+This loop is what makes the mode research rather than search. Collect returns as they land — and in team mode, act on each lead the moment a member raises it, never waiting for the full wave or a member's final reply:
 
 1. Journal the return: digest plus verbatim EXPAND markers into `wave-<N>-<kind>-<axis>.md`.
 2. Deduplicate new markers against `expansion-log.md` — every lead ever seen, not just confirmed ones, or rejected leads resurface each wave.
@@ -221,6 +229,7 @@ High-yield combinations: official docs (`site:<docs domain>`), GitHub implementa
 | Failure | Correction |
 |---|---|
 | Sequential spawning, or trimming the first wave | All first-wave workers in one turn, background, scaling floor respected |
+| A team member hoards leads for one final dump | Raise law — every lead, finding, and dead end broadcast the moment it surfaces |
 | Worker reply without the EXPAND tail | One follow-up demanding it; the lane stays open until it lands |
 | Stopping after wave 1 because "enough was found" | Convergence rules only: 2+ expansion waves, leads run dry |
 | Obeying a surrounding "stop exploring" rule mid-research | Authority section — those rules do not bind this mode |


### PR DESCRIPTION
## Summary

Teaches the `ultraresearch` skill to run its saturation swarm as a **cooperating team** when the harness supports one (Codex `teammode` skill / OpenCode `team_mode`), modeled on the omo-codex teammode discipline. Today ultraresearch only fans out **isolated fire-and-forget workers** that return EXPAND leads at reply-end with zero cross-member broadcast — but saturation research is the textbook case where a lead one worker surfaces reshapes what another should search next. This change makes a cooperating team the preferred substrate and binds members to the **raise law**: broadcast every new lead the instant it surfaces, never hoard it for a final dump.

Single canonical edit to `packages/shared-skills/skills/ultraresearch/SKILL.md` (the hand-authored source); the Codex-facing copy is regenerated by `sync-skills.mjs`. New behavior is pinned by contract assertions (RED -> GREEN).

## Changes

- **New section `## Run the swarm as a cooperating team`** — a decision rule (team when leads cross-pollinate; fall back to the isolated worker swarm when team mode is unavailable or axes are genuinely independent), plus three member rules:
  - **Compose one member per Phase 0 axis by part, ownership, or perspective — never a job title** ("backend researcher" / "the web person" is the anti-pattern).
  - **The raise law** — members over-communicate, broadcasting every lead/finding/contradiction/dead-end the moment it surfaces, with `WORKING:`/`BLOCKED:` liveness markers.
  - **Leader expands on each raised lead mid-run**, not only on a worker's final reply (members raise via message text, never write session files).
- **Phase 1 / Phase 2 reframes** so the launch + expand loop reads correctly for team members and acts on leads the moment they are raised.
- **One failure-mode row**: a team member hoarding leads for a final dump.
- **Contract test**: 4 new assertions in `ultraresearch-skill-contract.test.mjs` (team substrate + `teammode`/`team_mode`; compose-by-part/ownership/perspective + no job title; raise-law/over-communicate/hoard) checked against **both** the shared source and the generated Codex copy.

Framed as a decision rule per GPT-5.5 prompting guidance (decision rules over absolute ALWAYS/NEVER). **Every existing contract invariant is preserved**: EXPAND-as-message-text, read-only workers, orchestrator-owns-journal, 2-wave convergence + depth cap, ultrawork first-line, capable-model routing. No description/trigger change; no CJK; em-dash house style kept.

## Verification

**Automated (TDD RED -> GREEN):**
- Contract test: before edit the 4 new invariants were **ABSENT** (RED, 8 pass / 3 fail); after edit + `sync:skills`, **11/11 GREEN** on both shared + Codex copies.
- `sync-skills.test.mjs`: **14/14** (no hand-authored drift; Codex copy regenerated correctly).
- `shared-skills-package.test.ts`: **2/2** (every skill still parses + packaging intact).

**Manual QA (real surface):**
- **OpenCode skills-loader** loads `ultraresearch` from the shared root with the new section present **and** all preserved invariants intact — **11/11 PASS** (evidence `05-opencode-loader-proof.txt`).
- **Static proof** the new guidance lands in the generated Codex copy `packages/omo-codex/plugin/skills/ultraresearch/SKILL.md` (evidence `04-static-codex-copy.txt`).
- **Isolation**: real `~/.codex/config.toml` shasum unchanged; the installer is never invoked by this QA (evidence `00-isolation-receipt.txt`).

**No regression:** Diff is 2 files. The local `node --test plugin/test/*.test.mjs` shows 11 `bootstrap-*`/built-CLI/telemetry-bundle failures that require compiled `dist/` (absent in a fresh worktree on local Node 26) and a `TS7006` in the untouched `components/lsp/src/codex-hook.ts`; none reference skills, and CI's `codex-compatibility` job (full `bun run test:codex` on Node 24) is **green on this exact base** `aeb6ab1b7` (evidence `06-ci-base-health.txt`).

Evidence dir (synced back to main repo on merge): `.omo/evidence/20260620-ultraresearch-teammode/`.

## QA channel rationale

This is a prompt/skill-text change. Per repo convention, skill text is proven via the contract test (behavioral pin) + sync-drift + loader + static verification, not a live model drive (a live app-server drive proves hooks fire; a skill body is loaded as data, and the isolated sandbox cannot drive a live model). CI's `codex-compatibility` job is the authoritative full Codex gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach `ultraresearch` to run saturation swarms as a cooperating team when available (`teammode` / `team_mode`), using a raise-law broadcast so every lead is shared immediately. Falls back to isolated workers and keeps all existing behavior guarantees.

- **New Features**
  - Adds “Run the swarm as a cooperating team” guidance with a decision rule; compose members by part/ownership/perspective, not job titles.
  - Introduces the raise law: over-communicate; broadcast every lead instantly with `WORKING:`/`BLOCKED:` liveness; leader expands on raised leads mid-run.
  - Updates Phase 1/2 to launch the full first wave as a team and act on raised leads immediately; adds contract tests to pin team preference, composition, and anti-hoarding across shared and Codex copies.

<sup>Written for commit 5fa28fe27c37d8f9c065cb5c3022120acb4aa21c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

