### PR TITLE
docs(agents): refresh root + src hub AGENTS.md to v4.13.0 via init-deep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **HOLD THE FUCK UP. THIS ENTIRE GODDAMN CODEBASE IS BEING RIPPED APART AND REBUILT RIGHT NOW. A MASSIVE MULTI-HARNESS AGENT OS REFACTOR IS IN PROGRESS — WE ARE RESTRUCTURING EVERYTHING TO SUPPORT MULTIPLE AGENT HARNESSES (OPENCODE, CODEX, PI, AND OTHERS). DO NOT TRUST THE STRUCTURE BELOW AS STABLE. READ THE [ROADMAP](./ROADMAP.md) BEFORE YOU TOUCH ANYTHING OR SO HELP ME GOD.**
 
-**Generated:** 2026-06-17 | **Commit:** 437922bc0 | **Branch:** dev | **Release:** v4.10.0
+**Generated:** 2026-06-23 | **Commit:** 065534023 | **Branch:** dev | **Release:** v4.13.0
 
 ## STOP. QA IS MANDATORY. NON-NEGOTIABLE. EVERY SINGLE TIME YOU TOUCH AN OPENCODE- OR CODEX-CONNECTED COMPONENT.
 
@@ -61,10 +61,10 @@ oh-my-opencode/                      # workspace root (no root src/ — it moved
 │   │       ├── create-{managers,tools,hooks}.ts  # 4 managers / ToolRegistry / 5-tier hook composition
 │   │       ├── agents/              # 11 agent factories (Sisyphus, Hephaestus, Oracle, Librarian, Explore, Atlas, Prometheus, Metis, Momus, Multimodal-Looker, Sisyphus-Junior)
 │   │       ├── hooks/               # 53-60 lifecycle hooks across 60 dirs (incl. zauc-mocks sort-order hack + team-session-events/)
-│   │       ├── tools/               # 13 native tool dirs; LSP served via a built-in MCP, ast-grep via the bundled skill
-│   │       ├── features/            # 22 feature modules (team-mode, background-agent, skill-mcp-manager, opencode-skill-loader, mcp-oauth, claude-code-plugin-loader, boulder-state, …)
+│   │       ├── tools/               # 14 native tool dirs; LSP served via a built-in MCP, ast-grep via the bundled skill
+│   │       ├── features/            # 23 feature modules (team-mode, background-agent, skill-mcp-manager, opencode-skill-loader, mcp-oauth, claude-code-plugin-loader, boulder-state, …)
 │   │       ├── shared/              # cross-cutting utilities; logger → oh-my-opencode.log in os.tmpdir() (50 MB cap, .1/.2 backups)
-│   │       ├── config/             # Zod v4 schema system (32 schema files)
+│   │       ├── config/             # Zod v4 schema system (36 schema files)
 │   │       ├── cli/                 # Commander.js CLI: install, run, doctor, mcp-oauth, boulder, sparkshell, ulw-loop
 │   │       ├── mcp/                 # 5 built-in MCPs (3 remote + local stdio lsp + codegraph)
 │   │       ├── plugin/ plugin-handlers/  # OpenCode hook handlers + 6-phase config loading pipeline

--- a/packages/omo-opencode/src/AGENTS.md
+++ b/packages/omo-opencode/src/AGENTS.md
@@ -1,6 +1,6 @@
 # src/ — Plugin Source
 
-**Generated:** 2026-06-08
+**Generated:** 2026-06-23
 
 ## STOP. THIS IS THE OPENCODE PLUGIN. QA IS MANDATORY. EVERY SINGLE TIME YOU CHANGE ANYTHING HERE.
 
@@ -109,8 +109,8 @@ Total: 53 base, 60 with team-mode. Each tier produces an object whose values are
 |--------|---------|---------------|
 | `agents/` | 11 agent factories + dynamic prompt builder | yes (+ atlas, hephaestus, prometheus, sisyphus, sisyphus-junior, builtin-agents) |
 | `hooks/` | 53-60 lifecycle hooks across 60 dirs | yes (+ atlas, anthropic-context-window-limit-recovery, auto-update-checker, claude-code-hooks, comment-checker, compaction-context-injector, keyword-detector, ralph-loop, rules-injector, runtime-fallback, todo-continuation-enforcer) |
