### PR TITLE
fix(agent-overrides): translate providerOptions into options for OpenCode request body

### DIFF
--- a/packages/omo-opencode/src/agents/agent-identity.test.ts
+++ b/packages/omo-opencode/src/agents/agent-identity.test.ts
@@ -139,3 +139,78 @@ describe("Agent identity preservation through overrides", () => {
     })
   })
 })
+describe("mergeAgentConfig providerOptions → options translation", () => {
+  describe("#given a Sisyphus agent with providerOptions in the override", () => {
+    describe("#when merging the override", () => {
+      it("#then providerOptions contents appear in options", () => {
+        const baseConfig = createSisyphusAgent("anthropic/claude-opus-4-7")
+        const merged = mergeAgentConfig(baseConfig, {
+          providerOptions: { thinking_token_budget: 4096 },
+        })
+
+        expect((merged.options as Record<string, unknown>)?.thinking_token_budget).toBe(4096)
+      })
+
+      it("#then providerOptions key is removed from the merged config", () => {
+        const baseConfig = createSisyphusAgent("anthropic/claude-opus-4-7")
+        const merged = mergeAgentConfig(baseConfig, {
+          providerOptions: { thinking_token_budget: 2048 },
+        })
+
+        expect(merged.providerOptions).toBeUndefined()
+      })
+
+      it("#then existing options are preserved when providerOptions is merged", () => {
+        const baseConfig = {
+          ...createSisyphusAgent("anthropic/claude-opus-4-7"),
+          options: { existing_key: "keep_me" } as unknown,
+        }
+        const merged = mergeAgentConfig(
+          baseConfig as import("@opencode-ai/sdk").AgentConfig,
+          { providerOptions: { new_key: "added" } },
+        )
+
+        const opts = merged.options as Record<string, unknown>
+        expect(opts.existing_key).toBe("keep_me")
+        expect(opts.new_key).toBe("added")
+      })
+
+      it("#then providerOptions overrides existing options on key collision", () => {
+        const baseConfig = {
+          ...createSisyphusAgent("anthropic/claude-opus-4-7"),
+          options: { shared_key: "old_value" } as unknown,
+        }
+        const merged = mergeAgentConfig(
+          baseConfig as import("@opencode-ai/sdk").AgentConfig,
+          { providerOptions: { shared_key: "new_value" } },
+        )
+
+        const opts = merged.options as Record<string, unknown>
+        expect(opts.shared_key).toBe("new_value")
+      })
+
+      it("#then no translation occurs when providerOptions is absent", () => {
+        const baseConfig = createSisyphusAgent("anthropic/claude-opus-4-7")
+        const merged = mergeAgentConfig(baseConfig, { model: "openai/gpt-5.4" })
+
+        expect(merged.providerOptions).toBeUndefined()
+        expect(merged.options).toBeUndefined()
+      })
+    })
+  })
+
+  describe("#given a Hephaestus agent with nested providerOptions", () => {
+    describe("#when merging the override", () => {
+      it("#then nested object providerOptions is merged into options", () => {
+        const baseConfig = createHephaestusAgent("openai/gpt-5.4")
+        const merged = mergeAgentConfig(baseConfig, {
+          providerOptions: { chat_template_kwargs: { enable_thinking: false } },
+        })
+
+        const opts = merged.options as Record<string, unknown>
+        expect(opts.chat_template_kwargs).toEqual({ enable_thinking: false })
+        expect(merged.providerOptions).toBeUndefined()
+      })
+    })
+  })
+})

--- a/packages/omo-opencode/src/agents/builtin-agents/agent-overrides.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/agent-overrides.ts
@@ -52,6 +52,17 @@ export function mergeAgentConfig(
     merged.prompt = merged.prompt + "\n" + resolvePromptAppend(prompt_append, directory)
   }
 
+  // OpenCode reads `options` (flat record) for provider-specific request-body params.
+  // OMO's schema accepts `providerOptions` for ergonomic naming, but the key must be
+  // translated before it reaches OpenCode — otherwise it is silently dropped because
+  // OpenCode's agent assembly only enumerates known keys and passes `options` through.
+  const providerOptions = merged.providerOptions
+  if (providerOptions && typeof providerOptions === 'object' && !Array.isArray(providerOptions)) {
+    const existing = (merged.options as Record<string, unknown> | undefined) ?? {}
+    merged.options = { ...existing, ...(providerOptions as Record<string, unknown>) }
+    delete merged.providerOptions
+  }
+
   return merged
 }
 


### PR DESCRIPTION
## Bug

Closes #5479

Per-agent `providerOptions` in oh-my-openagent config was accepted by the schema (and documented as "Passed directly to OpenCode SDK") but silently dropped before reaching the model provider's request body.

## Root Cause

`mergeAgentConfig` wrote the user-supplied `providerOptions` as a top-level key on the agent config object. OpenCode's agent assembly only reads an enumerated set of known keys and passes the flat `options` record through to the request body. Since `providerOptions` is not in that enumerated set, its contents were never forwarded — no error is raised; the options simply have no effect.

## Fix

After the `deepMerge` in `mergeAgentConfig` (`packages/omo-opencode/src/agents/builtin-agents/agent-overrides.ts`):

1. Spread `providerOptions` contents into the `options` record (preserving existing `options` keys; `providerOptions` wins on collision).
2. Delete the now-redundant `providerOptions` key from the merged config.

This is the single choke point for all agent override merges, so it fixes the bug for every agent and every category-resolved override without further changes.

## Verification

Five new tests in `packages/omo-opencode/src/agents/agent-identity.test.ts` (confirmed RED without fix, GREEN with fix):

- `providerOptions` contents appear in `options`
- `providerOptions` key is absent after merge
- existing `options` keys are preserved alongside new ones
- `providerOptions` wins on key collision
- no-op when `providerOptions` is absent

```
bun test packages/omo-opencode/src/agents/agent-identity.test.ts
 18 pass  0 fail  [455ms]
```

All related tests continue to pass:

```
bun test packages/omo-opencode/src/plugin-handlers/agent-config-handler.test.ts
 28 pass  0 fail

bun test packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.test.ts
 5 pass  0 fail
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward per‑agent `providerOptions` to model providers by merging them into `options`, which `@opencode-ai/sdk` forwards to the request body. Fixes ignored provider settings across all agents (closes #5479).

- **Bug Fixes**
  - Translate `providerOptions` → `options` in `mergeAgentConfig` after the deep merge; `providerOptions` wins on conflicts, then the key is removed.
  - Applies at a single choke point, covering all agents and category-resolved overrides.
  - Added tests verifying contents appear in `options`, key removal, conflict precedence, preservation of existing `options`, and no-op when absent.

<sup>Written for commit 5215eb860d565c90636a86da7020b7b71599faa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

