### PR TITLE
test(utils): cover file change summaries

### DIFF
--- a/packages/utils/src/git-worktree/format-file-changes.test.ts
+++ b/packages/utils/src/git-worktree/format-file-changes.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+
+import { formatFileChanges } from "./format-file-changes"
+import type { GitFileStat } from "./types"
+
+describe("formatFileChanges", () => {
+  test("#given no stats #when formatting file changes #then reports no detected changes", () => {
+    expect(formatFileChanges([])).toBe("[FILE CHANGES SUMMARY]\nNo file changes detected.\n")
+  })
+
+  test("#given mixed statuses #when formatting file changes #then groups modified created and deleted files", () => {
+    const stats: GitFileStat[] = [
+      { path: "src/changed.ts", added: 5, removed: 2, status: "modified" },
+      { path: "src/new.ts", added: 9, removed: 0, status: "added" },
+      { path: "src/removed.ts", added: 0, removed: 4, status: "deleted" },
+    ]
+
+    const output = formatFileChanges(stats)
+
+    expect(output).toContain("Modified files:\n  src/changed.ts  (+5, -2)")
+    expect(output).toContain("Created files:\n  src/new.ts  (+9)")
+    expect(output).toContain("Deleted files:\n  src/removed.ts  (-4)")
+  })
+
+  test("#given matching notepad path #when formatting file changes #then includes notepad update marker", () => {
+    const stats: GitFileStat[] = [{ path: ".omo/notepads/task.md", added: 3, removed: 1, status: "modified" }]
+
+    const output = formatFileChanges(stats, ".omo/notepads/task.md")
+
+    expect(output).toContain("[NOTEPAD UPDATED]\n  .omo/notepads/task.md  (+3)")
+  })
+
+  test("#given Windows-style notepad path #when formatting file changes #then normalizes path separators for matching", () => {
+    const stats: GitFileStat[] = [{ path: ".omo/notepads/task.md", added: 3, removed: 1, status: "modified" }]
+
+    const output = formatFileChanges(stats, ".omo\\notepads\\task.md")
+
+    expect(output).toContain("[NOTEPAD UPDATED]\n  .omo/notepads/task.md  (+3)")
+  })
+
+  test("#given nonmatching notepad path #when formatting file changes #then omits notepad update marker", () => {
+    const stats: GitFileStat[] = [{ path: "src/changed.ts", added: 5, removed: 2, status: "modified" }]
+
+    const output = formatFileChanges(stats, ".omo/notepads/task.md")
+
+    expect(output).not.toContain("[NOTEPAD UPDATED]")
+  })
+})


### PR DESCRIPTION
## Summary
Adds focused coverage for `formatFileChanges` in the core `@oh-my-opencode/utils` package. The tests pin empty summaries, grouped modified/created/deleted sections, notepad update markers, and Windows-style path separator normalization.

## Changes
- Add `packages/utils/src/git-worktree/format-file-changes.test.ts`.
- Keep the change scoped to pure utils test coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/utils/src/git-worktree/format-file-changes.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core-only test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `formatFileChanges` in `@oh-my-opencode/utils`, covering empty summaries, grouped modified/created/deleted sections, notepad update markers, and Windows path normalization. Improves coverage and locks expected output without changing runtime behavior.

<sup>Written for commit f00159b0c248087447bd75a507428a292e6143f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

