### PR TITLE
Fix runtime fallback dispatch state

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -6191,6 +6191,9 @@
             },
             "notify_on_fallback": {
               "type": "boolean"
+            },
+            "restore_primary_after_cooldown": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false

--- a/packages/omo-opencode/src/config/schema/runtime-fallback.ts
+++ b/packages/omo-opencode/src/config/schema/runtime-fallback.ts
@@ -13,6 +13,7 @@ export const RuntimeFallbackConfigSchema = z.object({
   timeout_seconds: z.number().min(0).optional(),
   /** Show toast notification when switching to fallback model (default: true) */
   notify_on_fallback: z.boolean().optional(),
+  restore_primary_after_cooldown: z.boolean().optional(),
 })
 
 export type RuntimeFallbackConfig = z.infer<typeof RuntimeFallbackConfigSchema>

--- a/packages/omo-opencode/src/hooks/runtime-fallback/ai-sdk-retryable-session-error.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/ai-sdk-retryable-session-error.test.ts
@@ -19,6 +19,7 @@ describe("runtime-fallback AI SDK retryable session errors", () => {
       max_fallback_attempts: 3,
       cooldown_seconds: 60,
       notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
     }
   }
 

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.ts
@@ -10,6 +10,7 @@ export function createAbortSessionRequest(deps: HookDeps) {
     if (
       source === "session.status.retry-signal" ||
       source === "message.updated.retry-signal" ||
+      source === "message.updated.quota-fallback" ||
       source === "session.timeout"
     ) {
       deps.internallyAbortedSessions.add(sessionID)

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.test.ts
@@ -45,6 +45,7 @@ function createDeps(promptCalls: { count: number }): HookDeps {
       cooldown_seconds: 60,
       timeout_seconds: 0,
       notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
     },
     options: undefined,
     pluginConfig: undefined,

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
@@ -1,4 +1,4 @@
-import type { HookDeps } from "./types"
+import type { AutoRetryDispatchOutcome, HookDeps } from "./types"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { getSessionAgent, resolveRegisteredAgentName } from "../../features/claude-code-session-state"
@@ -31,10 +31,10 @@ export function createAutoRetryDispatcher(
     newModel: string,
     resolvedAgent: string | undefined,
     source: string,
-  ): Promise<void> => {
+  ): Promise<AutoRetryDispatchOutcome> => {
     if (sessionRetryInFlight.has(sessionID)) {
       log(`[${HOOK_NAME}] Retry already in flight, skipping (${source})`, { sessionID })
-      return
+      return { accepted: false, status: "blocked", reason: "retry already in flight" }
     }
 
     const agentSettings = resolvedAgent
@@ -53,7 +53,7 @@ export function createAutoRetryDispatcher(
       if (state) {
         state.pendingFallbackPromptMayHaveBeenAccepted = false
       }
-      return
+      return { accepted: false, status: "invalid-model", reason: "missing provider prefix" }
     }
 
     const hadAwaitingFallbackResult = sessionAwaitingFallbackResult.has(sessionID)
@@ -62,6 +62,7 @@ export function createAutoRetryDispatcher(
     sessionRetryInFlight.add(sessionID)
     let retryDispatched = false
     let retryMayHaveBeenAccepted = false
+    let acceptedStatus: AutoRetryDispatchOutcome["status"] = "dispatched"
     try {
       const messagesResp = await ctx.client.session.messages({
         path: { id: sessionID },
@@ -129,6 +130,7 @@ export function createAutoRetryDispatcher(
           sessionID,
         })
         promptResult = await dispatchRetryPrompt(`runtime-fallback:${source}:active-queue`)
+        acceptedStatus = "queued"
       }
       if (promptResult.status === "failed") {
         if (isAmbiguousPostDispatchPromptFailure(promptResult)) {
@@ -137,6 +139,7 @@ export function createAutoRetryDispatcher(
             sessionID,
             error: String(promptResult.error),
           })
+          return { accepted: true, status: "possibly-accepted" }
         }
         throw promptResult.error
       }
@@ -167,6 +170,7 @@ export function createAutoRetryDispatcher(
               sessionID,
               error: String(reservedResult.error),
             })
+            return { accepted: true, status: "possibly-accepted" }
           }
           throw reservedResult.error
         }
@@ -175,14 +179,15 @@ export function createAutoRetryDispatcher(
             sessionID,
             status: reservedResult.status,
           })
-          return
+          return { accepted: false, status: "blocked", reason: `prompt gate returned ${reservedResult.status}` }
         }
