### PR TITLE
fix(skills-loader-core): preserve path punctuation

### DIFF
--- a/packages/claude-code-compat-core/src/shared/skill-path-resolver.test.ts
+++ b/packages/claude-code-compat-core/src/shared/skill-path-resolver.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "bun:test"
+import { resolveSkillPathReferences } from "./skill-path-resolver"
+
+describe("resolveSkillPathReferences", () => {
+	it("resolves path references before trailing sentence punctuation", () => {
+		//#given
+		const content = "Run @scripts/search.py."
+		const basePath = "/skills/frontend"
+
+		//#when
+		const result = resolveSkillPathReferences(content, basePath)
+
+		//#then
+		expect(result).toBe("Run /skills/frontend/scripts/search.py.")
+	})
+
+	it("preserves punctuation after multiple path replacements", () => {
+		//#given
+		const content = "Script: @scripts/search.py. Data: @data/styles.csv;"
+		const basePath = "/skills/frontend"
+
+		//#when
+		const result = resolveSkillPathReferences(content, basePath)
+
+		//#then
+		expect(result).toBe(
+			"Script: /skills/frontend/scripts/search.py. Data: /skills/frontend/data/styles.csv;"
+		)
+	})
+})

--- a/packages/claude-code-compat-core/src/shared/skill-path-resolver.ts
+++ b/packages/claude-code-compat-core/src/shared/skill-path-resolver.ts
@@ -18,45 +18,68 @@ function looksLikeFilePath(path: string): boolean {
 	return /\.[a-zA-Z0-9]+$/.test(lastSegment)
 }
 
