### PR TITLE
docs(ulw-loop): sync component contract

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/README.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/README.md
@@ -2,37 +2,38 @@
 
 [![ci](https://img.shields.io/badge/ci-pending-lightgrey.svg)](#) [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Codex plugin scaffold for durable repo-native multi-goal orchestration with embedded success criteria and observable evidence audit.
+Codex plugin component for durable repo-native multi-goal orchestration with embedded success criteria and observable evidence audit. State lives under `.omo/ulw-loop/` and is mutated through the `omo ulw-loop` CLI.
 
-## Behavior
+## CLI
+
+Every subcommand below is implemented. Pass `--json` where supported for machine-readable output, and pass `--session-id <id>` or set `OMO_ULW_LOOP_SESSION_ID` to scope state to a parallel session.
 
 | Subcommand | Purpose |
 |------------|---------|
-| `omo ulw-loop create-goals` | Create repo-native goals from a brief and seed criteria. |
-| `omo ulw-loop record-evidence` | Record observable evidence for the active criterion. |
-| `omo ulw-loop criteria` | Inspect or revise goal success criteria. |
-| `omo ulw-loop complete-goals` | Complete eligible goals after criteria pass. |
-| `omo ulw-loop checkpoint` | Refuse completion until criteria and evidence gates pass. |
-| `omo ulw-loop steer` | Apply steering updates to the plan. |
+| `omo ulw-loop help` | Print CLI usage. |
+| `omo ulw-loop create-goals` | Create repo-native goals and seed success criteria from a brief. |
 | `omo ulw-loop status` | Report active goal, criteria, and evidence state. |
+| `omo ulw-loop complete-goals` | Start or resume the next eligible goal, or report aggregate completion / blocked handoff. |
+| `omo ulw-loop checkpoint` | Gate a goal transition with evidence; final completion requires a complete Codex goal snapshot and a passing quality gate. |
+| `omo ulw-loop steer` | Apply a steering mutation proposal to the plan. |
+| `omo ulw-loop add-goal` | Append a goal to the active plan. |
+| `omo ulw-loop criteria` | Inspect one goal's success criteria. |
+| `omo ulw-loop record-evidence` | Record observable evidence for one criterion. |
+| `omo ulw-loop record-review-blockers` | Mark a goal as review-blocked and add follow-up work from final-review findings. |
 
-Wave 1 is scaffold only. Command behavior lands in later waves.
+The final quality gate parsed by `checkpoint` validates `codeReview`, `manualQa`, `gateReview`, `iteration`, and `criteriaCoverage`. `criteriaCoverage` records the original intent, desired outcome, user-facing outcome review, pass counts, and covered adversarial classes.
 
 ## Codex Plugin
 
-The plugin ships:
+This directory is a component of the aggregate `@sisyphuslabs/omo-codex-plugin` root. Plugin discovery (`.codex-plugin/plugin.json`) is owned by that aggregate root, not by this component. The component ships:
 
-- `.codex-plugin/plugin.json` for Codex plugin discovery.
-- `hooks/hooks.json` for the `UserPromptSubmit` hook.
-- `skills/ulw-loop/` as the future skill directory.
+- `hooks/hooks.json` registering two hooks:
+  - `UserPromptSubmit` -> `node "${PLUGIN_ROOT}/dist/cli.js" hook user-prompt-submit --with-ultrawork`
+  - `PreToolUse` matching `^create_goal$` -> `node "${PLUGIN_ROOT}/dist/cli.js" hook pre-tool-use`
+- `skills/ulw-loop/` for the bundled `ulw-loop` skill.
+- `bin.omo-ulw-loop` -> `dist/cli.js` for standalone CLI invocation.
 
-The hook command is:
-
-```bash
-node "${PLUGIN_ROOT}/dist/cli.js" hook user-prompt-submit --with-ultrawork
-```
-
-No MCP server or Codex tool is exposed in this scaffold.
+This component ships a CLI, a skill, and hooks. It does not expose an MCP server.
 
 ## Local Development
 
@@ -43,6 +44,8 @@ npm run typecheck
 npm run check
 npm pack --dry-run
 ```
+
+`npm test` runs Vitest, `npm run typecheck` runs `tsc --noEmit`, and `npm run check` runs typecheck, Biome, and the build.
 
 ## Local Codex Installation
 
@@ -63,7 +66,7 @@ enabled = true
 
 ## Privacy
 
-This plugin runs locally. The scaffold does not call a network service by itself.
+This component runs locally and does not call a network service by itself.
 
 ## License
 
@@ -72,3 +75,4 @@ This plugin runs locally. The scaffold does not call a network service by itself
 ## Related
 
 - [lazycodex](https://github.com/code-yeongyu/lazycodex) - Sisyphus Labs Codex marketplace repository.
+- [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) - the monorepo this component is developed in.

--- a/packages/omo-codex/plugin/components/ulw-loop/biome.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { ULW_LOOP_SUBCOMMANDS } from "../src/cli-commands.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -200,5 +201,38 @@ describe("source LOC budget", () => {
 			}).length;
 			expect(pure, `${file} pure LOC`).toBeLessThanOrEqual(250);
 		}
+	});
+});
+
+describe("README implementation contract", () => {
+	it("#given the README #when subcommands are inspected #then every implemented CLI subcommand is documented", async () => {
+		const readme = await readText("README.md");
+
+		for (const subcommand of ULW_LOOP_SUBCOMMANDS) {
+			expect(readme, `README documents \`omo ulw-loop ${subcommand}\``).toContain(`omo ulw-loop ${subcommand}`);
+		}
+	});
+
+	it("#given the README #when stale scaffold language is checked #then it is absent", async () => {
+		const readme = await readText("README.md");
+
+		expect(readme).not.toMatch(/scaffold only/i);
+		expect(readme).not.toMatch(/Wave 1/i);
+		expect(readme).not.toMatch(/lands in later waves/i);
+	});
+
+	it("#given the README #when hooks are described #then both hook channels are documented", async () => {
+		const readme = await readText("README.md");
+
+		expect(readme).toContain("UserPromptSubmit");
+		expect(readme).toContain("user-prompt-submit");
+		expect(readme).toContain("PreToolUse");
+		expect(readme).toContain("pre-tool-use");
+	});
+
+	it("#given the README #when the quality gate is described #then criteriaCoverage is named", async () => {
+		const readme = await readText("README.md");
+
+		expect(readme).toContain("criteriaCoverage");
 	});
 });