+        acceptedStatus = "queued"
       } else if (!isInternalPromptDispatchAccepted(promptResult)) {
         log(`[${HOOK_NAME}] Auto-retry skipped by promptAsync gate (${source})`, {
           sessionID,
           status: promptResult.status,
         })
-        return
+        return { accepted: false, status: "blocked", reason: `prompt gate returned ${promptResult.status}` }
       }
       sessionAwaitingFallbackResult.add(sessionID)
       if (hadAwaitingFallbackResult) {
@@ -193,12 +198,14 @@ export function createAutoRetryDispatcher(
         state.pendingFallbackPromptMayHaveBeenAccepted = false
       }
       retryDispatched = true
+      return { accepted: true, status: acceptedStatus }
     } catch (retryError) {
       if (!(retryError instanceof Error)) {
         log(`[${HOOK_NAME}] Auto-retry failed (${source})`, { sessionID, error: String(retryError) })
-        return
+        return { accepted: false, status: "failed", reason: String(retryError) }
       }
       log(`[${HOOK_NAME}] Auto-retry failed (${source})`, { sessionID, error: String(retryError) })
+      return { accepted: false, status: "failed", reason: retryError.message }
     } finally {
       sessionRetryInFlight.delete(sessionID)
       if (retryMayHaveBeenAccepted) {

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { createFallbackTimeoutHelpers } from "./auto-retry-timeout"
+import { createFallbackState } from "./fallback-state"
+import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
+import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+
+function createContext(): RuntimeFallbackPluginInput {
+  return {
+    client: {
+      session: {
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+        promptAsync: async () => ({}),
+      },
+      tui: {
+        showToast: async () => ({}),
+      },
+    },
+    directory: "/test/dir",
+  }
+}
+
+function createDeps(): HookDeps {
+  return {
+    ctx: createContext(),
+    config: {
+      enabled: true,
+      retry_on_errors: [429, 503, 529],
+      max_fallback_attempts: 3,
+      cooldown_seconds: 60,
+      timeout_seconds: 30,
+      notify_on_fallback: true,
+      restore_primary_after_cooldown: false,
+    },
+    options: {
+      session_timeout_ms: 1,
+    },
+    pluginConfig: {
+      categories: {
+        test: {
+          fallback_models: ["litellm/openai.eu.gpt-5.5"],
+        },
+      },
+    },
+    sessionStates: new Map(),
+    sessionLastAccess: new Map(),
+    sessionRetryInFlight: new Set(),
+    sessionAwaitingFallbackResult: new Set(),
+    sessionFallbackTimeouts: new Map(),
+    sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
+  }
+}
+
+describe("createFallbackTimeoutHelpers", () => {
+  afterEach(() => {
+    SessionCategoryRegistry.clear()
+  })
+
+  test("#given timeout fallback dispatch is blocked #when the timeout fires #then fallback state is restored", async () => {
+    // given
+    const sessionID = "session-timeout-dispatch-blocked"
+    SessionCategoryRegistry.register(sessionID, "test")
+    const deps = createDeps()
+    const state = createFallbackState("openai/gpt-5.4")
+    deps.sessionStates.set(sessionID, state)
+
+    let retryModel: string | undefined
+    let resolveRetry: (() => void) | undefined
+    const retryCalled = new Promise<void>((resolve) => {
+      resolveRetry = resolve
+    })
+    const helpers = createFallbackTimeoutHelpers(
+      deps,
+      async () => {},
+      async (_sessionID, model) => {
+        retryModel = model
+        resolveRetry?.()
+        return { accepted: false, status: "blocked", reason: "test gate blocked dispatch" }
+      },
+    )
+
+    // when
+    helpers.scheduleSessionFallbackTimeout(sessionID)
+    await Promise.race([
+      retryCalled,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("timer did not fire")), 1000)
+      }),
+    ])
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // then
+    expect(retryModel).toBe("litellm/openai.eu.gpt-5.5")
+    expect(state.currentModel).toBe("openai/gpt-5.4")
+    expect(state.fallbackIndex).toBe(-1)
+    expect(state.attemptCount).toBe(0)
+    expect(state.pendingFallbackModel).toBe(undefined)
+    expect(state.failedModels.size).toBe(0)
+  })
+})

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.ts
@@ -1,8 +1,9 @@
-import type { HookDeps, RuntimeFallbackTimeout } from "./types"
+import type { AutoRetryDispatchOutcome, HookDeps, RuntimeFallbackTimeout } from "./types"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { prepareFallback } from "./fallback-state"
+import { restoreFallbackState, snapshotFallbackState } from "./fallback-state-snapshot"
 import { subagentSessions } from "../../features/claude-code-session-state"
 
 declare function setTimeout(callback: () => void | Promise<void>, delay?: number): RuntimeFallbackTimeout
