### PR TITLE
test(model-core): cover custom qwen runtime variants

### DIFF
--- a/packages/model-core/src/model-capabilities.test.ts
+++ b/packages/model-core/src/model-capabilities.test.ts
@@ -420,6 +420,28 @@ describe("getModelCapabilities", () => {
     })
   })
 
+  test("preserves runtime-declared Qwen variants beyond the generic heuristic", () => {
+    const result = getModelCapabilities({
+      providerID: "openai-compatible",
+      modelID: "qwen3.7-plus",
+      runtimeModel: {
+        variants: ["medium", "high", "xhigh", "max", "off"],
+      },
+      bundledSnapshot,
+    })
+
+    expect(result).toMatchObject({
+      canonicalModelID: "qwen3.7-plus",
+      family: "qwen",
+      variants: ["medium", "high", "xhigh", "max", "off"],
+    })
+    expect(result.diagnostics).toMatchObject({
+      resolutionMode: "heuristic-backed",
+      family: { source: "heuristic" },
+      variants: { source: "runtime" },
+    })
+  })
+
   test("keeps every built-in OmO requirement model snapshot-backed", () => {
     const bundledSnapshot = getBundledModelCapabilitiesSnapshot(bundledModelCapabilitiesSnapshotJson)
     const requirementModels = new Set<string>()

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -361,6 +361,30 @@ describe("resolveCompatibleModelSettings", () => {
       }
     }
   })
+
+  test("Qwen preserves provider-declared variants outside the generic ladder", () => {
+    const capabilities = getModelCapabilities({
+      providerID: "openai-compatible",
+      modelID: "qwen3.7-plus",
+      runtimeModel: {
+        variants: ["medium", "high", "xhigh", "max", "off"],
+      },
+    })
+
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai-compatible",
+      modelID: "qwen3.7-plus",
+      desired: { variant: "off" },
+      capabilities,
+    })
+
+    expect(result).toEqual({
+      variant: "off",
+      reasoningEffort: undefined,
+      changes: [],
+    })
+  })
+
   test("DeepSeek keeps canonical high and max reasoningEffort values", () => {
     for (const reasoningEffort of ["high", "max"]) {
       const result = resolveCompatibleModelSettings({


### PR DESCRIPTION
## Summary
- add coverage that custom Qwen models remain heuristic-backed while preserving runtime-declared variants
- pin compatibility behavior for provider-declared Qwen variants outside the generic ladder, such as off

Refs #5516

## Verification
- bun test packages/model-core/src/model-capabilities.test.ts packages/model-core/src/model-settings-compatibility.test.ts
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added tests in `packages/model-core` to ensure custom Qwen models stay heuristic-backed while preserving runtime-declared variants, and to pin compatibility for provider-declared Qwen variants outside the generic ladder (e.g., off).
Connects to Linear #5516 by verifying `resolveCompatibleModelSettings` respects the Qwen "off" variant.

<sup>Written for commit f58b52eb3432e6c635ffdacbade78415951f105a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

