### PR TITLE
fix(qa): render ANSI inverse by swapping colors

### DIFF
--- a/script/qa/web-terminal-renderer.mjs
+++ b/script/qa/web-terminal-renderer.mjs
@@ -32,6 +32,9 @@ const BASIC_ANSI_COLORS = {
   "bright-white": "#ffffff",
 };
 
+export const DEFAULT_TERMINAL_FOREGROUND = "#d8dee9";
+export const DEFAULT_TERMINAL_BACKGROUND = "#090b10";
+
 export function escapeHtml(value) {
   return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }
@@ -169,14 +172,16 @@ function spanAttributes(state) {
   if (state.dim) classes.push("ansi-dim");
   if (state.italic) classes.push("ansi-italic");
   if (state.underline) classes.push("ansi-underline");
-  if (state.inverse) classes.push("ansi-inverse");
   if (state.strike) classes.push("ansi-strike");
+  const effectiveFg = state.inverse ? state.bg || DEFAULT_TERMINAL_BACKGROUND : state.fg;
+  const effectiveBg = state.inverse ? state.fg || DEFAULT_TERMINAL_FOREGROUND : state.bg;
   for (const [value, cssProperty, classPrefix] of [
-    [state.fg, "color", "fg-"],
-    [state.bg, "background-color", "bg-"],
+    [effectiveFg, "color", "fg-"],
+    [effectiveBg, "background-color", "bg-"],
   ]) {
     if (!value) continue;
-    if (value.startsWith(classPrefix)) classes.push(`ansi-${value}`);
+    const colorName = value.match(/^(?:fg|bg)-(.+)$/)?.[1];
+    if (colorName) classes.push(`ansi-${classPrefix}${colorName}`);
     else styles.push(`${cssProperty}: ${value}`);
   }
   const attrs = [];

--- a/script/qa/web-terminal-visual-qa.mjs
+++ b/script/qa/web-terminal-visual-qa.mjs
@@ -4,7 +4,14 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { ansiColorCss, escapeHtml, renderAnsiToHtml, stripAnsi } from "./web-terminal-renderer.mjs";
+import {
+  DEFAULT_TERMINAL_BACKGROUND,
+  DEFAULT_TERMINAL_FOREGROUND,
+  ansiColorCss,
+  escapeHtml,
+  renderAnsiToHtml,
+  stripAnsi,
+} from "./web-terminal-renderer.mjs";
 
 const HELP = `web-terminal-visual-qa
 
@@ -102,9 +109,9 @@ function writeHtml({ title, ansi, outPath, cols, wrap }) {
 <title>${escapeHtml(title)}</title>
 <style>
 :root { color-scheme: dark; }
-body { margin: 0; background: #101217; color: #d8dee9; font: 13px/1.35 "SFMono-Regular", "Cascadia Mono", "JetBrains Mono", "Menlo", "Consolas", "Liberation Mono", ui-monospace, monospace; }
+body { margin: 0; background: #101217; color: ${DEFAULT_TERMINAL_FOREGROUND}; font: 13px/1.35 "SFMono-Regular", "Cascadia Mono", "JetBrains Mono", "Menlo", "Consolas", "Liberation Mono", ui-monospace, monospace; }
 main { min-height: 100vh; box-sizing: border-box; padding: 20px; }
-.terminal { width: min(100%, ${terminalWidth}ch); max-width: calc(100vw - 40px); border: 1px solid #3b4452; background: #090b10; box-shadow: 0 20px 80px rgb(0 0 0 / 40%); }
+.terminal { width: min(100%, ${terminalWidth}ch); max-width: calc(100vw - 40px); border: 1px solid #3b4452; background: ${DEFAULT_TERMINAL_BACKGROUND}; box-shadow: 0 20px 80px rgb(0 0 0 / 40%); }
 .bar { display: flex; gap: 8px; align-items: center; padding: 8px 12px; border-bottom: 1px solid #303846; color: #aab7c4; background: #171b22; font-size: 12px; }
 .dot { width: 10px; height: 10px; border-radius: 999px; background: #6b7280; }
 pre { margin: 0; padding: 14px 16px; white-space: ${whiteSpace}; overflow-wrap: ${overflowWrap}; tab-size: 8; overflow: auto; }
@@ -113,7 +120,6 @@ pre { margin: 0; padding: 14px 16px; white-space: ${whiteSpace}; overflow-wrap: 
 .ansi-italic { font-style: italic; }
 .ansi-underline { text-decoration: underline; }
 .ansi-strike { text-decoration: line-through; }
-.ansi-inverse { filter: invert(1); }
 ${ansiColorCss()}
 </style>
 </head>

--- a/script/web-terminal-visual-qa.test.ts
+++ b/script/web-terminal-visual-qa.test.ts
@@ -3,11 +3,6 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
-import {
-  DEFAULT_TERMINAL_BACKGROUND,
-  DEFAULT_TERMINAL_FOREGROUND,
-  renderAnsiToHtml,
-} from "./qa/web-terminal-renderer.mjs"
 
 const helperPath = new URL("./qa/web-terminal-visual-qa.mjs", import.meta.url)
 const helperFilePath = fileURLToPath(helperPath)
@@ -140,32 +135,74 @@ describe("web terminal visual QA helper", () => {
 
     const html = readFileSync(join(dir, "terminal.html"), "utf8")
     expect(html).toContain(
-      `<span style="color: ${DEFAULT_TERMINAL_BACKGROUND}; background-color: ${DEFAULT_TERMINAL_FOREGROUND}"> selected row </span>`,
+      '<span style="color: #090b10; background-color: #d8dee9"> selected row </span>',
     )
     expect(html).not.toContain("ansi-inverse")
     expect(html).not.toContain("filter: invert")
   })
 
-  test("#given inverse video with explicit colors #when rendering #then foreground and background classes swap", () => {
+  test("#given inverse video with explicit colors #when rendering #then foreground and background classes swap", async () => {
     // given
-    const ansi = "\u001b[31;44;7m selected \u001b[0m"
+    const dir = makeTempDir()
+    const transcript = join(dir, "inverse-explicit.txt")
+    writeFileSync(transcript, "\u001b[31;44;7m selected \u001b[0m\n", "utf8")
 
     // when
-    const html = renderAnsiToHtml(ansi)
+    const proc = Bun.spawn({
+      cmd: [
+        process.execPath,
+        helperFilePath,
+        "--title",
+        "Inverse Explicit QA",
+        "--from-file",
+        transcript,
+        "--evidence-dir",
+        dir,
+        "--no-browser",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [exitCode, stderrText] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
 
     // then
-    expect(html).toBe('<span class="ansi-fg-blue ansi-bg-red"> selected </span>')
+    expect(stderrText).toBe("")
+    expect(exitCode).toBe(0)
+
+    const html = readFileSync(join(dir, "terminal.html"), "utf8")
+    expect(html).toContain('<span class="ansi-fg-blue ansi-bg-red"> selected </span>')
   })
 
-  test("#given inverse video is reset #when rendering #then later text uses normal colors", () => {
+  test("#given inverse video is reset #when rendering #then later text uses normal colors", async () => {
     // given
-    const ansi = "\u001b[31;44;7minverse\u001b[27m normal\u001b[0m plain"
+    const dir = makeTempDir()
+    const transcript = join(dir, "inverse-reset.txt")
+    writeFileSync(transcript, "\u001b[31;44;7minverse\u001b[27m normal\u001b[0m plain\n", "utf8")
 
     // when
-    const html = renderAnsiToHtml(ansi)
+    const proc = Bun.spawn({
+      cmd: [
+        process.execPath,
+        helperFilePath,
+        "--title",
+        "Inverse Reset QA",
+        "--from-file",
+        transcript,
+        "--evidence-dir",
+        dir,
+        "--no-browser",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [exitCode, stderrText] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
 
     // then
-    expect(html).toBe(
+    expect(stderrText).toBe("")
+    expect(exitCode).toBe(0)
+
+    const html = readFileSync(join(dir, "terminal.html"), "utf8")
+    expect(html).toContain(
       '<span class="ansi-fg-blue ansi-bg-red">inverse</span><span class="ansi-fg-red ansi-bg-blue"> normal</span> plain',
     )
   })

--- a/script/web-terminal-visual-qa.test.ts
+++ b/script/web-terminal-visual-qa.test.ts
@@ -3,6 +3,11 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
+import {
+  DEFAULT_TERMINAL_BACKGROUND,
+  DEFAULT_TERMINAL_FOREGROUND,
+  renderAnsiToHtml,
+} from "./qa/web-terminal-renderer.mjs"
 
 const helperPath = new URL("./qa/web-terminal-visual-qa.mjs", import.meta.url)
 const helperFilePath = fileURLToPath(helperPath)
@@ -103,6 +108,66 @@ describe("web terminal visual QA helper", () => {
     expect(html).toContain('class="ansi-fg-red"')
     expect(html).toContain('class="ansi-bold ansi-fg-green"')
     expect(html).toContain("bold green")
+  })
+
+  test("#given inverse video with default colors #when rendering #then foreground and background swap without filter CSS", async () => {
+    // given
+    const dir = makeTempDir()
+    const transcript = join(dir, "inverse-default.txt")
+    writeFileSync(transcript, "\u001b[7m selected row \u001b[0m\n", "utf8")
+
+    // when
+    const proc = Bun.spawn({
+      cmd: [
+        process.execPath,
+        helperFilePath,
+        "--title",
+        "Inverse Default QA",
+        "--from-file",
+        transcript,
+        "--evidence-dir",
+        dir,
+        "--no-browser",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [exitCode, stderrText] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
+
+    // then
+    expect(stderrText).toBe("")
+    expect(exitCode).toBe(0)
+
+    const html = readFileSync(join(dir, "terminal.html"), "utf8")
+    expect(html).toContain(
+      `<span style="color: ${DEFAULT_TERMINAL_BACKGROUND}; background-color: ${DEFAULT_TERMINAL_FOREGROUND}"> selected row </span>`,
+    )
+    expect(html).not.toContain("ansi-inverse")
+    expect(html).not.toContain("filter: invert")
+  })
+
+  test("#given inverse video with explicit colors #when rendering #then foreground and background classes swap", () => {
+    // given
+    const ansi = "\u001b[31;44;7m selected \u001b[0m"
+
+    // when
+    const html = renderAnsiToHtml(ansi)
+
+    // then
+    expect(html).toBe('<span class="ansi-fg-blue ansi-bg-red"> selected </span>')
+  })
+
+  test("#given inverse video is reset #when rendering #then later text uses normal colors", () => {
+    // given
+    const ansi = "\u001b[31;44;7minverse\u001b[27m normal\u001b[0m plain"
+
+    // when
+    const html = renderAnsiToHtml(ansi)
+
+    // then
+    expect(html).toBe(
+      '<span class="ansi-fg-blue ansi-bg-red">inverse</span><span class="ansi-fg-red ansi-bg-blue"> normal</span> plain',
+    )
   })
 
   test("#given truecolor and OSC controls #when rendering #then colors are preserved and controls are stripped", async () => {


### PR DESCRIPTION
## Summary
Fixes the web terminal visual QA renderer's ANSI inverse video handling. Instead of rendering inverse video through CSS `filter: invert(1)`, the renderer now resolves the effective foreground/background colors and swaps them like a terminal, including default terminal foreground/background when either side is unset.

## Changes
- Export shared terminal default foreground/background colors from `script/qa/web-terminal-renderer.mjs`.
- Compute inverse video in the renderer by swapping effective fg/bg values while preserving normal ANSI classes, bright colors, 256/truecolor styling, resets, and OSC stripping behavior.
- Remove `.ansi-inverse { filter: invert(1); }` from the HTML helper and use the shared defaults for the page terminal colors.
- Add focused helper-surface tests for default inverse colors, explicit fg/bg inverse swaps, and SGR 27 reset/un-inverse behavior.

## Verification
Automated:
- `bun test script/web-terminal-visual-qa.test.ts` -> 10 pass, 0 fail. Output: `.omo/evidence/20260624-web-terminal-inverse-rendering/bun-test-web-terminal-visual-qa.txt`
- `bun run typecheck:script` -> exit 0. Output: `.omo/evidence/20260624-web-terminal-inverse-rendering/typecheck-script.txt`
- `node --check script/qa/web-terminal-renderer.mjs script/qa/web-terminal-visual-qa.mjs` -> exit 0. Output: `.omo/evidence/20260624-web-terminal-inverse-rendering/node-check-web-terminal.txt`
- `git diff --check` -> exit 0. Output: `.omo/evidence/20260624-web-terminal-inverse-rendering/git-diff-check.txt`

Manual/visual QA:
- Rendered an ANSI transcript containing a default inverse selected row and explicit inverse status bar through `script/qa/web-terminal-visual-qa.mjs`.
- Browser PNG capture succeeded: `.omo/evidence/20260624-web-terminal-inverse-rendering/terminal.png` (1268 x 840, non-empty).
- Binary observable: `terminal.html` contains `style="color: #090b10; background-color: #d8dee9"` for default inverse and `class="ansi-fg-white ansi-bg-black"` for explicit inverse.
- Binary observable: `terminal.html` contains no `ansi-inverse` class and no `filter: invert` CSS.
- Evidence summary: `.omo/evidence/20260624-web-terminal-inverse-rendering/evidence-summary.md`

## Residual Risk
Scoped to the web terminal visual QA renderer. This does not drive the full OpenCode/Codex harness because no OpenCode/Codex plugin component was changed; the user-facing proof is the generated renderer artifact plus targeted renderer tests.

## Verification Notes
- First CI loop failed `typecheck (ubuntu-latest)` because the test imported an `.mjs` helper without a declaration file. Fixed by exercising inverse behavior through the public helper script surface instead, then reran `bun run typecheck:script` successfully.
