### PR TITLE
test(boulder-state): cover current top-level task parsing

### DIFF
--- a/packages/boulder-state/src/top-level-task.test.ts
+++ b/packages/boulder-state/src/top-level-task.test.ts
@@ -1,0 +1,74 @@
+/// <reference path="../../../bun-test.d.ts" />
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { readCurrentTopLevelTask } from "./top-level-task"
+
+const cleanupRoots: string[] = []
+
+afterEach(() => {
+  for (const root of cleanupRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function writePlan(markdown: string): string {
+  const directory = mkdtempSync(join(tmpdir(), "boulder-top-level-task-"))
+  cleanupRoots.push(directory)
+  const planPath = join(directory, "plan.md")
+  writeFileSync(planPath, markdown, "utf-8")
+  return planPath
+}
+
+describe("readCurrentTopLevelTask", () => {
+  test("#given TODOs with nested and unnumbered unchecked boxes #when reading current task #then first numbered top-level TODO is returned", () => {
+    // given
+    const planPath = writePlan([
+      "# Plan",
+      "## TODOs",
+      "- [x] 1. Completed task",
+      "  - [ ] 1.1 Nested task",
+      "- [ ] Missing numeric label",
+      "- [ ] 2. Implement the next task",
+      "## Final Verification Wave",
+      "- [ ] F1. Verify later",
+    ].join("\n"))
+
+    // when
+    const task = readCurrentTopLevelTask(planPath)
+
+    // then
+    expect(task).toEqual({
+      key: "todo:2",
+      section: "todo",
+      label: "2",
+      title: "Implement the next task",
+    })
+  })
+
+  test("#given completed TODOs and pending final wave #when reading current task #then first final verification task is returned", () => {
+    // given
+    const planPath = writePlan([
+      "# Plan",
+      "## TODOs",
+      "- [x] 1. Completed task",
+      "## Final Verification Wave",
+      "- [ ] F1. Run the final gate",
+      "- [ ] F2. Archive evidence",
+    ].join("\n"))
+
+    // when
+    const task = readCurrentTopLevelTask(planPath)
+
+    // then
+    expect(task).toEqual({
+      key: "final-wave:f1",
+      section: "final-wave",
+      label: "F1",
+      title: "Run the final gate",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add coverage for readCurrentTopLevelTask
- pin that nested and unnumbered unchecked boxes are ignored in TODOs
- pin that pending Final Verification Wave tasks are returned after TODOs are complete

## Verification
- bun install --ignore-scripts
- bun test packages/boulder-state/src/top-level-task.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to `packages/boulder-state` for readCurrentTopLevelTask parsing. Confirms nested and unnumbered checkboxes are ignored, the first numbered top-level TODO is returned, and when TODOs are complete the first Final Verification Wave task is selected.

<sup>Written for commit 984058cb4081090a37f48112ebb5eb00d50ff4c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

