### PR TITLE
fix(visual-qa): enforce exhaustive per-page CJK review via mandatory subagent gate

### DIFF
--- a/packages/shared-skills/skills/visual-qa/SKILL.md
+++ b/packages/shared-skills/skills/visual-qa/SKILL.md
@@ -24,6 +24,16 @@ If the change touches both, run both capture tracks and feed both into the passe
 
 ## Step 2 - Capture objective reference evidence
 
+### Coverage - capture every page, not a sample
+
+A surface is rarely one screen. If the UI has multiple pages, slides, routes, tabs, modal states, viewport breakpoints, or scroll positions, enumerate the COMPLETE set first and capture every one. A 40-slide deck means 40 captures, not 5. Never sample a few representative screens and generalize: the defect you miss is always on the page you did not open.
+
+The verdict is per page. One failing page fails the whole surface, so "most pages look fine" is not a PASS. Record the enumerated list (page count and identifiers) so the reviewer in Step 3 can confirm nothing was skipped.
+
+### Evidence must be fresh
+
+Every gate runs on captures produced AFTER the last edit to the rendered source. If any screenshot, PDF, capture, or QA JSON is older than the source file it claims to verify, it is stale and invalid - regenerate it before trusting it. Never report a PASS from an artifact you did not just produce against the current build.
+
 ### Web
 
 1. Capture a REFERENCE image: the user's mock/target, or a known-good baseline. Save as PNG.
