### PR TITLE
fix(web): update stale model names, version badge, hook counts

### DIFF
--- a/packages/web/app/[locale]/layout.tsx
+++ b/packages/web/app/[locale]/layout.tsx
@@ -8,7 +8,7 @@ import { routing } from "@/i18n/routing"
 
 export const metadata: Metadata = {
   description:
-    "Meet Sisyphus: The batteries-included agent that codes like you. Multi-model orchestration, background agents, 54+ lifecycle hooks.",
+    "Meet Sisyphus: The batteries-included agent that codes like you. Multi-model orchestration, background agents, 60+ lifecycle hooks.",
 }
 
 export function generateStaticParams(): Array<{ readonly locale: string }> {

--- a/packages/web/app/_components/landing-page.tsx
+++ b/packages/web/app/_components/landing-page.tsx
@@ -14,7 +14,7 @@ import { UltraworkSection } from "@/components/landing/sections/ultrawork"
 export const landingMetadata: Metadata = {
   title: "Oh My OpenAgent — The Best Agent Harness",
   description:
-    "Meet Sisyphus: The batteries-included agent that codes like you. Multi-model orchestration, Team Mode, background agents, 54+ lifecycle hooks.",
+    "Meet Sisyphus: The batteries-included agent that codes like you. Multi-model orchestration, Team Mode, background agents, 60+ lifecycle hooks.",
 }
 
 export async function LandingPage(): Promise<JSX.Element> {

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     template: "%s | Oh My OpenAgent",
   },
   description:
-    "Meet Sisyphus: The batteries-included agent that codes like you. Multi-model orchestration, Team Mode, background agents, 54+ lifecycle hooks.",
+    "Meet Sisyphus: The batteries-included agent that codes like you. Multi-model orchestration, Team Mode, background agents, 60+ lifecycle hooks.",
   keywords: [
     "opencode",
     "oh-my-opencode",
@@ -50,7 +50,7 @@ export const metadata: Metadata = {
     siteName: "Oh My OpenAgent",
     title: "Oh My OpenAgent — The Best Agent Harness",
     description:
-      "Meet Sisyphus: The batteries-included agent that codes like you. Multi-model orchestration, Team Mode, background agents, 54+ lifecycle hooks.",
+      "Meet Sisyphus: The batteries-included agent that codes like you. Multi-model orchestration, Team Mode, background agents, 60+ lifecycle hooks.",
     // og:image is supplied by app/opengraph-image.tsx via Next.js file-based metadata convention.
   },
   twitter: {
@@ -84,7 +84,7 @@ const jsonLd = {
     url: "https://github.com/code-yeongyu",
   },
   description:
-    "The batteries-included agent harness for OpenCode. Multi-model orchestration, Team Mode, background agents, 54+ lifecycle hooks.",
+    "The batteries-included agent harness for OpenCode. Multi-model orchestration, Team Mode, background agents, 60+ lifecycle hooks.",
   offers: {
     "@type": "Offer",
     price: "0",

--- a/packages/web/components/landing/constants.ts
+++ b/packages/web/components/landing/constants.ts
@@ -88,7 +88,7 @@ export const CATEGORY_ROUTING = [
   { cat: "artistry", model: "Gemini 3.1 Pro" },
   { cat: "quick", model: "GPT 5.4 Mini" },
   { cat: "deep", model: "GPT 5.5 Medium" },
-  { cat: "writing", model: "Kimi K2.5" },
+  { cat: "writing", model: "Kimi K2.6" },
   { cat: "git", model: "Claude Haiku 4.5" },
 ] as const
 

--- a/packages/web/components/landing/sections/hero.tsx
+++ b/packages/web/components/landing/sections/hero.tsx
@@ -56,7 +56,7 @@ export async function HeroSection(): Promise<JSX.Element> {
             specializedAgents: t("hero.specializedAgents", { count: "11" }),
             totalDownloads: t("hero.totalDownloads", { count: "{count}" }),
             monthlyDownloads: t("hero.monthlyDownloads", { count: "{count}" }),
-            lifecycleHooks: t("hero.lifecycleHooks", { count: "54+" }),
+            lifecycleHooks: t("hero.lifecycleHooks", { count: "60+" }),
           }}
         />
 

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -142,7 +142,7 @@
       "model": "GPT 5.5 Medium"
     },
     "teamMode": {
-      "badge": "NEW · v4.0",
+      "badge": "v4.0+",
       "title": "Team Mode",
       "headline": "Multiple Agents. Side-by-Side. In Parallel.",
       "description": "A lead agent orchestrates a team of category-specialized members, all running in parallel and communicating through dedicated tools. Watch every member work simultaneously in tmux. Opt-in — flip team_mode.enabled and restart.",

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -142,7 +142,7 @@
       "model": "GPT 5.5 Medium"
     },
     "teamMode": {
-      "badge": "NEW · v4.0",
+      "badge": "v4.0+",
       "title": "Team Mode",
       "headline": "複数のエージェント。横並び。並列で。",
       "description": "リードエージェントがカテゴリ特化のメンバーチームを統括します。全員が並列で動き、専用ツールでリアルタイムに通信。tmuxで全メンバーの作業を同時に観察できます。オプトイン — team_mode.enabledを切り替えて再起動。",

--- a/packages/web/messages/ko.json
+++ b/packages/web/messages/ko.json
@@ -142,7 +142,7 @@
       "model": "GPT 5.5 Medium"
     },
     "teamMode": {
-      "badge": "NEW · v4.0",
+      "badge": "v4.0+",
       "title": "Team Mode",
       "headline": "여러 에이전트. 나란히. 병렬로.",
       "description": "리드 에이전트가 카테고리별 전문 멤버 팀을 지휘합니다. 모두 병렬로 동작하며 전용 도구로 실시간 통신합니다. tmux에서 모든 멤버가 동시에 작업하는 모습을 지켜보세요. 옵트인 — team_mode.enabled를 켜고 재시작하세요.",

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -142,7 +142,7 @@
       "model": "GPT 5.5 Medium"
     },
     "teamMode": {
-      "badge": "NEW · v4.0",
+      "badge": "v4.0+",
       "title": "Team Mode",
       "headline": "多个 Agent。并排运行。真正并行。",
       "description": "一个领导 Agent 协调一队按类别专业化的成员，全部并行运行，通过专用工具实时通信。在 tmux 中同时观察每个成员工作。选择性启用 — 翻转 team_mode.enabled 并重启。",


### PR DESCRIPTION
## Summary
Fix stale constants and strings on the marketing website.

## Changes
- `constants.ts`: Kimi K2.5 → K2.6
- `messages/{en,ko,ja,zh}.json`: Team Mode badge `NEW · v4.0` → `v4.0+`
- All files: lifecycle hooks `54+` → `60+` (actual count with Team Mode is 60)
- `app/layout.tsx`: metadata descriptions updated

## QA & Evidence
- Web build passes: `bun run build` exits 0
- grep confirms no stale references remain

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stale marketing copy across the website to match current releases. Kimi model is now K2.6, Team Mode badge shows v4.0+, and lifecycle hooks display 60+.

- **Bug Fixes**
  - Update Kimi model in `components/landing/constants.ts`: K2.5 → K2.6.
  - Update Team Mode badge in `messages/{en,ja,ko,zh}.json`: "NEW · v4.0" → "v4.0+".
  - Update lifecycle hooks in metadata and hero: "54+" → "60+" across layouts and landing.

<sup>Written for commit 767e14f7725449d8df14f8c0cbdb1618c6f79b0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

