### PR TITLE
fix(sisyphus): cache rebuilt prompt per runtime-model to stop per-turn rebuild (#5578)

### DIFF
--- a/packages/omo-opencode/src/agents/sisyphus-runtime-prompt-reconciler.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-runtime-prompt-reconciler.ts
@@ -17,12 +17,20 @@ export type SisyphusRuntimePromptContext = {
 
 let context: SisyphusRuntimePromptContext | undefined;
 
+// Per-session cache: avoid calling rebuildPromptForModel on every turn when the
+// runtime model is stable. The cache is keyed by the exact runtimeModel string
+// and is cleared together with `context` at session end.
+let lastReconciledModel: string | undefined;
+let cachedRebuiltPrompt: string | undefined;
+
 export function setSisyphusRuntimePromptContext(ctx: SisyphusRuntimePromptContext): void {
   context = ctx;
 }
 
 export function clearSisyphusRuntimePromptContext(): void {
   context = undefined;
+  lastReconciledModel = undefined;
+  cachedRebuiltPrompt = undefined;
 }
 
 /**
@@ -36,6 +44,12 @@ export function clearSisyphusRuntimePromptContext(): void {
  * model, so rebuild the whole prompt for the runtime family and swap it in here
  * rather than patching individual family-specific lines (which can never convert
  * a GPT body into a non-GPT one).
+ *
+ * Rebuilding is expensive and non-deterministic across calls (it reads live env
+ * and config state), so the result is cached per runtime-model string. The cache
+ * is invalidated when the runtime model changes or the session context is cleared
+ * (fix for #5578: reconciler was rebuilding on every turn causing behavioural
+ * non-determinism within a single session).
  *
  * Returns true if a swap was performed.
  */
@@ -53,7 +67,19 @@ export function reconcileSisyphusRuntimePrompt(
     return false
   }
 
-  const rebuilt = context.rebuildPromptForModel(runtimeModel)
+  // Use the cached rebuilt prompt when the runtime model has not changed since
+  // the last reconciliation. rebuildPromptForModel reads live env/config state
+  // and is therefore not guaranteed to be pure; calling it on every turn can
+  // produce subtly different prompts even with the same model id (#5578).
+  let rebuilt: string;
+  if (runtimeModel === lastReconciledModel && cachedRebuiltPrompt !== undefined) {
+    rebuilt = cachedRebuiltPrompt;
+  } else {
+    rebuilt = context.rebuildPromptForModel(runtimeModel);
+    lastReconciledModel = runtimeModel;
+    cachedRebuiltPrompt = rebuilt;
+  }
+
   if (rebuilt === context.bakedPrompt) return false
 
   // Substring replace rather than exact-equality: opencode core may concatenate

--- a/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-reconciler.test.ts
+++ b/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-reconciler.test.ts
@@ -95,3 +95,53 @@ describe("Sisyphus runtime prompt family reconciliation (#5297/#5316)", () => {
     expect(output.system[0]).not.toContain(GPT_APPLY_PATCH_GUIDANCE)
   })
 })
