### PR TITLE
test(utils): cover process stream reader

### DIFF
--- a/packages/utils/src/process-stream-reader.test.ts
+++ b/packages/utils/src/process-stream-reader.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { Readable } from "node:stream"
+
+import { readProcessStream } from "./process-stream-reader"
+
+describe("readProcessStream", () => {
+  test("#given nullish stream #when reading process output #then returns empty text", async () => {
+    expect(await readProcessStream(null)).toBe("")
+    expect(await readProcessStream(undefined)).toBe("")
+  })
+
+  test("#given Node readable chunks #when reading process output #then concatenates utf8 text", async () => {
+    const stream = Readable.from(["hello ", Buffer.from("from "), new Uint8Array(Buffer.from("node"))])
+
+    await expect(readProcessStream(stream)).resolves.toBe("hello from node")
+  })
+
+  test("#given Web readable chunks #when reading process output #then concatenates utf8 text", async () => {
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("hello "))
+        controller.enqueue(encoder.encode("from web"))
+        controller.close()
+      },
+    })
+
+    await expect(readProcessStream(stream)).resolves.toBe("hello from web")
+  })
+
+  test("#given unsupported Node stream chunk #when reading process output #then rejects with type error", async () => {
+    const stream = Readable.from([{ unsupported: true }], { objectMode: true })
+
+    await expect(readProcessStream(stream)).rejects.toThrow("Unsupported process stream chunk type: object")
+  })
+})


### PR DESCRIPTION
## Summary
Adds focused coverage for `readProcessStream` in the core `@oh-my-opencode/utils` package. The tests pin nullish streams, Node readable chunks from strings/Buffers/Uint8Arrays, Web `ReadableStream` chunks, and unsupported object-mode chunk rejection.

## Changes
- Add `packages/utils/src/process-stream-reader.test.ts`.
- Keep the change scoped to pure utils test coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/utils/src/process-stream-reader.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core-only test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add targeted tests for `readProcessStream` in `@oh-my-opencode/utils` to verify output concatenation and error handling across stream types. Covers nullish input, Node `Readable` chunks (string/Buffer/Uint8Array), Web `ReadableStream`, and rejection of unsupported object-mode chunks; no runtime changes.

<sup>Written for commit b01ad6ff4dc5dc7bfe99c6f1bd8f1265cf540279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

