### PR TITLE
test(utils): cover record type guards

### DIFF
--- a/packages/utils/src/record-type-guard.test.ts
+++ b/packages/utils/src/record-type-guard.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, test } from "bun:test"
 import { isPlainRecord, isRecord } from "./record-type-guard"
 
 describe("record type guards", () => {
+	test("#given a plain object input #when using record guards #then both guards accept it", () => {
+		// given
+		const value: unknown = { key: "value" }
+
+		// when
+		const recordResult = isRecord(value)
+		const plainRecordResult = isPlainRecord(value)
+
+		// then
+		expect(recordResult).toBe(true)
+		expect(plainRecordResult).toBe(true)
+	})
+
 	test("#given an array input #when using isRecord #then arrays remain record-like for legacy callers", () => {
 		// given
 		const value: unknown = []
@@ -22,5 +35,35 @@ describe("record type guards", () => {
 
 		// then
 		expect(result).toBe(false)
+	})
+
+	test("#given null and primitive inputs #when using record guards #then both guards reject them", () => {
+		// given
+		const values: unknown[] = [null, undefined, "text", 1, true, Symbol("record")]
+
+		// when
+		const results = values.map((value) => ({
+			isPlainRecord: isPlainRecord(value),
+			isRecord: isRecord(value),
+		}))
+
+		// then
+		expect(results).toEqual(
+			values.map(() => ({
+				isPlainRecord: false,
+				isRecord: false,
+			}))
+		)
+	})
+
+	test("#given object instances #when using isPlainRecord #then non-array objects are still accepted", () => {
+		// given
+		const value: unknown = new Date("2026-06-27T00:00:00.000Z")
+
+		// when
+		const result = isPlainRecord(value)
+
+		// then
+		expect(result).toBe(true)
 	})
 })


### PR DESCRIPTION
## Summary
Expands coverage for the core `record-type-guard` helpers in `@oh-my-opencode/utils`. The tests pin accepted plain objects, the intentional legacy array behavior for `isRecord`, array rejection for `isPlainRecord`, primitive/null rejection, and object instance behavior.

## Changes
- Extend `packages/utils/src/record-type-guard.test.ts`.
- Keep the change scoped to pure utils test coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/utils/src/record-type-guard.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core-only test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand tests for `isRecord` and `isPlainRecord` in `@oh-my-opencode/utils` to lock in current behavior and avoid regressions. Pins plain-object acceptance, legacy array behavior (`isRecord` accepts, `isPlainRecord` rejects), primitive/null rejection, and acceptance of non‑array object instances.

<sup>Written for commit 7cb848143610fdea1df64aa0347d97e01f98ae24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

