### PR TITLE
docs(codex): clarify LazyCodex compatibility

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -738,6 +738,8 @@ Skip this section if `--platform=opencode`. Otherwise, the user installed the **
 
 The Codex CLI Light edition is fully independent of the OpenCode plugin. You can install both side-by-side. They share no runtime state, no config files, and no model selection. Each emits its own daily telemetry event.
 
+Compatibility note: LazyCodex is the Codex-platform OmO install path for `oh-my-openagent`. The bundled Codex-native subagents in `~/.codex/agents` are expected. Do not enable duplicate Codex-layer OmO/LazyCodex installs in a single `CODEX_HOME`; keep one `omo@sisyphuslabs` Codex plugin source active there. If the setup looks confused, run `npx lazycodex-ai doctor` before deleting cache or config state.
+
 #### Codex troubleshooting
 
 | Symptom | Fix |


### PR DESCRIPTION
## Summary

Clarifies the Codex Light edition compatibility guidance for users coming from LazyCodex issue #67. The install guide now explicitly says LazyCodex is the Codex-platform OmO install path for `oh-my-openagent`, Codex-native subagents are expected, and users should not enable duplicate Codex-layer OmO/LazyCodex installs in one `CODEX_HOME`.

## Changes

- Added one compatibility note under the existing "Coexistence with OpenCode" section in `docs/guide/installation.md`.
- Pointed confused installs at `npx lazycodex-ai doctor` before deleting cache or config state.

## QA & Evidence

- **Failing-first content check:** verified the guide was missing explicit issue #67 compatibility wording before the edit.
  - Artifact: `.omo/evidence/20260626-issue-67-compatibility/red.txt`
- **Green content check:** reran the same text assertion after the edit and confirmed all required phrases are present.
  - Artifact: `.omo/evidence/20260626-issue-67-compatibility/green.txt`
- **Manual docs QA:** inspected the edited guide section with numbered source output and confirmed the compatibility note appears in the docs surface.
  - Artifact: `.omo/evidence/20260626-issue-67-compatibility/manual-qa.txt`
- **Whitespace check:** `git diff --check HEAD~1 HEAD` exited 0.

## Risks & Residuals

Docs-only change. No runtime code, installer logic, schema, generated artifacts, or harness QA paths were touched.

## Related Issues

Refs code-yeongyu/lazycodex#67


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies LazyCodex compatibility in the install guide to prevent duplicate Codex-layer OmO/LazyCodex installs and reduce setup confusion. Adds a note under “Coexistence with OpenCode” that LazyCodex is the Codex-platform OmO path for `oh-my-openagent`, Codex-native subagents in `~/.codex/agents` are expected, keep one `omo@sisyphuslabs` source per `CODEX_HOME`, and run `npx lazycodex-ai doctor` before deleting cache or config.

<sup>Written for commit 169ac63d49fecd4044117724dfa7584680c01e65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

