### PR TITLE
test(skills-loader-core): avoid shared skill fixture collision

### DIFF
--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-multiple.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-multiple.test.ts
@@ -238,15 +238,15 @@ describe("resolveMultipleSkillsAsync", () => {
 
 	it("resolves nested skill by unique short name in mixed batch", async () => {
 		// given: nested skill and builtin skill
-		createNestedSkill(testConfigDir, "toolkit", "systematic-debugging", "short name resolved")
+		createNestedSkill(testConfigDir, "toolkit", "nested-debug-fixture", "short name resolved")
 
 		// when: mixing short name with full builtin name
-		const result = await resolveMultipleSkillsAsync(["systematic-debugging", "playwright"])
+		const result = await resolveMultipleSkillsAsync(["nested-debug-fixture", "playwright"])
 
 		// then: both resolved
 		expect(result.resolved.size).toBe(2)
 		expect(result.notFound).toEqual([])
-		expect(result.resolved.get("systematic-debugging")).toContain("short name resolved")
+		expect(result.resolved.get("nested-debug-fixture")).toContain("short name resolved")
 		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
 	})
 

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-resolution.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-resolution.test.ts
@@ -144,11 +144,11 @@ describe("resolveSkillContentAsync", () => {
 	})
 
 	it("resolves nested skill by unique short name async", async () => {
-		// given: a discovered nested skill toolkit/systematic-debugging
-		createNestedSkill(testConfigDir, "toolkit", "systematic-debugging", "Short name test content")
+		// given: a discovered nested skill toolkit/nested-debug-fixture
+		createNestedSkill(testConfigDir, "toolkit", "nested-debug-fixture", "Short name test content")
 
 		// when: resolving by short name
-		const result = await resolveSkillContentAsync("systematic-debugging")
+		const result = await resolveSkillContentAsync("nested-debug-fixture")
 
 		// then: finds the nested skill
 		expect(result).not.toBeNull()
@@ -185,10 +185,10 @@ describe("resolveSkillContentAsync", () => {
 
 	it("is case-insensitive for short name matching async", async () => {
 		// given: a nested skill with lowercase name
-		createNestedSkill(testConfigDir, "toolkit", "systematic-debugging", "case insensitive match")
+		createNestedSkill(testConfigDir, "toolkit", "nested-debug-fixture", "case insensitive match")
 
 		// when: resolving by uppercase short name
-		const result = await resolveSkillContentAsync("Systematic-Debugging")
+		const result = await resolveSkillContentAsync("Nested-Debug-Fixture")
 
 		// then: finds it case-insensitively
 		expect(result).not.toBeNull()


### PR DESCRIPTION
## Summary
- Rename short-name resolver test fixtures away from `systematic-debugging`, which now collides with a real shared skill.
- Keeps the tests focused on unique nested short-name resolution instead of accidentally asserting against bundled shared skill precedence.
- Restores the local `skills-loader-core` package suite to green.

## Changes
- Use `nested-debug-fixture` in async single-skill short-name tests.
- Use the same collision-free fixture in async batch short-name tests.

## Verification
- `bun install --ignore-scripts` ✅
- `bun test packages\skills-loader-core\src\features\opencode-skill-loader\skill-content-async-resolution.test.ts` ✅ (12 pass, 0 fail)
- `bun test packages\skills-loader-core\src\features\opencode-skill-loader\skill-content-async-multiple.test.ts` ✅ (14 pass, 0 fail)
- `bun test packages\skills-loader-core\src` ✅ (217 pass, 0 fail)
- `bun run typecheck` from `packages/skills-loader-core` ✅
- `git diff --check` ✅
- `git diff --cached --check` ✅

## QA
Not run: test-only change in pure Core package; no OpenCode or Codex adapter wiring changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed short-name fixtures in `skills-loader-core` tests from "systematic-debugging" to "nested-debug-fixture" to avoid collision with a real shared skill. Keeps tests focused on nested short-name resolution and restores the local suite to green.

<sup>Written for commit 920183fef0d31d05adeff1673f44a193abfc3202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

