### PR TITLE
fix(qa): preserve terminal visual evidence fidelity

### DIFF
--- a/.agents/skills/work-with-pr/SKILL.md
+++ b/.agents/skills/work-with-pr/SKILL.md
@@ -139,6 +139,8 @@ git push -u origin "$BRANCH_NAME"
 
 Write the PR body in English, detailed enough that a reviewer understands the change without reading the diff. The Verification section is where the manual-QA evidence from Phase 1 earns its place — cite what you actually drove and where the artifact lives, not just that tests passed.
 
+If the PR body needs screenshots or terminal PNGs, follow `docs/reference/github-attachment-upload.md`: upload via GitHub user attachments from an authenticated web session, include only the final `https://github.com/user-attachments/assets/<uuid>` URLs, and never commit temporary images, use release assets, use external hosts, or log cookies/tokens.
+
 ```bash
 gh pr create \
   --base "$BASE_BRANCH" \

--- a/.opencode/skills/work-with-pr/SKILL.md
+++ b/.opencode/skills/work-with-pr/SKILL.md
@@ -139,6 +139,8 @@ git push -u origin "$BRANCH_NAME"
 
 Write the PR body in English, detailed enough that a reviewer understands the change without reading the diff. The Verification section is where the manual-QA evidence from Phase 1 earns its place — cite what you actually drove and where the artifact lives, not just that tests passed.
 
+If the PR body needs screenshots or terminal PNGs, follow `docs/reference/github-attachment-upload.md`: upload via GitHub user attachments from an authenticated web session, include only the final `https://github.com/user-attachments/assets/<uuid>` URLs, and never commit temporary images, use release assets, use external hosts, or log cookies/tokens.
+
 ```bash
 gh pr create \
   --base "$BASE_BRANCH" \

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -23,6 +23,7 @@
 | Shared core multi-PR extraction QA | [docs/reference/shared-core-multi-pr.md](reference/shared-core-multi-pr.md) |
 | Re-export shim inventory | [docs/reference/re-export-shim-inventory.md](reference/re-export-shim-inventory.md) |
 | Release process | [docs/reference/release-process.md](reference/release-process.md) |
+| GitHub PR evidence attachments | [docs/reference/github-attachment-upload.md](reference/github-attachment-upload.md) |
 | Claiming the lazycodex npm name | [docs/reference/lazycodex-npm-reservation.md](reference/lazycodex-npm-reservation.md) |
 | Rules-injector cross-module comparison | [docs/reference/rules-injection-cross-module-comparison.md](reference/rules-injection-cross-module-comparison.md) |
 | Sample configs | [docs/examples/](examples) (default, coding-focused, planning-focused) |

--- a/docs/reference/github-attachment-upload.md
+++ b/docs/reference/github-attachment-upload.md
@@ -1,0 +1,51 @@
+# GitHub PR Attachment Uploads
+
+Use this reference when a PR or issue body needs screenshots or other short-lived evidence images without committing them, creating a release asset, or using an external image host.
+
+## Contract
+
+- Upload through GitHub's own web attachment flow and use the resulting `https://github.com/user-attachments/assets/<uuid>` URL.
+- Keep temporary files under `/tmp` or an untracked evidence directory such as `.omo/evidence/...`.
+- Never commit generated screenshots, terminal PNGs, upload scripts with secrets, cookies, tokens, S3 form fields, or copied request headers.
+- Never use GitHub Releases for PR evidence images.
+- Never use external image hosters.
+
+## Direct Upload Flow
+
+The flow depends on an authenticated GitHub web session, not only a `gh` API token. GitHub's same-site cookie/session requirements mean the requests must carry the browser session cookies for `github.com`, the expected same-site/referrer context, and the CSRF tokens issued for the current PR or issue page. Treat every cookie and token as a secret.
+
+1. Open the target PR or issue page in an authenticated GitHub web session.
+2. Read the page's file-attachment CSRF token and repository id from the same page/session context.
+3. `POST https://github.com/upload/policies/assets` with:
+
+```json
+{
+  "repository_id": "REPOSITORY_ID",
+  "name": "terminal.png",
+  "size": 12345,
+  "content_type": "image/png",
+  "authenticity_token": "FILE_ATTACHMENT_CSRF_TOKEN"
+}
+```
+
+4. Upload the file bytes to S3 using the policy response's returned upload URL and form fields exactly as returned.
+5. `PUT https://github.com/upload/assets/:id` with the returned `asset_upload_authenticity_token`.
+6. Use only the final `https://github.com/user-attachments/assets/<uuid>` URL in the PR body.
+
+## Secret Handling
+
+Do not print cookies, authenticity tokens, S3 fields, authorization headers, or raw browser storage. A helper may print only the final user-attachments URL and non-secret file metadata such as filename, byte size, and content type. If a temporary script is needed, write it under `/tmp`, inspect it for accidental logging, and delete it after updating the PR body.
+
+For PR body editing, write the body to `/tmp/pr-body.md`, inspect it, then pass it to `gh pr edit --body-file /tmp/pr-body.md`. The body should include the final attachment URLs and local evidence paths, but never the upload transaction details.
+
+## Evidence Pattern
+
+```markdown
+## Visual Evidence
+
+- ANSI terminal rendering: https://github.com/user-attachments/assets/<uuid>
+- Long-line wrapping: https://github.com/user-attachments/assets/<uuid>
+- Local evidence: `.omo/evidence/20260623-web-terminal-rendering/`
+```
+
+If the authenticated browser session is unavailable, leave the PR ready with local evidence paths and state the blocker. Do not fall back to releases or external hosting.

