### PR TITLE
test(delegate-core): cover category model fallback paths

### DIFF
--- a/packages/delegate-core/src/model-selection.test.ts
+++ b/packages/delegate-core/src/model-selection.test.ts
@@ -7,6 +7,12 @@ const noCacheDeps: DelegateModelResolutionDeps = {
   hasConnectedProvidersCache: false,
 }
 
+const warmEmptyCacheDeps: DelegateModelResolutionDeps = {
+  connectedProviders: null,
+  hasProviderModelsCache: true,
+  hasConnectedProvidersCache: true,
+}
+
 describe("resolveModelForDelegateTask", () => {
   test("#given no provider cache exists #when no user override is configured #then returns skipped sentinel", () => {
     const result = resolveModelForDelegateTask({
@@ -48,6 +54,40 @@ describe("resolveModelForDelegateTask", () => {
       model: "openai/gpt-5.4",
       variant: "medium",
       fallbackEntry: { providers: ["openai"], model: "gpt-5.4", variant: "medium" },
+      matchedFallback: true,
+    })
+  })
+
+  test("#given user-configured category model has variant #when resolving #then bypasses validation and preserves variant", () => {
+    const result = resolveModelForDelegateTask({
+      categoryDefaultModel: "openai/gpt-5.4 high",
+      isUserConfiguredCategoryModel: true,
+      availableModels: new Set(),
+    }, warmEmptyCacheDeps)
+
+    expect(result).toEqual({
+      model: "openai/gpt-5.4",
+      variant: "high",
+    })
+  })
+
+  test("#given cold provider cache and disconnected category default #when fallback chain has connected provider #then selects connected fallback", () => {
+    const result = resolveModelForDelegateTask({
+      availableModels: new Set(),
+      categoryDefaultModel: "anthropic/claude-sonnet-4-6",
+      fallbackChain: [
+        { providers: ["anthropic"], model: "claude-sonnet-4-6" },
+        { providers: ["openai"], model: "gpt-5.4" },
+      ],
+    }, {
+      connectedProviders: ["openai"],
+      hasProviderModelsCache: true,
+      hasConnectedProvidersCache: true,
+    })
+
+    expect(result).toEqual({
+      model: "openai/gpt-5.4",
+      fallbackEntry: { providers: ["openai"], model: "gpt-5.4" },
       matchedFallback: true,
     })
   })


### PR DESCRIPTION
## Summary
- cover user-configured category models bypassing validation while preserving variants
- cover disconnected cold-cache category defaults falling through to connected fallback-chain providers

## Verification
- bun test packages/delegate-core/src/model-selection.test.ts
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests in `delegate-core` for category model selection: user-configured models with variants bypass validation, and with a cold provider cache a disconnected default falls back to a connected provider.
Covers `resolveModelForDelegateTask` to guard cache and fallback behavior against regressions.

<sup>Written for commit baa032787f62c0768199827a22d9763eea0c178e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

