### PR TITLE
fix(teammode): leader waits calmly instead of rushing members

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -121,8 +121,28 @@ members to the hard rules, so you mainly keep the channel open: expect frequent 
 from each member - findings, `WORKING:`/`BLOCKED:` markers, peer digests - rather than one final
 dump, and act on them as they arrive. All member-to-member and member-to-leader traffic is in English;
 when the END user addresses a member, that member replies in the user's own language. Members hand off
-files and memos through the team `artifacts/` directory and reference them by path. Wait for every
-required member's final report before you declare the team done.
+files and memos through the team `artifacts/` directory and reference them by path.
+
+## Let members work - do not rush them
+
+Members heartbeat every few tool calls and message you on every finding, blocker, and finished
+slice (their manual binds them to this). So a member that is quiet between heartbeats is **working,
+not stalled** - a stretch of silence is the normal sound of focused work, not a problem to chase.
+Re-reading `codex_app.read_thread` to check on a calm member, or sending "any update?" / "are you
+done?" / "hurry up" pings, interrupts that member and slows the whole team. Trust the heartbeat and
+let them cook.
+
+Message a member only when one of these is true:
+- you have new information, context, or a correction it needs to do its slice right;
+- you are reassigning, narrowing, or unblocking its scope;
+- a peer's result changes what it should do; or
+- it has gone fully silent well past its heartbeat cadence AND that stall is blocking the team -
+  then send one specific question, not a barrage.
+
+Otherwise stay calm and keep the channel open: read inbound updates as they arrive and act on them.
+A long-running member is alive; a heartbeat you have not received yet is not a failure. Wait for
+every required member's final report before you declare the team done - rushing toward "done" while
+members are still mid-slice just produces half-built work you will have to redo.
 
 ## Worktrees - isolate members who would touch the same files
 

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-guide.mjs
@@ -94,7 +94,9 @@ coordinate with each other, but the leader owns the final decision and integrati
   - to a **peer**: the instant you learn anything that touches their slice - a shared finding, a
     changed assumption, an interface they depend on. When unsure who owns it, send it to the leader.
 - **Going quiet is the only failure.** Many small lean messages beat one end-of-work dump; keep
-  every message short.
+  every message short. Your heartbeats are what let the leader relax and leave you to work: a leader
+  who can see your progress has no reason to interrupt you, while silence forces it to break in and
+  ask where things stand. Frequent lean updates buy you uninterrupted focus.
 
 ## Artifacts (how you hand work off)
 

--- a/packages/omo-codex/plugin/test/teammode-communication.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-communication.test.mjs
@@ -53,6 +53,9 @@ test("#given a bound team #when the member field manual renders #then it gives c
 		// then - an explicit peer-notify rule so cross-cutting findings are pushed, not siloed
 		assert.match(guide, /to a \*\*peer\*\*/, "guide must have an explicit peer-notify rule");
 		assert.match(guide, /touches their slice/, "guide must trigger peer messages on slice-touching findings");
+		// then - the reassurance WHY that ties the two halves together: frequent reporting is what earns
+		// uninterrupted focus, so the leader has no reason to interrupt a member who keeps it informed
+		assert.match(guide, /uninterrupted focus/i, "guide must tell members frequent updates buy uninterrupted focus from the leader");
 		// then - the end-only directive that previously won is gone (it licensed batch-at-the-end reporting)
 		assert.doesNotMatch(guide, /the moment your work is complete/, "the standalone end-only report directive must be removed");
 	} finally {
@@ -84,4 +87,21 @@ test("#given the leader-facing SKILL.md #when it describes communication #then i
 	// then - the --session requirement is stated WITH its reason (member->leader push needs a real leader thread)
 	assert.match(skill, /--session <your own thread id>/, "SKILL.md must require init --session <your own thread id>");
 	assert.match(skill, /stuck polling|cannot report to you/i, "SKILL.md must explain why --session matters");
+});
+
+// The leader (a GPT-5.5 main session) over-polls when nothing reframes silence as work: real jobdori
+// run 019f07a6- fired 6 leader->child pings, 4 pure "WORKING CHECK"/"NUDGE" nags that interrupted the
+// child mid-slice. The member guide already mandates frequent reporting; the missing half is telling the
+// leader to WAIT. These tests pin that the leader-facing skill reframes quiet-as-working and gates any
+// outbound ping behind concrete decision rules instead of letting anxiety drive a barrage.
+test("#given the leader-facing SKILL.md #when it covers waiting on members #then it reframes a quiet member as working and gates leader pings behind decision rules", () => {
+	const skill = readFileSync(join(root, "components", "teammode", "skills", "teammode", "SKILL.md"), "utf8");
+
+	// then - a quiet member between heartbeats is reframed as working, not a stall to chase
+	// (\s+ tolerates markdown line-wrapping between the two words)
+	assert.match(skill, /working,\s+not stalled/i, "SKILL.md must reframe a quiet member as working, not stalled");
+	// then - outbound leader messages are gated behind explicit decision rules, not anxiety
+	assert.match(skill, /Message a member only when/i, "SKILL.md must gate leader pings behind a concrete decision rule");
+	// then - the anti-pattern nag pings the real run produced are named as what NOT to send
+	assert.match(skill, /are you\s+done\?/i, "SKILL.md must name the 'are you done?' style nag as forbidden");
 });


