### PR TITLE
fix(sisyphus-junior): respect category field in agent override config

### DIFF
--- a/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
@@ -13,7 +13,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode } from "../types"
 import { isGlmModel, isGpt5_5Model, isGptModel, isGeminiModel, isKimiK2Model, isKimiK27Model, buildClaudeThinkingConfig } from "../types"
-import type { AgentOverrideConfig } from "../../config/schema"
+import type { AgentOverrideConfig, CategoryConfig } from "../../config/schema"
 import {
   createAgentToolRestrictions,
   migrateAgentConfig,
@@ -100,14 +100,19 @@ export function buildSisyphusJuniorPrompt(
 export function createSisyphusJuniorAgentWithOverrides(
   override: AgentOverrideConfig | undefined,
   systemDefaultModel?: string,
-  useTaskSystem = false
+  useTaskSystem = false,
+  categories?: Record<string, CategoryConfig>
 ): AgentConfig {
   if (override?.disable) {
     override = undefined
   }
 
   const overrideModel = (override as { model?: string } | undefined)?.model
-  const model = overrideModel ?? systemDefaultModel ?? SISYPHUS_JUNIOR_DEFAULTS.model
+  const overrideCategory = (override as { category?: string } | undefined)?.category
+  const categoryModel = overrideCategory && categories?.[overrideCategory]?.model
+    ? categories[overrideCategory].model
+    : undefined
+  const model = overrideModel ?? categoryModel ?? systemDefaultModel ?? SISYPHUS_JUNIOR_DEFAULTS.model
   const temperature = override?.temperature ?? SISYPHUS_JUNIOR_DEFAULTS.temperature
 
   const promptAppend = override?.prompt_append

--- a/packages/omo-opencode/src/agents/sisyphus-junior/index.test.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/index.test.ts
@@ -100,6 +100,70 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
     })
   })
 
