### PR TITLE
fix(model-core): support GLM max reasoning effort

### DIFF
--- a/packages/model-core/src/model-capabilities.test.ts
+++ b/packages/model-core/src/model-capabilities.test.ts
@@ -332,6 +332,27 @@ describe("getModelCapabilities", () => {
     })
   })
 
+  test("exposes GLM max reasoning effort through heuristic capabilities", () => {
+    const result = getModelCapabilities({
+      providerID: "zai-coding-plan",
+      modelID: "glm-5.2",
+      bundledSnapshot,
+    })
+
+    expect(result).toMatchObject({
+      canonicalModelID: "glm-5.2",
+      family: "glm",
+      variants: ["low", "medium", "high", "max"],
+      reasoningEfforts: ["high", "max"],
+    })
+    expect(result.diagnostics).toMatchObject({
+      resolutionMode: "heuristic-backed",
+      family: { source: "heuristic" },
+      variants: { source: "heuristic" },
+      reasoningEfforts: { source: "heuristic" },
+    })
+  })
+
   test("prefers snapshot reasoning over heuristic supportsThinking for MiniMax M2.7", () => {
     // given
     const modelID = "minimax-m2.7"

--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -75,7 +75,13 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   {
     family: "glm",
     includes: ["glm"],
-    variants: ["low", "medium", "high"],
+    variants: ["low", "medium", "high", "max"],
+    reasoningEfforts: ["high", "max"],
+    reasoningEffortAliases: {
+      low: "high",
+      medium: "high",
+      xhigh: "max",
+    },
   },
   {
     family: "minimax",

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -256,7 +256,7 @@ describe("resolveCompatibleModelSettings", () => {
       { name: "Grok", modelID: "grok-4.3", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: true },
       { name: "Kimi (kimi)", modelID: "kimi-k2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Kimi (k2)", modelID: "k2-v2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
-      { name: "GLM", modelID: "glm-5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "GLM", modelID: "glm-5.2", expectedVariants: ["low", "medium", "high", "max"], hasReasoningEffort: true },
       { name: "Minimax", modelID: "minimax-m2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high", "max"], hasReasoningEffort: true },
       { name: "Mistral", modelID: "mistral-large-next", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
@@ -361,6 +361,37 @@ describe("resolveCompatibleModelSettings", () => {
       }
     }
   })
+
+  test("GLM maps generic reasoningEffort levels to Z.AI high and max values", () => {
+    const cases = [
+      { requested: "low", expected: "high" },
+      { requested: "medium", expected: "high" },
+      { requested: "high", expected: "high" },
+      { requested: "xhigh", expected: "max" },
+      { requested: "max", expected: "max" },
+    ]
+
+    for (const { requested, expected } of cases) {
+      const result = resolveCompatibleModelSettings({
+        providerID: "zai-coding-plan",
+        modelID: "glm-5.2",
+        desired: { reasoningEffort: requested },
+      })
+
+      expect(result.reasoningEffort).toBe(expected)
+      expect(result.changes).toEqual(
+        requested === expected
+          ? []
+          : [{
+              field: "reasoningEffort",
+              from: requested,
+              to: expected,
+              reason: "unsupported-by-model-family",
+            }],
+      )
+    }
+  })
+
   test("DeepSeek keeps canonical high and max reasoningEffort values", () => {
     for (const reasoningEffort of ["high", "max"]) {
       const result = resolveCompatibleModelSettings({


### PR DESCRIPTION
## Summary
- add GLM heuristic support for max variants and high/max reasoning efforts
- map generic low/medium reasoning to high and xhigh to max for GLM
- cover heuristic capability diagnostics and compatibility normalization

Fixes #5300

## Verification
- bun test packages/model-core/src/model-capabilities.test.ts packages/model-core/src/model-settings-compatibility.test.ts
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds heuristic support in `model-core` for GLM “max” reasoning effort and variant, and normalizes requested reasoning levels to GLM-supported values. Fixes #5300.

- **Bug Fixes**
  - Expose GLM variants: low, medium, high, max; and reasoningEfforts: high, max.
  - Map reasoningEffort for GLM: low/medium -> high, xhigh -> max.
  - Update capability and compatibility tests, targeting `glm-5.2` with reasoning enabled.

<sup>Written for commit 3930f0d636e5dd53b5e463541ecba23fe601cb44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

