### PR TITLE
docs: make PR QA evidence reviewer-readable

### DIFF
--- a/.agents/skills/work-with-pr/SKILL.md
+++ b/.agents/skills/work-with-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-with-pr
-description: "Full PR lifecycle in a fresh task-owned git worktree: implement via the ulw-loop skill with mandatory evidence-bound manual QA → detailed English PR → verification loop (CI + review-work reviewers + Cubic, where Cubic is skipped only when its quota is exhausted) → merge by default → worktree cleanup. Decomposes one task into the smallest atomic, independently-mergeable PRs and builds the independent ones concurrently via one worktree per PR driven by parallel subagents or a team. Unbounded loop: any failing gate sends you back to fix-and-re-QA inside that PR's worktree. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'split into atomic PRs', 'parallel PRs', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
+description: "Full PR lifecycle in a fresh task-owned git worktree: implement via the ulw-loop skill with mandatory evidence-bound manual QA → reviewer-readable English PR → verification loop (CI + review-work reviewers + Cubic, where Cubic is skipped only when its quota is exhausted) → merge by default → worktree cleanup. Decomposes one task into the smallest atomic, independently-mergeable PRs and builds the independent ones concurrently via one worktree per PR driven by parallel subagents or a team. Unbounded loop: any failing gate sends you back to fix-and-re-QA inside that PR's worktree. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'split into atomic PRs', 'parallel PRs', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
 ---
 
 # Work With PR — Full PR Lifecycle
@@ -15,7 +15,7 @@ You are executing a complete PR lifecycle: from fresh task-owned worktree setup,
 Phase 0: Setup         → Split into atomic PRs, then branch + worktree per PR (parallel when independent)
 Phase 1: Implement     → Drive the work through the ulw-loop skill:
                          evidence-bound manual QA per success criterion, atomic commits
-Phase 2: PR Creation   → Push, create a detailed English PR targeting dev
+Phase 2: PR Creation   → Push, create a reviewer-readable English PR targeting dev
 Phase 3: Verify Loop   → Unbounded iteration; a failing gate routes back to Phase 1:
   ├─ Gate A: CI         → gh pr checks (bun test, typecheck, build)
   ├─ Gate B: review-work → 5-agent parallel review (the reviewer subagents)
@@ -137,7 +137,7 @@ Fix any failure before pushing; each fix is its own atomic commit.
 git push -u origin "$BRANCH_NAME"
 ```
 
-Write the PR body in English, detailed enough that a reviewer understands the change without reading the diff. The Verification section is where the manual-QA evidence from Phase 1 earns its place — cite what you actually drove and where the artifact lives, not just that tests passed.
+Write the PR body in English for a human reviewer who has not followed the implementation thread. It must explain the work in plain terms, group changes by reviewer-relevant area instead of dumping files, and make QA evidence auditable without forcing the reviewer to guess what each log proves. Cite sanitized artifacts; do not paste raw secret-bearing logs, env dumps, tokens, auth headers, or private credentials into the PR.
 
 ```bash
 gh pr create \
@@ -146,14 +146,20 @@ gh pr create \
   --title "$PR_TITLE" \
   --body "$(cat <<'EOF'
 ## Summary
