### PR TITLE
feat(codex): make teammode constant communication the default

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -98,17 +98,16 @@ fall back to a spawned agent.
 
 ## Communication
 
-Coordinate with `codex_app.send_message_to_thread` (leader-to-member and peer digests) and inspect
-status with `codex_app.read_thread`. The generated manual already binds members to the hard rules,
-so you mostly enforce them: all member-to-member and member-to-leader communication is in English;
-when the END user addresses a member, that member replies in the user's own language. Members
-over-communicate relentlessly - constant, small, lean updates that report every finding, hand-off,
-and even the smallest or most trivial step as it happens rather than one final dump - and send
-`WORKING:`/`BLOCKED:` markers so the leader always knows their state; stale, stuck, or
-silently-blocked members are not acceptable, and a finished
-member reports to the leader immediately. Members hand off files and
-memos through the team `artifacts/` directory and reference them by path instead of pasting large
-content. Wait for every required member's final report before you declare the team done.
+Members push to you and to one another with `codex_app.send_message_to_thread`; you inspect their
+state with `codex_app.read_thread`. So members can actually reach you, run `init` with
+`--session <your own thread id>` - that makes `leader.sessionId` in team.json a real, messageable
+thread; without it members cannot report to you and you are stuck polling. The generated manual binds
+members to the hard rules, so you mainly keep the channel open: expect frequent small inbound updates
+from each member - findings, `WORKING:`/`BLOCKED:` markers, peer digests - rather than one final
+dump, and act on them as they arrive. All member-to-member and member-to-leader traffic is in English;
+when the END user addresses a member, that member replies in the user's own language. Members hand off
+files and memos through the team `artifacts/` directory and reference them by path. Wait for every
+required member's final report before you declare the team done.
 
 ## Worktrees (optional isolation)
 

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
@@ -68,18 +68,17 @@ coordinate with each other, but the leader owns the final decision and integrati
   is mandatory regardless of the language the task was given in.
 - **Exception: when the END USER addresses you directly, reply in the user's own language.**
   Team-internal traffic stays English; user-facing replies match the user.
-- **Report to the leader the moment your work is complete.** A finished task that was never
-  reported does not count as done.
-- **Over-communicate relentlessly - report even the trivial.** Message constantly and
-  proactively: every finding, decision, hand-off, and even the smallest or most trivial step, the
-  moment it happens, in short lean notes. Never save it up for one final report. When in doubt,
-  send the message - far more and far smaller updates always beats going quiet. The instant
-  anything changes a peer's assumption, push it to them. Too many messages is correct here; the
-  only failure is going quiet.
-- **Stale, stuck, and silently-blocked states are NOT acceptable.** During long work send
-  \`WORKING: <your focus> - <phase>\` so the leader can see you are alive. If you truly cannot
-  proceed, send \`BLOCKED: <reason>\` immediately and propose the smallest unblock - never sit
-  idle and never disappear. Being quiet is a failure, not a pause.
+- **Reach the leader and your peers with \`codex_app.send_message_to_thread\` - not by narrating in
+  your own thread, where no one reads it.** The address book is in team.json: the leader thread id
+  is \`leader.sessionId\`, and each peer thread id is its \`members[].threadId\`.
+- **Push a short message at each of these moments - never batch them into one report at the end:**
+  - to the **leader**: every finding or decision, every file or sub-task you finish, a
+    \`WORKING: <focus> - <phase>\` heartbeat every few tool calls so you never look stale, a
+    \`BLOCKED: <reason>\` the instant you cannot proceed, and your result the moment your slice is done.
+  - to a **peer**: the instant you learn anything that touches their slice - a shared finding, a
+    changed assumption, an interface they depend on. When unsure who owns it, send it to the leader.
+- **Going quiet is the only failure.** Many small lean messages beat one end-of-work dump; keep
+  every message short.
 
 ## Artifacts (how you hand work off)
 
@@ -109,5 +108,5 @@ export function buildMemberPrompt(team, id) {
 FIRST read your field manual at \`${guide}\`, then the team state at \`${teamJson}\`; they define your scope, deliverable, the leader, the artifacts directory, and the communication rules.
 ${where}
 Communicate with the team and leader in English; reply to the end user in the user's own language.
-Start now, send WORKING/BLOCKED updates so you never look stale, and report to the leader the moment you are done.`;
+Start now. Push updates to the leader and relevant peers with \`codex_app.send_message_to_thread\` as you work - findings, \`WORKING:\` heartbeats, and \`BLOCKED:\` the instant you stall - never just one report at the end.`;
 }

