### PR TITLE
test(utils): cover diff numstat parsing

### DIFF
--- a/packages/utils/src/git-worktree/parse-diff-numstat.test.ts
+++ b/packages/utils/src/git-worktree/parse-diff-numstat.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+
+import { parseGitDiffNumstat } from "./parse-diff-numstat"
+import type { GitFileStatus } from "./types"
+
+describe("parseGitDiffNumstat", () => {
+  test("#given empty output #when parsing numstat #then returns no file stats", () => {
+    const result = parseGitDiffNumstat("", new Map<string, GitFileStatus>())
+
+    expect(result).toEqual([])
+  })
+
+  test("#given status map entries #when parsing numstat #then preserves matching statuses", () => {
+    const statusMap = new Map<string, GitFileStatus>([
+      ["src/changed.ts", "modified"],
+      ["src/new.ts", "added"],
+      ["src/removed.ts", "deleted"],
+    ])
+    const output = ["12\t3\tsrc/changed.ts", "7\t0\tsrc/new.ts", "0\t9\tsrc/removed.ts"].join("\n")
+
+    const result = parseGitDiffNumstat(output, statusMap)
+
+    expect(result).toEqual([
+      { path: "src/changed.ts", added: 12, removed: 3, status: "modified" },
+      { path: "src/new.ts", added: 7, removed: 0, status: "added" },
+      { path: "src/removed.ts", added: 0, removed: 9, status: "deleted" },
+    ])
+  })
+
+  test("#given missing status map entry #when parsing numstat #then defaults status to modified", () => {
+    const output = "4\t2\tsrc/unmapped.ts"
+
+    const result = parseGitDiffNumstat(output, new Map<string, GitFileStatus>())
+
+    expect(result).toEqual([{ path: "src/unmapped.ts", added: 4, removed: 2, status: "modified" }])
+  })
+
+  test("#given binary numstat markers #when parsing numstat #then records zero added and removed counts", () => {
+    const output = "-\t-\tassets/logo.png"
+
+    const result = parseGitDiffNumstat(output, new Map<string, GitFileStatus>([["assets/logo.png", "modified"]]))
+
+    expect(result).toEqual([{ path: "assets/logo.png", added: 0, removed: 0, status: "modified" }])
+  })
+
+  test("#given malformed lines #when parsing numstat #then skips incomplete rows", () => {
+    const output = ["missing-tabs", "1\t2", "5\t6\tsrc/valid.ts"].join("\n")
+
+    const result = parseGitDiffNumstat(output, new Map<string, GitFileStatus>())
+
+    expect(result).toEqual([{ path: "src/valid.ts", added: 5, removed: 6, status: "modified" }])
+  })
+})


### PR DESCRIPTION
## Summary
Adds focused coverage for `parseGitDiffNumstat` in the core `@oh-my-opencode/utils` package. The tests pin empty output, mapped statuses, default modified status, binary numstat markers, and malformed line skipping.

## Changes
- Add `packages/utils/src/git-worktree/parse-diff-numstat.test.ts`.
- Keep the change scoped to pure utils test coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/utils/src/git-worktree/parse-diff-numstat.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core-only test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

Local setup note: `bun install` created dependencies but the prepare build exits on Windows in `packages/lsp-tools-mcp` because the package build script invokes `rm`; that is outside this PR's scope. The scoped Bun test passed after dependencies were present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `parseGitDiffNumstat` in `@oh-my-opencode/utils`, covering empty output, status mapping, default "modified" status, binary markers, and skipping malformed lines. No runtime changes; only adds `packages/utils/src/git-worktree/parse-diff-numstat.test.ts`.

<sup>Written for commit 9a9219c297c4033a8c9b0ce537a77dcd741037dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

