### PR TITLE
test(telemetry-core): cover diagnostics cleanup

### DIFF
--- a/packages/telemetry-core/src/diagnostics.test.ts
+++ b/packages/telemetry-core/src/diagnostics.test.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { getTelemetryDiagnosticsFilePath, writeTelemetryDiagnostic } from "./index"
+
+const cleanupRoots: string[] = []
+
+afterEach(() => {
+  for (const root of cleanupRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function createDiagnosticsDir(): string {
+  const diagnosticsDir = mkdtempSync(join(tmpdir(), "telemetry-diagnostics-"))
+  cleanupRoots.push(diagnosticsDir)
+  return diagnosticsDir
+}
+
+function readJsonLines(filePath: string): Array<Record<string, unknown>> {
+  return readFileSync(filePath, "utf-8")
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+}
+
+describe("telemetry diagnostics", () => {
+  test("#given expired and malformed diagnostics #when writing a new diagnostic #then cleanup keeps only valid retained lines", () => {
+    // given
+    const diagnosticsDir = createDiagnosticsDir()
+    const diagnosticsFilePath = getTelemetryDiagnosticsFilePath(diagnosticsDir)
+    mkdirSync(diagnosticsDir, { recursive: true })
+    writeFileSync(
+      diagnosticsFilePath,
+      [
+        JSON.stringify({ timestamp: "2026-05-01T00:00:00.000Z", event: "old", source: "shared" }),
+        "{not-json",
+        JSON.stringify({ timestamp: "2026-05-08T00:00:00.000Z", event: "retained", source: "shared" }),
+        "",
+      ].join("\n"),
+      "utf-8",
+    )
+
+    // when
+    writeTelemetryDiagnostic(
+      {
+        event: "new_event",
+        source: "unit-test",
+        error: new Error("boom"),
+        errorKind: "error",
+      },
+      {
+        diagnosticsDir,
+        now: new Date("2026-05-10T00:00:00.000Z"),
+      },
+    )
+    const records = readJsonLines(diagnosticsFilePath)
+
+    // then
+    expect(records.map((record) => record.event)).toEqual(["retained", "new_event"])
+    expect(records[1]).toMatchObject({
+      timestamp: "2026-05-10T00:00:00.000Z",
+      event: "new_event",
+      source: "unit-test",
+      error_kind: "error",
+      error_name: "Error",
+      error_message: "boom",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add direct coverage for telemetry diagnostics cleanup
- pin that expired and malformed JSONL records are dropped before appending a new diagnostic
- assert serialized Error diagnostics keep timestamp, source, kind, name, and message fields

## Verification
- bun install --ignore-scripts
- bun test packages/telemetry-core/src/diagnostics.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests in `packages/telemetry-core` to cover diagnostics cleanup, ensuring expired and malformed JSONL lines are dropped and valid retained lines persist before a new diagnostic is appended. Also verifies error diagnostics serialize timestamp, source, kind, name, and message fields correctly.

<sup>Written for commit 7711fd02be0d3f99a5d08deb8961fb08e3d1f525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

