### PR TITLE
fix(codex): remove stale Context7 placeholder config

### DIFF
--- a/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 
 import { FALLBACK_CATALOG, readModelCatalog } from "./migrate-codex-config/catalog.mjs";
 import { configPaths } from "./migrate-codex-config/config-paths.mjs";
+import { removeStaleContext7PlaceholderMcpServer } from "./migrate-codex-config/context7-placeholder-guard.mjs";
 import { removeUnsupportedRootMultiAgentMode } from "./migrate-codex-config/multi-agent-mode-guard.mjs";
 import { forceDisableMultiAgentV2 } from "./migrate-codex-config/multi-agent-v2-guard.mjs";
 import { ensureCodexReasoningConfig as applyReasoningProfile, readRootSettings } from "./migrate-codex-config/root-settings.mjs";
@@ -62,7 +63,11 @@ export async function migrateConfigFile(configPath, { catalog = FALLBACK_CATALOG
 	const multiAgentModeChanged = afterMultiAgentModeGuard !== config;
 	if (multiAgentModeChanged) config = afterMultiAgentModeGuard;
 
-	const changed = reasoningApplied || multiAgentChanged || multiAgentModeChanged;
+	const afterContext7PlaceholderGuard = removeStaleContext7PlaceholderMcpServer(config);
+	const context7PlaceholderChanged = afterContext7PlaceholderGuard !== config;
+	if (context7PlaceholderChanged) config = afterContext7PlaceholderGuard;
+
+	const changed = reasoningApplied || multiAgentChanged || multiAgentModeChanged || context7PlaceholderChanged;
 	if (changed) {
 		await mkdir(dirname(configPath), { recursive: true });
 		await writeFile(configPath, `${config.trimEnd()}\n`);

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/context7-placeholder-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/context7-placeholder-guard.mjs
@@ -1,0 +1,131 @@
+const CONTEXT7_HEADER = "[mcp_servers.context7]";
+
+export function removeStaleContext7PlaceholderMcpServer(config) {
+	return removeSections(config, (section) => section.header === CONTEXT7_HEADER && isContext7PlaceholderSection(section.text));
+}
+
+function isContext7PlaceholderSection(sectionText) {
+	const args = readStringArraySetting(sectionText, "args");
+	if (args === null || !args.includes("@upstash/context7-mcp")) return false;
+	const apiKey = valueAfter(args, "--api-key");
+	return apiKey !== null && isPlaceholderApiKey(apiKey);
+}
+
+function valueAfter(values, key) {
+	const index = values.indexOf(key);
+	return index >= 0 ? values[index + 1] ?? null : null;
+}
+
+function isPlaceholderApiKey(value) {
+	return /^your[-_ ]?api[-_ ]?key$/i.test(value);
+}
+
+function readStringArraySetting(sectionText, key) {
+	for (const line of sectionText.split("\n")) {
+		if (!new RegExp(`^\\s*${key}\\s*=`).test(line)) continue;
+		const assignmentIndex = line.indexOf("=");
+		if (assignmentIndex === -1) return null;
+		return parseTomlStringArray(stripUnquotedInlineComment(line.slice(assignmentIndex + 1)).trim());
+	}
+	return null;
+}
+
+function parseTomlStringArray(value) {
+	if (!value.startsWith("[") || !value.endsWith("]")) return null;
+	const items = [];
+	let index = 1;
+	while (index < value.length - 1) {
+		const char = value[index];
+		if (char === "\"" || char === "'") {
+			const parsed = parseTomlString(value, index);
+			if (parsed === null) return null;
+			items.push(parsed.value);
+			index = parsed.nextIndex;
+			continue;
+		}
+		index += 1;
+	}
+	return items;
+}
+
+function parseTomlString(input, startIndex) {
+	const quote = input[startIndex];
+	let value = "";
+	let index = startIndex + 1;
+	while (index < input.length) {
+		const char = input[index];
+		if (quote === "\"" && char === "\\") {
+			const next = input[index + 1];
+			if (next === undefined) return null;
+			value += next;
+			index += 2;
+			continue;
+		}
+		if (char === quote) return { value, nextIndex: index + 1 };
+		value += char;
+		index += 1;
+	}
+	return null;
+}
+
+function stripUnquotedInlineComment(line) {
+	let quote = null;
+	let index = 0;
+	while (index < line.length) {
+		const char = line[index];
+		if (quote === "\"") {
+			if (char === "\\") {
+				index += 2;
+				continue;
+			}
+			if (char === "\"") quote = null;
+			index += 1;
+			continue;
+		}
+		if (quote === "'") {
+			if (char === "'") quote = null;
+			index += 1;
+			continue;
+		}
+		if (char === "\"" || char === "'") {
+			quote = char;
+			index += 1;
+			continue;
+		}
+		if (char === "#") return line.slice(0, index);
+		index += 1;
+	}
+	return line;
+}
+
+function removeSections(config, shouldRemove) {
+	return splitSections(config)
+		.filter((section) => !shouldRemove(section))
+		.map((section) => section.text)
+		.join("")
+		.replace(/\n{3,}/g, "\n\n");
+}
+
+function splitSections(config) {
+	const lines = config.match(/[^\n]*\n?|$/g) ?? [];
+	const sections = [];
+	let current = { header: null, text: "" };
+	for (const line of lines) {
+		if (line.length === 0) break;
+		const header = tableHeader(line);
+		if (header !== null) {
+			if (current.text.length > 0) sections.push(current);
+			current = { header, text: line };
+		} else {
+			current = { ...current, text: current.text + line };
+		}
+	}
+	if (current.text.length > 0) sections.push(current);
+	return sections;
+}
+
+function tableHeader(line) {
+	const trimmed = stripUnquotedInlineComment(line).trim();
+	if (!trimmed.startsWith("[") || !trimmed.endsWith("]") || trimmed.startsWith("[[")) return null;
+	return trimmed;
+}

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -401,6 +401,80 @@ test("#given config already matches current catalog #when catalog version advanc
 	assert.doesNotMatch(content, /^\s*multi_agent_mode\s*=/m);
 });
 
+test("#given stale Context7 placeholder MCP config #when migrating #then removes it and keeps plugin policy", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-context7-placeholder-cleanup-"));
+	const codexHome = join(root, "codex-home");
+	const configPath = join(codexHome, "config.toml");
+	await mkdir(codexHome, { recursive: true });
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.5"',
+			"model_context_window = 400000",
+			'model_reasoning_effort = "high"',
+			'plan_mode_reasoning_effort = "xhigh"',
+			"",
+			"[mcp_servers.context7] # stale npx package from old docs",
+			'command = "npx"',
+			'args = ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]',
+			"startup_timeout_sec = 20",
+			"",
+			'[plugins."omo@sisyphuslabs".mcp_servers.context7]',
+			"enabled = true",
+			"",
+		].join("\n"),
+	);
+
+	const result = await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json") },
+		cwd: root,
+	});
+
+	const content = await readFile(configPath, "utf8");
+	assert.deepEqual(result.changed, [configPath]);
+	assert.doesNotMatch(content, /\[mcp_servers\.context7\]/);
+	assert.doesNotMatch(content, /@upstash\/context7-mcp/);
+	assert.doesNotMatch(content, /YOUR_API_KEY/);
+	assert.match(content, /\[plugins\."omo@sisyphuslabs"\.mcp_servers\.context7\][\s\S]*?enabled = true/);
+});
+
+test("#given real Context7 API key and placeholder comment #when migrating #then preserves user server settings", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-context7-real-key-"));
+	const codexHome = join(root, "codex-home");
+	const configPath = join(codexHome, "config.toml");
+	await mkdir(codexHome, { recursive: true });
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.5"',
+			"model_context_window = 400000",
+			'model_reasoning_effort = "high"',
+			'plan_mode_reasoning_effort = "xhigh"',
+			"",
+			"[mcp_servers.context7]",
+			'command = "npx"',
+			'args = ["-y", "@upstash/context7-mcp", "--api-key", "ctx7sk_live_example"] # replace YOUR_API_KEY in docs only',
+			"startup_timeout_sec = 20",
+			"",
+			'[plugins."omo@sisyphuslabs".mcp_servers.context7]',
+			"enabled = true",
+			"",
+		].join("\n"),
+	);
+
+	const result = await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json") },
+		cwd: root,
+	});
+
+	const content = await readFile(configPath, "utf8");
+	assert.deepEqual(result.changed, [configPath]);
+	assert.match(content, /\[mcp_servers\.context7\]/);
+	assert.match(content, /ctx7sk_live_example/);
+	assert.match(content, /replace YOUR_API_KEY in docs only/);
+	assert.match(content, /\[plugins\."omo@sisyphuslabs"\.mcp_servers\.context7\][\s\S]*?enabled = true/);
+});
+
 test("#given multi_agent_v2 enabled #when forcing disable #then flips the flag to false", () => {
 	const config = [
 		'model = "gpt-5.5"',

--- a/packages/omo-codex/scripts/install-config.test.mjs
+++ b/packages/omo-codex/scripts/install-config.test.mjs
@@ -137,7 +137,7 @@ test("#given existing Context7 MCP config #when script installer updates config 
 	await writeFile(
 		configPath,
 		[
-			"[mcp_servers.context7]",
+			"[mcp_servers.context7] # stale npx package from old docs",
 			'command = "node"',
 			'args = ["/opt/context7/server.js"]',
 			'startup_timeout_sec = 40',
@@ -160,6 +160,70 @@ test("#given existing Context7 MCP config #when script installer updates config 
 	assert.match(config, /command = "node"/);
 	assert.match(config, /args = \["\/opt\/context7\/server\.js"\]/);
 	assert.match(config, /startup_timeout_sec = 40/);
+	assert.doesNotMatch(config, /YOUR_API_KEY/);
+});
+
+test("#given real Context7 API key and placeholder comment #when script installer updates config #then preserves user setup", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-context7-real-key-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			"[mcp_servers.context7]",
+			'command = "npx"',
+			'args = ["-y", "@upstash/context7-mcp", "--api-key", "ctx7sk_live_example"] # replace YOUR_API_KEY in docs only',
+			"startup_timeout_sec = 20",
+			"",
+		].join("\n"),
+	);
+
+	// when
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "sisyphuslabs",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex/cache/sisyphuslabs" },
+		pluginNames: ["omo"],
+	});
+
+	// then
+	const config = await readFile(configPath, "utf8");
+	assert.match(config, /\[mcp_servers\.context7\]/);
+	assert.match(config, /ctx7sk_live_example/);
+	assert.match(config, /replace YOUR_API_KEY in docs only/);
+	assert.match(config, /\[plugins\."omo@sisyphuslabs"\.mcp_servers\.context7\]/);
+});
+
+test("#given stale Context7 placeholder MCP config #when script installer updates config #then removes it for plugin MCP", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-context7-placeholder-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			"[mcp_servers.context7]",
+			'command = "npx"',
+			'args = ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]',
+			"startup_timeout_sec = 20",
+			"",
+		].join("\n"),
+	);
+
+	// when
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "sisyphuslabs",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex/cache/sisyphuslabs" },
+		pluginNames: ["omo"],
+	});
+
+	// then
+	const config = await readFile(configPath, "utf8");
+	assert.match(config, /\[plugins\."omo@sisyphuslabs"\.mcp_servers\.context7\]/);
+	assert.doesNotMatch(config, /\[mcp_servers\.context7\]/);
+	assert.doesNotMatch(config, /@upstash\/context7-mcp/);
 	assert.doesNotMatch(config, /YOUR_API_KEY/);
 });
 

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -7753,7 +7753,7 @@ function skipWhitespace(input, startIndex) {
 
 // packages/omo-codex/src/install/codex-config-toml-sections.ts
 function removeTomlSections(config, shouldRemove) {
-  return splitTomlSections(config).filter((section) => section.header === null || !shouldRemove(section.header)).map((section) => section.text).join("").replace(/\n{3,}/g, `
+  return splitTomlSections(config).filter((section) => section.header === null || !shouldRemove(section.header, section)).map((section) => section.text).join("").replace(/\n{3,}/g, `
 
 `);
 }
@@ -7792,10 +7792,42 @@ function parseHookStateHeaderKey(header) {
   return path[2] ?? null;
 }
 function parseTomlHeader(line) {
-  const trimmed = line.trim();
+  const trimmed = stripTomlLineComment(line).trim();
   if (!trimmed.startsWith("[") || !trimmed.endsWith("]") || trimmed.startsWith("[["))
     return null;
   return trimmed.slice(1, -1);
+}
+function stripTomlLineComment(line) {
+  let quote = null;
+  let index = 0;
+  while (index < line.length) {
+    const char = line[index];
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"')
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'")
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      index += 1;
+      continue;
+    }
+    if (char === "#")
+      return line.slice(0, index);
+    index += 1;
+  }
+  return line;
 }
 
 // packages/omo-codex/src/install/codex-config-agents.ts
@@ -8020,7 +8052,8 @@ function ensureOmoBuiltinMcpPolicies(config, input) {
     return config;
   const codegraphEnabled = input.codegraphMcpEnabled ?? true;
   const gitBashEnabled = (input.platform ?? process.platform) === "win32" && input.gitBashEnabled === true;
-  let nextConfig = ensurePluginMcpEnabled(config, "omo@sisyphuslabs", "context7", true);
+  let nextConfig = removeStaleContext7PlaceholderMcp(config);
+  nextConfig = ensurePluginMcpEnabled(nextConfig, "omo@sisyphuslabs", "context7", true);
   nextConfig = ensurePluginMcpEnabled(nextConfig, "omo@sisyphuslabs", "codegraph", codegraphEnabled);
   nextConfig = ensurePluginMcpEnabled(nextConfig, "omo@sisyphuslabs", "git_bash", gitBashEnabled);
   return nextConfig;
@@ -8043,6 +8076,107 @@ function ensurePluginMcpEnabled(config, pluginKey, serverName, enabled) {
 enabled = ${enabledValue}
 `);
   return replaceOrInsertSetting(config, section, "enabled", enabledValue);
+}
+function removeStaleContext7PlaceholderMcp(config) {
+  return removeTomlSections(config, (header, section) => header === "mcp_servers.context7" && isContext7PlaceholderSection(section.text));
+}
+function isContext7PlaceholderSection(sectionText) {
+  const args = readStringArraySetting(sectionText, "args");
+  if (args === null || !args.includes("@upstash/context7-mcp"))
+    return false;
+  const apiKey = valueAfter(args, "--api-key");
+  return apiKey !== null && isPlaceholderApiKey(apiKey);
+}
+function valueAfter(values, key) {
+  const index = values.indexOf(key);
+  return index >= 0 ? values[index + 1] ?? null : null;
+}
+function isPlaceholderApiKey(value) {
+  return /^your[-_ ]?api[-_ ]?key$/i.test(value);
+}
+function readStringArraySetting(sectionText, key) {
+  for (const line of sectionText.split(`
+`)) {
+    if (!new RegExp(`^\\s*${key}\\s*=`).test(line))
+      continue;
+    const assignmentIndex = line.indexOf("=");
+    if (assignmentIndex === -1)
+      return null;
+    return parseTomlStringArray(stripUnquotedInlineComment2(line.slice(assignmentIndex + 1)).trim());
+  }
+  return null;
+}
+function parseTomlStringArray(value) {
+  if (!value.startsWith("[") || !value.endsWith("]"))
+    return null;
+  const items = [];
+  let index = 1;
+  while (index < value.length - 1) {
+    const char = value[index];
+    if (char === '"' || char === "'") {
+      const parsed = parseTomlString(value, index);
+      if (parsed === null)
+        return null;
+      items.push(parsed.value);
+      index = parsed.nextIndex;
+      continue;
+    }
+    index += 1;
+  }
+  return items;
+}
+function parseTomlString(input, startIndex) {
+  const quote = input[startIndex];
+  let value = "";
+  let index = startIndex + 1;
+  while (index < input.length) {
+    const char = input[index];
+    if (quote === '"' && char === "\\") {
+      const next = input[index + 1];
+      if (next === undefined)
+        return null;
+      value += next;
+      index += 2;
+      continue;
+    }
+    if (char === quote)
+      return { value, nextIndex: index + 1 };
+    value += char;
+    index += 1;
+  }
+  return null;
+}
+function stripUnquotedInlineComment2(line) {
+  let quote = null;
+  let index = 0;
+  while (index < line.length) {
+    const char = line[index];
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"')
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'")
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      index += 1;
+      continue;
+    }
+    if (char === "#")
+      return line.slice(0, index);
+    index += 1;
+  }
+  return line;
 }
 
 // packages/omo-codex/src/install/codex-config-reasoning.ts

