### PR TITLE
fix(skills): default ulw research to visual team reports

### DIFF
--- a/packages/omo-codex/plugin/test/ulw-research-skill-contract.test.mjs
+++ b/packages/omo-codex/plugin/test/ulw-research-skill-contract.test.mjs
@@ -22,6 +22,24 @@ function frontmatterDescription(content) {
 	return match[1];
 }
 
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function markdownSection(content, heading, nextHeading) {
+	const headingPattern = new RegExp(`^${escapeRegExp(heading)}\\r?$`, "m");
+	const headingMatch = content.match(headingPattern);
+	assert.notEqual(headingMatch, null, `SKILL.md section not found: ${heading}`);
+	assert.notEqual(headingMatch.index, undefined, `SKILL.md section index not found: ${heading}`);
+	const bodyStart = headingMatch.index + headingMatch[0].length;
+	if (nextHeading === undefined) {
+		return content.slice(bodyStart);
+	}
+	const nextHeadingIndex = content.indexOf(`\n${nextHeading}`, bodyStart);
+	assert.notEqual(nextHeadingIndex, -1, `SKILL.md next section not found: ${nextHeading}`);
+	return content.slice(bodyStart, nextHeadingIndex);
+}
+
 test("#given renamed research skill #when frontmatter is inspected #then ulw-research is the canonical name", async () => {
 	for (const copy of await readUlwResearchCopies()) {
 		assert.match(copy.content, /^name: ulw-research$/m, `${copy.label}: frontmatter must expose ulw-research`);
@@ -197,6 +215,16 @@ test("#given ulw-research team communication #when the raise law is inspected #t
 	}
 });
 
+test("#given ulw-research default swarm #when team guidance is inspected #then teammode, many teammates, and hyperdebate are defaulted", async () => {
+	for (const copy of await readUlwResearchCopies()) {
+		const teamSection = markdownSection(copy.content, "## Run the swarm as a cooperating team", "## Worker ground rules");
+		assert.match(teamSection, /default(?:s)? to teammode|teammode by default/i, `${copy.label}: teammode must be the default`);
+		assert.match(teamSection, /many teammates|larger roster|5-8 teammates|5\+ teammates/i, `${copy.label}: body must prefer many teammates`);
+		assert.match(teamSection, /hyperdebate|ultradebate/i, `${copy.label}: body must require adversarial debate`);
+		assert.match(teamSection, /skeptic|red-team|cross-critique/i, `${copy.label}: body must include a critique perspective`);
+	}
+});
+
 test("#given ulw-research non-code verification #when the gate is inspected #then a claim ledger / verified-claims data-flow-lock exists", async () => {
 	for (const copy of await readUlwResearchCopies()) {
 		assert.match(
@@ -214,6 +242,33 @@ test("#given ulw-research claim ledger #when ownership is inspected #then worker
 			/worker[^.]*\b(?:write|append|create)s?\b[^.]*(?:ledger|verified-claims)/i,
 			`${copy.label}: workers must not be instructed to write/append/create the ledger or verified-claims`,
 		);
+	}
+});
+
+test("#given ulw-research report output #when defaults are inspected #then HTML/PDF reports go through frontend, visual QA, and reviewer approval", async () => {
+	for (const copy of await readUlwResearchCopies()) {
+		const phase0 = markdownSection(copy.content, "## Phase 0 — Decompose and open the journal", "## Phase 1 — Saturation wave");
+		const phase4 = markdownSection(copy.content, "## Phase 4 — Synthesize", "## Phase 5 — Final materials");
+		const phase5 = markdownSection(copy.content, "## Phase 5 — Final materials", "## Search craft");
+		assert.match(phase0, /Final material format:\s*<HTML\/PDF default \| explicit format \| markdown only>/, `${copy.label}: Phase 0 must track the default final-material contract`);
+		assert.match(phase4, /citation source of truth/i, `${copy.label}: Phase 4 synthesis must be a source of truth, not the default final artifact`);
+		assert.doesNotMatch(phase4, /When no report was requested, this is the deliverable/i, `${copy.label}: Phase 4 must not contradict default HTML/PDF final materials`);
+		assert.match(phase5, /Default final materials to HTML\/PDF unless the user explicitly asks/i, `${copy.label}: Phase 5 must default final materials to HTML/PDF`);
+		assert.match(phase5, /HTML first[\s\S]{0,120}PDF default/i, `${copy.label}: report output must default to HTML with PDF availability`);
+		assert.match(phase5, /\bfrontend\b/i, `${copy.label}: report assembly must load the frontend skill`);
+		assert.match(phase5, /visual-qa/i, `${copy.label}: report assembly must require visual-qa`);
+		assert.match(phase5, /ulw-loop|ULW loop/i, `${copy.label}: report QA must run under the ULW loop`);
+		assert.match(phase5, /reviewer[\s\S]{0,120}(?:approve|says no broken parts|no broken parts)/i, `${copy.label}: report completion must wait for reviewer approval`);
+	}
+});
+
+test("#given ulw-research final materials #when visual artifact guidance is inspected #then charts Mermaid graphs and imagegen are strongly required", async () => {
+	for (const copy of await readUlwResearchCopies()) {
+		const phase5 = markdownSection(copy.content, "## Phase 5 — Final materials", "## Search craft");
+		assert.match(phase5, /actively use charts/i, `${copy.label}: reports must strongly require charts`);
+		assert.match(phase5, /Mermaid graphs/i, `${copy.label}: reports must require Mermaid graphs`);
+		assert.match(phase5, /imagegen skill/i, `${copy.label}: reports must require imagegen visuals`);
+		assert.match(phase5, /generated (?:diagrams|visuals)|generated diagrams or editorial visuals/i, `${copy.label}: report assets must include generated visual guidance`);
 	}
 });
 

--- a/packages/shared-skills/skills/ulw-research/SKILL.md
+++ b/packages/shared-skills/skills/ulw-research/SKILL.md
@@ -49,13 +49,15 @@ The research is done when all of these hold:
 - Every EXPAND lead was investigated or explicitly closed as a duplicate or dead end, and convergence was reached under the Phase 2 rules.
 - Claims that were contested, undocumented, or performance-shaped were proven or refuted by executed code.
 - Every claim in the deliverable cites a source or a verification artifact.
+- Final materials follow the Phase 5 format default or the user's explicit format.
 - The session journal reconstructs what was searched, found, and expanded, wave by wave.
 
 ## Run the swarm as a cooperating team
 
-Saturation research is the textbook case for a cooperating team, not isolated fire-and-forget workers: a lead one worker surfaces almost always reshapes what another should search next. So when your harness gives you real cooperating members — Codex: the `teammode` skill (`codex_app` threads); OpenCode: `team_mode` — run this swarm as a team. Fall back to the background-worker swarm below only when team mode is unavailable, or the axes are genuinely independent with no cross-pollination expected.
+Saturation research defaults to teammode, not isolated fire-and-forget workers: a lead one worker surfaces almost always reshapes what another should search next. When your harness gives you real cooperating members — Codex: the `teammode` skill (`codex_app` threads); OpenCode: `team_mode` — run this swarm as a team. Fall back to the background-worker swarm below only when team mode is unavailable, or the axes are genuinely independent with no cross-pollination expected.
 
 - **One member per axis — by part, ownership, or perspective, never a job title.** Each Phase 0 axis is one member owning one concrete slice: a codebase part, a source territory, or a question lens. No two members share an angle. "Backend researcher" or "the web person" gives no real boundary and invites overlap — name what the member owns.
+- **Many teammates by default.** Prefer a larger roster, usually 5-8 teammates, whenever the axes can be made distinct. Add at least one skeptic or red-team perspective for hyperdebate/ultradebate: cross-critique claims, evidence quality, synthesis structure, and visual-report choices before they reach the final deliverable.
 - **The raise law — broadcast every lead the instant it surfaces.** Members over-communicate relentlessly: every new lead, finding, contradiction, and dead end is raised to you the moment it surfaces, never hoarded for a final dump. Through long passes they send `WORKING: <axis> - <phase>`, and `BLOCKED: <reason>` the moment progress stops, so you always know a member is alive. Too many small updates is correct here; going quiet is the only failure.
 - **You lead; expand on each raised lead.** Members raise via message text, never write session files. Journal each lead and spawn its expansion the instant it lands (Phase 2), not only when a member's final reply arrives.
 
@@ -94,7 +96,7 @@ Before spawning anything, decompose the query:
 <analysis>
 Core question: <the actual information need>
 Axes (3+ orthogonal): <axis — what to search, where, why> ...
-Codebase relevant: <yes/no> · External: <yes/no> · Browsing: <yes/no> · Verification likely: <yes/no> · Report requested: <no | format>
+Codebase relevant: <yes/no> · External: <yes/no> · Browsing: <yes/no> · Verification likely: <yes/no> · Final material format: <HTML/PDF default | explicit format | markdown only>
 </analysis>
 ```
 
@@ -216,15 +218,15 @@ Workers: <total> · Waves: <count> · Sources: <count> · Verifications: <count>
 ## Expansion trace          — per wave: workers → markers; convergence reason
 ```
 
-Deliver the synthesis with inline `[Source N]` citations on every claim. Every high-risk non-code claim you assert must be a verified-claims row from Phase 3b — assert nothing the gate left in the unresolved/refuted annex. When no report was requested, this is the deliverable.
+`SYNTHESIS.md` is the citation source of truth for final materials: every claim carries inline `[Source N]` citations, and every high-risk non-code claim you assert must be a verified-claims row from Phase 3b. Assert nothing the gate left in the unresolved/refuted annex.
 
-## Phase 5 — Report (only when requested)
+## Phase 5 — Final materials
 
-Format by the user's words: "report" / "document" → Markdown (default) · "pdf" → HTML first, then weasyprint (`uv run --with weasyprint python`) · "slides" / "presentation" / "deck" → python-pptx · "html" / "webpage" → standalone HTML.
+Default final materials to HTML/PDF unless the user explicitly asks for a different format: "report" / "document" → HTML first, with a PDF default available through weasyprint (`uv run --with weasyprint python`) · "pdf" → HTML first, then weasyprint · "slides" / "presentation" / "deck" → python-pptx · "html" / "webpage" → standalone HTML · "markdown only" → Markdown.
 
-Asset workers (background, parallel): charts for quantitative findings (`uv run --with matplotlib --with plotly python`) saved by you to `$SESSION_DIR/assets/`; full-page screenshots of the top 5-10 sources (browsing skill); generated diagrams (imagegen skill) when architecture or flows need them.
+Asset workers (background, parallel): actively use charts for quantitative findings (`uv run --with matplotlib --with plotly python`) saved by you to `$SESSION_DIR/assets/`; Mermaid graphs for process, architecture, argument, and evidence-flow structure; full-page screenshots of the top 5-10 sources (browsing skill); generated diagrams or editorial visuals with the imagegen skill when architecture, flows, or narrative framing benefit from bitmap assets.
 
-Assembly worker — `task(category="deep", load_skills=["frontend-design", "open-design", "data-scientist", "imagegen"], run_in_background=true, ...)`: before writing, read every available design and visualization skill and apply it — the report is a designed artifact, not a text dump. Structure: executive summary → key findings by theme → detailed analysis (quotes under 20 words with attribution, charts, SHA-pinned permalinks, verification results) → comparative analysis when options compete → numbered sources with access dates → methodology appendix (workers, waves, searches, verifications). Every claim cites `[Source N]`.
+Assembly worker — `task(category="deep", load_skills=["frontend", "visual-qa", "open-design", "data-scientist", "imagegen", "ulw-loop"], run_in_background=true, ...)`: before writing, read every available design and visualization skill and apply it — the report is a designed artifact, not a text dump. Run HTML/PDF output through the ULW loop with frontend and visual-qa, then repair until the reviewer says no broken parts and gives approval. Structure: executive summary → key findings by theme → detailed analysis (quotes under 20 words with attribution, charts, Mermaid graphs, generated visuals, SHA-pinned permalinks, verification results) → comparative analysis when options compete → numbered sources with access dates → methodology appendix (workers, waves, searches, verifications). Every claim cites `[Source N]`.
 
 ## Search craft
 


### PR DESCRIPTION
## Summary

Updates the canonical `ulw-research` skill contract so saturation research now defaults to teammode, larger teammate rosters, and adversarial hyperdebate/ultradebate critique. It also changes final materials from Markdown-by-default to HTML/PDF-by-default, with frontend, visual-qa, ULW-loop repair, charts, Mermaid graphs, screenshots, and imagegen visuals called out as first-class report requirements.

## Changes

- Default `ulw-research` swarm execution to `teammode` / `team_mode` when available, with 5-8 teammates where axes can be distinct.
- Add skeptic/red-team critique as the default debate posture for evidence, claims, synthesis, and visual report decisions.
- Make `SYNTHESIS.md` the citation source of truth, while Phase 5 owns final materials and defaults to HTML/PDF unless the user explicitly asks otherwise.
- Require HTML/PDF final materials to go through `frontend`, `visual-qa`, and `ulw-loop` repair until reviewer approval.
- Strengthen contract tests to assert the relevant sections, not just scattered keywords, including charts, Mermaid graphs, and `imagegen` guidance.

## Verification

Evidence directory: `.omo/evidence/20260623-ulw-research-visual-defaults/`

- RED: `red-ulw-research-contract.txt` showed the new contract tests failing before the prompt changes.
- RED after review hardening: `red-section-aware-contract-helper.txt` caught the initial section-helper issue on fenced Markdown headings.
- GREEN focused, final rebased branch:
  - `green-ulw-research-contract-after-rebase-sync.txt`: `node --test packages/omo-codex/plugin/test/ulw-research-skill-contract.test.mjs` passed 19/19.
  - `green-sync-skills-test-after-rebase-sync.txt`: `node --test packages/omo-codex/plugin/test/sync-skills.test.mjs` passed 14/14.
  - `git-diff-check-after-rebase-sync.txt`: `git diff --check HEAD~1..HEAD` passed.
- Codex QA:
  - `codex-qa-install-verify-after-review-fix.txt`: isolated local install succeeded; plugin cache/config/bin/agent checks passed; real `~/.codex/config.toml` unchanged.
  - `codex-qa-app-server-plugin-after-review-fix.txt`: real `codex app-server` with isolated `CODEX_HOME` and local mock model completed; `sessionStart` and `userPromptSubmit` hook completions observed; real `~/.codex/config.toml` unchanged.
- Full Codex gate:
  - `bun-run-test-codex-after-rebase-sync.txt`: `bun run test:codex` passed on the rebased commit, including 302 Bun tests and 394 Node tests.
- Review gate:
  - QA evidence review passed and wrote `audit-manualQa.md`.
  - Context-mining review passed with no missing tracked generated/doc updates.
  - Security/safety review passed with no blockers.
  - Code review initially caught a Phase 4/Phase 5 contradiction; fixed and re-reviewed PASS in `.omo/evidence/ulw-research-skill-contract-code-review.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `ulw-research` to team-based execution and HTML/PDF final reports, with stronger visual requirements and a hardened test suite to enforce the contract.

- **New Features**
  - Team default: run with `teammode`/`team_mode`, prefer 5–8 teammates, include a skeptic/red-team, and use hyperdebate/ultradebate.
  - Final materials: default to HTML first with PDF via `weasyprint`; Phase 5 assembles; `SYNTHESIS.md` is the citation source of truth.
  - Report QA: require `frontend`, `visual-qa`, and `ulw-loop`; repair until reviewer approval.
  - Visuals: charts (`matplotlib`, `plotly`), Mermaid graphs, screenshots, and `imagegen` diagrams.
  - Tests: add section-aware assertions to validate these defaults and visual-report requirements.

<sup>Written for commit 32288d9f04beee6fecd5752dec596e50b37d9203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