@@ -57,7 +67,11 @@ This JSON (diff ratio, similarity score, hotspots or overflow lines, border alig
 
 ## Step 3 - Dispatch two read-only QA subagents in parallel
 
-Send BOTH task calls in a single message so they run concurrently. Each oracle is read-only: it reviews and reports, it cannot modify files. Each returns PASS, REVISE, or FAIL with concrete, located findings. Pass A proves the surface is a real design-system implementation, not a mock-only or faked-image substitute. Pass B directly opens screenshots and inspects source/content for visual and CJK defects.
+This independent review is REQUIRED before any "done" claim. Do not self-review inside the main agent and call the UI verified - a self-graded pass is the failure mode this step exists to stop. Dispatch it yourself, every time, without waiting to be told. Give each reviewer the captures for every enumerated page from Step 2, not a sample, and tell it the page count so it can confirm none were skipped.
+
+Dispatch through your harness's own subagent tool. In OpenCode: `task(subagent_type="oracle", ...)`. In Codex: `multi_agent_v1.spawn_agent({"message": "...", "agent_type": "lazycodex-gate-reviewer", "fork_context": false})` (the code blocks below are written in OpenCode `task(...)` form; translate them to that `spawn_agent` call, putting the full prompt in `message`).
+
+Send BOTH calls in a single message so they run concurrently. Each oracle is read-only: it reviews and reports, it cannot modify files. Each returns PASS, REVISE, or FAIL with concrete, located findings. Pass A proves the surface is a real design-system implementation, not a mock-only or faked-image substitute. Pass B directly opens screenshots and inspects source/content for visual and CJK defects.
 
 Paste evidence directly into each prompt: source code, the plain-text TUI captures, the script JSON, and the screenshot paths plus your described observations for web. The two passes differ in depth by charter, not by any model or effort setting, which cannot be pinned per call.
 
@@ -137,7 +151,12 @@ USE THE EVIDENCE:
 CHECK:
 1. Does the rendered output match what the user requested: layout, spacing, color, type, alignment?
 2. CJK precision:
-   - Web: natural CJK line breaking for display and body text. Flag oversized headings or narrow containers that create orphaned one-character or final-syllable lines, split Korean/Japanese/Chinese semantic phrases unnaturally (for example `놀라운 변 / 화`), detach labels such as `[Image #1]` from their content, clip baselines/descenders, drop glyphs (tofu), or show font metric mismatch. Treat screenshot patterns like `에이전트 오케스트 / 레이션 현황 및 미 / 래` as REVISE/FAIL, not acceptable wrapping.
+   - Web: natural CJK line breaking for display and body text. Inspect every page's screenshot for this, not a sample. A high `similarityScore` never excuses a break: each class below is REVISE/FAIL and blocking regardless of similarityScore. Flag every one of:
+     - a particle or ending orphaned onto its own line, for example `핵심 자료 / 도` or `끝에서 / 만난다`.
+     - a short subject or topic phrase split from its predicate, for example `두 강은 / 끝에서 만난다` (the whole clause should sit on one line).
+     - a connective or auxiliary expression split mid-phrase, for example `쓸 수 / 있지만` or `방 / 식이`.
+     - a parenthetical or source/citation English string broken across lines, for example `(Vaswani et al. 2017, Attention Is / All You Need)` or `(Schulman et al. 2017); AlphaGo (Silver et al. / 2016)`.
+     - oversized headings or narrow containers that create orphaned one-character or final-syllable lines, split Korean/Japanese/Chinese semantic phrases unnaturally (for example `놀라운 변 / 화`), detach labels such as `[Image #1]` from their content, clip baselines/descenders, drop glyphs (tofu), or show font metric mismatch. Treat screenshot patterns like `에이전트 오케스트 / 레이션 현황 및 미 / 래` as REVISE/FAIL, not acceptable wrapping.
    - TUI: wide-character column drift (CJK cells counted as 1 instead of 2), box-drawing border misalignment, content overflowing past the terminal width.
 
 OUTPUT:
@@ -155,7 +174,15 @@ BLOCKING: items that must be fixed; empty if PASS
 
 When both passes return, merge them into a single report. Per dimension, mark good or bad with evidence. For each bad item, state what is wrong, where (file/line, hotspot grid, or capture line), and the concrete fix. Call out what is genuinely good so it is not regressed later.
 
-Completion gate: do not declare the UI done until both passes are satisfied, OR the remaining gaps are explicitly listed and accepted by the user. A high `similarityScore` with an open Pass A finding, for example a faked-image layout or a broken feature, is still a FAIL.
+### Completion gate - loop until an independent pass on fresh evidence
+
+This is a hard stop rule, not a guideline. The UI is NOT done until ALL of these hold at once on the SAME current build:
+
+- An independent read-only reviewer subagent returned PASS with no BLOCKING findings.
+- That reviewer judged a FRESH capture of every enumerated page from Step 2 - no stale artifacts, no skipped pages.
+- Every CJK and layout finding is resolved in the rendered output, not merely noted.
+
+If any page fails, you are not done: fix it, re-capture the full set, re-dispatch the reviewer, and repeat. Loop until the independent reviewer passes on the current build. Do not stop because the automated script reports zero issues - the script aims the reviewer, it does not replace it, and it routinely passes text while the rendered page is still broken. Do not stop because an earlier pass approved an older build. The only non-loop exit is to list the exact remaining gaps and get explicit user acceptance; never self-certify a silent PASS.
 
 ```markdown
 # Visual QA - Verdict: GOOD | NEEDS WORK

--- a/packages/shared-skills/skills/visual-qa/scripts/skill-prompt-contract.test.ts
+++ b/packages/shared-skills/skills/visual-qa/scripts/skill-prompt-contract.test.ts
@@ -127,3 +127,71 @@ describe("visual-qa skill prompt contract", () => {
 		}
 	})
 })
+
+describe("visual-qa skill exhaustive-coverage and review-gate contract", () => {
+	test("#given a multi-page surface #when capturing #then every page is enumerated and verified per page, not sampled", () => {
+		for (const fixture of fixtures()) {
+			const capture = sectionBetween(fixture.text, "## Step 2", "## Step 3")
+			const lower = capture.toLowerCase()
+
+			expect(lower, fixture.label).toContain("every page")
+			expect(lower, fixture.label).toContain("enumerate")
+			expect(lower, fixture.label).toContain("never sample")
+			expect(lower, fixture.label).toContain("per page")
+			expect(lower, fixture.label).toContain("one failing page fails")
+		}
+	})
+
+	test("#given prior QA artifacts #when verifying #then stale evidence older than the source must be regenerated", () => {
+		for (const fixture of fixtures()) {
+			const capture = sectionBetween(fixture.text, "## Step 2", "## Step 3")
+			const lower = capture.toLowerCase()
+
+			expect(lower, fixture.label).toContain("stale")
+			expect(lower, fixture.label).toContain("older than")
+			expect(lower, fixture.label).toContain("regenerate")
+		}
+	})
+
+	test("#given Step 3 dispatch #when running the review #then it is required pre-done, harness-native, and covers every enumerated page", () => {
+		for (const fixture of fixtures()) {
+			const dispatch = sectionBetween(fixture.text, "## Step 3", "### Pass A")
+			const lower = dispatch.toLowerCase()
+
+			expect(lower, fixture.label).toContain("required before")
+			expect(lower, fixture.label).toContain("do not self-review")
+			expect(dispatch, fixture.label).toContain("spawn_agent")
+			expect(dispatch, fixture.label).toContain("lazycodex-gate-reviewer")
+			expect(lower, fixture.label).toContain("every enumerated page")
+		}
+	})
+
+	test("#given the completion gate #when deciding done #then an independent reviewer must PASS on a fresh full capture, looping until clean", () => {
+		for (const fixture of fixtures()) {
+			const gate = sectionBetween(fixture.text, "## Step 4", "## Step 5")
+			const lower = gate.toLowerCase()
+
+			expect(lower, fixture.label).toContain("hard stop rule")
+			expect(lower, fixture.label).toContain("independent")
+			expect(lower, fixture.label).toContain("no blocking")
+			expect(lower, fixture.label).toContain("fresh")
+			expect(lower, fixture.label).toContain("every enumerated page")
+			expect(lower, fixture.label).toContain("loop until")
+			expect(lower, fixture.label).toContain("do not stop because the automated script")
+		}
+	})
+
+	test("#given Pass B CJK checks #when inspecting #then it flags topic, connective, and source-citation splits across every page", () => {
+		for (const fixture of fixtures()) {
+			const passB = sectionBetween(fixture.text, "### Pass B", "## Step 4")
+			const lower = passB.toLowerCase()
+
+			expect(passB, fixture.label).toContain("두 강은")
+			expect(passB, fixture.label).toContain("쓸 수")
+			expect(passB, fixture.label).toContain("Attention Is")
+			expect(lower, fixture.label).toContain("citation")
+			expect(lower, fixture.label).toContain("every page")
+			expect(lower, fixture.label).toContain("regardless of similarityscore")
+		}
+	})
+})


### PR DESCRIPTION
## Summary

While building a 40-slide Korean deck in a Codex GPT-5.5 session (`019ef25c`), the `visual-qa` skill kept failing the user in three ways that they had to correct by hand every time: broken CJK line breaks slipped through, only a sample of pages was checked, and an independent reviewer subagent was dispatched only when the user explicitly ordered it. The skill was even loaded correctly — the failures were **structural in the prompt**, not a missing CJK word list.

This rewrites the skill outcome-first with binary success criteria and hard stop rules (the GPT-5.5 prompting levers), so the agent does all three **without being told**.

## Root cause (from session `019ef25c`)

| User had to keep saying | Transcript proof |
|---|---|
| `cjk new line ... 지금 망가져있어많이` (MSG #64/65/67) | declared done with CJK broken; `update_goal complete` at line 2851 after one early approval |
| `전체 모든 페이지 다 검증해야함` (MSG #66) | only 11 `view_image` calls for a 40-slide deck |
| `서브에이전트 써서 검사받아가면서 ... 허가받을떄까지` (MSG #68) | exactly 1 `spawn_agent` in the whole episode, fired only after the order; it instantly found splits on slides 3/4/10/23 + stale evidence |

## Changes (`packages/shared-skills/skills/visual-qa/SKILL.md`)

- **Step 2 — Coverage:** enumerate and capture *every* page/slide/route/state; never sample; per-page verdict (one failing page fails the surface).
- **Step 2 — Fresh evidence:** every gate runs on captures newer than the source; anything older is stale and must be regenerated.
- **Step 3 — mandatory + harness-native:** the dual-oracle review is REQUIRED before any "done" claim, self-initiated, dispatched via the harness's own tool (OpenCode `task` / Codex `spawn_agent` `lazycodex-gate-reviewer`), over every enumerated page.
- **Step 4 — hard stop loop:** not done until an independent reviewer returns PASS with no blocking findings on a fresh full capture; fix → re-capture → re-dispatch → repeat; never self-certify; never trust a prior pass on an older build.
- **Pass B — CJK classes:** add the exact split types the session missed (particle/ending orphan, subject/topic split, connective split, source/citation English split) as blocking regardless of `similarityScore`, on every page.
- Contract tests pin all five invariants on the shared **and** Codex copies (Codex copy is regenerated by `sync-skills.mjs`, gitignored).

## Verification

**Automated:** `bun run typecheck` ✅ · `bun test` ✅ (10111 pass / 0 fail) · `bun run test:codex` ✅ (exit 0) · contract test RED→GREEN ✅ (10 pass across both shared + Codex fixtures).

**Manual QA (evidence under `.omo/evidence/20260623-visual-qa-exhaustive-gate/`):**
- *Isolated install landing* — `codex-qa/install-verify.sh --keep` installed this build into a temp `CODEX_HOME`; all new invariants present in the landed skill; real `~/.codex/config.toml` shasum unchanged before/after (`9f43e94f...`).
- *Live gpt-5.5 behavioral proof* — drove real `gpt-5.5` via `codex exec --profile quotio` in that isolated home, on a 3-slide fixture with a forced CJK split (`두 강은 끝에서 만난다` → `두 강 / 은 끝 / 에서 / 만난다`) and a citation split. The prompt **never mentioned** CJK, all-pages, or subagents. With the new skill the model spontaneously: captured all 3 slides fresh, dispatched the dual reviewer (`spawn_agent` ×2), caught both CJK splits precisely, and returned **NEEDS WORK / not ready to ship** with a re-capture instruction. Old arm = the original session (sampled, self-certified, 1 forced spawn).

## Related

Codex Desktop session `019ef25c-9ba7-76d3-997e-c6385234a314`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces exhaustive per-page CJK visual QA and a mandatory independent subagent gate to prevent skipped pages, stale evidence, and self-certified passes. Updates the `visual-qa` skill prompt and adds contract tests to lock these rules.

- **Bug Fixes**
  - Full coverage and freshness: enumerate and capture every page/state with a per-page verdict; regenerate any evidence older than the source.
  - Mandatory independent review: dispatch two read-only reviewers via the harness (Codex `spawn_agent` with `lazycodex-gate-reviewer`) across all pages; loop until an external PASS on a fresh full capture.
  - CJK safeguards: block particle/ending orphans, subject/topic splits, connective splits, and source/citation line breaks on any page, regardless of `similarityScore`.
  - Tests: add contract tests to enforce these invariants for both the shared skill and the Codex-synced copy.

<sup>Written for commit a645839ace0c82a0dfeaf37747252334b9e31950. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

