### PR TITLE
fix(opencode): hint builtin codegraph mcp calls

### DIFF
--- a/packages/omo-opencode/src/tools/skill-mcp/builtin-mcp-hint.test.ts
+++ b/packages/omo-opencode/src/tools/skill-mcp/builtin-mcp-hint.test.ts
@@ -15,6 +15,26 @@ const mockContext = {
 }
 
 describe("skill_mcp builtin MCP hint", () => {
+  it("returns builtin hint for codegraph", async () => {
+    const tool = createSkillMcpTool({
+      manager: new SkillMcpManager(),
+      getLoadedSkills: () => [],
+      getSessionID: () => "session",
+    })
+
+    await expect(
+      tool.execute({ mcp_name: "codegraph", tool_name: "codegraph_status" }, mockContext),
+    ).rejects.toThrow(/builtin MCP/)
+
+    await expect(
+      tool.execute({ mcp_name: "codegraph", tool_name: "codegraph_status" }, mockContext),
+    ).rejects.toThrow(/codegraph_status/)
+
+    await expect(
+      tool.execute({ mcp_name: "codegraph", tool_name: "codegraph_status" }, mockContext),
+    ).rejects.toThrow(/do not retry this builtin through skill_mcp/)
+  })
+
   it("returns builtin hint for context7", async () => {
     const tool = createSkillMcpTool({
       manager: new SkillMcpManager(),

--- a/packages/omo-opencode/src/tools/skill-mcp/constants.ts
+++ b/packages/omo-opencode/src/tools/skill-mcp/constants.ts
@@ -3,6 +3,16 @@ export const SKILL_MCP_TOOL_NAME = "skill_mcp"
 export const SKILL_MCP_DESCRIPTION = `Invoke MCP server operations from skill-embedded MCPs. Requires mcp_name plus exactly one of: tool_name, resource_name, or prompt_name.`
 
 export const BUILTIN_MCP_TOOL_HINTS: Record<string, string[]> = {
+  codegraph: [
+    "codegraph_status",
+    "codegraph_explore",
+    "codegraph_search",
+    "codegraph_node",
+    "codegraph_callers",
+    "codegraph_callees",
+    "codegraph_impact",
+    "codegraph_files",
+  ],
   context7: ["context7_resolve-library-id", "context7_query-docs"],
   websearch: ["websearch_web_search_exa"],
   grep_app: ["grep_app_searchGitHub"],

--- a/packages/omo-opencode/src/tools/skill-mcp/tools.ts
+++ b/packages/omo-opencode/src/tools/skill-mcp/tools.ts
@@ -78,7 +78,8 @@ function formatBuiltinMcpHint(mcpName: string): string | null {
   if (!nativeTools) return null
   return (
     `"${mcpName}" is a builtin MCP, not a skill MCP.\n` +
-    `Use the native tools directly:\n` +
+    `skill_mcp can only call MCP servers declared by loaded skills; do not retry this builtin through skill_mcp.\n` +
+    `Use the native builtin tool names when OpenCode exposes them:\n` +
     nativeTools.map((toolName) => `  - ${toolName}`).join("\n")
   )
 }


### PR DESCRIPTION
## Summary

This PR makes the `skill_mcp` error path recognize `codegraph` as one of OMO's built-in MCPs. When an agent mistakenly tries to call `codegraph_status` through `skill_mcp`, it now gets an explicit hint to use the native built-in MCP tool route instead of retrying the same failing call.

The behavior is intentionally narrow: this does not add a wrapper layer or change codegraph startup. It fixes the confusing recovery path that turned a builtin MCP mismatch into an unhelpful `MCP server "codegraph" not found` style error.

## Changes

- Adds `codegraph` to the builtin MCP hint table with the native codegraph tool names.
- Updates the `skill_mcp` failure copy to state that `skill_mcp` only calls MCPs declared by skills, not built-in MCPs.
- Adds a regression test proving `mcp_name: "codegraph"` returns a builtin hint that includes `codegraph_status`.

## QA & Evidence

- **What was tested:** Focused regression tests for builtin MCP hint behavior.
  **Observed result:** 20 passing tests, 0 failures.
  **Artifact:** `.omo/evidence/20260626-codegraph-skill-mcp-hint/focused-tests.log`
  **Why sufficient:** Covers the exact `skill_mcp` hint behavior changed by this PR.

- **What was tested:** Isolated real OpenCode run using the worktree plugin with a fake local OpenAI-compatible model that calls `skill_mcp` with `mcp_name: "codegraph"` and `tool_name: "codegraph_status"`.
  **Observed result:** The tool error now says `"codegraph" is a builtin MCP, not a skill MCP`, says not to retry through `skill_mcp`, includes `codegraph_status`, and the run completed with marker `CODEGRAPH_SKILL_MCP_QA_DONE`.
  **Artifact:** `.omo/evidence/20260626-codegraph-skill-mcp-hint/isolated-opencode-run-key-events.ndjson`
  **Why sufficient:** Drives the real OpenCode surface in an isolated XDG sandbox and proves the user-visible recovery hint appears for the reported misuse pattern.

- **What was tested:** Real OpenCode DB isolation before/after the isolated run.
  **Observed result:** Real session count stayed unchanged at `5737`.
  **Artifact:** `.omo/evidence/20260626-codegraph-skill-mcp-hint/real-db-session-count-diff.txt`
  **Why sufficient:** Proves the live QA did not pollute the user's real OpenCode database.

- **What was tested:** Isolated `opencode mcp list` visibility for built-in MCPs.
  **Observed result:** The isolated MCP list includes `codegraph`.
  **Artifact:** `.omo/evidence/20260626-codegraph-skill-mcp-hint/isolated-mcp-list-summary.txt`
  **Why sufficient:** Confirms codegraph is present as a builtin MCP in the same isolated environment, so the changed hint points users at the correct category.

- **What was tested:** Local repository gates.
  **Observed result:** `bun run typecheck:packages`, `bun run build`, `bun test`, `bun run check:diff`, and TypeScript no-excuse checks passed after build refreshed generated skill content.
  **Artifacts:** `.omo/evidence/20260626-codegraph-skill-mcp-hint/typecheck-packages.log`, `.omo/evidence/20260626-codegraph-skill-mcp-hint/build.log`, `.omo/evidence/20260626-codegraph-skill-mcp-hint/bun-test-after-build.log`, `.omo/evidence/20260626-codegraph-skill-mcp-hint/git-diff-check.log`, `.omo/evidence/20260626-codegraph-skill-mcp-hint/typescript-no-excuse.log`
  **Why sufficient:** Covers compile, build, full test suite, generated output cleanliness, and local style constraints.

## Risks & Residuals

- This does not repair a separate codegraph server crash if one exists. It makes OMO's recovery message actionable when the builtin MCP is mistakenly routed through `skill_mcp`.
- Runtime risk is low because the change only affects the error message assembled after `skill_mcp` cannot find a skill-declared MCP server.

## Related Issues

User-reported OpenCode OMO symptom: `codegraph MCP error -32000: Connection closed`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds builtin MCP hinting for `codegraph` in `skill_mcp` so users see clear guidance and native tool suggestions (e.g., `codegraph_status`) instead of “MCP server not found.” This stops retry loops by telling users not to route builtin MCPs through `skill_mcp`.

- **Bug Fixes**
  - Added `codegraph` to `BUILTIN_MCP_TOOL_HINTS` with native tool names.
  - Updated `skill_mcp` error copy to explain builtin vs skill MCPs and to not retry via `skill_mcp`.
  - Added a regression test validating the `codegraph` hint (includes `codegraph_status`).

<sup>Written for commit 93d46912abf7fb5158cbbaa2a2d53e55e05b59c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

