### PR TITLE
feat(codex): teammode worktree automation + ulw-plan bridge + leader-orchestration role

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -26,11 +26,15 @@ Use plain subagents (`$ulw` / `multi_agent_v1.spawn_agent`) - NOT a team - when 
 A team buys cross-member coordination at a real overhead cost; only spend it when coordination
 is the thing you actually need.
 
-## You are the leader
+## You are the leader - orchestrate, do not implement
 
-The main session is ALWAYS the team leader. Do NOT create a separate leader thread - you
-orchestrate directly. Members are the threads you create; they report to you, and you own the
-final synthesis and any integration.
+The main session is ALWAYS the team leader; you orchestrate directly and never spin up a separate
+leader thread. Your job is orchestration, NOT writing product code: split the work and assign each
+slice, hold live situational awareness of every member, verify and QA what they deliver, relay
+findings between members, instruct and unblock, and synthesize the result. DELEGATE every code edit
+to a member - if you catch yourself editing product files while the team runs, that work was a
+member's slice you should have handed off. You own direction, verification, and integration (the
+merge), not the keystrokes.
 
 ## Compose by part, ownership, or perspective - not by job title
 
@@ -61,6 +65,9 @@ node "<skill-root>/scripts/team.mjs" add-member  --team <session_id> --id A --na
 node "<skill-root>/scripts/team.mjs" bind-thread  --team <session_id> --id A --thread <thread_id> [--cwd <path>]
 node "<skill-root>/scripts/team.mjs" member-prompt --team <session_id> --id A
 node "<skill-root>/scripts/team.mjs" set-status   --team <session_id> --id A --status reported|blocked|active|archived [--note "<...>"]
+node "<skill-root>/scripts/team.mjs" worktree-add    --team <session_id> --id A [--base-branch <branch>]
+node "<skill-root>/scripts/team.mjs" worktree-remove --team <session_id> --id A [--force]
+node "<skill-root>/scripts/team.mjs" integrate       --team <session_id> [--id A]
 node "<skill-root>/scripts/team.mjs" archive      --team <session_id> [--id A]
 node "<skill-root>/scripts/team.mjs" delete       --team <session_id> [--force]
 node "<skill-root>/scripts/team.mjs" status       --team <session_id>
@@ -109,12 +116,30 @@ when the END user addresses a member, that member replies in the user's own lang
 files and memos through the team `artifacts/` directory and reference them by path. Wait for every
 required member's final report before you declare the team done.
 
-## Worktrees (optional isolation)
+## Worktrees - isolate members who would touch the same files
 
-When parallel members would edit overlapping files, enable isolation with `init --worktree`. Create
-one git worktree per member off the base branch, `bind-thread --cwd <worktree>` so each member's
-worktree is recorded in `team.json`, and rely on the manual to direct each member into its own
-worktree. Each member commits inside its worktree so you can integrate.
+The moment two members' slices would edit the same files, give each its own git worktree so they
+cannot clobber each other. Decide this whenever you see the collision - at team creation OR mid-run,
+not only up front. For each colliding member run `worktree-add --team <id> --id <member>`: it creates
+the worktree off the base branch on a derived branch, flips the team into worktree mode, records it in
+`team.json`, and prints the `cd` path to hand that member. The member works and commits only inside
+its own worktree. To land the work, `integrate --team <id>` merges every member branch back with a
+merge commit (never a squash or rebase); resolve any conflict it reports, then `worktree-remove` each
+worktree at cleanup.
+
+## Run a ulw-plan in parallel
+
+When a decision-complete plan already exists at `.omo/plans/<slug>.md` (from ulw-plan), execute its
+parallel waves as a team instead of one todo at a time. Map it directly:
+- one wave's independent todos -> one member each; the todo's scope/files become that member's `focus`,
+  and its acceptance criteria + QA become the member's `deliverable`.
+- the plan's dependency matrix sets the shape: todos with no unmet dependency inside a wave run as
+  concurrent members; a todo that depends on another waits, so launch the next wave only after the
+  blocking members report.
+- todos in the same wave that touch overlapping files -> give those members worktrees (see above).
+
+Keep the plan file as the shared spec: point each member at its todo by path, and verify the member's
+result against that todo's acceptance criteria before you integrate.
 
 ## Archive, delete, and cleanup
 
@@ -128,9 +153,9 @@ then delete the team state. A finished team that is never disbanded is a leak.
   and tell the user - never pretend a member was archived.
 - `delete` removes `.omo/teams/{session_id}` and refuses while the team is unarchived or any member
   is still active unless `--force`.
-- When the work wraps up, integrate each member's worktree the way the user asked - merge directly,
-  or open a fresh PR and merge it - then archive and delete. Cleanup is real work; respect the
-  user's instruction on how to land it.
+- When the work wraps up, land it the way the user asked: `integrate --team <id>` for a direct merge
+  commit, or push each member branch and open a PR. Then `worktree-remove` each worktree, archive, and
+  delete. Cleanup is real work; respect the user's instruction on how to land it.
 
 ## Stop rules
 

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -123,9 +123,9 @@ cannot clobber each other. Decide this whenever you see the collision - at team 
 not only up front. For each colliding member run `worktree-add --team <id> --id <member>`: it creates
 the worktree off the base branch on a derived branch, flips the team into worktree mode, records it in
 `team.json`, and prints the `cd` path to hand that member. The member works and commits only inside
