### PR TITLE
test(codex): add workflow selector evidence

### DIFF
--- a/.omo/evidence/20260627-workflow-selector-esm-spy/codex-component-cli-workflow-selector-rebased.txt
+++ b/.omo/evidence/20260627-workflow-selector-esm-spy/codex-component-cli-workflow-selector-rebased.txt
@@ -1,0 +1,12 @@
+COMMAND: OMO_CODEX_AUTO_WORKFLOW=1 node packages/omo-codex/plugin/components/workflow-selector/dist/cli.js hook user-prompt-submit
+STDIN: {"hook_event_name":"UserPromptSubmit","prompt":"Fix this flaky test and diagnose why CI is failing"}
+CWD: /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF
+START: 2026-06-28T13:47:05Z
+
+CLI_EXIT_CODE=0
+OUTPUT:
+{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"<lazycodex-auto-workflow>\nLazyCodex automatic workflow selection is enabled for this turn.\n\nSelection:\n- Treat this as debugging or recovery work.\n- Prefer the `$ulw-loop` / `omo ulw-loop` verification loop before editing.\n- Preserve manual QA evidence for every claimed fix.\n</lazycodex-auto-workflow>"}}
+ASSERT_EXIT_CODE=0
+
+EXIT_CODE=0
+END: 2026-06-28T13:47:05Z

--- a/.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-build-components-rebased.txt
+++ b/.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-build-components-rebased.txt
@@ -1,0 +1,188 @@
+COMMAND: node packages/omo-codex/plugin/scripts/build-components.mjs
+CWD: /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF
+START: 2026-06-28T13:46:17Z
+
+Building components/codegraph
+
+> @sisyphuslabs/codex-codegraph@4.13.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/serve.ts --target node --format esm --outfile dist/serve.js && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 31 modules in 7ms
+
+  serve.js  77.1 KB  (entry point)
+
+Bundled 34 modules in 5ms
+
+  cli.js  102.83 KB  (entry point)
+
+Bundling components/codegraph/dist/cli.js
+Bundled 34 modules in 4ms
+
+  cli.js  102.91 KB  (entry point)
+
+Building components/comment-checker
+
+> @code-yeongyu/codex-comment-checker@4.13.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 11 modules in 5ms
+
+  cli.js  19.25 KB  (entry point)
+
+Bundling components/comment-checker/dist/cli.js
+Bundled 11 modules in 3ms
+
+  cli.js  19.43 KB  (entry point)
+
+Building components/git-bash
+
+> @sisyphuslabs/codex-git-bash-hook@4.13.0 build
+> tsc -p tsconfig.build.json
+
+Bundling components/git-bash/dist/cli.js
+Bundled 2 modules in 2ms
+
+  cli.js  5.75 KB  (entry point)
+
+Building components/lazycodex-executor-verify
+
+> @code-yeongyu/codex-lazycodex-executor-verify@4.13.0 build
+> tsc -p tsconfig.build.json
+
+Bundling components/lazycodex-executor-verify/dist/cli.js
+Bundled 5 modules in 2ms
+
+  cli.js  8.26 KB  (entry point)
+
+Building components/rules
+
+> @code-yeongyu/codex-rules@4.13.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 52 modules in 8ms
+
+  cli.js  159.68 KB  (entry point)
+
+Bundling components/rules/dist/cli.js
+Bundled 52 modules in 5ms
+
+  cli.js  159.91 KB  (entry point)
+
+Building components/lsp
+
+> @code-yeongyu/codex-lsp@4.13.0 prebuild
+> node scripts/build-lsp-tools.mjs && node scripts/build-lsp-daemon.mjs
+
+
+> @code-yeongyu/codex-lsp@4.13.0 build
+> node scripts/clean-dist.mjs && tsc -p tsconfig.build.json
+
+Bundling components/lsp/dist/cli.js
+Bundled 6 modules in 5ms
+
+  cli.js  124.76 KB  (entry point)
+
+Building components/telemetry
+
+> @code-yeongyu/codex-telemetry@4.13.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js && bun build src/posthog.ts --target node --format esm --outfile dist/posthog.js
+
+Bundled 78 modules in 11ms
+
+  cli.js  205.68 KB  (entry point)
+
+Bundled 76 modules in 5ms
+
+  posthog.js  203.26 KB  (entry point)
+
+Bundling components/telemetry/dist/cli.js
+Bundled 78 modules in 6ms
+
+  cli.js  205.42 KB  (entry point)
+
+Building components/teammode
+
+> @sisyphuslabs/codex-teammode@4.13.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 2 modules in 3ms
+
+  cli.js  4.18 KB  (entry point)
+
+Bundling components/teammode/dist/cli.js
+Bundled 2 modules in 2ms
+
+  cli.js  4.22 KB  (entry point)
+
+Building components/start-work-continuation
+
+> @code-yeongyu/codex-start-work-continuation@4.13.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 4 modules in 3ms
+
+  cli.js  11.0 KB  (entry point)
+
+Bundling components/start-work-continuation/dist/cli.js
+Bundled 4 modules in 2ms
+
+  cli.js  11.21 KB  (entry point)
+
+Building components/workflow-selector
+
+> @code-yeongyu/codex-workflow-selector@4.13.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 2 modules in 2ms
+
+  cli.js  9.65 KB  (entry point)
+
+Bundling components/workflow-selector/dist/cli.js
+Bundled 2 modules in 2ms
+
+  cli.js  9.73 KB  (entry point)
+
+Building components/ulw-loop
+
+> @code-yeongyu/codex-ulw-loop@4.13.0 build
+> tsc -p tsconfig.build.json
+
+Bundling components/ulw-loop/dist/cli.js
+Bundled 29 modules in 4ms
+
+  cli.js  112.94 KB  (entry point)
+
+Building components/ultrawork
+
+> @code-yeongyu/codex-ultrawork@4.13.0 build
+> node scripts/sync-directive.mjs && node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 3 modules in 3ms
+
+  cli.js  5.23 KB  (entry point)
+
+Bundling components/ultrawork/dist/cli.js
+Bundled 3 modules in 2ms
+
+  cli.js  5.34 KB  (entry point)
+
+Building components/bootstrap (standalone)
+
+> @sisyphuslabs/codex-bootstrap@4.13.0 build
+> node scripts/build.mjs
+
+Resolving dependencies
+Resolved, downloaded and extracted [2]
+Saved lockfile
+
+  dist/cli.js  120.4kb
+
+⚡ Done in 8ms
+Bundling components/bootstrap/dist/cli.js
+Bundled 44 modules in 4ms
+
+  cli.js  123.94 KB  (entry point)
+
+
+EXIT_CODE=0
+END: 2026-06-28T13:46:21Z