+
+describe("Sisyphus runtime prompt reconciler — per-turn rebuild cache (#5578)", () => {
+  test("#given a stable runtime model #when reconcile runs on consecutive turns #then rebuildPromptForModel is called only once", () => {
+    const baked = createSisyphusAgent(GPT_MODEL, [], [], [], []).prompt ?? ""
+    let rebuildCalls = 0
+    setSisyphusRuntimePromptContext({
+      configuredModel: GPT_MODEL,
+      bakedPrompt: baked,
+      rebuildPromptForModel: (model) => {
+        rebuildCalls++
+        return createSisyphusAgent(model, [], [], [], []).prompt ?? ""
+      },
+    })
+
+    // Turn 1: first reconciliation with a non-GPT model
+    const system1 = [baked]
+    const swapped1 = reconcileSisyphusRuntimePrompt(system1, NON_GPT_MODEL)
+    expect(swapped1).toBe(true)
+    expect(rebuildCalls).toBe(1)
+
+    // Turn 2: same stable runtime model — rebuild must be skipped, swap still applied
+    const system2 = [baked]
+    const swapped2 = reconcileSisyphusRuntimePrompt(system2, NON_GPT_MODEL)
+    expect(swapped2).toBe(true)
+    expect(rebuildCalls).toBe(1) // must NOT have incremented
+    expect(system2[0]).not.toContain("based on GPT-5.5")
+  })
+
+  test("#given a model switch between turns #when reconcile runs #then rebuildPromptForModel is called again for the new model", () => {
+    const ANOTHER_NON_GPT_MODEL = "kimi-k2/Kimi-K2"
+    const baked = createSisyphusAgent(GPT_MODEL, [], [], [], []).prompt ?? ""
+    let rebuildCalls = 0
+    setSisyphusRuntimePromptContext({
+      configuredModel: GPT_MODEL,
+      bakedPrompt: baked,
+      rebuildPromptForModel: (model) => {
+        rebuildCalls++
+        return createSisyphusAgent(model, [], [], [], []).prompt ?? ""
+      },
+    })
+
+    // Turn 1: NON_GPT_MODEL
+    reconcileSisyphusRuntimePrompt([baked], NON_GPT_MODEL)
+    expect(rebuildCalls).toBe(1)
+
+    // Turn 2: different model — must trigger a fresh rebuild
+    reconcileSisyphusRuntimePrompt([baked], ANOTHER_NON_GPT_MODEL)
+    expect(rebuildCalls).toBe(2)
+  })
+})


### PR DESCRIPTION
## Bug

Closes #5578

The `reconcileSisyphusRuntimePrompt` system-transform hook called `rebuildPromptForModel` on **every request** whenever the runtime model family differed from the configured model. Because `rebuildPromptForModel` reads live env/config state it is not guaranteed to produce identical output across calls — so two adjacent turns in the same session could receive materially different system prompts. This caused the behaviour reported in #5578: Sisyphus commits to waiting for the user on turn 1, then proceeds autonomously on turn 2 without any user input.

## Fix

Add two module-level variables (`lastReconciledModel` / `cachedRebuiltPrompt`) that persist the last rebuild result, keyed by the exact `runtimeModel` string:

- **Cache hit (stable model):** the cached rebuilt prompt is reused directly; `rebuildPromptForModel` is **not** called again.
- **Cache miss (model changed or first call):** `rebuildPromptForModel` is invoked, the result is cached, and the swap is applied.
- **Session end:** `clearSisyphusRuntimePromptContext` now also clears both cache variables so a fresh session starts clean.

The substring swap into the system array still executes on every turn so that a freshly-assembled system array always receives the correct family body.

## Verification

Two new unit tests added to `packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-reconciler.test.ts`:

| Test | Before fix | After fix |
|---|---|---|
| Stable runtime model: `rebuildPromptForModel` call count across 2 turns | **2 (FAIL)** | 1 (PASS) |
| Model switch between turns: rebuild fired for new model | PASS | PASS |

All 8 tests in the file pass; the 6 broader pre-existing failures are in `git-master-template-injection.test.ts` and unrelated to this change.

```
bun test packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-reconciler.test.ts
 8 pass, 0 fail
```

## Changed files

- `packages/omo-opencode/src/agents/sisyphus-runtime-prompt-reconciler.ts` — cache logic + updated JSDoc
- `packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-reconciler.test.ts` — 2 new tests for #5578

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent Sisyphus system prompts by caching the rebuilt prompt per runtime model and clearing it at session end. Prevents per-turn rebuilds and stops behavior drift (fixes #5578).

- **Bug Fixes**
  - Cache the rebuilt system prompt keyed by the exact `runtimeModel` to avoid calling `rebuildPromptForModel` each turn.
  - Invalidate the cache when the model changes or `clearSisyphusRuntimePromptContext` runs; still perform the substring swap every turn.
  - Added tests to verify one rebuild for a stable model and a new rebuild on model switch.

<sup>Written for commit 8ea7e58fe7db4fe735f089c9ef871731f87eb336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

