### PR TITLE
fix(codex): surface teammode thread links

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -93,6 +93,10 @@ subcommand rewrites `guide.md`, so the manual always matches the current team.
    trigger (printed by `add-member` / `member-prompt`) as the thread's first message. The trigger
    is short on purpose: it tells the new thread to READ its `guide.md` and `team.json` rather than
    carrying the whole protocol inline.
+4. Whenever you report, audit, reopen, or hand off a member thread, include the app deep link
+   `codex://threads/<thread_id>` next to the raw id. For example:
+   `codex://threads/019ef350-ee78-72a3-bd5e-e40cebc3d814`. Worktree-backed threads are easy to
+   lose in the sidebar without this link.
 
 Every team member is a real Codex thread created with `codex_app.create_thread` - this is strict,
 not a preference. NEVER substitute `multi_agent_v1.spawn_agent`, or any other in-process subagent,
@@ -126,6 +130,11 @@ the worktree off the base branch on a derived branch, flips the team into worktr
 its own worktree. To land the work, `integrate --team <id>` merges every member branch into your
 current branch with a merge commit (never a squash or rebase); resolve any conflict it reports, then
 `worktree-remove` each worktree at cleanup.
+
+After `worktree-add`, immediately send the member a follow-up that includes both its assigned
+worktree path and its `codex://threads/<thread_id>` link. Use `bind-thread --cwd <worktree>` or
+`--worktree-path <worktree>` after the thread exists so `team.json`, `guide.md`, `status`, and
+`member-prompt` all point at the same worktree-backed thread.
 
 ## Run a ulw-plan in parallel
 

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
@@ -5,8 +5,12 @@
 // writes it once at team creation, and every member thread is told to READ it instead of
 // receiving the rules inline each turn.
 
+export function codexThreadLink(threadId) {
+	return `codex://threads/${threadId}`;
+}
+
 function memberLine(member) {
-	const thread = member.threadId ? ` | thread ${member.threadId}` : " | thread not created yet";
+	const thread = member.threadId ? ` | thread ${member.threadId} (${codexThreadLink(member.threadId)})` : " | thread not created yet";
 	const wt = member.worktree?.path ? ` | worktree ${member.worktree.path}` : "";
 	const name = member.name ? ` "${member.name}"` : "";
 	const title = member.threadTitle ? ` | thread title \`${member.threadTitle}\`` : "";
@@ -23,7 +27,10 @@ that is a coordination signal: mark yourself \`blocked\` and tell the leader at 
 	}
 	const lines = team.members
 		.filter((m) => m.worktree?.path || m.worktree?.branch)
-		.map((m) => `- **${m.id}**: worktree \`${m.worktree.path ?? "(assign with bind-thread --cwd)"}\` on branch \`${m.worktree.branch ?? team.worktree.baseBranch}\``);
+		.map((m) => {
+			const thread = m.threadId ? `; thread ${codexThreadLink(m.threadId)}` : "";
+			return `- **${m.id}**: worktree \`${m.worktree.path ?? "(assign with bind-thread --cwd)"}\` on branch \`${m.worktree.branch ?? team.worktree.baseBranch}\`${thread}`;
+		});
 	return `## Worktrees (ISOLATION IS ON - this is not optional for you)
 
 This team runs each member in its own git worktree branched off \`${team.worktree.baseBranch}\`.
@@ -71,6 +78,8 @@ coordinate with each other, but the leader owns the final decision and integrati
 - **Reach the leader and your peers with \`codex_app.send_message_to_thread\` - not by narrating in
   your own thread, where no one reads it.** The address book is in team.json: the leader thread id
   is \`leader.sessionId\`, and each peer thread id is its \`members[].threadId\`.
+- **When you mention a Codex thread, include its app link too:** \`codex://threads/<threadId>\`.
+  These links are the fastest way for the leader to reopen worktree-backed member threads.
 - **Push a short message at each of these moments - never batch them into one report at the end:**
   - to the **leader**: every finding or decision, every file or sub-task you finish, a
     \`WORKING: <focus> - <phase>\` heartbeat every few tool calls so you never look stale, a
@@ -104,9 +113,10 @@ export function buildMemberPrompt(team, id) {
 	const guide = team.paths?.guide ?? ".omo/teams/<session_id>/guide.md";
 	const teamJson = team.paths?.team ?? ".omo/teams/<session_id>/team.json";
 	const where = member.cwd ? `Work inside \`${member.cwd}\`.` : "Work from the repository root unless your manual assigns a worktree.";
