### PR TITLE
fix(chat-params): drop reasoningEffort injection for openai-compatible providers (fixes #5529)

### DIFF
--- a/packages/omo-opencode/src/plugin/chat-params.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-params.test.ts
@@ -248,4 +248,103 @@ describe("createChatParamsHandler", () => {
     //#then
     expect(output.maxOutputTokens).toBe(4096)
   })
+
+  test("strips reasoningEffort for openai-compatible providers (issue #5529)", async () => {
+    //#given — gpt-5.5 agent config injects reasoningEffort: "medium", but the provider
+    // is openai-compatible (e.g. local llama.cpp, vLLM, salad-cloud) and OpenAI
+    // rejects requests that combine tools + reasoning_effort on /v1/chat/completions
+    setSessionPromptParams("ses_chat_params_compat", {
+      options: {
+        reasoningEffort: "medium",
+      },
+    })
+
+    const handler = createChatParamsHandler()
+
+    const input = {
+      sessionID: "ses_chat_params_compat",
+      agent: { name: "oracle" },
+      model: {
+        providerID: "salad-cloud",
+        modelID: "gpt-5.5",
+        api: { npm: "@ai-sdk/openai-compatible" },
+      },
+      provider: { id: "salad-cloud" },
+      message: {},
+    }
+
+    const output: ChatParamsOutput = {
+      options: {},
+    }
+
+    //#when
+    await handler(input, output)
+
+    //#then — reasoningEffort must NOT be injected for openai-compatible providers
+    expect(output.options).not.toHaveProperty("reasoningEffort")
+  })
+
+  test("preserves reasoningEffort for native openai provider (issue #5529)", async () => {
+    //#given — same agent config, but native openai provider DOES support it
+    setSessionPromptParams("ses_chat_params_native", {
+      options: {
+        reasoningEffort: "medium",
+      },
+    })
+
+    const handler = createChatParamsHandler()
+
+    const input = {
+      sessionID: "ses_chat_params_native",
+      agent: { name: "oracle" },
+      model: {
+        providerID: "openai",
+        modelID: "gpt-5.5",
+        api: { npm: "@ai-sdk/openai" },
+      },
+      provider: { id: "openai" },
+      message: {},
+    }
+
+    const output: ChatParamsOutput = {
+      options: {},
+    }
+
+    //#when
+    await handler(input, output)
+
+    //#then — native openai provider must keep reasoningEffort
+    expect(output.options.reasoningEffort).toBe("medium")
+  })
+
+  test("preserves reasoningEffort when api.npm is missing (backward compat, issue #5529)", async () => {
+    //#given — when the chat-params hook does not receive api.npm, fall back to
+    // existing behavior and let reasoningEffort through. This preserves backward
+    // compatibility for any plugin/hook that does not forward the api field.
+    setSessionPromptParams("ses_chat_params_legacy", {
+      options: {
+        reasoningEffort: "medium",
+      },
+    })
+
+    const handler = createChatParamsHandler()
+
+    const input = {
+      sessionID: "ses_chat_params_legacy",
+      agent: { name: "oracle" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
+      provider: { id: "openai" },
+      message: {},
+    }
+
+    const output: ChatParamsOutput = {
+      options: {},
+    }
+
+    //#when
+    await handler(input, output)
+
+    //#then — without api.npm, preserve legacy behavior
+    expect(output.options.reasoningEffort).toBe("medium")
+  })
 })

