### PR TITLE
fix(ulw-plan): replace Codex CLI review with Oracle for OpenCode compatibility

### DIFF
--- a/packages/shared-skills/skills/ulw-plan/references/full-workflow.md
+++ b/packages/shared-skills/skills/ulw-plan/references/full-workflow.md
@@ -82,7 +82,7 @@ Runs in parallel; ALL must APPROVE; surface results and wait for the user's expl
 - UNCLEAR: run Metis plus the high-accuracy review AUTOMATICALLY before presenting (unless Classify=Trivial), then present a brief that LEADS with the derived approach and the adopted defaults; still wait for the user's explicit okay.
 
 ### High-accuracy review (dual Momus)
-The high-accuracy review is DUAL and both passes must return OKAY before handoff: (1) the native `momus` reviewer subagent, and (2) an independent Codex CLI review on gpt-5.5 at xhigh reasoning, run in a disposable isolated workspace and `CODEX_HOME` with the harness's normal approval and sandbox policy. Do not add flags that disable approvals or sandboxing. Fix every cited issue and resubmit BOTH fresh until each approves. CLEAR: runs only if the user opts in at delivery. UNCLEAR: runs automatically unless Classify=Trivial.
+The high-accuracy review is DUAL and both passes must return OKAY before handoff: (1) the native `momus` reviewer subagent, and (2) an independent Oracle review via `task(subagent_type="oracle", ...)` on the strongest available reasoning model, in a fully isolated sub-session with normal approval and sandbox policy. Do not add flags that disable approvals or sandboxing. Fix every cited issue and resubmit BOTH fresh until each approves. CLEAR: runs only if the user opts in at delivery. UNCLEAR: runs automatically unless Classify=Trivial.
 
 ## Delegation discipline (OpenCode-native)
 Every delegated prompt starts with `TASK:`, then DELIVERABLE / SCOPE / VERIFY; state the role inside the prompt and include only the context the child needs:


### PR DESCRIPTION
## Problem

The `ulw-plan` high-accuracy review defined pass 2 as requiring an independent Codex CLI review on gpt-5.5 at xhigh reasoning. This breaks when Prometheus runs the skill in OpenCode, where `codex` is not available.

- **CLEAR path**: user is asked whether to run — can skip, but if they opt in, pass 2 fails
- **UNCLEAR path**: runs **automatically** — always fails

Fixes #5504

## Solution

Replace pass 2's Codex CLI requirement with an Oracle subagent review via `task(subagent_type="oracle", ...)`.

### Why Oracle over `category="ultrabrain"`
- Oracle is **read-only** (no write/edit tools) — truly independent review
- Oracle's system prompt is designed for **consultation/review** — natural fit
- ultrabrain spawns Sisyphus-Junior (an executor), which has write access and is wired for implementation, not review
- Oracle has its own fallback chain (gpt-5.5 high → gemini-3.1-pro high → claude-opus-4-7 max → glm-5.1), so it works regardless of which provider is connected

### What changed
- **Only**: `packages/shared-skills/skills/ulw-plan/references/full-workflow.md` line 85
- Codex edition copy unchanged (Codex CLI works there)
- `sync-skills.mjs` unchanged (independent copy paths: OpenCode loads from shared-skills, Codex syncs from its component source)

## Verification

- [x] Change is in the shared skill only (OpenCode edition)
- [x] Codex edition unaffected
- [x] No new adapter code needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced pass 2 Codex CLI review with an Oracle subagent review in the `ulw-plan` high-accuracy workflow to work in OpenCode. Codex edition is unchanged. Fixes #5504.

- **Bug Fixes**
  - Use `task(subagent_type="oracle", ...)` on the strongest available reasoning model in an isolated sub-session.
  - Oracle is read-only and follows normal approval/sandbox policy with harness fallback.
  - Change limited to `packages/shared-skills/skills/ulw-plan/references/full-workflow.md` (OpenCode shared skill only).

<sup>Written for commit f88ad0e2863524582c9cba1c2cc3d3295e4272ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

