### PR TITLE
test: cover release gate behavior semantically

### DIFF
--- a/.omo/evidence/20260622-release-gate-test-slop/SUMMARY.md
+++ b/.omo/evidence/20260622-release-gate-test-slop/SUMMARY.md
@@ -1,0 +1,50 @@
+# Release Gate Test Slop Evidence
+
+## Success Criteria
+
+- Scenario: `setup.sh` offline tolerance for failing provenance submodule and frontend materialization commands.
+  Invocation: `bun test script/agent-env.test.ts script/agent-setup-offline.test.ts`.
+  Binary observable: `script/agent-setup-offline.test.ts` passed after fake `git submodule` and fake `node materialize-frontend-refs.mjs` failed; stdout contained both warning messages and the later skip-build message.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/bun-test-agent-env-and-setup-offline.txt`.
+
+- Scenario: LazyCodex auto-update started notice avoids full-string pinning.
+  Invocation: `node --test packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs`.
+  Binary observable: 7 Node tests passed; started notice assertions cover version transition, background install, new-session recommendation, preferred tone instruction, and release-notes-unavailable fallback.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/node-test-auto-update-restart-notice-rerun.txt`.
+
+- Scenario: whitespace/conflict hygiene.
+  Invocation: `git diff --check`.
+  Binary observable: exit 0, no output after the command banner.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/git-diff-check-rerun.txt`.
+
+- Scenario: focused TypeScript check for changed script tests.
+  Invocation: `bun run typecheck:script`.
+  Binary observable: `tsgo --noEmit -p script/tsconfig.json` exited 0.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/typecheck-script-rerun.txt`.
+
+- Scenario: focused MJS syntax check.
+  Invocation: `node --check packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs`.
+  Binary observable: exit 0.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/node-check-auto-update-restart-notice-rerun.txt`.
+
+- Scenario: suppression/slop scan on changed test files.
+  Invocation: `rg -n "as any|@ts-ignore|@ts-expect-error|catch\\s*\\([^)]*\\)\\s*\\{\\s*\\}" script/agent-env.test.ts script/agent-setup-offline.test.ts packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs`.
+  Binary observable: exit 0 from the wrapper, no matches after the command banner.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/no-suppression-scan-rerun.txt`.
+
+- Scenario: Codex QA isolation harness self-check.
+  Invocation: `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check`.
+  Binary observable: dependencies present, isolated `CODEX_HOME` auto-removed, mock model served Responses SSE, real `~/.codex/config.toml` hash unchanged.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/codex-qa-common-self-check.txt`.
+
+- Scenario: Codex deterministic local-plugin hook probe.
+  Invocation: `bash .agents/skills/codex-qa/scripts/hook-unit-probe.sh --self-test`.
+  Binary observable: local plugin installed into isolated `CODEX_HOME`, real `~/.codex/config.toml` hash unchanged, `ultrawork` hook injected `<ultrawork-mode>`.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/codex-qa-hook-unit-probe-rerun.txt`.
+
+## Bootstrap Receipts
+
+- `bun install --ignore-scripts` created workspace links in this fresh worktree without running the repo build.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/bun-install-ignore-scripts.txt`.
+- `npm --prefix packages/lsp-tools-mcp ci` installed the vendored Node-targeted LSP MCP dependencies required by the Codex QA hook probe.
+  Artifact: `.omo/evidence/20260622-release-gate-test-slop/npm-ci-lsp-tools-mcp.txt`.

--- a/.omo/evidence/20260622-release-gate-test-slop/bun-install-ignore-scripts.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/bun-install-ignore-scripts.txt
@@ -1,0 +1,28 @@
+$ bun install --ignore-scripts
+bun install v1.3.14 (0d9b296a)
+
++ @types/js-yaml@4.0.9
++ @types/picomatch@4.0.3
++ @typescript/native-preview@7.0.0-dev.20260518.1
++ bun-types@1.3.14
++ typescript@6.0.3
++ @clack/prompts@1.5.0
++ @code-yeongyu/comment-checker@0.8.0
++ @modelcontextprotocol/sdk@1.29.0
++ @opencode-ai/plugin@1.15.13
++ @opencode-ai/sdk@1.15.13
++ @opentui/core@0.2.16
++ @opentui/keymap@0.2.16
++ @opentui/solid@0.2.16
++ commander@14.0.3
++ detect-libc@2.1.2
++ diff@9.0.0
++ js-yaml@4.2.0
++ jsonc-parser@3.3.1
++ picocolors@1.1.1
++ picomatch@4.0.4
++ posthog-node@5.35.12
++ vscode-jsonrpc@8.2.1
++ zod@4.4.3
+
+468 packages installed [413.00ms]

--- a/.omo/evidence/20260622-release-gate-test-slop/bun-test-agent-env-and-setup-offline.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/bun-test-agent-env-and-setup-offline.txt
@@ -1,0 +1,23 @@
+$ bun test script/agent-env.test.ts script/agent-setup-offline.test.ts
+bun test v1.3.14 (0d9b296a)
+
+script/agent-setup-offline.test.ts:
+(pass) #given submodule and materialize failures #when setup runs #then it warns and continues [1093.58ms]
+
+script/agent-env.test.ts:
+(pass) agent dev-environment scripts > setup.sh > #given the shared bootstrap #when inspected #then it is an executable strict bash script [0.20ms]
+(pass) agent dev-environment scripts > setup.sh > #given the bootstrap #when it runs #then it verifies tools, installs, and conditionally builds [0.11ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the teardown #when inspected #then it is an executable strict bash script with a --deep mode [0.10ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when inspected #then it is executable bash [0.10ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when sync mode runs #then it executes cleanup and exits successfully [9.47ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when async mode runs #then it returns before cleanup finishes [1236.03ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given a hostile cleanup log override #when the launcher runs #then it keeps logs in temp [34.53ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the teardown #when inspected for safety #then it guards repo root and never nukes source or host [0.34ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given transient files in source and skipped trees #when cleanup runs #then it prunes skipped trees [15.14ms]
+(pass) agent dev-environment scripts > qa-sandbox.sh > #given the QA isolation helper #when inspected #then it isolates XDG + CODEX_HOME and injects creds [0.21ms]
+(pass) agent dev-environment scripts > .env.example > #given the credential template #when inspected #then it documents the injection points without real secrets [0.10ms]
+
+ 12 pass
+ 0 fail
+ 66 expect() calls
+Ran 12 tests across 2 files. [2.45s]

--- a/.omo/evidence/20260622-release-gate-test-slop/codex-qa-common-self-check.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/codex-qa-common-self-check.txt
@@ -1,0 +1,9 @@
+$ bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check
+PASS: dependencies present (codex node jq tmux)
+PASS: codex binary -> /Users/yeongyu/.local/bin/codex
+PASS: isolated CODEX_HOME auto-removed on exit (/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/cqa-home.XXXXXX.9Yevr3w4gQ)
+PASS: CODEX_HOME points inside sandbox, not ~/.codex
+PASS: mock model serves Responses SSE on :50510
+PASS: real ~/.codex/config.toml unchanged (7b02b43fa7a59859ddb12f7585eda8509d8229e5)
+PASS: common.sh self-check
+.agents/skills/codex-qa/scripts/lib/common.sh: line 131: 42062 Terminated: 15          node "$lib_dir/mock-model.mjs" > "$log" 2>&1

--- a/.omo/evidence/20260622-release-gate-test-slop/codex-qa-hook-unit-probe-rerun.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/codex-qa-hook-unit-probe-rerun.txt
@@ -1,0 +1,4 @@
+$ bash .agents/skills/codex-qa/scripts/hook-unit-probe.sh --self-test
+installing local omo into /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/cqa-home.XXXXXX.JoNaCE5TOs/codex ...
+PASS: real ~/.codex/config.toml unchanged (7b02b43fa7a59859ddb12f7585eda8509d8229e5)
+PASS: ultrawork UserPromptSubmit injected <ultrawork-mode> on an ulw prompt

--- a/.omo/evidence/20260622-release-gate-test-slop/git-diff-check-rerun.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/git-diff-check-rerun.txt
@@ -1,0 +1,1 @@
+$ git diff --check

--- a/.omo/evidence/20260622-release-gate-test-slop/no-suppression-scan-rerun.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/no-suppression-scan-rerun.txt
@@ -1,0 +1,1 @@
+$ rg -n "as any|@ts-ignore|@ts-expect-error|catch\s*\([^)]*\)\s*\{\s*\}" script/agent-env.test.ts script/agent-setup-offline.test.ts packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs

--- a/.omo/evidence/20260622-release-gate-test-slop/node-check-auto-update-restart-notice-rerun.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/node-check-auto-update-restart-notice-rerun.txt
@@ -1,0 +1,1 @@
+$ node --check packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs

--- a/.omo/evidence/20260622-release-gate-test-slop/node-test-auto-update-restart-notice-rerun.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/node-test-auto-update-restart-notice-rerun.txt
@@ -1,0 +1,16 @@
+$ node --test packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+✔ #given a newer version #when resolving auto update plan #then plan carries current and latest versions (1.27125ms)
+✔ #given a newer version #when waited update succeeds #then returns update-started notice and persists pendingNotice (55.337875ms)
+✔ #given completed pending update #when startup check is throttled #then emits completed notice and clears pendingNotice (2.9125ms)
+✔ #given incomplete pending update #when startup check runs #then no notice and pendingNotice retained (2.228792ms)
+✔ #given waited update fails #then no notice and no pendingNotice (50.034334ms)
+✔ #given malformed pendingNotice toVersion #when check runs #then pendingNotice dropped silently (2.64825ms)
+✔ #given completed pending update #when hook session-start runs as CLI #then prints one SessionStart JSON line (137.75175ms)
+ℹ tests 7
+ℹ suites 0
+ℹ pass 7
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 333.807042

--- a/.omo/evidence/20260622-release-gate-test-slop/npm-ci-lsp-tools-mcp.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/npm-ci-lsp-tools-mcp.txt
@@ -1,0 +1,8 @@
+$ npm --prefix packages/lsp-tools-mcp ci
+
+added 52 packages, and audited 55 packages in 500ms
+
+18 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities

--- a/.omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-1.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-1.txt
@@ -1,0 +1,84 @@
+STOP-HOOK VERIFICATION RUN
+UTC 2026-06-22T12:19:29Z
+
+$ pwd
+/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-release-gate-test-slop-20260622
+
+$ git rev-parse HEAD
+cc741f5a8fe4ac254490c755aa0216b769b008bd
+
+$ git status --short
+
+$ test -s .omo/evidence/20260622-release-gate-test-slop/SUMMARY.md && echo SUMMARY_PRESENT_NONEMPTY
+SUMMARY_PRESENT_NONEMPTY
+
+$ bun test script/agent-env.test.ts script/agent-setup-offline.test.ts
+bun test v1.3.14 (0d9b296a)
+
+script/agent-setup-offline.test.ts:
+(pass) #given submodule and materialize failures #when setup runs #then it warns and continues [454.12ms]
+
+script/agent-env.test.ts:
+(pass) agent dev-environment scripts > setup.sh > #given the shared bootstrap #when inspected #then it is an executable strict bash script [0.27ms]
+(pass) agent dev-environment scripts > setup.sh > #given the bootstrap #when it runs #then it verifies tools, installs, and conditionally builds [0.17ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the teardown #when inspected #then it is an executable strict bash script with a --deep mode [0.09ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when inspected #then it is executable bash [0.10ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when sync mode runs #then it executes cleanup and exits successfully [11.15ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when async mode runs #then it returns before cleanup finishes [1233.60ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given a hostile cleanup log override #when the launcher runs #then it keeps logs in temp [32.13ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the teardown #when inspected for safety #then it guards repo root and never nukes source or host [0.20ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given transient files in source and skipped trees #when cleanup runs #then it prunes skipped trees [15.77ms]
+(pass) agent dev-environment scripts > qa-sandbox.sh > #given the QA isolation helper #when inspected #then it isolates XDG + CODEX_HOME and injects creds [0.21ms]
+(pass) agent dev-environment scripts > .env.example > #given the credential template #when inspected #then it documents the injection points without real secrets [0.11ms]
+
+ 12 pass
+ 0 fail
+ 66 expect() calls
+Ran 12 tests across 2 files. [1.81s]
+
+$ node --test packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+✔ #given a newer version #when resolving auto update plan #then plan carries current and latest versions (1.12525ms)
+✔ #given a newer version #when waited update succeeds #then returns update-started notice and persists pendingNotice (57.908959ms)
+✔ #given completed pending update #when startup check is throttled #then emits completed notice and clears pendingNotice (2.953917ms)
+✔ #given incomplete pending update #when startup check runs #then no notice and pendingNotice retained (2.649833ms)
+✔ #given waited update fails #then no notice and no pendingNotice (49.040583ms)
+✔ #given malformed pendingNotice toVersion #when check runs #then pendingNotice dropped silently (2.910333ms)
+✔ #given completed pending update #when hook session-start runs as CLI #then prints one SessionStart JSON line (134.553292ms)
+ℹ tests 7
+ℹ suites 0
+ℹ pass 7
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 329.409
+
+$ git diff --check
+
+$ bun run typecheck:script
+$ tsgo --noEmit -p script/tsconfig.json
+
+$ node --check packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+
+$ rg no suppressions
+
+$ bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check
+PASS: dependencies present (codex node jq tmux)
+PASS: codex binary -> /Users/yeongyu/.local/bin/codex
+PASS: isolated CODEX_HOME auto-removed on exit (/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/cqa-home.XXXXXX.QrGR3QW3BF)
+PASS: CODEX_HOME points inside sandbox, not ~/.codex
+PASS: mock model serves Responses SSE on :51011
+PASS: real ~/.codex/config.toml unchanged (7b02b43fa7a59859ddb12f7585eda8509d8229e5)
+PASS: common.sh self-check
+.agents/skills/codex-qa/scripts/lib/common.sh: line 131: 49618 Terminated: 15          node "$lib_dir/mock-model.mjs" > "$log" 2>&1
+
+$ bash .agents/skills/codex-qa/scripts/hook-unit-probe.sh --self-test
+installing local omo into /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/cqa-home.XXXXXX.iVtNQwZukj/codex ...
+PASS: real ~/.codex/config.toml unchanged (7b02b43fa7a59859ddb12f7585eda8509d8229e5)
+PASS: ultrawork UserPromptSubmit injected <ultrawork-mode> on an ulw prompt
+
+POST-QA GENERATED FILE MODE CLEANUP
+$ chmod 0644 packages/omo-codex/plugin/components/codegraph/dist/serve.js
+
+$ git status --short
+ M .omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-1.txt

--- a/.omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-2.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-2.txt
@@ -1,0 +1,87 @@
+STOP-HOOK VERIFICATION RUN 2
+UTC 2026-06-22T12:20:31Z
+
+$ pwd
+/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-release-gate-test-slop-20260622
+
+$ git rev-parse HEAD
+f101126b947eac447347219b9b4ac11a95c70cc5
+
+$ git status --short
+
+$ test -s .omo/evidence/20260622-release-gate-test-slop/SUMMARY.md && echo SUMMARY_PRESENT_NONEMPTY
+SUMMARY_PRESENT_NONEMPTY
+
+$ test -s .omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-1.txt && echo PREVIOUS_STOP_HOOK_EVIDENCE_PRESENT_NONEMPTY
+PREVIOUS_STOP_HOOK_EVIDENCE_PRESENT_NONEMPTY
+
+$ bun test script/agent-env.test.ts script/agent-setup-offline.test.ts
+bun test v1.3.14 (0d9b296a)
+
+script/agent-setup-offline.test.ts:
+(pass) #given submodule and materialize failures #when setup runs #then it warns and continues [452.91ms]
+
+script/agent-env.test.ts:
+(pass) agent dev-environment scripts > setup.sh > #given the shared bootstrap #when inspected #then it is an executable strict bash script [0.19ms]
+(pass) agent dev-environment scripts > setup.sh > #given the bootstrap #when it runs #then it verifies tools, installs, and conditionally builds [0.11ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the teardown #when inspected #then it is an executable strict bash script with a --deep mode [0.09ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when inspected #then it is executable bash [0.10ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when sync mode runs #then it executes cleanup and exits successfully [10.74ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when async mode runs #then it returns before cleanup finishes [1128.12ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given a hostile cleanup log override #when the launcher runs #then it keeps logs in temp [26.56ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the teardown #when inspected for safety #then it guards repo root and never nukes source or host [0.21ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given transient files in source and skipped trees #when cleanup runs #then it prunes skipped trees [12.38ms]
+(pass) agent dev-environment scripts > qa-sandbox.sh > #given the QA isolation helper #when inspected #then it isolates XDG + CODEX_HOME and injects creds [0.18ms]
+(pass) agent dev-environment scripts > .env.example > #given the credential template #when inspected #then it documents the injection points without real secrets [0.10ms]
+
+ 12 pass
+ 0 fail
+ 66 expect() calls
+Ran 12 tests across 2 files. [1.69s]
+
+$ node --test packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+✔ #given a newer version #when resolving auto update plan #then plan carries current and latest versions (1.163958ms)
+✔ #given a newer version #when waited update succeeds #then returns update-started notice and persists pendingNotice (55.569083ms)
+✔ #given completed pending update #when startup check is throttled #then emits completed notice and clears pendingNotice (2.73275ms)
+✔ #given incomplete pending update #when startup check runs #then no notice and pendingNotice retained (1.820833ms)
+✔ #given waited update fails #then no notice and no pendingNotice (46.894542ms)
+✔ #given malformed pendingNotice toVersion #when check runs #then pendingNotice dropped silently (2.776542ms)
+✔ #given completed pending update #when hook session-start runs as CLI #then prints one SessionStart JSON line (138.0545ms)
+ℹ tests 7
+ℹ suites 0
+ℹ pass 7
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 327.232959
+
+$ git diff --check
+
+$ bun run typecheck:script
+$ tsgo --noEmit -p script/tsconfig.json
+
+$ node --check packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+
+$ rg no suppressions
+
+$ bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check
+PASS: dependencies present (codex node jq tmux)
+PASS: codex binary -> /Users/yeongyu/.local/bin/codex
+PASS: isolated CODEX_HOME auto-removed on exit (/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/cqa-home.XXXXXX.EqbNTrKotF)
+PASS: CODEX_HOME points inside sandbox, not ~/.codex
+PASS: mock model serves Responses SSE on :51118
+PASS: real ~/.codex/config.toml unchanged (7b02b43fa7a59859ddb12f7585eda8509d8229e5)
+PASS: common.sh self-check
+.agents/skills/codex-qa/scripts/lib/common.sh: line 131: 52221 Terminated: 15          node "$lib_dir/mock-model.mjs" > "$log" 2>&1
+
+$ bash .agents/skills/codex-qa/scripts/hook-unit-probe.sh --self-test
+installing local omo into /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/cqa-home.XXXXXX.e6LtE10nWn/codex ...
+PASS: real ~/.codex/config.toml unchanged (7b02b43fa7a59859ddb12f7585eda8509d8229e5)
+PASS: ultrawork UserPromptSubmit injected <ultrawork-mode> on an ulw prompt
+
+POST-QA GENERATED FILE MODE CLEANUP RUN 2
+$ git status --short before cleanup
+ M packages/omo-codex/plugin/components/codegraph/dist/serve.js
+$ chmod 0644 packages/omo-codex/plugin/components/codegraph/dist/serve.js
+$ git status --short after cleanup

--- a/.omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-3.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-3.txt
@@ -1,0 +1,87 @@
+STOP-HOOK VERIFICATION RUN 3
+UTC 2026-06-22T12:21:31Z
+
+$ pwd
+/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-release-gate-test-slop-20260622
+
+$ git rev-parse HEAD
+83304b2e64645c7623b350ee2b27cf22c5097377
+
+$ git status --short
+
+$ test -s .omo/evidence/20260622-release-gate-test-slop/SUMMARY.md && echo SUMMARY_PRESENT_NONEMPTY
+SUMMARY_PRESENT_NONEMPTY
+
+$ test -s .omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-2.txt && echo PREVIOUS_STOP_HOOK_EVIDENCE_PRESENT_NONEMPTY
+PREVIOUS_STOP_HOOK_EVIDENCE_PRESENT_NONEMPTY
+
+$ bun test script/agent-env.test.ts script/agent-setup-offline.test.ts
+bun test v1.3.14 (0d9b296a)
+
+script/agent-setup-offline.test.ts:
+(pass) #given submodule and materialize failures #when setup runs #then it warns and continues [471.04ms]
+
+script/agent-env.test.ts:
+(pass) agent dev-environment scripts > setup.sh > #given the shared bootstrap #when inspected #then it is an executable strict bash script [0.20ms]
+(pass) agent dev-environment scripts > setup.sh > #given the bootstrap #when it runs #then it verifies tools, installs, and conditionally builds [0.10ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the teardown #when inspected #then it is an executable strict bash script with a --deep mode [0.09ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when inspected #then it is executable bash [0.10ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when sync mode runs #then it executes cleanup and exits successfully [10.25ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the Claude SessionEnd launcher #when async mode runs #then it returns before cleanup finishes [1234.91ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given a hostile cleanup log override #when the launcher runs #then it keeps logs in temp [34.65ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given the teardown #when inspected for safety #then it guards repo root and never nukes source or host [0.21ms]
+(pass) agent dev-environment scripts > cleanup.sh > #given transient files in source and skipped trees #when cleanup runs #then it prunes skipped trees [15.20ms]
+(pass) agent dev-environment scripts > qa-sandbox.sh > #given the QA isolation helper #when inspected #then it isolates XDG + CODEX_HOME and injects creds [0.21ms]
+(pass) agent dev-environment scripts > .env.example > #given the credential template #when inspected #then it documents the injection points without real secrets [0.11ms]
+
+ 12 pass
+ 0 fail
+ 66 expect() calls
+Ran 12 tests across 2 files. [1.83s]
+
+$ node --test packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+✔ #given a newer version #when resolving auto update plan #then plan carries current and latest versions (1.172542ms)
+✔ #given a newer version #when waited update succeeds #then returns update-started notice and persists pendingNotice (60.324625ms)
+✔ #given completed pending update #when startup check is throttled #then emits completed notice and clears pendingNotice (3.307667ms)
+✔ #given incomplete pending update #when startup check runs #then no notice and pendingNotice retained (2.599083ms)
+✔ #given waited update fails #then no notice and no pendingNotice (53.097208ms)
+✔ #given malformed pendingNotice toVersion #when check runs #then pendingNotice dropped silently (3.427ms)
+✔ #given completed pending update #when hook session-start runs as CLI #then prints one SessionStart JSON line (132.528333ms)
+ℹ tests 7
+ℹ suites 0
+ℹ pass 7
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 335.942417
+
+$ git diff --check
+
+$ bun run typecheck:script
+$ tsgo --noEmit -p script/tsconfig.json
+
+$ node --check packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+
+$ rg no suppressions
+
+$ bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check
+PASS: dependencies present (codex node jq tmux)
+PASS: codex binary -> /Users/yeongyu/.local/bin/codex
+PASS: isolated CODEX_HOME auto-removed on exit (/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/cqa-home.XXXXXX.LiEPZ72UTn)
+PASS: CODEX_HOME points inside sandbox, not ~/.codex
+PASS: mock model serves Responses SSE on :51193
+PASS: real ~/.codex/config.toml unchanged (7b02b43fa7a59859ddb12f7585eda8509d8229e5)
+PASS: common.sh self-check
+.agents/skills/codex-qa/scripts/lib/common.sh: line 131: 54251 Terminated: 15          node "$lib_dir/mock-model.mjs" > "$log" 2>&1
+
+$ bash .agents/skills/codex-qa/scripts/hook-unit-probe.sh --self-test
+installing local omo into /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/cqa-home.XXXXXX.JH26sDAgk2/codex ...
+PASS: real ~/.codex/config.toml unchanged (7b02b43fa7a59859ddb12f7585eda8509d8229e5)
+PASS: ultrawork UserPromptSubmit injected <ultrawork-mode> on an ulw prompt
+
+POST-QA GENERATED FILE MODE CLEANUP RUN 3
+$ git status --short before cleanup
+ M packages/omo-codex/plugin/components/codegraph/dist/serve.js
+$ chmod 0644 packages/omo-codex/plugin/components/codegraph/dist/serve.js
+$ git status --short after cleanup

--- a/.omo/evidence/20260622-release-gate-test-slop/typecheck-script-rerun.txt
+++ b/.omo/evidence/20260622-release-gate-test-slop/typecheck-script-rerun.txt
@@ -1,0 +1,2 @@
+$ bun run typecheck:script
+$ tsgo --noEmit -p script/tsconfig.json

--- a/packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
@@ -9,8 +9,6 @@ import { fileURLToPath } from "node:url";
 import { resolveAutoUpdatePlan, runAutoUpdateCheck } from "../scripts/auto-update.mjs";
 
 const SCRIPT_PATH = fileURLToPath(new URL("../scripts/auto-update.mjs", import.meta.url));
-const STARTED_NOTICE =
-	"[LazyCodex] Auto-update started in the background: v1.0.0 -> v1.0.1. Tell the user, in the user's preferred tone, that a new LazyCodex version is installing; recommend starting a new Codex session after it completes to apply the update. Release notes for v1.0.1 were not available.";
 const COMPLETED_NOTICE =
 	"[LazyCodex] Auto-update completed: v1.0.0 -> v1.0.1. This session is already running the new version. Tell the user the auto-update was applied.";
 
@@ -24,6 +22,17 @@ function autoUpdateEnv(root, extra = {}) {
 		LAZYCODEX_AUTO_UPDATE_LOG_PATH: join(root, "auto-update.log"),
 		...extra,
 	};
+}
+
+function assertStartedNotice(notices) {
+	assert.equal(notices.length, 1);
+	const [notice] = notices;
+	assert.equal(typeof notice, "string");
+	assert.match(notice, /v1\.0\.0 -> v1\.0\.1/);
+	assert.match(notice, /Auto-update started in the background/i);
+	assert.match(notice, /new Codex session after it completes/i);
+	assert.match(notice, /user's preferred tone/i);
+	assert.match(notice, /Release notes for v1\.0\.1 were not available/);
 }
 
 test("#given a newer version #when resolving auto update plan #then plan carries current and latest versions", () => {
@@ -54,7 +63,7 @@ test("#given a newer version #when waited update succeeds #then returns update-s
 
 	assert.equal(result.started, true);
 	assert.equal(result.status, 0);
-	assert.deepEqual(result.notices, [STARTED_NOTICE]);
+	assertStartedNotice(result.notices);
 	const state = JSON.parse(await readFile(env.LAZYCODEX_AUTO_UPDATE_STATE_PATH, "utf8"));
 	assert.deepEqual(state.pendingNotice, {
 		fromVersion: "1.0.0",

--- a/script/agent-env.test.ts
+++ b/script/agent-env.test.ts
@@ -79,16 +79,6 @@ describe("agent dev-environment scripts", () => {
       expect(body).toContain("materialize-frontend-refs") // frontend ref materialize
     })
 
-    test("#given the submodule + materialize steps #when setup runs offline #then both are non-fatal", () => {
-      // given
-      const body = read(join(AGENT_DIR, "setup.sh"))
-      const submoduleLine = body.split("\n").find((line) => line.includes("submodule update --init"))
-      const materializeLine = body.split("\n").find((line) => line.includes("materialize-frontend-refs.mjs"))
-
-      // then both steps tolerate failure with a warn-and-continue fallback
-      expect(submoduleLine).toContain("||")
-      expect(materializeLine).toContain("||")
-    })
   })
 
   describe("cleanup.sh", () => {

--- a/script/agent-setup-offline.test.ts
+++ b/script/agent-setup-offline.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test"
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const AGENT_DIR = join(import.meta.dir, "agent")
+const posixBashTest = test.skipIf(process.platform === "win32")
+
+function toBashPath(path: string): string {
+  if (process.platform !== "win32") {
+    return path
+  }
+
+  const normalized = path.replaceAll("\\", "/")
+  const drivePath = normalized.match(/^([A-Za-z]):(\/.*)$/)
+  if (drivePath === null) {
+    return normalized
+  }
+
+  const drive = drivePath[1]
+  const rest = drivePath[2]
+  if (drive === undefined || rest === undefined) {
+    return normalized
+  }
+  return `/${drive.toLowerCase()}${rest}`
+}
+
+function writeExecutable(path: string, body: string): void {
+  writeFileSync(path, body)
+  chmodSync(path, 0o755)
+}
+
+function createSetupFixture(): { readonly repo: string; readonly fakeBin: string } {
+  const repo = mkdtempSync(join(tmpdir(), "omo-setup-test-"))
+  const agentDir = join(repo, "script", "agent")
+  const fakeBin = join(repo, "fake-bin")
+  mkdirSync(agentDir, { recursive: true })
+  mkdirSync(fakeBin, { recursive: true })
+  mkdirSync(join(repo, "dist"), { recursive: true })
+  copyFileSync(join(AGENT_DIR, "setup.sh"), join(agentDir, "setup.sh"))
+  writeFileSync(join(repo, "dist", "index.js"), "built\n")
+  chmodSync(join(agentDir, "setup.sh"), 0o755)
+  writeExecutable(join(fakeBin, "bun"), "#!/usr/bin/env bash\n[ \"$1\" = \"--version\" ] && { printf '1.3.12\\n'; exit 0; }\n[ \"$1\" = \"install\" ] && { printf 'fake bun install\\n'; exit 0; }\nprintf 'unexpected bun command: %s\\n' \"$*\" >&2\nexit 64\n")
+  writeExecutable(join(fakeBin, "node"), "#!/usr/bin/env bash\n[ \"$1\" = \"--version\" ] && { printf 'v24.0.0\\n'; exit 0; }\nprintf 'fake materialize failure\\n' >&2\nexit 42\n")
+  writeExecutable(join(fakeBin, "git"), "#!/usr/bin/env bash\n[ \"$1\" = \"--version\" ] && { printf 'git version 2.50.0\\n'; exit 0; }\n[ \"$1\" = \"submodule\" ] && { printf 'fake submodule failure\\n' >&2; exit 43; }\nprintf 'unexpected git command: %s\\n' \"$*\" >&2\nexit 64\n")
+  return { repo, fakeBin }
+}
+
+posixBashTest("#given submodule and materialize failures #when setup runs #then it warns and continues", () => {
+  // given
+  const fixture = createSetupFixture()
+
+  try {
+    // when
+    const result = Bun.spawnSync({
+      cmd: ["bash", "script/agent/setup.sh"],
+      cwd: fixture.repo,
+      env: {
+        ...process.env,
+        PATH: `${toBashPath(fixture.fakeBin)}:${process.env.PATH ?? ""}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const stdout = result.stdout.toString()
+
+    // then
+    expect(result.exitCode).toBe(0)
+    expect(stdout).toContain("WARN: submodule init skipped")
+    expect(stdout).toContain("WARN: frontend refs not materialized")
+    expect(stdout).toContain("dist/index.js present - skipping build")
+  } finally {
+    rmSync(fixture.repo, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
Fixes two final release-gate slop blockers by replacing implementation/string-mirror assertions with behavior/semantic coverage.

## Changes
- Replaces the `setup.sh` offline-tolerance `||` source inspection with a bash fixture test that makes `git submodule` and frontend materialization fail, then verifies setup warns and continues.
- Replaces full-string pinning for the LazyCodex auto-update started notice with semantic assertions for the version transition, background install, new-session guidance, preferred-tone instruction, and release-notes fallback.
- Records focused release-gate evidence under `.omo/evidence/20260622-release-gate-test-slop/`.

## Verification
- `bun test script/agent-env.test.ts script/agent-setup-offline.test.ts` ✅
- `node --test packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs` ✅
- `git diff --check` ✅
- `bun run typecheck:script` ✅
- `node --check packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs` ✅
- Suppression scan over changed test files: no matches ✅
- Codex QA common self-check ✅
- Codex hook-unit probe self-test ✅

Evidence:
- `.omo/evidence/20260622-release-gate-test-slop/SUMMARY.md`
- `.omo/evidence/20260622-release-gate-test-slop/stop-hook-verification-3.txt`

## Release Gate Context
This addresses the two direct slop blockers named in:
- `.omo/teams/team-46791fa8/artifacts/final-after-5512-release-gate.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces brittle release‑gate tests with semantic coverage to clear the last two blockers. Adds an offline‑tolerant `setup.sh` fixture test and updates LazyCodex auto‑update notice checks.

- **Refactors**
  - Added `script/agent-setup-offline.test.ts` to simulate `git submodule` and frontend materialization failures; verifies `setup.sh` warns and continues without failing.
  - Updated `packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs` to assert behavior (version transition, background install, new‑session guidance, preferred‑tone instruction, release‑notes fallback) instead of pinning the full notice string.

<sup>Written for commit f587dc45d01e15c9c89c9f0527678f78235778bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