--- a/packages/omo-opencode/src/plugin/chat-params.ts
+++ b/packages/omo-opencode/src/plugin/chat-params.ts
@@ -14,6 +14,7 @@ export type ChatParamsInput = {
 
 type ChatParamsHookInput = ChatParamsInput & {
   rawMessage?: Record<string, unknown>
+  apiNpm?: string
 }
 
 export type ChatParamsOutput = {
@@ -22,6 +23,12 @@ export type ChatParamsOutput = {
   topK?: number
   maxOutputTokens?: number
   options: Record<string, unknown>
+}
+
+const NATIVE_OPENAI_NPM = "@ai-sdk/openai"
+
+function isNativeOpenAIProvider(apiNpm: string | undefined): boolean {
+  return apiNpm === NATIVE_OPENAI_NPM
 }
 
 
@@ -62,6 +69,9 @@ function buildChatParamsInput(raw: unknown): ChatParamsHookInput | null {
   if (typeof modelID !== "string") return null
   if (typeof providerId !== "string") return null
 
+  const api = isRecord(model.api) ? model.api : undefined
+  const apiNpm = api && typeof api.npm === "string" ? api.npm : undefined
+
   return {
     sessionID,
     agent: { name: agentName },
@@ -69,6 +79,7 @@ function buildChatParamsInput(raw: unknown): ChatParamsHookInput | null {
     provider: { id: providerId },
     message,
     rawMessage: message,
+    apiNpm,
   }
 }
 
@@ -143,7 +154,15 @@ export function createChatParamsHandler(_args: {
     normalizedInput.message = normalizedInput.rawMessage as { variant?: string }
 
     if (compatibility.reasoningEffort !== undefined) {
-      output.options.reasoningEffort = compatibility.reasoningEffort
+      if (normalizedInput.apiNpm !== undefined && !isNativeOpenAIProvider(normalizedInput.apiNpm)) {
+        // OpenAI rejects requests that combine tools + reasoning_effort on
+        // /v1/chat/completions (issue #5529). openai-compatible providers and
+        // non-native OpenAI variants may use that endpoint, so drop the
+        // reasoning_effort injection entirely.
+        delete output.options.reasoningEffort
+      } else {
+        output.options.reasoningEffort = compatibility.reasoningEffort
+      }
     } else if ("reasoningEffort" in output.options) {
       delete output.options.reasoningEffort
     }


### PR DESCRIPTION
## Problem

When an agent config (e.g. Sisyphus, Oracle, Hephaestus) hard-codes `reasoningEffort: "medium"` for gpt-5.5, that value was injected into the chat-params output regardless of the underlying provider package. OpenAI rejects requests that combine `tools` + `reasoning_effort` on `/v1/chat/completions`:

> Function tools with reasoning_effort are not supported for gpt-5.5 in /v1/chat/completions. Please use /v1/responses instead.

`openai-compatible` providers (vLLM, llama.cpp, SaladCloud, etc.) and any non-native-openai variant may route through that endpoint, so the unconditional injection broke those setups silently with a 400 error.

## Root Cause

`packages/omo-opencode/src/plugin/chat-params.ts` injects `output.options.reasoningEffort` from the resolved compatibility value without checking which provider package the request is going to. The OpenCode core fix ([anomalyco/opencode#31465](https://github.com/anomalyco/opencode/pull/31465)) scoped `reasoningEffort` to native providers only, but omo re-injects the value at the chat-params layer, bypassing that fix.

## Fix

Read `model.api.npm` from the chat-params hook input and drop the `reasoningEffort` injection when the npm is set to anything other than `"@ai-sdk/openai"`. When `api.npm` is missing (backward compat — older plugins or hook consumers that don't forward the api field), preserve the existing behavior.

The change is localized to the chokepoint that actually writes the value to the request output, so all five sites that hardcode `reasoningEffort: "medium"` in the agent configs (Sisyphus, Hephaestus, Oracle, Momus, Sisyphus-Junior) are covered without touching them.

## TDD Evidence

- **RED**: `openai-compatible` provider + `gpt-5.5` + stored `reasoningEffort: "medium"` → test asserted `output.options` must NOT contain `reasoningEffort`, but the actual output retained `"reasoningEffort": "medium"` (bug reproduced).
- **GREEN**: same input now strips `reasoningEffort` cleanly.
- **Native openai** (`api.npm === "@ai-sdk/openai"`) + `gpt-5.5` → `reasoningEffort` preserved.
- **api.npm missing** → `reasoningEffort` preserved (backward compat for any consumer that doesn't forward the api field).
- All 5 existing tests still pass.
- Full `packages/omo-opencode` suite: 8048 pass, 4 pre-existing failures (unrelated to this change — `fixEmptyMessagesWithSDK` failures exist on upstream/dev as well).
- `bun run typecheck:packages`: clean.

## Files

- `packages/omo-opencode/src/plugin/chat-params.ts` (+16/-1) — read `api.npm`; gate `reasoningEffort` injection on native-openai npm
- `packages/omo-opencode/src/plugin/chat-params.test.ts` (+103/-1) — 3 new test cases

Fixes #5529

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop injecting `reasoningEffort` into chat params for OpenAI‑compatible providers to avoid 400s on `/v1/chat/completions` with gpt‑5.5 + tools; keep it only for native `@ai-sdk/openai` (fixes #5529).

- **Bug Fixes**
  - Gate on `model.api.npm`: keep for `@ai-sdk/openai`; strip for others; keep when `api.npm` is missing (backward compat).
  - Added tests for strip (openai‑compatible), keep (native), and legacy no‑`api.npm` cases.

<sup>Written for commit ec50ca718d2660263c0004afb3c4c2a5d8f7d9a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

