### PR TITLE
fix(model-core): add Qwen heuristic variants

### DIFF
--- a/packages/model-core/src/model-capabilities.test.ts
+++ b/packages/model-core/src/model-capabilities.test.ts
@@ -332,6 +332,26 @@ describe("getModelCapabilities", () => {
     })
   })
 
+  test("falls back to Qwen heuristic rules for custom provider model IDs", () => {
+    const result = getModelCapabilities({
+      providerID: "ksi",
+      modelID: "qwen3.6-35b-a3b-nvfp4",
+      bundledSnapshot,
+    })
+
+    expect(result).toMatchObject({
+      canonicalModelID: "qwen3.6-35b-a3b-nvfp4",
+      family: "qwen",
+      variants: ["low", "medium", "high"],
+    })
+    expect(result.diagnostics).toMatchObject({
+      resolutionMode: "heuristic-backed",
+      snapshot: { source: "none" },
+      family: { source: "heuristic" },
+      variants: { source: "heuristic" },
+    })
+  })
+
   test("prefers snapshot reasoning over heuristic supportsThinking for MiniMax M2.7", () => {
     // given
     const modelID = "minimax-m2.7"

--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -48,6 +48,7 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   {
     family: "qwen",
     includes: ["qwen"],
+    variants: ["low", "medium", "high"],
   },
   {
     family: "grok",

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -258,6 +258,7 @@ describe("resolveCompatibleModelSettings", () => {
       { name: "Kimi (k2)", modelID: "k2-v2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "GLM", modelID: "glm-5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Minimax", modelID: "minimax-m2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Qwen", modelID: "qwen3.6-35b-a3b-nvfp4", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high", "max"], hasReasoningEffort: true },
       { name: "Mistral", modelID: "mistral-large-next", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Codestral → Mistral", modelID: "codestral-2506", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
@@ -735,6 +736,18 @@ describe("resolveCompatibleModelSettings", () => {
     })
 
     expect(result.maxTokens).toBeUndefined()
+    expect(result.changes).toEqual([])
+  })
+
+  test("uses Qwen provider metadata variants before heuristic family fallback", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "ksi",
+      modelID: "qwen3.7-plus",
+      capabilities: { variants: ["medium", "high", "xhigh", "max", "off"] },
+      desired: { variant: "xhigh" },
+    })
+
+    expect(result.variant).toBe("xhigh")
     expect(result.changes).toEqual([])
   })
 


### PR DESCRIPTION
Summary:
- Completes the existing Qwen heuristic family entry by adding fallback variants.
- Makes custom/local Qwen model IDs resolve as heuristic-backed instead of variant-unknown.
- Keeps provider-declared Qwen variants such as xhigh/max/off taking precedence over heuristic fallback.

Verification:
- bun test packages\\model-core\\src
- bun run typecheck (from packages\\model-core)
- git diff --check
- git diff --cached --check

QA: not run; pure Core model capability logic only, no OpenCode/Codex adapter wiring changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Qwen heuristic variants and enable heuristic fallback for custom/local Qwen model IDs, preventing variant-unknown resolution. Provider-declared Qwen variants still override the fallback.

- **Bug Fixes**
  - Added ["low", "medium", "high"] variants to the Qwen family in `packages/model-core`.
  - Heuristic-backed resolution now applies to custom Qwen IDs; provider variants (e.g., xhigh/max/off) take precedence.
  - Expanded tests in `model-capabilities.test.ts` and `model-settings-compatibility.test.ts` to cover both behaviors.

<sup>Written for commit 3ca30f8a341ddda6044212d9110e7f4c618615cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

