### PR TITLE
fix(codex): guard LazyCodex cleanup paths

### DIFF
--- a/packages/omo-codex/src/install/codex-cleanup-safety.test.ts
+++ b/packages/omo-codex/src/install/codex-cleanup-safety.test.ts
@@ -1,0 +1,106 @@
+/// <reference path="../../../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { lstat, mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, parse } from "node:path"
+import { removeManagedPathBestEffort } from "./codex-cleanup"
+import type { SkippedCleanupPath } from "./codex-cleanup"
+
+describe("codex cleanup safety", () => {
+  test("#given destructive cleanup targets #when managed removal runs #then rejects them and records skipped paths", async () => {
+    // given
+    const homeRoot = await mkdtemp(join(tmpdir(), "omo-codex-cleanup-safety-home-"))
+    const codexHome = join(homeRoot, ".codex")
+    const workspaceRoot = join(homeRoot, "workspace")
+    const managedCacheParent = join(codexHome, "plugins", "cache")
+    await writeFixtureFile(join(codexHome, "config.toml"), "[features]\nplugins = true\n")
+    await writeFixtureFile(join(workspaceRoot, "README.md"), "keep me\n")
+    await mkdir(managedCacheParent, { recursive: true })
+
+    const skipped: SkippedCleanupPath[] = []
+    const targets = [homeRoot, codexHome, workspaceRoot, managedCacheParent]
+
+    // when
+    const removals: boolean[] = []
+    for (const target of targets) {
+      removals.push(
+        await removeManagedPathBestEffort(target, {
+          codexHome,
+          onSkip: (skip) => skipped.push(skip),
+        }),
+      )
+    }
+
+    // then
+    expect(removals).toEqual([false, false, false, false])
+    expect(skipped.map((skip) => skip.path)).toEqual(targets)
+    expect(skipped.every((skip) => skip.reason.includes("managed Codex cleanup scope"))).toBe(true)
+    expect(await pathExists(join(codexHome, "config.toml"))).toBe(true)
+    expect(await pathExists(join(workspaceRoot, "README.md"))).toBe(true)
+    expect(await pathExists(managedCacheParent)).toBe(true)
+  })
+
+  test("#given traversal-shaped cleanup target #when managed removal runs #then canonical parent escapes are skipped", async () => {
+    // given
+    const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-cleanup-safety-codex-"))
+    const managedCacheRoot = join(codexHome, "plugins", "cache", "sisyphuslabs")
+    const traversalTarget = join(managedCacheRoot, "..", "..")
+    await writeFixtureFile(join(managedCacheRoot, "omo", "0.1.0", "package.json"), "{}\n")
+    const skipped: SkippedCleanupPath[] = []
+
+    // when
+    const removed = await removeManagedPathBestEffort(traversalTarget, {
+      codexHome,
+      onSkip: (skip) => skipped.push(skip),
+    })
+
+    // then
+    expect(removed).toBe(false)
+    expect(skipped).toEqual([
+      {
+        path: traversalTarget,
+        reason: "outside managed Codex cleanup scope",
+      },
+    ])
+    expect(await pathExists(join(managedCacheRoot, "omo", "0.1.0", "package.json"))).toBe(true)
+  })
+
+  test("#given filesystem root as Codex home #when managed removal runs #then refuses even shaped managed paths", async () => {
+    // given
+    const codexHome = parse(tmpdir()).root
+    const shapedManagedTarget = join(codexHome, "plugins", "cache", "sisyphuslabs")
+    const skipped: SkippedCleanupPath[] = []
+
+    // when
+    const removed = await removeManagedPathBestEffort(shapedManagedTarget, {
+      codexHome,
+      onSkip: (skip) => skipped.push(skip),
+    })
+
+    // then
+    expect(removed).toBe(false)
+    expect(skipped).toEqual([
+      {
+        path: shapedManagedTarget,
+        reason: "Codex home resolves to a filesystem root",
+      },
+    ])
+  })
+})
+
+async function writeFixtureFile(path: string, contents: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, contents)
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path)
+    return true
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false
+    throw error
+  }
+}

