### PR TITLE
ci: avoid duplicate script typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,6 @@ jobs:
       - name: Type check
         run: bun run typecheck
 
-      - name: Type check script tooling
-        run: bun run typecheck:script
-
       - name: Write job summary
         if: always()
         shell: bash
@@ -174,8 +171,7 @@ jobs:
           JOB_SUMMARY_STATUS: ${{ job.status }}
           JOB_SUMMARY_DETAILS: |
             - Builds vendored LSP packages required by the workspace.
-            - Runs root `bun run typecheck`.
-            - Runs `bun run typecheck:script` for release/build tooling.
+            - Runs root `bun run typecheck`, including script and package checks.
           JOB_SUMMARY_NEXT: Start with the first TypeScript diagnostic; shared package failures can cascade into adapters.
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 

--- a/packages/team-core/src/team-state-store/locks.test.ts
+++ b/packages/team-core/src/team-state-store/locks.test.ts
@@ -8,6 +8,19 @@ async function createTempDirectory(prefix: string): Promise<string> {
   return await mkdtemp(join(tmpdir(), prefix))
 }
 
+function createSignal(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolveSignal: (() => void) | undefined
+  const promise = new Promise<void>((resolve) => {
+    resolveSignal = resolve
+  })
+
+  if (resolveSignal === undefined) {
+    throw new Error("signal resolver was not initialized")
+  }
+
+  return { promise, resolve: resolveSignal }
+}
+
 test("withLock serializes concurrent work", async () => {
   // given
   const { withLock } = await import("./locks")
@@ -17,16 +30,21 @@ test("withLock serializes concurrent work", async () => {
   await writeFile(probePath, "ready")
   const activeMarkers = new Set<string>()
   const overlapObserved: string[] = []
+  const firstAcquired = createSignal()
+  const releaseFirst = createSignal()
 
   // when
   const first = withLock(lockPath, async () => {
     activeMarkers.add("first")
     await writeFile(probePath, "first-start")
-    await new Promise((resolve) => setTimeout(resolve, 75))
+    firstAcquired.resolve()
+    await releaseFirst.promise
     if (activeMarkers.has("second")) overlapObserved.push("first")
     activeMarkers.delete("first")
     return "first"
   })
+
+  await firstAcquired.promise
 
   const second = withLock(lockPath, async () => {
     activeMarkers.add("second")
@@ -36,6 +54,7 @@ test("withLock serializes concurrent work", async () => {
     return currentProbe
   })
 
+  releaseFirst.resolve()
   const results = await Promise.all([first, second])
 
   // then

--- a/script/ci-typecheck-workflow.test.ts
+++ b/script/ci-typecheck-workflow.test.ts
@@ -1,0 +1,31 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const ciWorkflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
+
+function sliceWorkflowSection(workflow: string, startMarker: string, endMarker: string): string {
+  const start = workflow.indexOf(startMarker)
+  const end = workflow.indexOf(endMarker, start)
+  if (start < 0 || end < 0 || end <= start) {
+    throw new Error(`missing workflow section between ${startMarker} and ${endMarker}`)
+  }
+  return workflow.slice(start, end)
+}
+
+describe("CI typecheck workflow", () => {
+  test("#given root typecheck includes script tooling #when CI typecheck job is inspected #then script tooling is not rerun as a duplicate step", () => {
+    // given
+    const workflow = readFileSync(ciWorkflowPath, "utf8")
+    const typecheckJob = sliceWorkflowSection(workflow, "  typecheck:", "  codex-compatibility:")
+
+    // when
+    const rootTypecheckStepCount = (typecheckJob.match(/run: bun run typecheck$/gm) ?? []).length
+    const duplicateScriptTypecheckStepCount = (typecheckJob.match(/run: bun run typecheck:script$/gm) ?? []).length
+
+    // then
+    expect(rootTypecheckStepCount, "CI typecheck job must keep the root typecheck command").toBe(1)
+    expect(duplicateScriptTypecheckStepCount, "root typecheck already runs typecheck:script").toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
Removes a duplicate CI `typecheck:script` step because root `bun run typecheck` already runs script and package checks. Adds a focused workflow contract test so the duplicate does not come back.

Also replaces a fixed 75ms sleep in the team-core lock serialization test with explicit synchronization signals. This preserves the same lock behavior assertion without relying on wall-clock delay.

## Changes
- Add `script/ci-typecheck-workflow.test.ts` to pin the CI typecheck contract.
- Remove the redundant `Type check script tooling` step from `.github/workflows/ci.yml` and update the summary copy.
- Replace `setTimeout(75)` in `packages/team-core/src/team-state-store/locks.test.ts` with `firstAcquired` / `releaseFirst` signals.

## Verification
**RED / characterization**
- `bun test script/ci-typecheck-workflow.test.ts` failed before the workflow edit because the duplicate `typecheck:script` step existed: `.omo/evidence/20260623-test-ci-speed-pin/red-ci-typecheck-duplicate.txt`
- `bun test packages/team-core/src/team-state-store/locks.test.ts` passed before the sleep cleanup, pinning baseline behavior: `.omo/evidence/20260623-test-ci-speed-pin/pin-team-locks-before.txt`

**GREEN / automated**
- `bun test script/ci-typecheck-workflow.test.ts`: `.omo/evidence/20260623-test-ci-speed-pin/green-ci-typecheck-duplicate.txt`
- `bun test packages/team-core/src/team-state-store/locks.test.ts`: `.omo/evidence/20260623-test-ci-speed-pin/green-team-locks-signal.txt`
- `bun test script/ci-typecheck-workflow.test.ts script/publish-workflow.test.ts script/script-typecheck.test.ts`: `.omo/evidence/20260623-test-ci-speed-pin/green-workflow-contracts.txt`
- `actionlint .github/workflows/ci.yml`: `.omo/evidence/20260623-test-ci-speed-pin/actionlint-ci.txt`
- `bun run typecheck`: `.omo/evidence/20260623-test-ci-speed-pin/typecheck-full.txt`
- `bun test`: `.omo/evidence/20260623-test-ci-speed-pin/bun-test-full.txt` (10,152 pass / 2 skip / 0 fail)
- `git diff --check`: `.omo/evidence/20260623-test-ci-speed-pin/git-diff-check.txt`

**Harness / surface receipts**
- OpenCode QA common self-check: `.omo/evidence/20260623-test-ci-speed-pin/opencode-qa-common-self-check.txt`
- Codex QA common self-check: `.omo/evidence/20260623-test-ci-speed-pin/codex-qa-common-self-check.txt`
- `mengmotaHost` baseline repo state recorded: `.omo/evidence/20260623-test-ci-speed-pin/mengmotaHost-local-baseline.txt`

**Review**
- LazyCodex code reviewer: APPROVE, no blockers. Reviewer explicitly allowed the lock-test sleep cleanup to stay with the CI duplicate removal because both are scoped to test/CI speed and touch no production code: `.omo/evidence/20260623-test-ci-speed-pin/code-review-approval.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicate `typecheck:script` step from CI since `bun run typecheck` already covers it. Adds a workflow test to prevent regressions and makes the lock serialization test deterministic to speed up CI.

- **Refactors**
  - Remove redundant “Type check script tooling” step in `.github/workflows/ci.yml`; update summary text.
  - Add `script/ci-typecheck-workflow.test.ts` to assert only one root `bun run typecheck` runs and `typecheck:script` is not duplicated.
  - Replace `setTimeout(75)` in `packages/team-core/src/team-state-store/locks.test.ts` with `firstAcquired`/`releaseFirst` signals to avoid wall-clock sleeps.

<sup>Written for commit 6a29c080923eb4b21b9386fbcf34b16eb616d9ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