-| `tools/` | 13 native tool dirs (+1 shared utilities dir); LSP + AST-grep moved to built-in MCPs | yes (+ background-task, call-omo-agent, delegate-task, hashline-edit, look-at, skill) |
-| `features/` | 22 feature modules (some now shimming `team-core`, `tmux-core`, `skills-loader-core`, `mcp-client-core`, and `claude-code-compat-core`) | yes (+ 11 sub-AGENTS.md including builtin-skills, team-mode, background-agent, claude-code-*) |
+| `tools/` | 14 native tool dirs (+1 shared utilities dir); LSP + AST-grep moved to built-in MCPs | yes (+ background-task, call-omo-agent, delegate-task, hashline-edit, look-at, skill) |
+| `features/` | 23 feature modules (some now shimming `team-core`, `tmux-core`, `skills-loader-core`, `mcp-client-core`, and `claude-code-compat-core`) | yes (+ 11 sub-AGENTS.md including builtin-skills, team-mode, background-agent, claude-code-*) |
 | `shared/` | Cross-cutting adapter utilities plus shims over extracted Core packages, barrel-exported | yes |
 | `cli/` | Commander.js CLI: install, run, doctor, mcp-oauth, boulder | yes (+ config-manager, doctor, run) |
 | `plugin/` | 12 OpenCode hook handlers + hook composition | yes |
@@ -118,7 +118,7 @@ Total: 53 base, 60 with team-mode. Each tier produces an object whose values are
 | `plugin-handlers/` | 6-phase config loading pipeline | yes |
 | `openclaw/` | Bidirectional Discord/Telegram/HTTP integration | yes |
 | `__tests__/` | Plugin-level integration tests + perf fixtures | — |
-| `mcp/` | 4 built-in MCPs (3 remote + local stdio lsp) | yes |
+| `mcp/` | 5 built-in MCPs (3 remote + local stdio lsp + codegraph) | yes |
 | `testing/` | Test utilities + `create-plugin-module.ts` | — |
 | `help/` | CLI help schema definitions (acp, doctor, sandbox, status) | — |
 | `locales/` | i18n strings (en, zh): toasts + model-fallback labels | — |


### PR DESCRIPTION
## Summary

`init-deep` (update mode) refresh of the repo's AGENTS.md knowledge base. The hierarchical AGENTS.md set is already mature (96 files) and almost entirely accurate, so this is a surgical correction of the two files whose init-deep-generated structural facts had drifted, not a regeneration.

The root `AGENTS.md` header was 379 commits stale (generated at v4.10.0 / 437922bc0; HEAD is v4.13.0 / 065534023). Discovery (bash structure scan + two `explore` agents + deterministic count checks) confirmed the drift is confined to the root and the `packages/omo-opencode/src` hub. All operational and policy content (QA mandate, default workflow, PR merge policy, prompt-async-gate invariants, dev-environment, CI/CD) is preserved verbatim.

## Changes

### `AGENTS.md` (root)
| Field | Was | Now |
|-------|-----|-----|
| header | 2026-06-17 / 437922bc0 / v4.10.0 | 2026-06-23 / 065534023 / v4.13.0 |
| tools | 13 native tool dirs | 14 (tools/monitor added) |
| features | 22 feature modules | 23 |
| config | 32 schema files | 36 |

### `packages/omo-opencode/src/AGENTS.md` (src hub)
| Field | Was | Now |
|-------|-----|-----|
| header date | 2026-06-08 | 2026-06-23 |
| tools | 13 native tool dirs | 14 |
| features | 22 feature modules | 23 |
| mcp | 4 built-in MCPs | 5 (codegraph was missing) |

## Verified accurate, left unchanged

37 sibling packages (the local `packages/ast-grep-mcp/` is an untracked stale `dist/` artifact with zero tracked files; the package was removed in #5313, so "37" is correct), 11 agents, 14 OpenCode hook handlers, 5 built-in MCPs, 12 platform binaries, the INITIALIZATION FLOW, and "53-60 hooks across 60 dirs".

## QA

Documentation-only change; no harness-connected code is touched, so the opencode-qa / codex-qa harness gates are not applicable. QA for a docs change is factual accuracy plus a clean intended diff:

- Every changed number cross-checked against HEAD via `git ls-files` / directory enumeration and two `explore` agents.
- `git diff` is exactly the 8 intended line changes across 2 files, nothing else.
- Slop gate: no new em/en-dash or AI filler in added lines.
- Evidence: `.omo/evidence/20260623-init-deep-agents-md-refresh/verification.md`.

## Notes

- This branch is docs-only by design. Concurrent unrelated `packages/omo-codex/` work present in the shared worktree was deliberately left unstaged and is not part of this PR.
- Per repo policy this PR targets `dev` and must land with a merge commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed the root `AGENTS.md` and `packages/omo-opencode/src/AGENTS.md` to v4.13.0, fixing stale generated headers and aligning counts with the current repo structure. Root: tools 13→14, features 22→23, config 32→36; src hub: tools 13→14, features 22→23, MCPs 4→5; docs-only.

<sup>Written for commit f00981217a0dae9f78d765f34ba3a085543c29ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

