### PR TITLE
fix(release): resolve prepublish blockers

### DIFF
--- a/.omo/evidence/20260625-codex-config-generated-bundle/generated-bundle-false-shorthand-probe.txt
+++ b/.omo/evidence/20260625-codex-config-generated-bundle/generated-bundle-false-shorthand-probe.txt
@@ -20,4 +20,3 @@ source = "/repo/packages/omo-codex"
 
 [plugins."omo@debug"]
 enabled = true
-

--- a/.omo/evidence/20260627-atlas-background-output-gate/windows-ci-red-timeout.txt
+++ b/.omo/evidence/20260627-atlas-background-output-gate/windows-ci-red-timeout.txt
@@ -1,7 +1,7 @@
 5604-test (windows-latest)	Run tests	2026-06-27T17:18:56.5250643Z (pass) listUnreadMessages > returns FIFO messages while skipping malformed, processed, and dot files [62.00ms]
-5605-test (windows-latest)	Run tests	2026-06-27T17:18:56.5251275Z 
+5605-test (windows-latest)	Run tests	2026-06-27T17:18:56.5251275Z
 5606-test (windows-latest)	Run tests	2026-06-27T17:18:56.5251617Z ##[endgroup]
-5607-test (windows-latest)	Run tests	2026-06-27T17:18:56.5251729Z 
+5607-test (windows-latest)	Run tests	2026-06-27T17:18:56.5251729Z
 5608-test (windows-latest)	Run tests	2026-06-27T17:18:56.5252040Z ##[group]packages\team-core\src\team-mailbox\poll.test.ts:
 5609-test (windows-latest)	Run tests	2026-06-27T17:18:57.7852899Z (pass) pollAndBuildInjection > prevents duplicate injection in the same turn marker [1266.00ms]
 5610:test (windows-latest)	Run tests	2026-06-27T17:19:02.8051831Z (fail) pollAndBuildInjection > #given concurrent transforms for one turn #when mailbox injection is claimed #then only one call injects the peer message [5015.00ms]
@@ -10,19 +10,19 @@
 5613-test (windows-latest)	Run tests	2026-06-27T17:19:04.4646944Z (pass) pollAndBuildInjection > records pending ids without acking or moving files [579.00ms]
 5614-test (windows-latest)	Run tests	2026-06-27T17:19:04.6127736Z (pass) pollAndBuildInjection > does not re-inject a pending message on a later turn [140.00ms]
 5615-test (windows-latest)	Run tests	2026-06-27T17:19:04.8329436Z (pass) pollAndBuildInjection > injects only new unread messages when older unread messages are pending ack [219.00ms]
-5616-test (windows-latest)	Run tests	2026-06-27T17:19:04.8330011Z 
+5616-test (windows-latest)	Run tests	2026-06-27T17:19:04.8330011Z
 5617-test (windows-latest)	Run tests	2026-06-27T17:19:04.8330333Z ##[endgroup]
 --
 15362-test (windows-latest)	Run tests	2026-06-27T17:21:37.4746620Z (skip) sparkshell appserver routing > #given unresponsive appserver socket #when direct argv runs #then raw fallback is bounded
 15363-test (windows-latest)	Run tests	2026-06-27T17:21:37.4748844Z (skip) team-mode live tmux smoke > #given a real caller tmux session and two mock members #when createTeamLayout runs #then teammate panes appear in the caller window and cleanup leaves the session intact
 15364-test (windows-latest)	Run tests	2026-06-27T17:21:37.4751035Z (skip) spawnMonitoredProcess real subprocess smoke > #given printf emits two lines #when monitored #then stdout lines arrive and no process group remains
 15365-test (windows-latest)	Run tests	2026-06-27T17:21:37.4753683Z (skip) team-mode live tmux smoke > #given a real caller tmux session and two mock members #when createTeamLayout runs #then teammate panes appear in the caller window and cleanup leaves the session intact
-15366-test (windows-latest)	Run tests	2026-06-27T17:21:37.4754526Z 
-15367-test (windows-latest)	Run tests	2026-06-27T17:21:37.4754551Z 
+15366-test (windows-latest)	Run tests	2026-06-27T17:21:37.4754526Z
+15367-test (windows-latest)	Run tests	2026-06-27T17:21:37.4754551Z
 15368:test (windows-latest)	Run tests	2026-06-27T17:21:37.4754715Z 1 tests failed:
 15369:test (windows-latest)	Run tests	2026-06-27T17:21:37.4755660Z (fail) pollAndBuildInjection > #given concurrent transforms for one turn #when mailbox injection is claimed #then only one call injects the peer message [5015.00ms]
 15370:test (windows-latest)	Run tests	2026-06-27T17:21:37.4756404Z   ^ this test timed out after 5000ms.
-15371-test (windows-latest)	Run tests	2026-06-27T17:21:37.4756584Z 
+15371-test (windows-latest)	Run tests	2026-06-27T17:21:37.4756584Z
 15372-test (windows-latest)	Run tests	2026-06-27T17:21:37.4756667Z  10232 pass
 15373-test (windows-latest)	Run tests	2026-06-27T17:21:37.4756834Z  11 skip
 15374-test (windows-latest)	Run tests	2026-06-27T17:21:37.4763508Z  1 fail

