### PR TITLE
fix(codex): quiet initialized CodeGraph bootstrap

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -7,13 +7,31 @@ import { stderr as processStderr3 } from "node:process";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
 // components/codegraph/src/hook.ts
-import { spawn } from "node:child_process";
+import { execFile as execFile3, spawn } from "node:child_process";
 import { homedir as homedir9 } from "node:os";
+import { join as join8 } from "node:path";
 import { cwd as processCwd2, env as processEnv2, stdin as processStdin, stdout as processStdout } from "node:process";
 import { fileURLToPath } from "node:url";
 
+// ../../utils/src/codegraph/env.ts
+import { homedir } from "node:os";
+import { join } from "node:path";
+var CODEGRAPH_INSTALL_DIR_ENV = "CODEGRAPH_INSTALL_DIR";
+var CODEGRAPH_NO_DOWNLOAD_ENV = "CODEGRAPH_NO_DOWNLOAD";
+var CODEGRAPH_TELEMETRY_ENV = "CODEGRAPH_TELEMETRY";
+var DO_NOT_TRACK_ENV = "DO_NOT_TRACK";
+function buildCodegraphEnv(options = {}) {
+  const homeDir = options.homeDir ?? homedir();
+  return {
+    [CODEGRAPH_INSTALL_DIR_ENV]: join(homeDir, ".omo", "codegraph"),
+    [CODEGRAPH_NO_DOWNLOAD_ENV]: "1",
+    [CODEGRAPH_TELEMETRY_ENV]: "0",
+    [DO_NOT_TRACK_ENV]: "1"
+  };
+}
+
 // ../../utils/src/codegraph/guidance.ts
-import { homedir as homedir2 } from "node:os";
+import { homedir as homedir3 } from "node:os";
 
 // ../../utils/src/codegraph/workspace.ts
 import { createHash } from "node:crypto";
@@ -29,14 +47,14 @@ import {
   statSync,
   symlinkSync
 } from "node:fs";