+	const threadLink = member.threadId ? `\nYour Codex thread link is ${codexThreadLink(member.threadId)}. Include it when reporting handoffs or worktree status.` : "";
 	return `You are member ${member.id}${member.name ? ` (${member.name})` : ""} of team ${team.teamName} - owner of: ${member.focus}. Your thread title is \`${member.threadTitle}\`.
 FIRST read your field manual at \`${guide}\`, then the team state at \`${teamJson}\`; they define your scope, deliverable, the leader, the artifacts directory, and the communication rules.
-${where}
+${where}${threadLink}
 Communicate with the team and leader in English; reply to the end user in the user's own language.
 Start now. Push updates to the leader and relevant peers with \`codex_app.send_message_to_thread\` as you work - findings, \`WORKING:\` heartbeats, and \`BLOCKED:\` the instant you stall - never just one report at the end.`;
 }

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -20,7 +20,7 @@ import { randomUUID } from "node:crypto";
 import { realpathSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { buildGuide, buildMemberPrompt } from "./team-guide.mjs";
+import { buildGuide, buildMemberPrompt, codexThreadLink } from "./team-guide.mjs";
 import {
 	addMember,
 	archive,
@@ -164,8 +164,9 @@ const handlers = {
 		setMemberWorktree(team, { id: member.id, path: result.path, branch: result.branch });
 		await persist(team, dir);
 		const note = result.created ? "" : " (already exists)";
+		const thread = member.threadId ? `\nMember thread: ${codexThreadLink(member.threadId)}` : "";
 		process.stdout.write(
-			`worktree for member ${member.id}${note}: ${result.path} on branch ${result.branch} (off ${result.base}).\nTell that member to: cd "${result.path}"\n`,
+			`worktree for member ${member.id}${note}: ${result.path} on branch ${result.branch} (off ${result.base}).${thread}\nTell that member to: cd "${result.path}"\n`,
 		);
 	},
 
@@ -232,7 +233,8 @@ const handlers = {
 		const { team } = await loadTeam(cwd, sessionId);
 		process.stdout.write(`Team ${team.teamName} [${team.status}] - leader: main session - ${team.members.length} member(s)\n`);
 		for (const m of team.members) {
-			process.stdout.write(`  ${m.id} (${m.lens}) ${m.focus} -> ${m.deliverable || "(no deliverable)"} [${m.status}]${m.threadId ? ` thread=${m.threadId}` : ""}${m.cwd ? ` cwd=${m.cwd}` : ""}\n`);
+			const thread = m.threadId ? ` thread=${m.threadId} link=${codexThreadLink(m.threadId)}` : "";
+			process.stdout.write(`  ${m.id} (${m.lens}) ${m.focus} -> ${m.deliverable || "(no deliverable)"} [${m.status}]${thread}${m.cwd ? ` cwd=${m.cwd}` : ""}\n`);
 		}
 		if (isUnderstaffed(team)) {
 			process.stdout.write(

--- a/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
@@ -73,16 +73,31 @@ function formatIdentifier(value: string): string {
 }
 
 function extractThreadCreationReference(toolResponse: unknown): ThreadCreationReference | null {
-	if (!isRecord(toolResponse)) return null;
-	const threadId = toolResponse["threadId"];
+	const response = parseToolResponseRecord(toolResponse);
+	if (response === null) return null;
+	const threadId = response["threadId"];
 	if (typeof threadId === "string" && threadId.trim().length > 0) {
 		return { kind: "thread", id: threadId };
 	}
-	const pendingWorktreeId = toolResponse["pendingWorktreeId"];
+	const pendingWorktreeId = response["pendingWorktreeId"];
 	if (typeof pendingWorktreeId === "string" && pendingWorktreeId.trim().length > 0) {
 		return { kind: "pendingWorktree", id: pendingWorktreeId };
 	}
 	return null;
+}
+
+function parseToolResponseRecord(toolResponse: unknown): Record<string, unknown> | null {
+	if (isRecord(toolResponse)) return toolResponse;
+	if (typeof toolResponse !== "string") return null;
+	const trimmed = toolResponse.trim();
+	if (trimmed.length === 0) return null;
+	try {
+		const parsed: unknown = JSON.parse(trimmed);
+		return isRecord(parsed) ? parsed : null;
+	} catch (error) {
+		if (error instanceof SyntaxError) return null;
+		return null;
+	}
 }
 
 function isPostToolUsePayload(value: unknown): value is PostToolUsePayload {

--- a/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
+++ b/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
@@ -34,6 +34,36 @@ describe("thread title PostToolUse guidance", () => {
 		);
 	});
 
+	it("#given Codex reports create_thread output as a JSON string #when the hook runs #then it still extracts the thread id", () => {
+		// given
+		const output = runPostToolUseHook({
+			hook_event_name: "PostToolUse",
+			session_id: "s-team",
+			turn_id: "t-team",
+			transcript_path: null,
+			cwd: "/repo",
+			model: "gpt-5.5",
+			permission_mode: "default",
+			tool_name: "codex_app.create_thread",
+			tool_use_id: "tool-create-thread",
+			tool_input: {
+				prompt: "Review a worktree PR",
+				target: { type: "project", projectId: "/repo", environment: { type: "local" } },
+			},
+			tool_response: '{"threadId":"019ef350-ee78-72a3-bd5e-e40cebc3d814"}',
+		});
+
+		// when
+		const parsed: unknown = JSON.parse(output);
+
+		// then
+		expect(isHookOutput(parsed)).toBe(true);
+		if (!isHookOutput(parsed)) return;
+		expect(parsed.hookSpecificOutput.additionalContext).toBe(
+			"THREAD ID 019ef350-ee78-72a3-bd5e-e40cebc3d814: CALL codex_app.set_thread_title NOW. USE THE REAL TASK/ROLE.",
+		);
+	});
+
 	it("#given an unrelated tool completed #when the hook runs #then it stays silent", () => {
 		// given
 		const output = runPostToolUseHook({

--- a/packages/omo-codex/plugin/test/teammode-thread-links.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-thread-links.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { cleanupTeamRoot, createTeamRoot, runTeam, teamDir } from "./teammode-safety-fixture.mjs";
+
+function addMember(tempRoot, sessionId, { id, name, focus, lens, deliverable }) {
+	runTeam(
+		tempRoot,
+		"add-member",
+		"--team",
+		sessionId,
+		"--id",
+		id,
+		"--name",
+		name,
+		"--focus",
+		focus,
+		"--lens",
+		lens,
+		"--deliverable",
+		deliverable,
+	);
+}
+
+test("#given a worktree-backed team has bound member threads #when guide and status render #then they include codex thread links", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-thread-links-");
+	try {
+		const sessionId = "thread-links";
+		runTeam(tempRoot, "init", "--name", "Review", "--session-name", "worktrees", "--session", sessionId, "--worktree");
+		addMember(tempRoot, sessionId, {
+			id: "A",
+			name: "qa-review-r2",
+			focus: "review PR 545 QA audit",
+			lens: "perspective",
+			deliverable: "write qa-review artifact",
+		});
+		addMember(tempRoot, sessionId, {
+			id: "B",
+			name: "pr-driver",
+			focus: "drive PR readiness",
+			lens: "ownership",
+			deliverable: "prepare review handoff",
+		});
+		runTeam(
+			tempRoot,
+			"bind-thread",
+			"--team",
+			sessionId,
+			"--id",
+			"A",
+			"--thread",
+			"019ef350-ee78-72a3-bd5e-e40cebc3d814",
+			"--cwd",
+			"/tmp/review-worktree",
+		);
+		runTeam(
+			tempRoot,
+			"bind-thread",
+			"--team",
+			sessionId,
+			"--id",
+			"B",
+			"--thread",
+			"019ef2dd-5b99-7ae2-8461-ffa6ca309d23",
+			"--cwd",
+			"/tmp/pr-driver-worktree",
+		);
+
+		const guide = readFileSync(`${teamDir(tempRoot, sessionId)}/guide.md`, "utf8");
+		const status = runTeam(tempRoot, "status", "--team", sessionId).stdout;
+		const prompt = runTeam(tempRoot, "member-prompt", "--team", sessionId, "--id", "A").stdout;
+
+		assert.match(guide, /codex:\/\/threads\/019ef350-ee78-72a3-bd5e-e40cebc3d814/);
+		assert.match(guide, /codex:\/\/threads\/019ef2dd-5b99-7ae2-8461-ffa6ca309d23/);
+		assert.match(guide, /worktree `\/tmp\/review-worktree`/);
+		assert.match(status, /link=codex:\/\/threads\/019ef350-ee78-72a3-bd5e-e40cebc3d814/);
+		assert.match(prompt, /Your Codex thread link is codex:\/\/threads\/019ef350-ee78-72a3-bd5e-e40cebc3d814/);
+		assert.match(prompt, /Work inside `\/tmp\/review-worktree`/);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});


### PR DESCRIPTION
## Summary

Fixes Codex teammode thread-title guidance when `codex_app.create_thread` reports `tool_response` as a JSON string instead of an object. Also makes worktree-backed team members easier to reopen by surfacing `codex://threads/<id>` links in the generated guide, member prompt, `status`, and `worktree-add` output.

## Changes

- Parse object-shaped and JSON-string `tool_response` values before extracting `threadId` / `pendingWorktreeId`.
- Add `codex://threads/<id>` rendering for bound team members and worktree sections.
- Update the teammode skill guidance to require deep links in reports, audits, handoffs, and post-worktree-add follow-ups.
- Add regression coverage for JSON-string create-thread responses and worktree-backed thread link rendering.

## Verification

- `npm --prefix packages/omo-codex/plugin/components/teammode test -- thread-title-hook.test.ts`
- `node --test packages/omo-codex/plugin/test/teammode-thread-links.test.mjs packages/omo-codex/plugin/test/teammode-thread-title.test.mjs packages/omo-codex/plugin/test/teammode-communication.test.mjs packages/omo-codex/plugin/test/teammode-safety.test.mjs`
- `node --test packages/omo-codex/plugin/test/*.test.mjs`
- `bun run typecheck`
- `bun run test:codex`
- `bash codex-qa/scripts/lib/common.sh --self-check`
- `bash codex-qa/scripts/hook-unit-probe.sh --self-test`
- `bash codex-qa/scripts/app-server-drive.sh --plugin`
- Built teammode CLI PostToolUse proof: JSON-string `tool_response` produced `THREAD ID 019ef350-ee78-72a3-bd5e-e40cebc3d814: CALL codex_app.set_thread_title NOW...`

## Evidence

Local QA artifacts are under `.omo/evidence/20260623-teammode-thread-links/` in the PR worktree:

- `test-codex.txt`: 399 Codex tests passed
- `typecheck.txt`: root typecheck passed
- `codex-qa-app-server-plugin.txt`: isolated Codex app-server completed and plugin hooks fired (`sessionStart`, `userPromptSubmit`, `stop`)
- `teammode-post-tool-use-json-string.txt`: teammode built CLI extracted the thread id from JSON-string `tool_response`
- `teammode-focused-node-tests.txt` and `teammode-thread-title-hook-test.txt`: focused regressions passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PostToolUse thread-title guidance when `codex_app.create_thread` returns a JSON-string `tool_response`, and adds `codex://threads/<id>` deep links across teammode so worktree-backed threads are easy to reopen.

- **Bug Fixes**
  - PostToolUse hook now parses object-shaped and JSON-string `tool_response` to extract `threadId`/`pendingWorktreeId`.
  - Added regression tests for JSON-string responses.

- **New Features**
  - Surfaces `codex://threads/<id>` in the team guide, worktree sections, member prompts, `status`, and `worktree-add` output.
  - Updated `SKILL.md` to require including deep links in reports, audits, handoffs, and post-`worktree-add` follow-ups.

<sup>Written for commit 7a81a40ed53d3c42c3fedf9f9f13c677aa6ddc3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

