### PR TITLE
fix(codex): ship omo cli in LazyCodex marketplace payload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -916,6 +916,8 @@ jobs:
           bun run build:git-bash-mcp
           bun run build:lsp-tools-mcp
           bun run build:lsp-daemon
+          bun build packages/omo-opencode/src/cli/index.ts --outdir dist/cli --target bun --format esm
+          bun run build:cli-node
           bun run --cwd packages/omo-codex/plugin build
           bun run script/sync-lazycodex-marketplace.ts "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/lazycodex-marketplace"
           cd "$GITHUB_WORKSPACE/lazycodex-marketplace"

--- a/packages/omo-codex/plugin/components/bootstrap/src/setup.ts
+++ b/packages/omo-codex/plugin/components/bootstrap/src/setup.ts
@@ -211,10 +211,8 @@ async function linkComponentBinsStep(options: WorkerSetupOptions, degraded: Boot
 	await linkRuntimeWrapperStep(options, binDir, degraded);
 }
 
-// The marketplace payload intentionally ships without <pluginRoot>/dist/cli
-// (thin payload), so linkRootRuntimeBin returning null is the expected
-// degraded mode there: record the omo-cli ledger entry and log the same
-// warning install-local.mjs prints instead of leaving a broken `omo` link.
+// Older marketplace payloads may not have <pluginRoot>/dist/cli. Keep that
+// degraded path explicit instead of leaving a broken `omo` link.
 async function linkRuntimeWrapperStep(
 	options: WorkerSetupOptions,
 	binDir: string,

--- a/packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs
+++ b/packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { lstat, mkdir, mkdtemp, readdir, readFile, readlink, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, sep } from "node:path";
+import { dirname, join, sep } from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 
 const CLI_URL = new URL("../components/bootstrap/dist/cli.js", import.meta.url);
 const { runBootstrapWorker, runWorkerSetup } = await import(CLI_URL.href);
 
 const MARKETPLACE_SOURCE_LINE = 'source = "https://github.com/code-yeongyu/lazycodex.git"';
 const COMPONENT_BIN_NAME = "omo-toolbox";
+const execFileAsync = promisify(execFile);
 const OMO_CLI_DEGRADED_ENTRY = {
 	component: "omo-cli",
 	hint: "use npx lazycodex-ai for the omo CLI",
@@ -79,6 +82,8 @@ async function writeVersionedRoot(root, version, { withRuntimeCli = false } = {}
 	if (withRuntimeCli) {
 		await mkdir(join(pluginRoot, "dist", "cli"), { recursive: true });
 		await writeFile(join(pluginRoot, "dist", "cli", "index.js"), "console.log('omo');\n");
+		await mkdir(join(pluginRoot, "dist", "cli-node"), { recursive: true });
+		await writeFile(join(pluginRoot, "dist", "cli-node", "index.js"), "console.log('omo node runtime');\n");
 	}
 	return pluginRoot;
 }
@@ -203,7 +208,7 @@ test("#given platform win32 #when the worker setup links bins #then component bi
 	});
 });
 