-import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { homedir as homedir2 } from "node:os";
+import { basename, join as join2, resolve } from "node:path";
 function sanitizeBase(value) {
   const sanitized = value.replace(/[^A-Za-z0-9._-]/g, "-").replace(/-+/g, "-");
   return sanitized.length > 0 ? sanitized : "workspace";
 }
 function codegraphDataRoot(homeDir) {
-  return join(homeDir, ".omo", "codegraph");
+  return join2(homeDir, ".omo", "codegraph");
 }
 function workspaceStorageName(workspace) {
   const resolved = resolve(workspace);
@@ -45,11 +63,11 @@ function workspaceStorageName(workspace) {
 }
 function resolveCodegraphWorkspacePaths(workspace, options = {}) {
   const resolvedWorkspace = resolve(workspace);
-  const dataRoot = codegraphDataRoot(options.homeDir ?? homedir());
+  const dataRoot = codegraphDataRoot(options.homeDir ?? homedir2());
   return {
-    dataDir: join(dataRoot, "projects", workspaceStorageName(resolvedWorkspace)),
+    dataDir: join2(dataRoot, "projects", workspaceStorageName(resolvedWorkspace)),
     dataRoot,
-    projectLink: join(resolvedWorkspace, ".codegraph")
+    projectLink: join2(resolvedWorkspace, ".codegraph")
   };
 }
 function fallbackResult(dataRoot, projectLink, reason) {
@@ -97,12 +115,12 @@ function prepareCodegraphWorkspace(workspace, options = {}) {
   }
 }
 function ensureCodegraphGitignored(workspace) {
-  const gitDir = join(workspace, ".git");
+  const gitDir = join2(workspace, ".git");
   if (!existsSync(gitDir))
     return false;
-  const excludePath = join(gitDir, "info", "exclude");
+  const excludePath = join2(gitDir, "info", "exclude");
   try {
-    mkdirSync(join(gitDir, "info"), { recursive: true });
+    mkdirSync(join2(gitDir, "info"), { recursive: true });
     const existing = existsSync(excludePath) ? readFileSync(excludePath, "utf8") : "";
     if (existing.split(/\r?\n/).includes(".codegraph"))
       return true;
@@ -137,7 +155,7 @@ function getCodegraphUninitializedProject(input) {
 }
 function buildCodegraphInitGuidance(projectPath, options = {}) {
   const { dataDir, dataRoot, projectLink } = resolveCodegraphWorkspacePaths(projectPath, {
-    homeDir: options.homeDir ?? homedir2()
+    homeDir: options.homeDir ?? homedir3()
   });
   const displayProjectPath = formatDisplayPath(projectPath);
   const displayProjectLink = formatDisplayPath(projectLink);
@@ -204,12 +222,245 @@ function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-// shared/src/config-loader.ts
+// ../../utils/src/codegraph/resolve.ts
+import { existsSync as existsSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
+import { spawnSync } from "node:child_process";
+import { basename as basename2, dirname, join as join4 } from "node:path";
+import { createRequire } from "node:module";
+
+// ../../utils/src/runtime/which.ts
+import { accessSync, constants } from "node:fs";
+import { delimiter, join as join3 } from "node:path";
+var runtime = globalThis;
+function isUnsafeCommandName(commandName) {
+  if (commandName.includes("/") || commandName.includes("\\"))
+    return true;
+  if (commandName === "." || commandName === ".." || commandName.includes(".."))
+    return true;
+  if (/^[a-zA-Z]:/.test(commandName))
+    return true;
+  if (commandName.includes("\x00"))
+    return true;
+  return false;
+}
+function isExecutable(filePath) {
+  try {
+    accessSync(filePath, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+    return true;
+  } catch (error) {
+    if (!(error instanceof Error) && Object.prototype.toString.call(error) !== "[object Error]") {
+      throw error;
+    }
+    return false;
+  }
+}
+function resolvePathValue() {
+  if (process.platform === "win32")
+    return process.env["Path"] ?? process.env["PATH"];
+  return process.env["PATH"];
+}
+function getWindowsCandidates(commandName) {
+  if (process.platform !== "win32")
+    return [commandName];
+  if (/\.[^\\/]+$/.test(commandName))
+    return [commandName];
+  return [commandName, `${commandName}.exe`, `${commandName}.cmd`, `${commandName}.bat`, `${commandName}.com`];
+}
+function bunWhich(commandName) {
+  if (!commandName)
+    return null;
+  if (isUnsafeCommandName(commandName))
+    return null;
+  const candidateNames = getWindowsCandidates(commandName);
+  for (const candidateName of candidateNames) {
+    const resolvedPath = runtime.Bun?.which(candidateName) ?? null;
+    if (resolvedPath !== null)
+      return resolvedPath;
+  }
+  const pathValue = resolvePathValue();
+  if (!pathValue)
+    return null;
+  const pathEntries = pathValue.split(delimiter).filter((pathEntry) => pathEntry.length > 0);
+  if (pathEntries.length === 0)
+    return null;
+  for (const pathEntry of pathEntries) {
+    for (const candidateName of candidateNames) {
+      const candidatePath = join3(pathEntry, candidateName);
+      if (isExecutable(candidatePath))
+        return candidatePath;
+    }
+  }
+  return null;
+}
+
+// ../../utils/src/codegraph/node-support.ts
+var CODEGRAPH_MIN_NODE_MAJOR = 20;
+var CODEGRAPH_BLOCKED_NODE_MAJOR = 25;
+var CODEGRAPH_UNSAFE_NODE_ENV = "CODEGRAPH_ALLOW_UNSAFE_NODE";
+var CODEGRAPH_NODE_BIN_ENV = "CODEGRAPH_NODE_BIN";
+function evaluateCodegraphNodeSupport(options = {}) {
+  const nodeVersion = options.nodeVersion ?? process.versions.node;
+  const env = options.env ?? process.env;
+  const override = (env[CODEGRAPH_UNSAFE_NODE_ENV]?.trim().length ?? 0) > 0;
+  const major = parseNodeMajor(nodeVersion);
+  if (major >= CODEGRAPH_BLOCKED_NODE_MAJOR) {
+    return { major, override, reason: "too-new", supported: override };
+  }
+  if (major < CODEGRAPH_MIN_NODE_MAJOR) {
+    return { major, override, reason: "too-old", supported: override };
+  }
+  return { major, override, supported: true };
+}
+function buildCodegraphNodeSkipHint(support) {
+  const detail = support.reason === "too-new" ? `Node ${support.major} is unsupported (>= ${CODEGRAPH_BLOCKED_NODE_MAJOR} crashes CodeGraph mid-indexing)` : `Node ${support.major} is too old (CodeGraph requires >= ${CODEGRAPH_MIN_NODE_MAJOR})`;
+  return `CodeGraph MCP skipped: ${detail}. Use Node ${CODEGRAPH_MIN_NODE_MAJOR}-${CODEGRAPH_BLOCKED_NODE_MAJOR - 1} (e.g. Node 22 LTS) or set ${CODEGRAPH_UNSAFE_NODE_ENV}=1 to override.
+`;
+}
+function parseNodeMajor(version) {
+  const normalized = version.startsWith("v") ? version.slice(1) : version;
+  const major = Number.parseInt(normalized.split(".")[0] ?? "", 10);
+  return Number.isNaN(major) ? 0 : major;
+}
+
+// ../../utils/src/codegraph/resolve.ts
+function codegraphCommandRequiresSupportedLocalNode(resolution) {
+  return resolution.source !== "bundled" && resolution.source !== "env" && resolution.source !== "provisioned";
+}
+var CODEGRAPH_PACKAGE = "@colbymchenry/codegraph";
+var CODEGRAPH_ENV_BIN = "OMO_CODEGRAPH_BIN";
+var CODEGRAPH_LEGACY_ENV_BIN = "CODEGRAPH_BIN";
+var CODEGRAPH_NODE_CANDIDATES = ["node24", "node22", "node20", "node"];
+var CODEGRAPH_NODE_PATH_CANDIDATES = [
+  "/opt/homebrew/opt/node@24/bin/node",
+  "/opt/homebrew/opt/node@22/bin/node",
+  "/opt/homebrew/opt/node@20/bin/node",
+  "/usr/local/opt/node@24/bin/node",
+  "/usr/local/opt/node@22/bin/node",
+  "/usr/local/opt/node@20/bin/node"
+];
+var requireFromHere = createRequire(import.meta.url);
+function defaultRequireResolve(specifier) {
+  return requireFromHere.resolve(specifier);
+}
+function defaultNodeVersion(nodePath) {
+  if (nodePath === process.execPath && isNodeExecutableName(nodePath))
+    return process.versions.node;
+  try {
+    const result = spawnSync(nodePath, ["--version"], {
+      encoding: "utf8",
+      timeout: 2000,
+      windowsHide: true
+    });
+    if (result.error !== undefined || result.status !== 0)
+      return null;
+    const version = `${result.stdout}
+${result.stderr}`.trim().split(/\s+/)[0];
+    return version === undefined || version.length === 0 ? null : version;
+  } catch (error) {
+    if (error instanceof Error)
+      return null;
+    throw error;
+  }
+}
+function isNodeExecutableName(filePath) {
+  const executable = basename2(filePath).toLowerCase();
+  return executable === "node" || executable === "node.exe" || /^node\d+(\.exe)?$/.test(executable);
+}
+function looksLikePath(command) {
+  return command.includes("/") || command.includes("\\") || /^[a-zA-Z]:/.test(command);
+}
+function resolveConfiguredNodeRuntime(configured, fileExists, which) {
+  if (looksLikePath(configured))
+    return fileExists(configured) ? configured : null;
+  return which(configured);
+}
+function supportsCodegraphNodeRuntime(nodePath, env, nodeVersion) {
+  const version = nodeVersion(nodePath);
+  if (version === null)
+    return false;
+  return evaluateCodegraphNodeSupport({ env, nodeVersion: version }).supported;
+}
+function defaultNodeRuntime(env, fileExists, which, nodeVersion) {
+  const configured = env[CODEGRAPH_NODE_BIN_ENV]?.trim();
+  if (configured !== undefined && configured.length > 0) {
+    const resolved = resolveConfiguredNodeRuntime(configured, fileExists, which);
+    return resolved !== null && supportsCodegraphNodeRuntime(resolved, env, nodeVersion) ? resolved : null;
+  }
+  const candidates = [
+    ...isNodeExecutableName(process.execPath) ? [process.execPath] : [],
+    ...CODEGRAPH_NODE_CANDIDATES.map((commandName) => which(commandName)).filter((candidate) => candidate !== null),
+    ...CODEGRAPH_NODE_PATH_CANDIDATES.filter((candidate) => fileExists(candidate))
+  ];
+  const seen = new Set;
+  for (const candidate of candidates) {
+    if (seen.has(candidate))
+      continue;
+    seen.add(candidate);
+    if (supportsCodegraphNodeRuntime(candidate, env, nodeVersion))
+      return candidate;
+  }
+  return null;
+}
+function defaultProvisionedBin(homeDir, fileExists) {
+  const binaryName = process.platform === "win32" ? "codegraph.cmd" : "codegraph";
+  const candidates = [
+    join4(homeDir, ".omo", "codegraph", "bin", binaryName),
+    join4(homeDir, ".omo", "codegraph", "node-servers", "node_modules", ".bin", binaryName)
+  ];
+  return candidates.find((candidate) => fileExists(candidate)) ?? null;
+}
+function resolveBundledShim(requireResolve, fileExists) {
+  try {
+    const packageJson = requireResolve(`${CODEGRAPH_PACKAGE}/package.json`);
+    const packageRoot = dirname(packageJson);
+    const candidates = [join4(packageRoot, "bin", "codegraph.js"), join4(packageRoot, "npm-shim.js")];
+    return candidates.find((candidate) => fileExists(candidate)) ?? null;
+  } catch (error) {
+    if (error instanceof Error)
+      return null;
+    if (error === null || error === undefined)
+      return null;
+    if (typeof error === "object" || typeof error === "string" || typeof error === "number")
+      return null;
+    if (typeof error === "boolean" || typeof error === "bigint" || typeof error === "symbol")
+      return null;
+    return null;
+  }
+}
+function resolveCodegraphCommand(options = {}) {
+  const env = options.env ?? process.env;
+  const fileExists = options.fileExists ?? existsSync2;
+  const configuredBin = env[CODEGRAPH_ENV_BIN]?.trim() || env[CODEGRAPH_LEGACY_ENV_BIN]?.trim();
+  if (configuredBin !== undefined && configuredBin.length > 0) {
+    return { argsPrefix: [], command: configuredBin, exists: fileExists(configuredBin), source: "env" };
+  }
+  const which = options.which ?? bunWhich;
+  const nodeRuntime = options.nodeRuntime ?? (() => defaultNodeRuntime(env, fileExists, which, options.nodeVersion ?? defaultNodeVersion));
+  const bundled = resolveBundledShim(options.requireResolve ?? defaultRequireResolve, fileExists);
+  const runtime2 = nodeRuntime();
+  if (bundled !== null && runtime2 !== null) {
+    return { argsPrefix: [bundled], command: runtime2, exists: true, source: "bundled" };
+  }
+  const provisioned = options.provisioned?.() ?? defaultProvisionedBin(options.homeDir ?? homedir4(), fileExists);
+  if (provisioned !== null && fileExists(provisioned)) {
+    return { argsPrefix: [], command: provisioned, exists: true, source: "provisioned" };
+  }
+  const pathCommand = which("codegraph");
+  return {
+    argsPrefix: [],
+    command: pathCommand ?? "codegraph",
+    exists: pathCommand !== null,
+    source: "path"
+  };
+}
+
+// shared/src/config-loader.ts
+import { homedir as homedir6 } from "node:os";
 
 // ../../utils/src/omo-config/loader.ts
-import { existsSync as existsSync3, readFileSync as readFileSync2 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
+import { existsSync as existsSync4, readFileSync as readFileSync2 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
 
 // ../../utils/src/deep-merge.ts
 var DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -1165,8 +1416,8 @@ function buildEnvOverrides(harness, env, warnings, merge) {
 }
 
 // ../../utils/src/omo-config/resolve.ts
-import { existsSync as existsSync2 } from "node:fs";
-import { dirname, isAbsolute, join as join2, relative, resolve as resolve2 } from "node:path";
+import { existsSync as existsSync3 } from "node:fs";
+import { dirname as dirname2, isAbsolute, join as join5, relative, resolve as resolve2 } from "node:path";
 function containsPath(parent, child) {
   const pathToChild = relative(parent, child);
   return pathToChild === "" || !pathToChild.startsWith("..") && !isAbsolute(pathToChild);
@@ -1179,11 +1430,11 @@ function findProjectConfigPathsNearestFirst(cwd, homeDir) {
   while (true) {
     if (stopBeforeDir !== null && currentDir === stopBeforeDir)
       break;
-    const configPath = join2(currentDir, ".omo", "config.jsonc");
-    if (existsSync2(configPath)) {
+    const configPath = join5(currentDir, ".omo", "config.jsonc");
+    if (existsSync3(configPath)) {
       paths.push(configPath);
     }
-    const parentDir = dirname(currentDir);
+    const parentDir = dirname2(currentDir);
     if (parentDir === currentDir)
       break;
     currentDir = parentDir;
@@ -1191,7 +1442,7 @@ function findProjectConfigPathsNearestFirst(cwd, homeDir) {
   return paths;
 }
 function resolveOmoConfigPaths(options) {
-  const globalPath = join2(resolve2(options.homeDir), ".omo", "config.jsonc");
+  const globalPath = join5(resolve2(options.homeDir), ".omo", "config.jsonc");
   const projectPathsFarthestFirst = findProjectConfigPathsNearestFirst(options.cwd, options.homeDir).reverse();
   return [
     { path: globalPath, scope: "global" },
@@ -1402,13 +1653,13 @@ function validateHarnessApplicability(config, harness) {
 }
 function loadOmoConfig(options) {
   const cwd = options.cwd ?? process.cwd();
-  const homeDir = options.homeDir ?? process.env["HOME"] ?? process.env["USERPROFILE"] ?? homedir3();
+  const homeDir = options.homeDir ?? process.env["HOME"] ?? process.env["USERPROFILE"] ?? homedir5();
   const env = options.env ?? process.env;
   let config = BUILT_IN_DEFAULTS;
   const sources = [];
   const warnings = [];
   for (const candidate of resolveOmoConfigPaths({ cwd, homeDir })) {
-    if (!existsSync3(candidate.path)) {
+    if (!existsSync4(candidate.path)) {
       if (candidate.scope === "global") {
         sources.push(toMissingSource(candidate));
       }
@@ -1456,7 +1707,7 @@ function getCodexOmoConfig(options = {}) {
 }
 function resolveHomeDir(options) {
   const env = options.env ?? process.env;
-  return options.homeDir ?? env["HOME"] ?? env["USERPROFILE"] ?? homedir4();
+  return options.homeDir ?? env["HOME"] ?? env["USERPROFILE"] ?? homedir6();
 }
 
 // components/codegraph/src/session-start-worker.ts
@@ -1466,59 +1717,13 @@ import { homedir as homedir8 } from "node:os";
 import { extname, join as join7 } from "node:path";
 import { cwd as processCwd, env as processEnv, stderr as processStderr } from "node:process";
 
-// ../../utils/src/codegraph/env.ts
-import { homedir as homedir5 } from "node:os";
-import { join as join3 } from "node:path";
-var CODEGRAPH_INSTALL_DIR_ENV = "CODEGRAPH_INSTALL_DIR";
-var CODEGRAPH_NO_DOWNLOAD_ENV = "CODEGRAPH_NO_DOWNLOAD";
-var CODEGRAPH_TELEMETRY_ENV = "CODEGRAPH_TELEMETRY";
-var DO_NOT_TRACK_ENV = "DO_NOT_TRACK";
-function buildCodegraphEnv(options = {}) {
-  const homeDir = options.homeDir ?? homedir5();
-  return {
-    [CODEGRAPH_INSTALL_DIR_ENV]: join3(homeDir, ".omo", "codegraph"),
-    [CODEGRAPH_NO_DOWNLOAD_ENV]: "1",
-    [CODEGRAPH_TELEMETRY_ENV]: "0",
-    [DO_NOT_TRACK_ENV]: "1"
-  };
-}
-
-// ../../utils/src/codegraph/node-support.ts
-var CODEGRAPH_MIN_NODE_MAJOR = 20;
-var CODEGRAPH_BLOCKED_NODE_MAJOR = 25;
-var CODEGRAPH_UNSAFE_NODE_ENV = "CODEGRAPH_ALLOW_UNSAFE_NODE";
-var CODEGRAPH_NODE_BIN_ENV = "CODEGRAPH_NODE_BIN";
-function evaluateCodegraphNodeSupport(options = {}) {
-  const nodeVersion = options.nodeVersion ?? process.versions.node;
-  const env = options.env ?? process.env;
-  const override = (env[CODEGRAPH_UNSAFE_NODE_ENV]?.trim().length ?? 0) > 0;
-  const major = parseNodeMajor(nodeVersion);
-  if (major >= CODEGRAPH_BLOCKED_NODE_MAJOR) {
-    return { major, override, reason: "too-new", supported: override };
-  }
-  if (major < CODEGRAPH_MIN_NODE_MAJOR) {
-    return { major, override, reason: "too-old", supported: override };
-  }
-  return { major, override, supported: true };
-}
-function buildCodegraphNodeSkipHint(support) {
-  const detail = support.reason === "too-new" ? `Node ${support.major} is unsupported (>= ${CODEGRAPH_BLOCKED_NODE_MAJOR} crashes CodeGraph mid-indexing)` : `Node ${support.major} is too old (CodeGraph requires >= ${CODEGRAPH_MIN_NODE_MAJOR})`;
-  return `CodeGraph MCP skipped: ${detail}. Use Node ${CODEGRAPH_MIN_NODE_MAJOR}-${CODEGRAPH_BLOCKED_NODE_MAJOR - 1} (e.g. Node 22 LTS) or set ${CODEGRAPH_UNSAFE_NODE_ENV}=1 to override.
-`;
-}
-function parseNodeMajor(version) {
-  const normalized = version.startsWith("v") ? version.slice(1) : version;
-  const major = Number.parseInt(normalized.split(".")[0] ?? "", 10);
-  return Number.isNaN(major) ? 0 : major;
-}
-
 // ../../utils/src/codegraph/provision.ts
 import { createHash as createHash2, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { chmod, mkdir, readdir, readFile, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
-import { existsSync as existsSync4 } from "node:fs";
-import { homedir as homedir6, hostname } from "node:os";
-import { basename as basename2, join as join4 } from "node:path";
+import { existsSync as existsSync5 } from "node:fs";
+import { homedir as homedir7, hostname } from "node:os";
+import { basename as basename3, join as join6 } from "node:path";
 import { promisify } from "node:util";
 
 // ../../utils/src/codegraph/manifest.ts
@@ -1567,10 +1772,10 @@ function platformKey() {
   return `${process.platform}-${process.arch}`;
 }
 function markerPath(installDir, version) {
-  return join4(installDir, ".provisioned", `codegraph-${version}.json`);
+  return join6(installDir, ".provisioned", `codegraph-${version}.json`);
 }
 function defaultInstallDir() {
-  return join4(homedir6(), ".omo", "codegraph");
+  return join6(homedir7(), ".omo", "codegraph");
 }
 function sha256(bytes) {
   return createHash2("sha256").update(bytes).digest("hex");
@@ -1604,7 +1809,7 @@ function forcedBadChecksumOptions(options) {
   const key = options.platformKey ?? platformKey();
   return {
     downloader: async () => new TextEncoder().encode("checksum mismatch"),
-    installDir: options.installDir ?? join4(options.lockDir, "codegraph-force-bad-checksum"),
+    installDir: options.installDir ?? join6(options.lockDir, "codegraph-force-bad-checksum"),
     manifest: {
       assets: {
         [key]: { executableName: process.platform === "win32" ? "codegraph.cmd" : "codegraph", sha256: "0000", url: "memory://bad" }
@@ -1615,13 +1820,13 @@ function forcedBadChecksumOptions(options) {
   };
 }
 async function readMarker(path) {
-  if (!existsSync4(path))
+  if (!existsSync5(path))
     return null;
   try {
     const raw = JSON.parse(await readFile(path, "utf8"));
     if (typeof raw === "object" && raw !== null && "binPath" in raw) {
       const value = raw.binPath;
-      return typeof value === "string" && existsSync4(value) ? value : null;
+      return typeof value === "string" && existsSync5(value) ? value : null;
     }
     return null;
   } catch (error) {
@@ -1632,7 +1837,7 @@ async function readMarker(path) {
 }
 async function acquireLock(lockPath, waitMs, staleMs) {
   const startedAt = Date.now();
-  await mkdir(join4(lockPath, ".."), { recursive: true });
+  await mkdir(join6(lockPath, ".."), { recursive: true });
   while (Date.now() - startedAt <= waitMs) {
     try {
       await mkdir(lockPath);
@@ -1657,44 +1862,44 @@ async function installExtractedBundle(extractDir, installDir, executableName) {
   const roots = await readdir(extractDir);
   if (roots.length !== 1)
     throw new Error(`CodeGraph archive should contain one root directory, found ${roots.length}`);
-  const bundleDir = join4(extractDir, roots[0] ?? "");
+  const bundleDir = join6(extractDir, roots[0] ?? "");
   const bundleEntries = await readdir(bundleDir);
   await mkdir(installDir, { recursive: true });
   for (const entry of bundleEntries) {
-    await rm(join4(installDir, entry), { force: true, recursive: true });
-    await rename(join4(bundleDir, entry), join4(installDir, entry));
+    await rm(join6(installDir, entry), { force: true, recursive: true });
+    await rename(join6(bundleDir, entry), join6(installDir, entry));
   }
-  const destination = join4(installDir, "bin", executableName);
-  if (!existsSync4(destination))
+  const destination = join6(installDir, "bin", executableName);
+  if (!existsSync5(destination))
     throw new Error(`CodeGraph archive did not contain bin/${executableName}`);
   await chmod(destination, 493);
   return destination;
 }
 async function installAsset(layout) {
   const { asset, downloader, installDir, version } = layout;
-  const stagingDir = join4(installDir, ".staging", randomUUID());
-  const archivePath = join4(stagingDir, basename2(asset.url));
-  const extractDir = join4(stagingDir, "extract");
+  const stagingDir = join6(installDir, ".staging", randomUUID());
+  const archivePath = join6(stagingDir, basename3(asset.url));
+  const extractDir = join6(stagingDir, "extract");
   try {
     await mkdir(extractDir, { recursive: true });
     const bytes = await downloader(asset);
     const actualChecksum = sha256(bytes);
     if (actualChecksum !== asset.sha256) {
-      throw new Error(`checksum mismatch for ${basename2(asset.url)}: expected ${asset.sha256}, got ${actualChecksum}`);
+      throw new Error(`checksum mismatch for ${basename3(asset.url)}: expected ${asset.sha256}, got ${actualChecksum}`);
     }
     if (!asset.url.endsWith(".tar.gz") && !asset.url.endsWith(".tgz")) {
-      throw new Error(`unsupported CodeGraph archive type for ${basename2(asset.url)}`);
+      throw new Error(`unsupported CodeGraph archive type for ${basename3(asset.url)}`);
     }
     await writeFile(archivePath, bytes);
     await extractTarGz(archivePath, extractDir);
     const destination = await installExtractedBundle(extractDir, installDir, asset.executableName);
-    await mkdir(join4(installDir, ".provisioned"), { recursive: true });
+    await mkdir(join6(installDir, ".provisioned"), { recursive: true });
     await writeFile(markerPath(installDir, version), `${JSON.stringify({ binPath: destination, version })}
 `);
     return destination;
   } finally {
     await rm(stagingDir, { force: true, recursive: true });
-    await removeEmptyDirectory(join4(installDir, ".staging"));
+    await removeEmptyDirectory(join6(installDir, ".staging"));
   }
 }
 async function ensureCodegraphProvisioned(options) {
@@ -1707,7 +1912,7 @@ async function ensureCodegraphProvisioned(options) {
   const existing = await readMarker(marker);
   if (existing !== null)
     return { binPath: existing, provisioned: true };
-  const lockPath = join4(options.lockDir, `codegraph-${hostname()}.lock`);
+  const lockPath = join6(options.lockDir, `codegraph-${hostname()}.lock`);
   const release = await acquireLock(lockPath, options.lockWaitMs ?? DEFAULT_LOCK_WAIT_MS, options.lockStaleMs ?? DEFAULT_LOCK_STALE_MS);
   if (release === null)
     return { error: "timed out waiting for codegraph provisioning lock", provisioned: false };
@@ -1729,210 +1934,6 @@ async function ensureCodegraphProvisioned(options) {
   } finally {
     await release();
   }
-}
-
-// ../../utils/src/codegraph/resolve.ts
-import { existsSync as existsSync5 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { spawnSync } from "node:child_process";
-import { basename as basename3, dirname as dirname2, join as join6 } from "node:path";
-import { createRequire } from "node:module";
-
-// ../../utils/src/runtime/which.ts
-import { accessSync, constants } from "node:fs";
-import { delimiter, join as join5 } from "node:path";
-var runtime = globalThis;
-function isUnsafeCommandName(commandName) {
-  if (commandName.includes("/") || commandName.includes("\\"))
-    return true;
-  if (commandName === "." || commandName === ".." || commandName.includes(".."))
-    return true;
-  if (/^[a-zA-Z]:/.test(commandName))
-    return true;
-  if (commandName.includes("\x00"))
-    return true;
-  return false;
-}
-function isExecutable(filePath) {
-  try {
-    accessSync(filePath, process.platform === "win32" ? constants.F_OK : constants.X_OK);
-    return true;
-  } catch (error) {
-    if (!(error instanceof Error) && Object.prototype.toString.call(error) !== "[object Error]") {
-      throw error;
-    }
-    return false;
-  }
-}
-function resolvePathValue() {
-  if (process.platform === "win32")
-    return process.env["Path"] ?? process.env["PATH"];
-  return process.env["PATH"];
-}
-function getWindowsCandidates(commandName) {
-  if (process.platform !== "win32")
-    return [commandName];
-  if (/\.[^\\/]+$/.test(commandName))
-    return [commandName];
-  return [commandName, `${commandName}.exe`, `${commandName}.cmd`, `${commandName}.bat`, `${commandName}.com`];
-}
-function bunWhich(commandName) {
-  if (!commandName)
-    return null;
-  if (isUnsafeCommandName(commandName))
-    return null;
-  const candidateNames = getWindowsCandidates(commandName);
-  for (const candidateName of candidateNames) {
-    const resolvedPath = runtime.Bun?.which(candidateName) ?? null;
-    if (resolvedPath !== null)
-      return resolvedPath;
-  }
-  const pathValue = resolvePathValue();
-  if (!pathValue)
-    return null;
-  const pathEntries = pathValue.split(delimiter).filter((pathEntry) => pathEntry.length > 0);
-  if (pathEntries.length === 0)
-    return null;
-  for (const pathEntry of pathEntries) {
-    for (const candidateName of candidateNames) {
-      const candidatePath = join5(pathEntry, candidateName);
-      if (isExecutable(candidatePath))
-        return candidatePath;
-    }
-  }
-  return null;
-}
-
-// ../../utils/src/codegraph/resolve.ts
-function codegraphCommandRequiresSupportedLocalNode(resolution) {
-  return resolution.source !== "bundled" && resolution.source !== "env" && resolution.source !== "provisioned";
-}
-var CODEGRAPH_PACKAGE = "@colbymchenry/codegraph";
-var CODEGRAPH_ENV_BIN = "OMO_CODEGRAPH_BIN";
-var CODEGRAPH_LEGACY_ENV_BIN = "CODEGRAPH_BIN";
-var CODEGRAPH_NODE_CANDIDATES = ["node24", "node22", "node20", "node"];
-var CODEGRAPH_NODE_PATH_CANDIDATES = [
-  "/opt/homebrew/opt/node@24/bin/node",
-  "/opt/homebrew/opt/node@22/bin/node",
-  "/opt/homebrew/opt/node@20/bin/node",
-  "/usr/local/opt/node@24/bin/node",
-  "/usr/local/opt/node@22/bin/node",
-  "/usr/local/opt/node@20/bin/node"
-];
-var requireFromHere = createRequire(import.meta.url);
-function defaultRequireResolve(specifier) {
-  return requireFromHere.resolve(specifier);
-}
-function defaultNodeVersion(nodePath) {
-  if (nodePath === process.execPath && isNodeExecutableName(nodePath))
-    return process.versions.node;
-  try {
-    const result = spawnSync(nodePath, ["--version"], {
-      encoding: "utf8",
-      timeout: 2000,
-      windowsHide: true
-    });
-    if (result.error !== undefined || result.status !== 0)
-      return null;
-    const version = `${result.stdout}
-${result.stderr}`.trim().split(/\s+/)[0];
-    return version === undefined || version.length === 0 ? null : version;
-  } catch (error) {
-    if (error instanceof Error)
-      return null;
-    throw error;
-  }
-}
-function isNodeExecutableName(filePath) {
-  const executable = basename3(filePath).toLowerCase();
-  return executable === "node" || executable === "node.exe" || /^node\d+(\.exe)?$/.test(executable);
-}
-function looksLikePath(command) {
-  return command.includes("/") || command.includes("\\") || /^[a-zA-Z]:/.test(command);
-}
-function resolveConfiguredNodeRuntime(configured, fileExists, which) {
-  if (looksLikePath(configured))
-    return fileExists(configured) ? configured : null;
-  return which(configured);
-}
-function supportsCodegraphNodeRuntime(nodePath, env, nodeVersion) {
-  const version = nodeVersion(nodePath);
-  if (version === null)
-    return false;
-  return evaluateCodegraphNodeSupport({ env, nodeVersion: version }).supported;
-}
-function defaultNodeRuntime(env, fileExists, which, nodeVersion) {
-  const configured = env[CODEGRAPH_NODE_BIN_ENV]?.trim();
-  if (configured !== undefined && configured.length > 0) {
-    const resolved = resolveConfiguredNodeRuntime(configured, fileExists, which);
-    return resolved !== null && supportsCodegraphNodeRuntime(resolved, env, nodeVersion) ? resolved : null;
-  }
-  const candidates = [
-    ...isNodeExecutableName(process.execPath) ? [process.execPath] : [],
-    ...CODEGRAPH_NODE_CANDIDATES.map((commandName) => which(commandName)).filter((candidate) => candidate !== null),
-    ...CODEGRAPH_NODE_PATH_CANDIDATES.filter((candidate) => fileExists(candidate))
-  ];
-  const seen = new Set;
-  for (const candidate of candidates) {
-    if (seen.has(candidate))
-      continue;
-    seen.add(candidate);
-    if (supportsCodegraphNodeRuntime(candidate, env, nodeVersion))
-      return candidate;
-  }
-  return null;
-}
-function defaultProvisionedBin(homeDir, fileExists) {
-  const binaryName = process.platform === "win32" ? "codegraph.cmd" : "codegraph";
-  const candidates = [
-    join6(homeDir, ".omo", "codegraph", "bin", binaryName),
-    join6(homeDir, ".omo", "codegraph", "node-servers", "node_modules", ".bin", binaryName)
-  ];
-  return candidates.find((candidate) => fileExists(candidate)) ?? null;
-}
-function resolveBundledShim(requireResolve, fileExists) {
-  try {
-    const packageJson = requireResolve(`${CODEGRAPH_PACKAGE}/package.json`);
-    const packageRoot = dirname2(packageJson);
-    const candidates = [join6(packageRoot, "bin", "codegraph.js"), join6(packageRoot, "npm-shim.js")];
-    return candidates.find((candidate) => fileExists(candidate)) ?? null;
-  } catch (error) {
-    if (error instanceof Error)
-      return null;
-    if (error === null || error === undefined)
-      return null;
-    if (typeof error === "object" || typeof error === "string" || typeof error === "number")
-      return null;
-    if (typeof error === "boolean" || typeof error === "bigint" || typeof error === "symbol")
-      return null;
-    return null;
-  }
-}
-function resolveCodegraphCommand(options = {}) {
-  const env = options.env ?? process.env;
-  const fileExists = options.fileExists ?? existsSync5;
-  const configuredBin = env[CODEGRAPH_ENV_BIN]?.trim() || env[CODEGRAPH_LEGACY_ENV_BIN]?.trim();
-  if (configuredBin !== undefined && configuredBin.length > 0) {
-    return { argsPrefix: [], command: configuredBin, exists: fileExists(configuredBin), source: "env" };
-  }
-  const which = options.which ?? bunWhich;
-  const nodeRuntime = options.nodeRuntime ?? (() => defaultNodeRuntime(env, fileExists, which, options.nodeVersion ?? defaultNodeVersion));
-  const bundled = resolveBundledShim(options.requireResolve ?? defaultRequireResolve, fileExists);
-  const runtime2 = nodeRuntime();
-  if (bundled !== null && runtime2 !== null) {
-    return { argsPrefix: [bundled], command: runtime2, exists: true, source: "bundled" };
-  }
-  const provisioned = options.provisioned?.() ?? defaultProvisionedBin(options.homeDir ?? homedir7(), fileExists);
-  if (provisioned !== null && fileExists(provisioned)) {
-    return { argsPrefix: [], command: provisioned, exists: true, source: "provisioned" };
-  }
-  const pathCommand = which("codegraph");
-  return {
-    argsPrefix: [],
-    command: pathCommand ?? "codegraph",
-    exists: pathCommand !== null,
-    source: "path"
-  };
 }
 
 // components/codegraph/src/session-start-worker.ts
@@ -2114,6 +2115,7 @@ function isRecord3(value) {
 
 // components/codegraph/src/hook.ts
 var CODEGRAPH_SESSION_START_NOTICE = "LazyCodex CodeGraph bootstrap scheduled in background";
+var STATUS_PROBE_TIMEOUT_MS = 2000;
 async function runCodegraphSessionStartHook(options = {}) {
   return (await executeCodegraphSessionStartHook(options)).exitCode;
 }
@@ -2129,6 +2131,15 @@ async function executeCodegraphSessionStartHook(options = {}) {
   if (config.codegraph?.enabled === false) {
     return { action: "skipped-disabled", exitCode: 0 };
   }
+  const isInitialized = await (options.statusProbe ?? isCodegraphProjectInitialized)({
+    env,
+    homeDir,
+    projectRoot,
+    ...config.trustedCodegraphInstallDir === undefined ? {} : { trustedCodegraphInstallDir: config.trustedCodegraphInstallDir }
+  });
+  if (isInitialized) {
+    return { action: "skipped-initialized", exitCode: 0 };
+  }
   (options.spawnWorker ?? spawnDetachedWorker)({
     args: [options.workerCliPath ?? defaultWorkerCliPath(), "hook", "session-start-worker"],
     command: process.execPath,
@@ -2136,6 +2147,63 @@ async function executeCodegraphSessionStartHook(options = {}) {
   });
   writeHookJson(options.stdout ?? processStdout);
   return { action: "spawned", exitCode: 0 };
+}
+async function isCodegraphProjectInitialized(options) {
+  const resolved = resolveCodegraphCommand({
+    env: options.env,
+    homeDir: options.homeDir,
+    provisioned: () => provisionedBinFromInstallDir2(options.trustedCodegraphInstallDir)
+  });
+  if (!resolved.exists)
+    return false;
+  const invocation = resolveCodegraphCommandInvocation(resolved.command, [...resolved.argsPrefix, "status", "--json"]);
+  const status = await runStatusProbe(options.projectRoot, invocation.command, invocation.args, {
+    ...buildCodegraphEnv({ homeDir: options.homeDir }),
+    ...options.trustedCodegraphInstallDir === undefined ? {} : { CODEGRAPH_INSTALL_DIR: options.trustedCodegraphInstallDir },
+    ...definedEnv(options.env)
+  });
+  if (status.exitCode !== 0 || status.timedOut)
+    return false;
+  return codegraphStatusSaysInitialized(status.stdout);
+}
+function runStatusProbe(projectRoot, command, args, env) {
+  return new Promise((resolveProbe) => {
+    execFile3(command, [...args], {
+      cwd: projectRoot,
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+      maxBuffer: 1024 * 1024,
+      timeout: STATUS_PROBE_TIMEOUT_MS,
+      windowsHide: true
+    }, (error, stdout) => {
+      if (error === null) {
+        resolveProbe({ exitCode: 0, stdout: toOutputText2(stdout), timedOut: false });
+        return;
+      }
+      resolveProbe({ exitCode: resolveExitCode2(error), stdout: toOutputText2(stdout), timedOut: error.killed === true });
+    });
+  });
+}
+function codegraphStatusSaysInitialized(stdout) {
+  const parsed = parseJson2(stdout);
+  if (!isRecord4(parsed))
+    return false;
+  const initialized = parsed["initialized"] ?? parsed["isInitialized"] ?? parsed["ready"];
+  if (typeof initialized === "boolean")
+    return initialized;
+  const status = parsed["status"];
+  if (typeof status !== "string")
+    return false;
+  const normalized = status.toLowerCase();
+  return (normalized.includes("initialized") || normalized.includes("ready")) && !normalized.includes("not initialized") && !normalized.includes("uninitialized");
+}
+function definedEnv(env) {
+  return Object.fromEntries(Object.entries(env).filter((entry) => entry[1] !== undefined));
+}
+function provisionedBinFromInstallDir2(installDir) {
+  if (installDir === undefined)
+    return null;
+  return join8(installDir, "bin", process.platform === "win32" ? "codegraph.cmd" : "codegraph");
 }
 async function executeCodegraphPostToolUseHook(options = {}) {
   const env = options.env ?? processEnv2;
@@ -2178,6 +2246,14 @@ function spawnDetachedWorker(invocation) {
 function resolveHomeDir3(env) {
   return env["HOME"] ?? env["USERPROFILE"] ?? homedir9();
 }
+function resolveExitCode2(error) {
+  if ("code" in error && typeof error.code === "number")
+    return error.code;
+  return 1;
+}
+function toOutputText2(value) {
+  return Buffer.isBuffer(value) ? value.toString("utf8") : value;
+}
 function resolveProjectRoot(input, fallback) {
   if (!isRecord4(input))
     return fallback;
@@ -2213,7 +2289,7 @@ function defaultWorkerCliPath() {
 // components/codegraph/src/serve.ts
 import { existsSync as existsSync7, realpathSync as realpathSync2 } from "node:fs";
 import { homedir as homedir10 } from "node:os";
-import { basename as basename4, join as join8, resolve as resolve3 } from "node:path";
+import { basename as basename4, join as join9, resolve as resolve3 } from "node:path";
 import {
   cwd as processCwd3,
   env as processEnv3,
@@ -2601,7 +2677,7 @@ async function runCodegraphServe(options = {}) {
   const resolutionOptions = {
     env,
     homeDir,
-    provisioned: () => provisionedBinFromInstallDir2(trustedInstallDir)
+    provisioned: () => provisionedBinFromInstallDir3(trustedInstallDir)
   };
   let resolution = options.resolve?.(resolutionOptions) ?? resolveCodegraphCommand(resolutionOptions);
   const nodeSupport = evaluateCodegraphNodeSupport({ env, nodeVersion: options.nodeVersion });
@@ -2654,10 +2730,10 @@ async function provisionMissingCodegraph(options) {
     return null;
   if (options.config.auto_provision === false)
     return null;
-  const installDir = options.trustedInstallDir ?? join8(options.homeDir, ".omo", "codegraph");
+  const installDir = options.trustedInstallDir ?? join9(options.homeDir, ".omo", "codegraph");
   const result = await options.ensureProvisioned({
     installDir,
-    lockDir: join8(installDir, ".locks"),
+    lockDir: join9(installDir, ".locks"),
     version: CODEGRAPH_VERSION2
   });
   if (!result.provisioned || result.binPath === undefined)
@@ -2689,10 +2765,10 @@ function resolveProjectCwd(env, fallback) {
   }
   return resolve3(fallback);
 }
-function provisionedBinFromInstallDir2(installDir) {
+function provisionedBinFromInstallDir3(installDir) {
   if (installDir === undefined)
     return null;
-  const candidate = join8(installDir, "bin", process.platform === "win32" ? "codegraph.cmd" : "codegraph");
+  const candidate = join9(installDir, "bin", process.platform === "win32" ? "codegraph.cmd" : "codegraph");
   return existsSync7(candidate) ? candidate : null;
 }
 async function runCodegraphServeCli() {

--- a/packages/omo-codex/plugin/components/codegraph/src/hook-types.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/hook-types.ts
@@ -9,7 +9,7 @@ import type {
 import type { CodegraphWorkspacePreparation as SharedCodegraphWorkspacePreparation } from "../../../../../utils/src/codegraph/workspace.ts";
 import type { CodegraphConfig as SharedCodegraphConfig } from "../../../../../utils/src/omo-config.ts";
 
-export type SessionStartAction = "skipped-disabled" | "spawned";
+export type SessionStartAction = "skipped-disabled" | "skipped-initialized" | "spawned";
 export type PostToolUseAction = "emitted-guidance" | "skipped";
 export type WorkerAction = "failed" | "initialized" | "skipped-disabled" | "skipped-status" | "skipped-unavailable" | "skipped-unsupported-node" | "synced";
 
@@ -74,6 +74,12 @@ export interface SessionStartHookOptions {
 	readonly cwd?: string;
 	readonly env?: Record<string, string | undefined>;
 	readonly spawnWorker?: (invocation: WorkerSpawnInvocation) => void;
+	readonly statusProbe?: (options: {
+		readonly env: Record<string, string | undefined>;
+		readonly homeDir: string;
+		readonly projectRoot: string;
+		readonly trustedCodegraphInstallDir?: string;
+	}) => Promise<boolean>;
 	readonly stdin?: Readable & { readonly isTTY?: boolean };
 	readonly stdout?: HookStdout;
 	readonly workerCliPath?: string;

--- a/packages/omo-codex/plugin/components/codegraph/src/hook.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/hook.ts
@@ -1,12 +1,15 @@
-import { spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { homedir } from "node:os";
+import { join } from "node:path";
 import { cwd as processCwd, env as processEnv, stdin as processStdin, stdout as processStdout } from "node:process";
 import type { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
+import { buildCodegraphEnv } from "../../../../../utils/src/codegraph/env.ts";
 import { buildCodegraphInitGuidanceForToolResult } from "../../../../../utils/src/codegraph/guidance.ts";
+import { resolveCodegraphCommand } from "../../../../../utils/src/codegraph/resolve.ts";
 import { getCodexOmoConfig } from "../../../shared/src/config-loader.ts";
-import { SESSION_START_CWD_ENV } from "./session-start-worker.js";
+import { resolveCodegraphCommandInvocation, SESSION_START_CWD_ENV } from "./session-start-worker.js";
 import type {
 	HookStdout,
 	PostToolUseHookOptions,
@@ -38,6 +41,7 @@ export type {
 export { resolveCodegraphCommandInvocation, runCodegraphSessionStartWorker } from "./session-start-worker.js";
 
 export const CODEGRAPH_SESSION_START_NOTICE = "LazyCodex CodeGraph bootstrap scheduled in background";
+const STATUS_PROBE_TIMEOUT_MS = 2_000;
 
 export async function runCodegraphSessionStartHook(options: SessionStartHookOptions = {}): Promise<number> {
 	return (await executeCodegraphSessionStartHook(options)).exitCode;
@@ -58,6 +62,16 @@ export async function executeCodegraphSessionStartHook(options: SessionStartHook
 		return { action: "skipped-disabled", exitCode: 0 };
 	}
 
+	const isInitialized = await (options.statusProbe ?? isCodegraphProjectInitialized)({
+		env,
+		homeDir,
+		projectRoot,
+		...(config.trustedCodegraphInstallDir === undefined ? {} : { trustedCodegraphInstallDir: config.trustedCodegraphInstallDir }),
+	});
+	if (isInitialized) {
+		return { action: "skipped-initialized", exitCode: 0 };
+	}
+
 	(options.spawnWorker ?? spawnDetachedWorker)({
 		args: [options.workerCliPath ?? defaultWorkerCliPath(), "hook", "session-start-worker"],
 		command: process.execPath,
@@ -65,6 +79,78 @@ export async function executeCodegraphSessionStartHook(options: SessionStartHook
 	});
 	writeHookJson(options.stdout ?? processStdout);
 	return { action: "spawned", exitCode: 0 };
+}
+
+async function isCodegraphProjectInitialized(options: {
+	readonly env: Record<string, string | undefined>;
+	readonly homeDir: string;
+	readonly projectRoot: string;
+	readonly trustedCodegraphInstallDir?: string;
+}): Promise<boolean> {
+	const resolved = resolveCodegraphCommand({
+		env: options.env,
+		homeDir: options.homeDir,
+		provisioned: () => provisionedBinFromInstallDir(options.trustedCodegraphInstallDir),
+	});
+	if (!resolved.exists) return false;
+
+	const invocation = resolveCodegraphCommandInvocation(resolved.command, [...resolved.argsPrefix, "status", "--json"]);
+	const status = await runStatusProbe(options.projectRoot, invocation.command, invocation.args, {
+		...buildCodegraphEnv({ homeDir: options.homeDir }),
+		...(options.trustedCodegraphInstallDir === undefined ? {} : { CODEGRAPH_INSTALL_DIR: options.trustedCodegraphInstallDir }),
+		...definedEnv(options.env),
+	});
+	if (status.exitCode !== 0 || status.timedOut) return false;
+	return codegraphStatusSaysInitialized(status.stdout);
+}
+
+function runStatusProbe(
+	projectRoot: string,
+	command: string,
+	args: readonly string[],
+	env: Record<string, string>,
+): Promise<{ readonly exitCode: number; readonly stdout: string; readonly timedOut: boolean }> {
+	return new Promise((resolveProbe) => {
+		execFile(
+			command,
+			[...args],
+			{
+				cwd: projectRoot,
+				encoding: "utf8",
+				env: { ...process.env, ...env },
+				maxBuffer: 1024 * 1024,
+				timeout: STATUS_PROBE_TIMEOUT_MS,
+				windowsHide: true,
+			},
+			(error, stdout) => {
+				if (error === null) {
+					resolveProbe({ exitCode: 0, stdout: toOutputText(stdout), timedOut: false });
+					return;
+				}
+				resolveProbe({ exitCode: resolveExitCode(error), stdout: toOutputText(stdout), timedOut: error.killed === true });
+			},
+		);
+	});
+}
+
+function codegraphStatusSaysInitialized(stdout: string): boolean {
+	const parsed = parseJson(stdout);
+	if (!isRecord(parsed)) return false;
+	const initialized = parsed["initialized"] ?? parsed["isInitialized"] ?? parsed["ready"];
+	if (typeof initialized === "boolean") return initialized;
+	const status = parsed["status"];
+	if (typeof status !== "string") return false;
+	const normalized = status.toLowerCase();
+	return (normalized.includes("initialized") || normalized.includes("ready")) && !normalized.includes("not initialized") && !normalized.includes("uninitialized");
+}
+
+function definedEnv(env: Record<string, string | undefined>): Record<string, string> {
+	return Object.fromEntries(Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined));
+}
+
+function provisionedBinFromInstallDir(installDir: string | undefined): string | null {
+	if (installDir === undefined) return null;
+	return join(installDir, "bin", process.platform === "win32" ? "codegraph.cmd" : "codegraph");
 }
 
 export async function executeCodegraphPostToolUseHook(options: PostToolUseHookOptions = {}): Promise<PostToolUseHookResult> {
@@ -109,6 +195,15 @@ function spawnDetachedWorker(invocation: WorkerSpawnInvocation): void {
 
 function resolveHomeDir(env: Record<string, string | undefined>): string {
 	return env["HOME"] ?? env["USERPROFILE"] ?? homedir();
+}
+
+function resolveExitCode(error: Error): number {
+	if ("code" in error && typeof error.code === "number") return error.code;
+	return 1;
+}
+
+function toOutputText(value: string | Buffer): string {
+	return Buffer.isBuffer(value) ? value.toString("utf8") : value;
 }
 
 function resolveProjectRoot(input: unknown, fallback: string): string {

--- a/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
@@ -30,6 +30,7 @@ describe("CodeGraph SessionStart hook", () => {
 				stdin: Readable.from(["{}"]),
 				stdout: { write: (chunk) => stdout.push(chunk) },
 				spawnWorker: (invocation) => spawned.push(invocation),
+				statusProbe: () => Promise.resolve(false),
 			});
 
 			// then
@@ -218,6 +219,7 @@ describe("CodeGraph SessionStart hook", () => {
 				stdin: Readable.from(["{}"]),
 				stdout: { write: (chunk) => stdout.push(chunk) },
 				spawnWorker: (invocation) => spawned.push(invocation),
+				statusProbe: () => Promise.resolve(false),
 				workerCliPath: "/plugin/components/codegraph/dist/cli.js",
 			});
 
@@ -240,6 +242,33 @@ describe("CodeGraph SessionStart hook", () => {
 					hookEventName: "SessionStart",
 				},
 			});
+		} finally {
+			rmSync(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("#given CodeGraph is already initialized #when SessionStart fires #then it stays silent without spawning", async () => {
+		// given
+		const stdout: string[] = [];
+		const spawned: WorkerSpawnInvocation[] = [];
+		const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-initialized-workspace-"));
+
+		try {
+			// when
+			const result = await executeCodegraphSessionStartHook({
+				config: { codegraph: { enabled: true }, sources: [], warnings: [] },
+				cwd: workspace,
+				env: { HOME: "/tmp/home", KEEP: "1" },
+				stdin: Readable.from(["{}"]),
+				stdout: { write: (chunk) => stdout.push(chunk) },
+				spawnWorker: (invocation) => spawned.push(invocation),
+				statusProbe: () => Promise.resolve(true),
+			});
+
+			// then
+			expect(result).toEqual({ action: "skipped-initialized", exitCode: 0 });
+			expect(spawned).toEqual([]);
+			expect(stdout.join("")).toBe("");
 		} finally {
 			rmSync(workspace, { recursive: true, force: true });
 		}

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
@@ -2,7 +2,6 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
-import { spawnSync } from "node:child_process"
 import { mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -86,31 +85,11 @@ interface ParsedCodexConfig {
 }
 
 function parseToml(config: string): ParsedCodexConfig {
-  const result = spawnSync(
-    resolvePython(),
-    [
-      "-c",
-      [
-        "import json, sys, tomllib",
-        "print(json.dumps(tomllib.loads(sys.stdin.read())))",
-      ].join("; "),
-    ],
-    { encoding: "utf8", input: config },
-  )
-  expect(result.status, result.stderr).toBe(0)
-  const parsed: unknown = JSON.parse(result.stdout)
+  const parsed: unknown = Bun.TOML.parse(config)
   if (!isParsedCodexConfig(parsed)) {
     throw new Error("Parsed TOML did not have the expected Codex config shape")
   }
   return parsed
-}
-
-function resolvePython(): string {
-  for (const command of ["python3", "python"]) {
-    const result = spawnSync(command, ["-c", "import tomllib"], { encoding: "utf8" })
-    if (result.status === 0) return command
-  }
-  throw new Error("Python with tomllib is required for TOML parse assertions")
 }
 
 function isParsedCodexConfig(value: unknown): value is ParsedCodexConfig {

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
@@ -41,7 +41,7 @@ describe("codex MultiAgentV2 config", () => {
     expect(content).not.toMatch(/^\s*multi_agent_v2\s*=/m)
     expect(parsed.features.multi_agent_v2).toEqual({
       usage_hint_enabled: false,
-      max_concurrent_threads_per_session: 10000,
+      max_concurrent_threads_per_session: 1000,
     })
   })
 
@@ -74,7 +74,7 @@ describe("codex MultiAgentV2 config", () => {
     expect(content).not.toMatch(/^\s*multi_agent_v2\s*=/m)
     expect(parsed.features.multi_agent_v2).toEqual({
       enabled: false,
-      max_concurrent_threads_per_session: 10000,
+      max_concurrent_threads_per_session: 1000,
     })
   })
 })


### PR DESCRIPTION
## Summary
Suppress the noisy LazyCodex CodeGraph SessionStart context when the current workspace is already initialized. The hook now probes `codegraph status --json` first; initialized/ready workspaces return quietly, while uninitialized or uncertain states still schedule the existing background bootstrap worker.

## Changes
- Added a foreground CodeGraph status probe before emitting `LazyCodex CodeGraph bootstrap scheduled in background`.
- Preserved existing bootstrap behavior when status is uninitialized, unavailable, timed out, or inconclusive.
- Honored trusted home `codegraph.install_dir` during the foreground probe.
- Added a regression test for the initialized quiet path and refreshed the shipped CodeGraph CLI bundle.

## QA & Evidence
- **What was tested:** `bun run typecheck` in `packages/omo-codex/plugin/components/codegraph`.
  **Observed result:** `tsc --noEmit` exited 0.
  **Artifact:** `.omo/evidence/20260627-quiet-codegraph-session-start/codegraph-typecheck.txt`.
  **Why sufficient:** Covers TypeScript correctness for the changed component.

- **What was tested:** `bun test test/*.test.ts` in `packages/omo-codex/plugin/components/codegraph`.
  **Observed result:** 44 pass, 0 fail.
  **Artifact:** `.omo/evidence/20260627-quiet-codegraph-session-start/codegraph-component-tests.txt`.
  **Why sufficient:** Covers existing CodeGraph hook/worker/serve behavior and the new initialized quiet-path regression.

- **What was tested:** Manual hook invocation against `/Users/yeongyu/local-workspaces/omo`, whose `.codegraph` is already initialized.
  **Observed result:** stdout was empty and exit was 0; no `LazyCodex CodeGraph bootstrap scheduled in background` context emitted.
  **Artifact:** `.omo/evidence/20260627-quiet-codegraph-session-start/initialized-session-start-hook.txt`.
  **Why sufficient:** Proves the reported confusing message is gone for the real initialized workspace case.

- **What was tested:** `codex-qa` app-server plugin drive with isolated `CODEX_HOME` and local mock model.
  **Observed result:** app-server turn completed; plugin `sessionStart,userPromptSubmit` hooks completed; real `~/.codex/config.toml` unchanged.
  **Artifact:** `.omo/evidence/20260627-quiet-codegraph-session-start/app-server-drive-plugin.json`.
  **Why sufficient:** Proves the local Codex plugin still loads and fires hooks through the real Codex app-server surface without touching the user home.

## Risks & Residuals
- The foreground status probe is bounded to 2 seconds and falls back to the existing background worker path on failure, so first-run/bootstrap behavior is preserved.
- Evidence files live under the repo's ignored `.omo/evidence` workspace path per project rules; paths are included here for local review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses the “LazyCodex CodeGraph bootstrap scheduled in background” message when the workspace is already initialized by probing `codegraph status --json` first. Also aligns MultiAgentV2 tests with the current concurrency limit and removes the Python test dependency by parsing TOML in-process.

- **Bug Fixes**
  - Added a 2s foreground status probe; skips quietly if initialized, otherwise spawns the existing background worker.
  - Honored trusted `codegraph.install_dir` via `CODEGRAPH_INSTALL_DIR` during the probe.
  - Extended hook types with `skipped-initialized` and an injectable `statusProbe`.
  - Added a regression test for the quiet path and refreshed the bundled CodeGraph CLI.
  - Updated MultiAgentV2 config tests to expect `max_concurrent_threads_per_session: 1000`.
  - Replaced Python TOML parsing in tests with `Bun.TOML.parse` to drop the subprocess dependency.

<sup>Written for commit c9e61fe6a9a1f272ec6795483626d90693535215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

