### PR TITLE
fix(skills): resolve skill_mcp servers from runtime config (lazy, no deadlock)

### DIFF
--- a/packages/omo-opencode/src/plugin/runtime-skill-resolver.test.ts
+++ b/packages/omo-opencode/src/plugin/runtime-skill-resolver.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "bun:test"
+import { createRuntimeSkillsResolver, type RuntimeHostSkills } from "./runtime-skill-resolver"
+import type { LoadedSkill } from "../features/opencode-skill-loader/types"
+
+function skill(name: string, mcp?: Record<string, unknown>): LoadedSkill {
+  return {
+    name,
+    definition: { name, description: `Test skill ${name}` },
+    scope: "config",
+    ...(mcp ? { mcpConfig: mcp as LoadedSkill["mcpConfig"] } : {}),
+  }
+}
+
+describe("createRuntimeSkillsResolver", () => {
+  it("does NOT fetch the runtime config at construction (deadlock guard)", () => {
+    // given
+    let readCount = 0
+    const base = [skill("playwright", { playwright: {} })]
+
+    // when - resolver is created (this happens during plugin load)
+    createRuntimeSkillsResolver({
+      baseSkills: base,
+      readRuntimeHostSkills: async () => {
+        readCount += 1
+        return undefined
+      },
+      buildMergedSkills: async () => base,
+    })
+
+    // then - no roundtrip happened at construction time
+    expect(readCount).toBe(0)
+  })
+
+  it("on first call returns merged skills including a runtime-injected MCP skill not in base", async () => {
+    // given - base lacks slack; runtime config injects a skill source that
+    // surfaces a slack MCP skill (as the claude-bridge does at runtime)
+    const base = [skill("playwright", { playwright: {} })]
+    const hostSkills: RuntimeHostSkills = { paths: ["/cache/bridge/sjawhar"] }
+    const merged = [...base, skill("slack-bot", { slack: {} })]
+
+    const getLoadedSkills = createRuntimeSkillsResolver({
+      baseSkills: base,
+      readRuntimeHostSkills: async () => hostSkills,
+      buildMergedSkills: async (hs) => {
+        expect(hs).toBe(hostSkills)
+        return merged
+      },
+    })
+
+    // when
+    const result = await getLoadedSkills()
+
+    // then
+    const slack = result.find((s) => s.name === "slack-bot")
+    expect(slack).toBeDefined()
+    expect(Boolean(slack?.mcpConfig && "slack" in slack.mcpConfig)).toBe(true)
+  })
+
+  it("caches: the runtime config is fetched at most once across calls", async () => {
+    // given
+    let readCount = 0
+    let buildCount = 0
+    const base = [skill("playwright", { playwright: {} })]
+    const merged = [...base, skill("slack-bot", { slack: {} })]
+
+    const getLoadedSkills = createRuntimeSkillsResolver({
+      baseSkills: base,
+      readRuntimeHostSkills: async () => {
+        readCount += 1
+        return { paths: ["/cache/bridge"] }
+      },
+      buildMergedSkills: async () => {
+        buildCount += 1
+        return merged
+      },
+    })
+
+    // when - several concurrent + sequential calls
+    const [a, b] = await Promise.all([getLoadedSkills(), getLoadedSkills()])
+    const c = await getLoadedSkills()
+
+    // then
+    expect(readCount).toBe(1)
+    expect(buildCount).toBe(1)
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+  })
+
+  it("falls back to base skills when the runtime config is unavailable", async () => {
+    // given
+    const base = [skill("playwright", { playwright: {} })]
+    const getLoadedSkills = createRuntimeSkillsResolver({
+      baseSkills: base,
+      readRuntimeHostSkills: async () => undefined,
+      buildMergedSkills: async () => {
+        throw new Error("must not be called when host skills are absent")
+      },
+    })
+
+    // when
+    const result = await getLoadedSkills()
+
+    // then
+    expect(result).toBe(base)
+  })
+
+  it("falls back to base skills when building merged skills throws", async () => {
+    // given
+    const base = [skill("playwright", { playwright: {} })]
+    const getLoadedSkills = createRuntimeSkillsResolver({
+      baseSkills: base,
+      readRuntimeHostSkills: async () => ({ paths: ["/cache/bridge"] }),
+      buildMergedSkills: async () => {
+        throw new Error("discovery failed")
+      },
+    })
+
+    // when
+    const result = await getLoadedSkills()
+
+    // then
+    expect(result).toBe(base)
+  })
+})

