### PR TITLE
Clarify Sparkshell-first Codex guidance

### DIFF
--- a/packages/omo-codex/plugin/components/rules/src/sparkshell-awareness.ts
+++ b/packages/omo-codex/plugin/components/rules/src/sparkshell-awareness.ts
@@ -81,9 +81,9 @@ export function getSparkShellRuntimeAwareness(env: RuntimeEnv = process.env, dep
 	return [
 		SPARKSHELL_AWARENESS_MARKER,
 		"",
-		`- Prefer \`${command} sparkshell <command>\` for repo inspection, CLI smoke tests, git/history checks, and bounded verification before falling back to raw shell commands.`,
-		`- Use \`${command} sparkshell --shell '<command>'\` only when shell metacharacters are required.`,
-		`- Use \`${command} sparkshell --tmux-pane <pane-id> --tail-lines 400\` to inspect an existing tmux pane. Tail lines must stay between 100 and 1000.`,
+		`- Use \`${command} sparkshell <command>\` first for repo inspection, CLI smoke tests, git/history checks, and bounded command output. Raw \`rg\`/\`grep\`/\`cat\`/\`git\` are fallbacks when Sparkshell is unavailable or too narrow for the task.`,
+		`- Use \`${command} sparkshell --shell '<command>'\` only for shell metacharacters or pipelines.`,
+		`- Use \`${command} sparkshell --tmux-pane <pane-id> --tail-lines 400\` only to inspect an existing pane, never to launch ordinary commands. Tail lines must stay between 100 and 1000.`,
 		"- When no native sidecar or appserver is available, Sparkshell silently falls back to raw command execution. `OMO_SPARKSHELL_BIN` selects a native sidecar path.",
 		"- When `CODEX_THREAD_ID` identifies a Codex session, Sparkshell feeds recent session context (first/latest user request + last 5 conversation messages) into oversized-output condensation for relevance ranking, but never appends that context to command output. `OMO_SPARKSHELL_SESSION_CONTEXT=0` disables the lookup.",
 		`- Route potentially huge output (full log files, big diffs, \`cat\`/\`grep\` over large artifacts) through \`${command} sparkshell\` instead of reading it raw: oversized output is condensed to a budget while preserving error signatures, repeated patterns, session-goal-relevant lines, and head/tail. Tune with \`--budget <chars>\`; disable with \`OMO_SPARKSHELL_CONDENSE=0\`.`,

--- a/packages/omo-codex/plugin/components/rules/test/sparkshell-awareness.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/sparkshell-awareness.test.ts
@@ -85,15 +85,23 @@ describe("Codex Sparkshell awareness", () => {
 		);
 
 		// then
-		expect(parseAdditionalContext(output)).toContain("omo sparkshell <command>");
-		expect(parseAdditionalContext(output)).toContain("OMO_SPARKSHELL_SESSION_CONTEXT");
-		expect(parseAdditionalContext(output)).toContain("OMO_SPARKSHELL_CONDENSE");
-		expect(parseAdditionalContext(output)).toContain("OMO_SPARKSHELL_SPARK");
-		expect(parseAdditionalContext(output)).toContain("[sparkshell caption]");
-		expect(parseAdditionalContext(output)).toContain("never appends that context to command output");
-		expect(parseAdditionalContext(output)).toContain("what the full output contained");
-		expect(parseAdditionalContext(output)).not.toContain("[REDACTED]");
-		expect(parseAdditionalContext(output)).not.toContain("appends recent session context");
+		const context = parseAdditionalContext(output);
+		expect(context).toContain("Use `omo sparkshell <command>` first for repo inspection");
+		expect(context).toContain("CLI smoke tests");
+		expect(context).toContain("git/history checks");
+		expect(context).toContain("bounded command output");
+		expect(context).toContain("Raw `rg`/`grep`/`cat`/`git` are fallbacks");
+		expect(context).toContain("Sparkshell is unavailable or too narrow");
+		expect(context).toContain("`omo sparkshell --shell '<command>'` only for shell metacharacters or pipelines");
+		expect(context).toContain("`omo sparkshell --tmux-pane <pane-id> --tail-lines 400` only to inspect an existing pane, never to launch ordinary commands");
+		expect(context).toContain("OMO_SPARKSHELL_SESSION_CONTEXT");
+		expect(context).toContain("OMO_SPARKSHELL_CONDENSE");
+		expect(context).toContain("OMO_SPARKSHELL_SPARK");
+		expect(context).toContain("[sparkshell caption]");
+		expect(context).toContain("never appends that context to command output");
+		expect(context).toContain("what the full output contained");
+		expect(context).not.toContain("[REDACTED]");
+		expect(context).not.toContain("appends recent session context");
 	});
 
 	it("#given inactive env #when SessionStart runs #then emits no Sparkshell guidance", async () => {

--- a/packages/omo-codex/plugin/components/rules/test/sparkshell-awareness.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/sparkshell-awareness.test.ts
@@ -19,6 +19,29 @@ function parseAdditionalContext(output: string): string {
 	return parsed.hookSpecificOutput?.additionalContext ?? "";
 }
 
+function normalizeGuidance(value: string): string {
+	return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function expectSparkshellFirstContract(value: string): void {
+	const guidance = normalizeGuidance(value);
+
+	expect(guidance).toMatch(/`omo sparkshell <command>`[^.]*\bfirst\b/);
+	expect(guidance).toMatch(/\brepo inspection\b/);
+	expect(guidance).toMatch(/\bcli smoke tests\b/);
+	expect(guidance).toMatch(/\bgit\/history checks\b/);
+	expect(guidance).toMatch(/\bbounded command output\b/);
+	expect(guidance).toMatch(/\braw\b[^.]*`rg`\/`grep`\/`cat`\/`git`[^.]*\bfallbacks?\b/);
+	expect(guidance).toMatch(/\bsparkshell is unavailable\b/);
+	expect(guidance).toMatch(/\btoo narrow\b/);
+	expect(guidance).toMatch(/`omo sparkshell --shell '<command>'`[^.]*\bmetacharacters\b[^.]*\bpipelines\b/);
+	expect(guidance).toMatch(
+		/`omo sparkshell --tmux-pane <pane-id> --tail-lines 400`[^.]*\bonly\b[^.]*\binspect\b[^.]*\bexisting pane\b/,
+	);
+	expect(guidance).toMatch(/`omo sparkshell --tmux-pane <pane-id> --tail-lines 400`[^.]*\bnever\b[^.]*\blaunch ordinary commands\b/);
+	expect(guidance).not.toMatch(/\bprefer\b[^.]*\bbefore raw shell commands\b/);
+}
+
 function parseHookOutput(value: unknown): HookOutput {
 	if (typeof value !== "object" || value === null) {
 		return {};
@@ -86,14 +109,7 @@ describe("Codex Sparkshell awareness", () => {
 
 		// then
 		const context = parseAdditionalContext(output);
-		expect(context).toContain("Use `omo sparkshell <command>` first for repo inspection");
-		expect(context).toContain("CLI smoke tests");
-		expect(context).toContain("git/history checks");
-		expect(context).toContain("bounded command output");
-		expect(context).toContain("Raw `rg`/`grep`/`cat`/`git` are fallbacks");
-		expect(context).toContain("Sparkshell is unavailable or too narrow");
-		expect(context).toContain("`omo sparkshell --shell '<command>'` only for shell metacharacters or pipelines");
-		expect(context).toContain("`omo sparkshell --tmux-pane <pane-id> --tail-lines 400` only to inspect an existing pane, never to launch ordinary commands");
+		expectSparkshellFirstContract(context);
 		expect(context).toContain("OMO_SPARKSHELL_SESSION_CONTEXT");
 		expect(context).toContain("OMO_SPARKSHELL_CONDENSE");
 		expect(context).toContain("OMO_SPARKSHELL_SPARK");

--- a/packages/omo-codex/plugin/components/ultrawork/agents/explorer.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/explorer.toml
@@ -46,7 +46,7 @@ If asked "where is auth?", explain the auth flow you found.]
 </results>
 
 # Tool strategy (parallel, flood the first wave)
-- Prefer `omo sparkshell <command>` before raw shell commands for repo-wide inspection, CLI smoke tests, git/history checks, and bounded command output. Use `omo sparkshell --shell '<command>'` only when shell metacharacters are required. Use `omo sparkshell --tmux-pane <pane-id> --tail-lines 400` only to inspect an existing tmux pane.
+- Use `omo sparkshell <command>` first for repo-wide inspection, CLI smoke tests, git/history checks, and bounded command output. Raw `rg`/`grep`/`cat`/`git` are fallbacks when Sparkshell is unavailable or too narrow. Use `omo sparkshell --shell '<command>'` only for shell metacharacters or pipelines. Use `omo sparkshell --tmux-pane <pane-id> --tail-lines 400` only to inspect an existing tmux pane, never to launch ordinary commands.
 - Symbol questions -> `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols`, `lsp_diagnostics`.
 - Structural shapes -> the `ast-grep` skill helper or `sg` CLI with `$VAR` / `$$$` metavars.
 - Text / strings / comments / logs -> `rg` (grep).

--- a/packages/omo-codex/plugin/components/ultrawork/directive.md
+++ b/packages/omo-codex/plugin/components/ultrawork/directive.md
@@ -178,10 +178,11 @@ serialize only when one output strictly feeds the next.
   inactive/uninitialized, or cold-start unavailable, keep moving with
   Read/Grep/Glob/LSP and the ast-grep skill.
 - Repo-wide inspection, CLI smoke tests, git/history, bounded command
-  output → prefer `omo sparkshell <command>` before raw shell commands
-  (use `omo sparkshell --shell '<cmd>'` only when shell metacharacters
-  are required; `--tmux-pane <id> --tail-lines N` only to inspect an
-  existing pane). Sparkshell is your default lens on the tree.
+  output → use `omo sparkshell <command>` first. Raw
+  `rg`/`grep`/`cat`/`git` are fallbacks when Sparkshell is unavailable
+  or too narrow. `--shell` is only for shell metacharacters or
+  pipelines; `--tmux-pane` is only for inspecting an existing pane,
+  never for launching ordinary commands. Sparkshell is your default lens.
 - Symbols — definitions, references, rename impact, diagnostics →
   `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols`,
   `lsp_diagnostics`. Use the LSP, not text search, for anything

--- a/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
@@ -52,9 +52,11 @@ describe("codex ultrawork package metadata", () => {
 	it("#given explorer guidance #when inspected #then starts codebase inspection with Sparkshell", () => {
 		// given
 		const explorer = readTextFile("agents/explorer.toml");
+		const directive = readTextFile("directive.md");
 
 		// when
 		const guidance = explorer.toLowerCase();
+		const directiveGuidance = directive.toLowerCase().replace(/\s+/g, " ");
 		const sparkshellIndex = guidance.indexOf("omo sparkshell <command>");
 		const lspIndex = guidance.indexOf("lsp_goto_definition");
 		const structuralIndex = guidance.indexOf("ast-grep");
@@ -63,9 +65,15 @@ describe("codex ultrawork package metadata", () => {
 		expect(sparkshellIndex).toBeGreaterThanOrEqual(0);
 		expect(lspIndex).toBeGreaterThan(sparkshellIndex);
 		expect(structuralIndex).toBeGreaterThan(sparkshellIndex);
-		expect(guidance).toContain("prefer `omo sparkshell <command>` before raw shell commands");
-		expect(guidance).toContain("--shell '<command>'");
-		expect(guidance).toContain("--tmux-pane");
+		expect(guidance).toContain("use `omo sparkshell <command>` first for repo-wide inspection");
+		expect(guidance).toContain("raw `rg`/`grep`/`cat`/`git` are fallbacks");
+		expect(guidance).toContain("sparkshell is unavailable or too narrow");
+		expect(guidance).toContain("sparkshell --shell '<command>'` only for shell metacharacters or pipelines");
+		expect(guidance).toContain("sparkshell --tmux-pane <pane-id> --tail-lines 400` only to inspect an existing tmux pane, never to launch ordinary commands");
+		expect(directiveGuidance).toContain("use `omo sparkshell <command>` first");
+		expect(directiveGuidance).toContain("raw `rg`/`grep`/`cat`/`git` are fallbacks when sparkshell is unavailable or too narrow");
+		expect(directiveGuidance).toContain("`--shell` is only for shell metacharacters or pipelines");
+		expect(directiveGuidance).toContain("`--tmux-pane` is only for inspecting an existing pane, never for launching ordinary commands");
 	});
 
 	it("#given librarian guidance #when inspected #then names the packaged research MCP surfaces", () => {

--- a/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
@@ -8,6 +8,27 @@ import {
 	requireScripts,
 } from "../../test-support/package-smoke-fixture.js";
 
+function normalizeGuidance(value: string): string {
+	return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function expectSparkshellToolStrategyContract(value: string): void {
+	const guidance = normalizeGuidance(value);
+
+	expect(guidance).toMatch(/`omo sparkshell <command>`[^.]*\bfirst\b/);
+	expect(guidance).toMatch(/\brepo-wide inspection\b/);
+	expect(guidance).toMatch(/\bcli smoke tests\b/);
+	expect(guidance).toMatch(/\bgit\/history\b/);
+	expect(guidance).toMatch(/\bbounded command output\b/);
+	expect(guidance).toMatch(/\braw\b[^.]*`rg`\/`grep`\/`cat`\/`git`[^.]*\bfallbacks?\b/);
+	expect(guidance).toMatch(/\bsparkshell is unavailable\b/);
+	expect(guidance).toMatch(/\btoo narrow\b/);
+	expect(guidance).toMatch(/--shell[^.]*\bmetacharacters\b[^.]*\bpipelines\b/);
+	expect(guidance).toMatch(/--tmux-pane[^.]*\bonly\b[^.]*\binspect(?:ing)?\b[^.]*\bexisting (?:tmux )?pane\b/);
+	expect(guidance).toMatch(/--tmux-pane[^.]*\bnever\b[^.]*\blaunch(?:ing)? ordinary commands\b/);
+	expect(guidance).not.toMatch(/\bprefer\b[^.]*\bbefore raw shell commands\b/);
+}
+
 describe("codex ultrawork package metadata", () => {
 	it("#given package metadata #when inspected #then hook ships as bundled CLI", () => {
 		// given
@@ -56,7 +77,6 @@ describe("codex ultrawork package metadata", () => {
 
 		// when
 		const guidance = explorer.toLowerCase();
-		const directiveGuidance = directive.toLowerCase().replace(/\s+/g, " ");
 		const sparkshellIndex = guidance.indexOf("omo sparkshell <command>");
 		const lspIndex = guidance.indexOf("lsp_goto_definition");
 		const structuralIndex = guidance.indexOf("ast-grep");
@@ -65,15 +85,8 @@ describe("codex ultrawork package metadata", () => {
 		expect(sparkshellIndex).toBeGreaterThanOrEqual(0);
 		expect(lspIndex).toBeGreaterThan(sparkshellIndex);
 		expect(structuralIndex).toBeGreaterThan(sparkshellIndex);
-		expect(guidance).toContain("use `omo sparkshell <command>` first for repo-wide inspection");
-		expect(guidance).toContain("raw `rg`/`grep`/`cat`/`git` are fallbacks");
-		expect(guidance).toContain("sparkshell is unavailable or too narrow");
-		expect(guidance).toContain("sparkshell --shell '<command>'` only for shell metacharacters or pipelines");
-		expect(guidance).toContain("sparkshell --tmux-pane <pane-id> --tail-lines 400` only to inspect an existing tmux pane, never to launch ordinary commands");
-		expect(directiveGuidance).toContain("use `omo sparkshell <command>` first");
-		expect(directiveGuidance).toContain("raw `rg`/`grep`/`cat`/`git` are fallbacks when sparkshell is unavailable or too narrow");
-		expect(directiveGuidance).toContain("`--shell` is only for shell metacharacters or pipelines");
-		expect(directiveGuidance).toContain("`--tmux-pane` is only for inspecting an existing pane, never for launching ordinary commands");
+		expectSparkshellToolStrategyContract(explorer);
+		expectSparkshellToolStrategyContract(directive);
 	});
 
 	it("#given librarian guidance #when inspected #then names the packaged research MCP surfaces", () => {

--- a/packages/prompts-core/prompts/ultrawork/codex.md
+++ b/packages/prompts-core/prompts/ultrawork/codex.md
@@ -178,10 +178,11 @@ serialize only when one output strictly feeds the next.
   inactive/uninitialized, or cold-start unavailable, keep moving with
   Read/Grep/Glob/LSP and the ast-grep skill.
 - Repo-wide inspection, CLI smoke tests, git/history, bounded command
-  output → prefer `omo sparkshell <command>` before raw shell commands
-  (use `omo sparkshell --shell '<cmd>'` only when shell metacharacters
-  are required; `--tmux-pane <id> --tail-lines N` only to inspect an
-  existing pane). Sparkshell is your default lens on the tree.
+  output → use `omo sparkshell <command>` first. Raw
+  `rg`/`grep`/`cat`/`git` are fallbacks when Sparkshell is unavailable
+  or too narrow. `--shell` is only for shell metacharacters or
+  pipelines; `--tmux-pane` is only for inspecting an existing pane,
+  never for launching ordinary commands. Sparkshell is your default lens.
 - Symbols — definitions, references, rename impact, diagnostics →
   `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols`,
   `lsp_diagnostics`. Use the LSP, not text search, for anything


### PR DESCRIPTION
## Summary
This PR tightens Codex-side Sparkshell guidance after investigating local session patterns where agents confused normal command execution, raw shell fallbacks, and `--tmux-pane` capture usage.

The originally named Codex session `019eedd3-1fc8-7242-9990-9974eb4590b3` was not present in local stores, so the fix is based on nearby concrete patterns captured in `.omo/evidence/20260622-sparkshell-guidance/session-patterns.txt`: direct command vs tmux confusion, weak Sparkshell guidance, and CLI routing context.

## Changes
- Codex rules `SessionStart` Sparkshell awareness now says to use `omo sparkshell <command>` first for repo inspection, CLI smoke tests, git/history checks, and bounded output.
- The same runtime guidance now names raw `rg`/`grep`/`cat`/`git` as fallbacks only when Sparkshell is unavailable or too narrow.
- `--shell` is scoped to shell metacharacters/pipelines, and `--tmux-pane` is scoped to inspecting an existing pane, never launching ordinary commands.
- Ultrawork Codex prompt, generated directive, and explorer agent guidance now use the same Sparkshell-first framing.
- Tests pin both the runtime rules guidance and the ultrawork packaged prompt guidance.

## Verification
**Automated**
- `npm --prefix packages/omo-codex/plugin/components/rules exec -- vitest --run --no-file-parallelism test/sparkshell-awareness.test.ts` ✅
  - Evidence: `.omo/evidence/20260622-sparkshell-guidance/rules-sparkshell-awareness-green.txt`
- `(cd packages/omo-codex/plugin/components/ultrawork && npm exec -- vitest --run test/package-smoke.test.ts)` ✅
  - Evidence: `.omo/evidence/20260622-sparkshell-guidance/ultrawork-package-smoke-green.txt`
- `npm --prefix packages/omo-codex/plugin/components/rules run build --silent` ✅
  - Evidence: `.omo/evidence/20260622-sparkshell-guidance/rules-build.txt`
- `bun run test:codex` ✅
  - Evidence: `.omo/evidence/20260622-sparkshell-guidance/bun-run-test-codex.txt`
- `git diff --check` ✅
  - Evidence: `.omo/evidence/20260622-sparkshell-guidance/git-diff-check.txt`

**Failing-first / regression evidence**
- Runtime rules RED→GREEN: `.omo/evidence/20260622-sparkshell-guidance/rules-sparkshell-awareness-redgreen.txt`
- Ultrawork prompt RED→GREEN: `.omo/evidence/20260622-sparkshell-guidance/ultrawork-sparkshell-redgreen.txt`
- Prompt size check: `.omo/evidence/20260622-sparkshell-guidance/ultrawork-prompt-size.txt`

**Manual QA / real Codex harness**
- `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` ✅
  - Evidence: `.omo/evidence/20260622-sparkshell-guidance/codex-app-server-drive.json`
  - Proves live `hook/started` and `hook/completed` notifications for `sessionStart` and `userPromptSubmit` through isolated `CODEX_HOME` + local mock model.
  - Proves the real `~/.codex/config.toml` shasum remained unchanged.
- Direct rules hook execution: `.omo/evidence/20260622-sparkshell-guidance/rules-session-start-direct.json`

## Notes
- The prompt edit is a misframing fix, not a new capability: it replaces soft “prefer before raw shell” language with explicit first-use and fallback boundaries.
- `packages/omo-codex/plugin/components/ultrawork/directive.md` was regenerated from `packages/prompts-core/prompts/ultrawork/codex.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Sparkshell-first guidance so agents default to `omo sparkshell <command>` for repo inspection and bounded output, with clear fallbacks and option scopes. Adds contract-level tests that enforce this wording across Codex runtime and Ultrawork prompts.

- **Bug Fixes**
  - Updated `packages/omo-codex/plugin/components/rules` to: use `omo sparkshell <command>` first; treat raw `rg`/`grep`/`cat`/`git` as fallbacks; scope `--shell` to metacharacters/pipelines; scope `--tmux-pane` to inspecting an existing pane (not launching commands).
  - Aligned `packages/omo-codex/plugin/components/ultrawork/agents/explorer.toml`, `packages/omo-codex/plugin/components/ultrawork/directive.md`, and `packages/prompts-core/prompts/ultrawork/codex.md` with the same Sparkshell-first wording.
  - Strengthened tests in `packages/omo-codex/plugin/components/rules/test` and `packages/omo-codex/plugin/components/ultrawork/test` with contract assertions that require “use first,” validate raw-tool fallbacks, and enforce `--shell`/`--tmux-pane` scopes across both the runtime rules and the packaged Explorer/Directive.

<sup>Written for commit 58224675d270ba9afb9d012181b0f8a40e7f8849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

