### PR TITLE
fix(lsp-core): keep markerless directory roots

### DIFF
--- a/packages/lsp-core/src/lsp/client-wrapper.test.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+const tempDirectories: string[] = [];
+const WORKSPACE_MARKERS = new Set([".git", "package.json", "pyproject.toml", "Cargo.toml", "go.mod", "pom.xml", "build.gradle"]);
+const originalExistsSync = fs.existsSync.bind(fs);
+
+afterEach(() => {
+	mock.restore();
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("findWorkspaceRoot", () => {
+	test("#given a markerless directory path #when finding workspace root #then the directory itself is the fallback root", async () => {
+		// given
+		const root = mkdtempSync(join(tmpdir(), "omo-lsp-markerless-root-"));
+		tempDirectories.push(root);
+		const workspace = join(root, "workspace");
+		mkdirSync(workspace, { recursive: true });
+
+		// when / then
+		expect(await findWorkspaceRootWithNoMarkers(workspace)).toBe(workspace);
+	});
+
+	test("#given a markerless file path #when finding workspace root #then the containing directory stays the fallback root", async () => {
+		// given
+		const workspace = mkdtempSync(join(tmpdir(), "omo-lsp-markerless-file-"));
+		tempDirectories.push(workspace);
+		const filePath = join(workspace, "app.ts");
+		writeFileSync(filePath, "export const value = 1;\n");
+
+		// when / then
+		expect(await findWorkspaceRootWithNoMarkers(filePath)).toBe(workspace);
+	});
+});
+
+async function findWorkspaceRootWithNoMarkers(filePath: string): Promise<string> {
+	mock.module("node:fs", () => ({
+		...fs,
+		existsSync: (path: fs.PathLike): boolean => {
+			if (typeof path === "string" && WORKSPACE_MARKERS.has(basename(path))) return false;
+			return originalExistsSync(path);
+		},
+	}));
+
+	const module = await import(`./client-wrapper.js?markerless=${Date.now()}-${Math.random()}`);
+	return module.findWorkspaceRoot(filePath);
+}

--- a/packages/lsp-core/src/lsp/client-wrapper.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.ts
@@ -27,11 +27,8 @@ export function isDirectoryPath(filePath: string): boolean {
 
 export function findWorkspaceRoot(filePath: string): string {
 	const abs = resolve(contextCwd(), filePath);
-	let dir = abs;
-
-	if (!isDirectoryPath(dir)) {
-		dir = dirname(dir);
-	}
+	const fallbackRoot = isDirectoryPath(abs) ? abs : dirname(abs);
+	let dir = fallbackRoot;
 
 	let prevDir = "";
 	while (dir !== prevDir) {
@@ -44,7 +41,7 @@ export function findWorkspaceRoot(filePath: string): string {
 		dir = dirname(dir);
 	}
 
-	return dirname(abs);
+	return fallbackRoot;
 }
 
 export function formatServerLookupError(result: Exclude<ServerLookupResult, { status: "found" }>): string {


### PR DESCRIPTION
## Summary
Keep markerless directory inputs as their own LSP workspace root when no workspace markers are found. File inputs keep the existing fallback behavior of using their containing directory.

## Changes
- Compute the fallback root from the resolved input kind before walking ancestors.
- Return the original directory for markerless directory inputs instead of its parent.
- Add regression coverage for markerless directory and markerless file fallback behavior.

## Verification
- `bun install --ignore-scripts`
- `bun test ./packages/lsp-core/src/lsp/client-wrapper.test.ts`
- `bun test ./packages/lsp-core/src`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace root detection so markerless directory inputs remain their own LSP workspace root. Markerless file inputs still fall back to their containing directory.

- **Bug Fixes**
  - Compute the fallback root from the resolved input type before walking ancestors.
  - Return the original directory for markerless directory inputs; keep containing directory for files.
  - Add tests covering markerless directory and markerless file behavior.

<sup>Written for commit ad817d66cd3c0e1c80c509398c0546faf769245a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

