### PR TITLE
fix: translate providerOptions to options so they reach the request body

### DIFF
--- a/packages/omo-opencode/src/plugin-handlers/agent-config-finalizer.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/agent-config-finalizer.test.ts
@@ -35,4 +35,141 @@ describe("finalizeAgentConfig", () => {
     expect(result).toEqual({});
     expect(isAgentRegistered("stale-agent")).toBe(false);
   });
+
+  describe("providerOptions translation", () => {
+    test("translates providerOptions to options for a single agent", () => {
+      // given - "oracle" maps to itself so result key stays "oracle"
+      const config = {
+        agent: {
+          oracle: {
+            model: "anthropic/claude-opus-4-7",
+            mode: "primary",
+            providerOptions: { thinking_token_budget: 4096 },
+          },
+        },
+      };
+
+      // when
+      const result = finalizeAgentConfig({
+        config,
+        pluginConfig: createPluginConfig(),
+        configuredDefaultAgent: undefined,
+      });
+
+      // then - providerOptions is converted to options; providerOptions key is removed
+      expect(result["oracle"]).toEqual(
+        expect.objectContaining({
+          model: "anthropic/claude-opus-4-7",
+          options: { thinking_token_budget: 4096 },
+        }),
+      );
+      expect((result["oracle"] as Record<string, unknown>)["providerOptions"]).toBeUndefined();
+    });
+
+    test("merges providerOptions into existing options without overwriting", () => {
+      // given - agent already has an options key from another source
+      const config = {
+        agent: {
+          librarian: {
+            model: "provider/model",
+            mode: "subagent",
+            options: { existing_key: "existing_value" },
+            providerOptions: { chat_template_kwargs: { enable_thinking: false } },
+          },
+        },
+      };
+
+      // when
+      const result = finalizeAgentConfig({
+        config,
+        pluginConfig: createPluginConfig(),
+        configuredDefaultAgent: undefined,
+      });
+
+      // then - both existing and new options survive; providerOptions is removed
+      const agent = result["librarian"] as Record<string, unknown>;
+      expect(agent["options"]).toEqual({
+        existing_key: "existing_value",
+        chat_template_kwargs: { enable_thinking: false },
+      });
+      expect(agent["providerOptions"]).toBeUndefined();
+    });
+
+    test("providerOptions overwrites same-named keys already in options", () => {
+      // given - conflict: same key in both options and providerOptions
+      const config = {
+        agent: {
+          oracle: {
+            options: { thinking_token_budget: 0 },
+            providerOptions: { thinking_token_budget: 8192 },
+          },
+        },
+      };
+
+      // when
+      const result = finalizeAgentConfig({
+        config,
+        pluginConfig: createPluginConfig(),
+        configuredDefaultAgent: undefined,
+      });
+
+      // then - providerOptions wins (last-write semantics)
+      const agent = result["oracle"] as Record<string, unknown>;
+      expect(agent["options"]).toEqual({ thinking_token_budget: 8192 });
+      expect(agent["providerOptions"]).toBeUndefined();
+    });
+
+    test("leaves agent unchanged when providerOptions is absent", () => {
+      // given - "librarian" maps to itself so result key stays "librarian"
+      const config = {
+        agent: {
+          librarian: {
+            model: "openai/gpt-5.4",
+            temperature: 0.7,
+          },
+        },
+      };
+
+      // when
+      const result = finalizeAgentConfig({
+        config,
+        pluginConfig: createPluginConfig(),
+        configuredDefaultAgent: undefined,
+      });
+
+      // then - no options key created, no providerOptions key present
+      const agent = result["librarian"] as Record<string, unknown>;
+      expect(agent["options"]).toBeUndefined();
+      expect(agent["providerOptions"]).toBeUndefined();
+      expect(agent["model"]).toBe("openai/gpt-5.4");
+    });
+
+    test("translates providerOptions across multiple agents in one pass", () => {
+      // given - oracle/librarian/explore all map to themselves
+      const config = {
+        agent: {
+          oracle: { providerOptions: { thinking_token_budget: 8192 } },
+          librarian: { providerOptions: { thinking_token_budget: 2048 } },
+          explore: { providerOptions: { chat_template_kwargs: { enable_thinking: false } } },
+        },
+      };
+
+      // when
+      const result = finalizeAgentConfig({
+        config,
+        pluginConfig: createPluginConfig(),
+        configuredDefaultAgent: undefined,
+      });
+
+      // then - all three agents are translated
+      for (const name of ["oracle", "librarian", "explore"]) {
+        const agent = result[name] as Record<string, unknown>;
+        expect(agent["providerOptions"]).toBeUndefined();
+        expect(typeof agent["options"]).toBe("object");
+      }
+      expect((result["explore"] as Record<string, unknown>)["options"]).toEqual({
+        chat_template_kwargs: { enable_thinking: false },
+      });
+    });
+  });
 });