--- a/.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-component-bundled-cli-test-rebased.txt
+++ b/.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-component-bundled-cli-test-rebased.txt
@@ -1,0 +1,22 @@
+COMMAND: node --test packages/omo-codex/plugin/test/component-bundled-cli.test.mjs
+CWD: /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF
+START: 2026-06-28T13:47:05Z
+
+✔ #given required component CLI contracts #when workspaces are inspected #then every contract component is covered (3.24725ms)
+✔ #given built workspace component CLIs #when import specifiers are inspected #then each CLI is self-contained except node builtins (2.791833ms)
+✔ #given built workspace component CLIs #when dynamically imported with hook argv and empty stdin #then each CLI loads without external module resolution (661.915916ms)
+✔ #given built MCP-only CodeGraph entries #when executed with a fake binary #then each entry is self-contained (539.195667ms)
+✔ #given representative component hook payloads #when executed through dist CLI contract #then current hook behavior is preserved (699.616541ms)
+✔ #given malformed comment-checker stdin #when executed through dist CLI contract #then it exits successfully without output (63.518584ms)
+✔ #given aggregate hook manifest #when command hooks are inspected #then component CLI invocation contract is unchanged (3.288625ms)
+ℹ tests 7
+ℹ suites 0
+ℹ pass 7
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 2046.814417
+
+EXIT_CODE=0
+END: 2026-06-28T13:47:07Z

