### PR TITLE
test(agents-md-core): cover stored injection dedupe

### DIFF
--- a/packages/agents-md-core/src/injector.test.ts
+++ b/packages/agents-md-core/src/injector.test.ts
@@ -80,6 +80,48 @@ describe("processFilePathForAgentsInjection", () => {
     expect(output.output).not.toContain(rootAgents);
   });
 
+  it("#given injected paths already persisted #when memory cache is reset #then storage prevents duplicate injection", async () => {
+    // given
+    rootDirectory = join(tmpdir(), `agents-md-core-injector-${randomUUID()}`);
+    const srcDirectory = join(rootDirectory, "src");
+    mkdirSync(srcDirectory, { recursive: true });
+    writeFileSync(join(srcDirectory, "AGENTS.md"), "# src");
+    writeFileSync(join(srcDirectory, "first.ts"), "export const first = true;\n");
+    writeFileSync(join(srcDirectory, "second.ts"), "export const second = true;\n");
+
+    const output = {
+      title: "read result",
+      output: "base output",
+      metadata: {},
+    };
+
+    // when
+    await processFilePathForAgentsInjection({
+      rootDirectory,
+      truncator,
+      sessionCaches,
+      storage,
+      filePath: join(srcDirectory, "first.ts"),
+      sessionID: "session-storage-dedupe",
+      output,
+    });
+    const outputAfterFirstInjection = output.output;
+    sessionCaches.clear();
+    await processFilePathForAgentsInjection({
+      rootDirectory,
+      truncator,
+      sessionCaches,
+      storage,
+      filePath: join(srcDirectory, "second.ts"),
+      sessionID: "session-storage-dedupe",
+      output,
+    });
+
+    // then
+    expect(output.output).toBe(outputAfterFirstInjection);
+    expect(output.output.match(/\[Directory Context:/g)).toHaveLength(1);
+  });
+
   it("#given absolute file path outside root #when injecting AGENTS.md #then outside context is ignored", async () => {
     // given
     rootDirectory = join(tmpdir(), `agents-md-core-injector-${randomUUID()}`);


### PR DESCRIPTION
## Summary
- add core coverage for AGENTS.md injection dedupe after the in-memory session cache is reset
- pin that persisted injected paths prevent duplicate directory-context injection for the same session

## Verification
- bun install --ignore-scripts
- bun test packages/agents-md-core/src/injector.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test in `agents-md-core` to verify AGENTS.md injection is deduped via persisted storage after the in-memory session cache is reset, ensuring a session only gets one Directory Context block across files.

<sup>Written for commit 6210fee04b520d7ed0fb8f42ae89cd2f3034ff3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

