### PR TITLE
fix(atlas): compact repeated verification reminders

### DIFF
--- a/packages/omo-opencode/src/hooks/atlas/tool-execute-after-reminder-compression.test.ts
+++ b/packages/omo-opencode/src/hooks/atlas/tool-execute-after-reminder-compression.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import type { Project } from "@opencode-ai/sdk"
+import { writeBoulderState } from "../../features/boulder-state"
+import { createToolExecuteAfterHandler } from "./tool-execute-after"
+import type { SessionState } from "./types"
+
+type SessionGetInput = { readonly path: { readonly id: string } }
+type SessionGetResult = {
+  readonly data: { readonly parentID: string | undefined }
+  readonly error?: undefined
+  readonly request: Request
+  readonly response: Response
+}
+
+describe("createToolExecuteAfterHandler reminder compression", () => {
+  const parentSessionID = "ses_parent_compression"
+  let testDirectory = ""
+  let sessionState: SessionState
+
+  beforeEach(() => {
+    testDirectory = join(tmpdir(), `atlas-reminder-compression-${crypto.randomUUID()}`)
+    mkdirSync(testDirectory, { recursive: true })
+    sessionState = { promptFailureCount: 0 }
+  })
+
+  afterEach(() => {
+    if (existsSync(testDirectory)) {
+      rmSync(testDirectory, { recursive: true, force: true })
+    }
+    mock.restore()
+  })
+
+  function createProject(): Project {
+    return {
+      id: "project-1",
+      worktree: testDirectory,
+      time: { created: 0 },
+    }
+  }
+
+  function createSessionGetResult(parentID: string | undefined): SessionGetResult {
+    return {
+      data: { parentID },
+      error: undefined,
+      request: new Request("https://example.com/session"),
+      response: new Response(null, { status: 200 }),
+    }
+  }
+
+  function createPluginInput(): PluginInput {
+    const client = createOpencodeClient({ baseUrl: "https://example.com" })
+    const sessionGet = mock(async (input: SessionGetInput): Promise<SessionGetResult> => (
+      createSessionGetResult(input.path.id.startsWith("ses_child_") ? parentSessionID : undefined)
+    ))
+    Reflect.set(client.session, "get", sessionGet)
+
+    return {
+      client,
+      project: createProject(),
+      directory: testDirectory,
+      worktree: testDirectory,
+      experimental_workspace: { register: () => {} },
+      serverUrl: new URL("https://example.com"),
+      $: Bun.$,
+    }
+  }
+
+  it("keeps the first verification reminder full and compresses later boulder completions", async () => {
+    // given
+    const planPath = join(testDirectory, "compression-plan.md")
+    writeFileSync(planPath, "# Plan\n\n## TODOs\n- [ ] 1. Implement auth flow\n- [ ] 2. Add validation\n", "utf-8")
+    writeBoulderState(testDirectory, {
+      active_plan: planPath,
+      started_at: "2026-01-02T10:00:00Z",
+      session_ids: [parentSessionID],
+      plan_name: "compression-plan",
+    })
+
+    const collectGitDiffStats = mock(() => [])
+    const formatFileChanges = mock(() => "[FILE CHANGES SUMMARY]\nNo file changes detected.\n")
+    const handler = createToolExecuteAfterHandler({
+      ctx: createPluginInput(),
+      pendingFilePaths: new Map(),
+      pendingTaskRefs: new Map(),
+      autoCommit: true,
+      getState: () => sessionState,
+      isCallerOrchestrator: async () => true,
+      collectGitDiffStats,
+      formatFileChanges,
+    })
+
+    const firstOutput = {
+      title: "Sisyphus Task",
+      output: "First task completed",
+      metadata: { sessionId: "ses_child_first" },
+    }
+    const secondOutput = {
+      title: "Sisyphus Task",
+      output: "Second task completed",
+      metadata: { sessionId: "ses_child_second" },
+    }
+
+    // when
+    await handler({ tool: "task", sessionID: parentSessionID }, firstOutput)
+    await handler({ tool: "task", sessionID: parentSessionID }, secondOutput)
+
+    // then
+    expect(firstOutput.output).toContain("PHASE 1: READ THE CODE FIRST")
+    expect(secondOutput.output).not.toContain("PHASE 1: READ THE CODE FIRST")
+    expect(secondOutput.output).toContain("Full verification protocol was already shown earlier")
+    expect(secondOutput.output).toContain("Read every changed file")
+  })
+})

--- a/packages/omo-opencode/src/hooks/atlas/tool-execute-after-subagent-completion.ts
+++ b/packages/omo-opencode/src/hooks/atlas/tool-execute-after-subagent-completion.ts
@@ -19,6 +19,7 @@ import { extractSessionIdFromOutput, validateSubagentSessionId } from "./subagen
 import { resolvePreferredSessionId, resolveTaskContext } from "./task-context"
 import { isTrackedTaskChecked } from "./tool-execute-after-plan-tasks"
 import type { PendingTaskRef, SessionState, ToolExecuteAfterInput, ToolExecuteAfterOutput } from "./types"
