### PR TITLE
fix(model-core): normalize parenthesized variants

### DIFF
--- a/packages/model-core/src/fallback-chain-from-models.test.ts
+++ b/packages/model-core/src/fallback-chain-from-models.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildFallbackChainFromModels,
+  parseFallbackModelEntry,
+} from "./fallback-chain-from-models"
+
+describe("fallback chain model parsing", () => {
+  test("#given parenthesized variant syntax #when parsing fallback model entry #then variant is normalized to lowercase", () => {
+    expect(parseFallbackModelEntry("openai/gpt-5.5(HIGH)", undefined)).toEqual({
+      providers: ["openai"],
+      model: "gpt-5.5",
+      variant: "high",
+    })
+  })
+
+  test("#given fallback model list with parenthesized variant #when building chain #then variant is normalized to lowercase", () => {
+    expect(buildFallbackChainFromModels(["openai/gpt-5.5(XHIGH)"], undefined)).toEqual([
+      {
+        providers: ["openai"],
+        model: "gpt-5.5",
+        variant: "xhigh",
+      },
+    ])
+  })
+})

--- a/packages/model-core/src/fallback-chain-from-models.ts
+++ b/packages/model-core/src/fallback-chain-from-models.ts
@@ -15,7 +15,7 @@ function parseVariantFromModel(rawModel: string): { modelID: string; variant?: s
   const parenthesizedVariant = trimmedModel.match(/^(.*)\(([^()]+)\)\s*$/)
   if (parenthesizedVariant) {
     const modelID = parenthesizedVariant[1]?.trim() ?? ""
-    const variant = parenthesizedVariant[2]?.trim()
+    const variant = parenthesizedVariant[2]?.trim().toLowerCase()
     return variant ? { modelID, variant } : { modelID }
   }
 

--- a/packages/model-core/src/model-string-parser.test.ts
+++ b/packages/model-core/src/model-string-parser.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+
+import { parseModelString, parseVariantFromModelID } from "./model-string-parser"
+
+describe("model string parser", () => {
+  test("#given parenthesized variant syntax #when parsing a model ID #then variant is normalized to lowercase", () => {
+    expect(parseVariantFromModelID("gpt-5.4(HIGH)")).toEqual({
+      modelID: "gpt-5.4",
+      variant: "high",
+    })
+  })
+
+  test("#given parenthesized variant syntax #when parsing provider model string #then variant is normalized to lowercase", () => {
+    expect(parseModelString("openai/gpt-5.4(XHIGH)")).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      variant: "xhigh",
+    })
+  })
+
+  test("#given space variant syntax #when parsing provider model string #then existing lowercase behavior remains unchanged", () => {
+    expect(parseModelString("openai/gpt-5.4 HIGH")).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      variant: "high",
+    })
+  })
+})

--- a/packages/model-core/src/model-string-parser.ts
+++ b/packages/model-core/src/model-string-parser.ts
@@ -22,7 +22,7 @@ export function parseVariantFromModelID(rawModelID: string): { modelID: string; 
   const parenthesizedVariant = trimmedModelID.match(/^(.*)\(([^()]+)\)\s*$/)
   if (parenthesizedVariant) {
     const modelID = parenthesizedVariant[1]?.trim() ?? ""
-    const variant = parenthesizedVariant[2]?.trim()
+    const variant = parenthesizedVariant[2]?.trim().toLowerCase()
     return variant ? { modelID, variant } : { modelID }
   }
 


### PR DESCRIPTION
## Summary
- normalize parenthesized model variant tokens to lowercase
- keep fallback chain parser consistent with model string parser and existing space-suffix behavior
- add focused parser coverage for uppercase parenthesized variants

## Tests
- `bun test packages/model-core/src/model-string-parser.test.ts packages/model-core/src/fallback-chain-from-models.test.ts`
- `bun test ./packages/model-core/src`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize parenthesized model variant tokens to lowercase in `model-core` parsers. This matches existing space-suffix behavior and keeps the fallback-chain parser consistent with the model string parser.

<sup>Written for commit 5f4bc69629a8596e5d56c7a6c0ea1bd6c160d190. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

