### PR TITLE
test(utils): avoid shell chmod in CodeGraph provision fixtures

### DIFF
--- a/packages/utils/src/codegraph-provision.test.ts
+++ b/packages/utils/src/codegraph-provision.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { execFileSync } from "node:child_process"
 import { createHash } from "node:crypto"
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -24,7 +24,7 @@ function fixtureArchive(
   const binDir = join(root, rootName, "bin")
   mkdirSync(binDir, { recursive: true })
   writeFileSync(join(binDir, executableName), "#!/bin/sh\nprintf 'codegraph fixture\\n'\n")
-  execFileSync("chmod", ["755", join(binDir, executableName)])
+  chmodSync(join(binDir, executableName), 0o755)
   execFileSync("tar", ["-czf", archive, rootName], { cwd: root })
   const bytes = readFileSync(archive)
   const sha256 = createHash("sha256").update(bytes).digest("hex")


### PR DESCRIPTION
## Summary
- replace the test fixture's shell chmod call with Node's chmodSync
- make CodeGraph provision archive tests pass on Windows without Unix chmod on PATH

## Tests
- bun test packages/utils/src/codegraph-provision.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced shell `chmod` with Node’s `chmodSync` in the CodeGraph provision test fixture. This removes the Unix `chmod` dependency and makes the archive tests pass on Windows.

<sup>Written for commit 79fa9ffec67e9f858219ec623c7a211be836a07a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