--- a/packages/omo-codex/plugin/test/teammode-communication.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-communication.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { root } from "./aggregate-plugin-fixture.mjs";
+import { cleanupTeamRoot, createTeamRoot, runTeam, teamDir } from "./teammode-safety-fixture.mjs";
+
+// The teammode guide.md is what every member actually reads. The real run of leader session
+// 019eed1e- proved members default to silence: 10 members, ~6 min, 4 end-of-work reports, zero
+// peer messages, zero mid-task reports, zero send_message_to_thread calls - because the prose said
+// "over-communicate relentlessly" (aspirational, no trigger) and never named the tool or targets.
+// These tests pin the fix: a concrete push-communication protocol is the default the manual renders.
+
+function buildTwoMemberTeam(tempRoot, sessionId) {
+	runTeam(tempRoot, "init", "--name", "Comms", "--session-name", "frequent", "--session", sessionId);
+	runTeam(tempRoot, "add-member", "--team", sessionId, "--id", "A", "--name", "alpha", "--focus", "slice one", "--lens", "area", "--deliverable", "x");
+	runTeam(tempRoot, "add-member", "--team", sessionId, "--id", "B", "--name", "beta", "--focus", "slice two", "--lens", "area", "--deliverable", "y");
+	runTeam(tempRoot, "bind-thread", "--team", sessionId, "--id", "A", "--thread", "thread-A");
+	runTeam(tempRoot, "bind-thread", "--team", sessionId, "--id", "B", "--thread", "thread-B");
+}
+
+function readGuide(tempRoot, sessionId) {
+	return readFileSync(join(teamDir(tempRoot, sessionId), "guide.md"), "utf8");
+}
+
+test("#given a bound team #when the member field manual renders #then it names the cross-thread tool and the team.json address book", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-comms-");
+	try {
+		buildTwoMemberTeam(tempRoot, "comms-tool");
+		const guide = readGuide(tempRoot, "comms-tool");
+
+		// then - members are told the concrete TOOL to reach leader+peers, not left to narrate
+		assert.match(guide, /codex_app\.send_message_to_thread/, "guide must name the cross-thread messaging tool");
+		// then - members are pointed at the concrete address book in team.json
+		assert.match(guide, /leader\.sessionId/, "guide must say the leader thread id is team.json leader.sessionId");
+		assert.match(guide, /members\[\]\.threadId/, "guide must say peer thread ids are team.json members[].threadId");
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a bound team #when the member field manual renders #then it gives concrete per-moment cadence triggers, not aspirational 'constantly'", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-comms-");
+	try {
+		buildTwoMemberTeam(tempRoot, "comms-cadence");
+		const guide = readGuide(tempRoot, "comms-cadence");
+
+		// then - a concrete heartbeat cadence the model can bind to
+		assert.match(guide, /every few tool calls/, "guide must give a concrete heartbeat trigger");
+		assert.match(guide, /WORKING:/, "guide must keep the WORKING heartbeat marker");
+		assert.match(guide, /BLOCKED:/, "guide must keep the BLOCKED marker");
+		// then - an explicit peer-notify rule so cross-cutting findings are pushed, not siloed
+		assert.match(guide, /to a \*\*peer\*\*/, "guide must have an explicit peer-notify rule");
+		assert.match(guide, /touches their slice/, "guide must trigger peer messages on slice-touching findings");
+		// then - the end-only directive that previously won is gone (it licensed batch-at-the-end reporting)
+		assert.doesNotMatch(guide, /the moment your work is complete/, "the standalone end-only report directive must be removed");
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a member bootstrap trigger #when it is generated #then it points at the push tool and a continuous cadence, not an end-of-work report", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-comms-");
+	try {
+		buildTwoMemberTeam(tempRoot, "comms-bootstrap");
+		const prompt = runTeam(tempRoot, "member-prompt", "--team", "comms-bootstrap", "--id", "A").stdout;
+
+		// then - the first thing a member reads tells it to push via the tool as it works
+		assert.match(prompt, /codex_app\.send_message_to_thread/, "bootstrap must name the push tool");
+		assert.match(prompt, /never just one report at the end/, "bootstrap must reject end-only reporting");
+		// then - it no longer frames reporting as a one-shot completion event
+		assert.doesNotMatch(prompt, /report to the leader the moment you are done/, "the end-only bootstrap line must be removed");
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given the leader-facing SKILL.md #when it describes communication #then it requires --session so members can reach the leader and frames members as pushing", () => {
+	const skill = readFileSync(join(root, "components", "teammode", "skills", "teammode", "SKILL.md"), "utf8");
+
+	// then - the leader is told members PUSH to it (not only that the leader sends)
+	assert.match(skill, /Members push to you/i, "SKILL.md must frame members as pushing to the leader");
+	// then - the --session requirement is stated WITH its reason (member->leader push needs a real leader thread)
+	assert.match(skill, /--session <your own thread id>/, "SKILL.md must require init --session <your own thread id>");
+	assert.match(skill, /stuck polling|cannot report to you/i, "SKILL.md must explain why --session matters");
+});


### PR DESCRIPTION
## Summary

omo-codex (lazycodex) team members were going silent during work. In a real 10-member run (leader Codex session `019eed1e-…`, team `prepublish-gate`, ~6 min) the leader received **4 messages total** — all single end-of-work "DONE" dumps — with **0 member-to-member messages** and **0 mid-task progress reports**, even though the user had explicitly asked the team to "ultradebate hyperdebate agile talk ultrafrequently". This PR makes constant peer communication and constant leader-reporting the **default** the skill renders.

The fix is prompt-only and surgical (no patch-on-top): it edits the three diagnosed surfaces in the teammode skill at the canonical source.

## Root cause (prompt-engineering, GPT-5.5)

The capability already existed — a member's tool list includes `codex_app.send_message_to_thread`, and `team.json` already stores the address book (`leader.sessionId`, `members[].threadId`) the bootstrap tells members to read. So this was never architectural. The guide already screamed "over-communicate relentlessly", so it was never a "say it louder" problem either. The real defects:

- **(B) Misframing.** GPT-5.5's default style is "efficient, direct… avoids unnecessary conversational padding". Aspirational superlatives ("constantly", "the moment it happens", "too many messages is correct") give no concrete trigger to bind to, so a member collapses to the cheapest compliant behavior: do the work, send one summary.
- **(C) Missing mechanism.** The member-facing guide never named the messaging tool or the leader/peer thread-id targets, so "send `WORKING:`" degraded into self-narration in the member's own thread (the leader never saw it).
- **(B) Competing instruction.** "Report to the leader the moment your work is complete" was the only *concrete* line, so it was the only one followed — exactly the 4 end-of-work dumps observed.

## Changes

- `team-guide.mjs` `buildGuide()` `## Communication rules` — replaced the superlatives + the standalone end-only directive with a concrete push protocol: names `codex_app.send_message_to_thread`, points at the `team.json` address book, and gives per-moment decision-rule triggers for the leader (finding/decision/file + a `WORKING:` heartbeat every few tool calls + `BLOCKED:` on stall) and an explicit peer-notify rule (the instant a finding touches their slice). Kept the English-language invariants.
- `team-guide.mjs` `buildMemberPrompt()` — the bootstrap now pushes via the tool as-you-work, "never just one report at the end" (was "report to the leader the moment you are done").
- `SKILL.md` `## Communication` — frames members as pushing; requires `init --session <your own thread id>` so `leader.sessionId` is a messageable thread (else members cannot report and the leader is stuck polling); tells the leader to expect frequent inbound and act on it.

Net diff on the two source files: **22 insertions / 24 deletions** (the prompt got *shorter* while gaining the missing mechanism — entropy gate satisfied). Synced copy under `plugin/skills/` is regenerated by `sync-skills.mjs` (gitignored).

## Verification

**Automated (TDD red → green):** new `packages/omo-codex/plugin/test/teammode-communication.test.mjs` failed red against the old text, passes green after the edit (4/4). No regression: `teammode-safety` + `teammode-thread-title` (9/9), `sync-skills` + `sync-skills-orchestration` + `aggregate-skills` (24/24). Synced `team-guide.mjs`/`SKILL.md` byte-identical to source (`cmp`).

**Manual QA (tmux, real surface):** drove the **shipped** (synced) `team.mjs` end-to-end in an isolated mktemp dir (init → 2 members → bind threads) and captured the actual rendered `guide.md` + bootstrap a member reads, plus the resolved `team.json` address book. The rendered manual shows the new protocol verbatim. Evidence under `.omo/evidence/20260622-teammode-frequent-comms/` (`01-diagnosis.md`, `02-qa-driver.sh`, `03-rendered-guide-tmux.txt`, `04-qa-summary.md`).

**Known limitation:** a live multi-thread proof that a GPT-5.5 member emits more `send_message_to_thread` calls needs a real model driving real app-server threads (non-deterministic, out of scope for a hermetic gate). CI `codex-compatibility` (`test:codex`, ubuntu/macos/windows) runs the full unit gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make constant peer and leader updates the default in `teammode` by defining a concrete push-communication protocol and updating the member bootstrap. Members now message via `codex_app.send_message_to_thread` with a clear cadence to prevent silent runs.

- **New Features**
  - Member manual names `codex_app.send_message_to_thread` and points to `team.json` (`leader.sessionId`, `members[].threadId`).
  - Concrete cadence: leader gets findings/decisions/files; `WORKING:` every few tool calls; `BLOCKED:` on stall; peers get updates when a finding touches their slice.
  - Bootstrap prompt pushes as-you-work and removes end-only reporting.
  - Added tests to lock the protocol in `plugin/test/teammode-communication.test.mjs`.

- **Migration**
  - Leaders must run `init --session <your own thread id>` so `leader.sessionId` is a messageable thread.

<sup>Written for commit eec3b8887a0c9f42a9a6f6835de049b4463ba64a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

