### PR TITLE
test(utils): cover semver extraction

### DIFF
--- a/packages/utils/src/extract-semver.test.ts
+++ b/packages/utils/src/extract-semver.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test"
+import { extractSemverFromOutput } from "./extract-semver"
+
+describe("extractSemverFromOutput", () => {
+  describe("#given blank or non-version output #when extracting semver #then it returns null", () => {
+    it("returns null for blank output", () => {
+      expect(extractSemverFromOutput("")).toBe(null)
+      expect(extractSemverFromOutput(" \n\t ")).toBe(null)
+    })
+
+    it("returns null when output has no version", () => {
+      expect(extractSemverFromOutput("opencode command completed without version text")).toBe(null)
+    })
+  })
+
+  describe("#given semver output #when extracting semver #then it returns the version token", () => {
+    it("accepts an optional leading v", () => {
+      expect(extractSemverFromOutput("v1.2.3")).toBe("1.2.3")
+      expect(extractSemverFromOutput("1.2.3")).toBe("1.2.3")
+    })
+
+    it("supports prerelease and build metadata", () => {
+      expect(extractSemverFromOutput("release 1.2.3-beta.4+build.20260627")).toBe(
+        "1.2.3-beta.4+build.20260627",
+      )
+    })
+  })
+
+  describe("#given noisy command output #when extracting semver #then it finds the real version", () => {
+    it("ignores timestamp-like millisecond fragments and extracts a later semver", () => {
+      const output = "00:24:25.202 [info] booting\nopencode v1.14.33"
+
+      expect(extractSemverFromOutput(output)).toBe("1.14.33")
+    })
+
+    it("trims multiline noisy command output", () => {
+      const output = "\nwarning: stale cache ignored\n  detected version 2.0.1\n"
+
+      expect(extractSemverFromOutput(output)).toBe("2.0.1")
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Adds focused Bun coverage for `extractSemverFromOutput` in the core `@oh-my-opencode/utils` package. The cases pin blank/no-version output, optional `v` prefixes, prerelease/build metadata, noisy multiline command output, and timestamp-like millisecond fragments that should not be mistaken for versions.

## Changes
- Add `packages/utils/src/extract-semver.test.ts` with six regression tests.
- Keep the change scoped to the pure utils package; no OpenCode or Codex harness wiring is touched.

## Verification
- `bun test packages/utils/src/extract-semver.test.ts` ✅
- `git diff --check upstream/dev...HEAD` ✅

## Notes
This is a core-only test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add targeted tests for extractSemverFromOutput in `@oh-my-opencode/utils` to increase coverage and lock in parsing behavior. Covers blank/no-version output, optional v prefix, prerelease/build metadata, noisy multiline output, and ignores timestamp-like millisecond fragments.

<sup>Written for commit 9ff49ad0af73da97a88b9b65509dedf4dd1e8fca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

