### PR TITLE
fix(ulw-plan): announce intent routing decision to user before proceeding

### DIFF
--- a/packages/shared-skills/skills/ulw-plan/SKILL.md
+++ b/packages/shared-skills/skills/ulw-plan/SKILL.md
@@ -15,7 +15,10 @@ Outcome-first: explore a lot, ask few sharp questions - or none, when the intent
 
 ## INTENT ROUTING - pick ONE intent reference
 
-After grounding, make ONE judgment and load ONE intent reference (you ALSO read `references/full-workflow.md` for the shared mechanics - see below). The test keys on whether the desired **OUTCOME** is clear, NOT on request length.
+After grounding, make ONE judgment, **ANNOUNCE it to the user in one line**, then load ONE intent reference (you ALSO read `references/full-workflow.md` for the shared mechanics - see below). The test keys on whether the desired **OUTCOME** is clear, NOT on request length. The announcement is the user's first signal of whether they will be interviewed — never skip it.
+
+> "Intent: **CLEAR** — you specified the exact endpoint and behavior. I will ask you the genuine forks I cannot resolve from the codebase."
+> "Intent: **UNCLEAR** — 'make auth better' is open-ended. I will research best-practice defaults and present them for your veto, no interview."
 
 - **OVERRIDE - explicit ask wins:** if the user explicitly asks to be questioned or interviewed ("ask me", "interview me", "why aren't you asking me" - in any language), route **CLEAR**, run the interview, and turn the adopt-default filter OFF: the user has claimed the forks, so every surviving one is ASKED, not defaulted. This beats the OUTCOME test below, even on a fuzzy brief.
 - **CLEAR** - the user knows the outcome; the only open items are preferences/tradeoffs the repo cannot answer (genuine owner-decisions). Read **`references/intent-clear.md`**: ask the surviving forks with WHY, run the normal approval gate, high-accuracy review is OPTIONAL (offered as one question).


### PR DESCRIPTION
## What

The INTENT ROUTING section told the model to "make ONE judgment" but never instructed it to **announce** that judgment. Users had no signal whether they would be interviewed (CLEAR path) or given defaults (UNCLEAR path).

## Why

- The concept of announcing the routing call already existed in `intent-unclear.md`'s approval gate ("LEAD that block with the routing call itself") but was placed at the **end** of the flow — too late for the user to know what's coming.
- Prompt engineering diagnosis: **(B) misframing** — the instruction existed but was in the wrong position in the flow.

## Change

Add an announcement step at the routing decision point in `SKILL.md` with two concrete format examples (one CLEAR, one UNCLEAR). Growth: ~3 lines, justified by genuinely missing user-visible behavior.

```
> "Intent: **CLEAR** — you specified the exact endpoint and behavior. I will ask you the genuine forks I cannot resolve from the codebase."
> "Intent: **UNCLEAR** — 'make auth better' is open-ended. I will research best-practice defaults and present them for your veto, no interview."
```

## Scope

- `packages/shared-skills/skills/ulw-plan/SKILL.md` only — prompt-only change, no product code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Announce the intent routing decision up front so users know if they’ll be interviewed (CLEAR) or given defaults (UNCLEAR) before proceeding. Adds a one-line announcement step with two example formats in `packages/shared-skills/skills/ulw-plan/SKILL.md`.

<sup>Written for commit f7a0db823c8074cc1006e5a0a2651f19f0cd9371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

