### PR TITLE
Fix run JSON parent wake completion race

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/background-task-marker.ts
+++ b/packages/omo-opencode/src/features/background-agent/background-task-marker.ts
@@ -1,0 +1,41 @@
+import { setContinuationMarkerSource } from "../run-continuation-state"
+
+export const BACKGROUND_COMPLETION_WAKE_PENDING_REASON = "background completion wake pending"
+
+export type BackgroundTaskMarkerInput = {
+  readonly directory: string
+  readonly parentSessionID: string
+  readonly activeTaskCount: number
+  readonly hasUndeliveredParentWake: boolean
+}
+
+export function writeBackgroundTaskMarker(input: BackgroundTaskMarkerInput): void {
+  if (input.activeTaskCount > 0) {
+    setContinuationMarkerSource(
+      input.directory,
+      input.parentSessionID,
+      "background-task",
+      "active",
+      `${input.activeTaskCount} background task(s) active`,
+    )
+    return
+  }
+
+  if (input.hasUndeliveredParentWake) {
+    setContinuationMarkerSource(
+      input.directory,
+      input.parentSessionID,
+      "background-task",
+      "active",
+      BACKGROUND_COMPLETION_WAKE_PENDING_REASON,
+    )
+    return
+  }
+
+  setContinuationMarkerSource(
+    input.directory,
+    input.parentSessionID,
+    "background-task",
+    "idle",
+  )
+}

