### PR TITLE
fix(utils): parse git status rename destinations

### DIFF
--- a/packages/utils/src/git-worktree/parse-status-porcelain-line.test.ts
+++ b/packages/utils/src/git-worktree/parse-status-porcelain-line.test.ts
@@ -48,6 +48,17 @@ describe("parseGitStatusPorcelainLine", () => {
 		expect(result).toEqual({ filePath: "src/d.ts", status: "deleted" })
 	})
 
+	test("#given renamed porcelain line #when parsing #then returns the destination path", () => {
+		//#given
+		const line = "R  src/old.ts -> src/new.ts"
+
+		//#when
+		const result = parseGitStatusPorcelainLine(line)
+
+		//#then
+		expect(result).toEqual({ filePath: "src/new.ts", status: "modified" })
+	})
+
 	test("#given empty line #when parsing #then returns null", () => {
 		//#given
 		const line = ""

--- a/packages/utils/src/git-worktree/parse-status-porcelain-line.ts
+++ b/packages/utils/src/git-worktree/parse-status-porcelain-line.ts
@@ -11,13 +11,19 @@ function toGitFileStatus(statusToken: string): GitFileStatus {
 	return "modified"
 }
 
+function normalizeGitStatusPath(statusToken: string, filePath: string): string {
+	if (statusToken !== "R" && statusToken !== "C") return filePath
+	const arrowIndex = filePath.lastIndexOf(" -> ")
+	return arrowIndex === -1 ? filePath : filePath.slice(arrowIndex + 4)
+}
+
 export function parseGitStatusPorcelainLine(
 	line: string,
 ): ParsedGitStatusPorcelainLine | null {
 	if (!line) return null
 
 	const statusToken = line.substring(0, 2).trim()
-	const filePath = line.substring(3)
+	const filePath = normalizeGitStatusPath(statusToken, line.substring(3))
 	if (!filePath) return null
 
 	return {


### PR DESCRIPTION
## Summary
- normalize git porcelain rename/copy lines to the destination path
- keep renamed files categorized as modified in the existing summary model
- add parser regression coverage for R status output

## Tests
- bun test packages/utils/src/git-worktree/parse-status-porcelain-line.test.ts packages/utils/src/git-worktree/git-worktree.test.ts packages/utils/src/git-worktree/collect-git-diff-stats.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes git status parsing so renamed and copied files use the destination path, not the source, in `packages/utils`. Renamed files still show as modified, and rename parsing now has regression tests.

- **Bug Fixes**
  - Parse `R`/`C` lines and return the destination path (e.g., "src/new.ts").
  - Keep renamed files categorized as "modified" to match the existing summary model.

<sup>Written for commit 520f793d2356f8a663c6caee550aaab9ad2e13aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

