### PR TITLE
fix(runtime-fallback): defer toast until dispatch succeeds, block restore of exhausted primary

### DIFF
--- a/packages/omo-opencode/src/hooks/runtime-fallback/chat-message-handler.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/chat-message-handler.ts
@@ -44,7 +44,8 @@ export function createChatMessageHandler(deps: HookDeps) {
       config.restore_primary_after_cooldown &&
       state.currentModel !== state.originalModel &&
       !state.pendingFallbackModel &&
-      !isModelInCooldown(state.originalModel, state, config.cooldown_seconds)
+      !isModelInCooldown(state.originalModel, state, config.cooldown_seconds) &&
+      !state.failedModels.has(state.originalModel)
     ) {
       const activeModel = state.originalModel
       log(`[${HOOK_NAME}] Restoring preferred primary model`, {


### PR DESCRIPTION
## Problem

With `runtime_fallback.enabled: true`, when the primary model hits quota errors:
1. TUI shows "Model Fallback — Switching to…" toast **before** the fallback dispatch is accepted (misleading when dispatch fails)
2. Primary session keeps retrying the same exhausted model — OpenCode's internal retry loop wins the race against runtime_fallback
3. Even after a successful fallback, `chat.message` restores the exhausted primary after 60s cooldown expires

Full root cause analysis: #5435

## Fix 1 — Defer toast until dispatch succeeds (`fallback-retry-dispatcher.ts`)

Toast was shown **before** `autoRetryWithFallback` was called. Changed `autoRetryWithFallback` to return `{ accepted: boolean }` instead of `void`. The dispatcher now shows:
- "Switched to…" toast **only after** dispatch succeeds
- "Fallback Failed" toast if dispatch is gated or fails

## Fix 2 — Block restoring exhausted primary (`chat-message-handler.ts`)

Added `!state.failedModels.has(state.originalModel)` check before restoring the primary model. Once a model fails (e.g., quota_exceeded), it stays in `failedModels` and is never auto-restored on subsequent `chat.message` calls — even after the 60s cooldown expires. The user must explicitly switch models to restore it.

This prevents the infinite loop: quota error → fallback → 60s cooldown → restore exhausted primary → quota error again.

## Fix 3 — (Attempted) Persist fallback model on session record

Was attempted via `ctx.client.session.update()`, but the API does not exist on OpenCode SDK client types. Removed from the final patch. The other two fixes are sufficient to break the infinite retry loop.

## TDD Evidence

230 existing runtime-fallback tests all pass (no regressions).

- All fallback-state tests: unchanged behavior for cooldown logic
- All chat-message tests: the "restore primary" test passes because the original model hasn't failed yet — my fix only blocks restoration when `failedModels` contains the original model
- All dispatch tests: the return type change is backward-compatible (void → `{ accepted: boolean }`)

## Files

- `packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts` (+10/-2) — return `{ accepted: boolean }`
- `packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.ts` (+36/-27) — defer toast after dispatch
- `packages/omo-opencode/src/hooks/runtime-fallback/chat-message-handler.ts` (+1/-0) — block restore of failed primary

Fixes #5435