-[2-4 sentences: what this PR does, why it's needed, and the approach taken]
+[2-4 sentences in plain language: what changed, why it changed, and how observable behavior is different after this PR.]
 
 ## Changes
-[Bullet list of key changes, grouped by area; enough that a reviewer can map each bullet to the diff]
+[Group bullets by reviewer-relevant area, not by file. Each bullet should say what changed and how a reviewer can map it to the diff.]
 
-## Verification
-**Automated:** `bun run typecheck` ✅ · `bun test` ✅ · `bun run build` ✅
-**Manual QA:** [per success criterion — the channel driven (tmux/HTTP/browser/GUI), what you observed, and the evidence artifact path]
+## QA & Evidence
+For each automated command or manual QA action:
+- **What was tested:** [command or surface driven, with the behavior it was meant to prove]
+- **Observed result:** [actual result, including before/after when relevant]
+- **Artifact:** [`path/to/sanitized-log-or-report`]
+- **Why sufficient:** [which risk or success criterion this evidence covers]
+
+## Risks & Residuals
+[Map each meaningful risk to the evidence above and state the conclusion: mitigated, accepted, or blocked. Include unavailable gates here with the concrete reason.]
 
 ## Related Issues
 [Link to issue if applicable]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,29 @@
 ## Summary
 
-<!-- Brief description of what this PR does. 1-3 bullet points. -->
+<!-- Explain what changed, why it changed, and how observable behavior is different. Use plain reviewer-facing language, not a file list. -->
 
-- 
+- <!-- summary item -->
 
 ## Changes
 
-<!-- What was changed and how. List specific modifications. -->
+<!-- Group by reviewer-relevant area. Each bullet should say what changed and how to map it to the diff. -->
 
-- 
+- <!-- change item -->
+
+## QA & Evidence
+
+<!-- For each command or manual QA action: what was tested, what you observed, where the saved artifact/log lives, and why that evidence is sufficient. Link sanitized artifacts under .omo/evidence/ when applicable. Do not paste raw secret-bearing logs, env dumps, tokens, auth headers, or private credentials. -->
+
+- **What was tested:** <!-- command or surface driven -->
+  **Observed result:** <!-- actual result -->
+  **Artifact:** <!-- saved sanitized artifact/log path -->
+  **Why sufficient:** <!-- covered behavior or risk -->
+
+## Risks & Residuals
+
+<!-- Map each meaningful risk to the evidence above and state the conclusion: mitigated, accepted, blocked, or not applicable. -->
+
+- <!-- risk item -->
 
 ## Screenshots
 
@@ -18,9 +33,9 @@
 |:---:|:---:|
 |  |  |
 
-## Testing
+## Automated Checks
 
-<!-- How to verify this PR works correctly. Delete if not applicable. -->
+<!-- Keep only commands actually run. Explain unavailable gates in Risks & Residuals. -->
 
 ```bash
 bun run typecheck

--- a/.opencode/skills/work-with-pr/SKILL.md
+++ b/.opencode/skills/work-with-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-with-pr
-description: "Full PR lifecycle in a fresh task-owned git worktree: implement via the ulw-loop skill with mandatory evidence-bound manual QA → detailed English PR → verification loop (CI + review-work reviewers + Cubic, where Cubic is skipped only when its quota is exhausted) → merge by default → worktree cleanup. Decomposes one task into the smallest atomic, independently-mergeable PRs and builds the independent ones concurrently via one worktree per PR driven by parallel subagents or a team. Unbounded loop: any failing gate sends you back to fix-and-re-QA inside that PR's worktree. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'split into atomic PRs', 'parallel PRs', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
+description: "Full PR lifecycle in a fresh task-owned git worktree: implement via the ulw-loop skill with mandatory evidence-bound manual QA → reviewer-readable English PR → verification loop (CI + review-work reviewers + Cubic, where Cubic is skipped only when its quota is exhausted) → merge by default → worktree cleanup. Decomposes one task into the smallest atomic, independently-mergeable PRs and builds the independent ones concurrently via one worktree per PR driven by parallel subagents or a team. Unbounded loop: any failing gate sends you back to fix-and-re-QA inside that PR's worktree. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'split into atomic PRs', 'parallel PRs', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
 ---
 
 # Work With PR — Full PR Lifecycle
@@ -15,7 +15,7 @@ You are executing a complete PR lifecycle: from fresh task-owned worktree setup,
 Phase 0: Setup         → Split into atomic PRs, then branch + worktree per PR (parallel when independent)
 Phase 1: Implement     → Drive the work through the ulw-loop skill:
                          evidence-bound manual QA per success criterion, atomic commits
-Phase 2: PR Creation   → Push, create a detailed English PR targeting dev
+Phase 2: PR Creation   → Push, create a reviewer-readable English PR targeting dev
 Phase 3: Verify Loop   → Unbounded iteration; a failing gate routes back to Phase 1:
   ├─ Gate A: CI         → gh pr checks (bun test, typecheck, build)
   ├─ Gate B: review-work → 5-agent parallel review (the reviewer subagents)
@@ -137,7 +137,7 @@ Fix any failure before pushing; each fix is its own atomic commit.
 git push -u origin "$BRANCH_NAME"
 ```
 
-Write the PR body in English, detailed enough that a reviewer understands the change without reading the diff. The Verification section is where the manual-QA evidence from Phase 1 earns its place — cite what you actually drove and where the artifact lives, not just that tests passed.
+Write the PR body in English for a human reviewer who has not followed the implementation thread. It must explain the work in plain terms, group changes by reviewer-relevant area instead of dumping files, and make QA evidence auditable without forcing the reviewer to guess what each log proves. Cite sanitized artifacts; do not paste raw secret-bearing logs, env dumps, tokens, auth headers, or private credentials into the PR.
 
 ```bash
 gh pr create \
@@ -146,14 +146,20 @@ gh pr create \
   --title "$PR_TITLE" \
   --body "$(cat <<'EOF'
 ## Summary
-[2-4 sentences: what this PR does, why it's needed, and the approach taken]
+[2-4 sentences in plain language: what changed, why it changed, and how observable behavior is different after this PR.]
 
 ## Changes
-[Bullet list of key changes, grouped by area; enough that a reviewer can map each bullet to the diff]
+[Group bullets by reviewer-relevant area, not by file. Each bullet should say what changed and how a reviewer can map it to the diff.]
 
-## Verification
-**Automated:** `bun run typecheck` ✅ · `bun test` ✅ · `bun run build` ✅
-**Manual QA:** [per success criterion — the channel driven (tmux/HTTP/browser/GUI), what you observed, and the evidence artifact path]
+## QA & Evidence
+For each automated command or manual QA action:
+- **What was tested:** [command or surface driven, with the behavior it was meant to prove]
+- **Observed result:** [actual result, including before/after when relevant]
+- **Artifact:** [`path/to/sanitized-log-or-report`]
+- **Why sufficient:** [which risk or success criterion this evidence covers]
+
+## Risks & Residuals
+[Map each meaningful risk to the evidence above and state the conclusion: mitigated, accepted, or blocked. Include unavailable gates here with the concrete reason.]
 
 ## Related Issues
 [Link to issue if applicable]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,16 +28,17 @@ This is repeated on purpose, because it is the single most ignored rule in this 
 
 ### EVIDENCE: record it under `.omo/evidence/` or it DID NOT HAPPEN
 
-**WRITE EVERY QA ARTIFACT TO `.omo/evidence/<YYYYMMDD>-<short-slug>/`** (the existing evidence dir; one subfolder per change, keep it ORGANIZED). For EVERY change you MUST record, in plain files:
-- **WHY THERE IS NO REGRESSION:** before/after, the isolation proof (session-count unchanged), and the EXACT commands you ran with their output.
-- **PROOF THAT EVERY INTENDED CHANGE LANDED:** the new behavior OBSERVED on the real harness, not merely asserted.
-- The QA case(s) run, the tmux capture(s), and the isolation receipts.
+**WRITE EVERY QA ARTIFACT TO `.omo/evidence/<YYYYMMDD>-<short-slug>/`** (the existing evidence dir; one subfolder per change, keep it ORGANIZED). For EVERY change you MUST record reviewer-readable plain files:
+- **WHAT WAS TESTED:** the command or manual action, the surface driven, and the behavior it was meant to prove.
+- **WHAT WAS OBSERVED:** the before/after or new behavior, isolation proof such as unchanged session counts, and the artifact path for the exact captured output.
+- **WHY IT IS ENOUGH:** how the evidence covers the intended behavior and remaining regression risk.
+- **WHAT WAS OMITTED:** redact or summarize raw secret-bearing logs, env dumps, tokens, auth headers, and private credentials instead of copying them.
 
 **NO EVIDENCE FILE == NO QA == NO COMMIT == NO PUSH.** ALWAYS. EVERY TIME. NO EXCEPTIONS.
 
 ## DEFAULT WORKFLOW — how to take on any task
 
-Unless the user EXPLICITLY says otherwise, or the task is an urgent must-fix-now hotfix, deliver every change through the **`work-with-pr`** skill: it works in an isolated git worktree, implements with evidence-bound manual QA, opens a detailed English PR, runs the verification loop, and merges. Do NOT hand-commit normal work straight to `dev`.
+Unless the user EXPLICITLY says otherwise, or the task is an urgent must-fix-now hotfix, deliver every change through the **`work-with-pr`** skill: it works in an isolated git worktree, implements with evidence-bound manual QA, opens a reviewer-readable English PR (what changed, why, observed behavior, QA/evidence, residual risk), runs the verification loop, and merges. Do NOT hand-commit normal work straight to `dev`.
 
 - **QA is the evidence gate, scoped to what you touched.** A change under `packages/omo-opencode/` MUST run the **`opencode-qa`** skill; a change under `packages/omo-codex/` (lazycodex) MUST run the **`codex-qa`** skill (see the QA section above for each). Run the matching skill, and treat its captured output (written under `.omo/evidence/`) as the QA evidence `work-with-pr` requires. A change touching both runs both.
 - **Conflicts → `smart-rebase`.** If the worktree branch conflicts with its base, resolve it with the **`smart-rebase`** skill, then re-run the scoped QA. Never hand-resolve by force-pushing shared history.


### PR DESCRIPTION
## Summary

This PR makes the repo's PR, QA, and evidence instructions easier for a human reviewer to understand without reading the whole implementation thread. Future agents are now steered to explain what changed, why it changed, how behavior changed, which QA surfaces were actually driven, where the evidence lives, and what risk remains.

The behavioral change is in the agent-facing prompts and PR template: evidence is no longer framed as a terse proof blob or command checklist. It is framed as reviewer-readable proof with explicit tested/observed/artifact/sufficiency fields and a risk section that maps evidence to conclusions.

## Changes

- **Root agent instructions**: rewrote the `.omo/evidence/` mandate so evidence files must state what was tested, what was observed, why it is enough, and what secret-bearing material was omitted or summarized.
- **Work-with-PR skill**: updated both `.agents` and `.opencode` shared copies so future PRs are described as reviewer-readable, with grouped changes, auditable QA evidence, and residual risk mapping.
- **GitHub PR template**: replaced the old terse Testing section with `QA & Evidence`, `Risks & Residuals`, and `Automated Checks` sections that tell authors exactly what a reviewer needs.

## QA & Evidence

- **What was tested:** Prompt-engineering pass over the existing instruction surfaces using the repo-local `work-with-pr` skill and GPT-5.5 prompt guidance.
  **Observed result:** The edit replaces the terse source wording instead of adding a trailing warning block; shared `.agents`/`.opencode` copies remain byte-identical.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/shared-skill-sync.txt`, `.omo/evidence/20260623-qa-evidence-pr-readable-logs/reviewer-readable-static-scan.txt`
  **Why sufficient:** Confirms the behavior lives in the instruction surfaces future agents actually load and that the migration duplicate did not drift.

- **What was tested:** Standalone manual QA matrix for this PR.
  **Observed result:** The matrix maps changed behavior, OpenCode/Codex surfaces, CI, Cubic quota skip, local broad-suite residuals, and sensitive-data handling to concrete artifacts and risk conclusions.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-manual-qa-matrix.md`
  **Why sufficient:** Gives reviewers a single auditable index instead of forcing them to reconstruct the gate story from raw logs.

- **What was tested:** Whitespace and Markdown patch sanity with `git diff --check origin/dev...HEAD`.
  **Observed result:** Passed with no whitespace errors or conflict markers; the artifact records the empty-output success explicitly.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/git-diff-check.txt`
  **Why sufficient:** Covers the immediate Markdown formatting risk introduced by template edits.

- **What was tested:** Repo setup/build lifecycle through `bun install` in the fresh worktree.
  **Observed result:** `bun install` completed successfully and its postinstall build completed; it emitted the existing platform-binary warning but exited 0.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/bun-install.txt`
  **Why sufficient:** Proves the dependency workspace and generated build artifacts still initialize after the docs-only change.

- **What was tested:** OpenCode QA surface with `bash .agents/skills/opencode-qa/scripts/tui-smoke.sh --self-test`.
  **Observed result:** TUI rendered under tmux, `send-keys` reached the composer, the tmux session was torn down, and the real OpenCode DB session count remained unchanged.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/opencode-qa-tui-smoke.txt`
  **Why sufficient:** This PR changes OpenCode-facing instruction text, not runtime hook logic; the selected real OpenCode smoke proves the QA harness and isolation path work.

- **What was tested:** Codex QA surface with `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin`.
  **Observed result:** Local omo installed into an isolated `CODEX_HOME`, the mock-model app-server turn completed, plugin hooks fired for `sessionStart`, `userPromptSubmit`, and `stop`, and the real `~/.codex/config.toml` hash stayed unchanged.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/codex-qa-app-server-plugin.txt`
  **Why sufficient:** This PR changes Codex-facing instruction text, not Codex component logic; the selected live app-server path proves plugin wiring and isolation.

- **What was tested:** Focused instruction/doc tests with `bun test script/contributing-accuracy.test.ts script/agents-md-dev-env.test.ts packages/omo-opencode/src/features/opencode-skill-loader/project-skill-tool-references.test.ts packages/skills-loader-core/src/features/opencode-skill-loader/project-skill-tool-references.test.ts`.
  **Observed result:** 12 pass, 0 fail.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/targeted-doc-skill-tests.txt`
  **Why sufficient:** Covers the repo tests that scan AGENTS.md and the work-with-pr skill surfaces touched by this PR.

- **What was tested:** Full TypeScript check with `bun run typecheck`.
  **Observed result:** Passed.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/typecheck.txt`
  **Why sufficient:** Confirms no generated or setup side effect left the TypeScript workspace broken.

- **What was tested:** Full root test suite with `bun test` on current `origin/dev` plus this PR.
  **Observed result:** 10151 pass, 2 skip, 7 fail. The failures are outside this PR's diff: `packages/shared-skills/provenance-gate.test.ts` reports an ATTRIBUTION/submodule HEAD mismatch, and `packages/shared-skills/skills/visual-qa/scripts/skill-prompt-contract.test.ts` reports visual-qa prompt contract drift in the Codex plugin copy.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/bun-test.txt`
  **Why sufficient:** Shows the broad local suite was attempted after replaying onto current `origin/dev`; the failing surfaces are unrelated to the four files in this PR.

- **What was tested:** GitHub CI checks, including a rerun of the failed Windows test job.
  **Observed result:** Initial `test (windows-latest)` failed only because the unrelated dependency-security import scan timed out after 5000 ms; that run had 10153 pass, 11 skip, 1 fail. The branch changes only Markdown instruction/template files, the same targeted dependency-security test passed locally, and the failed CI job rerun passed in 7m16s. All active GitHub checks are now green.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/ci-windows-first-attempt-failed-log.txt`, `.omo/evidence/20260623-qa-evidence-pr-readable-logs/ci-windows-rerun-job-log.txt`, `.omo/evidence/20260623-qa-evidence-pr-readable-logs/dependency-security-targeted.txt`, `.omo/evidence/20260623-qa-evidence-pr-readable-logs/ci-pr-checks-after-rerun.txt`, `.omo/evidence/20260623-qa-evidence-pr-readable-logs/ci-windows-rerun-summary.json`
  **Why sufficient:** Confirms the only CI failure was a Windows timing issue in a TypeScript source scan outside this docs-only diff, and that the required Windows gate passed on rerun.

- **What was tested:** Cubic Gate C status.
  **Observed result:** Cubic completed as `neutral` because the monthly review line limit was reached; no blocking Cubic issue report was produced.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/cubic-neutral-receipt.txt`
  **Why sufficient:** Matches the `work-with-pr` allowed skip condition for quota/usage-limit exhaustion.

- **What was tested:** Programming/remove-ai-slops scope applicability.
  **Observed result:** No programming-language source files changed; the diff is limited to Markdown instruction/template files.
  **Artifact:** `.omo/evidence/20260623-qa-evidence-pr-readable-logs/programming-slop-scope-review.txt`
  **Why sufficient:** Documents why code-slop cleanup is not applicable; prompt slop/overfit risk is covered by prompt-engineering and review-work lanes.

## Risks & Residuals

- **Risk: future agents still write opaque PR bodies.** Mitigated by updating the root mandate, both shared `work-with-pr` skill copies, and the GitHub PR template with the same reviewer-readable evidence shape.
- **Risk: evidence leaks secrets while trying to be explicit.** Mitigated by adding explicit redaction/summarization language for raw logs, env dumps, tokens, auth headers, and private credentials. Security review found no live secret values in the inspected diff/body/artifacts.
- **Risk: `.agents` and `.opencode` shared skills diverge.** Mitigated by same-commit updates and byte-identical verification.
- **Residual: local full `bun test` is not green on this machine.** The local failures are current-base prompt/provenance issues outside the four Markdown files changed here. GitHub CI passed after rerunning the transient Windows timeout.
- **Residual: Cubic did not perform a full review.** Accepted under the repo's documented quota-exhaustion skip path; the check output says the monthly review line limit was reached.

## Related Issues

None.