--- a/packages/omo-opencode/src/plugin/runtime-skill-resolver.ts
+++ b/packages/omo-opencode/src/plugin/runtime-skill-resolver.ts
@@ -1,0 +1,66 @@
+import type { LoadedSkill } from "../features/opencode-skill-loader/types"
+import type { PluginContext } from "./types"
+
+export type RuntimeHostSkills = { paths?: string[]; urls?: string[] }
+
+/**
+ * Read `skills` from opencode's merged runtime config via the plugin client.
+ * This includes skill source paths that other plugins add to the merged config
+ * through their `config` hooks, which the on-disk config reader cannot see.
+ *
+ * MUST only be called after server startup (e.g. at tool-execute time). Calling
+ * it during plugin load deadlocks: the plugin's `server()` runs inside the
+ * config/plugin initialization, so a roundtrip back to `/config` waits on an
+ * initialization that cannot complete until `server()` returns.
+ *
+ * Returns undefined on any failure so callers can fall back to base skills.
+ */
+export async function readRuntimeHostSkills(
+  client: PluginContext["client"],
+): Promise<RuntimeHostSkills | undefined> {
+  try {
+    const result = await client.config.get()
+    const skills = (result as { data?: { skills?: unknown } }).data?.skills
+    if (skills && typeof skills === "object") {
+      return skills as RuntimeHostSkills
+    }
+  } catch {
+    // Fall back to base skills in the caller.
+  }
+  return undefined
+}
+
+/**
+ * Build a lazily-evaluated, cached resolver for the skill list used by
+ * `skill_mcp`.
+ *
+ * The base skill list is built during plugin load, before any plugin's `config`
+ * hook runs, so it cannot see skill source paths that other plugins add to the
+ * merged config at load time. Reading the merged config requires a server
+ * roundtrip that deadlocks during plugin load, so the fetch is deferred to the
+ * first `skill_mcp` call (after startup) and cached. On any failure the base
+ * skills are returned unchanged.
+ */
+export function createRuntimeSkillsResolver(args: {
+  baseSkills: LoadedSkill[]
+  readRuntimeHostSkills: () => Promise<RuntimeHostSkills | undefined>
+  buildMergedSkills: (hostSkills: RuntimeHostSkills) => Promise<LoadedSkill[]>
+}): () => Promise<LoadedSkill[]> {
+  const { baseSkills, readRuntimeHostSkills: readHostSkills, buildMergedSkills } = args
+  let inflight: Promise<LoadedSkill[]> | undefined
+
+  const resolve = async (): Promise<LoadedSkill[]> => {
+    const hostSkills = await readHostSkills()
+    if (!hostSkills) return baseSkills
+    try {
+      return await buildMergedSkills(hostSkills)
+    } catch {
+      return baseSkills
+    }
+  }
+
+  return () => {
+    if (!inflight) inflight = resolve()
+    return inflight
+  }
+}

--- a/packages/omo-opencode/src/plugin/skill-context.test.ts
+++ b/packages/omo-opencode/src/plugin/skill-context.test.ts
@@ -242,6 +242,70 @@ describe("createSkillContext", () => {
     }
   })
 
