### PR TITLE
fix(lsp-core): normalize directory diagnostic extensions

### DIFF
--- a/packages/lsp-core/src/lsp/directory-diagnostics.test.ts
+++ b/packages/lsp-core/src/lsp/directory-diagnostics.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+import { collectFilesWithExtension } from "./directory-diagnostics.js";
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("collectFilesWithExtension", () => {
+	test("#given uppercase extension input #when collecting diagnostics inputs #then lowercase matching files are included", () => {
+		// given
+		const root = mkdtempSync(join(tmpdir(), "omo-lsp-directory-"));
+		tempDirectories.push(root);
+		mkdirSync(join(root, "src"), { recursive: true });
+		writeFileSync(join(root, "src", "app.ts"), "export const value = 1;\n");
+		writeFileSync(join(root, "src", "notes.md"), "# Notes\n");
+
+		// when
+		const files = collectFilesWithExtension(root, ".TS", 10);
+
+		// then
+		expect(files.map((file) => basename(file))).toEqual(["app.ts"]);
+	});
+});

--- a/packages/lsp-core/src/lsp/directory-diagnostics.ts
+++ b/packages/lsp-core/src/lsp/directory-diagnostics.ts
@@ -19,6 +19,7 @@ interface FileDiagnostic {
 
 export function collectFilesWithExtension(dir: string, extension: string, maxFiles: number): string[] {
 	const files: string[] = [];
+	const normalizedExtension = extension.toLowerCase();
 
 	function walk(currentDir: string): void {
 		if (files.length >= maxFiles) return;
@@ -48,7 +49,7 @@ export function collectFilesWithExtension(dir: string, extension: string, maxFil
 				if (!SKIP_DIRECTORIES.has(entry)) {
 					walk(fullPath);
 				}
-			} else if (stat.isFile() && effectiveExtension(fullPath) === extension) {
+			} else if (stat.isFile() && effectiveExtension(fullPath).toLowerCase() === normalizedExtension) {
 				files.push(fullPath);
 			}
 		}


### PR DESCRIPTION
## Summary
Normalize directory diagnostic file filtering so extension inputs are compared case-insensitively. This keeps `collectFilesWithExtension()` from missing lowercase files when a caller passes an uppercase extension string.

## Changes
- Lowercase the requested extension once before directory traversal.
- Lowercase each discovered effective extension before comparing it.
- Add a regression test covering `.TS` input matching `app.ts`.

## Verification
- `bun install --ignore-scripts`
- `bun test ./packages/lsp-core/src/lsp/directory-diagnostics.test.ts`
- `bun test ./packages/lsp-core/src`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make file extension filtering in directory diagnostics case-insensitive so uppercase inputs don’t miss lowercase files. `collectFilesWithExtension()` now matches `.TS` to files like `app.ts`.

- **Bug Fixes**
  - Normalize the requested extension once before traversal.
  - Compare with `effectiveExtension(path).toLowerCase()` against the normalized input.
  - Add a regression test for `.TS` matching `app.ts`.

<sup>Written for commit 949e4fe33a6c50ddf2db614ff3cdbcc58f6cb4c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

