### PR TITLE
Update ultimate browsing runtime pins

### DIFF
--- a/packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
+++ b/packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
@@ -32,7 +32,7 @@ The Tier-2 stealth browser is **CloakBrowser**, installed at runtime via `pip`
 (`pip install cloakbrowser`). No CloakBrowser source is vendored in this repository.
 
 - Source: https://github.com/CloakHQ/CloakBrowser
-- Pinned runtime version: **0.3.28** (documented in `references/chrome-stealth.md`;
+- Pinned runtime version: **0.4.0** (documented in `references/chrome-stealth.md`;
   this is a documented version string, not an automated drift check).
 - Wrapper source license: MIT License.
 - Binary license: the compiled CloakBrowser Chromium binary downloaded by
@@ -79,7 +79,7 @@ The Tier-2 automation CLI is **agent-browser**, installed at runtime via `npm`
 (`npm i -g agent-browser`). No agent-browser source is vendored in this repository.
 
 - Source: https://github.com/vercel-labs/agent-browser
-- Pinned runtime version: **0.27.1** (documented in `references/chrome-stealth.md`;
+- Pinned runtime version: **0.29.1** (documented in `references/chrome-stealth.md`;
   documented version string, no automated drift check).
 - Licensed under the Apache License, Version 2.0 (the "License"); you may not use
   these files except in compliance with the License. You may obtain a copy of the

--- a/packages/shared-skills/skills/ultimate-browsing/engine/templates/package.json
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/templates/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Local deps for Playwright real-Chrome templates. npm install && npx playwright install chrome",
   "dependencies": {
-    "playwright": "^1.58.2",
+    "playwright": "^1.61.0",
     "playwright-extra": "^4.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2"
   }

--- a/packages/shared-skills/skills/ultimate-browsing/references/chrome-stealth.md
+++ b/packages/shared-skills/skills/ultimate-browsing/references/chrome-stealth.md
@@ -2,8 +2,8 @@
 
 Real interaction (clicks, forms, screenshots, video, persistent login) for pages that defeat Tier 1/1.5. Two runtime tools, both installed on demand — neither is vendored in this skill:
 
-- **CloakBrowser** (`pip`) — stealth Chromium with source-level C++ fingerprint patches. The Python wrapper source is MIT; the downloaded Chromium binary is covered by CloakBrowser's separate binary license and is not redistributed by this package. Passes Cloudflare Turnstile, FingerprintJS, BrowserScan, and 30+ detectors. Pin **0.3.28**.
-- **agent-browser** (`npm`, Apache-2.0) — native CDP automation CLI that drives CloakBrowser. AX-tree snapshots, `@eN` refs, click/fill/type/scroll, screenshots, video, cookie/state/session management. Pin **0.27.1**.
+- **CloakBrowser** (`pip`) — stealth Chromium with source-level C++ fingerprint patches. The Python wrapper source is MIT; the downloaded Chromium binary is covered by CloakBrowser's separate binary license and is not redistributed by this package. Passes Cloudflare Turnstile, FingerprintJS, BrowserScan, and 30+ detectors. Pin **0.4.0**.
+- **agent-browser** (`npm`, Apache-2.0) — native CDP automation CLI that drives CloakBrowser. AX-tree snapshots, `@eN` refs, click/fill/type/scroll, screenshots, video, cookie/state/session management. Pin **0.29.1**.
 
 ```
 CloakBrowser (stealth Chromium) <- CDP port 9242 -> agent-browser CLI
@@ -18,22 +18,22 @@ CloakBrowser (stealth Chromium) <- CDP port 9242 -> agent-browser CLI
 CloakBrowser runs in a dedicated Python venv. Cross-platform: macOS, Linux, and Windows all supported by both tools (use the venv path convention for your OS).
 
 ```bash
-# CloakBrowser (MIT wrapper source; separate binary license, pin 0.3.28):
+# CloakBrowser (MIT wrapper source; separate binary license, pin 0.4.0):
 uv venv .cloak-venv --python 3.13
 # macOS/Linux: source .cloak-venv/bin/activate    Windows: .cloak-venv\Scripts\activate
-uv pip install "cloakbrowser==0.3.28"
+uv pip install "cloakbrowser==0.4.0"
 python -c "import cloakbrowser; cloakbrowser.ensure_binary()"   # downloads stealth Chromium on first import
 
-# agent-browser (Apache-2.0, pin 0.27.1):
-npm i -g agent-browser@0.27.1 && agent-browser install
-agent-browser --version   # 0.27.1
+# agent-browser (Apache-2.0, pin 0.29.1):
+npm i -g agent-browser@0.29.1 && agent-browser install
+agent-browser --version   # 0.29.1
 ```
 
 Verify CloakBrowser:
 
 ```bash
 python -c "import cloakbrowser; print(cloakbrowser.__version__, cloakbrowser.CHROMIUM_VERSION, cloakbrowser.binary_info()['installed'])"
-# -> 0.3.28  <chromium-version>  True
+# -> 0.4.0  <chromium-version>  True
 ```
 
 ## Launch + drive
@@ -115,6 +115,6 @@ lsof -ti:9242 | xargs kill -9
 # agent-browser can't connect:
 curl -s http://127.0.0.1:9242/json/version | head -5   # empty -> CloakBrowser not running
 # Update either tool:
-uv pip install --upgrade "cloakbrowser==0.3.28" && python -c "import cloakbrowser; cloakbrowser.ensure_binary()"
-npm i -g agent-browser@0.27.1
+uv pip install --upgrade "cloakbrowser==0.4.0" && python -c "import cloakbrowser; cloakbrowser.ensure_binary()"
+npm i -g agent-browser@0.29.1
 ```


### PR DESCRIPTION
## Summary
Update the shared `ultimate-browsing` skill so its Tier-1 insane-search local Playwright fallback points at the latest Playwright runtime discovered today. While touching the skill's runtime pins, also align the Tier-2 Chrome stealth documentation and attribution pins with the latest published `cloakbrowser` and `agent-browser` versions.

Latest-version lookup performed on 2026-06-22:
- `npm view playwright version` => `1.61.0`
- `npm view playwright-extra version` => `4.3.6`
- `npm view puppeteer-extra-plugin-stealth version` => `2.11.2`
- `npm view agent-browser version` => `0.29.1`
- `python3 -m pip index versions cloakbrowser` => latest `0.4.0`

## Changes
- Bump `packages/shared-skills/skills/ultimate-browsing/engine/templates/package.json` from `playwright ^1.58.2` to `^1.61.0`.
- Update `references/chrome-stealth.md` runtime install, verify, and troubleshooting examples from `cloakbrowser 0.3.28` / `agent-browser 0.27.1` to `cloakbrowser 0.4.0` / `agent-browser 0.29.1`.
- Update `ATTRIBUTION.md` documented runtime pins to match the new Chrome stealth pins.

## Verification
**Automated:**
- `python3 -m unittest discover -s packages/shared-skills/skills/ultimate-browsing/engine/tests` ✅ 9 tests
- `bun test packages/shared-skills/depersonalization-gate.test.ts packages/shared-skills/upstreams.test.ts` ✅ 6 tests
- `node --test packages/omo-codex/plugin/test/sync-skills.test.mjs packages/omo-codex/plugin/test/ultraresearch-skill-contract.test.mjs` ✅ 28 tests
- `bun run typecheck` ✅
- `bun test` ✅ 10143 pass / 2 skip / 0 fail
- `bun run build` ✅ after cleaning generated nested `node_modules` from the fresh worktree
- `bun run test:codex` ✅ after cleaning generated nested `node_modules` from the fresh worktree

**Manual/live QA evidence:**
- `python3 -m engine 'https://example.com/' --selector h1 --json --no-playwright` ✅ returned `ok: true`, `verdict: strong_ok`
- `codex-qa` `app-server-drive.sh --plugin` ✅ real isolated Codex app-server turn completed; plugin hooks fired for `sessionStart`, `userPromptSubmit`, and `stop`; real `~/.codex/config.toml` unchanged
- `opencode-qa` `sse-hook-probe.sh --self-test` ✅ isolated `/event` stream opened and delivered `server.connected`

Evidence artifacts are saved locally under `.omo/evidence/20260622-ultimate-browsing-insane-search-latest/`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `ultimate-browsing` skill to use the latest Playwright for the Tier‑1 insane-search fallback and refreshes Tier‑2 Chrome stealth docs and attribution to current versions. Improves compatibility with modern Playwright and stealth tooling.

- **Dependencies**
  - `playwright` to `^1.61.0` in engine template (from `^1.58.2`).
  - Docs/attribution now pin `cloakbrowser` `0.4.0` (from `0.3.28`) and `agent-browser` `0.29.1` (from `0.27.1`).

<sup>Written for commit b4e91bfb7c886b109bfc78006133f2d2a6ec2163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