--- a/docs/reference/web-terminal-visual-qa.md
+++ b/docs/reference/web-terminal-visual-qa.md
@@ -8,11 +8,11 @@ Each run writes these files under the chosen evidence directory:
 
 - `terminal.txt`: plain terminal text for review and assertions.
 - `terminal-ansi.txt`: original ANSI capture when available.
-- `terminal.html`: browser-renderable terminal frame.
-- `terminal.png`: Chrome/Chromium screenshot, unless `--no-browser` is used.
+- `terminal.html`: browser-renderable terminal frame that preserves ANSI colors and SGR styles.
+- `terminal.png`: Chrome/Chromium screenshot with the same ANSI styling, unless `--no-browser` is used.
 - `metadata.json`: connector, source, output paths, and cleanup receipt.
 
-The PR should cite `metadata.json` and attach or link `terminal.png` for OpenCode/Codex TUI proof.
+The PR should cite `metadata.json` and attach or link `terminal.png` for OpenCode/Codex TUI proof. For PR-body image hosting, use GitHub user attachments as documented in [docs/reference/github-attachment-upload.md](github-attachment-upload.md); do not commit temporary PNGs, use releases, or use external image hosts.
 
 ## Replay An Existing Capture
 
@@ -24,6 +24,8 @@ node script/qa/web-terminal-visual-qa.mjs \
   --from-file .omo/evidence/run/capture.txt \
   --evidence-dir .omo/evidence/run/codex-web-terminal
 ```
+
+Long terminal lines wrap by default for readable PR evidence. Pass `--no-wrap` only when horizontal scrolling is part of the behavior under test.
 
 ## Run Through The PTY Connector
 

--- a/packages/shared-skills/skills/git-master/SKILL.md
+++ b/packages/shared-skills/skills/git-master/SKILL.md
@@ -36,6 +36,10 @@ git merge-base HEAD origin/master
 
 Missing upstream or missing `main`/`master` is normal. Fall back to the best available branch or report the missing fact. Never treat a failed lookup as proof.
 
+## PR Body Evidence Attachments
+
+When a PR body needs screenshots or terminal PNGs, use the repo reference at `docs/reference/github-attachment-upload.md`. The allowed hosting path is GitHub user attachments from the authenticated web attachment flow; never commit temporary images, never use GitHub Releases for PR evidence, and never use external image hosts. Do not log browser cookies, CSRF tokens, S3 form fields, or upload headers.
+
 ## Commit Mode
 
 Commit only the user's requested changes. Preserve unrelated dirty work.

--- a/packages/team-core/src/team-state-store/locks.test.ts
+++ b/packages/team-core/src/team-state-store/locks.test.ts
@@ -21,6 +21,10 @@ function createSignal(): { readonly promise: Promise<void>; readonly resolve: ()
   return { promise, resolve: resolveSignal }
 }
 
+function createErrnoError(code: string): Error & { code: string } {
+  return Object.assign(new Error(code), { code })
+}
+
 test("withLock serializes concurrent work", async () => {
   // given
   const { withLock } = await import("./locks")
@@ -88,6 +92,35 @@ test("atomicWrite leaves no partial file when rename fails", async () => {
 
   const directoryEntries = await readdir(rootDirectory)
   expect(directoryEntries.some((entry) => entry.startsWith("target.txt.tmp."))).toBe(false)
+  await rm(rootDirectory, { recursive: true, force: true })
+})
+
+test("lock open treats EPERM as contention when the lock path exists", async () => {
+  // given
+  const { assertRetryableLockOpenError } = await import("./locks")
+  const rootDirectory = await createTempDirectory("locks-eperm-existing-")
+  const lockPath = join(rootDirectory, "lock")
+  await writeFile(lockPath, "owner\n123\n456\n")
+
+  // when
+  const result = assertRetryableLockOpenError(lockPath, createErrnoError("EPERM"))
+
+  // then
+  await expect(result).resolves.toBeUndefined()
+  await rm(rootDirectory, { recursive: true, force: true })
+})
+
+test("lock open rethrows EPERM when the lock path does not exist", async () => {
+  // given
+  const { assertRetryableLockOpenError } = await import("./locks")
+  const rootDirectory = await createTempDirectory("locks-eperm-missing-")
+  const lockPath = join(rootDirectory, "lock")
+
+  // when
+  const result = assertRetryableLockOpenError(lockPath, createErrnoError("EPERM"))
+
+  // then
+  await expect(result).rejects.toThrow("EPERM")
   await rm(rootDirectory, { recursive: true, force: true })
 })
 

--- a/packages/team-core/src/team-state-store/locks.ts
+++ b/packages/team-core/src/team-state-store/locks.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto"
-import { open, readFile, rename, rm, unlink } from "node:fs/promises"
+import { access, open, readFile, rename, rm, unlink } from "node:fs/promises"
 
 import { tolerantFsync } from "../tolerant-fsync"
 
@@ -39,6 +39,28 @@ function parseOwnerContent(content: string): { ownerPid: number; acquiredAtEpoch
   return { ownerPid, acquiredAtEpochMs }
 }
 
+function errorCode(error: unknown): string | null {
+  if (!(error instanceof Error) || !("code" in error)) return null
+  return typeof error.code === "string" ? error.code : null
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
+    return false
+  }
+}
+
+export async function assertRetryableLockOpenError(lockPath: string, error: unknown): Promise<void> {
+  const code = errorCode(error)
+  if (code === "EEXIST") return
+  if (code === "EPERM" && (await pathExists(lockPath))) return
+  throw error
+}
+
 function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0)
@@ -68,8 +90,7 @@ async function acquireLock(lockPath: string, ownerTag: string, staleAfterMs: num
       }
       return
     } catch (error) {
-      const err = error as NodeJS.ErrnoException
-      if (err.code !== "EEXIST") throw error
+      await assertRetryableLockOpenError(lockPath, error)
 
       if (await detectStaleLock(lockPath, staleAfterMs)) {
         await reapStaleLock(lockPath)

--- a/script/qa/web-terminal-renderer.mjs
+++ b/script/qa/web-terminal-renderer.mjs
@@ -1,0 +1,198 @@
+const ANSI_PATTERN = /\u001b\[[0-?]*[ -/]*[@-~]/g;
+const SGR_PATTERN = /\u001b\[([0-9;:]*)m/g;
+
+const COLOR_NAMES = [
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+];
+
+const BASIC_ANSI_COLORS = {
+  black: "#0c0d10",
+  red: "#ff6b6b",
+  green: "#51cf66",
+  yellow: "#ffd43b",
+  blue: "#4dabf7",
+  magenta: "#d0bfff",
+  cyan: "#66d9e8",
+  white: "#f1f3f5",
+  "bright-black": "#868e96",
+  "bright-red": "#ff8787",
+  "bright-green": "#69db7c",
+  "bright-yellow": "#ffe066",
+  "bright-blue": "#74c0fc",
+  "bright-magenta": "#e599f7",
+  "bright-cyan": "#99e9f2",
+  "bright-white": "#ffffff",
+};
+
+export function escapeHtml(value) {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+export function stripAnsi(value) {
+  return value.replace(ANSI_PATTERN, "");
+}
+
+function createState() {
+  return {
+    bold: false,
+    dim: false,
+    italic: false,
+    underline: false,
+    inverse: false,
+    strike: false,
+    fg: null,
+    bg: null,
+  };
+}
+
+function parseCodes(raw) {
+  if (raw === "") return [0];
+  return raw.split(/[;:]/).map((part) => Number.parseInt(part || "0", 10));
+}
+
+function basicColor(code, base, brightBase, prefix) {
+  if (code >= base && code < base + COLOR_NAMES.length) return `${prefix}-${COLOR_NAMES[code - base]}`;
+  if (code >= brightBase && code < brightBase + COLOR_NAMES.length) {
+    return `${prefix}-bright-${COLOR_NAMES[code - brightBase]}`;
+  }
+  return null;
+}
+
+function rgbFrom256(index) {
+  if (index < 0 || index > 255) return null;
+  if (index < 16) {
+    const base = [
+      "#000000",
+      "#800000",
+      "#008000",
+      "#808000",
+      "#000080",
+      "#800080",
+      "#008080",
+      "#c0c0c0",
+      "#808080",
+      "#ff0000",
+      "#00ff00",
+      "#ffff00",
+      "#0000ff",
+      "#ff00ff",
+      "#00ffff",
+      "#ffffff",
+    ];
+    return base[index] ?? null;
+  }
+  if (index >= 232) {
+    const level = 8 + (index - 232) * 10;
+    return `rgb(${level}, ${level}, ${level})`;
+  }
+  const offset = index - 16;
+  const levels = [0, 95, 135, 175, 215, 255];
+  const r = levels[Math.floor(offset / 36) % 6] ?? 0;
+  const g = levels[Math.floor(offset / 6) % 6] ?? 0;
+  const b = levels[offset % 6] ?? 0;
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+function readExtendedColor(codes, index) {
+  const mode = codes[index + 1];
+  if (mode === 5) return { color: rgbFrom256(codes[index + 2] ?? -1), next: index + 3 };
+  if (mode === 2) {
+    const [r, g, b] = [codes[index + 2], codes[index + 3], codes[index + 4]];
+    if ([r, g, b].every((value) => Number.isInteger(value) && value >= 0 && value <= 255)) {
+      return { color: `rgb(${r}, ${g}, ${b})`, next: index + 5 };
+    }
+  }
+  return { color: null, next: index + 1 };
+}
+
+function applySgr(state, raw) {
+  const codes = parseCodes(raw);
+  let nextState = { ...state };
+  for (let i = 0; i < codes.length; i += 1) {
+    const code = codes[i] ?? 0;
+    if (code === 0) nextState = createState();
+    else if (code === 1) nextState.bold = true;
+    else if (code === 2) nextState.dim = true;
+    else if (code === 3) nextState.italic = true;
+    else if (code === 4) nextState.underline = true;
+    else if (code === 7) nextState.inverse = true;
+    else if (code === 9) nextState.strike = true;
+    else if (code === 22) {
+      nextState.bold = false;
+      nextState.dim = false;
+    } else if (code === 23) nextState.italic = false;
+    else if (code === 24) nextState.underline = false;
+    else if (code === 27) nextState.inverse = false;
+    else if (code === 29) nextState.strike = false;
+    else if (code === 39) nextState.fg = null;
+    else if (code === 49) nextState.bg = null;
+    else if (code === 38 || code === 48) {
+      const extended = readExtendedColor(codes, i);
+      if (code === 38) nextState.fg = extended.color;
+      else nextState.bg = extended.color;
+      i = extended.next - 1;
+    } else {
+      const fg = basicColor(code, 30, 90, "fg");
+      const bg = basicColor(code, 40, 100, "bg");
+      if (fg) nextState.fg = fg;
+      if (bg) nextState.bg = bg;
+    }
+  }
+  return nextState;
+}
+
+function spanAttributes(state) {
+  const classes = [];
+  const styles = [];
+  if (state.bold) classes.push("ansi-bold");
+  if (state.dim) classes.push("ansi-dim");
+  if (state.italic) classes.push("ansi-italic");
+  if (state.underline) classes.push("ansi-underline");
+  if (state.inverse) classes.push("ansi-inverse");
+  if (state.strike) classes.push("ansi-strike");
+  for (const [value, cssProperty, classPrefix] of [
+    [state.fg, "color", "fg-"],
+    [state.bg, "background-color", "bg-"],
+  ]) {
+    if (!value) continue;
+    if (value.startsWith(classPrefix)) classes.push(`ansi-${value}`);
+    else styles.push(`${cssProperty}: ${value}`);
+  }
+  const attrs = [];
+  if (classes.length > 0) attrs.push(`class="${classes.join(" ")}"`);
+  if (styles.length > 0) attrs.push(`style="${styles.join("; ")}"`);
+  return attrs.join(" ");
+}
+
+function renderSegment(value, state) {
+  const escaped = escapeHtml(value);
+  const attrs = spanAttributes(state);
+  return attrs ? `<span ${attrs}>${escaped}</span>` : escaped;
+}
+
+export function renderAnsiToHtml(value) {
+  let state = createState();
+  let cursor = 0;
+  let output = "";
+  for (const match of value.matchAll(SGR_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > cursor) output += renderSegment(value.slice(cursor, index), state);
+    state = applySgr(state, match[1] ?? "");
+    cursor = index + match[0].length;
+  }
+  if (cursor < value.length) output += renderSegment(value.slice(cursor), state);
+  return output.replace(ANSI_PATTERN, "");
+}
+
+export function ansiColorCss() {
+  return Object.entries(BASIC_ANSI_COLORS)
+    .map(([name, value]) => `.ansi-fg-${name} { color: ${value}; }\n.ansi-bg-${name} { background-color: ${value}; }`)
+    .join("\n");
+}

--- a/script/qa/web-terminal-renderer.mjs
+++ b/script/qa/web-terminal-renderer.mjs
@@ -1,4 +1,5 @@
 const ANSI_PATTERN = /\u001b\[[0-?]*[ -/]*[@-~]/g;
+const OSC_PATTERN = /\u001b\][\s\S]*?(?:\u0007|\u001b\\|\u009c)/g;
 const SGR_PATTERN = /\u001b\[([0-9;:]*)m/g;
 
 const COLOR_NAMES = [
@@ -36,7 +37,7 @@ export function escapeHtml(value) {
 }
 
 export function stripAnsi(value) {
-  return value.replace(ANSI_PATTERN, "");
+  return value.replace(OSC_PATTERN, "").replace(ANSI_PATTERN, "");
 }
 
 function createState() {
@@ -53,8 +54,20 @@ function createState() {
 }
 
 function parseCodes(raw) {
-  if (raw === "") return [0];
-  return raw.split(/[;:]/).map((part) => Number.parseInt(part || "0", 10));
+  if (raw === "") return { values: [0], separators: [null] };
+  const values = [];
+  const separators = [];
+  let separator = null;
+  for (const part of raw.split(/([;:])/)) {
+    if (part === ";" || part === ":") {
+      separator = part;
+      continue;
+    }
+    values.push(part === "" ? null : Number.parseInt(part, 10));
+    separators.push(separator);
+    separator = null;
+  }
+  return { values, separators };
 }
 
 function basicColor(code, base, brightBase, prefix) {
@@ -100,20 +113,21 @@ function rgbFrom256(index) {
   return `rgb(${r}, ${g}, ${b})`;
 }
 
-function readExtendedColor(codes, index) {
+function readExtendedColor(codes, separators, index) {
   const mode = codes[index + 1];
   if (mode === 5) return { color: rgbFrom256(codes[index + 2] ?? -1), next: index + 3 };
   if (mode === 2) {
-    const [r, g, b] = [codes[index + 2], codes[index + 3], codes[index + 4]];
+    const offset = separators[index + 1] === ":" && codes[index + 5] !== undefined ? 3 : 2;
+    const [r, g, b] = [codes[index + offset], codes[index + offset + 1], codes[index + offset + 2]];
     if ([r, g, b].every((value) => Number.isInteger(value) && value >= 0 && value <= 255)) {
-      return { color: `rgb(${r}, ${g}, ${b})`, next: index + 5 };
+      return { color: `rgb(${r}, ${g}, ${b})`, next: index + offset + 3 };
     }
   }
   return { color: null, next: index + 1 };
 }
 
 function applySgr(state, raw) {
-  const codes = parseCodes(raw);
+  const { values: codes, separators } = parseCodes(raw);
   let nextState = { ...state };
   for (let i = 0; i < codes.length; i += 1) {
     const code = codes[i] ?? 0;
@@ -134,7 +148,7 @@ function applySgr(state, raw) {
     else if (code === 39) nextState.fg = null;
     else if (code === 49) nextState.bg = null;
     else if (code === 38 || code === 48) {
-      const extended = readExtendedColor(codes, i);
+      const extended = readExtendedColor(codes, separators, i);
       if (code === 38) nextState.fg = extended.color;
       else nextState.bg = extended.color;
       i = extended.next - 1;
@@ -178,16 +192,17 @@ function renderSegment(value, state) {
 }
 
 export function renderAnsiToHtml(value) {
+  const cleanValue = value.replace(OSC_PATTERN, "");
   let state = createState();
   let cursor = 0;
   let output = "";
-  for (const match of value.matchAll(SGR_PATTERN)) {
+  for (const match of cleanValue.matchAll(SGR_PATTERN)) {
     const index = match.index ?? 0;
-    if (index > cursor) output += renderSegment(value.slice(cursor, index), state);
+    if (index > cursor) output += renderSegment(cleanValue.slice(cursor, index), state);
     state = applySgr(state, match[1] ?? "");
     cursor = index + match[0].length;
   }
-  if (cursor < value.length) output += renderSegment(value.slice(cursor), state);
+  if (cursor < cleanValue.length) output += renderSegment(cleanValue.slice(cursor), state);
   return output.replace(ANSI_PATTERN, "");
 }
 

--- a/script/qa/web-terminal-visual-qa.mjs
+++ b/script/qa/web-terminal-visual-qa.mjs
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { ansiColorCss, escapeHtml, renderAnsiToHtml, stripAnsi } from "./web-terminal-renderer.mjs";
 
 const HELP = `web-terminal-visual-qa
 