+  it("sources host skill MCPs from the runtime hostSkills arg (not on-disk config)", async () => {
+    // given - a skill with an embedded mcp, registered only via the runtime
+    // hostSkills arg (as a plugin like claude-bridge injects at runtime), with
+    // NOTHING on disk.
+    const runtimeSkillsDir = join(testDirectory, "runtime-skills")
+    const runtimeSkillDir = join(runtimeSkillsDir, "runtime-host-skill")
+    mkdirSync(runtimeSkillDir, { recursive: true })
+    writeFileSync(
+      join(runtimeSkillDir, "SKILL.md"),
+      [
+        "---",
+        "name: runtime-host-skill",
+        "description: Skill injected via runtime config skills.paths",
+        "mcp:",
+        "  testmcp:",
+        "    command: echo",
+        '    args: ["hi"]',
+        "---",
+        "Body.",
+        "",
+      ].join("\n"),
+    )
+
+    // on-disk config returns nothing: proves the runtime arg is the source.
+    const readOpencodeConfigSkillsSpy = spyOn(
+      skillLoader,
+      "readOpencodeConfigSkills",
+    ).mockReturnValue(undefined)
+    const discoverUserClaudeSkillsSpy = spyOn(skillLoader, "discoverUserClaudeSkills").mockResolvedValue([])
+    const discoverProjectClaudeSkillsSpy = spyOn(skillLoader, "discoverProjectClaudeSkills").mockResolvedValue([])
+    const discoverOpencodeGlobalSkillsSpy = spyOn(skillLoader, "discoverOpencodeGlobalSkills").mockResolvedValue([])
+    const discoverOpencodeProjectSkillsSpy = spyOn(skillLoader, "discoverOpencodeProjectSkills").mockResolvedValue([])
+    const discoverProjectAgentsSkillsSpy = spyOn(skillLoader, "discoverProjectAgentsSkills").mockResolvedValue([])
+    const discoverGlobalAgentsSkillsSpy = spyOn(skillLoader, "discoverGlobalAgentsSkills").mockResolvedValue([])
+    const getSystemMcpServerNamesSpy = spyOn(mcpLoader, "getSystemMcpServerNames").mockReturnValue(new Set<string>())
+
+    const pluginConfig = OhMyOpenCodeConfigSchema.parse({})
+
+    try {
+      // when - hostSkills is provided, as createTools does from the runtime config
+      const result = await createSkillContext({
+        directory: testDirectory,
+        pluginConfig,
+        hostSkills: { paths: [runtimeSkillsDir] },
+      })
+
+      // then - the skill is discovered AND its embedded mcp survives into mergedSkills
+      const skill = result.mergedSkills.find((s) => s.name === "runtime-host-skill")
+      expect(skill).toBeDefined()
+      expect(Boolean(skill?.mcpConfig && "testmcp" in skill.mcpConfig)).toBe(true)
+      // and the on-disk reader was bypassed entirely
+      expect(readOpencodeConfigSkillsSpy).not.toHaveBeenCalled()
+    } finally {
+      readOpencodeConfigSkillsSpy.mockRestore()
+      discoverUserClaudeSkillsSpy.mockRestore()
+      discoverProjectClaudeSkillsSpy.mockRestore()
+      discoverOpencodeGlobalSkillsSpy.mockRestore()
+      discoverOpencodeProjectSkillsSpy.mockRestore()
+      discoverProjectAgentsSkillsSpy.mockRestore()
+      discoverGlobalAgentsSkillsSpy.mockRestore()
+      getSystemMcpServerNamesSpy.mockRestore()
+    }
+  })
+
   it("excludes discovered dev-browser skill when browser provider is playwright", async () => {
     // given
     const discoveredDevBrowserSkill = {

--- a/packages/omo-opencode/src/plugin/skill-context.ts
+++ b/packages/omo-opencode/src/plugin/skill-context.ts
@@ -87,8 +87,14 @@ function isDisabledConfigSkillEntryName(
 export async function createSkillContext(args: {
   directory: string
   pluginConfig: OhMyOpenCodeConfig
+  /**
+   * Host skill config from opencode's merged runtime config (e.g. fetched via
+   * the plugin client). Includes runtime-injected `skills.paths` from other
+   * plugins. When omitted, falls back to reading the on-disk opencode config.
+   */
+  hostSkills?: { paths?: string[]; urls?: string[] }
 }): Promise<SkillContext> {
-  const { directory, pluginConfig } = args
+  const { directory, pluginConfig, hostSkills } = args
 
   const browserProvider: BrowserAutomationProvider =
     pluginConfig.browser_automation_engine?.provider ?? "playwright"
@@ -103,7 +109,7 @@ export async function createSkillContext(args: {
   })
 
   const includeClaudeSkills = pluginConfig.claude_code?.skills !== false
-  const hostSkillConfig = adaptHostSkillConfig(readOpencodeConfigSkills(directory))
+  const hostSkillConfig = adaptHostSkillConfig(hostSkills ?? readOpencodeConfigSkills(directory))
   const [
     configSourceSkills,
     hostConfigSkills,

--- a/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
@@ -11,6 +11,8 @@ import { getMainSessionID } from "../features/claude-code-session-state"
 import * as openclawRuntimeDispatch from "../openclaw/runtime-dispatch"
 import { log } from "../shared"
 import { getSisyphusJuniorModelOverride } from "./tool-registry-team-tools"
+import { createSkillContext } from "./skill-context"
+import { createRuntimeSkillsResolver, readRuntimeHostSkills } from "./runtime-skill-resolver"
 
 export function createCoreTools(args: {
   readonly ctx: PluginContext
@@ -82,9 +84,15 @@ export function createCoreTools(args: {
   })
 
   const getSessionIDForMcp = (): string | undefined => getMainSessionID()
+  const getLoadedSkillsForMcp = createRuntimeSkillsResolver({
+    baseSkills: skillContext.mergedSkills,
+    readRuntimeHostSkills: () => readRuntimeHostSkills(ctx.client),
+    buildMergedSkills: async (hostSkills) =>
+      (await createSkillContext({ directory: ctx.directory, pluginConfig, hostSkills })).mergedSkills,
+  })
   const skillMcpTool = factories.createSkillMcpTool({
     manager: managers.skillMcpManager,
-    getLoadedSkills: () => skillContext.mergedSkills,
+    getLoadedSkills: getLoadedSkillsForMcp,
     getSessionID: getSessionIDForMcp,
   })
   const commands = factories.discoverCommandsSync(ctx.directory, {

--- a/packages/omo-opencode/src/tools/skill-mcp/tools.ts
+++ b/packages/omo-opencode/src/tools/skill-mcp/tools.ts
@@ -8,7 +8,7 @@ import type { LoadedSkill } from "../../features/opencode-skill-loader/types"
 
 interface SkillMcpToolOptions {
   manager: SkillMcpManager
-  getLoadedSkills: () => LoadedSkill[]
+  getLoadedSkills: () => LoadedSkill[] | Promise<LoadedSkill[]>
   getSessionID?: () => string | undefined
 }
 
@@ -123,7 +123,7 @@ export function createSkillMcpTool(options: SkillMcpToolOptions): ToolDefinition
     },
     async execute(args: SkillMcpArgs, toolContext: ToolContext) {
       const operation = validateOperationParams(args)
-      const skills = getLoadedSkills()
+      const skills = await getLoadedSkills()
       const found = findMcpServer(args.mcp_name, skills)
 
       if (!found) {


### PR DESCRIPTION
## Summary

- `skill_mcp` could not find MCP servers from skills whose source paths are injected into opencode's merged config **at runtime** by other plugins — their `config` hooks run after plugin `server()`, so the on-disk-built skill list never saw them.
- Fixes it by lazily resolving the runtime config on the first `skill_mcp` call (after startup) and caching it — avoiding the startup **deadlock** that a load-time `client.config.get()` causes.
- Skill MCPs stay lazy and skill-scoped; nothing is written to global `config.mcp`.

## Changes

- **`plugin/runtime-skill-resolver.ts`** (new): `createRuntimeSkillsResolver` — on first call, fetches the merged runtime `skills` via `client.config.get()`, rebuilds merged skills through `createSkillContext({ hostSkills })`, and caches. `readRuntimeHostSkills` documents why it must run post-startup (the plugin's `server()` executes inside the Plugin service's `InstanceState.make`, so a `/config` roundtrip there waits on an init that can't complete until `server()` returns → deadlock). Falls back to base skills on any failure.
- **`plugin/skill-context.ts`**: `createSkillContext` gains an optional `hostSkills` arg; when omitted it still reads the on-disk config (default unchanged).
- **`plugin/tool-registry-core-tools.ts`**: wires the resolver into `skill_mcp`'s `getLoadedSkills`.
- **`tools/skill-mcp/tools.ts`**: `getLoadedSkills` is now awaited (type widened to allow async).
- Tests: new `runtime-skill-resolver.test.ts` (no fetch at construction / fetch+merge on first call / single-fetch caching / fallback on error) and a new `skill-context` case proving a runtime-injected skill's embedded `mcp:` survives into `mergedSkills`.

## Testing

```bash
bun run typecheck   # clean
bun run build       # succeeds (CI green)
bun test            # resolver + skill-mcp + skill-context + skills-loader suites pass
```

End-to-end via the local-build method in CONTRIBUTING (`opencode run` against `dist/index.js`): with a skill source injected into the runtime config by another plugin, `skill_mcp(mcp_name="slack", tool_name="channels_list")` resolved and returned live data (previously reported the server "not found"); startup no longer hangs.

## Related Issues

<!-- none -->

## PR Checklist

- [x] Code follows project conventions
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] `bun test` passes
- [x] `bun run test:codex` passes — no Codex-side changes; CI `codex-compatibility` (ubuntu/macos/windows) green
- [x] Tested locally with OpenCode
- [x] QA evidence under `.omo/evidence/` — N/A (not a harness-connected change)
- [x] Updated documentation if needed — N/A (no doc-facing change)
- [x] No version changes in `package.json`
