### PR TITLE
test(mcp-stdio-core): cover JSON-RPC helpers

### DIFF
--- a/packages/mcp-stdio-core/src/record.test.ts
+++ b/packages/mcp-stdio-core/src/record.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+
+import { isPlainRecord } from "./record.js"
+
+describe("isPlainRecord", () => {
+  test("#given non-array objects #when checking plain record shape #then accepts them", () => {
+    expect(isPlainRecord({ method: "tools/list" })).toBe(true)
+    expect(isPlainRecord(new Date("2026-06-27T00:00:00.000Z"))).toBe(true)
+  })
+
+  test("#given arrays null and primitives #when checking plain record shape #then rejects them", () => {
+    expect(isPlainRecord([])).toBe(false)
+    expect(isPlainRecord(null)).toBe(false)
+    expect(isPlainRecord("text")).toBe(false)
+    expect(isPlainRecord(1)).toBe(false)
+    expect(isPlainRecord(true)).toBe(false)
+  })
+})

--- a/packages/mcp-stdio-core/src/responses.test.ts
+++ b/packages/mcp-stdio-core/src/responses.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+
+import { errorResponse, jsonRpcId, messageFromError, successResponse } from "./responses.js"
+
+describe("JSON-RPC response helpers", () => {
+  test("#given result payload #when creating success response #then includes jsonrpc id and result", () => {
+    expect(successResponse("req_1", { content: [{ type: "text", text: "ok" }] })).toEqual({
+      id: "req_1",
+      jsonrpc: "2.0",
+      result: { content: [{ type: "text", text: "ok" }] },
+    })
+  })
+
+  test("#given error without data #when creating error response #then omits data field", () => {
+    expect(errorResponse(1, -32601, "Method not found")).toEqual({
+      error: { code: -32601, message: "Method not found" },
+      id: 1,
+      jsonrpc: "2.0",
+    })
+  })
+
+  test("#given error with data #when creating error response #then includes data field", () => {
+    expect(errorResponse(null, -32700, "Parse error", "not-json")).toEqual({
+      error: { code: -32700, data: "not-json", message: "Parse error" },
+      id: null,
+      jsonrpc: "2.0",
+    })
+  })
+})
+
+describe("jsonRpcId", () => {
+  test("#given valid JSON-RPC id values #when normalizing #then preserves them", () => {
+    expect(jsonRpcId("abc")).toBe("abc")
+    expect(jsonRpcId(7)).toBe(7)
+    expect(jsonRpcId(null)).toBe(null)
+  })
+
+  test("#given invalid JSON-RPC id values #when normalizing #then returns null", () => {
+    expect(jsonRpcId(undefined)).toBe(null)
+    expect(jsonRpcId({ id: "abc" })).toBe(null)
+    expect(jsonRpcId(true)).toBe(null)
+  })
+})
+
+describe("messageFromError", () => {
+  test("#given Error instance #when extracting message #then returns error message", () => {
+    expect(messageFromError(new Error("boom"))).toBe("boom")
+  })
+
+  test("#given non-Error value #when extracting message #then stringifies it", () => {
+    expect(messageFromError("plain")).toBe("plain")
+    expect(messageFromError(42)).toBe("42")
+  })
+})


### PR DESCRIPTION
## Summary
Adds focused coverage for low-level JSON-RPC helpers in `@oh-my-opencode/mcp-stdio-core`. The tests pin plain record detection, success and error response shapes, JSON-RPC id normalization, and error message extraction.

## Changes
- Add `packages/mcp-stdio-core/src/record.test.ts`.
- Add `packages/mcp-stdio-core/src/responses.test.ts`.
- Keep the change scoped to pure MCP stdio core helper coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/mcp-stdio-core/src/responses.test.ts packages/mcp-stdio-core/src/record.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core package test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for low-level JSON-RPC helpers in `@oh-my-opencode/mcp-stdio-core` to pin response shapes, id normalization, and error message extraction. No runtime changes.

Covers `isPlainRecord`, `successResponse`, `errorResponse`, `jsonRpcId`, and `messageFromError` via `record.test.ts` and `responses.test.ts`.

<sup>Written for commit 0dd9fdcf781eb41740ca54912cce745b59088917. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

