### PR TITLE
fix(look-at): treat empty optional arrays as not provided in validation

### DIFF
--- a/packages/omo-opencode/src/tools/look-at/look-at-arguments.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-arguments.ts
@@ -44,9 +44,9 @@ export function validateArgs(args: LookAtArgs): string | null {
   const normalizedArgs = args as NormalizedLookAtArgs
   const filePath = args.file_path
   const hasFilePath = hasNonEmptyString(args.file_path)
-  const hasFilePaths = Array.isArray(args.file_paths)
+  const hasFilePaths = hasValues(args.file_paths)
   const hasImageData = hasNonEmptyString(args.image_data)
-  const hasImageDataList = Array.isArray(args.image_data_list)
+  const hasImageDataList = hasValues(args.image_data_list)
   const filePathsFromSingular = normalizedArgs._normalized_file_paths_from_singular === true
   const imageDataListFromSingular = normalizedArgs._normalized_image_data_list_from_singular === true
 
@@ -56,14 +56,6 @@ export function validateArgs(args: LookAtArgs): string | null {
 
   if (hasImageData && hasImageDataList && !imageDataListFromSingular) {
     return "Error: Provide either 'image_data' or 'image_data_list', not both."
-  }
-
-  if (hasFilePaths && !hasValues(args.file_paths)) {
-    return "Error: 'file_paths' must contain at least one local file path."
-  }
-
-  if (hasImageDataList && !hasValues(args.image_data_list)) {
-    return "Error: 'image_data_list' must contain at least one Base64 image string."
   }
 
   if (hasValues(args.file_paths)) {
@@ -88,7 +80,7 @@ export function validateArgs(args: LookAtArgs): string | null {
   if (hasNonEmptyString(filePath) && isRemoteUrl(filePath)) {
     return "Error: Remote URLs are not supported for file_path. Download the file first or use a local path."
   }
-  if (!hasFilePath && !hasValues(args.file_paths) && !hasImageData && !hasValues(args.image_data_list)) {
+  if (!hasFilePath && !hasFilePaths && !hasImageData && !hasImageDataList) {
     return `Error: Must provide at least one of 'file_path', 'file_paths', 'image_data', or 'image_data_list'. Usage:
 - look_at(file_path="/path/to/file", goal="what to extract")
 - look_at(file_paths=["/path/to/file-1", "/path/to/file-2"], goal="what to extract")


### PR DESCRIPTION
## Problem

When OpenCode generates a `look_at` tool call with unused optional arguments serialized as empty arrays, the tool rejects otherwise valid calls:

```json
{
  "file_path": "/tmp/image.jpg",
  "file_paths": [],
  "goal": "Analyze this image"
}
```

Returns: `Error: Provide either 'file_path' or 'file_paths', not both.`

Similarly for `image_data` + `image_data_list: []`.

## Root Cause

`validateArgs()` used `Array.isArray()` to check if optional array parameters were provided. `Array.isArray([])` returns `true`, so an empty array was treated as a *provided* value even though it carries no actual content. The mutual-exclusion check then fired and rejected the call.

## Fix

Changed `hasFilePaths` and `hasImageDataList` from `Array.isArray()` to `hasValues()` (which checks `Array.isArray && length > 0`). Empty arrays are now treated as *not provided* for mutual exclusion checks.

Still correctly rejected: calling with only `file_paths: []` and no other input triggers the "Must provide at least one" error.

## TDD

All 12 existing `look-at-arguments.test.ts` tests pass — including the "empty file_paths" test which still expects an error containing "file_paths" (the generic "must provide at least one" error message includes the parameter names).

## File

- `packages/omo-opencode/src/tools/look-at/look-at-arguments.ts` (+3/-11)

Fixes #5465

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `look_at` validation to ignore empty `file_paths`/`image_data_list` so valid calls no longer fail the mutual-exclusion check. Fixes #5465.

- **Bug Fixes**
  - Use `hasValues()` instead of `Array.isArray()` for `file_paths` and `image_data_list` in mutual-exclusion checks.
  - Still return "must provide at least one" when only empty arrays are passed.

<sup>Written for commit 32d454120fe129302f0ec50a4eb83597529fca13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

