### PR TITLE
Fix ultimate-browsing cookie domain matching

### DIFF
--- a/packages/omo-codex/src/install/codex-cache-install.test.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.test.ts
@@ -8,37 +8,41 @@ import { join } from "node:path"
 import { installCachedPlugin } from "./codex-cache"
 
 describe("codex-cache install", () => {
-  test("#given source plugin has development-only directories #when caching plugin #then writes only the plugin payload under the versioned cache", async () => {
-    // given
-    const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-layout-"))
-    const codexHome = join(root, "codex-home")
-    const sourceRoot = join(root, "plugin")
-    await mkdir(join(sourceRoot, ".git", "objects"), { recursive: true })
-    await mkdir(join(sourceRoot, "node_modules", "left-pad"), { recursive: true })
-    await mkdir(join(sourceRoot, "components", "rules", "node_modules", "debug"), { recursive: true })
-    await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }))
-    await writeFile(join(sourceRoot, ".git", "HEAD"), "ref: refs/heads/dev\n")
-    await writeFile(join(sourceRoot, "node_modules", "left-pad", "package.json"), "{}")
-    await writeFile(join(sourceRoot, "components", "rules", "node_modules", "debug", "package.json"), "{}")
-    await writeFile(join(sourceRoot, "components", "rules", "payload.txt"), "payload\n")
+  test(
+    "#given source plugin has development-only directories #when caching plugin #then writes only the plugin payload under the versioned cache",
+    async () => {
+      // given
+      const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-layout-"))
+      const codexHome = join(root, "codex-home")
+      const sourceRoot = join(root, "plugin")
+      await mkdir(join(sourceRoot, ".git", "objects"), { recursive: true })
+      await mkdir(join(sourceRoot, "node_modules", "left-pad"), { recursive: true })
+      await mkdir(join(sourceRoot, "components", "rules", "node_modules", "debug"), { recursive: true })
+      await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }))
+      await writeFile(join(sourceRoot, ".git", "HEAD"), "ref: refs/heads/dev\n")
+      await writeFile(join(sourceRoot, "node_modules", "left-pad", "package.json"), "{}")
+      await writeFile(join(sourceRoot, "components", "rules", "node_modules", "debug", "package.json"), "{}")
+      await writeFile(join(sourceRoot, "components", "rules", "payload.txt"), "payload\n")
 
-    // when
-    const installed = await installCachedPlugin({
-      codexHome,
-      marketplaceName: "debug",
-      name: "omo",
-      sourcePath: sourceRoot,
-      version: "0.1.0",
-      runCommand: async () => undefined,
-    })
+      // when
+      const installed = await installCachedPlugin({
+        codexHome,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async () => undefined,
+      })
 
