### PR TITLE
fix(keyword-detector): append mode instructions after user text to preserve session title

### DIFF
--- a/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
@@ -33,7 +33,7 @@ function filterAlreadyInjectedKeywords(
   detected: DetectedKeyword[],
   text: string,
 ): DetectedKeyword[] {
-  return detected.filter((keyword) => !text.includes(keyword.message))
+  return detected.filter((keyword) => !text.includes(keyword.message.trim()))
 }
 
 export function createKeywordDetectorHook(
@@ -238,7 +238,7 @@ export function createKeywordDetectorHook(
       const allMessages = detectedKeywords.map((k) => k.message).join("\n\n")
       const originalText = output.parts[textPartIndex].text ?? ""
 
-      output.parts[textPartIndex].text = `${allMessages}\n\n---\n\n${originalText}`
+      output.parts[textPartIndex].text = `${originalText}\n\n---\n\n${allMessages}`
 
       log(`[keyword-detector] Detected ${detectedKeywords.length} keywords`, {
         sessionID: input.sessionID,

--- a/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
@@ -66,7 +66,7 @@ describe("keyword-detector message transform", () => {
     return createPluginInputWithToast(async () => {})
   }
 
-  test("should prepend ultrawork message to text part", async () => {
+  test("should append ultrawork message after user text in text part", async () => {
     // given - a fresh ContextCollector and keyword-detector hook
     const collector = new ContextCollector()
     const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
@@ -79,11 +79,35 @@ describe("keyword-detector message transform", () => {
     // when - keyword detection runs
     await hook["chat.message"]({ sessionID }, output)
 
-    // then - message should be prepended to text part with separator and original text
+    // then - original user text comes first, mode instructions appended after separator
     const text = expectTextPartText(output.parts)
     expect(text).toContain("---")
     expect(text).toContain("do something")
     expect(text).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
+  })
+
+  test("should place user text before mode instructions so session title stays task-focused", async () => {
+    // given - ulw trigger with a concrete user task
+    const collector = new ContextCollector()
+    const sessionID = "title-order-test"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ulw build the reporting dashboard" }],
+    }
+
+    // when - keyword detection runs
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - user text must appear before ULW instructions so OpenCode's title model
+    // generates a meaningful title from the task, not from "ULTRAWORK MODE ENABLED!"
+    const text = expectTextPartText(output.parts)
+    const userTextPos = text.indexOf("build the reporting dashboard")
+    const ulwInstructionsPos = text.indexOf("<ultrawork-mode>")
+    expect(userTextPos).toBeGreaterThan(-1)
+    expect(ulwInstructionsPos).toBeGreaterThan(-1)
+    expect(userTextPos).toBeLessThan(ulwInstructionsPos)
   })
 
   test("should leave search wording as plain user text", async () => {


### PR DESCRIPTION
## Bug

When a ULW/hyperplan/team-mode keyword is detected, the injected mode instructions were **prepended** before the user's message:

```typescript
output.parts[textPartIndex].text = `${allMessages}\n\n---\n\n${originalText}`
```

OpenCode's title model reads the **first content** of the user message to generate the session title. With this ordering, the title became **"ULTRAWORK MODE ENABLED!"** instead of the user's actual task description (e.g. "Build the reporting dashboard").

## Fix

Append the mode instructions **after** the user's original text so the title model sees the real task first:

```typescript
output.parts[textPartIndex].text = `${originalText}\n\n---\n\n${allMessages}`
```

Also fix `filterAlreadyInjectedKeywords` to use `keyword.message.trim()` in the `includes()` check. `removeSystemReminders()` trims the clean text, which strips the trailing newline from the appended `allMessages` block. Without this fix, the idempotency guard fails on the second invocation (same message processed twice gets double-injected).

## Verification

```
bun test packages/omo-opencode/src/hooks/keyword-detector/
90 pass, 0 fail across 7 files
```

New regression test added:
- `"should place user text before mode instructions so session title stays task-focused"` — verifies `indexOf(userText) < indexOf("<ultrawork-mode>")`

Closes #5586

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Append ULW/hyperplan/team-mode instructions after the user's text so session titles use the task instead of the mode banner. Also harden duplicate-injection checks by trimming keyword messages to keep the transform idempotent.

- **Bug Fixes**
  - Append mode instructions after the original user text to preserve task-first titles (Linear #5586).
  - Use `keyword.message.trim()` in `filterAlreadyInjectedKeywords` to handle trailing newline removal from `removeSystemReminders()`.

<sup>Written for commit 283073ee34dc70330d1f7b957f2af96df0ed6171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

