### PR TITLE
test(release): document final size exceptions

### DIFF
--- a/packages/omo-codex/plugin/components/bootstrap/scripts/bootstrap.ps1
+++ b/packages/omo-codex/plugin/components/bootstrap/scripts/bootstrap.ps1
@@ -1,3 +1,4 @@
+# allow: SIZE_OK - Windows bootstrap hook keeps PowerShell 5.1-compatible resolver/provisioning flow in one audited entrypoint.
 # LazyCodex bootstrap SessionStart hook for native Windows (Windows PowerShell 5.1).
 # Codex runs hooks through %COMSPEC%, so node may be absent from PATH entirely.
 # Resolve Codex-managed Node first, then the portable ZIP pinned by

--- a/script/qa/codex-marketplace-e2e.sh
+++ b/script/qa/codex-marketplace-e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# allow: SIZE_OK - Single end-to-end marketplace install/upgrade scenario; split future additions by phase before expanding.
 # Task 16 e2e marketplace QA against real codex (plan: .omo/plans/codex-marketplace-bootstrap.md).
 # Usage: bash script/qa/codex-marketplace-e2e.sh 2>&1 | tee .omo/evidence/task-16-e2e.log
 # Traps this script must dodge (facts that live outside this repo):


### PR DESCRIPTION
## Summary

This PR documents the final two oversized hand-maintained scripts that the pre-publish review flagged after #5717. It adds first-five-line `SIZE_OK` allow comments to the marketplace e2e script and the Windows bootstrap hook script.

No runtime behavior changes: this is release-gate metadata so the size scanner can distinguish intentional audited exceptions from accidental growth.

## Changes

- Added a `SIZE_OK` rationale to `script/qa/codex-marketplace-e2e.sh`.
- Added a `SIZE_OK` rationale to `packages/omo-codex/plugin/components/bootstrap/scripts/bootstrap.ps1`.

## QA & Evidence

- **What was tested:** Size-gate scan for both touched scripts.
  **Observed result:** Both scripts report `SIZE_OK` in the first five lines.
  **Artifact:** `.omo/evidence/20260628-final-size-gate/size-ok-scan.log`
  **Why sufficient:** Covers the specific pre-publish blocker.

- **What was tested:** Patch scope check.
  **Observed result:** Only two comment additions are present.
  **Artifact:** `.omo/evidence/20260628-final-size-gate/diff-check-rerun.log`
  **Why sufficient:** Confirms this PR does not change runtime behavior.

- **What was tested:** Codex hermetic installer verification.
  **Observed result:** Plugin cache, config enablement, component bins, and agent TOMLs landed inside an isolated Codex home; real `~/.codex/config.toml` stayed unchanged.
  **Artifact:** `.omo/evidence/20260628-final-size-gate/codex-install-verify-final-rerun.log`
  **Why sufficient:** Proves the Codex install path still works after the release-gate repair.

- **What was tested:** Codex hook unit probe.
  **Observed result:** Ultrawork hook injection passed in isolation; real `~/.codex/config.toml` stayed unchanged.
  **Artifact:** `.omo/evidence/20260628-final-size-gate/codex-hook-unit-probe-self-test.log`
  **Why sufficient:** Covers Codex hook wiring adjacent to the touched bootstrap component.

- **What was tested:** Codex test gate.
  **Observed result:** `bun run test:codex` passed, 421 tests.
  **Artifact:** `.omo/evidence/20260628-final-size-gate/test-codex-rerun.log`
  **Why sufficient:** Covers installer/config/plugin component regression tests.

- **What was tested:** Syntax smoke.
  **Observed result:** `bash -n script/qa/codex-marketplace-e2e.sh` passed. Local `pwsh` is unavailable, so PowerShell parser syntax was not run locally.
  **Artifact:** `.omo/evidence/20260628-final-size-gate/syntax-check.log`
  **Why sufficient:** Covers the executable shell script; PowerShell syntax limitation is documented.

## Risks & Residuals

Risk is low because only comments changed. The only residual is that `pwsh` is unavailable on this Mac, so local PowerShell parser validation was omitted; the Codex install/test gates and CI remain the active safeguards for the Windows bootstrap payload.

## Related Issues

Part of the 2026-06-28 pre-publish repair loop.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add first-five-line `SIZE_OK` comments to two hand-maintained scripts so the pre-publish size gate treats them as audited exceptions. Changes touch `script/qa/codex-marketplace-e2e.sh` and `packages/omo-codex/plugin/components/bootstrap/scripts/bootstrap.ps1` only; no runtime behavior changes.

<sup>Written for commit 763ae0d346ec3833d46dc4b123cdee240fc02c63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

