### PR TITLE
fix(skill): load OpenCode native skills after base registry miss

### DIFF
--- a/packages/omo-opencode/src/plugin/native-skills.test.ts
+++ b/packages/omo-opencode/src/plugin/native-skills.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { unsafeTestValue } from "../../../../test-support/unsafe-test-value"
+import { createNativeSkills, getPluginInputNativeSkills } from "./native-skills"
+import type { PluginContext } from "./types"
+
+describe("native skill accessor", () => {
+  test("uses PluginContext.skills when the host exposes it directly", () => {
+    //#given
+    const directNativeSkills = {
+      all() { return [] },
+      get() { return undefined },
+      dirs() { return [] },
+    }
+    const ctx = unsafeTestValue<PluginContext>({ skills: directNativeSkills })
+
+    //#when
+    const result = getPluginInputNativeSkills(ctx)
+
+    //#then
+    expect(result).toBe(directNativeSkills)
+  })
+
+  test("loads native skills through the v2 app.skills method on the generated client", async () => {
+    //#given
+    const calls: unknown[] = []
+    const generatedClient = {
+      async get(options: unknown) {
+        calls.push(options)
+        return {
+          data: [{
+            name: "customize-opencode",
+            description: "Customize OpenCode",
+            location: "/opencode/customize-opencode.md",
+            content: "# Customizing opencode",
+          }],
+          request: new Request("http://localhost/skill"),
+          response: new Response(null),
+        }
+      },
+    }
+    const nativeSkills = createNativeSkills({
+      client: unsafeTestValue<PluginContext["client"]>({ _client: generatedClient }),
+      directory: "/repo",
+    })
+
+    //#when
+    const result = await nativeSkills.all()
+
+    //#then
+    expect(result).toEqual([{
+      name: "customize-opencode",
+      description: "Customize OpenCode",
+      location: "/opencode/customize-opencode.md",
+      content: "# Customizing opencode",
+    }])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({ url: "/skill", query: { directory: "/repo" } })
+  })
+})

