### PR TITLE
test(boulder-state): cover plan progress parsing

### DIFF
--- a/packages/boulder-state/src/plan-progress.test.ts
+++ b/packages/boulder-state/src/plan-progress.test.ts
@@ -1,0 +1,66 @@
+/// <reference path="../../../bun-test.d.ts" />
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { getPlanProgress } from "./index"
+
+const cleanupRoots: string[] = []
+
+afterEach(() => {
+  for (const root of cleanupRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function writePlan(markdown: string): string {
+  const directory = mkdtempSync(join(tmpdir(), "boulder-plan-progress-"))
+  cleanupRoots.push(directory)
+  const planPath = join(directory, "plan.md")
+  writeFileSync(planPath, markdown, "utf-8")
+  return planPath
+}
+
+describe("getPlanProgress", () => {
+  test("#given structured plan sections #when progress is read #then only labeled top-level TODO and final wave tasks count", () => {
+    // given
+    const planPath = writePlan([
+      "# Plan",
+      "- [ ] Preamble checkbox",
+      "## TODOs",
+      "- [x] 1. Completed task",
+      "  - [ ] 1.1 Nested task",
+      "- [ ] Missing numeric label",
+      "- [ ] 2. Remaining task",
+      "## Acceptance Criteria",
+      "- [ ] Ignored checkbox",
+      "## Final Verification Wave",
+      "- [X] F1. Verified task",
+      "- [ ] F2. Remaining verification",
+    ].join("\n"))
+
+    // when
+    const progress = getPlanProgress(planPath)
+
+    // then
+    expect(progress).toEqual({ total: 4, completed: 2, isComplete: false })
+  })
+
+  test("#given simple plan without structured headings #when progress is read #then all top-level checkboxes count", () => {
+    // given
+    const planPath = writePlan([
+      "# Plan",
+      "- [x] Completed",
+      "- [ ] Remaining",
+      "  - [ ] Nested ignored by simple fallback",
+    ].join("\n"))
+
+    // when
+    const progress = getPlanProgress(planPath)
+
+    // then
+    expect(progress).toEqual({ total: 2, completed: 1, isComplete: false })
+  })
+})


### PR DESCRIPTION
## Summary
- add direct coverage for getPlanProgress
- pin structured TODO/Final Verification Wave progress counting
- pin simple-plan fallback counting for top-level checkboxes

## Verification
- bun install --ignore-scripts
- bun test packages/boulder-state/src/plan-progress.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for plan progress parsing in `boulder-state` to lock behavior for structured and simple plans. Ensures only labeled TODOs and "Final Verification Wave" tasks count in structured plans, and all top-level checkboxes count in simple plans.

<sup>Written for commit a4ab5c39f19fc4d739f09c733079c239e6073903. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

