### PR TITLE
fix(delegate-task): avoid sync tmux callback deadlock

### DIFF
--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+
+import { _resetForTesting } from "../../features/claude-code-session-state"
+import { clearAllDelegatedChildSessionBootstrap } from "../../shared/delegated-child-session-bootstrap"
+import type { ExecutorContext, ParentContext } from "./executor-types"
+import { registerSyncSessionSideEffects } from "./sync-session-lifecycle"
+import type { DelegateTaskArgs } from "./types"
+
+function createArgs(): DelegateTaskArgs {
+  return {
+    description: "sync tmux callback ordering",
+    prompt: "do sync work",
+    category: "quick",
+    run_in_background: false,
+    load_skills: [],
+  }
+}
+
+function createExecutorContext(
+  onSyncSessionCreated: ExecutorContext["onSyncSessionCreated"]
+): ExecutorContext {
+  return {
+    client: {} as ExecutorContext["client"],
+    directory: "/tmp",
+    manager: {} as ExecutorContext["manager"],
+    onSyncSessionCreated,
+  }
+}
+
+const parentContext: ParentContext = {
+  sessionID: "ses_parent",
+  messageID: "msg_parent",
+  agent: "sisyphus",
+}
+
+describe("registerSyncSessionSideEffects", () => {
+  beforeEach(() => {
+    _resetForTesting()
+    clearAllDelegatedChildSessionBootstrap()
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearAllDelegatedChildSessionBootstrap()
+    mock.restore()
+  })
+
+  test("returns without waiting for a blocking onSyncSessionCreated callback", async () => {
+    // given
+    const events: string[] = []
+    let resolveCallback: () => void = () => {}
+    const blockingCallback = new Promise<void>((resolve) => {
+      resolveCallback = resolve
+    })
+
+    const onSyncSessionCreated = mock(async () => {
+      events.push("callback.start")
+      await blockingCallback
+      events.push("callback.end")
+    })
+
+    const registerPromise = registerSyncSessionSideEffects({
+      args: createArgs(),
+      executorCtx: createExecutorContext(onSyncSessionCreated),
+      sessionID: "ses_sync_tmux_deadlock",
+      parentContext,
+      agentToUse: "sisyphus-junior",
+      categoryModel: undefined,
+      fallbackChain: undefined,
+      systemContent: undefined,
+    }).then(() => {
+      events.push("register.return")
+    })
+
+    await Promise.resolve()
+
+    // when
+    const result = await Promise.race([
+      registerPromise.then(() => "resolved" as const),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 25)),
+    ])
+
+    try {
+      // then
+      expect(events).toContain("callback.start")
+      expect(events).not.toContain("callback.end")
+      expect(result).toBe("resolved")
+      expect(events).toContain("register.return")
+      expect(onSyncSessionCreated).toHaveBeenCalledTimes(1)
+      expect(onSyncSessionCreated.mock.calls[0]?.[0]).toEqual({
+        sessionID: "ses_sync_tmux_deadlock",
+        parentID: "ses_parent",
+        title: "sync tmux callback ordering",
+      })
+    } finally {
+      resolveCallback()
+      await registerPromise
+    }
+  })
+})

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
@@ -43,17 +43,14 @@ export async function registerSyncSessionSideEffects(input: {
       sessionID: input.sessionID,
       parentID: input.parentContext.sessionID,
     })
-    try {
-      await input.executorCtx.onSyncSessionCreated({
-        sessionID: input.sessionID,
-        parentID: input.parentContext.sessionID,
-        title: input.args.description,
-      })
-    } catch (error) {
+    void input.executorCtx.onSyncSessionCreated({
+      sessionID: input.sessionID,
+      parentID: input.parentContext.sessionID,
+      title: input.args.description,
+    }).catch((error) => {
       const message = error instanceof Error ? String(error) : String(error)
       log("[task] onSyncSessionCreated callback failed", { error: message })
-    }
-    await new Promise(resolve => setTimeout(resolve, 200))
+    })
   }
 }
 


### PR DESCRIPTION
## Summary
- Make sync subagent session-created side effects fire-and-forget so tmux readiness waits no longer block sync prompt dispatch.
- Remove the sync-only 200ms post-callback delay that kept the prompt behind the tmux callback.
- Add a focused regression test proving registration resolves while a blocking `onSyncSessionCreated` callback is still pending.

## Why
Issue #5608 documents the tmux readiness deadlock: the callback waits for the child session to become attachable, but sync prompt dispatch only happens after registration returns. The background path already uses fire-and-forget callback dispatch; this applies the same ordering to the sync path.

## Verification
- `bun test packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.test.ts packages/omo-opencode/src/tools/delegate-task/sync-task.test.ts` (19 pass)
- `bun run typecheck:packages`
- OpenCode QA evidence written under `.omo/evidence/20260629-sync-tmux-callback-deadlock-5608/`:
  - `common.sh --self-check` passed using PATH-local `jq`/`sqlite3` shims because this Windows host lacks those binaries globally.
  - `server-smoke.sh --self-test` passed against OpenCode 1.17.11 in an isolated sandbox.
  - `tui-smoke.sh --self-test` was attempted; Windows psmux launched the pane through `cmd.exe`, which rejects the POSIX `HOME=... opencode ...` prefix, so render failed. The same run still proved tmux teardown and real DB session count unchanged.

Fixes #5608

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a deadlock in sync delegate tasks by dispatching the tmux session-created callback asynchronously and removing the extra delay. Sync prompts now dispatch without waiting for tmux readiness. Fixes #5608.

- **Bug Fixes**
  - Fire-and-forget `onSyncSessionCreated` invocation; no awaiting.
  - Removed the sync-only 200ms post-callback delay.
  - Added a regression test confirming registration resolves while the callback is still pending.

<sup>Written for commit 68961992d1ed4b82e3c9ac6cc3285469db8b5ae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

