### PR TITLE
test(prompts-core): cover opus and minimax variants

### DIFF
--- a/packages/prompts-core/src/variant-resolver.test.ts
+++ b/packages/prompts-core/src/variant-resolver.test.ts
@@ -10,12 +10,18 @@ const variants = {
   gemini: promptSource("/prompts/gemini"),
   kimi: promptSource("/prompts/kimi"),
   glm: promptSource("/prompts/glm"),
+  "opus-4-7": promptSource("/prompts/opus-4-7"),
+  minimax: promptSource("/prompts/minimax"),
   default: promptSource("/prompts/default"),
 } satisfies VariantTable
 
 describe("resolveVariant", () => {
   test("#given Claude Opus 4.7 model #then resolves default variant", () => {
-    expect(resolveVariant({ modelID: "claude-opus-4-7", variants })).toBe("default")
+    const variantsWithoutOpus = {
+      default: promptSource("/prompts/default"),
+    } satisfies VariantTable
+
+    expect(resolveVariant({ modelID: "claude-opus-4-7", variants: variantsWithoutOpus })).toBe("default")
   })
 
   test("#given GPT model #then resolves gpt variant", () => {
@@ -43,6 +49,14 @@ describe("resolveVariant", () => {
 
   test("#given GLM model #then resolves glm variant", () => {
     expect(resolveVariant({ modelID: "glm-5-1", variants })).toBe("glm")
+  })
+
+  test("#given Claude Opus 4.7 model #then resolves opus prompt variant when available", () => {
+    expect(resolveVariant({ modelID: "anthropic/claude-opus-4-7", variants })).toBe("opus-4-7")
+  })
+
+  test("#given MiniMax model #then resolves minimax prompt variant when available", () => {
+    expect(resolveVariant({ modelID: "volcengine/minimax-m2.7", variants })).toBe("minimax")
   })
 
   test("#given Prometheus agent #then planner overrides model variant", () => {


### PR DESCRIPTION
## Summary
- add resolveVariant coverage for the opus-4-7 prompt variant
- add resolveVariant coverage for the minimax prompt variant
- keep the existing Claude Opus default fallback covered when no opus variant exists

## Verification
- bun install --ignore-scripts
- bun test packages/prompts-core/src/variant-resolver.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand `prompts-core` resolveVariant test coverage to include `opus-4-7` and `minimax`, and verify the default fallback when an Opus variant is missing. Adds cases for `anthropic/claude-opus-4-7` → `opus-4-7`, `volcengine/minimax-m2.7` → `minimax`, and `claude-opus-4-7` → `default` when only `default` exists.

<sup>Written for commit edcc951900c221352fd74a4ca0c23dd6274de5cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