+  describe("category model resolution", () => {
+    test("resolves model from category when no explicit model is set", () => {
+      // given
+      const override = { category: "deep" }
+      const categories = { deep: { model: "opencode-go/deepseek-v4-flash" } }
+
+      // when
+      const result = createSisyphusJuniorAgentWithOverrides(override, undefined, false, categories)
+
+      // then
+      expect(result.model).toBe("opencode-go/deepseek-v4-flash")
+    })
+
+    test("explicit model takes priority over category model", () => {
+      // given
+      const override = { model: "openai/gpt-5.4", category: "deep" }
+      const categories = { deep: { model: "opencode-go/deepseek-v4-flash" } }
+
+      // when
+      const result = createSisyphusJuniorAgentWithOverrides(override, undefined, false, categories)
+
+      // then
+      expect(result.model).toBe("openai/gpt-5.4")
+    })
+
+    test("category model takes priority over systemDefaultModel", () => {
+      // given
+      const override = { category: "deep" }
+      const categories = { deep: { model: "opencode-go/deepseek-v4-flash" } }
+      const systemDefaultModel = "anthropic/claude-opus-4-7"
+
+      // when
+      const result = createSisyphusJuniorAgentWithOverrides(override, systemDefaultModel, false, categories)
+
+      // then
+      expect(result.model).toBe("opencode-go/deepseek-v4-flash")
+    })
+
+    test("falls back to systemDefaultModel when category has no model", () => {
+      // given
+      const override = { category: "deep" }
+      const categories = { deep: {} }
+      const systemDefaultModel = "anthropic/claude-opus-4-7"
+
+      // when
+      const result = createSisyphusJuniorAgentWithOverrides(override, systemDefaultModel, false, categories)
+
+      // then
+      expect(result.model).toBe(systemDefaultModel)
+    })
+
+    test("falls back to default when category not found in categories map", () => {
+      // given
+      const override = { category: "nonexistent" }
+      const categories = { deep: { model: "opencode-go/deepseek-v4-flash" } }
+
+      // when
+      const result = createSisyphusJuniorAgentWithOverrides(override, undefined, false, categories)
+
+      // then
+      expect(result.model).toBe(SISYPHUS_JUNIOR_DEFAULTS.model)
+    })
+  })
+
   describe("disable semantics", () => {
     test("disable: true causes override block to be ignored", () => {
       // given

--- a/packages/omo-opencode/src/plugin-handlers/agent-config-assembly.ts
+++ b/packages/omo-opencode/src/plugin-handlers/agent-config-assembly.ts
@@ -132,6 +132,7 @@ async function createCoreAgentConfig(
     pluginConfig.agents?.["sisyphus-junior"],
     (builtinAgents.atlas as { model?: string } | undefined)?.model,
     useTaskSystem,
+    pluginConfig.categories,
   );
 
   return agentConfig;

--- a/packages/omo-opencode/src/plugin-handlers/agent-config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/agent-config-handler.test.ts
@@ -471,7 +471,7 @@ describe("applyAgentConfig builtin override protection", () => {
     })
 
     // then
-    expect(createSisyphusJuniorAgentSpy).toHaveBeenCalledWith(undefined, "openai/gpt-5.4", false)
+    expect(createSisyphusJuniorAgentSpy).toHaveBeenCalledWith(undefined, "openai/gpt-5.4", false, undefined)
   })
 
   test("defaults mode to subagent for configAgent entries missing mode", async () => {


### PR DESCRIPTION
Closes #5574

## Bug

When a user configures `sisyphus-junior` with a `category` (e.g. `category: "deep"`) and no explicit `model`, `createSisyphusJuniorAgentWithOverrides` silently ignored the category and fell back to the system default or hard-coded default model (`anthropic/claude-sonnet-4-6`).

This is the root cause reported in #5574: after oh-my-openagent migrates the user-configured key `Sisyphus-Junior` → `sisyphus-junior`, the category-based model lookup happens via `pluginConfig.agents["sisyphus-junior"]`, which returns the override object correctly — but the function only read `override.model`, never `override.category`. So a config like:

```json
{"agents": {"sisyphus-junior": {"category": "deep"}}}
```

…where `categories.deep.model = "opencode-go/deepseek-v4-flash"` silently used the fallback model instead.

## Fix

- Added an optional `categories?: Record<string, CategoryConfig>` parameter to `createSisyphusJuniorAgentWithOverrides`.
- Resolves the category model in priority order: `override.model` > `categoryModel` > `systemDefaultModel` > built-in default. This matches the `applyOverrides` behaviour used by all other builtin agents.
- Updated the `createCoreAgentConfig` call-site in `agent-config-assembly.ts` to pass `pluginConfig.categories`.

## Verification

5 new tests in `packages/omo-opencode/src/agents/sisyphus-junior/index.test.ts`:

| # | Scenario | RED (before) | GREEN (after) |
|---|---|---|---|
| 1 | `category: "deep"` → resolves deepseek model | ❌ received claude-sonnet default | ✅ |
| 2 | explicit `model` beats `category` model | ✅ (already passed) | ✅ |
| 3 | category model beats `systemDefaultModel` | ❌ received systemDefault | ✅ |
| 4 | fallback to systemDefaultModel when category has no model | ✅ | ✅ |
| 5 | fallback to built-in default when category key missing | ✅ | ✅ |

```
58 pass, 0 fail  (53 existing + 5 new)
```

TypeScript compiles clean (`bunx tsc --noEmit`). No pre-existing tests were changed in behaviour; the single spy assertion update in `agent-config-handler.test.ts` reflects the new optional 4th argument being passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model selection for `sisyphus-junior` to honor the `category` override when no `model` is set. Ensures the correct model is chosen by clear priority to avoid wrong fallbacks.

- **Bug Fixes**
  - `sisyphus-junior`: resolves model by priority `override.model` > category model > `systemDefaultModel` > built-in default; added optional `categories` param to `createSisyphusJuniorAgentWithOverrides` and passed `pluginConfig.categories` in `agent-config-assembly`; added 5 tests for category resolution, precedence, and fallbacks; updated one spy assertion for the new 4th arg.

<sup>Written for commit 2ba00df7645028d7be4acc8cfe78398fbdc8ecaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

