### PR TITLE
fix(codex): write proactive multi-agent mode at root

### DIFF
--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -220,7 +220,7 @@ async function runConfigMigration({ env }) {
 		const result = await migrateCodexConfig({ env });
 		if (result.modeChanged.length === 0) return [];
 		return [
-			'[LazyCodex] Codex multi_agent_mode was changed to "steering" for Team Mode support. Tell the user LazyCodex updated the setting from SessionStart so team-mode steering works by default.',
+			'[LazyCodex] Codex multi_agent_mode was changed to "proactive" for Team Mode support. Tell the user LazyCodex updated the setting from SessionStart so proactive team mode works by default.',
 		];
 	} catch (error) {
 		if (!(error instanceof Error)) throw error;

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 
 import { FALLBACK_CATALOG, readModelCatalog } from "./migrate-codex-config/catalog.mjs";
 import { configPaths } from "./migrate-codex-config/config-paths.mjs";
-import { forceMultiAgentModeSteering } from "./migrate-codex-config/multi-agent-mode-guard.mjs";
+import { forceMultiAgentModeProactive } from "./migrate-codex-config/multi-agent-mode-guard.mjs";
 import { forceDisableMultiAgentV2 } from "./migrate-codex-config/multi-agent-v2-guard.mjs";
 import { ensureCodexReasoningConfig as applyReasoningProfile, readRootSettings } from "./migrate-codex-config/root-settings.mjs";
 import { readState, resolveStatePath, writeState } from "./migrate-codex-config/state.mjs";
@@ -58,7 +58,7 @@ export async function migrateConfigFile(configPath, { catalog = FALLBACK_CATALOG
 	const multiAgentChanged = afterMultiAgentGuard !== config;
 	if (multiAgentChanged) config = afterMultiAgentGuard;
 
-	const afterMultiAgentModeGuard = forceMultiAgentModeSteering(config);
+	const afterMultiAgentModeGuard = forceMultiAgentModeProactive(config);
 	const multiAgentModeChanged = afterMultiAgentModeGuard !== config;
 	if (multiAgentModeChanged) config = afterMultiAgentModeGuard;
 

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-mode-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-mode-guard.mjs
@@ -1,9 +1,9 @@
 const MULTI_AGENT_MODE_KEY = "multi_agent_mode";
-const MULTI_AGENT_MODE_STEERING = "steering";
+const MULTI_AGENT_MODE_PROACTIVE = "proactive";
 
-export function forceMultiAgentModeSteering(config) {
-	if (readRootStringSetting(config, MULTI_AGENT_MODE_KEY) === MULTI_AGENT_MODE_STEERING) return config;
-	return replaceOrInsertRootSetting(config, MULTI_AGENT_MODE_KEY, JSON.stringify(MULTI_AGENT_MODE_STEERING));
+export function forceMultiAgentModeProactive(config) {
+	if (readRootStringSetting(config, MULTI_AGENT_MODE_KEY) === MULTI_AGENT_MODE_PROACTIVE) return config;
+	return replaceOrInsertRootSetting(config, MULTI_AGENT_MODE_KEY, JSON.stringify(MULTI_AGENT_MODE_PROACTIVE));
 }
 
 function readRootStringSetting(config, key) {
@@ -42,7 +42,7 @@ function replaceOrInsertRootSetting(config, key, value) {
 }
 
 function isSectionHeader(line) {
-	const trimmed = line.trim();
+	const trimmed = stripUnquotedInlineComment(line).trim();
 	return trimmed.startsWith("[") && trimmed.endsWith("]");
 }
 
@@ -51,4 +51,34 @@ function isRootSetting(line, key) {
 	if (trimmed.startsWith("#") || trimmed.startsWith("[")) return false;
 	const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=/);
 	return match?.[1] === key;
+}
+
+function stripUnquotedInlineComment(line) {
+	let quote = null;
+	let index = 0;
+	while (index < line.length) {
+		const char = line[index];
+		if (quote === "\"") {
+			if (char === "\\") {
+				index += 2;
+				continue;
+			}
+			if (char === "\"") quote = null;
+			index += 1;
+			continue;
+		}
+		if (quote === "'") {
+			if (char === "'") quote = null;
+			index += 1;
+			continue;
+		}
+		if (char === "\"" || char === "'") {
+			quote = char;
+			index += 1;
+			continue;
+		}
+		if (char === "#") return line.slice(0, index);
+		index += 1;
+	}
+	return line;
 }

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/root-settings.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/root-settings.mjs
@@ -62,7 +62,7 @@ function replaceOrInsertRootSetting(config, key, value) {
 }
 
 function isSectionHeader(line) {
-	const trimmed = line.trim();
+	const trimmed = stripUnquotedInlineComment(line).trim();
 	return trimmed.startsWith("[") && trimmed.endsWith("]");
 }
 
@@ -71,4 +71,34 @@ function isRootSetting(line, key) {
 	if (trimmed.startsWith("#") || trimmed.startsWith("[")) return false;
 	const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=/);
 	return match?.[1] === key;
+}
+
+function stripUnquotedInlineComment(line) {
+	let quote = null;
+	let index = 0;
+	while (index < line.length) {
+		const char = line[index];
+		if (quote === "\"") {
+			if (char === "\\") {
+				index += 2;
+				continue;
+			}
+			if (char === "\"") quote = null;
+			index += 1;
+			continue;
+		}
+		if (quote === "'") {
+			if (char === "'") quote = null;
+			index += 1;
+			continue;
+		}
+		if (char === "\"" || char === "'") {
+			quote = char;
+			index += 1;
+			continue;
+		}
+		if (char === "#") return line.slice(0, index);
+		index += 1;
+	}
+	return line;
 }

--- a/packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
@@ -49,7 +49,7 @@ test("#given a newer version #when resolving auto update plan #then plan carries
 });
 
 test("#given SessionStart migration changes multi-agent mode #when startup check runs #then emits team-mode support notice", async () => {
-	const root = await mkdtemp(join(tmpdir(), "lazycodex-steering-notice-"));
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-proactive-notice-"));
 	const env = autoUpdateEnv(root, {
 		LAZYCODEX_CURRENT_VERSION: "1.0.1",
 		LAZYCODEX_LATEST_VERSION: "1.0.1",
@@ -64,10 +64,10 @@ test("#given SessionStart migration changes multi-agent mode #when startup check
 	assert.equal(result.reason, "up-to-date");
 	assert.equal(result.notices.length, 1);
 	assert.match(result.notices[0], /multi_agent_mode/);
-	assert.match(result.notices[0], /steering/);
+	assert.match(result.notices[0], /proactive/);
 	assert.match(result.notices[0], /Team Mode support/);
 	const config = await readFile(join(env.CODEX_HOME, "config.toml"), "utf8");
-	assert.match(config, /^multi_agent_mode = "steering"$/m);
+	assert.match(config, /^multi_agent_mode = "proactive"$/m);
 });
 
 test("#given a newer version #when waited update succeeds #then returns update-started notice and persists pendingNotice", async () => {

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -1,12 +1,38 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
-import { forceMultiAgentModeSteering } from "../scripts/migrate-codex-config/multi-agent-mode-guard.mjs";
+import { forceMultiAgentModeProactive } from "../scripts/migrate-codex-config/multi-agent-mode-guard.mjs";
 import { forceDisableMultiAgentV2 } from "../scripts/migrate-codex-config/multi-agent-v2-guard.mjs";
 import { ensureCodexReasoningConfig, migrateCodexConfig } from "../scripts/migrate-codex-config.mjs";
+
+function parseTomlWithPython(config) {
+	const python = resolvePython();
+	const result = spawnSync(
+		python,
+		[
+			"-c",
+			[
+				"import json, sys, tomllib",
+				"print(json.dumps(tomllib.loads(sys.stdin.read())))",
+			].join("; "),
+		],
+		{ encoding: "utf8", input: config },
+	);
+	assert.equal(result.status, 0, result.stderr);
+	return JSON.parse(result.stdout);
+}
+
+function resolvePython() {
+	for (const command of ["python3", "python"]) {
+		const result = spawnSync(command, ["-c", "import tomllib"], { encoding: "utf8" });
+		if (result.status === 0) return command;
+	}
+	assert.fail("Python with tomllib is required for TOML parse assertions");
+}
 
 test("#given stale root reasoning config #when ensuring config #then replaces stale values without duplicate keys", () => {
 	const result = ensureCodexReasoningConfig(
@@ -212,7 +238,7 @@ test("#given user-customized Codex model config #when migrating #then user value
 	assert.match(content, /model_context_window = 123456/);
 	assert.match(content, /model_reasoning_effort = "medium"/);
 	assert.match(content, /plan_mode_reasoning_effort = "medium"/);
-	assert.match(content, /^multi_agent_mode = "steering"$/m);
+	assert.match(content, /^multi_agent_mode = "proactive"$/m);
 });
 
 test("#given managed config state is malformed #when migrating #then migration ignores stale state safely", async () => {
@@ -331,7 +357,7 @@ test("#given config already matches current catalog #when catalog version advanc
 			"model_context_window = 400000",
 			'model_reasoning_effort = "high"',
 			'plan_mode_reasoning_effort = "xhigh"',
-			'multi_agent_mode = "steering"',
+			'multi_agent_mode = "proactive"',
 			"",
 			"[features.multi_agent_v2]",
 			"enabled = false",
@@ -527,25 +553,46 @@ test("#given global config without multi_agent_v2 section #when full migration r
 	assert.deepEqual(result.modeChanged, [configPath]);
 	const content = await readFile(configPath, "utf8");
 	assert.match(content, /\[features\.multi_agent_v2\]\nenabled = false\n/);
-	assert.match(content, /^multi_agent_mode = "steering"$/m);
+	assert.match(content, /^multi_agent_mode = "proactive"$/m);
 });
 
-test("#given queue multi-agent mode #when forcing steering #then patches root setting", () => {
+test("#given queue multi-agent mode #when forcing proactive #then patches root setting", () => {
 	const config = ['multi_agent_mode = "queue"', "", "[features]", "multi_agent = true", ""].join("\n");
 
-	const result = forceMultiAgentModeSteering(config);
+	const result = forceMultiAgentModeProactive(config);
 
-	assert.match(result, /^multi_agent_mode = "steering"$/m);
+	assert.match(result, /^multi_agent_mode = "proactive"$/m);
 	assert.doesNotMatch(result, /multi_agent_mode = "queue"/);
 	assert.match(result, /\[features\]/);
 });
 
-test("#given steering multi-agent mode #when forcing steering #then returns config unchanged", () => {
-	const config = ['multi_agent_mode = "steering" # user already opted in', "", "[features]", "multi_agent = true", ""].join("\n");
+test("#given proactive multi-agent mode #when forcing proactive #then returns config unchanged", () => {
+	const config = ['multi_agent_mode = "proactive" # user already opted in', "", "[features]", "multi_agent = true", ""].join("\n");
 
-	const result = forceMultiAgentModeSteering(config);
+	const result = forceMultiAgentModeProactive(config);
 
 	assert.equal(result, config);
+});
+
+test("#given inline-comment features table #when forcing proactive #then parsed setting remains at root", () => {
+	const config = ["[features] # keep comment", "multi_agent = true", ""].join("\n");
+
+	const result = forceMultiAgentModeProactive(config);
+	const parsed = parseTomlWithPython(result);
+
+	assert.equal(parsed.multi_agent_mode, "proactive");
+	assert.equal(parsed.features.multi_agent, true);
+	assert.equal("multi_agent_mode" in parsed.features, false);
+	assert.match(result, /^multi_agent_mode = "proactive"\n\[features\] # keep comment/m);
+});
+
+test("#given indented root proactive mode #when forcing proactive #then no duplicate root setting is inserted", () => {
+	const config = ['  multi_agent_mode = "proactive" # user already opted in', "", "[features] # keep comment", "multi_agent = true", ""].join("\n");
+
+	const result = forceMultiAgentModeProactive(config);
+
+	assert.equal(result, config);
+	assert.equal(result.match(/multi_agent_mode\s*=/g)?.length, 1);
 });
 
 test("#given global config with forced multi_agent_v2 #when full migration runs #then disables it on disk", async () => {

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -556,6 +556,42 @@ test("#given global config without multi_agent_v2 section #when full migration r
 	assert.match(content, /^multi_agent_mode = "proactive"$/m);
 });
 
+test("#given global config starts with inline-comment features table #when full migration runs #then managed root settings stay at TOML root", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-root-settings-inline-features-"));
+	const codexHome = join(root, "codex-home");
+	await mkdir(codexHome, { recursive: true });
+	const configPath = join(codexHome, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			"[features] # keep comment",
+			"plugins = true",
+			"",
+		].join("\n"),
+	);
+
+	const result = await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json") },
+		cwd: root,
+	});
+
+	assert.deepEqual(result.changed, [configPath]);
+	const content = await readFile(configPath, "utf8");
+	const parsed = parseTomlWithPython(content);
+	assert.equal(parsed.multi_agent_mode, "proactive");
+	assert.equal(parsed.model, "gpt-5.5");
+	assert.equal(parsed.model_context_window, 400000);
+	assert.equal(parsed.model_reasoning_effort, "high");
+	assert.equal(parsed.plan_mode_reasoning_effort, "xhigh");
+	assert.equal(parsed.features.plugins, true);
+	assert.equal("multi_agent_mode" in parsed.features, false);
+	assert.equal("model" in parsed.features, false);
+	assert.equal("model_context_window" in parsed.features, false);
+	assert.match(content, /^model = "gpt-5\.5"\nmodel_context_window = 400000/m);
+	assert.match(content, /^multi_agent_mode = "proactive"$/m);
+	assert.match(content, /\[features\] # keep comment\nplugins = true/);
+});
+
 test("#given queue multi-agent mode #when forcing proactive #then patches root setting", () => {
 	const config = ['multi_agent_mode = "queue"', "", "[features]", "multi_agent = true", ""].join("\n");
 


### PR DESCRIPTION
## Summary
This PR fixes the Codex plugin SessionStart config migration to write Codex's supported proactive multi-agent mode at the TOML root. The previous value, `steering`, is not a valid `MultiAgentMode` in the current Codex source, and the guard could also insert the setting under `[features] # comment` instead of root.

The migration guard now forces root `multi_agent_mode = "proactive"`, recognizes inline-comment table headers, and keeps the restart notice aligned with the actual Codex mode.

## Changes
- Rename the migration helper from steering to proactive and write `multi_agent_mode = "proactive"`.
- Keep the setting at TOML root even when the next table header has an inline comment.
- Preserve existing indented root proactive settings instead of duplicating them.
- Update auto-update SessionStart notice copy to mention proactive mode.
- Add Python `tomllib` parse assertions for the inline-comment table regression.

## Verification
- `node --test packages/omo-codex/plugin/test/migrate-codex-config.test.mjs` => 33 pass
- `node --test packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs` => 8 pass
- `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` => PASS; live isolated Codex app-server turn completed with plugin `hook/started` and `hook/completed` notifications for `sessionStart` and `userPromptSubmit`; real `~/.codex/config.toml` unchanged

Manual QA / evidence:
- `.omo/evidence/20260624-codex-plugin-multi-agent-mode/plugin-guard-repro.txt`
- `.omo/evidence/20260624-codex-plugin-multi-agent-mode/final-precommit-verification.txt`
- `.omo/evidence/20260624-codex-plugin-multi-agent-mode/app-server-drive-plugin-worktree.txt`
- `.omo/evidence/20260624-codex-plugin-multi-agent-mode/codex-source-notes.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes `multi_agent_mode = "proactive"` at the TOML root and keeps all managed settings at the root even with inline-commented table headers. Updates the SessionStart notice so Team Mode defaults to a valid proactive mode.

- **Bug Fixes**
  - Force root `multi_agent_mode = "proactive"` (replaces invalid `steering`).
  - Keep managed root settings (model, context window, reasoning efforts, multi_agent_mode) at TOML root when the next table header has an inline comment.
  - Preserve existing indented root proactive settings to avoid duplicates.
  - Update SessionStart restart notice to mention proactive mode and add Python `tomllib` parse assertions.

<sup>Written for commit 9cdce04371b53b9f8962b58ddc097fd9f6015bb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

