### PR TITLE
test(utils): cover prompt failure classification

### DIFF
--- a/packages/utils/src/prompt-failure-classifier.test.ts
+++ b/packages/utils/src/prompt-failure-classifier.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  extractPromptFailureMessage,
+  isAmbiguousPostDispatchPromptFailure,
+  isAmbiguousPromptDispatchFailure,
+} from "./prompt-failure-classifier"
+
+describe("extractPromptFailureMessage", () => {
+  test("#given string and Error inputs #when extracting failure messages #then returns their text", () => {
+    expect(extractPromptFailureMessage("unexpected eof")).toBe("unexpected eof")
+    expect(extractPromptFailureMessage(new Error("timed out"))).toBe("timed out")
+  })
+
+  test("#given object with message #when extracting failure message #then prefers the message field", () => {
+    expect(extractPromptFailureMessage({ message: "json parse error", code: "E_PARSE" })).toBe("json parse error")
+  })
+
+  test("#given object without string message #when extracting failure message #then serializes the object", () => {
+    expect(extractPromptFailureMessage({ code: "E_PARSE" })).toBe('{"code":"E_PARSE"}')
+  })
+
+  test("#given circular object #when extracting failure message #then returns an empty string", () => {
+    const value: Record<string, unknown> = {}
+    value.self = value
+
+    expect(extractPromptFailureMessage(value)).toBe("")
+  })
+})
+
+describe("isAmbiguousPromptDispatchFailure", () => {
+  test("#given known ambiguous transport errors #when classifying #then returns true", () => {
+    expect(isAmbiguousPromptDispatchFailure("unexpected EOF while reading response")).toBe(true)
+    expect(isAmbiguousPromptDispatchFailure("JSON parse error at position 1")).toBe(true)
+    expect(isAmbiguousPromptDispatchFailure("Unexpected end of JSON input")).toBe(true)
+    expect(isAmbiguousPromptDispatchFailure(new Error("request timed out"))).toBe(true)
+  })
+
+  test("#given ordinary provider rejection #when classifying #then returns false", () => {
+    expect(isAmbiguousPromptDispatchFailure("model rejected the request")).toBe(false)
+  })
+})
+
+describe("isAmbiguousPostDispatchPromptFailure", () => {
+  test("#given ambiguous error after dispatch #when classifying #then returns true", () => {
+    expect(
+      isAmbiguousPostDispatchPromptFailure({
+        dispatchAttempted: true,
+        error: "unexpected eof",
+        status: "failed",
+      })
+    ).toBe(true)
+  })
+
+  test("#given ambiguous error before dispatch #when classifying #then returns false", () => {
+    expect(
+      isAmbiguousPostDispatchPromptFailure({
+        dispatchAttempted: false,
+        error: "unexpected eof",
+        status: "failed",
+      })
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Adds focused coverage for the core prompt failure classifier helpers in `@oh-my-opencode/utils`. The tests pin message extraction for strings, `Error`s, message-bearing objects, serializable objects, circular objects, ambiguous transport error detection, and the post-dispatch gating rule.

## Changes
- Add `packages/utils/src/prompt-failure-classifier.test.ts`.
- Keep the change scoped to pure utils test coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/utils/src/prompt-failure-classifier.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core-only test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for the prompt failure classifier in `@oh-my-opencode/utils` to lock down message extraction and ambiguous failure detection with no runtime changes.
Covers strings and Error inputs, objects with/without message, circular objects, transport errors, and post-dispatch gating.

<sup>Written for commit 81aa4ddd51a32451ac7d22f8b25f599ed4e8e9a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

