### PR TITLE
fix(docs): correct stale module/tool counts in features.md

### DIFF
--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -130,8 +130,8 @@ See the **[Team Mode Guide](../guide/team-mode.md)** for configuration, team spe
 
 ### Architecture Snapshot (current)
 
-- **Feature modules**: `packages/omo-opencode/src/features/` has 20 modules.
-- **Tool system**: `packages/omo-opencode/src/tools/` has 16 tool directories that produce **20 to 39 tools** depending on config gates.
+- **Feature modules**: `packages/omo-opencode/src/features/` has 23 modules.
+- **Tool system**: `packages/omo-opencode/src/tools/` has 15 tool directories that produce **20 to 39 tools** depending on config gates.
 - **Hook system**: 5-tier composition is **54 base hooks**. With team mode it becomes **61** (extra tool guard + transforms + direct team session event handlers).
 - **MCP system**: 3 tiers: built-in remote MCPs (`websearch`, `context7`, `grep_app`), `.mcp.json` loader, and skill-embedded MCP from `SKILL.md` frontmatter.
 - **Managers**: plugin startup creates 4 managers: TmuxSessionManager, BackgroundManager, SkillMcpManager, ConfigHandler.
@@ -242,7 +242,7 @@ When you use a Category, a special agent called **Sisyphus-Junior** performs the
 
 ### Rename Compatibility
 
-The published package and binary remain `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`, while legacy `oh-my-opencode` entries still load with a warning. Plugin config files (`oh-my-openagent.json[c]` or legacy `oh-my-opencode.json[c]`) are recognized during the transition. Run `bunx oh-my-opencode doctor` to check for legacy package name warnings.
+The published package and binary remain `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`, while legacy `oh-my-opencode` entries still load with a warning. Plugin config files (`oh-my-openagent.json[c]` or legacy `oh-my-opencode.json[c]`) are recognized during the transition. Run `bunx oh-my-openagent doctor` to check for legacy package name warnings.
 
 ### Fallback Models
 
@@ -605,15 +605,15 @@ When delegating, **clear and specific** prompts are essential. Include these 7 e
 
 **Good Example**:
 
-> **TASK**: Fix mobile layout breaking issue in `LoginButton.tsx`
-> **CONTEXT**: `src/components/LoginButton.tsx`, using Tailwind CSS
+> **TASK**: Fix mobile layout breaking issue in the navbar component
+> **CONTEXT**: `packages/web/components/Navbar.tsx`, using Tailwind CSS
 > **MUST DO**: Change flex-direction at `md:` breakpoint
 > **MUST NOT DO**: Modify existing desktop layout
 > **EXPECTED**: Buttons align vertically on mobile
 
 ## Tools
 
-Tool registration is config-gated. `packages/omo-opencode/src/tools/` has 16 directories, and exposed tools range from **20 minimum to 39 maximum**.
+Tool registration is config-gated. `packages/omo-opencode/src/tools/` has 15 directories, and exposed tools range from **20 minimum to 39 maximum**.
 
 ### Code Search Tools
 
@@ -1051,7 +1051,7 @@ When a skill MCP has `oauth` configured:
 Pre-authenticate via CLI:
 
 ```bash
-bunx oh-my-opencode mcp oauth login <server-name> --server-url https://api.example.com
+bunx oh-my-openagent mcp oauth login <server-name> --server-url https://api.example.com
 ```
 
 ## Model Capabilities
@@ -1063,7 +1063,7 @@ Model capabilities are models.dev-backed, with a refreshable cache and compatibi
 Update the local cache with the latest model information:
 
 ```bash
-bunx oh-my-opencode refresh-model-capabilities
+bunx oh-my-openagent refresh-model-capabilities
 ```
 
 Configure automatic refresh at startup:
@@ -1081,7 +1081,7 @@ Configure automatic refresh at startup:
 
 ### Capability Diagnostics
 
-Run `bunx oh-my-opencode doctor` to see capability diagnostics including:
+Run `bunx oh-my-openagent doctor` to see capability diagnostics including:
 - effective model resolution for agents and categories
 - warnings when configured models rely on compatibility fallback
 - override compatibility details alongside model resolution output


### PR DESCRIPTION
## Summary
Fix stale numeric counts and path references in `docs/reference/features.md`.

## Changes
- Feature module count updated to match actual `ls -d packages/omo-opencode/src/features/*/`
- Tool directory count updated to match actual `ls -d packages/omo-opencode/src/tools/*/`
- Removed stale `src/components/LoginButton.tsx` reference
- Updated CLI invocations to prefer `oh-my-openagent`

## QA & Evidence
- Counts verified against filesystem
- No stale references remain

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stale counts and CLI references in `docs/reference/features.md` and remove an outdated component path example to keep the docs accurate and aligned with `oh-my-openagent`.

- **Bug Fixes**
  - Update counts: 23 feature modules and 15 tool directories, with 20–39 tools depending on config.
  - Prefer `oh-my-openagent` in CLI examples (`doctor`, `mcp oauth login`, `refresh-model-capabilities`).
  - Replace stale component reference with `packages/web/components/Navbar.tsx`.

<sup>Written for commit dd3753e98bf1fb4095eccba6ed771d4bb19ab426. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

