### PR TITLE
test(delegate-core): cover retry error patterns

### DIFF
--- a/packages/delegate-core/src/retry-patterns.test.ts
+++ b/packages/delegate-core/src/retry-patterns.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, test } from "bun:test"
-import { buildRetryGuidance, detectDelegateTaskError } from "./index"
+import { buildRetryGuidance, DELEGATE_TASK_ERROR_PATTERNS, detectDelegateTaskError } from "./index"
 
 describe("delegate task retry contract", () => {
+  test("#given every known task error pattern #when detected #then maps to the configured error type", () => {
+    for (const pattern of DELEGATE_TASK_ERROR_PATTERNS) {
+      const output = `[ERROR] ${pattern.pattern}`
+
+      expect(detectDelegateTaskError(output)).toEqual({
+        errorType: pattern.errorType,
+        originalOutput: output,
+      })
+    }
+  })
+
   test("#given unknown category output #when detected #then retry guidance preserves available options", () => {
     const output = '[ERROR] Unknown category: "bad". Available: visual-engineering, ultrabrain'
     const error = detectDelegateTaskError(output)
@@ -11,5 +22,18 @@ describe("delegate task retry contract", () => {
       originalOutput: output,
     })
     expect(error ? buildRetryGuidance(error) : "").toContain("**Available Options**: visual-engineering, ultrabrain")
+  })
+
+  test("#given invalid arguments without known pattern #when detected #then no retry error is returned", () => {
+    expect(detectDelegateTaskError("Invalid arguments: unrelated validation failure")).toBe(null)
+  })
+
+  test("#given unknown error type #when building guidance #then returns generic task retry guidance", () => {
+    expect(
+      buildRetryGuidance({
+        errorType: "new_error_type",
+        originalOutput: "[ERROR] new failure",
+      })
+    ).toBe("[task ERROR] Fix the error and retry with correct parameters.")
   })
 })


### PR DESCRIPTION
## Summary
Expands coverage for delegate task retry error detection in `@oh-my-opencode/delegate-core`. The tests now pin every configured task error pattern, preserve the existing available-options regression, assert unrelated invalid arguments are ignored, and cover generic retry guidance for unknown error types.

## Changes
- Extend `packages/delegate-core/src/retry-patterns.test.ts`.
- Keep the change scoped to pure delegate-core test coverage; no OpenCode or Codex harness behavior is changed.

## Verification
- `bun test packages/delegate-core/src/retry-patterns.test.ts` ✅
- `git diff --cached --check` ✅

## Notes
This is a core package test coverage PR, so the repo's live OpenCode/Codex harness QA gate is not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand test coverage for delegate task retry error handling in `@oh-my-opencode/delegate-core`. Tests cover every configured pattern mapping to its error type, keep the available-options message intact, ignore unrelated invalid-arg outputs, and check generic guidance for unknown error types.

<sup>Written for commit bb5911441124e560ae4e2fae92d3a894543ca511. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

