### PR TITLE
test(utils): cover blank Git Bash env override

### DIFF
--- a/packages/utils/src/runtime/git-bash.test.ts
+++ b/packages/utils/src/runtime/git-bash.test.ts
@@ -47,6 +47,22 @@ describe("runtime git-bash resolver", () => {
     expect(result.installHint).toContain("OMO_CODEX_GIT_BASH_PATH=C:\\path\\to\\bash.exe")
   })
 
+  test("#given blank Windows env override #when resolving #then fallback probing continues", () => {
+    const result = resolveGitBash({
+      platform: "win32",
+      env: { OMO_CODEX_GIT_BASH_PATH: "  " },
+      exists: (path: string) => path === PROGRAM_FILES_GIT_BASH,
+      where: () => [],
+    })
+
+    expect(result).toEqual({
+      found: true,
+      path: PROGRAM_FILES_GIT_BASH,
+      source: "program-files",
+      checkedPaths: [PROGRAM_FILES_GIT_BASH],
+    })
+  })
+
   test("#given both standard Windows installs exist #when resolving #then Program Files has priority", () => {
     const result = resolveGitBash({
       platform: "win32",


### PR DESCRIPTION
## Summary
- cover the Windows Git Bash resolver path where OMO_CODEX_GIT_BASH_PATH is blank
- pin that blank env overrides are ignored so Program Files fallback probing still runs

## Verification
- bun install --ignore-scripts
- git diff --check
- bun test packages/utils/src/runtime/git-bash.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add test to cover the Windows Git Bash resolver when `OMO_CODEX_GIT_BASH_PATH` is blank, ensuring fallback probing finds `bash.exe` in Program Files. Pins behavior that blank env overrides are ignored in `packages/utils/src/runtime/git-bash.test.ts`.

<sup>Written for commit 6c41ba33ec71a73499f0de15d462b51f058a4fb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

