### PR TITLE
fix(tmux-core): quote attach directory paths

### DIFF
--- a/packages/tmux-core/src/tmux-utils/pane-command.test.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-command.test.ts
@@ -27,6 +27,22 @@ describe("buildTmuxAttachCommand", () => {
     expect(cmd).toContain('\\"')
     expect(cmd).toContain("\\$")
   })
+
+  it("quotes directory paths with spaces for the inner shell", () => {
+    const cmd = buildTmuxAttachCommand(
+      "http://localhost:3000",
+      "ses_abc123",
+      "/Users/me/Library/Mobile Documents/project",
+    )
+
+    expect(cmd).toContain("--dir '/Users/me/Library/Mobile Documents/project'")
+  })
+
+  it("quotes directory paths with apostrophes for the inner shell", () => {
+    const cmd = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123", "/tmp/Bob's Project")
+
+    expect(cmd).toContain("--dir '/tmp/Bob'\\\\''s Project'")
+  })
 })
 
 describe("buildTmuxPlaceholderCommand", () => {

--- a/packages/tmux-core/src/tmux-utils/pane-command.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-command.ts
@@ -2,10 +2,14 @@ import { shellEscapeForDoubleQuotedCommand } from "@oh-my-opencode/utils"
 
 const TMUX_COMMAND_SHELL = "/bin/sh"
 
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
 export function buildTmuxAttachCommand(serverUrl: string, sessionId: string, directory: string = process.cwd()): string {
   const escapedUrl = shellEscapeForDoubleQuotedCommand(serverUrl)
   const escapedSessionId = shellEscapeForDoubleQuotedCommand(sessionId)
-  const escapedDirectory = shellEscapeForDoubleQuotedCommand(directory || process.cwd())
+  const escapedDirectory = shellEscapeForDoubleQuotedCommand(shellSingleQuote(directory || process.cwd()))
   return `${TMUX_COMMAND_SHELL} -c "opencode attach ${escapedUrl} --session ${escapedSessionId} --dir ${escapedDirectory}"`
 }
 


### PR DESCRIPTION
## Summary
- quote buildTmuxAttachCommand --dir values for the inner shell so paths with spaces remain a single argument
- preserve existing outer double-quote escaping for the tmux respawn command
- add regression coverage for directory paths with spaces and apostrophes

Fixes #5596

## Verification
- bun test packages/tmux-core/src/tmux-utils/pane-command.test.ts
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quotes directory paths in the tmux attach command so paths with spaces or apostrophes are treated as a single argument. Prevents failed attaches when `--dir` includes special characters.

- **Bug Fixes**
  - In `tmux-core`, wrap `--dir` for the inner shell in single quotes and escape apostrophes; keep existing outer double-quote escaping.
  - Added regression tests for directories with spaces and apostrophes.

<sup>Written for commit 6b7efe628e21197925836a8ea0195243409d8496. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