--- a/packages/omo-codex/src/install/codex-config-plugins.ts
+++ b/packages/omo-codex/src/install/codex-config-plugins.ts
@@ -1,4 +1,5 @@
 import { appendBlock, findTomlSection, replaceOrInsertSetting } from "./toml-section-editor"
+import { removeTomlSections } from "./codex-config-toml-sections"
 import type { CodexInstallPlatform, TrustedHookState } from "./types"
 
 export function ensurePluginEnabled(config: string, pluginKey: string): string {
@@ -18,7 +19,8 @@ export function ensureOmoBuiltinMcpPolicies(config: string, input: {
   if (input.marketplaceName !== "sisyphuslabs" || !input.pluginNames.includes("omo")) return config
   const codegraphEnabled = input.codegraphMcpEnabled ?? true
   const gitBashEnabled = (input.platform ?? process.platform) === "win32" && input.gitBashEnabled === true
-  let nextConfig = ensurePluginMcpEnabled(config, "omo@sisyphuslabs", "context7", true)
+  let nextConfig = removeStaleContext7PlaceholderMcp(config)
+  nextConfig = ensurePluginMcpEnabled(nextConfig, "omo@sisyphuslabs", "context7", true)
   nextConfig = ensurePluginMcpEnabled(nextConfig, "omo@sisyphuslabs", "codegraph", codegraphEnabled)
   nextConfig = ensurePluginMcpEnabled(nextConfig, "omo@sisyphuslabs", "git_bash", gitBashEnabled)
   return nextConfig
@@ -37,4 +39,105 @@ function ensurePluginMcpEnabled(config: string, pluginKey: string, serverName: s
   const enabledValue = enabled ? "true" : "false"
   if (!section) return appendBlock(config, `[${header}]\nenabled = ${enabledValue}\n`)
   return replaceOrInsertSetting(config, section, "enabled", enabledValue)
+}
+
+function removeStaleContext7PlaceholderMcp(config: string): string {
+  return removeTomlSections(
+    config,
+    (header, section) => header === "mcp_servers.context7" && isContext7PlaceholderSection(section.text),
+  )
+}
+
+function isContext7PlaceholderSection(sectionText: string): boolean {
+  const args = readStringArraySetting(sectionText, "args")
+  if (args === null || !args.includes("@upstash/context7-mcp")) return false
+  const apiKey = valueAfter(args, "--api-key")
+  return apiKey !== null && isPlaceholderApiKey(apiKey)
+}
+
+function valueAfter(values: readonly string[], key: string): string | null {
+  const index = values.indexOf(key)
+  return index >= 0 ? (values[index + 1] ?? null) : null
+}
+
+function isPlaceholderApiKey(value: string): boolean {
+  return /^your[-_ ]?api[-_ ]?key$/i.test(value)
+}
+
+function readStringArraySetting(sectionText: string, key: string): readonly string[] | null {
+  for (const line of sectionText.split("\n")) {
+    if (!new RegExp(`^\\s*${key}\\s*=`).test(line)) continue
+    const assignmentIndex = line.indexOf("=")
+    if (assignmentIndex === -1) return null
+    return parseTomlStringArray(stripUnquotedInlineComment(line.slice(assignmentIndex + 1)).trim())
+  }
+  return null
+}
+
+function parseTomlStringArray(value: string): readonly string[] | null {
+  if (!value.startsWith("[") || !value.endsWith("]")) return null
+  const items: string[] = []
+  let index = 1
+  while (index < value.length - 1) {
+    const char = value[index]
+    if (char === '"' || char === "'") {
+      const parsed = parseTomlString(value, index)
+      if (parsed === null) return null
+      items.push(parsed.value)
+      index = parsed.nextIndex
+      continue
+    }
+    index += 1
+  }
+  return items
+}
+
+function parseTomlString(input: string, startIndex: number): { readonly value: string; readonly nextIndex: number } | null {
+  const quote = input[startIndex]
+  let value = ""
+  let index = startIndex + 1
+  while (index < input.length) {
+    const char = input[index]
+    if (quote === '"' && char === "\\") {
+      const next = input[index + 1]
+      if (next === undefined) return null
+      value += next
+      index += 2
+      continue
+    }
+    if (char === quote) return { value, nextIndex: index + 1 }
+    value += char
+    index += 1
+  }
+  return null
+}
+
+function stripUnquotedInlineComment(line: string): string {
+  let quote: string | null = null
+  let index = 0
+  while (index < line.length) {
+    const char = line[index]
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2
+        continue
+      }
+      if (char === '"') quote = null
+      index += 1
+      continue
+    }
+    if (quote === "'") {
+      if (char === "'") quote = null
+      index += 1
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      index += 1
+      continue
+    }
+    if (char === "#") return line.slice(0, index)
+    index += 1
+  }
+  return line
 }

--- a/packages/omo-codex/src/install/codex-config-toml-sections.ts
+++ b/packages/omo-codex/src/install/codex-config-toml-sections.ts
@@ -5,9 +5,9 @@ export interface TomlSection {
   readonly text: string
 }
 
-export function removeTomlSections(config: string, shouldRemove: (header: string) => boolean): string {
+export function removeTomlSections(config: string, shouldRemove: (header: string, section: TomlSection) => boolean): string {
   return splitTomlSections(config)
-    .filter((section) => section.header === null || !shouldRemove(section.header))
+    .filter((section) => section.header === null || !shouldRemove(section.header, section))
     .map((section) => section.text)
     .join("")
     .replace(/\n{3,}/g, "\n\n")
@@ -58,7 +58,37 @@ export function parseHookStateHeaderKey(header: string): string | null {
 }
 
 function parseTomlHeader(line: string): string | null {
-  const trimmed = line.trim()
+  const trimmed = stripTomlLineComment(line).trim()
   if (!trimmed.startsWith("[") || !trimmed.endsWith("]") || trimmed.startsWith("[[")) return null
   return trimmed.slice(1, -1)
+}
+
+function stripTomlLineComment(line: string): string {
+  let quote: string | null = null
+  let index = 0
+  while (index < line.length) {
+    const char = line[index]
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2
+        continue
+      }
+      if (char === '"') quote = null
+      index += 1
+      continue
+    }
+    if (quote === "'") {
+      if (char === "'") quote = null
+      index += 1
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      index += 1
+      continue
+    }
+    if (char === "#") return line.slice(0, index)
+    index += 1
+  }
+  return line
 }

--- a/packages/omo-codex/src/install/codex-config-toml.test.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.test.ts
@@ -249,7 +249,7 @@ describe("codex-config-toml", () => {
     await writeFile(
       configPath,
       [
-        "[mcp_servers.context7]",
+        "[mcp_servers.context7] # stale npx package from old docs",
         'command = "node"',
         'args = ["/opt/context7/server.js"]',
         "startup_timeout_sec = 40",
@@ -272,6 +272,70 @@ describe("codex-config-toml", () => {
     expect(content).toContain('command = "node"')
     expect(content).toContain('args = ["/opt/context7/server.js"]')
     expect(content).toContain("startup_timeout_sec = 40")
+    expect(content).not.toContain("YOUR_API_KEY")
+  })
+
+  test("#given real Context7 API key and placeholder comment #when updating config #then preserves user server settings", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-context7-real-key-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      [
+        "[mcp_servers.context7]",
+        'command = "npx"',
+        'args = ["-y", "@upstash/context7-mcp", "--api-key", "ctx7sk_live_example"] # replace YOUR_API_KEY in docs only',
+        "startup_timeout_sec = 20",
+        "",
+      ].join("\n"),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "sisyphuslabs",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex/cache/sisyphuslabs" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content).toContain("[mcp_servers.context7]")
+    expect(content).toContain("ctx7sk_live_example")
+    expect(content).toContain("replace YOUR_API_KEY in docs only")
+    expect(content).toContain('[plugins."omo@sisyphuslabs".mcp_servers.context7]')
+  })
+
+  test("#given stale Context7 placeholder MCP server #when updating config #then removes it for the plugin MCP", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-context7-placeholder-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      [
+        "[mcp_servers.context7]",
+        'command = "npx"',
+        'args = ["-y", "@upstash/context7-mcp", "--api-key", "YOUR_API_KEY"]',
+        "startup_timeout_sec = 20",
+        "",
+      ].join("\n"),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "sisyphuslabs",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex/cache/sisyphuslabs" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content).toContain('[plugins."omo@sisyphuslabs".mcp_servers.context7]')
+    expect(content).not.toContain("[mcp_servers.context7]")
+    expect(content).not.toContain("@upstash/context7-mcp")
     expect(content).not.toContain("YOUR_API_KEY")
   })
 


### PR DESCRIPTION
## Summary
Removes stale root-level Context7 MCP placeholder config from Codex installer and startup migration paths while preserving real user Context7 credentials and plugin-scoped Context7 policy. This prevents `YOUR_API_KEY` / placeholder-style Context7 entries from lingering in `~/.codex/config.toml` after installing omo for Codex.

## Changes
- Added a Context7 placeholder guard to the Codex config migration path.
- Updated installer config generation and generated local installer bundle so stale placeholder root MCP entries are removed.
- Preserved real/custom Context7 server configs, including configs with placeholder text only in comments.
- Added source, script installer, and migration tests for stale-placeholder removal and real-key preservation.

## QA & Evidence
- RED/GREEN and full Codex gate evidence from the isolated Jobdori worktree:
  - `.omo/evidence/20260626-context7-api-key/green-source-codex-config-toml-clean-rerun.txt`
  - `.omo/evidence/20260626-context7-api-key/green-script-install-config-clean-rerun.txt`
  - `.omo/evidence/20260626-context7-api-key/green-migration-context7-clean-rerun.txt`
  - `.omo/evidence/20260626-context7-api-key/bun-test-codex-final-clean-rerun.txt`
  - `.omo/evidence/20260626-context7-api-key/codex-qa-app-server-plugin-clean-rerun.txt`
  - `.omo/evidence/20260626-context7-api-key/codex-qa-install-verify-clean-rerun.txt`
  - `.omo/evidence/20260626-context7-api-key/codex-qa-common-self-check-clean-rerun.txt`
- Reviewer approval artifact:
  - `.omo/evidence/20260626-context7-api-key-rerun-code-review.md`
- Rebase safety evidence captured during recovery:
  - `.omo/ulw-loop/evidence/session-recovery-20260626/context7-rebase.txt`
  - `.omo/ulw-loop/evidence/session-recovery-20260626/context7-post-rebase-focused-tests.txt`

## Risks & Residuals
- This touches Codex install/config surfaces, so CI and the Codex compatibility matrix should be treated as required before merge.
- The main local checkout had unrelated dirty changes; all work was verified in the isolated Jobdori worktree `/Users/yeongyu/local-workspaces/omo-context7-fix`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale root-level Context7 MCP placeholder entries during install and migration, preventing `YOUR_API_KEY` from lingering in `~/.codex/config.toml` while keeping real keys and the plugin-scoped policy intact.

- **Bug Fixes**
  - Adds a Context7 placeholder guard to migration and the script installer to delete root `[mcp_servers.context7]` entries using `@upstash/context7-mcp` with a placeholder API key.
  - Preserves valid setups: keeps real API keys and `[plugins."omo@sisyphuslabs".mcp_servers.context7]` enabled.
  - Updates TOML helpers to ignore inline comments and allow section-aware removal; adds tests covering removal and preservation.

<sup>Written for commit ae9097a5c2c164454a6a6b95a374400914098487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