@@ -20,6 +21,8 @@ Inputs:
   --cols <n>             Terminal columns for tmux connector. Default: 140.
   --rows <n>             Terminal rows for tmux connector. Default: 40.
   --dwell-ms <n>         Milliseconds to let --command render before capture. Default: 3000.
+  --wrap                 Wrap long terminal lines in HTML/PNG evidence. Default.
+  --no-wrap              Preserve long lines with horizontal scrolling.
   --evidence-dir <path>  Directory for terminal.txt, terminal-ansi.txt, terminal.html, terminal.png, metadata.json.
   --chrome-bin <path>    Chrome/Chromium executable for PNG capture.
   --no-browser           Skip PNG capture, but still write HTML/text/metadata.
@@ -30,12 +33,20 @@ Connector notes:
 `;
 
 function parseArgs(argv) {
-  const args = { cols: 140, rows: 40, dwellMs: 3000, cwd: process.cwd(), browser: true };
+  const args = { cols: 140, rows: 40, dwellMs: 3000, cwd: process.cwd(), browser: true, wrap: true };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--help" || arg === "-h") return { ...args, help: true };
     if (arg === "--no-browser") {
       args.browser = false;
+      continue;
+    }
+    if (arg === "--wrap") {
+      args.wrap = true;
+      continue;
+    }
+    if (arg === "--no-wrap") {
+      args.wrap = false;
       continue;
     }
     const next = argv[i + 1];
@@ -68,15 +79,21 @@ function requireArgs(args) {
   if (!args.fromFile && !args.command) throw new Error("choose --from-file or --command");
 }
 
-function escapeHtml(value) {
-  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+function terminalWidthCh(cols) {
+  return Math.max(80, Math.min(cols, 160));
 }
 
-function stripAnsi(value) {
-  return value.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "");
+function screenshotSize({ cols, rows }) {
+  return {
+    width: Math.max(900, Math.min(1440, Math.round(cols * 8.2 + 120))),
+    height: Math.max(520, Math.min(1200, Math.round(rows * 18 + 120))),
+  };
 }
 
-function writeHtml({ title, text, outPath, cols }) {
+function writeHtml({ title, ansi, outPath, cols, wrap }) {
+  const whiteSpace = wrap ? "pre-wrap" : "pre";
+  const overflowWrap = wrap ? "anywhere" : "normal";
+  const terminalWidth = terminalWidthCh(cols);
   const html = `<!doctype html>
 <html lang="en">
 <head>
