### PR TITLE
fix(lsp-core): normalize extension lookups

### DIFF
--- a/packages/lsp-core/src/lsp/language-mappings.test.ts
+++ b/packages/lsp-core/src/lsp/language-mappings.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+
+import { getLanguageId } from "./language-mappings.js";
+
+describe("getLanguageId", () => {
+	test("#given uppercase extension #when resolving language id #then matches lowercase registry entry", () => {
+		// given / when / then
+		expect(getLanguageId(".TS")).toBe("typescript");
+		expect(getLanguageId(".TsX")).toBe("typescriptreact");
+	});
+});

--- a/packages/lsp-core/src/lsp/language-mappings.ts
+++ b/packages/lsp-core/src/lsp/language-mappings.ts
@@ -169,5 +169,5 @@ export const EXT_TO_LANG: Record<string, string> = {
 };
 
 export function getLanguageId(ext: string): string {
-	return EXT_TO_LANG[ext] ?? "plaintext";
+	return EXT_TO_LANG[ext.toLowerCase()] ?? "plaintext";
 }

--- a/packages/lsp-core/src/lsp/server-resolution.test.ts
+++ b/packages/lsp-core/src/lsp/server-resolution.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { findServerForExtension } from "./server-resolution.js";
+
+describe("findServerForExtension", () => {
+	test("#given uppercase extension #when resolving server #then matches lowercase registry entry", () => {
+		// given / when
+		const result = findServerForExtension(".TS");
+
+		// then
+		expect(result.status).not.toBe("not_configured");
+		if (result.status === "found" || result.status === "not_installed") {
+			expect(result.server.id).toBe("typescript");
+		}
+	});
+});

--- a/packages/lsp-core/src/lsp/server-resolution.ts
+++ b/packages/lsp-core/src/lsp/server-resolution.ts
@@ -5,9 +5,10 @@ import type { ServerLookupResult } from "./types.js";
 
 export function findServerForExtension(ext: string): ServerLookupResult {
 	const servers = getMergedServers();
+	const normalizedExtension = ext.toLowerCase();
 
 	for (const server of servers) {
-		if (server.extensions.includes(ext) && isServerInstalled(server.command)) {
+		if (includesExtension(server.extensions, normalizedExtension) && isServerInstalled(server.command)) {
 			const resolvedServer = {
 				id: server.id,
 				command: server.command,
@@ -35,7 +36,7 @@ export function findServerForExtension(ext: string): ServerLookupResult {
 	}
 
 	for (const server of servers) {
-		if (server.extensions.includes(ext)) {
+		if (includesExtension(server.extensions, normalizedExtension)) {
 			const installHint =
 				LSP_INSTALL_HINTS[server.id] ?? `Install '${server.command[0]}' and ensure it's in your PATH`;
 			return {
@@ -56,6 +57,10 @@ export function findServerForExtension(ext: string): ServerLookupResult {
 		extension: ext,
 		availableServers,
 	};
+}
+
+function includesExtension(extensions: string[], normalizedExtension: string): boolean {
+	return extensions.some((extension) => extension.toLowerCase() === normalizedExtension);
 }
 
 export interface ServerStatus {


### PR DESCRIPTION
## Summary
- normalize language-id lookup extensions before checking the LSP language registry
- normalize server-resolution extension comparisons so user-supplied uppercase extensions still find configured servers
- add focused coverage for uppercase extension lookup paths

## Tests
- `bun test packages/lsp-core/src/lsp/language-mappings.test.ts packages/lsp-core/src/lsp/server-resolution.test.ts`
- `bun test ./packages/lsp-core/src`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make extension lookups case-insensitive in `lsp-core`, so uppercase extensions map to the correct language IDs and servers. Adds focused tests for `.TS`/`.TsX` paths.

- **Bug Fixes**
  - Lowercase extensions in `getLanguageId` before registry lookup.
  - Compare extensions case-insensitively in `findServerForExtension` via a new helper, ensuring server discovery and install hints work with uppercase inputs.

<sup>Written for commit 924cce5649ed4f167bddd8a9998ddd27ea1663cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

