### PR TITLE
test(boulder-state): cover reserved task keys

### DIFF
--- a/packages/boulder-state/src/task-state.test.ts
+++ b/packages/boulder-state/src/task-state.test.ts
@@ -1,0 +1,50 @@
+/// <reference path="../../../bun-test.d.ts" />
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, test } from "bun:test"
+
+import {
+  createBoulderState,
+  readBoulderState,
+  upsertTaskSessionStateForWork,
+  writeBoulderState,
+} from "./index"
+
+const cleanupRoots: string[] = []
+
+afterEach(() => {
+  for (const root of cleanupRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe("task session state", () => {
+  test("#given reserved task keys #when upserting task sessions #then prototype-polluting keys are rejected", () => {
+    // given
+    const directory = mkdtempSync(join(tmpdir(), "boulder-task-state-"))
+    cleanupRoots.push(directory)
+    const state = createBoulderState(".omo/plans/prototype-guard.md", "sess-a")
+    const workId = state.active_work_id
+    expect(workId).toBeDefined()
+    expect(writeBoulderState(directory, state)).toBe(true)
+
+    // when
+    const results = ["__proto__", "prototype", "constructor"].map((taskKey) =>
+      upsertTaskSessionStateForWork(directory, workId ?? "", {
+        taskKey,
+        taskLabel: taskKey,
+        taskTitle: `Task ${taskKey}`,
+        sessionId: "sess-task",
+      }),
+    )
+    const storedState = readBoulderState(directory)
+    const storedWork = workId ? storedState?.works?.[workId] : undefined
+
+    // then
+    expect(results).toEqual([null, null, null])
+    expect(storedWork?.task_sessions).toEqual({})
+    expect(storedState?.task_sessions).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary
- add boulder-state coverage for reserved task session keys
- pin that __proto__, prototype, and constructor task keys are rejected
- assert rejected upserts do not mutate root or active-work task session state

## Verification
- bun install --ignore-scripts
- bun test packages/boulder-state/src/task-state.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `boulder-state` task session state to guard against prototype pollution. Ensures upserts using reserved keys (`__proto__`, `prototype`, `constructor`) return null and do not mutate root or active-work task session state.

<sup>Written for commit 2cc595800e78015d0d4175c49a39f87c9a75fdae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

