### PR TITLE
test(mcp-stdio-core): cover framed transport edges

### DIFF
--- a/packages/mcp-stdio-core/src/transport.test.ts
+++ b/packages/mcp-stdio-core/src/transport.test.ts
@@ -34,6 +34,46 @@ describe("stdio JSON-RPC transport", () => {
     ])
   })
 
+  test("#given multiple content-length frames #when read #then it yields each framed request", async () => {
+    const input = new PassThrough()
+    const firstBody = '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
+    const secondBody = '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+    input.end([
+      `Content-Length: ${Buffer.byteLength(firstBody, "utf8")}\r\n\r\n${firstBody}`,
+      `Content-Length: ${Buffer.byteLength(secondBody, "utf8")}\r\n\r\n${secondBody}`,
+    ].join(""))
+
+    const messages = await collect(input)
+
+    expect(messages).toEqual([
+      {
+        kind: "request",
+        payload: { jsonrpc: "2.0", id: 1, method: "initialize" },
+        responseMode: "framed",
+      },
+      {
+        kind: "request",
+        payload: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+        responseMode: "framed",
+      },
+    ])
+  })
+
+  test("#given invalid content-length header #when read #then it yields framed parse error", async () => {
+    const input = new PassThrough()
+    input.end("Content-Length: nope\r\n\r\n")
+
+    const messages = await collect(input)
+
+    expect(messages).toEqual([
+      {
+        kind: "parse_error",
+        message: "Missing or invalid Content-Length header",
+        responseMode: "framed",
+      },
+    ])
+  })
+
   test("#given response mode #when written #then framing bytes are stable", () => {
     const output = new PassThrough()
     const chunks: string[] = []


### PR DESCRIPTION
## Summary
- cover reading multiple Content-Length framed JSON-RPC messages from one stream buffer
- cover framed parse error output for invalid Content-Length headers

## Verification
- bun test packages/mcp-stdio-core/src/transport.test.ts
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests in `mcp-stdio-core` for framed JSON-RPC transport edge cases. Covers reading multiple Content-Length frames from a single buffer and emitting a framed parse error for invalid Content-Length headers.

<sup>Written for commit 33a5570576f2d601df6f7b440f078470c20cbd5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

