### PR TITLE
fix(codex): remove root multi_agent_mode writes

### DIFF
--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -220,7 +220,7 @@ async function runConfigMigration({ env }) {
 		const result = await migrateCodexConfig({ env });
 		if (result.modeChanged.length === 0) return [];
 		return [
-			'[LazyCodex] Codex multi_agent_mode was changed to "proactive" for Team Mode support. Tell the user LazyCodex updated the setting from SessionStart so proactive team mode works by default.',
+			"[LazyCodex] Removed unsupported Codex root multi_agent_mode from config.toml. Tell the user LazyCodex cleaned up a stale OMO-managed setting so Codex uses its supported per-turn multiAgentMode API.",
 		];
 	} catch (error) {
 		if (!(error instanceof Error)) throw error;

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 
 import { FALLBACK_CATALOG, readModelCatalog } from "./migrate-codex-config/catalog.mjs";
 import { configPaths } from "./migrate-codex-config/config-paths.mjs";
-import { forceMultiAgentModeProactive } from "./migrate-codex-config/multi-agent-mode-guard.mjs";
+import { removeUnsupportedRootMultiAgentMode } from "./migrate-codex-config/multi-agent-mode-guard.mjs";
 import { forceDisableMultiAgentV2 } from "./migrate-codex-config/multi-agent-v2-guard.mjs";
 import { ensureCodexReasoningConfig as applyReasoningProfile, readRootSettings } from "./migrate-codex-config/root-settings.mjs";
 import { readState, resolveStatePath, writeState } from "./migrate-codex-config/state.mjs";
@@ -58,7 +58,7 @@ export async function migrateConfigFile(configPath, { catalog = FALLBACK_CATALOG
 	const multiAgentChanged = afterMultiAgentGuard !== config;
 	if (multiAgentChanged) config = afterMultiAgentGuard;
 
-	const afterMultiAgentModeGuard = forceMultiAgentModeProactive(config);
+	const afterMultiAgentModeGuard = removeUnsupportedRootMultiAgentMode(config);
 	const multiAgentModeChanged = afterMultiAgentModeGuard !== config;
 	if (multiAgentModeChanged) config = afterMultiAgentModeGuard;
 

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-mode-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-mode-guard.mjs
@@ -1,44 +1,20 @@
 const MULTI_AGENT_MODE_KEY = "multi_agent_mode";
-const MULTI_AGENT_MODE_PROACTIVE = "proactive";
 
-export function forceMultiAgentModeProactive(config) {
-	if (readRootStringSetting(config, MULTI_AGENT_MODE_KEY) === MULTI_AGENT_MODE_PROACTIVE) return config;
-	return replaceOrInsertRootSetting(config, MULTI_AGENT_MODE_KEY, JSON.stringify(MULTI_AGENT_MODE_PROACTIVE));
-}
-
-function readRootStringSetting(config, key) {
-	for (const line of config.split(/\n/)) {
-		if (isSectionHeader(line)) return null;
-		const match = line.trimStart().match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]*)"/);
-		if (match?.[1] === key) return match[2] ?? null;
-	}
-	return null;
-}
-
-function replaceOrInsertRootSetting(config, key, value) {
+export function removeUnsupportedRootMultiAgentMode(config) {
 	const lines = config.split(/\n/);
 	const output = [];
-	let replaced = false;
-	let inserted = false;
 	let inRoot = true;
+	let changed = false;
 	for (const line of lines) {
 		const sectionHeader = isSectionHeader(line);
-		if (inRoot && !inserted && sectionHeader) {
-			if (!replaced) output.push(`${key} = ${value}`);
-			inserted = true;
-		}
-		if (inRoot && isRootSetting(line, key)) {
-			if (!replaced) {
-				output.push(`${key} = ${value}`);
-				replaced = true;
-			}
+		if (inRoot && isRootSetting(line, MULTI_AGENT_MODE_KEY)) {
+			changed = true;
 			continue;
 		}
 		output.push(line);
 		if (sectionHeader) inRoot = false;
 	}
-	if (!replaced && !inserted) output.push(`${key} = ${value}`);
-	return output.join("\n");
+	return changed ? output.join("\n") : config;
 }
 
 function isSectionHeader(line) {

--- a/packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs
@@ -48,8 +48,8 @@ test("#given a newer version #when resolving auto update plan #then plan carries
 	assert.equal(plan.latestVersion, "1.0.1");
 });
 
-test("#given SessionStart migration changes multi-agent mode #when startup check runs #then emits team-mode support notice", async () => {
-	const root = await mkdtemp(join(tmpdir(), "lazycodex-proactive-notice-"));
+test("#given SessionStart migration removes unsupported root multi-agent mode #when startup check runs #then emits cleanup notice", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-root-mode-cleanup-notice-"));
 	const env = autoUpdateEnv(root, {
 		LAZYCODEX_CURRENT_VERSION: "1.0.1",
 		LAZYCODEX_LATEST_VERSION: "1.0.1",
@@ -64,10 +64,10 @@ test("#given SessionStart migration changes multi-agent mode #when startup check
 	assert.equal(result.reason, "up-to-date");
 	assert.equal(result.notices.length, 1);
 	assert.match(result.notices[0], /multi_agent_mode/);
-	assert.match(result.notices[0], /proactive/);
-	assert.match(result.notices[0], /Team Mode support/);
+	assert.match(result.notices[0], /Removed unsupported Codex root/);
+	assert.match(result.notices[0], /per-turn multiAgentMode API/);
 	const config = await readFile(join(env.CODEX_HOME, "config.toml"), "utf8");
-	assert.match(config, /^multi_agent_mode = "proactive"$/m);
+	assert.doesNotMatch(config, /^\s*multi_agent_mode\s*=/m);
 });
 
 test("#given a newer version #when waited update succeeds #then returns update-started notice and persists pendingNotice", async () => {

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
-import { forceMultiAgentModeProactive } from "../scripts/migrate-codex-config/multi-agent-mode-guard.mjs";
+import { removeUnsupportedRootMultiAgentMode } from "../scripts/migrate-codex-config/multi-agent-mode-guard.mjs";
 import { forceDisableMultiAgentV2 } from "../scripts/migrate-codex-config/multi-agent-v2-guard.mjs";
 import { ensureCodexReasoningConfig, migrateCodexConfig } from "../scripts/migrate-codex-config.mjs";
 
@@ -208,7 +208,7 @@ test("#given model catalog is malformed and stale config #when migrating #then f
 	assert.match(content, /model_context_window = 400000/);
 });
 
-test("#given user-customized Codex model config #when migrating #then user values are preserved", async () => {
+test("#given user-customized Codex model config #when migrating #then user values are preserved without root multi-agent mode", async () => {
 	const root = await mkdtemp(join(tmpdir(), "lazycodex-config-custom-"));
 	const codexHome = join(root, "codex-home");
 	await mkdir(codexHome, { recursive: true });
@@ -232,13 +232,13 @@ test("#given user-customized Codex model config #when migrating #then user value
 	});
 
 	const content = await readFile(join(codexHome, "config.toml"), "utf8");
-	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
-	assert.deepEqual(result.modeChanged, [join(codexHome, "config.toml")]);
+	assert.deepEqual(result.changed, []);
+	assert.deepEqual(result.modeChanged, []);
 	assert.match(content, /model = "gpt-5\.4"/);
 	assert.match(content, /model_context_window = 123456/);
 	assert.match(content, /model_reasoning_effort = "medium"/);
 	assert.match(content, /plan_mode_reasoning_effort = "medium"/);
-	assert.match(content, /^multi_agent_mode = "proactive"$/m);
+	assert.doesNotMatch(content, /^\s*multi_agent_mode\s*=/m);
 });
 
 test("#given managed config state is malformed #when migrating #then migration ignores stale state safely", async () => {
@@ -393,9 +393,12 @@ test("#given config already matches current catalog #when catalog version advanc
 	});
 
 	const state = JSON.parse(await readFile(statePath, "utf8"));
-	assert.deepEqual(result.changed, []);
+	assert.deepEqual(result.changed, [configPath]);
+	assert.deepEqual(result.modeChanged, [configPath]);
 	assert.equal(state.files[configPath].managed, true);
 	assert.equal(state.files[configPath].catalogVersion, "test.role-only");
+	const content = await readFile(configPath, "utf8");
+	assert.doesNotMatch(content, /^\s*multi_agent_mode\s*=/m);
 });
 
 test("#given multi_agent_v2 enabled #when forcing disable #then flips the flag to false", () => {
@@ -550,10 +553,10 @@ test("#given global config without multi_agent_v2 section #when full migration r
 	});
 
 	assert.deepEqual(result.changed, [configPath]);
-	assert.deepEqual(result.modeChanged, [configPath]);
+	assert.deepEqual(result.modeChanged, []);
 	const content = await readFile(configPath, "utf8");
 	assert.match(content, /\[features\.multi_agent_v2\]\nenabled = false\n/);
-	assert.match(content, /^multi_agent_mode = "proactive"$/m);
+	assert.doesNotMatch(content, /^\s*multi_agent_mode\s*=/m);
 });
 
 test("#given global config starts with inline-comment features table #when full migration runs #then managed root settings stay at TOML root", async () => {
@@ -578,7 +581,7 @@ test("#given global config starts with inline-comment features table #when full 
 	assert.deepEqual(result.changed, [configPath]);
 	const content = await readFile(configPath, "utf8");
 	const parsed = parseTomlWithPython(content);
-	assert.equal(parsed.multi_agent_mode, "proactive");
+	assert.equal("multi_agent_mode" in parsed, false);
 	assert.equal(parsed.model, "gpt-5.5");
 	assert.equal(parsed.model_context_window, 400000);
 	assert.equal(parsed.model_reasoning_effort, "high");
@@ -588,47 +591,47 @@ test("#given global config starts with inline-comment features table #when full 
 	assert.equal("model" in parsed.features, false);
 	assert.equal("model_context_window" in parsed.features, false);
 	assert.match(content, /^model = "gpt-5\.5"\nmodel_context_window = 400000/m);
-	assert.match(content, /^multi_agent_mode = "proactive"$/m);
+	assert.doesNotMatch(content, /^\s*multi_agent_mode\s*=/m);
 	assert.match(content, /\[features\] # keep comment\nplugins = true/);
 });
 
-test("#given queue multi-agent mode #when forcing proactive #then patches root setting", () => {
+test("#given queue multi-agent mode #when removing unsupported root key #then deletes root setting", () => {
 	const config = ['multi_agent_mode = "queue"', "", "[features]", "multi_agent = true", ""].join("\n");
 
-	const result = forceMultiAgentModeProactive(config);
+	const result = removeUnsupportedRootMultiAgentMode(config);
 
-	assert.match(result, /^multi_agent_mode = "proactive"$/m);
+	assert.doesNotMatch(result, /^\s*multi_agent_mode\s*=/m);
 	assert.doesNotMatch(result, /multi_agent_mode = "queue"/);
 	assert.match(result, /\[features\]/);
 });
 
-test("#given proactive multi-agent mode #when forcing proactive #then returns config unchanged", () => {
+test("#given proactive multi-agent mode #when removing unsupported root key #then deletes root setting", () => {
 	const config = ['multi_agent_mode = "proactive" # user already opted in', "", "[features]", "multi_agent = true", ""].join("\n");
 
-	const result = forceMultiAgentModeProactive(config);
+	const result = removeUnsupportedRootMultiAgentMode(config);
 
-	assert.equal(result, config);
+	assert.doesNotMatch(result, /^\s*multi_agent_mode\s*=/m);
+	assert.match(result, /\[features\]/);
 });
 
-test("#given inline-comment features table #when forcing proactive #then parsed setting remains at root", () => {
+test("#given inline-comment features table #when removing unsupported root key #then config stays unchanged", () => {
 	const config = ["[features] # keep comment", "multi_agent = true", ""].join("\n");
 
-	const result = forceMultiAgentModeProactive(config);
+	const result = removeUnsupportedRootMultiAgentMode(config);
 	const parsed = parseTomlWithPython(result);
 
-	assert.equal(parsed.multi_agent_mode, "proactive");
+	assert.equal(result, config);
+	assert.equal("multi_agent_mode" in parsed, false);
 	assert.equal(parsed.features.multi_agent, true);
-	assert.equal("multi_agent_mode" in parsed.features, false);
-	assert.match(result, /^multi_agent_mode = "proactive"\n\[features\] # keep comment/m);
 });
 
-test("#given indented root proactive mode #when forcing proactive #then no duplicate root setting is inserted", () => {
+test("#given indented root proactive mode #when removing unsupported root key #then no root setting remains", () => {
 	const config = ['  multi_agent_mode = "proactive" # user already opted in', "", "[features] # keep comment", "multi_agent = true", ""].join("\n");
 
-	const result = forceMultiAgentModeProactive(config);
+	const result = removeUnsupportedRootMultiAgentMode(config);
 
-	assert.equal(result, config);
-	assert.equal(result.match(/multi_agent_mode\s*=/g)?.length, 1);
+	assert.equal(result.match(/multi_agent_mode\s*=/g)?.length ?? 0, 0);
+	assert.match(result, /^\[features\] # keep comment$/m);
 });
 
 test("#given global config with forced multi_agent_v2 #when full migration runs #then disables it on disk", async () => {

--- a/packages/omo-codex/scripts/install-config.test.mjs
+++ b/packages/omo-codex/scripts/install-config.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { updateCodexConfig } from "./install-dist/install-local.mjs";
 
-test("#given empty Codex config #when script installer updates config #then enables proactive mode with ten thousand session threads", async () => {
+test("#given empty Codex config #when script installer updates config #then avoids unsupported root multi-agent mode", async () => {
 	// given
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-"));
 	const configPath = join(root, "config.toml");
@@ -22,14 +22,14 @@ test("#given empty Codex config #when script installer updates config #then enab
 
 	// then
 	const config = await readFile(configPath, "utf8");
-	assert.match(config, /^multi_agent_mode = "proactive"$/m);
+	assert.doesNotMatch(config, /^\s*multi_agent_mode\s*=/m);
 	assert.match(config, /\[features\.multi_agent_v2\]/);
 	const v2Section = config.slice(config.indexOf("[features.multi_agent_v2]")).split(/^\[/m).slice(0, 1).join("");
 	assert.doesNotMatch(v2Section, /enabled\s*=/);
 	assert.match(config, /max_concurrent_threads_per_session = 10000/);
 });
 
-test("#given queue multi-agent mode #when script installer updates config #then switches to proactive mode for team support", async () => {
+test("#given queue multi-agent mode #when script installer updates config #then removes unsupported root key", async () => {
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-mode-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
@@ -52,17 +52,17 @@ test("#given queue multi-agent mode #when script installer updates config #then 
 	});
 
 	const config = await readFile(configPath, "utf8");
-	assert.match(config, /^multi_agent_mode = "proactive"$/m);
+	assert.doesNotMatch(config, /^\s*multi_agent_mode\s*=/m);
 	assert.doesNotMatch(config, /multi_agent_mode = "queue"/);
 });
 
-test("#given indented root mode and inline-comment features table #when script installer updates config #then emits one proactive root key and one features table", async () => {
+test("#given indented steering mode and inline-comment features table #when script installer updates config #then removes root key and keeps one features table", async () => {
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-toml-root-regression-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
 		configPath,
 		[
-			'  multi_agent_mode = "queue"',
+			'  multi_agent_mode = "steering"',
 			"",
 			"[features] # keep comment",
 			"plugins = false",
@@ -79,9 +79,8 @@ test("#given indented root mode and inline-comment features table #when script i
 	});
 
 	const config = await readFile(configPath, "utf8");
-	assert.equal(config.match(/^\s*multi_agent_mode\s*=/gm)?.length, 1);
+	assert.equal(config.match(/^\s*multi_agent_mode\s*=/gm)?.length ?? 0, 0);
 	assert.equal(config.match(/^\s*\[features\](?:\s*#.*)?$/gm)?.length, 1);
-	assert.match(config, /^multi_agent_mode = "proactive"$/m);
 	assert.match(config, /^\[features\] # keep comment$/m);
 	assert.doesNotMatch(config, /multi_agent_mode = "queue"/);
 	assert.doesNotMatch(config, /multi_agent_mode = "steering"/);

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -8186,25 +8186,33 @@ function parseProfileMatch(match) {
 
 // packages/omo-codex/src/install/codex-multi-agent-mode-config.ts
 var CODEX_MULTI_AGENT_MODE_KEY = "multi_agent_mode";
-var CODEX_MULTI_AGENT_MODE_PROACTIVE = "proactive";
-function ensureCodexMultiAgentModeConfig(config) {
-  if (readRootStringSetting(config, CODEX_MULTI_AGENT_MODE_KEY) === CODEX_MULTI_AGENT_MODE_PROACTIVE) {
-    return config;
+function removeUnsupportedCodexMultiAgentModeConfig(config) {
+  const lines = config.split(/\n/);
+  const output = [];
+  let inRoot = true;
+  let changed = false;
+  for (const line of lines) {
+    const sectionHeader = isSectionHeader2(line);
+    if (inRoot && isRootSetting2(line, CODEX_MULTI_AGENT_MODE_KEY)) {
+      changed = true;
+      continue;
+    }
+    output.push(line);
+    if (sectionHeader)
+      inRoot = false;
   }
-  return replaceOrInsertRootSetting(config, CODEX_MULTI_AGENT_MODE_KEY, JSON.stringify(CODEX_MULTI_AGENT_MODE_PROACTIVE));
-}
-function readRootStringSetting(config, key) {
-  for (const line of config.split(/\n/)) {
-    if (isSectionHeader2(line))
-      return null;
-    const match = line.trimStart().match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]*)"/);
-    if (match?.[1] === key)
-      return match[2] ?? null;
-  }
-  return null;
+  return changed ? output.join(`
+`) : config;
 }
 function isSectionHeader2(line) {
   return isTomlTableHeaderLine(line);
+}
+function isRootSetting2(line, key) {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("#") || trimmed.startsWith("["))
+    return false;
+  const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+  return match?.[1] === key;
 }
 
 // packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
@@ -8253,7 +8261,7 @@ async function updateCodexConfig(input) {
   config = ensureFeatureEnabled(config, "plugin_hooks");
   config = ensureFeatureEnabled(config, "multi_agent");
   config = ensureFeatureEnabled(config, "child_agents_md");
-  config = ensureCodexMultiAgentModeConfig(config);
+  config = removeUnsupportedCodexMultiAgentModeConfig(config);
   config = ensureCodexReasoningConfig(config, await readCodexModelCatalog(input.repoRoot));
   config = ensureCodexMultiAgentV2Config(config);
   if (input.autonomousPermissions === true)

--- a/packages/omo-codex/src/install/codex-config-toml.test.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.test.ts
@@ -57,7 +57,7 @@ describe("codex-config-toml", () => {
     expect(content).not.toContain('sandbox = "elevated"')
   })
 
-  test("#given empty Codex config #when updating config #then creates MultiAgentV2 section with thread limit but no forced enabled flag", async () => {
+  test("#given empty Codex config #when updating config #then creates MultiAgentV2 section without root multi-agent mode", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-"))
     const configPath = join(root, "config.toml")
@@ -73,7 +73,7 @@ describe("codex-config-toml", () => {
 
     // then
     const content = await readFile(configPath, "utf8")
-    expect(content).toContain('multi_agent_mode = "proactive"')
+    expect(content).not.toMatch(/^\s*multi_agent_mode\s*=/m)
     expect(content).toContain("[features.multi_agent_v2]")
     const v2Section = content.slice(content.indexOf("[features.multi_agent_v2]"))
       .split(/^\[/m).slice(0, 1).join("")
@@ -81,7 +81,7 @@ describe("codex-config-toml", () => {
     expect(content).toContain("max_concurrent_threads_per_session = 10000")
   })
 
-  test("#given queue multi-agent mode #when updating config #then switches to proactive mode for team support", async () => {
+  test("#given stale queue multi-agent mode #when updating config #then removes unsupported root key", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-mode-"))
     const configPath = join(root, "config.toml")
@@ -107,18 +107,18 @@ describe("codex-config-toml", () => {
 
     // then
     const content = await readFile(configPath, "utf8")
-    expect(content).toContain('multi_agent_mode = "proactive"')
+    expect(content).not.toMatch(/^\s*multi_agent_mode\s*=/m)
     expect(content).not.toContain('multi_agent_mode = "queue"')
   })
 
-  test("#given indented root mode and inline-comment features table #when updating config #then replaces without duplicate TOML keys", async () => {
+  test("#given stale indented steering mode and inline-comment features table #when updating config #then removes root key and preserves table", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-toml-root-regression-"))
     const configPath = join(root, "config.toml")
     await writeFile(
       configPath,
       [
-        '  multi_agent_mode = "queue"',
+        '  multi_agent_mode = "steering"',
         "",
         "[features] # keep comment",
         "plugins = false",
@@ -137,12 +137,32 @@ describe("codex-config-toml", () => {
 
     // then
     const content = await readFile(configPath, "utf8")
-    expect(content.match(/^\s*multi_agent_mode\s*=/gm)).toHaveLength(1)
+    expect(content.match(/^\s*multi_agent_mode\s*=/gm)).toBeNull()
     expect(content.match(/^\s*\[features\](?:\s*#.*)?$/gm)).toHaveLength(1)
-    expect(content).toContain('multi_agent_mode = "proactive"')
     expect(content).toContain("[features] # keep comment")
     expect(content).not.toContain('multi_agent_mode = "queue"')
     expect(content).not.toContain('multi_agent_mode = "steering"')
+  })
+
+  test("#given stale proactive multi-agent mode #when updating config #then removes unsupported root key", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-proactive-cleanup-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(configPath, ['multi_agent_mode = "proactive"', "", "[features]", "multi_agent = true", ""].join("\n"))
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content).not.toMatch(/^\s*multi_agent_mode\s*=/m)
+    expect(content).toContain("[features]")
   })
 
   test("#given existing MultiAgentV2 table #when updating config #then preserves user enabled flag and unrelated tuning while setting thread limit", async () => {

--- a/packages/omo-codex/src/install/codex-config-toml.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.ts
@@ -15,7 +15,7 @@ import { ensureAutonomousPermissions } from "./codex-config-permissions"
 import { ensureHookTrusted, ensureOmoBuiltinMcpPolicies, ensurePluginEnabled } from "./codex-config-plugins"
 import { ensureCodexReasoningConfig } from "./codex-config-reasoning"
 import { readCodexModelCatalog } from "./codex-model-catalog"
-import { ensureCodexMultiAgentModeConfig } from "./codex-multi-agent-mode-config"
+import { removeUnsupportedCodexMultiAgentModeConfig } from "./codex-multi-agent-mode-config"
 import { ensureCodexMultiAgentV2Config } from "./codex-multi-agent-v2-config"
 import type { CodexAgentConfig, CodexInstallPlatform, CodexMarketplaceSource, TrustedHookState } from "./types"
 
@@ -53,7 +53,7 @@ export async function updateCodexConfig(input: {
   config = ensureFeatureEnabled(config, "plugin_hooks")
   config = ensureFeatureEnabled(config, "multi_agent")
   config = ensureFeatureEnabled(config, "child_agents_md")
-  config = ensureCodexMultiAgentModeConfig(config)
+  config = removeUnsupportedCodexMultiAgentModeConfig(config)
   config = ensureCodexReasoningConfig(config, await readCodexModelCatalog(input.repoRoot))
   config = ensureCodexMultiAgentV2Config(config)
   if (input.autonomousPermissions === true) config = ensureAutonomousPermissions(config)

--- a/packages/omo-codex/src/install/codex-multi-agent-mode-config.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-mode-config.ts
@@ -1,28 +1,31 @@
-import { isTomlTableHeaderLine, replaceOrInsertRootSetting } from "./toml-section-editor"
+import { isTomlTableHeaderLine } from "./toml-section-editor"
 
 const CODEX_MULTI_AGENT_MODE_KEY = "multi_agent_mode"
-const CODEX_MULTI_AGENT_MODE_PROACTIVE = "proactive"
 
-export function ensureCodexMultiAgentModeConfig(config: string): string {
-  if (readRootStringSetting(config, CODEX_MULTI_AGENT_MODE_KEY) === CODEX_MULTI_AGENT_MODE_PROACTIVE) {
-    return config
+export function removeUnsupportedCodexMultiAgentModeConfig(config: string): string {
+  const lines = config.split(/\n/)
+  const output: string[] = []
+  let inRoot = true
+  let changed = false
+  for (const line of lines) {
+    const sectionHeader = isSectionHeader(line)
+    if (inRoot && isRootSetting(line, CODEX_MULTI_AGENT_MODE_KEY)) {
+      changed = true
+      continue
+    }
+    output.push(line)
+    if (sectionHeader) inRoot = false
   }
-  return replaceOrInsertRootSetting(
-    config,
-    CODEX_MULTI_AGENT_MODE_KEY,
-    JSON.stringify(CODEX_MULTI_AGENT_MODE_PROACTIVE),
-  )
-}
-
-function readRootStringSetting(config: string, key: string): string | null {
-  for (const line of config.split(/\n/)) {
-    if (isSectionHeader(line)) return null
-    const match = line.trimStart().match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]*)"/)
-    if (match?.[1] === key) return match[2] ?? null
-  }
-  return null
+  return changed ? output.join("\n") : config
 }
 
 function isSectionHeader(line: string): boolean {
   return isTomlTableHeaderLine(line)
+}
+
+function isRootSetting(line: string, key: string): boolean {
+  const trimmed = line.trimStart()
+  if (trimmed.startsWith("#") || trimmed.startsWith("[")) return false
+  const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=/)
+  return match?.[1] === key
 }


### PR DESCRIPTION
## Summary
This PR fixes the LazyCodex release blocker where OMO wrote unsupported root `multi_agent_mode = "proactive"` into Codex `config.toml`.

Codex treats `multiAgentMode` as a thread/turn API surface, not a supported root TOML config field. The installer and SessionStart migration now remove stale OMO-managed root `multi_agent_mode` keys instead of writing or rewriting them, while preserving the supported managed root reasoning settings and existing section comments.

## Changes
- Replaced installer root `multi_agent_mode` enforcement with cleanup of stale root `multi_agent_mode`.
- Replaced plugin SessionStart `forceMultiAgentModeProactive` guard with stale-root-key cleanup.
- Updated auto-update notice text so it no longer claims proactive Team Mode is enabled via config.
- Updated TS installer tests, generated installer parity tests, plugin migration tests, and restart-notice tests to assert the root key is absent.
- Regenerated `packages/omo-codex/scripts/install-dist/install-local.mjs` from the fixed TS installer source.

## Verification
Evidence directory: `.omo/evidence/20260624-codex-remove-root-multi-agent-mode/`

- `bun run build:codex-install` -> `build-codex-install.txt`
- `bun test packages/omo-codex/src/install/codex-config-toml.test.ts` -> `bun-codex-config-toml-test.txt` (18 pass)
- `node --test packages/omo-codex/scripts/install-config.test.mjs` -> `node-install-config-test.txt` (15 pass)
- `node --test packages/omo-codex/plugin/test/migrate-codex-config.test.mjs` -> `node-migrate-codex-config-test.txt` (34 pass)
- `node --test packages/omo-codex/plugin/test/auto-update-restart-notice.test.mjs` -> `node-auto-update-restart-notice-test.txt` (8 pass)
- Isolated real local install scenario -> `manual-isolated-install-no-root-multi-agent-mode.txt`
  - `CODEX_HOME=<tmp>/codex OMO_CODEX_LOCAL_BIN_DIR=<tmp>/bin node packages/omo-codex/scripts/install-local.mjs install`
  - observed sandbox `config.toml` had no root `multi_agent_mode`
  - observed real `~/.codex/config.toml` sha256 unchanged
- Codex QA install self-test -> `codex-qa-install-verify-self-test.txt`
- Codex QA app-server plugin proof -> `codex-qa-app-server-drive-plugin.txt`
  - real `codex app-server` with isolated `CODEX_HOME` and mock model completed a turn
  - observed `hook/started` and `hook/completed` for plugin `sessionStart` and `userPromptSubmit`
  - observed real `~/.codex/config.toml` unchanged
- Grep proof -> `grep-no-root-multi-agent-mode-writes.txt`
  - production hits are cleanup constant/notice/generated cleanup helper only
  - stale `multi_agent_mode = "proactive"` strings remain only as test input for removal coverage
- Full Codex gate: `bun run test:codex` -> `bun-run-test-codex.txt` (404 pass)

## Notes
- The worktree has an intentionally uncommitted mode-only dirty file from build/test execution: `packages/omo-codex/plugin/components/codegraph/dist/serve.js` (`100644 => 100755`). It is not staged and is not part of this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops writing unsupported root `multi_agent_mode` to Codex `config.toml`. The installer and plugin migration now remove any stale root key and rely on Codex’s per‑turn `multiAgentMode` API while preserving managed reasoning settings and comments.

- **Bug Fixes**
  - Replaced root mode enforcement with cleanup in `packages/omo-codex/src/install/codex-multi-agent-mode-config.ts` and `packages/omo-codex/plugin/scripts/migrate-codex-config/*.mjs`.
  - Updated auto‑update startup notice to reflect cleanup, not proactive mode.
  - Regenerated `packages/omo-codex/scripts/install-dist/install-local.mjs`.
  - Updated tests to assert the root `multi_agent_mode` key is absent.

<sup>Written for commit 560cca2ebb53cddb3ffdf7d108b816b4cc106cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

