### PR TITLE
fix(lsp-daemon): terminate proxy on stdin close to prevent orphaned processes

### DIFF
--- a/packages/lsp-daemon/src/proxy.ts
+++ b/packages/lsp-daemon/src/proxy.ts
@@ -32,16 +32,35 @@ export async function runMcpStdioProxy(options: ProxyOptions = {}): Promise<void
 	const context = options.context ?? currentRequestContext();
 	const callOptions: CallToolOptions = { paths, context, ...(options.ensure ? { ensure: options.ensure } : {}) };
 
-	await runJsonRpcStdioServer({
-		input,
-		output,
-		idleTimeoutMs: 0,
-		handler: handleProxyRequest,
-		handlerOptions: callOptions,
-		onHandlerError: (error: unknown) => {
-			process.stderr.write(`[lsp-daemon] proxy error: ${error instanceof Error ? error.message : String(error)}\n`);
-		},
-	});
+	// Prevent orphan: force-exit when stdin closes (parent died) or the server
+	// loop returns, since dangling daemon sockets can keep the event loop alive.
+	const isRealStdin = input === process.stdin;
+	if (isRealStdin) {
+		input.on("close", () => {
+			process.exitCode = 0;
+			setTimeout(() => process.exit(0), 500).unref();
+		});
+	}
+
+	try {
+		await runJsonRpcStdioServer({
+			input,
+			output,
+			idleTimeoutMs: 0,
+			handler: handleProxyRequest,
+			handlerOptions: callOptions,
+			onHandlerError: (error: unknown) => {
+				process.stderr.write(`[lsp-daemon] proxy error: ${error instanceof Error ? error.message : String(error)}\n`);
+			},
+		});
+	} catch (error: unknown) {
+		// Stream destroyed (parent killed) → ERR_STREAM_PREMATURE_CLOSE; expected.
+		if (!isPrematureClose(error)) throw error;
+	}
+
+	if (isRealStdin) {
+		process.exit(0);
+	}
 }
 
 async function handleProxyRequest(parsed: unknown, callOptions: CallToolOptions): Promise<JsonRpcResponse | undefined> {
@@ -50,6 +69,10 @@ async function handleProxyRequest(parsed: unknown, callOptions: CallToolOptions)
 
 	const result = await callToolViaDaemon(toolCall.name, toolCall.args, callOptions);
 	return successResponse(toolCall.id, { content: result.content, isError: result.isError ?? false, details: result.details });
+}
+
+function isPrematureClose(error: unknown): boolean {
+	return error instanceof Error && (error as NodeJS.ErrnoException).code === "ERR_STREAM_PREMATURE_CLOSE";
 }
 
 function asToolCall(parsed: unknown): ToolCall | null {

--- a/packages/lsp-daemon/test/proxy.test.ts
+++ b/packages/lsp-daemon/test/proxy.test.ts
@@ -128,6 +128,26 @@ describe("mcp stdio proxy", () => {
 		}
 	});
 
+	it("#given a live proxy #when stdin is destroyed mid-session #then the proxy resolves instead of hanging", async () => {
+		const paths = tempPaths();
+		const input = new PassThrough();
+		const out: string[] = [];
+		const proxy = runMcpStdioProxy({
+			input,
+			output: collectingWritable(out),
+			paths,
+			ensure: noSpawn,
+		});
+
+		input.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} })}\n`);
+		await new Promise((r) => setTimeout(r, 50));
+		input.destroy();
+
+		await proxy;
+		const responses = parseResponses(out);
+		expect((responses[0]?.["result"] as { serverInfo?: unknown }).serverInfo).toBeDefined();
+	});
+
 	it("#given an unreachable daemon #when several tools are proxied #then each gets a structured error and the proxy keeps serving", async () => {
 		const paths = tempPaths();
 		const out: string[] = [];


### PR DESCRIPTION
## Summary

Fixes #5560 — lsp-daemon MCP proxy processes accumulate as orphans across sessions.

When the parent process (opencode) exits, the proxy's stdin closes but dangling daemon socket handles keep the Node event loop alive, leaving the proxy (and its language server children) running indefinitely. Over multiple sessions this accumulates orphaned processes consuming 1+ GB of RAM.

## Changes

**`packages/lsp-daemon/src/proxy.ts`**:
- Listen for stdin `close` event and force `process.exit(0)` after a 500ms grace period (handles parent killed via SIGKILL)
- Catch `ERR_STREAM_PREMATURE_CLOSE` from the server loop instead of propagating it as unhandled (stdin destroyed mid-request)
- Force `process.exit(0)` after the server loop returns normally when running on real stdin

All three paths are guarded by `isRealStdin` (`input === process.stdin`) so test harnesses using synthetic streams are unaffected.

**`packages/lsp-daemon/test/proxy.test.ts`**:
- Added regression test: stdin destroyed mid-session → proxy resolves cleanly instead of hanging

## Test Results

```
 Test Files  10 passed (10)
      Tests  48 passed (48)
```

## Root Cause Analysis

The `for await (const chunk of input)` loop in `readStdioJsonRpcMessages` exits on EOF, but:
1. If a daemon request is in-flight when stdin closes, the loop may not exit promptly
2. Even after the loop exits, open daemon socket connections keep the event loop alive
3. `destroy()` on stdin throws `ERR_STREAM_PREMATURE_CLOSE` which was unhandled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terminate the `lsp-daemon` MCP proxy when stdin closes to prevent orphaned processes and memory leaks. Also handle premature stream closes and exit after the server loop so dangling sockets can’t keep the process alive.

- **Bug Fixes**
  - Listen for stdin close and force-exit after a 500ms grace period (real stdin only).
  - Catch `ERR_STREAM_PREMATURE_CLOSE` from the server loop instead of propagating it.
  - Exit after the server loop returns when using real stdin.
  - Add regression test: destroying stdin mid-session resolves the proxy.

<sup>Written for commit 6d081a82816cf764062c384aee67e0aebb23aa81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

