### PR TITLE
Fix background task result retrieval so an agent can read a subagent's final answer

### DIFF
--- a/packages/omo-opencode/src/tools/background-task/create-background-output.filters.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/create-background-output.filters.test.ts
@@ -1,0 +1,129 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import type { ToolContext } from "@opencode-ai/plugin/tool"
+import type { BackgroundTask } from "../../features/background-agent"
+import type { BackgroundOutputClient, BackgroundOutputManager } from "./clients"
+import { createBackgroundOutput } from "./create-background-output"
+
+const projectDir = "/Users/yeongyu/local-workspaces/oh-my-opencode"
+
+const mockContext = {
+  sessionID: "test-session",
+  messageID: "test-message",
+  agent: "test-agent",
+  directory: projectDir,
+  worktree: projectDir,
+  abort: new AbortController().signal,
+  metadata: () => {},
+  ask: async () => {},
+} as ToolContext
+
+function createTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: "bg_filters_task",
+    sessionId: "ses-filters",
+    parentSessionId: "main-1",
+    parentMessageId: "msg-1",
+    description: "background task",
+    prompt: "do work",
+    agent: "test-agent",
+    status: "running",
+    ...overrides,
+  }
+}
+
+function createClientWithToolResult(): BackgroundOutputClient {
+  return {
+    session: {
+      messages: async () => ({
+        data: [
+          {
+            id: "m1",
+            info: { role: "assistant", time: "2026-01-01T00:00:00Z" },
+            parts: [{ type: "text", text: "assistant text" }],
+          },
+          {
+            id: "m2",
+            info: { role: "tool", time: "2026-01-01T00:00:01Z" },
+            parts: [{ type: "tool_result", content: "SECRET_TOOL_OUTPUT" }],
+          },
+        ],
+      }),
+    },
+  }
+}
+
+describe("createBackgroundOutput include_tool_results gating on a running task", () => {
+  test("excludes tool_result blocks when include_tool_results is explicitly false", async () => {
+    // #given a running task and a full_session request with include_tool_results:false
+    const task = createTask()
+    const manager: BackgroundOutputManager = {
+      getTask: (id: string) => (id === task.id ? task : undefined),
+    }
+    const tool = createBackgroundOutput(manager, createClientWithToolResult())
+
+    // #when
+    const output = await tool.execute(
+      { task_id: task.id, full_session: true, include_tool_results: false },
+      mockContext
+    )
+
+    // #then explicit false is honored even though the task is active
+    expect(output).toContain("# Full Session Output")
+    expect(output).not.toContain("[tool result]")
+    expect(output).not.toContain("SECRET_TOOL_OUTPUT")
+  })
+
+  test("includes tool_result blocks when include_tool_results is undefined (default-on while active)", async () => {
+    // #given a running task and a full_session request without include_tool_results
+    const task = createTask()
+    const manager: BackgroundOutputManager = {
+      getTask: (id: string) => (id === task.id ? task : undefined),
+    }
+    const tool = createBackgroundOutput(manager, createClientWithToolResult())
+
+    // #when
+    const output = await tool.execute({ task_id: task.id, full_session: true }, mockContext)
+
+    // #then existing pollers keep tool results by default
+    expect(output).toContain("[tool result]")
+    expect(output).toContain("SECRET_TOOL_OUTPUT")
+  })
+})
+
+describe("createBackgroundOutput completed-task branch passes from_end through", () => {
+  test("formats a completed task result when from_end is true", async () => {
+    // #given a completed task with assistant output
+    const task = createTask({
+      id: "bg_completed_from_end",
+      sessionId: "ses-completed-from-end",
+      status: "completed",
+    })
+    const manager: BackgroundOutputManager = {
+      getTask: (id: string) => (id === task.id ? task : undefined),
+    }
+    const client: BackgroundOutputClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              id: "m1",
+              info: { role: "assistant", time: "2026-01-01T00:00:00Z" },
+              parts: [{ type: "text", text: "final answer text" }],
+            },
+          ],
+        }),
+      },
+    }
+    const tool = createBackgroundOutput(manager, client)
+
+    // #when from_end is passed for a completed task
+    const output = await tool.execute({ task_id: task.id, from_end: true }, mockContext)
+
+    // #then the completed-task formatter runs and surfaces the final answer
+    expect(output).toContain("Task Result")
+    expect(output).toContain("Final answer")
+    expect(output).toContain("final answer text")
+  })
+})