--- a/packages/omo-opencode/src/plugin-handlers/agent-config-finalizer.ts
+++ b/packages/omo-opencode/src/plugin-handlers/agent-config-finalizer.ts
@@ -7,6 +7,36 @@ import { setDefaultAgentForSort } from "../shared/agent-sort-shim";
 import { remapAgentKeysToDisplayNames } from "./agent-key-remapper";
 import { reorderAgentsByPriority } from "./agent-priority-order";
 import type { ApplyAgentConfigParams } from "./agent-config-types";
+/**
+ * Translates `providerOptions` to `options` for OpenCode compatibility.
+ *
+ * omo accepts `providerOptions` in agent override configs, but OpenCode reads
+ * provider-specific options from the `options` key on each agent entry. This
+ * translation ensures user-configured provider options actually reach the
+ * request body sent to the model provider.
+ *
+ * @see https://github.com/code-yeongyu/oh-my-openagent/issues/5479
+ */
+export function translateProviderOptions(agent: Record<string, unknown>): Record<string, unknown> {
+  const { providerOptions, ...rest } = agent;
+  if (
+    providerOptions === undefined ||
+    providerOptions === null ||
+    typeof providerOptions !== "object" ||
+    Array.isArray(providerOptions)
+  ) {
+    return agent;
+  }
+  const existingOptions =
+    typeof rest.options === "object" && rest.options !== null && !Array.isArray(rest.options)
+      ? (rest.options as Record<string, unknown>)
+      : {};
+  return {
+    ...rest,
+    options: { ...existingOptions, ...(providerOptions as Record<string, unknown>) },
+  };
+}
+
 
 export function finalizeAgentConfig(
   params: Pick<ApplyAgentConfigParams, "config" | "pluginConfig"> & {
@@ -22,6 +52,14 @@ export function finalizeAgentConfig(
       params.config.agent as Record<string, unknown>,
       params.pluginConfig.agent_order,
     );
+
+    // Translate providerOptions -> options so OpenCode forwards them to the provider.
+    const agentsMap = params.config.agent as Record<string, unknown>;
+    for (const [key, entry] of Object.entries(agentsMap)) {
+      if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+        agentsMap[key] = translateProviderOptions(entry as Record<string, unknown>);
+      }
+    }
   }
 
   if (params.configuredDefaultAgent) {


### PR DESCRIPTION
## Bug

Closes #5479

Per-agent `providerOptions` configured in `oh-my-openagent.jsonc` were silently dropped and never appeared in the HTTP request body sent to the model provider.

## Root Cause

omo writes `providerOptions` as a top-level key on agent config entries through its plugin `config` hook. OpenCode reads provider-specific request-body overrides from the `options` key on agent entries. Because the plugin hook runs *after* OpenCode has already decoded the config file (where unrecognised keys would normally be folded into `options`), the `providerOptions` key is never processed — it is silently discarded with no error or warning.

## Fix

Added a `translateProviderOptions` step in `agent-config-finalizer.ts` that runs over every assembled agent entry before handing the config to OpenCode. It:

1. Extracts `providerOptions` from the agent entry.
2. Merges its contents into the existing `options` record (preserving any values already there, with `providerOptions` winning on key conflicts).
3. Removes the `providerOptions` key.

This single centralised translation covers all agent paths: builtins, prometheus, user custom agents, and category-inherited agents — including the plan-demote copy that `buildPlanDemoteConfig` propagates from prometheus.

## Verification

**RED → GREEN** with 5 new unit tests in `agent-config-finalizer.test.ts`:

- Single agent: `providerOptions` converted to `options`; key removed ✓  
- Merge: existing `options` values preserved alongside new ones ✓  
- Conflict: `providerOptions` wins over same-named keys already in `options` ✓  
- No-op: agent without `providerOptions` is unchanged ✓  
- Multi-agent: all agents in one pass translated ✓  

```
bun test packages/omo-opencode/src/plugin-handlers/agent-config-finalizer.test.ts
6 pass  0 fail
```

Full plugin-handlers suite: **228 pass, 1 fail** — the 1 failure (`plan agent remains unchanged when planner is disabled`) is pre-existing on `dev` and unrelated to this change (confirmed by running against unmodified `dev`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate per-agent `providerOptions` into `options` during config finalization so provider-specific settings reach the HTTP request body. Fixes settings being silently dropped across all agent types.

- **Bug Fixes**
  - Added `translateProviderOptions` to move `providerOptions` into `options` for each agent and remove `providerOptions`.
  - Merges with existing `options`; `providerOptions` values take precedence.
  - Added unit tests covering single, merge, conflict, no-op, and multi-agent cases.

<sup>Written for commit 27b4931df7adb5684e4eca5c40b54ae40fa70153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

