### PR TITLE
fix(ultimate-browsing): report template best-effort failures

### DIFF
--- a/packages/omo-codex/src/python-migration-inventory.test.ts
+++ b/packages/omo-codex/src/python-migration-inventory.test.ts
@@ -30,6 +30,7 @@ const optionalGeneratedPythonFiles = [
   "packages/omo-codex/plugin/skills/ultimate-browsing/engine/result_schema.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/engine/summary.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/engine/tests/test_fetch_chain.py",
+  "packages/omo-codex/plugin/skills/ultimate-browsing/engine/tests/test_playwright_templates.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/engine/url_transforms.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/engine/validators.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/engine/waf_detector.py",

--- a/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_mobile_chrome.js
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_mobile_chrome.js
@@ -44,8 +44,9 @@ function isMissingTopLevelModule(error, moduleName) {
 }
 
 function requireOptionalModule(moduleName) {
+  let resolvedModule;
   try {
-    return require(moduleName);
+    resolvedModule = require.resolve(moduleName);
   } catch (e) {
     if (isMissingTopLevelModule(e, moduleName)) {
       warnBestEffort(`optional module ${moduleName}`, e);
@@ -53,6 +54,7 @@ function requireOptionalModule(moduleName) {
     }
     throw e;
   }
+  return require(resolvedModule);
 }
 
 async function main() {

--- a/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_mobile_chrome.js
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_mobile_chrome.js
@@ -34,14 +34,35 @@ function warnBestEffort(action, error) {
   process.stderr.write(`best-effort ${action} failed: ${describeError(error)}\n`);
 }
 
-function isMissingOptionalDependency(error) {
-  return error instanceof Error && error.code === 'MODULE_NOT_FOUND';
+function isMissingTopLevelModule(error, moduleName) {
+  return (
+    error instanceof Error &&
+    error.code === 'MODULE_NOT_FOUND' &&
+    typeof error.message === 'string' &&
+    error.message.includes(`Cannot find module '${moduleName}'`)
+  );
+}
+
+function requireOptionalModule(moduleName) {
+  try {
+    return require(moduleName);
+  } catch (e) {
+    if (isMissingTopLevelModule(e, moduleName)) {
+      warnBestEffort(`optional module ${moduleName}`, e);
+      return null;
+    }
+    throw e;
+  }
 }
 
 async function main() {
   const args = await readStdinJson();
   const url = args.url;
-  if (!url) { process.stderr.write('missing url\n'); process.exit(2); }
+  if (!url) {
+    process.stderr.write('missing url\n');
+    process.exitCode = 2;
+    return;
+  }
 
   const profileDir = args.profileDir || '/tmp/.insane_pw_mobile_profile';
   const deviceName = args.device || 'iPhone 13 Pro';
@@ -50,22 +71,21 @@ async function main() {
   const headless = args.headless ?? false;
 
   let chromium, devices;
-  try {
-    ({ chromium, devices } = require('playwright-extra'));
-    const stealth = require('puppeteer-extra-plugin-stealth')();
+  const playwrightExtra = requireOptionalModule('playwright-extra');
+  const stealthPlugin = playwrightExtra ? requireOptionalModule('puppeteer-extra-plugin-stealth') : null;
+  if (playwrightExtra && stealthPlugin) {
+    ({ chromium, devices } = playwrightExtra);
+    const stealth = stealthPlugin();
     chromium.use(stealth);
-  } catch (e) {
-    if (!isMissingOptionalDependency(e)) {
-      throw e;
-    }
-    warnBestEffort('stealth setup', e);
+  } else {
     ({ chromium, devices } = require('playwright'));
   }
 
   const dev = devices[deviceName];
   if (!dev) {
     process.stderr.write(`unknown device: ${deviceName}\n`);
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
 
   let ctx;
@@ -83,16 +103,18 @@ async function main() {
       try {
         await page.waitForSelector(waitSelector, { timeout: Math.min(timeoutMs, 20000) });
       } catch (e) {
-        warnBestEffort(`waitSelector ${waitSelector}`, e);
+        warnBestEffort('waitSelector', e);
       }
     }
 
     const html = await page.content();
     process.stdout.write(html);
-    process.exit(0);
+    process.exitCode = 0;
+    return;
   } catch (e) {
     process.stderr.write(`${describeError(e)}\n`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   } finally {
     try {
       if (ctx) await ctx.close();

--- a/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_mobile_chrome.js
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_mobile_chrome.js
@@ -23,6 +23,21 @@ async function readStdinJson() {
   });
 }
 
+function describeError(error) {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+function warnBestEffort(action, error) {
+  process.stderr.write(`best-effort ${action} failed: ${describeError(error)}\n`);
+}
+
+function isMissingOptionalDependency(error) {
+  return error instanceof Error && error.code === 'MODULE_NOT_FOUND';
+}
+
 async function main() {
   const args = await readStdinJson();
   const url = args.url;
@@ -39,7 +54,11 @@ async function main() {
     ({ chromium, devices } = require('playwright-extra'));
     const stealth = require('puppeteer-extra-plugin-stealth')();
     chromium.use(stealth);
-  } catch (_e) {
+  } catch (e) {
+    if (!isMissingOptionalDependency(e)) {
+      throw e;
+    }
+    warnBestEffort('stealth setup', e);
     ({ chromium, devices } = require('playwright'));
   }
 
@@ -63,17 +82,23 @@ async function main() {
     if (waitSelector) {
       try {
         await page.waitForSelector(waitSelector, { timeout: Math.min(timeoutMs, 20000) });
-      } catch (_e) {}
+      } catch (e) {
+        warnBestEffort(`waitSelector ${waitSelector}`, e);
+      }
     }
 
     const html = await page.content();
     process.stdout.write(html);
     process.exit(0);
   } catch (e) {
-    process.stderr.write(`${e.name || 'Error'}: ${e.message || e}\n`);
+    process.stderr.write(`${describeError(e)}\n`);
     process.exit(1);
   } finally {
-    try { if (ctx) await ctx.close(); } catch (_e) {}
+    try {
+      if (ctx) await ctx.close();
+    } catch (e) {
+      warnBestEffort('browser context close', e);
+    }
   }
 }
 

--- a/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_real_chrome.js
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_real_chrome.js
@@ -29,6 +29,21 @@ async function readStdinJson() {
   });
 }
 
+function describeError(error) {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+function warnBestEffort(action, error) {
+  process.stderr.write(`best-effort ${action} failed: ${describeError(error)}\n`);
+}
+
+function isMissingOptionalDependency(error) {
+  return error instanceof Error && error.code === 'MODULE_NOT_FOUND';
+}
+
 async function main() {
   const args = await readStdinJson();
   const url = args.url;
@@ -45,7 +60,11 @@ async function main() {
     ({ chromium } = require('playwright-extra'));
     const stealth = require('puppeteer-extra-plugin-stealth')();
     chromium.use(stealth);
-  } catch (_e) {
+  } catch (e) {
+    if (!isMissingOptionalDependency(e)) {
+      throw e;
+    }
+    warnBestEffort('stealth setup', e);
     // Fallback to plain playwright (no stealth). Still uses channel:chrome.
     ({ chromium } = require('playwright'));
   }
@@ -72,7 +91,8 @@ async function main() {
         await page.goto(rootUrl, { waitUntil: 'domcontentloaded', timeout: navTimeout });
         await page.waitForTimeout(3500);   // let sensor JS finish
       }
-    } catch (_e) {
+    } catch (e) {
+      warnBestEffort('warmup navigation', e);
       // warmup is best-effort; continue even if it hiccups
     }
 
@@ -91,10 +111,12 @@ async function main() {
           await page.waitForTimeout(2000);
           try {
             await page.waitForSelector(waitSelector, { timeout: 10000 });
-          } catch (_e2) {
+          } catch (e2) {
+            warnBestEffort(`retry waitSelector ${waitSelector}`, e2);
             // Still no luck — caller validates HTML anyway.
           }
-        } catch (_e3) {
+        } catch (e3) {
+          warnBestEffort('selector recovery reload', e3);
           // reload failed — proceed with whatever we have
         }
       }
@@ -107,10 +129,14 @@ async function main() {
     process.stdout.write(html);
     process.exit(0);
   } catch (e) {
-    process.stderr.write(`${e.name || 'Error'}: ${e.message || e}\n`);
+    process.stderr.write(`${describeError(e)}\n`);
     process.exit(1);
   } finally {
-    try { if (ctx) await ctx.close(); } catch (_e) {}
+    try {
+      if (ctx) await ctx.close();
+    } catch (e) {
+      warnBestEffort('browser context close', e);
+    }
   }
 }
 

--- a/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_real_chrome.js
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_real_chrome.js
@@ -50,8 +50,9 @@ function isMissingTopLevelModule(error, moduleName) {
 }
 
 function requireOptionalModule(moduleName) {
+  let resolvedModule;
   try {
-    return require(moduleName);
+    resolvedModule = require.resolve(moduleName);
   } catch (e) {
     if (isMissingTopLevelModule(e, moduleName)) {
       warnBestEffort(`optional module ${moduleName}`, e);
@@ -59,6 +60,7 @@ function requireOptionalModule(moduleName) {
     }
     throw e;
   }
+  return require(resolvedModule);
 }
 
 async function main() {

--- a/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_real_chrome.js
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_real_chrome.js
@@ -40,14 +40,35 @@ function warnBestEffort(action, error) {
   process.stderr.write(`best-effort ${action} failed: ${describeError(error)}\n`);
 }
 
-function isMissingOptionalDependency(error) {
-  return error instanceof Error && error.code === 'MODULE_NOT_FOUND';
+function isMissingTopLevelModule(error, moduleName) {
+  return (
+    error instanceof Error &&
+    error.code === 'MODULE_NOT_FOUND' &&
+    typeof error.message === 'string' &&
+    error.message.includes(`Cannot find module '${moduleName}'`)
+  );
+}
+
+function requireOptionalModule(moduleName) {
+  try {
+    return require(moduleName);
+  } catch (e) {
+    if (isMissingTopLevelModule(e, moduleName)) {
+      warnBestEffort(`optional module ${moduleName}`, e);
+      return null;
+    }
+    throw e;
+  }
 }
 
 async function main() {
   const args = await readStdinJson();
   const url = args.url;
-  if (!url) { process.stderr.write('missing url\n'); process.exit(2); }
+  if (!url) {
+    process.stderr.write('missing url\n');
+    process.exitCode = 2;
+    return;
+  }
 
   const profileDir = args.profileDir || '/tmp/.insane_pw_profile';
   const waitSelector = args.waitSelector || null;
@@ -56,15 +77,13 @@ async function main() {
   const viewport = args.viewport || { width: 1366, height: 900 };
 
   let chromium;
-  try {
-    ({ chromium } = require('playwright-extra'));
-    const stealth = require('puppeteer-extra-plugin-stealth')();
+  const playwrightExtra = requireOptionalModule('playwright-extra');
+  const stealthPlugin = playwrightExtra ? requireOptionalModule('puppeteer-extra-plugin-stealth') : null;
+  if (playwrightExtra && stealthPlugin) {
+    ({ chromium } = playwrightExtra);
+    const stealth = stealthPlugin();
     chromium.use(stealth);
-  } catch (e) {
-    if (!isMissingOptionalDependency(e)) {
-      throw e;
-    }
-    warnBestEffort('stealth setup', e);
+  } else {
     // Fallback to plain playwright (no stealth). Still uses channel:chrome.
     ({ chromium } = require('playwright'));
   }
@@ -103,7 +122,8 @@ async function main() {
     if (waitSelector) {
       try {
         await page.waitForSelector(waitSelector, { timeout: Math.min(timeoutMs, 20000) });
-      } catch (_e) {
+      } catch (e) {
+        warnBestEffort('waitSelector', e);
         // Selector still missing — try one hard reload in case the first hit
         // landed on a challenge page and the sensor has just cleared.
         try {
@@ -112,7 +132,7 @@ async function main() {
           try {
             await page.waitForSelector(waitSelector, { timeout: 10000 });
           } catch (e2) {
-            warnBestEffort(`retry waitSelector ${waitSelector}`, e2);
+            warnBestEffort('retry waitSelector', e2);
             // Still no luck — caller validates HTML anyway.
           }
         } catch (e3) {
@@ -127,10 +147,12 @@ async function main() {
 
     const html = await page.content();
     process.stdout.write(html);
-    process.exit(0);
+    process.exitCode = 0;
+    return;
   } catch (e) {
     process.stderr.write(`${describeError(e)}\n`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   } finally {
     try {
       if (ctx) await ctx.close();

--- a/packages/shared-skills/skills/ultimate-browsing/engine/tests/test_playwright_templates.py
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/tests/test_playwright_templates.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
+TEMPLATE_NAMES = ("playwright_real_chrome.js", "playwright_mobile_chrome.js")
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+def _write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+
+
+def _install_fake_playwright(node_modules: Path) -> None:
+    _write_file(
+        node_modules / "playwright" / "index.js",
+        """
+        const page = {
+          async goto() {},
+          async waitForTimeout() {},
+          async waitForSelector(selector) {
+            if (process.env.PW_FAKE_SELECTOR_FAIL === '1') {
+              throw new Error(`missing selector ${selector}`);
+            }
+          },
+          async reload() {},
+          async content() {
+            return '<html><article>ok</article></html>';
+          },
+        };
+
+        const context = {
+          async newPage() { return page; },
+          async close() {
+            if (process.env.PW_FAKE_CLOSE_FAIL === '1') {
+              throw new Error('close failed');
+            }
+          },
+        };
+
+        exports.chromium = {
+          use() {},
+          async launchPersistentContext() { return context; },
+        };
+        exports.devices = {
+          'iPhone 13 Pro': { viewport: { width: 390, height: 844 }, userAgent: 'fake-mobile' },
+        };
+        """,
+    )
+
+
+def _install_broken_playwright_extra(node_modules: Path) -> None:
+    _write_file(
+        node_modules / "playwright-extra" / "index.js",
+        """
+        const error = new Error('stealth init failed');
+        error.code = 'EACCES';
+        throw error;
+        """,
+    )
+    _write_file(
+        node_modules / "puppeteer-extra-plugin-stealth" / "index.js",
+        """
+        module.exports = function stealth() { return {}; };
+        """,
+    )
+
+
+def _install_working_playwright_extra(node_modules: Path) -> None:
+    _write_file(
+        node_modules / "playwright-extra" / "index.js",
+        """
+        const playwright = require('playwright');
+        exports.chromium = playwright.chromium;
+        exports.devices = playwright.devices;
+        """,
+    )
+
+
+def _install_playwright_extra_with_internal_missing_dependency(node_modules: Path) -> None:
+    _write_file(
+        node_modules / "playwright-extra" / "index.js",
+        """
+        require('transitive-stealth-runtime');
+        """,
+    )
+
+
+def _run_template(
+    template_name: str,
+    payload: dict[str, JsonValue],
+    *,
+    include_broken_extra: bool = False,
+    include_working_extra: bool = False,
+    include_internal_missing_extra: bool = False,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory(prefix="ultimate-browsing-template-test-") as tmp:
+        tmp_path = Path(tmp)
+        node_modules = tmp_path / "node_modules"
+        _install_fake_playwright(node_modules)
+        if include_working_extra:
+            _install_working_playwright_extra(node_modules)
+        if include_broken_extra:
+            _install_broken_playwright_extra(node_modules)
+        if include_internal_missing_extra:
+            _install_playwright_extra_with_internal_missing_dependency(node_modules)
+
+        script_path = tmp_path / template_name
+        script_path.write_text((TEMPLATES_DIR / template_name).read_text(encoding="utf-8"), encoding="utf-8")
+
+        env = os.environ.copy()
+        env.pop("NODE_PATH", None)
+        if env_overrides:
+            env.update(env_overrides)
+
+        return subprocess.run(
+            ["node", str(script_path)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            timeout=5,
+            env=env,
+            check=False,
+        )
+
+
+@unittest.skipUnless(shutil.which("node"), "node is required for Playwright template tests")
+class PlaywrightTemplateErrorHandling(unittest.TestCase):
+    def test_missing_playwright_extra_warns_and_falls_back_to_plain_playwright(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/ultimate-browsing-test-profile",
+                        "headless": True,
+                    },
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("best-effort optional module playwright-extra failed:", result.stderr)
+                self.assertIn("Cannot find module 'playwright-extra'", result.stderr)
+
+    def test_missing_stealth_plugin_warns_and_falls_back_to_plain_playwright(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/ultimate-browsing-test-profile",
+                        "headless": True,
+                    },
+                    include_working_extra=True,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("best-effort optional module puppeteer-extra-plugin-stealth failed:", result.stderr)
+                self.assertIn("Cannot find module 'puppeteer-extra-plugin-stealth'", result.stderr)
+
+    def test_non_missing_stealth_dependency_error_is_not_swallowed(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/ultimate-browsing-test-profile",
+                        "headless": True,
+                    },
+                    include_broken_extra=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("stealth init failed", result.stderr)
+                self.assertNotIn("best-effort optional module", result.stderr)
+                self.assertEqual(result.stdout, "")
+
+    def test_internal_module_resolution_error_is_not_treated_as_optional_missing_dependency(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/ultimate-browsing-test-profile",
+                        "headless": True,
+                    },
+                    include_internal_missing_extra=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("Cannot find module 'transitive-stealth-runtime'", result.stderr)
+                self.assertNotIn("best-effort optional module", result.stderr)
+                self.assertEqual(result.stdout, "")
+
+    def test_selector_failures_are_reported_as_best_effort_warnings(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/ultimate-browsing-test-profile",
+                        "headless": True,
+                        "waitSelector": "article.ready",
+                    },
+                    env_overrides={"PW_FAKE_SELECTOR_FAIL": "1"},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("best-effort waitSelector failed:", result.stderr)
+                self.assertNotIn("waitSelector article.ready", result.stderr)
+
+    def test_context_close_failures_are_reported_after_successful_html_output(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/ultimate-browsing-test-profile",
+                        "headless": True,
+                    },
+                    env_overrides={"PW_FAKE_CLOSE_FAIL": "1"},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("best-effort browser context close failed:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/shared-skills/skills/ultimate-browsing/engine/tests/test_playwright_templates.py
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/tests/test_playwright_templates.py
@@ -94,6 +94,17 @@ def _install_playwright_extra_with_internal_missing_dependency(node_modules: Pat
     )
 
 
+def _install_self_missing_optional_module(node_modules: Path, module_name: str) -> None:
+    _write_file(
+        node_modules / module_name / "index.js",
+        f"""
+        const error = new Error("Cannot find module '{module_name}'");
+        error.code = 'MODULE_NOT_FOUND';
+        throw error;
+        """,
+    )
+
+
 def _run_template(
     template_name: str,
     payload: dict[str, JsonValue],
@@ -101,6 +112,7 @@ def _run_template(
     include_broken_extra: bool = False,
     include_working_extra: bool = False,
     include_internal_missing_extra: bool = False,
+    include_self_missing_module: str | None = None,
     env_overrides: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     with tempfile.TemporaryDirectory(prefix="ultimate-browsing-template-test-") as tmp:
@@ -113,6 +125,8 @@ def _run_template(
             _install_broken_playwright_extra(node_modules)
         if include_internal_missing_extra:
             _install_playwright_extra_with_internal_missing_dependency(node_modules)
+        if include_self_missing_module:
+            _install_self_missing_optional_module(node_modules, include_self_missing_module)
 
         script_path = tmp_path / template_name
         script_path.write_text((TEMPLATES_DIR / template_name).read_text(encoding="utf-8"), encoding="utf-8")
@@ -205,6 +219,27 @@ class PlaywrightTemplateErrorHandling(unittest.TestCase):
                 self.assertIn("Cannot find module 'transitive-stealth-runtime'", result.stderr)
                 self.assertNotIn("best-effort optional module", result.stderr)
                 self.assertEqual(result.stdout, "")
+
+    def test_present_optional_module_self_missing_error_is_not_swallowed(self) -> None:
+        cases = (("playwright-extra", False), ("puppeteer-extra-plugin-stealth", True))
+        for template_name in TEMPLATE_NAMES:
+            for module_name, include_working_extra in cases:
+                with self.subTest(template_name=template_name, module_name=module_name):
+                    result = _run_template(
+                        template_name,
+                        {
+                            "url": "https://example.com/article",
+                            "profileDir": "/tmp/ultimate-browsing-test-profile",
+                            "headless": True,
+                        },
+                        include_working_extra=include_working_extra,
+                        include_self_missing_module=module_name,
+                    )
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(f"Cannot find module '{module_name}'", result.stderr)
+                    self.assertNotIn("best-effort optional module", result.stderr)
+                    self.assertEqual(result.stdout, "")
 
     def test_selector_failures_are_reported_as_best_effort_warnings(self) -> None:
         for template_name in TEMPLATE_NAMES:


### PR DESCRIPTION
## Summary

This PR removes silent/swallowing catch behavior from the shipped Ultimate Browsing Playwright templates while preserving intended best-effort browser fallback paths. Optional top-level stealth packages now fall back to plain Playwright with bounded stderr warnings, installed/tampered optional-package failures rethrow, selector/reload/cleanup failures are observable, and successful HTML output still exits cleanly.

## Changes

- Add shared `describeError`, `warnBestEffort`, `isMissingTopLevelModule`, and `requireOptionalModule` helpers to both Playwright templates.
- Fall back only when the top-level optional packages `playwright-extra` or `puppeteer-extra-plugin-stealth` are truly absent at `require.resolve(...)` time.
- Rethrow internal module-resolution/setup failures, including forged self-`MODULE_NOT_FOUND` failures from installed optional packages.
- Replace `process.exit(...)` paths with `process.exitCode` + `return` so `finally` cleanup can run and report close failures.
- Use constant warning action labels for selector failures.
- Add `test_playwright_templates.py`, which runs the real Node templates with fake local Node modules to prove fallback/warning/rethrow/cleanup behavior.
- Classify the generated Codex plugin copy of the new Python template test in `python-migration-inventory.test.ts`, matching the existing generated Ultimate Browsing test inventory.

## Verification

- `node --check packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_mobile_chrome.js`
- `node --check packages/shared-skills/skills/ultimate-browsing/engine/templates/playwright_real_chrome.js`
- `git diff --check`
- `git grep -n 'catch[[:space:]]*(.*)[[:space:]]*{[[:space:]]*}' -- ...` returned no matches for the changed templates.
- `python3 .../skills/programming/scripts/python/check-no-excuse-rules.py packages/shared-skills/skills/ultimate-browsing/engine/tests/test_playwright_templates.py` passed: no violations.
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-codex/src/python-migration-inventory.test.ts` passed: no violations.
- `uv run --with pytest --with requests --with pyyaml --with curl_cffi python -m pytest packages/shared-skills/skills/ultimate-browsing/engine/tests/test_fetch_chain.py packages/shared-skills/skills/ultimate-browsing/engine/tests/test_playwright_templates.py` passed: 9 passed.
- `bun test packages/omo-codex/src/python-migration-inventory.test.ts` passed: 1 passed.
- Evidence artifacts:
  - `.omo/evidence/20260622-ultimate-browsing-template-catches/syntax-static-checks.txt`
  - `.omo/evidence/20260622-ultimate-browsing-template-catches/focused-python-tests-uv.txt`
  - `.omo/evidence/20260622-ultimate-browsing-template-catches/template-runtime-proof.txt`
  - `.omo/evidence/20260622-ultimate-browsing-template-catches/opencode-live-skill-proof.txt`
  - `.omo/evidence/20260622-ultimate-browsing-template-catches/security-fix-static-checks.txt`
  - `.omo/evidence/20260622-ultimate-browsing-template-catches/security-fix-focused-tests.txt`
- Live OpenCode QA evidence shows isolated XDG/OpenCode config loaded the local plugin wrapper, `/global/health` returned healthy OpenCode 1.17.8, `/experimental/tool/ids` included the OMO `skill` tool, `/experimental/tool` advertised `/ultimate-browsing` with WAF/Cloudflare/blocked wording, and real `~/.local/share/opencode/opencode.db` session count stayed unchanged before/after: 5737.

## Notes

The live QA evidence directory is ignored by repo policy (`.gitignore: .omo/*`) and is intentionally kept on disk rather than committed.
