### PR TITLE
feat(telemetry): unify architecture, add config control and plugin-side telemetry

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,43 @@
+name: Download Stats
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    if: github.repository == 'code-yeongyu/oh-my-openagent'
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Fetch download stats
+        run: bun run script/stats.ts --dry-run
+
+      - name: Send download stats
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+        run: bun run script/stats.ts
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        env:
+          JOB_SUMMARY_TITLE: Download stats
+          JOB_SUMMARY_STATUS: ${{ job.status }}
+          JOB_SUMMARY_DETAILS: |
+            - Fetches npm package downloads and GitHub release asset downloads.
+            - Sends aggregate download counts to PostHog when POSTHOG_KEY is available.
+          JOB_SUMMARY_NEXT: Check the fetch step for API issues, then the send step for PostHog upload failures.
+        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh

--- a/README.md
+++ b/README.md
@@ -167,11 +167,11 @@ The recommended `bunx`/`npx` invocation is `oh-my-openagent install` (or the ori
 
 ### Telemetry
 
-Anonymous telemetry is enabled by default to track active installations (DAU/WAU/MAU). For both products, a single event is sent **at most once per UTC day per machine** using a SHA256-hashed installation identifier (never the raw hostname), and PostHog person profiles are not created. The main plugin emits `oh_my_openagent_daily_active`; the Codex CLI Light edition emits `omo_codex_daily_active` from two sources (`install_completed` and `session_start`).
+Anonymous telemetry is enabled by default to track active installations (DAU/WAU/MAU). For both products, a single event is sent **at most once per UTC day per machine** using a SHA256-hashed installation identifier (never the raw hostname), and PostHog person profiles are not created. The main plugin emits `omo_daily_active` from plugin load (`plugin_loaded`) and CLI run (`run_started`) sources; the Codex CLI Light edition emits `omo_codex_daily_active` from two sources (`install_completed` and `session_start`).
 
 Opt out per product:
 
-- Main plugin: `OMO_DISABLE_POSTHOG=1` or `OMO_SEND_ANONYMOUS_TELEMETRY=0`
+- Main plugin: set `"telemetry": false` in oh-my-openagent config, `OMO_DISABLE_POSTHOG=1`, or `OMO_SEND_ANONYMOUS_TELEMETRY=0`
 - Codex CLI Light edition: `OMO_CODEX_DISABLE_POSTHOG=1` or `OMO_CODEX_SEND_ANONYMOUS_TELEMETRY=0` (the global flags also disable Codex)
 
 See [Privacy Policy](docs/legal/privacy-policy.md) and [Terms of Service](docs/legal/terms-of-service.md).

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -91,6 +91,10 @@
     "hashline_edit": {
       "type": "boolean"
     },
+    "telemetry": {
+      "description": "Enable or disable anonymous telemetry. Default: enabled when omitted. Set to false to disable. Independent of codegraph.telemetry.",
+      "type": "boolean"
+    },
     "model_fallback": {
       "type": "boolean"
     },

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -889,7 +889,7 @@ Per product:
 
 | Product | Event name | Sources |
 |---------|-----------|---------|
-| Main plugin | `oh_my_openagent_daily_active` | Session start |
+| Main plugin | `omo_daily_active` | Plugin load (`plugin_loaded`) + `run` CLI (`run_started`) |
 | Codex CLI Light edition | `omo_codex_daily_active` | Installer (`install_completed`) + Codex `SessionStart` hook (`session_start`) |
 
 Opt-out:
@@ -907,6 +907,14 @@ export OMO_CODEX_SEND_ANONYMOUS_TELEMETRY=0
 ```
 
 The global flags (`OMO_DISABLE_POSTHOG`, `OMO_SEND_ANONYMOUS_TELEMETRY`) also suppress the Codex CLI Light edition telemetry.
+
+The main plugin can also opt out through config:
+
+```jsonc
+{
+  "telemetry": false
+}
+```
 
 See [Privacy Policy](../legal/privacy-policy.md) and [Terms of Service](../legal/terms-of-service.md).
 

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -16,7 +16,7 @@ We collect limited non-personal information needed to operate and improve the Se
 
 When anonymous telemetry is enabled, the Application may collect a single anonymous usage event:
 
-- `omo_daily_active`, sent at most once per UTC day per machine when the plugin loads or when the `run` CLI is invoked, used to estimate daily, weekly, and monthly active installations
+- `omo_daily_active`, sent at most once per UTC day per machine when the plugin loads (`reason: "plugin_loaded"`) or when the `run` CLI is invoked (`reason: "run_started"`), used to estimate daily, weekly, and monthly active installations
 - `omo_codex_daily_active`, sent at most once per UTC day per machine when the `omo-codex` adapter is installed (`reason: "install_completed"`) or when its Codex plugin runtime fires on a Codex `SessionStart` hook (`reason: "session_start"`), with the same opt-out posture as `omo_daily_active`
 - Anonymous machine metadata bundled with that event, such as package version, plugin name, runtime, OS family, locale, and timezone
 - A pseudonymous installation identifier derived from a one-way hash of the local hostname
@@ -46,6 +46,8 @@ export OMO_CODEX_SEND_ANONYMOUS_TELEMETRY=0
 Global flags (`OMO_DISABLE_POSTHOG`, `OMO_SEND_ANONYMOUS_TELEMETRY`) suppress telemetry for both oh-my-openagent/oh-my-opencode and omo-codex.
 
 When telemetry is disabled, PostHog events are not sent.
+
+For the OpenCode plugin, telemetry can also be disabled in the oh-my-openagent config with `"telemetry": false`.
 
 ## 3. Third-Party Services
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,13 +79,15 @@ Subscription flags (`--claude`, `--openai`, etc.) only apply when `--platform` i
 
 Anonymous telemetry uses PostHog with a hashed installation identifier. Two streams exist:
 
-- `omo_daily_active`: fired by the main plugin and `oh-my-openagent run`.
+- `omo_daily_active`: fired by the main plugin when it loads (`reason: "plugin_loaded"`) and by `oh-my-openagent run` (`reason: "run_started"`).
 - `omo_codex_daily_active`: fired by `omo install --platform=codex` or `--platform=both` (`reason: "install_completed"`) and by the Codex plugin's `SessionStart` hook on every Codex session (`reason: "session_start"`). Both sources share the same UTC-day deduplication, so daily/weekly/monthly active counts reflect real Codex usage, not just install events.
 
 Opt-out env vars:
 
 - Global opt-out for oh-my-openagent and omo-codex: `OMO_SEND_ANONYMOUS_TELEMETRY=0` or `OMO_DISABLE_POSTHOG=1`
 - Codex-only opt-out for `omo_codex_daily_active`: `OMO_CODEX_SEND_ANONYMOUS_TELEMETRY=0` or `OMO_CODEX_DISABLE_POSTHOG=1`
+
+The OpenCode plugin can also opt out through oh-my-openagent config with `"telemetry": false`.
 
 For the full Codex Light event inventory, collected properties, local state path, and lazycodex marketplace copy path, see [Codex Light telemetry](./codex-telemetry.md).
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -997,6 +997,18 @@ When enabled, OmO registers the hash-anchored `edit` tool and activates the `has
 | `strategies.supersede_writes.aggressive` | `false`    | Prune any write if ANY subsequent read exists                                        |
 | `strategies.purge_errors.turns`          | `5`        | Turns before pruning errored tool inputs                                             |
 
+### Telemetry
+
+```jsonc
+{
+  "telemetry": false
+}
+```
+
+| Option      | Default | Description                                                            |
+| ----------- | ------- | ---------------------------------------------------------------------- |
+| `telemetry` | `true`  | Enable anonymous daily-active telemetry. Set to `false` to disable it. |
+
 ---
 
 ## Reference
@@ -1007,7 +1019,7 @@ When enabled, OmO registers the hash-anchored `edit` tool and activates the `has
 | --------------------- | ----------------------------------------------------------------- |
 | `OPENCODE_CONFIG_DIR` | Override OpenCode config directory (useful for profile isolation) |
 | `OMO_SEND_ANONYMOUS_TELEMETRY` | Set to `0`, `false`, or `no` to disable anonymous telemetry |
-| `OMO_DISABLE_POSTHOG` | Legacy telemetry opt-out flag. Set to `1` or `true` to disable PostHog |
+| `OMO_DISABLE_POSTHOG` | Legacy telemetry opt-out flag. Set to `1`, `true`, or `yes` to disable PostHog |
 | `OMO_CODEX_DISABLE_POSTHOG` | Set to `1` or `true` to disable PostHog telemetry for the `omo-codex` adapter only. Does not affect oh-my-opencode telemetry |
 | `OMO_CODEX_SEND_ANONYMOUS_TELEMETRY` | Set to `0`, `false`, or `no` to disable anonymous telemetry for `omo-codex` only |
 | `OMO_CODEX_GIT_BASH_PATH` | Native Windows Codex installs only. Absolute path to Git Bash, for example `C:\Program Files\Git\bin\bash.exe`, when `where bash` cannot find it |

--- a/packages/omo-opencode/src/cli/doctor/checks/index.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/index.ts
@@ -4,6 +4,7 @@ import { checkSystem, gatherSystemInfo } from "./system"
 import { checkConfig } from "./config"
 import { checkTools, gatherToolsSummary } from "./tools"
 import { checkModels } from "./model-resolution"
+import { checkTelemetry } from "./telemetry"
 import { checkTeamMode } from "./team-mode"
 import { checkTuiPluginConfig } from "./tui-plugin-config"
 import { checkCodex, gatherCodexSummary } from "./codex"
@@ -42,6 +43,11 @@ export function getAllCheckDefinitions(): CheckDefinition[] {
       id: CHECK_IDS.MODELS,
       name: CHECK_NAMES[CHECK_IDS.MODELS],
       check: checkModels,
+    },
+    {
+      id: CHECK_IDS.TELEMETRY,
+      name: CHECK_NAMES[CHECK_IDS.TELEMETRY],
+      check: checkTelemetry,
     },
     {
       id: CHECK_IDS.TEAM_MODE,

--- a/packages/omo-opencode/src/cli/doctor/checks/telemetry.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/telemetry.test.ts
@@ -1,0 +1,69 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+const originalXdgDataHome = process.env.XDG_DATA_HOME
+const originalOmoDisablePostHog = process.env.OMO_DISABLE_POSTHOG
+const originalOmoSendAnonymousTelemetry = process.env.OMO_SEND_ANONYMOUS_TELEMETRY
+
+function resetEnv(): void {
+  if (originalXdgDataHome === undefined) {
+    delete process.env.XDG_DATA_HOME
+  } else {
+    process.env.XDG_DATA_HOME = originalXdgDataHome
+  }
+  if (originalOmoDisablePostHog === undefined) {
+    delete process.env.OMO_DISABLE_POSTHOG
+  } else {
+    process.env.OMO_DISABLE_POSTHOG = originalOmoDisablePostHog
+  }
+  if (originalOmoSendAnonymousTelemetry === undefined) {
+    delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
+  } else {
+    process.env.OMO_SEND_ANONYMOUS_TELEMETRY = originalOmoSendAnonymousTelemetry
+  }
+}
+
+afterEach(() => {
+  resetEnv()
+})
+
+describe("checkTelemetry", () => {
+  it("reports enabled status and last daily active date", async () => {
+    // given
+    const dataHomePath = join(tmpdir(), `doctor-telemetry-${Date.now()}-${Math.random()}`)
+    const stateDir = join(dataHomePath, "oh-my-opencode")
+    mkdirSync(stateDir, { recursive: true })
+    writeFileSync(join(stateDir, "posthog-activity.json"), `${JSON.stringify({ lastActiveDayUTC: "2026-06-28" })}\n`)
+    process.env.XDG_DATA_HOME = dataHomePath
+    delete process.env.OMO_DISABLE_POSTHOG
+    delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
+    const { checkTelemetry } = await import(`./telemetry?enabled=${Date.now()}`)
+
+    // when
+    const result = await checkTelemetry()
+
+    // then
+    expect(result.status).toBe("pass")
+    expect(result.message).toBe("Telemetry: enabled")
+    expect(result.details).toContain("Last daily active date: 2026-06-28")
+    rmSync(dataHomePath, { recursive: true, force: true })
+  })
+
+  it("reports disabled status when env disables PostHog", async () => {
+    // given
+    process.env.OMO_DISABLE_POSTHOG = "1"
+    const { checkTelemetry } = await import(`./telemetry?disabled=${Date.now()}`)
+
+    // when
+    const result = await checkTelemetry()
+
+    // then
+    expect(result.status).toBe("pass")
+    expect(result.message).toBe("Telemetry: disabled")
+    expect(result.issues).toEqual([])
+  })
+})

--- a/packages/omo-opencode/src/cli/doctor/checks/telemetry.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/telemetry.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "node:fs"
+import {
+  getTelemetryActivityStateFilePath,
+  getTelemetryHost,
+  resolveTelemetryStateDir,
+} from "@oh-my-opencode/telemetry-core"
+import { validatePluginConfig } from "../../../config/validate"
+import { createOpencodeTelemetryProductConfig } from "../../../shared/telemetry-product-identity"
+import { shouldDisablePostHog } from "../../../shared/posthog"
+import { CHECK_IDS, CHECK_NAMES } from "../framework/constants"
+import type { CheckResult } from "../framework/types"
+
+type TelemetryState = {
+  readonly lastActiveDayUTC?: string
+}
+
+function isTelemetryState(value: unknown): value is TelemetryState {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function readLastActiveDay(stateFilePath: string): string {
+  if (!existsSync(stateFilePath)) {
+    return "never"
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(stateFilePath, "utf-8"))
+  } catch (error) {
+    if (error instanceof Error) {
+      return "unreadable"
+    }
+    throw error
+  }
+  if (!isTelemetryState(parsed)) {
+    return "unreadable"
+  }
+
+  return parsed.lastActiveDayUTC ?? "never"
+}
+
+function describeTelemetryStatus(configEnabled: boolean | undefined): string {
+  return shouldDisablePostHog(process.env, configEnabled) ? "disabled" : "enabled"
+}
+
+export async function checkTelemetry(): Promise<CheckResult> {
+  const product = createOpencodeTelemetryProductConfig()
+  const validation = validatePluginConfig(process.cwd())
+  const status = describeTelemetryStatus(validation.config.telemetry)
+  const stateFilePath = getTelemetryActivityStateFilePath(resolveTelemetryStateDir(product))
+  const lastActiveDay = readLastActiveDay(stateFilePath)
+
+  return {
+    name: CHECK_NAMES[CHECK_IDS.TELEMETRY],
+    status: "pass",
+    message: `Telemetry: ${status}`,
+    details: [
+      `PostHog host: ${getTelemetryHost(process.env, product.defaultHost)}`,
+      `Last daily active date: ${lastActiveDay}`,
+      `State file: ${stateFilePath}`,
+    ],
+    issues: [],
+  }
+}

--- a/packages/omo-opencode/src/cli/doctor/framework/constants.ts
+++ b/packages/omo-opencode/src/cli/doctor/framework/constants.ts
@@ -24,6 +24,7 @@ export const CHECK_IDS = {
   TUI_PLUGIN: "tui-plugin",
   TOOLS: "tools",
   MODELS: "models",
+  TELEMETRY: "telemetry",
   TEAM_MODE: "team-mode",
   CODEX: "codex",
 } as const
@@ -34,6 +35,7 @@ export const CHECK_NAMES: Record<string, string> = {
   [CHECK_IDS.TUI_PLUGIN]: "TUI Plugin",
   [CHECK_IDS.TOOLS]: "Tools",
   [CHECK_IDS.MODELS]: "Models",
+  [CHECK_IDS.TELEMETRY]: "Telemetry",
   [CHECK_IDS.TEAM_MODE]: "Team Mode",
   [CHECK_IDS.CODEX]: "Codex",
 } as const

--- a/packages/omo-opencode/src/cli/run/runner.telemetry.test.ts
+++ b/packages/omo-opencode/src/cli/run/runner.telemetry.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, mock } from "bun:test"
 import type { TelemetryCaptureMessage, TelemetryTransportFactory } from "@oh-my-opencode/telemetry-core"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import * as posthogModule from "../../shared/posthog"
 import type * as runnerModuleType from "./runner"
 
@@ -97,6 +100,21 @@ function createThrowingTransportFactory(): TelemetryTransportFactory {
   })
 }
 
+function createRunConfigFixture(telemetry: boolean): string {
+  const directory = mkdtempSync(join(tmpdir(), "omo-run-telemetry-"))
+  const configDirectory = join(directory, ".opencode")
+  mkdirSync(configDirectory, { recursive: true })
+  writeFileSync(
+    join(configDirectory, "oh-my-openagent.jsonc"),
+    JSON.stringify({ telemetry }),
+  )
+  return directory
+}
+
+function removeRunConfigFixture(directory: string): void {
+  rmSync(directory, { recursive: true, force: true })
+}
+
 function resetTelemetrySeams(): void {
   posthogModule.__resetActivityStateProviderForTesting()
   posthogModule.__resetTransportFactoryForTesting()
@@ -112,6 +130,7 @@ describe("run telemetry isolation", () => {
   it("does not capture CLI telemetry when config disables telemetry", async () => {
     // given
     enableTelemetryEnv()
+    const directory = createRunConfigFixture(false)
     const capturedMessages: TelemetryCaptureMessage[] = []
     posthogModule.__setTransportFactoryForTesting(createCapturingTransportFactory(capturedMessages))
     posthogModule.__setActivityStateProviderForTesting(() => ({
@@ -120,12 +139,16 @@ describe("run telemetry isolation", () => {
     }))
     testPluginConfig = { telemetry: false }
 
-    // when
-    const result = await run({ message: "test" })
+    try {
+      // when
+      const result = await run({ directory, message: "test" })
 
-    // then
-    expect(result).toBe(0)
-    expect(capturedMessages).toHaveLength(0)
+      // then
+      expect(result).toBe(0)
+      expect(capturedMessages).toHaveLength(0)
+    } finally {
+      removeRunConfigFixture(directory)
+    }
   })
 
   it("does not crash CLI run when telemetry throws", async () => {

--- a/packages/omo-opencode/src/cli/run/runner.telemetry.test.ts
+++ b/packages/omo-opencode/src/cli/run/runner.telemetry.test.ts
@@ -1,80 +1,142 @@
 import { afterEach, describe, expect, it, mock } from "bun:test"
+import type { TelemetryCaptureMessage, TelemetryTransportFactory } from "@oh-my-opencode/telemetry-core"
+import * as posthogModule from "../../shared/posthog"
+import type * as runnerModuleType from "./runner"
 
 async function* createEmptyEventStream(): AsyncIterable<unknown> {}
 
+let testPluginConfig: { readonly telemetry?: boolean } = {}
+
+mock.module("../../plugin-config", () => ({
+  loadPluginConfig: mock(() => testPluginConfig),
+}))
+mock.module("./agent-resolver", () => ({
+  resolveRunAgent: mock(() => "Sisyphus - Ultraworker"),
+}))
+mock.module("./server-connection", () => ({
+  createServerConnection: mock(async () => ({
+    client: {
+      event: {
+        subscribe: mock(async () => ({ stream: createEmptyEventStream() })),
+      },
+      session: {
+        promptAsync: mock(async () => undefined),
+      },
+    },
+    cleanup: mock(() => {}),
+  })),
+}))
+mock.module("./session-resolver", () => ({
+  resolveSession: mock(async () => "ses_test"),
+}))
+mock.module("./json-output", () => ({
+  createJsonOutputManager: mock(() => ({
+    redirectToStderr: mock(() => {}),
+    restore: mock(() => {}),
+    emitResult: mock(() => {}),
+  })),
+}))
+mock.module("./on-complete-hook", () => ({
+  executeOnCompleteHook: mock(async () => {}),
+}))
+mock.module("./model-resolver", () => ({
+  resolveRunModel: mock(() => null),
+}))
+mock.module("./poll-for-completion", () => ({
+  pollForCompletion: mock(async () => 0),
+}))
+mock.module("./prompt-start", () => ({
+  waitForPromptStart: mock(async () => {}),
+}))
+mock.module("./agent-profile-colors", () => ({
+  loadAgentProfileColors: mock(async () => ({})),
+}))
+mock.module("./stdin-suppression", () => ({
+  suppressRunInput: mock(() => mock(() => {})),
+}))
+mock.module("./timestamp-output", () => ({
+  createTimestampedStdoutController: mock(() => ({
+    enable: mock(() => {}),
+    restore: mock(() => {}),
+  })),
+}))
+
+const runnerModulePath = ["./runner?telemetry", "isolation"].join("-")
+const runnerModule: typeof runnerModuleType = await import(runnerModulePath)
+const { run } = runnerModule
+
+function enableTelemetryEnv(): void {
+  process.env.OMO_DISABLE_POSTHOG = "0"
+  process.env.OMO_SEND_ANONYMOUS_TELEMETRY = "1"
+  process.env.POSTHOG_API_KEY = "test-api-key"
+}
+
+function clearTelemetryEnv(): void {
+  delete process.env.OMO_DISABLE_POSTHOG
+  delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
+  delete process.env.POSTHOG_API_KEY
+}
+
+function createCapturingTransportFactory(capturedMessages: TelemetryCaptureMessage[]): TelemetryTransportFactory {
+  return () => ({
+    capture: (message) => {
+      capturedMessages.push(message)
+    },
+    shutdown: async () => undefined,
+  })
+}
+
+function createThrowingTransportFactory(): TelemetryTransportFactory {
+  return () => ({
+    capture: () => {
+      throw new Error("telemetry failed")
+    },
+    shutdown: async () => {
+      throw new Error("shutdown failed")
+    },
+  })
+}
+
+function resetTelemetrySeams(): void {
+  posthogModule.__resetActivityStateProviderForTesting()
+  posthogModule.__resetTransportFactoryForTesting()
+  clearTelemetryEnv()
+}
+
 describe("run telemetry isolation", () => {
   afterEach(() => {
-    mock.restore()
+    resetTelemetrySeams()
+    testPluginConfig = {}
+  })
+
+  it("does not capture CLI telemetry when config disables telemetry", async () => {
+    // given
+    enableTelemetryEnv()
+    const capturedMessages: TelemetryCaptureMessage[] = []
+    posthogModule.__setTransportFactoryForTesting(createCapturingTransportFactory(capturedMessages))
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: true,
+    }))
+    testPluginConfig = { telemetry: false }
+
+    // when
+    const result = await run({ message: "test" })
+
+    // then
+    expect(result).toBe(0)
+    expect(capturedMessages).toHaveLength(0)
   })
 
   it("does not crash CLI run when telemetry throws", async () => {
     // given
-    mock.module("../../plugin-config", () => ({
-      loadPluginConfig: mock(() => ({})),
+    enableTelemetryEnv()
+    posthogModule.__setTransportFactoryForTesting(createThrowingTransportFactory())
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: true,
     }))
-    mock.module("./agent-resolver", () => ({
-      resolveRunAgent: mock(() => "Sisyphus - Ultraworker"),
-    }))
-    mock.module("./server-connection", () => ({
-      createServerConnection: mock(async () => ({
-        client: {
-          event: {
-            subscribe: mock(async () => ({ stream: createEmptyEventStream() })),
-          },
-          session: {
-            promptAsync: mock(async () => undefined),
-          },
-        },
-        cleanup: mock(() => {}),
-      })),
-    }))
-    mock.module("./session-resolver", () => ({
-      resolveSession: mock(async () => "ses_test"),
-    }))
-    mock.module("./json-output", () => ({
-      createJsonOutputManager: mock(() => ({
-        redirectToStderr: mock(() => {}),
-        restore: mock(() => {}),
-        emitResult: mock(() => {}),
-      })),
-    }))
-    mock.module("./on-complete-hook", () => ({
-      executeOnCompleteHook: mock(async () => {}),
-    }))
-    mock.module("./model-resolver", () => ({
-      resolveRunModel: mock(() => null),
-    }))
-    mock.module("./poll-for-completion", () => ({
-      pollForCompletion: mock(async () => 0),
-    }))
-    mock.module("./prompt-start", () => ({
-      waitForPromptStart: mock(async () => {}),
-    }))
-    mock.module("./agent-profile-colors", () => ({
-      loadAgentProfileColors: mock(async () => ({})),
-    }))
-    mock.module("./stdin-suppression", () => ({
-      suppressRunInput: mock(() => mock(() => {})),
-    }))
-    mock.module("./timestamp-output", () => ({
-      createTimestampedStdoutController: mock(() => ({
-        enable: mock(() => {}),
-        restore: mock(() => {}),
-      })),
-    }))
-    mock.module("../../shared/posthog", () => ({
-      createCliPostHog: mock(() => ({
-        trackActive: () => {
-          throw new Error("telemetry failed")
-        },
-        shutdown: mock(async () => {
-          throw new Error("shutdown failed")
-        }),
-      })),
-      getPostHogDistinctId: mock(() => "run-distinct-id"),
-    }))
-
-    const { run } = await import(`./runner?telemetry=${Date.now()}-${Math.random()}`)
+    testPluginConfig = { telemetry: true }
 
     // when
     const result = await run({ message: "test" })

--- a/packages/omo-opencode/src/cli/run/runner.ts
+++ b/packages/omo-opencode/src/cli/run/runner.ts
@@ -55,7 +55,7 @@ export async function run(options: RunOptions): Promise<number> {
   const resolvedAgent = resolveRunAgent(options, pluginConfig)
   const abortController = new AbortController()
 
-  const posthog = createCliPostHog()
+  const posthog = createCliPostHog({ configEnabled: pluginConfig.telemetry })
   const distinctId = getPostHogDistinctId()
   try {
     posthog.trackActive(distinctId, "run_started")

--- a/packages/omo-opencode/src/config/schema/oh-my-opencode-config.test.ts
+++ b/packages/omo-opencode/src/config/schema/oh-my-opencode-config.test.ts
@@ -39,6 +39,53 @@ describe("OhMyOpenCodeConfigSchema team_mode", () => {
   })
 })
 
+describe("OhMyOpenCodeConfigSchema telemetry", () => {
+  it("allows telemetry omission", () => {
+    // given
+    const rawConfig = {}
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.telemetry).toBeUndefined()
+    }
+  })
+
+  it("accepts boolean telemetry settings", () => {
+    // given
+    const enabledConfig = { telemetry: true }
+    const disabledConfig = { telemetry: false }
+
+    // when
+    const enabledResult = OhMyOpenCodeConfigSchema.safeParse(enabledConfig)
+    const disabledResult = OhMyOpenCodeConfigSchema.safeParse(disabledConfig)
+
+    // then
+    expect(enabledResult.success).toBe(true)
+    expect(disabledResult.success).toBe(true)
+    if (enabledResult.success) {
+      expect(enabledResult.data.telemetry).toBe(true)
+    }
+    if (disabledResult.success) {
+      expect(disabledResult.data.telemetry).toBe(false)
+    }
+  })
+
+  it("rejects string telemetry settings", () => {
+    // given
+    const rawConfig = { telemetry: "yes" }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+})
+
 describe("OhMyOpenCodeConfigSchema tui", () => {
   it("defaults the TUI sidebar to enabled", () => {
     // given

--- a/packages/omo-opencode/src/config/schema/oh-my-opencode-config.ts
+++ b/packages/omo-opencode/src/config/schema/oh-my-opencode-config.ts
@@ -58,6 +58,8 @@ export const OhMyOpenCodeConfigSchema = z.object({
   mcp_env_allowlist: z.array(z.string()).optional(),
   /** Enable hashline_edit tool/hook integrations (default: false) */
   hashline_edit: z.boolean().optional(),
+  /** Enable anonymous telemetry. Default: enabled when omitted. Set to false to disable. Independent of codegraph.telemetry. */
+  telemetry: z.boolean().optional().describe("Enable or disable anonymous telemetry. Default: enabled when omitted. Set to false to disable. Independent of codegraph.telemetry."),
   /** Enable model fallback on API errors (default: false). Set to true to enable automatic model switching when model errors occur. */
   model_fallback: z.boolean().optional(),
   agents: AgentOverridesSchema.optional(),

--- a/packages/omo-opencode/src/hooks/write-existing-file-guard/lazy-canonical-path-init.test.ts
+++ b/packages/omo-opencode/src/hooks/write-existing-file-guard/lazy-canonical-path-init.test.ts
@@ -34,6 +34,8 @@ describe("createWriteExistingFileGuardHook", () => {
       },
     }))
     const { createWriteExistingFileGuardHook } = await import(`./hook?test=${crypto.randomUUID()}`)
+    existsSyncMock.mockClear()
+    realpathNativeMock.mockClear()
     const existingFile = join(tempDir, "existing.txt")
     writeFileSync(existingFile, "content")
 

--- a/packages/omo-opencode/src/index.telemetry.test.ts
+++ b/packages/omo-opencode/src/index.telemetry.test.ts
@@ -1,5 +1,7 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test"
-import { createPluginModule } from "./testing/create-plugin-module"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import type { TelemetryCaptureMessage, TelemetryTransportFactory } from "@oh-my-opencode/telemetry-core"
+import { createPluginModule, type PluginModuleDeps } from "./testing/create-plugin-module"
+import * as posthogModule from "./shared/posthog"
 
 const mockInitConfigContext = mock(() => {})
 const mockInjectServerAuthIntoClient = mock(() => {})
@@ -34,7 +36,28 @@ const mockCreateHooks = mock(() => ({
 const mockCreatePluginInterface = mock(() => ({}))
 const mockLog = mock(() => {})
 
-function createTestPluginModule(): ReturnType<typeof createPluginModule> {
+function enableTelemetryEnv(): void {
+  process.env.OMO_DISABLE_POSTHOG = "0"
+  process.env.OMO_SEND_ANONYMOUS_TELEMETRY = "1"
+  process.env.POSTHOG_API_KEY = "test-api-key"
+}
+
+function clearTelemetryEnv(): void {
+  delete process.env.OMO_DISABLE_POSTHOG
+  delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
+  delete process.env.POSTHOG_API_KEY
+}
+
+function createCapturingTransportFactory(capturedMessages: TelemetryCaptureMessage[]): TelemetryTransportFactory {
+  return () => ({
+    capture: (message) => {
+      capturedMessages.push(message)
+    },
+    shutdown: async () => new Promise<void>(() => {}),
+  })
+}
+
+function createTestPluginModule(overrides: Partial<PluginModuleDeps> = {}): ReturnType<typeof createPluginModule> {
   return createPluginModule({
     initConfigContext: mockInitConfigContext,
     injectServerAuthIntoClient: mockInjectServerAuthIntoClient,
@@ -68,11 +91,16 @@ function createTestPluginModule(): ReturnType<typeof createPluginModule> {
     })) as never,
     installAgentSortShim: mock(() => {}),
     setAgentSortOrder: mock(() => {}),
+    ...overrides,
   })
 }
 
 describe("oh-my-openagent telemetry isolation", () => {
   beforeEach(() => {
+    clearTelemetryEnv()
+    posthogModule.__resetActivityStateProviderForTesting()
+    posthogModule.__resetOsProviderForTesting()
+    posthogModule.__resetTransportFactoryForTesting()
     mockInitConfigContext.mockClear()
     mockInjectServerAuthIntoClient.mockClear()
     mockLogLegacyPluginStartupWarning.mockClear()
@@ -87,9 +115,20 @@ describe("oh-my-openagent telemetry isolation", () => {
     mockLog.mockClear()
   })
 
+  afterEach(() => {
+    clearTelemetryEnv()
+    posthogModule.__resetActivityStateProviderForTesting()
+    posthogModule.__resetOsProviderForTesting()
+    posthogModule.__resetTransportFactoryForTesting()
+  })
+
   it("does not crash plugin load when telemetry throws", async () => {
     // given
-    const plugin = createTestPluginModule()
+    const plugin = createTestPluginModule({
+      recordPluginTelemetry: mock(() => {
+        throw new Error("telemetry failed")
+      }),
+    })
 
     // when
     const result = await plugin.server({
@@ -100,5 +139,51 @@ describe("oh-my-openagent telemetry isolation", () => {
     // then
     expect(typeof result).toBe("object")
     expect(result).not.toBeNull()
+  })
+
+  it("passes config telemetry into plugin telemetry after config loads", async () => {
+    // given
+    mockLoadPluginConfig.mockImplementationOnce(() => ({ telemetry: false }))
+    const recordPluginTelemetry = mock(() => {})
+    const plugin = createTestPluginModule({ recordPluginTelemetry })
+
+    // when
+    await plugin.server({
+      directory: "/tmp/project",
+      client: {},
+    } as Parameters<typeof plugin.server>[0])
+
+    // then
+    expect(recordPluginTelemetry).toHaveBeenCalledWith({ configEnabled: false })
+  })
+
+  it("records plugin_loaded without waiting for telemetry shutdown", async () => {
+    // given
+    enableTelemetryEnv()
+    const captured: TelemetryCaptureMessage[] = []
+    posthogModule.__setTransportFactoryForTesting(createCapturingTransportFactory(captured))
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: true,
+    }))
+    const plugin = createTestPluginModule()
+
+    // when
+    const result = await Promise.race([
+      plugin.server({
+        directory: "/tmp/project",
+        client: {},
+      } as Parameters<typeof plugin.server>[0]),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 50)),
+    ])
+
+    // then
+    expect(result).not.toBe("timeout")
+    expect(captured).toHaveLength(1)
+    expect(captured[0]?.event).toBe("omo_daily_active")
+    expect(captured[0]?.properties).toMatchObject({
+      reason: "plugin_loaded",
+      source: "plugin",
+    })
   })
 })

--- a/packages/omo-opencode/src/shared/posthog-activity-state.ts
+++ b/packages/omo-opencode/src/shared/posthog-activity-state.ts
@@ -6,7 +6,7 @@ import {
 import type { TelemetryDiagnosticInput } from "@oh-my-opencode/telemetry-core"
 
 import { log } from "./logger"
-import { CACHE_DIR_NAME } from "./plugin-identity"
+import { createOpencodeTelemetryProductConfig } from "./telemetry-product-identity"
 
 type PostHogActivityCaptureState = {
   dayUTC: string
@@ -14,7 +14,7 @@ type PostHogActivityCaptureState = {
 }
 
 function getPostHogActivityStateDir(): string {
-  return resolveTelemetryStateDir({ cacheDirName: CACHE_DIR_NAME })
+  return resolveTelemetryStateDir(createOpencodeTelemetryProductConfig())
 }
 
 function logActivityStateDiagnostic(input: TelemetryDiagnosticInput): void {

--- a/packages/omo-opencode/src/shared/posthog.test.ts
+++ b/packages/omo-opencode/src/shared/posthog.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import type {
   TelemetryCaptureMessage,
@@ -216,6 +218,45 @@ describe("posthog disable env var parsing", () => {
       expect(captured).toHaveLength(0)
     })
   }
+
+  it("keeps OMO_SEND_ANONYMOUS_TELEMETRY=yes enabled for env compatibility", async () => {
+    // given
+    process.env.OMO_SEND_ANONYMOUS_TELEMETRY = "yes"
+    process.env.POSTHOG_API_KEY = "test-api-key"
+    const captured: CapturedPostHogMessage[] = []
+    const posthogModule = usePostHogModule(await importPostHogModule())
+    posthogModule.__setTransportFactoryForTesting(createCapturingTransportFactory(captured))
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: true,
+    }))
+    const client = posthogModule.createCliPostHog()
+
+    // when
+    client.trackActive("distinct-cli", "run_started")
+
+    // then
+    expect(captured).toHaveLength(1)
+  })
+
+  it("treats configEnabled false as disabled", async () => {
+    // given
+    enableTelemetryEnv()
+    const captured: CapturedPostHogMessage[] = []
+    const posthogModule = usePostHogModule(await importPostHogModule())
+    posthogModule.__setTransportFactoryForTesting(createCapturingTransportFactory(captured))
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: true,
+    }))
+    const client = posthogModule.createCliPostHog({ configEnabled: false })
+
+    // when
+    client.trackActive("distinct-cli", "run_started")
+
+    // then
+    expect(captured).toHaveLength(0)
+  })
 })
 
 describe("posthog trackActive emission contract", () => {
@@ -263,12 +304,13 @@ describe("posthog trackActive emission contract", () => {
     expect(dailyEvent?.event).toBe("omo_daily_active")
     expect(dailyEvent?.distinctId).toBe("distinct-cli")
     const properties = dailyEvent.properties ?? {}
-    const expectedPropertyKeys = ["$os", "$os_version", "$process_person_profile", "ci", "cpu_count", "cpu_model", "day_utc", "locale", "os_arch", "os_type", "package_name", "package_version", "platform", "plugin_name", "reason", "runtime", "runtime_version", "shell", "source", "terminal", "timezone", "total_memory_gb"]
+    const expectedPropertyKeys = ["$os", "$os_version", "$process_person_profile", "ci", "cpu_count", "cpu_model", "day_utc", "locale", "os_arch", "os_type", "package_name", "package_version", "platform", "plugin_name", "product_name", "reason", "runtime", "runtime_version", "shell", "source", "terminal", "timezone", "total_memory_gb"]
     expect(Object.keys(properties).sort()).toEqual(expectedPropertyKeys.sort())
     expect(properties).toMatchObject({
       platform: "oh-my-opencode",
       package_name: "oh-my-openagent",
       plugin_name: "oh-my-openagent",
+      product_name: "oh-my-openagent",
       source: "cli",
       $os: "linux",
       $os_version: "6.8.0-test",
@@ -303,5 +345,32 @@ describe("posthog trackActive emission contract", () => {
     const emittedEvents = captured.map((message) => message.event)
     expect(emittedEvents).not.toContain("omo_daily_active")
     expect(emittedEvents).not.toContain("omo_hourly_active")
+  })
+
+  it("records plugin load telemetry with the plugin_loaded reason", async () => {
+    // given
+    enableTelemetryEnv()
+    const captured: CapturedPostHogMessage[] = []
+    const posthogModule = usePostHogModule(await importPostHogModule())
+    posthogModule.__setTransportFactoryForTesting(createCapturingTransportFactory(captured))
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: true,
+    }))
+
+    // when
+    posthogModule.recordPluginTelemetry({ configEnabled: true })
+
+    // then
+    expect(captured).toHaveLength(1)
+    const [dailyEvent] = captured
+    if (!dailyEvent) {
+      throw new Error("Expected plugin telemetry event")
+    }
+    expect(dailyEvent.event).toBe("omo_daily_active")
+    expect(dailyEvent.properties).toMatchObject({
+      reason: "plugin_loaded",
+      source: "plugin",
+    })
   })
 })

--- a/packages/omo-opencode/src/shared/posthog.ts
+++ b/packages/omo-opencode/src/shared/posthog.ts
@@ -1,33 +1,31 @@
-import os from "os"
 import {
-  DEFAULT_POSTHOG_API_KEY,
-  DEFAULT_POSTHOG_HOST,
   createDefaultPostHogTransport,
+  createTelemetryClient,
+  getDefaultTelemetryOsProvider,
   getTelemetryDistinctId,
-  getTelemetryHost,
 } from "@oh-my-opencode/telemetry-core"
 import type {
-  TelemetryCaptureMessage,
-  TelemetryTransport,
+  PostHogActivityCaptureState,
+  TelemetryDiagnosticInput,
+  TelemetryEnv,
+  TelemetryOsProvider,
   TelemetryTransportFactory,
-  TelemetryTransportOptions,
 } from "@oh-my-opencode/telemetry-core"
-import packageJson from "../../../../package.json" with { type: "json" }
-import { PLUGIN_NAME, PUBLISHED_PACKAGE_NAME } from "./plugin-identity"
 import { getPostHogActivityCaptureState } from "./posthog-activity-state"
+import { log } from "./logger"
+import { createOpencodeTelemetryProductConfig } from "./telemetry-product-identity"
 
 /** @internal test-only seam: keep null in production to use the real implementation. */
 let activityStateProviderOverride: typeof getPostHogActivityCaptureState | null = null
-type OsProvider = Pick<typeof os, "arch" | "cpus" | "hostname" | "platform" | "release" | "totalmem" | "type">
-let osProviderOverride: OsProvider | null = null
+let osProviderOverride: TelemetryOsProvider | null = null
 let transportFactoryOverride: TelemetryTransportFactory | null = null
 
-function resolveActivityState(): ReturnType<typeof getPostHogActivityCaptureState> {
+function resolveActivityState(): PostHogActivityCaptureState {
   return (activityStateProviderOverride ?? getPostHogActivityCaptureState)()
 }
 
-function resolveOsProvider(): OsProvider {
-  return osProviderOverride ?? os
+function resolveOsProvider(): TelemetryOsProvider {
+  return osProviderOverride ?? getDefaultTelemetryOsProvider()
 }
 
 function resolveTransportFactory(): TelemetryTransportFactory {
@@ -47,7 +45,7 @@ export function __resetActivityStateProviderForTesting(): void {
 }
 
 /** @internal test-only */
-export function __setOsProviderForTesting(provider: OsProvider): void {
+export function __setOsProviderForTesting(provider: TelemetryOsProvider): void {
   osProviderOverride = provider
 }
 
@@ -64,13 +62,20 @@ export function __resetTransportFactoryForTesting(): void {
   transportFactoryOverride = null
 }
 
-type PostHogCaptureProperties = NonNullable<TelemetryCaptureMessage["properties"]>
-type PostHogSource = "cli" | "plugin"
-type PostHogActivityReason = "run_started"
+export type PostHogSource = "cli" | "plugin"
+export type PostHogActivityReason = "run_started" | "plugin_loaded"
 
-type PostHogClient = {
-  trackActive: (distinctId: string, reason: PostHogActivityReason) => void
-  shutdown: () => Promise<void>
+export type PostHogClient = {
+  readonly trackActive: (distinctId: string, reason: PostHogActivityReason) => void
+  readonly shutdown: () => Promise<void>
+}
+
+type CreatePostHogOptions = {
+  readonly configEnabled?: boolean
+}
+
+type RecordPluginTelemetryInput = {
+  readonly configEnabled?: boolean
 }
 
 const NO_OP_POSTHOG: PostHogClient = {
@@ -86,148 +91,91 @@ function isTruthy(value: string | undefined): boolean {
   return value === "1" || value === "true" || value === "yes"
 }
 
-function shouldDisablePostHog(): boolean {
-  if (isTruthy(process.env.OMO_DISABLE_POSTHOG?.trim().toLowerCase())) {
+export function shouldDisablePostHog(env: TelemetryEnv, configEnabled: boolean | undefined): boolean {
+  if (configEnabled === false) {
     return true
   }
 
-  return isFalsy(process.env.OMO_SEND_ANONYMOUS_TELEMETRY?.trim().toLowerCase())
-}
-
-function hasPostHogApiKey(): boolean {
-  return getPostHogApiKey().length > 0
-}
-
-function getPostHogApiKey(): string {
-  return process.env.POSTHOG_API_KEY?.trim() || DEFAULT_POSTHOG_API_KEY
-}
-
-function getPostHogHost(): string {
-  return getTelemetryHost(process.env, DEFAULT_POSTHOG_HOST)
-}
-
-function safeCpus(): { length: number; model: string | undefined } {
-  try {
-    const cpus = resolveOsProvider().cpus()
-    return { length: cpus.length, model: cpus[0]?.model }
-  } catch (error) {
-    if (!(error instanceof Error)) {
-      throw error
-    }
-    return { length: 0, model: undefined }
+  if (isTruthy(env.OMO_DISABLE_POSTHOG?.trim().toLowerCase())) {
+    return true
   }
+
+  return isFalsy(env.OMO_SEND_ANONYMOUS_TELEMETRY?.trim().toLowerCase())
 }
 
-function getSharedProperties(source: PostHogSource): PostHogCaptureProperties {
-  const cpus = safeCpus()
-  const osProvider = resolveOsProvider()
+function createCoreCompatibleTelemetryEnv(env: NodeJS.ProcessEnv): TelemetryEnv {
+  if (env.OMO_SEND_ANONYMOUS_TELEMETRY?.trim().toLowerCase() !== "yes") {
+    return env
+  }
 
   return {
-    platform: "oh-my-opencode",
-    package_name: PUBLISHED_PACKAGE_NAME,
-    plugin_name: PLUGIN_NAME,
-    package_version: packageJson.version,
-    runtime: "bun",
-    runtime_version: process.versions.bun ?? process.version,
-    source,
-    $os: osProvider.platform(),
-    $os_version: osProvider.release(),
-    os_arch: osProvider.arch(),
-    os_type: osProvider.type(),
-    cpu_count: cpus.length,
-    cpu_model: cpus.model,
-    total_memory_gb: Math.round(osProvider.totalmem() / 1024 / 1024 / 1024),
-    locale: Intl.DateTimeFormat().resolvedOptions().locale,
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    shell: process.env.SHELL,
-    ci: Boolean(process.env.CI),
-    terminal: process.env.TERM_PROGRAM,
+    ...env,
+    OMO_SEND_ANONYMOUS_TELEMETRY: "1",
   }
 }
 
-function createPostHogClient(
-  source: PostHogSource,
-  options: Omit<TelemetryTransportOptions, "disableGeoip" | "host">,
-): PostHogClient {
-  if (shouldDisablePostHog() || !hasPostHogApiKey()) {
+function logTelemetryDiagnostic(input: TelemetryDiagnosticInput): void {
+  log("[posthog] telemetry diagnostic", {
+    event: input.event,
+    error: input.error === undefined ? undefined : String(input.error),
+    errorKind: input.errorKind,
+    source: input.source,
+  })
+}
+
+function createPostHogClient(source: PostHogSource, options: CreatePostHogOptions = {}): PostHogClient {
+  const env = process.env
+  if (shouldDisablePostHog(env, options.configEnabled)) {
     return NO_OP_POSTHOG
   }
 
-  let configuredClient: TelemetryTransport
+  const client = createTelemetryClient({
+    diagnostics: logTelemetryDiagnostic,
+    env: createCoreCompatibleTelemetryEnv(env),
+    osProvider: resolveOsProvider(),
+    product: createOpencodeTelemetryProductConfig(),
+    source,
+    transportFactory: resolveTransportFactory(),
+  })
 
-  try {
-    configuredClient = resolveTransportFactory()(getPostHogApiKey(), {
-      ...options,
-      host: getPostHogHost(),
-      disableGeoip: false,
-    })
-  } catch (error) {
-    if (!(error instanceof Error)) {
-      throw error
-    }
+  if (!client.enabled) {
     return NO_OP_POSTHOG
   }
-  const sharedProperties = getSharedProperties(source)
 
   return {
     trackActive: (distinctId, reason) => {
       const activityState = resolveActivityState()
-
-      if (activityState.captureDaily) {
-        try {
-          configuredClient.capture({
-            distinctId,
-            event: "omo_daily_active",
-            properties: {
-              ...sharedProperties,
-              $process_person_profile: false,
-              day_utc: activityState.dayUTC,
-              reason,
-            },
-          })
-        } catch (error) {
-          if (error instanceof Error) {
-            return
-          }
-          return
-        }
-      }
-    },
-    shutdown: async () => {
-      try {
-        await configuredClient.shutdown()
-      } catch (error) {
-        if (error instanceof Error) {
-          return
-        }
+      if (!activityState.captureDaily) {
         return
       }
+
+      client.trackActive({
+        dayUTC: activityState.dayUTC,
+        distinctId,
+        reason,
+      })
+    },
+    shutdown: async () => {
+      await client.shutdown()
     },
   }
 }
 
 export function getPostHogDistinctId(): string {
-  return getTelemetryDistinctId(`${PUBLISHED_PACKAGE_NAME}:`, resolveOsProvider())
+  return getTelemetryDistinctId(createOpencodeTelemetryProductConfig().machineIdPrefix, resolveOsProvider())
 }
 
-export function createCliPostHog(): PostHogClient {
-  return createPostHogClient("cli", {
-    enableExceptionAutocapture: false,
-    enableLocalEvaluation: false,
-    strictLocalEvaluation: true,
-    disableRemoteConfig: true,
-    flushAt: 1,
-    flushInterval: 0,
-  })
+export function createCliPostHog(options: CreatePostHogOptions = {}): PostHogClient {
+  return createPostHogClient("cli", options)
 }
 
-export function createPluginPostHog(): PostHogClient {
-  return createPostHogClient("plugin", {
-    enableExceptionAutocapture: false,
-    enableLocalEvaluation: false,
-    strictLocalEvaluation: true,
-    disableRemoteConfig: true,
-    flushAt: 1,
-    flushInterval: 0,
-  })
+export function createPluginPostHog(options: CreatePostHogOptions = {}): PostHogClient {
+  return createPostHogClient("plugin", options)
+}
+
+export function recordPluginTelemetry(input: RecordPluginTelemetryInput): void {
+  const posthog = createPluginPostHog({ configEnabled: input.configEnabled })
+  const distinctId = getPostHogDistinctId()
+  posthog.trackActive(distinctId, "plugin_loaded")
+  void posthog.shutdown()
 }

--- a/packages/omo-opencode/src/shared/telemetry-architecture.test.ts
+++ b/packages/omo-opencode/src/shared/telemetry-architecture.test.ts
@@ -1,0 +1,44 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import {
+  DEFAULT_POSTHOG_API_KEY,
+  type TelemetryProductConfig,
+} from "@oh-my-opencode/telemetry-core"
+import { createOpencodeTelemetryProductConfig } from "./telemetry-product-identity"
+
+const REPO_ROOT = join(import.meta.dir, "../../..", "..")
+const TELEMETRY_CORE_PACKAGE = "@oh-my-opencode/telemetry-core"
+
+function readText(path: string): string {
+  return readFileSync(path, "utf-8")
+}
+
+describe("omo-opencode telemetry architecture", () => {
+  it("uses telemetry-core as the PostHog implementation boundary", () => {
+    // given
+    const posthogSource = readText(join(REPO_ROOT, "packages", "omo-opencode", "src", "shared", "posthog.ts"))
+
+    // when / then
+    expect(posthogSource).toContain(TELEMETRY_CORE_PACKAGE)
+    expect(posthogSource).toContain("createTelemetryClient")
+    expect(posthogSource).not.toContain("recordDailyActive")
+  })
+
+  it("exports a valid product config with the shared PostHog key", () => {
+    // given
+    const product = createOpencodeTelemetryProductConfig()
+
+    // when
+    const typedProduct = product satisfies TelemetryProductConfig
+
+    // then
+    expect(typedProduct.defaultApiKey).toBe(DEFAULT_POSTHOG_API_KEY)
+    expect(typedProduct.eventName).toBe("omo_daily_active")
+    expect(typedProduct.additionalProperties).toMatchObject({
+      plugin_name: "oh-my-openagent",
+    })
+  })
+})

--- a/packages/omo-opencode/src/shared/telemetry-parity.test.ts
+++ b/packages/omo-opencode/src/shared/telemetry-parity.test.ts
@@ -1,0 +1,168 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, it } from "bun:test"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import type {
+  TelemetryCaptureMessage,
+  TelemetryOsProvider,
+  TelemetryTransportFactory,
+} from "@oh-my-opencode/telemetry-core"
+import {
+  getTelemetryActivityStateFilePath,
+  resolveTelemetryStateDir,
+} from "@oh-my-opencode/telemetry-core"
+import { createOpencodeTelemetryProductConfig } from "./telemetry-product-identity"
+
+type CapturedPostHogMessage = TelemetryCaptureMessage
+type PostHogModule = Awaited<ReturnType<typeof importPostHogModule>>
+
+const EXPECTED_DISTINCT_ID_FOR_PARITY_HOST =
+  "ad898a24f97bd14de34b9f3de62ab7cf1c2a77330ba41906af6e517f20e8272d"
+
+let activePostHogModule: PostHogModule | null = null
+const originalXdgDataHome = process.env.XDG_DATA_HOME
+
+async function importPostHogModule(): Promise<typeof import("./posthog")> {
+  return import(`./posthog?parity=${Date.now()}-${Math.random()}`)
+}
+
+function usePostHogModule(posthogModule: PostHogModule): PostHogModule {
+  activePostHogModule = posthogModule
+  return posthogModule
+}
+
+function resetPostHogModuleTestSeams(): void {
+  activePostHogModule?.__resetActivityStateProviderForTesting()
+  activePostHogModule?.__resetOsProviderForTesting()
+  activePostHogModule?.__resetTransportFactoryForTesting()
+  activePostHogModule = null
+}
+
+function resetTelemetryEnv(): void {
+  delete process.env.OMO_DISABLE_POSTHOG
+  delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
+  process.env.POSTHOG_API_KEY = "test-api-key"
+}
+
+function createCapturingTransportFactory(
+  capturedMessages: CapturedPostHogMessage[],
+): TelemetryTransportFactory {
+  return () => ({
+    capture: (message) => {
+      capturedMessages.push(message)
+    },
+    shutdown: async () => undefined,
+  })
+}
+
+function createParityOsProvider(hostname: string): TelemetryOsProvider {
+  return {
+    arch: () => "arm64",
+    cpus: () => [{ model: "Parity CPU" }],
+    hostname: () => hostname,
+    platform: () => "darwin",
+    release: () => "26.0.0",
+    totalmem: () => 32 * 1024 * 1024 * 1024,
+    type: () => "Darwin",
+  }
+}
+
+async function captureWithEnv(
+  envPatch: Readonly<Record<string, string | undefined>>,
+): Promise<readonly CapturedPostHogMessage[]> {
+  resetTelemetryEnv()
+  for (const [key, value] of Object.entries(envPatch)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+
+  const captured: CapturedPostHogMessage[] = []
+  const posthogModule = usePostHogModule(await importPostHogModule())
+  posthogModule.__setTransportFactoryForTesting(createCapturingTransportFactory(captured))
+  posthogModule.__setActivityStateProviderForTesting(() => ({
+    dayUTC: "2026-06-28",
+    captureDaily: true,
+  }))
+
+  const client = posthogModule.createCliPostHog()
+  client.trackActive("distinct-cli", "run_started")
+  await client.shutdown()
+
+  return captured
+}
+
+afterEach(() => {
+  resetPostHogModuleTestSeams()
+  delete process.env.OMO_DISABLE_POSTHOG
+  delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
+  delete process.env.POSTHOG_API_KEY
+  if (originalXdgDataHome === undefined) {
+    delete process.env.XDG_DATA_HOME
+  } else {
+    process.env.XDG_DATA_HOME = originalXdgDataHome
+  }
+})
+
+describe("telemetry before/after parity", () => {
+  it("pins event name, distinct ID prefix, state file path, env matrix, and payload keys", async () => {
+    // given
+    resetTelemetryEnv()
+    const captured: CapturedPostHogMessage[] = []
+    const xdgDataHome = join(tmpdir(), `telemetry-parity-${Date.now()}-${Math.random()}`)
+    process.env.XDG_DATA_HOME = xdgDataHome
+    const product = createOpencodeTelemetryProductConfig()
+    const posthogModule = usePostHogModule(await importPostHogModule())
+    posthogModule.__setTransportFactoryForTesting(createCapturingTransportFactory(captured))
+    posthogModule.__setOsProviderForTesting(createParityOsProvider("telemetry-parity-host"))
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-06-28",
+      captureDaily: true,
+    }))
+    const expectedStateFilePath = join(xdgDataHome, "oh-my-opencode", "posthog-activity.json")
+
+    // when
+    const distinctId = posthogModule.getPostHogDistinctId()
+    const stateFilePath = getTelemetryActivityStateFilePath(resolveTelemetryStateDir(product))
+    const client = posthogModule.createCliPostHog()
+    client.trackActive(distinctId, "run_started")
+    await client.shutdown()
+
+    // then
+    expect(product.eventName).toBe("omo_daily_active")
+    expect(product.machineIdPrefix).toBe("oh-my-openagent:")
+    expect(product.cacheDirName).toBe("oh-my-opencode")
+    expect(distinctId).toBe(EXPECTED_DISTINCT_ID_FOR_PARITY_HOST)
+    expect(stateFilePath).toBe(expectedStateFilePath)
+    expect(existsSync(stateFilePath)).toBe(false)
+    expect(captured).toHaveLength(1)
+    const [dailyEvent] = captured
+    if (!dailyEvent) {
+      throw new Error("Expected telemetry parity event")
+    }
+    expect(dailyEvent.event).toBe("omo_daily_active")
+    const payloadKeys = Object.keys(dailyEvent.properties ?? {}).sort()
+    expect(payloadKeys).toContain("plugin_name")
+    expect(payloadKeys).toContain("product_name")
+  })
+
+  it("preserves the legacy env opt-out matrix including yes as enabled", async () => {
+    // given / when
+    const disabledByPostHogFlag = await captureWithEnv({ OMO_DISABLE_POSTHOG: "1" })
+    const disabledBySendZero = await captureWithEnv({ OMO_SEND_ANONYMOUS_TELEMETRY: "0" })
+    const enabledBySendYes = await captureWithEnv({ OMO_SEND_ANONYMOUS_TELEMETRY: "yes" })
+    const disabledBySendNo = await captureWithEnv({ OMO_SEND_ANONYMOUS_TELEMETRY: "no" })
+    const enabledByUnset = await captureWithEnv({})
+
+    // then
+    expect(disabledByPostHogFlag).toHaveLength(0)
+    expect(disabledBySendZero).toHaveLength(0)
+    expect(enabledBySendYes).toHaveLength(1)
+    expect(disabledBySendNo).toHaveLength(0)
+    expect(enabledByUnset).toHaveLength(1)
+  })
+})

--- a/packages/omo-opencode/src/shared/telemetry-product-identity.test.ts
+++ b/packages/omo-opencode/src/shared/telemetry-product-identity.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test"
+import packageJson from "../../../../package.json" with { type: "json" }
+import { PLUGIN_NAME } from "./plugin-identity"
+import { createOpencodeTelemetryProductConfig } from "./telemetry-product-identity"
+
+describe("createOpencodeTelemetryProductConfig", () => {
+  it("pins the omo-opencode telemetry identity for zero data breakage", () => {
+    // given
+    const expectedVersion = packageJson.version
+
+    // when
+    const product = createOpencodeTelemetryProductConfig()
+
+    // then
+    expect(product).toMatchObject({
+      cacheDirName: "oh-my-opencode",
+      eventName: "omo_daily_active",
+      machineIdPrefix: "oh-my-openagent:",
+      packageName: "oh-my-openagent",
+      packageVersion: expectedVersion,
+      platform: "oh-my-opencode",
+      productEnvPrefix: "OMO",
+      productName: "oh-my-openagent",
+      additionalProperties: {
+        plugin_name: PLUGIN_NAME,
+      },
+    })
+  })
+})

--- a/packages/omo-opencode/src/shared/telemetry-product-identity.ts
+++ b/packages/omo-opencode/src/shared/telemetry-product-identity.ts
@@ -1,0 +1,25 @@
+import {
+  DEFAULT_POSTHOG_API_KEY,
+  DEFAULT_POSTHOG_HOST,
+  type TelemetryProductConfig,
+} from "@oh-my-opencode/telemetry-core"
+import packageJson from "../../../../package.json" with { type: "json" }
+import { CACHE_DIR_NAME, PLUGIN_NAME, PUBLISHED_PACKAGE_NAME } from "./plugin-identity"
+
+export function createOpencodeTelemetryProductConfig(): TelemetryProductConfig {
+  return {
+    cacheDirName: CACHE_DIR_NAME,
+    defaultApiKey: DEFAULT_POSTHOG_API_KEY,
+    defaultHost: DEFAULT_POSTHOG_HOST,
+    eventName: "omo_daily_active",
+    machineIdPrefix: "oh-my-openagent:",
+    packageName: PUBLISHED_PACKAGE_NAME,
+    packageVersion: packageJson.version,
+    platform: "oh-my-opencode",
+    productEnvPrefix: "OMO",
+    productName: PUBLISHED_PACKAGE_NAME,
+    additionalProperties: {
+      plugin_name: PLUGIN_NAME,
+    },
+  }
+}

--- a/packages/omo-opencode/src/testing/create-plugin-module.ts
+++ b/packages/omo-opencode/src/testing/create-plugin-module.ts
@@ -31,6 +31,7 @@ import { log } from "../shared/logger"
 import { logLegacyPluginStartupWarning } from "../shared/log-legacy-plugin-startup-warning"
 import { migrateLegacyWorkspaceDirectory } from "../shared/legacy-workspace-migration"
 import { injectServerAuthIntoClient } from "../shared/opencode-server-auth"
+import { recordPluginTelemetry } from "../shared/posthog"
 import {
   initLiveServerRoute,
   setLiveParentWakeRoutingDisabled,
@@ -59,6 +60,7 @@ export type PluginModuleDeps = {
   setLiveParentWakeRoutingDisabled: typeof setLiveParentWakeRoutingDisabled
   warmLiveServerProbe: typeof warmLiveServerProbe
   loadPluginConfig: typeof loadPluginConfig
+  recordPluginTelemetry: typeof recordPluginTelemetry
   initI18n: typeof initI18n
   initializeOpenClaw: typeof initializeOpenClaw
   isTmuxIntegrationEnabled: typeof isTmuxIntegrationEnabled
@@ -89,6 +91,7 @@ const defaultPluginModuleDeps: PluginModuleDeps = {
   setLiveParentWakeRoutingDisabled,
   warmLiveServerProbe,
   loadPluginConfig,
+  recordPluginTelemetry,
   initI18n,
   initializeOpenClaw,
   isTmuxIntegrationEnabled,
@@ -128,6 +131,13 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
     deps.injectServerAuthIntoClient(input.client)
 
     const pluginConfig = deps.loadPluginConfig(input.directory, input)
+    try {
+      deps.recordPluginTelemetry({ configEnabled: pluginConfig.telemetry })
+    } catch (error) {
+      deps.log("[posthog] plugin telemetry failed", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
     if (pluginConfig.tui?.sidebar?.enabled !== false) {
       try {
         ensureTuiPluginEntry()

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -44,6 +44,7 @@ const workflowExpectations = [
   },
   { path: ".github/workflows/refresh-model-capabilities.yml", jobs: ["refresh"] },
   { path: ".github/workflows/sisyphus-agent.yml", jobs: ["agent"] },
+  { path: ".github/workflows/stats.yml", jobs: ["stats"] },
   { path: ".github/workflows/web-ci.yml", jobs: ["format-lint-typecheck-build"] },
   { path: ".github/workflows/web-deploy.yml", jobs: ["deploy"] },
 ] as const satisfies readonly WorkflowExpectation[]

--- a/script/stats.test.ts
+++ b/script/stats.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { readFile } from "node:fs/promises"
+import { collectDownloadStats, createPostHogDownloadEvents } from "./stats"
+
+describe("download stats automation", () => {
+  test("#given package and release counts #when collected #then stats use aggregate download sources", async () => {
+    // given
+    const stats = await collectDownloadStats({
+      fetchJson: async (url) => ({ downloads: url.includes("lazycodex-ai") ? 30 : 10 }),
+      runGhApi: async () => [
+        { assets: [{ download_count: 4 }, { download_count: 6 }] },
+        { assets: [{ download_count: 9 }] },
+      ],
+    })
+
+    // when
+    const events = createPostHogDownloadEvents(stats, "test-key")
+
+    // then
+    expect(events).toContainEqual({
+      api_key: "test-key",
+      event: "omo_download_stats",
+      distinct_id: "download",
+      properties: {
+        $process_person_profile: false,
+        count: 19,
+        package_name: "code-yeongyu/oh-my-openagent",
+        source: "github_release",
+      },
+    })
+    expect(events.filter((event) => event.properties.source === "npm")).toHaveLength(3)
+  })
+
+  test("#given stats workflow #when inspected #then it is weekly manual and scopes POSTHOG_KEY to send only", async () => {
+    // given
+    const workflow = await readFile(".github/workflows/stats.yml", "utf8")
+    const fetchStepIndex = workflow.indexOf("name: Fetch download stats")
+    const sendStepIndex = workflow.indexOf("name: Send download stats")
+
+    // when / then
+    expect(workflow).toContain("schedule:")
+    expect(workflow).toContain('cron: "0 0 * * 0"')
+    expect(workflow).toContain("workflow_dispatch:")
+    expect(workflow).not.toContain("pull_request")
+    expect(workflow).toContain("contents: read")
+    expect(fetchStepIndex).toBeGreaterThanOrEqual(0)
+    expect(sendStepIndex).toBeGreaterThan(fetchStepIndex)
+    expect(workflow.slice(fetchStepIndex, sendStepIndex)).not.toContain("POSTHOG_KEY")
+    expect(workflow.slice(sendStepIndex)).toContain("POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}")
+  })
+})

--- a/script/stats.ts
+++ b/script/stats.ts
@@ -1,0 +1,151 @@
+import { $ } from "bun"
+import { z } from "zod"
+
+const NPM_PACKAGES = ["oh-my-opencode", "oh-my-openagent", "lazycodex-ai"] as const
+const POSTHOG_CAPTURE_URL = "https://us.i.posthog.com/capture/"
+const GITHUB_REPOSITORY = "code-yeongyu/oh-my-openagent"
+
+const NpmDownloadsSchema = z.object({
+  downloads: z.number().int().nonnegative(),
+})
+
+const GitHubAssetSchema = z.object({
+  download_count: z.number().int().nonnegative(),
+})
+
+const GitHubReleaseSchema = z.object({
+  assets: z.array(GitHubAssetSchema),
+})
+
+type DownloadSource = "npm" | "github_release"
+
+export type DownloadStat = {
+  readonly count: number
+  readonly packageName: string
+  readonly source: DownloadSource
+}
+
+type PostHogDownloadEvent = {
+  readonly api_key: string
+  readonly event: "omo_download_stats"
+  readonly distinct_id: "download"
+  readonly properties: {
+    readonly $process_person_profile: false
+    readonly count: number
+    readonly package_name: string
+    readonly source: DownloadSource
+  }
+}
+
+type StatsDeps = {
+  readonly fetchJson: (url: string) => Promise<unknown>
+  readonly runGhApi: () => Promise<unknown>
+}
+
+function parseArgs(args: readonly string[]): { readonly dryRun: boolean } {
+  return { dryRun: args.includes("--dry-run") }
+}
+
+async function defaultFetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}: ${response.status}`)
+  }
+  return response.json()
+}
+
+async function defaultRunGhApi(): Promise<unknown> {
+  const output = await $`gh api repos/${GITHUB_REPOSITORY}/releases --paginate`.text()
+  return JSON.parse(output)
+}
+
+async function fetchNpmStat(packageName: string, fetchJson: StatsDeps["fetchJson"]): Promise<DownloadStat> {
+  const data = NpmDownloadsSchema.parse(
+    await fetchJson(`https://api.npmjs.org/downloads/point/last-week/${packageName}`),
+  )
+  return {
+    count: data.downloads,
+    packageName,
+    source: "npm",
+  }
+}
+
+function readGitHubReleaseDownloadStat(releasesJson: unknown): DownloadStat {
+  const releases = z.array(GitHubReleaseSchema).parse(releasesJson)
+  const count = releases.reduce(
+    (total, release) =>
+      total + release.assets.reduce((assetTotal, asset) => assetTotal + asset.download_count, 0),
+    0,
+  )
+  return {
+    count,
+    packageName: GITHUB_REPOSITORY,
+    source: "github_release",
+  }
+}
+
+export async function collectDownloadStats(deps: StatsDeps): Promise<readonly DownloadStat[]> {
+  const npmStats = await Promise.all(
+    NPM_PACKAGES.map((packageName) => fetchNpmStat(packageName, deps.fetchJson)),
+  )
+  return [...npmStats, readGitHubReleaseDownloadStat(await deps.runGhApi())]
+}
+
+export function createPostHogDownloadEvents(
+  stats: readonly DownloadStat[],
+  apiKey: string,
+): readonly PostHogDownloadEvent[] {
+  return stats.map((stat) => ({
+    api_key: apiKey,
+    event: "omo_download_stats",
+    distinct_id: "download",
+    properties: {
+      $process_person_profile: false,
+      count: stat.count,
+      package_name: stat.packageName,
+      source: stat.source,
+    },
+  }))
+}
+
+async function sendPostHogEvent(event: PostHogDownloadEvent): Promise<void> {
+  const response = await fetch(POSTHOG_CAPTURE_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(event),
+  })
+  if (!response.ok) {
+    throw new Error(`PostHog capture failed: ${response.status}`)
+  }
+}
+
+export async function runStats(args: readonly string[], deps: StatsDeps): Promise<number> {
+  const { dryRun } = parseArgs(args)
+  const stats = await collectDownloadStats(deps)
+  const events = createPostHogDownloadEvents(stats, process.env.POSTHOG_KEY ?? "dry-run")
+
+  if (dryRun) {
+    console.log(JSON.stringify({ dryRun: true, events }, null, 2))
+    return 0
+  }
+
+  const apiKey = process.env.POSTHOG_KEY
+  if (!apiKey) {
+    console.log("POSTHOG_KEY is not set; skipping download stats upload")
+    return 0
+  }
+
+  for (const event of createPostHogDownloadEvents(stats, apiKey)) {
+    await sendPostHogEvent(event)
+  }
+  console.log(`Sent ${events.length} download stats events`)
+  return 0
+}
+
+if (import.meta.main) {
+  const exitCode = await runStats(Bun.argv.slice(2), {
+    fetchJson: defaultFetchJson,
+    runGhApi: defaultRunGhApi,
+  })
+  process.exit(exitCode)
+}