+import type { VerificationReminderDetail } from "./verification-reminders"
 import {
   buildCompletionGate,
   buildFinalWaveApprovalReminder,
@@ -30,6 +31,13 @@ function isBackgroundLaunchOutput(output: string): boolean {
   return output.includes("Background task launched") || output.includes("Background task continued")
     || output.includes("Background delegate launched")
     || output.includes("Background agent task launched")
+}
+
+function consumeVerificationReminderDetail(sessionState: SessionState | undefined): VerificationReminderDetail {
+  if (!sessionState) return "full"
+  if (sessionState.fullVerificationReminderShown) return "compact"
+  sessionState.fullVerificationReminderShown = true
+  return "full"
 }
 
 export async function handleSubagentCompletionAfter(input: {
@@ -82,6 +90,7 @@ export async function handleSubagentCompletionAfter(input: {
   const gitStats = collectGitDiffStatsImpl(verificationDirectory)
   const fileChanges = formatFileChangesImpl(gitStats)
   const extractedSessionId = metadataSessionId ?? extractSessionIdFromOutput(outputStr)
+  const sessionState = toolInput.sessionID ? getState(toolInput.sessionID) : undefined
 
   if (!boulderState) {
     const lineageSessionIDs = toolInput.sessionID ? [toolInput.sessionID] : []
@@ -95,6 +104,7 @@ export async function handleSubagentCompletionAfter(input: {
       : subagentSessionId
     toolOutput.output += `\n<system-reminder>\n${buildStandaloneVerificationReminder(
       resolvePreferredSessionId(preferredSessionId),
+      consumeVerificationReminderDetail(sessionState),
     )}\n</system-reminder>`
 
     log(`[${HOOK_NAME}] Verification reminder appended for orchestrator`, {
@@ -136,7 +146,6 @@ export async function handleSubagentCompletionAfter(input: {
   const trackedTaskSession = currentTask
     ? getTaskSessionState(ctx.directory, currentTask.key)
     : null
-  const sessionState = toolInput.sessionID ? getState(toolInput.sessionID) : undefined
 
   const lineageSessionIDs = sessionWork?.session_ids ?? boulderState.session_ids
   const subagentSessionId = await validateSubagentSessionId({
@@ -198,7 +207,14 @@ export async function handleSubagentCompletionAfter(input: {
     : buildCompletionGate(workScopedBoulderState.plan_name, preferredSessionId)
   const followupReminder = shouldPauseForApproval
     ? null
-    : buildOrchestratorReminder(workScopedBoulderState.plan_name, progress, preferredSessionId, autoCommit, false)
+    : buildOrchestratorReminder(
+        workScopedBoulderState.plan_name,
+        progress,
+        preferredSessionId,
+        autoCommit,
+        false,
+        consumeVerificationReminderDetail(sessionState),
+      )
 
   toolOutput.output = `
 <system-reminder>

--- a/packages/omo-opencode/src/hooks/atlas/types.ts
+++ b/packages/omo-opencode/src/hooks/atlas/types.ts
@@ -56,4 +56,5 @@ export interface SessionState {
   stalledContinuationPlanPath?: string
   /** The plan path the in-progress no-tool-progress counter is keyed to. Changes here reset the counter. */
   activeContinuationPlanPath?: string
+  fullVerificationReminderShown?: boolean
 }

--- a/packages/omo-opencode/src/hooks/atlas/verification-reminders.test.ts
+++ b/packages/omo-opencode/src/hooks/atlas/verification-reminders.test.ts
@@ -90,5 +90,16 @@ describe("buildOrchestratorReminder", () => {
         expect(gateIndex).toBeLessThan(verificationIndex)
       })
     })
+
+    when("buildOrchestratorReminder is called with compact verification detail", () => {
+      const reminder = buildOrchestratorReminder(planName, progress, sessionId, true, true, "compact")
+
+      then("full phase text is omitted while verification remains mandatory", () => {
+        expect(reminder).not.toContain("PHASE 1")
+        expect(reminder).toContain("Full verification protocol was already shown earlier")
+        expect(reminder).toContain("Drive the real surface")
+        expect(reminder).toContain(`task(task_id="${sessionId}"`)
+      })
+    })
   })
 })

--- a/packages/omo-opencode/src/hooks/atlas/verification-reminders.ts
+++ b/packages/omo-opencode/src/hooks/atlas/verification-reminders.ts
@@ -1,5 +1,7 @@
 import { VERIFICATION_REMINDER } from "./system-reminder-templates"
 
+export type VerificationReminderDetail = "full" | "compact"
+
 function buildReuseHint(sessionId: string): string {
   return `
 **PREFERRED REUSE SESSION FOR THE CURRENT TOP-LEVEL PLAN TASK**
@@ -38,7 +40,29 @@ task(task_id="${sessionId}", load_skills=[], prompt="fix: checkbox not recorded 
 ${buildReuseHint(sessionId)}`
 }
 
-function buildVerificationReminder(sessionId: string): string {
+function buildCompactVerificationReminder(sessionId: string): string {
+  return `**VERIFICATION_REMINDER**
+
+Full verification protocol was already shown earlier in this orchestrator session. Keep the same gate:
+
+1. Read every changed file before running checks.
+2. Run targeted diagnostics/tests first, then the broader build or test gate.
+3. Drive the real surface for user-facing behavior.
+4. Reject or resume the subagent if any claim is unproven.
+
+**If ANY verification fails, use this immediately:**
+\`\`\`
+task(task_id="${sessionId}", load_skills=[], prompt="fix: [describe the specific failure]")
+\`\`\`
+
+${buildReuseHint(sessionId)}`
+}
+
+function buildVerificationReminder(sessionId: string, detail: VerificationReminderDetail = "full"): string {
+  if (detail === "compact") {
+    return buildCompactVerificationReminder(sessionId)
+  }
+
   return `**VERIFICATION_REMINDER**
 
 ${VERIFICATION_REMINDER}
@@ -58,7 +82,8 @@ export function buildOrchestratorReminder(
   progress: { total: number; completed: number },
   sessionId: string,
   autoCommit: boolean = true,
-  includeCompletionGate: boolean = true
+  includeCompletionGate: boolean = true,
+  verificationDetail: VerificationReminderDetail = "full"
 ): string {
   const remaining = progress.total - progress.completed
 
@@ -82,7 +107,7 @@ export function buildOrchestratorReminder(
 
 ${includeCompletionGate ? `${buildCompletionGate(planName, sessionId)}
 
-` : ""}${buildVerificationReminder(sessionId)}
+` : ""}${buildVerificationReminder(sessionId, verificationDetail)}
 
 **STEP 5: READ SUBAGENT NOTEPAD (LEARNINGS, ISSUES, PROBLEMS)**
 
@@ -160,11 +185,14 @@ If the user rejects or requests changes:
 **DO NOT mark the final-wave checkbox complete until the user explicitly says okay.**`
 }
 
-export function buildStandaloneVerificationReminder(sessionId: string): string {
+export function buildStandaloneVerificationReminder(
+  sessionId: string,
+  detail: VerificationReminderDetail = "full",
+): string {
   return `
 ---
 
-${buildVerificationReminder(sessionId)}
+${buildVerificationReminder(sessionId, detail)}
 
 **STEP 5: CHECK YOUR PROGRESS DIRECTLY (EVERY TIME - NO EXCEPTIONS)**
 


### PR DESCRIPTION
## Summary
Reduce context growth in Atlas/Boulder orchestrator sessions by showing the full verification reminder only once per parent session. Later subagent completions now get a compact reminder that points back to the already-shown protocol while preserving the verification gate, real-surface QA requirement, and `task(task_id=...)` resume guidance.

This is intentionally narrow for reviewability. It does not change boulder state, task tracking, file-change summaries, completion-gate ordering, or continuation injection.

## Changes
- Track whether the full verification reminder has already been shown in `SessionState`.
- Add a compact verification reminder for repeated same-session completions.
- Consume the "full reminder shown" state only when a verification reminder is actually emitted, so final-wave approval waits do not accidentally skip the first full reminder.
- Add focused coverage for repeated completion behavior and compact reminder content.

## Verification
- `bun test ./packages/omo-opencode/src/hooks/atlas/verification-reminders.test.ts ./packages/omo-opencode/src/hooks/atlas/tool-execute-after-reminder-compression.test.ts`
  - latest post-edge-fix run: 13 pass, 0 fail
- `bun test ./packages/omo-opencode/src/hooks/atlas/*.test.ts`
  - latest post-edge-fix run: 188 pass, 0 fail
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts <changed files>`
  - latest post-edge-fix run: no violations in 5 files
- `bun run typecheck:packages`
  - passed
- `bun build packages/omo-opencode/src/index.ts --outdir <tmp> --target bun --format esm --external zod`
  - passed
- `bash .omo/evidence/20260621-start-work-reminder-compression/live-hook-qa.sh`
  - passed against isolated `opencode serve`
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check`
  - passed
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test`
  - passed
- `bash .agents/skills/opencode-qa/scripts/server-smoke.sh --self-test`
  - passed
- `bash .agents/skills/opencode-qa/scripts/serve-wake-split-probe.sh --self-test --evidence-dir .omo/evidence/20260621-start-work-reminder-compression/opencode-qa-serve-wake-self-test`
  - passed

Live hook-fire QA proof from the isolated run:
- real OpenCode DB session count stayed unchanged: `2738 -> 2738`
- sandbox DB contained 3 sessions
- captured reminder parts showed `db_phase_count=1` and `db_compact_count=1`
- local plugin initialized once for the isolated server run

## Notes
Full `bun run build` was not used as the primary build gate because this worktree's install/build path previously stalled while cloning the unrelated `packages/shared-skills/upstreams/open-design` submodule. The focused plugin entry build and package typecheck both passed.

LSP MCP diagnostics could not be collected at the end because the MCP transport was closed. TypeScript package typecheck passed as the substitute static gate.