-    // then
-    expect(installed.path).toBe(join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0"))
-    expect(await readFile(join(installed.path, "components", "rules", "payload.txt"), "utf8")).toBe("payload\n")
-    await expect(stat(join(installed.path, ".git"))).rejects.toThrow()
-    await expect(stat(join(installed.path, "node_modules"))).rejects.toThrow()
-    await expect(stat(join(installed.path, "components", "rules", "node_modules"))).rejects.toThrow()
-  })
+      // then
+      expect(installed.path).toBe(join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0"))
+      expect(await readFile(join(installed.path, "components", "rules", "payload.txt"), "utf8")).toBe("payload\n")
+      await expect(stat(join(installed.path, ".git"))).rejects.toThrow()
+      await expect(stat(join(installed.path, "node_modules"))).rejects.toThrow()
+      await expect(stat(join(installed.path, "components", "rules", "node_modules"))).rejects.toThrow()
+    },
+    15000,
+  )
 
   test("#given source plugin references missing hook command target #when caching plugin #then previous active cache is preserved", async () => {
     // given

--- a/packages/omo-codex/src/python-migration-inventory.test.ts
+++ b/packages/omo-codex/src/python-migration-inventory.test.ts
@@ -35,8 +35,10 @@ const optionalGeneratedPythonFiles = [
   "packages/omo-codex/plugin/skills/ultimate-browsing/engine/validators.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/engine/waf_detector.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/scripts/cookie_crypto.py",
+  "packages/omo-codex/plugin/skills/ultimate-browsing/scripts/cookie_domains.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/scripts/cookie_paths.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/scripts/extract_cookies.py",
+  "packages/omo-codex/plugin/skills/ultimate-browsing/scripts/tests/test_cookie_domain_filter.py",
   "packages/omo-codex/plugin/skills/ultimate-browsing/scripts/tests/test_extract_cookies.py",
 ] as const
 const retainedPythonFiles = [

--- a/packages/shared-skills/skills/ultimate-browsing/engine/validators.py
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/validators.py
@@ -18,7 +18,7 @@ from typing import Optional
 try:
     from bs4 import BeautifulSoup
 except ImportError:  # bs4 is a soft dep: only used when selectors given
-    BeautifulSoup = None  # type: ignore
+    BeautifulSoup = None
 
 
 # Markers are WAF-product strings only. Never include site brand / domain.

--- a/packages/shared-skills/skills/ultimate-browsing/engine/waf_detector.py
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/waf_detector.py
@@ -19,7 +19,7 @@ from typing import Optional
 try:
     import yaml  # PyYAML
 except ImportError:
-    yaml = None  # type: ignore
+    yaml = None
 
 
 PROFILES_PATH = os.path.join(os.path.dirname(__file__), "waf_profiles.yaml")

--- a/packages/shared-skills/skills/ultimate-browsing/scripts/cookie_crypto.py
+++ b/packages/shared-skills/skills/ultimate-browsing/scripts/cookie_crypto.py
@@ -15,8 +15,8 @@ def derive_key(platform: str, secret: bytes) -> bytes:
             raise ValueError(f"win32 os_crypt key must be 32 bytes, got {len(secret)}")
         return secret
     if platform in ("darwin", "linux"):
-        from cryptography.hazmat.primitives import hashes  # type: ignore[import-untyped]
-        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC  # type: ignore[import-untyped]
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
         iterations = 1003 if platform == "darwin" else 1
         return PBKDF2HMAC(algorithm=hashes.SHA1(), length=16, salt=b"saltysalt", iterations=iterations).derive(secret)
@@ -26,14 +26,16 @@ def derive_key(platform: str, secret: bytes) -> bytes:
 def decrypt_chromium_value(platform: str, key: bytes, encrypted: bytes) -> str:
     if not encrypted:
         return ""
-    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes  # type: ignore[import-untyped]
-
     prefix = encrypted[:3]
     if prefix in (b"v10", b"v11") and platform == "win32":
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
         nonce, ciphertext, tag = encrypted[3:15], encrypted[15:-16], encrypted[-16:]
         decryptor = Cipher(algorithms.AES(key), modes.GCM(nonce, tag)).decryptor()
         return (decryptor.update(ciphertext) + decryptor.finalize()).decode("utf-8", errors="replace")
     if prefix in (b"v10", b"v11"):
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
         decryptor = Cipher(algorithms.AES128(key), modes.CBC(b" " * 16)).decryptor()
         decrypted = decryptor.update(encrypted[3:]) + decryptor.finalize()
         pad = decrypted[-1]
@@ -55,7 +57,7 @@ def macos_keyring_secret(safe_storage: str) -> bytes:
 
 def linux_keyring_secret(safe_storage: str) -> bytes:
     try:
-        import secretstorage  # type: ignore[import-not-found,import-untyped]
+        import secretstorage
     except ImportError:
         return b"peanuts"
     conn = secretstorage.dbus_init()
@@ -68,6 +70,6 @@ def linux_keyring_secret(safe_storage: str) -> bytes:
 def windows_oscrypt_key(local_state_path: Path) -> bytes:
     state = json.loads(local_state_path.read_text())
     blob = base64.b64decode(state["os_crypt"]["encrypted_key"])[5:]
-    import win32crypt  # type: ignore[import-not-found,import-untyped]
+    import win32crypt
 
     return win32crypt.CryptUnprotectData(blob, None, None, None, 0)[1]

--- a/packages/shared-skills/skills/ultimate-browsing/scripts/cookie_domains.py
+++ b/packages/shared-skills/skills/ultimate-browsing/scripts/cookie_domains.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+SQL_LIKE_ESCAPE = "\\"
+
+
+class CookieDomainError(ValueError):
+    pass
+
+
+def normalize_cookie_domain(domain: str) -> str:
+    normalized = domain.strip().lower().lstrip(".")
+    if not normalized:
+        raise CookieDomainError("cookie domain must not be empty")
+    return normalized
+
+
+def escape_sql_like(value: str) -> str:
+    return (
+        value
+        .replace(SQL_LIKE_ESCAPE, SQL_LIKE_ESCAPE * 2)
+        .replace("%", f"{SQL_LIKE_ESCAPE}%")
+        .replace("_", f"{SQL_LIKE_ESCAPE}_")
+    )
+
+
+def domain_where_clause(column: str, domains: list[str]) -> tuple[str, list[str]]:
+    normalized_domains = sorted({normalize_cookie_domain(domain) for domain in domains})
+    if not normalized_domains:
+        raise CookieDomainError("at least one cookie domain is required")
+
+    clauses: list[str] = []
+    params: list[str] = []
+    for domain in normalized_domains:
+        clauses.append(
+            f"({column} = ? OR {column} = ? OR {column} LIKE ? ESCAPE '{SQL_LIKE_ESCAPE}')"
+        )
+        params.extend([domain, f".{domain}", f"%.{escape_sql_like(domain)}"])
+    return " OR ".join(clauses), params

--- a/packages/shared-skills/skills/ultimate-browsing/scripts/extract_cookies.py
+++ b/packages/shared-skills/skills/ultimate-browsing/scripts/extract_cookies.py
@@ -30,6 +30,7 @@ from cookie_crypto import (
     macos_keyring_secret,
     windows_oscrypt_key,
 )
+from cookie_domains import domain_where_clause
 from cookie_paths import BROWSERS, BrowserSpec, UnsupportedPlatform, platform_base, resolve_cookie_db
 
 _SAMESITE = {-1: "None", 0: "None", 1: "Lax", 2: "Strict"}
@@ -148,8 +149,7 @@ def write_cookie_file(path: Path, cookies: list[CookieRecord]) -> None:
 def extract_firefox(db_path: Path, domains: list[str]) -> list[CookieRecord]:
     tmp = _secure_cookie_db_copy(db_path)
     try:
-        where = " OR ".join("host LIKE ?" for _ in domains)
-        params = [f"%{d}%" for d in domains]
+        where, params = domain_where_clause("host", domains)
         conn = sqlite3.connect(str(tmp))
         rows = conn.execute(
             f"SELECT name, value, host, path, expiry, isSecure, isHttpOnly, sameSite "
@@ -171,8 +171,7 @@ def extract_firefox(db_path: Path, domains: list[str]) -> list[CookieRecord]:
 def extract_chromium(db_path: Path, domains: list[str], platform: str, key: bytes) -> list[CookieRecord]:
     tmp = _secure_cookie_db_copy(db_path)
     try:
-        where = " OR ".join("host_key LIKE ?" for _ in domains)
-        params = [f"%{d}%" for d in domains]
+        where, params = domain_where_clause("host_key", domains)
         conn = sqlite3.connect(str(tmp))
         rows = conn.execute(
             f"SELECT name, encrypted_value, host_key, path, expires_utc, is_secure, is_httponly, samesite "

--- a/packages/shared-skills/skills/ultimate-browsing/scripts/tests/test_cookie_domain_filter.py
+++ b/packages/shared-skills/skills/ultimate-browsing/scripts/tests/test_cookie_domain_filter.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from extract_cookies import extract_cookies  # noqa: E402
+
+
+def _make_chromium_db(path: Path, rows: list[tuple[str, bytes, str]]) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE cookies (name TEXT, encrypted_value BLOB, host_key TEXT, path TEXT, "
+        "expires_utc INTEGER, is_secure INTEGER, is_httponly INTEGER, samesite INTEGER)"
+    )
+    conn.executemany(
+        "INSERT INTO cookies VALUES (?,?,?,?,?,?,?,?)",
+        [
+            (name, value, host, "/", 13_300_000_000_000_000, 1, 1, 1)
+            for name, value, host in rows
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _make_firefox_db(path: Path, rows: list[tuple[str, str, str]]) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE moz_cookies (name TEXT, value TEXT, host TEXT, path TEXT, "
+        "expiry INTEGER, isSecure INTEGER, isHttpOnly INTEGER, sameSite INTEGER)"
+    )
+    conn.executemany(
+        "INSERT INTO moz_cookies VALUES (?,?,?,?,?,?,?,?)",
+        [
+            (name, value, host, "/", 9999999999, 1, 1, 1)
+            for name, value, host in rows
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+class DomainFilter(unittest.TestCase):
+    def _base_with_db(self, rel: str, make: Callable[[Path], None]) -> Path:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        db = base / rel
+        db.parent.mkdir(parents=True)
+        make(db)
+        return base
+
+    def test_chromium_does_not_overmatch_suffix_text(self) -> None:
+        base = self._base_with_db(
+            "Google/Chrome/User Data/Default/Cookies",
+            lambda p: _make_chromium_db(
+                p,
+                [
+                    ("exact", b"exact-value", "example.com"),
+                    ("sub", b"sub-value", ".login.example.com"),
+                    ("near", b"near-value", ".example.com"),
+                ],
+            ),
+        )
+
+        near = extract_cookies(
+            "chrome", ["ample.com"], platform="win32",
+            keyring_reader=lambda _s: b"k" * 32, base_override=base,
+        )
+        exact = extract_cookies(
+            "chrome", ["example.com"], platform="win32",
+            keyring_reader=lambda _s: b"k" * 32, base_override=base,
+        )
+
+        self.assertEqual(near, [])
+        self.assertEqual({cookie["name"] for cookie in exact}, {"exact", "near", "sub"})
+
+    def test_firefox_does_not_overmatch_suffix_text(self) -> None:
+        base = self._base_with_db(
+            "Firefox/Profiles/abc.default/cookies.sqlite",
+            lambda p: _make_firefox_db(
+                p,
+                [
+                    ("exact", "exact-value", "example.com"),
+                    ("sub", "sub-value", ".login.example.com"),
+                    ("near", "near-value", ".example.com"),
+                ],
+            ),
+        )
+
+        near = extract_cookies(
+            "firefox", ["ample.com"], platform="darwin", base_override=base,
+        )
+        exact = extract_cookies(
+            "firefox", ["example.com"], platform="darwin", base_override=base,
+        )
+
+        self.assertEqual(near, [])
+        self.assertEqual({cookie["name"] for cookie in exact}, {"exact", "near", "sub"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
Fixes the remaining ultimate-browsing publish blocker from the release review. Browser cookie extraction no longer uses broad `%domain%` SQL matching, so a request for `ample.com` cannot extract `.example.com` cookies.

This PR also removes the reviewed Python `# type: ignore` suppressions in the ultimate-browsing cookie/engine files.

## Changes
- Add `cookie_domains.py` to build exact-or-subdomain SQL predicates with escaped `LIKE` wildcards.
- Use the stricter domain predicate in Chromium and Firefox cookie extraction.
- Add dependency-free regression coverage for Chromium and Firefox cookie-domain filtering.
- Remove `# type: ignore` suppressions from `cookie_crypto.py`, `validators.py`, and `waf_detector.py`.
- Avoid importing `cryptography` for plaintext Chromium cookie values.

## Verification
- `python3 packages/shared-skills/skills/ultimate-browsing/scripts/tests/test_cookie_domain_filter.py` ✅
- `python3 -m py_compile` on changed Python files ✅
- strict scan for `type: ignore`, old `host LIKE ?` / `host_key LIKE ?`, and `f"%{d}%"` patterns ✅
- `python3 packages/shared-skills/skills/programming/scripts/python/check-no-excuse-rules.py packages/shared-skills/skills/ultimate-browsing/scripts/cookie_domains.py packages/shared-skills/skills/ultimate-browsing/scripts/tests/test_cookie_domain_filter.py` ✅
- `git diff --check origin/dev..HEAD` ✅
- `bun test packages/shared-skills/depersonalization-gate.test.ts` ✅
- `bun run typecheck` ✅

Evidence directory: `/Users/yeongyu/local-workspaces/omo-wt/fix-ultimate-browsing-cookie-domain/.omo/evidence/20260622-ultimate-browsing-cookie-domain-pr/`

Caveat: the legacy full `test_extract_cookies.py` suite still fails locally where it requires the optional `cryptography` package, which is not installed in this worktree environment. The new regression suite avoids that dependency and passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cookie domain matching in `ultimate-browsing` so extraction only returns exact or subdomain matches; a request for "ample.com" no longer matches ".example.com". Adds a small regression test suite and removes obsolete type suppressions. Also stabilizes a `@omo-codex` cache layout test on Windows.

- **Bug Fixes**
  - Use precise, escaped SQL predicates from `cookie_domains.py` for Firefox (`host`) and Chromium (`host_key`) extraction.
  - Stabilize `@omo-codex` cache layout test on Windows by increasing the timeout.

- **Refactors**
  - Remove `# type: ignore` in engine/scripts, lazy‑load `cryptography`, `secretstorage`, and `win32crypt`, and skip crypto imports for plaintext Chromium values; update `@omo-codex` Python inventory to include `cookie_domains.py` and its test.

<sup>Written for commit ae0d2050931cf3adba4a09bc646470ab16afc31d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

