### PR TITLE
test(utils): cover path containment

### DIFF
--- a/packages/utils/src/contains-path.test.ts
+++ b/packages/utils/src/contains-path.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import { containsPath, isWithinProject } from "./contains-path"
+
+const tempRoots = new Set<string>()
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "omo-contains-path-"))
+  tempRoots.add(root)
+  return root
+}
+
+afterEach(() => {
+  for (const root of tempRoots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  tempRoots.clear()
+})
+
+describe("containsPath", () => {
+  test("#given identical paths #when checking containment #then root contains itself", () => {
+    const root = createTempRoot()
+
+    expect(containsPath(root, root)).toBe(true)
+  })
+
+  test("#given an existing child file #when checking containment #then root contains the child", () => {
+    const root = createTempRoot()
+    const childDir = join(root, "src")
+    const childFile = join(childDir, "index.ts")
+    mkdirSync(childDir)
+    writeFileSync(childFile, "export {}\n")
+
+    expect(containsPath(root, childFile)).toBe(true)
+  })
+
+  test("#given a missing descendant #when checking containment #then root still contains the future path", () => {
+    const root = createTempRoot()
+    const missingChild = join(root, "generated", "future.json")
+
+    expect(containsPath(root, missingChild)).toBe(true)
+  })
+
+  test("#given a sibling with the same path prefix #when checking containment #then it is rejected", () => {
+    const parent = createTempRoot()
+    const root = join(parent, "project")
+    const sibling = join(parent, "project-copy")
+    mkdirSync(root)
+    mkdirSync(sibling)
+
+    expect(containsPath(root, join(sibling, "file.ts"))).toBe(false)
+  })
+})
+
+describe("isWithinProject", () => {
+  test("#given candidate under project root #when checking project containment #then returns true", () => {
+    const projectRoot = createTempRoot()
+    const candidate = join(projectRoot, "docs", "guide.md")
+
+    expect(isWithinProject(candidate, projectRoot)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Adds focused coverage for `containsPath` and `isWithinProject` in the core `@oh-my-opencode/utils` package. The tests pin self-containment, existing child files, missing future descendants, and same-prefix sibling rejection.

## Changes
- Add `packages/utils/src/contains-path.test.ts`.
- Use temp directories only; no symlink assertions, keeping the test stable on Windows.
- Keep the change scoped to pure utils test coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/utils/src/contains-path.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core-only test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `containsPath` and `isWithinProject` in `@oh-my-opencode/utils`, covering root self-containment, child files, missing descendants (still contained), and rejecting same-prefix siblings. Tests use temp dirs only (no symlinks) for cross-platform stability.

<sup>Written for commit 696f34722f3866d61131e0c0843b13f32ab867cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

