### PR TITLE
fix(rules-engine): split quoted comma glob scalars

### DIFF
--- a/packages/rules-engine/src/engine/parser-yaml.ts
+++ b/packages/rules-engine/src/engine/parser-yaml.ts
@@ -83,9 +83,8 @@ function parseGlobValue(rawValue: string, lines: readonly string[], lineIndex: n
 		return parseMultilineArray(lines, lineIndex);
 	}
 
-	const quotedScalar = isQuotedScalar(rawValue);
 	const value = parseStringValue(rawValue);
-	if (!quotedScalar && value.includes(",")) {
+	if (value.includes(",")) {
 		return {
 			values: value
 				.split(",")
@@ -96,10 +95,6 @@ function parseGlobValue(rawValue: string, lines: readonly string[], lineIndex: n
 	}
 
 	return { values: [value], consumed: 1 };
-}
-
-function isQuotedScalar(value: string): boolean {
-	return value.startsWith('"') || value.startsWith("'");
 }
 
 function parseMultilineArray(lines: readonly string[], lineIndex: number): ParsedGlobValue {

--- a/packages/rules-engine/src/engine/parser.test.ts
+++ b/packages/rules-engine/src/engine/parser.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseRule } from "./parser.js";
+
+describe("parseRule", () => {
+	it("#given quoted comma-separated glob scalar #when parsing #then glob aliases split into ordered patterns", () => {
+		// given
+		const content = [
+			"---",
+			'globs: "*.md"',
+			'paths: "src/**/*.ts, test/**/*.ts"',
+			'applyTo: "docs/**/*.md, src/**/*.ts"',
+			"---",
+			"",
+			"Prefer project rules.",
+		].join("\n");
+
+		// when
+		const parsed = parseRule(content);
+
+		// then
+		expect(parsed.frontmatter.globs).toEqual(["*.md", "src/**/*.ts", "test/**/*.ts", "docs/**/*.md"]);
+		expect(parsed.body).toBe("\nPrefer project rules.");
+	});
+
+	it("#given inline array item contains comma #when parsing #then the quoted item remains one glob", () => {
+		// given
+		const content = [
+			"---",
+			'applyTo: ["docs/{draft,final}.md", "src/**/*.ts"]',
+			"---",
+			"Prefer scoped rules.",
+		].join("\n");
+
+		// when
+		const parsed = parseRule(content);
+
+		// then
+		expect(parsed.frontmatter.globs).toEqual(["docs/{draft,final}.md", "src/**/*.ts"]);
+	});
+});


### PR DESCRIPTION
## Summary
- split quoted comma-separated rule glob scalars after unquoting them in the engine parser
- add parser coverage for quoted scalar aliases and inline array comma preservation

## Tests
- bun test packages/rules-engine/src/engine/parser.test.ts packages/rules-engine/src/frontmatter-corpus.test.ts

## Notes
- I also ran \un test packages/rules-engine/src/engine/parser.test.ts packages/rules-engine/src/frontmatter-corpus.test.ts packages/rules-engine/src/index.test.ts\; parser/corpus passed, but an existing Windows markerless-workspace assertion in \index.test.ts\ failed because \indProjectRoot()\ resolved \C:\\Users\\hiend\ instead of null. I left that unrelated behavior untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split comma-separated glob scalars even when quoted in the rules engine YAML parser, so aliases like `"src/**/*.ts, test/**/*.ts"` are expanded. Inline array items that include commas (e.g., brace expansions) stay intact.

- **Bug Fixes**
  - Split quoted comma-separated glob scalars after unquoting to produce ordered patterns.
  - Preserve quoted inline array items containing commas as single globs (e.g., `"docs/{draft,final}.md"`).

<sup>Written for commit b910654bf5c5845351bce4224bb6260c7c391dcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