+function splitTrailingSentencePunctuation(path: string): {
+	pathWithoutPunctuation: string
+	trailingPunctuation: string
+} {
+	const match = path.match(/[.,;:!?]+$/)
+	if (!match) {
+		return { pathWithoutPunctuation: path, trailingPunctuation: "" }
+	}
+
+	return {
+		pathWithoutPunctuation: path.slice(0, -match[0].length),
+		trailingPunctuation: match[0],
+	}
+}
+
 export function resolveSkillPathReferences(content: string, basePath: string): string {
 	const normalizedBase = basePath.replace(/[\\/]$/, "")
 	return content.replace(
 		/(?<![a-zA-Z0-9="\(])@([a-zA-Z0-9_-]+\/[a-zA-Z0-9_.\-\/]*)/g,
 		(match, relativePath: string) => {
-			if (!looksLikeFilePath(relativePath)) return match
+			const { pathWithoutPunctuation, trailingPunctuation } =
+				splitTrailingSentencePunctuation(relativePath)
+			if (!looksLikeFilePath(pathWithoutPunctuation)) return match
 			if (isWindowsAbsolutePath(normalizedBase)) {
-				const resolvedPath = win32.resolve(normalizedBase, relativePath)
+				const resolvedPath = win32.resolve(normalizedBase, pathWithoutPunctuation)
 				const relativePathFromBase = win32.relative(normalizedBase, resolvedPath)
 				if (relativePathFromBase.startsWith("..") || win32.isAbsolute(relativePathFromBase)) {
 					return match
 				}
 				const displayPath = toDisplayPath(resolvedPath)
-				return relativePath.endsWith("/") && !displayPath.endsWith("/")
-					? `${displayPath}/`
-					: displayPath
+				const resolvedDisplayPath =
+					pathWithoutPunctuation.endsWith("/") && !displayPath.endsWith("/")
+						? `${displayPath}/`
+						: displayPath
+				return `${resolvedDisplayPath}${trailingPunctuation}`
 			}
 
 			if (isPosixAbsolutePath(normalizedBase)) {
 				const displayBase = toDisplayPath(normalizedBase)
-				const resolvedPath = posix.resolve(displayBase, relativePath)
+				const resolvedPath = posix.resolve(displayBase, pathWithoutPunctuation)
 				const relativePathFromBase = posix.relative(displayBase, resolvedPath)
 				if (relativePathFromBase.startsWith("..") || posix.isAbsolute(relativePathFromBase)) {
 					return match
 				}
-				return relativePath.endsWith("/") && !resolvedPath.endsWith("/")
-					? `${resolvedPath}/`
-					: resolvedPath
+				const resolvedDisplayPath =
+					pathWithoutPunctuation.endsWith("/") && !resolvedPath.endsWith("/")
+						? `${resolvedPath}/`
+						: resolvedPath
+				return `${resolvedDisplayPath}${trailingPunctuation}`
 			}
 
-			const resolvedPath = resolve(normalizedBase, relativePath)
+			const resolvedPath = resolve(normalizedBase, pathWithoutPunctuation)
 			const relativePathFromBase = relative(normalizedBase, resolvedPath)
 			if (relativePathFromBase.startsWith("..") || isAbsolute(relativePathFromBase)) {
 				return match
 			}
 			const displayPath = toDisplayPath(resolvedPath)
-			return relativePath.endsWith("/") && !displayPath.endsWith("/")
-				? `${displayPath}/`
-				: displayPath
+			const resolvedDisplayPath =
+				pathWithoutPunctuation.endsWith("/") && !displayPath.endsWith("/")
+					? `${displayPath}/`
+					: displayPath
+			return `${resolvedDisplayPath}${trailingPunctuation}`
 		}
 	)
 }

--- a/packages/skills-loader-core/src/shared/skill-path-resolver.test.ts
+++ b/packages/skills-loader-core/src/shared/skill-path-resolver.test.ts
@@ -42,6 +42,32 @@ describe("resolveSkillPathReferences", () => {
 		expect(result).toBe("Data files: /skills/frontend/data/")
 	})
 
+	it("resolves path references before trailing sentence punctuation", () => {
+		//#given
+		const content = "Run @scripts/search.py."
+		const basePath = "/skills/frontend"
+
+		//#when
+		const result = resolveSkillPathReferences(content, basePath)
+
+		//#then
+		expect(result).toBe("Run /skills/frontend/scripts/search.py.")
+	})
+
+	it("preserves punctuation after multiple path replacements", () => {
+		//#given
+		const content = "Script: @scripts/search.py. Data: @data/styles.csv;"
+		const basePath = "/skills/frontend"
+
+		//#when
+		const result = resolveSkillPathReferences(content, basePath)
+
+		//#then
+		expect(result).toBe(
+			"Script: /skills/frontend/scripts/search.py. Data: /skills/frontend/data/styles.csv;"
+		)
+	})
+
 	it("does not resolve single-segment @references without slash", () => {
 		//#given
 		const content = "@param value @ts-ignore @path"

--- a/packages/skills-loader-core/src/shared/skill-path-resolver.ts
+++ b/packages/skills-loader-core/src/shared/skill-path-resolver.ts
@@ -18,45 +18,68 @@ function looksLikeFilePath(path: string): boolean {
 	return /\.[a-zA-Z0-9]+$/.test(lastSegment)
 }
 
+function splitTrailingSentencePunctuation(path: string): {
+	pathWithoutPunctuation: string
+	trailingPunctuation: string
+} {
+	const match = path.match(/[.,;:!?]+$/)
+	if (!match) {
+		return { pathWithoutPunctuation: path, trailingPunctuation: "" }
+	}
+
+	return {
+		pathWithoutPunctuation: path.slice(0, -match[0].length),
+		trailingPunctuation: match[0],
+	}
+}
+
 export function resolveSkillPathReferences(content: string, basePath: string): string {
 	const normalizedBase = basePath.replace(/[\\/]$/, "")
 	return content.replace(
 		/(?<![a-zA-Z0-9="\(])@([a-zA-Z0-9_-]+\/[a-zA-Z0-9_.\-\/]*)/g,
 		(match, relativePath: string) => {
-			if (!looksLikeFilePath(relativePath)) return match
+			const { pathWithoutPunctuation, trailingPunctuation } =
+				splitTrailingSentencePunctuation(relativePath)
+			if (!looksLikeFilePath(pathWithoutPunctuation)) return match
 			if (isWindowsAbsolutePath(normalizedBase)) {
-				const resolvedPath = win32.resolve(normalizedBase, relativePath)
+				const resolvedPath = win32.resolve(normalizedBase, pathWithoutPunctuation)
 				const relativePathFromBase = win32.relative(normalizedBase, resolvedPath)
 				if (relativePathFromBase.startsWith("..") || win32.isAbsolute(relativePathFromBase)) {
 					return match
 				}
 				const displayPath = toDisplayPath(resolvedPath)
-				return relativePath.endsWith("/") && !displayPath.endsWith("/")
-					? `${displayPath}/`
-					: displayPath
+				const resolvedDisplayPath =
+					pathWithoutPunctuation.endsWith("/") && !displayPath.endsWith("/")
+						? `${displayPath}/`
+						: displayPath
+				return `${resolvedDisplayPath}${trailingPunctuation}`
 			}
 
 			if (isPosixAbsolutePath(normalizedBase)) {
 				const displayBase = toDisplayPath(normalizedBase)
-				const resolvedPath = posix.resolve(displayBase, relativePath)
+				const resolvedPath = posix.resolve(displayBase, pathWithoutPunctuation)
 				const relativePathFromBase = posix.relative(displayBase, resolvedPath)
 				if (relativePathFromBase.startsWith("..") || posix.isAbsolute(relativePathFromBase)) {
 					return match
 				}
-				return relativePath.endsWith("/") && !resolvedPath.endsWith("/")
-					? `${resolvedPath}/`
-					: resolvedPath
+				const resolvedDisplayPath =
+					pathWithoutPunctuation.endsWith("/") && !resolvedPath.endsWith("/")
+						? `${resolvedPath}/`
+						: resolvedPath
+				return `${resolvedDisplayPath}${trailingPunctuation}`
 			}
 
-			const resolvedPath = resolve(normalizedBase, relativePath)
+			const resolvedPath = resolve(normalizedBase, pathWithoutPunctuation)
 			const relativePathFromBase = relative(normalizedBase, resolvedPath)
 			if (relativePathFromBase.startsWith("..") || isAbsolute(relativePathFromBase)) {
 				return match
 			}
 			const displayPath = toDisplayPath(resolvedPath)
-			return relativePath.endsWith("/") && !displayPath.endsWith("/")
-				? `${displayPath}/`
-				: displayPath
+			const resolvedDisplayPath =
+				pathWithoutPunctuation.endsWith("/") && !displayPath.endsWith("/")
+					? `${displayPath}/`
+					: displayPath
+			return `${resolvedDisplayPath}${trailingPunctuation}`
 		}
 	)
 }


### PR DESCRIPTION
## Summary
- Strip trailing sentence punctuation from skill-local `@path` references before resolving them, then append the punctuation back to the resolved display path.
- Keeps the skills-loader-core resolver and the claude-code-compat-core mirror in sync.
- Adds regression coverage for sentence punctuation after a single `@scripts/search.py.` reference and after multiple replacements.

## Changes
- `packages/skills-loader-core/src/shared/skill-path-resolver.ts`: resolve the path portion separately from trailing `. , ; : ! ?` punctuation.
- `packages/claude-code-compat-core/src/shared/skill-path-resolver.ts`: mirror the same behavior.
- Added/updated resolver tests in both packages.

## Verification
- `bun install --ignore-scripts` ✅
- `bun test packages\skills-loader-core\src\shared\skill-path-resolver.test.ts` ✅ (16 pass, 0 fail)
- `bun test packages\claude-code-compat-core\src\shared\skill-path-resolver.test.ts` ✅ (2 pass, 0 fail)
- `bun run typecheck` from `packages/skills-loader-core` ✅
- `bun run typecheck` from `packages/claude-code-compat-core` ✅
- Isolated Claude core sweep: `XDG_CONFIG_HOME=<temp> bun test D:\oh-my-openagent-wt\fix-skill-path-reference-trailing-punctuation-20260628\packages\claude-code-compat-core\src` ✅ (183 pass, 0 fail)
- `git diff --check` ✅
- `git diff --cached --check` ✅

Attempted broader local `bun test packages\skills-loader-core\src`; unrelated existing short-name resolution fixtures fail because `systematic-debugging` resolves to the checked-in/shared skill content instead of the test fixture. The resolver test file touched here passes.

## QA
Not run: this changes only pure Core resolver logic and tests, not OpenCode or Codex adapter wiring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix path resolution for inline `@...` references so trailing punctuation (.,;:!?) is preserved. Applies to both `skills-loader-core` and `claude-code-compat-core`.

- **Bug Fixes**
  - Resolve paths before trailing sentence punctuation and re-append it after.
  - Support multiple replacements in a sentence without losing punctuation.
  - Mirror logic and add tests in `skills-loader-core` and `claude-code-compat-core`.

<sup>Written for commit 00a74cb014d3c87cd3a310865ec95464edd5f365. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

