### PR TITLE
feat(teammode): per-member thread titles named by role

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -45,6 +45,9 @@ member by a concrete slice: a specific part of the codebase, an ownership area, 
 perspective/lens. Assigning a vague role ("backend dev", "release analyst", "the tester") is an
 anti-pattern - it gives the member no real boundary and invites overlap. Each member's `focus`
 names what they own concretely; the `lens` is one of `area`, `ownership`, or `perspective`.
+Give each member a short, distinct `--name` too - its role or what it watches (e.g.
+`app-server-lifecycle`, `mailbox-delivery`) - because that name titles its thread; never reuse
+one name for two members.
 
 ## Run the script - never hand-write team state
 
@@ -54,7 +57,7 @@ Replace `<skill-root>` with this skill's own directory.
 
 ```
 node "<skill-root>/scripts/team.mjs" init        --name "<team>" --session-name "<session>" [--session <leader_session_id>] [--worktree] [--base-branch dev]
-node "<skill-root>/scripts/team.mjs" add-member  --team <session_id> --id A --focus "<part/ownership/perspective>" --lens area|ownership|perspective --deliverable "<...>" [--branch <branch>]
+node "<skill-root>/scripts/team.mjs" add-member  --team <session_id> --id A --name "<short role>" --focus "<part/ownership/perspective>" --lens area|ownership|perspective --deliverable "<...>" [--branch <branch>]
 node "<skill-root>/scripts/team.mjs" bind-thread  --team <session_id> --id A --thread <thread_id> [--cwd <path>]
 node "<skill-root>/scripts/team.mjs" member-prompt --team <session_id> --id A
 node "<skill-root>/scripts/team.mjs" set-status   --team <session_id> --id A --status reported|blocked|active|archived [--note "<...>"]
@@ -74,11 +77,11 @@ subcommand rewrites `guide.md`, so the manual always matches the current team.
 
 1. `init` the team, then `add-member` once per member.
 2. Create a durable thread per member with `codex_app.create_thread` - ALWAYS this tool for every
-   member, never a spawned agent - titled EXACTLY
-   `[team name] {session name}` (keep this convention strictly). If `codex_app.create_thread`
-   accepts a working directory / cwd argument, set it to that member's worktree; otherwise the
-   member's manual tells it to `cd` there first. Use `codex_app.set_thread_title` if the title
-   did not land at creation.
+   member, never a spawned agent - titled `[team name] <member name>`, using THAT member's own
+   name (its role / what it watches), so no two threads share a title. `add-member` prints the
+   exact title to use. If `codex_app.create_thread` accepts a working directory / cwd argument,
+   set it to that member's worktree; otherwise the member's manual tells it to `cd` there first.
+   Use `codex_app.set_thread_title` if the title did not land at creation.
 3. `bind-thread` to record each thread id (and `--cwd`), then send that member's bootstrap
    trigger (printed by `add-member` / `member-prompt`) as the thread's first message. The trigger
    is short on purpose: it tells the new thread to READ its `guide.md` and `team.json` rather than
@@ -87,7 +90,7 @@ subcommand rewrites `guide.md`, so the manual always matches the current team.
 Every team member is a real Codex thread created with `codex_app.create_thread` - this is strict,
 not a preference. NEVER substitute `multi_agent_v1.spawn_agent`, or any other in-process subagent,
 for a team member: a spawned agent is an ephemeral helper that does not show up as a team thread,
-cannot carry the `[team name] {session name}` title, and cannot be inspected, titled, archived, or
+cannot carry the `[team name] <member name>` title, and cannot be inspected, titled, archived, or
 re-opened with the `codex_app.*` thread tools - which defeats the entire point of a durable team.
 A member only counts once you have `bind-thread`-ed it to a real `codex_app.create_thread` thread
 id. If the thread-creation tool is unavailable, STOP and say so (see Stop rules); do not quietly

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
@@ -8,7 +8,9 @@
 function memberLine(member) {
 	const thread = member.threadId ? ` | thread ${member.threadId}` : " | thread not created yet";
 	const wt = member.worktree?.path ? ` | worktree ${member.worktree.path}` : "";
-	return `- **${member.id}** (${member.lens}) - ${member.focus}${member.deliverable ? ` -> ${member.deliverable}` : ""}${thread}${wt} [${member.status}]`;
+	const name = member.name ? ` "${member.name}"` : "";
+	const title = member.threadTitle ? ` | thread title \`${member.threadTitle}\`` : "";
+	return `- **${member.id}**${name} (${member.lens}) - ${member.focus}${member.deliverable ? ` -> ${member.deliverable}` : ""}${title}${thread}${wt} [${member.status}]`;
 }
 
 function worktreeSection(team) {
@@ -43,7 +45,7 @@ export function buildGuide(team) {
 
 - Team: **${team.teamName}** (id \`${team.teamId}\`)
 - Team state: \`${teamJson}\`
-- Thread/session title convention (use it EXACTLY): \`${team.threadTitleConvention}\`
+- Thread title convention: \`${team.threadTitleConvention}\` - each member's thread takes its OWN title from its name (your row below shows yours); two members never share a title
 
 ## Who you are (your identity is fixed)
 
@@ -103,7 +105,7 @@ export function buildMemberPrompt(team, id) {
 	const guide = team.paths?.guide ?? ".omo/teams/<session_id>/guide.md";
 	const teamJson = team.paths?.team ?? ".omo/teams/<session_id>/team.json";
 	const where = member.cwd ? `Work inside \`${member.cwd}\`.` : "Work from the repository root unless your manual assigns a worktree.";
-	return `You are member ${member.id} of team ${team.teamName} - owner of: ${member.focus}.
+	return `You are member ${member.id}${member.name ? ` (${member.name})` : ""} of team ${team.teamName} - owner of: ${member.focus}. Your thread title is \`${member.threadTitle}\`.
 FIRST read your field manual at \`${guide}\`, then the team state at \`${teamJson}\`; they define your scope, deliverable, the leader, the artifacts directory, and the communication rules.
 ${where}
 Communicate with the team and leader in English; reply to the end user in the user's own language.

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -39,7 +39,7 @@ export function buildTeam({ teamName, sessionName, sessionId = null, dir = null,
 		teamName: teamName.trim(),
 		sessionName: sessionName.trim(),
 		sessionId,
-		threadTitleConvention: `[${teamName.trim()}] ${sessionName.trim()}`,
+		threadTitleConvention: `[${teamName.trim()}] <member name>`,
 		status: "active",
 		createdAt: ts,
 		updatedAt: ts,
@@ -93,22 +93,26 @@ function assertTeamReadyForThreadBinding(team) {
 	assertUniqueMemberFocus(team);
 }
 
-export function addMember(team, { id, focus, lens, deliverable = "", branch = null }) {
+export function addMember(team, { id, focus, lens, deliverable = "", branch = null, name = null }) {
 	if (!id?.trim()) throw new Error("member id is required");
 	if (!focus?.trim()) throw new Error("member focus is required - a concrete part, ownership area, or perspective");
 	if (!LENSES.includes(lens)) throw new Error(`invalid lens "${lens}" - use one of: ${LENSES.join(", ")}`);
 	const memberId = id.trim();
 	const memberFocus = focus.trim();
+	// The member name is the short role label that titles this member's thread. Fall back to the
+	// focus so the title is ALWAYS per-member and never the shared team-wide session name.
+	const memberName = name?.trim() || memberFocus;
 	if (team.members.some((m) => m.id === memberId)) throw new Error(`member id "${memberId}" already exists (duplicate)`);
 	const duplicate = team.members.find((m) => normalizedFocus(m.focus) === normalizedFocus(memberFocus));
 	if (duplicate) throw new Error(`member focus "${memberFocus}" duplicates "${duplicate.focus}" (no two members may own the same thing)`);
 	team.members.push({
 		id: memberId,
+		name: memberName,
 		focus: memberFocus,
 		lens,
 		deliverable: deliverable.trim(),
 		threadId: null,
-		threadTitle: team.threadTitleConvention,
+		threadTitle: `[${team.teamName}] ${memberName}`,
 		cwd: null,
 		worktree: { path: null, branch: branch ?? null },
 		status: "pending",

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -7,7 +7,7 @@
 // macOS, Linux, and Windows.
 //
 //   node "<skill-root>/scripts/team.mjs" init        --name "<team>" --session-name "<sess>" [--session <id>] [--worktree] [--base-branch dev]
-//   node "<skill-root>/scripts/team.mjs" add-member  --team <id> --id A --focus "<part/ownership/perspective>" --lens area|ownership|perspective --deliverable "<...>" [--branch <b>]
+//   node "<skill-root>/scripts/team.mjs" add-member  --team <id> --id A --name "<short role>" --focus "<part/ownership/perspective>" --lens area|ownership|perspective --deliverable "<...>" [--branch <b>]
 //   node "<skill-root>/scripts/team.mjs" bind-thread  --team <id> --id A --thread <thread-id> [--cwd <path>]
 //   node "<skill-root>/scripts/team.mjs" member-prompt --team <id> --id A
 //   node "<skill-root>/scripts/team.mjs" set-status   --team <id> --id A --status reported|blocked|active|archived [--note "<...>"]
@@ -95,7 +95,7 @@ const handlers = {
 		await persist(team, dir);
 		process.stdout.write(`created: ${dir}\n`);
 		process.stdout.write(`team.json + guide.md written; artifacts/ ready. session id: ${sessionId}\n`);
-		process.stdout.write(`next: add-member --team ${sessionId} --id A --focus "<part/ownership/perspective>" --lens area|ownership|perspective --deliverable "<...>"\n`);
+		process.stdout.write(`next: add-member --team ${sessionId} --id A --name "<short role>" --focus "<part/ownership/perspective>" --lens area|ownership|perspective --deliverable "<...>"\n`);
 	},
 
 	async "add-member"(cwd, flags) {
@@ -104,13 +104,15 @@ const handlers = {
 		const memberId = requireFlag(flags, "id").trim();
 		addMember(team, {
 			id: memberId,
+			name: typeof flags.name === "string" ? flags.name : null,
 			focus: requireFlag(flags, "focus"),
 			lens: requireFlag(flags, "lens"),
 			deliverable: typeof flags.deliverable === "string" ? flags.deliverable : "",
 			branch: typeof flags.branch === "string" ? flags.branch : null,
 		});
 		await persist(team, dir);
-		process.stdout.write(`added member ${memberId} to team ${sessionId}.\n\nSend this as the new thread's first message (title it "${team.threadTitleConvention}"):\n---\n${buildMemberPrompt(team, memberId)}\n---\n`);
+		const member = team.members.find((m) => m.id === memberId);
+		process.stdout.write(`added member ${memberId} to team ${sessionId}.\n\nSend this as the new thread's first message (title the thread "${member.threadTitle}"):\n---\n${buildMemberPrompt(team, memberId)}\n---\n`);
 	},
 
 	async "bind-thread"(cwd, flags) {

--- a/packages/omo-codex/plugin/test/teammode-thread-title.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-thread-title.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam } from "./teammode-safety-fixture.mjs";
+
+function addMember(tempRoot, sessionId, { id, name, focus, lens, deliverable }) {
+	const args = ["add-member", "--team", sessionId, "--id", id, "--focus", focus, "--lens", lens, "--deliverable", deliverable];
+	if (name !== undefined) args.push("--name", name);
+	return runTeam(tempRoot, ...args);
+}
+
+test("#given two members with distinct names #when added #then each thread title is per-member and the two never collide", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-title-");
+	try {
+		runTeam(tempRoot, "init", "--name", "Recovery", "--session-name", "app-server-research", "--session", "title-distinct");
+		addMember(tempRoot, "title-distinct", { id: "A", name: "app-server-lifecycle", focus: "app-server thread lifecycle", lens: "area", deliverable: "lifecycle map" });
+		addMember(tempRoot, "title-distinct", { id: "B", name: "mailbox-delivery", focus: "mailbox live-delivery path", lens: "ownership", deliverable: "delivery audit" });
+
+		const team = readTeamJson(tempRoot, "title-distinct");
+		const byId = Object.fromEntries(team.members.map((m) => [m.id, m]));
+
+		// then - the title carries the member's own name, not a fixed team-wide session name
+		assert.equal(byId.A.threadTitle, "[Recovery] app-server-lifecycle");
+		assert.equal(byId.B.threadTitle, "[Recovery] mailbox-delivery");
+		// then - the member name is recorded for identity
+		assert.equal(byId.A.name, "app-server-lifecycle");
+		assert.equal(byId.B.name, "mailbox-delivery");
+		// then - no two members share a title (the core bug)
+		assert.notEqual(byId.A.threadTitle, byId.B.threadTitle);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a member added without an explicit name #when state is read #then the title falls back to the focus, never a shared session name", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-title-fallback-");
+	try {
+		runTeam(tempRoot, "init", "--name", "Recovery", "--session-name", "shared-session", "--session", "title-fallback");
+		addMember(tempRoot, "title-fallback", { id: "A", focus: "installer config", lens: "area", deliverable: "x" });
+		addMember(tempRoot, "title-fallback", { id: "B", focus: "runtime qa", lens: "perspective", deliverable: "y" });
+
+		const team = readTeamJson(tempRoot, "title-fallback");
+		const byId = Object.fromEntries(team.members.map((m) => [m.id, m]));
+
+		// then - fallback uses the member's own focus, so titles still differ per member
+		assert.equal(byId.A.threadTitle, "[Recovery] installer config");
+		assert.equal(byId.B.threadTitle, "[Recovery] runtime qa");
+		assert.notEqual(byId.A.threadTitle, byId.B.threadTitle);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});


### PR DESCRIPTION
## Summary

Today every teammode member's thread is titled the identical team-wide `[team name] {session name}` (e.g. `[codex-cli-teammode] app-server-research`). Members are indistinguishable by title, the title says nothing about each member's role, and members have no name beyond the `A`/`B` id. It also contradicts the new `create_thread` PostToolUse hook, which already nudges "USE THE REAL TASK/ROLE."

This makes the thread title **per-member**: `[team name] <member name>`, where the member name is a short, well-chosen role label (what it owns / watches). `add-member` gains an optional `--name` that falls back to the member's `focus`, so a title is always per-member and never the shared session name.

## Changes

- **`scripts/team-state.mjs`** — `addMember` accepts `name`; each member now stores `name` and `threadTitle = [team] <name||focus>`. The team-level `threadTitleConvention` becomes the pattern `[team] <member name>` instead of the concrete `[team] {session name}`.
- **`scripts/team-guide.mjs`** — the roster line shows each member's `"name"` + its concrete `thread title`; the convention line explains titles are per-member (two members never share one); the bootstrap prompt tells the member its own title.
- **`scripts/team.mjs`** — `--name` flag wired through; `add-member` output prints `title the thread "[team] <name>"` (the member's own title); `--name` added to the usage docs and the `init` next-step hint.
- **`skills/teammode/SKILL.md`** — compose-section guidance to give each member a short distinct `--name`; `--name` in the CLI signature; step-2 title convention rewritten to `[team name] <member name>` (no two threads share a title); the stale `[team name] {session name}` reference fixed.
- **`test/teammode-thread-title.test.mjs`** — new contract test.

`--name` is **optional** (falls back to `focus`), so the 6 existing `add-member` call sites and the teammode-safety suite are untouched.

## Verification

**Automated (TDD RED -> GREEN):**
- New test: before the fix both members got `[Recovery] app-server-research` (RED 0/2); after, A=`[Recovery] app-server-lifecycle`, B=`[Recovery] mailbox-delivery` (**GREEN 2/2**), including the focus-fallback case.
- `teammode-safety.test.mjs`: **7/7** unchanged. teammode component vitest (thread-title hook): **3/3** unchanged.

**Manual QA (real surface — drove the actual `team.mjs` CLI the skill runs):**
- `init` + two `add-member --name ...` against a mktemp `.omo/teams` sandbox. `team.json` shows two **distinct** per-member titles; the `add-member` stdout prints each member's title; `guide.md` roster + convention line + the bootstrap member-prompt all carry the per-member title. Evidence: `.omo/evidence/20260620-teammode-per-member-title/01-live-cli-drive.txt`.
- `sync:skills` regenerates the shipped Codex copy with the per-member title logic.
- Isolation: real `~/.codex/config.toml` shasum unchanged (QA used a temp sandbox).

**No regression:** Diff is 5 files, all under `components/teammode/` + one new test. Full plugin suite = 202 tests, 191 pass, 11 fail — all `bootstrap-*`/built-CLI/telemetry tests needing compiled `dist/` (fresh-worktree/Node-26 artifacts), **none teammode**; CI's `codex-compatibility` (full `bun run test:codex` on Node 24) is green on dev. The pre-existing `resolveTeamDir` unused-import in `team.mjs` is unchanged by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Per-member thread titles now use `[team] <member name>` instead of the shared `[team] {session name}`, so each member is clearly identified by role. Adds optional `--name` to `add-member` and updates guides/prompts to show the exact title to use.

- New Features
  - `addMember` accepts `name`; stored on the member and used for `threadTitle = [team] <name||focus>`.
  - Team `threadTitleConvention` is now `[team] <member name>`.
  - CLI: `add-member --name` wired; `init` next-step hints include `--name`.
  - Guide: roster shows `"name"` and the concrete `thread title`; convention text and member prompt updated.
  - Test `teammode-thread-title.test.mjs` pins distinct titles and the focus fallback.

- Migration
  - No breaking changes. `--name` is optional.
  - When creating threads via `codex_app.create_thread`, use the printed per-member title.

<sup>Written for commit f3c7359dd03870244375b58b273816f2817d968b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