--- a/packages/omo-opencode/src/features/background-agent/manager-continuation-marker.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-continuation-marker.test.ts
@@ -12,6 +12,8 @@ import { BackgroundManager } from "./manager"
 type ParentWakeNotifierForMarkerTest = {
   readonly reserveNotificationPreparation: (sessionID: string) => void
   readonly releaseNotificationPreparation: (sessionID: string) => void
+  readonly requeueDispatchedParentWake: (sessionID: string, reason: string) => Promise<boolean>
+  readonly requeueDispatchedParentWakeAfterEmptyAssistantTurn: (sessionID: string) => boolean
 }
 
 type BackgroundManagerMarkerInternals = BackgroundManager & {
@@ -149,6 +151,63 @@ describe("BackgroundManager run continuation marker parent-wake races", () => {
       // then
       const marker = readContinuationMarker(directory, parentSessionID)
       expect(marker?.sources["background-task"]?.state).toBe("idle")
+    } finally {
+      manager.shutdown()
+    }
+  })
+
+  test("#given a dispatched completion wake is requeued after session.error #when the prompt failure requeue returns #then the marker is active immediately", async () => {
+    // given
+    const directory = createTestDirectory()
+    const parentSessionID = "parent-session-error-requeue"
+    const manager = createManager(directory)
+    const internals = unsafeTestValue<BackgroundManagerMarkerInternals>(manager)
+    const notification = "ALL BACKGROUND TASKS COMPLETE\nTask bg_789 completed."
+
+    try {
+      internals.queuePendingParentWake(parentSessionID, notification, {}, true, 10_000)
+      await internals.flushPendingParentWake(parentSessionID)
+      const dispatchedMarker = readContinuationMarker(directory, parentSessionID)
+      expect(dispatchedMarker?.sources["background-task"]?.state).toBe("idle")
+
+      // when
+      const requeued = await internals.parentWakeNotifier.requeueDispatchedParentWake(
+        parentSessionID,
+        "session.error",
+      )
+
+      // then
+      expect(requeued).toBe(true)
+      const requeuedMarker = readContinuationMarker(directory, parentSessionID)
+      expect(requeuedMarker?.sources["background-task"]?.state).toBe("active")
+      expect(requeuedMarker?.sources["background-task"]?.reason).toBe(BACKGROUND_COMPLETION_WAKE_PENDING_REASON)
+    } finally {
+      manager.shutdown()
+    }
+  })
+
+  test("#given a dispatched completion wake is requeued after an empty assistant turn #when the retry is queued #then the marker is active immediately", async () => {
+    // given
+    const directory = createTestDirectory()
+    const parentSessionID = "parent-empty-assistant-turn-requeue"
+    const manager = createManager(directory)
+    const internals = unsafeTestValue<BackgroundManagerMarkerInternals>(manager)
+    const notification = "ALL BACKGROUND TASKS COMPLETE\nTask bg_empty completed."
+
+    try {
+      internals.queuePendingParentWake(parentSessionID, notification, {}, true, 10_000)
+      await internals.flushPendingParentWake(parentSessionID)
+      const dispatchedMarker = readContinuationMarker(directory, parentSessionID)
+      expect(dispatchedMarker?.sources["background-task"]?.state).toBe("idle")
+
+      // when
+      const requeued = internals.parentWakeNotifier.requeueDispatchedParentWakeAfterEmptyAssistantTurn(parentSessionID)
+
+      // then
+      expect(requeued).toBe(true)
+      const requeuedMarker = readContinuationMarker(directory, parentSessionID)
+      expect(requeuedMarker?.sources["background-task"]?.state).toBe("active")
+      expect(requeuedMarker?.sources["background-task"]?.reason).toBe(BACKGROUND_COMPLETION_WAKE_PENDING_REASON)
     } finally {
       manager.shutdown()
     }

--- a/packages/omo-opencode/src/features/background-agent/manager-continuation-marker.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-continuation-marker.test.ts
@@ -64,6 +64,24 @@ function createManager(directory: string): BackgroundManager {
   return new BackgroundManager({ pluginContext })
 }
 
+async function waitForBackgroundTaskMarkerState(
+  directory: string,
+  parentSessionID: string,
+  expectedState: "active" | "idle",
+): Promise<void> {
+  const deadline = Date.now() + 1_000
+  let observedState: string | undefined
+  while (Date.now() < deadline) {
+    const marker = readContinuationMarker(directory, parentSessionID)
+    observedState = marker?.sources["background-task"]?.state
+    if (observedState === expectedState) {
+      return
+    }
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(`Timed out waiting for background-task marker ${expectedState}; last state: ${observedState ?? "missing"}`)
+}
+
 describe("BackgroundManager run continuation marker parent-wake races", () => {
   test("#given no active child tasks but a completion parent wake is preparing #when refreshing the run marker #then the marker remains active", () => {
     // given
@@ -110,6 +128,27 @@ describe("BackgroundManager run continuation marker parent-wake races", () => {
       // then
       const dispatchedMarker = readContinuationMarker(directory, parentSessionID)
       expect(dispatchedMarker?.sources["background-task"]?.state).toBe("idle")
+    } finally {
+      manager.shutdown()
+    }
+  })
+
+  test("#given a completion parent wake is queued on the scheduled timer #when the timer flush accepts it #then the marker returns idle", async () => {
+    // given
+    const directory = createTestDirectory()
+    const parentSessionID = "parent-timer-wake"
+    const manager = createManager(directory)
+    const internals = unsafeTestValue<BackgroundManagerMarkerInternals>(manager)
+    const notification = "ALL BACKGROUND TASKS COMPLETE\nTask bg_456 completed."
+
+    try {
+      // when
+      internals.queuePendingParentWake(parentSessionID, notification, {}, true, 0)
+      await waitForBackgroundTaskMarkerState(directory, parentSessionID, "idle")
+
+      // then
+      const marker = readContinuationMarker(directory, parentSessionID)
+      expect(marker?.sources["background-task"]?.state).toBe("idle")
     } finally {
       manager.shutdown()
     }

--- a/packages/omo-opencode/src/features/background-agent/manager-continuation-marker.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-continuation-marker.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
+import { readContinuationMarker } from "../run-continuation-state"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { BACKGROUND_COMPLETION_WAKE_PENDING_REASON } from "./background-task-marker"
+import { BackgroundManager } from "./manager"
+
+type ParentWakeNotifierForMarkerTest = {
+  readonly reserveNotificationPreparation: (sessionID: string) => void
+  readonly releaseNotificationPreparation: (sessionID: string) => void
+}
+
+type BackgroundManagerMarkerInternals = BackgroundManager & {
+  readonly parentWakeNotifier: ParentWakeNotifierForMarkerTest
+  readonly updateBackgroundTaskMarker: (parentSessionID: string) => void
+  readonly queuePendingParentWake: (
+    sessionID: string,
+    notification: string,
+    promptContext: Record<string, never>,
+    shouldReply: boolean,
+    delayMs?: number,
+  ) => void
+  readonly flushPendingParentWake: (sessionID: string) => Promise<void>
+}
+
+const testDirectories: string[] = []
+
+afterEach(() => {
+  releaseAllPromptAsyncReservationsForTesting()
+  while (testDirectories.length > 0) {
+    const directory = testDirectories.pop()
+    if (directory) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  }
+})
+
+function createTestDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "omo-bg-marker-"))
+  testDirectories.push(directory)
+  return directory
+}
+
+function createManager(directory: string): BackgroundManager {
+  const promptAsyncCalls: unknown[] = []
+  const pluginContext = unsafeTestValue<PluginInput>({
+    client: {
+      session: {
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+        promptAsync: async (input: unknown) => {
+          promptAsyncCalls.push(input)
+          return { data: {} }
+        },
+        status: async () => ({ data: {} }),
+      },
+    },
+    directory,
+  })
+  return new BackgroundManager({ pluginContext })
+}
+
+describe("BackgroundManager run continuation marker parent-wake races", () => {
+  test("#given no active child tasks but a completion parent wake is preparing #when refreshing the run marker #then the marker remains active", () => {
+    // given
+    const directory = createTestDirectory()
+    const parentSessionID = "parent-preparing-wake"
+    const manager = createManager(directory)
+    const internals = unsafeTestValue<BackgroundManagerMarkerInternals>(manager)
+    internals.parentWakeNotifier.reserveNotificationPreparation(parentSessionID)
+
+    try {
+      // when
+      internals.updateBackgroundTaskMarker(parentSessionID)
+
+      // then
+      const marker = readContinuationMarker(directory, parentSessionID)
+      expect(marker?.sources["background-task"]?.state).toBe("active")
+      expect(marker?.sources["background-task"]?.reason).toBe(BACKGROUND_COMPLETION_WAKE_PENDING_REASON)
+    } finally {
+      internals.parentWakeNotifier.releaseNotificationPreparation(parentSessionID)
+      manager.shutdown()
+    }
+  })
+
+  test("#given a completion parent wake is queued #when dispatch accepts it #then the marker returns idle", async () => {
+    // given
+    const directory = createTestDirectory()
+    const parentSessionID = "parent-queued-wake"
+    const manager = createManager(directory)
+    const internals = unsafeTestValue<BackgroundManagerMarkerInternals>(manager)
+    const notification = "ALL BACKGROUND TASKS COMPLETE\nTask bg_123 completed."
+
+    try {
+      // when
+      internals.queuePendingParentWake(parentSessionID, notification, {}, true, 10_000)
+
+      // then
+      const queuedMarker = readContinuationMarker(directory, parentSessionID)
+      expect(queuedMarker?.sources["background-task"]?.state).toBe("active")
+      expect(queuedMarker?.sources["background-task"]?.reason).toBe(BACKGROUND_COMPLETION_WAKE_PENDING_REASON)
+
+      // when
+      await internals.flushPendingParentWake(parentSessionID)
+
+      // then
+      const dispatchedMarker = readContinuationMarker(directory, parentSessionID)
+      expect(dispatchedMarker?.sources["background-task"]?.state).toBe("idle")
+    } finally {
+      manager.shutdown()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -306,6 +306,7 @@ export class BackgroundManager {
         client: this.client,
         directory: this.directory,
         enqueueNotificationForParent: this.enqueueNotificationForParent.bind(this),
+        onPendingWakeRequeued: (sessionID) => this.updateBackgroundTaskMarker(sessionID),
         onScheduledFlushSettled: (sessionID) => this.updateBackgroundTaskMarker(sessionID),
       },
       {

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -1,7 +1,6 @@
 import { join } from "node:path"
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundTaskConfig, TmuxConfig } from "../../config/schema"
-import { setContinuationMarkerSource } from "../../features/run-continuation-state"
 import type { ModelFallbackControllerAccessor } from "../../hooks/model-fallback"
 import {
   dispatchInternalPrompt,
@@ -50,6 +49,7 @@ import {
   type BackgroundTaskNotificationTask,
   buildBackgroundTaskNotificationText,
 } from "./background-task-notification-template"
+import { writeBackgroundTaskMarker } from "./background-task-marker"
 import {
   findNearestMessageExcludingCompaction,
   resolvePromptContextFromSessionMessages,
@@ -1107,28 +1107,27 @@ The fallback retry session is now created and can be inspected directly.
    * would report false between the status flip and the wake landing in the pending map.
    */
   hasPendingParentWake(sessionID: string): boolean {
+    return this.hasUndeliveredParentWake(sessionID) || this.parentWakeNotifier.getDispatchedParentWakes().has(sessionID)
+  }
+
+  private hasUndeliveredParentWake(sessionID: string): boolean {
     return (
       this.parentWakeNotifier.hasNotificationPreparation(sessionID) ||
       this.parentWakeNotifier.getPendingParentWakes().has(sessionID) ||
       this.parentWakeNotifier.getPendingParentWakeTimers().has(sessionID) ||
-      this.parentWakeNotifier.hasInFlightParentWakeDispatch(sessionID) ||
-      this.parentWakeNotifier.getDispatchedParentWakes().has(sessionID)
+      this.parentWakeNotifier.hasInFlightParentWakeDispatch(sessionID)
     )
   }
 
   private updateBackgroundTaskMarker(parentSessionID: string): void {
     const tasks = this.getTasksByParentSession(parentSessionID)
     const activeTasks = tasks.filter(t => t.status === "running" || t.status === "pending")
-    if (activeTasks.length > 0) {
-      setContinuationMarkerSource(
-        this.directory, parentSessionID, "background-task", "active",
-        `${activeTasks.length} background task(s) active`,
-      )
-    } else {
-      setContinuationMarkerSource(
-        this.directory, parentSessionID, "background-task", "idle",
-      )
-    }
+    writeBackgroundTaskMarker({
+      directory: this.directory,
+      parentSessionID,
+      activeTaskCount: activeTasks.length,
+      hasUndeliveredParentWake: this.hasUndeliveredParentWake(parentSessionID),
+    })
   }
 
   getAllDescendantTasks(sessionID: string): BackgroundTask[] {
@@ -2799,10 +2798,15 @@ The task was re-queued on a fallback model after a retryable failure.
     delayMs?: number,
   ): void {
     this.parentWakeNotifier.queuePendingParentWake(sessionID, notification, promptContext, shouldReply, delayMs)
+    this.updateBackgroundTaskMarker(sessionID)
   }
 
   private async flushPendingParentWake(sessionID: string): Promise<void> {
-    await this.parentWakeNotifier.flushPendingParentWake(sessionID)
+    try {
+      await this.parentWakeNotifier.flushPendingParentWake(sessionID)
+    } finally {
+      this.updateBackgroundTaskMarker(sessionID)
+    }
   }
 
   private hasRunningTasks(): boolean {

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -306,6 +306,7 @@ export class BackgroundManager {
         client: this.client,
         directory: this.directory,
         enqueueNotificationForParent: this.enqueueNotificationForParent.bind(this),
+        onScheduledFlushSettled: (sessionID) => this.updateBackgroundTaskMarker(sessionID),
       },
       {
         pendingRetryMs: PENDING_PARENT_WAKE_RETRY_MS,

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -144,7 +144,13 @@ export class ParentWakeFlushRunner {
   }
 
   schedulePendingParentWakeFlush(sessionID: string, delayMs?: number): void {
-    this.deps.pendingQueue.scheduleFlush(sessionID, () => this.flushPendingParentWake(sessionID), delayMs)
+    this.deps.pendingQueue.scheduleFlush(sessionID, async () => {
+      try {
+        await this.flushPendingParentWake(sessionID)
+      } finally {
+        this.deps.notifierDeps.onScheduledFlushSettled?.(sessionID)
+      }
+    }, delayMs)
   }
 
   // Reply-required wakes must never be consumed by an admit-only noReply

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
@@ -29,6 +29,7 @@ export type ParentWakeNotifierDeps = {
     parentSessionID: string | undefined,
     operation: () => Promise<void>,
   ) => Promise<void>
+  readonly onPendingWakeRequeued?: (sessionID: string) => void
   readonly onScheduledFlushSettled?: (sessionID: string) => void
 }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
@@ -29,6 +29,7 @@ export type ParentWakeNotifierDeps = {
     parentSessionID: string | undefined,
     operation: () => Promise<void>,
   ) => Promise<void>
+  readonly onScheduledFlushSettled?: (sessionID: string) => void
 }
 
 export type ParentWakeNotifierOptions = {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
@@ -20,11 +20,13 @@ export class ParentWakeNotifier {
   private readonly dispatchedTracker: ParentWakeDispatchedTracker
   private readonly sessionInspector: ParentWakeSessionInspector
   private readonly flushRunner: ParentWakeFlushRunner
+  private readonly onPendingWakeRequeued?: (sessionID: string) => void
 
   constructor(
     deps: ParentWakeNotifierDeps,
     options: ParentWakeNotifierOptions,
   ) {
+    this.onPendingWakeRequeued = deps.onPendingWakeRequeued
     this.pendingQueue = new ParentWakePendingQueue({
       pendingRetryMs: options.pendingRetryMs,
       enqueueNotificationForParent: deps.enqueueNotificationForParent,
@@ -179,6 +181,7 @@ export class ParentWakeNotifier {
 
   private requeueWake(sessionID: string, latestWake: PendingParentWake): void {
     this.pendingQueue.requeueWake(sessionID, latestWake)
+    this.onPendingWakeRequeued?.(sessionID)
   }
 
   private async shouldDeferParentWakeForSessionHistory(

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-window-requeue.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-window-requeue.test.ts
@@ -19,7 +19,9 @@ type SessionMessageStub = {
 
 const FINAL_WAKE = "<system-reminder>\n[BACKGROUND TASK COMPLETED]\n[ALL BACKGROUND TASKS COMPLETE]\n</system-reminder>"
 
-function createNotifier(): {
+function createNotifier(options: {
+  readonly onPendingWakeRequeued?: (sessionID: string) => void
+} = {}): {
   readonly notifier: ParentWakeNotifier
   readonly promptAsyncCalls: readonly PromptAsyncCall[]
 } {
@@ -50,6 +52,7 @@ function createNotifier(): {
       enqueueNotificationForParent: async (_sessionID, operation) => {
         await operation()
       },
+      ...(options.onPendingWakeRequeued ? { onPendingWakeRequeued: options.onPendingWakeRequeued } : {}),
     },
     {
       pendingRetryMs: 1_000,
@@ -94,6 +97,34 @@ describe("ParentWakeNotifier dispatched wake recovery", () => {
       // then
       expect(notifier.getDispatchedParentWakes().has(sessionID)).toBe(false)
       expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([FINAL_WAKE])
+      expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a parent wake is accepted but produces no assistant output #when recovery requeues it #then the manager callback fires before the retry timer settles", async () => {
+    // given
+    const requeuedSessionIDs: string[] = []
+    const { notifier, promptAsyncCalls } = createNotifier({
+      onPendingWakeRequeued: (sessionID) => {
+        requeuedSessionIDs.push(sessionID)
+      },
+    })
+    const sessionID = "parent-window-requeue-callback"
+    notifier.queuePendingParentWake(sessionID, FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(1)
+
+      // when
+      await waitForTimer()
+
+      // then
+      expect(requeuedSessionIDs).toEqual([sessionID])
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(true)
       expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
     } finally {
       notifier.shutdown()


### PR DESCRIPTION
## Summary

Fixes #4721.

`oh-my-openagent run --json` could decide that a parent session was complete after the last background child stopped, but before the completion parent wake was queued/dispatched and answered. This keeps the run-continuation background marker active while a completion parent wake is still preparing, queued, timer-backed, or in-flight, so the run poller cannot exit before the parent wake lands.

## Changes

- Add `background-task-marker.ts` to centralize background-task continuation marker writes.
- Treat undelivered parent wakes as active background marker state with reason `background completion wake pending`.
- Refresh the marker when parent wakes are queued and after flush attempts.
- Add a failing-first regression for the no-active-child + parent-wake-preparing gap and queued-wake dispatch cleanup.

## Evidence

Evidence root: `.omo/evidence/20260622-4721-run-json-parent-wake/`

- Failing-first proof: `failing-first-manager-marker-test-red.txt`
  - `bun test ./packages/omo-opencode/src/features/background-agent/manager-continuation-marker.test.ts`
  - Before fix: expected marker state `active`, received `idle`.
- Focused regression suite: `focused-regression-tests.txt`
  - 55 pass, 0 fail.
- Typecheck: `typecheck.txt`
  - `bun run typecheck` green.
- Full test gate: `bun-test.txt`
  - 10125 pass, 2 skip, 0 fail.
- Build: `build.txt`
  - `bun run build` green.
- Diff check: `git-diff-check.txt`
  - clean.
- OpenCode live run JSON proof: `run-json-live-qa.txt`, `run-json-live-verdict.txt`, `run-json-live/`
  - Isolated XDG + fake OpenAI + local plugin.
  - Real OpenCode DB unchanged: 21617 before/after.
  - `run --json` exit 0.
  - Observed 10 waits on `background completion wake pending`.
  - Final JSON summary was `WAKE_ACK 5`, proving the parent completion wake answer was not missed.
- Stock opencode-qa probe: `opencode-qa-serve-wake-split-fixed.txt`, `serve-wake-split-fixed/`
  - `RESULT=FIXED`
  - `parent_assistant_messages=3 parent_tool_call_turns=2 terminal_stops=1 child_task_sessions=1`
  - `route_live_dispatch=true`
  - Real OpenCode DB unchanged: 21617 before/after.

## Notes

`packages/omo-opencode/src/features/background-agent/manager.ts` is a pre-existing oversized module (2734 pure LOC in this worktree). This fix avoids adding marker-writing logic there by extracting a focused helper, but a full manager split is deliberately left out of this race fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4721 by keeping `oh-my-openagent run --json` active until the parent completion wake is actually delivered. The run now waits through preparing, queued, timer-backed, in-flight, and requeued wake states.

- **Bug Fixes**
  - Treat undelivered parent wakes as active marker state with reason "background completion wake pending".
  - Centralize background-task continuation marker writes in `background-task-marker.ts`.
  - Refresh the marker on queue, on requeue, and after manual or scheduled flush to keep state accurate (idle after acceptance; active immediately on requeue).
  - Add regression tests covering preparing, queued, scheduled timer, and requeue cases (e.g., `session.error`, empty assistant turn).

<sup>Written for commit 991363b821425b3a0c96bfd869ea185dece06e64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