@@ -16,7 +17,7 @@ export function createFallbackTimeoutHelpers(
     newModel: string,
     resolvedAgent: string | undefined,
     source: string,
-  ) => Promise<void>,
+  ) => Promise<AutoRetryDispatchOutcome>,
 ) {
   const {
     config,
@@ -64,6 +65,7 @@ export function createFallbackTimeoutHelpers(
         state.pendingFallbackModel = undefined
       }
       state.pendingFallbackPromptMayHaveBeenAccepted = false
+      const stateSnapshot = snapshotFallbackState(state)
 
       const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, pluginConfig)
       if (fallbackModels.length === 0) return
@@ -76,7 +78,15 @@ export function createFallbackTimeoutHelpers(
 
       const result = prepareFallback(sessionID, state, fallbackModels, config)
       if (result.success && result.newModel) {
-        await autoRetryWithFallback(sessionID, result.newModel, resolvedAgent, "session.timeout")
+        const dispatchOutcome = await autoRetryWithFallback(sessionID, result.newModel, resolvedAgent, "session.timeout")
+        if (!dispatchOutcome.accepted) {
+          restoreFallbackState(state, stateSnapshot)
+          log(`[${HOOK_NAME}] Session timeout fallback dispatch was not accepted`, {
+            sessionID,
+            status: dispatchOutcome.status,
+            reason: dispatchOutcome.reason,
+          })
+        }
       }
     }, timeoutMs)
 

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry.test.ts
@@ -42,6 +42,7 @@ function createDeps(promptCalls: { count: number }): HookDeps {
       cooldown_seconds: 60,
       timeout_seconds: 0,
       notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
     },
     options: undefined,
     pluginConfig: undefined,

--- a/packages/omo-opencode/src/hooks/runtime-fallback/chat-message-handler.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/chat-message-handler.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test"
+
+import { createChatMessageHandler } from "./chat-message-handler"
+import { createFallbackState } from "./fallback-state"
+import type { HookDeps } from "./types"
+
+function createDeps(): HookDeps {
+  return {
+    ctx: {
+      client: {
+        session: {},
+        tui: {},
+      },
+      directory: "/test/dir",
+    },
+    config: {
+      enabled: true,
+      retry_on_errors: [429, 503, 529],
+      max_fallback_attempts: 3,
+      cooldown_seconds: 0,
+      timeout_seconds: 30,
+      notify_on_fallback: true,
+      restore_primary_after_cooldown: false,
+    },
+    options: undefined,
+    pluginConfig: undefined,
+    sessionStates: new Map(),
+    sessionLastAccess: new Map(),
+    sessionRetryInFlight: new Set(),
+    sessionAwaitingFallbackResult: new Set(),
+    sessionFallbackTimeouts: new Map(),
+    sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
+  }
+}
+
+describe("createChatMessageHandler runtime fallback model override", () => {
+  test("#given session is on an accepted fallback #when a later user message is transformed after cooldown #then it stays on the fallback model", async () => {
+    // given
+    const deps = createDeps()
+    const sessionID = "session-active-fallback"
+    const state = createFallbackState("openai/gpt-5.4")
+    state.currentModel = "litellm/openai.eu.gpt-5.5"
+    state.fallbackIndex = 0
+    state.failedModels.set("openai/gpt-5.4", Date.now() - 60_000)
+    deps.sessionStates.set(sessionID, state)
+    const handler = createChatMessageHandler(deps)
+    const output: { message: { model?: { providerID: string; modelID: string } } } = { message: {} }
+
+    // when
+    await handler(
+      {
+        sessionID,
+        model: {
+          providerID: "litellm",
+          modelID: "openai.eu.gpt-5.5",
+        },
+      },
+      output,
+    )
+
+    // then
+    expect(output.message.model).toEqual({
+      providerID: "litellm",
+      modelID: "openai.eu.gpt-5.5",
+    })
+    expect(deps.sessionStates.get(sessionID)?.currentModel).toBe("litellm/openai.eu.gpt-5.5")
+  })
+})

