### PR TITLE
fix(docs): use opencode-go/kimi-k2.7-code in recommended model stacks (fixes #5371)

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -183,7 +183,7 @@ There are two separate systems:
 
 Two things move at different speeds, and the difference explains why "Opus 4.7" still appears as a default below:
 
-- **The current top models** are Claude **Fable 5** and **Opus 4.8**, and Kimi **K2.7**. Sisyphus and Atlas have dedicated tuned prompt paths for these models; Prometheus keeps one `ulw-plan`-backed prompt. Pin one in your config: `"anthropic/claude-opus-4-8"`, `"anthropic/claude-fable-5"`, `"opencode-go/kimi-k2.7"`. Use that when you want to opt into the newer model explicitly.
+- **The current top models** are Claude **Fable 5** and **Opus 4.8**, and Kimi **K2.7**. Sisyphus and Atlas have dedicated tuned prompt paths for these models; Prometheus keeps one `ulw-plan`-backed prompt. Pin one in your config: `"anthropic/claude-opus-4-8"`, `"anthropic/claude-fable-5"`, `"opencode-go/kimi-k2.7-code"`. Use that when you want to opt into the newer model explicitly.
 - **The auto-resolution fallback chains** below still lead with **Opus 4.7** and **Kimi K2.6**. That is intentional, not stale: the chains only auto-select models the bundled capability snapshot is built against, so variant and context-window resolution stay correct. They promote Opus 4.8 / K2.7 to chain defaults once those land in the model catalog; until then you opt into the newer models — and their prompts — by naming them explicitly.
 
 So an "Opus 4.7 (max)" entry in the chains below is the snapshot-backed floor, not a recommendation to prefer 4.7 over 4.8.
@@ -389,8 +389,8 @@ See the [Orchestration System Guide](./orchestration.md) for how agents dispatch
   "agents": {
     // Sisyphus: Kimi K2.7 is the top alternative to Claude for orchestration
     "sisyphus": {
-      "model": "opencode-go/kimi-k2.7",
-      "ultrawork": { "model": "opencode-go/kimi-k2.7" },
+      "model": "opencode-go/kimi-k2.7-code",
+      "ultrawork": { "model": "opencode-go/kimi-k2.7-code" },
     },
 
     // Hephaestus: needs GPT. ChatGPT Plus gets you here.
@@ -400,10 +400,10 @@ See the [Orchestration System Guide](./orchestration.md) for how agents dispatch
     "oracle": { "model": "openai/gpt-5.5", "variant": "high" },
 
     // Prometheus keeps the same ulw-plan-backed prompt across model families
-    "prometheus": { "model": "opencode-go/kimi-k2.7" },
+    "prometheus": { "model": "opencode-go/kimi-k2.7-code" },
 
     // Atlas also communicative — Kimi works great
-    "atlas": { "model": "opencode-go/kimi-k2.7" },
+    "atlas": { "model": "opencode-go/kimi-k2.7-code" },
 
     // Utility agents stay cheap
     "explore": { "model": "opencode-go/qwen3.5-plus" },
@@ -415,9 +415,9 @@ See the [Orchestration System Guide](./orchestration.md) for how agents dispatch
     "deep": { "model": "openai/gpt-5.5", "variant": "medium" },
     "ultrabrain": { "model": "openai/gpt-5.5", "variant": "xhigh" },
     "quick": { "model": "openai/gpt-5.4-mini" },
-    "unspecified-low": { "model": "opencode-go/kimi-k2.7" },
-    "unspecified-high": { "model": "opencode-go/kimi-k2.7" },
-    "writing": { "model": "opencode-go/kimi-k2.7" },
+    "unspecified-low": { "model": "opencode-go/kimi-k2.7-code" },
+    "unspecified-high": { "model": "opencode-go/kimi-k2.7-code" },
+    "writing": { "model": "opencode-go/kimi-k2.7-code" },
   },
 
   "background_task": {
@@ -458,8 +458,8 @@ Cheapest full-stack path. Hephaestus won't activate — accept that trade-off.
 ```jsonc
 {
   "agents": {
-    "sisyphus": { "model": "opencode-go/kimi-k2.7" },
-    "atlas": { "model": "opencode-go/kimi-k2.7" },
+    "sisyphus": { "model": "opencode-go/kimi-k2.7-code" },
+    "atlas": { "model": "opencode-go/kimi-k2.7-code" },
     // Omit hephaestus entirely; it needs GPT.
     "oracle": { "model": "opencode-go/glm-5.1" },  // Degraded but functional
     "explore": { "model": "opencode-go/qwen3.5-plus" },
@@ -467,11 +467,11 @@ Cheapest full-stack path. Hephaestus won't activate — accept that trade-off.
   },
   "categories": {
     "visual-engineering": { "model": "opencode-go/qwen3.6-plus" },
-    "deep": { "model": "opencode-go/kimi-k2.7" },  // Not ideal — Kimi isn't GPT, but best available
-    "unspecified-high": { "model": "opencode-go/kimi-k2.7" },
-    "unspecified-low": { "model": "opencode-go/kimi-k2.7" },
+    "deep": { "model": "opencode-go/kimi-k2.7-code" },  // Not ideal — Kimi isn't GPT, but best available
+    "unspecified-high": { "model": "opencode-go/kimi-k2.7-code" },
+    "unspecified-low": { "model": "opencode-go/kimi-k2.7-code" },
     "quick": { "model": "opencode-go/minimax-m2.7" },
-    "writing": { "model": "opencode-go/kimi-k2.7" },
+    "writing": { "model": "opencode-go/kimi-k2.7-code" },
   },
 }
 ```


### PR DESCRIPTION
## Summary

The recommended model stacks in `docs/guide/agent-model-matching.md` pin `opencode-go/kimi-k2.7`, but OpenCode Go does not expose that model id. Users who copy the recommended config hit a `configured model opencode-go/kimi-k2.7 is not valid` error at runtime. This corrects the 14 affected config values to `opencode-go/kimi-k2.7-code`, the canonical id OpenCode Go actually offers.

## Root Cause

Per the [official OpenCode Go docs](https://opencode.ai/docs/go/), the Kimi K2.7 Code model is exposed with the id `kimi-k2.7-code` (config form `opencode-go/kimi-k2.7-code`); there is no bare `kimi-k2.7` on the `opencode-go` provider. The docs quote it directly: "for Kimi K2.7 Code, you would use `opencode-go/kimi-k2.7-code` in your config."

`docs/guide/agent-model-matching.md` used `opencode-go/kimi-k2.7` in the "current top models" pin hint, the Recommended Stack (Example A), and the OpenCode Go-only stack (Example C). Following those examples produces the `... is not valid` error reported in #5371.

OMO already handles the correct id: `isKimiK27Model` in `packages/model-core/src/model-family-detectors.ts` matches `/kimi-k2[.\-]?7/`, which matches `kimi-k2.7-code`, so the Kimi-tuned Sisyphus/Atlas prompt paths keep applying with the corrected id. No code change is required.

## Changes

| File | Change |
|------|--------|
| `docs/guide/agent-model-matching.md` | Replace all 14 `opencode-go/kimi-k2.7` config values with `opencode-go/kimi-k2.7-code` |

The conceptual model-family references (the bare `kimi-k2.7` family name in the Claude Family table and surrounding prose) are intentionally left unchanged, since they refer to the model family across providers, not the `opencode-go` config id.

## Reproduction (before fix)

14 config-value occurrences of the non-existent id, for example:

```
L186: ... Pin one in your config: ... "opencode-go/kimi-k2.7" ...
L392: "model": "opencode-go/kimi-k2.7",
L393: "ultrawork": { "model": "opencode-go/kimi-k2.7" },
L418: "unspecified-low": { "model": "opencode-go/kimi-k2.7" },
L461: "sisyphus": { "model": "opencode-go/kimi-k2.7" },
```

Using any of these in `oh-my-opencode.jsonc` yields: `Agent Sisyphus - ultraworker's configured model opencode-go/kimi-k2.7 is not valid`.

## Verification (after fix)

```
STALE_REMAINING (opencode-go/kimi-k2.7 without -code): 0
FIXED_OCCURRENCES (opencode-go/kimi-k2.7-code): 14
docs/guide/agent-model-matching.md | 28 ++++++++++++++--------------
1 file changed, 14 insertions(+), 14 deletions(-)
```

## Test

- Docs-only change (no code; nothing in this diff is wired into the OpenCode/Codex runtime), so no runtime QA applies.
- Corrected id `opencode-go/kimi-k2.7-code` verified against the authoritative OpenCode Go documentation.
- Confirmed `isKimiK27Model` still matches `kimi-k2.7-code`, so Kimi-specific prompt routing is preserved.
- Grep confirms 0 remaining `opencode-go/kimi-k2.7` (without `-code`) and 14 corrected occurrences.

Fixes #5371


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the model id in the docs’ recommended stacks from `opencode-go/kimi-k2.7` to `opencode-go/kimi-k2.7-code` to prevent invalid-model runtime errors (fixes #5371). Updated 14 config examples in `docs/guide/agent-model-matching.md`; Kimi-specific prompt routing still applies.

<sup>Written for commit e88e4b426c35ed0b8bb06bb4dfc5439449649ec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

