### PR TITLE
fix(ulw-loop): explain missing steering kind

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/src/cli-steering.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/cli-steering.ts
@@ -5,6 +5,18 @@ import type { SteerUlwLoopResult, UlwLoopSteeringChildGoal, UlwLoopSteeringMutat
 import { ULW_LOOP_STEERING_MUTATION_KINDS, ULW_LOOP_SUCCESS_CRITERION_USER_MODELS, UlwLoopError } from "./types.js";
 
 const SOURCES = ["user_prompt_submit", "finding", "cli"] as const satisfies readonly UlwLoopSteeringSource[];
+const STEERING_KIND_HELP = [
+	`Allowed --kind values: ${ULW_LOOP_STEERING_MUTATION_KINDS.join(", ")}`,
+	"Kind-specific required flags:",
+	"  add_subgoal: --title, --objective, --evidence, --rationale",
+	"  split_subgoal: --goal-id, --children, --evidence, --rationale",
+	"  reorder_pending: --order, --evidence, --rationale",
+	"  revise_pending_wording: --goal-id, --title or --objective, --evidence, --rationale",
+	"  revise_criterion: --goal-id, --criterion-id, one of --scenario/--expected-evidence/--user-model, --evidence, --rationale",
+	"  annotate_ledger: --evidence, --rationale",
+	"  mark_blocked_superseded: --goal-id, optional --replacements, --evidence, --rationale",
+	"Example: omo ulw-loop steer --kind annotate_ledger --evidence \"observed behavior\" --rationale \"why this changes the plan\" --json",
+].join("\n");
 
 export type CliSteeringProposal = UlwLoopSteeringProposal & { readonly goalId?: string; readonly scenario?: string; readonly expectedEvidence?: string; readonly userModel?: UlwLoopSuccessCriterionUserModel };
 
@@ -12,6 +24,7 @@ function isKind(value: string | undefined): value is UlwLoopSteeringMutationKind
 function isSource(value: string | undefined): value is UlwLoopSteeringSource { return value !== undefined && SOURCES.some((source) => source === value); }
 function isModel(value: string): value is UlwLoopSuccessCriterionUserModel { return ULW_LOOP_SUCCESS_CRITERION_USER_MODELS.some((model) => model === value); }
 function fail(message: string, code: string, details: Record<string, unknown>): never { throw new UlwLoopError(message, code, { details }); }
+function kindMessage(prefix: string): string { return `${prefix}\n\n${STEERING_KIND_HELP}`; }
 function text(value: string | undefined, field: string): string | undefined { if (value === undefined) return undefined; const trimmed = value.trim(); if (trimmed.length > 0) return trimmed; return fail(`Empty ${field}.`, "ULW_LOOP_STEERING_FIELD_EMPTY", { field }); }
 function required(argv: readonly string[], flag: string): string { const value = text(readValue(argv, flag), flag); return value ?? fail(`Missing ${flag}.`, "ULW_LOOP_STEERING_FIELD_REQUIRED", { flag }); }
 function requiredGoal(argv: readonly string[]): string { const value = text(parseGoalArg(argv), "--goal-id"); return value ?? fail("Missing --goal-id.", "ULW_LOOP_GOAL_ID_REQUIRED", { flag: "--goal-id" }); }
@@ -22,7 +35,7 @@ function objectText(value: object, key: string): string | undefined { const cand
 export function parseSteeringKind(argv: readonly string[]): UlwLoopSteeringMutationKind {
 	const value = readValue(argv, "--kind");
 	if (isKind(value)) return value;
-	return value === undefined ? fail("Missing --kind.", "ULW_LOOP_STEERING_KIND_REQUIRED", { flag: "--kind" }) : fail(`Invalid --kind: ${value}.`, "ULW_LOOP_STEERING_KIND_INVALID", { value, expected: ULW_LOOP_STEERING_MUTATION_KINDS });
+	return value === undefined ? fail(kindMessage("Missing --kind."), "ULW_LOOP_STEERING_KIND_REQUIRED", { flag: "--kind", expected: ULW_LOOP_STEERING_MUTATION_KINDS, usage: STEERING_KIND_HELP }) : fail(kindMessage(`Invalid --kind: ${value}.`), "ULW_LOOP_STEERING_KIND_INVALID", { value, expected: ULW_LOOP_STEERING_MUTATION_KINDS, usage: STEERING_KIND_HELP });
 }
 
 export function parseSteeringSource(argv: readonly string[]): UlwLoopSteeringSource {

--- a/packages/omo-codex/plugin/components/ulw-loop/test/cli-steering-kind-guidance.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/cli-steering-kind-guidance.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSteeringKind } from "../src/cli-steering.js";
+
+describe("#given a steering command without --kind", () => {
+	describe("#when parsing the steering kind", () => {
+		it("#then explains allowed kinds and shows a usable example", () => {
+			const action = (): void => {
+				parseSteeringKind([]);
+			};
+
+			expect(action).toThrow(/Allowed --kind values:/);
+			expect(action).toThrow(/annotate_ledger/);
+			expect(action).toThrow(/omo ulw-loop steer --kind annotate_ledger/);
+		});
+	});
+});
+
+describe("#given a steering command with an invalid --kind", () => {
+	describe("#when parsing the steering kind", () => {
+		it("#then reports the invalid value and lists valid kinds", () => {
+			const action = (): void => {
+				parseSteeringKind(["--kind", "bogus"]);
+			};
+
+			expect(action).toThrow(/Invalid --kind: bogus\./);
+			expect(action).toThrow(/revise_criterion/);
+			expect(action).toThrow(/mark_blocked_superseded/);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This makes `omo ulw-loop steer` self-explanatory when `--kind` is missing or invalid. Instead of only printing `[ulw-loop] Missing --kind.`, the CLI now lists the allowed steering kinds, the required flags for each kind, and a usable `annotate_ledger` example in both human and JSON error output.

## Changes

- Adds shared steering-kind usage text to the ulw-loop CLI parser.
- Includes `expected` and `usage` details in missing/invalid `--kind` JSON errors.
- Adds focused Vitest coverage for missing and invalid steering kind guidance without growing the existing oversized `cli-steering.test.ts` file.

## QA & Evidence

- **What was tested:** component typecheck/lint/build via `npm --prefix packages/omo-codex/plugin/components/ulw-loop run check`.
  **Observed result:** `tsc --noEmit`, Biome check, and `tsc -p tsconfig.build.json` completed successfully; Biome only reported its pre-existing schema-version info.
  **Artifact:** `.omo/evidence/20260626-ulw-steer-kind-guidance/final-ulw-loop-component-check.txt`
  **Why sufficient:** covers the changed TypeScript parser and generated component build.

- **What was tested:** focused steering guidance tests via `npm --prefix packages/omo-codex/plugin/components/ulw-loop run test -- test/cli-steering-kind-guidance.test.ts`.
  **Observed result:** 1 file passed, 2 tests passed.
  **Artifact:** `.omo/evidence/20260626-ulw-steer-kind-guidance/final-focused-kind-guidance-test.txt`
  **Why sufficient:** pins the new missing/invalid `--kind` guidance behavior.

- **What was tested:** real CLI surface for missing `--kind`, human and JSON modes, using the built component CLI.
  **Observed result:** human output now shows allowed kinds, per-kind required flags, and an example; JSON output includes `expected` and `usage`; both exit non-zero as intended.
  **Artifacts:** `.omo/evidence/20260626-ulw-steer-kind-guidance/final-manual-missing-kind-human.txt`, `.omo/evidence/20260626-ulw-steer-kind-guidance/final-manual-missing-kind-json.txt`
  **Why sufficient:** directly exercises the user-reported failure surface.

- **What was tested:** repo Codex compatibility gate via `bun run test:codex`.
  **Observed result:** 409 tests passed.
  **Artifact:** `.omo/evidence/20260626-ulw-steer-kind-guidance/final-bun-run-test-codex-rerun.txt`
  **Why sufficient:** covers the broader Codex plugin/installer compatibility suite touched by ulw-loop component changes.

- **What was tested:** isolated Codex QA with local plugin install and app-server hook drive.
  **Observed result:** `install-verify` passed, app-server turn completed, `sessionStart`, `userPromptSubmit`, and `stop` hooks fired; real `~/.codex/config.toml` SHA stayed unchanged.
  **Artifacts:** `.omo/evidence/20260626-ulw-steer-kind-guidance/codex-qa-install-verify.txt`, `.omo/evidence/20260626-ulw-steer-kind-guidance/codex-qa-app-server-plugin.json`
  **Why sufficient:** satisfies the repo's Codex QA requirement against an isolated `CODEX_HOME` and live Codex app-server surface.

- **What was tested:** TypeScript no-excuse checker and direct LSP diagnostics for changed files.
  **Observed result:** no no-excuse violations; LSP daemon diagnostics returned zero diagnostics for both changed files.
  **Artifacts:** `.omo/evidence/20260626-ulw-steer-kind-guidance/final-no-excuse-check.txt`, `.omo/evidence/20260626-ulw-steer-kind-guidance/lsp-diagnostics-changed-files.txt`
  **Why sufficient:** covers strict TypeScript rules and symbol-level diagnostics after the prior `lsp.status` transport issue was investigated separately.

## Risks & Residuals

- `bun run test:codex` flips the executable bit on `packages/omo-codex/plugin/components/codegraph/dist/serve.js` as a test/build side effect; that unrelated mode change was restored before committing.
- The existing `cli-steering.test.ts` remains over 250 pure LOC, so the new tests live in a focused adjacent file rather than adding more lines to the oversized file.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves `omo ulw-loop steer` errors for missing or invalid `--kind` by listing valid kinds, per-kind required flags, and a working example. JSON errors now include `expected` and `usage` for better tooling.

- **Bug Fixes**
  - Show allowed `--kind` values and required flags when `--kind` is missing or invalid.
  - Add a usable `annotate_ledger` example to guidance text.
  - Include `expected` and `usage` fields in JSON error payloads.
  - Add focused tests for the new guidance behavior.

<sup>Written for commit 39c0a89325565893fc2ff009fa1bae27e3c306cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