@@ -85,15 +102,22 @@ function writeHtml({ title, text, outPath, cols }) {
 <title>${escapeHtml(title)}</title>
 <style>
 :root { color-scheme: dark; }
-body { margin: 0; background: #111318; color: #e7edf3; font: 14px/1.35 ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
+body { margin: 0; background: #101217; color: #d8dee9; font: 13px/1.35 "SFMono-Regular", "Cascadia Mono", "JetBrains Mono", "Menlo", "Consolas", "Liberation Mono", ui-monospace, monospace; }
 main { min-height: 100vh; box-sizing: border-box; padding: 20px; }
-.terminal { width: max-content; max-width: 100%; min-width: min(100%, ${cols}ch); border: 1px solid #3b4452; background: #090b10; box-shadow: 0 20px 80px rgb(0 0 0 / 40%); }
-.bar { display: flex; gap: 8px; align-items: center; padding: 8px 12px; border-bottom: 1px solid #303846; color: #aab7c4; background: #171b22; }
+.terminal { width: min(100%, ${terminalWidth}ch); max-width: calc(100vw - 40px); border: 1px solid #3b4452; background: #090b10; box-shadow: 0 20px 80px rgb(0 0 0 / 40%); }
+.bar { display: flex; gap: 8px; align-items: center; padding: 8px 12px; border-bottom: 1px solid #303846; color: #aab7c4; background: #171b22; font-size: 12px; }
 .dot { width: 10px; height: 10px; border-radius: 999px; background: #6b7280; }
-pre { margin: 0; padding: 14px 16px; white-space: pre; tab-size: 8; overflow: auto; }
+pre { margin: 0; padding: 14px 16px; white-space: ${whiteSpace}; overflow-wrap: ${overflowWrap}; tab-size: 8; overflow: auto; }
+.ansi-bold { font-weight: 700; }
+.ansi-dim { opacity: 0.72; }
+.ansi-italic { font-style: italic; }
+.ansi-underline { text-decoration: underline; }
+.ansi-strike { text-decoration: line-through; }
+.ansi-inverse { filter: invert(1); }
+${ansiColorCss()}
 </style>
 </head>
-<body><main><section class="terminal"><div class="bar"><span class="dot"></span><strong>${escapeHtml(title)}</strong></div><pre>${escapeHtml(text)}</pre></section></main></body>
+<body><main><section class="terminal"><div class="bar"><span class="dot"></span><strong>${escapeHtml(title)}</strong></div><pre>${renderAnsiToHtml(ansi)}</pre></section></main></body>
 </html>
 `;
   writeFileSync(outPath, html, "utf8");
@@ -163,13 +187,16 @@ function main() {
   const text = stripAnsi(capture.ansi);
   writeFileSync(textPath, text, "utf8");
   writeFileSync(ansiPath, capture.ansi, "utf8");
-  writeHtml({ title: args.title, text, outPath: htmlPath, cols: args.cols });
-  const browser = args.browser ? capturePng({ chromeBin: args.chromeBin, htmlPath, pngPath, width: 1280, height: 900 }) : { status: "skipped" };
+  writeHtml({ title: args.title, ansi: capture.ansi, outPath: htmlPath, cols: args.cols, wrap: args.wrap });
+  const size = screenshotSize({ cols: args.cols, rows: args.rows });
+  const browser = args.browser ? capturePng({ chromeBin: args.chromeBin, htmlPath, pngPath, ...size }) : { status: "skipped" };
   const metadata = {
     title: args.title,
     connector: capture.connector,
     browserCapture: browser.status,
     source: args.fromFile ? resolve(args.fromFile) : args.command,
+    wrap: args.wrap ? "on" : "off",
+    dimensions: { cols: args.cols, rows: args.rows, screenshotWidth: size.width, screenshotHeight: size.height },
     cleanup: capture.cleanup,
     files: { html: htmlPath, text: textPath, ansi: ansiPath, png: browser.status === "captured" ? pngPath : null, metadata: metadataPath },
   };

--- a/script/web-terminal-visual-qa.test.ts
+++ b/script/web-terminal-visual-qa.test.ts
@@ -122,4 +122,36 @@ describe("web terminal visual QA helper", () => {
     }
     expect(contents.map((content) => content.text).join("\n")).toContain("TUI visual")
   })
+
+  test("#given PR visual evidence docs #when attaching screenshots #then GitHub user attachment guidance is discoverable", () => {
+    // given
+    const repo = new URL("..", import.meta.url)
+    const attachmentDoc = readFileSync(new URL("docs/reference/github-attachment-upload.md", repo), "utf8")
+    const pointerFiles = [
+      "docs/AGENTS.md",
+      "docs/reference/web-terminal-visual-qa.md",
+      "packages/shared-skills/skills/git-master/SKILL.md",
+      ".agents/skills/work-with-pr/SKILL.md",
+      ".opencode/skills/work-with-pr/SKILL.md",
+    ] as const
+
+    // when
+    const pointers = pointerFiles.map((path) => ({
+      path,
+      text: readFileSync(new URL(path, repo), "utf8"),
+    }))
+
+    // then
+    expect(attachmentDoc).toContain("/upload/policies/assets")
+    expect(attachmentDoc).toContain("asset_upload_authenticity_token")
+    expect(attachmentDoc).toContain("https://github.com/user-attachments/assets/<uuid>")
+    expect(attachmentDoc).toContain("Never use GitHub Releases")
+    expect(attachmentDoc).toContain("Never use external image hosters")
+    expect(attachmentDoc).toContain("Do not print cookies")
+    for (const pointer of pointers) {
+      expect(pointer.text, `${pointer.path} must point at attachment upload guidance`).toContain(
+        "docs/reference/github-attachment-upload.md",
+      )
+    }
+  })
 })

--- a/script/web-terminal-visual-qa.test.ts
+++ b/script/web-terminal-visual-qa.test.ts
@@ -61,10 +61,86 @@ describe("web terminal visual QA helper", () => {
     expect(metadata).toMatchObject({
       connector: "file-replay",
       browserCapture: "skipped",
+      wrap: "on",
       files: {
         html: join(dir, "terminal.html"),
         text: join(dir, "terminal.txt"),
       },
+    })
+  })
+
+  test("#given ANSI color and style escapes #when rendering #then HTML preserves terminal styling while text stays plain", async () => {
+    // given
+    const dir = makeTempDir()
+    const transcript = join(dir, "ansi-capture.txt")
+    writeFileSync(transcript, "\u001b[31mred\u001b[0m \u001b[1;32mbold green\u001b[0m\n", "utf8")
+
+    // when
+    const proc = Bun.spawn({
+      cmd: [
+        process.execPath,
+        helperFilePath,
+        "--title",
+        "ANSI QA",
+        "--from-file",
+        transcript,
+        "--evidence-dir",
+        dir,
+        "--no-browser",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [exitCode, stderrText] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
+
+    // then
+    expect(stderrText).toBe("")
+    expect(exitCode).toBe(0)
+    expect(readFileSync(join(dir, "terminal-ansi.txt"), "utf8")).toContain("\u001b[31mred")
+    expect(readFileSync(join(dir, "terminal.txt"), "utf8")).toBe("red bold green\n")
+
+    const html = readFileSync(join(dir, "terminal.html"), "utf8")
+    expect(html).toContain('class="ansi-fg-red"')
+    expect(html).toContain('class="ansi-bold ansi-fg-green"')
+    expect(html).toContain("bold green")
+  })
+
+  test("#given a very long line #when rendering with defaults #then wrapping is enabled and recorded", async () => {
+    // given
+    const dir = makeTempDir()
+    const transcript = join(dir, "long-line.txt")
+    writeFileSync(transcript, `${"x".repeat(260)}\n`, "utf8")
+
+    // when
+    const proc = Bun.spawn({
+      cmd: [
+        process.execPath,
+        helperFilePath,
+        "--title",
+        "Long Line QA",
+        "--from-file",
+        transcript,
+        "--evidence-dir",
+        dir,
+        "--no-browser",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [exitCode, stderrText] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
+
+    // then
+    expect(stderrText).toBe("")
+    expect(exitCode).toBe(0)
+
+    const html = readFileSync(join(dir, "terminal.html"), "utf8")
+    expect(html).toContain("white-space: pre-wrap")
+    expect(html).toContain("overflow-wrap: anywhere")
+
+    const metadata: unknown = JSON.parse(readFileSync(join(dir, "metadata.json"), "utf8"))
+    expect(metadata).toMatchObject({
+      wrap: "on",
+      dimensions: { cols: 140, rows: 40 },
     })
   })
 
@@ -86,6 +162,7 @@ describe("web terminal visual QA helper", () => {
     expect(exitCode).toBe(0)
     expect(stdoutText).toContain("--command")
     expect(stdoutText).toContain("--from-file")
+    expect(stdoutText).toContain("--no-wrap")
     expect(stdoutText).toContain("tmux-backed PTY connector")
     expect(stdoutText).toContain("PNG")
   })

--- a/script/web-terminal-visual-qa.test.ts
+++ b/script/web-terminal-visual-qa.test.ts
@@ -105,6 +105,55 @@ describe("web terminal visual QA helper", () => {
     expect(html).toContain("bold green")
   })
 
+  test("#given truecolor and OSC controls #when rendering #then colors are preserved and controls are stripped", async () => {
+    // given
+    const dir = makeTempDir()
+    const transcript = join(dir, "truecolor-osc.txt")
+    writeFileSync(
+      transcript,
+      [
+        "\u001b[38;2;12;34;56msemicolon truecolor\u001b[0m",
+        "\u001b[38:2::255:0:0mcolon truecolor\u001b[0m",
+        "\u001b[38:2:0:255:0:0mcolon truecolor colorspace\u001b[0m",
+        "\u001b]8;;https://example.com\u0007visible label\u001b]8;;\u0007",
+      ].join("\n"),
+      "utf8",
+    )
+
+    // when
+    const proc = Bun.spawn({
+      cmd: [
+        process.execPath,
+        helperFilePath,
+        "--title",
+        "Truecolor OSC QA",
+        "--from-file",
+        transcript,
+        "--evidence-dir",
+        dir,
+        "--no-browser",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [exitCode, stderrText] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
+
+    // then
+    expect(stderrText).toBe("")
+    expect(exitCode).toBe(0)
+    expect(readFileSync(join(dir, "terminal.txt"), "utf8")).toBe(
+      "semicolon truecolor\ncolon truecolor\ncolon truecolor colorspace\nvisible label",
+    )
+
+    const html = readFileSync(join(dir, "terminal.html"), "utf8")
+    expect(html).toContain('style="color: rgb(12, 34, 56)"')
+    expect(html).toContain('<span style="color: rgb(255, 0, 0)">colon truecolor</span>')
+    expect(html).toContain('<span style="color: rgb(255, 0, 0)">colon truecolor colorspace</span>')
+    expect(html).toContain("visible label")
+    expect(html).not.toContain("\u001b]")
+    expect(html).not.toContain("https://example.com")
+  })
+
   test("#given a very long line #when rendering with defaults #then wrapping is enabled and recorded", async () => {
     // given
     const dir = makeTempDir()


### PR DESCRIPTION
## Summary

This PR improves `script/qa/web-terminal-visual-qa.mjs` so terminal evidence keeps ANSI styling instead of flattening everything to plain escaped text. It also gives future agents a repo-owned reference for GitHub PR/issue attachment uploads using GitHub user attachments, without committing temporary images, using Releases, or relying on external hosts.

## Changes

- Added `script/qa/web-terminal-renderer.mjs` for SGR ANSI parsing/rendering, including bold/dim/italic/underline/strike/inverse, 8/16-color, 256-color, and RGB foreground/background support.
- Updated the web terminal helper to render HTML/PNG from raw ANSI, preserve raw `terminal-ansi.txt`, keep stripped `terminal.txt`, default to readable wrapping, and record wrap/dimension metadata.
- Documented `--wrap`/`--no-wrap`, ANSI-preserving output, and the GitHub user-attachment evidence flow.
- Added `docs/reference/github-attachment-upload.md` and linked it from docs, work-with-pr guidance, and the repo-owned git-master shared skill.
- Extended focused tests for ANSI styling, long-line wrapping, helper docs, QA guidance pointers, and attachment guidance discoverability.

## Visual Evidence

GitHub user attachments, generated from uncommitted local evidence PNGs:

- ANSI color fixture: https://github.com/user-attachments/assets/3fe612e8-2e69-4b8f-acbe-ea00b71fc6f7

  ![ANSI color terminal rendering](https://github.com/user-attachments/assets/3fe612e8-2e69-4b8f-acbe-ea00b71fc6f7)

- Long-line fixture: https://github.com/user-attachments/assets/cc79776a-9f64-434b-bb14-2c88a4a7dea2

  ![Long-line terminal wrapping](https://github.com/user-attachments/assets/cc79776a-9f64-434b-bb14-2c88a4a7dea2)

Local evidence was generated but intentionally not committed:

- `.omo/evidence/20260623-web-terminal-rendering/ansi-color/terminal.png`
- `.omo/evidence/20260623-web-terminal-rendering/long-line/terminal.png`
- `.omo/evidence/20260623-web-terminal-rendering/manual-qa.md`

## Verification

- `bun test script/web-terminal-visual-qa.test.ts`
- `bun run typecheck:script`
- `node --check script/qa/web-terminal-visual-qa.mjs && node --check script/qa/web-terminal-renderer.mjs`
- Browser QA via Chrome for ANSI color and long-line fixtures; both metadata files report `browserCapture: captured`, `wrap: on`, and `cleanup: file replay; no live process`.
- Pure LOC check: changed script/test files are 182, 184, and 192 pure LOC respectively.
