### PR TITLE
fix(opencode): release stale parent wake marker

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager-continuation-marker.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-continuation-marker.test.ts
@@ -8,6 +8,7 @@ import { readContinuationMarker } from "../run-continuation-state"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import { BACKGROUND_COMPLETION_WAKE_PENDING_REASON } from "./background-task-marker"
 import { BackgroundManager } from "./manager"
+import type { BackgroundTask } from "./types"
 
 type ParentWakeNotifierForMarkerTest = {
   readonly reserveNotificationPreparation: (sessionID: string) => void
@@ -18,6 +19,8 @@ type ParentWakeNotifierForMarkerTest = {
 
 type BackgroundManagerMarkerInternals = BackgroundManager & {
   readonly parentWakeNotifier: ParentWakeNotifierForMarkerTest
+  readonly tasks: Map<string, BackgroundTask>
+  readonly pendingByParent: Map<string, Set<string>>
   readonly updateBackgroundTaskMarker: (parentSessionID: string) => void
   readonly queuePendingParentWake: (
     sessionID: string,
@@ -27,6 +30,7 @@ type BackgroundManagerMarkerInternals = BackgroundManager & {
     delayMs?: number,
   ) => void
   readonly flushPendingParentWake: (sessionID: string) => Promise<void>
+  readonly tryCompleteTask: (task: BackgroundTask, source: string) => Promise<boolean>
 }
 
 const testDirectories: string[] = []
@@ -47,7 +51,7 @@ function createTestDirectory(): string {
   return directory
 }
 
-function createManager(directory: string): BackgroundManager {
+function createManager(directory: string, enableParentSessionNotifications = true): BackgroundManager {
   const promptAsyncCalls: unknown[] = []
   const pluginContext = unsafeTestValue<PluginInput>({
     client: {
@@ -63,7 +67,19 @@ function createManager(directory: string): BackgroundManager {
     },
     directory,
   })
-  return new BackgroundManager({ pluginContext })
+  return new BackgroundManager({ pluginContext, enableParentSessionNotifications })
+}
+
+function createRunningTask(overrides: Partial<BackgroundTask> & { id: string; parentSessionId: string }): BackgroundTask {
+  return {
+    parentMessageId: "parent-message-id",
+    description: "test background task",
+    prompt: "test prompt",
+    agent: "test-agent",
+    status: "running",
+    startedAt: new Date("2026-06-22T00:00:00.000Z"),
+    ...overrides,
+  }
 }
 
 async function waitForBackgroundTaskMarkerState(
@@ -130,6 +146,33 @@ describe("BackgroundManager run continuation marker parent-wake races", () => {
       // then
       const dispatchedMarker = readContinuationMarker(directory, parentSessionID)
       expect(dispatchedMarker?.sources["background-task"]?.state).toBe("idle")
+    } finally {
+      manager.shutdown()
+    }
+  })
+
+  test("#given parent notifications are disabled #when final child completion releases preparation #then the marker returns idle", async () => {
+    // given
+    const directory = createTestDirectory()
+    const parentSessionID = "parent-disabled-notifications"
+    const manager = createManager(directory, false)
+    const internals = unsafeTestValue<BackgroundManagerMarkerInternals>(manager)
+    const task = createRunningTask({
+      id: "task-disabled-notifications",
+      parentSessionId: parentSessionID,
+      sessionId: "child-disabled-notifications",
+    })
+    internals.tasks.set(task.id, task)
+    internals.pendingByParent.set(parentSessionID, new Set([task.id]))
+
+    try {
+      // when
+      const completed = await internals.tryCompleteTask(task, "marker regression")
+
+      // then
+      expect(completed).toBe(true)
+      const marker = readContinuationMarker(directory, parentSessionID)
+      expect(marker?.sources["background-task"]?.state).toBe("idle")
     } finally {
       manager.shutdown()
     }

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -1970,6 +1970,7 @@ The fallback retry session is now created and can be inspected directly.
     const releaseNotificationPreparation = (): void => {
       if (notificationParentSessionID) {
         this.parentWakeNotifier.releaseNotificationPreparation(notificationParentSessionID)
+        this.updateBackgroundTaskMarker(notificationParentSessionID)
       }
     }
 
@@ -2597,6 +2598,7 @@ The task was re-queued on a fallback model after a retryable failure.
     } finally {
       if (notificationParentSessionID) {
         this.parentWakeNotifier.releaseNotificationPreparation(notificationParentSessionID)
+        this.updateBackgroundTaskMarker(notificationParentSessionID)
       }
     }
   }


### PR DESCRIPTION
## Summary
Fixes the release-gate blocker where OpenCode background-task continuation markers could remain active after a final child task completed with parent notifications disabled.

The fix refreshes the background-task marker immediately after notification-preparation reservations are released, covering both the async-prompt failure path and the normal `tryCompleteTask` finalization path.

## Changes
- Refresh `background-task` marker state after `releaseNotificationPreparation(...)` in `BackgroundManager`.
- Add a regression for `enableParentSessionNotifications: false` proving final-child completion returns the marker to `idle`.

## Verification
**Automated / focused:**
- Focused regression: 6 pass
- Related background-agent behavior tests: pass
- `manager.test.ts --filter tryCompleteTask`: 191 pass
- `git diff --check`: pass
- `bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json`: pass

**OpenCode QA / isolation:**
- `opencode-qa` common self-test: pass
- `opencode-qa` SSE self-test: pass
- Real OpenCode DB session count unchanged before/after: `5737 -> 5737`

Evidence recorded under:
- `.omo/evidence/20260622-parent-wake-marker-release/stop-hook-verification-3.txt`

## Release Gate Context
This addresses the HIGH blocker from:
- `.omo/teams/team-46791fa8/artifacts/ultra-05-opencode-parent-wake.md`

A separate after-#5511 QA refresh showed current `origin/dev` executable gates green, with this stale-marker blocker as the remaining release blocker:
- `.omo/teams/team-46791fa8/artifacts/after-5511-qa/summary.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the background-task continuation marker could stay active after the final child task completed, especially when parent notifications are disabled. The marker is now refreshed right after releasing notification-preparation reservations so it returns to idle in both normal completion and failure paths.

- **Bug Fixes**
  - Refresh `background-task` marker immediately after `releaseNotificationPreparation(...)` in `BackgroundManager` (covers async-prompt failure and `tryCompleteTask`).
  - Add regression test for `enableParentSessionNotifications: false` to verify the marker returns to `idle` on final-child completion.

<sup>Written for commit 71300901c26193bae0bcc223e03ad751230568d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

