### PR TITLE
Seal read-only agents with deny-all allowlist

### DIFF
--- a/packages/omo-opencode/src/agents/explore.ts
+++ b/packages/omo-opencode/src/agents/explore.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode, AgentPromptMetadata } from "./types"
-import { createAgentToolRestrictions } from "../shared/permission-compat"
+import { createAgentToolAllowlist } from "../shared/permission-compat"
 
 const MODE: AgentMode = "subagent"
 
@@ -25,10 +25,17 @@ export const EXPLORE_PROMPT_METADATA: AgentPromptMetadata = {
 }
 
 export function createExploreAgent(model: string): AgentConfig {
-  const restrictions = createAgentToolRestrictions(
-    ["write", "edit", "apply_patch", "task", "call_omo_agent"],
-    ["lsp_symbols", "lsp_goto_definition", "lsp_find_references", "lsp_diagnostics"],
-  )
+  // ponytail: deny-all allowlist, not a write-tool blocklist; a blocklist leaves bash + MCP write tools open.
+  const restrictions = createAgentToolAllowlist([
+    "read",
+    "grep",
+    "glob",
+    "list",
+    "lsp_symbols",
+    "lsp_goto_definition",
+    "lsp_find_references",
+    "lsp_diagnostics",
+  ])
 
   return {
     description:

--- a/packages/omo-opencode/src/agents/librarian.ts
+++ b/packages/omo-opencode/src/agents/librarian.ts
@@ -22,6 +22,7 @@ export const LIBRARIAN_PROMPT_METADATA: AgentPromptMetadata = {
 }
 
 export function createLibrarianAgent(model: string): AgentConfig {
+  // ponytail: stays a blocklist (not deny-all allowlist) because librarian's job needs bash for gh/git; allowing bash would reopen the FS-write leak anyway.
   const restrictions = createAgentToolRestrictions([
     "write",
     "edit",

--- a/packages/omo-opencode/src/agents/metis.ts
+++ b/packages/omo-opencode/src/agents/metis.ts
@@ -2,7 +2,7 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode, AgentPromptMetadata } from "./types"
 import { buildClaudeThinkingConfig, isKimiK27Model } from "./types"
 import { buildAntiDuplicationSection } from "./dynamic-agent-prompt-builder"
-import { createAgentToolRestrictions } from "../shared/permission-compat"
+import { createAgentToolAllowlist } from "../shared/permission-compat"
 
 const MODE: AgentMode = "subagent"
 
@@ -389,10 +389,17 @@ For Build and Research, run the exploration yourself before questioning. Prompt 
 **ALWAYS**: classify first; be specific ("change UserService only, or AuthService too?"); explore before asking for Build and Research intents; give Prometheus actionable directives; and include the agent-executable QA directives in every output.
 </critical_rules>`
 
-const metisRestrictions = createAgentToolRestrictions([
-  "write",
-  "edit",
-  "apply_patch",
+// ponytail: deny-all allowlist, not a write-tool blocklist; a blocklist leaves bash + MCP write tools open.
+const metisRestrictions = createAgentToolAllowlist([
+  "read",
+  "grep",
+  "glob",
+  "list",
+  "webfetch",
+  "lsp_symbols",
+  "lsp_goto_definition",
+  "lsp_find_references",
+  "lsp_diagnostics",
 ])
 
 export function createMetisAgent(model: string): AgentConfig {

--- a/packages/omo-opencode/src/agents/momus.ts
+++ b/packages/omo-opencode/src/agents/momus.ts
@@ -1,7 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
 import { buildClaudeThinkingConfig, isGptModel } from "./types";
-import { createAgentToolRestrictions } from "../shared/permission-compat";
+import { createAgentToolAllowlist } from "../shared/permission-compat";
 
 const MODE: AgentMode = "subagent";
 
@@ -279,10 +279,17 @@ Response language: match the language of the plan content.
 export { MOMUS_DEFAULT_PROMPT as MOMUS_SYSTEM_PROMPT };
 
 export function createMomusAgent(model: string): AgentConfig {
-  const restrictions = createAgentToolRestrictions([
-    "write",
-    "edit",
-    "apply_patch",
+  // ponytail: deny-all allowlist, not a write-tool blocklist; a blocklist leaves bash + MCP write tools open.
+  const restrictions = createAgentToolAllowlist([
+    "read",
+    "grep",
+    "glob",
+    "list",
+    "webfetch",
+    "lsp_symbols",
+    "lsp_goto_definition",
+    "lsp_find_references",
+    "lsp_diagnostics",
   ]);
 
   const base = {

--- a/packages/omo-opencode/src/agents/oracle.ts
+++ b/packages/omo-opencode/src/agents/oracle.ts
@@ -1,7 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
 import { buildClaudeThinkingConfig, isGpt5_5Model, isGptModel } from "./types";
-import { createAgentToolRestrictions } from "../shared/permission-compat";
+import { createAgentToolAllowlist } from "../shared/permission-compat";
 
 const MODE: AgentMode = "subagent";
 
@@ -409,11 +409,17 @@ If the follow-up contradicts what you recommended and you still believe the orig
 
 
 export function createOracleAgent(model: string): AgentConfig {
-  const restrictions = createAgentToolRestrictions([
-    "write",
-    "edit",
-    "apply_patch",
-    "task",
+  // ponytail: deny-all allowlist, not a write-tool blocklist; a blocklist leaves bash + MCP write tools open.
+  const restrictions = createAgentToolAllowlist([
+    "read",
+    "grep",
+    "glob",
+    "list",
+    "webfetch",
+    "lsp_symbols",
+    "lsp_goto_definition",
+    "lsp_find_references",
+    "lsp_diagnostics",
   ]);
 
   const base = {

--- a/packages/omo-opencode/src/agents/tool-restrictions.test.ts
+++ b/packages/omo-opencode/src/agents/tool-restrictions.test.ts
@@ -29,6 +29,20 @@ const TEAM_TOOL_NAMES = [
 
 describe("read-only agent tool restrictions", () => {
   const FILE_WRITE_TOOLS = ["write", "edit", "apply_patch"]
+  // tools that must NOT be reachable on a deny-all allowlist agent: bash leaks
+  // (echo > file, sed -i) and MCP write tools were the actual bypass paths.
+  const LEAK_TOOLS = ["bash", "mcpm_morphllm-fast-apply_edit_file"]
+  const REQUIRED_READ_TOOLS = ["read", "grep", "glob", "list"]
+
+  const expectDenyAllAllowlist = (permission: Record<string, string>) => {
+    expect(permission["*"]).toBe("deny")
+    for (const tool of [...FILE_WRITE_TOOLS, ...LEAK_TOOLS]) {
+      expect(permission[tool]).not.toBe("allow")
+    }
+    for (const tool of REQUIRED_READ_TOOLS) {
+      expect(permission[tool]).toBe("allow")
+    }
+  }
 
   test("denies team tools for every delegated subagent prompt", () => {
     // given
@@ -69,7 +83,7 @@ describe("read-only agent tool restrictions", () => {
   })
 
   describe("Oracle", () => {
-    test("denies all file-writing tools", () => {
+    test("uses deny-all allowlist blocking bash and MCP writers", () => {
       // given
       const agent = createOracleAgent(TEST_MODEL)
 
@@ -77,12 +91,10 @@ describe("read-only agent tool restrictions", () => {
       const permission = agent.permission as Record<string, string>
 
       // then
-      for (const tool of FILE_WRITE_TOOLS) {
-        expect(permission[tool]).toBe("deny")
-      }
+      expectDenyAllAllowlist(permission)
     })
 
-    test("denies task but allows call_omo_agent for research", () => {
+    test("does not grant task or call_omo_agent", () => {
       // given
       const agent = createOracleAgent(TEST_MODEL)
 
@@ -90,13 +102,13 @@ describe("read-only agent tool restrictions", () => {
       const permission = agent.permission as Record<string, string>
 
       // then
-      expect(permission["task"]).toBe("deny")
-      expect(permission["call_omo_agent"]).toBeUndefined()
+      expect(permission["task"]).not.toBe("allow")
+      expect(permission["call_omo_agent"]).not.toBe("allow")
     })
   })
 
   describe("Librarian", () => {
-    test("denies all file-writing tools", () => {
+    test("denies all file-writing tools (blocklist: needs bash for gh/git)", () => {
       // given
       const agent = createLibrarianAgent(TEST_MODEL)
 
@@ -111,7 +123,7 @@ describe("read-only agent tool restrictions", () => {
   })
 
   describe("Explore", () => {
-    test("denies all file-writing tools", () => {
+    test("uses deny-all allowlist blocking bash and MCP writers", () => {
       // given
       const agent = createExploreAgent(TEST_MODEL)
 
@@ -119,14 +131,12 @@ describe("read-only agent tool restrictions", () => {
       const permission = agent.permission as Record<string, string>
 
       // then
-      for (const tool of FILE_WRITE_TOOLS) {
-        expect(permission[tool]).toBe("deny")
-      }
+      expectDenyAllAllowlist(permission)
     })
   })
 
   describe("Momus", () => {
-    test("denies all file-writing tools", () => {
+    test("uses deny-all allowlist blocking bash and MCP writers", () => {
       // given
       const agent = createMomusAgent(TEST_MODEL)
 
@@ -134,12 +144,10 @@ describe("read-only agent tool restrictions", () => {
       const permission = agent.permission as Record<string, string>
 
       // then
-      for (const tool of FILE_WRITE_TOOLS) {
-        expect(permission[tool]).toBe("deny")
-      }
+      expectDenyAllAllowlist(permission)
     })
 
-    test("allows task delegation while remaining ineligible for team membership", () => {
+    test("does not grant task delegation and stays ineligible for team membership", () => {
       // given
       const agent = createMomusAgent(TEST_MODEL)
 
@@ -148,13 +156,13 @@ describe("read-only agent tool restrictions", () => {
       const sessionRestrictions = getAgentToolRestrictions("momus")
 
       // then
-      expect(permission["task"]).toBeUndefined()
+      expect(permission["task"]).not.toBe("allow")
       expect(sessionRestrictions["task"]).toBeUndefined()
     })
   })
 
   describe("Metis", () => {
-    test("denies all file-writing tools", () => {
+    test("uses deny-all allowlist blocking bash and MCP writers", () => {
       // given
       const agent = createMetisAgent(TEST_MODEL)
 
@@ -162,12 +170,10 @@ describe("read-only agent tool restrictions", () => {
       const permission = agent.permission as Record<string, string>
 
       // then
-      for (const tool of FILE_WRITE_TOOLS) {
-        expect(permission[tool]).toBe("deny")
-      }
+      expectDenyAllAllowlist(permission)
     })
 
-    test("allows task delegation while remaining ineligible for team membership", () => {
+    test("does not grant task delegation and stays ineligible for team membership", () => {
       // given
       const agent = createMetisAgent(TEST_MODEL)
 
@@ -176,7 +182,7 @@ describe("read-only agent tool restrictions", () => {
       const sessionRestrictions = getAgentToolRestrictions("metis")
 
       // then
-      expect(permission["task"]).toBeUndefined()
+      expect(permission["task"]).not.toBe("allow")
       expect(sessionRestrictions["task"]).toBeUndefined()
     })
   })


### PR DESCRIPTION
## Summary

- Read-only advisor/search agents (oracle, momus, metis, explore) used a write-tool **blocklist** that left `bash` and MCP write tools reachable, letting a "read-only" agent (e.g. Momus, the plan critic) mutate the filesystem and start implementing instead of reviewing.
- Switch them to `createAgentToolAllowlist` (`"*": "deny"` + explicit read tools), so every mutation path is denied by default, including any future MCP write tool.

## Changes

- `oracle.ts`, `momus.ts`, `metis.ts`, `explore.ts`: replace `createAgentToolRestrictions([...write tools])` with `createAgentToolAllowlist([read, grep, glob, list, webfetch, lsp_*])` (explore omits `webfetch`; it is internal-only).
- `librarian.ts`: deliberately kept on the blocklist with an inline note. Its job requires `bash` for `gh`/`git`, so an allowlist would have to re-allow `bash` and reopen the same leak.
- `tool-restrictions.test.ts`: assert deny-all semantics for the four sealed agents — `permission["*"] === "deny"`, `bash` and `mcpm_morphllm-fast-apply_edit_file` are NOT allowed, and required read tools (`read`/`grep`/`glob`/`list`) ARE allowed.

### Root cause

A named-tool blocklist only blocks what it enumerates. The previous list named `write`/`edit`/`apply_patch` (+ `task` for oracle), but `bash` (`echo > file`, `sed -i`, `tee`) and MCP write tools were never named, so they stayed allowed. The deny-all allowlist primitive already existed in the codebase (`createAgentToolAllowlist`, used by `multimodal-looker`) and is the correct, leak-proof default.

## Testing

```bash
bun run typecheck   # clean
bun test packages/omo-opencode/src/agents/   # 342 pass / 0 fail
bun run build       # succeeds
```

- `tool-restrictions.test.ts` + `permission-compat.test.ts`: 26 pass / 0 fail.
- Full agents suite: 342 pass / 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch read-only advisor/search agents to a deny-all allowlist that only permits read tools, blocking writes via `bash` and MCP write tools. This locks down Oracle, Momus, Metis, and Explore so they can’t mutate the filesystem.

- **Bug Fixes**
  - Switched to `createAgentToolAllowlist` in `oracle.ts`, `momus.ts`, `metis.ts`, `explore.ts` with allowed: `read`, `grep`, `glob`, `list`, `lsp_*` (+ `webfetch` for Oracle/Momus/Metis).
  - Kept `librarian.ts` on the blocklist since it needs `bash` for `gh`/`git`.
  - Updated tests to assert deny-all (`"*": "deny"`), block `bash` and MCP writers, keep required read tools, and ensure `task`/`call_omo_agent` are not granted.

<sup>Written for commit 4555355a32bd5aa6b1c2db763cb7f4ad240191eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

