### PR TITLE
fix(atlas): ignore repeated status-only progress loops

### DIFF
--- a/packages/omo-opencode/src/hooks/atlas/index.test.ts
+++ b/packages/omo-opencode/src/hooks/atlas/index.test.ts
@@ -2041,6 +2041,57 @@ session_id: ses_untrusted_999
       }
     })
 
+    test("#given repeated identical bash status output #when Atlas continuations repeat #then Atlas stalls instead of looping forever", async () => {
+      // given - a boulder plan whose continuation only repeats the same read-only status snapshot
+      const planPath = join(TEST_DIR, "repeated-bash-status-plan.md")
+      writeFileSync(planPath, "# Plan\n- [x] Task 8\n- [ ] Task 2\n- [ ] Task 3\n- [ ] Task 5")
+
+      writeBoulderState(TEST_DIR, {
+        active_plan: planPath,
+        started_at: "2026-01-02T10:00:00Z",
+        session_ids: [MAIN_SESSION_ID],
+        plan_name: "repeated-bash-status-plan",
+      })
+
+      const statusOutput = {
+        title: "Bash",
+        output: "T8 completed: 1\nT2/T3/T5/T1/T4/T6 open: 12\nPlan done: 1\nPlan remaining: 12",
+        metadata: {},
+      }
+      const mockInput = createMockPluginInput()
+      const hook = createTestAtlasHook(mockInput)
+
+      const originalDateNow = Date.now
+      let now = 0
+      Date.now = () => now
+
+      try {
+        // when - the first repeated status snapshot gets one retry budget, but identical repeats do not reset it forever
+        await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
+        await hook["tool.execute.after"]({ tool: "bash", sessionID: MAIN_SESSION_ID, callID: "status-1" }, statusOutput)
+        await flushMicrotasks()
+        now += 6000
+
+        for (let iteration = 2; iteration <= 4; iteration += 1) {
+          await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
+          await hook["tool.execute.after"](
+            { tool: "bash", sessionID: MAIN_SESSION_ID, callID: `status-${iteration}` },
+            statusOutput,
+          )
+          await flushMicrotasks()
+          now += 6000
+        }
+
+        await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
+        await flushMicrotasks()
+
+        // then - Atlas stops after the no-progress threshold instead of accepting identical bash as fresh progress forever
+        expect(mockInput._promptMock).toHaveBeenCalledTimes(4)
+      } finally {
+        Date.now = originalDateNow
+      }
+    })
+
     test("#given continuation makes tangible tool progress #when idle repeats #then no-progress stall counter resets", async () => {
       // given - boulder state with incomplete work and a successful edit between continuation turns
       const planPath = join(TEST_DIR, "progress-plan.md")

--- a/packages/omo-opencode/src/hooks/atlas/tool-execute-after.ts
+++ b/packages/omo-opencode/src/hooks/atlas/tool-execute-after.ts
@@ -4,7 +4,7 @@ import { collectGitDiffStats, formatFileChanges } from "../../shared/git-worktre
 import { extractSessionIdFromMetadata } from "./subagent-session-id"
 import { handleDirectWorkToolAfter } from "./tool-execute-after-direct-work"
 import { handleSubagentCompletionAfter } from "./tool-execute-after-subagent-completion"
-import { didToolMakeProgress, isTangibleProgressTool, recordToolProgress } from "./tool-progress"
+import { recordTangibleToolProgress } from "./tool-progress"
 import type { PendingTaskRef, SessionState } from "./types"
 import type { ToolExecuteAfterInput, ToolExecuteAfterOutput } from "./types"
 
@@ -29,8 +29,8 @@ export function createToolExecuteAfterHandler(input: {
       return
     }
 
-    if (toolInput.sessionID && isTangibleProgressTool(toolInput.tool) && didToolMakeProgress(toolOutput)) {
-      recordToolProgress(getState(toolInput.sessionID))
+    if (toolInput.sessionID) {
+      recordTangibleToolProgress(getState(toolInput.sessionID), toolInput.tool, toolOutput)
     }
 
     if (!(await resolveIsCallerOrchestrator(toolInput.sessionID))) {

--- a/packages/omo-opencode/src/hooks/atlas/tool-progress.test.ts
+++ b/packages/omo-opencode/src/hooks/atlas/tool-progress.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import {
   recordToolProgress,
+  recordTangibleToolProgress,
   resetStallStateForPlanChange,
   shouldAbortForNoToolProgress,
   updateNoToolProgressIterations,
@@ -39,6 +40,8 @@ describe("#given a session that already accumulated no-tool-progress for plan A"
       // given - plan A starts and the agent racks up 2 no-progress iterations without stalling yet
       const state = emptyState()
       resetStallStateForPlanChange(state, "/plans/a.md")
+      recordTangibleToolProgress(state, "bash", { output: "Plan done: 1\nPlan remaining: 12" })
+      expect(state.lastBashProgressFingerprint).toBeDefined()
       markContinuationInjectedAwaitingToolProgress(state)
       updateNoToolProgressIterations(state)
       markContinuationInjectedAwaitingToolProgress(state)
@@ -52,6 +55,7 @@ describe("#given a session that already accumulated no-tool-progress for plan A"
       expect(state.activeContinuationPlanPath).toBe("/plans/b.md")
       expect(state.iterationsSinceLastToolProgress).toBe(0)
       expect(state.awaitingToolProgressAfterContinuation).toBe(false)
+      expect(state.lastBashProgressFingerprint).toBeUndefined()
       expect(shouldAbortForNoToolProgress(state)).toBe(false)
     })
   })
@@ -119,6 +123,76 @@ describe("#given a session running on plan A with tool progress", () => {
       expect(state.awaitingToolProgressAfterContinuation).toBe(false)
       expect(state.lastToolProgressAt).toBe(1000)
       expect(state.activeContinuationPlanPath).toBe("/plans/a.md")
+    })
+  })
+
+  describe("#when repeated bash output is recorded after a continuation", () => {
+    test("#then the repeated fingerprint does not clear awaiting progress", () => {
+      // given
+      const state = emptyState()
+      resetStallStateForPlanChange(state, "/plans/a.md")
+      const statusOutput = { title: "Bash", output: "Plan done: 1\r\nPlan remaining: 12\n" }
+
+      // when - the first bash snapshot is allowed to reset the continuation budget
+      const firstRecorded = recordTangibleToolProgress(state, "bash", statusOutput, 1000)
+      markContinuationInjectedAwaitingToolProgress(state)
+      const secondRecorded = recordTangibleToolProgress(
+        state,
+        "bash",
+        { title: "Bash", output: "Plan done: 1\nPlan remaining: 12   " },
+        2000,
+      )
+
+      // then
+      expect(firstRecorded).toBe(true)
+      expect(secondRecorded).toBe(false)
+      expect(state.awaitingToolProgressAfterContinuation).toBe(true)
+      expect(state.iterationsSinceLastToolProgress).toBe(0)
+      expect(state.lastToolProgressAt).toBe(1000)
+      expect(state.lastBashProgressFingerprint).toBeDefined()
+    })
+  })
+
+  describe("#when bash output changes after a continuation", () => {
+    test("#then the new fingerprint counts as progress", () => {
+      // given
+      const state = emptyState()
+      resetStallStateForPlanChange(state, "/plans/a.md")
+      recordTangibleToolProgress(state, "bash", { output: "Plan done: 1\nPlan remaining: 12" }, 1000)
+      markContinuationInjectedAwaitingToolProgress(state)
+
+      // when
+      const recorded = recordTangibleToolProgress(
+        state,
+        "bash",
+        { output: "Plan done: 2\nPlan remaining: 11" },
+        2000,
+      )
+
+      // then
+      expect(recorded).toBe(true)
+      expect(state.awaitingToolProgressAfterContinuation).toBe(false)
+      expect(state.lastToolProgressAt).toBe(2000)
+      expect(state.lastBashProgressFingerprint).toBeDefined()
+    })
+  })
+
+  describe("#when edit or write progress follows bash progress", () => {
+    test("#then the bash fingerprint clears so future status output gets a fresh baseline", () => {
+      // given
+      const state = emptyState()
+      resetStallStateForPlanChange(state, "/plans/a.md")
+      recordTangibleToolProgress(state, "bash", { output: "Plan done: 1\nPlan remaining: 12" }, 1000)
+      markContinuationInjectedAwaitingToolProgress(state)
+
+      // when
+      const recorded = recordTangibleToolProgress(state, "edit", { output: "Updated file" }, 2000)
+
+      // then
+      expect(recorded).toBe(true)
+      expect(state.awaitingToolProgressAfterContinuation).toBe(false)
+      expect(state.lastToolProgressAt).toBe(2000)
+      expect(state.lastBashProgressFingerprint).toBeUndefined()
     })
   })
 })

