### PR TITLE
fix(codex): shorten thread title nudge

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
@@ -62,20 +62,9 @@ export async function runTeammodeHookCli(
 
 function threadTitleReminder(threadReference: ThreadCreationReference): string {
 	const id = formatIdentifier(threadReference.id);
-	const reminder =
-		threadReference.kind === "thread"
-			? [
-					`codex_app.create_thread created thread ${id}.`,
-					"Call codex_app.set_thread_title immediately for that thread before doing any other follow-up work.",
-					"Use a concise, descriptive title that reflects the thread's concrete task or team role, not a generic auto-generated title.",
-				]
-			: [
-					`codex_app.create_thread returned pendingWorktreeId ${id} for a worktree-backed thread.`,
-					"As soon as the real threadId is available, call codex_app.set_thread_title before doing any other follow-up work.",
-					"Use a concise, descriptive title that reflects the pending thread's concrete task or team role, not a generic auto-generated title.",
-				];
-	reminder.push("Do not leave the new thread with a vague default title.");
-	return reminder.join(" ");
+	return threadReference.kind === "thread"
+		? `THREAD ID ${id}: CALL codex_app.set_thread_title NOW. USE THE REAL TASK/ROLE.`
+		: `PENDING WORKTREE ID ${id}: CALL codex_app.set_thread_title AS SOON AS THREAD ID EXISTS. USE THE REAL TASK/ROLE.`;
 }
 
 function formatIdentifier(value: string): string {

--- a/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
+++ b/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
@@ -29,10 +29,9 @@ describe("thread title PostToolUse guidance", () => {
 		expect(isHookOutput(parsed)).toBe(true);
 		if (!isHookOutput(parsed)) return;
 		expect(parsed.hookSpecificOutput.hookEventName).toBe("PostToolUse");
-		expect(parsed.hookSpecificOutput.additionalContext).toContain("codex_app.set_thread_title");
-		expect(parsed.hookSpecificOutput.additionalContext).toContain("thread-123");
-		expect(parsed.hookSpecificOutput.additionalContext).toContain("immediately");
-		expect(parsed.hookSpecificOutput.additionalContext).toContain("descriptive");
+		expect(parsed.hookSpecificOutput.additionalContext).toBe(
+			"THREAD ID thread-123: CALL codex_app.set_thread_title NOW. USE THE REAL TASK/ROLE.",
+		);
 	});
 
 	it("#given an unrelated tool completed #when the hook runs #then it stays silent", () => {
@@ -89,10 +88,9 @@ describe("thread title PostToolUse guidance", () => {
 		// then
 		expect(isHookOutput(parsed)).toBe(true);
 		if (!isHookOutput(parsed)) return;
-		expect(parsed.hookSpecificOutput.additionalContext).toContain("pendingWorktreeId");
-		expect(parsed.hookSpecificOutput.additionalContext).toContain("remote-control:env:test-worktree");
-		expect(parsed.hookSpecificOutput.additionalContext).toContain("As soon as the real threadId is available");
-		expect(parsed.hookSpecificOutput.additionalContext).toContain("codex_app.set_thread_title");
+		expect(parsed.hookSpecificOutput.additionalContext).toBe(
+			"PENDING WORKTREE ID remote-control:env:test-worktree: CALL codex_app.set_thread_title AS SOON AS THREAD ID EXISTS. USE THE REAL TASK/ROLE.",
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary
Shortens the Codex thread-title PostToolUse nudge added for `codex_app.create_thread` so it is terse, ID-focused, and uses stronger uppercase wording.

## Changes
- Replaces the longer descriptive `additionalContext` with compact uppercase instructions for both immediate `threadId` and delayed `pendingWorktreeId` cases.
- Updates the focused hook tests to assert the exact short strings.

## Verification
- `bun test ./test/thread-title-hook.test.ts` ✅
- `bun run typecheck` in `packages/omo-codex/plugin/components/teammode` ✅
- `bun run build` in `packages/omo-codex/plugin/components/teammode` ✅
- Built CLI probes for `threadId` and `pendingWorktreeId` output ✅
- `bun run test:codex` ✅ (355 pass)
- `codex-qa` `app-server-drive.sh --plugin` ✅, isolated CODEX_HOME and real `~/.codex/config.toml` unchanged

Evidence: `.omo/evidence/20260620-short-thread-title-nudge/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens the Codex thread-title PostToolUse nudge to a terse, ID-first instruction after `codex_app.create_thread`, using uppercase phrasing to prompt `codex_app.set_thread_title` immediately. Handles both `threadId` and `pendingWorktreeId`; updates tests to assert the exact new strings.

<sup>Written for commit 0e5e78db77052e3ff18c12fc074f110d587126e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

