### PR TITLE
fix(docs): prefer oh-my-openagent CLI invocation in guides

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -134,7 +134,7 @@ You can also skip the picker: `opencode auth login --provider opencode-go`.
 ### Verify what oh-my-openagent will actually use
 
 ```bash
-bunx oh-my-opencode doctor
+bunx oh-my-openagent doctor
 ```
 
 This shows the **effective model resolution** for every agent and category based on your current auth state. If an agent says "system-default" instead of a real fallback, that's a signal you're missing providers from its chain.
@@ -543,9 +543,9 @@ Your explicit configuration always wins. If you set a specific model for an agen
 
 Variant and `reasoningEffort` overrides are normalized to model-supported values, so cross-provider overrides degrade gracefully instead of failing hard.
 
-Model capabilities are `models.dev`-backed, with a refreshable cache and capability diagnostics. Use `bunx oh-my-opencode refresh-model-capabilities` to update the cache, or configure `model_capabilities.auto_refresh_on_start` to refresh at startup.
+Model capabilities are `models.dev`-backed, with a refreshable cache and capability diagnostics. Use `bunx oh-my-openagent refresh-model-capabilities` to update the cache, or configure `model_capabilities.auto_refresh_on_start` to refresh at startup.
 
-To see which models your agents will actually use, run `bunx oh-my-opencode doctor`. This shows effective model resolution based on your current authentication and config.
+To see which models your agents will actually use, run `bunx oh-my-openagent doctor`. This shows effective model resolution based on your current authentication and config.
 
 ```
 Agent Request → User Override (if configured) → Fallback Chain → System Default

--- a/docs/guide/team-mode.md
+++ b/docs/guide/team-mode.md
@@ -128,7 +128,7 @@ When enabled, each member gets a dedicated tmux pane attached to that member's s
 
 ## Diagnostics
 
-`bunx oh-my-opencode doctor` includes a `team-mode` check showing tmux/git availability, declared team count, and active runtime dirs.
+`bunx oh-my-openagent doctor` includes a `team-mode` check showing tmux/git availability, declared team count, and active runtime dirs.
 
 ## Storage layout
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,8 +11,8 @@ Plugin registration inside `opencode.json` prefers `oh-my-openagent`.
 
 All published packages expose the same compiled CLI with these bin entries:
 
-- `oh-my-opencode` (legacy name, still primary)
-- `oh-my-openagent` (renamed primary)
+- `oh-my-openagent` (preferred name)
+- `oh-my-opencode` (legacy compatibility name)
 - `omo` (short alias, recommended in docs and prompts)
 - `lazycodex-ai` (Light edition shortcut; `lazycodex-ai install` is equivalent to `omo install --platform=codex` unless `--platform` is explicitly overridden)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -66,7 +66,7 @@ Enable schema autocomplete:
 }
 ```
 
-Run `bunx oh-my-opencode install` for guided setup. Run `opencode models` to list available models.
+Run `bunx oh-my-openagent install` for guided setup. Run `opencode models` to list available models.
 
 ### Quick Start Example
 
@@ -362,7 +362,7 @@ Examples:
 - o-series models support `none` through `high` - `xhigh` is downgraded to `high`
 - GPT-5 supports `none`, `minimal`, `low`, `medium`, `high`, `xhigh` - all pass through
 
-Capability data comes from provider runtime metadata first. OmO also ships bundled models.dev-backed capability data, supports a refreshable local models.dev cache, and falls back to heuristic family detection plus alias rules when exact metadata is unavailable. `bunx oh-my-opencode doctor` surfaces capability diagnostics and warns when a configured model relies on compatibility fallback.
+Capability data comes from provider runtime metadata first. OmO also ships bundled models.dev-backed capability data, supports a refreshable local models.dev cache, and falls back to heuristic family detection plus alias rules when exact metadata is unavailable. `bunx oh-my-openagent doctor` surfaces capability diagnostics and warns when a configured model relies on compatibility fallback.
 
 
 #### Agent Provider Chains
@@ -395,7 +395,7 @@ This table documents the first entry of each hardcoded provider fallback chain, 
 | **unspecified-high**   | `claude-opus-4-7`   | `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `openai\|github-copilot\|opencode/gpt-5.5 (high)` → `zai-coding-plan\|opencode/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5.1` → `opencode/kimi-k2.5` → `opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix/kimi-k2.5` |
 | **writing**            | `gemini-3-flash`    | `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/kimi-k2.6` → `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `opencode-go/minimax-m3` → `opencode-go/minimax-m2.7` |
 
-Run `bunx oh-my-opencode doctor --verbose` to see effective model resolution for your config.
+Run `bunx oh-my-openagent doctor --verbose` to see effective model resolution for your config.
 
 ---
 
@@ -938,7 +938,7 @@ OmO can refresh a local models.dev capability snapshot on startup. This cache is
 Notes:
 
 - Startup refresh runs through the auto-update checker hook.
-- Manual refresh is available via `bunx oh-my-opencode refresh-model-capabilities`.
+- Manual refresh is available via `bunx oh-my-openagent refresh-model-capabilities`.
 - Provider runtime metadata still takes priority when OmO resolves capabilities for compatibility checks.
 
 ### Hashline Edit


### PR DESCRIPTION
## Summary
Update documentation files to prefer `bunx oh-my-openagent` over the legacy `bunx oh-my-opencode` CLI invocation.

## Changes
- `docs/guide/agent-model-matching.md`: 3 CLI invocation updates
- `docs/guide/team-mode.md`: 1 CLI invocation update
- `docs/reference/configuration.md`: 4 CLI invocation updates
- `docs/reference/cli.md`: Priority labeling fix (oh-my-openagent is preferred, oh-my-opencode is legacy)

## QA & Evidence
- Verified no `bunx oh-my-opencode` remains in the 4 modified files
- Config file names (`oh-my-opencode.json[c]`), log file name, and schema file name preserved as-is
- `docs/guide/installation.md` already used `oh-my-openagent` throughout — no changes needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated docs to prefer `bunx oh-my-openagent` over legacy `bunx oh-my-opencode` across guides and reference pages. Clarified CLI priority labeling and updated doctor/refresh/install commands; config, log, and schema file names remain unchanged.

- **Migration**
  - No action required; `oh-my-opencode` remains supported for compatibility.

<sup>Written for commit bea998420e7ce578d9300a6bd03b80f560c07a00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