### PR DESCRIPTION
## Summary
- unify the main OpenCode telemetry path around the shared telemetry client architecture while preserving the existing `omo_daily_active` event shape
- add config-level `telemetry: false` opt-out wiring for CLI and plugin-load telemetry
- add plugin-load telemetry, telemetry doctor diagnostics, weekly stats collection, schema/docs updates, and regression tests

## Zero data-breakage guardrails
- preserves `OMO_SEND_ANONYMOUS_TELEMETRY=yes` as enabled in the OpenCode adapter
- preserves `additionalProperties.plugin_name = oh-my-openagent`
- pins `eventName: omo_daily_active`, `machineIdPrefix: oh-my-openagent:`, and `cacheDirName: oh-my-opencode`
- adds a before/after telemetry parity test for the known legacy hostname/id path

## Local verification
- `bun test`
- `GIT_ALLOW_PROTOCOL=file bun run typecheck`
- `GIT_ALLOW_PROTOCOL=file bun run build`
- targeted telemetry/schema/doctor/stats/workflow tests
- LSP diagnostics clean on modified TypeScript files
- `git diff --check --staged`

## Real OpenCode QA evidence
Evidence is on disk at `.omo/evidence/20260628-telemetry-overhaul/` in the worktree.

Observed:
- `opencode --version`: `1.17.11`
- real OpenCode DB session count stayed unchanged at `21676`
- isolated server and SSE smoke checks passed
- plugin-load telemetry captured `omo_daily_active` with `reason: plugin_loaded`, `source: plugin`, and `plugin_name: oh-my-openagent`
- CLI-run telemetry captured `omo_daily_active` with `reason: run_started`, `source: cli`, and `plugin_name: oh-my-openagent`

Artifacts:
- `QA-SUMMARY.md`
- `opencode-server-smoke.txt`
- `opencode-sse-self-test.txt`
- `opencode-plugin-telemetry-config-load-probe.txt`
- `posthog-config-load-decoded.ndjson`
- `omo-cli-run-telemetry-probe.txt`
- `posthog-cli-run-decoded.ndjson`
- `cli-run-invalid-model-corrected.txt`

## Risk
Main risk is accidental telemetry identity or payload drift. The parity test, product identity constants, architecture guard, and real-harness local PostHog capture cover that path without sending data to real PostHog.