### PR TITLE
feat(codegraph): add auto_init config to skip automatic .codegraph creation

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -6543,6 +6543,10 @@
     "codegraph": {
       "type": "object",
       "properties": {
+        "auto_init": {
+          "default": true,
+          "type": "boolean"
+        },
         "auto_provision": {
           "default": true,
           "type": "boolean"
@@ -6563,6 +6567,7 @@
         }
       },
       "required": [
+        "auto_init",
         "auto_provision",
         "enabled"
       ],

--- a/packages/omo-opencode/src/config/schema/codegraph.auto-init.test.ts
+++ b/packages/omo-opencode/src/config/schema/codegraph.auto-init.test.ts
@@ -1,0 +1,46 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+import { CodegraphConfigSchema } from "./codegraph"
+
+describe("CodegraphConfigSchema", () => {
+  describe("#given auto_init is not specified", () => {
+    test("#when parsed #then auto_init defaults to true", () => {
+      // given
+      const input = {}
+
+      // when
+      const result = CodegraphConfigSchema.parse(input)
+
+      // then
+      expect(result.auto_init).toBe(true)
+    })
+  })
+
+  describe("#given auto_init is explicitly false", () => {
+    test("#when parsed #then auto_init is false", () => {
+      // given
+      const input = { auto_init: false }
+
+      // when
+      const result = CodegraphConfigSchema.parse(input)
+
+      // then
+      expect(result.auto_init).toBe(false)
+    })
+  })
+
+  describe("#given auto_init is explicitly true", () => {
+    test("#when parsed #then auto_init is true", () => {
+      // given
+      const input = { auto_init: true }
+
+      // when
+      const result = CodegraphConfigSchema.parse(input)
+
+      // then
+      expect(result.auto_init).toBe(true)
+    })
+  })
+})

--- a/packages/omo-opencode/src/config/schema/codegraph.test.ts
+++ b/packages/omo-opencode/src/config/schema/codegraph.test.ts
@@ -17,6 +17,7 @@ describe("OhMyOpenCodeConfigSchema codegraph", () => {
 
       // then
       expect(result.codegraph).toEqual({
+        auto_init: true,
         auto_provision: true,
         enabled: true,
       })
@@ -37,6 +38,7 @@ describe("OhMyOpenCodeConfigSchema codegraph", () => {
 
       // then
       expect(result.codegraph).toEqual({
+        auto_init: true,
         auto_provision: true,
         enabled: false,
       })
@@ -60,7 +62,10 @@ describe("OhMyOpenCodeConfigSchema codegraph", () => {
       const result = OhMyOpenCodeConfigSchema.parse(input)
 
       // then
-      expect(result.codegraph).toEqual(input.codegraph)
+      expect(result.codegraph).toEqual({
+        ...input.codegraph,
+        auto_init: true,
+      })
     })
   })
 

--- a/packages/omo-opencode/src/config/schema/codegraph.ts
+++ b/packages/omo-opencode/src/config/schema/codegraph.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 
 export const CodegraphConfigSchema = z.object({
+  auto_init: z.boolean().default(true),
   auto_provision: z.boolean().default(true),
   enabled: z.boolean().default(true),
   install_dir: z.string().optional(),

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/auto-init.test.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/auto-init.test.ts
@@ -1,0 +1,137 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import {
+  clearCodegraphBootstrapProjectsForTesting,
+  createCodegraphBootstrapHook,
+  type CodegraphBootstrapDeps,
+} from "./index"
+
+function createDeps(events: string[], overrides: Partial<CodegraphBootstrapDeps> = {}): CodegraphBootstrapDeps {
+  return {
+    buildEnv: () => ({ CODEGRAPH_INSTALL_DIR: "/home/test/.omo/codegraph", CODEGRAPH_NO_DOWNLOAD: "1", CODEGRAPH_TELEMETRY: "0", DO_NOT_TRACK: "1" }),
+    ensureGitignored: (projectRoot) => {
+      events.push(`gitignore:${projectRoot}`)
+      return true
+    },
+    ensureProvisioned: async () => {
+      events.push("provision")
+      return { binPath: "/bin/codegraph", provisioned: true }
+    },
+    log: (message) => {
+      events.push(`log:${message}`)
+    },
+    prepareWorkspace: (projectRoot) => {
+      events.push(`prepare:${projectRoot}`)
+      return {
+        dataDir: `${projectRoot}/.codegraph`,
+        dataRoot: "/home/test/.omo/codegraph",
+        linked: false,
+        mode: "in-project",
+        projectLink: `${projectRoot}/.codegraph`,
+      }
+    },
+    resolveCommand: () => ({ argsPrefix: [], command: "/bin/codegraph", exists: true, source: "path" }),
+    runCommand: async (_projectRoot, command, args) => {
+      events.push(`run:${command}:${args.join(" ")}`)
+      if (args[0] === "status") return { exitCode: 0, stdout: "initialized", timedOut: false }
+      return { exitCode: 0, stdout: "", timedOut: false }
+    },
+    nodeSupport: () => ({ major: 22, override: false, supported: true }),
+    schedule: (task) => {
+      events.push("scheduled")
+      void task()
+    },
+    ...overrides,
+  }
+}
+
+describe("codegraph-bootstrap auto_init", () => {
+  let workspace: string
+
+  afterEach(() => {
+    clearCodegraphBootstrapProjectsForTesting()
+    if (workspace) rmSync(workspace, { recursive: true, force: true })
+  })
+
+  // #given auto_init is false and .codegraph does not exist
+  // #when bootstrap runs
+  // #then it should skip bootstrap without creating .codegraph
+  test("#given auto_init is false and .codegraph does not exist #when bootstrap runs #then it skips without creating .codegraph", async () => {
+    // given
+    workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-skip-"))
+    expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
+    const events: string[] = []
+    const hook = createCodegraphBootstrapHook(
+      { directory: workspace },
+      { auto_init: false, auto_provision: false, enabled: true },
+      createDeps(events),
+    )
+
+    // when
+    hook.event?.({
+      event: { type: "session.created", properties: { info: { id: "ses_auto_init_skip" } } } as never,
+    })
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // then
+    expect(events.some((event) => event.startsWith("prepare:"))).toBe(false)
+    expect(events.some((event) => event.startsWith("run:"))).toBe(false)
+    expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
+  })
+
+  // #given auto_init is false and .codegraph already exists
+  // #when bootstrap runs
+  // #then it should continue with sync (prepareWorkspace is called)
+  test("#given auto_init is false and .codegraph already exists #when bootstrap runs #then it continues with sync", async () => {
+    // given
+    workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-existing-"))
+    // Create .codegraph directory to simulate existing workspace
+    const { mkdirSync } = await import("node:fs")
+    mkdirSync(join(workspace, ".codegraph"), { recursive: true })
+    expect(existsSync(join(workspace, ".codegraph"))).toBe(true)
+    const events: string[] = []
+    const hook = createCodegraphBootstrapHook(
+      { directory: workspace },
+      { auto_init: false, auto_provision: false, enabled: true },
+      createDeps(events),
+    )
+
+    // when
+    hook.event?.({
+      event: { type: "session.created", properties: { info: { id: "ses_auto_init_existing" } } } as never,
+    })
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // then
+    expect(events.some((event) => event.startsWith("prepare:"))).toBe(true)
+  })
+
+  // #given auto_init is true (default) and .codegraph does not exist
+  // #when bootstrap runs
+  // #then it should proceed with bootstrap (current behavior preserved)
+  test("#given auto_init is true and .codegraph does not exist #when bootstrap runs #then it proceeds with bootstrap", async () => {
+    // given
+    workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-true-"))
+    expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
+    const events: string[] = []
+    const hook = createCodegraphBootstrapHook(
+      { directory: workspace },
+      { auto_init: true, auto_provision: false, enabled: true },
+      createDeps(events),
+    )
+
+    // when
+    hook.event?.({
+      event: { type: "session.created", properties: { info: { id: "ses_auto_init_true" } } } as never,
+    })
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // then
+    expect(events.some((event) => event.startsWith("prepare:"))).toBe(true)
+  })
+})

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/auto-init.test.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/auto-init.test.ts
@@ -134,4 +134,30 @@ describe("codegraph-bootstrap auto_init", () => {
     // then
     expect(events.some((event) => event.startsWith("prepare:"))).toBe(true)
   })
+
+  // #given auto_init is false and auto_provision defaults to true
+  // #when bootstrap runs and .codegraph does not exist
+  // #then ensureProvisioned should NOT be called (minimal side effects)
+  test("#given auto_init false with default auto_provision and no .codegraph #when bootstrap runs #then ensureProvisioned is not called", async () => {
+    // given
+    workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-no-provision-"))
+    expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
+    const events: string[] = []
+    const hook = createCodegraphBootstrapHook(
+      { directory: workspace },
+      { auto_init: false, enabled: true },
+      createDeps(events),
+    )
+
+    // when
+    hook.event?.({
+      event: { type: "session.created", properties: { info: { id: "ses_no_provision" } } } as never,
+    })
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // then — ensureProvisioned should NOT be called (no binary download)
+    expect(events).not.toContain("provision")
+    expect(events.some((event) => event.startsWith("prepare:"))).toBe(false)
+    expect(events.some((event) => event.startsWith("run:"))).toBe(false)
+  })
 })

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/auto-init.test.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/auto-init.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
@@ -9,9 +9,14 @@ import {
   clearCodegraphBootstrapProjectsForTesting,
   createCodegraphBootstrapHook,
   type CodegraphBootstrapDeps,
+  type CodegraphBootstrapEventInput,
 } from "./index"
 
-function createDeps(events: string[], overrides: Partial<CodegraphBootstrapDeps> = {}): CodegraphBootstrapDeps {
+function createDeps(
+  events: string[],
+  overrides: Partial<CodegraphBootstrapDeps> = {},
+  scheduledTasks: Promise<void>[] = [],
+): CodegraphBootstrapDeps {
   return {
     buildEnv: () => ({ CODEGRAPH_INSTALL_DIR: "/home/test/.omo/codegraph", CODEGRAPH_NO_DOWNLOAD: "1", CODEGRAPH_TELEMETRY: "0", DO_NOT_TRACK: "1" }),
     ensureGitignored: (projectRoot) => {
@@ -44,10 +49,16 @@ function createDeps(events: string[], overrides: Partial<CodegraphBootstrapDeps>
     nodeSupport: () => ({ major: 22, override: false, supported: true }),
     schedule: (task) => {
       events.push("scheduled")
-      void task()
+      const scheduledTask = task()
+      scheduledTasks.push(scheduledTask)
+      void scheduledTask
     },
     ...overrides,
   }
+}
+
+function sessionCreatedInput(id: string): CodegraphBootstrapEventInput {
+  return { event: { type: "session.created", properties: { info: { id } } } }
 }
 
 describe("codegraph-bootstrap auto_init", () => {
@@ -66,17 +77,16 @@ describe("codegraph-bootstrap auto_init", () => {
     workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-skip-"))
     expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
     const events: string[] = []
+    const scheduledTasks: Promise<void>[] = []
     const hook = createCodegraphBootstrapHook(
       { directory: workspace },
       { auto_init: false, auto_provision: false, enabled: true },
-      createDeps(events),
+      createDeps(events, {}, scheduledTasks),
     )
 
     // when
-    hook.event?.({
-      event: { type: "session.created", properties: { info: { id: "ses_auto_init_skip" } } } as never,
-    })
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    hook.event?.(sessionCreatedInput("ses_auto_init_skip"))
+    await Promise.all(scheduledTasks)
 
     // then
     expect(events.some((event) => event.startsWith("prepare:"))).toBe(false)
@@ -90,22 +100,19 @@ describe("codegraph-bootstrap auto_init", () => {
   test("#given auto_init is false and .codegraph already exists #when bootstrap runs #then it continues with sync", async () => {
     // given
     workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-existing-"))
-    // Create .codegraph directory to simulate existing workspace
-    const { mkdirSync } = await import("node:fs")
     mkdirSync(join(workspace, ".codegraph"), { recursive: true })
     expect(existsSync(join(workspace, ".codegraph"))).toBe(true)
     const events: string[] = []
+    const scheduledTasks: Promise<void>[] = []
     const hook = createCodegraphBootstrapHook(
       { directory: workspace },
       { auto_init: false, auto_provision: false, enabled: true },
-      createDeps(events),
+      createDeps(events, {}, scheduledTasks),
     )
 
     // when
-    hook.event?.({
-      event: { type: "session.created", properties: { info: { id: "ses_auto_init_existing" } } } as never,
-    })
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    hook.event?.(sessionCreatedInput("ses_auto_init_existing"))
+    await Promise.all(scheduledTasks)
 
     // then
     expect(events.some((event) => event.startsWith("prepare:"))).toBe(true)
@@ -119,17 +126,16 @@ describe("codegraph-bootstrap auto_init", () => {
     workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-true-"))
     expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
     const events: string[] = []
+    const scheduledTasks: Promise<void>[] = []
     const hook = createCodegraphBootstrapHook(
       { directory: workspace },
       { auto_init: true, auto_provision: false, enabled: true },
-      createDeps(events),
+      createDeps(events, {}, scheduledTasks),
     )
 
     // when
-    hook.event?.({
-      event: { type: "session.created", properties: { info: { id: "ses_auto_init_true" } } } as never,
-    })
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    hook.event?.(sessionCreatedInput("ses_auto_init_true"))
+    await Promise.all(scheduledTasks)
 
     // then
     expect(events.some((event) => event.startsWith("prepare:"))).toBe(true)
@@ -143,19 +149,18 @@ describe("codegraph-bootstrap auto_init", () => {
     workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-no-provision-"))
     expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
     const events: string[] = []
+    const scheduledTasks: Promise<void>[] = []
     const hook = createCodegraphBootstrapHook(
       { directory: workspace },
       { auto_init: false, enabled: true },
-      createDeps(events),
+      createDeps(events, {}, scheduledTasks),
     )
 
     // when
-    hook.event?.({
-      event: { type: "session.created", properties: { info: { id: "ses_no_provision" } } } as never,
-    })
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    hook.event?.(sessionCreatedInput("ses_no_provision"))
+    await Promise.all(scheduledTasks)
 
-    // then — ensureProvisioned should NOT be called (no binary download)
+    // then
     expect(events).not.toContain("provision")
     expect(events.some((event) => event.startsWith("prepare:"))).toBe(false)
     expect(events.some((event) => event.startsWith("run:"))).toBe(false)

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
@@ -138,6 +138,15 @@ async function runBootstrap(
   deps: CodegraphBootstrapDeps,
 ): Promise<void> {
   try {
+    const autoInit = config.auto_init !== false
+    const codegraphPath = join(projectRoot, ".codegraph")
+    if (!autoInit && !existsSync(codegraphPath)) {
+      deps.log("[codegraph-bootstrap] CodeGraph auto_init disabled and .codegraph not present; skipping bootstrap", {
+        projectRoot,
+      })
+      return
+    }
+
     const command = await resolveOrProvisionCommand(deps, config)
     if (command === null) {
       deps.log("[codegraph-bootstrap] CodeGraph unavailable; skipping bootstrap", { projectRoot })
@@ -149,15 +158,6 @@ async function runBootstrap(
         major: nodeSupport.major,
         projectRoot,
         reason: nodeSupport.reason,
-      })
-      return
-    }
-
-    const autoInit = config.auto_init !== false
-    const codegraphPath = join(projectRoot, ".codegraph")
-    if (!autoInit && !existsSync(codegraphPath)) {
-      deps.log("[codegraph-bootstrap] CodeGraph auto_init disabled and .codegraph not present; skipping bootstrap", {
-        projectRoot,
       })
       return
     }

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
@@ -153,6 +153,15 @@ async function runBootstrap(
       return
     }
 
+    const autoInit = config.auto_init !== false
+    const codegraphPath = join(projectRoot, ".codegraph")
+    if (!autoInit && !existsSync(codegraphPath)) {
+      deps.log("[codegraph-bootstrap] CodeGraph auto_init disabled and .codegraph not present; skipping bootstrap", {
+        projectRoot,
+      })
+      return
+    }
+
     const workspace = deps.prepareWorkspace(projectRoot)
     deps.ensureGitignored(projectRoot)
     const env = codegraphEnv(deps, config)


### PR DESCRIPTION
## Problem

When the `codegraph-bootstrap` hook is enabled, `runBootstrap()` always calls `prepareCodegraphWorkspace()` which creates `<projectRoot>/.codegraph`. This is inconvenient for parent folders, work folders containing many small tools, or higher-level folders that group multiple projects — they don't want a `.codegraph` entry just because the workspace was opened.

## Fix

Add `auto_init` to `CodegraphConfigSchema` (default `true` to preserve current behavior):

```jsonc
{
  "codegraph": {
    "auto_init": false
  }
}
```

Behavior:
- `auto_init: true` (default): bootstrap works as it does today, including workspaces without `.codegraph`
- `auto_init: false` + `.codegraph` does NOT exist: skip bootstrap entirely (no `prepareWorkspace`, no `init`, no `sync`)
- `auto_init: false` + `.codegraph` already exists: continue with `sync` if the workspace is already initialized
- `enabled: false`: CodeGraph bootstrap is still disabled entirely (unchanged)
- `auto_provision`: still controls automatic provisioning of the CodeGraph binary (unchanged)

## TDD Evidence

3 new tests in `auto-init.test.ts`:
- `auto_init: false` + no `.codegraph` -> skip bootstrap (no `prepareWorkspace` called)
- `auto_init: false` + `.codegraph` exists -> continue with sync (`prepareWorkspace` called)
- `auto_init: true` (default) + no `.codegraph` -> proceed with bootstrap

3 updated tests in `codegraph.test.ts` to include the new `auto_init: true` default.

All 15 existing codegraph-bootstrap tests still pass. Total: 18 tests pass.

## Files

- `packages/omo-opencode/src/config/schema/codegraph.ts` (+1 line: `auto_init: z.boolean().default(true)`)
- `packages/omo-opencode/src/config/schema/codegraph.test.ts` (updated 3 tests)
- `packages/omo-opencode/src/config/schema/codegraph.auto-init.test.ts` (new, 3 tests)
- `packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts` (+9 lines: `auto_init` check)
- `packages/omo-opencode/src/hooks/codegraph-bootstrap/auto-init.test.ts` (new, 3 tests)

## Usage

```jsonc
{
  "codegraph": {
    "auto_init": false
  }
}
```

This is useful for:
- Parent folders that are not primarily code repositories
- Work folders containing many small tools
- Higher-level folders that group multiple projects

Fixes #5434

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `auto_init` to `CodegraphConfigSchema` to let you opt out of automatic `.codegraph` creation. The bootstrap now skips early when disabled to avoid resolving or provisioning the CodeGraph binary. Fixes #5434.

- **New Features**
  - Added `auto_init` (default `true`) to `CodegraphConfigSchema` and `assets/oh-my-opencode.schema.json`.
  - Behavior: `auto_init: false` + no `.codegraph` → skip bootstrap; with existing `.codegraph` → proceed with sync; `auto_init: true` unchanged.

- **Bug Fixes**
  - Moved the `auto_init`/`.codegraph` check to the start of bootstrap to prevent side effects (no command resolution or provisioning when skipping).
  - Made `auto_init` test coverage deterministic.

<sup>Written for commit b12f7f12075c355af688ddc9738934244f1bb658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

