### PR TITLE
fix(team-core): retry Windows EPERM lock release

### DIFF
--- a/packages/team-core/src/team-state-store/locks.test.ts
+++ b/packages/team-core/src/team-state-store/locks.test.ts
@@ -145,6 +145,37 @@ test("lock open rethrows EPERM when the lock path does not exist", async () => {
   await rm(rootDirectory, { recursive: true, force: true })
 })
 
+test("lock release retries transient EPERM before removing the lock file", async () => {
+  // given
+  const { reapStaleLock } = await import("./locks")
+  const rootDirectory = await createTempDirectory("locks-release-eperm-")
+  const lockPath = join(rootDirectory, "lock")
+  await writeFile(lockPath, "owner\n123\n456\n")
+  const delayCalls: number[] = []
+  let unlinkCalls = 0
+
+  // when
+  const result = reapStaleLock(lockPath, {
+    delay: async (ms: number) => {
+      delayCalls.push(ms)
+    },
+    unlink: async (path: PathLike) => {
+      unlinkCalls += 1
+      if (unlinkCalls < 3) {
+        throw createErrnoError("EPERM")
+      }
+      await rm(path, { force: true })
+    },
+  })
+
+  // then
+  await expect(result).resolves.toBeUndefined()
+  expect(unlinkCalls).toBe(3)
+  expect(delayCalls).toEqual([25, 25])
+  await expect(readFile(lockPath, "utf8")).rejects.toThrow()
+  await rm(rootDirectory, { recursive: true, force: true })
+})
+
 test("atomicWrite syncs temp files through a writable handle", async () => {
   // given
   const rootDirectory = await createTempDirectory("locks-atomic-writable-")

--- a/packages/team-core/src/team-state-store/locks.ts
+++ b/packages/team-core/src/team-state-store/locks.ts
@@ -18,8 +18,15 @@ type LockOpenErrorDeps = {
   readonly access?: typeof access
 }
 
+type LockReleaseDeps = {
+  readonly delay?: typeof delay
+  readonly unlink?: typeof unlink
+}
+
 const LOCK_RETRY_MS = 50
 const LOCK_WAIT_TIMEOUT_MS = 15_000
+const LOCK_RELEASE_RETRY_ATTEMPTS = 3
+const LOCK_RELEASE_RETRY_MS = 25
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -51,6 +58,11 @@ function errorCode(error: unknown): string | null {
 function isPathAbsenceError(error: unknown): boolean {
   const code = errorCode(error)
   return code === "ENOENT" || code === "ENOTDIR"
+}
+
+function isRetryableLockReleaseError(error: unknown): boolean {
+  const code = errorCode(error)
+  return code === "EPERM" || code === "EBUSY"
 }
 
 async function pathMayExist(path: string, deps: LockOpenErrorDeps = {}): Promise<boolean> {
@@ -150,11 +162,21 @@ export async function detectStaleLock(lockPath: string, staleAfterMs: number): P
   }
 }
 
-export async function reapStaleLock(lockPath: string): Promise<void> {
-  await unlink(lockPath).catch((error: unknown) => {
-    if (error instanceof Error) return undefined
-    return undefined
-  })
+export async function reapStaleLock(lockPath: string, deps: LockReleaseDeps = {}): Promise<void> {
+  const wait = deps.delay ?? delay
+  const unlinkFile = deps.unlink ?? unlink
+
+  for (let attempt = 1; attempt <= LOCK_RELEASE_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      await unlinkFile(lockPath)
+      return
+    } catch (error) {
+      if (!(error instanceof Error)) return
+      if (isPathAbsenceError(error)) return
+      if (!isRetryableLockReleaseError(error) || attempt === LOCK_RELEASE_RETRY_ATTEMPTS) return
+      await wait(LOCK_RELEASE_RETRY_MS)
+    }
+  }
 }
 
 export async function atomicWrite(


### PR DESCRIPTION
## Summary
This fixes the Windows lock flake seen on PR #5563 where `withLock serializes concurrent work` could fail with `EPERM` while opening a lock file. The previous fix retried `EPERM` during lock acquisition; this extends the same defensive behavior to lock release, where Windows can transiently reject `unlink` right after a handle closes.

## Changes
- Retries transient `EPERM`/`EBUSY` lock-file removal before giving up.
- Keeps missing-lock cleanup idempotent.
- Adds a focused regression test for transient `EPERM` during lock release.

## QA & Evidence
- **What was tested:** failing-first targeted lock test after adding the regression test.
  **Observed result:** failed before implementation with `unlinkCalls` remaining `0`.
  **Artifact:** `.omo/evidence/20260626-omo-pr-reaudit/team-lock-red-test.txt`
  **Why sufficient:** proves the new regression test would have caught the missing release retry behavior.
- **What was tested:** `bun test packages/team-core/src/team-state-store/locks.test.ts`
  **Observed result:** 8 pass, 0 fail.
  **Artifact:** `.omo/evidence/20260626-omo-pr-reaudit/team-lock-green-test.txt`
  **Why sufficient:** exercises the changed lock implementation and regression test directly.
- **What was tested:** `bun run --cwd packages/team-core typecheck`
  **Observed result:** `tsgo --noEmit -p tsconfig.json` completed successfully.
  **Artifact:** `.omo/evidence/20260626-omo-pr-reaudit/team-core-typecheck.txt`
  **Why sufficient:** verifies the changed API shape remains type-safe for the package.
- **What was tested:** `bun run --cwd packages/team-core test`
  **Observed result:** 147 pass, 1 skipped, 0 fail.
  **Artifact:** `.omo/evidence/20260626-omo-pr-reaudit/team-core-test.txt`
  **Why sufficient:** covers adjacent team state, mailbox, tasklist, and worktree behavior.
- **What was tested:** opencode-qa self-tests for common harness, SSE, and TUI isolation.
  **Observed result:** all passed; TUI smoke confirmed the real DB session count stayed unchanged.
  **Artifacts:** `.omo/evidence/20260626-omo-pr-reaudit/team-lock-opencode-common-selfcheck.txt`, `.omo/evidence/20260626-omo-pr-reaudit/team-lock-opencode-sse-selftest.txt`, `.omo/evidence/20260626-omo-pr-reaudit/team-lock-opencode-tui-selftest.txt`
  **Why sufficient:** this package feeds OpenCode team-mode behavior, so the OpenCode QA harness was exercised in isolation.

## Risks & Residuals
The retry is intentionally narrow: it only applies to lock-file release errors that Windows commonly reports while a just-closed file is still settling. Persistent removal failures still leave the cleanup path idempotent as before, but the transient CI flake gets a bounded recovery window.

## Related
Unblocks #5563 Windows CI failure.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a retry for Windows `EPERM`/`EBUSY` during lock file removal in `team-core` to prevent flaky lock-release failures after a handle closes. Stabilizes `withLock` behavior on Windows without changing public APIs.

- **Bug Fixes**
  - Retries lock-file `unlink` on `EPERM`/`EBUSY` (3 attempts, 25 ms delay).
  - Treats missing-path errors as already cleaned to keep release idempotent.
  - Adds a focused regression test for transient `EPERM` on release.

<sup>Written for commit 84c5aa36ac6b4e1bf21aa67e8148d87255b57ab0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

