### PR TITLE
fix(codex): isolate workflow selector hook runtime

### DIFF
--- a/packages/omo-codex/plugin/components/workflow-selector/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/workflow-selector/src/codex-hook.ts
@@ -89,6 +89,11 @@ export type CodexUserPromptSubmitInput = {
 
 type TranscriptReader = (transcriptPath: string) => string;
 
+type UserPromptSubmitHookRuntime = {
+	readonly hookEnv?: NodeJS.ProcessEnv;
+	readonly transcriptReader?: TranscriptReader;
+};
+
 interface UserPromptSubmitHookOutput {
 	readonly hookSpecificOutput: {
 		readonly hookEventName: "UserPromptSubmit";
@@ -96,14 +101,25 @@ interface UserPromptSubmitHookOutput {
 	};
 }
 
-export function runUserPromptSubmitHook(input: unknown, transcriptReader: TranscriptReader = readTranscriptTail): string {
+export function runUserPromptSubmitHook(
+	input: unknown,
+	runtime: UserPromptSubmitHookRuntime = {},
+): string {
 	if (!isCodexUserPromptSubmitInput(input)) return "";
-	if (!isAutoWorkflowEnabled(env)) return "";
+	const hookEnv = runtime.hookEnv ?? env;
+	if (!isAutoWorkflowEnabled(hookEnv)) return "";
+	const transcriptReader = runtime.transcriptReader ?? readTranscriptTail;
 	if (isContextPressureRecoveryPrompt(input.prompt)) return "";
-	if (hasAutoWorkflowContextAlreadyInTranscript(input.transcript_path, transcriptReader))
+	if (
+		hasAutoWorkflowContextAlreadyInTranscript(
+			input.transcript_path,
+			transcriptReader,
+		)
+	)
 		return "";
-	if (isContextPressureTranscript(input.transcript_path, transcriptReader)) return "";
-	const autoWorkflowContext = buildAutoWorkflowContext(input.prompt);
+	if (isContextPressureTranscript(input.transcript_path, transcriptReader))
+		return "";
+	const autoWorkflowContext = buildAutoWorkflowContext(input.prompt, hookEnv);
 	return autoWorkflowContext === null
 		? ""
 		: formatAdditionalContextOutput(autoWorkflowContext);

--- a/packages/omo-codex/plugin/components/workflow-selector/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/workflow-selector/test/codex-hook.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
 	buildAutoWorkflowContext,
@@ -24,7 +24,6 @@ describe("codex workflow selector hook", () => {
 		} else {
 			process.env["OMO_CODEX_AUTO_WORKFLOW"] = originalAutoWorkflowFlag;
 		}
-		vi.restoreAllMocks();
 	});
 
 	it("#given auto workflow is disabled #when prompt asks for debugging #then hook stays quiet", () => {
@@ -45,10 +44,7 @@ describe("codex workflow selector hook", () => {
 
 	it("#given auto workflow is disabled #when transcript path is present #then hook does not read transcript", () => {
 		// given
-		delete process.env["OMO_CODEX_AUTO_WORKFLOW"];
-		const transcriptReader = vi.fn(() => {
-			throw new Error("transcript should not be read");
-		});
+		let readCount = 0;
 		const payload = {
 			hook_event_name: "UserPromptSubmit",
 			prompt: "Fix this flaky test and diagnose why CI is failing",
@@ -56,11 +52,17 @@ describe("codex workflow selector hook", () => {
 		};
 
 		// when
-		const output = runUserPromptSubmitHook(payload, transcriptReader);
+		const output = runUserPromptSubmitHook(payload, {
+			hookEnv: {},
+			transcriptReader: () => {
+				readCount += 1;
+				throw new Error("Transcript should not be read while disabled");
+			},
+		});
 
 		// then
 		expect(output).toBe("");
-		expect(transcriptReader).not.toHaveBeenCalled();
+		expect(readCount).toBe(0);
 	});
 
 	it("#given auto workflow is enabled #when prompt asks for debugging #then hook selects ulw-loop guidance", () => {


### PR DESCRIPTION
## Summary

This PR keeps the workflow-selector hook test seam out of ESM module namespace spying by injecting the hook runtime dependencies directly. The production path still defaults to the real process environment and transcript tail reader, while tests can prove the disabled auto-workflow path does not touch the transcript reader.

## Changes

- Added a small `UserPromptSubmitHookRuntime` object for `runUserPromptSubmitHook` so tests can inject `hookEnv` and `transcriptReader` without spying on `node:fs` exports.
- Updated the disabled-auto-workflow regression test to assert the transcript reader is not called via an injected counter instead of an ESM namespace spy.
- Rebased onto current `origin/dev`; regenerated codegraph dist files from `build-components.mjs` were restored and are not part of the commit.

## QA & Evidence

- RED: `npm test --workspace components/workflow-selector` reproduced the release blocker, `Cannot spy on export "readFileSync". Module namespace is not configurable in ESM`.
  Artifact: `.omo/evidence/20260627-workflow-selector-esm-spy/red-npm-test-workflow-selector-esm-spy.txt`
- GREEN, rebased: `npm test --workspace components/workflow-selector` passed 2 files / 14 tests.
  Artifact: `.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-test-workflow-selector-rebased.txt`
- Focused component check, rebased: `npm run check --workspace components/workflow-selector` exited 0; Biome reported existing informational `useLiteralKeys` suggestions and the build completed.
  Artifact: `.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-check-workflow-selector-rebased.txt`
- Codex component build, rebased: `node packages/omo-codex/plugin/scripts/build-components.mjs` exited 0.
  Artifact: `.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-build-components-rebased.txt`
- Bundled CLI contract, rebased: `node --test packages/omo-codex/plugin/test/component-bundled-cli.test.mjs` passed 7 tests.
  Artifact: `.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-component-bundled-cli-test-rebased.txt`
- Workflow-selector CLI proof, rebased: `OMO_CODEX_AUTO_WORKFLOW=1 node packages/omo-codex/plugin/components/workflow-selector/dist/cli.js hook user-prompt-submit` emitted `<lazycodex-auto-workflow>`, `$ulw-loop`, and `manual QA evidence`.
  Artifact: `.omo/evidence/20260627-workflow-selector-esm-spy/codex-component-cli-workflow-selector-rebased.txt`

## Codex QA Limitation

Full first-party `codex app-server` QA was attempted but blocked before Codex launch during isolated local plugin install. `sync-skills.mjs` failed opening `packages/omo-codex/plugin/skills/ast-grep/SKILL.md`, so no live hook notifications could be captured from that path.

Artifacts:
- `.omo/evidence/20260627-workflow-selector-esm-spy/codex-qa-app-server-drive-plugin.txt`
- `.omo/evidence/20260627-workflow-selector-esm-spy/qa-limitation-codex-app-server.md`

For this narrow hook/test seam, the package test, component build, bundled CLI contract, and direct workflow-selector CLI proof cover the behavior changed by this PR. The app-server blocker is unrelated generated skill sync state and remains out of scope here.

## Risks & Residuals

Risk is low: the CLI production call still uses default runtime dependencies, and the changed test seam only makes dependency injection explicit. Residual live-Codex coverage is limited by the generated `ast-grep` skill sync blocker described above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects a small runtime into the workflow-selector hook so tests can pass `hookEnv` and `transcriptReader` without ESM namespace spying. Fixes the Vitest error and keeps production behavior the same.

- **Bug Fixes**
  - Added `UserPromptSubmitHookRuntime` and updated `runUserPromptSubmitHook` to accept `{ hookEnv, transcriptReader }`.
  - Default to real process env and transcript tail reader in production.
  - Reworked tests to use injected runtime and a simple counter instead of spying on `node:fs` exports.
  - Verified the disabled `OMO_CODEX_AUTO_WORKFLOW` path does not read the transcript.

<sup>Written for commit ec8046b97e3965b5ffd197c3d28b8fc2396c47e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