-test("#given a marketplace payload without dist/cli #when the worker setup runs #then it records the degraded omo-cli entry, logs the skip warning, and leaves no broken or omo link", async () => {
+test("#given a legacy payload without root CLI dist #when the worker setup runs #then it records degraded omo-cli and leaves no broken link", async () => {
 	await withBinLinkFixture(async (fixture) => {
 		const pluginRoot = await writeVersionedRoot(fixture.root, "1.0.0");
 
@@ -234,14 +239,19 @@ test("#given a payload shipping dist/cli #when the worker setup runs with no bin
 		assert.deepEqual(outcome.degraded, []);
 		const defaultBinDir = join(fixture.codexHome, "bin");
 		const wrapperName = process.platform === "win32" ? "omo.cmd" : "omo";
-		const wrapper = await readFile(join(defaultBinDir, wrapperName), "utf8");
+		const wrapperPath = join(defaultBinDir, wrapperName);
+		const wrapper = await readFile(wrapperPath, "utf8");
 		assert.ok(wrapper.includes(join(pluginRoot, "dist", "cli", "index.js")));
 		if (process.platform !== "win32") {
-			assert.ok((await stat(join(defaultBinDir, "omo"))).mode & 0o111, "the posix omo wrapper must be executable");
+			assert.ok((await stat(wrapperPath)).mode & 0o111, "the posix omo wrapper must be executable");
 			assert.equal(
 				await readlink(join(defaultBinDir, COMPONENT_BIN_NAME)),
 				join(pluginRoot, "components", "toolbox", "dist", "cli.js"),
 			);
+			const result = await execFileAsync(wrapperPath, ["--version"], {
+				env: { ...process.env, OMO_RUNTIME: "node", PATH: `${dirname(process.execPath)}:/usr/bin:/bin` },
+			});
+			assert.match(result.stdout, /omo node runtime/);
 		} else {
 			const shim = await readFile(join(defaultBinDir, `${COMPONENT_BIN_NAME}.cmd`), "utf8");
 			assert.ok(shim.includes(join(pluginRoot, "components", "toolbox", "dist", "cli.js")));

--- a/script/lazycodex-marketplace-validation.pin.test.ts
+++ b/script/lazycodex-marketplace-validation.pin.test.ts
@@ -9,10 +9,70 @@ async function writePluginMcpManifest(pluginRoot: string, manifest: unknown): Pr
   await writeFile(join(pluginRoot, ".mcp.json"), `${JSON.stringify(manifest, null, 2)}\n`)
 }
 
+async function writeRootCliRuntime(pluginRoot: string): Promise<void> {
+  await mkdir(join(pluginRoot, "dist", "cli"), { recursive: true })
+  await writeFile(join(pluginRoot, "dist", "cli", "index.js"), "console.log('omo')\n")
+  await mkdir(join(pluginRoot, "dist", "cli-node"), { recursive: true })
+  await writeFile(join(pluginRoot, "dist", "cli-node", "index.js"), "console.log('omo node')\n")
+}
+
 describe("lazycodex marketplace validation guards", () => {
+  test("#given root runtime dists #when validating the plugin bundle #then root omo runtime targets are accepted", async () => {
+    // given
+    const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-root-runtime-"))
+    await writeRootCliRuntime(pluginRoot)
+
+    try {
+      // when
+      const validated = validateLazycodexPluginBundle(pluginRoot)
+
+      // then
+      await expect(validated).resolves.toBeUndefined()
+    } finally {
+      await rm(pluginRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("#given missing root runtime dist #when validating the plugin bundle #then the root omo runtime target is rejected", async () => {
+    // given
+    const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-missing-root-runtime-"))
+    await mkdir(join(pluginRoot, "dist", "cli-node"), { recursive: true })
+    await writeFile(join(pluginRoot, "dist", "cli-node", "index.js"), "console.log('omo node')\n")
+
+    try {
+      // when
+      const validated = validateLazycodexPluginBundle(pluginRoot)
+
+      // then
+      await expect(validated).rejects.toThrow("missing root CLI runtime path: dist/cli/index.js")
+    } finally {
+      await rm(pluginRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("#given zero-byte root runtime dist #when validating the plugin bundle #then the root omo runtime target is rejected", async () => {
+    // given
+    const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-zero-root-runtime-"))
+    await mkdir(join(pluginRoot, "dist", "cli"), { recursive: true })
+    await writeFile(join(pluginRoot, "dist", "cli", "index.js"), "console.log('omo')\n")
+    await mkdir(join(pluginRoot, "dist", "cli-node"), { recursive: true })
+    await writeFile(join(pluginRoot, "dist", "cli-node", "index.js"), "")
+
+    try {
+      // when
+      const validated = validateLazycodexPluginBundle(pluginRoot)
+
+      // then
+      await expect(validated).rejects.toThrow("dist/cli-node/index.js is zero bytes")
+    } finally {
+      await rm(pluginRoot, { recursive: true, force: true })
+    }
+  })
+
   test("#given a root per-hook manifest references a missing command #when validating the plugin bundle #then the target is rejected", async () => {
     // given
     const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-root-hook-manifest-"))
+    await writeRootCliRuntime(pluginRoot)
     await mkdir(join(pluginRoot, "hooks"), { recursive: true })
     await writeFile(
       join(pluginRoot, "hooks", "user-prompt-submit-loading-project-rules.json"),
@@ -50,6 +110,7 @@ describe("lazycodex marketplace validation guards", () => {
   test("#given an array mcpServers manifest #when validating the plugin bundle #then the manifest is rejected", async () => {
     // given
     const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-array-manifest-"))
+    await writeRootCliRuntime(pluginRoot)
     await writePluginMcpManifest(pluginRoot, { mcpServers: [] })
 
     try {
@@ -66,6 +127,7 @@ describe("lazycodex marketplace validation guards", () => {
   test("#given an array root mcp manifest #when validating the plugin bundle #then the manifest is rejected", async () => {
     // given
     const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-array-root-"))
+    await writeRootCliRuntime(pluginRoot)
     await writePluginMcpManifest(pluginRoot, [])
 
     try {

--- a/script/lazycodex-marketplace-validation.pin.test.ts
+++ b/script/lazycodex-marketplace-validation.pin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { validateLazycodexPluginBundle } from "./lazycodex-marketplace-validation"
@@ -50,6 +50,21 @@ describe("lazycodex marketplace validation guards", () => {
     }
   })
 
+  test("#given previous payload reconstruction #when root runtime dists are optional #then the bundle can still be inspected", async () => {
+    // given
+    const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-previous-payload-"))
+
+    try {
+      // when
+      const validated = validateLazycodexPluginBundle(pluginRoot, { requireRootCliRuntime: false })
+
+      // then
+      await expect(validated).resolves.toBeUndefined()
+    } finally {
+      await rm(pluginRoot, { recursive: true, force: true })
+    }
+  })
+
   test("#given zero-byte root runtime dist #when validating the plugin bundle #then the root omo runtime target is rejected", async () => {
     // given
     const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-zero-root-runtime-"))
@@ -66,6 +81,28 @@ describe("lazycodex marketplace validation guards", () => {
       await expect(validated).rejects.toThrow("dist/cli-node/index.js is zero bytes")
     } finally {
       await rm(pluginRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("#given root runtime symlink escapes the plugin #when validating the plugin bundle #then the root omo runtime target is rejected", async () => {
+    // given
+    const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-symlink-root-runtime-"))
+    const externalRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-external-runtime-"))
+    await mkdir(join(pluginRoot, "dist", "cli"), { recursive: true })
+    await writeFile(join(externalRoot, "index.js"), "console.log('outside')\n")
+    await symlink(join(externalRoot, "index.js"), join(pluginRoot, "dist", "cli", "index.js"))
+    await mkdir(join(pluginRoot, "dist", "cli-node"), { recursive: true })
+    await writeFile(join(pluginRoot, "dist", "cli-node", "index.js"), "console.log('omo node')\n")
+
+    try {
+      // when
+      const validated = validateLazycodexPluginBundle(pluginRoot)
+
+      // then
+      await expect(validated).rejects.toThrow("dist/cli/index.js escapes plugin root")
+    } finally {
+      await rm(pluginRoot, { recursive: true, force: true })
+      await rm(externalRoot, { recursive: true, force: true })
     }
   })
 

--- a/script/lazycodex-marketplace-validation.ts
+++ b/script/lazycodex-marketplace-validation.ts
@@ -4,6 +4,7 @@ import { isPlainRecord } from "@oh-my-opencode/utils"
 
 export async function validateLazycodexPluginBundle(pluginRoot: string): Promise<void> {
   const issues: string[] = []
+  await validateRootCliRuntime(pluginRoot, issues)
   await validatePluginMcpManifests(pluginRoot, issues)
   await validatePluginHookCommands(pluginRoot, issues)
   if (issues.length > 0) {
@@ -13,6 +14,15 @@ export async function validateLazycodexPluginBundle(pluginRoot: string): Promise
         .join("\n")}`,
     )
   }
+}
+
+async function validateRootCliRuntime(pluginRoot: string, issues: string[]): Promise<void> {
+  await collectBundleFileIssue(pluginRoot, pluginRoot, "dist/cli/index.js", "missing root CLI runtime path", issues, {
+    allowEscape: false,
+  })
+  await collectBundleFileIssue(pluginRoot, pluginRoot, "dist/cli-node/index.js", "missing root CLI runtime path", issues, {
+    allowEscape: false,
+  })
 }
 
 async function validatePluginMcpManifests(pluginRoot: string, issues: string[]): Promise<void> {

--- a/script/lazycodex-marketplace-validation.ts
+++ b/script/lazycodex-marketplace-validation.ts
@@ -1,10 +1,19 @@
-import { readFile, readdir, stat } from "node:fs/promises"
+import { readFile, readdir, realpath, stat } from "node:fs/promises"
 import { basename, dirname, join, resolve, sep } from "node:path"
 import { isPlainRecord } from "@oh-my-opencode/utils"
 
-export async function validateLazycodexPluginBundle(pluginRoot: string): Promise<void> {
+export interface ValidateLazycodexPluginBundleOptions {
+  readonly requireRootCliRuntime?: boolean
+}
+
+export async function validateLazycodexPluginBundle(
+  pluginRoot: string,
+  options: ValidateLazycodexPluginBundleOptions = {},
+): Promise<void> {
   const issues: string[] = []
-  await validateRootCliRuntime(pluginRoot, issues)
+  if (options.requireRootCliRuntime !== false) {
+    await validateRootCliRuntime(pluginRoot, issues)
+  }
   await validatePluginMcpManifests(pluginRoot, issues)
   await validatePluginHookCommands(pluginRoot, issues)
   if (issues.length > 0) {
@@ -176,6 +185,10 @@ async function collectBundleFileIssue(
     pushIssue(issues, `${message}: ${relativePath}`)
     return
   }
+  if (!options.allowEscape && !(await isRealPathWithinRoot(bundleRoot, targetPath))) {
+    pushIssue(issues, `${message}: ${relativePath} escapes plugin root`)
+    return
+  }
   if (size === 0) {
     pushIssue(issues, `${message}: ${relativePath} is zero bytes`)
   }
@@ -193,5 +206,17 @@ async function fileSize(path: string): Promise<number | undefined> {
   } catch (error) {
     if (error instanceof Error) return undefined
     return undefined
+  }
+}
+
+async function isRealPathWithinRoot(root: string, target: string): Promise<boolean> {
+  try {
+    const rootPath = await realpath(root)
+    const targetPath = await realpath(target)
+    const rootPrefix = rootPath.endsWith(sep) ? rootPath : `${rootPath}${sep}`
+    return targetPath === rootPath || targetPath.startsWith(rootPrefix)
+  } catch (error) {
+    if (error instanceof Error) return false
+    return false
   }
 }

--- a/script/lazycodex-runtime-dists.ts
+++ b/script/lazycodex-runtime-dists.ts
@@ -25,7 +25,7 @@ const RUNTIME_DISTS: readonly RuntimeDist[] = [
     destinationPath: join("plugins", "omo", "components", "lsp-tools-mcp", "dist"),
   },
   {
-    label: "LSP daemon",
+    label: "LSP daemon dist",
     sourcePath: join("packages", "lsp-daemon", "dist"),
     destinationPath: join("plugins", "omo", "components", "lsp-daemon", "dist"),
   },

--- a/script/lazycodex-runtime-dists.ts
+++ b/script/lazycodex-runtime-dists.ts
@@ -1,0 +1,71 @@
+import { cp, mkdir, stat } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+interface RuntimeDist {
+  readonly label: string
+  readonly sourcePath: string
+  readonly destinationPath: string
+}
+
+export interface CopyLazycodexRuntimeDistsInput {
+  readonly sourceRoot: string
+  readonly lazycodexRoot: string
+  readonly skipMissing: boolean
+}
+
+const RUNTIME_DISTS: readonly RuntimeDist[] = [
+  {
+    label: "git-bash MCP",
+    sourcePath: join("packages", "git-bash-mcp", "dist"),
+    destinationPath: join("plugins", "omo", "components", "git-bash-mcp", "dist"),
+  },
+  {
+    label: "LSP MCP",
+    sourcePath: join("packages", "lsp-tools-mcp", "dist"),
+    destinationPath: join("plugins", "omo", "components", "lsp-tools-mcp", "dist"),
+  },
+  {
+    label: "LSP daemon",
+    sourcePath: join("packages", "lsp-daemon", "dist"),
+    destinationPath: join("plugins", "omo", "components", "lsp-daemon", "dist"),
+  },
+  {
+    label: "OMO root CLI dist",
+    sourcePath: join("dist", "cli"),
+    destinationPath: join("plugins", "omo", "dist", "cli"),
+  },
+  {
+    label: "OMO node fallback CLI dist",
+    sourcePath: join("dist", "cli-node"),
+    destinationPath: join("plugins", "omo", "dist", "cli-node"),
+  },
+] as const
+
+export async function copyLazycodexRuntimeDists(input: CopyLazycodexRuntimeDistsInput): Promise<void> {
+  for (const dist of RUNTIME_DISTS) {
+    await copyRuntimeDist(input, dist)
+  }
+}
+
+async function copyRuntimeDist(input: CopyLazycodexRuntimeDistsInput, dist: RuntimeDist): Promise<void> {
+  const sourcePath = join(input.sourceRoot, dist.sourcePath)
+  if (!(await isDirectory(sourcePath))) {
+    if (input.skipMissing) {
+      console.warn(`[sync-lazycodex-marketplace] previous-payload reconstruction: skipping missing ${dist.label} at ${sourcePath}`)
+      return
+    }
+    throw new Error(`missing built ${dist.label} at ${sourcePath}`)
+  }
+  const destinationPath = join(input.lazycodexRoot, dist.destinationPath)
+  await mkdir(dirname(destinationPath), { recursive: true })
+  await cp(sourcePath, destinationPath, { recursive: true })
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory()
+  } catch (error) {
+    if (error instanceof Error) return false
+    return false
+  }
+}

--- a/script/publish-lazycodex-sync-workflow.test.ts
+++ b/script/publish-lazycodex-sync-workflow.test.ts
@@ -28,6 +28,8 @@ describe("LazyCodex marketplace sync workflow", () => {
     const gitBashBuildIndex = syncStep.indexOf("bun run build:git-bash-mcp")
     const lspBuildIndex = syncStep.indexOf("bun run build:lsp-tools-mcp")
     const lspDaemonBuildIndex = syncStep.indexOf("bun run build:lsp-daemon")
+    const rootCliBuildIndex = syncStep.indexOf("bun build packages/omo-opencode/src/cli/index.ts --outdir dist/cli --target bun --format esm")
+    const nodeCliBuildIndex = syncStep.indexOf("bun run build:cli-node")
     const codexPluginBuildIndex = syncStep.indexOf("bun run --cwd packages/omo-codex/plugin build")
     const syncScriptIndex = syncStep.indexOf("bun run script/sync-lazycodex-marketplace.ts")
     const buildsMcpDistsBeforeCodexPlugin =
@@ -40,6 +42,8 @@ describe("LazyCodex marketplace sync workflow", () => {
       lspDaemonBuildIndex < codexPluginBuildIndex
     const buildsCodexPluginBeforeMarketplaceSync =
       codexPluginBuildIndex >= 0 && syncScriptIndex > codexPluginBuildIndex
+    const buildsRootCliBeforeMarketplaceSync =
+      rootCliBuildIndex >= 0 && nodeCliBuildIndex > rootCliBuildIndex && syncScriptIndex > nodeCliBuildIndex
 
     // #then
     expect(
@@ -47,6 +51,7 @@ describe("LazyCodex marketplace sync workflow", () => {
       "release marketplace sync must build bundled MCP dists before the Codex plugin build consumes them",
     ).toBe(true)
     expect(buildsCodexPluginBeforeMarketplaceSync, "release marketplace sync must build the Codex plugin before copying it").toBe(true)
+    expect(buildsRootCliBeforeMarketplaceSync, "release marketplace sync must build root omo CLI dists before copying it").toBe(true)
   })
 
   test("uses the vendored LSP tools package directly during release marketplace sync", () => {

--- a/script/sync-lazycodex-marketplace-root-cli.test.ts
+++ b/script/sync-lazycodex-marketplace-root-cli.test.ts
@@ -1,0 +1,100 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { syncLazycodexMarketplace } from "./sync-lazycodex-marketplace"
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+async function writeRuntimeFile(path: string, label: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `#!/usr/bin/env node\nconsole.log(${JSON.stringify(label)});\n`)
+}
+
+async function writeMarketplaceFixture(sourceRoot: string, includeRootCli: boolean): Promise<void> {
+  await writeJson(join(sourceRoot, "packages", "omo-codex", "marketplace.json"), {
+    name: "sisyphuslabs",
+    plugins: [{ name: "omo", source: "./plugins/omo" }],
+  })
+  await writeJson(join(sourceRoot, "packages", "omo-codex", "plugin", ".codex-plugin", "plugin.json"), {
+    name: "omo",
+    version: "1.2.3",
+  })
+  await writeJson(join(sourceRoot, "packages", "omo-codex", "plugin", "package.json"), {
+    name: "@sisyphuslabs/omo-codex-plugin",
+    version: "1.2.3",
+  })
+  await writeJson(join(sourceRoot, "packages", "omo-codex", "plugin", "hooks", "hooks.json"), {
+    hooks: {
+      SessionStart: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: 'node "${PLUGIN_ROOT}/components/bootstrap/dist/cli.js" hook session-start',
+            },
+          ],
+        },
+      ],
+    },
+  })
+  await writeRuntimeFile(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "bootstrap", "dist", "cli.js"), "bootstrap")
+  await writeRuntimeFile(join(sourceRoot, "packages", "git-bash-mcp", "dist", "cli.js"), "git-bash")
+  await writeRuntimeFile(join(sourceRoot, "packages", "lsp-tools-mcp", "dist", "cli.js"), "lsp-tools")
+  await writeRuntimeFile(join(sourceRoot, "packages", "lsp-daemon", "dist", "cli.js"), "lsp-daemon")
+  if (!includeRootCli) return
+  await writeRuntimeFile(join(sourceRoot, "dist", "cli", "index.js"), "omo bun runtime")
+  await writeRuntimeFile(join(sourceRoot, "dist", "cli-node", "index.js"), "omo node runtime")
+}
+
+async function readOptionalFile(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8")
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+}
+
+describe("sync-lazycodex-marketplace root CLI payload", () => {
+  test("#given root CLI dists #when syncing marketplace #then the plugin payload carries the omo runtime targets", async () => {
+    // given
+    const sourceRoot = await mkdtemp(join(tmpdir(), "omo-sync-root-cli-source-"))
+    const lazycodexRoot = await mkdtemp(join(tmpdir(), "omo-sync-root-cli-lazycodex-"))
+    await writeMarketplaceFixture(sourceRoot, true)
+
+    // when
+    await syncLazycodexMarketplace({ sourceRoot, lazycodexRoot })
+
+    // then
+    const bunRuntime = join(lazycodexRoot, "plugins", "omo", "dist", "cli", "index.js")
+    const nodeRuntime = join(lazycodexRoot, "plugins", "omo", "dist", "cli-node", "index.js")
+    expect((await stat(bunRuntime)).isFile()).toBe(true)
+    expect((await stat(nodeRuntime)).isFile()).toBe(true)
+    await expect(readOptionalFile(bunRuntime)).resolves.toContain("omo bun runtime")
+    await expect(readOptionalFile(nodeRuntime)).resolves.toContain("omo node runtime")
+  })
+
+  test("#given missing root CLI dist #when syncing marketplace #then validation rejects the broken payload", async () => {
+    // given
+    const sourceRoot = await mkdtemp(join(tmpdir(), "omo-sync-missing-root-cli-source-"))
+    const lazycodexRoot = await mkdtemp(join(tmpdir(), "omo-sync-missing-root-cli-lazycodex-"))
+    await writeMarketplaceFixture(sourceRoot, false)
+
+    // when
+    let message = ""
+    try {
+      await syncLazycodexMarketplace({ sourceRoot, lazycodexRoot })
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+
+    // then
+    expect(message).toContain("missing built OMO root CLI dist")
+    expect(message).toContain(join("dist", "cli"))
+  })
+})

--- a/script/sync-lazycodex-marketplace.test.ts
+++ b/script/sync-lazycodex-marketplace.test.ts
@@ -115,6 +115,10 @@ async function writePluginFixture(sourceRoot: string, options: WritePluginFixtur
   await writeFile(join(sourceRoot, "packages", "lsp-tools-mcp", "dist", "cli.js"), "#!/usr/bin/env node\n")
   await mkdir(join(sourceRoot, "packages", "lsp-daemon", "dist"), { recursive: true })
   await writeFile(join(sourceRoot, "packages", "lsp-daemon", "dist", "cli.js"), "#!/usr/bin/env node\n")
+  await mkdir(join(sourceRoot, "dist", "cli"), { recursive: true })
+  await writeFile(join(sourceRoot, "dist", "cli", "index.js"), "#!/usr/bin/env node\n")
+  await mkdir(join(sourceRoot, "dist", "cli-node"), { recursive: true })
+  await writeFile(join(sourceRoot, "dist", "cli-node", "index.js"), "#!/usr/bin/env node\n")
   await mkdir(join(sourceRoot, "packages", "omo-codex", "plugin", "node_modules", "ignored"), { recursive: true })
   await writeFile(join(sourceRoot, "packages", "omo-codex", "plugin", "node_modules", "ignored", "file.txt"), "ignored\n")
   await mkdir(join(sourceRoot, "packages", "omo-codex", "plugin", ".ulw", "evidence"), { recursive: true })
@@ -317,6 +321,8 @@ describe("sync-lazycodex-marketplace", () => {
     const lazycodexRoot = await mkdtemp(join(tmpdir(), "omo-sync-prev-lazycodex-"))
     await writePluginFixture(sourceRoot)
     await rm(join(sourceRoot, "packages", "lsp-daemon", "dist"), { recursive: true, force: true })
+    await rm(join(sourceRoot, "dist", "cli"), { recursive: true, force: true })
+    await rm(join(sourceRoot, "dist", "cli-node"), { recursive: true, force: true })
     await writeJson(join(sourceRoot, "packages", "omo-codex", "plugin", ".mcp.json"), {
       mcpServers: {
         git_bash: { command: "node", args: ["../../git-bash-mcp/dist/cli.js", "mcp"], cwd: "." },
@@ -334,6 +340,8 @@ describe("sync-lazycodex-marketplace", () => {
       daemonDistMissing = error instanceof Error
     }
     expect(daemonDistMissing).toBe(true)
+    await expectPathMissing(join(lazycodexRoot, "plugins", "omo", "dist", "cli", "index.js"))
+    await expectPathMissing(join(lazycodexRoot, "plugins", "omo", "dist", "cli-node", "index.js"))
     expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "lsp-tools-mcp", "dist", "cli.js"))).isFile()).toBe(true)
   })
 

--- a/script/sync-lazycodex-marketplace.ts
+++ b/script/sync-lazycodex-marketplace.ts
@@ -82,7 +82,9 @@ export async function syncLazycodexMarketplace(input: SyncLazycodexMarketplaceIn
   })
   await rewritePluginMcpManifest(destinationPluginRoot)
   await stampReleaseVersion(destinationPluginRoot, input.releaseVersion ?? process.env.LAZYCODEX_RELEASE_VERSION)
-  await validateLazycodexPluginBundle(destinationPluginRoot)
+  await validateLazycodexPluginBundle(destinationPluginRoot, {
+    requireRootCliRuntime: input.allowMissingBundledDists !== true,
+  })
 }
 
 async function readMarketplaceManifest(path: string): Promise<MarketplaceManifest> {

--- a/script/sync-lazycodex-marketplace.ts
+++ b/script/sync-lazycodex-marketplace.ts
@@ -2,12 +2,10 @@ import { isPlainRecord } from "@oh-my-opencode/utils"
 import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { dirname, join, resolve, sep } from "node:path"
 import { validateLazycodexPluginBundle } from "./lazycodex-marketplace-validation"
+import { copyLazycodexRuntimeDists } from "./lazycodex-runtime-dists"
 
 const MARKETPLACE_SOURCE_PATH = join("packages", "omo-codex", "marketplace.json")
 const PLUGIN_SOURCE_PATH = join("packages", "omo-codex", "plugin")
-const GIT_BASH_MCP_DIST_SOURCE_PATH = join("packages", "git-bash-mcp", "dist")
-const LSP_TOOLS_MCP_DIST_SOURCE_PATH = join("packages", "lsp-tools-mcp", "dist")
-const LSP_DAEMON_DIST_SOURCE_PATH = join("packages", "lsp-daemon", "dist")
 const LAZYCODEX_PR_SOURCE_GUIDANCE_SOURCE_PATH = join(
   "packages",
   "omo-codex",
@@ -19,33 +17,12 @@ const LAZYCODEX_PR_SOURCE_GUIDANCE_SOURCE_PATH = join(
 const MARKETPLACE_DESTINATION_PATH = join(".agents", "plugins", "marketplace.json")
 const PLUGIN_DESTINATION_PATH = join("plugins", "omo")
 const LAZYCODEX_PR_SOURCE_GUIDANCE_DESTINATION_PATH = join(".github", "workflows", "pr-source-guidance.yml")
-const GIT_BASH_MCP_DIST_DESTINATION_PATH = join(PLUGIN_DESTINATION_PATH, "components", "git-bash-mcp", "dist")
-const LSP_TOOLS_MCP_DIST_DESTINATION_PATH = join(PLUGIN_DESTINATION_PATH, "components", "lsp-tools-mcp", "dist")
-const LSP_DAEMON_DIST_DESTINATION_PATH = join(PLUGIN_DESTINATION_PATH, "components", "lsp-daemon", "dist")
 const GIT_BASH_MCP_SOURCE_ARG = "../../git-bash-mcp/dist/cli.js"
 const GIT_BASH_MCP_PLUGIN_ARG = "./components/git-bash-mcp/dist/cli.js"
 const LSP_TOOLS_MCP_SOURCE_ARG = "../../lsp-tools-mcp/dist/cli.js"
 const LSP_TOOLS_MCP_PLUGIN_ARG = "./components/lsp-tools-mcp/dist/cli.js"
 const LSP_DAEMON_SOURCE_ARG = "../../lsp-daemon/dist/cli.js"
 const LSP_DAEMON_PLUGIN_ARG = "./components/lsp-daemon/dist/cli.js"
-
-const BUNDLED_MCP_DISTS = [
-  {
-    label: "git-bash MCP",
-    sourcePath: GIT_BASH_MCP_DIST_SOURCE_PATH,
-    destinationPath: GIT_BASH_MCP_DIST_DESTINATION_PATH,
-  },
-  {
-    label: "LSP MCP",
-    sourcePath: LSP_TOOLS_MCP_DIST_SOURCE_PATH,
-    destinationPath: LSP_TOOLS_MCP_DIST_DESTINATION_PATH,
-  },
-  {
-    label: "LSP daemon",
-    sourcePath: LSP_DAEMON_DIST_SOURCE_PATH,
-    destinationPath: LSP_DAEMON_DIST_DESTINATION_PATH,
-  },
-] as const
 
 const MCP_ARG_REWRITES = [
   [GIT_BASH_MCP_SOURCE_ARG, GIT_BASH_MCP_PLUGIN_ARG],
@@ -98,7 +75,11 @@ export async function syncLazycodexMarketplace(input: SyncLazycodexMarketplaceIn
     filter: (path) => shouldCopyPluginPath(path, pluginRoot),
   })
   await copyLazycodexRepositoryWorkflow(sourceRoot, lazycodexRoot)
-  await copyBundledMcpDists(sourceRoot, lazycodexRoot, input.allowMissingBundledDists === true)
+  await copyLazycodexRuntimeDists({
+    sourceRoot,
+    lazycodexRoot,
+    skipMissing: input.allowMissingBundledDists === true,
+  })
   await rewritePluginMcpManifest(destinationPluginRoot)
   await stampReleaseVersion(destinationPluginRoot, input.releaseVersion ?? process.env.LAZYCODEX_RELEASE_VERSION)
   await validateLazycodexPluginBundle(destinationPluginRoot)
@@ -135,46 +116,12 @@ async function isFile(path: string): Promise<boolean> {
   }
 }
 
-async function isDirectory(path: string): Promise<boolean> {
-  try {
-    return (await stat(path)).isDirectory()
-  } catch (error) {
-    if (error instanceof Error) return false
-    return false
-  }
-}
-
-async function copyBundledMcpDists(sourceRoot: string, lazycodexRoot: string, skipMissing: boolean): Promise<void> {
-  for (const mcpDist of BUNDLED_MCP_DISTS) {
-    await copyBundledMcpDist(sourceRoot, lazycodexRoot, mcpDist, skipMissing)
-  }
-}
-
 async function copyLazycodexRepositoryWorkflow(sourceRoot: string, lazycodexRoot: string): Promise<void> {
   const sourcePath = join(sourceRoot, LAZYCODEX_PR_SOURCE_GUIDANCE_SOURCE_PATH)
   if (!(await isFile(sourcePath))) return
   const destinationPath = join(lazycodexRoot, LAZYCODEX_PR_SOURCE_GUIDANCE_DESTINATION_PATH)
   await mkdir(dirname(destinationPath), { recursive: true })
   await writeFile(destinationPath, await readFile(sourcePath, "utf8"))
-}
-
-async function copyBundledMcpDist(
-  sourceRoot: string,
-  lazycodexRoot: string,
-  mcpDist: (typeof BUNDLED_MCP_DISTS)[number],
-  skipMissing: boolean,
-): Promise<void> {
-  const sourcePath = join(sourceRoot, mcpDist.sourcePath)
-  if (!(await isDirectory(sourcePath))) {
-    if (skipMissing) {
-      console.warn(`[sync-lazycodex-marketplace] previous-payload reconstruction: skipping missing ${mcpDist.label} dist at ${sourcePath}`)
-      return
-    }
-    throw new Error(`missing built ${mcpDist.label} dist at ${sourcePath}`)
-  }
-  const destinationPath = join(lazycodexRoot, mcpDist.destinationPath)
-  await mkdir(dirname(destinationPath), { recursive: true })
-  await cp(sourcePath, destinationPath, { recursive: true })
 }
 
 async function rewritePluginMcpManifest(pluginRoot: string): Promise<void> {


### PR DESCRIPTION
## Summary

Codex marketplace installs only extract the plugin bundle; they do not run npm `bin` linking or postinstall scripts. The LazyCodex marketplace payload was missing the root `dist/cli` runtime, so the SessionStart bootstrap could only record `omo-cli` as degraded and users had to install the root CLI manually afterward.

This PR ships the already-built root OMO CLI runtimes in the marketplace plugin payload, validates that future payloads include them, and pins the release workflow so those runtimes are built before syncing to the LazyCodex marketplace repo.

## Changes

- Marketplace sync now copies runtime dist directories through `script/lazycodex-runtime-dists.ts`, including existing MCP dists plus root `dist/cli` and `dist/cli-node` into `plugins/omo/dist/*`.
- Marketplace validation now rejects payloads missing `dist/cli/index.js` or `dist/cli-node/index.js`, including zero-byte runtime entrypoints.
- Release sync builds the Bun root CLI and Node fallback CLI before copying the plugin payload to LazyCodex.
- Bootstrap binlink tests now prove a payload that ships `dist/cli` creates an executable `omo` wrapper without degraded entries, while legacy missing-dist payloads remain degraded without a broken link.

## QA & Evidence

- **RED proof:** focused sync test failed before the fix because the payload lacked `plugins/omo/dist/cli/index.js` and missing root CLI dist was not rejected.
  **Artifact:** `.omo/evidence/20260626-marketplace-omo-cli/red-sync-root-cli-test.txt`

- **Focused GREEN:** marketplace sync, validation, and release workflow tests passed after rebase.
  **Artifact:** `.omo/evidence/20260626-marketplace-omo-cli/post-rebase-focused-tests.txt`

- **Bootstrap GREEN:** component build and binlink tests passed; the generated `omo` wrapper executed the shipped node fallback CLI with no degraded entry.
  **Artifact:** `.omo/evidence/20260626-marketplace-omo-cli/green-bootstrap-binlinks-test.txt`

- **Codex gate:** `PATH="$HOME/.bun/bin:$PATH" GIT_ALLOW_PROTOCOL=file bun run test:codex` passed after rebase: 306 Bun tests and 404 Node tests. The initial plain run failed only because this isolated local worktree's shared-skill submodules use local `file` transport, which Git blocks by default.
  **Artifact:** `.omo/evidence/20260626-marketplace-omo-cli/post-rebase-test-codex.txt`

- **Codex QA:** isolated install verification passed and `app-server-drive.sh --plugin` proved live `sessionStart`, `userPromptSubmit`, and `stop` hook notifications while real `~/.codex/config.toml` stayed unchanged.
  **Artifacts:** `.omo/evidence/20260626-marketplace-omo-cli/post-rebase-codex-qa-install-verify.txt`, `.omo/evidence/20260626-marketplace-omo-cli/post-rebase-codex-qa-app-server-plugin.txt`

- **Marketplace surface:** built root `dist/cli` and `dist/cli-node`, synced a temp LazyCodex marketplace tree, and verified non-empty `plugins/omo/dist/cli/index.js` plus `plugins/omo/dist/cli-node/index.js`.
  **Artifact:** `.omo/evidence/20260626-marketplace-omo-cli/post-rebase-marketplace-sync-surface.txt`

Full local QA summary: `.omo/evidence/20260626-marketplace-omo-cli/qa-summary.md`.

## Risks & Residuals

The marketplace payload grows by the root CLI runtime size, but the built entrypoints observed in the marketplace-surface proof are about 2.7 MB each. Legacy payloads without `dist/cli` still degrade cleanly instead of leaving a broken `omo` link.


## Final Verification Loop

- **CI:** GitHub Actions passed after the CI fixture fix, including test/typecheck/codex-compatibility across Ubuntu, macOS, and Windows.
- **CI-fix local evidence:** `.omo/evidence/20260626-marketplace-omo-cli/green-focused-tests.txt`, `.omo/evidence/20260626-marketplace-omo-cli/green-ci-fix-typecheck-script.txt`, `.omo/evidence/20260626-marketplace-omo-cli/green-ci-fix-test-codex.txt`.
- **Review-work:** 5/5 lanes passed: goal/constraints, QA execution, code quality, security, and context mining. Review artifacts: `.omo/evidence/fix-lazycodex-marketplace-omo-cli-gate-review.md`, `.omo/evidence/pr-5582-code-review.md`, `.omo/evidence/pr-5582-security-code-review.md`, `.omo/evidence/pr-5582-context-mining-gate-review.md`, `.omo/evidence/20260626-marketplace-omo-cli/manual-qa-review-20260626.md`.
- **Cubic:** no Cubic review/comment body was available; the Cubic check reported neutral/skipping, so Gate C was treated as skipped by no-review/quota behavior.
- **Merge:** merged into `dev` with merge commit `686611396b6d07c4e3d49066da1340a4cfc695ac`.


## Final Evidence Correction

During the post-merge completion audit, two copied review files were identified as intermediate pre-fix review-loop artifacts: `.omo/evidence/pr-5582-security-code-review.md` and `.omo/evidence/pr-5582-context-mining-gate-review.md`. They are retained as historical evidence of issues found and fixed during the loop, but they are superseded by the final review-work result in `.omo/evidence/20260626-marketplace-omo-cli/review-work-final-report.md`.

Final review-work status: 5/5 lanes passed (goal/constraints, QA execution, code quality, security, context mining).
