### PR TITLE
fix(hook-message-injector): guard fetchSDKMessages against non-array SDK responses (fixes #5486)

### DIFF
--- a/packages/omo-opencode/src/features/hook-message-injector/injector.test.ts
+++ b/packages/omo-opencode/src/features/hook-message-injector/injector.test.ts
@@ -152,6 +152,21 @@ describe("findNearestMessageWithFieldsFromSDK", () => {
     expect(result).toBeNull()
   })
 
+  it("returns null when the SDK returns a non-array messages payload", async () => {
+    // given
+    const mockClient = {
+      session: {
+        messages: async () => ({ info: { agent: "sisyphus" } }),
+      },
+    }
+
+    // when
+    const result = await findNearestMessageWithFieldsFromSDK(unsafeTestValue(mockClient), "ses_123")
+
+    // then
+    expect(result).toBeNull()
+  })
+
   it("includes tools when available", async () => {
     const mockClient = createMockClient([
       {
@@ -314,6 +329,21 @@ describe("findFirstMessageWithAgentFromSDK", () => {
 
     const result = await findFirstMessageWithAgentFromSDK(unsafeTestValue(mockClient), "ses_123")
 
+    expect(result).toBeNull()
+  })
+
+  it("returns null when the SDK returns a non-array messages payload", async () => {
+    // given
+    const mockClient = {
+      session: {
+        messages: async () => ({ info: { agent: "sisyphus" } }),
+      },
+    }
+
+    // when
+    const result = await findFirstMessageWithAgentFromSDK(unsafeTestValue(mockClient), "ses_123")
+
+    // then
     expect(result).toBeNull()
   })
 })

--- a/packages/omo-opencode/src/features/hook-message-injector/sdk-message-lookup.ts
+++ b/packages/omo-opencode/src/features/hook-message-injector/sdk-message-lookup.ts
@@ -57,7 +57,8 @@ export async function fetchSDKMessages(client: OpencodeClient, sessionID: string
   try {
     const response = await client.session.messages({ path: { id: sessionID } })
     const emptyMessages: SDKMessage[] = []
-    return normalizeSDKResponse(response, emptyMessages, { preferResponseOnMissingData: true })
+    const normalized = normalizeSDKResponse(response, emptyMessages, { preferResponseOnMissingData: true })
+    return Array.isArray(normalized) ? normalized : emptyMessages
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     log("[hook-message-injector] SDK message fetch failed", {


### PR DESCRIPTION
## Summary

Invoking a sub-agent on OpenCode 1.17.9 crashes with a non-iterable error (`messages.map` undefined / "Spread syntax requires ...iterable") before the sub-agent starts. `fetchSDKMessages` could return a truthy non-array value, which the downstream lookups then `.map()` / spread over. This guards `fetchSDKMessages` to always return an array (or null), keeping the lookups safe.

## Root Cause

`findNearestMessageWithFieldsFromMessages` (`messages.map(...)`) and `findFirstMessageWithAgentFromMessages` (`[...messages].sort(...)`) assume an array. Their input comes from `fetchSDKMessages`, which returns `normalizeSDKResponse(response, emptyMessages, { preferResponseOnMissingData: true })`.

When `client.session.messages()` returns a truthy non-array payload (for example a bare object without a `data` array), `normalizeSDKResponse` with `preferResponseOnMissingData: true` returns that raw object. `fetchSDKMessages` then returns the non-array, the `if (!messages)` / `messages ?` guards accept it (objects are truthy), and `.map` / array spread throw, surfacing as "Error invoking sub-agent".

`normalizeSDKResponse` is a generic shared helper with 40+ callers, so the array guard belongs in the SDKMessage-specific consumer (`fetchSDKMessages`), not the shared util.

## Changes

| File | Change |
|------|--------|
| `packages/omo-opencode/src/features/hook-message-injector/sdk-message-lookup.ts` | `fetchSDKMessages` returns the normalized value only when it is an array, otherwise an empty array |
| `packages/omo-opencode/src/features/hook-message-injector/injector.test.ts` | Regression tests: both SDK lookup wrappers return null (no throw) on a non-array payload |

## Reproduction (before fix)

~~~
(fail) findNearestMessageWithFieldsFromSDK > returns null when the SDK returns a non-array messages payload
(fail) findFirstMessageWithAgentFromSDK > returns null when the SDK returns a non-array messages payload
TypeError: Spread syntax requires ...iterable[Symbol.iterator] to be a function
  at findFirstMessageWithAgentFromMessages (sdk-message-lookup.ts:98:38)
24 pass, 2 fail
~~~

## Verification (after fix)

~~~
bun test .../hook-message-injector/injector.test.ts  -> 26 pass, 0 fail
bun test .../hook-message-injector/                  -> 36 pass, 0 fail
bun run typecheck:packages                           -> exit 0
~~~

## Test

- Regression tests added to `injector.test.ts` (RED before the fix, GREEN after).
- Full `hook-message-injector` suite: 36 pass, 0 fail.
- `bun run typecheck:packages`: clean (exit 0).

Fixes #5486


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `fetchSDKMessages` to always return an array, preventing non-iterable crashes when the SDK returns a truthy non-array payload. Fixes #5486.

- **Bug Fixes**
  - Return an empty array when `normalizeSDKResponse` yields a non-array, keeping downstream `.map` and spread operations safe.
  - Added regression tests to ensure both SDK lookup wrappers return null (no throw) on non-array payloads.

<sup>Written for commit d903438ea30d440620cd860c71510715eefe8749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

