### PR TITLE
test(utils): cover Windows archive entry paths

### DIFF
--- a/packages/utils/src/archive-entry-validator.test.ts
+++ b/packages/utils/src/archive-entry-validator.test.ts
@@ -20,6 +20,24 @@ describe("validateArchiveEntries", () => {
 		expect(rejectTraversalPath).toThrow(/path traversal/i)
 	})
 
+	it("rejects Windows-style absolute paths and backslash traversal entries", () => {
+		//#given
+		const destDir = "/tmp/archive-root"
+
+		//#when
+		const rejectDriveAbsolutePath = () =>
+			validateArchiveEntries([{ path: String.raw`C:\Windows\System32\drivers\etc\hosts`, type: "file" }], destDir)
+		const rejectUncAbsolutePath = () =>
+			validateArchiveEntries([{ path: String.raw`\\server\share\payload.txt`, type: "file" }], destDir)
+		const rejectBackslashTraversalPath = () =>
+			validateArchiveEntries([{ path: String.raw`nested\..\..\evil.txt`, type: "file" }], destDir)
+
+		//#then
+		expect(rejectDriveAbsolutePath).toThrow(/absolute path/i)
+		expect(rejectUncAbsolutePath).toThrow(/absolute path/i)
+		expect(rejectBackslashTraversalPath).toThrow(/path traversal/i)
+	})
+
 	it("rejects symlink targets that escape the extraction directory", () => {
 		//#given
 		const destDir = "/tmp/archive-root"


### PR DESCRIPTION
## Summary
- add archive-entry validator coverage for Windows drive absolute paths
- add UNC path coverage after backslash normalization
- pin backslash traversal rejection for archive entries

## Verification
- bun install --ignore-scripts
- bun test packages/utils/src/archive-entry-validator.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand tests for archive entry validation to cover Windows drive absolute paths, UNC paths, and backslash-based traversal. Ensures these paths are rejected as absolute or traversal, pinning cross-platform safety behavior.

<sup>Written for commit b792910ab8442a1bb1fb31eb660aa864e9936948. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