--- a/packages/omo-opencode/src/tools/background-task/create-background-output.ts
+++ b/packages/omo-opencode/src/tools/background-task/create-background-output.ts
@@ -171,8 +171,8 @@ export function createBackgroundOutput(manager: BackgroundOutputManager, client:
 
         const isActive = isTaskActiveStatus(resolvedTask.status)
         const fullSession = args.full_session ?? false
-        const includeThinking = isActive || (args.include_thinking ?? false)
-        const includeToolResults = isActive || (args.include_tool_results ?? false)
+        const includeThinking = args.include_thinking ?? isActive
+        const includeToolResults = args.include_tool_results ?? isActive
 
         if (fullSession) {
           const output = await formatFullSession(resolvedTask, client, {
@@ -189,7 +189,10 @@ export function createBackgroundOutput(manager: BackgroundOutputManager, client:
 
         if (resolvedTask.status === "completed") {
           recordBackgroundOutputConsumption(ctx.sessionID, ctx.messageID, resolvedTask.sessionId)
-          return await formatTaskResult(resolvedTask, client)
+          return await formatTaskResult(resolvedTask, client, {
+            fromEnd: args.from_end,
+            messageLimit: args.message_limit,
+          })
         }
 
         if (resolvedTask.status === "error" || resolvedTask.status === "cancelled" || resolvedTask.status === "interrupt") {

--- a/packages/omo-opencode/src/tools/background-task/full-session-format.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/full-session-format.test.ts
@@ -11,6 +11,14 @@ function makeMessage(id: string, role: "user" | "assistant", text: string, time:
   }
 }
 
+function makeToolResultMessage(id: string, output: string, time: number) {
+  return {
+    id,
+    info: { role: "assistant" as const, time },
+    parts: [{ type: "tool_result", output }],
+  }
+}
+
 function makeClient(messages: ReturnType<typeof makeMessage>[]): BackgroundOutputClient {
   return {
     session: {
@@ -136,5 +144,85 @@ describe("formatFullSession", () => {
     expect(output).not.toContain("PROMPT_1")
     expect(output).not.toContain("RESPONSE_1")
     expect(output).not.toContain("PROMPT_2")
+  })
+
+  test("#given 25 messages, fromEnd=true and NO messageLimit #when formatFullSession runs #then at most 20 messages are returned and the LAST message is present", async () => {
+    // given
+    const messages = Array.from({ length: 25 }, (_, i) =>
+      makeMessage(`msg_${String(i + 1).padStart(2, "0")}`, "assistant", `TAIL_BODY_${i + 1}`, 1778525000000 + (i + 1) * 1000),
+    )
+    const client = makeClient(messages)
+
+    // when
+    const output = await formatFullSession(makeTask(), client, {
+      includeThinking: false,
+      includeToolResults: false,
+      fromEnd: true,
+    })
+
+    // then
+    expect(output).toContain("TAIL_BODY_25")
+    expect(output).toContain("Returned: 20")
+    expect(output).not.toContain("TAIL_BODY_5\n")
+    expect(output).not.toContain("TAIL_BODY_1\n")
+  })
+
+  test("#given a tool_result longer than 2000 chars #when formatFullSession runs with includeToolResults #then it is truncated with an ellipsis suffix", async () => {
+    // given
+    const hugeOutput = "X".repeat(5000)
+    const messages = [makeToolResultMessage("msg_tool", hugeOutput, 1778525000100)] as unknown as ReturnType<
+      typeof makeMessage
+    >[]
+    const client = makeClient(messages)
+
+    // when
+    const output = await formatFullSession(makeTask(), client, {
+      includeThinking: false,
+      includeToolResults: true,
+    })
+
+    // then
+    expect(output).toContain("...")
+    expect(output).not.toContain("X".repeat(2001))
+    expect(output).toContain("X".repeat(2000))
+  })
+
+  test("#given messageLimit provided (default direction) #when formatFullSession runs #then output is byte-identical to the documented head-slice behavior (regression guard)", async () => {
+    // given
+    const messages = [
+      makeMessage("msg_1", "user", "REG_FIRST", 1778525000100),
+      makeMessage("msg_2", "assistant", "REG_SECOND", 1778525000200),
+      makeMessage("msg_3", "assistant", "REG_THIRD", 1778525000300),
+    ]
+    const client = makeClient(messages)
+
+    // when
+    const output = await formatFullSession(makeTask(), client, {
+      includeThinking: false,
+      includeToolResults: false,
+      messageLimit: 2,
+    })
+
+    // then
+    const expected = [
+      "# Full Session Output",
+      "",
+      "Task ID: bg_test",
+      "Description: test task",
+      "Status: completed",
+      "Session ID: ses_child",
+      "Total messages: 3",
+      "Returned: 2",
+      "Has more: true",
+      "",
+      "## Messages",
+      "",
+      "[user] Unknown time id=msg_1",
+      "REG_FIRST",
+      "",
+      "[assistant] Unknown time id=msg_2",
+      "REG_SECOND",
+    ].join("\n")
+    expect(output).toBe(expected)
   })
 })

--- a/packages/omo-opencode/src/tools/background-task/full-session-format.ts
+++ b/packages/omo-opencode/src/tools/background-task/full-session-format.ts
@@ -8,6 +8,8 @@ import { getBackgroundOutputFetchTimeoutMs, withSdkCallTimeout } from "./with-sd
 
 const MAX_MESSAGE_LIMIT = 100
 const THINKING_MAX_CHARS = 2000
+const DEFAULT_FROM_END_TAIL = 20
+const TOOL_RESULT_MAX_CHARS = 2000
 
 function extractToolResultText(part: NonNullable<BackgroundOutputMessage["parts"]>[number]): string[] {
   if (typeof part.content === "string" && part.content.length > 0) {
@@ -112,7 +114,7 @@ export async function formatFullSession(
   const hasMore = limit !== undefined && normalizedMessages.length > limit
   let visibleMessages: typeof normalizedMessages
   if (limit === undefined) {
-    visibleMessages = normalizedMessages
+    visibleMessages = options.fromEnd ? normalizedMessages.slice(-DEFAULT_FROM_END_TAIL) : normalizedMessages
   } else if (options.fromEnd) {
     visibleMessages = normalizedMessages.slice(-limit)
   } else {
@@ -156,7 +158,7 @@ export async function formatFullSession(
       } else if (part.type === "tool_result") {
         const toolTexts = extractToolResultText(part)
         for (const toolText of toolTexts) {
-          lines.push(`[tool result] ${toolText}`)
+          lines.push(`[tool result] ${truncateText(toolText, TOOL_RESULT_MAX_CHARS)}`)
         }
       } else if ((part.type === "tool_use" || part.type === "tool") && part.tool) {
         const input = part.input === undefined ? "" : truncateText(JSON.stringify(part.input), thinkingMaxChars)

--- a/packages/omo-opencode/src/tools/background-task/task-result-format.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/task-result-format.test.ts
@@ -45,4 +45,96 @@ describe("formatTaskResult", () => {
     expect(output).toContain("Session error")
     expect(output).toContain("Forbidden: Selected provider is forbidden")
   })
+
+  test("leads with the final assistant answer before older context", async () => {
+    // given a session with an intermediate step, a tool result, then a final answer
+    const task = createTask({ sessionId: "ses-final-first" })
+    const client: BackgroundOutputClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { role: "assistant", time: { created: 1 } }, parts: [{ type: "text", text: "OLDER_INTERMEDIATE_STEP" }] },
+            { info: { role: "tool", time: { created: 2 } }, parts: [{ type: "tool_result", content: "TOOL_OUTPUT_DATA" }] },
+            { info: { role: "assistant", time: { created: 3 } }, parts: [{ type: "text", text: "FINAL_ANSWER_HERE" }] },
+          ],
+        }),
+      },
+    }
+
+    // when the result is formatted
+    const output = await formatTaskResult(task, client)
+
+    // then the final answer leads under its heading, before any older context
+    expect(output).toContain("## Final answer")
+    expect(output.indexOf("FINAL_ANSWER_HERE")).toBeGreaterThanOrEqual(0)
+    expect(output.indexOf("FINAL_ANSWER_HERE")).toBeLessThan(output.indexOf("OLDER_INTERMEDIATE_STEP"))
+    expect(output.indexOf("FINAL_ANSWER_HERE")).toBeLessThan(output.indexOf("TOOL_OUTPUT_DATA"))
+    expect(output).toContain("Full detail available via `full_session:true`")
+  })
+
+  test("truncates an oversized tool_result block", async () => {
+    // given a tool_result far larger than the cap
+    const huge = "A".repeat(5000)
+    const task = createTask({ sessionId: "ses-truncate" })
+    const client: BackgroundOutputClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { role: "tool", time: { created: 1 } }, parts: [{ type: "tool_result", content: huge }] },
+            { info: { role: "assistant", time: { created: 2 } }, parts: [{ type: "text", text: "done" }] },
+          ],
+        }),
+      },
+    }
+
+    // when the result is formatted
+    const output = await formatTaskResult(task, client)
+
+    // then the tool_result is capped at TOOL_RESULT_MAX_CHARS with an ellipsis marker
+    expect(output).not.toContain("A".repeat(2001))
+    expect(output).toContain(`${"A".repeat(2000)}...`)
+  })
+
+  test("bounds total output for a huge fixture", async () => {
+    // given a session with 100 sizeable messages plus a final answer
+    const data = Array.from({ length: 100 }, (_, index) => ({
+      info: { role: "tool" as const, time: { created: index } },
+      parts: [{ type: "tool_result" as const, content: "C".repeat(1000) }],
+    }))
+    data.push({
+      info: { role: "tool" as const, time: { created: 100 } },
+      parts: [{ type: "tool_result" as const, content: "FINAL".repeat(1) }],
+    })
+    const task = createTask({ sessionId: "ses-bounded" })
+    const client: BackgroundOutputClient = {
+      session: {
+        messages: async () => ({ data }),
+      },
+    }
+
+    // when the result is formatted
+    const output = await formatTaskResult(task, client)
+
+    // then the trailing older-context section keeps the body bounded
+    expect(output.length).toBeLessThan(40000)
+  })
+
+  test("returns the no-new-output notice when nothing is new since last check", async () => {
+    // given the same messages consumed twice on one session
+    const task = createTask({ sessionId: "ses-no-new" })
+    const client: BackgroundOutputClient = {
+      session: {
+        messages: async () => ({
+          data: [{ info: { role: "assistant", time: { created: 1 } }, parts: [{ type: "text", text: "first pass" }] }],
+        }),
+      },
+    }
+
+    // when formatted a first time then a second time
+    await formatTaskResult(task, client)
+    const output = await formatTaskResult(task, client)
+
+    // then the second pass reports no new output
+    expect(output).toContain("(No new output since last check)")
+  })
 })