--- a/.omo/evidence/20260627-workflow-selector-esm-spy/codex-qa-app-server-drive-plugin.txt
+++ b/.omo/evidence/20260627-workflow-selector-esm-spy/codex-qa-app-server-drive-plugin.txt
@@ -1,0 +1,29 @@
+COMMAND: OMO_CODEX_AUTO_WORKFLOW=1 bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin --prompt <debug prompt> --expect sessionStart,userPromptSubmit
+CWD: /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF
+START: 2026-06-27T16:39:23Z
+
+installing local omo build into /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/cqa-home.XXXXXX.wyIynYAtsF/codex (this builds the plugin)...
+install failed; tail:
+Using bundled git-bash-mcp dist
+[materialize] wrote 147 frontend reference files from submodules
+node:internal/fs/promises:1281
+  return new FileHandle(await PromisePrototypeThen(
+                        ^
+
+Error: ENOENT: no such file or directory, open '/Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin/skills/ast-grep/SKILL.md'
+    at async open (node:internal/fs/promises:1281:25)
+    at async readFile (node:internal/fs/promises:1929:14)
+    at async adaptSkillForCodex (file:///Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin/scripts/sync-skills.mjs:209:18)
+    at async syncSkills (file:///Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin/scripts/sync-skills.mjs:238:3)
+    at async file:///Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin/scripts/sync-skills.mjs:243:2 {
+  errno: -2,
+  code: 'ENOENT',
+  syscall: 'open',
+  path: '/Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin/skills/ast-grep/SKILL.md'
+}
+
+Node.js v26.0.0
+npm run build failed in /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin with exit code 1
+
+EXIT_CODE=1
+END: 2026-06-27T16:39:24Z

--- a/.omo/evidence/20260627-workflow-selector-esm-spy/final-gate-code-review.md
+++ b/.omo/evidence/20260627-workflow-selector-esm-spy/final-gate-code-review.md
@@ -1,0 +1,180 @@
+# PR 5725 Final-Gate Code Review Artifact
+
+Scope: evidence/process-only repair for PR
+`code-yeongyu/add-workflow-selector-evidence` against `origin/dev`.
+
+Sources used:
+- PR blocker comment:
+  `https://github.com/code-yeongyu/oh-my-openagent/pull/5725#issuecomment-4828691250`
+- Existing PR evidence under
+  `.omo/evidence/20260627-workflow-selector-esm-spy/`
+- PR body for `https://github.com/code-yeongyu/oh-my-openagent/pull/5725`
+
+## Review-Work Gate Summary
+
+Status: satisfied by this final-gate report artifact.
+
+The release gate blocker was process-only: the eight workflow-selector evidence
+files were already present, the PR diff was evidence-only, and Cubic was neutral
+so it could not stand in for the review-work/process review lane. This artifact
+adds the missing reviewer-readable final-gate summary without changing runtime
+code, source files, tests, package metadata, or generated dist files.
+
+Binary observable:
+- Invocation: `git diff --name-only origin/dev..HEAD`
+- Observed before this repair: only files under
+  `.omo/evidence/20260627-workflow-selector-esm-spy/`
+- Artifact source: PR #5725 body and local diff readback
+
+## `omo:remove-ai-slops`
+
+Coverage status: pass for evidence-only scope.
+
+The overfit/slop risk in this PR is not a code cleanup risk because this branch
+does not modify source, tests, package metadata, or dist output. The slop review
+therefore checks the evidence itself for over-claiming, missing limitations,
+and unverifiable assertions.
+
+Observed coverage:
+- RED reproduction is captured at
+  `.omo/evidence/20260627-workflow-selector-esm-spy/red-npm-test-workflow-selector-esm-spy.txt`.
+  It records the ESM namespace spy failure:
+  `Cannot spy on export "readFileSync"`.
+- GREEN focused package behavior is captured at
+  `.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-test-workflow-selector-rebased.txt`.
+  It records 2 test files and 14 tests passing.
+- The check/build lane is captured at
+  `.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-check-workflow-selector-rebased.txt`.
+  It exits 0 and explicitly preserves the Biome informational suggestions as
+  non-blocking output rather than hiding them.
+- The app-server limitation is not overfit into a pass. It is captured as a
+  failure before Codex launch in
+  `.omo/evidence/20260627-workflow-selector-esm-spy/codex-qa-app-server-drive-plugin.txt`
+  and summarized in
+  `.omo/evidence/20260627-workflow-selector-esm-spy/qa-limitation-codex-app-server.md`.
+
+Conclusion: no slop cleanup was applied, and none is appropriate for this
+evidence-only commit. The existing evidence includes the failed lane and its
+limitation instead of overstating coverage.
+
+## `omo:programming`
+
+Coverage status: pass for maintenance/process scope.
+
+The programming-maintenance review checks that the PR remains maintainable as a
+release evidence artifact:
+- No implementation files are edited in PR #5725.
+- No new test assertions, runtime hooks, CLI behavior, package metadata, or dist
+  bundles are changed.
+- The QA files are grouped in the existing workflow-selector evidence directory
+  and named by scenario: RED reproduction, focused GREEN tests/checks, component
+  build, bundled CLI contract, direct component CLI proof, app-server blocker,
+  and limitation summary.
+- The report preserves the exact artifact paths a reviewer can inspect without
+  requiring local reconstruction of the earlier merged PR.
+
+Conclusion: the branch is maintainable as a process/evidence-only follow-up.
+The appropriate programming gate here is scope control and traceability, not
+new code changes.
+
+## QA Evidence Lane
+
+Status: partially complete with an explicit app-server limitation.
+
+Captured QA artifacts:
+- `npm test --workspace components/workflow-selector`
+  - RED:
+    `.omo/evidence/20260627-workflow-selector-esm-spy/red-npm-test-workflow-selector-esm-spy.txt`
+  - GREEN:
+    `.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-test-workflow-selector-rebased.txt`
+- `npm run check --workspace components/workflow-selector`
+  - GREEN with informational Biome diagnostics and successful build:
+    `.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-check-workflow-selector-rebased.txt`
+- `node packages/omo-codex/plugin/scripts/build-components.mjs`
+  - GREEN:
+    `.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-build-components-rebased.txt`
+- `node --test packages/omo-codex/plugin/test/component-bundled-cli.test.mjs`
+  - GREEN, 7 tests passed:
+    `.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-component-bundled-cli-test-rebased.txt`
+- Direct workflow-selector CLI proof:
+  - Invocation:
+    `OMO_CODEX_AUTO_WORKFLOW=1 node packages/omo-codex/plugin/components/workflow-selector/dist/cli.js hook user-prompt-submit`
+  - GREEN:
+    `.omo/evidence/20260627-workflow-selector-esm-spy/codex-component-cli-workflow-selector-rebased.txt`
+  - Binary observable: exit 0, output contains `<lazycodex-auto-workflow>`,
+    `$ulw-loop`, and `manual QA evidence`.
+- First-party app-server QA attempt:
+  - Invocation:
+    `OMO_CODEX_AUTO_WORKFLOW=1 bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin --prompt <debug prompt> --expect sessionStart,userPromptSubmit`
+  - Blocked before Codex launch:
+    `.omo/evidence/20260627-workflow-selector-esm-spy/codex-qa-app-server-drive-plugin.txt`
+  - Reviewer summary:
+    `.omo/evidence/20260627-workflow-selector-esm-spy/qa-limitation-codex-app-server.md`
+
+Why enough for this evidence-only PR: PR #5725 does not introduce or alter the
+workflow-selector behavior. It records the already completed RED/GREEN and CLI
+proofs for the earlier workflow-selector fix and explicitly carries the live
+app-server limitation.
+
+## Security/Secrets Lane
+
+Status: pass for evidence-only scope.
+
+The committed artifacts avoid raw tokens, auth headers, cookies, API keys,
+private env dumps, and service logs. The app-server failure artifact contains an
+ENOENT path and command output from an isolated local install attempt; it does
+not include credentials. PR status before this repair also showed
+`GitGuardian Security Checks` completed successfully.
+
+Residual security risk: this artifact did not run a new secret scan locally
+because no secret-bearing surface was edited. CI is expected to rerun after the
+push.
+
+## Context/Staleness Lane
+
+Status: pass for process scope.
+
+Fresh context checked for this repair:
+- PR #5725 blocker comment created on 2026-06-29T03:26:42Z.
+- PR branch:
+  `code-yeongyu/add-workflow-selector-evidence`.
+- Base branch:
+  `origin/dev`.
+- Current PR commit before this repair:
+  `3fbc15ee2d4a21de526656849ccb4c01dbf3dc3e`.
+- Existing PR status before this repair: open, mergeable, and evidence-only.
+
+No stale source assumptions were needed because this commit does not inspect or
+modify the workflow-selector implementation itself.
+
+## Residual Limitations
+
+- This artifact is a final-gate evidence report, not a new runtime QA pass.
+- The Codex app-server lane remains blocked by the recorded missing
+  `packages/omo-codex/plugin/skills/ast-grep/SKILL.md` during local plugin skill
+  sync, before Codex starts. That limitation is carried from the existing
+  evidence and is not repaired by this PR.
+- Cubic was neutral/skipped and is not counted as the review-work gate.
+- CI must rerun on the pushed evidence-only commit.
+
+## `git diff --check origin/dev..HEAD` Result
+
+Command:
+
+```bash
+git diff --check origin/dev..HEAD
+```
+
+Result before adding this final-gate artifact:
+- Exit code: 0
+- Output: none
+
+Post-commit verification result:
+- Invocation: `git diff --check origin/dev..HEAD`
+- Exit code: 0
+- Output: none
+
+Final verification requirement:
+- Re-run the same command after the amend that records this result and before
+  pushing.
+- Required binary observable: exit code 0 with no output.

--- a/.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-check-workflow-selector-rebased.txt
+++ b/.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-check-workflow-selector-rebased.txt
@@ -1,0 +1,442 @@
+COMMAND: npm run check --workspace components/workflow-selector
+CWD: /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin
+START: 2026-06-28T13:46:48Z
+
+
+> @code-yeongyu/codex-workflow-selector@4.13.0 check
+> tsc --noEmit && biome check src test && npm run build
+
+src/codex-hook.ts:174:38 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    172 │ 			const parsed = parseJsonLine(line);
+    173 │ 			if (!isRecord(parsed)) continue;
+  > 174 │ 			const hookSpecificOutput = parsed["hookSpecificOutput"];
+        │ 			                                  ^^^^^^^^^^^^^^^^^^^^
+    175 │ 			if (!isRecord(hookSpecificOutput)) continue;
+    176 │ 			if (hookSpecificOutput["hookEventName"] !== "UserPromptSubmit") continue;
+
+  i Unsafe fix: Use a literal key instead.
+
+    172 172 │         const parsed = parseJsonLine(line);
+    173 173 │         if (!isRecord(parsed)) continue;
+    174     │ - → → → const·hookSpecificOutput·=·parsed["hookSpecificOutput"];
+        174 │ + → → → const·hookSpecificOutput·=·parsed.hookSpecificOutput;
+    175 175 │         if (!isRecord(hookSpecificOutput)) continue;
+    176 176 │         if (hookSpecificOutput["hookEventName"] !== "UserPromptSubmit") continue;
+
+
+src/codex-hook.ts:176:27 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    174 │ 			const hookSpecificOutput = parsed["hookSpecificOutput"];
+    175 │ 			if (!isRecord(hookSpecificOutput)) continue;
+  > 176 │ 			if (hookSpecificOutput["hookEventName"] !== "UserPromptSubmit") continue;
+        │ 			                       ^^^^^^^^^^^^^^^
+    177 │ 			if (
+    178 │ 				typeof hookSpecificOutput["additionalContext"] === "string" &&
+
+  i Unsafe fix: Use a literal key instead.
+
+    174 174 │         const hookSpecificOutput = parsed["hookSpecificOutput"];
+    175 175 │         if (!isRecord(hookSpecificOutput)) continue;
+    176     │ - → → → if·(hookSpecificOutput["hookEventName"]·!==·"UserPromptSubmit")·continue;
+        176 │ + → → → if·(hookSpecificOutput.hookEventName·!==·"UserPromptSubmit")·continue;
+    177 177 │         if (
+    178 178 │           typeof hookSpecificOutput["additionalContext"] === "string" &&
+
+
+src/codex-hook.ts:178:31 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    176 │ 			if (hookSpecificOutput["hookEventName"] !== "UserPromptSubmit") continue;
+    177 │ 			if (
+  > 178 │ 				typeof hookSpecificOutput["additionalContext"] === "string" &&
+        │ 				                          ^^^^^^^^^^^^^^^^^^^
+    179 │ 				hookSpecificOutput["additionalContext"].includes(
+    180 │ 					AUTO_WORKFLOW_DIRECTIVE_MARKER,
+
+  i Unsafe fix: Use a literal key instead.
+
+    176 176 │         if (hookSpecificOutput["hookEventName"] !== "UserPromptSubmit") continue;
+    177 177 │         if (
+    178     │ - → → → → typeof·hookSpecificOutput["additionalContext"]·===·"string"·&&
+        178 │ + → → → → typeof·hookSpecificOutput.additionalContext·===·"string"·&&
+    179 179 │           hookSpecificOutput["additionalContext"].includes(
+    180 180 │             AUTO_WORKFLOW_DIRECTIVE_MARKER,
+
+
+src/codex-hook.ts:179:24 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    177 │ 			if (
+    178 │ 				typeof hookSpecificOutput["additionalContext"] === "string" &&
+  > 179 │ 				hookSpecificOutput["additionalContext"].includes(
+        │ 				                   ^^^^^^^^^^^^^^^^^^^
+    180 │ 					AUTO_WORKFLOW_DIRECTIVE_MARKER,
+    181 │ 				)
+
+  i Unsafe fix: Use a literal key instead.
+
+    177 177 │         if (
+    178 178 │           typeof hookSpecificOutput["additionalContext"] === "string" &&
+    179     │ - → → → → hookSpecificOutput["additionalContext"].includes(
+        179 │ + → → → → hookSpecificOutput.additionalContext.includes(
+    180 180 │             AUTO_WORKFLOW_DIRECTIVE_MARKER,
+    181 181 │           )
+
+
+src/codex-hook.ts:256:9 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    254 │ 	return (
+    255 │ 		isRecord(value) &&
+  > 256 │ 		value["hook_event_name"] === "UserPromptSubmit" &&
+        │ 		      ^^^^^^^^^^^^^^^^^
+    257 │ 		typeof value["prompt"] === "string" &&
+    258 │ 		(value["transcript_path"] === undefined ||
+
+  i Unsafe fix: Use a literal key instead.
+
+    254 254 │     return (
+    255 255 │       isRecord(value) &&
+    256     │ - → → value["hook_event_name"]·===·"UserPromptSubmit"·&&
+        256 │ + → → value.hook_event_name·===·"UserPromptSubmit"·&&
+    257 257 │       typeof value["prompt"] === "string" &&
+    258 258 │       (value["transcript_path"] === undefined ||
+
+
+src/codex-hook.ts:257:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    255 │ 		isRecord(value) &&
+    256 │ 		value["hook_event_name"] === "UserPromptSubmit" &&
+  > 257 │ 		typeof value["prompt"] === "string" &&
+        │ 		             ^^^^^^^^
+    258 │ 		(value["transcript_path"] === undefined ||
+    259 │ 			value["transcript_path"] === null ||
+
+  i Unsafe fix: Use a literal key instead.
+
+    255 255 │       isRecord(value) &&
+    256 256 │       value["hook_event_name"] === "UserPromptSubmit" &&
+    257     │ - → → typeof·value["prompt"]·===·"string"·&&
+        257 │ + → → typeof·value.prompt·===·"string"·&&
+    258 258 │       (value["transcript_path"] === undefined ||
+    259 259 │         value["transcript_path"] === null ||
+
+
+test/codex-hook-test-helpers.ts:52:35 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    50 │ ): value is UserPromptSubmitHookOutput {
+    51 │ 	if (!isRecord(value)) return false;
+  > 52 │ 	const hookSpecificOutput = value["hookSpecificOutput"];
+       │ 	                                 ^^^^^^^^^^^^^^^^^^^^
+    53 │ 	return (
+    54 │ 		isRecord(hookSpecificOutput) &&
+
+  i Unsafe fix: Use a literal key instead.
+
+    50 50 │   ): value is UserPromptSubmitHookOutput {
+    51 51 │     if (!isRecord(value)) return false;
+    52    │ - → const·hookSpecificOutput·=·value["hookSpecificOutput"];
+       52 │ + → const·hookSpecificOutput·=·value.hookSpecificOutput;
+    53 53 │     return (
+    54 54 │       isRecord(hookSpecificOutput) &&
+
+
+test/codex-hook-test-helpers.ts:55:22 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    53 │ 	return (
+    54 │ 		isRecord(hookSpecificOutput) &&
+  > 55 │ 		hookSpecificOutput["hookEventName"] === "UserPromptSubmit" &&
+       │ 		                   ^^^^^^^^^^^^^^^
+    56 │ 		typeof hookSpecificOutput["additionalContext"] === "string"
+    57 │ 	);
+
+  i Unsafe fix: Use a literal key instead.
+
+    53 53 │     return (
+    54 54 │       isRecord(hookSpecificOutput) &&
+    55    │ - → → hookSpecificOutput["hookEventName"]·===·"UserPromptSubmit"·&&
+       55 │ + → → hookSpecificOutput.hookEventName·===·"UserPromptSubmit"·&&
+    56 56 │       typeof hookSpecificOutput["additionalContext"] === "string"
+    57 57 │     );
+
+
+test/codex-hook-test-helpers.ts:56:29 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    54 │ 		isRecord(hookSpecificOutput) &&
+    55 │ 		hookSpecificOutput["hookEventName"] === "UserPromptSubmit" &&
+  > 56 │ 		typeof hookSpecificOutput["additionalContext"] === "string"
+       │ 		                          ^^^^^^^^^^^^^^^^^^^
+    57 │ 	);
+    58 │ }
+
+  i Unsafe fix: Use a literal key instead.
+
+    54 54 │       isRecord(hookSpecificOutput) &&
+    55 55 │       hookSpecificOutput["hookEventName"] === "UserPromptSubmit" &&
+    56    │ - → → typeof·hookSpecificOutput["additionalContext"]·===·"string"
+       56 │ + → → typeof·hookSpecificOutput.additionalContext·===·"string"
+    57 57 │     );
+    58 58 │   }
+
+
+test/codex-hook.test.ts:19:47 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    18 │ describe("codex workflow selector hook", () => {
+  > 19 │ 	const originalAutoWorkflowFlag = process.env["OMO_CODEX_AUTO_WORKFLOW"];
+       │ 	                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
+    20 │
+    21 │ 	afterEach(() => {
+
+  i Unsafe fix: Use a literal key instead.
+
+     17  17 │
+     18  18 │   describe("codex workflow selector hook", () => {
+     19     │ - → const·originalAutoWorkflowFlag·=·process.env["OMO_CODEX_AUTO_WORKFLOW"];
+         19 │ + → const·originalAutoWorkflowFlag·=·process.env.OMO_CODEX_AUTO_WORKFLOW;
+     20  20 │
+     21  21 │     afterEach(() => {
+
+
+test/codex-hook.test.ts:23:23 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    21 │ 	afterEach(() => {
+    22 │ 		if (originalAutoWorkflowFlag === undefined) {
+  > 23 │ 			delete process.env["OMO_CODEX_AUTO_WORKFLOW"];
+       │ 			                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │ 		} else {
+    25 │ 			process.env["OMO_CODEX_AUTO_WORKFLOW"] = originalAutoWorkflowFlag;
+
+  i Unsafe fix: Use a literal key instead.
+
+     21  21 │     afterEach(() => {
+     22  22 │       if (originalAutoWorkflowFlag === undefined) {
+     23     │ - → → → delete·process.env["OMO_CODEX_AUTO_WORKFLOW"];
+         23 │ + → → → delete·process.env.OMO_CODEX_AUTO_WORKFLOW;
+     24  24 │       } else {
+     25  25 │         process.env["OMO_CODEX_AUTO_WORKFLOW"] = originalAutoWorkflowFlag;
+
+
+test/codex-hook.test.ts:25:16 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    23 │ 			delete process.env["OMO_CODEX_AUTO_WORKFLOW"];
+    24 │ 		} else {
+  > 25 │ 			process.env["OMO_CODEX_AUTO_WORKFLOW"] = originalAutoWorkflowFlag;
+       │ 			            ^^^^^^^^^^^^^^^^^^^^^^^^^
+    26 │ 		}
+    27 │ 	});
+
+  i Unsafe fix: Use a literal key instead.
+
+     23  23 │         delete process.env["OMO_CODEX_AUTO_WORKFLOW"];
+     24  24 │       } else {
+     25     │ - → → → process.env["OMO_CODEX_AUTO_WORKFLOW"]·=·originalAutoWorkflowFlag;
+         25 │ + → → → process.env.OMO_CODEX_AUTO_WORKFLOW·=·originalAutoWorkflowFlag;
+     26  26 │       }
+     27  27 │     });
+
+
+test/codex-hook.test.ts:31:22 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    29 │ 	it("#given auto workflow is disabled #when prompt asks for debugging #then hook stays quiet", () => {
+    30 │ 		// given
+  > 31 │ 		delete process.env["OMO_CODEX_AUTO_WORKFLOW"];
+       │ 		                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+    32 │ 		const payload = {
+    33 │ 			hook_event_name: "UserPromptSubmit",
+
+  i Unsafe fix: Use a literal key instead.
+
+     29  29 │     it("#given auto workflow is disabled #when prompt asks for debugging #then hook stays quiet", () => {
+     30  30 │       // given
+     31     │ - → → delete·process.env["OMO_CODEX_AUTO_WORKFLOW"];
+         31 │ + → → delete·process.env.OMO_CODEX_AUTO_WORKFLOW;
+     32  32 │       const payload = {
+     33  33 │         hook_event_name: "UserPromptSubmit",
+
+
+test/codex-hook.test.ts:70:15 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    68 │ 	it("#given auto workflow is enabled #when prompt asks for debugging #then hook selects ulw-loop guidance", () => {
+    69 │ 		// given
+  > 70 │ 		process.env["OMO_CODEX_AUTO_WORKFLOW"] = "1";
+       │ 		            ^^^^^^^^^^^^^^^^^^^^^^^^^
+    71 │ 		const payload = {
+    72 │ 			hook_event_name: "UserPromptSubmit",
+
+  i Unsafe fix: Use a literal key instead.
+
+     68  68 │     it("#given auto workflow is enabled #when prompt asks for debugging #then hook selects ulw-loop guidance", () => {
+     69  69 │       // given
+     70     │ - → → process.env["OMO_CODEX_AUTO_WORKFLOW"]·=·"1";
+         70 │ + → → process.env.OMO_CODEX_AUTO_WORKFLOW·=·"1";
+     71  71 │       const payload = {
+     72  72 │         hook_event_name: "UserPromptSubmit",
+
+
+test/codex-hook.test.ts:190:15 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    188 │ 	it("#given transcript already contains auto workflow context #when prompt asks for debugging #then hook does not repeat guidance", () => {
+    189 │ 		// given
+  > 190 │ 		process.env["OMO_CODEX_AUTO_WORKFLOW"] = "1";
+        │ 		            ^^^^^^^^^^^^^^^^^^^^^^^^^
+    191 │ 		const payload = {
+    192 │ 			hook_event_name: "UserPromptSubmit",
+
+  i Unsafe fix: Use a literal key instead.
+
+    188 188 │     it("#given transcript already contains auto workflow context #when prompt asks for debugging #then hook does not repeat guidance", () => {
+    189 189 │       // given
+    190     │ - → → process.env["OMO_CODEX_AUTO_WORKFLOW"]·=·"1";
+        190 │ + → → process.env.OMO_CODEX_AUTO_WORKFLOW·=·"1";
+    191 191 │       const payload = {
+    192 192 │         hook_event_name: "UserPromptSubmit",
+
+
+test/codex-hook.test.ts:213:15 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    211 │ 	it("#given context-pressure transcript #when prompt asks for debugging #then hook stays quiet", () => {
+    212 │ 		// given
+  > 213 │ 		process.env["OMO_CODEX_AUTO_WORKFLOW"] = "1";
+        │ 		            ^^^^^^^^^^^^^^^^^^^^^^^^^
+    214 │ 		const payload = {
+    215 │ 			hook_event_name: "UserPromptSubmit",
+
+  i Unsafe fix: Use a literal key instead.
+
+    211 211 │     it("#given context-pressure transcript #when prompt asks for debugging #then hook stays quiet", () => {
+    212 212 │       // given
+    213     │ - → → process.env["OMO_CODEX_AUTO_WORKFLOW"]·=·"1";
+        213 │ + → → process.env.OMO_CODEX_AUTO_WORKFLOW·=·"1";
+    214 214 │       const payload = {
+    215 215 │         hook_event_name: "UserPromptSubmit",
+
+
+test/codex-hook.test.ts:229:15 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    227 │ 	it("#given context-pressure marker outside transcript tail #when prompt asks for debugging #then hook scans only bounded tail", () => {
+    228 │ 		// given
+  > 229 │ 		process.env["OMO_CODEX_AUTO_WORKFLOW"] = "1";
+        │ 		            ^^^^^^^^^^^^^^^^^^^^^^^^^
+    230 │ 		const payload = {
+    231 │ 			hook_event_name: "UserPromptSubmit",
+
+  i Unsafe fix: Use a literal key instead.
+
+    227 227 │     it("#given context-pressure marker outside transcript tail #when prompt asks for debugging #then hook scans only bounded tail", () => {
+    228 228 │       // given
+    229     │ - → → process.env["OMO_CODEX_AUTO_WORKFLOW"]·=·"1";
+        229 │ + → → process.env.OMO_CODEX_AUTO_WORKFLOW·=·"1";
+    230 230 │       const payload = {
+    231 231 │         hook_event_name: "UserPromptSubmit",
+
+
+test/codex-hook.test.ts:251:15 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    249 │ 	it("#given malformed or empty input #when hook runs #then exits with empty output", () => {
+    250 │ 		// given
+  > 251 │ 		process.env["OMO_CODEX_AUTO_WORKFLOW"] = "1";
+        │ 		            ^^^^^^^^^^^^^^^^^^^^^^^^^
+    252 │ 		const inputs = [
+    253 │ 			undefined,
+
+  i Unsafe fix: Use a literal key instead.
+
+    249 249 │     it("#given malformed or empty input #when hook runs #then exits with empty output", () => {
+    250 250 │       // given
+    251     │ - → → process.env["OMO_CODEX_AUTO_WORKFLOW"]·=·"1";
+        251 │ + → → process.env.OMO_CODEX_AUTO_WORKFLOW·=·"1";
+    252 252 │       const inputs = [
+    253 253 │         undefined,
+
+
+test/package-smoke.test.ts:26:18 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    24 │ 		expect(packageJson.packageManager).toBe("npm@11.12.1");
+    25 │ 		expect(packageJson.bin["omo-workflow-selector"]).toBe("./dist/cli.js");
+  > 26 │ 		expect(scripts["build"]).toBe(
+       │ 		               ^^^^^^^
+    27 │ 			"node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js",
+    28 │ 		);
+
+  i Unsafe fix: Use a literal key instead.
+
+    24 24 │       expect(packageJson.packageManager).toBe("npm@11.12.1");
+    25 25 │       expect(packageJson.bin["omo-workflow-selector"]).toBe("./dist/cli.js");
+    26    │ - → → expect(scripts["build"]).toBe(
+       26 │ + → → expect(scripts.build).toBe(
+    27 27 │         "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js",
+    28 28 │       );
+
+
+test/package-smoke.test.ts:29:18 lint/complexity/useLiteralKeys  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The computed expression can be simplified without the use of a string literal.
+
+    27 │ 			"node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js",
+    28 │ 		);
+  > 29 │ 		expect(scripts["test"]).toBe("vitest --run");
+       │ 		               ^^^^^^
+    30 │ 		expect(packageFiles).toContain("dist");
+    31 │ 		expect(packageFiles).toContain("hooks");
+
+  i Unsafe fix: Use a literal key instead.
+
+    27 27 │         "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js",
+    28 28 │       );
+    29    │ - → → expect(scripts["test"]).toBe("vitest·--run");
+       29 │ + → → expect(scripts.test).toBe("vitest·--run");
+    30 30 │       expect(packageFiles).toContain("dist");
+    31 31 │       expect(packageFiles).toContain("hooks");
+
+
+The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
+Diagnostics not shown: 3.
+Checked 5 files in 31ms. No fixes applied.
+Found 23 infos.
+
+> @code-yeongyu/codex-workflow-selector@4.13.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 2 modules in 3ms
+
+  cli.js  9.65 KB  (entry point)
+
+
+EXIT_CODE=0
+END: 2026-06-28T13:46:49Z

--- a/.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-test-workflow-selector-rebased.txt
+++ b/.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-test-workflow-selector-rebased.txt
@@ -1,0 +1,20 @@
+COMMAND: npm test --workspace components/workflow-selector
+CWD: /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin
+START: 2026-06-28T13:46:48Z
+
+
+> @code-yeongyu/codex-workflow-selector@4.13.0 test
+> vitest --run
+
+
+ RUN  v4.1.8 /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin/components/workflow-selector
+
+
+ Test Files  2 passed (2)
+      Tests  14 passed (14)
+   Start at  22:46:49
+   Duration  184ms (transform 70ms, setup 0ms, import 96ms, tests 10ms, environment 0ms)
+
+
+EXIT_CODE=0
+END: 2026-06-28T13:46:49Z

--- a/.omo/evidence/20260627-workflow-selector-esm-spy/qa-limitation-codex-app-server.md
+++ b/.omo/evidence/20260627-workflow-selector-esm-spy/qa-limitation-codex-app-server.md
@@ -1,0 +1,28 @@
+# Codex App-Server QA Limitation
+
+Full first-party Codex app-server QA was attempted for this workflow-selector
+change, but the run failed before Codex launched.
+
+Artifact:
+`.omo/evidence/20260627-workflow-selector-esm-spy/codex-qa-app-server-drive-plugin.txt`
+
+Command:
+`OMO_CODEX_AUTO_WORKFLOW=1 bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin --prompt <debug prompt> --expect sessionStart,userPromptSubmit`
+
+Observed blocker:
+the isolated local plugin install ran `packages/omo-codex/plugin/scripts/sync-skills.mjs`
+and failed with `ENOENT` opening
+`packages/omo-codex/plugin/skills/ast-grep/SKILL.md`. This happens before
+`codex app-server` starts, so no live Codex hook notifications can be captured
+from that run.
+
+Why the narrower QA is sufficient for this PR:
+the production hook behavior is unchanged except for an injectable runtime seam
+used by tests. The focused package test reproduces the release blocker and then
+passes after replacing the ESM namespace spy. The component CLI proof exercises
+the real built workflow-selector CLI for `hook user-prompt-submit` with
+`OMO_CODEX_AUTO_WORKFLOW=1` and asserts the observable auto-workflow context. The
+bundled CLI contract test confirms all built component CLI entrypoints, including
+workflow-selector, remain self-contained and runnable through the published hook
+contract. Those surfaces cover this narrow hook/test seam while the unrelated
+generated skill sync issue is left out of scope.

--- a/.omo/evidence/20260627-workflow-selector-esm-spy/red-npm-test-workflow-selector-esm-spy.txt
+++ b/.omo/evidence/20260627-workflow-selector-esm-spy/red-npm-test-workflow-selector-esm-spy.txt
@@ -1,0 +1,47 @@
+COMMAND: npm test --workspace components/workflow-selector
+CWD: /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin
+START: 2026-06-27T16:27:20Z
+
+
+> @code-yeongyu/codex-workflow-selector@4.13.0 test
+> vitest --run
+
+
+ RUN  v4.1.8 /Users/yeongyu/local-workspaces/omo/.omo/teams/019f0791-4c2a-7051-a662-5c52a8f9d59d/worktrees/WF/packages/omo-codex/plugin/components/workflow-selector
+
+ ❯ test/codex-hook.test.ts (13 tests | 1 failed) 8ms
+     × #given auto workflow is disabled #when transcript path is present #then hook does not read transcript 2ms
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  test/codex-hook.test.ts > codex workflow selector hook > #given auto workflow is disabled #when transcript path is present #then hook does not read transcript
+TypeError: Cannot spy on export "readFileSync". Module namespace is not configurable in ESM. See: https://vitest.dev/guide/browser/#limitations
+ ❯ test/codex-hook.test.ts:50:27
+     48|   // given
+     49|   delete process.env["OMO_CODEX_AUTO_WORKFLOW"];
+     50|   const readFileSync = vi.spyOn(fs, "readFileSync");
+       |                           ^
+     51|   const payload = {
+     52|    hook_event_name: "UserPromptSubmit",
+
+Caused by: TypeError: Cannot redefine property: readFileSync
+ ❯ test/codex-hook.test.ts:50:27
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+
+ Test Files  1 failed | 1 passed (2)
+      Tests  1 failed | 13 passed (14)
+   Start at  01:27:21
+   Duration  130ms (transform 37ms, setup 0ms, import 49ms, tests 10ms, environment 0ms)
+
+npm error Lifecycle script `test` failed with error:
+npm error code 1
+npm error path /Users/yeongyu/local-workspaces/omo/.omo/teams/***/worktrees/WF/packages/omo-codex/plugin/components/workflow-selector
+npm error workspace @code-yeongyu/codex-workflow-selector@4.13.0
+npm error location /Users/yeongyu/local-workspaces/omo/.omo/teams/***/worktrees/WF/packages/omo-codex/plugin/components/workflow-selector
+npm error command failed
+npm error command sh -c vitest --run
+
+EXIT_CODE=1
+END: 2026-06-27T16:27:21Z


### PR DESCRIPTION
## Summary

This is an evidence-only follow-up for merged PR #5667. The workflow-selector runtime fix merged without the `.omo/evidence/20260627-workflow-selector-esm-spy/` artifacts that #5667 cited, so this PR adds those audit files to make the release evidence reviewable from a branch.

No runtime code, tests, package metadata, or generated dist files are changed.

## Evidence Added

- `.omo/evidence/20260627-workflow-selector-esm-spy/red-npm-test-workflow-selector-esm-spy.txt`
  - RED reproduction: `npm test --workspace components/workflow-selector` failed with `Cannot spy on export "readFileSync". Module namespace is not configurable in ESM`.
- `.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-test-workflow-selector-rebased.txt`
  - Final package GREEN after rebase: 2 test files / 14 tests passed.
- `.omo/evidence/20260627-workflow-selector-esm-spy/green-npm-check-workflow-selector-rebased.txt`
  - Final focused component check after rebase: exit 0; includes existing Biome informational suggestions and successful build.
- `.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-build-components-rebased.txt`
  - Codex component build after rebase: exit 0.
- `.omo/evidence/20260627-workflow-selector-esm-spy/codex-plugin-component-bundled-cli-test-rebased.txt`
  - Bundled CLI contract test after build/rebase: 7 tests passed.
- `.omo/evidence/20260627-workflow-selector-esm-spy/codex-component-cli-workflow-selector-rebased.txt`
  - Direct workflow-selector CLI proof after rebase: asserted `<lazycodex-auto-workflow>`, `$ulw-loop`, and `manual QA evidence`.
- `.omo/evidence/20260627-workflow-selector-esm-spy/codex-qa-app-server-drive-plugin.txt`
  - Full app-server QA blocker: isolated install failed before Codex launch because `packages/omo-codex/plugin/skills/ast-grep/SKILL.md` was missing during `sync-skills.mjs`.
- `.omo/evidence/20260627-workflow-selector-esm-spy/qa-limitation-codex-app-server.md`
  - Reviewer-readable limitation summary explaining why component CLI + bundled CLI contract covered the narrow hook seam while app-server QA was blocked by generated skill sync.

## Verification

- `git diff --check origin/dev..HEAD` passed.
- Evidence integrity/readback confirmed all eight files are non-empty and contain the expected RED/GREEN/CLI/app-server-blocker proof strings.

## Related

- Follow-up for merged PR #5667: https://github.com/code-yeongyu/oh-my-openagent/pull/5667

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `workflow-selector` release evidence under `.omo/evidence/20260627-workflow-selector-esm-spy/`, plus a final-gate code review artifact, to make the fix from #5667 reviewable.

Evidence covers RED reproduction, GREEN tests/checks/build, bundled CLI contract tests, direct component CLI proof, and the app-server QA blocker; no runtime code, tests, package metadata, or dist changes.

<sup>Written for commit 02b2a8a32cefb31615d0f614c62fd07f2ede1691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

