### PR TITLE
docs: add memory-safe orchestration guidance

### DIFF
--- a/docs/guide/orchestration.md
+++ b/docs/guide/orchestration.md
@@ -366,6 +366,45 @@ Background task concurrency defaults to **5** when no overrides are configured.
 - Keyed by model/provider routing key
 - Configurable via `background_task.defaultConcurrency`, `background_task.providerConcurrency`, and `background_task.modelConcurrency`
 
+### Memory-Safe Autonomous Runs
+
+Large `ultrawork` or `/start-work` runs can amplify host memory pressure because each child session has its own prompt history, tool output, subprocesses, and optional tmux pane. If you are running inside an IDE terminal such as Zed, VS Code, or JetBrains, start conservative and raise limits only after the host stays stable.
+
+Use this baseline when investigating memory pressure:
+
+```jsonc
+{
+  "background_task": {
+    "defaultConcurrency": 2,
+    "providerConcurrency": {
+      "anthropic": 1,
+      "openai": 2,
+      "opencode-go": 2
+    },
+    "maxDepth": 2,
+    "maxToolCalls": 120,
+    "staleTimeoutMs": 120000,
+    "messageStalenessTimeoutMs": 600000,
+    "taskTtlMs": 900000,
+    "taskCleanupDelayMs": 60000
+  },
+  "team_mode": {
+    "max_parallel_members": 2,
+    "max_members": 4,
+    "max_wall_clock_minutes": 45,
+    "max_member_turns": 120,
+    "max_messages_per_run": 2000
+  }
+}
+```
+
+Operational rules:
+
+- Prefer one foreground implementation lane plus background `explore`/`librarian` lanes; avoid launching multiple build/test/dev-server workers from an IDE terminal.
+- Treat repeated stale-task interruptions, disappeared sessions, or host memory-pressure warnings as a stop condition. Collect the useful output, cancel disposable lanes individually, and restart from a smaller plan slice.
+- Keep `tmux_visualization` off while diagnosing host memory pressure. Turn it back on only after the same workload is stable without pane rendering.
+- For leak investigations, run outside the IDE terminal when possible and capture host process memory alongside `oh-my-opencode.log`; this separates OMO orchestration pressure from editor/runtime leaks.
+
 ### Team Mode
 
 Team mode is parallel multi-agent orchestration and is **OFF by default**.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -410,20 +410,39 @@ Control parallel agent execution and concurrency limits.
   "background_task": {
     "defaultConcurrency": 5,
     "staleTimeoutMs": 180000,
+    "maxDepth": 3,
+    "maxToolCalls": 200,
     "providerConcurrency": { "anthropic": 3, "openai": 5, "google": 10 },
-    "modelConcurrency": { "anthropic/claude-opus-4-7": 2 }
+    "modelConcurrency": { "anthropic/claude-opus-4-7": 2 },
+    "circuitBreaker": {
+      "enabled": true,
+      "maxToolCalls": 200,
+      "consecutiveThreshold": 10
+    }
   }
 }
 ```
 
-| Option                | Default  | Description                                                           |
-| --------------------- | -------- | --------------------------------------------------------------------- |
-| `defaultConcurrency`  | -        | Max concurrent tasks (all providers)                                  |
-| `staleTimeoutMs`      | `180000` | Interrupt tasks with no activity (min: 60000)                         |
-| `providerConcurrency` | -        | Per-provider limits (key = provider name)                             |
-| `modelConcurrency`    | -        | Per-model limits (key = `provider/model`). Overrides provider limits. |
+| Option                        | Default   | Description                                                           |
+| ----------------------------- | --------- | --------------------------------------------------------------------- |
+| `defaultConcurrency`          | -         | Max concurrent tasks (all providers)                                  |
+| `providerConcurrency`         | -         | Per-provider limits (key = provider name)                             |
+| `modelConcurrency`            | -         | Per-model limits (key = `provider/model`). Overrides provider limits. |
+| `maxDepth`                    | -         | Maximum nested background-task delegation depth                        |
+| `staleTimeoutMs`              | `180000`  | Interrupt tasks with no activity (min: 60000)                         |
+| `messageStalenessTimeoutMs`   | `1800000` | Interrupt tasks that never produced a progress update (min: 60000)    |
+| `taskTtlMs`                   | `1800000` | Prune non-terminal tasks older than this TTL (min: 300000)            |
+| `sessionGoneTimeoutMs`        | `60000`   | Short timeout when a child session disappears (min: 10000)            |
+| `taskCleanupDelayMs`          | `600000`  | Delay before completed/cancelled/errored tasks leave memory (min: 60000) |
+| `syncPollTimeoutMs`           | -         | Timeout for synchronous polling paths (min: 60000)                    |
+| `maxToolCalls`                | `200`     | Maximum tool calls per subagent task before the runaway guard trips   |
+| `circuitBreaker.enabled`      | -         | Enable the nested circuit-breaker guard                               |
+| `circuitBreaker.maxToolCalls` | -         | Circuit-breaker tool-call threshold (min: 10)                         |
+| `circuitBreaker.consecutiveThreshold` | -  | Consecutive-threshold trip point (min: 5)                             |
 
 Priority: `modelConcurrency` > `providerConcurrency` > `defaultConcurrency`
+
+For memory-pressure investigations, lower `defaultConcurrency`, provider/model concurrency, `maxDepth`, and `maxToolCalls` together. Team Mode has separate bounds under `team_mode.max_parallel_members`, `team_mode.max_wall_clock_minutes`, `team_mode.max_member_turns`, and `team_mode.max_messages_per_run`.
 
 ### Sisyphus Agent
 


### PR DESCRIPTION
## Summary
- add a memory-safe autonomous-run preset for IDE-hosted `ultrawork` and `/start-work` sessions
- document stop conditions for stale/disappeared child sessions and host memory-pressure warnings
- expand the `background_task` config reference with existing budget and circuit-breaker knobs

Refs #5330

## Verification
- `git diff --check`
- `git diff --cached --check`
- `rg -n maxDepth|maxToolCalls|messageStalenessTimeoutMs|taskTtlMs|sessionGoneTimeoutMs|taskCleanupDelayMs|syncPollTimeoutMs|circuitBreaker|max_parallel_members|max_wall_clock_minutes|max_member_turns|max_messages_per_run packages\\omo-opencode\\src\\config\\schema\\background-task.ts docs\\guide\\orchestration.md docs\\reference\\configuration.md docs\\guide\\team-mode.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds memory-safe orchestration guidance for IDE-hosted `ultrawork` and `/start-work` runs, including a conservative baseline preset and stop conditions for stale/disappeared child sessions and host memory-pressure warnings. Updates the `background_task` config reference to include budget and circuit-breaker controls (`maxDepth`, `maxToolCalls`, `messageStalenessTimeoutMs`, `taskTtlMs`, `sessionGoneTimeoutMs`, `taskCleanupDelayMs`, `syncPollTimeoutMs`, `circuitBreaker.*`) and tips for tuning concurrency and Team Mode limits, addressing #5330.

<sup>Written for commit ece937ca72fa9309d31f0136ee8ae1dde80a53a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