--- a/packages/omo-opencode/src/tools/background-task/task-result-format.ts
+++ b/packages/omo-opencode/src/tools/background-task/task-result-format.ts
@@ -1,16 +1,95 @@
 import type { BackgroundTask } from "../../features/background-agent"
 import { extractErrorMessage } from "../../features/background-agent/error-classifier"
 import { consumeNewMessages } from "../../shared/session-cursor"
-import type { BackgroundOutputClient, BackgroundOutputMessagesResult } from "./clients"
+import type { BackgroundOutputClient, BackgroundOutputMessage, BackgroundOutputMessagesResult } from "./clients"
 import { extractMessages, getErrorMessage } from "./session-messages"
 import { formatDuration } from "./time-format"
+import { truncateText } from "./truncate-text"
 import { getBackgroundOutputFetchTimeoutMs, withSdkCallTimeout } from "./with-sdk-call-timeout"
+
+const TOOL_RESULT_MAX_CHARS = 2000
+const DEFAULT_FROM_END_TAIL = 20
 
 function getTimeString(value: unknown): string {
   return typeof value === "string" ? value : ""
 }
 
-export async function formatTaskResult(task: BackgroundTask, client: BackgroundOutputClient): Promise<string> {
+function extractAssistantText(message: BackgroundOutputMessage): string {
+  const texts: string[] = []
+  for (const part of message.parts ?? []) {
+    if ((part.type === "text" || part.type === "reasoning") && part.text) {
+      texts.push(part.text)
+    }
+  }
+  return texts.join("\n\n")
+}
+
+function extractMessageContent(message: BackgroundOutputMessage): string {
+  const chunks: string[] = []
+  for (const part of message.parts ?? []) {
+    if ((part.type === "text" || part.type === "reasoning") && part.text) {
+      chunks.push(part.text)
+      continue
+    }
+
+    if (part.type === "tool_result") {
+      const content = part.content
+      if (typeof content === "string" && content) {
+        chunks.push(truncateText(content, TOOL_RESULT_MAX_CHARS))
+        continue
+      }
+
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if ((block.type === "text" || block.type === "reasoning") && block.text) {
+            chunks.push(truncateText(block.text, TOOL_RESULT_MAX_CHARS))
+          }
+        }
+      }
+    }
+  }
+  return chunks.filter((chunk) => chunk.length > 0).join("\n\n")
+}
+
+function findLastAssistantIndex(messages: BackgroundOutputMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.info?.role === "assistant" && extractAssistantText(messages[index]!).length > 0) {
+      return index
+    }
+  }
+  return -1
+}
+
+function buildResultBody(newMessages: BackgroundOutputMessage[], olderContextTail: number): string {
+  const finalAnswerIndex = findLastAssistantIndex(newMessages)
+  const finalAnswerText = finalAnswerIndex >= 0 ? extractAssistantText(newMessages[finalAnswerIndex]!) : ""
+
+  const olderMessages = newMessages.filter((_, index) => index !== finalAnswerIndex).slice(-olderContextTail)
+  const olderContext = olderMessages
+    .map((message) => extractMessageContent(message))
+    .filter((text) => text.length > 0)
+    .join("\n\n")
+
+  const sections: string[] = []
+  if (finalAnswerText) {
+    sections.push(`## Final answer\n\n${finalAnswerText}`)
+  }
+  if (olderContext) {
+    sections.push(`## Older context\n\n${olderContext}`)
+  }
+  sections.push("> Full detail available via `full_session:true`")
+
+  if (!finalAnswerText && !olderContext) {
+    return "(No text output)"
+  }
+  return sections.join("\n\n")
+}
+
+export async function formatTaskResult(
+  task: BackgroundTask,
+  client: BackgroundOutputClient,
+  options?: { fromEnd?: boolean; messageLimit?: number },
+): Promise<string> {
   if (!task.sessionId) {
     return `Error: Task has no sessionID`
   }
@@ -96,33 +175,11 @@ Session ID: ${task.sessionId}
 (No new output since last check)`
   }
 
-  const extractedContent: string[] = []
-  for (const message of newMessages) {
-    for (const part of message.parts ?? []) {
-      if ((part.type === "text" || part.type === "reasoning") && part.text) {
-        extractedContent.push(part.text)
-        continue
-      }
-
-      if (part.type === "tool_result") {
-        const toolResult = part as { content?: string | Array<{ type: string; text?: string }> }
-        if (typeof toolResult.content === "string" && toolResult.content) {
-          extractedContent.push(toolResult.content)
-          continue
-        }
-
-        if (Array.isArray(toolResult.content)) {
-          for (const block of toolResult.content) {
-            if ((block.type === "text" || block.type === "reasoning") && block.text) {
-              extractedContent.push(block.text)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  const textContent = extractedContent.filter((text) => text.length > 0).join("\n\n")
+  const olderContextTail =
+    typeof options?.messageLimit === "number" && options.messageLimit > 0
+      ? options.messageLimit
+      : DEFAULT_FROM_END_TAIL
+  const body = buildResultBody(newMessages, olderContextTail)
   const duration = formatDuration(task.startedAt ?? new Date(), task.completedAt)
 
   return `Task Result
@@ -134,5 +191,5 @@ Session ID: ${task.sessionId}
 
 ---
 
-${textContent || "(No text output)"}`
+${body}`
 }


