### PR TITLE
fix(todo-continuation): detect text-based questions in last assistant message (fixes #5548)

### DIFF
--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/pending-question-detection.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/pending-question-detection.test.ts
@@ -172,4 +172,69 @@ describe("hasUnansweredQuestion", () => {
     ]
     expect(hasUnansweredQuestion(messages)).toBe(true)
   })
+
+  test("#given last assistant message with text ending in question mark #when checking pending question #then returns true (issue #5548)", () => {
+    const messages = [
+      { info: { role: "user" } },
+      {
+        info: { role: "assistant" },
+        parts: [
+          {
+            type: "text",
+            text: "Please provide the preferred date and time?",
+          },
+        ],
+      },
+    ]
+    expect(hasUnansweredQuestion(messages)).toBe(true)
+  })
+
+  test("#given last assistant message with multi-line text ending in question mark #when checking pending question #then returns true (issue #5548)", () => {
+    const messages = [
+      { info: { role: "user" } },
+      {
+        info: { role: "assistant" },
+        parts: [
+          {
+            type: "text",
+            text: "I have a couple of questions before I continue.\n\nWhat time works best for you?",
+          },
+        ],
+      },
+    ]
+    expect(hasUnansweredQuestion(messages)).toBe(true)
+  })
+
+  test("#given last assistant message with text NOT ending in question mark #when checking pending question #then returns false (issue #5548)", () => {
+    const messages = [
+      { info: { role: "user" } },
+      {
+        info: { role: "assistant" },
+        parts: [
+          {
+            type: "text",
+            text: "I am going to start working on this now.",
+          },
+        ],
+      },
+    ]
+    expect(hasUnansweredQuestion(messages)).toBe(false)
+  })
+
+  test("#given last assistant message with both text question and tool #when checking pending question #then returns true (issue #5548)", () => {
+    const messages = [
+      { info: { role: "user" } },
+      {
+        info: { role: "assistant" },
+        parts: [
+          { type: "tool_use", name: "bash" },
+          {
+            type: "text",
+            text: "I checked the calendar. What time works for you?",
+          },
+        ],
+      },
+    ]
+    expect(hasUnansweredQuestion(messages)).toBe(true)
+  })
 })

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/pending-question-detection.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/pending-question-detection.ts
@@ -32,6 +32,39 @@ function isUnansweredQuestionTool(part: MessagePart): boolean {
   return part.state?.status !== "completed"
 }
 
+function getLastTextTail(part: MessagePart): string {
+  if (part.type !== "text" || typeof part.text !== "string") return ""
+  return part.text.trimEnd()
+}
+
+function lastTextEndsWithQuestion(messages: Message[]): boolean {
+  if (!messages || messages.length === 0) return false
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    const role = msg.info?.role ?? msg.role
+
+    if (role === "user") {
+      if (isSyntheticOrInternalUserMessage(msg)) {
+        continue
+      }
+      return false
+    }
+
+    if (role === "assistant" && msg.parts) {
+      for (let j = msg.parts.length - 1; j >= 0; j--) {
+        const part = msg.parts[j]
+        if (part.type === "text" && typeof part.text === "string") {
+          return getLastTextTail(part).endsWith("?")
+        }
+      }
+      return false
+    }
+  }
+
+  return false
+}
+
 export function hasUnansweredQuestion(messages: Message[]): boolean {
   if (!messages || messages.length === 0) return false
 
@@ -54,6 +87,10 @@ export function hasUnansweredQuestion(messages: Message[]): boolean {
       )
       if (hasQuestion) {
         log(`[${HOOK_NAME}] Detected pending question tool in last assistant message`)
+        return true
+      }
+      if (lastTextEndsWithQuestion([msg])) {
+        log(`[${HOOK_NAME}] Detected pending text question in last assistant message`)
         return true
       }
       return false


### PR DESCRIPTION
## Problem

The todo-continuation enforcer (boulder) was injecting a forced-continuation prompt whenever the model stopped with unfinished todos, even when the model had intentionally paused to ask the user for input via plain text rather than the `question` tool. The existing `pending-question-detection` only catches the `question` tool, so models that emit questions as text (e.g. "Please provide the preferred date and time?") got auto-resumed and convinced themselves to make a default decision on behalf of the user.

## Root Cause

`hasUnansweredQuestion` in `packages/omo-opencode/src/hooks/todo-continuation-enforcer/pending-question-detection.ts` only checks for the `question` / `ask_user_question` tool invocations on the last assistant message. The Sisyphus prompt explicitly tells the model to "Ask ONE clarifying question" when intent is ambiguous, and most models answer with plain text rather than calling a tool — so this code path was the common case, not the edge case.

## Fix

Extend `hasUnansweredQuestion` to also detect when the last assistant message's last text part ends with `?` (after `trimEnd()`). The check is wired into the same call site in `idle-event.ts` (line 97), so the existing `Skipped: pending question awaiting user response` log line is reused and the countdown never starts.

## Trade-off

This is a heuristic. A model that ends a sentence with `?` unrelated to user input would also skip continuation. This is consistent with the existing question-tool heuristic (also best-effort) and can be tightened if false positives surface in practice. If users hit false positives, the easy escape hatches are:
- `disabled_hooks: ["todo-continuation-enforcer"]` to disable the entire hook
- `/stop-continuation` slash command to halt mid-session

## TDD Evidence

- **RED**: text ending in `?` → expected `true`, got `false` (bug reproduced in 3 of 4 new tests).
- **GREEN**: same input now returns `true`.
- Text NOT ending in `?` → returns `false` (regression guard).
- Mixed `text` + `tool_use` → returns `true` (text question takes precedence after the existing question-tool check returns false).
- All 14 existing question-detection tests still pass.
- All 125 `todo-continuation-enforcer` tests pass.
- 79 pre-existing failures in the broader omo-opencode suite (`fixEmptyMessagesWithSDK`, `executeSyncTask`, `plugin init performance`) are unrelated to this change and exist on upstream/dev.
- `bun run typecheck:packages` reports the same pre-existing `cleanup.ts: skippedPaths` error as upstream/dev.

## Files

- `packages/omo-opencode/src/hooks/todo-continuation-enforcer/pending-question-detection.ts` (+27/-0) — add `lastTextEndsWithQuestion` helper, extend `hasUnansweredQuestion`
- `packages/omo-opencode/src/hooks/todo-continuation-enforcer/pending-question-detection.test.ts` (+65/-0) — 4 new test cases

Fixes #5548

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent forced continuation when the assistant asks a question in plain text by detecting a trailing “?” in the last assistant message. Treated like the `question` tool so the countdown is skipped (fixes #5548).

- **Bug Fixes**
  - Extend `hasUnansweredQuestion` to detect pending text questions by checking if the last assistant text part ends with `?` (after `trimEnd()`); ignores synthetic/internal user messages.
  - Same skip behavior as the `question` tool; heuristic may skip on unrelated `?`.
  - Add 4 tests (single-line, multi-line, non-question, mixed text+tool); all existing tests still pass.

<sup>Written for commit 44480a7b61231ddc88f3641e13b007fe041c80d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