--- a/packages/omo-codex/src/install/codex-cleanup-safety.ts
+++ b/packages/omo-codex/src/install/codex-cleanup-safety.ts
@@ -1,0 +1,50 @@
+import { dirname, isAbsolute, join, relative, resolve } from "node:path"
+
+export interface SkippedCleanupPath {
+  readonly path: string
+  readonly reason: "outside managed Codex cleanup scope" | "Codex home resolves to a filesystem root"
+}
+
+export function validateManagedCleanupTarget(input: {
+  readonly codexHome: string
+  readonly path: string
+}): SkippedCleanupPath | null {
+  if (!isAbsolute(input.path)) return skipped(input.path, "outside managed Codex cleanup scope")
+
+  const codexHome = resolve(input.codexHome)
+  if (dirname(codexHome) === codexHome) return skipped(input.path, "Codex home resolves to a filesystem root")
+
+  const target = resolve(input.path)
+  if (!isWithinDirectory(codexHome, target)) return skipped(input.path, "outside managed Codex cleanup scope")
+  if (target === codexHome) return skipped(input.path, "outside managed Codex cleanup scope")
+
+  const exactManagedRoots = new Set([
+    resolve(join(codexHome, "plugins", "cache", "sisyphuslabs")),
+    resolve(join(codexHome, ".tmp", "marketplaces", "sisyphuslabs")),
+    resolve(join(codexHome, "runtime", "ast-grep")),
+    resolve(join(codexHome, "runtime", "node")),
+    resolve(join(codexHome, "plugins", "data", "omo-sisyphuslabs", "bootstrap")),
+  ])
+  if (exactManagedRoots.has(target)) return null
+  if (isManagedBootstrapDriftPath(codexHome, target)) return null
+
+  return skipped(input.path, "outside managed Codex cleanup scope")
+}
+
+function isWithinDirectory(parent: string, child: string): boolean {
+  const relativePath = relative(parent, child)
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))
+}
+
+function isManagedBootstrapDriftPath(codexHome: string, target: string): boolean {
+  const relativePath = relative(codexHome, target)
+  const segments = relativePath.split(/[\\/]/)
+  if (segments[0] !== "plugins") return false
+  if (segments[segments.length - 1] !== "bootstrap") return false
+  const ownerName = segments[segments.length - 2]
+  return ownerName !== undefined && ownerName.startsWith("omo") && ownerName.slice("omo".length).includes("sisyphuslabs")
+}
+
+function skipped(path: string, reason: SkippedCleanupPath["reason"]): SkippedCleanupPath {
+  return { path, reason }
+}

