### PR TITLE
fix(lcx-doctor): use ${TMPDIR:-/tmp} and correct obsolete hooks/hooks.json wiring check

### DIFF
--- a/packages/shared-skills/lcx-doctor-skill-contract.test.ts
+++ b/packages/shared-skills/lcx-doctor-skill-contract.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+const skillPath = new URL("./skills/lcx-doctor/SKILL.md", import.meta.url);
+
+describe("lcx-doctor SKILL.md contract", () => {
+	test("#given lcx-doctor skill #when checked for temp path handling #then uses TMPDIR variable not hardcoded /tmp", async () => {
+		const text = await Bun.file(skillPath).text();
+
+		// Must use TMPDIR-aware pattern so the skill works when TMPDIR differs from /tmp
+		expect(text).toContain("${TMPDIR:-/tmp}");
+
+		// Must NOT hard-code bare /tmp as the sync destination root
+		expect(text).not.toMatch(/sync_latest_source [^\n]+ \/tmp\//);
+	});
+
+	test("#given lcx-doctor skill #when checking plugin payload wiring #then does not expect obsolete hooks/hooks.json aggregate file", async () => {
+		const text = await Bun.file(skillPath).text();
+
+		// The aggregate manifest enumerates individual hook JSON files in the hooks array.
+		// Checking for a single hooks/hooks.json is an obsolete expectation that produces
+		// false-negative FAIL verdicts even on correct installs.
+		expect(text).not.toMatch(/`hooks\/hooks\.json`[^`]*plugin payload/);
+		// The wiring check section must not mention hooks/hooks.json as the expected payload artifact
+		const wiringSection = text.slice(
+			text.indexOf("Plugin payload present"),
+			text.indexOf("Plugin payload present") + 200,
+		);
+		expect(wiringSection).not.toContain("hooks/hooks.json");
+	});
+
+	test("#given lcx-doctor skill #when instructed on source sync #then temp root variable is assigned before use", async () => {
+		const text = await Bun.file(skillPath).text();
+
+		// The skill must define SOURCE_ROOT (or equivalent) from TMPDIR before calling sync_latest_source
+		expect(text).toMatch(/SOURCE_ROOT\s*=\s*"\$\{TMPDIR/);
+	});
+});

--- a/packages/shared-skills/skills/lcx-doctor/SKILL.md
+++ b/packages/shared-skills/skills/lcx-doctor/SKILL.md
@@ -7,13 +7,13 @@ metadata:
 
 # lcx-doctor
 
-You are a LazyCodex install doctor. Inspect the local installation, compare it against the latest LazyCodex and Codex sources, and return a PASS/WARN/FAIL report where every verdict cites the command output or file that produced it. Diagnose only: the only writes you make are under `/tmp`. Never mutate the user's install, config, or repositories during diagnosis; propose remediations and apply one only when the user explicitly asks afterward.
+You are a LazyCodex install doctor. Inspect the local installation, compare it against the latest LazyCodex and Codex sources, and return a PASS/WARN/FAIL report where every verdict cites the command output or file that produced it. Diagnose only: the only writes you make are under `${TMPDIR:-/tmp}`. Never mutate the user's install, config, or repositories during diagnosis; propose remediations and apply one only when the user explicitly asks afterward.
 
 Use GPT-5.5 style: outcome first, concise, evidence-bound.
 
 ## Required Workflow
 
-1. Materialize the latest sources under `/tmp` first. Every source comparison below reads from these checkouts, never from memory. Re-sync on every run so a cached checkout cannot go stale:
+1. Materialize the latest sources under `${TMPDIR:-/tmp}` first. Every source comparison below reads from these checkouts, never from memory. Re-sync on every run so a cached checkout cannot go stale:
 
 ```bash
 sync_latest_source() {
@@ -26,18 +26,19 @@ sync_latest_source() {
   git -C "$DEST" fetch --depth=1 origin "$DEFAULT_BRANCH"
   git -C "$DEST" checkout -B "$DEFAULT_BRANCH" FETCH_HEAD
 }
-sync_latest_source code-yeongyu/lazycodex /tmp/lazycodex-source
-sync_latest_source openai/codex /tmp/openai-codex-source
+SOURCE_ROOT="${TMPDIR:-/tmp}"
+sync_latest_source code-yeongyu/lazycodex "$SOURCE_ROOT/lazycodex-source"
+sync_latest_source openai/codex "$SOURCE_ROOT/openai-codex-source"
 ```
 
 2. Inventory the installed surface. Resolve `CODEX_HOME` (default `~/.codex`), then collect:
    - `codex --version` and how `codex` resolves (`command -v codex`).
    - Installed LazyCodex version: the `version` in the installed plugin manifest, discoverable with `find "${CODEX_HOME:-$HOME/.codex}/plugins" -path '*/.codex-plugin/plugin.json'`. Installed plugins live under `$CODEX_HOME/plugins/cache/<marketplace>/<name>/<version>/`.
-   - Latest LazyCodex version from `/tmp/lazycodex-source` (release tags or the version stamped in the repo) and latest Codex release (`gh release view --repo openai/codex`).
+   - Latest LazyCodex version from `$SOURCE_ROOT/lazycodex-source` (release tags or the version stamped in the repo) and latest Codex release (`gh release view --repo openai/codex`).
    - OS, install method, and `lazycodex` / `lazycodex-ai` bin links resolving (`command -v`).
-3. Check config and wiring against the latest installer, not against assumptions. Read what the current installer under `/tmp/lazycodex-source` writes (installer sources live in the omo-codex package, e.g. `scripts/install/`), then verify the local equivalents:
+3. Check config and wiring against the latest installer, not against assumptions. Read what the current installer under `$SOURCE_ROOT/lazycodex-source` writes (installer sources live in the omo-codex package, e.g. `scripts/install/`), then verify the local equivalents:
    - `$CODEX_HOME/config.toml` exists and parses; LazyCodex-managed entries match what the latest installer would write.
-   - Plugin payload present and non-empty: `hooks/hooks.json`, `skills/`, `.mcp.json`, components under the installed plugin root.
+   - Plugin payload present and non-empty: the installed `plugin.json` must have a `hooks` array of individual hook JSON files (e.g. `./hooks/session-start-*.json`); `skills/` directory; `.mcp.json`; and components under the installed plugin root. A single `hooks/hooks.json` is the obsolete aggregate format — flag its presence as a mismatch against current source.
    - Stale project-local leftovers the installer now removes (e.g. `.codex/hooks.json`, `.codex/skills` in the project) are flagged, not deleted.
 4. Probe the real surface. Do not invoke `lazycodex doctor`; this skill is already running inside that doctor workflow, so calling it would recurse. Instead run non-recursive probes directly: `codex --version`, `command -v codex`, the bin-link checks above, config/plugin payload inspections, and a trivial non-interactive Codex invocation that loads the plugin. Capture stderr verbatim; a clean exit with warnings is WARN, not PASS.
 5. Compare for drift. Where installed bundled files differ from the same files at the installed version, or the latest source renamed or removed something the local config still references, record it with both paths.
@@ -67,7 +68,7 @@ sync_latest_source openai/codex /tmp/openai-codex-source
 | Plugin payload wiring | PASS/WARN/FAIL | [evidence] |
 | Bin links / aliases | PASS/WARN/FAIL | [evidence] |
 | Runtime probe | PASS/WARN/FAIL | [evidence] |
-| Drift vs latest source | PASS/WARN/FAIL | [evidence, citing /tmp/lazycodex-source or /tmp/openai-codex-source paths] |
+| Drift vs latest source | PASS/WARN/FAIL | [evidence, citing $SOURCE_ROOT/lazycodex-source or $SOURCE_ROOT/openai-codex-source paths] |
 
 ### Remediations
 1. [Most important fix first: exact command or config edit, and what it resolves.]
@@ -79,7 +80,7 @@ sync_latest_source openai/codex /tmp/openai-codex-source
 ## Follow-up Routing
 
 - Local misconfiguration or stale install: give the remediation; reinstalling via the standard LazyCodex install command is the default fix for payload drift.
-- Defect in LazyCodex or Codex product code: recommend `$lcx-report-bug` to file it, or `$lcx-contribute-bug-fix` when the user wants a fix PR. Both reuse the `/tmp` checkouts you already synced.
+- Defect in LazyCodex or Codex product code: recommend `$lcx-report-bug` to file it, or `$lcx-contribute-bug-fix` when the user wants a fix PR. Both reuse the `$SOURCE_ROOT` checkouts you already synced.
 
 ## Stop Conditions
 
@@ -89,5 +90,5 @@ Do not:
 
 - mutate config, installs, or repositories during diagnosis
 - report a verdict without captured evidence
-- compare against remembered source layout instead of `/tmp/lazycodex-source` and `/tmp/openai-codex-source`
+- compare against remembered source layout instead of `$SOURCE_ROOT/lazycodex-source` and `$SOURCE_ROOT/openai-codex-source`
 - declare healthy while any probe output was never captured


### PR DESCRIPTION
## Bug

`lcx-doctor` (`packages/shared-skills/skills/lcx-doctor/SKILL.md`) has two bugs reported in [lazycodex#80](https://github.com/code-yeongyu/lazycodex/issues/80):

**1. Hardcoded `/tmp` paths** — The skill instructs the agent to sync sources into `/tmp/lazycodex-source` and `/tmp/openai-codex-source`, and subsequent prose references the same bare `/tmp` paths. On macOS (where `TMPDIR` typically points to `/var/folders/…`) the syncs either land in the wrong location or fail entirely.

**2. Obsolete `hooks/hooks.json` payload check** — Step 3 tells the doctor to verify that `hooks/hooks.json` is present under the installed plugin root. The aggregate `plugin.json` was migrated to enumerate individual hook JSON files in its `hooks` array (asserted by the existing `test/aggregate-manifest.test.mjs`: `assert(!hookPaths.includes('./hooks/hooks.json'))`). A correct install therefore never has `hooks/hooks.json`, so the old check always fires a false-negative FAIL verdict on valid installations.

## Fix

- Introduce `SOURCE_ROOT="${TMPDIR:-/tmp}"` before the `sync_latest_source` calls and update every `/tmp/lazycodex-source` / `/tmp/openai-codex-source` reference throughout the skill (workflow steps, report template, follow-up routing, stop conditions) to use `$SOURCE_ROOT`.
- Replace the wiring check bullet that says `hooks/hooks.json` with the correct expectation: the installed `plugin.json`'s `hooks` field must be an **array of individual hook JSON files** (e.g. `./hooks/session-start-*.json`); a monolithic `hooks/hooks.json` is the obsolete format and should be flagged as a mismatch.

## Verification

New test file `packages/shared-skills/lcx-doctor-skill-contract.test.ts` (3 `bun:test` tests):

| | Before | After |
|---|---|---|
| TMPDIR pattern present | FAIL | PASS |
| hooks/hooks.json absent from wiring check | FAIL | PASS |
| SOURCE_ROOT variable assigned before use | FAIL | PASS |

```
bun test packages/shared-skills/lcx-doctor-skill-contract.test.ts
# 3 pass, 0 fail

bun test packages/shared-skills/
# 74 pass, 0 fail (no regressions)
```

Refs: lazycodex#80

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `lcx-doctor` to respect `${TMPDIR:-/tmp}` and updates the plugin payload check to the current per-hook manifest, preventing macOS temp-path issues and false FAIL results. Addresses lazycodex#80.

- **Bug Fixes**
  - Use `SOURCE_ROOT="${TMPDIR:-/tmp}"` for source syncs and replace all `/tmp/...` references with `$SOURCE_ROOT`.
  - Update payload wiring check: require `plugin.json` to list individual hook JSON files in `hooks`; flag a monolithic `hooks/hooks.json` as obsolete.
  - Add `packages/shared-skills/lcx-doctor-skill-contract.test.ts` to assert TMPDIR handling, correct wiring check, and variable assignment before use.

<sup>Written for commit 4dd7ea0459d30063239f6d5d2d824cfd89899dbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

