### PR TITLE
fix(tui): declare optional OpenTUI solid runtime

### DIFF
--- a/packages/omo-opencode/src/types/opentui-solid.d.ts
+++ b/packages/omo-opencode/src/types/opentui-solid.d.ts
@@ -1,0 +1,5 @@
+declare module "@opentui/solid" {
+  export function createElement(tag: string): unknown
+  export function insert(parent: unknown, child: unknown): unknown
+  export function setProp(node: unknown, name: string, value: unknown): unknown
+}


### PR DESCRIPTION
## Summary
Fixes the post-merge `origin/dev` macOS typecheck failure where `packages/omo-opencode/src/tui.ts` could not resolve `@opentui/solid` types. The TUI loads OpenTUI Solid as an optional runtime dependency, so this PR adds a narrow local module declaration for the three runtime functions the sidebar materializer uses.

## Changes
- Add `packages/omo-opencode/src/types/opentui-solid.d.ts` with the optional OpenTUI Solid runtime surface used by `tui.ts`.
- Leave runtime behavior unchanged: the existing dynamic import still returns early when `@opentui/solid` is unavailable.

## Verification
Automated:
- `bun install --frozen-lockfile` passed in isolated worktree `/private/tmp/omo-fix-tui-opentui-solid-types`.
- `bun run typecheck` passed.
- Simulated missing `@opentui/solid` by temporarily moving `node_modules/@opentui/solid`, then `bun run typecheck` passed.
- `bun test packages/omo-opencode/src/tui.test.ts` passed: 3 pass, 0 fail.
- `git diff --check` passed.

Manual QA:
- `opencode-qa` TUI smoke passed under tmux: TUI rendered, `send-keys` reached composer, tmux session tore down, and the real OpenCode DB session count stayed unchanged.
- Evidence directory: `/private/tmp/omo-fix-tui-opentui-solid-types/.omo/evidence/20260622-tui-opentui-solid-types/`.

Fixes release-gate blocker from push run `27929629729`, job `82638729823`:
`packages/omo-opencode/src/tui.ts(120,32): error TS2307: Cannot find module '@opentui/solid' or its corresponding type declarations.`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix typecheck errors in the TUI when `@opentui/solid` is absent by adding `packages/omo-opencode/src/types/opentui-solid.d.ts`, which declares `createElement`, `insert`, and `setProp` used by `tui.ts`. This preserves the optional runtime: the dynamic import still no-ops if `@opentui/solid` isn’t installed.

<sup>Written for commit 671b5dfd627c40adef0d59ddef1cb601468082a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