### PR DESCRIPTION
**Fix background task result retrieval so an agent can read a subagent's final answer**

**The problem.** When an agent delegates work to run in the background and later asks for the result, it frequently can't get the one thing it needs: the subagent's final answer. Asking for the result returns the entire background conversation — including very large intermediate output like full build and test logs — instead of the recent, relevant part. The option meant to return "just the most recent message" doesn't actually narrow anything, so even when the agent explicitly asks for the ending, it still receives everything, and the final answer at the very end gets dropped before the agent can see it. In practice the agent asks again and again, never receives the conclusion, and its own working memory fills with noise it never wanted.

**When it started.** The "most recent message" option was added in v4.10.0 (commit 6092c8ef1), on top of result formatting that had never limited large intermediate output.

**The solution.** Make result retrieval honor what the caller asks for. A request for the most recent part of a background task returns a bounded slice from the end that reliably contains the final answer, whether the task is finished or still running, and the final answer is shown first so it can't be cut off. Bulky intermediate output no longer crowds out that answer, and a caller's choice to leave heavy detail out is respected even while the task is still in progress. Lightweight status checks stay small and cheap; only an explicit request for full detail returns more.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes background task result retrieval so agents reliably get a subagent’s final answer without being buried by logs. Adds bounded tail slicing and truncation for smaller, cheaper status checks.

- **Bug Fixes**
  - Honor `from_end` for both `full_session` and completed results; when no limit is given, return the last 20 messages.
  - Completed results lead with the “Final answer,” followed by a bounded “Older context” (size set by `message_limit`, default 20).
  - Respect `include_thinking` and `include_tool_results`: explicit values are honored; defaults are on only while the task is active.
  - Truncate `tool_result` blocks to 2000 chars with an ellipsis to avoid log bloat.
  - Preserve the “No new output since last check” notice; added tests for tail slicing, truncation, and include-flag behavior.

<sup>Written for commit 3ebb34125c3a05d00bbf16d2a93678a743d7cda6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

