### PR TITLE
feat(team-mode): per-member allowedPaths with edit hard-gate + bash guardrail

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
@@ -103,6 +103,14 @@ function buildMemberPrompt(
   const promptLines = [`Team: ${spec.name}`, `TeamRunId: ${teamRunId}`, `Member: ${member.name}`]
   if (worktreePath) promptLines.push(`Worktree: ${worktreePath}`)
   if (member.prompt) promptLines.push(member.prompt)
+  if (!worktreePath && member.allowedPaths && member.allowedPaths.length > 0) {
+    promptLines.push(
+      `Allowed paths (inline protection): ${member.allowedPaths.join(", ")}`,
+      "You are in inline mode (shared working directory). The `edit` tool is hard-gated to these paths.",
+      "The `bash` tool also has a best-effort guardrail: destructive git/rm commands (git restore, git reset --hard, git clean -f, git rm, rm -rf, etc.) will be rejected.",
+      "Do NOT attempt to modify, revert, or destroy files outside your assignment — other members' in-flight work shares this directory.",
+    )
+  }
   promptLines.push(buildTeammateCommunicationAddendum(config))
   return promptLines.join("\n")
 }

--- a/packages/omo-opencode/src/features/team-mode/tools/lifecycle-create-tool.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/lifecycle-create-tool.ts
@@ -28,6 +28,7 @@ const TeamCreateInlineMemberToolSchema = tool.schema.object({
   loadSkills: tool.schema.array(tool.schema.string()).optional().describe("Optional skills to load for this member."),
   role: tool.schema.string().optional().describe("Optional natural-language role used to build a prompt when prompt is omitted."),
   description: tool.schema.string().optional().describe("Optional natural-language description used to build a prompt when prompt is omitted."),
+  allowedPaths: tool.schema.array(tool.schema.string()).optional().describe("Inline-mode-only file protection. When set on an inline member (no worktreePath), the `edit` tool is hard-gated to these glob patterns (picomatch) and the `bash` tool gets a best-effort destructive-command guardrail. Worktree members bypass; unset = unrestricted. Glob patterns are matched relative to the repo cwd."),
 })
 
 const TeamCreateInlineSpecToolSchema = tool.schema.union([

--- a/packages/omo-opencode/src/hooks/team-tool-gating/hook.ts
+++ b/packages/omo-opencode/src/hooks/team-tool-gating/hook.ts
@@ -7,6 +7,7 @@ import {
   listActiveTeams,
   loadRuntimeState,
 } from "../../features/team-mode/team-state-store"
+import { detectDestructiveBashCommand, isEditPathAllowed } from "./inline-file-guard"
 
 const ACTIVE_RUNTIME_STATUSES = new Set<RuntimeState["status"]>(["creating", "active", "shutdown_requested"])
 const UNIVERSAL_TOOL_NAMES = new Set([
@@ -78,7 +79,7 @@ function isTargetMember(participant: TeamParticipant, teamRunId: string | undefi
     && participant.memberName === memberName
 }
 
-export function createTeamToolGating(_ctx: PluginInput, config: TeamModeConfig | undefined): Hooks {
+export function createTeamToolGating(ctx: PluginInput, config: TeamModeConfig | undefined): Hooks {
   return {
     "tool.execute.before": async (
       input: { tool: string; sessionID: string; callID: string },
@@ -89,6 +90,17 @@ export function createTeamToolGating(_ctx: PluginInput, config: TeamModeConfig |
       }
 
       const toolName = input.tool
+
+      if (toolName === "edit") {
+        await enforceEditAllowedPaths(input.sessionID, output.args, ctx, config)
+        return
+      }
+
+      if (toolName === "bash") {
+        await enforceBashGuardrail(input.sessionID, output.args, ctx, config)
+        return
+      }
+
       if (!toolName.startsWith("team_") && toolName !== "delegate-task") {
         return
       }
@@ -145,5 +157,72 @@ export function createTeamToolGating(_ctx: PluginInput, config: TeamModeConfig |
         )
       }
     },
+  }
+}
+
+type MemberFileBoundary = {
+  worktreePath?: string
+  allowedPaths?: string[]
+}
+
+async function resolveMemberFileBoundary(
+  teamRunId: string,
+  memberName: string,
+  config: TeamModeConfig,
+): Promise<MemberFileBoundary | undefined> {
+  const runtimeState = await loadRuntimeState(teamRunId, config)
+  if (!ACTIVE_RUNTIME_STATUSES.has(runtimeState.status)) return undefined
+  const member = runtimeState.members.find((entry) => entry.name === memberName)
+  if (!member) return undefined
+  return { worktreePath: member.worktreePath, allowedPaths: member.allowedPaths }
+}
+
+async function enforceEditAllowedPaths(
+  sessionID: string,
+  args: Record<string, unknown>,
+  ctx: PluginInput,
+  config: TeamModeConfig,
+): Promise<void> {
+  const participant = await resolveParticipant(sessionID, config)
+  if (participant.role !== "member") return
+
+  const boundary = await resolveMemberFileBoundary(participant.teamRunId, participant.memberName, config)
+  if (!boundary) return
+  if (boundary.worktreePath) return
+  if (!boundary.allowedPaths || boundary.allowedPaths.length === 0) return
+
+  const filePath = getStringArg(args, "filePath")
+  if (!filePath) {
+    throw new Error(`edit denied: member ${participant.memberName} has allowedPaths set but no filePath was provided`)
+  }
+  if (!isEditPathAllowed(boundary.allowedPaths, filePath, ctx.directory)) {
+    throw new Error(
+      `edit denied: "${filePath}" is outside member ${participant.memberName}'s allowedPaths [${boundary.allowedPaths.join(", ")}]`,
+    )
+  }
+}
+
+async function enforceBashGuardrail(
+  sessionID: string,
+  args: Record<string, unknown>,
+  ctx: PluginInput,
+  config: TeamModeConfig,
+): Promise<void> {
+  const participant = await resolveParticipant(sessionID, config)
+  if (participant.role !== "member") return
+
+  const boundary = await resolveMemberFileBoundary(participant.teamRunId, participant.memberName, config)
+  if (!boundary) return
+  if (boundary.worktreePath) return
+  if (!boundary.allowedPaths || boundary.allowedPaths.length === 0) return
+
+  const command = getStringArg(args, "command")
+  if (!command) return
+
+  const matchedPattern = detectDestructiveBashCommand(command)
+  if (matchedPattern !== null) {
+    throw new Error(
+      `bash denied: command matches destructive pattern "${matchedPattern}". Member ${participant.memberName} is in inline mode with allowedPaths set; destructive git/rm commands that could destroy other members' work are blocked. If you genuinely need this, ask the lead or use a worktree member.`,
+    )
   }
 }

--- a/packages/omo-opencode/src/hooks/team-tool-gating/inline-file-guard.test.ts
+++ b/packages/omo-opencode/src/hooks/team-tool-gating/inline-file-guard.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test"
+
+import { detectDestructiveBashCommand, isEditPathAllowed } from "./inline-file-guard"
+
+const CWD = "/repo"
+
+describe("isEditPathAllowed", () => {
+  test("matches a glob inside cwd", () => {
+    expect(isEditPathAllowed(["src/ui/**"], "src/ui/Button.tsx", CWD)).toBe(true)
+    expect(isEditPathAllowed(["src/ui/**", "src/components/**"], "src/components/Modal.tsx", CWD)).toBe(true)
+  })
+
+  test("rejects a path outside the glob", () => {
+    expect(isEditPathAllowed(["src/ui/**"], "src/api/handler.ts", CWD)).toBe(false)
+    expect(isEditPathAllowed(["src/ui/**"], "package.json", CWD)).toBe(false)
+  })
+
+  test("rejects cwd-escape via ../ traversal", () => {
+    expect(isEditPathAllowed(["src/ui/**"], "../sibling/file.ts", CWD)).toBe(false)
+    expect(isEditPathAllowed(["src/ui/**"], "src/ui/../../api/handler.ts", CWD)).toBe(false)
+  })
+
+  test("rejects absolute paths outside cwd", () => {
+    expect(isEditPathAllowed(["src/ui/**"], "/etc/passwd", CWD)).toBe(false)
+    expect(isEditPathAllowed(["src/ui/**"], "/repo/src/ui/Button.tsx", CWD)).toBe(true)
+  })
+
+  test("treats filePath === cwd as outside scope", () => {
+    expect(isEditPathAllowed(["**"], ".", CWD)).toBe(false)
+  })
+
+  test("honors dot:true (hidden files match **)", () => {
+    expect(isEditPathAllowed(["**"], ".env", CWD)).toBe(true)
+  })
+})
+
+describe("detectDestructiveBashCommand", () => {
+  describe("destructive git commands (caught)", () => {
+    const cases: Array<[string, string]> = [
+      ["git restore .", "git restore"],
+      ["git restore --staged file.ts", "git restore"],
+      ["git checkout -- file.ts", "git checkout (discard)"],
+      ["git checkout .", "git checkout (discard)"],
+      ["git checkout HEAD file.ts", "git checkout (discard)"],
+      ["git checkout -f", "git checkout (discard)"],
+      ["git checkout --force", "git checkout (discard)"],
+      ["git switch --force main", "git switch --force"],
+      ["git switch -f main", "git switch --force"],
+      ["git reset --hard", "git reset --hard"],
+      ["git reset --hard HEAD", "git reset --hard"],
+      ["git clean -fd", "git clean -f"],
+      ["git clean -fdx", "git clean -f"],
+      ["git stash drop", "git stash drop/clear"],
+      ["git stash clear", "git stash drop/clear"],
+      ["git rm file.ts", "git rm"],
+      ["git rm --cached file.ts", "git rm"],
+      ["git branch -D feature", "git branch -D/-d"],
+      ["git branch -d feature", "git branch -D/-d"],
+      ["git worktree remove --force ../other", "git worktree remove"],
+    ]
+    for (const [cmd, expectedLabel] of cases) {
+      test(`catches: ${cmd}`, () => {
+        expect(detectDestructiveBashCommand(cmd)).toBe(expectedLabel)
+      })
+    }
+  })
+
+  describe("destructive filesystem commands (caught)", () => {
+    const cases: Array<[string, string]> = [
+      ["rm -rf build", "rm -r/-f"],
+      ["rm -r build", "rm -r/-f"],
+      ["rm -f file.ts", "rm -r/-f"],
+      ["rm -fr build", "rm -r/-f"],
+      ["find . -delete", "find -delete/-exec rm"],
+      ["find . -exec rm {} \\;", "find -delete/-exec rm"],
+    ]
+    for (const [cmd, expectedLabel] of cases) {
+      test(`catches: ${cmd}`, () => {
+        expect(detectDestructiveBashCommand(cmd)).toBe(expectedLabel)
+      })
+    }
+  })
+
+  describe("token-split: catches destructive command in pipeline segment", () => {
+    const cases = [
+      "echo hi && git reset --hard",
+      "git status; git clean -fd",
+      "git log || git restore .",
+      "echo done | git stash drop",
+      "echo a\ngit reset --hard",
+    ]
+    for (const cmd of cases) {
+      test(`catches segment in: ${JSON.stringify(cmd)}`, () => {
+        expect(detectDestructiveBashCommand(cmd)).not.toBeNull()
+      })
+    }
+  })
+
+  describe("case-insensitive git", () => {
+    test("catches Git, GIT, git", () => {
+      expect(detectDestructiveBashCommand("Git reset --hard")).not.toBeNull()
+      expect(detectDestructiveBashCommand("GIT RESET --HARD")).not.toBeNull()
+      expect(detectDestructiveBashCommand("git reset --hard")).not.toBeNull()
+    })
+  })
+
+  describe("safe commands (allowed)", () => {
+    const safeCases = [
+      "git status",
+      "git diff",
+      "git log --oneline",
+      "git add src/ui/Button.tsx",
+      "git commit -m 'feat: add button'",
+      "git stash push",
+      "git stash list",
+      "git push",
+      "git pull",
+      "git checkout -b new-branch",
+      "git checkout main",
+      "git switch main",
+      "git branch",
+      "git branch new-branch",
+      "ls -la",
+      "cat README.md",
+      "npm test",
+      "pytest tests/",
+      "ruff check src/",
+      "python script.py",
+      "echo hello",
+      "echo $(date)",
+      "dirname $(pwd)",
+      "echo $(git rev-parse HEAD)",
+      "mkdir -p build/out",
+      "touch src/ui/New.tsx",
+    ]
+    for (const cmd of safeCases) {
+      test(`allows: ${cmd}`, () => {
+        expect(detectDestructiveBashCommand(cmd)).toBeNull()
+      })
+    }
+  })
+
+  describe("known limitations (documented, NOT caught)", () => {
+    // eval/bash -c with LITERAL destructive text IS caught (whole-string scan).
+    const literalTextWrapperCases = [
+      'eval "git reset --hard"',
+      'bash -c "git reset --hard"',
+    ]
+    for (const cmd of literalTextWrapperCases) {
+      test(`catches literal destructive text inside wrapper: ${cmd}`, () => {
+        expect(detectDestructiveBashCommand(cmd)).not.toBeNull()
+      })
+    }
+
+    // Dynamic eval (no literal destructive text) — adversarial, out of scope.
+    // File overwrite via redirection/cp/mv/tee — also out of scope (edit-gate bypass via bash).
+    const trueGaps = [
+      'eval "$malicious"',
+      "echo x > important.py",
+      "cp a.py b.py",
+      "mv a.py b.py",
+      "tee important.py",
+    ]
+    for (const cmd of trueGaps) {
+      test(`does NOT catch (documented limitation): ${cmd}`, () => {
+        expect(detectDestructiveBashCommand(cmd)).toBeNull()
+      })
+    }
+  })
+})

--- a/packages/omo-opencode/src/hooks/team-tool-gating/inline-file-guard.ts
+++ b/packages/omo-opencode/src/hooks/team-tool-gating/inline-file-guard.ts
@@ -1,0 +1,83 @@
+import picomatch from "picomatch"
+import path from "node:path"
+
+// Inline-mode file protection for Team Mode members.
+//
+// Design (see issue #5333):
+//   - edit hard-gate: deterministic path check against an allowedPaths glob list.
+//   - bash guardrail: best-effort destructive-command deny-list over the WHOLE
+//     command string (token-split on shell operators so each pipeline segment
+//     is scanned independently). This is a GUARDRAIL / tripwire, NOT a sandbox.
+//
+// Threat model: a CARELESS model mistake (running `git reset --hard` to "clean
+// up", `rm -rf build/`, etc.) — NOT an adversarial shell-injection attack.
+// Known limitations (documented in the PR):
+//   - Does not catch `>`/`>>`/`tee`/`cp`/`mv` file-overwrite via bash (edit
+//     hard-gate is bypassable via bash; the edit gate is a soft primary that
+//     catches the common case where the model uses the `edit` tool).
+//   - Does not catch dynamic eval obfuscation (`eval "$x"`, `bash -c "$x"`)
+//     where the destructive text never appears literally.
+//   - Does not catch git aliases (`git config alias.zap 'reset --hard'`).
+//   - Only applies to the `bash` and `edit` tools; other MCP tools that spawn
+//     shells are out of scope.
+// For real isolation, use worktree mode (filesystem-isolated) instead of inline.
+
+const COMMAND_SPLIT_RE = /(?:\|\||&&|;|\||\n)/
+
+// Word-boundary, applied to each command segment after lowercasing.
+// `git` itself is case-sensitive at the CLI (`GIT` is invalid), so matching
+// the lowercase form is safe and lets us catch `Git`, `GIT` typos too.
+// NOTE: patterns match the LOWERCASED form — detectDestructiveBashCommand
+// lowercases each segment before testing. Use lowercase literals (head, not HEAD).
+const DESTRUCTIVE_PATTERNS: readonly RegExp[] = [
+  // --- Discard working tree / uncommitted work (primary threat) ---
+  /\bgit\s+restore\b/,
+  /\bgit\s+checkout\s+(?:--|\.|head\b|-\w*f|--force\b)/,
+  /\bgit\s+switch\s+(?:-\w*f|--force\b)/,
+  /\bgit\s+reset\s+--hard\b/,
+  /\bgit\s+clean\s+-\w*f/,
+  /\bgit\s+stash\s+(?:drop|clear)\b/,
+  // --- Index / refs / worktree destructive ---
+  /\bgit\s+rm\b/,
+  /\bgit\s+branch\s+-[dD]\b/,
+  /\bgit\s+worktree\s+remove\b/,
+  // --- Filesystem destructive ---
+  /\brm\s+(?:-\w*r\w*|-f)/, // rm -r*, rm -rf, rm -f
+  /\bfind\b.*(?:-delete|-exec\s+rm)/,
+]
+
+const DESTRUCTIVE_PATTERN_LABELS: readonly string[] = [
+  "git restore",
+  "git checkout (discard)",
+  "git switch --force",
+  "git reset --hard",
+  "git clean -f",
+  "git stash drop/clear",
+  "git rm",
+  "git branch -D/-d",
+  "git worktree remove",
+  "rm -r/-f",
+  "find -delete/-exec rm",
+]
+
+export function isEditPathAllowed(allowedPaths: string[], filePath: string, cwd: string): boolean {
+  const resolved = path.resolve(cwd, filePath)
+  const relative = path.relative(cwd, resolved)
+  if (relative === "") return false
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return false
+  return picomatch.isMatch(relative, allowedPaths, { dot: true })
+}
+
+export function detectDestructiveBashCommand(command: string): string | null {
+  const segments = command.split(COMMAND_SPLIT_RE)
+  for (const rawSegment of segments) {
+    const segment = rawSegment.trim().toLowerCase()
+    if (!segment) continue
+    for (let i = 0; i < DESTRUCTIVE_PATTERNS.length; i++) {
+      if (DESTRUCTIVE_PATTERNS[i].test(segment)) {
+        return DESTRUCTIVE_PATTERN_LABELS[i]
+      }
+    }
+  }
+  return null
+}

--- a/packages/omo-opencode/src/hooks/team-tool-gating/inline-member-protection.test.ts
+++ b/packages/omo-opencode/src/hooks/team-tool-gating/inline-member-protection.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { TeamModeConfig } from "../../config/schema/team-mode"
+import { TeamModeConfigSchema } from "../../config/schema/team-mode"
+import {
+  clearTeamSessionRegistry,
+  registerTeamSession,
+} from "../../features/team-mode/team-session-registry"
+import type { RuntimeState } from "../../features/team-mode/types"
+import { saveRuntimeState } from "../../features/team-mode/team-state-store/store"
+import { createTeamToolGating } from "./hook"
+
+function createConfig(overrides?: Partial<TeamModeConfig>, baseDir = "/tmp/team-mode"): TeamModeConfig {
+  return {
+    enabled: true,
+    tmux_visualization: false,
+    max_parallel_members: 4,
+    max_members: 8,
+    max_messages_per_run: 10_000,
+    max_wall_clock_minutes: 120,
+    max_member_turns: 500,
+    base_dir: baseDir,
+    message_payload_max_bytes: 32_768,
+    recipient_unread_max_bytes: 262_144,
+    mailbox_poll_interval_ms: 3_000,
+    ...overrides,
+  }
+}
+
+function createInlineMemberRuntimeState(allowedPaths?: string[], worktreePath?: string): RuntimeState {
+  return {
+    version: 1,
+    teamRunId: "33333333-3333-4333-8333-333333333333",
+    teamName: "team-inline",
+    specSource: "project",
+    createdAt: 1,
+    status: "active",
+    leadSessionId: "lead-session",
+    members: [
+      {
+        name: "scoped",
+        sessionId: "scoped-session",
+        agentType: "general-purpose",
+        status: "running",
+        pendingInjectedMessageIds: [],
+        allowedPaths,
+        worktreePath,
+      },
+      {
+        name: "unscoped",
+        sessionId: "unscoped-session",
+        agentType: "general-purpose",
+        status: "running",
+        pendingInjectedMessageIds: [],
+      },
+    ],
+    shutdownRequests: [],
+    bounds: { maxMembers: 8, maxParallelMembers: 4, maxMessagesPerRun: 10_000, maxWallClockMinutes: 120, maxMemberTurns: 500 },
+  }
+}
+
+async function seedTeams(baseDir: string, ...runtimeStates: RuntimeState[]): Promise<void> {
+  const config = TeamModeConfigSchema.parse({ base_dir: baseDir, enabled: true })
+  await Promise.all(runtimeStates.map(async (runtimeState) => {
+    await mkdir(path.join(baseDir, "runtime", runtimeState.teamRunId), { recursive: true })
+    await saveRuntimeState(runtimeState, config)
+  }))
+}
+
+async function runHook(
+  tool: string,
+  sessionID: string,
+  args: Record<string, unknown>,
+  baseDir: string,
+): Promise<void> {
+  const hook = createTeamToolGating({ directory: baseDir } as PluginInput, createConfig(undefined, baseDir))
+  await hook["tool.execute.before"]?.({ tool, sessionID, callID: "call-1" }, { args })
+}
+
+describe("createTeamToolGating — inline member file protection", () => {
+  const temporaryDirectories: string[] = []
+
+  beforeEach(() => {
+    temporaryDirectories.length = 0
+    clearTeamSessionRegistry()
+  })
+
+  afterEach(async () => {
+    clearTeamSessionRegistry()
+    await Promise.all(temporaryDirectories.splice(0).map(async (d) => rm(d, { recursive: true, force: true })))
+  })
+
+  describe("edit hard-gate", () => {
+    test("allows edit inside allowedPaths glob", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-edit-allow-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+      registerTeamSession("scoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "scoped", role: "member" })
+
+      await expect(
+        runHook("edit", "scoped-session", { filePath: "src/ui/Button.tsx", oldString: "a", newString: "b" }, baseDir),
+      ).resolves.toBeUndefined()
+    })
+
+    test("denies edit outside allowedPaths glob", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-edit-deny-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+      registerTeamSession("scoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "scoped", role: "member" })
+
+      await expect(
+        runHook("edit", "scoped-session", { filePath: "src/api/handler.ts", oldString: "a", newString: "b" }, baseDir),
+      ).rejects.toThrow(/edit denied: "src\/api\/handler\.ts" is outside member scoped's allowedPaths/)
+    })
+
+    test("denies edit with cwd-escape via ../", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-edit-escape-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+      registerTeamSession("scoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "scoped", role: "member" })
+
+      await expect(
+        runHook("edit", "scoped-session", { filePath: "src/ui/../../etc/passwd", oldString: "a", newString: "b" }, baseDir),
+      ).rejects.toThrow(/edit denied:/)
+    })
+
+    test("allows unrestricted edit when allowedPaths unset (backward compatible)", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-edit-unscoped-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState())
+      registerTeamSession("unscoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "unscoped", role: "member" })
+
+      await expect(
+        runHook("edit", "unscoped-session", { filePath: "anywhere/anyfile.ts", oldString: "a", newString: "b" }, baseDir),
+      ).resolves.toBeUndefined()
+    })
+
+    test("bypasses gate for worktree members (filesystem-isolated)", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-edit-worktree-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"], "/tmp/worktree-scoped"))
+      registerTeamSession("scoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "scoped", role: "member" })
+
+      await expect(
+        runHook("edit", "scoped-session", { filePath: "anywhere/outside.ts", oldString: "a", newString: "b" }, baseDir),
+      ).resolves.toBeUndefined()
+    })
+
+    test("bypasses gate for lead", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-edit-lead-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+      registerTeamSession("lead-session", { teamRunId: "33333333-3333-4333-8333-333333333333", role: "lead" })
+
+      await expect(
+        runHook("edit", "lead-session", { filePath: "anywhere.ts", oldString: "a", newString: "b" }, baseDir),
+      ).resolves.toBeUndefined()
+    })
+
+    test("bypasses gate for non-team sessions (neither)", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-edit-neither-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+
+      await expect(
+        runHook("edit", "random-session", { filePath: "anywhere.ts", oldString: "a", newString: "b" }, baseDir),
+      ).resolves.toBeUndefined()
+    })
+
+    test("denies edit when allowedPaths set but filePath missing", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-edit-noarg-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+      registerTeamSession("scoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "scoped", role: "member" })
+
+      await expect(
+        runHook("edit", "scoped-session", { oldString: "a", newString: "b" }, baseDir),
+      ).rejects.toThrow(/has allowedPaths set but no filePath was provided/)
+    })
+  })
+
+  describe("bash destructive-command guardrail", () => {
+    const destructiveCases = [
+      "git reset --hard",
+      "git restore .",
+      "git checkout -- file.ts",
+      "git clean -fd",
+      "git rm --cached file.ts",
+      "rm -rf build",
+      "find . -delete",
+      "git stash drop",
+      "git branch -D feature",
+      "git worktree remove ../other",
+    ]
+
+    for (const cmd of destructiveCases) {
+      test(`denies destructive: ${cmd}`, async () => {
+        const baseDir = await mkdtemp(path.join(tmpdir(), "team-bash-destruct-"))
+        temporaryDirectories.push(baseDir)
+        await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+        registerTeamSession("scoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "scoped", role: "member" })
+
+        await expect(
+          runHook("bash", "scoped-session", { command: cmd }, baseDir),
+        ).rejects.toThrow(/bash denied: command matches destructive pattern/)
+      })
+    }
+
+    const safeCases = [
+      "git status",
+      "git add src/ui/Button.tsx",
+      "git commit -m 'feat'",
+      "git stash push",
+      "pytest tests/",
+      "npm test",
+      "ls -la",
+      "cat README.md",
+    ]
+
+    for (const cmd of safeCases) {
+      test(`allows safe: ${cmd}`, async () => {
+        const baseDir = await mkdtemp(path.join(tmpdir(), "team-bash-safe-"))
+        temporaryDirectories.push(baseDir)
+        await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+        registerTeamSession("scoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "scoped", role: "member" })
+
+        await expect(
+          runHook("bash", "scoped-session", { command: cmd }, baseDir),
+        ).resolves.toBeUndefined()
+      })
+    }
+
+    test("catches destructive command in pipeline segment", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-bash-pipe-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+      registerTeamSession("scoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "scoped", role: "member" })
+
+      await expect(
+        runHook("bash", "scoped-session", { command: "echo hi && git reset --hard" }, baseDir),
+      ).rejects.toThrow(/bash denied:/)
+    })
+
+    test("bypasses guardrail when allowedPaths unset (unscoped member)", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-bash-unscoped-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState())
+      registerTeamSession("unscoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "unscoped", role: "member" })
+
+      await expect(
+        runHook("bash", "unscoped-session", { command: "git reset --hard" }, baseDir),
+      ).resolves.toBeUndefined()
+    })
+
+    test("bypasses guardrail for worktree members", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-bash-worktree-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"], "/tmp/worktree-scoped"))
+      registerTeamSession("scoped-session", { teamRunId: "33333333-3333-4333-8333-333333333333", memberName: "scoped", role: "member" })
+
+      await expect(
+        runHook("bash", "scoped-session", { command: "git reset --hard" }, baseDir),
+      ).resolves.toBeUndefined()
+    })
+
+    test("bypasses guardrail for lead", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-bash-lead-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+      registerTeamSession("lead-session", { teamRunId: "33333333-3333-4333-8333-333333333333", role: "lead" })
+
+      await expect(
+        runHook("bash", "lead-session", { command: "git reset --hard" }, baseDir),
+      ).resolves.toBeUndefined()
+    })
+
+    test("no-ops for non-team session", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-bash-neither-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+
+      await expect(
+        runHook("bash", "random-session", { command: "git reset --hard" }, baseDir),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe("team_* tools still gated (regression check)", () => {
+    test("team_* tool still goes through team gating path", async () => {
+      const baseDir = await mkdtemp(path.join(tmpdir(), "team-regression-"))
+      temporaryDirectories.push(baseDir)
+      await seedTeams(baseDir, createInlineMemberRuntimeState(["src/ui/**"]))
+
+      await expect(
+        runHook("team_send_message", "random-session", { teamRunId: "33333333-3333-4333-8333-333333333333", to: "scoped", body: "hi" }, baseDir),
+      ).rejects.toThrow(/denied: not a participant of team/)
+    })
+  })
+})

--- a/packages/team-core/src/team-state-store/store.ts
+++ b/packages/team-core/src/team-state-store/store.ts
@@ -141,6 +141,7 @@ export async function createRuntimeState(
       status: "pending",
       color: member.color,
       worktreePath: member.worktreePath,
+      allowedPaths: member.allowedPaths,
       lastInjectedTurnMarker: undefined,
       pendingInjectedMessageIds: [],
     })),

--- a/packages/team-core/src/types.ts
+++ b/packages/team-core/src/types.ts
@@ -27,6 +27,12 @@ const MemberBaseSchema = z.object({
   name: z.string().min(1).regex(/^[a-z0-9-]+$/),
   cwd: z.string().optional(),
   worktreePath: z.string().optional(),
+  // Inline-mode-only file protection: when set on an inline member (no worktreePath),
+  // the team-tool-gating hook (1) hard-gates the `edit` tool to these globs and
+  // (2) applies a best-effort destructive-command guardrail to the `bash` tool.
+  // Worktree members bypass (filesystem-isolated); unset = unrestricted (backward compatible).
+  // See packages/omo-opencode/src/hooks/team-tool-gating/hook.ts.
+  allowedPaths: z.array(z.string().min(1)).optional(),
   subscriptions: z.array(z.string()).optional(),
   backendType: z.enum(["in-process", "tmux"]).default("in-process"),
   color: z.string().optional(),
@@ -143,6 +149,7 @@ const RuntimeStateMemberSchema = z.object({
   status: z.enum(["pending", "running", "idle", "errored", "completed", "shutdown_approved"]),
   color: z.string().optional(),
   worktreePath: z.string().optional(),
+  allowedPaths: z.array(z.string()).optional(),
   lastInjectedTurnMarker: z.string().optional(),
   pendingInjectedMessageIds: z.array(z.string()).default([]),
 }).strict()


### PR DESCRIPTION
Closes #5333. Supersedes #5334 (edit-only, deferred bash).

## Problem

In **Team Mode inline mode** (no worktree), all member agents share the same working directory with no filesystem isolation. Today, `team-tool-gating` only inspects `team_*` tools — the `edit` and `bash` tools are never checked. So a careless member can:

- **edit** files belonging to another member's assignment (no path check)
- **bash** destructive git/filesystem commands (`git restore .`, `git reset --hard`, `git clean -fd`, `rm -rf build`) that silently destroy other members' uncommitted work

The lead's `git diff --stat` verification only catches *additive* scope creep; it does **not** catch destructive reverts. This is the exact failure mode from real parallel team runs (#2494, #3599).

My earlier PR #5334 added an `edit` hard-gate but **explicitly deferred** bash parsing as "a rabbit hole that gives a false sense of security." After real-world usage, the `edit`-only gate is insufficient: **the primary destructive vector in incidents is `bash`** (a model running `git reset --hard` to "clean up"), which #5334 left uncovered. This PR closes that gap.

## Solution

An optional **per-member `allowedPaths` allow-list** on `TeamSpec` members that activates two **layered** defenses for **inline members** (worktree members bypass; unset = unrestricted — fully backward compatible):

### Layer 1 — `edit` hard-gate (deterministic)

When an inline member with `allowedPaths` set calls `edit`, the `filePath` is picomatch-checked against the glob list. Paths escaping cwd (`../`, absolute outside cwd) are always rejected.

### Layer 2 — `bash` guardrail (best-effort tripwire)

The same member class gets a destructive-command deny-list over the `bash` command string. Each pipeline segment (split on `;`, `&&`, `||`, `|`, newline) is scanned for destructive patterns. The deny-list covers (Oracle review, expanded beyond the original #5334 proposal):

| Category | Patterns |
|----------|----------|
| Discard working tree | `git restore`, `git checkout --/.`/`HEAD`/`-f`/`--force`, `git switch -f`/`--force`, `git reset --hard`, `git clean -f`, `git stash drop`/`clear` |
| Index/refs/worktree | `git rm`, `git branch -D`/`-d`, `git worktree remove` |
| Filesystem | `rm -r*`/`-f`, `find ... -delete`/`-exec rm` |

**This is a GUARDRAIL / tripwire, NOT a sandbox.** The threat model is a **CARELESS model mistake** (running `git reset --hard` to "clean up"), NOT an adversarial shell-injection attack. Code comments and this PR body say so explicitly.

```yamlc
members:
  - name: frontend-worker
    category: visual-engineering
    allowedPaths: ["src/ui/**", "src/components/**"]
    prompt: "..."
  - name: backend-worker
    category: quick
    allowedPaths: ["src/api/**", "src/db/**"]
    prompt: "..."
```

## Design — Oracle review summary

The bash gate design went through a 6-question Oracle consultation. Key decisions:

1. **Scan whole-string instead of rejecting subshell syntax.** Original draft rejected `$(`/backtick/`eval`/`bash -c` outright; Oracle flagged this as too aggressive (`$(date)`, `$(pwd)`, `xargs` pipelines are extremely common). Refined: scan each token-split segment for deny patterns. Result: literal destructive text inside `$(git reset --hard)` or `eval "git reset --hard"` is **still caught** (the literal text is there); only dynamically-constructed `eval "$x"` (adversarial obfuscation) is a gap, and that's out of scope for the careless-mistake threat model.

2. **Apply to `allowedPaths`-set members only (opt-in).** Oracle recommended applying to ALL inline members (the destructive potential is symmetric), but acknowledged opt-in is a reasonable conservative v1. The gap (an unscoped member can still destroy shared state) is documented below as a Known Limitation.

3. **Deny-list expanded** with `git rm`, `git worktree remove`, `git branch -D`/`-d`, `git checkout -f`, `git switch -f`, `find -delete` (all missed in the original #5334 proposal).

4. **Token-split scan** on `;`, `&&`, `||`, `|`, newline — catches destructive commands in any pipeline segment (`echo hi && git reset --hard`) without full AST parsing.

## ⚠️ Known Limitations (PLEASE READ)

This is a **harm-reduction guardrail for inline mode**, not a security boundary. For real isolation, use **worktree mode**.

1. **File overwrite via bash is NOT caught.** `> file.py`, `echo x > file.py`, `cp a.py b.py`, `mv a.py b.py`, `tee file` — all bypass both the edit gate (it's bash) and the bash deny-list. **Consequence: the `edit` hard-gate is a SOFT primary, not a hard boundary** — a member can still clobber files via bash. The edit gate's value is catching the common case where the model uses the `edit` tool directly.
2. **Dynamic eval obfuscation NOT caught.** `eval "$malicious"` where `$malicious` is constructed elsewhere — the destructive text never appears literally. (Note: `eval "git reset --hard"` with literal text **IS** caught — the deny-list scans the whole string.)
3. **Git aliases NOT caught.** `git config alias.zap 'reset --hard'` then `git zap`. Setting up an alias is itself suspicious and not a careless-mistake vector.
4. **Opt-in scope gap.** A member WITHOUT `allowedPaths` set runs unrestricted — they can still `git reset --hard` and destroy a scoped member's work. This is the documented v1 trade-off (Oracle's preferred long-term default is role-aware restriction on all inline members — candidate for a follow-up).
5. **Only the `bash` and `edit` tools are gated.** Other MCP tools that spawn shells are out of scope.
6. **Case-insensitive git matching.** `Git`, `GIT`, `git` all caught (harmless — `GIT` is invalid at the CLI anyway).

**Framing**: this is a seatbelt, not a crash barrier. eslint doesn't catch all bugs; we still use it. Do-nothing leaves the actual incident vector (bash) at 0% coverage; this guardrail covers the common careless patterns. The escape hatch is worktree mode.

## Files Changed (8)

| File | Change |
|------|--------|
| `packages/team-core/src/types.ts` | `allowedPaths` on `MemberBaseSchema` + `RuntimeStateMemberSchema` |
| `packages/team-core/src/team-state-store/store.ts` | Copy `allowedPaths` from spec member → runtime member |
| `packages/omo-opencode/.../tools/lifecycle-create-tool.ts` | Expose `allowedPaths` on inline member tool schema |
| `packages/omo-opencode/.../team-runtime/create.ts` | `buildMemberPrompt` injects allowed paths + guardrail warning (inline only) |
| `packages/omo-opencode/.../hooks/team-tool-gating/hook.ts` | `edit` + `bash` enforcement entry points; `team_*` gating preserved |
| `packages/omo-opencode/.../hooks/team-tool-gating/inline-file-guard.ts` (NEW) | `isEditPathAllowed` + `detectDestructiveBashCommand` (pure, testable) |
| `packages/omo-opencode/.../hooks/team-tool-gating/inline-file-guard.test.ts` (NEW) | 67 unit tests for the guard logic |
| `packages/omo-opencode/.../hooks/team-tool-gating/inline-member-protection.test.ts` (NEW) | 26 integration tests for edit/bash gating through the hook |

+653 / −1 across 8 files. Backward compatible (optional field, opt-in, worktree bypass, unset = unrestricted).

## Explicitly out of scope (follow-up candidates)

- **Activating team-level `teamAllowedPaths`** — currently a dead field on `TeamSpec`; intersection semantics (team ∩ member) deferred.
- **Role-aware restriction on all inline members** (Oracle's preferred long-term default) — the opt-in nature of `allowedPaths` means unscoped members are unprotected.
- **`bash` file-write redirection blocking** (`>`, `tee`, `cp`, `mv`) — high false-positive rate, deferred.
- **Shell AST parsing** — overkill for the careless-mistake threat model.

## Verification

- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test packages/omo-opencode/src/hooks/team-tool-gating/` — **117 pass / 0 fail** ✅
- `bun test packages/team-core/` — all pass except 1 pre-existing environment-dependent `removeWorktree` test (git worktree filesystem state; unrelated to this PR)

## Checklist

- [x] Forked from `dev`, branch `feat/team-inline-mutation-gate`
- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] Tests added (93 new) and passing
- [x] No `as any` / `@ts-ignore`
- [x] Backward compatible (optional field, opt-in)
- [x] Known limitations explicitly documented in PR body and code comments


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-member `allowedPaths` for inline Team Mode members to hard-gate `edit` and add a best-effort `bash` guardrail, reducing accidental cross-member damage. Opt-in, backward compatible; worktree members bypass.

- New Features
  - Optional `allowedPaths` on members (in `team-core`), propagated to runtime and surfaced in prompts for inline mode.
  - `edit` hard-gate: picomatch globs; blocks path escapes and edits outside allowed paths.
  - `bash` guardrail: scans each pipeline segment for destructive git/rm patterns (e.g., `git reset --hard`, `git clean -f`, `rm -rf`); blocks when matched.
  - Applies only to inline members with `allowedPaths`; existing `team_*` gating unchanged.

- Migration
  - No action required. Unset `allowedPaths` = unrestricted; worktree members bypass.
  - To scope an inline member, set `allowedPaths` (e.g., `["src/ui/**"]`) via the create tool schema in `omo-opencode`.

<sup>Written for commit 2032965c4ab08d5ca49d481294afc9cdbdf8d67b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

