### PR TITLE
fix(runtime-fallback): rearm timeout after blocked escalation

### DIFF
--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.test.ts
@@ -39,7 +39,7 @@ function createDeps(): HookDeps {
     pluginConfig: {
       categories: {
         test: {
-          fallback_models: ["litellm/openai.eu.gpt-5.5"],
+          fallback_models: ["litellm/openai.eu.gpt-5.5", "google/gemini-2.5-pro"],
         },
       },
     },
@@ -98,5 +98,48 @@ describe("createFallbackTimeoutHelpers", () => {
     expect(state.attemptCount).toBe(0)
     expect(state.pendingFallbackModel).toBe(undefined)
     expect(state.failedModels.size).toBe(0)
+  })
+
+  test("#given an accepted fallback is awaiting its result #when timeout escalation is blocked #then the restored awaiting state keeps a timeout armed", async () => {
+    // given
+    const sessionID = "session-timeout-awaiting-dispatch-blocked"
+    SessionCategoryRegistry.register(sessionID, "test")
+    const deps = createDeps()
+    deps.options = {
+      session_timeout_ms: 1,
+    }
+    const state = createFallbackState("openai/gpt-5.4")
+    state.currentModel = "litellm/openai.eu.gpt-5.5"
+    state.fallbackIndex = 0
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+
+    let resolveRetry: (() => void) | undefined
+    const retryCalled = new Promise<void>((resolve) => {
+      resolveRetry = resolve
+    })
+    const helpers = createFallbackTimeoutHelpers(
+      deps,
+      async () => {},
+      async () => {
+        resolveRetry?.()
+        return { accepted: false, status: "blocked", reason: "test gate blocked dispatch" }
+      },
+    )
+
+    // when
+    helpers.scheduleSessionFallbackTimeout(sessionID)
+    await Promise.race([
+      retryCalled,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("timer did not fire")), 1000)
+      }),
+    ])
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(true)
+    expect(deps.sessionFallbackTimeouts.has(sessionID)).toBe(true)
+    helpers.clearSessionFallbackTimeout(sessionID)
   })
 })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.ts
@@ -81,6 +81,9 @@ export function createFallbackTimeoutHelpers(
         const dispatchOutcome = await autoRetryWithFallback(sessionID, result.newModel, resolvedAgent, "session.timeout")
         if (!dispatchOutcome.accepted) {
           restoreFallbackState(state, stateSnapshot)
+          if (deps.sessionAwaitingFallbackResult.has(sessionID)) {
+            scheduleSessionFallbackTimeout(sessionID, resolvedAgent)
+          }
           log(`[${HOOK_NAME}] Session timeout fallback dispatch was not accepted`, {
             sessionID,
             status: dispatchOutcome.status,


### PR DESCRIPTION
## Summary
Fixes a runtime-fallback timeout edge case where an accepted fallback result could be restored after a blocked timeout escalation without rearming the watchdog timeout. The fix preserves the awaiting state and schedules the timeout again so the fallback session cannot become permanently stuck.

## Changes
- Rearms `scheduleSessionFallbackTimeout` when a timeout escalation dispatch is rejected after state restoration.
- Adds a regression test for the accepted-fallback-awaiting-result path where timeout escalation is blocked.

## Verification
- `bun test packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.test.ts`
- `bun test packages/omo-opencode/src/hooks/runtime-fallback`
- `bun run --cwd packages/omo-opencode typecheck`
- `git diff --check`
- OpenCode QA: `server-smoke` + `sse-hook-probe --self-test`
- Evidence: `.omo/evidence/20260622-runtime-fallback-timeout/post-commit-verification.txt`
- Evidence: `.omo/evidence/20260622-runtime-fallback-timeout/opencode-harness-smoke.txt`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runtime-fallback timeout edge case where, after a blocked timeout escalation, the restored awaiting state didn’t rearm the watchdog. The timeout is now rearmed so sessions awaiting a fallback result don’t get stuck.

- **Bug Fixes**
  - Rearms `scheduleSessionFallbackTimeout` when a timeout-triggered dispatch is not accepted and the session is still awaiting a fallback result.
  - Adds a regression test for the accepted-fallback-awaiting scenario with a blocked timeout escalation.

<sup>Written for commit deaefafaa7723754611a34538a0dfcf02db43dc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




## Additional QA Evidence (2026-06-22)
- Runtime fallback hook-surface probe: `/Users/yeongyu/local-workspaces/omo/.omo/evidence/20260622-runtime-fallback-timeout/runtime-fallback-hook-surface-probe.txt`
  - Isolated OpenCode server emitted real `session.error` SSE events from an invalid-provider prompt.
  - Source timeout helper probe showed `awaitingStillSet: true` and `timeoutStillArmed: true` after blocked escalation.
  - Live OpenCode DB session count remained unchanged.
- Manual QA matrix: `/Users/yeongyu/local-workspaces/omo/.omo/evidence/manual-qa-matrix-pr-5490-5491-5492.md`
