### PR TITLE
Fix ultimate browsing cookie path typing

### DIFF
--- a/packages/shared-skills/skills/ultimate-browsing/scripts/cookie_paths.py
+++ b/packages/shared-skills/skills/ultimate-browsing/scripts/cookie_paths.py
@@ -3,14 +3,29 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Final, Literal, TypedDict, assert_never
 
 
 class UnsupportedPlatform(ValueError):
     """Raised when a browser/platform combination is not supported."""
 
 
-BROWSERS: dict[str, dict[str, Any]] = {
+BrowserKind = Literal["chromium", "firefox"]
+
+
+class BrowserDirs(TypedDict):
+    darwin: str
+    linux: str
+    win32: str
+
+
+class BrowserSpec(TypedDict):
+    kind: BrowserKind
+    safe_storage: str | None
+    dirs: BrowserDirs
+
+
+BROWSERS: Final[dict[str, BrowserSpec]] = {
     "chrome": {
         "kind": "chromium",
         "safe_storage": "Chrome Safe Storage",
@@ -37,43 +52,61 @@ BROWSERS: dict[str, dict[str, Any]] = {
     },
 }
 
-CHROMIUM_PROFILE_DIRS = ["Default", "Profile 1", "Profile 2"]
+CHROMIUM_PROFILE_DIRS: Final = ["Default", "Profile 1", "Profile 2"]
 
 
-def platform_base(platform: str, kind: str) -> Path:
+def platform_base(platform: str, kind: BrowserKind) -> Path:
     home = Path.home()
-    if platform == "darwin":
-        return home / "Library" / "Application Support"
-    if platform == "linux":
-        if kind == "firefox":
-            return home
-        return Path(os.environ.get("XDG_CONFIG_HOME", str(home / ".config")))
-    if platform == "win32":
-        return Path(os.environ.get("LOCALAPPDATA", str(home / "AppData" / "Local")))
-    raise UnsupportedPlatform(f"unsupported platform: {platform!r}")
+    match platform:
+        case "darwin":
+            return home / "Library" / "Application Support"
+        case "linux":
+            match kind:
+                case "firefox":
+                    return home
+                case "chromium":
+                    return Path(os.environ.get("XDG_CONFIG_HOME", str(home / ".config")))
+                case unreachable:
+                    assert_never(unreachable)
+        case "win32":
+            return Path(os.environ.get("LOCALAPPDATA", str(home / "AppData" / "Local")))
+        case _:
+            raise UnsupportedPlatform(f"unsupported platform: {platform!r}")
 
 
-def resolve_cookie_db(browser: str, platform: str, base_override: Optional[Path] = None) -> Path:
+def browser_dir(spec: BrowserSpec, platform: str) -> str:
+    match platform:
+        case "darwin":
+            return spec["dirs"]["darwin"]
+        case "linux":
+            return spec["dirs"]["linux"]
+        case "win32":
+            return spec["dirs"]["win32"]
+        case _:
+            raise UnsupportedPlatform(f"browser not mapped for platform {platform!r}")
+
+
+def resolve_cookie_db(browser: str, platform: str, base_override: Path | None = None) -> Path:
     spec = BROWSERS.get(browser)
     if spec is None:
         raise UnsupportedPlatform(f"unsupported browser: {browser!r}")
-    if platform not in spec["dirs"]:
-        raise UnsupportedPlatform(f"browser {browser!r} not mapped for platform {platform!r}")
-
     base = base_override if base_override is not None else platform_base(platform, spec["kind"])
-    profile_root = base / spec["dirs"][platform]
+    profile_root = base / browser_dir(spec, platform)
 
-    if spec["kind"] == "firefox":
-        if not profile_root.exists():
-            raise FileNotFoundError(f"no Firefox profile root at {profile_root}")
-        for entry in sorted(profile_root.iterdir()):
-            db = entry / "cookies.sqlite"
-            if db.exists():
-                return db
-        raise FileNotFoundError(f"no cookies.sqlite under {profile_root}")
-
-    for profile in CHROMIUM_PROFILE_DIRS:
-        for candidate in (profile_root / profile / "Cookies", profile_root / profile / "Network" / "Cookies"):
-            if candidate.exists():
-                return candidate
-    raise FileNotFoundError(f"no Cookies DB under {profile_root}")
+    match spec["kind"]:
+        case "firefox":
+            if not profile_root.exists():
+                raise FileNotFoundError(f"no Firefox profile root at {profile_root}")
+            for entry in sorted(profile_root.iterdir()):
+                db = entry / "cookies.sqlite"
+                if db.exists():
+                    return db
+            raise FileNotFoundError(f"no cookies.sqlite under {profile_root}")
+        case "chromium":
+            for profile in CHROMIUM_PROFILE_DIRS:
+                for candidate in (profile_root / profile / "Cookies", profile_root / profile / "Network" / "Cookies"):
+                    if candidate.exists():
+                        return candidate
+            raise FileNotFoundError(f"no Cookies DB under {profile_root}")
+        case unreachable:
+            assert_never(unreachable)

--- a/packages/shared-skills/skills/ultimate-browsing/scripts/extract_cookies.py
+++ b/packages/shared-skills/skills/ultimate-browsing/scripts/extract_cookies.py
@@ -30,7 +30,7 @@ from cookie_crypto import (
     macos_keyring_secret,
     windows_oscrypt_key,
 )
-from cookie_paths import BROWSERS, UnsupportedPlatform, platform_base, resolve_cookie_db
+from cookie_paths import BROWSERS, BrowserSpec, UnsupportedPlatform, platform_base, resolve_cookie_db
 
 _SAMESITE = {-1: "None", 0: "None", 1: "Lax", 2: "Strict"}
 
@@ -61,16 +61,6 @@ class CdpCookie(TypedDict):
     httpOnly: bool
     sameSite: str
     expires: NotRequired[int]
-
-
-class BrowserDirs(TypedDict, total=False):
-    win32: str
-
-
-class BrowserSpec(TypedDict):
-    kind: str
-    safe_storage: str
-    dirs: BrowserDirs
 
 
 _CDP_SET_COOKIES_SCRIPT = r"""
@@ -206,11 +196,7 @@ def _browser_spec(browser: str) -> BrowserSpec:
     spec = BROWSERS.get(browser)
     if spec is None:
         raise UnsupportedPlatform(f"unsupported browser: {browser!r}")
-    return {
-        "kind": spec["kind"],
-        "safe_storage": spec.get("safe_storage", ""),
-        "dirs": spec.get("dirs", {}),
-    }
+    return spec
 
 
 def default_keyring_reader(platform: str, spec: BrowserSpec) -> Callable[[str], bytes]:
@@ -238,7 +224,10 @@ def extract_cookies(
     if spec["kind"] == "firefox":
         return extract_firefox(db, domains)
     reader = keyring_reader or default_keyring_reader(platform, spec)
-    key = derive_key(platform, reader(spec["safe_storage"]))
+    safe_storage = spec["safe_storage"]
+    if safe_storage is None:
+        raise UnsupportedPlatform(f"browser {browser!r} has no keyring storage name")
+    key = derive_key(platform, reader(safe_storage))
     return extract_chromium(db, domains, platform, key)
 
 


### PR DESCRIPTION
## Summary

Removes the release-blocking Python `Any` escape hatch from the new ultimate-browsing cookie path resolver. The browser metadata now has an explicit typed shape, and the cookie extractor imports that source-of-truth type instead of maintaining a duplicate loose local definition.

## Changes

- Replaces `dict[str, dict[str, Any]]` browser metadata with `BrowserSpec` / `BrowserDirs` typed records and literal browser kinds.
- Resolves platform-specific browser directories through explicit typed cases instead of dynamic untyped dictionary indexing.
- Reuses `BrowserSpec` from `cookie_paths.py` in `extract_cookies.py` and handles the `safe_storage` nullable boundary before Chromium key derivation.

## Verification

Evidence directory in the worktree: `.omo/evidence/20260622-cookie-path-types/`

- `uv run --with cryptography python -m unittest packages/shared-skills/skills/ultimate-browsing/scripts/tests/test_extract_cookies.py` ✅
- `python3 -m py_compile packages/shared-skills/skills/ultimate-browsing/scripts/cookie_paths.py packages/shared-skills/skills/ultimate-browsing/scripts/extract_cookies.py packages/shared-skills/skills/ultimate-browsing/scripts/cookie_crypto.py` ✅
- `uvx ruff check packages/shared-skills/skills/ultimate-browsing/scripts/cookie_paths.py packages/shared-skills/skills/ultimate-browsing/scripts/extract_cookies.py` ✅
- `rg -n "\\bAny\\b|typing import .*Optional|dict\\[str, dict\\[str" packages/shared-skills/skills/ultimate-browsing/scripts/cookie_paths.py packages/shared-skills/skills/ultimate-browsing/scripts/extract_cookies.py` ✅ no matches
- `git diff --check` ✅


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened typing for the ultimate-browsing cookie path resolver to remove `Any` usage and clarify platform handling. Unified the browser metadata type across `cookie_paths.py` and `extract_cookies.py` for safer key derivation and clearer errors.

- **Refactors**
  - Added `BrowserKind` (`Literal`), `BrowserDirs`, and `BrowserSpec` (`TypedDict`); marked `BROWSERS` and `CHROMIUM_PROFILE_DIRS` as `Final`.
  - Rewrote `platform_base` with `match` and added `browser_dir()`; used `assert_never` for exhaustiveness.
  - Reused `BrowserSpec` in `extract_cookies.py`; removed duplicate local types and dynamic lookups.

- **Bug Fixes**
  - Validate `safe_storage` and fail early if missing before Chromium key derivation.
  - More consistent errors for unsupported browser/platform combos and missing cookie DBs.

<sup>Written for commit 8a13d95174fbd328e171b0fefcdd2e1c2c7fb73f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

