### PR TITLE
fix(codex): harden installer multi-agent TOML migration

### DIFF
--- a/packages/omo-codex/scripts/install-config.test.mjs
+++ b/packages/omo-codex/scripts/install-config.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { updateCodexConfig } from "./install-dist/install-local.mjs";
 
-test("#given empty Codex config #when script installer updates config #then enables steering mode with ten thousand session threads", async () => {
+test("#given empty Codex config #when script installer updates config #then enables proactive mode with ten thousand session threads", async () => {
 	// given
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-"));
 	const configPath = join(root, "config.toml");
@@ -22,14 +22,14 @@ test("#given empty Codex config #when script installer updates config #then enab
 
 	// then
 	const config = await readFile(configPath, "utf8");
-	assert.match(config, /^multi_agent_mode = "steering"$/m);
+	assert.match(config, /^multi_agent_mode = "proactive"$/m);
 	assert.match(config, /\[features\.multi_agent_v2\]/);
 	const v2Section = config.slice(config.indexOf("[features.multi_agent_v2]")).split(/^\[/m).slice(0, 1).join("");
 	assert.doesNotMatch(v2Section, /enabled\s*=/);
 	assert.match(config, /max_concurrent_threads_per_session = 10000/);
 });
 
-test("#given queue multi-agent mode #when script installer updates config #then switches to steering mode for team support", async () => {
+test("#given queue multi-agent mode #when script installer updates config #then switches to proactive mode for team support", async () => {
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-mode-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
@@ -52,8 +52,39 @@ test("#given queue multi-agent mode #when script installer updates config #then 
 	});
 
 	const config = await readFile(configPath, "utf8");
-	assert.match(config, /^multi_agent_mode = "steering"$/m);
+	assert.match(config, /^multi_agent_mode = "proactive"$/m);
 	assert.doesNotMatch(config, /multi_agent_mode = "queue"/);
+});
+
+test("#given indented root mode and inline-comment features table #when script installer updates config #then emits one proactive root key and one features table", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-toml-root-regression-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'  multi_agent_mode = "queue"',
+			"",
+			"[features] # keep comment",
+			"plugins = false",
+			"",
+		].join("\n"),
+	);
+
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "debug",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+		pluginNames: ["omo"],
+	});
+
+	const config = await readFile(configPath, "utf8");
+	assert.equal(config.match(/^\s*multi_agent_mode\s*=/gm)?.length, 1);
+	assert.equal(config.match(/^\s*\[features\](?:\s*#.*)?$/gm)?.length, 1);
+	assert.match(config, /^multi_agent_mode = "proactive"$/m);
+	assert.match(config, /^\[features\] # keep comment$/m);
+	assert.doesNotMatch(config, /multi_agent_mode = "queue"/);
+	assert.doesNotMatch(config, /multi_agent_mode = "steering"/);
 });
 
 test("#given empty Codex config #when script installer updates config #then leaves Context7 to the plugin MCP manifest", async () => {

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -7529,7 +7529,7 @@ function findTomlSection(config, header) {
     if (start === -1) {
       if (tomlTableHeaderMatches(trimmed, headerLine, targetHeaderPath))
         start = offset;
-    } else if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    } else if (isTomlTableHeaderLine(line)) {
       return { start, end: offset, text: config.slice(start, offset) };
     }
     offset += line.length;
@@ -7539,12 +7539,12 @@ function findTomlSection(config, header) {
   return { start, end: config.length, text: config.slice(start) };
 }
 function replaceOrInsertSetting(config, section, key, value) {
-  const linePattern = new RegExp(`^${escapeRegExp(key)}\\s*=.*$`, "m");
+  const linePattern = new RegExp(`^[ \\t]*${escapeRegExp(key)}[ \\t]*=.*$`, "m");
   const replacement = linePattern.test(section.text) ? section.text.replace(linePattern, `${key} = ${value}`) : insertSetting(section.text, key, value);
   return config.slice(0, section.start) + replacement + config.slice(section.end);
 }
 function removeSetting(config, section, key) {
-  const linePattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=.*(?:\\n|$)`, "m");
+  const linePattern = new RegExp(`^[ \\t]*${escapeRegExp(key)}[ \\t]*=.*(?:\\n|$)`, "m");
   const replacement = section.text.replace(linePattern, "");
   return config.slice(0, section.start) + replacement + config.slice(section.end);
 }
@@ -7552,7 +7552,7 @@ function replaceOrInsertRootSetting(config, key, value) {
   const sectionStart = findFirstTableStart(config);
   const root = config.slice(0, sectionStart);
   const suffix = config.slice(sectionStart);
-  const linePattern = new RegExp(`^${escapeRegExp(key)}\\s*=.*$`, "m");
+  const linePattern = new RegExp(`^[ \\t]*${escapeRegExp(key)}[ \\t]*=.*$`, "m");
   const replacement = linePattern.test(root) ? root.replace(linePattern, `${key} = ${value}`) : `${root.trimEnd()}${root.trimEnd().length > 0 ? `
 ` : ""}${key} = ${value}
 `;
@@ -7570,8 +7570,16 @@ function appendBlock(config, block) {
 `;
 }
 function findFirstTableStart(config) {
-  const match = config.match(/^[[].*$/m);
-  return match?.index ?? config.length;
+  const lines = config.match(/[^\n]*\n?|$/g) ?? [];
+  let offset = 0;
+  for (const line of lines) {
+    if (line.length === 0)
+      break;
+    if (isTomlTableHeaderLine(line))
+      return offset;
+    offset += line.length;
+  }
+  return config.length;
 }
 function insertSetting(sectionText, key, value) {
   const lines = sectionText.split(`
@@ -7584,19 +7592,57 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 function tomlTableHeaderMatches(line, headerLine, targetHeaderPath) {
-  if (line === headerLine)
+  const normalizedLine = stripUnquotedInlineComment(line).trim();
+  if (normalizedLine === headerLine)
     return true;
   if (!targetHeaderPath)
     return false;
-  const candidateHeaderPath = parseTomlTableHeader(line);
+  const candidateHeaderPath = parseTomlTableHeader(normalizedLine);
   if (!candidateHeaderPath || candidateHeaderPath.length !== targetHeaderPath.length)
     return false;
   return candidateHeaderPath.every((part, index) => part === targetHeaderPath[index]);
 }
 function parseTomlTableHeader(line) {
-  if (!line.startsWith("[") || !line.endsWith("]") || line.startsWith("[["))
+  const normalizedLine = stripUnquotedInlineComment(line).trim();
+  if (!normalizedLine.startsWith("[") || !normalizedLine.endsWith("]") || normalizedLine.startsWith("[["))
     return null;
-  return parseTomlDottedKey(line.slice(1, -1).trim());
+  return parseTomlDottedKey(normalizedLine.slice(1, -1).trim());
+}
+function isTomlTableHeaderLine(line) {
+  const normalizedLine = stripUnquotedInlineComment(line).trim();
+  return normalizedLine.startsWith("[") && normalizedLine.endsWith("]");
+}
+function stripUnquotedInlineComment(line) {
+  let quote = null;
+  let index = 0;
+  while (index < line.length) {
+    const char = line[index];
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"')
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'")
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      index += 1;
+      continue;
+    }
+    if (char === "#")
+      return line.slice(0, index);
+    index += 1;
+  }
+  return line;
 }
 function parseTomlDottedKey(input) {
   const parts = [];
@@ -8140,12 +8186,12 @@ function parseProfileMatch(match) {
 
 // packages/omo-codex/src/install/codex-multi-agent-mode-config.ts
 var CODEX_MULTI_AGENT_MODE_KEY = "multi_agent_mode";
-var CODEX_MULTI_AGENT_MODE_STEERING = "steering";
+var CODEX_MULTI_AGENT_MODE_PROACTIVE = "proactive";
 function ensureCodexMultiAgentModeConfig(config) {
-  if (readRootStringSetting(config, CODEX_MULTI_AGENT_MODE_KEY) === CODEX_MULTI_AGENT_MODE_STEERING) {
+  if (readRootStringSetting(config, CODEX_MULTI_AGENT_MODE_KEY) === CODEX_MULTI_AGENT_MODE_PROACTIVE) {
     return config;
   }
-  return replaceOrInsertRootSetting(config, CODEX_MULTI_AGENT_MODE_KEY, JSON.stringify(CODEX_MULTI_AGENT_MODE_STEERING));
+  return replaceOrInsertRootSetting(config, CODEX_MULTI_AGENT_MODE_KEY, JSON.stringify(CODEX_MULTI_AGENT_MODE_PROACTIVE));
 }
 function readRootStringSetting(config, key) {
   for (const line of config.split(/\n/)) {
@@ -8158,8 +8204,7 @@ function readRootStringSetting(config, key) {
   return null;
 }
 function isSectionHeader2(line) {
-  const trimmed = line.trim();
-  return trimmed.startsWith("[") && trimmed.endsWith("]");
+  return isTomlTableHeaderLine(line);
 }
 
 // packages/omo-codex/src/install/codex-multi-agent-v2-config.ts

--- a/packages/omo-codex/src/install/codex-config-toml.test.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.test.ts
@@ -73,7 +73,7 @@ describe("codex-config-toml", () => {
 
     // then
     const content = await readFile(configPath, "utf8")
-    expect(content).toContain('multi_agent_mode = "steering"')
+    expect(content).toContain('multi_agent_mode = "proactive"')
     expect(content).toContain("[features.multi_agent_v2]")
     const v2Section = content.slice(content.indexOf("[features.multi_agent_v2]"))
       .split(/^\[/m).slice(0, 1).join("")
@@ -81,7 +81,7 @@ describe("codex-config-toml", () => {
     expect(content).toContain("max_concurrent_threads_per_session = 10000")
   })
 
-  test("#given queue multi-agent mode #when updating config #then switches to steering mode for team support", async () => {
+  test("#given queue multi-agent mode #when updating config #then switches to proactive mode for team support", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-mode-"))
     const configPath = join(root, "config.toml")
@@ -107,8 +107,42 @@ describe("codex-config-toml", () => {
 
     // then
     const content = await readFile(configPath, "utf8")
-    expect(content).toContain('multi_agent_mode = "steering"')
+    expect(content).toContain('multi_agent_mode = "proactive"')
     expect(content).not.toContain('multi_agent_mode = "queue"')
+  })
+
+  test("#given indented root mode and inline-comment features table #when updating config #then replaces without duplicate TOML keys", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-toml-root-regression-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      [
+        '  multi_agent_mode = "queue"',
+        "",
+        "[features] # keep comment",
+        "plugins = false",
+        "",
+      ].join("\n"),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content.match(/^\s*multi_agent_mode\s*=/gm)).toHaveLength(1)
+    expect(content.match(/^\s*\[features\](?:\s*#.*)?$/gm)).toHaveLength(1)
+    expect(content).toContain('multi_agent_mode = "proactive"')
+    expect(content).toContain("[features] # keep comment")
+    expect(content).not.toContain('multi_agent_mode = "queue"')
+    expect(content).not.toContain('multi_agent_mode = "steering"')
   })
 
   test("#given existing MultiAgentV2 table #when updating config #then preserves user enabled flag and unrelated tuning while setting thread limit", async () => {

--- a/packages/omo-codex/src/install/codex-multi-agent-mode-config.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-mode-config.ts
@@ -1,16 +1,16 @@
-import { replaceOrInsertRootSetting } from "./toml-section-editor"
+import { isTomlTableHeaderLine, replaceOrInsertRootSetting } from "./toml-section-editor"
 
 const CODEX_MULTI_AGENT_MODE_KEY = "multi_agent_mode"
-const CODEX_MULTI_AGENT_MODE_STEERING = "steering"
+const CODEX_MULTI_AGENT_MODE_PROACTIVE = "proactive"
 
 export function ensureCodexMultiAgentModeConfig(config: string): string {
-  if (readRootStringSetting(config, CODEX_MULTI_AGENT_MODE_KEY) === CODEX_MULTI_AGENT_MODE_STEERING) {
+  if (readRootStringSetting(config, CODEX_MULTI_AGENT_MODE_KEY) === CODEX_MULTI_AGENT_MODE_PROACTIVE) {
     return config
   }
   return replaceOrInsertRootSetting(
     config,
     CODEX_MULTI_AGENT_MODE_KEY,
-    JSON.stringify(CODEX_MULTI_AGENT_MODE_STEERING),
+    JSON.stringify(CODEX_MULTI_AGENT_MODE_PROACTIVE),
   )
 }
 
@@ -24,6 +24,5 @@ function readRootStringSetting(config: string, key: string): string | null {
 }
 
 function isSectionHeader(line: string): boolean {
-  const trimmed = line.trim()
-  return trimmed.startsWith("[") && trimmed.endsWith("]")
+  return isTomlTableHeaderLine(line)
 }

--- a/packages/omo-codex/src/install/toml-section-editor.ts
+++ b/packages/omo-codex/src/install/toml-section-editor.ts
@@ -15,7 +15,7 @@ export function findTomlSection(config: string, header: string): TomlSection | n
     const trimmed = line.trim()
     if (start === -1) {
       if (tomlTableHeaderMatches(trimmed, headerLine, targetHeaderPath)) start = offset
-    } else if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    } else if (isTomlTableHeaderLine(line)) {
       return { start, end: offset, text: config.slice(start, offset) }
     }
     offset += line.length
@@ -25,7 +25,7 @@ export function findTomlSection(config: string, header: string): TomlSection | n
 }
 
 export function replaceOrInsertSetting(config: string, section: TomlSection, key: string, value: string): string {
-  const linePattern = new RegExp(`^${escapeRegExp(key)}\\s*=.*$`, "m")
+  const linePattern = new RegExp(`^[ \\t]*${escapeRegExp(key)}[ \\t]*=.*$`, "m")
   const replacement = linePattern.test(section.text)
     ? section.text.replace(linePattern, `${key} = ${value}`)
     : insertSetting(section.text, key, value)
@@ -33,7 +33,7 @@ export function replaceOrInsertSetting(config: string, section: TomlSection, key
 }
 
 export function removeSetting(config: string, section: TomlSection, key: string): string {
-  const linePattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=.*(?:\\n|$)`, "m")
+  const linePattern = new RegExp(`^[ \\t]*${escapeRegExp(key)}[ \\t]*=.*(?:\\n|$)`, "m")
   const replacement = section.text.replace(linePattern, "")
   return config.slice(0, section.start) + replacement + config.slice(section.end)
 }
@@ -42,7 +42,7 @@ export function replaceOrInsertRootSetting(config: string, key: string, value: s
   const sectionStart = findFirstTableStart(config)
   const root = config.slice(0, sectionStart)
   const suffix = config.slice(sectionStart)
-  const linePattern = new RegExp(`^${escapeRegExp(key)}\\s*=.*$`, "m")
+  const linePattern = new RegExp(`^[ \\t]*${escapeRegExp(key)}[ \\t]*=.*$`, "m")
   const replacement = linePattern.test(root)
     ? root.replace(linePattern, `${key} = ${value}`)
     : `${root.trimEnd()}${root.trimEnd().length > 0 ? "\n" : ""}${key} = ${value}\n`
@@ -56,8 +56,14 @@ export function appendBlock(config: string, block: string): string {
 }
 
 function findFirstTableStart(config: string): number {
-  const match = config.match(/^[[].*$/m)
-  return match?.index ?? config.length
+  const lines = config.match(/[^\n]*\n?|$/g) ?? []
+  let offset = 0
+  for (const line of lines) {
+    if (line.length === 0) break
+    if (isTomlTableHeaderLine(line)) return offset
+    offset += line.length
+  }
+  return config.length
 }
 
 function insertSetting(sectionText: string, key: string, value: string): string {
@@ -71,16 +77,53 @@ export function escapeRegExp(value: string): string {
 }
 
 function tomlTableHeaderMatches(line: string, headerLine: string, targetHeaderPath: readonly string[] | null): boolean {
-  if (line === headerLine) return true
+  const normalizedLine = stripUnquotedInlineComment(line).trim()
+  if (normalizedLine === headerLine) return true
   if (!targetHeaderPath) return false
-  const candidateHeaderPath = parseTomlTableHeader(line)
+  const candidateHeaderPath = parseTomlTableHeader(normalizedLine)
   if (!candidateHeaderPath || candidateHeaderPath.length !== targetHeaderPath.length) return false
   return candidateHeaderPath.every((part, index) => part === targetHeaderPath[index])
 }
 
 function parseTomlTableHeader(line: string): readonly string[] | null {
-  if (!line.startsWith("[") || !line.endsWith("]") || line.startsWith("[[")) return null
-  return parseTomlDottedKey(line.slice(1, -1).trim())
+  const normalizedLine = stripUnquotedInlineComment(line).trim()
+  if (!normalizedLine.startsWith("[") || !normalizedLine.endsWith("]") || normalizedLine.startsWith("[[")) return null
+  return parseTomlDottedKey(normalizedLine.slice(1, -1).trim())
+}
+
+export function isTomlTableHeaderLine(line: string): boolean {
+  const normalizedLine = stripUnquotedInlineComment(line).trim()
+  return normalizedLine.startsWith("[") && normalizedLine.endsWith("]")
+}
+
+function stripUnquotedInlineComment(line: string): string {
+  let quote: "'" | '"' | null = null
+  let index = 0
+  while (index < line.length) {
+    const char = line[index]
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2
+        continue
+      }
+      if (char === '"') quote = null
+      index += 1
+      continue
+    }
+    if (quote === "'") {
+      if (char === "'") quote = null
+      index += 1
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      index += 1
+      continue
+    }
+    if (char === "#") return line.slice(0, index)
+    index += 1
+  }
+  return line
 }
 
 export function parseTomlDottedKey(input: string): readonly string[] | null {


### PR DESCRIPTION
## Summary
This PR fixes the Codex installer config migration that previously wrote unsupported `multi_agent_mode = "steering"` and could duplicate root keys when an existing root setting was indented. It also hardens TOML table detection so `[features] # keep comment` remains the actual features table boundary instead of letting root settings leak under it.

The current Codex source only accepts `none`, `explicitRequestOnly`, and `proactive` for `MultiAgentMode`; `steering` is not a valid value. The installer now writes root-level `multi_agent_mode = "proactive"`, matching Codex's supported enum and proactive delegation behavior.

## Changes
- Update installer multi-agent mode config to emit root `multi_agent_mode = "proactive"`.
- Harden the shared TOML section editor:
  - root and section setting replacement handles indented keys without duplication
  - setting regexes no longer let `\s` consume newlines
  - TOML table headers with inline comments are recognized correctly
- Regenerate the Node installer dist bundle.
- Add source and generated installer regression coverage for indented root keys plus `[features] # comment`.

## Verification
- `bun test packages/omo-codex/src/install/codex-config-toml.test.ts` => 17 pass
- `node --test packages/omo-codex/scripts/install-config.test.mjs` => 15 pass
- `bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test` => PASS in isolated `CODEX_HOME`; real `~/.codex/config.toml` unchanged

Manual QA / evidence:
- `.omo/evidence/20260624-codex-install-toml-root/source-update-repro.txt`
- `.omo/evidence/20260624-codex-install-toml-root/dist-update-repro.txt`
- `.omo/evidence/20260624-codex-install-toml-root/final-precommit-verification.txt`
- `.omo/evidence/20260624-codex-install-toml-root/codex-source-notes.txt`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Codex installer to write a supported multi-agent mode and hardens TOML parsing to prevent duplicate root keys and misidentified tables. The installer now sets root `multi_agent_mode = "proactive"` and correctly handles `[features] # comment` table headers.

- **Bug Fixes**
  - Write root `multi_agent_mode = "proactive"` (replaces invalid `"steering"` and upgrades from `"queue"`).
  - Handle indented root and section keys without creating duplicates.
  - Tighten setting regexes to line-bound matches (use `[ \t]`, not `\s`).
  - Detect TOML table headers with inline comments (e.g., `[features] # keep comment`).
  - Regenerated the installer dist and added regression tests for these cases.

<sup>Written for commit dc92c1b2d19e6299221ca64947a3a0da51f95126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

