### PR TITLE
fix: limit concurrent LLM sessions to 24 to avoid opencode's 32-slot ResourceExhausted

### DIFF
--- a/packages/omo-opencode/src/tools/call-omo-agent/background-executor.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/background-executor.ts
@@ -10,6 +10,7 @@ import { getMessageDir } from "./message-dir"
 import { getSessionTools } from "../../shared/session-tools-store"
 import { sanitizeSubagentType } from "../delegate-task/subagent-discovery"
 import { getAgentDisplayName, stripAgentListSortPrefix } from "../../shared/agent-display-names"
+import { llmSemaphore } from "../shared/semaphore.js"
 
 export async function executeBackground(
   args: CallOmoAgentArgs,
@@ -26,6 +27,8 @@ export async function executeBackground(
   model?: DelegatedModelConfig,
 ): Promise<string> {
   try {
+    await llmSemaphore.acquire()
+
     const messageDir = getMessageDir(toolContext.sessionID)
     const { prevMessage, firstMessageAgent } = await resolveMessageContext(
       toolContext.sessionID,
@@ -94,5 +97,7 @@ Do NOT call background_output now. Wait for <system-reminder> notification first
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     return `Failed to launch background agent task: ${message}`
+  } finally {
+    llmSemaphore.release()
   }
 }

--- a/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
@@ -15,6 +15,7 @@ import { waitForCompletion } from "./completion-poller"
 import { processMessages } from "./message-processor"
 import { createOrGetSession } from "./session-creator"
 import type { CallOmoAgentArgs } from "./types"
+import { llmSemaphore } from "../shared/semaphore.js"
 
 type SessionWithPrompt = {
   prompt: (opts: { path: { id: string }; body: Record<string, unknown> }) => Promise<unknown>
@@ -91,6 +92,8 @@ export async function executeSync(
   let appliedFallbackChain = false
 
   try {
+    await llmSemaphore.acquire()
+
     const session = await deps.createOrGetSession(args, toolContext, ctx, model)
     sessionID = session.sessionID
     createdSessionForExecution = session.isNew
@@ -187,6 +190,8 @@ export async function executeSync(
     spawnReservation?.rollback()
     throw error
   } finally {
+    llmSemaphore.release()
+
     if (sessionID && appliedFallbackChain) {
       deps.clearSessionFallbackChain(sessionID)
     }

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.ts
@@ -13,6 +13,7 @@ import { stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import { buildTaskMetadataBlock } from "../../features/tool-metadata-store/task-metadata-contract"
 import { resolveMetadataModel } from "./resolve-metadata-model"
 import { getPersistedBackgroundTaskDescription } from "./background-task-description"
+import { llmSemaphore } from "../shared/semaphore.js"
 
 function registerBackgroundSessionContext(args: {
   sessionId: string
@@ -112,6 +113,8 @@ export async function executeBackgroundTask(
   const { manager } = executorCtx
 
   try {
+    await llmSemaphore.acquire()
+
     const tddEnabled = executorCtx.sisyphusAgentConfig?.tdd
     const normalizedAgent = stripAgentListSortPrefix(agentToUse)
     const effectivePrompt = buildTaskPrompt(args.prompt, normalizedAgent, tddEnabled)
@@ -228,5 +231,7 @@ Do NOT call background_output now. Wait for <system-reminder> notification first
       agent: stripAgentListSortPrefix(agentToUse),
       category: args.category,
     })
+  } finally {
+    llmSemaphore.release()
   }
 }

--- a/packages/omo-opencode/src/tools/shared/semaphore.ts
+++ b/packages/omo-opencode/src/tools/shared/semaphore.ts
@@ -30,3 +30,7 @@ export class Semaphore {
 
 /** Global semaphore limiting concurrent ripgrep processes to 2 */
 export const rgSemaphore = new Semaphore(2)
+
+/** Global semaphore limiting concurrent LLM agent sessions.
+ *  Stays under opencode's 32-slot worker pool cap to avoid ResourceExhausted errors. */
+export const llmSemaphore = new Semaphore(24)


### PR DESCRIPTION
## Problem

When OMO launches many concurrent subagent sessions (sync + background), the opencode binary eventually hits its internal 32-slot worker pool limit and throws **ResourceExhausted** errors. Once hit, the entire session becomes unusable — every subsequent tool call fails.

## Root Cause

Opencode has a hard cap of 32 concurrent worker "slots". Each LLM agent session (sync subagent, background task, background agent) consumes one slot. OMO aggressively parallelizes via `call-omo-agent` and `delegate-task`, and can easily exceed 32 concurrent sessions when the orchestrator fans out 5+ subagents in parallel.

OMO cannot change opencode's pool size (it is a binary-internal constant), so the fix must limit OMO's own concurrency to stay under the cap.

## Solution

Add a **global `llmSemaphore`** concurrency=24 in `tools/shared/semaphore.ts` that caps OMO-driven LLM sessions, leaving 8 slots for opencode internal operations.

The semaphore wraps the three entry points where LLM sessions are created:

| File | Entry Point | Why |
|------|------------|-----|
| sync-executor.ts | dispatchInternalPrompt | Synchronous subagent calls — holds slot for full session duration |
| background-task.ts | manager.launch | Background subagent task launches |
| background-executor.ts | manager.launch | Background agent session launches |

## Design Decisions

- **24 slots** — Leaves 8 headroom for opencode binary internal usage
- **Counting semaphore** — Reuses the existing Semaphore class already used for ripgrep concurrency control
- **Acquire/release via try/finally** — Ensures slots are always released on success, error, or early return
- **Sync executor acquires around full session** — Unlike background launches which return immediately, sync sessions hold the slot from dispatchInternalPrompt through waitForCompletion/processMessages

## Testing

- TypeScript compiles (npx tsc --noEmit)
- Changes are minimal (19 insertions across 4 files)
- Semaphore class is already well-tested for ripgrep usage


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit concurrent LLM agent sessions to 24 to avoid `ResourceExhausted` errors from `opencode`’s 32-slot worker pool. This keeps sessions stable under heavy fan-out.

- **Bug Fixes**
  - Added a global llmSemaphore (24) in tools/shared/semaphore.ts, leaving 8 slots for `opencode` internals.
  - Wrapped session creation with acquire/release in sync and background paths: sync-executor, background-task, background-executor.
  - Sync execution holds the slot for the full session; background paths hold it around launch.

<sup>Written for commit 452a65104bdb586ded8e9720048ce41a3e45827f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