### PR DESCRIPTION
## Summary
This picks up the still-valid part of #5302 on top of current `dev`: the ulw-loop component README no longer describes a scaffold and now matches the implemented CLI, hook wiring, and final quality-gate contract.

## Changes
- Documents every implemented `omo ulw-loop` subcommand, including `help`, `add-goal`, and `record-review-blockers`.
- Documents the aggregate Codex plugin ownership and both hook channels: `UserPromptSubmit` with `--with-ultrawork`, and `PreToolUse` for the `create_goal` budget guard.
- Adds a package smoke test that fails if the README drifts back to stale scaffold language or omits implemented subcommands/hooks/`criteriaCoverage`.
- Aligns the component Biome schema URL with its declared Biome 2.4.16 dev dependency so `npm run check` is clean.

## QA & Evidence
- What was tested: `npm test -- package-smoke.test.ts` in `packages/omo-codex/plugin/components/ulw-loop`.
  Observed result: 17 pass / 0 fail.
  Artifact: `.omo/evidence/20260626-ulw-loop-readme-contract/package-smoke.txt`.
  Why sufficient: locks README coverage for CLI subcommands, hook channels, quality-gate naming, and stale scaffold wording.

- What was tested: `npm run check` in `packages/omo-codex/plugin/components/ulw-loop`.
  Observed result: `tsc --noEmit`, Biome, and build all passed.
  Artifact: `.omo/evidence/20260626-ulw-loop-readme-contract/component-check.txt`.
  Why sufficient: verifies the component stays typechecked, lint-clean, and buildable after the docs/test/config update.

- What was tested: TypeScript no-excuse audit for the modified smoke test.
  Observed result: no violations in 1 file.
  Artifact: `.omo/evidence/20260626-ulw-loop-readme-contract/no-excuse.txt`.
  Why sufficient: catches forbidden TS escape hatches in the added contract test.

- What was tested: isolated Codex app-server plugin QA via `codex-qa`.
  Observed result: mock turn completed; real `~/.codex/config.toml` unchanged; plugin hooks fired for `sessionStart`, `userPromptSubmit`, and `stop`.
  Artifact: `.omo/evidence/20260626-ulw-loop-readme-contract/codex-app-server-drive.txt`.
  Why sufficient: proves the local omo Codex plugin still loads and fires hooks in the real app-server path without touching the user's Codex home.

## Risks & Residuals
- Runtime behavior is intentionally unchanged; this is docs/test/config alignment only.
- This supersedes the mergeable subset of #5302. The older PR still conflicts with current `dev` because the quality-gate types evolved after it was opened.

## Related Issues / PRs
Supersedes #5302.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the `ulw-loop` component README with the implemented CLI, hooks, and final quality-gate contract, and adds a smoke test to prevent future drift. Also aligns the Biome schema to keep `npm run check` clean.

- **Refactors**
  - Documents all `omo ulw-loop` subcommands, including `help`, `add-goal`, and `record-review-blockers`.
  - Clarifies Codex ownership by the aggregate `@sisyphuslabs/omo-codex-plugin` and documents both hooks: `UserPromptSubmit --with-ultrawork` and `PreToolUse` for `create_goal`.
  - Adds a README contract test that checks subcommand coverage, hook channels, `criteriaCoverage`, and removes stale scaffold wording.

- **Dependencies**
  - Updates Biome schema URL to `2.4.16`.

<sup>Written for commit 0c27263e55b94a32db26392ea530d20107094e1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

