### PR TITLE
release: v4.12.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,18 +53,18 @@
         "typescript": "^6.0.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.12.0",
-        "oh-my-opencode-darwin-x64": "4.12.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.12.0",
-        "oh-my-opencode-linux-arm64": "4.12.0",
-        "oh-my-opencode-linux-arm64-musl": "4.12.0",
-        "oh-my-opencode-linux-x64": "4.12.0",
-        "oh-my-opencode-linux-x64-baseline": "4.12.0",
-        "oh-my-opencode-linux-x64-musl": "4.12.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.12.0",
-        "oh-my-opencode-windows-arm64": "4.12.0",
-        "oh-my-opencode-windows-x64": "4.12.0",
-        "oh-my-opencode-windows-x64-baseline": "4.12.0",
+        "oh-my-opencode-darwin-arm64": "4.12.1",
+        "oh-my-opencode-darwin-x64": "4.12.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.12.1",
+        "oh-my-opencode-linux-arm64": "4.12.1",
+        "oh-my-opencode-linux-arm64-musl": "4.12.1",
+        "oh-my-opencode-linux-x64": "4.12.1",
+        "oh-my-opencode-linux-x64-baseline": "4.12.1",
+        "oh-my-opencode-linux-x64-musl": "4.12.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.12.1",
+        "oh-my-opencode-windows-arm64": "4.12.1",
+        "oh-my-opencode-windows-x64": "4.12.1",
+        "oh-my-opencode-windows-x64-baseline": "4.12.1",
       },
     },
     "packages/agents-md-core": {
@@ -154,7 +154,7 @@
     },
     "packages/omo-codex": {
       "name": "@oh-my-opencode/omo-codex",
-      "version": "4.12.0",
+      "version": "4.12.1",
       "dependencies": {
         "@oh-my-opencode/utils": "workspace:*",
       },
@@ -682,30 +682,6 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.12.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z8DCX5sH+9SRGQ+ZA6s2723eiBe3/0YkZN1ikOhTqyOYfJuUJNrJ0QGNVC3au4A3OXyyhxGHNvvT+SkuuSVcoQ=="],
-
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.12.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-cLoEprZqR+opmZgpv8y3IkBDSxCPrd70GbPpJAZLJ7WvFpSciVg7+vhBuc/B8hsleympCQ2EF76+r1SXFaa4eQ=="],
-
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.12.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-X5oHnUGOuNySIf5wIAp2KebAfR1CjeGqIJtSUtYtBLLz8u25l9o8hg66vaJhJv81V2p8JUPblLnA2mSefdBiyg=="],
-
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.12.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Jj+Aewxm8URaZ41BZXHQPWTi1pY6PrqHhg42ymdkhfpMG6nVdyzB8FPQ9oJk5Dx5fr+5ebZZJHdgD/ps1u+Dlg=="],
-
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.12.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zXadRjMlZqokB3NHK/mqqWsN3CDkpdP36bhKrRd2EOt15UL5hsB6vmotCfvLRsdAnOJ1VwpLOC9avDoAcKxbBQ=="],
-
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.12.0", "", { "os": "linux", "cpu": "x64" }, "sha512-93Jf8etIhuCnsZ9A1moi2kM9nH8QaKC3R5ackfqhIYsxU8zOMrOPIfJGBVXAeUNfdnE0Cm3drbKr0OM7xMf3Zg=="],
-
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.12.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bkT2vhksc757FFjeH4rrsnvumMVavRKy4s8EoxlfCiOXfFbdasac/zjQ3JyJ+9EWPaiZoStqy1UlIhoIMQ5SsQ=="],
-
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.12.0", "", { "os": "linux", "cpu": "x64" }, "sha512-hxCE6dbV2OmmrRdn3xfD4TzjGBtFvOZHbuzbFRnmT+iI3Gka8C3V2hcv25btRNZMUqsXQKS0iWh0GYzN3ShXrg=="],
-
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.12.0", "", { "os": "linux", "cpu": "x64" }, "sha512-09166gfTJ+v5rwTtVmt1B6aKkEWVjWeW0/W63NNejsIm7R3yrT7xBHvQRaJS6fsTb0IOSukEL0jHu5b+0O4AsQ=="],
-
-    "oh-my-opencode-windows-arm64": ["oh-my-opencode-windows-arm64@4.12.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ltz0/V3N7Ll6XAsDTd/auzCbwO2injOYcjedmxTXxsHkj6p4Lie6dNL87K9iLOrdryYLE0XMQu/tmipMSoal8w=="],
-
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.12.0", "", { "os": "win32", "cpu": "x64" }, "sha512-cBFpmYg4tcyHwiQK8ivE1KzhYV9UJMo+S+jVFkBeEbdnlKepAAUUVNpwckbK9XbAedio96k/uAnRg9p7Hiy1wg=="],
-
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.12.0", "", { "os": "win32", "cpu": "x64" }, "sha512-cpiJIKZRJyKxA1F4L4bhYHDzxUA5wO91DyTP2sN9cgEpqO9zpoiliKHr+iFsgn+m58BXOGY4dZtG2epiFrlcjQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "The Best AI Agent Harness - Batteries-Included OpenCode Plugin with Multi-Model Orchestration, Parallel Background Agents, and Crafted LSP/AST Tools",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -170,18 +170,18 @@
     "typescript": "^6.0.3"
   },
   "optionalDependencies": {
-    "oh-my-opencode-darwin-arm64": "4.12.0",
-    "oh-my-opencode-darwin-x64": "4.12.0",
-    "oh-my-opencode-darwin-x64-baseline": "4.12.0",
-    "oh-my-opencode-linux-arm64": "4.12.0",
-    "oh-my-opencode-linux-arm64-musl": "4.12.0",
-    "oh-my-opencode-linux-x64": "4.12.0",
-    "oh-my-opencode-linux-x64-baseline": "4.12.0",
-    "oh-my-opencode-linux-x64-musl": "4.12.0",
-    "oh-my-opencode-linux-x64-musl-baseline": "4.12.0",
-    "oh-my-opencode-windows-arm64": "4.12.0",
-    "oh-my-opencode-windows-x64": "4.12.0",
-    "oh-my-opencode-windows-x64-baseline": "4.12.0"
+    "oh-my-opencode-darwin-arm64": "4.12.1",
+    "oh-my-opencode-darwin-x64": "4.12.1",
+    "oh-my-opencode-darwin-x64-baseline": "4.12.1",
+    "oh-my-opencode-linux-arm64": "4.12.1",
+    "oh-my-opencode-linux-arm64-musl": "4.12.1",
+    "oh-my-opencode-linux-x64": "4.12.1",
+    "oh-my-opencode-linux-x64-baseline": "4.12.1",
+    "oh-my-opencode-linux-x64-musl": "4.12.1",
+    "oh-my-opencode-linux-x64-musl-baseline": "4.12.1",
+    "oh-my-opencode-windows-arm64": "4.12.1",
+    "oh-my-opencode-windows-x64": "4.12.1",
+    "oh-my-opencode-windows-x64-baseline": "4.12.1"
   },
   "overrides": {
     "hono": "^4.12.18",

--- a/packages/oh-my-opencode-darwin-arm64/package.json
+++ b/packages/oh-my-opencode-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-arm64",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (darwin-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-darwin-x64-baseline/package.json
+++ b/packages/oh-my-opencode-darwin-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-x64-baseline",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (darwin-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-darwin-x64/package.json
+++ b/packages/oh-my-opencode-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-x64",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (darwin-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-arm64-musl/package.json
+++ b/packages/oh-my-opencode-linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-arm64-musl",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-arm64-musl)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-arm64/package.json
+++ b/packages/oh-my-opencode-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-arm64",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64-baseline/package.json
+++ b/packages/oh-my-opencode-linux-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-baseline",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64-musl-baseline/package.json
+++ b/packages/oh-my-opencode-linux-x64-musl-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-musl-baseline",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-musl-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64-musl/package.json
+++ b/packages/oh-my-opencode-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-musl",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-musl)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-linux-x64/package.json
+++ b/packages/oh-my-opencode-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-windows-arm64/package.json
+++ b/packages/oh-my-opencode-windows-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-arm64",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (windows-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-windows-x64-baseline/package.json
+++ b/packages/oh-my-opencode-windows-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-x64-baseline",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (windows-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/oh-my-opencode-windows-x64/package.json
+++ b/packages/oh-my-opencode-windows-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-x64",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Platform-specific binary for oh-my-opencode (windows-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/omo-codex/package.json
+++ b/packages/omo-codex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oh-my-opencode/omo-codex",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"type": "module",
 	"private": true,
 	"description": "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",

--- a/packages/omo-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/omo-codex/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "omo",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "One Codex plugin namespace for Yeongyu's local Codex components.",
 	"author": {
 		"name": "Yeongyu Kim",

--- a/packages/omo-codex/plugin/components/bootstrap/package.json
+++ b/packages/omo-codex/plugin/components/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-bootstrap",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex SessionStart bootstrap component that provisions LazyCodex runtime dependencies from a detached worker.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/codegraph/package.json
+++ b/packages/omo-codex/plugin/components/codegraph/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-codegraph",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex plugin MCP wrapper for CodeGraph.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/comment-checker/package.json
+++ b/packages/omo-codex/plugin/components/comment-checker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-comment-checker",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex plugin that runs comment-checker after edit-like PostToolUse hooks.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/git-bash/package.json
+++ b/packages/omo-codex/plugin/components/git-bash/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-git-bash-hook",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex hook component that reminds Windows sessions to prefer the OMO git_bash MCP.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/package.json
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-lazycodex-executor-verify",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex SubagentStop evidence verifier for LazyCodex executor completions.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/lsp/package.json
+++ b/packages/omo-codex/plugin/components/lsp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-lsp",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex plugin that exposes Language Server Protocol tools and post-edit diagnostics.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/rules/package.json
+++ b/packages/omo-codex/plugin/components/rules/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-rules",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex plugin that injects project rule files into model context through lifecycle hooks.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/start-work-continuation/package.json
+++ b/packages/omo-codex/plugin/components/start-work-continuation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-start-work-continuation",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex Stop hook continuation injector for omo-codex start-work plans.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/teammode/package.json
+++ b/packages/omo-codex/plugin/components/teammode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/codex-teammode",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex team-mode hook component that keeps background thread titles descriptive after create_thread.",
 	"type": "module",
 	"private": true,

--- a/packages/omo-codex/plugin/components/telemetry/package.json
+++ b/packages/omo-codex/plugin/components/telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-telemetry",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex plugin component that emits omo-codex anonymous daily-active telemetry on SessionStart.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/ultrawork/package.json
+++ b/packages/omo-codex/plugin/components/ultrawork/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-ultrawork",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex plugin that injects the ultrawork orchestration directive and ships LazyCodex planning, review, QA, and gate agent roles.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/components/ulw-loop/package.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@code-yeongyu/codex-ulw-loop",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Codex plugin: durable repo-native multi-goal orchestration with embedded success criteria and observable evidence audit.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",

--- a/packages/omo-codex/plugin/package.json
+++ b/packages/omo-codex/plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sisyphuslabs/omo-codex-plugin",
-	"version": "4.12.0",
+	"version": "4.12.1",
 	"description": "Aggregate Codex plugin root for OMO components.",
 	"type": "module",
 	"packageManager": "npm@11.12.1",


### PR DESCRIPTION
Automated release-state PR for v4.12.1. This must merge before npm publication starts so protected-branch push failures cannot create a half-published release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v4.12.1 release by bumping versions and aligning platform binaries. Ensures all packages publish together and avoids partial releases.

- **Dependencies**
  - Set root `oh-my-opencode` and all platform binary packages (`oh-my-opencode-*`) to `4.12.1`.
  - Bumped `@oh-my-opencode/omo-codex` and all plugin components to `4.12.1`.
  - Updated root optionalDependencies to `4.12.1` and refreshed `bun.lock`.

<sup>Written for commit f62496a0b3e8f7ec1ac44e8ba334ba045033d52d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

