### PR TITLE
test(codex): smoke CodeGraph MCP initialize

### DIFF
--- a/packages/omo-codex/plugin/test/component-codegraph-mcp-smoke.test.mjs
+++ b/packages/omo-codex/plugin/test/component-codegraph-mcp-smoke.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import { root } from "./aggregate-plugin-fixture.mjs";
+
+const MCP_SMOKE_TIMEOUT_MS = 45_000;
+
+test("#given built CodeGraph MCP wrapper #when an MCP client initializes #then the resolved child responds over stdio", () => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-codegraph-mcp-smoke-"));
+	try {
+		const fakeBinaryPath = join(tempRoot, "codegraph-fake.cjs");
+		writeFileSync(
+			fakeBinaryPath,
+			[
+				"#!/usr/bin/env node",
+				"const readline = require('node:readline');",
+				"const rl = readline.createInterface({ input: process.stdin });",
+				"rl.on('line', (line) => {",
+				"  const request = JSON.parse(line);",
+				"  if (request.method !== 'initialize') return;",
+				"  process.stdout.write(JSON.stringify({",
+				"    jsonrpc: '2.0',",
+				"    id: request.id,",
+				"    result: {",
+				"      protocolVersion: request.params?.protocolVersion ?? '2024-11-05',",
+				"      capabilities: { tools: { listChanged: false } },",
+				"      serverInfo: { name: 'fake-codegraph', version: '0.0.0' }",
+				"    }",
+				"  }) + '\\n');",
+				"});",
+				"",
+			].join("\n"),
+		);
+		chmodSync(fakeBinaryPath, 0o755);
+
+		const result = spawnSync(process.execPath, [join(root, "components", "codegraph", "dist", "serve.js")], {
+			cwd: root,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				HOME: tempRoot,
+				OMO_CODEGRAPH_BIN: fakeBinaryPath,
+			},
+			input: `${JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {
+					capabilities: {},
+					clientInfo: { name: "lazycodex-smoke", version: "0.0.0" },
+					protocolVersion: "2024-11-05",
+				},
+			})}\n`,
+			timeout: MCP_SMOKE_TIMEOUT_MS,
+		});
+
+		assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+		assert.equal(result.stderr, "");
+		const response = JSON.parse(result.stdout.trim());
+		assert.deepEqual(response, {
+			jsonrpc: "2.0",
+			id: 1,
+			result: {
+				capabilities: { tools: { listChanged: false } },
+				protocolVersion: "2024-11-05",
+				serverInfo: { name: "fake-codegraph", version: "0.0.0" },
+			},
+		});
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

Adds the missing Lane D coverage for LazyCodex issue #61 after #5489: a built-wrapper smoke that drives `packages/omo-codex/plugin/components/codegraph/dist/serve.js` with a resolved fake CodeGraph child and asserts a real JSON-RPC `initialize` response over stdio.

References lazycodex#61 and follows up #5489, which already merged the CodeGraph runtime/provisioning work and Windows cache-test timeout adjustment.

## Evidence

Recorded under `.omo/evidence/20260622-codegraph-issue61-coverage/` in the Lane D worktree.

- `node --test packages/omo-codex/plugin/test/component-codegraph-mcp-smoke.test.mjs` -> 1 pass
- `node --test packages/omo-codex/plugin/test/component-bundled-cli.test.mjs packages/omo-codex/plugin/test/component-codegraph-mcp-smoke.test.mjs` -> 8 pass
- `npm --prefix packages/omo-codex/plugin/components/codegraph test -- --bail` -> 42 pass
- `bun test packages/omo-codex/src/install/codex-cache-install.test.ts --bail` -> 3 pass, including stale aggregate-skills cache install target
- `bun run test:codex` -> 370 pass
- `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check` -> pass, real `~/.codex/config.toml` unchanged
- `bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test` -> pass, isolated install verified, real config unchanged
- `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` -> pass, mock app-server turn completed and hooks fired

## LazyCodex #61 closeability

Closeable once this follow-up PR passes CI: #5489 covers the runtime/provisioning side, and this PR adds the explicit stdio initialize smoke for the resolved CodeGraph serve path that reviewer feedback called out.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a smoke test that runs the built CodeGraph MCP wrapper `packages/omo-codex/plugin/components/codegraph/dist/serve.js` with a fake CodeGraph child and asserts a valid JSON-RPC `initialize` reply over stdio. Satisfies LazyCodex #61 by adding coverage for the resolved serve path.

<sup>Written for commit 51b23f738ae8e97df0435c6d9f1396b8db339577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

