### PR TITLE
feat(shared-skills): add Aside and MotherDuck brand design references

### DIFF
--- a/packages/shared-skills/skills/frontend/.gitignore
+++ b/packages/shared-skills/skills/frontend/.gitignore
@@ -11,6 +11,8 @@ references/design/*.md
 !references/design/_INDEX.md
 !references/design/design-system-architecture.md
 !references/design/react-dev-tooling-skill.md
+!references/design/aside.md
+!references/design/motherduck.md
 
 # UI/UX intelligence database (ui-ux-pro-max upstream), entirely materialized.
 references/ui-ux-db/

--- a/packages/shared-skills/skills/frontend/references/design/_INDEX.md
+++ b/packages/shared-skills/skills/frontend/references/design/_INDEX.md
@@ -52,7 +52,7 @@ From [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill).
 
 ---
 
-## Layer B — Design Systems (69)
+## Layer B — Design Systems (71)
 
 From [VoltAgent/awesome-design-md](https://github.com/VoltAgent/awesome-design-md), based on [Google Stitch DESIGN.md format](https://stitch.withgoogle.com/docs/design-md/overview/). Each file captures one website's complete visual language: color palette, typography, components, layout principles, depth, do/don't, responsive behavior, and an agent prompt guide.
 
@@ -79,10 +79,11 @@ Each file ships with: visual theme, hex color palette + semantic roles, full typ
 | `voltagent.md` | AI agent framework. Void-black canvas, emerald accent, terminal-native. |
 | `x.ai.md` | Elon Musk's AI lab. Stark monochrome, futuristic minimalism. |
 
-### Developer Tools & IDEs (7)
+### Developer Tools & IDEs (8)
 
 | File | Aesthetic |
 |---|---|
+| `aside.md` | AI browser agent. Dark-mode squircle UI, AsideDisplay variable font, sky-blue brand accent. |
 | `cursor.md` | AI-first code editor. Sleek dark interface, gradient accents. |
 | `expo.md` | React Native platform. Dark theme, tight letter-spacing, code-centric. |
 | `lovable.md` | AI full-stack builder. Playful gradients, friendly dev aesthetic. |
@@ -91,7 +92,7 @@ Each file ships with: visual theme, hex color palette + semantic roles, full typ
 | `vercel.md` | Frontend deployment platform. Black and white precision, Geist font. |
 | `warp.md` | Modern terminal. Dark IDE-like interface, block-based command UI. |
 
-### Backend, Database & DevOps (8)
+### Backend, Database & DevOps (9)
 
 | File | Aesthetic |
 |---|---|
@@ -102,6 +103,7 @@ Each file ships with: visual theme, hex color palette + semantic roles, full typ
 | `posthog.md` | Product analytics. Playful hedgehog branding, developer-friendly dark UI. |
 | `sanity.md` | Headless CMS. Red accent, content-first editorial layout. |
 | `sentry.md` | Error monitoring. Dark dashboard, data-dense, pink-purple accent. |
+| `motherduck.md` | Serverless DuckDB data warehouse. Warm cream canvas, duck-yellow brand accent, Aeonik Fono display type. |
 | `supabase.md` | Open-source Firebase alternative. Dark emerald theme, code-first. |
 
 ### Productivity & SaaS (7)

--- a/packages/shared-skills/skills/frontend/references/design/aside.md
+++ b/packages/shared-skills/skills/frontend/references/design/aside.md
@@ -1,0 +1,298 @@
+# Design System Inspired by Aside
+
+> Category: Developer Tools & IDEs
+> AI browser agent. Dark-mode squircle UI, AsideDisplay variable font, sky-blue brand accent.
+
+## 1. Visual Theme & Atmosphere
+
+Aside's website presents a polished, app-like experience that mirrors the product itself — an AI-powered browser built to do real work. The design is dark-mode-first, opening on a near-black canvas (`#0a0a0a`) with carefully calibrated warm grays that avoid the cold, sterile feel of typical developer tools. The overall impression is of a premium native application rather than a marketing site, reinforced by the hero section's browser-frame mockup that blurs the line between product and page.
+
+The most distinctive visual element is the squircle border-radius system. Rather than standard CSS `border-radius`, Aside applies `corner-shape: superellipse()` to all rounded elements, producing the iOS-like continuous curvature that feels softer and more organic than circular arcs. This single detail — applied consistently from buttons to cards to the browser frame showcase — gives the entire interface a cohesive, platform-native quality that most web experiences lack.
+
+Typography is anchored by AsideDisplay, a custom variable font used exclusively for display headlines at tight tracking (`-0.0125em`). Body text and UI elements use Geist (Vercel's open-source sans-serif), while code surfaces use Geist Mono. The three-font stack creates a clear hierarchy: AsideDisplay commands attention, Geist handles utility, and Geist Mono signals technical content. All three are variable fonts supporting weight 100–900, giving the system fine-grained control without loading multiple font files.
+
+The color system uses a shadcn/ui-derived token architecture with full light and dark palettes, though the site presents exclusively in dark mode. A custom `mist` color scale (`#090b0c` at 950, `#22292b` at 800) replaces pure neutral black with a barely perceptible teal-green undertone — the foreground color in light mode is `#090b0c` (mist-950), not `#000000`. The brand accent is sky blue (`#00bcfe`), used sparingly for the `--brand` token but never as a primary CTA color. Instead, the primary button inverts the foreground/background relationship: dark text on light surface in dark mode, dark surface with light text in light mode.
+
+**Key Characteristics:**
+- Dark-mode-first presentation with warm mist-toned blacks (`#090b0c`, `#22292b`)
+- Squircle/superellipse border-radius on all rounded elements — iOS-like continuous curvature
+- AsideDisplay custom variable font for headlines, Geist for body, Geist Mono for code
+- Sky blue brand accent (`#00bcfe`) used as a signal color, not a CTA color
+- shadcn/ui token architecture with `--primary`, `--secondary`, `--muted`, `--accent` semantic tokens
+- Full light/dark dual palette, though the marketing site shows dark mode only
+- Browser-frame product showcase as the central hero element with glass morphism
+- Y Combinator-backed badge as a trust signal
+- Tailwind CSS v4 with `color-mix()` and `oklch` color space support
+
+## 2. Color Palette & Roles
+
+### Primary (Dark Theme — site default)
+- **Near Black** (`#0a0a0a`): `--background`. Page canvas. A pure neutral-950 — warm but not tinted.
+- **Off White** (`#fafafa`): `--foreground`. Primary text in dark mode. Neutral-50.
+- **Light Gray** (`#e5e5e5`): `--primary`. Primary interactive surface in dark mode — buttons, links. Neutral-200.
+- **Dark Gray** (`#171717`): `--primary-foreground`. Text on primary surfaces. Neutral-900.
+
+### Primary (Light Theme)
+- **White** (`#ffffff`): `--background`. Page canvas.
+- **Mist Black** (`#090b0c`): `--foreground` and `--primary`. A custom near-black with subtle teal undertone (not pure `#000`).
+- **Near White** (`#fafafa`): `--primary-foreground`. Text on primary surfaces.
+
+### Brand & Accent
+- **Sky Blue** (`#00bcfe`): `--brand` (mapped from `--color-sky-400`). The signature accent — used for brand moments, hover highlights, and decorative elements. Not used for primary CTAs.
+- **Sky Light** (`#f0f9ff`): `--color-sky-50`. Tinted surface for sky-themed elements.
+
+### Surface & Background
+- **Card Dark** (`#171717`): `--card`. Card and container surfaces in dark mode. Neutral-900.
+- **Card Light** (`#ffffff`): `--card`. Light-mode card surface.
+- **Muted Dark** (`#262626`): `--muted`. Subdued surface for de-emphasized areas. Neutral-800.
+- **Muted Light** (`#f5f5f5`): `--muted`. Light-mode subdued surface. Neutral-100.
+- **Popover Dark** (`#171717`): `--popover`. Dropdown/overlay surface. Neutral-900.
+- **Glass Surface**: `color-mix(in oklab, var(--background) 80%, transparent)`. Browser-frame web content background — translucent with backdrop blur.
+
+### Neutrals & Text
+- **Muted Foreground** (`#a1a1a1`): `--muted-foreground`. Secondary text, placeholders. Neutral-500.
+- **Ring** (`#737373` dark / `#a1a1a1` light): `--ring`. Focus ring color. Neutral-500/400.
+- **Border Dark** (`rgba(255,255,255,0.1)`): `--border`. Dark-mode borders — white at 10% opacity.
+- **Border Light** (`#e5e5e5`): `--border`. Light-mode borders. Neutral-200.
+- **Surface Border** (`rgba(250,250,250,0.15)`): `--border-surface`. Subtle surface separation.
+- **Surface Border Strong** (`rgba(250,250,250,0.2)`): `--border-surface-strong`. Emphasized surface borders.
+
+### Status Colors
+- **Destructive Dark** (`#ff6568`): `--destructive`. Error in dark mode — a soft coral-red. `--color-red-400`.
+- **Destructive Light** (`#e40014`): `--destructive`. Error in light mode — a deeper, more serious red.
+- **Success** (`#00bb7f`): `--color-emerald-500`. Success indicators.
+- **Warning** (`#f99c00`): `--color-amber-500`. Warning accents.
+- **Orange** (`#fe6e00`): `--color-orange-500`. Warm informational accent.
+- **Rose** (`#ff2357`): `--color-rose-500`. Decorative hot pink accent.
+
+### Custom Colors
+- **Mist 950** (`#090b0c`): The defining custom color — a near-black with a barely perceptible cool teal-green cast. Used as `--foreground` in light mode, distinguishing Aside from brands that use pure black.
+- **Mist 800** (`#22292b`): A dark teal-gray for elevated dark surfaces.
+
+## 3. Typography Rules
+
+### Font Family
+- **Display**: `AsideDisplay Variable` (CSS: `displayFont`), fallback: `Arial`
+- **Body / UI**: `Geist` (variable, weight 100–900), fallback: `Arial`
+- **Monospace**: `Geist Mono` (variable, weight 100–900), fallback: `Arial`
+- **CSS custom properties**: `--font-display`, `--font-sans`, `--font-mono`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | AsideDisplay | 48px (3rem) | 400–500 | 1.08 (tight) | -0.0125em | `font-display tracking-display`, xl: text-5xl |
+| Display Medium | AsideDisplay | 36px (2.25rem) | 400–500 | 1.10 (tight) | -0.0125em | Section headlines |
+| Section Heading | AsideDisplay | 30px (1.875rem) | 400 | 1.15 (tight) | -0.0125em | Feature section titles |
+| Sub-heading | Geist | 20px (1.25rem) | 500–600 | 1.20 | normal | Card titles, sub-sections |
+| Body Large | Geist | 18px (1.125rem) | 400 | 1.50 | normal | Intro text, hero subtitle |
+| Body | Geist | 16px (1rem) | 400 | 1.50 | normal | Standard reading text |
+| Body Small | Geist | 14px (0.875rem) | 400–500 | 1.43 | normal | Compact body, nav links |
+| Button | Geist | 14px (0.875rem) | 500 | 1.00 | normal | Primary/secondary buttons, `text-sm font-medium` |
+| Button Large | Geist | 16px (1rem) | 500 | 1.00 | normal | `md:text-base` size-up |
+| Caption | Geist | 12px (0.75rem) | 400–550 | 1.33 | 0.01em | Badges, labels, YC pill |
+| Code | Geist Mono | 14px (0.875rem) | 400 | 1.50 | normal | Inline code, terminal text |
+
+### Principles
+- **AsideDisplay is display-only**: Never used for body text, buttons, or UI chrome. Reserved for headlines where its custom letterforms create brand presence.
+- **Geist carries all functional weight**: Navigation, buttons, labels, body text — all Geist. The variable font makes weight transitions seamless.
+- **Tight tracking on display**: `-0.0125em` letter-spacing on all AsideDisplay text creates dense, engineered headlines that feel confident without being aggressive.
+- **Font-weight as hierarchy signal**: Display uses 400–500 (medium), UI elements use 500 (medium), body uses 400 (regular). No bold (700) in the primary hierarchy.
+- **`font-semimedium` utility**: A custom weight designation (`font-[550]` or `font-[450]`) for badge/pill text — between regular and medium.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary (Dark Mode)**
+- Background: `#e5e5e5` (`--primary`)
+- Text: `#171717` (`--primary-foreground`)
+- Padding: 0 10px (h-8 px-2.5) or 0 12px (h-9 px-3, md)
+- Radius: squircle `rounded-xl` (0.75rem superellipse)
+- Hover: `bg-primary/80` (80% opacity)
+- Font: 14px Geist weight 500
+- Active: `scale(0.95)` transform
+- Use: Primary CTA ("Download", "Try it")
+
+**Primary Pill (Hero CTA)**
+- Same as Primary but `rounded-full` (pill shape with squircle)
+- Larger: h-11 on mobile, h-9/h-10 on desktop
+- Includes leading icon (download arrow)
+- Use: Hero section download button
+
+**Ghost / Icon**
+- Background: transparent
+- Text: `--muted-foreground`
+- Hover: `bg-muted text-foreground`
+- Size: 36px square (`size-9`) or 44px (`size-11`)
+- Radius: squircle `rounded-xl`
+- Use: Icon-only actions, search, compose
+
+**Badge / Pill**
+- Background: transparent
+- Text: `text-primary/70` (70% opacity primary)
+- Border: `border-primary/20` (20% opacity)
+- Padding: 0 10px (h-6 px-2.5)
+- Radius: `rounded-full`
+- Font: 12px weight 550, tracking 0.01em
+- Use: Trust badges ("Backed by Y Combinator")
+
+### Cards & Containers
+- Background: `--card` (`#171717` dark)
+- Border: `--border-surface` (`rgba(250,250,250,0.15)`) or `--border-surface-strong` for emphasis
+- Radius: squircle `rounded-xl` (0.75rem) standard, `rounded-2xl` (1rem) featured, `rounded-3xl` (1.5rem) hero
+- Shadow: `shadow-xl` on the browser frame showcase
+- Glass variant: `bg-web-content-background/80` with backdrop blur for the browser frame
+
+### Browser Frame (Distinctive Component)
+- Full browser mockup with macOS traffic light dots (red `bg-red-400`, amber `bg-amber-400`, green `bg-green-500`)
+- Sidebar with bookmark items (favicons + labels)
+- Glass morphism web content area
+- Border: `border-glass` token
+- Responsive scaling via CSS `transform: scale()` at breakpoints
+- Min width 1200px, max width 1320px, centered
+
+### Inputs & Forms
+- Border: `--input` (`rgba(255,255,255,0.15)` dark / `#e5e5e5` light)
+- Focus: `--ring` focus ring
+- Radius: squircle `rounded-xl`
+- Text: `--foreground`
+- Placeholder: `--muted-foreground`
+
+### Navigation
+- Sticky top bar, transparent on hero background
+- Logo: Aside SVG wordmark, `h-9`, `#090b0c` fill in light / `currentColor` in dark
+- Links: Geist 14px weight 500, `font-sans text-sm font-medium`
+- Dropdowns via Base UI (`@base-ui/dropdown-menu`)
+- CTA: Primary button right-aligned ("Download")
+- Mobile: Hamburger toggle, `size-9` button
+- Height: `h-14` (56px)
+
+## 5. Layout Principles
+
+### Spacing System
+- Base unit: 4px (Tailwind `--spacing` default)
+- Scale: 0.5 (2px), 1 (4px), 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10, 12, 14, 16, 20, 24, 32, 40, 64
+- Page padding: `p-2 md:p-4` (8px mobile, 16px desktop) outer wrapper
+- Section padding: `py-16` (64px) for hero sections
+- Card spacing: `--card-spacing: calc(var(--spacing) * 4)` (16px)
+
+### Grid & Container
+- No explicit max-width container — content width controlled by component sizing
+- Browser frame: min 1200px, max 1320px, centered with 120px horizontal inset
+- Hero: centered text with generous padding, `max-sm:px-8 max-sm:text-left`
+- Feature sections: likely 2–3 column grids
+- Responsive scaling: browser frame scales from 1.0 (desktop) to 0.5 (mobile) via CSS transforms
+
+### Whitespace Philosophy
+- **App-like density**: Tighter than typical marketing sites — the interface mimics the product's native-app feel rather than luxurious editorial spacing.
+- **Hero breathes, UI compresses**: The hero section has generous `py-16` padding, but UI components within the browser showcase are densely packed (8px sidebar items, compact navigation).
+- **Responsive scaling over reflow**: The browser-frame hero uses CSS `transform: scale()` at breakpoints rather than reflowing content, maintaining visual fidelity across viewport sizes.
+
+### Border Radius Scale
+- Standard: `rounded-md` (6px squircle) — small interactive elements
+- Comfortable: `rounded-lg` (8px squircle) — sidebar items, small buttons, traffic light dots area
+- Generous: `rounded-xl` (12px squircle) — buttons, inputs, cards, primary radius
+- Large: `rounded-2xl` (16px squircle) — browser frame, featured containers
+- Hero: `rounded-3xl` (24px squircle) — hero wrapper, largest containers
+- Pill: `rounded-full` — badges, hero CTA, circular elements
+- **All with `corner-shape: superellipse(var(--squircle-factor))`** — the defining detail
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow | Page background, inline text |
+| Subtle (Level 1) | `0 1px 2px rgba(0,0,0,0.15)` (`--drop-shadow-sm`) | Subtle element lift |
+| Glass (Level 2) | `color-mix(in oklab, var(--background) 80%, transparent)` + backdrop-blur | Browser frame content area, translucent overlays |
+| Elevated (Level 3) | `shadow-xl` (Tailwind default xl shadow) | Browser frame showcase, modals |
+| Border-as-depth | `--border-surface` (15–20% opacity white/black) | Cards, containers — border creates perceived elevation without shadow |
+
+**Shadow Philosophy**: Aside communicates depth primarily through **opacity-based borders and glass morphism** rather than traditional drop shadows. The `--border-surface` (15% opacity) and `--border-surface-strong` (20% opacity) tokens create subtle containment lines that separate layers without the visual weight of shadows. The glass surface (`color-mix` with 80% background opacity) on the browser frame showcase is the most dramatic depth effect — a frosted-glass plane that suggests the product UI hovering above the marketing page.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use squircle/superellipse `corner-shape` on all rounded elements — this IS the Aside identity
+- Use mist-950 (`#090b0c`) for foreground in light mode instead of pure black — the teal undertone matters
+- Keep AsideDisplay exclusive to display-size headlines — never use it for body or UI text
+- Apply sky-blue (`#00bcfe`) as a brand signal sparingly — it's not a CTA color
+- Use opacity-based borders (`rgba(255,255,255,0.1–0.2)`) for dark-mode containment
+- Invert the primary button in dark mode: light surface (`#e5e5e5`) with dark text (`#171717`)
+- Match the product's native-app density — tighter spacing than typical marketing sites
+- Use `color-mix(in oklab, ...)` for glass/translucent surfaces
+
+### Don't
+- Don't use circular `border-radius` — always apply the squircle superellipse factor
+- Don't use pure black (`#000000`) for text — use mist-950 (`#090b0c`) or neutral-950 (`#0a0a0a`)
+- Don't use sky-blue for primary buttons — it's a decorative/brand accent only
+- Don't use AsideDisplay below 24px — it's not designed for small sizes
+- Don't use warm-toned grays — Aside's neutrals are pure (neutral scale) with the only warmth in the custom mist colors
+- Don't apply heavy drop shadows — depth comes from opacity borders and glass morphism
+- Don't use weight 700+ on Geist for UI elements — keep to 400–550 range
+- Don't introduce pill-shaped buttons except for the hero CTA and badges — standard CTAs use `rounded-xl`
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile | <640px | Single column, hamburger nav, hero text left-aligned, browser frame scales to 0.5x |
+| Tablet | 640–768px | Slightly wider content, nav still collapsed |
+| Small Desktop | 768–1024px | Full horizontal nav appears, browser frame at 0.7–0.8x scale |
+| Desktop | 1024–1280px | Full layout, browser frame at 0.9x |
+| Large Desktop | >1280px | Browser frame at 1.0x (1200–1320px), maximum hero height (832px) |
+
+### Touch Targets
+- Buttons: minimum h-8 (32px) compact, h-9 (36px) standard, h-11 (44px) hero CTA on mobile
+- Navigation links: adequate spacing in horizontal nav with dropdown triggers
+- Mobile hamburger: 36px (`size-9`) touch target
+- Sidebar items: 32px (`h-8`) minimum height
+
+### Collapsing Strategy
+- **Navigation**: Full horizontal with dropdowns → hamburger toggle on mobile
+- **Hero**: Centered text → left-aligned (`text-left`) on mobile, hero CTA gains full padding
+- **Browser frame**: CSS `transform: scale()` — 1.0x desktop → 0.9x → 0.8x → 0.7x → 0.5x mobile — no reflow, pure scaling
+- **Hero height**: 832px → 720px → 700px → 620px → 460px across breakpoints
+- **Page padding**: 16px desktop (`p-4`) → 8px mobile (`p-2`), with `pb-0` to allow content flush
+
+### Image Behavior
+- Browser frame showcase maintains squircle radius at all sizes via scaled container
+- Product screenshots within the browser frame scale proportionally
+- Background image on hero section via CSS `background-image`, covers full section
+- Favicon/bookmark icons maintain 16px (`size-4`) at all sizes
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Page background (dark): Near Black (`#0a0a0a`)
+- Page background (light): White (`#ffffff`)
+- Primary text (dark): Off White (`#fafafa`)
+- Primary text (light): Mist Black (`#090b0c`)
+- Primary button (dark): Light Gray (`#e5e5e5`) bg, Dark (`#171717`) text
+- Primary button (light): Mist Black (`#090b0c`) bg, Off White (`#fafafa`) text
+- Brand accent: Sky Blue (`#00bcfe`)
+- Muted surface (dark): Dark Gray (`#262626`)
+- Muted text: Medium Gray (`#a1a1a1`)
+- Border (dark): White 10% (`rgba(255,255,255,0.1)`)
+- Card (dark): Charcoal (`#171717`)
+- Error (dark): Coral (`#ff6568`)
+- Success: Emerald (`#00bb7f`)
+
+### Example Component Prompts
+- "Create a hero section on near-black (#0a0a0a) background. Headline in AsideDisplay at 48px weight 400, line-height 1.08, letter-spacing -0.0125em, color #fafafa. Subtitle in Geist 18px weight 400, #a1a1a1. Primary pill CTA: #e5e5e5 bg, #171717 text, rounded-full with superellipse, h-10 px-3. Include a download icon."
+- "Design a card on #171717 with rgba(250,250,250,0.15) border, squircle rounded-xl (12px superellipse). Title in Geist 20px weight 500, #fafafa. Body in 16px weight 400, #a1a1a1. No box-shadow — border is the depth signal."
+- "Build a navigation bar: transparent bg on hero, h-14. Geist 14px weight 500 for links, #fafafa text. Primary button right-aligned: #e5e5e5 bg, #171717 text, rounded-xl, h-8 px-2.5. Logo SVG left-aligned, h-9."
+- "Create a badge/pill: transparent bg, border at 20% primary opacity, rounded-full. Text in 12px Geist weight 550 at 70% primary opacity. Padding h-6 px-2.5. Include a trailing chevron icon at 50% opacity."
+- "Design a glass-morphism browser frame: #171717 base with border-glass, rounded-2xl squircle. Traffic light dots (red-400, amber-400, green-500) at 12px. Web content area uses color-mix(in oklab, #0a0a0a 80%, transparent) for frosted glass. Shadow-xl."
+
+### Iteration Guide
+1. Always apply `corner-shape: superellipse()` to any `border-radius` — this is the brand's most distinctive visual detail
+2. Use `#090b0c` (mist-950) for foreground in light mode, never `#000000`
+3. Primary buttons invert in dark mode: light surface, dark text — the opposite of most dark-mode systems
+4. Sky blue (`#00bcfe`) is decorative only — never use it for CTAs or primary buttons
+5. Borders use opacity (10–20%) rather than solid colors in dark mode — `rgba(255,255,255,0.1)`
+6. Glass surfaces use `color-mix(in oklab, background 80%, transparent)` — a modern CSS approach
+7. AsideDisplay only at display sizes (24px+) with tight tracking (-0.0125em)
+8. Geist at 500 weight for all UI elements (buttons, nav, labels) — 400 for body text
+9. Spacing follows the product's native-app density: tighter than typical marketing, generous in hero sections

--- a/packages/shared-skills/skills/frontend/references/design/motherduck.md
+++ b/packages/shared-skills/skills/frontend/references/design/motherduck.md
@@ -1,0 +1,319 @@
+# Design System Inspired by MotherDuck
+
+> Category: Backend, Database & DevOps
+> Serverless DuckDB data warehouse. Warm cream canvas, duck-yellow brand accent, Aeonik Fono display type.
+
+## 1. Visual Theme & Atmosphere
+
+MotherDuck's website radiates an unexpected warmth for a data warehouse product. Where competitors like Snowflake and BigQuery lean into cold, technical blue-gray palettes, MotherDuck opens on a rich cream canvas (`#F4EFEA`) that feels closer to a premium consumer brand than enterprise infrastructure. The warm foundation says "approachable analytics" before a single word is read — a deliberate contrast to the intimidating complexity that data warehouses usually project.
+
+The brand's defining visual element is Duck Yellow (`#FFDE00`) — a bright, saturated gold that references the DuckDB mascot without being cartoonish. It appears sparingly: as a CTA accent, in the logo, and in decorative moments. The restraint is important — yellow is notoriously difficult to use in interfaces without looking cheap, and MotherDuck succeeds by treating it as a highlight rather than a dominant color. The primary interactive color is actually a soft sky blue (`#6FC2FF`), which carries links, secondary CTAs, and data visualization accents.
+
+Typography is built on the Aeonik type family — a contemporary geometric sans-serif that bridges the gap between the warmth of humanist typefaces and the precision of neo-grotesques. Aeonik Fono handles display headlines with a distinctive mono-width quality that nods to the product's technical nature, while Inter serves as the body workhorse. Aeonik Mono completes the stack for code surfaces and SQL examples, which are central to the product experience.
+
+The overall design philosophy is "the answers company" — every layout decision prioritizes clarity and directness. Hero sections lead with bold claims ("Infrastructure for Answers"), feature grids use generous whitespace, and the color palette keeps saturated hues in supporting roles so the content hierarchy is never ambiguous. Dark text on warm cream creates a reading experience that's comfortable for the long-form technical content (case studies, documentation links, integration lists) that fills the lower sections.
+
+**Key Characteristics:**
+- Warm cream canvas (`#F4EFEA`) evoking paper-like comfort, not cold tech surfaces
+- Duck Yellow (`#FFDE00`) as a brand signature used with extreme restraint
+- Sky blue (`#6FC2FF`) as the primary interactive and link color
+- Aeonik type family: Fono for display, Mono for code, Inter for body
+- Dark warm gray (`#383838`) for primary text — not black, not cool gray
+- Multi-color accent palette (orange, teal, pink, purple) for data visualization and feature differentiation
+- Generous whitespace with content-first hierarchy
+- Light-mode-only marketing site — no dark mode toggle
+- Next.js with Tailwind CSS, image-heavy product showcases
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Warm Dark Gray** (`#383838`): Primary heading and body text color. The dominant color on the page (175 occurrences in the HTML). A warm neutral that avoids the heaviness of black while maintaining strong readability on cream.
+- **Duck Yellow** (`#FFDE00`): The brand signature — a bright, pure yellow-gold. Used for primary CTAs, logo accent, and decorative brand moments. Applied sparingly to maintain impact.
+- **Sky Blue** (`#6FC2FF`): Primary interactive color — links, secondary buttons, hover states, and data visualization primary. A soft, friendly blue that complements the warm palette.
+
+### Secondary & Accent
+- **Warm Orange** (`#FF9538`): Secondary accent for feature cards, icons, and warm decorative elements. Also used at reduced opacity (`#FF9538AA`) for subtle backgrounds.
+- **Teal Mint** (`#53DBC9`): Tertiary accent — success states, integration highlights, and decorative balance against the warm tones.
+- **Blue Accent** (`#2BA5FF`): A deeper, more saturated blue for interactive emphasis and link hover states.
+- **Light Sky** (`#97D4FF`): A pale sky blue for tinted surfaces and light decorative accents.
+- **Deep Blue** (`#0092D7`): A rich cerulean for high-contrast interactive elements and CTAs on dark surfaces.
+
+### Decorative (Multi-Color System)
+- **Pink** (`#FF92C3`): Decorative accent for illustrations and feature differentiation.
+- **Coral Red** (`#FF7169`): Warm red accent for visual variety in multi-color compositions.
+- **Deep Orange** (`#FF7800`): A more saturated orange variant for emphasis.
+- **Purple** (`#9F78DF`): Cool accent for data visualization and category differentiation.
+- **Cyan** (`#63C2EE`): A light cyan for subtle visual variety.
+- **Royal Blue** (`#0019D2`): Deep blue for dark-surface emphasis moments.
+
+### Surface & Background
+- **Cream Canvas** (`#F4EFEA`): Primary page background. A warm cream with subtle pink-beige undertone — the emotional foundation of the design.
+- **Off White** (`#F8F8F7`): Secondary surface — cards, elevated containers. Barely cooler than the canvas.
+- **Pure White** (`#FFFFFF`): Card surfaces, input backgrounds, maximum contrast elements. Also used at high opacity (`#FFFFFFEE`) for translucent overlays.
+- **White** (`#fff`): Standard white for contained elements.
+
+### Neutrals & Text
+- **Primary Text** (`#383838`): All headings and primary body text.
+- **Body Gray** (`#666666`): Secondary body text, descriptions, metadata.
+- **Muted Gray** (`#818181`): Tertiary text, placeholders, de-emphasized content.
+- **Gray** (`#9ca3af`): Tailwind gray-400, used for border and disabled states.
+- **Black** (`#000000`): Used sparingly for maximum-contrast elements like the logo and specific icons.
+- **Border Subtle** (`#38383815`): Primary text color at ~8% opacity — creates ultra-light borders that separate without drawing attention.
+
+### Semantic
+- **Error Red** (`#D90000`): Error states and destructive actions.
+- **Success Green** (`#187108`): Success indicators and positive states.
+- **Warning Brown** (`#66370D`): Warning states — a warm brown rather than typical amber, consistent with the warm palette.
+
+## 3. Typography Rules
+
+### Font Family
+- **Display**: `Aeonik Fono`, fallback: `Segoe UI`, sans-serif. A geometric sans with mono-width characteristics that give headlines a technical, engineered feel.
+- **Body / UI**: `Inter`, fallback: `system-ui`, sans-serif. The modern web standard for readable body text.
+- **Monospace**: `Aeonik Mono`, fallback: `monospace`. Brand-consistent code font for SQL examples and technical content.
+- **System fallback**: `ui-sans-serif, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Aeonik Fono | 56px (3.5rem) | 500–600 | 1.05 (tight) | -0.02em | Maximum impact, hero headlines |
+| Display Large | Aeonik Fono | 48px (3rem) | 500 | 1.10 (tight) | -0.015em | Secondary hero, section openers |
+| Section Heading | Aeonik Fono | 36px (2.25rem) | 500 | 1.15 | -0.01em | Feature section titles |
+| Sub-heading Large | Aeonik Fono | 28px (1.75rem) | 500 | 1.20 | -0.005em | Card titles, sub-sections |
+| Sub-heading | Inter | 22px (1.375rem) | 600 | 1.25 | normal | Small section heads |
+| Body Large | Inter | 18px (1.125rem) | 400 | 1.60 | normal | Intro text, hero subtitles, feature descriptions |
+| Body | Inter | 16px (1rem) | 400 | 1.60 | normal | Standard body text |
+| Body Small | Inter | 14px (0.875rem) | 400–500 | 1.50 | normal | Compact content, navigation |
+| Button | Inter | 14px (0.875rem) | 500–600 | 1.00 | normal | CTA buttons |
+| Button Large | Inter | 16px (1rem) | 500–600 | 1.00 | 0.01em | Hero CTAs |
+| Label | Inter | 12px (0.75rem) | 600 | 1.33 | 0.05em | Uppercase nav labels ("PRODUCT", "COMMUNITY") |
+| Code | Aeonik Mono | 14px (0.875rem) | 400 | 1.60 | normal | SQL examples, inline code |
+| Code Small | Aeonik Mono | 13px (0.8125rem) | 400 | 1.50 | normal | Compact code blocks |
+
+### Principles
+- **Aeonik Fono is display-only**: Its mono-width characteristics work at large sizes where the geometric precision reads as intentional, but would feel awkward at body sizes. 28px is the practical floor.
+- **Inter for everything functional**: Body text, buttons, navigation, labels — all Inter. The font is so ubiquitous that it disappears, letting the content and the Aeonik display headlines carry the personality.
+- **Uppercase navigation labels**: Navigation categories ("PRODUCT", "COMMUNITY", "COMPANY") use uppercase Inter at 12px with 600 weight and 0.05em tracking — a structural label pattern that signals hierarchy without serif.
+- **Generous body line-height**: 1.60 for body text creates a relaxed reading rhythm suited to the technical-but-approachable brand voice.
+- **Negative tracking at display sizes**: Aeonik Fono tightens progressively from -0.005em at 28px to -0.02em at 56px, creating dense headline blocks.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary Yellow**
+- Background: Duck Yellow (`#FFDE00`)
+- Text: Dark (`#383838` or `#000000`)
+- Padding: 12px 24px
+- Radius: 8px
+- Font: Inter 14–16px weight 600
+- Hover: slightly darkened yellow
+- Use: Primary CTA ("Try 7 Days Free", "START FREE")
+
+**Blue Outline / Secondary**
+- Background: transparent
+- Text: Sky Blue (`#6FC2FF`) or Deep Blue (`#0092D7`)
+- Border: `1px solid` current color
+- Padding: 12px 24px
+- Radius: 8px
+- Hover: light blue tinted background
+- Use: Secondary actions ("Learn more", "See pricing")
+
+**White Surface**
+- Background: White (`#ffffff`)
+- Text: Warm Dark Gray (`#383838`)
+- Padding: 12px 24px
+- Radius: 8px
+- Border: `1px solid #38383815` (subtle warm border)
+- Hover: light warm gray background
+- Use: Tertiary actions, alternative CTAs
+
+**Dark / Nav CTA**
+- Background: Dark (`#383838`)
+- Text: White (`#ffffff`)
+- Padding: 8px 16px
+- Radius: 6px
+- Font: Inter 14px weight 600
+- Use: Navigation CTAs ("LOG IN", "CONTACT US")
+
+### Cards & Containers
+- Background: White (`#ffffff`) or Off White (`#F8F8F7`)
+- Border: `1px solid #38383815` (ultra-subtle warm border) or no border with shadow
+- Radius: 8px standard, 12px featured, 16px hero
+- Shadow: `0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1)` for elevated cards
+- Internal padding: 24–32px
+- Use: Feature cards, case study cards, integration grids
+
+### Inputs & Forms
+- Background: White (`#ffffff`)
+- Border: `1px solid #9ca3af` (gray-400)
+- Radius: 6px
+- Focus: `ring-blue-500` / `rgba(59,130,246,0.5)` focus ring
+- Text: `#383838`
+- Placeholder: `#818181`
+
+### Navigation
+- Sticky top navigation with cream/white background
+- Logo: MotherDuck duck mark + wordmark
+- Eyebrow banner: full-width announcements above nav (e.g., hackathon, livestream)
+- Primary nav: dropdown mega-menus ("PRODUCT", "COMMUNITY", "COMPANY")
+- Labels: uppercase Inter 12px weight 600, tracking 0.05em
+- Link text: `#383838` with hover highlight
+- CTA buttons: "LOG IN" (outline) and "START FREE" (filled) right-aligned
+- Mobile: hamburger menu
+
+### Distinctive Components
+
+**Hero Section**
+- Aeonik Fono headline centered on cream canvas
+- Subtitle in Inter 18px body gray
+- Dual CTA: Yellow primary + secondary outline
+- Product screenshot or illustration below
+
+**Integration Grid**
+- Multi-column grid of partner logos/icons
+- Clean white cards with subtle borders
+- Category sections (Data Integration, BI, AI, etc.)
+
+**Case Study Cards**
+- Customer logo + quote + metrics
+- Multi-color accent system (each case study gets a color: orange, teal, blue, purple)
+- Clean typography with bold metric numbers
+
+**SQL Code Blocks**
+- Aeonik Mono on dark or light surface
+- Syntax highlighting with the multi-color accent palette
+- Generous padding and rounded corners
+
+## 5. Layout Principles
+
+### Spacing System
+- Base unit: 4px (Tailwind default)
+- Common values: 8px, 12px, 16px, 24px, 32px, 48px, 64px, 96px
+- Section vertical spacing: 80–120px between major sections
+- Card internal padding: 24–32px
+- Button padding: 12px 24px (standard), 8px 16px (compact)
+
+### Grid & Container
+- Max content width: approximately 1200px, centered
+- Hero: centered single-column with generous margins
+- Feature sections: 2–3 column grids (CSS Grid or Flexbox)
+- Integration grids: up to 4–6 columns for logo grids
+- Full-width accent sections occasionally break the container for visual drama
+
+### Whitespace Philosophy
+- **Cream breathing room**: The warm canvas creates a perception of more whitespace than actually exists — the color is so comfortable that even moderate spacing feels generous.
+- **Content-first hierarchy**: Headlines are bold and large (56px hero), but surrounded by so much whitespace that they never feel aggressive. The layout prioritizes scanability over density.
+- **Progressive density**: Hero sections are spacious, feature grids are moderately dense, integration lists and footer are tighter. This creates a natural reading rhythm that moves from inspiration to information.
+
+### Border Radius Scale
+- Compact (4px): Small inline elements, badges
+- Standard (6px): Inputs, compact buttons, small cards
+- Comfortable (8px): Standard buttons, primary cards, containers
+- Generous (12px): Featured cards, product screenshots
+- Large (16px): Hero containers, large media elements
+- Full (9999px): Pill badges, rounded avatar containers
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, cream canvas | Page background, inline content |
+| Subtle (Level 1) | `1px solid #38383815` (8% opacity border) | Standard cards, section containers |
+| Elevated (Level 2) | `0 1px 3px rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1)` | Interactive cards, hover states |
+| Featured (Level 3) | Larger shadow + border combination | Product showcases, hero elements |
+| Color accent | Multi-color backgrounds (orange, teal, blue, purple) at low opacity | Feature differentiation, case study cards |
+
+**Shadow Philosophy**: MotherDuck uses **minimal shadows with maximum border subtlety**. The primary depth mechanism is the ultra-light border at 8% opacity (`#38383815`) — barely visible on the cream canvas but enough to create containment. When shadows do appear, they're the standard Tailwind `shadow-sm` — functional, not decorative. The real depth in the design comes from the **multi-color accent system**: different sections and features are differentiated by color (orange for one product, teal for another, blue for a third), creating visual layers through hue rather than elevation.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use the warm cream canvas (`#F4EFEA`) as the primary background — the warmth IS the brand differentiation
+- Use Duck Yellow (`#FFDE00`) only for primary CTAs and logo — scarcity creates impact
+- Use `#383838` for all heading text — warm dark gray, never pure black
+- Apply the multi-color accent system (orange, teal, blue, purple, pink) for feature and data visualization differentiation
+- Use Aeonik Fono for display headlines (28px+) with negative letter-spacing
+- Use Inter for all body text and UI elements — reliability over personality at small sizes
+- Keep uppercase navigation labels at 12px/600/0.05em tracking
+- Apply ultra-light borders (`#38383815`) for card containment
+- Maintain generous section spacing (80–120px) for the breathing, approachable feel
+
+### Don't
+- Don't use Duck Yellow for body text, borders, or backgrounds — it's strictly a CTA/logo accent
+- Don't use pure black (`#000000`) for body text — always `#383838`
+- Don't use cool blue-grays for neutrals — the palette is exclusively warm-toned
+- Don't use Aeonik Fono below 28px — it loses its display character at body sizes
+- Don't apply heavy drop shadows — the design relies on borders and color, not elevation
+- Don't introduce a dark mode — the cream canvas is the core brand experience
+- Don't use saturated accent colors at full opacity for large surfaces — they're highlights, not backgrounds
+- Don't skip the eyebrow banner space — it's part of the nav structure even when empty
+- Don't use the multi-color accents randomly — each product/feature should have a consistent assigned color
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile | <640px | Single column, hamburger nav, reduced heading sizes, stacked CTAs |
+| Tablet | 640–1024px | 2-column feature grids, condensed nav |
+| Desktop | 1024–1280px | Full layout, mega-menu navigation, 3-column grids |
+| Large Desktop | >1280px | Centered content with generous side margins |
+
+### Touch Targets
+- Buttons: 44px minimum height for mobile CTAs
+- Navigation: adequately spaced dropdown triggers
+- Cards: full-surface touch targets on mobile
+- Integration logos: minimum 48px tap area
+
+### Collapsing Strategy
+- **Navigation**: Mega-menu dropdowns → hamburger with accordion sections
+- **Hero**: 56px headline → 36px on mobile, dual CTAs stack vertically
+- **Feature grids**: 3-column → 2-column → single column stacked
+- **Integration grids**: 4–6 columns → 3 columns → 2 columns
+- **Case study cards**: Horizontal → vertical stack
+- **Section spacing**: 96px+ → 64px → 48px on mobile
+- **Typography scale compresses**: 56px → 36px → 28px hero across breakpoints
+
+### Image Behavior
+- Product screenshots scale proportionally with maintained aspect ratio
+- Partner/integration logos maintain consistent sizing in grid
+- Illustrations scale with container width
+- Background decorative elements may be hidden on mobile
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Page Background: Cream Canvas (`#F4EFEA`)
+- Card Surface: White (`#FFFFFF`) or Off White (`#F8F8F7`)
+- Primary Text: Warm Dark Gray (`#383838`)
+- Secondary Text: Body Gray (`#666666`)
+- Muted Text: Gray (`#818181`)
+- Primary CTA: Duck Yellow (`#FFDE00`) bg, Dark text
+- Link / Interactive: Sky Blue (`#6FC2FF`)
+- Border: Subtle (`#38383815` — 8% dark opacity)
+- Accent Orange: (`#FF9538`)
+- Accent Teal: (`#53DBC9`)
+- Accent Blue: (`#2BA5FF`)
+- Error: Red (`#D90000`)
+- Success: Green (`#187108`)
+
+### Example Component Prompts
+- "Create a hero section on cream (#F4EFEA) canvas. Headline in Aeonik Fono at 56px weight 500, line-height 1.05, letter-spacing -0.02em, color #383838. Subtitle in Inter 18px weight 400, #666666, line-height 1.60. Yellow CTA (#FFDE00, #383838 text, 8px radius, 12px 24px padding) and blue outline secondary (transparent bg, #6FC2FF text/border, 8px radius)."
+- "Design a feature card on white with 1px solid rgba(56,56,56,0.08) border, 12px radius. Title in Aeonik Fono 28px weight 500, letter-spacing -0.005em, #383838. Body in Inter 16px weight 400, #666666, line-height 1.60. Orange (#FF9538) accent icon at 24px."
+- "Build a navigation bar: cream (#F4EFEA) background, sticky. Eyebrow banner full-width above nav. Duck logo left. Uppercase labels 'PRODUCT', 'COMMUNITY' in Inter 12px weight 600, tracking 0.05em, #383838. CTAs right: 'LOG IN' (#383838 outline) and 'START FREE' (#FFDE00 bg, dark text)."
+- "Create an integration grid on off-white (#F8F8F7): 4-column grid of partner cards (white bg, subtle border, 8px radius). Each card: 48px logo + partner name in Inter 14px weight 500. Category headers in Inter 12px weight 600 uppercase."
+- "Design a case study card: white surface, 12px radius, subtle border. Customer logo top, quote in Inter 18px italic #383838, metric number in Aeonik Fono 36px weight 600 with teal (#53DBC9) accent color. CTA link in Sky Blue (#6FC2FF)."
+
+### Iteration Guide
+1. Canvas is ALWAYS warm cream (`#F4EFEA`) — never white, never cool gray
+2. Primary text is `#383838` — warm dark gray, not black
+3. Duck Yellow (`#FFDE00`) is CTA-only — if you're using it on anything other than a button or the logo, stop
+4. Sky Blue (`#6FC2FF`) is the everyday interactive color — links, secondary CTAs, hover states
+5. Borders use 8% opacity of the primary text color (`#38383815`) — ultra-subtle containment
+6. Aeonik Fono at 28px+ only, with progressively tighter tracking at larger sizes
+7. Inter handles everything else at 400 weight (body) or 500–600 (UI/buttons)
+8. The multi-color accent system (orange, teal, blue, purple, pink) differentiates features — assign one per category
+9. Shadows are minimal — most depth comes from borders and color differentiation
+10. Uppercase labels at 12px/600/0.05em for navigation categories and section markers


### PR DESCRIPTION
## What changed

Add two new project-original brand design system references to the frontend skill's Layer B collection:

### New files
- **`aside.md`** — AI browser agent ([aside.com](https://aside.com)). Dark-mode squircle UI, AsideDisplay variable font, Geist body/mono, sky-blue brand accent (`#00bcfe`), shadcn/ui token architecture with full light/dark dual palette. Distinctive superellipse `corner-shape` border-radius system.
- **`motherduck.md`** — Serverless DuckDB data warehouse ([motherduck.com](https://motherduck.com)). Warm cream canvas (`#F4EFEA`), duck-yellow brand accent (`#FFDE00`), Aeonik Fono display type, Inter body, multi-color accent system (orange, teal, blue, purple) for feature differentiation.

Both files follow the standard 9-section format: Visual Theme & Atmosphere, Color Palette & Roles, Typography Rules, Component Stylings, Layout Principles, Depth & Elevation, Do's and Don'ts, Responsive Behavior, Agent Prompt Guide.

### Updated files
- **`_INDEX.md`** — Developer Tools & IDEs 7→8 (aside.md), Backend Database & DevOps 8→9 (motherduck.md), total Layer B count 69→71
- **`.gitignore`** — Added `!` exclusions for both files so they commit as project-original content (not materialized from upstream submodules)

## How tokens were extracted

- **Aside**: Fetched live CSS from `aside.com/_next/static/chunks/*.css`, extracted all CSS custom properties (`--primary`, `--background`, `--border`, `--brand`, neutral scale, status colors, radius tokens, shadow tokens). Font declarations verified from `@font-face` rules. HTML structure analyzed for component patterns (buttons, cards, navigation, browser-frame showcase).
- **MotherDuck**: Fetched live HTML from `motherduck.com`, extracted all hex color occurrences with frequency analysis. Font families extracted from inline `font-family` declarations. Page structure captured via Playwright snapshot. CSS custom properties extracted from their Tailwind stylesheet.

## QA scope

This change adds only `.md` data files and a `.gitignore` update under `packages/shared-skills/`. No TypeScript, no hooks, no tools, no runtime code. The shared-skills package is a pure data bundle (`cp -R` at build time) — these files will be picked up by the existing skill loader without any code changes.

**Not in scope for opencode-qa or codex-qa** — no plugin/hook/tool behavior was changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `aside.md` and `motherduck.md` brand design references to the frontend skill’s Layer B catalog to expand our design system dataset while keeping them as project-original content.

- **New Features**
  - `references/design/aside.md`: AI browser agent design — dark-mode squircle UI, `AsideDisplay` display font, Geist body/mono, sky-blue accent (`#00bcfe`), `shadcn/ui` token architecture with dual light/dark palettes.
  - `references/design/motherduck.md`: Serverless DuckDB warehouse design — warm cream canvas (`#F4EFEA`), duck-yellow accent (`#FFDE00`), Aeonik Fono display + Inter body, multi-color accent system.
  - Both files use the standard 9-section DESIGN.md format.
  - Updated `references/design/_INDEX.md`: Developer Tools 7→8, Backend & DevOps 8→9; total Layer B 71.
  - Updated `.gitignore` to include these files so they commit under `packages/shared-skills`.

<sup>Written for commit 4efeb5d76ade91fce3ccb36a26f6049a3ea57212. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

