### PR TITLE
fix(codex): reject duplicate teammode member names

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -76,6 +76,10 @@ function normalizedMemberName(name) {
 	return name.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
+function normalizedThreadTitle(title) {
+	return title.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
 function assertUniqueMemberFocus(team) {
 	const seen = new Map();
 	for (const member of team.members) {
@@ -101,6 +105,22 @@ function assertUniqueMemberName(team) {
 	}
 }
 
+function assertUniqueMemberThreadTitle(team) {
+	const seen = new Map();
+	for (const member of team.members) {
+		const threadTitle = member.threadTitle;
+		if (typeof threadTitle !== "string" || !threadTitle.trim()) {
+			throw new Error(`member "${member.id ?? member.name ?? member.focus ?? "(unknown)"}" has invalid threadTitle (non-empty string required)`);
+		}
+		const key = normalizedThreadTitle(threadTitle);
+		const previous = seen.get(key);
+		if (previous) {
+			throw new Error(`member threadTitle "${threadTitle}" duplicates "${previous.threadTitle}" (no two members may produce the same thread title)`);
+		}
+		seen.set(key, member);
+	}
+}
+
 function assertTeamReadyForThreadBinding(team) {
 	if (isUnderstaffed(team)) {
 		throw new Error(
@@ -109,6 +129,7 @@ function assertTeamReadyForThreadBinding(team) {
 	}
 	assertUniqueMemberFocus(team);
 	assertUniqueMemberName(team);
+	assertUniqueMemberThreadTitle(team);
 }
 
 export function addMember(team, { id, focus, lens, deliverable = "", branch = null, name = null }) {
@@ -195,6 +216,7 @@ export function validateTeam(team) {
 	if (!Array.isArray(team.members)) throw new Error("invalid team: members must be an array");
 	assertUniqueMemberFocus(team);
 	assertUniqueMemberName(team);
+	assertUniqueMemberThreadTitle(team);
 	return team;
 }
 

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -72,6 +72,10 @@ function normalizedFocus(focus) {
 	return focus.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
+function normalizedMemberName(name) {
+	return name.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
 function assertUniqueMemberFocus(team) {
 	const seen = new Map();
 	for (const member of team.members) {
@@ -103,6 +107,10 @@ export function addMember(team, { id, focus, lens, deliverable = "", branch = nu
 	// focus so the title is ALWAYS per-member and never the shared team-wide session name.
 	const memberName = name?.trim() || memberFocus;
 	if (team.members.some((m) => m.id === memberId)) throw new Error(`member id "${memberId}" already exists (duplicate)`);
+	const duplicateName = team.members.find((m) => normalizedMemberName(m.name ?? m.focus ?? "") === normalizedMemberName(memberName));
+	if (duplicateName) {
+		throw new Error(`member name "${memberName}" duplicates "${duplicateName.name ?? duplicateName.focus}" (no two members may produce the same thread title)`);
+	}
 	const duplicate = team.members.find((m) => normalizedFocus(m.focus) === normalizedFocus(memberFocus));
 	if (duplicate) throw new Error(`member focus "${memberFocus}" duplicates "${duplicate.focus}" (no two members may own the same thing)`);
 	team.members.push({

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -88,6 +88,19 @@ function assertUniqueMemberFocus(team) {
 	}
 }
 
+function assertUniqueMemberName(team) {
+	const seen = new Map();
+	for (const member of team.members) {
+		const memberName = member.name ?? member.focus ?? "";
+		const key = normalizedMemberName(memberName);
+		const previous = seen.get(key);
+		if (previous) {
+			throw new Error(`member name "${memberName}" duplicates "${previous.name ?? previous.focus}" (no two members may produce the same thread title)`);
+		}
+		seen.set(key, member);
+	}
+}
+
 function assertTeamReadyForThreadBinding(team) {
 	if (isUnderstaffed(team)) {
 		throw new Error(
@@ -95,6 +108,7 @@ function assertTeamReadyForThreadBinding(team) {
 		);
 	}
 	assertUniqueMemberFocus(team);
+	assertUniqueMemberName(team);
 }
 
 export function addMember(team, { id, focus, lens, deliverable = "", branch = null, name = null }) {
@@ -107,12 +121,12 @@ export function addMember(team, { id, focus, lens, deliverable = "", branch = nu
 	// focus so the title is ALWAYS per-member and never the shared team-wide session name.
 	const memberName = name?.trim() || memberFocus;
 	if (team.members.some((m) => m.id === memberId)) throw new Error(`member id "${memberId}" already exists (duplicate)`);
+	const duplicate = team.members.find((m) => normalizedFocus(m.focus) === normalizedFocus(memberFocus));
+	if (duplicate) throw new Error(`member focus "${memberFocus}" duplicates "${duplicate.focus}" (no two members may own the same thing)`);
 	const duplicateName = team.members.find((m) => normalizedMemberName(m.name ?? m.focus ?? "") === normalizedMemberName(memberName));
 	if (duplicateName) {
 		throw new Error(`member name "${memberName}" duplicates "${duplicateName.name ?? duplicateName.focus}" (no two members may produce the same thread title)`);
 	}
-	const duplicate = team.members.find((m) => normalizedFocus(m.focus) === normalizedFocus(memberFocus));
-	if (duplicate) throw new Error(`member focus "${memberFocus}" duplicates "${duplicate.focus}" (no two members may own the same thing)`);
 	team.members.push({
 		id: memberId,
 		name: memberName,
@@ -180,6 +194,7 @@ export function validateTeam(team) {
 	if (team.leader?.kind !== "main-session") throw new Error("invalid team: leader.kind must be main-session");
 	if (!Array.isArray(team.members)) throw new Error("invalid team: members must be an array");
 	assertUniqueMemberFocus(team);
+	assertUniqueMemberName(team);
 	return team;
 }
 

--- a/packages/omo-codex/plugin/test/teammode-thread-title.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-thread-title.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam } from "./teammode-safety-fixture.mjs";
+import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam, runTeamRaw } from "./teammode-safety-fixture.mjs";
 
 function addMember(tempRoot, sessionId, { id, name, focus, lens, deliverable }) {
 	const args = ["add-member", "--team", sessionId, "--id", id, "--focus", focus, "--lens", lens, "--deliverable", deliverable];
@@ -46,6 +46,48 @@ test("#given a member added without an explicit name #when state is read #then t
 		assert.equal(byId.A.threadTitle, "[Recovery] installer config");
 		assert.equal(byId.B.threadTitle, "[Recovery] runtime qa");
 		assert.notEqual(byId.A.threadTitle, byId.B.threadTitle);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a member name already exists #when add-member receives the same name with different spacing and case #then state is not partially mutated", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-title-duplicate-name-");
+	try {
+		runTeam(tempRoot, "init", "--name", "Recovery", "--session-name", "shared-session", "--session", "title-duplicate-name");
+		addMember(tempRoot, "title-duplicate-name", {
+			id: "A",
+			name: "App Server",
+			focus: "app-server lifecycle",
+			lens: "area",
+			deliverable: "lifecycle map",
+		});
+
+		const result = runTeamRaw(
+			tempRoot,
+			"add-member",
+			"--team",
+			"title-duplicate-name",
+			"--id",
+			"B",
+			"--name",
+			" app   server ",
+			"--focus",
+			"mailbox delivery",
+			"--lens",
+			"ownership",
+			"--deliverable",
+			"delivery audit",
+		);
+		const team = readTeamJson(tempRoot, "title-duplicate-name");
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /member name "app   server" duplicates "App Server"/);
+		assert.equal(team.members.length, 1);
+		assert.deepEqual(
+			team.members.map((member) => ({ id: member.id, name: member.name, threadTitle: member.threadTitle })),
+			[{ id: "A", name: "App Server", threadTitle: "[Recovery] App Server" }],
+		);
 	} finally {
 		cleanupTeamRoot(tempRoot);
 	}

--- a/packages/omo-codex/plugin/test/teammode-thread-title.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-thread-title.test.mjs
@@ -125,3 +125,45 @@ test("#given persisted team.json has duplicate member names #when a command load
 		cleanupTeamRoot(tempRoot);
 	}
 });
+
+test("#given persisted team.json has duplicate thread titles with distinct member names #when bind-thread runs #then state is rejected before activation", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-title-stale-duplicate-title-");
+	try {
+		runTeam(tempRoot, "init", "--name", "Recovery", "--session-name", "shared-session", "--session", "title-stale-duplicate-title");
+		addMember(tempRoot, "title-stale-duplicate-title", {
+			id: "A",
+			name: "App Server",
+			focus: "app-server lifecycle",
+			lens: "area",
+			deliverable: "lifecycle map",
+		});
+		addMember(tempRoot, "title-stale-duplicate-title", {
+			id: "B",
+			name: "Mailbox Delivery",
+			focus: "mailbox delivery",
+			lens: "ownership",
+			deliverable: "delivery audit",
+		});
+		const path = teamJsonPath(tempRoot, "title-stale-duplicate-title");
+		const team = JSON.parse(readFileSync(path, "utf8"));
+		team.members[0].threadTitle = "[Legacy] Alpha";
+		team.members[1].threadTitle = "[Legacy] Alpha";
+		writeFileSync(path, `${JSON.stringify(team, null, 2)}\n`);
+
+		const result = runTeamRaw(tempRoot, "bind-thread", "--team", "title-stale-duplicate-title", "--id", "A", "--thread", "thread-a");
+		const persisted = readTeamJson(tempRoot, "title-stale-duplicate-title");
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /member threadTitle "\[Legacy\] Alpha" duplicates "\[Legacy\] Alpha"/);
+		assert.deepEqual(
+			persisted.members.map((member) => ({ id: member.id, status: member.status, threadId: member.threadId })),
+			[
+				{ id: "A", status: "pending", threadId: null },
+				{ id: "B", status: "pending", threadId: null },
+			],
+		);
+		assert.equal(persisted.log.some((entry) => entry.event === "bind-thread"), false);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});

--- a/packages/omo-codex/plugin/test/teammode-thread-title.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-thread-title.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { readFileSync, writeFileSync } from "node:fs";
 import test from "node:test";
 
-import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam, runTeamRaw } from "./teammode-safety-fixture.mjs";
+import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam, runTeamRaw, teamJsonPath } from "./teammode-safety-fixture.mjs";
 
 function addMember(tempRoot, sessionId, { id, name, focus, lens, deliverable }) {
 	const args = ["add-member", "--team", sessionId, "--id", id, "--focus", focus, "--lens", lens, "--deliverable", deliverable];
@@ -88,6 +89,38 @@ test("#given a member name already exists #when add-member receives the same nam
 			team.members.map((member) => ({ id: member.id, name: member.name, threadTitle: member.threadTitle })),
 			[{ id: "A", name: "App Server", threadTitle: "[Recovery] App Server" }],
 		);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given persisted team.json has duplicate member names #when a command loads the team #then stale state is rejected", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-title-stale-duplicate-name-");
+	try {
+		runTeam(tempRoot, "init", "--name", "Recovery", "--session-name", "shared-session", "--session", "title-stale-duplicate-name");
+		addMember(tempRoot, "title-stale-duplicate-name", {
+			id: "A",
+			name: "App Server",
+			focus: "app-server lifecycle",
+			lens: "area",
+			deliverable: "lifecycle map",
+		});
+		addMember(tempRoot, "title-stale-duplicate-name", {
+			id: "B",
+			name: "Mailbox Delivery",
+			focus: "mailbox delivery",
+			lens: "ownership",
+			deliverable: "delivery audit",
+		});
+		const path = teamJsonPath(tempRoot, "title-stale-duplicate-name");
+		const team = JSON.parse(readFileSync(path, "utf8"));
+		team.members[1].name = " app   server ";
+		writeFileSync(path, `${JSON.stringify(team, null, 2)}\n`);
+
+		const result = runTeamRaw(tempRoot, "status", "--team", "title-stale-duplicate-name");
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /member name " app   server " duplicates "App Server"/);
 	} finally {
 		cleanupTeamRoot(tempRoot);
 	}


### PR DESCRIPTION
## Summary
Fixes a pre-publish Codex Team Mode blocker where `add-member --name` accepted duplicate member names even though durable Codex team threads are titled from the member name. Different ids/focuses could therefore produce identical `[team] <member name>` thread titles, making routing, inspection, and archival ambiguous.

This adds a normalized duplicate-name guard beside the existing duplicate-id and duplicate-focus guards, plus a regression test proving the failed add leaves persisted team state unchanged.

## Changes
- Reject duplicate normalized `member.name` values in `addMember()` before mutating team state.
- Preserve the existing focus fallback behavior and existing unique-focus invariant.
- Add a negative thread-title regression for spacing/case-normalized duplicate names.

## Verification
**Automated / CLI surfaces:**
- `node --test packages/omo-codex/plugin/test/teammode-thread-title.test.mjs` -> 3 pass, 0 fail.
- `node --test packages/omo-codex/plugin/test/teammode-worktree.test.mjs packages/omo-codex/plugin/test/teammode-communication.test.mjs packages/omo-codex/plugin/test/teammode-thread-title.test.mjs` -> 16 pass, 0 fail.
- `git diff --check` -> pass.

**Red/green evidence:**
- Red proof captured the new regression failing before the guard because the duplicate `--name` returned status 0.
- Green proof captured the targeted and related teammode suites passing after the guard.
- Evidence directory: `.omo/evidence/20260622-teammode-duplicate-name/` in the fix worktree.

**Codex QA (isolated live harness):**
- `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check` -> pass.
- `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` -> pass after dependency prep in the fresh worktree.
- Final app-server proof observed `turnStatus: "completed"`, `missingHooks: []`, plugin `hook/completed` notifications for `sessionStart` and `userPromptSubmit`, mock assistant text returned, and `PASS: real ~/.codex/config.toml unchanged`.
- Evidence directory: `.omo/evidence/20260622-teammode-duplicate-name/codex-qa/` in the fix worktree.

## Release Gate Context
This addresses the blocking HIGH finding from the Codex Team Mode / ULW pre-publish review artifact: duplicate explicit member names could produce colliding durable thread titles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate Team Mode member names and thread titles (case/spacing-insensitive) to prevent colliding durable threads. Validate team state on load and before binding to catch stale duplicates early.

- **Bug Fixes**
  - Normalize and compare member names; throw on duplicates in add-member.
  - Enforce unique member names and `threadTitle`s when loading and before `bind-thread`; reject stale duplicates in team.json.
  - Add tests for spacing/case variants, persisted duplicate names, duplicate thread titles, and no partial state changes.

<sup>Written for commit 92d3629c19d54c3dee2b46e92467a449cdb82b7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

