### PR TITLE
fix(codex): default LazyCodex to steering mode

### DIFF
--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -101,9 +101,9 @@ export async function runLazyCodexManualUpdate({ env = process.env, dryRun = fal
 }
 
 export async function runAutoUpdateCheck({ env = process.env, now = Date.now() } = {}) {
-	await runConfigMigration({ env });
+	const migrationNotices = await runConfigMigration({ env });
 	const statePath = resolveStatePath(env);
-	const notices = [];
+	const notices = [...migrationNotices];
 	const state = await settlePendingNotice({ env, now, statePath, state: await readState(statePath), notices });
 	const installFlow = detectAutoUpdateInstallFlow(env);
 	if (installFlow.flow === "unknown") {
@@ -214,13 +214,17 @@ function resolveUpdateContext({ env }) {
 }
 
 async function runConfigMigration({ env }) {
-	if (env.LAZYCODEX_CONFIG_MIGRATION_DISABLED === "1" || env.OMO_CODEX_CONFIG_MIGRATION_DISABLED === "1") return;
+	if (env.LAZYCODEX_CONFIG_MIGRATION_DISABLED === "1" || env.OMO_CODEX_CONFIG_MIGRATION_DISABLED === "1") return [];
 	try {
 		await migrateOmoSotConfig({ env, seed: true });
-		await migrateCodexConfig({ env });
+		const result = await migrateCodexConfig({ env });
+		if (result.modeChanged.length === 0) return [];
+		return [
+			'[LazyCodex] Codex multi_agent_mode was changed to "steering" for Team Mode support. Tell the user LazyCodex updated the setting from SessionStart so team-mode steering works by default.',
+		];
 	} catch (error) {
 		if (!(error instanceof Error)) throw error;
-		return;
+		return [];
 	}
 }
 

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 
 import { FALLBACK_CATALOG, readModelCatalog } from "./migrate-codex-config/catalog.mjs";
 import { configPaths } from "./migrate-codex-config/config-paths.mjs";
+import { forceMultiAgentModeSteering } from "./migrate-codex-config/multi-agent-mode-guard.mjs";
 import { forceDisableMultiAgentV2 } from "./migrate-codex-config/multi-agent-v2-guard.mjs";
 import { ensureCodexReasoningConfig as applyReasoningProfile, readRootSettings } from "./migrate-codex-config/root-settings.mjs";
 import { readState, resolveStatePath, writeState } from "./migrate-codex-config/state.mjs";
@@ -22,6 +23,7 @@ export async function migrateCodexConfig({ env = process.env, cwd = process.cwd(
 	const state = await readState(statePath);
 	const paths = await configPaths({ env, cwd });
 	const changed = [];
+	const modeChanged = [];
 	const nextState = { catalogVersion: catalog.version, files: {} };
 	for (const configPath of paths) {
 		const result = await migrateConfigFile(configPath, {
@@ -29,6 +31,7 @@ export async function migrateCodexConfig({ env = process.env, cwd = process.cwd(
 			previousState: state.files?.[configPath],
 		});
 		if (result.changed) changed.push(configPath);
+		if (result.multiAgentModeChanged) modeChanged.push(configPath);
 		nextState.files[configPath] = {
 			catalogVersion: catalog.version,
 			written: result.written,
@@ -36,7 +39,7 @@ export async function migrateCodexConfig({ env = process.env, cwd = process.cwd(
 		};
 	}
 	await writeState(statePath, nextState);
-	return { changed };
+	return { changed, modeChanged };
 }
 
 export async function migrateConfigFile(configPath, { catalog = FALLBACK_CATALOG, previousState } = {}) {
@@ -55,7 +58,11 @@ export async function migrateConfigFile(configPath, { catalog = FALLBACK_CATALOG
 	const multiAgentChanged = afterMultiAgentGuard !== config;
 	if (multiAgentChanged) config = afterMultiAgentGuard;
 
-	const changed = reasoningApplied || multiAgentChanged;
+	const afterMultiAgentModeGuard = forceMultiAgentModeSteering(config);
+	const multiAgentModeChanged = afterMultiAgentModeGuard !== config;
+	if (multiAgentModeChanged) config = afterMultiAgentModeGuard;
+
+	const changed = reasoningApplied || multiAgentChanged || multiAgentModeChanged;
 	if (changed) {
 		await mkdir(dirname(configPath), { recursive: true });
 		await writeFile(configPath, `${config.trimEnd()}\n`);
@@ -63,7 +70,7 @@ export async function migrateConfigFile(configPath, { catalog = FALLBACK_CATALOG
 
 	const written = decision.apply ? catalog.current : readRootSettings(config);
 	const managed = decision.apply ? true : decision.managed;
-	return { changed, written, managed };
+	return { changed, written, managed, multiAgentModeChanged };
 }
 
 function shouldApplyCatalog(config, catalog, previousState) {

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-mode-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-mode-guard.mjs
@@ -1,0 +1,54 @@
+const MULTI_AGENT_MODE_KEY = "multi_agent_mode";
+const MULTI_AGENT_MODE_STEERING = "steering";
+
+export function forceMultiAgentModeSteering(config) {
+	if (readRootStringSetting(config, MULTI_AGENT_MODE_KEY) === MULTI_AGENT_MODE_STEERING) return config;
+	return replaceOrInsertRootSetting(config, MULTI_AGENT_MODE_KEY, JSON.stringify(MULTI_AGENT_MODE_STEERING));
+}
+
+function readRootStringSetting(config, key) {
+	for (const line of config.split(/\n/)) {
+		if (isSectionHeader(line)) return null;
+		const match = line.trimStart().match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]*)"/);
+		if (match?.[1] === key) return match[2] ?? null;
+	}
+	return null;
+}
+
+function replaceOrInsertRootSetting(config, key, value) {
+	const lines = config.split(/\n/);
+	const output = [];
+	let replaced = false;
+	let inserted = false;
+	let inRoot = true;
+	for (const line of lines) {
+		const sectionHeader = isSectionHeader(line);
+		if (inRoot && !inserted && sectionHeader) {
+			if (!replaced) output.push(`${key} = ${value}`);
+			inserted = true;
+		}
+		if (inRoot && isRootSetting(line, key)) {
+			if (!replaced) {
+				output.push(`${key} = ${value}`);
+				replaced = true;
+			}
+			continue;
+		}
+		output.push(line);
+		if (sectionHeader) inRoot = false;
+	}
+	if (!replaced && !inserted) output.push(`${key} = ${value}`);
+	return output.join("\n");
+}
+
+function isSectionHeader(line) {
+	const trimmed = line.trim();
+	return trimmed.startsWith("[") && trimmed.endsWith("]");
+}
+
+function isRootSetting(line, key) {
+	const trimmed = line.trimStart();
+	if (trimmed.startsWith("#") || trimmed.startsWith("[")) return false;
+	const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+	return match?.[1] === key;
+}

--- a/packages/omo-codex/plugin/test/auto-update-release-notes.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update-release-notes.test.mjs
@@ -14,6 +14,7 @@ function autoUpdateEnv(root, extra = {}) {
 		LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json"),
 		LAZYCODEX_AUTO_UPDATE_STATE_PATH: join(root, "state.json"),
 		LAZYCODEX_AUTO_UPDATE_LOG_PATH: join(root, "auto-update.log"),
+		LAZYCODEX_CONFIG_MIGRATION_DISABLED: "1",
 		...extra,
 	};
 }

--- a/packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -20,6 +20,7 @@ function autoUpdateEnv(root, extra = {}) {
 		LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json"),
 		LAZYCODEX_AUTO_UPDATE_STATE_PATH: join(root, "state.json"),
 		LAZYCODEX_AUTO_UPDATE_LOG_PATH: join(root, "auto-update.log"),
+		LAZYCODEX_CONFIG_MIGRATION_DISABLED: "1",
 		...extra,
 	};
 }
@@ -45,6 +46,28 @@ test("#given a newer version #when resolving auto update plan #then plan carries
 	assert.equal(plan.shouldRun, true);
 	assert.equal(plan.currentVersion, "1.0.0");
 	assert.equal(plan.latestVersion, "1.0.1");
+});
+
+test("#given SessionStart migration changes multi-agent mode #when startup check runs #then emits team-mode support notice", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-steering-notice-"));
+	const env = autoUpdateEnv(root, {
+		LAZYCODEX_CURRENT_VERSION: "1.0.1",
+		LAZYCODEX_LATEST_VERSION: "1.0.1",
+		LAZYCODEX_CONFIG_MIGRATION_DISABLED: "0",
+	});
+	await mkdir(env.CODEX_HOME, { recursive: true });
+	await writeFile(join(env.CODEX_HOME, "config.toml"), ['multi_agent_mode = "queue"', ""].join("\n"));
+
+	const result = await runAutoUpdateCheck({ env, now: 90_000_000 });
+
+	assert.equal(result.started, false);
+	assert.equal(result.reason, "up-to-date");
+	assert.equal(result.notices.length, 1);
+	assert.match(result.notices[0], /multi_agent_mode/);
+	assert.match(result.notices[0], /steering/);
+	assert.match(result.notices[0], /Team Mode support/);
+	const config = await readFile(join(env.CODEX_HOME, "config.toml"), "utf8");
+	assert.match(config, /^multi_agent_mode = "steering"$/m);
 });
 
 test("#given a newer version #when waited update succeeds #then returns update-started notice and persists pendingNotice", async () => {

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
+import { forceMultiAgentModeSteering } from "../scripts/migrate-codex-config/multi-agent-mode-guard.mjs";
 import { forceDisableMultiAgentV2 } from "../scripts/migrate-codex-config/multi-agent-v2-guard.mjs";
 import { ensureCodexReasoningConfig, migrateCodexConfig } from "../scripts/migrate-codex-config.mjs";
 
@@ -205,11 +206,13 @@ test("#given user-customized Codex model config #when migrating #then user value
 	});
 
 	const content = await readFile(join(codexHome, "config.toml"), "utf8");
-	assert.deepEqual(result.changed, []);
+	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
+	assert.deepEqual(result.modeChanged, [join(codexHome, "config.toml")]);
 	assert.match(content, /model = "gpt-5\.4"/);
 	assert.match(content, /model_context_window = 123456/);
 	assert.match(content, /model_reasoning_effort = "medium"/);
 	assert.match(content, /plan_mode_reasoning_effort = "medium"/);
+	assert.match(content, /^multi_agent_mode = "steering"$/m);
 });
 
 test("#given managed config state is malformed #when migrating #then migration ignores stale state safely", async () => {
@@ -328,6 +331,7 @@ test("#given config already matches current catalog #when catalog version advanc
 			"model_context_window = 400000",
 			'model_reasoning_effort = "high"',
 			'plan_mode_reasoning_effort = "xhigh"',
+			'multi_agent_mode = "steering"',
 			"",
 			"[features.multi_agent_v2]",
 			"enabled = false",
@@ -520,8 +524,28 @@ test("#given global config without multi_agent_v2 section #when full migration r
 	});
 
 	assert.deepEqual(result.changed, [configPath]);
+	assert.deepEqual(result.modeChanged, [configPath]);
 	const content = await readFile(configPath, "utf8");
 	assert.match(content, /\[features\.multi_agent_v2\]\nenabled = false\n/);
+	assert.match(content, /^multi_agent_mode = "steering"$/m);
+});
+
+test("#given queue multi-agent mode #when forcing steering #then patches root setting", () => {
+	const config = ['multi_agent_mode = "queue"', "", "[features]", "multi_agent = true", ""].join("\n");
+
+	const result = forceMultiAgentModeSteering(config);
+
+	assert.match(result, /^multi_agent_mode = "steering"$/m);
+	assert.doesNotMatch(result, /multi_agent_mode = "queue"/);
+	assert.match(result, /\[features\]/);
+});
+
+test("#given steering multi-agent mode #when forcing steering #then returns config unchanged", () => {
+	const config = ['multi_agent_mode = "steering" # user already opted in', "", "[features]", "multi_agent = true", ""].join("\n");
+
+	const result = forceMultiAgentModeSteering(config);
+
+	assert.equal(result, config);
 });
 
 test("#given global config with forced multi_agent_v2 #when full migration runs #then disables it on disk", async () => {

--- a/packages/omo-codex/scripts/install-config.test.mjs
+++ b/packages/omo-codex/scripts/install-config.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { updateCodexConfig } from "./install-dist/install-local.mjs";
 
-test("#given empty Codex config #when script installer updates config #then enables MultiAgentV2 with ten thousand session threads", async () => {
+test("#given empty Codex config #when script installer updates config #then enables steering mode with ten thousand session threads", async () => {
 	// given
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-"));
 	const configPath = join(root, "config.toml");
@@ -22,9 +22,38 @@ test("#given empty Codex config #when script installer updates config #then enab
 
 	// then
 	const config = await readFile(configPath, "utf8");
+	assert.match(config, /^multi_agent_mode = "steering"$/m);
 	assert.match(config, /\[features\.multi_agent_v2\]/);
-	assert.match(config, /enabled = true/);
+	const v2Section = config.slice(config.indexOf("[features.multi_agent_v2]")).split(/^\[/m).slice(0, 1).join("");
+	assert.doesNotMatch(v2Section, /enabled\s*=/);
 	assert.match(config, /max_concurrent_threads_per_session = 10000/);
+});
+
+test("#given queue multi-agent mode #when script installer updates config #then switches to steering mode for team support", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-mode-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'multi_agent_mode = "queue"',
+			"",
+			"[features]",
+			"multi_agent = true",
+			"",
+		].join("\n"),
+	);
+
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "debug",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+		pluginNames: ["omo"],
+	});
+
+	const config = await readFile(configPath, "utf8");
+	assert.match(config, /^multi_agent_mode = "steering"$/m);
+	assert.doesNotMatch(config, /multi_agent_mode = "queue"/);
 });
 
 test("#given empty Codex config #when script installer updates config #then leaves Context7 to the plugin MCP manifest", async () => {

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5907,7 +5907,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.12.1",
+    version: "4.13.0",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -6042,7 +6042,7 @@ function createPostHogClient(source, options = {}) {
     osProvider: options.osProvider ?? resolveOsProvider(),
     product: createCodexTelemetryProductConfig(),
     source,
-    transportFactory: options.transportFactory
+    transportFactory: options.transportFactory ?? transportFactoryOverride ?? undefined
   });
   if (!client.enabled) {
     return NO_OP_POSTHOG;
@@ -6093,7 +6093,7 @@ function __setActivityStateProviderForTesting(provider) {
 function __resetActivityStateProviderForTesting() {
   activityStateProviderOverride = null;
 }
-var osProviderOverride2 = null, activityStateProviderOverride = null, NO_OP_POSTHOG;
+var osProviderOverride2 = null, activityStateProviderOverride = null, transportFactoryOverride = null, NO_OP_POSTHOG;
 var init_posthog = __esm(() => {
   init_src();
   init_diagnostics2();
@@ -8015,6 +8015,30 @@ function parseProfileMatch(match) {
   return profile;
 }
 
+// packages/omo-codex/src/install/codex-multi-agent-mode-config.ts
+var CODEX_MULTI_AGENT_MODE_KEY = "multi_agent_mode";
+var CODEX_MULTI_AGENT_MODE_STEERING = "steering";
+function ensureCodexMultiAgentModeConfig(config) {
+  if (readRootStringSetting(config, CODEX_MULTI_AGENT_MODE_KEY) === CODEX_MULTI_AGENT_MODE_STEERING) {
+    return config;
+  }
+  return replaceOrInsertRootSetting(config, CODEX_MULTI_AGENT_MODE_KEY, JSON.stringify(CODEX_MULTI_AGENT_MODE_STEERING));
+}
+function readRootStringSetting(config, key) {
+  for (const line of config.split(/\n/)) {
+    if (isSectionHeader2(line))
+      return null;
+    const match = line.trimStart().match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]*)"/);
+    if (match?.[1] === key)
+      return match[2] ?? null;
+  }
+  return null;
+}
+function isSectionHeader2(line) {
+  const trimmed = line.trim();
+  return trimmed.startsWith("[") && trimmed.endsWith("]");
+}
+
 // packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
 var CODEX_MULTI_AGENT_V2_HEADER = "features.multi_agent_v2";
 var CODEX_MULTI_AGENT_V2_MAX_CONCURRENT_THREADS_PER_SESSION = 1e4;
@@ -8061,6 +8085,7 @@ async function updateCodexConfig(input) {
   config = ensureFeatureEnabled(config, "plugin_hooks");
   config = ensureFeatureEnabled(config, "multi_agent");
   config = ensureFeatureEnabled(config, "child_agents_md");
+  config = ensureCodexMultiAgentModeConfig(config);
   config = ensureCodexReasoningConfig(config, await readCodexModelCatalog(input.repoRoot));
   config = ensureCodexMultiAgentV2Config(config);
   if (input.autonomousPermissions === true)
@@ -8454,7 +8479,7 @@ function extractServiceTier(content) {
 }
 function extractTopLevelStringSetting(content, key) {
   for (const line of content.split(/\n/)) {
-    if (isSectionHeader2(line))
+    if (isSectionHeader3(line))
       return null;
     const rawValue = topLevelStringSettingRawValue(line, key);
     if (rawValue === undefined)
@@ -8475,7 +8500,7 @@ function replaceTopLevelStringSetting(content, key, value, options) {
   const lines = content.split(/\n/);
   for (let index = 0;index < lines.length; index += 1) {
     const line = lines[index];
-    if (line === undefined || isSectionHeader2(line))
+    if (line === undefined || isSectionHeader3(line))
       break;
     if (topLevelStringSettingRawValue(line, key) === undefined)
       continue;
@@ -8505,7 +8530,7 @@ function topLevelStringSettingRawValue(line, key) {
   return rawValue;
 }
 function topLevelInsertionIndex(lines) {
-  const sectionIndex = lines.findIndex((line) => isSectionHeader2(line));
+  const sectionIndex = lines.findIndex((line) => isSectionHeader3(line));
   const topLevelEnd = sectionIndex === -1 ? lines.length : sectionIndex;
   let insertionIndex = topLevelEnd;
   while (insertionIndex > 0 && lines[insertionIndex - 1] === "") {
@@ -8513,7 +8538,7 @@ function topLevelInsertionIndex(lines) {
   }
   return insertionIndex;
 }
-function isSectionHeader2(line) {
+function isSectionHeader3(line) {
   const trimmed = line.trim();
   return trimmed.startsWith("[") && trimmed.endsWith("]");
 }

--- a/packages/omo-codex/src/install/codex-config-toml.test.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.test.ts
@@ -73,11 +73,42 @@ describe("codex-config-toml", () => {
 
     // then
     const content = await readFile(configPath, "utf8")
+    expect(content).toContain('multi_agent_mode = "steering"')
     expect(content).toContain("[features.multi_agent_v2]")
     const v2Section = content.slice(content.indexOf("[features.multi_agent_v2]"))
       .split(/^\[/m).slice(0, 1).join("")
     expect(v2Section).not.toContain("enabled")
     expect(content).toContain("max_concurrent_threads_per_session = 10000")
+  })
+
+  test("#given queue multi-agent mode #when updating config #then switches to steering mode for team support", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-mode-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      [
+        'multi_agent_mode = "queue"',
+        "",
+        "[features]",
+        "multi_agent = true",
+        "",
+      ].join("\n"),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content).toContain('multi_agent_mode = "steering"')
+    expect(content).not.toContain('multi_agent_mode = "queue"')
   })
 
   test("#given existing MultiAgentV2 table #when updating config #then preserves user enabled flag and unrelated tuning while setting thread limit", async () => {

--- a/packages/omo-codex/src/install/codex-config-toml.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.ts
@@ -15,6 +15,7 @@ import { ensureAutonomousPermissions } from "./codex-config-permissions"
 import { ensureHookTrusted, ensureOmoBuiltinMcpPolicies, ensurePluginEnabled } from "./codex-config-plugins"
 import { ensureCodexReasoningConfig } from "./codex-config-reasoning"
 import { readCodexModelCatalog } from "./codex-model-catalog"
+import { ensureCodexMultiAgentModeConfig } from "./codex-multi-agent-mode-config"
 import { ensureCodexMultiAgentV2Config } from "./codex-multi-agent-v2-config"
 import type { CodexAgentConfig, CodexInstallPlatform, CodexMarketplaceSource, TrustedHookState } from "./types"
 
@@ -52,6 +53,7 @@ export async function updateCodexConfig(input: {
   config = ensureFeatureEnabled(config, "plugin_hooks")
   config = ensureFeatureEnabled(config, "multi_agent")
   config = ensureFeatureEnabled(config, "child_agents_md")
+  config = ensureCodexMultiAgentModeConfig(config)
   config = ensureCodexReasoningConfig(config, await readCodexModelCatalog(input.repoRoot))
   config = ensureCodexMultiAgentV2Config(config)
   if (input.autonomousPermissions === true) config = ensureAutonomousPermissions(config)

--- a/packages/omo-codex/src/install/codex-multi-agent-mode-config.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-mode-config.ts
@@ -1,0 +1,29 @@
+import { replaceOrInsertRootSetting } from "./toml-section-editor"
+
+const CODEX_MULTI_AGENT_MODE_KEY = "multi_agent_mode"
+const CODEX_MULTI_AGENT_MODE_STEERING = "steering"
+
+export function ensureCodexMultiAgentModeConfig(config: string): string {
+  if (readRootStringSetting(config, CODEX_MULTI_AGENT_MODE_KEY) === CODEX_MULTI_AGENT_MODE_STEERING) {
+    return config
+  }
+  return replaceOrInsertRootSetting(
+    config,
+    CODEX_MULTI_AGENT_MODE_KEY,
+    JSON.stringify(CODEX_MULTI_AGENT_MODE_STEERING),
+  )
+}
+
+function readRootStringSetting(config: string, key: string): string | null {
+  for (const line of config.split(/\n/)) {
+    if (isSectionHeader(line)) return null
+    const match = line.trimStart().match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]*)"/)
+    if (match?.[1] === key) return match[2] ?? null
+  }
+  return null
+}
+
+function isSectionHeader(line: string): boolean {
+  const trimmed = line.trim()
+  return trimmed.startsWith("[") && trimmed.endsWith("]")
+}

--- a/packages/omo-opencode/src/features/team-mode/integration.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/integration.test.ts
@@ -177,7 +177,7 @@ describe("team-mode integration", () => {
     expect((await loadRuntimeState(deadRuntime.teamRunId, config)).status).toBe("orphaned")
     expect((await loadRuntimeState(stuckRuntime.teamRunId, config)).status).toBe("failed")
     expect(await exists(getRuntimeStateDir(resolveBaseDir(config), deletingRuntime.teamRunId))).toBe(false)
-  })
+  }, 15000)
 
   test("C-10.5 end-to-end: createTeamRun persists category-aware routing and team_send_message reapplies it on promptAsync", async () => {
     // given - a 2-member team; resolveMemberMock returns agentToUse + model per member


### PR DESCRIPTION
## Summary

This PR makes LazyCodex install and runtime migration default Codex `multi_agent_mode` to `"steering"` so Team Mode steering is available by default instead of queue mode.

The installer now writes or replaces the root-level setting during `lazycodex install`, and the SessionStart auto-update/migration path also forces existing queue configs to steering. When SessionStart changes the setting, it returns additional context telling the user LazyCodex updated it for Team Mode support.

## Changes

- Add installer-side `multi_agent_mode = "steering"` enforcement and generated installer output.
- Add SessionStart config migration guard for existing Codex configs.
- Add a SessionStart notice when LazyCodex changes the mode for Team Mode support.
- Extend installer, migration, and auto-update tests for steering mode behavior.

## Verification

- `bun run test:codex` ✅ 398 tests passed, evidence: `.omo/evidence/20260623-lazycodex-steering-default/test-codex.txt`
- Isolated `lazycodex install` proof ✅ wrote `multi_agent_mode = "steering"` and left real `~/.codex/config.toml` hash unchanged, evidence: `.omo/evidence/20260623-lazycodex-steering-default/install-steering.txt`
- SessionStart hook proof ✅ converted queue to steering and emitted the Team Mode support notice while leaving real `~/.codex/config.toml` unchanged, evidence: `.omo/evidence/20260623-lazycodex-steering-default/session-start-steering-notice.txt`
- Codex app-server live QA ✅ plugin hooks completed for `sessionStart` and `userPromptSubmit` with isolated `CODEX_HOME`, evidence: `.omo/evidence/20260623-lazycodex-steering-default/app-server-drive-plugin.txt`
- `git diff --check` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default Codex `multi_agent_mode` to steering so Team Mode works out of the box. Applied on install and during SessionStart migration with a user notice when changed.

- **Migration**
  - `lazycodex install` now writes/updates root `multi_agent_mode = "steering"`.
  - SessionStart migration switches existing queue configs to steering and emits a Team Mode notice via auto update.
  - Preserves `multi_agent_v2` enablement; still sets `max_concurrent_threads_per_session = 10000`.
  - Tests updated for installer, migration, and auto-update notices; relaxed team-mode integration test timeout; bumped `@oh-my-opencode/omo-codex` to `4.13.0`.

<sup>Written for commit 1a08028e299137d0045a080c15604b678fb42b2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