--- a/packages/omo-opencode/src/hooks/atlas/tool-progress.ts
+++ b/packages/omo-opencode/src/hooks/atlas/tool-progress.ts
@@ -26,18 +26,70 @@ export function didToolMakeProgress(output: ToolProgressOutput): boolean {
   return !FAILURE_TITLE_PATTERN.test(title) && !FAILURE_OUTPUT_PATTERN.test(body)
 }
 
+function normalizeFingerprintPart(value: string): string {
+  return value
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim()
+}
+
+function stableFingerprint(value: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return `${value.length}:${(hash >>> 0).toString(16)}`
+}
+
+function getBashProgressFingerprint(output: ToolProgressOutput): string {
+  const title = normalizeFingerprintPart(output.title ?? "")
+  const body = normalizeFingerprintPart(output.output ?? "")
+  return stableFingerprint(`title:${title}\noutput:${body}`)
+}
+
 export function recordToolProgress(state: SessionState, now = Date.now()): void {
   state.awaitingToolProgressAfterContinuation = false
   state.iterationsSinceLastToolProgress = 0
   state.lastToolProgressAt = now
+  state.lastBashProgressFingerprint = undefined
   state.stalledContinuationReason = undefined
   state.stalledContinuationPlanPath = undefined
+}
+
+export function recordTangibleToolProgress(
+  state: SessionState,
+  toolName: string,
+  output: ToolProgressOutput,
+  now = Date.now(),
+): boolean {
+  const normalizedToolName = toolName.toLowerCase()
+  if (!isTangibleProgressTool(normalizedToolName) || !didToolMakeProgress(output)) {
+    return false
+  }
+
+  if (normalizedToolName !== "bash") {
+    recordToolProgress(state, now)
+    return true
+  }
+
+  const fingerprint = getBashProgressFingerprint(output)
+  if (state.lastBashProgressFingerprint === fingerprint) {
+    return false
+  }
+
+  recordToolProgress(state, now)
+  state.lastBashProgressFingerprint = fingerprint
+  return true
 }
 
 export function resetStallStateForPlanChange(state: SessionState, planPath: string): void {
   const previousPlanPath = state.activeContinuationPlanPath
   if (previousPlanPath === undefined) {
     state.activeContinuationPlanPath = planPath
+    state.lastBashProgressFingerprint = undefined
     return
   }
   if (previousPlanPath === planPath) {
@@ -47,6 +99,7 @@ export function resetStallStateForPlanChange(state: SessionState, planPath: stri
   state.activeContinuationPlanPath = planPath
   state.iterationsSinceLastToolProgress = 0
   state.awaitingToolProgressAfterContinuation = false
+  state.lastBashProgressFingerprint = undefined
   if (state.stalledContinuationReason && state.stalledContinuationPlanPath !== planPath) {
     state.stalledContinuationReason = undefined
     state.stalledContinuationPlanPath = undefined

--- a/packages/omo-opencode/src/hooks/atlas/types.ts
+++ b/packages/omo-opencode/src/hooks/atlas/types.ts
@@ -52,6 +52,8 @@ export interface SessionState {
   awaitingToolProgressAfterContinuation?: boolean
   iterationsSinceLastToolProgress?: number
   lastToolProgressAt?: number
+  /** Last successful bash output fingerprint counted as progress; repeated matches do not reset stall tracking. */
+  lastBashProgressFingerprint?: string
   stalledContinuationReason?: string
   stalledContinuationPlanPath?: string
   /** The plan path the in-progress no-tool-progress counter is keyed to. Changes here reset the counter. */


### PR DESCRIPTION
## Summary

Fixes an Atlas continuation loop where repeated successful `bash` status checks could keep resetting the no-progress detector even when the plan did not advance. In the reported #5720 session, Atlas repeatedly ran the same read-only status command, saw the same output, and kept continuing because every successful `bash` call counted as fresh progress.

This PR keeps `edit` and `write` as tangible progress, but gives `bash` progress a per-session output fingerprint so identical status-only output does not reset the Atlas stall counter forever.

## Changes

- Track the last successful `bash` output fingerprint counted as Atlas continuation progress.
- Treat repeated identical successful `bash` output as no new progress, leaving the existing no-progress threshold to stop the loop.
- Clear the bash fingerprint on plan changes and after successful `edit` / `write` progress, so real work gets a fresh baseline.
- Add regression coverage for repeated identical bash status output and unit coverage for changed bash output, repeated output, and edit/write reset behavior.

## Verification

Automated:
- `bun test packages/omo-opencode/src/hooks/atlas/tool-progress.test.ts packages/omo-opencode/src/hooks/atlas/index.test.ts` - 82 pass, 0 fail.
- `bun run typecheck:packages` - pass.
- `git diff --check` / `git diff --cached --check` - pass.

OpenCode QA evidence:
- Evidence directory: `.omo/evidence/20260629-atlas-repeated-status-loop-5720/`.
- `scripts/lib/common.sh --self-check` - pass using evidence-local `jq` / `sqlite3` shims on this Windows host.
- `scripts/server-smoke.sh --self-test` - pass against isolated OpenCode 1.17.11 sandbox (`/global/health`, `/doc`, auth rejection).
- `scripts/tui-smoke.sh --self-test` - attempted; Windows psmux ran the pane through `cmd.exe`, which rejected POSIX `HOME=... opencode ...`. The script still proved tmux teardown and real DB session count stayed unchanged (`3368`).

## Related Issues

Fixes #5720.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Atlas from looping when `bash` status checks keep returning the same output by not counting identical output as progress. Fixes #5720.

- **Bug Fixes**
  - Fingerprints the last successful `bash` output per session; identical output no longer resets the no‑progress timer.
  - Resets the fingerprint on plan changes and after successful `edit`/`write` so real work gets a fresh baseline.
  - Adds `recordTangibleToolProgress` and updates `tool-execute-after` to only count tangible progress.
  - Adds tests for repeated/changed `bash` output and edit/write reset behavior.

<sup>Written for commit e8ddd3c9ad4050c7cf981c9f3196f30f766cc4c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

