### PR TITLE
fix(shared-skills): remove release diff whitespace

### DIFF
--- a/packages/shared-skills/skills/ultimate-browsing/references/agent-reach/dev.md
+++ b/packages/shared-skills/skills/ultimate-browsing/references/agent-reach/dev.md
@@ -1,6 +1,6 @@
 # 开发工具
 
-GitHub CLI 
+GitHub CLI
 
 ## GitHub (gh CLI)
 


### PR DESCRIPTION
## Summary
Removes the trailing whitespace in the vendored ultimate-browsing Agent Reach reference that was blocking the release diff check for `v4.12.1..origin/dev`.

## Changes
- Normalizes `GitHub CLI` line whitespace in `packages/shared-skills/skills/ultimate-browsing/references/agent-reach/dev.md`.

## Verification
- `git diff --check v4.12.1..HEAD`
- `git diff --check`
- Evidence: `.omo/evidence/20260622-release-whitespace/post-commit-verification.txt`

## Release Gate
Addresses the pre-publish blocker reported by the Codex adapter review lane: trailing whitespace in `packages/shared-skills/skills/ultimate-browsing/references/agent-reach/dev.md:3`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stray trailing space in the Agent Reach reference so release diff checks pass and the v4.12.1 → dev release can proceed. Normalized the "GitHub CLI" line in packages/shared-skills/skills/ultimate-browsing/references/agent-reach/dev.md.

- **Bug Fixes**
  - Removed one trailing space after "GitHub CLI" (line 3).

<sup>Written for commit bb90c46bd433807cd2ca71b313e8cfbed214840f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




## Additional QA Evidence (2026-06-22)
- Manual QA matrix: `/Users/yeongyu/local-workspaces/omo/.omo/evidence/manual-qa-matrix-pr-5490-5491-5492.md`
