### PR TITLE
test(utils): avoid shell chmod in codegraph fixtures

### DIFF
--- a/packages/utils/src/codegraph-provision.test.ts
+++ b/packages/utils/src/codegraph-provision.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { execFileSync } from "node:child_process"
 import { createHash } from "node:crypto"
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -24,7 +24,7 @@ function fixtureArchive(
   const binDir = join(root, rootName, "bin")
   mkdirSync(binDir, { recursive: true })
   writeFileSync(join(binDir, executableName), "#!/bin/sh\nprintf 'codegraph fixture\\n'\n")
-  execFileSync("chmod", ["755", join(binDir, executableName)])
+  chmodSync(join(binDir, executableName), 0o755)
   execFileSync("tar", ["-czf", archive, rootName], { cwd: root })
   const bytes = readFileSync(archive)
   const sha256 = createHash("sha256").update(bytes).digest("hex")


### PR DESCRIPTION
## Summary
Remove the test fixture dependency on a shell `chmod` executable in `codegraph-provision.test.ts`. The fixture now uses Node's `chmodSync`, which keeps the tests portable on Windows environments where `chmod` is not on PATH.

## Changes
- Import `chmodSync` from `node:fs`.
- Replace `execFileSync(chmod, ...)` with `chmodSync(..., 0o755)` when preparing fake CodeGraph archive binaries.

## Verification
- `bun install --ignore-scripts`
- `bun test ./packages/utils/src/codegraph-provision.test.ts`
- `bun test ./packages/utils/src` (365 pass, 0 fail)
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced shell `chmod` in the CodeGraph fixture with `chmodSync` from `node:fs` to remove the external binary dependency and fix tests on Windows. This keeps `packages/utils/src/codegraph-provision.test.ts` portable while preserving executable permissions for the fake archive binary.

<sup>Written for commit 7c532fc13c6e9133bb157f3469104b6c440f4067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

