### PR TITLE
test(utils): cover session idle status checks

### DIFF
--- a/packages/utils/src/session-idle-settle.test.ts
+++ b/packages/utils/src/session-idle-settle.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+
+import { isActiveSessionStatusType, isSessionActive, shouldPromptAfterSessionIdle } from "./session-idle-settle"
+
+describe("isActiveSessionStatusType", () => {
+  test("#given known active status types #when checking activity #then returns true", () => {
+    expect(isActiveSessionStatusType("busy")).toBe(true)
+    expect(isActiveSessionStatusType("retry")).toBe(true)
+    expect(isActiveSessionStatusType("running")).toBe(true)
+  })
+
+  test("#given inactive or unknown status types #when checking activity #then returns false", () => {
+    expect(isActiveSessionStatusType("idle")).toBe(false)
+    expect(isActiveSessionStatusType("error")).toBe(false)
+  })
+})
+
+describe("isSessionActive", () => {
+  test("#given client without status method #when checking session activity #then returns false", async () => {
+    expect(await isSessionActive({}, "ses_1")).toBe(false)
+  })
+
+  test("#given direct status payload #when session is busy #then returns true", async () => {
+    const client = {
+      session: {
+        status: async () => ({ ses_1: { type: "busy" } }),
+      },
+    }
+
+    expect(await isSessionActive(client, "ses_1")).toBe(true)
+  })
+
+  test("#given nested data payload #when session is running #then returns true", async () => {
+    const client = {
+      session: {
+        status: async () => ({ data: { ses_1: { type: "running" } } }),
+      },
+    }
+
+    expect(await isSessionActive(client, "ses_1")).toBe(true)
+  })
+
+  test("#given missing or inactive status #when checking session activity #then returns false", async () => {
+    const client = {
+      session: {
+        status: async () => ({ data: { ses_1: { type: "idle" } } }),
+      },
+    }
+
+    expect(await isSessionActive(client, "ses_1")).toBe(false)
+    expect(await isSessionActive(client, "ses_missing")).toBe(false)
+  })
+
+  test("#given status lookup rejection #when checking session activity #then returns false", async () => {
+    const client = {
+      session: {
+        status: async () => {
+          throw new Error("status unavailable")
+        },
+      },
+    }
+
+    expect(await isSessionActive(client, "ses_1")).toBe(false)
+  })
+})
+
+describe("shouldPromptAfterSessionIdle", () => {
+  test("#given idle session after settle #when checking prompt permission #then returns true", async () => {
+    const client = {
+      session: {
+        status: async () => ({ data: { ses_1: { type: "idle" } } }),
+      },
+    }
+
+    expect(await shouldPromptAfterSessionIdle(client, "ses_1", 0)).toBe(true)
+  })
+
+  test("#given active session after settle #when checking prompt permission #then returns false", async () => {
+    const client = {
+      session: {
+        status: async () => ({ data: { ses_1: { type: "retry" } } }),
+      },
+    }
+
+    expect(await shouldPromptAfterSessionIdle(client, "ses_1", 0)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Adds focused coverage for the core session idle status helpers in `@oh-my-opencode/utils`. The tests pin active status names, missing status clients, direct and nested status payloads, inactive/missing sessions, rejection handling, and `shouldPromptAfterSessionIdle` behavior with zero settle delay.

## Changes
- Add `packages/utils/src/session-idle-settle.test.ts`.
- Keep the change scoped to pure utils test coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/utils/src/session-idle-settle.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core-only test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for session idle helpers in `@oh-my-opencode/utils` to pin expected behavior and edge cases. Tests cover active status detection, session activity with direct and nested payloads, missing status clients or sessions, error handling, and shouldPromptAfterSessionIdle with zero settle delay.

<sup>Written for commit 3e451b0786b2036d45289b6ee22658ed683c6d42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