-its own worktree. To land the work, `integrate --team <id>` merges every member branch back with a
-merge commit (never a squash or rebase); resolve any conflict it reports, then `worktree-remove` each
-worktree at cleanup.
+its own worktree. To land the work, `integrate --team <id>` merges every member branch into your
+current branch with a merge commit (never a squash or rebase); resolve any conflict it reports, then
+`worktree-remove` each worktree at cleanup.
 
 ## Run a ulw-plan in parallel
 

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -137,6 +137,24 @@ export function setMemberStatus(team, { id, status, note = "" }) {
 	return touch(team, "set-status", `member ${id} -> ${status}${note ? `: ${note}` : ""}`);
 }
 
+// Record a provisioned worktree. Isolation is conflict-triggered: the first worktree-add flips
+// the whole team into worktree mode, so the leader can decide it mid-run, not only at init.
+export function setMemberWorktree(team, { id, path, branch }) {
+	const m = memberById(team, id);
+	team.worktree.enabled = true;
+	m.worktree.path = path;
+	m.worktree.branch = branch;
+	m.cwd = path;
+	return touch(team, "worktree-add", `member ${id} -> ${path} (${branch})`);
+}
+
+export function clearMemberWorktree(team, { id }) {
+	const m = memberById(team, id);
+	if (m.cwd === m.worktree?.path) m.cwd = null;
+	m.worktree.path = null;
+	return touch(team, "worktree-remove", `member ${id}`);
+}
+
 export function archive(team, { id = null, note = "" } = {}) {
 	if (id) {
 		memberById(team, id).status = "archived";

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-worktree.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-worktree.mjs
@@ -5,10 +5,22 @@
 // the skill. team-state.mjs stays the pure state model; this file owns the git side only.
 
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 // A member id that also names a directory and a branch segment: no "/", no "..", no leading dot.
 const MEMBER_ID_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+// Compare two on-disk paths regardless of OS. realpathSync canonicalizes separators, Windows
+// 8.3 short names (RUNNER~1) and drive-letter case, and the macOS /var -> /private/var symlink -
+// none of which plain resolve() reconciles. Returns false if either side no longer exists.
+function samePath(a, b) {
+	try {
+		return realpathSync(a) === realpathSync(b);
+	} catch {
+		return false;
+	}
+}
 
 function git(cwd, args) {
 	const result = spawnSync("git", args, { cwd, encoding: "utf8" });
@@ -65,8 +77,11 @@ export function addMemberWorktree(cwd, team, member, { baseBranch } = {}) {
 	const base = baseBranch || team.worktree?.baseBranch || "dev";
 	const branch = deriveMemberBranch(team, member);
 	const path = memberWorktreePath(team, member);
-	const absolutePath = resolve(cwd, path);
-	if (listWorktrees(cwd).some((w) => resolve(cwd, w.path) === absolutePath)) {
+	// Idempotent: skip if a worktree is already checked out on this member's branch (matched on the
+	// branch ref, which is OS-agnostic) or already lives at this path (matched on realpath, so a
+	// Windows 8.3 git path vs an 8.3-or-long script path still compares equal). Plain string/resolve
+	// comparison missed the 8.3-vs-canonical case and re-`git worktree add`-ed into a fatal error.
+	if (listWorktrees(cwd).some((w) => w.branch === `refs/heads/${branch}` || samePath(resolve(cwd, w.path), resolve(cwd, path)))) {
 		return { path, branch, base, created: false };
 	}
 	const add = branchExists(cwd, branch)

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-worktree.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-worktree.mjs
@@ -1,0 +1,98 @@
+// team-worktree.mjs - git worktree provisioning + merge integration for teammode.
+//
+// Shells out to `git` through node:child_process so the leader never hand-runs worktree or
+// merge commands and never improvises a branch name. Zero npm dependencies, like the rest of
+// the skill. team-state.mjs stays the pure state model; this file owns the git side only.
+
+import { spawnSync } from "node:child_process";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+// A member id that also names a directory and a branch segment: no "/", no "..", no leading dot.
+const MEMBER_ID_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+function git(cwd, args) {
+	const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+	if (result.error) throw new Error(`git ${args.join(" ")} could not run: ${result.error.message}`);
+	return result;
+}
+
+function gitOrThrow(cwd, args) {
+	const result = git(cwd, args);
+	if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${(result.stderr || result.stdout || "").trim()}`);
+	return result.stdout ?? "";
+}
+
+export function deriveMemberBranch(team, member) {
+	if (member.worktree?.branch) return member.worktree.branch;
+	return `team/${team.sessionId ?? team.teamId}/${member.id}`;
+}
+
+// Confine a member worktree to <worktree.root>/<member id>; reject any id that would escape it.
+export function memberWorktreePath(team, member) {
+	if (!MEMBER_ID_SEGMENT.test(member.id ?? "")) throw new Error(`unsafe member id for a worktree path: "${member.id}"`);
+	const root = team.worktree?.root;
+	if (!root) throw new Error("team has no worktree root; re-init the team");
+	const path = join(root, member.id);
+	const rel = relative(root, path);
+	if (rel !== member.id || rel.startsWith("..") || isAbsolute(rel)) throw new Error(`refused: worktree path escapes ${root}`);
+	return path;
+}
+
+export function listWorktrees(cwd) {
+	const out = gitOrThrow(cwd, ["worktree", "list", "--porcelain"]);
+	const worktrees = [];
+	let current = null;
+	for (const line of out.split("\n")) {
+		if (line.startsWith("worktree ")) {
+			current = { path: line.slice("worktree ".length) };
+			worktrees.push(current);
+		} else if (line.startsWith("branch ") && current) {
+			current.branch = line.slice("branch ".length);
+		}
+	}
+	return worktrees;
+}
+
+function branchExists(cwd, branch) {
+	return git(cwd, ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`]).status === 0;
+}
+
+function currentBranch(cwd) {
+	return gitOrThrow(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+}
+
+export function addMemberWorktree(cwd, team, member, { baseBranch } = {}) {
+	const base = baseBranch || team.worktree?.baseBranch || "dev";
+	const branch = deriveMemberBranch(team, member);
+	const path = memberWorktreePath(team, member);
+	const absolutePath = resolve(cwd, path);
+	if (listWorktrees(cwd).some((w) => resolve(cwd, w.path) === absolutePath)) {
+		return { path, branch, base, created: false };
+	}
+	const add = branchExists(cwd, branch)
+		? ["worktree", "add", path, branch]
+		: ["worktree", "add", "-b", branch, path, base];
+	gitOrThrow(cwd, add);
+	return { path, branch, base, created: true };
+}
+
+export function removeMemberWorktree(cwd, team, member, { force = false } = {}) {
+	const path = memberWorktreePath(team, member);
+	gitOrThrow(cwd, ["worktree", "remove", ...(force ? ["--force"] : []), path]);
+	return { path };
+}
+
+// Land a member branch with a MERGE COMMIT (--no-ff). Never squash, never rebase (repo policy).
+// On conflict the working tree is left mid-merge so the leader can resolve and re-run.
+export function integrateMemberBranch(cwd, branch) {
+	const result = git(cwd, ["merge", "--no-ff", "--no-edit", branch]);
+	if (result.status === 0) return { branch, merged: true, into: currentBranch(cwd) };
+	const conflicts = gitOrThrow(cwd, ["diff", "--name-only", "--diff-filter=U"]).trim();
+	return {
+		branch,
+		merged: false,
+		into: currentBranch(cwd),
+		conflicts: conflicts ? conflicts.split("\n") : [],
+		message: (result.stderr || result.stdout || "").trim(),
+	};
+}

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -187,9 +187,15 @@ const handlers = {
 		for (const member of targets) {
 			const result = integrateMemberBranch(cwd, member.worktree.branch);
 			if (!result.merged) {
-				process.stdout.write(`member ${member.id} (${member.worktree.branch}): CONFLICT into ${result.into}\n`);
+				if (result.conflicts.length > 0) {
+					process.stdout.write(`member ${member.id} (${member.worktree.branch}): CONFLICT into ${result.into}\n`);
+					throw new Error(
+						`merge conflict integrating member ${member.id} (branch ${member.worktree.branch}). Resolve the conflict, commit the merge, then re-run integrate. Conflicting files: ${result.conflicts.join(", ")}`,
+					);
+				}
+				process.stdout.write(`member ${member.id} (${member.worktree.branch}): could not start merge into ${result.into}\n`);
 				throw new Error(
-					`merge conflict integrating member ${member.id} (branch ${member.worktree.branch}). Resolve it, commit the merge, then re-run integrate. Conflicting files: ${result.conflicts.join(", ") || "(see git status)"}`,
+					`could not integrate member ${member.id} (branch ${member.worktree.branch}): ${result.message || "git merge failed; see git status"}`,
 				);
 			}
 			process.stdout.write(`member ${member.id} (${member.worktree.branch}): merged into ${result.into}\n`);

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -27,16 +27,18 @@ import {
 	assertSafeTeamDir,
 	bindThread,
 	buildTeam,
+	clearMemberWorktree,
 	ensureTeamDir,
 	isUnderstaffed,
 	MIN_MEMBERS,
 	readTeam,
-	resolveTeamDir,
 	setMemberStatus,
+	setMemberWorktree,
 	teamExists,
 	writeGuideAtomic,
 	writeTeamAtomic,
 } from "./team-state.mjs";
+import { addMemberWorktree, integrateMemberBranch, removeMemberWorktree } from "./team-worktree.mjs";
 
 function parseFlags(args) {
 	const flags = { _: [] };
@@ -67,6 +69,12 @@ function requireFlag(flags, name) {
 async function loadTeam(cwd, sessionId) {
 	const dir = await assertSafeTeamDir(cwd, sessionId);
 	return { dir, team: await readTeam(dir) };
+}
+
+function memberOrThrow(team, id) {
+	const member = team.members.find((m) => m.id === id);
+	if (!member) throw new Error(`no member with id "${id}"`);
+	return member;
 }
 
 async function persist(team, dir) {
@@ -144,6 +152,49 @@ const handlers = {
 		});
 		await persist(team, dir);
 		process.stdout.write(`member ${flags.id} -> ${flags.status}\n`);
+	},
+
+	async "worktree-add"(cwd, flags) {
+		const sessionId = requireFlag(flags, "team");
+		const { dir, team } = await loadTeam(cwd, sessionId);
+		const member = memberOrThrow(team, requireFlag(flags, "id"));
+		const result = addMemberWorktree(cwd, team, member, {
+			baseBranch: typeof flags["base-branch"] === "string" ? flags["base-branch"] : null,
+		});
+		setMemberWorktree(team, { id: member.id, path: result.path, branch: result.branch });
+		await persist(team, dir);
+		const note = result.created ? "" : " (already exists)";
+		process.stdout.write(
+			`worktree for member ${member.id}${note}: ${result.path} on branch ${result.branch} (off ${result.base}).\nTell that member to: cd "${result.path}"\n`,
+		);
+	},
+
+	async "worktree-remove"(cwd, flags) {
+		const sessionId = requireFlag(flags, "team");
+		const { dir, team } = await loadTeam(cwd, sessionId);
+		const member = memberOrThrow(team, requireFlag(flags, "id"));
+		removeMemberWorktree(cwd, team, member, { force: flags.force === true });
+		clearMemberWorktree(team, { id: member.id });
+		await persist(team, dir);
+		process.stdout.write(`removed worktree for member ${member.id}\n`);
+	},
+
+	async integrate(cwd, flags) {
+		const sessionId = requireFlag(flags, "team");
+		const { team } = await loadTeam(cwd, sessionId);
+		const targets = typeof flags.id === "string" ? [memberOrThrow(team, flags.id)] : team.members.filter((m) => m.worktree?.branch);
+		if (targets.length === 0) throw new Error("no member has a worktree branch to integrate; run worktree-add first");
+		for (const member of targets) {
+			const result = integrateMemberBranch(cwd, member.worktree.branch);
+			if (!result.merged) {
+				process.stdout.write(`member ${member.id} (${member.worktree.branch}): CONFLICT into ${result.into}\n`);
+				throw new Error(
+					`merge conflict integrating member ${member.id} (branch ${member.worktree.branch}). Resolve it, commit the merge, then re-run integrate. Conflicting files: ${result.conflicts.join(", ") || "(see git status)"}`,
+				);
+			}
+			process.stdout.write(`member ${member.id} (${member.worktree.branch}): merged into ${result.into}\n`);
+		}
+		process.stdout.write(`integrated ${targets.length} member branch(es) with merge commits\n`);
 	},
 
 	async archive(cwd, flags) {

--- a/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
@@ -1,15 +1,23 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
 import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam, runTeamRaw, teamDir, teamJsonPath } from "./teammode-safety-fixture.mjs";
 
-// team.mjs derives paths from process.cwd(), which is the realpath; on macOS the temp dir is a
-// symlink (/var -> /private/var), so compare against the resolved root, not the symlink form.
 function memberWorktreePath(tempRoot, sessionId, memberId) {
-	return join(realpathSync(tempRoot), ".omo", "teams", sessionId, "worktrees", memberId);
+	return join(tempRoot, ".omo", "teams", sessionId, "worktrees", memberId);
+}
+
+// Compare two on-disk paths regardless of OS: realpathSync canonicalizes separators, drive-letter
+// case (Windows), and symlinks (macOS /var -> /private/var). Returns false if either side is gone.
+function samePath(a, b) {
+	try {
+		return realpathSync(a) === realpathSync(b);
+	} catch {
+		return false;
+	}
 }
 
 function git(cwd, ...args) {
@@ -37,11 +45,13 @@ function bootstrapTeam(cwd, sessionId, { worktree = false, baseBranch = "main" }
 	runTeam(cwd, "add-member", "--team", sessionId, "--id", "B", "--focus", "beta slice", "--lens", "ownership", "--deliverable", "b");
 }
 
-function worktreePaths(cwd) {
+// The branch each worktree is checked out on. Branch refs are "/"-delimited on every OS, so this
+// is a separator-proof way to assert which worktrees git knows about (porcelain paths are not).
+function worktreeBranches(cwd) {
 	return git(cwd, "worktree", "list", "--porcelain")
 		.split("\n")
-		.filter((line) => line.startsWith("worktree "))
-		.map((line) => line.slice("worktree ".length));
+		.filter((line) => line.startsWith("branch "))
+		.map((line) => line.slice("branch ".length).replace("refs/heads/", ""));
 }
 
 function branchExists(cwd, branch) {
@@ -59,14 +69,14 @@ test("#given a worktree team #when worktree-add A #then a real git worktree on a
 		// then - git itself knows about the worktree on the member branch
 		const expectedBranch = "team/wt-add/A";
 		assert.equal(branchExists(tempRoot, expectedBranch), true, "member branch must exist");
-		const expectedPath = memberWorktreePath(tempRoot, "wt-add", "A");
-		assert.ok(worktreePaths(tempRoot).some((p) => p === expectedPath), `git worktree list must include ${expectedPath}`);
+		assert.ok(worktreeBranches(tempRoot).includes(expectedBranch), "git worktree list must include the member branch");
 
-		// then - team.json records the worktree for the member
+		// then - team.json records the worktree for the member (compare by realpath: OS-agnostic)
+		const expectedPath = memberWorktreePath(tempRoot, "wt-add", "A");
 		const member = readTeamJson(tempRoot, "wt-add").members.find((m) => m.id === "A");
-		assert.equal(member.worktree.path, expectedPath);
+		assert.ok(existsSync(member.worktree.path) && samePath(member.worktree.path, expectedPath), "worktree.path must point at the member worktree dir");
 		assert.equal(member.worktree.branch, expectedBranch);
-		assert.equal(member.cwd, expectedPath);
+		assert.ok(samePath(member.cwd, expectedPath), "cwd must be the member worktree dir");
 
 		// then - the leader is told the exact cd target
 		assert.match(result.stdout, /cd /);
@@ -105,7 +115,7 @@ test("#given a team initialized WITHOUT --worktree #when worktree-add is called 
 
 		const team = readTeamJson(tempRoot, "wt-auto");
 		assert.equal(team.worktree.enabled, true, "worktree-add must flip the team into isolation mode");
-		assert.ok(worktreePaths(tempRoot).some((p) => p === memberWorktreePath(tempRoot, "wt-auto", "A")));
+		assert.ok(worktreeBranches(tempRoot).includes("team/wt-auto/A"), "git must have created the member worktree");
 	} finally {
 		cleanupTeamRoot(tempRoot);
 	}
@@ -121,7 +131,7 @@ test("#given an existing member worktree #when worktree-add runs again #then it 
 		const second = runTeam(tempRoot, "worktree-add", "--team", "wt-idem", "--id", "A");
 
 		assert.match(second.stdout, /exist/i, "re-running must report the worktree already exists, not crash");
-		assert.equal(worktreePaths(tempRoot).filter((p) => p.endsWith(join("worktrees", "A"))).length, 1);
+		assert.equal(worktreeBranches(tempRoot).filter((b) => b === "team/wt-idem/A").length, 1, "no duplicate worktree");
 	} finally {
 		cleanupTeamRoot(tempRoot);
 	}
@@ -132,13 +142,12 @@ test("#given a member worktree #when worktree-remove A #then git drops it and te
 	try {
 		initGitRepo(tempRoot);
 		bootstrapTeam(tempRoot, "wt-rm", { worktree: true });
-		const path = memberWorktreePath(tempRoot, "wt-rm", "A");
 		runTeam(tempRoot, "worktree-add", "--team", "wt-rm", "--id", "A");
-		assert.ok(worktreePaths(tempRoot).includes(path));
+		assert.ok(worktreeBranches(tempRoot).includes("team/wt-rm/A"));
 
 		runTeam(tempRoot, "worktree-remove", "--team", "wt-rm", "--id", "A");
 
-		assert.ok(!worktreePaths(tempRoot).includes(path), "git worktree list must no longer include the removed worktree");
+		assert.ok(!worktreeBranches(tempRoot).includes("team/wt-rm/A"), "git worktree list must no longer include the removed worktree");
 		const member = readTeamJson(tempRoot, "wt-rm").members.find((m) => m.id === "A");
 		assert.equal(member.worktree.path, null);
 	} finally {

--- a/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
@@ -4,7 +4,7 @@ import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
-import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam, runTeamRaw, teamDir } from "./teammode-safety-fixture.mjs";
+import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam, runTeamRaw, teamDir, teamJsonPath } from "./teammode-safety-fixture.mjs";
 
 // team.mjs derives paths from process.cwd(), which is the realpath; on macOS the temp dir is a
 // symlink (/var -> /private/var), so compare against the resolved root, not the symlink form.
@@ -192,6 +192,28 @@ test("#given two members edited the same line #when integrate hits the conflict 
 		assert.notEqual(conflict.status, 0, "a merge conflict must surface as a non-zero exit");
 		assert.match(`${conflict.stdout}${conflict.stderr}`, /conflict/i);
 		assert.match(`${conflict.stdout}${conflict.stderr}`, /\bB\b/);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a member branch that cannot be merged #when integrate runs #then it surfaces git's real reason, not a fake conflict", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-wt-fatal-");
+	try {
+		initGitRepo(tempRoot);
+		bootstrapTeam(tempRoot, "wt-fatal", { worktree: true });
+		runTeam(tempRoot, "worktree-add", "--team", "wt-fatal", "--id", "A");
+		// point member A at a branch that does not exist: a fatal git error, NOT a content conflict
+		const team = readTeamJson(tempRoot, "wt-fatal");
+		team.members.find((m) => m.id === "A").worktree.branch = "ghost-branch-404";
+		writeFileSync(teamJsonPath(tempRoot, "wt-fatal"), `${JSON.stringify(team, null, 2)}\n`);
+
+		const result = runTeamRaw(tempRoot, "integrate", "--team", "wt-fatal", "--id", "A");
+
+		const out = `${result.stdout}${result.stderr}`;
+		assert.notEqual(result.status, 0);
+		assert.match(out, /could not integrate|not something we can merge|ghost-branch-404/i, "must surface git's actual reason");
+		assert.doesNotMatch(out, /Conflicting files/, "a non-conflict failure must NOT be mislabeled as a merge conflict");
 	} finally {
 		cleanupTeamRoot(tempRoot);
 	}

--- a/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam, runTeamRaw, teamDir } from "./teammode-safety-fixture.mjs";
+
+// team.mjs derives paths from process.cwd(), which is the realpath; on macOS the temp dir is a
+// symlink (/var -> /private/var), so compare against the resolved root, not the symlink form.
+function memberWorktreePath(tempRoot, sessionId, memberId) {
+	return join(realpathSync(tempRoot), ".omo", "teams", sessionId, "worktrees", memberId);
+}
+
+function git(cwd, ...args) {
+	const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+	assert.equal(result.status, 0, `git ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+	return result.stdout;
+}
+
+// A real git repo on a known base branch so worktree-add/integrate exercise real git, not mocks.
+function initGitRepo(cwd, { baseBranch = "main" } = {}) {
+	git(cwd, "init", "-b", baseBranch);
+	git(cwd, "config", "user.email", "team@example.com");
+	git(cwd, "config", "user.name", "Teammode Test");
+	writeFileSync(join(cwd, "file.txt"), "base\n");
+	git(cwd, "add", "file.txt");
+	git(cwd, "commit", "-m", "base commit");
+	return baseBranch;
+}
+
+function bootstrapTeam(cwd, sessionId, { worktree = false, baseBranch = "main" } = {}) {
+	const args = ["init", "--name", "WT", "--session-name", "wt-session", "--session", sessionId, "--base-branch", baseBranch];
+	if (worktree) args.push("--worktree");
+	runTeam(cwd, ...args);
+	runTeam(cwd, "add-member", "--team", sessionId, "--id", "A", "--focus", "alpha slice", "--lens", "area", "--deliverable", "a");
+	runTeam(cwd, "add-member", "--team", sessionId, "--id", "B", "--focus", "beta slice", "--lens", "ownership", "--deliverable", "b");
+}
+
+function worktreePaths(cwd) {
+	return git(cwd, "worktree", "list", "--porcelain")
+		.split("\n")
+		.filter((line) => line.startsWith("worktree "))
+		.map((line) => line.slice("worktree ".length));
+}
+
+function branchExists(cwd, branch) {
+	return spawnSync("git", ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`], { cwd, encoding: "utf8" }).status === 0;
+}
+
+test("#given a worktree team #when worktree-add A #then a real git worktree on a derived branch is created and recorded", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-wt-add-");
+	try {
+		initGitRepo(tempRoot);
+		bootstrapTeam(tempRoot, "wt-add", { worktree: true });
+
+		const result = runTeam(tempRoot, "worktree-add", "--team", "wt-add", "--id", "A");
+
+		// then - git itself knows about the worktree on the member branch
+		const expectedBranch = "team/wt-add/A";
+		assert.equal(branchExists(tempRoot, expectedBranch), true, "member branch must exist");
+		const expectedPath = memberWorktreePath(tempRoot, "wt-add", "A");
+		assert.ok(worktreePaths(tempRoot).some((p) => p === expectedPath), `git worktree list must include ${expectedPath}`);
+
+		// then - team.json records the worktree for the member
+		const member = readTeamJson(tempRoot, "wt-add").members.find((m) => m.id === "A");
+		assert.equal(member.worktree.path, expectedPath);
+		assert.equal(member.worktree.branch, expectedBranch);
+		assert.equal(member.cwd, expectedPath);
+
+		// then - the leader is told the exact cd target
+		assert.match(result.stdout, /cd /);
+		assert.match(result.stdout, /A/);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given worktree-add ran #when the field manual is regenerated #then it flips the member's guide to ISOLATION IS ON with the derived branch", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-wt-guide-");
+	try {
+		initGitRepo(tempRoot);
+		bootstrapTeam(tempRoot, "wt-guide", { worktree: false });
+		// before: no isolation, so the manual tells members to signal collisions instead
+		assert.match(readFileSync(join(teamDir(tempRoot, "wt-guide"), "guide.md"), "utf8"), /does not use isolated git worktrees/);
+
+		runTeam(tempRoot, "worktree-add", "--team", "wt-guide", "--id", "A");
+
+		const guide = readFileSync(join(teamDir(tempRoot, "wt-guide"), "guide.md"), "utf8");
+		assert.match(guide, /ISOLATION IS ON/);
+		assert.match(guide, /team\/wt-guide\/A/, "the member's row must show its derived worktree branch");
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a team initialized WITHOUT --worktree #when worktree-add is called mid-run #then it auto-enables isolation (conflict-triggered)", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-wt-autoenable-");
+	try {
+		initGitRepo(tempRoot);
+		bootstrapTeam(tempRoot, "wt-auto", { worktree: false });
+		assert.equal(readTeamJson(tempRoot, "wt-auto").worktree.enabled, false, "precondition: worktree starts disabled");
+
+		runTeam(tempRoot, "worktree-add", "--team", "wt-auto", "--id", "A");
+
+		const team = readTeamJson(tempRoot, "wt-auto");
+		assert.equal(team.worktree.enabled, true, "worktree-add must flip the team into isolation mode");
+		assert.ok(worktreePaths(tempRoot).some((p) => p === memberWorktreePath(tempRoot, "wt-auto", "A")));
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given an existing member worktree #when worktree-add runs again #then it is a safe no-op that reports the existing worktree", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-wt-idem-");
+	try {
+		initGitRepo(tempRoot);
+		bootstrapTeam(tempRoot, "wt-idem", { worktree: true });
+		runTeam(tempRoot, "worktree-add", "--team", "wt-idem", "--id", "A");
+
+		const second = runTeam(tempRoot, "worktree-add", "--team", "wt-idem", "--id", "A");
+
+		assert.match(second.stdout, /exist/i, "re-running must report the worktree already exists, not crash");
+		assert.equal(worktreePaths(tempRoot).filter((p) => p.endsWith(join("worktrees", "A"))).length, 1);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a member worktree #when worktree-remove A #then git drops it and team.json clears the path", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-wt-remove-");
+	try {
+		initGitRepo(tempRoot);
+		bootstrapTeam(tempRoot, "wt-rm", { worktree: true });
+		const path = memberWorktreePath(tempRoot, "wt-rm", "A");
+		runTeam(tempRoot, "worktree-add", "--team", "wt-rm", "--id", "A");
+		assert.ok(worktreePaths(tempRoot).includes(path));
+
+		runTeam(tempRoot, "worktree-remove", "--team", "wt-rm", "--id", "A");
+
+		assert.ok(!worktreePaths(tempRoot).includes(path), "git worktree list must no longer include the removed worktree");
+		const member = readTeamJson(tempRoot, "wt-rm").members.find((m) => m.id === "A");
+		assert.equal(member.worktree.path, null);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a member committed work in its worktree #when integrate --id A #then the base branch gets a NO-FF merge commit", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-wt-integrate-");
+	try {
+		initGitRepo(tempRoot);
+		bootstrapTeam(tempRoot, "wt-int", { worktree: true });
+		runTeam(tempRoot, "worktree-add", "--team", "wt-int", "--id", "A");
+
+		// member A does work inside its own worktree and commits
+		const wtA = join(tempRoot, ".omo", "teams", "wt-int", "worktrees", "A");
+		writeFileSync(join(wtA, "alpha.txt"), "alpha work\n");
+		git(wtA, "add", "alpha.txt");
+		git(wtA, "commit", "-m", "alpha: add alpha.txt");
+
+		runTeam(tempRoot, "integrate", "--team", "wt-int", "--id", "A");
+
+		// then - base branch carries the member's file via a merge commit (not a fast-forward / squash)
+		const mergeCommits = git(tempRoot, "log", "main", "--merges", "--oneline");
+		assert.notEqual(mergeCommits.trim(), "", "integrate must produce a merge commit on the base branch");
+		const tracked = git(tempRoot, "ls-files");
+		assert.match(tracked, /alpha\.txt/, "the member's committed file must be present on the base branch");
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given two members edited the same line #when integrate hits the conflict #then it stops, reports the conflicting member, and exits non-zero", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-wt-conflict-");
+	try {
+		initGitRepo(tempRoot);
+		bootstrapTeam(tempRoot, "wt-conf", { worktree: true });
+		runTeam(tempRoot, "worktree-add", "--team", "wt-conf", "--id", "A");
+		runTeam(tempRoot, "worktree-add", "--team", "wt-conf", "--id", "B");
+
+		const wtA = join(tempRoot, ".omo", "teams", "wt-conf", "worktrees", "A");
+		writeFileSync(join(wtA, "file.txt"), "A changed the line\n");
+		git(wtA, "commit", "-am", "A edits file.txt");
+		const wtB = join(tempRoot, ".omo", "teams", "wt-conf", "worktrees", "B");
+		writeFileSync(join(wtB, "file.txt"), "B changed the line\n");
+		git(wtB, "commit", "-am", "B edits file.txt");
+
+		runTeam(tempRoot, "integrate", "--team", "wt-conf", "--id", "A");
+		const conflict = runTeamRaw(tempRoot, "integrate", "--team", "wt-conf", "--id", "B");
+
+		assert.notEqual(conflict.status, 0, "a merge conflict must surface as a non-zero exit");
+		assert.match(`${conflict.stdout}${conflict.stderr}`, /conflict/i);
+		assert.match(`${conflict.stdout}${conflict.stderr}`, /\bB\b/);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a member id that is not a safe path segment #when worktree-add runs #then it refuses instead of escaping the team dir", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-wt-escape-");
+	try {
+		initGitRepo(tempRoot);
+		runTeam(tempRoot, "init", "--name", "WT", "--session-name", "wt", "--session", "wt-escape", "--base-branch", "main", "--worktree");
+		runTeam(tempRoot, "add-member", "--team", "wt-escape", "--id", "A", "--focus", "alpha", "--lens", "area", "--deliverable", "a");
+		// craft an unsafe member id directly in state, then try to provision a worktree for it
+		mkdirSync(join(tempRoot, "sentinel"), { recursive: true });
+		const result = runTeamRaw(tempRoot, "worktree-add", "--team", "wt-escape", "--id", "../../sentinel");
+
+		assert.notEqual(result.status, 0);
+		assert.match(`${result.stdout}${result.stderr}`, /unsafe|no member|escape/i);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});


### PR DESCRIPTION
## Summary

Makes the omo-codex `teammode` skill actually deliver three things it only gestured at before, tuned for its GPT-5.5 (Codex) runtime:

1. **Worktrees now work, and are conflict-triggered.** Before, `init --worktree` only recorded `worktree.enabled/baseBranch/root` and `bind-thread` recorded a path — nothing ever ran `git worktree add`/`remove`, and there was no merge story (the SKILL told the model to "create one worktree per member" in prose, so GPT-5.5 improvised). Now a deterministic script owns it.
2. **ulw-plan integration (was zero).** The skill never mentioned plans; now a decision-complete `.omo/plans/<slug>.md` maps onto a team.
3. **Leader orchestrates instead of coding.** The old "you own the final synthesis and any integration" invited the leader to do hands-on work.

Canonical source is `packages/omo-codex/plugin/components/teammode/skills/teammode/`; `plugin/skills/teammode` is the gitignored synced copy (verified to carry every change).

## Changes

- **New `team-worktree.mjs`** (git side, isolated from the pure state model): `addMemberWorktree` / `removeMemberWorktree` / `integrateMemberBranch` + `listWorktrees`, with a path-escape guard on member ids.
- **`team.mjs`**: new `worktree-add`, `worktree-remove`, `integrate` subcommands; drop a pre-existing dead `resolveTeamDir` import.
- **`team-state.mjs`**: `setMemberWorktree` (records path/branch/cwd and **auto-enables** worktree mode so isolation is decidable mid-run) and `clearMemberWorktree`.
- `worktree-add` creates a real per-member worktree off the base branch on derived branch `team/<session>/<member>`; `integrate` lands member branches with a **`--no-ff` merge commit** (repo policy: never squash/rebase) and stops + reports the conflicting member on conflict.
- **SKILL.md**: rewrote "You are the leader — orchestrate, do not implement"; reframed the Worktrees section to conflict-triggered isolation via the new subcommands; added "Run a ulw-plan in parallel" (one wave's independent todos → one member each; dependency matrix decides concurrent-member vs sequential-under-leader; overlapping-file todos → worktrees); pointed cleanup at `integrate`/`worktree-remove`.
- **New `teammode-worktree.test.mjs`**: 8 tests driving the real CLI against a real git repo (RED-first), incl. the `guide.md` regen lock.

## Verification

**Automated:** `bun run test:codex` ✅ (exit 0; build + installer + config + full plugin component suite — node suite 383/383). Existing teammode tests unchanged & green (16/16); 8 new worktree tests green.

**Manual QA (real surface):** drove the actual `team.mjs` CLI end to end against a throwaway git repo — `init` (no `--worktree`) → `worktree-add` (auto-enabled, confirmed via `git worktree list --porcelain` on branch `team/demo/A`) → member commit inside its own worktree → `integrate` (produced a real `Merge branch 'team/demo/A' into dev` `--no-ff` commit landing the member's file on `dev`) → `worktree-remove` (clean). Evidence captured under `.omo/evidence/20260622-teammode-worktree-plan-leader/` (gitignored): `00-summary.md`, `03-test-codex.log`, `04-lifecycle-real-surface.txt`.

**Scope note:** the teammode `create_thread` title hook (`codex-hook.ts`) is untouched, so the app-server hook path is unaffected; the surfaces changed here are the bundled script (driven live) and the synced skill text (sync verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates teammode git worktrees and `--no-ff` merge integration so the leader never runs git by hand, and reframes the leader to orchestrate. Adds idempotent, Windows-safe `worktree-add`/`worktree-remove` and `integrate` with deterministic branches and safe paths.

- **New Features**
  - New teammode git layer and CLI: `worktree-add`/`worktree-remove`/`integrate` create per‑member worktrees on `team/<session>/<member>`, integrate into the current branch with merge commits, print the member `cd` path, and auto‑enable isolation on first `worktree-add`.
  - Docs: leader orchestrates (not coding), conflict‑triggered isolation via the new commands, a bridge to run `.omo/plans/<slug>.md` waves in parallel, and cleanup via `integrate`/`worktree-remove`.

- **Bug Fixes**
  - `integrate` separates real merge conflicts from other git failures and surfaces git’s actual error.
  - `worktree-add` is idempotent across OS path quirks (Windows 8.3 names, symlinks) by deduping on branch ref with a `realpath` backstop; tests run cross‑platform against a real git repo.

<sup>Written for commit 3e8e573d4fca19d03ea03d2d265a68a25cc5a79e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

