### PR TITLE
fix(model-core): classify runtime-backed custom models

### DIFF
--- a/packages/model-core/src/model-capabilities.test.ts
+++ b/packages/model-core/src/model-capabilities.test.ts
@@ -144,6 +144,40 @@ describe("getModelCapabilities", () => {
     })
   })
 
+  test("marks custom models with runtime provider metadata as runtime-backed", () => {
+    const result = getModelCapabilities({
+      providerID: "olmx",
+      modelID: "North-Mini-Code-1.0-4bit",
+      runtimeModel: {
+        capabilities: {
+          toolcall: true,
+          input: {
+            text: true,
+          },
+          output: {
+            text: true,
+          },
+        },
+      },
+      bundledSnapshot,
+    })
+
+    expect(result).toMatchObject({
+      canonicalModelID: "north-mini-code-1.0-4bit",
+      toolCall: true,
+      modalities: {
+        input: ["text"],
+        output: ["text"],
+      },
+    })
+    expect(result.diagnostics).toMatchObject({
+      resolutionMode: "runtime-backed",
+      snapshot: { source: "none" },
+      toolCall: { source: "runtime" },
+      modalities: { source: "runtime" },
+    })
+  })
+
   test("respects root-level thinking flags when providers do not nest them under capabilities", () => {
     findProviderModelMetadataSpy = spyOn(connectedProvidersCache, "findProviderModelMetadata").mockReturnValue(undefined)
     const result = getModelCapabilities({

--- a/packages/model-core/src/model-capabilities/get-model-capabilities.ts
+++ b/packages/model-core/src/model-capabilities/get-model-capabilities.ts
@@ -41,6 +41,19 @@ function getProviderOverride(providerID: string, modelID: string): ModelCapabili
 		: undefined
 }
 
+function hasRuntimeCapabilityEvidence(sources: {
+	variants: ModelCapabilitiesDiagnostics["variants"]["source"]
+	reasoning: ModelCapabilitiesDiagnostics["reasoning"]["source"]
+	supportsThinking: ModelCapabilitiesDiagnostics["supportsThinking"]["source"]
+	supportsTemperature: ModelCapabilitiesDiagnostics["supportsTemperature"]["source"]
+	supportsTopP: ModelCapabilitiesDiagnostics["supportsTopP"]["source"]
+	maxOutputTokens: ModelCapabilitiesDiagnostics["maxOutputTokens"]["source"]
+	toolCall: ModelCapabilitiesDiagnostics["toolCall"]["source"]
+	modalities: ModelCapabilitiesDiagnostics["modalities"]["source"]
+}): boolean {
+	return Object.values(sources).some((source) => source === "runtime")
+}
+
 export function getModelCapabilities(input: GetModelCapabilitiesInput): ModelCapabilities {
 	const canonicalization = resolveModelIDAlias(input.modelID)
 	const override = getOverride(input.modelID)
@@ -107,13 +120,25 @@ export function getModelCapabilities(input: GetModelCapabilitiesInput): ModelCap
 		runtimeToolCall !== undefined ? "runtime" : snapshotEntry?.toolCall !== undefined ? snapshotSource : "none"
 	const modalitiesSource: ModelCapabilitiesDiagnostics["modalities"]["source"] =
 		runtimeModalities !== undefined ? "runtime" : snapshotEntry?.modalities !== undefined ? snapshotSource : "none"
+	const runtimeCapabilityBacked = hasRuntimeCapabilityEvidence({
+		variants: variantsSource,
+		reasoning: reasoningSource,
+		supportsThinking: supportsThinkingSource,
+		supportsTemperature: supportsTemperatureSource,
+		supportsTopP: supportsTopPSource,
+		maxOutputTokens: maxOutputTokensSource,
+		toolCall: toolCallSource,
+		modalities: modalitiesSource,
+	})
 	const resolutionMode: ModelCapabilitiesDiagnostics["resolutionMode"] =
 		snapshotSource !== "none" && canonicalization.source === "canonical"
 			? "snapshot-backed"
-			: snapshotSource !== "none"
+		: snapshotSource !== "none"
 			? "alias-backed"
-			: familySource === "heuristic" || variantsSource === "heuristic" || reasoningEffortsSource === "heuristic"
+		: familySource === "heuristic" || variantsSource === "heuristic" || reasoningEffortsSource === "heuristic"
 			? "heuristic-backed"
+		: runtimeCapabilityBacked
+			? "runtime-backed"
 			: "unknown"
 
 	return {

--- a/packages/model-core/src/model-capabilities/types.ts
+++ b/packages/model-core/src/model-capabilities/types.ts
@@ -24,7 +24,7 @@ export type ModelCapabilitiesSnapshot = {
 }
 
 export type ModelCapabilitiesDiagnostics = {
-	resolutionMode: "snapshot-backed" | "alias-backed" | "heuristic-backed" | "unknown"
+	resolutionMode: "snapshot-backed" | "alias-backed" | "heuristic-backed" | "runtime-backed" | "unknown"
 	canonicalization: {
 		source: "canonical" | "exact-alias" | "pattern-alias"
 		ruleID?: string

--- a/packages/omo-opencode/src/cli/doctor/checks/model-resolution.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/model-resolution.test.ts
@@ -337,6 +337,34 @@ describe("model-resolution check", () => {
       const atlas = expectDefined(info.agents.find((agent) => agent.name === "atlas"), "atlas agent resolution")
       expect(atlas.capabilityDiagnostics?.resolutionMode).toBe("heuristic-backed")
     })
+
+    it("does not warn when custom local overrides are backed by runtime provider metadata", async () => {
+      const { collectCapabilityResolutionIssues, getModelResolutionInfoWithOverrides } = await import("./model-resolution")
+
+      // #given a custom local model override with runtime-backed diagnostics from model-core
+      const info = getModelResolutionInfoWithOverrides({
+        agents: {
+          atlas: { model: "olmx/North-Mini-Code-1.0-4bit" },
+        },
+      })
+      const atlasIndex = info.agents.findIndex((agent) => agent.name === "atlas")
+      expect(atlasIndex).toBeGreaterThanOrEqual(0)
+      const atlas = expectDefined(info.agents[atlasIndex], "atlas agent resolution")
+      info.agents[atlasIndex] = {
+        ...atlas,
+        capabilityDiagnostics: {
+          ...expectDefined(atlas.capabilityDiagnostics, "atlas capability diagnostics"),
+          resolutionMode: "runtime-backed",
+        },
+      }
+
+      // #when collecting doctor capability issues
+      const issues = collectCapabilityResolutionIssues(info)
+
+      // #then runtime-backed metadata is enough to avoid a compatibility fallback warning
+      expect(issues).toHaveLength(0)
+      expect(info.agents[atlasIndex]?.capabilityDiagnostics?.resolutionMode).toBe("runtime-backed")
+    })
   })
 
 })


### PR DESCRIPTION
## Summary
- Add a `runtime-backed` model capability resolution mode when provider cache metadata supplies usable runtime capabilities for custom/local models.
- Keep snapshot, alias, and heuristic resolution precedence unchanged, and keep metadata-only cache entries without parsed capabilities as `unknown`.
- Add regression coverage for the model-core resolver and the doctor fallback-warning path from #5719.

## Verification
- `bun test packages/model-core/src/model-capabilities.test.ts packages/omo-opencode/src/cli/doctor/checks/model-resolution.test.ts`
- `bun run typecheck:packages`

## Related Issues
Fixes #5719

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies custom/local models as runtime-backed when provider cache exposes any runtime capabilities, so we stop marking them as unknown and the doctor no longer warns. Keeps snapshot/alias/heuristic precedence unchanged. Addresses #5719.

- **Bug Fixes**
  - Added evidence-based "runtime-backed" resolution in `model-core` when runtime sources are detected (e.g., variants, reasoning, tool call, modalities).
  - Extended diagnostics to include `runtime-backed`; added tests for classification, canonical IDs, and doctor behavior in `omo-opencode`.

<sup>Written for commit 128efa2bf768960465bf09cd6cc4dd72987838b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