--- a/packages/omo-opencode/src/plugin/native-skills.ts
+++ b/packages/omo-opencode/src/plugin/native-skills.ts
@@ -1,0 +1,79 @@
+import { OpencodeClient as V2OpencodeClient } from "@opencode-ai/sdk/v2"
+import type { Client as V2GeneratedClient } from "@opencode-ai/sdk/v2/gen/client"
+import { z } from "zod"
+import { log } from "../shared"
+import type { SkillLoadOptions } from "../tools/skill/types"
+import type { PluginContext } from "./types"
+
+const NativeSkillEntrySchema = z.object({
+  name: z.string(),
+  description: z.string().default(""),
+  location: z.string(),
+  content: z.string(),
+})
+const NativeSkillEntriesSchema = z.array(NativeSkillEntrySchema)
+
+type NativeSkills = NonNullable<SkillLoadOptions["nativeSkills"]>
+
+function getObjectProperty(value: unknown, property: string): unknown {
+  if (typeof value !== "object" || value === null) return undefined
+  return Reflect.get(value, property)
+}
+
+function isNativeSkills(value: unknown): value is NativeSkills {
+  return (
+    typeof getObjectProperty(value, "all") === "function" &&
+    typeof getObjectProperty(value, "get") === "function" &&
+    typeof getObjectProperty(value, "dirs") === "function"
+  )
+}
+
+function isV2GeneratedClient(value: unknown): value is V2GeneratedClient {
+  return typeof getObjectProperty(value, "get") === "function"
+}
+
+function getGeneratedClientFromPluginClient(client: PluginContext["client"]): unknown {
+  return getObjectProperty(client, "_client")
+}
+
+export function getPluginInputNativeSkills(ctx: PluginContext): NativeSkills | undefined {
+  const value = getObjectProperty(ctx, "skills")
+  return isNativeSkills(value) ? value : undefined
+}
+
+export function createNativeSkills(input: { readonly client: PluginContext["client"]; readonly directory: string }): NativeSkills {
+  const load = async () => {
+    const generatedClient = getGeneratedClientFromPluginClient(input.client)
+    if (!isV2GeneratedClient(generatedClient)) {
+      log("[native-skills] v2 sdk nativeSkills unavailable", {
+        hasGeneratedClient: generatedClient !== undefined,
+      })
+      return []
+    }
+
+    try {
+      const client = new V2OpencodeClient({ client: generatedClient })
+      const result = await client.app.skills({ directory: input.directory }, { throwOnError: true })
+      const parsed = NativeSkillEntriesSchema.safeParse(getObjectProperty(result, "data"))
+      if (!parsed.success) {
+        log("[native-skills] v2 sdk nativeSkills parse failed", { error: parsed.error.message })
+      }
+      return parsed.success ? parsed.data : []
+    } catch (error) {
+      log("[native-skills] v2 sdk nativeSkills load failed", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return []
+    }
+  }
+
+  return {
+    all: load,
+    async get(name) {
+      return (await load()).find((skill) => skill.name === name)
+    },
+    dirs() {
+      return []
+    },
+  }
+}

--- a/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
@@ -1,18 +1,17 @@
 import type { ToolDefinition } from "@opencode-ai/plugin"
-import type { SkillLoadOptions } from "../tools/skill/types"
 import type { AvailableCategory } from "../agents/dynamic-agent-prompt-builder"
 import type { OhMyOpenCodeConfig } from "../config"
 import type { Managers } from "../create-managers"
-import type { SkillContext } from "./skill-context"
-import type { PluginContext, ToolsRecord } from "./types"
-import type { ToolRegistryFactories } from "./tool-registry-factories"
-
 import { getMainSessionID } from "../features/claude-code-session-state"
 import * as openclawRuntimeDispatch from "../openclaw/runtime-dispatch"
 import { log } from "../shared"
-import { getSisyphusJuniorModelOverride } from "./tool-registry-team-tools"
-import { createSkillContext } from "./skill-context"
+import { createNativeSkills, getPluginInputNativeSkills } from "./native-skills"
 import { createRuntimeSkillsResolver, readRuntimeHostSkills } from "./runtime-skill-resolver"
+import type { SkillContext } from "./skill-context"
+import { createSkillContext } from "./skill-context"
+import type { ToolRegistryFactories } from "./tool-registry-factories"
+import { getSisyphusJuniorModelOverride } from "./tool-registry-team-tools"
+import type { PluginContext, ToolsRecord } from "./types"
 
 export function createCoreTools(args: {
   readonly ctx: PluginContext
@@ -35,6 +34,7 @@ export function createCoreTools(args: {
   const isMultimodalLookerEnabled = !(pluginConfig.disabled_agents ?? []).some(
     (agent) => agent.toLowerCase() === "multimodal-looker",
   )
+  const nativeSkills = getPluginInputNativeSkills(ctx) ?? createNativeSkills({ client: ctx.client, directory: ctx.directory })
   const delegateTask = factories.createDelegateTask({
     manager: managers.backgroundManager,
     client: ctx.client,
@@ -48,7 +48,7 @@ export function createCoreTools(args: {
     teamModeEnabled: pluginConfig.team_mode?.enabled ?? false,
     availableCategories,
     availableSkills: skillContext.availableSkills,
-    nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
+    nativeSkills,
     sisyphusAgentConfig: pluginConfig.sisyphus_agent,
     syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
     modelFallbackControllerAccessor: managers.modelFallbackControllerAccessor,
@@ -109,7 +109,7 @@ export function createCoreTools(args: {
     browserProvider: skillContext.browserProvider,
     disabledSkills: skillContext.disabledSkills,
     teamModeEnabled: pluginConfig.team_mode?.enabled ?? false,
-    nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
+    nativeSkills,
     pluginsEnabled: pluginConfig.claude_code?.plugins ?? true,
     enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
     includeSkillsInDescription: true,

--- a/packages/omo-opencode/src/tools/skill/native-routing.test.ts
+++ b/packages/omo-opencode/src/tools/skill/native-routing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, mock, test } from "bun:test"
+import type { ToolContext } from "@opencode-ai/plugin/tool"
+import type { LoadedSkill } from "../../features/opencode-skill-loader/types"
+import { createSkillTool } from "./tools"
+
+function createConfigSkill(name: string): LoadedSkill {
+  return {
+    name,
+    path: `/test/skills/${name}/SKILL.md`,
+    definition: {
+      name,
+      description: `Test skill ${name}`,
+      template: "Test template",
+    },
+    scope: "config",
+  }
+}
+
+const mockContext: ToolContext = {
+  sessionID: "test-session",
+  messageID: "msg-1",
+  agent: "test-agent",
+  directory: "/test",
+  worktree: "/test",
+  abort: new AbortController().signal,
+  metadata: () => {},
+  ask: async () => {},
+}
+
+describe("skill tool native routing", () => {
+  test("does not load native skills when a base skill matches", async () => {
+    //#given
+    const nativeAll = mock(() => [{
+      name: "native-only-skill",
+      description: "Native only skill",
+      location: "/external/skills/native-only-skill/SKILL.md",
+      content: "Native only skill body",
+    }])
+    const tool = createSkillTool({
+      directory: "/test",
+      skills: [createConfigSkill("base-skill")],
+      nativeSkills: {
+        all: nativeAll,
+        get() { return undefined },
+        dirs() { return [] },
+      },
+    })
+    nativeAll.mockClear()
+
+    //#when
+    const result = await tool.execute({ name: "base-skill" }, mockContext)
+
+    //#then
+    expect(result).toContain("base-skill")
+    expect(nativeAll).not.toHaveBeenCalled()
+  })
+})

--- a/packages/omo-opencode/src/tools/skill/tools.ts
+++ b/packages/omo-opencode/src/tools/skill/tools.ts
@@ -1,34 +1,33 @@
 import { dirname } from "node:path"
-import { tool, type ToolDefinition } from "@opencode-ai/plugin"
+import { type ToolDefinition, tool } from "@opencode-ai/plugin"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
-import { TOOL_DESCRIPTION_PREFIX } from "./constants"
-import { shouldInvalidateSkillCacheForSession } from "./session-skill-cache"
-import type { SkillArgs, SkillLoadOptions } from "./types"
 import type { LoadedSkill } from "../../features/opencode-skill-loader"
-import { clearSkillCache, getAllSkills } from "../../features/opencode-skill-loader/skill-content"
-import { injectGitMasterConfig } from "../../features/opencode-skill-loader/skill-content"
+import { clearSkillCache, getAllSkills, injectGitMasterConfig } from "../../features/opencode-skill-loader/skill-content"
 import * as commandDiscovery from "../slashcommand/command-discovery"
-import type { CommandInfo } from "../slashcommand/types"
 import { formatLoadedCommand } from "../slashcommand/command-output-formatter"
+import type { CommandInfo } from "../slashcommand/types"
+import { TOOL_DESCRIPTION_PREFIX } from "./constants"
 import { formatCombinedDescription } from "./description-formatter"
 import { formatMcpCapabilities } from "./mcp-capability-formatter"
-import {
-  findPartialMatches,
-  matchCommandByName,
-  matchSkillByName,
-} from "./skill-matcher"
-import { extractSkillBody } from "./skill-body"
 import {
   isPromiseLike,
   loadedSkillToInfo,
   mergeNativeSkillInfos,
   mergeNativeSkills,
 } from "./native-skills"
+import { shouldInvalidateSkillCacheForSession } from "./session-skill-cache"
+import { extractSkillBody } from "./skill-body"
+import {
+  findPartialMatches,
+  matchCommandByName,
+  matchSkillByName,
+} from "./skill-matcher"
+import type { SkillArgs, SkillLoadOptions } from "./types"
 
 export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
   let cachedDescription: string | null = null
 
-  const getSkills = async (context?: ToolContext): Promise<LoadedSkill[]> => {
+  const getBaseSkills = async (context?: ToolContext): Promise<LoadedSkill[]> => {
     if (shouldInvalidateSkillCacheForSession(context?.sessionID)) {
       clearSkillCache()
     }
@@ -39,17 +38,23 @@ export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
       teamModeEnabled: options?.teamModeEnabled,
       directory: options.directory,
     })) ?? []
-    const allSkills = options.skills ? [...options.skills] : discovered
+    return options.skills ? [...options.skills] : discovered
+  }
 
+  const mergeNativeSkillsInto = async (skills: LoadedSkill[]): Promise<void> => {
     if (options.nativeSkills) {
       try {
         const nativeAll = await options.nativeSkills.all()
-        mergeNativeSkills(allSkills, nativeAll, options.disabledSkills)
+        mergeNativeSkills(skills, nativeAll, options.disabledSkills)
       } catch (error) {
         if (!(error instanceof Error)) throw error
       }
     }
+  }
 
+  const getSkills = async (context?: ToolContext): Promise<LoadedSkill[]> => {
+    const allSkills = await getBaseSkills(context)
+    await mergeNativeSkillsInto(allSkills)
     return allSkills
   }
 
@@ -123,14 +128,20 @@ export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
         .describe("Optional arguments or context for command invocation. Example: name='publish', user_message='patch'"),
     },
     async execute(args: SkillArgs, ctx?: ToolContext) {
-      const skills = await getSkills(ctx)
+      const skills = await getBaseSkills(ctx)
       const commands = getCommands()
+
+      const requestedName = args.name.replace(/^\//, "")
+      let matchedSkill = matchSkillByName(skills, requestedName)
+
+      if (!matchedSkill && options.nativeSkills) {
+        await mergeNativeSkillsInto(skills)
+        matchedSkill = matchSkillByName(skills, requestedName)
+      }
+
       cachedDescription = formatCombinedDescription(skills.map(loadedSkillToInfo), commands, {
         includeSkills: options.includeSkillsInDescription,
       })
-
-      const requestedName = args.name.replace(/^\//, "")
-      const matchedSkill = matchSkillByName(skills, requestedName)
 
       if (matchedSkill) {
         await ctx?.ask({


### PR DESCRIPTION
## Summary

- Fixes an issue where oMo's `skill` tool could not load native skills injected by OpenCode, which prevented `customize-opencode` from being loaded.
- Normal oMo skills continue to prefer the base registry as before. The OpenCode native skill registry is consulted only when the base registry does not contain a matching skill.
- The Markdown body for `customize-opencode` is not bundled into oMo. It is retrieved through OpenCode's skill API.
- Since the current OpenCode plugin API does not expose the direct transport through public APIs, access to the generated client inside `ctx.client` is isolated in one place. The actual retrieval logic is routed through the v2 SDK call, `client.app.skills({ directory })`.

## Changes

- **OpenCode native skill accessor**
  - Added `packages/omo-opencode/src/plugin/native-skills.ts`, which implements an accessor for reading the OpenCode native skill list.
  - If OpenCode plugin input exposes `skills` directly in the future, that path is preferred. Otherwise, the accessor extracts the generated client from `ctx.client._client` and passes it to the v2 SDK wrapper.
  - Because `_client` is not a public API, all access to it is contained within this file.

- **Graceful degradation for the private SDK bridge**
  - If the generated client is unavailable, the v2 SDK call fails, or the response shape cannot be parsed, the accessor logs the issue and returns `[]`.
  - This means that even if an OpenCode internal change breaks the private bridge, the plugin as a whole and normal oMo skills will continue to work.
  - The impact is limited to native-only skills, such as `customize-opencode`, being treated as “not found.”

- **Tool registry wiring**
  - Updated `packages/omo-opencode/src/plugin/tool-registry-core-tools.ts` to create the `nativeSkills` accessor once and pass the same accessor to both the `task` tool and the `skill` tool.

- **Base-first skill routing**
  - Updated the resolution order in `execute()` in `packages/omo-opencode/src/tools/skill/tools.ts`.
  - The tool now first calls `matchSkillByName()` against only the existing base registry. Native skills are merged and matched only if the base registry misses.
  - This ensures existing oMo skills such as `git-master` are not affected by native skill retrieval.

- **Regression tests**
  - Added coverage in `packages/omo-opencode/src/plugin/native-skills.test.ts` for both the direct `ctx.skills` path and the v2 SDK bridge path.
  - Added coverage in `packages/omo-opencode/src/tools/skill/native-routing.test.ts` to ensure `nativeSkills.all()` is not called when a base skill matches.

## QA & Evidence

- **Automated checks:** Ran targeted `bun test` coverage for the native skill bridge, base-first routing, async description refresh, core tool registry wiring, and existing skill tool behavior.
  - Result: `41 pass, 0 fail`.

- **Static checks:** Ran Biome on changed TypeScript files, LSP diagnostics on changed TypeScript files, and `git diff --check`.
  - Result: Biome reported no fixes, LSP reported `No diagnostics found`, and `git diff --check` produced no output.

- **Build:** Ran `bun run build`.
  - Result: The build completed successfully and regenerated the schema artifact.

- **Manual runtime QA:** Tested the real local OpenCode runtime through the `skill` tool.
  - Result: `customize-opencode` loaded successfully and returned the OpenCode configuration customization skill content.
  - Result: `git-master` loaded successfully, confirming that existing base-registry skills are not forced through the native fallback path.

- **Evidence policy:** QA evidence was recorded locally according to the repository QA policy. It is not referenced by file path here because that evidence directory is gitignored and is not part of this PR diff.

## Risks & Residuals

- **Accepted:** `ctx.client._client` is not a public API, so this bridge may break if OpenCode changes its internals.
  - Mitigation: The `_client` access is isolated in `packages/omo-opencode/src/plugin/native-skills.ts`.
  - Mitigation: Missing generated client, SDK call failure, and parse failure all degrade to logging plus returning `[]`, so the plugin as a whole and normal oMo skills continue to work.
  - Residual impact: If the private bridge breaks, native-only skills will be treated as “not found.”

- **Mitigated:** External HTTP fetch against `ctx.serverUrl + /skill` does not work in a normal OpenCode startup.
  - Conclusion: This PR does not use an HTTP fallback. Instead, it passes the OpenCode SDK generated client's direct transport to the v2 SDK wrapper.

- **Mitigated:** Existing oMo skills could become slower or break if every `skill` call loaded native skills first.
  - Conclusion: `execute()` now performs the base registry match first and merges native skills only on a miss. This was also verified through runtime QA with `git-master` as the control case.

- **Not applicable:** Screenshots are not included because this change affects tool/runtime behavior, not UI rendering.

## Automated Checks

```bash
bun test packages/omo-opencode/src/tools/skill/native-routing.test.ts packages/omo-opencode/src/plugin/native-skills.test.ts packages/omo-opencode/src/tools/skill/async-description-refresh.test.ts packages/omo-opencode/src/plugin/tool-registry-core-tools.test.ts packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
bunx biome check packages/omo-opencode/src/plugin/native-skills.ts packages/omo-opencode/src/plugin/native-skills.test.ts packages/omo-opencode/src/plugin/tool-registry-core-tools.ts packages/omo-opencode/src/tools/skill/tools.ts packages/omo-opencode/src/tools/skill/native-routing.test.ts
git diff --check -- packages/omo-opencode/src/plugin/native-skills.ts packages/omo-opencode/src/plugin/native-skills.test.ts packages/omo-opencode/src/plugin/tool-registry-core-tools.ts packages/omo-opencode/src/tools/skill/tools.ts packages/omo-opencode/src/tools/skill/native-routing.test.ts
bun run build
```

Additional checks run outside shell command form:

- LSP diagnostics on all changed TypeScript files: `No diagnostics found`
- Real local OpenCode runtime QA for `customize-opencode`: loaded successfully
- Real local OpenCode runtime QA for `git-master`: loaded successfully

## Related Issues

Closes #5559

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the skill tool to load OpenCode native skills only when the base registry misses, restoring `customize-opencode` while keeping existing oMo skills like `git-master` unchanged. Native skills are fetched on demand via `@opencode-ai/sdk/v2` instead of bundling Markdown.

- **Bug Fixes**
  - On-demand loading: in `execute`, match base skills first; merge native skills only if no base match.
  - Native skills accessor: prefer `ctx.skills`; otherwise use `ctx.client._client` with `@opencode-ai/sdk/v2` to call `client.app.skills({ directory })`.
  - Graceful fallback: if the generated client is missing or the SDK call/parse fails, log and return `[]`.
  - Shared wiring: create the accessor once in the core tool registry and pass it to both `task` and `skill`.
  - Tests: coverage for direct `ctx.skills`, the SDK bridge, and a routing test ensuring `nativeSkills.all()` is not called when a base skill matches.

<sup>Written for commit 17e8dc2edb0aee968235e225425267f8744f54e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

