### PR TITLE
fix(delegate-task): requeue silent parent wake

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
@@ -15,6 +15,7 @@ export type PendingParentWake = {
   noReplyAdmittedAt?: number
   toolCallDeferralStartedAt?: number
   allowEmptyAssistantTurnRetry?: boolean
+  noAssistantOutputRetryCount?: number
 }
 
 export function resolveParentWakePromptContext(promptContext: ParentWakePromptContext): ParentWakePromptContext {
@@ -40,6 +41,9 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
       : {}),
     ...(wake.allowEmptyAssistantTurnRetry !== undefined
       ? { allowEmptyAssistantTurnRetry: wake.allowEmptyAssistantTurnRetry }
+      : {}),
+    ...(wake.noAssistantOutputRetryCount !== undefined
+      ? { noAssistantOutputRetryCount: wake.noAssistantOutputRetryCount }
       : {}),
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-late-error-recovery.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-late-error-recovery.test.ts
@@ -95,7 +95,7 @@ async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<v
 }
 
 describe("ParentWakeNotifier late error recovery", () => {
-  test("#given session.error arrives after the recovery window #when no assistant output accepted the wake #then the final wake is still requeued", async () => {
+  test("#given session.error arrives after the recovery window #when no assistant output accepted the wake #then the final wake is already requeued", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier()
     const sessionID = "parent-late-session-error-after-window"
@@ -111,7 +111,7 @@ describe("ParentWakeNotifier late error recovery", () => {
       const requeued = await notifier.requeueDispatchedParentWake(sessionID, "late session.error")
 
       // then
-      expect(requeued).toBe(true)
+      expect(requeued).toBe(false)
       expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([FINAL_WAKE])
       expect(notifier.getDispatchedParentWakes().has(sessionID)).toBe(false)
       releaseParentWakeHold(sessionID)

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
@@ -37,6 +37,8 @@ export class ParentWakeNotifier {
           wake,
           dispatchedTracker: this.dispatchedTracker,
           sessionInspector: this.sessionInspector,
+          requeueWake: (latestWake) => this.requeueWake(sessionID, latestWake),
+          scheduleFlush: () => this.schedulePendingParentWakeFlush(sessionID),
         }).catch((error: unknown) => {
           logParentWakeWindowRecoveryError(
             sessionID,

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -59,6 +59,7 @@ export class ParentWakePendingQueue {
       pendingWake.shouldReply = pendingWake.shouldReply || shouldReply
       if (notificationsChanged) {
         delete pendingWake.noReplyAdmittedAt
+        delete pendingWake.noAssistantOutputRetryCount
       }
       return
     }
@@ -82,6 +83,13 @@ export class ParentWakePendingQueue {
       pendingWake.noReplyAdmittedAt ??= latestWake.noReplyAdmittedAt
       pendingWake.toolCallDeferralStartedAt ??= latestWake.toolCallDeferralStartedAt
       pendingWake.allowEmptyAssistantTurnRetry ||= latestWake.allowEmptyAssistantTurnRetry
+      const noAssistantOutputRetryCount = Math.max(
+        pendingWake.noAssistantOutputRetryCount ?? 0,
+        latestWake.noAssistantOutputRetryCount ?? 0,
+      )
+      if (noAssistantOutputRetryCount > 0) {
+        pendingWake.noAssistantOutputRetryCount = noAssistantOutputRetryCount
+      }
       return
     }
     this.pendingParentWakes.set(sessionID, cloneParentWake(latestWake))

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-window-recovery.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-window-recovery.ts
@@ -8,6 +8,8 @@ type ParentWakeWindowRecoveryInput = {
   readonly wake: PendingParentWake
   readonly dispatchedTracker: ParentWakeDispatchedTracker
   readonly sessionInspector: ParentWakeSessionInspector
+  readonly requeueWake: (wake: PendingParentWake) => void
+  readonly scheduleFlush: () => void
 }
 
 export async function handleDispatchedParentWakeWindowElapsed(
@@ -26,8 +28,10 @@ export async function handleDispatchedParentWakeWindowElapsed(
     return
   }
 
-  input.dispatchedTracker.refreshWakeTimer(input.sessionID)
-  log("[background-agent] Kept dispatched parent wake awaiting late failure or assistant output:", {
+  input.dispatchedTracker.clearWake(input.sessionID)
+  input.requeueWake(input.wake)
+  input.scheduleFlush()
+  log("[background-agent] Requeued dispatched parent wake after no assistant output:", {
     sessionID: input.sessionID,
   })
 }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-window-recovery.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-window-recovery.ts
@@ -3,6 +3,8 @@ import type { PendingParentWake } from "./parent-wake-dedupe"
 import type { ParentWakeDispatchedTracker } from "./parent-wake-dispatched-tracker"
 import type { ParentWakeSessionInspector } from "./parent-wake-session-inspector"
 
+const MAX_NO_ASSISTANT_OUTPUT_RETRIES = 1
+
 type ParentWakeWindowRecoveryInput = {
   readonly sessionID: string
   readonly wake: PendingParentWake
@@ -28,11 +30,23 @@ export async function handleDispatchedParentWakeWindowElapsed(
     return
   }
 
+  const retryCount = input.wake.noAssistantOutputRetryCount ?? 0
+  if (retryCount >= MAX_NO_ASSISTANT_OUTPUT_RETRIES) {
+    input.dispatchedTracker.clearWake(input.sessionID)
+    log("[background-agent] Stopped retrying parent wake after repeated no-output dispatch:", {
+      sessionID: input.sessionID,
+      retryCount,
+    })
+    return
+  }
+
   input.dispatchedTracker.clearWake(input.sessionID)
+  input.wake.noAssistantOutputRetryCount = retryCount + 1
   input.requeueWake(input.wake)
   input.scheduleFlush()
   log("[background-agent] Requeued dispatched parent wake after no assistant output:", {
     sessionID: input.sessionID,
+    retryCount: input.wake.noAssistantOutputRetryCount,
   })
 }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-window-requeue.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-window-requeue.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+import {
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "../../hooks/shared/prompt-async-gate"
 import { ParentWakeNotifier } from "./parent-wake-notifier"
 
 type ParentWakeNotifierClientForTest = ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
@@ -65,6 +68,13 @@ async function waitForTimer(): Promise<void> {
   })
 }
 
+function releaseParentWakeHold(sessionID: string): void {
+  const released = releasePromptAsyncReservation(sessionID, "test:simulate-expired-parent-wake-hold", {
+    reservedBy: "background-agent-parent-wake",
+  })
+  expect(released).toBe(true)
+}
+
 describe("ParentWakeNotifier dispatched wake recovery", () => {
   test("#given a parent wake is accepted but produces no assistant output #when the recovery window elapses #then the wake is requeued for another dispatch", async () => {
     // given
@@ -85,6 +95,36 @@ describe("ParentWakeNotifier dispatched wake recovery", () => {
       expect(notifier.getDispatchedParentWakes().has(sessionID)).toBe(false)
       expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([FINAL_WAKE])
       expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a requeued parent wake still produces no assistant output #when the retry window elapses #then the wake is not retried forever", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-window-no-continuation-retry-budget"
+    notifier.queuePendingParentWake(sessionID, FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(1)
+      await waitForTimer()
+      expect(notifier.getPendingParentWakes().get(sessionID)?.noAssistantOutputRetryCount).toBe(1)
+
+      releaseParentWakeHold(sessionID)
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(2)
+
+      // when
+      await waitForTimer()
+
+      // then
+      expect(notifier.getDispatchedParentWakes().has(sessionID)).toBe(false)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+      expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(false)
+      expect(promptAsyncCalls).toHaveLength(2)
     } finally {
       notifier.shutdown()
       releaseAllPromptAsyncReservationsForTesting()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-window-requeue.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-window-requeue.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+import { ParentWakeNotifier } from "./parent-wake-notifier"
+
+type ParentWakeNotifierClientForTest = ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
+type PromptAsyncCall = Parameters<ParentWakeNotifierClientForTest["session"]["promptAsync"]>[0]
+
+type SessionMessageStub = {
+  readonly info?: {
+    readonly role?: string
+    readonly finish?: string
+    readonly time?: { readonly created?: number }
+  }
+  readonly parts?: readonly { readonly type?: string; readonly text?: string }[]
+}
+
+const FINAL_WAKE = "<system-reminder>\n[BACKGROUND TASK COMPLETED]\n[ALL BACKGROUND TASKS COMPLETE]\n</system-reminder>"
+
+function createNotifier(): {
+  readonly notifier: ParentWakeNotifier
+  readonly promptAsyncCalls: readonly PromptAsyncCall[]
+} {
+  const promptAsyncCalls: PromptAsyncCall[] = []
+  const sessionMessages: readonly SessionMessageStub[] = [
+    {
+      info: {
+        role: "assistant",
+        finish: "stop",
+        time: { created: Date.now() - 10_000 },
+      },
+    },
+  ]
+  const client: ParentWakeNotifierClientForTest = {
+    session: {
+      messages: async () => ({ data: sessionMessages }),
+      status: async () => ({ data: {} }),
+      promptAsync: async (call: PromptAsyncCall) => {
+        promptAsyncCalls.push(call)
+        return { data: {} }
+      },
+    },
+  }
+  const notifier = new ParentWakeNotifier(
+    {
+      client,
+      directory: "/tmp/test-omo",
+      enqueueNotificationForParent: async (_sessionID, operation) => {
+        await operation()
+      },
+    },
+    {
+      pendingRetryMs: 1_000,
+      acceptedMessageSkewMs: 100,
+      toolCallDeferMaxMs: 5_000,
+      failureRequeueWindowMs: 1,
+      userMessageInProgressWindowMs: 0,
+    },
+  )
+  return { notifier, promptAsyncCalls }
+}
+
+async function waitForTimer(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 10)
+  })
+}
+
+describe("ParentWakeNotifier dispatched wake recovery", () => {
+  test("#given a parent wake is accepted but produces no assistant output #when the recovery window elapses #then the wake is requeued for another dispatch", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-window-no-continuation"
+    notifier.queuePendingParentWake(sessionID, FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getDispatchedParentWakes().get(sessionID)?.notifications).toEqual([FINAL_WAKE])
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+
+      // when
+      await waitForTimer()
+
+      // then
+      expect(notifier.getDispatchedParentWakes().has(sessionID)).toBe(false)
+      expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([FINAL_WAKE])
+      expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Fixes the Discord-reported OpenCode issue where the main agent can fail to wake after subagents complete.

The root cause was that a parent wake accepted by OpenCode but followed by no assistant/tool output and no later `session.error` stayed in the dispatched tracker forever. That made the wake look already handled even though the parent never actually continued.

## Changes
- Requeue dispatched parent wakes when the recovery window elapses without assistant/tool output.
- Keep the existing successful-output path unchanged: assistant/tool output still clears the dispatched wake.
- Update late-error recovery expectations for the new already-requeued state.
- Add a focused regression test for the silent no-output parent wake path.

## Verification
**Red first**
- `bun test packages/omo-opencode/src/features/background-agent/parent-wake-window-requeue.test.ts` with source hunks temporarily reversed failed as expected: `.omo/evidence/20260622-fix-subagent-wake-main/task-2-red/parent-wake-window-requeue-red.log`

**Focused automated**
- `bun test packages/omo-opencode/src/features/background-agent/parent-wake-window-requeue.test.ts packages/omo-opencode/src/features/background-agent/parent-wake-late-error-recovery.test.ts packages/omo-opencode/src/features/background-agent/parent-wake-non-error-retry.test.ts` → 9 pass
- `bun test packages/omo-opencode/src/tools/delegate-task/sync-session-poller.internal-wake.test.ts packages/omo-opencode/src/tools/delegate-task/sync-session-poller.test.ts` → 28 pass
- Post-rebase focused check → 11 pass
- `bun run --cwd packages/omo-opencode typecheck` → pass

**Mandatory OpenCode QA**
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check` → pass
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test` → delivered `server.connected`
- `bash .agents/skills/opencode-qa/scripts/serve-wake-split-probe.sh --expect fixed --evidence-dir .omo/evidence/20260622-fix-subagent-wake-main/task-6-serve-wake-split-fixed` → `RESULT=FIXED`
- Isolation proof: real OpenCode DB session count stayed `5737 -> 5737`

**Full local gates**
- `bun run typecheck` → pass
- `bun test` → 10115 pass, 2 skip, 0 fail
- `bun run build` → pass

## Evidence
Evidence is recorded locally under `.omo/evidence/20260622-fix-subagent-wake-main/`, including OpenCode harness logs, DB isolation receipt, upstream OpenCode source/history inspection, and command outputs.

## Related
Discord report: https://discord.com/channels/1452487457085063218/1490536332961906829/1518445264770306078

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the parent agent could fail to resume after a subagent finished. We now requeue the parent wake when no assistant/tool output arrives and cap it to one retry so the parent continues without looping.

- **Bug Fixes**
  - Requeue dispatched parent wake when the window expires without assistant/tool output, clearing the dispatched tracker and scheduling a flush.
  - Bound silent no-output retries to a single attempt via `noAssistantOutputRetryCount` (reset on notification changes); align late-error recovery for already-requeued wakes, and add regression tests for the silent path and retry budget.

<sup>Written for commit 5bd586448f8050c5bfe1d8d3dd24f4084aee25eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

