### PR TITLE
test(rules-engine): cover rule truncator invariants

### DIFF
--- a/packages/rules-engine/src/engine/truncator.test.ts
+++ b/packages/rules-engine/src/engine/truncator.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import { TRUNCATION_NOTICE } from "./constants.js";
+import { isNeverTruncatedRule, truncateBudget, truncateRule } from "./truncator.js";
+
+function notice(relativePath: string): string {
+	return TRUNCATION_NOTICE.replace("{path}", relativePath);
+}
+
+describe("rules engine truncator", () => {
+	it("#given Hephaestus rule paths #when checking never-truncate status #then only the filename controls the match", () => {
+		// given
+		const unixPath = "bundled-rules/Hephaestus.md";
+		const windowsPath = "bundled-rules\\hephaestus.md";
+		const siblingPath = "bundled-rules/hephaestus.md.backup";
+
+		// when / then
+		expect(isNeverTruncatedRule(unixPath)).toBe(true);
+		expect(isNeverTruncatedRule(windowsPath)).toBe(true);
+		expect(isNeverTruncatedRule(siblingPath)).toBe(false);
+	});
+
+	it("#given a truncation boundary inside an emoji #when truncating one rule #then it does not emit a dangling surrogate", () => {
+		// given
+		const relativePath = "rules/emoji.md";
+		const body = `😀${"tail".repeat(20)}`;
+		const maxChars = notice(relativePath).length + 1;
+
+		// when
+		const result = truncateRule(body, { maxChars, relativePath });
+
+		// then
+		expect(result.truncated).toBe(true);
+		expect(result.originalLength).toBe(body.length);
+		expect(result.body).toBe(notice(relativePath));
+		expect(result.body).not.toContain("\uD83D");
+	});
+
+	it("#given an oversized Hephaestus rule #when applying a result budget #then the full rule is preserved", () => {
+		// given
+		const body = `${"Hephaestus guidance. ".repeat(20)}TAIL`;
+
+		// when
+		const result = truncateBudget({
+			maxResultChars: 24,
+			rules: [{ body, relativePath: "bundled-rules/hephaestus.md" }],
+		});
+
+		// then
+		expect(result).toEqual([{ body, relativePath: "bundled-rules/hephaestus.md", truncated: false }]);
+	});
+});


### PR DESCRIPTION
## Summary
- add direct coverage for rules-engine truncation invariants
- pin Hephaestus never-truncate filename matching across Unix and Windows separators
- cover surrogate-safe truncation so budget slicing does not emit a dangling high surrogate

## Tests
- `bun test packages/rules-engine/src/engine/truncator.test.ts`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `bun test ./packages/rules-engine/src` was also attempted: the new truncator test passed, but the suite has one environment-dependent failure in `packages/rules-engine/src/index.test.ts` where project-root detection returns `C:\Users\hiend` instead of null for a markerless workspace fixture. This PR only adds `engine/truncator.test.ts`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add targeted tests for the rules engine truncator to lock in key invariants. Verifies Hephaestus filenames are never truncated across Unix/Windows paths, truncation avoids dangling high surrogates when cutting through emoji, and result-budget truncation preserves full Hephaestus rules.

<sup>Written for commit d07ef5bbd86b161a01d93d7589ee2f4281752d80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

