### PR TITLE
fix(codex): wait for teammode worktree readiness

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -89,6 +89,10 @@ subcommand rewrites `guide.md`, so the manual always matches the current team.
    exact title to use. If `codex_app.create_thread` accepts a working directory / cwd argument,
    set it to that member's worktree; otherwise the member's manual tells it to `cd` there first.
    Use `codex_app.set_thread_title` if the title did not land at creation.
+   If Codex returns only `pendingWorktreeId`, the worktree-backed thread is not ready yet: do not
+   `bind-thread` and do not send the member bootstrap. Wait until Codex surfaces a real `threadId`
+   or the thread appears in the thread list, then set the title, bind that real id with the cwd,
+   and only then send the bootstrap.
 3. `bind-thread` to record each thread id (and `--cwd`), then send that member's bootstrap
    trigger (printed by `add-member` / `member-prompt`) as the thread's first message. The trigger
    is short on purpose: it tells the new thread to READ its `guide.md` and `team.json` rather than
@@ -135,6 +139,11 @@ After `worktree-add`, immediately send the member a follow-up that includes both
 worktree path and its `codex://threads/<thread_id>` link. Use `bind-thread --cwd <worktree>` or
 `--worktree-path <worktree>` after the thread exists so `team.json`, `guide.md`, `status`, and
 `member-prompt` all point at the same worktree-backed thread.
+
+When the member starts inside a worktree, it must verify the assigned cwd exists and contains the
+repository checkout before editing. If the directory is missing, empty, or does not look like a git
+worktree/repository yet, the member reports `BLOCKED: worktree not ready` to the leader and waits
+instead of editing a parent checkout or an empty directory.
 
 ## Run a ulw-plan in parallel
 

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
@@ -37,6 +37,13 @@ This team runs each member in its own git worktree branched off \`${team.worktre
 **You MUST work only inside your own worktree.** The very first thing you do is \`cd\` into it;
 every edit, command, and commit happens there. Never touch another member's worktree, and
 never edit files outside your assigned scope. Commit your work so the leader can integrate it.
+Before editing, verify that your assigned worktree exists and contains repo files. If the path is
+missing, empty, or does not look like a git worktree/repository yet, send \`BLOCKED: worktree not ready\`
+to the leader and wait instead of editing any parent checkout or empty directory.
+
+If Codex returns only \`pendingWorktreeId\` while the leader is creating a worktree-backed member
+thread, the thread is not ready yet. The leader must wait until Codex surfaces a real thread id,
+then bind that real id and send the bootstrap.
 
 ${lines.length ? lines.join("\n") : "- (worktree paths are assigned as threads are bound; read team.json for yours)"}`;
 }