--- a/packages/omo-opencode/src/hooks/runtime-fallback/chat-message-handler.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/chat-message-handler.ts
@@ -41,6 +41,7 @@ export function createChatMessageHandler(deps: HookDeps) {
     }
 
     if (
+      config.restore_primary_after_cooldown &&
       state.currentModel !== state.originalModel &&
       !state.pendingFallbackModel &&
       !isModelInCooldown(state.originalModel, state, config.cooldown_seconds)

--- a/packages/omo-opencode/src/hooks/runtime-fallback/constants.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_CONFIG: Required<RuntimeFallbackConfig> = {
   cooldown_seconds: 60,
   timeout_seconds: 30,
   notify_on_fallback: true,
+  restore_primary_after_cooldown: false,
 }
 
 /**

--- a/packages/omo-opencode/src/hooks/runtime-fallback/event-handler.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/event-handler.test.ts
@@ -30,6 +30,7 @@ function createDeps(): HookDeps {
       cooldown_seconds: 60,
       timeout_seconds: 30,
       notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
     },
     options: undefined,
     pluginConfig: {},

--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+
+import type { AutoRetryHelpers } from "./auto-retry"
+import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
+import { createFallbackState } from "./fallback-state"
+import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
+
+function createContext(toastMessages: string[]): RuntimeFallbackPluginInput {
+  return {
+    client: {
+      session: {
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+        promptAsync: async () => ({}),
+      },
+      tui: {
+        showToast: async (input) => {
+          toastMessages.push(input.body.message)
+          return {}
+        },
+      },
+    },
+    directory: "/test/dir",
+  }
+}
+
+function createDeps(toastMessages: string[]): HookDeps {
+  return {
+    ctx: createContext(toastMessages),
+    config: {
+      enabled: true,
+      retry_on_errors: [429, 503, 529],
+      max_fallback_attempts: 3,
+      cooldown_seconds: 60,
+      timeout_seconds: 30,
+      notify_on_fallback: true,
+      restore_primary_after_cooldown: false,
+    },
+    options: undefined,
+    pluginConfig: undefined,
+    sessionStates: new Map(),
+    sessionLastAccess: new Map(),
+    sessionRetryInFlight: new Set(),
+    sessionAwaitingFallbackResult: new Set(),
+    sessionFallbackTimeouts: new Map(),
+    sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
+  }
+}
+
+function createRejectedDispatchHelpers(dispatchCalls: string[]): AutoRetryHelpers {
+  return {
+    abortSessionRequest: async () => {},
+    clearSessionFallbackTimeout: () => {},
+    scheduleSessionFallbackTimeout: () => {},
+    autoRetryWithFallback: async (_sessionID, model) => {
+      dispatchCalls.push(model)
+      return { accepted: false, status: "blocked", reason: "test gate blocked dispatch" }
+    },
+    resolveAgentForSessionFromContext: async () => undefined,
+    cleanupStaleSessions: () => {},
+  }
+}
+
+describe("dispatchFallbackRetry", () => {
+  test("#given fallback dispatch is blocked #when fallback retry runs #then state is restored and no success toast is shown", async () => {
+    // given
+    const toastMessages: string[] = []
+    const dispatchCalls: string[] = []
+    const deps = createDeps(toastMessages)
+    const helpers = createRejectedDispatchHelpers(dispatchCalls)
+    const sessionID = "session-dispatch-rejected"
+    const state = createFallbackState("openai/gpt-5.4")
+    deps.sessionStates.set(sessionID, state)
+
+    // when
+    await dispatchFallbackRetry(deps, helpers, {
+      sessionID,
+      state,
+      fallbackModels: ["litellm/openai.eu.gpt-5.5"],
+      source: "message.updated",
+    })
+
+    // then
+    expect(dispatchCalls).toEqual(["litellm/openai.eu.gpt-5.5"])
+    expect(toastMessages).toEqual([])
+    expect(state.currentModel).toBe("openai/gpt-5.4")
+    expect(state.fallbackIndex).toBe(-1)
+    expect(state.attemptCount).toBe(0)
+    expect(state.pendingFallbackModel).toBe(undefined)
+    expect(state.failedModels.size).toBe(0)
+  })
+})

--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.ts
@@ -1,8 +1,9 @@
 import type { AutoRetryHelpers } from "./auto-retry"
-import type { HookDeps, FallbackState } from "./types"
+import type { AutoRetryDispatchOutcome, HookDeps, FallbackState } from "./types"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { prepareFallback } from "./fallback-state"
+import { restoreFallbackState, snapshotFallbackState } from "./fallback-state-snapshot"
 
 type DispatchFallbackRetryOptions = {
   sessionID: string
@@ -12,11 +13,19 @@ type DispatchFallbackRetryOptions = {
   source: string
 }
 
+function resolveDispatchMessage(result: AutoRetryDispatchOutcome, newModel: string): string {
+  const modelName = newModel.split("/").pop() || newModel
+  if (result.status === "queued") return `Fallback queued for ${modelName}`
+  if (result.status === "possibly-accepted") return `Fallback dispatch may have been accepted for ${modelName}`
+  return `Switched to ${modelName} for next request`
+}
+
 export async function dispatchFallbackRetry(
   deps: HookDeps,
   helpers: AutoRetryHelpers,
   options: DispatchFallbackRetryOptions,
 ): Promise<void> {
+  const snapshot = snapshotFallbackState(options.state)
   const result = prepareFallback(
     options.sessionID,
     options.state,
@@ -24,26 +33,45 @@ export async function dispatchFallbackRetry(
     deps.config,
   )
 
-  if (result.success && deps.config.notify_on_fallback) {
-    await deps.ctx.client.tui
-      .showToast({
-        body: {
-          title: "Model Fallback",
-          message: `Switching to ${result.newModel?.split("/").pop() || result.newModel} for next request`,
-          variant: "warning",
-          duration: 5000,
-        },
-      })
-      .catch(() => {})
-  }
-
   if (result.success && result.newModel) {
-    await helpers.autoRetryWithFallback(
+    const rawDispatchOutcome = await helpers.autoRetryWithFallback(
       options.sessionID,
       result.newModel,
       options.resolvedAgent,
       options.source,
     )
+    const dispatchOutcome = rawDispatchOutcome ?? {
+      accepted: true,
+      status: "dispatched",
+    }
+    if (rawDispatchOutcome === undefined) {
+      log(`[${HOOK_NAME}] Fallback dispatch returned no outcome; treating as accepted for compatibility`, {
+        sessionID: options.sessionID,
+        source: options.source,
+      })
+    }
+    if (!dispatchOutcome.accepted) {
+      restoreFallbackState(options.state, snapshot)
+      log(`[${HOOK_NAME}] Fallback dispatch was not accepted`, {
+        sessionID: options.sessionID,
+        source: options.source,
+        status: dispatchOutcome.status,
+        reason: dispatchOutcome.reason,
+      })
+      return
+    }
+    if (deps.config.notify_on_fallback) {
+      await deps.ctx.client.tui
+        .showToast({
+          body: {
+            title: "Model Fallback",
+            message: resolveDispatchMessage(dispatchOutcome, result.newModel),
+            variant: "warning",
+            duration: 5000,
+          },
+        })
+        .catch(() => {})
+    }
     return
   }
 

--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-state-snapshot.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-state-snapshot.ts
@@ -1,0 +1,33 @@
+import type { FallbackState } from "./types"
+
+type FallbackStateSnapshot = {
+  readonly originalModel: string
+  readonly currentModel: string
+  readonly fallbackIndex: number
+  readonly failedModels: Map<string, number>
+  readonly attemptCount: number
+  readonly pendingFallbackModel: string | undefined
+  readonly pendingFallbackPromptMayHaveBeenAccepted: boolean | undefined
+}
+
+export function snapshotFallbackState(state: FallbackState): FallbackStateSnapshot {
+  return {
+    originalModel: state.originalModel,
+    currentModel: state.currentModel,
+    fallbackIndex: state.fallbackIndex,
+    failedModels: new Map(state.failedModels),
+    attemptCount: state.attemptCount,
+    pendingFallbackModel: state.pendingFallbackModel,
+    pendingFallbackPromptMayHaveBeenAccepted: state.pendingFallbackPromptMayHaveBeenAccepted,
+  }
+}
+
+export function restoreFallbackState(state: FallbackState, snapshot: FallbackStateSnapshot): void {
+  state.originalModel = snapshot.originalModel
+  state.currentModel = snapshot.currentModel
+  state.fallbackIndex = snapshot.fallbackIndex
+  state.failedModels = new Map(snapshot.failedModels)
+  state.attemptCount = snapshot.attemptCount
+  state.pendingFallbackModel = snapshot.pendingFallbackModel
+  state.pendingFallbackPromptMayHaveBeenAccepted = snapshot.pendingFallbackPromptMayHaveBeenAccepted
+}

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -101,6 +101,7 @@ function createDeps(pluginConfig: HookDeps["pluginConfig"] = undefined): HookDep
       cooldown_seconds: 60,
       timeout_seconds: 30,
       notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
     },
     options: undefined,
     pluginConfig,

--- a/packages/omo-opencode/src/hooks/runtime-fallback/hook-dispose-cleanup.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/hook-dispose-cleanup.test.ts
@@ -37,6 +37,7 @@ describe("createRuntimeFallbackHook dispose retry-key cleanup", () => {
         cooldown_seconds: 60,
         timeout_seconds: 30,
         notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
       },
       pluginConfig: {
         categories: {

--- a/packages/omo-opencode/src/hooks/runtime-fallback/hook.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/hook.ts
@@ -42,6 +42,7 @@ export function createRuntimeFallbackHook(
     cooldown_seconds: options?.config?.cooldown_seconds ?? DEFAULT_CONFIG.cooldown_seconds,
     timeout_seconds: options?.config?.timeout_seconds ?? DEFAULT_CONFIG.timeout_seconds,
     notify_on_fallback: options?.config?.notify_on_fallback ?? DEFAULT_CONFIG.notify_on_fallback,
+    restore_primary_after_cooldown: options?.config?.restore_primary_after_cooldown ?? DEFAULT_CONFIG.restore_primary_after_cooldown,
   }
 
   const deps: HookDeps = {

--- a/packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts
@@ -97,6 +97,7 @@ describe("runtime-fallback", () => {
       max_fallback_attempts: 3,
       cooldown_seconds: 60,
       notify_on_fallback: true,
+      restore_primary_after_cooldown: false,
       ...overrides,
     }
   }
@@ -2642,7 +2643,7 @@ describe("runtime-fallback", () => {
 
     test("should restore configured primary when reopened on a configured fallback model", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
-        config: createMockConfig({ notify_on_fallback: false }),
+        config: createMockConfig({ notify_on_fallback: false, restore_primary_after_cooldown: true }),
         pluginConfig: createMockPluginConfigWithCategoryModel(
           "test",
           "anthropic/claude-opus-4-5",

--- a/packages/omo-opencode/src/hooks/runtime-fallback/message-update-handler.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/message-update-handler.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "bun:test"
-import type { RuntimeFallbackPluginInput } from "./types"
+import { afterEach, describe, expect, it } from "bun:test"
+import type { AutoRetryHelpers } from "./auto-retry"
+import { createMessageUpdateHandler } from "./message-update-handler"
+import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import { hasVisibleAssistantResponse } from "./visible-assistant-response"
 import { extractAutoRetrySignal } from "./error-classifier"
+import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 
 function createContext(messagesResponse: unknown): RuntimeFallbackPluginInput {
   return {
@@ -78,5 +81,109 @@ describe("hasVisibleAssistantResponse", () => {
 
     // then
     expect(result).toBe(false)
+  })
+})
+
+function createRuntimeFallbackContext(operations: string[]): RuntimeFallbackPluginInput {
+  return {
+    client: {
+      session: {
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+        promptAsync: async () => ({}),
+      },
+      tui: {
+        showToast: async () => {
+          operations.push("toast")
+          return {}
+        },
+      },
+    },
+    directory: "/test/dir",
+  }
+}
+
+function createRuntimeFallbackDeps(operations: string[]): HookDeps {
+  return {
+    ctx: createRuntimeFallbackContext(operations),
+    config: {
+      enabled: true,
+      retry_on_errors: [429, 503, 529],
+      max_fallback_attempts: 3,
+      cooldown_seconds: 60,
+      timeout_seconds: 30,
+      notify_on_fallback: true,
+      restore_primary_after_cooldown: false,
+    },
+    options: undefined,
+    pluginConfig: {
+      categories: {
+        test: {
+          fallback_models: ["litellm/openai.eu.gpt-5.5"],
+        },
+      },
+    },
+    sessionStates: new Map(),
+    sessionLastAccess: new Map(),
+    sessionRetryInFlight: new Set(),
+    sessionAwaitingFallbackResult: new Set(),
+    sessionFallbackTimeouts: new Map(),
+    sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
+  }
+}
+
+function createRuntimeFallbackHelpers(deps: HookDeps, operations: string[]): AutoRetryHelpers {
+  return {
+    abortSessionRequest: async (_sessionID: string, source: string) => {
+      operations.push(`abort:${source}`)
+      if (source === "message.updated.quota-fallback") {
+        deps.internallyAbortedSessions.add(_sessionID)
+      }
+    },
+    clearSessionFallbackTimeout: () => {},
+    scheduleSessionFallbackTimeout: () => {},
+    autoRetryWithFallback: async (_sessionID: string, model: string) => {
+      operations.push(`retry:${model}`)
+      return { accepted: true, status: "dispatched" }
+    },
+    resolveAgentForSessionFromContext: async () => undefined,
+    cleanupStaleSessions: () => {},
+  }
+}
+
+describe("createMessageUpdateHandler runtime fallback dispatch", () => {
+  afterEach(() => {
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given quota-exceeded assistant error with a fallback #when message update is handled #then primary request is aborted before fallback dispatch and toast", async () => {
+    // given
+    const sessionID = "session-quota-fallback"
+    const operations: string[] = []
+    SessionCategoryRegistry.register(sessionID, "test")
+    const deps = createRuntimeFallbackDeps(operations)
+    const handler = createMessageUpdateHandler(deps, createRuntimeFallbackHelpers(deps, operations))
+
+    // when
+    await handler({
+      sessionID,
+      info: {
+        role: "assistant",
+        model: "openai/gpt-5.4",
+        error: {
+          name: "ProviderRateLimitError",
+          message: "The usage limit has been reached for this model.",
+        },
+      },
+    })
+
+    // then
+    expect(operations).toEqual([
+      "abort:message.updated.quota-fallback",
+      "retry:litellm/openai.eu.gpt-5.5",
+      "toast",
+    ])
+    expect(deps.internallyAbortedSessions.has(sessionID)).toBe(true)
   })
 })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/message-update-handler.ts
@@ -179,13 +179,18 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
             state.pendingFallbackModel = undefined
             state.pendingFallbackPromptMayHaveBeenAccepted = false
           } else {
-          log(`[${HOOK_NAME}] message.updated fallback skipped (pending fallback in progress)`, {
-            sessionID,
-            pendingFallbackModel: state.pendingFallbackModel,
-          })
-          return
+            log(`[${HOOK_NAME}] message.updated fallback skipped (pending fallback in progress)`, {
+              sessionID,
+              pendingFallbackModel: state.pendingFallbackModel,
+            })
+            return
           }
         }
+      }
+
+      if (classifyErrorType(error) === "quota_exceeded") {
+        await helpers.abortSessionRequest(sessionID, "message.updated.quota-fallback")
+        sessionRetryInFlight.delete(sessionID)
       }
 
       await dispatchFallbackRetry(deps, helpers, {

--- a/packages/omo-opencode/src/hooks/runtime-fallback/session-status-handler.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/session-status-handler.test.ts
@@ -31,6 +31,7 @@ function createDeps(): HookDeps {
       cooldown_seconds: 60,
       timeout_seconds: 30,
       notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
     },
     options: undefined,
     pluginConfig: {
@@ -58,6 +59,7 @@ function createHelpers(abortCalls: string[], retryCalls: Array<{ sessionID: stri
     scheduleSessionFallbackTimeout: () => {},
     autoRetryWithFallback: async (sessionID: string, model: string, _resolvedAgent: string | undefined, source: string) => {
       retryCalls.push({ sessionID, model, source })
+      return { accepted: true, status: "dispatched" }
     },
     resolveAgentForSessionFromContext: async () => undefined,
     cleanupStaleSessions: () => {},

--- a/packages/omo-opencode/src/hooks/runtime-fallback/subagent-quota-abort.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/subagent-quota-abort.test.ts
@@ -35,6 +35,7 @@ function createDeps(): HookDeps {
       cooldown_seconds: 60,
       timeout_seconds: 30,
       notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
     },
     options: undefined,
     pluginConfig: {},

--- a/packages/omo-opencode/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
@@ -35,6 +35,7 @@ function createDeps(messagesResponse: unknown): HookDeps {
       cooldown_seconds: 60,
       timeout_seconds: 30,
       notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
     },
     options: undefined,
     pluginConfig: {},

--- a/packages/omo-opencode/src/hooks/runtime-fallback/types.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/types.ts
@@ -54,6 +54,17 @@ export interface FallbackResult {
   maxAttemptsReached?: boolean
 }
 
+export type AutoRetryDispatchOutcome =
+  | {
+      readonly accepted: true
+      readonly status: "dispatched" | "queued" | "possibly-accepted"
+    }
+  | {
+      readonly accepted: false
+      readonly status: "blocked" | "invalid-model" | "failed"
+      readonly reason: string
+    }
+
 export interface RuntimeFallbackOptions {
   config?: RuntimeFallbackConfig
   pluginConfig?: OhMyOpenCodeConfig

--- a/packages/team-core/src/team-registry/paths.test.ts
+++ b/packages/team-core/src/team-registry/paths.test.ts
@@ -51,6 +51,17 @@ describe("paths", () => {
     expect(resolvedBaseDir).toBe("/tmp/test-abc")
   })
 
+  test("#given base dir starts with tilde #when resolving team base dir #then it expands to the user home directory", () => {
+    // given
+    const config = TeamModeConfigSchema.parse({ base_dir: "~/.omo" })
+
+    // when
+    const resolvedBaseDir = resolveBaseDir(config)
+
+    // then
+    expect(resolvedBaseDir).toBe(path.join(homedir(), ".omo"))
+  })
+
   test("#given team runtime ids contain traversal #when runtime paths are built #then they are rejected before escaping base dir", () => {
     // given
     const baseDir = "/tmp/omo-contained"

--- a/packages/team-core/src/team-registry/paths.ts
+++ b/packages/team-core/src/team-registry/paths.ts
@@ -66,7 +66,19 @@ function resolveContainedPath(baseDir: string, pathSegments: readonly string[]):
 }
 
 export function resolveBaseDir(config: TeamModeConfig): string {
-  return config.base_dir ?? path.join(homedir(), ".omo")
+  return expandHomeDirectory(config.base_dir ?? path.join(homedir(), ".omo"))
+}
+
+function expandHomeDirectory(directoryPath: string): string {
+  if (directoryPath === "~") {
+    return homedir()
+  }
+
+  if (directoryPath.startsWith("~/") || directoryPath.startsWith("~\\")) {
+    return path.join(homedir(), directoryPath.slice(2))
+  }
+
+  return directoryPath
 }
 
 export function getTeamSpecPath(


### PR DESCRIPTION
## Summary
- make runtime fallback retry dispatch report accepted/blocked/failed outcomes and restore fallback state when dispatch is not accepted
- defer success toast until fallback dispatch is accepted, abort quota message.updated retries before dispatch, and keep accepted fallbacks active by default via `restore_primary_after_cooldown: false`
- expand `~` in team registry base paths and regenerate the OpenCode schema

## Evidence
- `.omo/evidence/20260621-dirty-runtime-fallback/runtime-fallback-suite-after-restore-config-2.log` — 234 pass, 0 fail
- `.omo/evidence/20260621-dirty-runtime-fallback/typecheck-after-restore-config.log` — typecheck pass
- `.omo/evidence/20260621-dirty-runtime-fallback/build-final.log` — build pass
- `.omo/evidence/20260621-dirty-runtime-fallback/bun-test-final.log` — 10112 pass, 2 skip, 0 fail
- `.omo/evidence/20260621-dirty-runtime-fallback/opencode-server-smoke-final.log` — isolated OpenCode server smoke pass
- `.omo/evidence/20260621-dirty-runtime-fallback/opencode-sse-selftest-final.log` — isolated SSE self-test pass
- `.omo/evidence/20260621-dirty-runtime-fallback/message-updated-sse.log` — isolated local plugin `message.updated` SSE proof, live DB unchanged
- `.omo/evidence/20260621-dirty-runtime-fallback/review-context-final/` — final review bundle

## Review
- QA executor: PASS
- Security reviewer: PASS
- Context miner: PASS; confirmed #5435 and #5331 addressed by this diff
- Code reviewer: PASS; no blocking findings

## Merge policy
Merge commit only. Do not squash or rebase merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runtime fallback so state only changes after a retry dispatch is accepted, and keeps accepted fallbacks active by default. Also adds home directory expansion for team registry paths.

- **Bug Fixes**
  - Gate fallback state updates on accepted dispatch; if blocked/failed, restore the previous state snapshot.
  - Report dispatch outcomes (`dispatched`, `queued`, `possibly-accepted`, `blocked`, `invalid-model`, `failed`) and defer success toast until accepted.
  - Abort the primary request on quota errors before dispatching a fallback (`message.updated.quota-fallback`) and track internal aborts.
  - On session timeouts, restore state when fallback dispatch is rejected.

- **New Features**
  - Add `restore_primary_after_cooldown` to runtime fallback config (default `false`); when `false`, accepted fallbacks stay active after cooldown. Schema and handler logic updated in `omo-opencode`.
  - Expand `~` in team registry `base_dir` paths in `team-core`.

<sup>Written for commit c619019ac3e53967b1fcf73942b1a2db5c25e3bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