### PR DESCRIPTION
## Summary
In omo-codex `teammode`, the leader (a GPT-5.5 main session) keeps rushing and nagging members instead of waiting. This adds explicit leader-side patience guidance and reinforces the member guide with the reciprocal reason to report often, so the leader has visibility and no reason to interrupt. Behavior change: the leader-facing skill now tells the model that a quiet member is working (not stalled) and gates outbound pings behind concrete decision rules; the member field manual now explains that frequent heartbeats are what earn uninterrupted focus.

## Why (the bug)
A real jobdori Codex run made the failure mode concrete:
- leader/parent `codex://threads/019f07a6-71f3-7eb3-8457-c81d96ef424d`
- child `codex://threads/019f07a8-233d-7423-9392-82cabded3b89`

The leader fired **6** leader to child messages; **4 were pure status-poll nags** (`WORKING CHECK: report only concrete state now... Continue immediately after reporting`, `NUDGE: you have enough context...`), interrupting the child mid-slice. The member guide already mandated frequent reporting (PR #5487); the missing half was telling the leader to wait.

## Changes
- **Leader skill** (`components/teammode/skills/teammode/SKILL.md`): new `## Let members work - do not rush them` section. Reframes a quiet member as "working, not stalled"; names the anti-pattern pings ("any update?"/"are you done?"/"hurry up") as what NOT to send; gates any outbound message behind a 4-item decision rule (new info / reassignment / a peer result changes its work / silent past heartbeat AND blocking the team). Mirrors the ulw-loop "a running child is alive; a missing heartbeat is not a failure" pattern. The existing "wait for every required member's final report" sentence is relocated into this section (no duplication).
- **Member guide** (`scripts/team-guide.mjs`, `buildGuide()`): one reassurance line tying the two halves together - frequent heartbeats let the leader relax and leave you to work; silence forces it to interrupt; frequent lean updates buy uninterrupted focus.
- **Contract test** (`plugin/test/teammode-communication.test.mjs`): RED->GREEN assertions pinning both invariants.

Style follows the GPT-5.5 prompt-engineering rule used for the prior teammode PRs (#5487, #5502): concrete decision rules, not aspirational "be patient" superlatives the model treats as padding.

## QA & Evidence
Evidence dir (gitignored, synced back to the main repo): `.omo/evidence/20260627-teammode-leader-patience/`.

- **Contract test RED->GREEN** — `node --test packages/omo-codex/plugin/test/teammode-communication.test.mjs`
  - Observed: RED before edits (`/uninterrupted focus/i`, `/working,\s+not stalled/i` absent), then **5/5 GREEN**; full teammode suite **28/28 GREEN**.
  - Artifact: `red-green.txt`
  - Why sufficient: the change is prompt text; the test pins the exact invariants in the rendered member manual and the leader skill.
- **Real-surface render (tmux, isolated mktemp cwd)** — drove the zero-dependency `team.mjs` CLI (`init -> add-member x2 -> bind-thread -> member-prompt`) and captured what a member/leader actually reads.
  - Observed: member manual now carries the reassurance line; bootstrap still says "never just one report at the end"; leader section renders the decision-rule block. `~/.codex` untouched, worktree `.omo/teams` clean.
  - Artifacts: `tmux-render-transcript.txt`, `rendered-guide.md`, `leader-skill-patience-section.md`, `team.json`
- **shipped == authored source** — ran `sync-skills.mjs`; `diff` of component vs synced `plugin/skills/teammode/{SKILL.md,scripts/team-guide.mjs}` is identical (verbatim copy).
  - Artifact: `shipped-skill-has-patience.txt`
- **No regression** — `node --test packages/omo-codex/plugin/test/*.test.mjs`: 233 pass / 11 fail; the 11 are pre-existing build-artifact gaps (no `dist/` in a fresh worktree). Proven by an identical failing-test name set on the pristine base via `git stash`.
  - Artifacts: `plugin-suite-failures-BASE.txt`, `plugin-suite-failures-WITH-change.txt`

## Risks & Residuals
- **Live model behavior** (does GPT-5.5 actually wait now): not provable in the hermetic gate - needs a real model + live app-server threads. Accepted, same scope as #5487/#5502; the render + contract test is the established gate for skill TEXT.
- **codex-qa app-server hook proof**: N/A - `teammode` is a model-invoked skill, not a Codex lifecycle hook, so there is no hook event to assert.
- The 11 suite failures are environmental (fresh-worktree, no build), not introduced here; CI builds `dist/` and runs the full `bun run test:codex` gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leader rushing in `omo-codex` teammode by adding clear patience rules and reinforcing member heartbeats. Leader now treats quiet periods as active work and only pings on defined triggers, reducing interruptions.

- **Bug Fixes**
  - Leader skill: add “Let members work” section; treat quiet as working; forbid nag pings; gate pings behind four concrete rules.
  - Member guide: add a short line explaining that frequent heartbeats buy uninterrupted focus.
  - Tests: add contract tests for “working, not stalled”, decision-rule gating, and “uninterrupted focus”; suite passes.

<sup>Written for commit 95779b134cbe18d7f902c7d57e4654c3004d43aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