--- a/docs/reference/web-terminal-visual-qa.md
+++ b/docs/reference/web-terminal-visual-qa.md
@@ -29,6 +29,8 @@ node script/qa/web-terminal-visual-qa.mjs \
   --redact-regex 'session_[A-Za-z0-9]+'
 ```
 
+Custom `--redact-regex` rules replace the full regex match, even when the expression contains capture groups. Prefix-preserving redaction is reserved for the built-in authorization and key-assignment rules.
+
 Do not rely on screenshots to hide secrets. If a capture might include cookies, auth headers, raw env dumps, launchd environments, provider keys, or browser storage, redact first or summarize the run instead of storing the transcript.
 
 ## Replay An Existing Capture

--- a/packages/omo-codex/plugin/components/start-work-continuation/directive.md
+++ b/packages/omo-codex/plugin/components/start-work-continuation/directive.md
@@ -38,11 +38,9 @@ You are mid-flight on a Prometheus work plan; this turn is an automatic continua
 - PR or branch implementation/review/merge work requires a task-owned git worktree. Treat the main worktree as read-only context.
 - session_ids you write to boulder.json MUST be prefixed `codex:`. Bare ids on read are legacy `opencode:`.
 
-# Global Review and Debugging Gate
+# Final gate
 
-Before completion, run `review-work` and a `debugging` runtime audit. Timeout, missing deliverable, ack-only, `BLOCKED:`, or inconclusive review lanes fail. Record three debugging hypotheses and the runtime evidence for each.
-
-Do not print `ORCHESTRATION COMPLETE`. Do not create a PR, PR handoff, branch handoff, merge, or final completion answer until this gate passes. For PR/branch work, stay in the task-owned worktree: create/update the PR, wait for CI/review/Cubic gates, merge by default unless explicitly opted out, then clean up. Redact secrets, tokens, credentials, auth headers, cookies, env dumps, private logs, and PII from ledgers, PR bodies, and handoffs.
+Before completion, run `review-work` and a `debugging` runtime audit; inconclusive lanes fail. Do not create a PR, PR handoff, branch handoff, merge, or final completion answer until this gate passes. For PR/branch work, stay in the task-owned worktree: create/update the PR, wait for CI/review/Cubic gates, merge by default unless explicitly opted out, then clean up. Redact secrets, tokens, credentials, auth headers, cookies, env dumps, logs, and PII.
 
 # Stop conditions for THIS turn
 

--- a/packages/omo-codex/plugin/components/ultrawork/directive.md
+++ b/packages/omo-codex/plugin/components/ultrawork/directive.md
@@ -77,11 +77,12 @@ printing the command, "should respond", and "looks correct" never
 count.
 
 For TUI visual QA, terminal transcripts alone are not enough when a
-visual surface is being evaluated. Capture the pane and render it with
+visual surface is being evaluated. In this repo, prefer
 `node script/qa/web-terminal-visual-qa.mjs --title "<surface>" --from-file <capture.txt> --evidence-dir <dir>`
-or use the helper's `--command` tmux-backed PTY connector when tmux is
-available. The evidence must include `terminal.png`, `terminal.txt`,
-`terminal.html`, and `metadata.json` with the cleanup receipt.
+or the helper's `--command` tmux-backed PTY connector when available.
+Outside this repo, capture equivalent browser/computer-use rendered
+terminal evidence: screenshot, plain transcript, rendered HTML or action
+log, and cleanup receipt.
 
 # Bootstrap (DO ALL FOUR BEFORE ANY OTHER WORK — NO SKIPPING)
 

--- a/packages/omo-codex/plugin/components/ultrawork/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/src/codex-hook.ts
@@ -91,7 +91,7 @@ function isContextPressureRecoveryPrompt(prompt: string): boolean {
 function isContextPressureTranscript(transcriptPath: string | null | undefined): boolean {
 	if (transcriptPath === undefined || transcriptPath === null) return false;
 	try {
-		return isContextPressureRecoveryPrompt(readFileSync(transcriptPath, "utf8"));
+		return isContextPressureRecoveryPrompt(readTranscriptTail(transcriptPath));
 	} catch (error) {
 		if (error instanceof Error) return false;
 		throw error;

--- a/packages/omo-codex/plugin/components/workflow-selector/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/workflow-selector/src/codex-hook.ts
@@ -87,6 +87,8 @@ export type CodexUserPromptSubmitInput = {
 	readonly transcript_path?: string | null;
 };
 
+type TranscriptReader = (transcriptPath: string) => string;
+
 interface UserPromptSubmitHookOutput {
 	readonly hookSpecificOutput: {
 		readonly hookEventName: "UserPromptSubmit";
@@ -94,13 +96,13 @@ interface UserPromptSubmitHookOutput {
 	};
 }
 
-export function runUserPromptSubmitHook(input: unknown): string {
+export function runUserPromptSubmitHook(input: unknown, transcriptReader: TranscriptReader = readTranscriptTail): string {
 	if (!isCodexUserPromptSubmitInput(input)) return "";
 	if (!isAutoWorkflowEnabled(env)) return "";
 	if (isContextPressureRecoveryPrompt(input.prompt)) return "";
-	if (hasAutoWorkflowContextAlreadyInTranscript(input.transcript_path))
+	if (hasAutoWorkflowContextAlreadyInTranscript(input.transcript_path, transcriptReader))
 		return "";
-	if (isContextPressureTranscript(input.transcript_path)) return "";
+	if (isContextPressureTranscript(input.transcript_path, transcriptReader)) return "";
 	const autoWorkflowContext = buildAutoWorkflowContext(input.prompt);
 	return autoWorkflowContext === null
 		? ""
@@ -145,10 +147,11 @@ function selectAutoWorkflow(prompt: string): string | null {
 
 function hasAutoWorkflowContextAlreadyInTranscript(
 	transcriptPath: string | null | undefined,
+	transcriptReader: TranscriptReader,
 ): boolean {
 	if (transcriptPath === undefined || transcriptPath === null) return false;
 	try {
-		const rawTranscript = readTranscriptTail(transcriptPath);
+		const rawTranscript = transcriptReader(transcriptPath);
 		for (const line of rawTranscript.split(/\r?\n/)) {
 			const parsed = parseJsonLine(line);
 			if (!isRecord(parsed)) continue;
@@ -187,10 +190,11 @@ function isContextPressureRecoveryPrompt(prompt: string): boolean {
 
 function isContextPressureTranscript(
 	transcriptPath: string | null | undefined,
+	transcriptReader: TranscriptReader,
 ): boolean {
 	if (transcriptPath === undefined || transcriptPath === null) return false;
 	try {
-		return isContextPressureRecoveryPrompt(readTranscriptTail(transcriptPath));
+		return isContextPressureRecoveryPrompt(transcriptReader(transcriptPath));
 	} catch (error) {
 		if (error instanceof Error) return false;
 		throw error;

--- a/packages/omo-codex/plugin/components/workflow-selector/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/workflow-selector/test/codex-hook.test.ts
@@ -1,4 +1,3 @@
-import * as fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -47,7 +46,9 @@ describe("codex workflow selector hook", () => {
 	it("#given auto workflow is disabled #when transcript path is present #then hook does not read transcript", () => {
 		// given
 		delete process.env["OMO_CODEX_AUTO_WORKFLOW"];
-		const readFileSync = vi.spyOn(fs, "readFileSync");
+		const transcriptReader = vi.fn(() => {
+			throw new Error("transcript should not be read");
+		});
 		const payload = {
 			hook_event_name: "UserPromptSubmit",
 			prompt: "Fix this flaky test and diagnose why CI is failing",
@@ -55,11 +56,11 @@ describe("codex workflow selector hook", () => {
 		};
 
 		// when
-		const output = runUserPromptSubmitHook(payload);
+		const output = runUserPromptSubmitHook(payload, transcriptReader);
 
 		// then
 		expect(output).toBe("");
-		expect(readFileSync).not.toHaveBeenCalled();
+		expect(transcriptReader).not.toHaveBeenCalled();
 	});
 
 	it("#given auto workflow is enabled #when prompt asks for debugging #then hook selects ulw-loop guidance", () => {

--- a/packages/omo-opencode/src/hooks/atlas/final-wave-approval-gate.test.ts
+++ b/packages/omo-opencode/src/hooks/atlas/final-wave-approval-gate.test.ts
@@ -225,6 +225,62 @@ session_id: ses_final_wave_review
 
   })
 
+  test("pauses for escalation when a final-wave reviewer rejects", async () => {
+    // given
+    const sessionID = "atlas-final-wave-session"
+
+    const planPath = join(testDirectory, "final-wave-reject-plan.md")
+    writeFileSync(
+      planPath,
+      `# Plan
+
+## TODOs
+- [x] 1. Ship the implementation
+
+## Final Verification Wave (MANDATORY - after ALL implementation tasks)
+- [x] F1. **Plan Compliance Audit** - \`oracle\`
+- [x] F2. **Code Quality Review** - \`unspecified-high\`
+- [ ] F3. **Real Manual QA** - \`unspecified-high\`
+- [ ] F4. **Scope Fidelity Check** - \`deep\`
+`,
+    )
+
+    const state: BoulderState = {
+      active_plan: planPath,
+      started_at: "2026-01-02T10:00:00Z",
+      session_ids: [sessionID],
+      plan_name: "final-wave-reject-plan",
+      agent: "atlas",
+    }
+    writeBoulderState(testDirectory, state)
+
+    const mockInput = createMockPluginInput()
+    const hook = createAtlasHook(mockInput, { directory: testDirectory, isCallerOrchestrator: async () => true })
+    const toolOutput = {
+      title: "Sisyphus Task",
+      output: `Manual QA could not verify the shipped behavior.
+
+Tasks [3/4 compliant] | Contamination [CLEAN] | Unaccounted [CLEAN] | VERDICT: REJECT
+
+<task_metadata>
+session_id: ses_final_wave_review
+</task_metadata>`,
+      metadata: {},
+    }
+
+    // when
+    await hook["tool.execute.after"]({ tool: "task", sessionID }, toolOutput)
+    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+
+    // then
+    expect(toolOutput.output).toContain("FINAL REVIEW REJECTED")
+    expect(toolOutput.output).toContain("Boulder paused")
+    expect(toolOutput.output).toContain("VERDICT: REJECT")
+    expect(toolOutput.output).not.toContain("COMPLETION GATE")
+    expect(toolOutput.output).not.toContain("STEP 8")
+    expect(mockInput._promptMock).not.toHaveBeenCalled()
+  })
+
   test("keeps normal auto-continue instructions for non-final tasks", async () => {
     // given
     const sessionID = "atlas-non-final-session"

--- a/packages/omo-opencode/src/hooks/atlas/subagent-completion-reminder.ts
+++ b/packages/omo-opencode/src/hooks/atlas/subagent-completion-reminder.ts
@@ -1,0 +1,147 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { classifyFinalWaveVerdict, shouldPauseForFinalWaveApproval } from "./final-wave-approval-gate"
+import { readFinalWavePlanState } from "./final-wave-plan-state"
+import type { SessionState } from "./types"
+import {
+  buildAdvanceDirective,
+  buildCompletionGate,
+  buildFinalWaveApprovalReminder,
+  buildMissingVerdictEscalation,
+  buildOrchestratorReminder,
+  buildRejectedVerdictEscalation,
+} from "./verification-reminders"
+
+type CurrentTask = {
+  readonly key: string
+  readonly label: string
+} | null
+
+type ReminderDecision = {
+  readonly leadReminder: string
+  readonly followupReminder: string | null
+  readonly isFinalWaveTask: boolean
+  readonly isMissingFinalWaveVerdict: boolean
+  readonly isRejectedFinalWaveVerdict: boolean
+  readonly shouldPauseForApproval: boolean
+}
+
+export async function buildSubagentCompletionReminder(input: {
+  readonly ctx: PluginInput
+  readonly planPath: string
+  readonly planName: string
+  readonly progress: { readonly total: number; readonly completed: number }
+  readonly preferredSessionId: string
+  readonly originalResponse: string
+  readonly currentTask: CurrentTask
+  readonly sessionState: SessionState | undefined
+  readonly isAlreadyVerified: boolean
+  readonly autoCommit: boolean
+}): Promise<ReminderDecision> {
+  const shouldPauseForApproval = input.sessionState
+    ? shouldPauseForFinalWaveApproval({
+        planPath: input.planPath,
+        taskOutput: input.originalResponse,
+        sessionState: input.sessionState,
+      })
+    : false
+
+  const finalWavePlanState = readFinalWavePlanState(input.planPath)
+  const isFinalWaveTask = input.currentTask?.key.startsWith("final-wave:") === true
+    || ((finalWavePlanState?.pendingImplementationTaskCount ?? 1) === 0
+      && (finalWavePlanState?.pendingFinalWaveTaskCount ?? 0) > 0)
+  const finalWaveVerdict = isFinalWaveTask
+    ? classifyFinalWaveVerdict(input.originalResponse)
+    : "missing"
+  const isMissingFinalWaveVerdict = isFinalWaveTask && finalWaveVerdict === "missing"
+  const isRejectedFinalWaveVerdict = isFinalWaveTask && finalWaveVerdict === "reject"
+  const shouldPause = shouldPauseForApproval || isMissingFinalWaveVerdict || isRejectedFinalWaveVerdict
+
+  if (input.sessionState) {
+    input.sessionState.waitingForFinalWaveApproval = shouldPause
+    if (shouldPause && input.sessionState.pendingRetryTimer) {
+      clearTimeout(input.sessionState.pendingRetryTimer)
+      input.sessionState.pendingRetryTimer = undefined
+    }
+  }
+
+  if (isMissingFinalWaveVerdict) {
+    await showFinalWaveToast(input.ctx, "Final review incomplete", "A reviewer returned no clear verdict. Boulder paused - confirm or re-run the review.")
+    return {
+      leadReminder: buildMissingVerdictEscalation(
+        input.planName,
+        input.currentTask?.label ?? "the final-wave task",
+        input.preferredSessionId,
+      ),
+      followupReminder: null,
+      isFinalWaveTask,
+      isMissingFinalWaveVerdict,
+      isRejectedFinalWaveVerdict,
+      shouldPauseForApproval,
+    }
+  }
+
+  if (isRejectedFinalWaveVerdict) {
+    await showFinalWaveToast(input.ctx, "Final review rejected", "A reviewer returned VERDICT: REJECT. Boulder paused - fix or ask the user how to proceed.")
+    return {
+      leadReminder: buildRejectedVerdictEscalation(
+        input.planName,
+        input.currentTask?.label ?? "the final-wave task",
+        input.preferredSessionId,
+      ),
+      followupReminder: null,
+      isFinalWaveTask,
+      isMissingFinalWaveVerdict,
+      isRejectedFinalWaveVerdict,
+      shouldPauseForApproval,
+    }
+  }
+
+  if (shouldPauseForApproval) {
+    return {
+      leadReminder: buildFinalWaveApprovalReminder(input.planName, input.progress, input.preferredSessionId),
+      followupReminder: null,
+      isFinalWaveTask,
+      isMissingFinalWaveVerdict,
+      isRejectedFinalWaveVerdict,
+      shouldPauseForApproval,
+    }
+  }
+
+  if (input.isAlreadyVerified) {
+    return {
+      leadReminder: buildAdvanceDirective(input.planName),
+      followupReminder: null,
+      isFinalWaveTask,
+      isMissingFinalWaveVerdict,
+      isRejectedFinalWaveVerdict,
+      shouldPauseForApproval,
+    }
+  }
+
+  if (input.currentTask && input.sessionState && !isFinalWaveTask) {
+    input.sessionState.verifiedTaskKeys ??= new Set<string>()
+    input.sessionState.verifiedTaskKeys.add(input.currentTask.key)
+  }
+
+  return {
+    leadReminder: buildCompletionGate(input.planName, input.preferredSessionId),
+    followupReminder: buildOrchestratorReminder(input.planName, input.progress, input.preferredSessionId, input.autoCommit, false),
+    isFinalWaveTask,
+    isMissingFinalWaveVerdict,
+    isRejectedFinalWaveVerdict,
+    shouldPauseForApproval,
+  }
+}
+
+async function showFinalWaveToast(ctx: PluginInput, title: string, message: string): Promise<void> {
+  await ctx.client.tui
+    .showToast({
+      body: {
+        title,
+        message,
+        variant: "warning" as const,
+        duration: 10000,
+      },
+    })
+    .catch(() => {})
+}

--- a/packages/omo-opencode/src/hooks/atlas/tool-execute-after-subagent-completion.ts
+++ b/packages/omo-opencode/src/hooks/atlas/tool-execute-after-subagent-completion.ts
@@ -13,21 +13,13 @@ import {
 import { collectGitDiffStats, formatFileChanges } from "../../shared/git-worktree"
 import { log } from "../../shared/logger"
 import { syncBackgroundLaunchSessionTracking } from "./background-launch-session-tracking"
-import { classifyFinalWaveVerdict, shouldPauseForFinalWaveApproval } from "./final-wave-approval-gate"
-import { readFinalWavePlanState } from "./final-wave-plan-state"
 import { HOOK_NAME } from "./hook-name"
+import { buildSubagentCompletionReminder } from "./subagent-completion-reminder"
 import { extractSessionIdFromOutput, validateSubagentSessionId } from "./subagent-session-id"
 import { resolvePreferredSessionId, resolveTaskContext } from "./task-context"
 import { isTrackedTaskChecked } from "./tool-execute-after-plan-tasks"
 import type { PendingTaskRef, SessionState, ToolExecuteAfterInput, ToolExecuteAfterOutput } from "./types"
-import {
-  buildAdvanceDirective,
-  buildCompletionGate,
-  buildFinalWaveApprovalReminder,
-  buildMissingVerdictEscalation,
-  buildOrchestratorReminder,
-  buildStandaloneVerificationReminder,
-} from "./verification-reminders"
+import { buildStandaloneVerificationReminder } from "./verification-reminders"
 
 function isBackgroundLaunchOutput(output: string): boolean {
   return output.includes("Background task launched") || output.includes("Background task continued")
@@ -179,85 +171,32 @@ export async function handleSubagentCompletionAfter(input: {
   )
 
   const originalResponse = toolOutput.output
-  const shouldPauseForApproval = sessionState
-    ? shouldPauseForFinalWaveApproval({
-        planPath,
-        taskOutput: originalResponse,
-        sessionState,
-      })
-    : false
-
-  const finalWavePlanState = readFinalWavePlanState(planPath)
-  const isFinalWaveTask = currentTask?.key.startsWith("final-wave:") === true
-    || ((finalWavePlanState?.pendingImplementationTaskCount ?? 1) === 0
-      && (finalWavePlanState?.pendingFinalWaveTaskCount ?? 0) > 0)
-  const isMissingFinalWaveVerdict = isFinalWaveTask
-    && classifyFinalWaveVerdict(originalResponse) === "missing"
-
   if (sessionState) {
     if (sessionState.activeContinuationPlanPath !== undefined
       && sessionState.activeContinuationPlanPath !== planPath) {
       sessionState.verifiedTaskKeys = undefined
     }
-
-    sessionState.waitingForFinalWaveApproval = shouldPauseForApproval || isMissingFinalWaveVerdict
-
-    if ((shouldPauseForApproval || isMissingFinalWaveVerdict) && sessionState.pendingRetryTimer) {
-      clearTimeout(sessionState.pendingRetryTimer)
-      sessionState.pendingRetryTimer = undefined
-    }
   }
-
-  const isAlreadyVerified = currentTask && !isFinalWaveTask
+  const isAlreadyVerified = currentTask
     ? isTrackedTaskChecked(planPath, currentTask.key)
       || sessionState?.verifiedTaskKeys?.has(currentTask.key) === true
     : false
-
-  let leadReminder: string
-  let followupReminder: string | null
-  if (isMissingFinalWaveVerdict) {
-    await ctx.client.tui
-      .showToast({
-        body: {
-          title: "Final review incomplete",
-          message: "A reviewer returned no clear verdict. Boulder paused - confirm or re-run the review.",
-          variant: "warning" as const,
-          duration: 10000,
-        },
-      })
-      .catch(() => {})
-    leadReminder = buildMissingVerdictEscalation(
-      workScopedBoulderState.plan_name,
-      currentTask?.label ?? "the final-wave task",
-      preferredSessionId,
-    )
-    followupReminder = null
-  } else if (shouldPauseForApproval) {
-    leadReminder = buildFinalWaveApprovalReminder(workScopedBoulderState.plan_name, progress, preferredSessionId)
-    followupReminder = null
-  } else if (isAlreadyVerified) {
-    leadReminder = buildAdvanceDirective(workScopedBoulderState.plan_name)
-    followupReminder = null
-  } else {
-    if (currentTask && sessionState && !isFinalWaveTask) {
-      if (!sessionState.verifiedTaskKeys) {
-        sessionState.verifiedTaskKeys = new Set<string>()
-      }
-      sessionState.verifiedTaskKeys.add(currentTask.key)
-    }
-    leadReminder = buildCompletionGate(workScopedBoulderState.plan_name, preferredSessionId)
-    followupReminder = buildOrchestratorReminder(
-      workScopedBoulderState.plan_name,
-      progress,
-      preferredSessionId,
-      autoCommit,
-      false,
-    )
-  }
+  const reminderDecision = await buildSubagentCompletionReminder({
+    ctx,
+    planPath,
+    planName: workScopedBoulderState.plan_name,
+    progress,
+    preferredSessionId,
+    originalResponse,
+    currentTask,
+    sessionState,
+    isAlreadyVerified,
+    autoCommit,
+  })
 
   toolOutput.output = `
 <system-reminder>
-${leadReminder}
+${reminderDecision.leadReminder}
 </system-reminder>
 
 ## SUBAGENT WORK COMPLETED
@@ -271,17 +210,18 @@ ${fileChanges}
 ${originalResponse}
 
 ${
-  followupReminder === null
+  reminderDecision.followupReminder === null
     ? ""
-    : `<system-reminder>\n${followupReminder}\n</system-reminder>`
+    : `<system-reminder>\n${reminderDecision.followupReminder}\n</system-reminder>`
 }`
   log(`[${HOOK_NAME}] Output transformed for orchestrator mode (boulder)`, {
     plan: workScopedBoulderState.plan_name,
     progress: `${progress.completed}/${progress.total}`,
     fileCount: gitStats.length,
     preferredSessionId,
-    waitingForFinalWaveApproval: shouldPauseForApproval || isMissingFinalWaveVerdict,
-    isMissingFinalWaveVerdict,
+    waitingForFinalWaveApproval: sessionState?.waitingForFinalWaveApproval === true,
+    isMissingFinalWaveVerdict: reminderDecision.isMissingFinalWaveVerdict,
+    isRejectedFinalWaveVerdict: reminderDecision.isRejectedFinalWaveVerdict,
     isAlreadyVerified,
   })
 }

--- a/packages/omo-opencode/src/hooks/atlas/verification-reminders.ts
+++ b/packages/omo-opencode/src/hooks/atlas/verification-reminders.ts
@@ -209,6 +209,20 @@ The boulder has paused. Please either:
 Do NOT auto-continue until you have a clear verdict.`
 }
 
+export function buildRejectedVerdictEscalation(planName: string, taskLabel: string, sessionId: string): string {
+  return `
+**FINAL REVIEW REJECTED - BOULDER PAUSED**
+
+A reviewer for task \`${taskLabel}\` in plan \`${planName}\` returned VERDICT: REJECT. Boulder paused.
+
+The boulder has paused. Please either:
+1. Delegate the required fix: \`task(task_id="${sessionId}", prompt="Fix the final review rejection and preserve the reviewer evidence")\`
+2. Ask the user how to proceed if the rejection requires a product or scope decision
+3. Re-run the affected final-wave reviewer after fixes
+
+Do NOT mark any final-wave checkbox complete and do NOT auto-continue until the rejection is resolved.`
+}
+
 export function buildAdvanceDirective(planName: string): string {
   return `
 **TASK ALREADY COMPLETE - ADVANCE TO NEXT**

--- a/packages/prompts-core/prompts/ultrawork/codex.md
+++ b/packages/prompts-core/prompts/ultrawork/codex.md
@@ -77,11 +77,12 @@ printing the command, "should respond", and "looks correct" never
 count.
 
 For TUI visual QA, terminal transcripts alone are not enough when a
-visual surface is being evaluated. Capture the pane and render it with
+visual surface is being evaluated. In this repo, prefer
 `node script/qa/web-terminal-visual-qa.mjs --title "<surface>" --from-file <capture.txt> --evidence-dir <dir>`
-or use the helper's `--command` tmux-backed PTY connector when tmux is
-available. The evidence must include `terminal.png`, `terminal.txt`,
-`terminal.html`, and `metadata.json` with the cleanup receipt.
+or the helper's `--command` tmux-backed PTY connector when available.
+Outside this repo, capture equivalent browser/computer-use rendered
+terminal evidence: screenshot, plain transcript, rendered HTML or action
+log, and cleanup receipt.
 
 # Bootstrap (DO ALL FOUR BEFORE ANY OTHER WORK — NO SKIPPING)
 

--- a/packages/team-core/src/team-state-store/locks.test.ts
+++ b/packages/team-core/src/team-state-store/locks.test.ts
@@ -131,6 +131,30 @@ test("lock open treats EPERM access probes as possible contention", async () => 
   await rm(rootDirectory, { recursive: true, force: true })
 })
 
+test("lock open treats Windows EPERM with an existing parent as possible contention", async () => {
+  // given
+  const { assertRetryableLockOpenError } = await import("./locks")
+  const rootDirectory = await createTempDirectory("locks-eperm-win-parent-")
+  const lockPath = join(rootDirectory, "lock")
+  const accessCalls: string[] = []
+
+  // when
+  const result = assertRetryableLockOpenError(lockPath, createErrnoError("EPERM"), {
+    platform: "win32",
+    access: async (path: PathLike) => {
+      accessCalls.push(String(path))
+      if (String(path) === lockPath) {
+        throw createErrnoError("ENOENT")
+      }
+    },
+  })
+
+  // then
+  await expect(result).resolves.toBeUndefined()
+  expect(accessCalls).toEqual([lockPath, rootDirectory])
+  await rm(rootDirectory, { recursive: true, force: true })
+})
+
 test("lock open rethrows EPERM when the lock path does not exist", async () => {
   // given
   const { assertRetryableLockOpenError } = await import("./locks")
@@ -138,7 +162,21 @@ test("lock open rethrows EPERM when the lock path does not exist", async () => {
   const lockPath = join(rootDirectory, "lock")
 
   // when
-  const result = assertRetryableLockOpenError(lockPath, createErrnoError("EPERM"))
+  const result = assertRetryableLockOpenError(lockPath, createErrnoError("EPERM"), { platform: "linux" })
+
+  // then
+  await expect(result).rejects.toThrow("EPERM")
+  await rm(rootDirectory, { recursive: true, force: true })
+})
+
+test("lock open rethrows Windows EPERM when the lock parent does not exist", async () => {
+  // given
+  const { assertRetryableLockOpenError } = await import("./locks")
+  const rootDirectory = await createTempDirectory("locks-eperm-win-missing-")
+  const lockPath = join(rootDirectory, "missing", "lock")
+
+  // when
+  const result = assertRetryableLockOpenError(lockPath, createErrnoError("EPERM"), { platform: "win32" })
 
   // then
   await expect(result).rejects.toThrow("EPERM")

--- a/packages/team-core/src/team-state-store/locks.ts
+++ b/packages/team-core/src/team-state-store/locks.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto"
 import { access, open, readFile, rename, rm, unlink } from "node:fs/promises"
+import { dirname } from "node:path"
 
 import { tolerantFsync } from "../tolerant-fsync"
 
@@ -16,6 +17,7 @@ type AtomicWriteDeps = {
 
 type LockOpenErrorDeps = {
   readonly access?: typeof access
+  readonly platform?: NodeJS.Platform
 }
 
 type LockReleaseDeps = {
@@ -83,7 +85,10 @@ export async function assertRetryableLockOpenError(
 ): Promise<void> {
   const code = errorCode(error)
   if (code === "EEXIST") return
-  if (code === "EPERM" && (await pathMayExist(lockPath, deps))) return
+  if (code === "EPERM") {
+    if (await pathMayExist(lockPath, deps)) return
+    if ((deps?.platform ?? process.platform) === "win32" && (await pathMayExist(dirname(lockPath), deps))) return
+  }
   throw error
 }
 

--- a/script/qa/web-terminal-redaction.mjs
+++ b/script/qa/web-terminal-redaction.mjs
@@ -1,4 +1,4 @@
-const BUILT_IN_REDACTION_RULES = [
+const BUILT_IN_REDACTION_REGEXES = [
   /((?:authorization|proxy-authorization):\s*(?:bearer|basic)\s+)[^\s"'<>]+/gi,
   /\b((?:api[_-]?key|token|password|secret|access[_-]?token|refresh[_-]?token)=)[^\s"'<>]+/gi,
   /\b(?:gh[pousr]_[A-Za-z0-9_]{20,})\b/g,
@@ -6,19 +6,24 @@ const BUILT_IN_REDACTION_RULES = [
   /\b(?:sk-[A-Za-z0-9_-]{20,})\b/g,
 ];
 
-export const BUILT_IN_REDACTION_RULE_COUNT = BUILT_IN_REDACTION_RULES.length;
+export const BUILT_IN_REDACTION_RULE_COUNT = BUILT_IN_REDACTION_REGEXES.length;
 
 function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function compileRedactions({ redactions, redactRegexes }) {
-  const rules = [...BUILT_IN_REDACTION_RULES];
+  const rules = BUILT_IN_REDACTION_REGEXES.map((regex) => ({
+    regex,
+    preservePrefix: true,
+  }));
   for (const literal of redactions) {
-    if (literal.length > 0) rules.push(new RegExp(escapeRegex(literal), "g"));
+    if (literal.length > 0) {
+      rules.push({ regex: new RegExp(escapeRegex(literal), "g"), preservePrefix: false });
+    }
   }
   for (const source of redactRegexes) {
-    rules.push(new RegExp(source, "g"));
+    rules.push({ regex: new RegExp(source, "g"), preservePrefix: false });
   }
   return rules;
 }
@@ -26,8 +31,8 @@ export function compileRedactions({ redactions, redactRegexes }) {
 export function redactEvidence(text, rules) {
   return rules.reduce(
     (current, rule) =>
-      current.replace(rule, (match, prefix) =>
-        typeof prefix === "string" ? `${prefix}[REDACTED]` : "[REDACTED]",
+      current.replace(rule.regex, (match, prefix) =>
+        rule.preservePrefix && typeof prefix === "string" ? `${prefix}[REDACTED]` : "[REDACTED]",
       ),
     text,
   );

--- a/script/web-terminal-visual-qa.test.ts
+++ b/script/web-terminal-visual-qa.test.ts
@@ -87,6 +87,7 @@ describe("web terminal visual QA helper", () => {
   test("#given secret-bearing terminal output #when rendering #then text ansi html and metadata are redacted", async () => {
     // given
     const literalSecret = "local-secret-value"
+    const customCapturingSecret = "cap-secret-12345"
     const rendered = await renderTranscript(
       "secret-capture.txt",
       "Secret QA",
@@ -94,9 +95,10 @@ describe("web terminal visual QA helper", () => {
         "Authorization: Bearer ghp_1234567890abcdefghijklmnop",
         "OPENAI_API_KEY=sk-1234567890abcdefghijklmnop",
         `custom=${literalSecret}`,
+        `capturing=${customCapturingSecret}`,
         "session_id=sess_live_12345",
       ].join("\n"),
-      ["--redact", literalSecret, "--redact-regex", "sess_live_[0-9]+"],
+      ["--redact", literalSecret, "--redact-regex", "(cap-secret-)([0-9]+)", "--redact-regex", "sess_live_[0-9]+"],
     )
 
     // then
@@ -104,13 +106,15 @@ describe("web terminal visual QA helper", () => {
     expect(combinedArtifacts).not.toContain("ghp_1234567890abcdefghijklmnop")
     expect(combinedArtifacts).not.toContain("sk-1234567890abcdefghijklmnop")
     expect(combinedArtifacts).not.toContain(literalSecret)
+    expect(combinedArtifacts).not.toContain(customCapturingSecret)
+    expect(combinedArtifacts).not.toContain("cap-secret-")
     expect(combinedArtifacts).not.toContain("sess_live_12345")
     expect(combinedArtifacts).toContain("[REDACTED]")
     expect(rendered.metadata()).toMatchObject({
       redaction: {
         builtInRules: 5,
         literalRules: 1,
-        regexRules: 1,
+        regexRules: 2,
       },
     })
   })


### PR DESCRIPTION
## Summary

This PR resolves the release-blocking issues found by the 2026-06-28 pre-publish review. It fixes the custom redaction leak, removes a repo-local hard requirement from the Codex ultrawork prompt, repairs brittle Codex component tests, trims the start-work continuation directive back to budget, makes Atlas pause on final-wave `VERDICT: REJECT`, clears whitespace blockers in release evidence files, and fixes the Windows lock-create `EPERM` race exposed by PR CI.

## Changes

- Redaction helper now treats custom `--redact-regex` rules as full-match redactions even when they contain capture groups; built-in auth/key rules keep prefix-preserving behavior.
- Codex ultrawork guidance now prefers the repo helper when present and allows equivalent rendered terminal evidence outside this repo; prompts-core and bundled component directive remain byte-equal.
- Workflow selector tests no longer spy on immutable Node ESM `fs`, and ultrawork context-pressure detection reads only the bounded transcript tail.
- Start-work continuation directive is trimmed to the 1100-word budget while preserving tested required markers.
- Atlas final-wave rejection handling now pauses with explicit escalation guidance and avoids completion-gate/auto-continue reminders.
- Release evidence whitespace failures from `git diff --check v4.13.0..HEAD` are cleaned up.
- Team-core lock acquisition now retries Windows `EPERM` when the lock parent still exists, while preserving missing-parent and non-Windows missing-lock rethrows.

## QA & Evidence

- `git diff --check v4.13.0..HEAD`
  - Observed: exit 0 after the fix and after the final amend.
  - Artifacts: `.omo/evidence/20260628-prepublish-blockers/green-git-diff-check.txt`, `.omo/evidence/20260628-prepublish-blockers/green-git-diff-check-after-amend.txt`

- `bun test script/web-terminal-visual-qa.test.ts script/web-terminal-guidance.test.ts`
  - Observed: 11 pass, 0 fail; regression covers a capturing custom regex and confirms no captured secret survives in text/ANSI/HTML/metadata.
  - Artifact: `.omo/evidence/20260628-prepublish-blockers/green-web-terminal-tests-post-review.txt`

- `npm --prefix packages/omo-codex/plugin/components/workflow-selector test`
  - Observed: 2 files passed, 14 tests passed.
  - Artifact: `.omo/evidence/20260628-prepublish-blockers/green-workflow-selector-test-post-review.txt`

- `npm --prefix packages/omo-codex/plugin/components/start-work-continuation test`
  - Observed: 3 files passed, 30 tests passed.
  - Artifact: `.omo/evidence/20260628-prepublish-blockers/green-start-work-continuation-npm-test-post-review.txt`

- `npm --prefix packages/omo-codex/plugin/components/ultrawork test -- test/codex-hook.test.ts test/directive-source.test.ts`
  - Observed: 2 files passed, 14 tests passed; directive source equality remains covered.
  - Artifact: `.omo/evidence/20260628-prepublish-blockers/green-ultrawork-npm-tests-post-review.txt`

- `bun test packages/omo-opencode/src/hooks/atlas/final-wave-approval-gate.test.ts`
  - Observed: 11 pass, 0 fail; reject output contains escalation guidance and omits `COMPLETION GATE` / `STEP 8`.
  - Artifact: `.omo/evidence/20260628-prepublish-blockers/green-atlas-final-wave-test-post-review.txt`

- `bun run test:codex`
  - Observed: 421 pass, 0 fail.
  - Artifact: `.omo/evidence/20260628-prepublish-blockers/green-test-codex-post-review.txt`

- Windows CI lock failure follow-up
  - Observed RED: PR #5655 `test (windows-latest)` failed on `withLock serializes concurrent work` with `EPERM: operation not permitted, open ... locks-serialize-.../lock`.
  - Observed GREEN: `bun test packages/team-core/src/team-state-store/locks.test.ts` has 10 pass; `bun test packages/omo-opencode/src/features/team-mode/team-state-store/locks.test.ts` has 4 pass; `bun run typecheck` passed; `git diff --check v4.13.0..HEAD` passed.
  - Artifacts: `.omo/evidence/20260628-prepublish-blockers/red-ci-windows-test-failure-pr5655.txt`, `.omo/evidence/20260628-prepublish-blockers/green-team-core-locks-test.txt`, `.omo/evidence/20260628-prepublish-blockers/green-opencode-team-mode-locks-test.txt`, `.omo/evidence/20260628-prepublish-blockers/green-typecheck-after-windows-lock-fix.txt`, `.omo/evidence/20260628-prepublish-blockers/green-git-diff-check-after-windows-lock-fix.txt`

- Codex QA skill local fallback
  - Commands: `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check`; `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin`
  - Observed: isolated `CODEX_HOME`; real `~/.codex/config.toml` unchanged; app-server plugin run emitted `hook/started` and `hook/completed` notifications for `sessionStart`, `userPromptSubmit`, and `stop`.
  - Artifacts: `.omo/evidence/20260628-prepublish-blockers/green-codex-qa-common-self-check-post-review.txt`, `.omo/evidence/20260628-prepublish-blockers/green-codex-qa-app-server-drive-plugin-post-review.txt`

- OpenCode QA skill local fallback
  - Commands: `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check`; `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test`
  - Observed: isolated XDG sandbox; SSE `/event` delivered `server.connected`.
  - Artifacts: `.omo/evidence/20260628-prepublish-blockers/green-opencode-qa-common-self-check-post-review.txt`, `.omo/evidence/20260628-prepublish-blockers/green-opencode-qa-sse-self-test-post-review.txt`

## Risks & Residuals

- Native Windows Codex Desktop install evidence remains a release-level residual from the broader pre-publish review. This PR fixes the code/test/evidence blockers that were actionable locally.
- Literal root `bun test packages/omo-codex/plugin/components/...` paths are still blocked by root `bunfig.toml` ignores, so component-local Vitest and package-local Bun/Vitest evidence is used for those files.



## Verification Loop Update

- CI gate: current checks pass across macOS, Ubuntu, and Windows, including typecheck, tests, Codex compatibility, build, lazycodex published smoke, CLA, labels, and GitGuardian.
- review-work gate: rerun with five Codex lanes. QA, code quality, security, and context mining passed; the initial goal-verification failure was a stale evidence-summary note and is superseded by `.omo/evidence/20260628-prepublish-blockers/review-work-pr5655.md` plus `.omo/evidence/pr-5655-code-review.md`.
- Manual QA refresh: `.omo/evidence/20260628-prepublish-blockers/manual-qa-pr5655-20260628/` contains scenarios 00-08, including unchanged real `~/.codex/config.toml` hash and unchanged real OpenCode DB session count.
- Cubic gate: GitHub check is neutral and no Cubic PR review/comment with issues was posted, so it is recorded as skipped/neutral per work-with-pr bounded-skip policy.
