### PR TITLE
test(utils): cover shell command escaping

### DIFF
--- a/packages/utils/src/shell-command-escape.test.ts
+++ b/packages/utils/src/shell-command-escape.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+
+import { shellEscapeForDoubleQuotedCommand } from "./shell-command-escape"
+
+describe("shellEscapeForDoubleQuotedCommand", () => {
+  test("#given plain command text #when escaping #then leaves it unchanged", () => {
+    expect(shellEscapeForDoubleQuotedCommand("echo hello-world_123")).toBe("echo hello-world_123")
+  })
+
+  test("#given double quote shell interpolation characters #when escaping #then prefixes them with backslashes", () => {
+    expect(shellEscapeForDoubleQuotedCommand("\\")).toBe("\\\\")
+    expect(shellEscapeForDoubleQuotedCommand("$HOME")).toBe("\\$HOME")
+    expect(shellEscapeForDoubleQuotedCommand("`cmd`")).toBe("\\`cmd\\`")
+    expect(shellEscapeForDoubleQuotedCommand('"quoted"')).toBe('\\"quoted\\"')
+  })
+
+  test("#given shell control characters #when escaping #then neutralizes separators and grouping", () => {
+    expect(shellEscapeForDoubleQuotedCommand("run; next | alt & tail # comment (group)")).toBe(
+      String.raw`run\; next \| alt \& tail \# comment \(group\)`
+    )
+  })
+})


### PR DESCRIPTION
## Summary
Adds focused coverage for `shellEscapeForDoubleQuotedCommand` in the core `@oh-my-opencode/utils` package. The tests pin unchanged plain text plus escaping for double-quoted shell interpolation characters and shell control characters.

## Changes
- Add `packages/utils/src/shell-command-escape.test.ts`.
- Keep the change scoped to pure utils test coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/utils/src/shell-command-escape.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core-only test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `shellEscapeForDoubleQuotedCommand` in `@oh-my-opencode/utils`, covering plain text and escaping for interpolation characters and shell control characters. Test-only change; no runtime behavior affected.

<sup>Written for commit 2ecefb2df828f56be96bef646912b6cca3cb280d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

