### PR TITLE
fix(visual-qa): flag CJK semantic line breaks

### DIFF
--- a/packages/shared-skills/skills/visual-qa/SKILL.md
+++ b/packages/shared-skills/skills/visual-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: visual-qa
-description: "Rigorous visual QA for any UI you built or changed, across BOTH web/page UIs and TUI/terminal UIs. MUST USE after building or changing any UI to verify it visually before declaring it done. Captures objective reference evidence with a bundled diff script (image-diff for screenshots, tui-check for terminal captures), then runs two parallel read-only oracle passes (design-system and functional integrity; visual fidelity and CJK precision) and synthesizes one good/bad verdict. Triggers: visual QA, visual regression, screenshot diff, pixel diff, image comparison, UI looks wrong, design system check, is this really a design system or just an image, alpha channel breakage, responsive check, CJK text, Korean/Japanese/Chinese text clipping, baseline drop, glyph drop, TUI alignment, terminal UI, tmux capture, box-drawing border misalignment, wide-character column drift. Use it even when the user does not say visual QA but asks whether a page, component, or terminal layout looks right."
+description: "Rigorous visual QA for any UI you built or changed, across BOTH web/page UIs and TUI/terminal UIs. MUST USE after building or changing any UI to verify it visually before declaring it done. Captures objective reference evidence with a bundled diff script (image-diff for screenshots, tui-check for terminal captures), then runs two parallel read-only oracle passes (design-system and functional integrity; visual fidelity and CJK precision) and synthesizes one good/bad verdict. Triggers: visual QA, visual regression, screenshot diff, pixel diff, image comparison, UI looks wrong, design system check, is this really a design system or just an image, alpha channel breakage, responsive check, CJK text, Korean/Japanese/Chinese text clipping or semantic line breaks, baseline drop, glyph drop, TUI alignment, terminal UI, tmux capture, box-drawing border misalignment, wide-character column drift. Use it even when the user does not say visual QA but asks whether a page, component, or terminal layout looks right."
 ---
 
 # Visual QA - Dual-Oracle Web and TUI Verification
@@ -137,7 +137,7 @@ USE THE EVIDENCE:
 CHECK:
 1. Does the rendered output match what the user requested: layout, spacing, color, type, alignment?
 2. CJK precision:
-   - Web: natural CJK line breaking for display and body text. Flag oversized headings that create orphaned one-character or final-syllable lines, split Korean/Japanese/Chinese semantic phrases unnaturally, detach labels such as `[Image #1]` from their content, clip baselines/descenders, drop glyphs (tofu), or show font metric mismatch. Treat the screenshot pattern `에이전트 오케스트 / 레이션 현황 및 미 / 래` as REVISE/FAIL, not acceptable wrapping.
+   - Web: natural CJK line breaking for display and body text. Flag oversized headings or narrow containers that create orphaned one-character or final-syllable lines, split Korean/Japanese/Chinese semantic phrases unnaturally (for example `놀라운 변 / 화`), detach labels such as `[Image #1]` from their content, clip baselines/descenders, drop glyphs (tofu), or show font metric mismatch. Treat screenshot patterns like `에이전트 오케스트 / 레이션 현황 및 미 / 래` as REVISE/FAIL, not acceptable wrapping.
    - TUI: wide-character column drift (CJK cells counted as 1 instead of 2), box-drawing border misalignment, content overflowing past the terminal width.
 
 OUTPUT:

--- a/packages/shared-skills/skills/visual-qa/scripts/skill-prompt-contract.test.ts
+++ b/packages/shared-skills/skills/visual-qa/scripts/skill-prompt-contract.test.ts
@@ -68,6 +68,8 @@ describe("visual-qa skill prompt contract", () => {
 			expect(lowerPassB, fixture.label).toContain("view_image")
 			expect(lowerPassB, fixture.label).toContain("source code")
 			expect(passB, fixture.label).toContain("[Image #1]")
+			expect(passB, fixture.label).toContain("semantic phrases")
+			expect(passB, fixture.label).toContain("놀라운 변 / 화")
 			expect(passB, fixture.label).toContain("에이전트 오케스트")
 			expect(passB, fixture.label).toContain("레이션 현황 및 미")
 			expect(passB, fixture.label).toContain("래")


### PR DESCRIPTION
## Summary
This PR tightens the shared `visual-qa` skill so CJK visual QA treats awkward semantic line breaks as a first-class defect, not just clipping or overflow. In particular, it makes patterns like `놀라운 변 / 화` explicit REVISE/FAIL material for Pass B while keeping the edit inside the existing CJK precision rule.

## Changes
- Adds `semantic line breaks` to the visual-qa skill trigger text.
- Updates Pass B CJK precision guidance to flag narrow-container or oversized-heading splits of Korean/Japanese/Chinese semantic phrases, including `놀라운 변 / 화`.
- Extends the prompt contract test to pin the new semantic phrase guidance and exemplar.

## Verification
**Automated:**
- `bun test packages/shared-skills/skills/visual-qa/scripts/skill-prompt-contract.test.ts` PASS, 5 tests / 55 assertions.
- `node --test packages/omo-codex/plugin/test/sync-skills.test.mjs packages/omo-codex/plugin/test/sync-skills-orchestration.test.mjs` PASS, 21 tests.
- `bun run typecheck` PASS.
- `git diff --check` PASS.

**Manual QA / evidence:**
- Evidence directory: `.omo/evidence/20260623-visual-qa-cjk-line-breaks/`
- Prompt surface proof: `.omo/evidence/20260623-visual-qa-cjk-line-breaks/prompt-surface-evidence.txt`
- Manual QA matrix: `.omo/evidence/20260623-visual-qa-cjk-line-breaks/manual-qa-matrix.md`
- Code review coverage: `.omo/evidence/20260623-visual-qa-cjk-line-breaks/code-review-coverage.md`
- Notepad: `.omo/notepads/20260623-visual-qa-cjk-line-breaks.md`
- Subagent code review: APPROVE, no blockers.
- Gate reviewer rerun: APPROVE.

## Notes
Initial evidence includes two superseded command attempts from the fresh worktree setup: the first prompt-contract test ran before `bun install`, and the first sync-skills attempt used Bun against Node test files. Both are superseded by the passing reruns listed above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flags CJK semantic line breaks in the `visual-qa` skill to catch awkward phrase splits in Pass B. Tightens CJK web guidance and adds tests to pin the behavior.

- **Bug Fixes**
  - Added "semantic line breaks" to trigger text.
  - Updated Pass B CJK web guidance to flag unnatural splits (e.g., "놀라운 변 / 화").
  - Extended prompt contract test to assert "semantic phrases" and the example.

<sup>Written for commit 3fa57777fb9fa0005c929642bf88f433a27f073c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

