### PR TITLE
fix(skill): resolve plugin-registered skills via runtime resolver

### DIFF
--- a/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
@@ -84,7 +84,7 @@ export function createCoreTools(args: {
   })
 
   const getSessionIDForMcp = (): string | undefined => getMainSessionID()
-  const getLoadedSkillsForMcp = createRuntimeSkillsResolver({
+  const getLoadedSkills = createRuntimeSkillsResolver({
     baseSkills: skillContext.mergedSkills,
     readRuntimeHostSkills: () => readRuntimeHostSkills(ctx.client),
     buildMergedSkills: async (hostSkills) =>
@@ -92,7 +92,7 @@ export function createCoreTools(args: {
   })
   const skillMcpTool = factories.createSkillMcpTool({
     manager: managers.skillMcpManager,
-    getLoadedSkills: getLoadedSkillsForMcp,
+    getLoadedSkills,
     getSessionID: getSessionIDForMcp,
   })
   const commands = factories.discoverCommandsSync(ctx.directory, {
@@ -103,6 +103,7 @@ export function createCoreTools(args: {
     directory: ctx.directory,
     commands,
     skills: skillContext.mergedSkills,
+    getLoadedSkills,
     mcpManager: managers.skillMcpManager,
     getSessionID: getSessionIDForMcp,
     gitMasterConfig: pluginConfig.git_master,

--- a/packages/omo-opencode/src/tools/skill/get-loaded-skills-resolver.test.ts
+++ b/packages/omo-opencode/src/tools/skill/get-loaded-skills-resolver.test.ts
@@ -1,0 +1,164 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import type { ToolContext } from "@opencode-ai/plugin/tool"
+import { createSkillTool } from "./tools"
+import type { LoadedSkill } from "../../features/opencode-skill-loader/types"
+import { createRuntimeSkillsResolver } from "../../plugin/runtime-skill-resolver"
+import { createSkillContext } from "../../plugin/skill-context"
+import { OhMyOpenCodeConfigSchema } from "../../config"
+
+function requireFresh<T>(modulePath: string): T {
+  const resolvedPath = require.resolve(modulePath)
+  if (require.cache?.[resolvedPath]) {
+    delete require.cache[resolvedPath]
+  }
+  return require(modulePath) as T
+}
+
+function createFreshSkillTool(
+  ...args: Parameters<typeof import("./tools").createSkillTool>
+): ReturnType<typeof import("./tools").createSkillTool> {
+  return requireFresh<typeof import("./tools")>("./tools").createSkillTool(...args)
+}
+
+function createMockSkill(name: string): LoadedSkill {
+  return {
+    name,
+    path: `/test/skills/${name}/SKILL.md`,
+    resolvedPath: `/test/skills/${name}`,
+    definition: {
+      name,
+      description: `Test skill ${name}`,
+      template: `<skill-instruction>Body for ${name}</skill-instruction>`,
+    },
+    scope: "config",
+  }
+}
+
+const mockContext: ToolContext = {
+  sessionID: "test-session",
+  messageID: "msg-1",
+  agent: "test-agent",
+  directory: "/test",
+  worktree: "/test",
+  abort: new AbortController().signal,
+  metadata: () => {},
+  ask: async () => {},
+}
+
+describe("skill tool - getLoadedSkills runtime resolver (execute path)", () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "skill-resolver-test-"))
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it("#given a plugin-registered skill reachable only via getLoadedSkills #when execute(name) is called #then the skill body is returned (not 'not found')", async () => {
+    // given — a skill that simulates a plugin-registered path: only the runtime
+    // resolver knows about it. The static `skills` array is empty, mirroring
+    // createTools() which cannot see plugin paths at load time.
+    const pluginSkill = createMockSkill("plugin-registered-skill")
+    let resolverCallCount = 0
+    const tool = createFreshSkillTool({
+      directory: testDir,
+      skills: [],
+      commands: [],
+      getLoadedSkills: async () => {
+        resolverCallCount += 1
+        return [pluginSkill]
+      },
+    })
+
+    // when — the agent invokes the skill tool by name (the real user path)
+    const result = await tool.execute({ name: "plugin-registered-skill" }, mockContext)
+
+    // then — execute consulted the resolver and returned the skill body
+    expect(resolverCallCount).toBeGreaterThanOrEqual(1)
+    expect(result).toContain("## Skill: plugin-registered-skill")
+    expect(result).toContain("Body for plugin-registered-skill")
+  })
+
+  it("#given getLoadedSkills is set but skills is unset and commands is set #when execute(name) is called #then the resolver still resolves (no description-path dependency)", async () => {
+    // given — edge case: no static `skills`, only `commands` (which sets a
+    // command-only sync description). Execute must still reach the resolver.
+    const pluginSkill = createMockSkill("edge-plugin-skill")
+    const tool = createFreshSkillTool({
+      directory: testDir,
+      commands: [],
+      getLoadedSkills: async () => [pluginSkill],
+    })
+
+    // when
+    const result = await tool.execute({ name: "edge-plugin-skill" }, mockContext)
+
+    // then
+    expect(result).toContain("## Skill: edge-plugin-skill")
+  })
+
+  it("#given getLoadedSkills is unset #when execute runs #then falls back to the static skills array (no regression)", async () => {
+    // given — legacy callers that pass only `skills` must keep working
+    const staticSkill = createMockSkill("static-skill")
+    const tool = createFreshSkillTool({
+      directory: testDir,
+      skills: [staticSkill],
+      commands: [],
+    })
+
+    // when
+    const result = await tool.execute({ name: "static-skill" }, mockContext)
+
+    // then
+    expect(result).toContain("## Skill: static-skill")
+  })
+
+  it("#given the real runtime resolver chain (resolver + createSkillContext) wired against a plugin skill dir #when execute runs #then the skill is discovered and returned", async () => {
+    // given — a real SKILL.md on disk that simulates a plugin-registered path
+    // injected into opencode's merged config. readRuntimeHostSkills returns
+    // that path the way client.config.get() would post-startup. This exercises
+    // the full production wiring (resolver -> createSkillContext ->
+    // discoverConfigSourceSkills -> createSkillTool.execute) minus the real
+    // opencode client.
+    const skillName = "zz-integration-plugin-skill"
+    const pluginSkillDir = mkdtempSync(join(tmpdir(), "plugin-skill-"))
+    const skillSubdir = join(pluginSkillDir, skillName)
+    mkdirSync(skillSubdir, { recursive: true })
+    writeFileSync(
+      join(skillSubdir, "SKILL.md"),
+      `---\nname: ${skillName}\ndescription: integration test plugin skill\n---\nIntegration body.\n`,
+    )
+
+    const pluginConfig = OhMyOpenCodeConfigSchema.parse({})
+    const getLoadedSkills = createRuntimeSkillsResolver({
+      baseSkills: [],
+      readRuntimeHostSkills: async () => ({ paths: [pluginSkillDir] }),
+      buildMergedSkills: async (hostSkills) =>
+        (await createSkillContext({ directory: testDir, pluginConfig, hostSkills })).mergedSkills,
+    })
+
+    const tool = createFreshSkillTool({
+      directory: testDir,
+      skills: [],
+      commands: [],
+      getLoadedSkills,
+    })
+
+    try {
+      // when
+      const result = await tool.execute({ name: skillName }, mockContext)
+
+      // then
+      expect(result).toContain(`## Skill: ${skillName}`)
+      expect(result).toContain("Integration body.")
+    } finally {
+      rmSync(pluginSkillDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/omo-opencode/src/tools/skill/tools.ts
+++ b/packages/omo-opencode/src/tools/skill/tools.ts
@@ -33,13 +33,20 @@ export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
       clearSkillCache()
     }
 
-    const discovered = (await getAllSkills({
-      disabledSkills: options?.disabledSkills,
-      browserProvider: options?.browserProvider,
-      teamModeEnabled: options?.teamModeEnabled,
-      directory: options.directory,
-    })) ?? []
-    const allSkills = options.skills ? [...options.skills] : discovered
+    let allSkills: LoadedSkill[]
+    if (options.getLoadedSkills) {
+      // Runtime resolver path: picks up plugin-registered skills whose paths
+      // only exist in opencode's in-memory merged config (not on disk).
+      allSkills = await options.getLoadedSkills()
+    } else {
+      const discovered = (await getAllSkills({
+        disabledSkills: options?.disabledSkills,
+        browserProvider: options?.browserProvider,
+        teamModeEnabled: options?.teamModeEnabled,
+        directory: options.directory,
+      })) ?? []
+      allSkills = options.skills ? [...options.skills] : discovered
+    }
 
     if (options.nativeSkills) {
       try {

--- a/packages/omo-opencode/src/tools/skill/types.ts
+++ b/packages/omo-opencode/src/tools/skill/types.ts
@@ -24,6 +24,8 @@ export interface SkillLoadOptions {
   opencodeOnly?: boolean
   /** Pre-merged skills to use instead of discovering */
   skills?: LoadedSkill[]
+  /** Lazily-resolved skill list. When set, getSkills() prefers this over the static `skills` array so plugin-registered skills (whose paths only exist in opencode's in-memory merged config) are picked up at execute time. Falls back to `skills` / discovery when undefined. */
+  getLoadedSkills?: () => Promise<LoadedSkill[]>
   /** Pre-discovered commands to use instead of discovering */
   commands?: CommandInfo[]
   /** MCP manager for querying skill-embedded MCP servers */


### PR DESCRIPTION
## Summary

The `skill` tool could not resolve skills that plugins register via opencode's `plugin` array (e.g. `ulw-interview@git+https://...`). Such skills exist only in opencode's in-memory merged config — never on disk — so `skill(name="...")` returned `not found`, even though opencode's native discovery listed them, `/ulw-interview` worked, and `skill_mcp` resolved them fine.

The `skill` tool's execute path used a static `skillContext.mergedSkills` built at plugin-load time without `hostSkills` (because reading the merged config via `client.config.get()` during plugin load deadlocks). `skill_mcp` already avoided this via `createRuntimeSkillsResolver` — a lazy resolver that fetches the merged config after startup and rebuilds merged skills with `hostSkills`. This PR shares that resolver with the `skill` tool.

## Changes

- **`packages/omo-opencode/src/tools/skill/types.ts`** — added optional `getLoadedSkills?: () => Promise<LoadedSkill[]>` to `SkillLoadOptions`.
- **`packages/omo-opencode/src/tools/skill/tools.ts`** — `getSkills()` now prefers `options.getLoadedSkills` over the static `options.skills` array (used by both `execute()` and the lazy description builder). No constructor-time resolver call is triggered, so `client.config.get()` is only ever reached post-startup (the deadlock documented in `runtime-skill-resolver.ts:11-14` is preserved).
- **`packages/omo-opencode/src/plugin/tool-registry-core-tools.ts`** — renamed `getLoadedSkillsForMcp` → shared `getLoadedSkills` (one resolver instance) and wired it to both `createSkillTool` and `createSkillMcpTool`. The `skill` tool still receives `skills: skillContext.mergedSkills` for the initial synchronous description paint; the resolver overrides it at execute time.

## QA & Evidence

End-to-end on real opencode **1.17.11** + real model (`openai/gpt-5.4-mini-fast`), isolated XDG sandbox (auth copied in; real `opencode.db` session count unchanged at 11313 before and after both runs). Same prompt both runs: *"Call the 'skill' tool with name='ulw-interview'."*

- **What was tested:** `opencode run --format json` driving the model to invoke `skill(name="ulw-interview")`, against two builds of this branch's tree.
  **Observed result:**
  | Build | `skill(name="ulw-interview")` |
  |---|---|
  | BEFORE (this PR's 3-file change `git stash`ed, rebuilt) | `STATUS: error` → "not found. Available" |
  | AFTER (this PR applied) | `STATUS: completed` → `## Skill: ulw-interview` + full SKILL.md body |

  **Why sufficient:** the only variable between the two runs is this PR's diff. Dev source, model, sandbox layout, and isolation proof are identical. The AFTER `tool_use` event carries the complete ULW Interview SKILL.md in `part.state.output`, proving the resolver chain (`client.config.get()` → `hostSkills` → `createSkillContext` → `discoverConfigSourceSkills` → `createSkillTool.execute`) resolves the plugin-registered skill.

Unit tests (`packages/omo-opencode/src/tools/skill/get-loaded-skills-resolver.test.ts`, new): 4 execute-based tests covering (1) primary fix — `execute` returns the skill body when only `getLoadedSkills` knows the skill; (2) edge — `getLoadedSkills` without `skills`, with `commands`; (3) no-regression — legacy `skills`-only caller; (4) real-resolver integration — wires the real `createRuntimeSkillsResolver` + `createSkillContext` + `createSkillTool.execute` against a temp SKILL.md with only the transport stubbed.

## Risks & Residuals

- **Shared resolver cache:** `createRuntimeSkillsResolver` caches a single `inflight` promise for the process lifetime. Sharing one instance between `skill` and `skill_mcp` means both see the same resolved list. This is preferable to splitting (splitting would increase divergence, not reduce it) and matches the pre-existing `skill_mcp` semantics. **Mitigated** — the first call now happens post-startup (from `execute`), not from a risky constructor-time trigger, so transient-failure cache poisoning is far less likely than in `skill_mcp`'s prior stand-alone usage.
- **Description freshness before first execute:** the initial synchronous description paints from the static cache only; it refreshes to include plugin-registered skills after the first `execute` (which updates `cachedDescription` from the freshly-resolved skills). **Accepted** — the agent learns about plugin skills from opencode's native system-prompt listing (which is exactly why the bug surfaced: opencode listed `ulw-interview`, the agent called `skill`, omo's execute failed). The fix makes execute succeed; description freshness is a secondary concern that does not block the user path.
- **Case A model-driven run:** closed (see QA & Evidence). Non-determinism of the model choosing to call the tool was handled by an explicit instruction prompt; the run is reproducible with the documented sandbox setup.

## Automated Checks

```bash
bun run typecheck:packages   # exit 0
bun test packages/omo-opencode/src/tools/skill/ \
              packages/omo-opencode/src/tools/skill-mcp/ \
              packages/omo-opencode/src/tools/delegate-task/ \
              packages/omo-opencode/src/plugin/   # 862/862 pass
bun run build                # exit 0
```

## Related Issues

<!-- If a maintainer points me at the tracking issue for plugin-skill discovery, I'll link it here. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the skill tool so it can resolve plugin-registered skills (from opencode’s plugin array) at runtime. Calls like skill(name="ulw-interview") now succeed, matching `skill_mcp` behavior.

- **Bug Fixes**
  - Added optional `getLoadedSkills` to the skill tool; execute prefers it so plugin-only skills are discovered after startup (avoids the config fetch deadlock).
  - Shared one runtime skills resolver in tool-registry and wired it to both the skill tool and `skill_mcp`; initial description still uses the static list, execute uses the resolver.

<sup>Written for commit edf896a5b3c4cb1631a7e6bfd6ed7768fcaa6af5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

