### PR TITLE
test(tmux-core): cover attach directory escaping

### DIFF
--- a/packages/tmux-core/src/tmux-utils/pane-command.test.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-command.test.ts
@@ -27,6 +27,25 @@ describe("buildTmuxAttachCommand", () => {
     expect(cmd).toContain('\\"')
     expect(cmd).toContain("\\$")
   })
+
+  it("passes explicit working directory to opencode attach", () => {
+    const cmd = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123", "/tmp/project")
+
+    expect(cmd).toContain("--dir /tmp/project")
+  })
+
+  it("escapes directory shell metacharacters", () => {
+    const cmd = buildTmuxAttachCommand(
+      "http://localhost:3000",
+      "ses_abc123",
+      '/tmp/project";$(whoami);rm -rf /',
+    )
+
+    expect(cmd).toContain('\\"')
+    expect(cmd).toContain("\\$")
+    expect(cmd).toContain("\\;")
+    expect(cmd).not.toMatch(/[^\\];\s*rm/)
+  })
 })
 
 describe("buildTmuxPlaceholderCommand", () => {


### PR DESCRIPTION
## Summary
- cover buildTmuxAttachCommand emitting an explicit --dir argument
- pin shell escaping for directory metacharacters alongside existing URL/session escaping coverage

## Verification
- bun test packages/tmux-core/src/tmux-utils/pane-command.test.ts
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend `tmux-core` test coverage for buildTmuxAttachCommand to verify it passes an explicit --dir and escapes working directory metacharacters (quotes, $, ;), preventing command injection. Improves safety of attach invocations and locks down escaping behavior.

<sup>Written for commit 64fc1deed4ddd69ba4aa3acabcda6c2bac0994ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

