### PR TITLE
fix(utils): parse double-quoted CodeGraph init hints

### DIFF
--- a/packages/utils/src/codegraph-guidance.test.ts
+++ b/packages/utils/src/codegraph-guidance.test.ts
@@ -20,6 +20,40 @@ describe("CodeGraph initialization guidance", () => {
     expect(projectPath).toBe("/Users/me/project")
   })
 
+  test("#given CodeGraph MCP reports an uninitialized dotted project #when parsed #then the full project path is extracted", () => {
+    // given
+    const output = [
+      "Tool execution failed: CodeGraph not initialized in /Users/me/my.repo.",
+      "Run 'codegraph init' in that project first.",
+    ].join(" ")
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      toolName: "codegraph.codegraph_status",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBe("/Users/me/my.repo")
+  })
+
+  test("#given CodeGraph MCP reports a double-quoted init hint #when parsed #then the project path is extracted", () => {
+    // given
+    const output = [
+      "Tool execution failed: CodeGraph not initialized in /Users/me/project.",
+      'Run "codegraph init" in that project first.',
+    ].join(" ")
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      toolName: "codegraph.codegraph_status",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBe("/Users/me/project")
+  })
+
   test("#given non-CodeGraph output mentions initialization #when parsed #then no guidance is emitted", () => {
     // given
     const output = [

--- a/packages/utils/src/codegraph/guidance.ts
+++ b/packages/utils/src/codegraph/guidance.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os"
 import { resolveCodegraphWorkspacePaths } from "./workspace"
 
 const CODEGRAPH_UNINITIALIZED_PATTERN =
-  /CodeGraph not initialized in ([\s\S]*?)\.\s*Run ['`]codegraph init['`] in that project first\./i
+  /CodeGraph not initialized in ([\s\S]*?)\.\s*Run ["'`]codegraph init["'`] in that project first\./i
 const ANSI_ESCAPE_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g
 const CODEGRAPH_STATUS_PROJECT_PATTERN = /^.*?\bProject:\s*(.+?)\s*$/im
 const CODEGRAPH_STATUS_UNINITIALIZED_PATTERN =


### PR DESCRIPTION
## Summary
- accept double-quoted "codegraph init" hints in CodeGraph uninitialized output parsing
- add regression coverage for double-quoted hints and dotted project paths

## Tests
- bun test packages/utils/src/codegraph-guidance.test.ts

## Notes
- Broader CodeGraph utility test sweep was attempted; unrelated Windows failures remain in codegraph-provision.test.ts because this environment lacks chmod on PATH.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CodeGraph uninitialized output parsing to accept double-quoted init hints and dotted project paths, so the project path is extracted reliably.

- **Bug Fixes**
  - Updated regex in `packages/utils/src/codegraph/guidance.ts` to accept `"`, `'`, and `` ` `` around `codegraph init`.
  - Added tests in `packages/utils/src/codegraph-guidance.test.ts` covering double-quoted hints and dotted project paths.

<sup>Written for commit 073ebdb315b99993869b510a5dc187df9c789de0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