--- a/packages/omo-codex/src/install/codex-cleanup.test.ts
+++ b/packages/omo-codex/src/install/codex-cleanup.test.ts
@@ -312,12 +312,13 @@ describe("codex cleanup", () => {
   test("#given an artifact recreated after the first removal pass #when removeManagedPathBestEffort runs #then the retry clears it within one call", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-cleanup-retry-"))
-    const bootstrapDir = join(root, "bootstrap")
+    const bootstrapDir = join(root, "plugins", "data", "omo-sisyphuslabs", "bootstrap")
     const statePath = join(bootstrapDir, "state.json")
     await writeFixtureFile(statePath, "{}\n")
 
     // when
     const removed = await removeManagedPathBestEffort(bootstrapDir, {
+      codexHome: root,
       afterFirstAttempt: async () => {
         await writeFixtureFile(statePath, "{}\n")
       },

--- a/packages/omo-codex/src/install/codex-cleanup.ts
+++ b/packages/omo-codex/src/install/codex-cleanup.ts
@@ -3,7 +3,9 @@ import { lstat, readFile, readdir, rm, rmdir } from "node:fs/promises"
 import { homedir } from "node:os"
 import { isAbsolute, join, relative, resolve } from "node:path"
 import { cleanupCodexConfig, MANAGED_CODEX_AGENT_NAMES } from "./codex-cleanup-config"
+import { validateManagedCleanupTarget } from "./codex-cleanup-safety"
 import { repairProjectLocalCodexArtifactsBestEffort } from "./codex-project-local-cleanup-best-effort"
+import type { SkippedCleanupPath } from "./codex-cleanup-safety"
 import type { ProjectLocalCodexCleanupResult } from "./codex-project-local-cleanup"
 
 const INSTALLED_AGENTS_MANIFEST = ".installed-agents.json"
@@ -21,6 +23,7 @@ export interface CodexCleanupResult {
   readonly configChanged: boolean
   readonly configBackupPath?: string
   readonly removedPaths: readonly string[]
+  readonly skippedPaths: readonly SkippedCleanupPath[]
   readonly removedAgentLinks: readonly string[]
   readonly skippedAgentLinks: readonly string[]
   readonly projectCleanup: ProjectLocalCodexCleanupResult
@@ -36,12 +39,15 @@ export async function cleanupCodexLight(input: CodexCleanupOptions = {}): Promis
   const agentCleanup = await removeManifestListedAgentLinks(codexHome, agentPaths)
 
   const removedPaths: string[] = []
+  const skippedPaths: SkippedCleanupPath[] = []
   const managedStatePaths = new Set([
     ...managedGlobalStatePaths(codexHome),
     ...(await collectBootstrapDataDirsByGlob(codexHome)),
   ])
   for (const path of managedStatePaths) {
-    if (await removeManagedPathBestEffort(path)) removedPaths.push(path)
+    if (await removeManagedPathBestEffort(path, { codexHome, onSkip: (skip) => skippedPaths.push(skip) })) {
+      removedPaths.push(path)
+    }
   }
   await pruneEmptyRuntimeDirBestEffort(codexHome)
 
@@ -59,6 +65,7 @@ export async function cleanupCodexLight(input: CodexCleanupOptions = {}): Promis
     configChanged: configCleanup.changed,
     configBackupPath: configCleanup.backupPath,
     removedPaths,
+    skippedPaths,
     removedAgentLinks: agentCleanup.removed,
     skippedAgentLinks: agentCleanup.skipped,
     projectCleanup,
@@ -66,6 +73,7 @@ export async function cleanupCodexLight(input: CodexCleanupOptions = {}): Promis
 }
 
 export { cleanupCodexLightConfigText } from "./codex-cleanup-config"
+export type { SkippedCleanupPath } from "./codex-cleanup-safety"
 
 function managedGlobalStatePaths(codexHome: string): readonly string[] {
   return [
@@ -113,6 +121,8 @@ function isManagedBootstrapOwnerName(name: string): boolean {
 
 export interface RemoveManagedPathSeams {
   readonly afterFirstAttempt?: () => Promise<void> | void
+  readonly codexHome: string
+  readonly onSkip?: (skip: SkippedCleanupPath) => void
 }
 
 // Removal is best-effort with a single retry: a mid-flight bootstrap worker
@@ -121,8 +131,14 @@ export interface RemoveManagedPathSeams {
 // second `lazycodex-ai uninstall` run clears it.
 export async function removeManagedPathBestEffort(
   path: string,
-  seams: RemoveManagedPathSeams = {},
+  seams: RemoveManagedPathSeams,
 ): Promise<boolean> {
+  const skip = validateManagedCleanupTarget({ codexHome: seams.codexHome, path })
+  if (skip !== null) {
+    seams.onSkip?.(skip)
+    return false
+  }
+
   const removedOnFirstAttempt = await attemptRemove(path)
   await seams.afterFirstAttempt?.()
   const removedOnRetry = await attemptRemove(path)
@@ -145,9 +161,14 @@ async function attemptRemove(path: string): Promise<boolean> {
 async function pruneEmptyRuntimeDirBestEffort(codexHome: string): Promise<void> {
   try {
     await rmdir(join(codexHome, "runtime"))
-  } catch {
-    // best-effort: missing, non-empty, or locked runtime dirs are left as-is
+  } catch (error) {
+    if (isExpectedRuntimePruneFailure(error)) return
+    throw error
   }
+}
+
+function isExpectedRuntimePruneFailure(error: unknown): boolean {
+  return ["ENOENT", "ENOTEMPTY", "EEXIST", "EPERM", "EBUSY", "ENOTDIR"].includes(nodeErrorCode(error) ?? "")
 }
 
 async function collectInstalledAgentPaths(codexHome: string, configPath: string): Promise<readonly string[]> {

--- a/packages/omo-opencode/src/cli/cleanup.ts
+++ b/packages/omo-opencode/src/cli/cleanup.ts
@@ -43,6 +43,9 @@ export async function cleanup(options: CleanupOptions): Promise<number> {
   for (const path of result.removedPaths) {
     console.log(`- Removed ${path}`)
   }
+  for (const skippedPath of result.skippedPaths) {
+    console.log(`- Skipped cleanup target ${skippedPath.path}: ${skippedPath.reason}`)
+  }
   for (const path of result.removedAgentLinks) {
     console.log(`- Removed managed agent link ${path}`)
   }


### PR DESCRIPTION
## Summary
Hardens LazyCodex cleanup/uninstall deletion paths for lazycodex#62 by making recursive cleanup fail closed unless the target is a known managed OMO/LazyCodex subtree under a non-root Codex home. Unsafe candidates such as home/workspace roots, Codex home itself, parent traversal targets, cache parent directories, and filesystem roots are skipped instead of removed.

## Changes
- Add `validateManagedCleanupTarget()` for managed cleanup target classification.
- Require `removeManagedPathBestEffort()` callers to pass `codexHome`, then audit skipped destructive targets through `skippedPaths`.
- Add cleanup safety tests for home/workspace-style paths, traversal-shaped parent escapes, and filesystem-root Codex homes.
- Surface skipped cleanup targets in the CLI plain-text output, while JSON output includes the structured audit field.
- Keep project-local artifacts and non-managed files intact; cleanup continues to remove only known managed cache/snapshot/runtime/bootstrap roots.

## Verification
**Automated:**
- `bun test packages/omo-codex/src/install/codex-cleanup-safety.test.ts packages/omo-codex/src/install/codex-cleanup.test.ts`  
  Evidence: `.omo/evidence/20260622-lazycodex-cleanup-safety/focused-cleanup-tests.txt`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts ...`  
  Evidence: `.omo/evidence/20260622-lazycodex-cleanup-safety/no-excuse-audit.txt`
- `bun run --cwd packages/omo-codex typecheck`  
  Evidence: `.omo/evidence/20260622-lazycodex-cleanup-safety/omo-codex-typecheck.txt`
- `bun run typecheck`  
  Evidence: `.omo/evidence/20260622-lazycodex-cleanup-safety/root-typecheck.txt`
- `bun run test:codex`  
  Evidence: `.omo/evidence/20260622-lazycodex-cleanup-safety/test-codex.txt`

**Manual / harness QA:**
- Codex QA common isolation self-check: `.omo/evidence/20260622-lazycodex-cleanup-safety/codex-qa-common-self-check.txt`
- Codex install verify self-test against isolated `CODEX_HOME`: `.omo/evidence/20260622-lazycodex-cleanup-safety/codex-install-verify-self-test.txt`
- Live `codex app-server` plugin run with mock model and hook notifications: `.omo/evidence/20260622-lazycodex-cleanup-safety/codex-app-server-plugin.json`
- Manual isolated cleanup scenario: install local LazyCodex into throwaway `CODEX_HOME`, run cleanup, assert managed cache/snapshot removed, custom agent preserved, filesystem-root cleanup refused and audited, and real `~/.codex/config.toml` unchanged.  
  Evidence: `.omo/evidence/20260622-lazycodex-cleanup-safety/manual-cleanup-qa.txt`

## Related Issues
- References lazycodex#62


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened LazyCodex cleanup to fail closed and only remove known managed subtrees under a non-root Codex home. Prevents accidental deletion of roots and parent-escape paths; skipped targets are reported in CLI and JSON. Addresses lazycodex#62.

- **Bug Fixes**
  - Added `validateManagedCleanupTarget()` and required `codexHome` in `removeManagedPathBestEffort()`; skipped targets are collected in `skippedPaths` and shown by the `cleanup` CLI.
  - Restricted deletions to managed roots: `plugins/cache/sisyphuslabs`, `.tmp/marketplaces/sisyphuslabs`, `runtime/{ast-grep,node}`, and `plugins/data/omo-sisyphuslabs/bootstrap` (including drifted bootstrap paths); all others are skipped.
  - Added tests for destructive targets, traversal escapes, and filesystem-root Codex homes; runtime prune now ignores expected FS errors.

<sup>Written for commit cbac5fe898ac8047ed6f2f460fb775fb8863ff73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

