### PR TITLE
fix(model-core): recognize Mimo model aliases

### DIFF
--- a/packages/model-core/src/model-capabilities.test.ts
+++ b/packages/model-core/src/model-capabilities.test.ts
@@ -348,6 +348,29 @@ describe("getModelCapabilities", () => {
     expect(result.diagnostics.supportsThinking.source).toBe("bundled-snapshot")
   })
 
+  test("detects OpenCode Go Mimo aliases as non-thinking MiniMax models", () => {
+    const result = getModelCapabilities({
+      providerID: "opencode-go",
+      modelID: "opencode-go/mimo-v2.5-pro",
+      bundledSnapshot,
+    })
+
+    expect(result).toMatchObject({
+      requestedModelID: "opencode-go/mimo-v2.5-pro",
+      canonicalModelID: "mimo-v2.5-pro",
+      family: "minimax",
+      supportsThinking: false,
+      variants: ["low", "medium", "high"],
+    })
+    expect(result.diagnostics).toMatchObject({
+      resolutionMode: "heuristic-backed",
+      snapshot: { source: "none" },
+      family: { source: "heuristic" },
+      supportsThinking: { source: "heuristic" },
+      variants: { source: "heuristic" },
+    })
+  })
+
   test("marks non-thinking Kimi K2.6 as not supporting thinking", () => {
     // given
     const modelID = "kimi-k2.6"

--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -79,7 +79,7 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   },
   {
     family: "minimax",
-    includes: ["minimax"],
+    pattern: /(?:minimax|(?:^|\/)mimo(?:$|[-.]))/,
     variants: ["low", "medium", "high"],
     supportsThinking: false,
   },

--- a/packages/model-core/src/model-family-detectors.test.ts
+++ b/packages/model-core/src/model-family-detectors.test.ts
@@ -110,6 +110,10 @@ describe("model family detectors", () => {
   test("#given MiniMax model ids #then detects MiniMax family only", () => {
     expect(isMiniMaxModel("opencode/minimax-m2.7")).toBe(true)
     expect(isMiniMaxModel("minimax-m2.7-highspeed")).toBe(true)
+    expect(isMiniMaxModel("opencode-go/mimo-v2.5")).toBe(true)
+    expect(isMiniMaxModel("opencode-go/mimo-v2.5-pro")).toBe(true)
+    expect(isMiniMaxModel("mimo-v2.5")).toBe(true)
+    expect(isMiniMaxModel("mimosa-v1")).toBe(false)
     expect(isMiniMaxModel("moonshotai/kimi-k2.6")).toBe(false)
   })
 })

--- a/packages/model-core/src/model-family-detectors.ts
+++ b/packages/model-core/src/model-family-detectors.ts
@@ -71,9 +71,11 @@ export function isKimiK27Model(model: string): boolean {
   return false
 }
 
+const MINIMAX_MODEL_RE = /(?:minimax|^mimo(?:$|[-.]))/
+
 export function isMiniMaxModel(model: string): boolean {
   const modelName = extractModelName(model).toLowerCase()
-  return modelName.includes("minimax")
+  return MINIMAX_MODEL_RE.test(modelName)
 }
 
 export function isGlmModel(model: string): boolean {

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -258,6 +258,7 @@ describe("resolveCompatibleModelSettings", () => {
       { name: "Kimi (k2)", modelID: "k2-v2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "GLM", modelID: "glm-5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Minimax", modelID: "minimax-m2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Mimo -> MiniMax", modelID: "opencode-go/mimo-v2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high", "max"], hasReasoningEffort: true },
       { name: "Mistral", modelID: "mistral-large-next", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Codestral → Mistral", modelID: "codestral-2506", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
@@ -587,6 +588,28 @@ describe("resolveCompatibleModelSettings", () => {
     })
 
     // then
+    expect(result.thinking).toBeUndefined()
+    expect(result.changes[0]?.field).toBe("thinking")
+    expect(result.changes[0]?.reason).toBe("unsupported-by-model-metadata")
+  })
+
+  test("drops thinking for Mimo aliases resolved as MiniMax from heuristics", () => {
+    // given
+    const capabilities = getModelCapabilities({
+      providerID: "opencode-go",
+      modelID: "opencode-go/mimo-v2.5",
+    })
+
+    // when
+    const result = resolveCompatibleModelSettings({
+      providerID: "opencode-go",
+      modelID: "opencode-go/mimo-v2.5",
+      desired: { thinking: { type: "enabled", budgetTokens: 4096 } },
+      capabilities,
+    })
+
+    // then
+    expect(capabilities.family).toBe("minimax")
     expect(result.thinking).toBeUndefined()
     expect(result.changes[0]?.field).toBe("thinking")
     expect(result.changes[0]?.reason).toBe("unsupported-by-model-metadata")


### PR DESCRIPTION
## Summary
- recognize OpenCode Go Mimo aliases as MiniMax-family models in model family detection
- map provider-prefixed and bare mimo-* IDs through the heuristic capability registry
- cover detector, capability inference, and compatible-settings behavior for Mimo aliases

## Verification
- bun install --ignore-scripts
- bun test packages/model-core/src/model-family-detectors.test.ts packages/model-core/src/model-capabilities.test.ts packages/model-core/src/model-settings-compatibility.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes OpenCode Go Mimo aliases (e.g., `opencode-go/mimo-v2.5`, `mimo-v2.5-pro`) as MiniMax models. Fixes capability inference and settings so these IDs resolve to MiniMax, disable thinking, and expose standard variants.

- **Bug Fixes**
  - Extend MiniMax detection to include `mimo-*` (provider-prefixed and bare).
  - Update heuristic registry to map `mimo-*` to MiniMax with variants `low`, `medium`, `high` and no thinking.
  - Ensure settings compatibility drops thinking for these aliases.
  - Add tests for family detection, capability inference, and settings behavior.

<sup>Written for commit f0e39405baa79915434743220872039388408703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