@@ -112,11 +119,19 @@ export function buildMemberPrompt(team, id) {
 	if (!member) throw new Error(`no member with id "${id}"`);
 	const guide = team.paths?.guide ?? ".omo/teams/<session_id>/guide.md";
 	const teamJson = team.paths?.team ?? ".omo/teams/<session_id>/team.json";
-	const where = member.cwd ? `Work inside \`${member.cwd}\`.` : "Work from the repository root unless your manual assigns a worktree.";
+	const where = member.cwd
+		? `Work inside \`${member.cwd}\`.`
+		: team.worktree?.enabled
+			? "Wait for the leader to bind your worktree cwd before editing."
+			: "Work from the repository root unless your manual assigns a worktree.";
 	const threadLink = member.threadId ? `\nYour Codex thread link is ${codexThreadLink(member.threadId)}. Include it when reporting handoffs or worktree status.` : "";
+	const readiness =
+		team.worktree?.enabled
+			? "\nBefore editing, verify that your assigned worktree exists and contains repo files. If this prompt arrived before your Codex worktree checkout is ready, or the path is missing, empty, or not a git worktree/repository yet, report `BLOCKED: worktree not ready` to the leader and wait."
+			: "";
 	return `You are member ${member.id}${member.name ? ` (${member.name})` : ""} of team ${team.teamName} - owner of: ${member.focus}. Your thread title is \`${member.threadTitle}\`.
 FIRST read your field manual at \`${guide}\`, then the team state at \`${teamJson}\`; they define your scope, deliverable, the leader, the artifacts directory, and the communication rules.
-${where}${threadLink}
+${where}${threadLink}${readiness}
 Communicate with the team and leader in English; reply to the end user in the user's own language.
 Start now. Push updates to the leader and relevant peers with \`codex_app.send_message_to_thread\` as you work - findings, \`WORKING:\` heartbeats, and \`BLOCKED:\` the instant you stall - never just one report at the end.`;
 }

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -165,10 +165,10 @@ const handlers = {
 		await persist(team, dir);
 		const note = result.created ? "" : " (already exists)";
 		const thread = member.threadId
-			? `\nMember thread: ${codexThreadLink(member.threadId)}`
-			: "\nMember thread is not bound yet; wait for the real Codex thread id, then bind-thread before sending bootstrap.";
+			? `\nMember thread: ${codexThreadLink(member.threadId)}\nTell that member to: cd "${result.path}"`
+			: "\nMember thread is not bound yet; wait for the real Codex thread id, then bind-thread before sending bootstrap. After binding, send the member this worktree path.";
 		process.stdout.write(
-			`worktree for member ${member.id}${note}: ${result.path} on branch ${result.branch} (off ${result.base}).${thread}\nTell that member to: cd "${result.path}"\n`,
+			`worktree for member ${member.id}${note}: ${result.path} on branch ${result.branch} (off ${result.base}).${thread}\n`,
 		);
 	},
 

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -164,7 +164,9 @@ const handlers = {
 		setMemberWorktree(team, { id: member.id, path: result.path, branch: result.branch });
 		await persist(team, dir);
 		const note = result.created ? "" : " (already exists)";
-		const thread = member.threadId ? `\nMember thread: ${codexThreadLink(member.threadId)}` : "";
+		const thread = member.threadId
+			? `\nMember thread: ${codexThreadLink(member.threadId)}`
+			: "\nMember thread is not bound yet; wait for the real Codex thread id, then bind-thread before sending bootstrap.";
 		process.stdout.write(
 			`worktree for member ${member.id}${note}: ${result.path} on branch ${result.branch} (off ${result.base}).${thread}\nTell that member to: cd "${result.path}"\n`,
 		);

--- a/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/teammode/src/codex-hook.ts
@@ -64,7 +64,7 @@ function threadTitleReminder(threadReference: ThreadCreationReference): string {
 	const id = formatIdentifier(threadReference.id);
 	return threadReference.kind === "thread"
 		? `THREAD ID ${id}: CALL codex_app.set_thread_title NOW. USE THE REAL TASK/ROLE.`
-		: `PENDING WORKTREE ID ${id}: CALL codex_app.set_thread_title AS SOON AS THREAD ID EXISTS. USE THE REAL TASK/ROLE.`;
+		: `PENDING WORKTREE ID ${id}: WORKTREE THREAD IS NOT READY YET. DO NOT bind-thread OR SEND THE MEMBER BOOTSTRAP UNTIL A REAL THREAD ID EXISTS. THEN CALL codex_app.set_thread_title USING THE REAL TASK/ROLE.`;
 }
 
 function formatIdentifier(value: string): string {

--- a/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
+++ b/packages/omo-codex/plugin/components/teammode/test/thread-title-hook.test.ts
@@ -87,7 +87,7 @@ describe("thread title PostToolUse guidance", () => {
 		expect(actual).toBe("");
 	});
 
-	it("#given worktree-backed thread creation is pending #when the hook runs #then it tells Codex to title the thread once the thread id exists", () => {
+	it("#given worktree-backed thread creation is pending #when the hook runs #then it tells Codex to wait for the real thread before bootstrapping", () => {
 		// given
 		const output = runPostToolUseHook({
 			hook_event_name: "PostToolUse",
@@ -119,7 +119,7 @@ describe("thread title PostToolUse guidance", () => {
 		expect(isHookOutput(parsed)).toBe(true);
 		if (!isHookOutput(parsed)) return;
 		expect(parsed.hookSpecificOutput.additionalContext).toBe(
-			"PENDING WORKTREE ID remote-control:env:test-worktree: CALL codex_app.set_thread_title AS SOON AS THREAD ID EXISTS. USE THE REAL TASK/ROLE.",
+			"PENDING WORKTREE ID remote-control:env:test-worktree: WORKTREE THREAD IS NOT READY YET. DO NOT bind-thread OR SEND THE MEMBER BOOTSTRAP UNTIL A REAL THREAD ID EXISTS. THEN CALL codex_app.set_thread_title USING THE REAL TASK/ROLE.",
 		);
 	});
 });

--- a/packages/omo-codex/plugin/test/teammode-thread-links.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-thread-links.test.mjs
@@ -77,6 +77,40 @@ test("#given a worktree-backed team has bound member threads #when guide and sta
 		assert.match(status, /link=codex:\/\/threads\/019ef350-ee78-72a3-bd5e-e40cebc3d814/);
 		assert.match(prompt, /Your Codex thread link is codex:\/\/threads\/019ef350-ee78-72a3-bd5e-e40cebc3d814/);
 		assert.match(prompt, /Work inside `\/tmp\/review-worktree`/);
+		assert.match(prompt, /Before editing, verify that your assigned worktree exists and contains repo files/);
+		assert.match(prompt, /BLOCKED: worktree not ready/);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given a worktree member has no cwd bound yet #when guide and prompt render #then they tell Codex to wait for readiness", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-worktree-wait-");
+	try {
+		const sessionId = "worktree-wait";
+		runTeam(tempRoot, "init", "--name", "Wait", "--session-name", "worktrees", "--session", sessionId, "--worktree", "--base-branch", "main");
+		addMember(tempRoot, sessionId, {
+			id: "A",
+			name: "worktree-driver",
+			focus: "drive a pending Codex worktree thread",
+			lens: "ownership",
+			deliverable: "ready worktree report",
+		});
+		addMember(tempRoot, sessionId, {
+			id: "B",
+			name: "integration-watch",
+			focus: "watch integration boundaries",
+			lens: "perspective",
+			deliverable: "integration notes",
+		});
+		runTeam(tempRoot, "bind-thread", "--team", sessionId, "--id", "A", "--thread", "019ef350-ee78-72a3-bd5e-e40cebc3d814");
+
+		const guide = readFileSync(`${teamDir(tempRoot, sessionId)}/guide.md`, "utf8");
+		const prompt = runTeam(tempRoot, "member-prompt", "--team", sessionId, "--id", "A").stdout;
+
+		assert.match(guide, /If Codex returns only `pendingWorktreeId`/);
+		assert.match(guide, /wait until Codex surfaces a real thread id/);
+		assert.match(prompt, /If this prompt arrived before your Codex worktree checkout is ready/);
 	} finally {
 		cleanupTeamRoot(tempRoot);
 	}

--- a/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
@@ -78,11 +78,12 @@ test("#given a worktree team #when worktree-add A #then a real git worktree on a
 		assert.equal(member.worktree.branch, expectedBranch);
 		assert.ok(samePath(member.cwd, expectedPath), "cwd must be the member worktree dir");
 
-		// then - the leader is told the exact cd target
-		assert.match(result.stdout, /cd /);
+		// then - the leader is told the exact worktree target without prompting an unbound member
+		assert.match(result.stdout, new RegExp(expectedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 		assert.match(result.stdout, /A/);
 		assert.match(result.stdout, /wait for the real Codex thread id/);
 		assert.match(result.stdout, /bind-thread before sending bootstrap/);
+		assert.doesNotMatch(result.stdout, /Tell that member to:/);
 	} finally {
 		cleanupTeamRoot(tempRoot);
 	}

--- a/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-worktree.test.mjs
@@ -81,6 +81,8 @@ test("#given a worktree team #when worktree-add A #then a real git worktree on a
 		// then - the leader is told the exact cd target
 		assert.match(result.stdout, /cd /);
 		assert.match(result.stdout, /A/);
+		assert.match(result.stdout, /wait for the real Codex thread id/);
+		assert.match(result.stdout, /bind-thread before sending bootstrap/);
 	} finally {
 		cleanupTeamRoot(tempRoot);
 	}


### PR DESCRIPTION
## Summary

This PR makes Codex teammode safer when member threads are created with worktree-backed Codex environments. Codex can return only `pendingWorktreeId` while the actual thread/worktree is still being provisioned, so teammode now tells the leader not to bind or bootstrap the member until a real `threadId` exists.

It also teaches generated member prompts and the team field manual to verify the assigned worktree is actually present and populated before editing, and to report `BLOCKED: worktree not ready` instead of touching a parent checkout or an empty directory.

## Changes

- Expanded the `PostToolUse` `create_thread` reminder for `pendingWorktreeId` responses to block premature `bind-thread` and bootstrap sends.
- Added leader guidance in the bundled teammode skill for pending worktree-backed Codex thread setup.
- Added generated member prompt and guide guidance for worktree readiness checks.
- Added `worktree-add` CLI output warning when no real member thread is bound yet.
- Added focused regression coverage for hook output, guide/member prompt text, and worktree-add output.

## QA & Evidence

The original local evidence directory named for this work was `.omo/evidence/20260623-teammode-worktree-wait/`, but the useful reviewer signal is below: each item says what it proves, what was observed, and how it maps to the risk in this PR. Raw logs stay local/sanitized; no secrets, env dumps, tokens, or auth headers are included here.

- **What was tested:** `bun --cwd packages/omo-codex/plugin/components/teammode test test/thread-title-hook.test.ts` against the teammode hook/unit tests.
  **Observed result:** Passed in local verification before opening this PR.
  **Artifact:** Local QA log set: `.omo/evidence/20260623-teammode-worktree-wait/`.
  **Why sufficient:** Covers the hook-facing regression where Codex thread creation returns `pendingWorktreeId` before a usable member thread exists.

- **What was tested:** `node --test packages/omo-codex/plugin/test/teammode-thread-links.test.mjs packages/omo-codex/plugin/test/teammode-worktree.test.mjs packages/omo-codex/plugin/test/teammode-thread-title.test.mjs packages/omo-codex/plugin/test/teammode-communication.test.mjs packages/omo-codex/plugin/test/teammode-safety.test.mjs`.
  **Observed result:** Passed in local verification before opening this PR.
  **Artifact:** Local QA log set: `.omo/evidence/20260623-teammode-worktree-wait/`.
  **Why sufficient:** Exercises the generated teammode prompt/guide and worktree flow regressions around thread links, worktree readiness, thread titles, communication, and safety wording.

- **What was tested:** `bun run --cwd packages/omo-codex/plugin/components/teammode typecheck`, root `bun run typecheck`, and root `bun run test:codex`.
  **Observed result:** Passed in local verification before opening this PR.
  **Artifact:** Local QA log set: `.omo/evidence/20260623-teammode-worktree-wait/`.
  **Why sufficient:** Confirms the changed TypeScript/CLI surfaces compile and the Codex plugin regression suite still accepts the teammode behavior.

- **What was tested:** Codex QA helper self-checks: `common.sh --self-check`, `hook-unit-probe.sh --self-test`, and `app-server-drive.sh --plugin`.
  **Observed result:** Passed in local verification before opening this PR.
  **Artifact:** Local QA log set: `.omo/evidence/20260623-teammode-worktree-wait/`.
  **Why sufficient:** Confirms the QA harness used for Codex plugin hook/app-server evidence is itself runnable before trusting its output.

- **What was tested:** Manual hook proof with `node packages/omo-codex/plugin/components/teammode/dist/cli.js hook post-tool-use` using a `pendingWorktreeId` create-thread payload.
  **Observed result:** The hook emitted wait-before-bootstrap guidance instead of telling the leader to bind or bootstrap a member before a real `threadId` exists.
  **Artifact:** Local QA log set: `.omo/evidence/20260623-teammode-worktree-wait/`.
  **Why sufficient:** This is the core user-facing failure mode: without this behavior, teammode can send a member into the wrong checkout or an unready worktree.

- **What was tested:** Source-guidance regression for reviewer-readable PR evidence after this follow-up: this branch was merged with current `origin/dev`, bringing in PR #5535's updated `AGENTS.md`, `.agents/skills/work-with-pr/SKILL.md`, `.opencode/skills/work-with-pr/SKILL.md`, and `.github/pull_request_template.md`.
  **Observed result:** The branch now contains the reviewer-facing `QA & Evidence` template that asks for what was tested, observed result, artifact path, and why the evidence is sufficient.
  **Artifact:** Follow-up evidence: `.omo/evidence/20260623-pr5538-readable-verification/` in the maintainer worktree.
  **Why sufficient:** Prevents this PR branch from continuing to use the stale Verification template that allowed a directory pointer plus command list.

## Risks & Residuals

- **Pending-worktree race:** Mitigated by hook/member prompt/guide behavior that waits for a real `threadId` and tells members to report `BLOCKED: worktree not ready` when the checkout is not usable.
- **Wrong-directory edits:** Mitigated by generated member guidance that verifies the assigned worktree exists and is populated before editing.
- **Evidence readability:** Mitigated by replacing the bare evidence-directory pointer with per-check purpose, observed result, artifact path, and sufficiency notes, and by merging the latest reviewer-readable PR guidance from `dev`.
- **External gates:** GitGuardian and lightweight repository checks have passed; Cubic reported a neutral/skipping status rather than a review. GitHub CI is still running on the latest branch update at the time this body was refreshed.

## Related Context

- Investigated `codex://threads/019ef341-d2db-7e81-b362-e569c2d38371`; the relevant behavior is that Codex worktree creation can expose a `pendingWorktreeId` before a usable member thread exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make teammode wait for a real worktree-backed Codex thread before binding or bootstrapping, and stop telling members to cd into paths before a thread/cwd is bound. This prevents wrong-directory edits and has members report “BLOCKED: worktree not ready”.

- **Bug Fixes**
  - On `pendingWorktreeId`, the hook now blocks `bind-thread` and bootstrap, and tells the leader to wait for a real `threadId`, then set the title.
  - Team guide and member prompts explain the pending-worktree flow; members must verify the worktree exists and, if no cwd is bound or the checkout isn’t ready, report `BLOCKED: worktree not ready` and wait.
  - `worktree-add` CLI only prints “cd <path>” when a member thread is bound; otherwise it instructs the leader to wait for the real id, run `bind-thread --cwd`, then send bootstrap.
  - Tests updated/added for hook guidance, guide/prompt readiness text, thread-link rendering, and the new CLI output.

<sup>Written for commit 73c5fa38089d96a7ed78b41f2afbe53d4df318c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

