### PR TITLE
fix(prompts): use /start-work not $start-work in Prometheus prompt (fixes #5530)

### DIFF
--- a/packages/prompts-core/prompts/prometheus/default.md
+++ b/packages/prompts-core/prompts/prometheus/default.md
@@ -1,5 +1,5 @@
 You are Prometheus, a planning consultant. Your only job: gather the MAXIMUM relevant information about the request and the codebase, give the user the appropriate best practice for their situation, and ALWAYS act in dependence on the ulw-plan skill.
 
-You are a PLANNER. You read, search, and write only plan artifacts under `.omo/`; you never edit product code and never implement. Plan mode is sticky: "do X" / "fix X" / "just do it" all mean "plan X" - execution belongs to the worker and begins only when the user explicitly starts it (e.g. `$start-work`).
+You are a PLANNER. You read, search, and write only plan artifacts under `.omo/`; you never edit product code and never implement. Plan mode is sticky: "do X" / "fix X" / "just do it" all mean "plan X" - execution belongs to the worker and begins only when the user explicitly starts it (e.g. `/start-work`).
 
 Your FIRST action in every planning session is to LOAD the shared ulw-plan skill - call the `skill` tool with `skill(name="shared/ulw-plan")` - and read it before anything else. For everything else - how to explore, when to ask versus adopt a best-practice default, the clear/unclear intent routing, the approval gate, the plan template, the scaffold script, and the dual-Momus high-accuracy review - follow the ulw-plan skill exactly. Do not restate or override it here.


### PR DESCRIPTION
## Summary

The Prometheus system prompt tells users that execution begins with `$start-work`, which is Codex CLI command syntax. In OpenCode the correct command is `/start-work`. Prometheus is an OpenCode-only orchestration agent, so this prompt only ever renders for OpenCode users; the `$` form makes them type a non-existent command and bypass agent orchestration.

## Root Cause

`packages/prompts-core/prompts/prometheus/default.md` (line 3) reads: "... begins only when the user explicitly starts it (e.g. `$start-work`)." `$start-work` is Codex CLI syntax.

Per the `prompts-core` consumer map, this prompt is loaded by `omo-opencode/src/agents/prometheus/system-prompt.ts` (OpenCode), while the Codex Light edition resolves only `prompts-core/prompts/ultrawork/codex.md` and has no agent orchestration (no Prometheus). So the prompt is OpenCode-only, and the correct command is the slash form `/start-work`.

## Changes

| File | Change |
|------|--------|
| `packages/prompts-core/prompts/prometheus/default.md` | `$start-work` to `/start-work` (single literal occurrence) |

## Reproduction (before fix)

~~~
L3: ... begins only when the user explicitly starts it (e.g. `$start-work`).
~~~

## Verification (after fix)

~~~
grep $start-work  -> 0 occurrences
grep /start-work  -> 1 occurrence (L3)
1 file changed, 1 insertion(+), 1 deletion(-)
~~~

## Test

- Content-only prompt fix. No `prompts-core` test references the `start-work` string (verified by grep), so there is no test impact.
- Confirmed `/start-work` is the OpenCode slash-command syntax and `$start-work` is the Codex CLI syntax; the Prometheus prompt renders only in OpenCode (Codex resolves only `ultrawork/codex.md` from `prompts-core`).

Fixes #5530


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `$start-work` with `/start-work` in the Prometheus system prompt so OpenCode users see the correct command. This prevents invalid commands and keeps orchestration flow working as intended.

<sup>Written for commit 8e0edd85a0c84c0b52d71437ee232c272466e3b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

