### PR TITLE
fix(stats): handle paginated release output

### DIFF
--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/QA-SUMMARY.md
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/QA-SUMMARY.md
@@ -1,0 +1,42 @@
+# Stats Pagination Fix QA
+
+## Success Criteria
+
+1. Real paginated GitHub releases output is represented at the script boundary.
+   - Scenario: direct GitHub CLI pagination probe.
+   - Invocation: `gh api repos/code-yeongyu/oh-my-openagent/releases --paginate --slurp | bun -e '<summarize pages/releases/downloads>'`.
+   - Binary observable: command exits 0 and reports a slurped page array with `pages: 3`, `releases: 207`, `asset_downloads: 12615`.
+   - Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/gh-slurp-shape.txt`.
+
+2. Download aggregation handles slurped paginated release pages.
+   - RED invocation: `bun test script/stats.test.ts`.
+   - RED observable: new slurped-pages test fails with Zod `expected object, received array` at page indices.
+   - RED artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/red-bun-test-stats.txt`.
+   - GREEN invocation: `bun test script/stats.test.ts`.
+   - GREEN observable: 3 tests pass, including `#given slurped GitHub release pages #when collected #then stats aggregate every page`.
+   - GREEN artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/green-bun-test-stats.txt`.
+
+3. The real stats CLI can run through the GitHub + npm data path without uploading.
+   - Scenario: dry-run stats script against live npm and GitHub APIs.
+   - Invocation: `bun run script/stats.ts --dry-run`.
+   - Binary observable: command exits 0 and prints four PostHog event payloads; GitHub release event count is `12615`, matching the direct slurp probe.
+   - Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/cli-dry-run.txt`.
+
+4. TypeScript/script quality gates pass for the touched surface.
+   - Invocation: `bun run typecheck:script`.
+   - Observable: exits 0.
+   - Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/typecheck-script.txt`.
+   - Invocation: `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts script/stats.ts script/stats.test.ts`.
+   - Observable: exits 0 with no violations.
+   - Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/no-excuse-typescript.txt`.
+   - Invocation: `git diff --check`.
+   - Observable: exits 0 with no whitespace errors.
+   - Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/git-diff-check.txt`.
+
+## Why This Is Enough
+
+The failing test pins the exact release blocker shape chosen for the fix: GitHub CLI pagination with `--slurp`, where the JSON value is an array of pages. The implementation now calls `gh api --paginate --slurp` and parses both historical flat release arrays and slurped page arrays into the same aggregation path. The direct GitHub probe and dry-run script show the live command shape and the stats script agree on the same GitHub asset download total.
+
+## Omitted
+
+No PostHog send was performed; `--dry-run` was used to avoid writing analytics events. No OpenCode or Codex harness QA was run because this change is limited to a repository script and its workflow-facing data parsing.

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/bun-install.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/bun-install.txt
@@ -1,0 +1,302 @@
+bun install v1.3.14 (0d9b296a)
+
+$ node postinstall.mjs
+⚠ oh-my-opencode: No platform binary package installed. Tried: oh-my-opencode-darwin-arm64
+  The CLI may not work on this platform.
+$ bun run build
+$ bun run build:git-bash-mcp && bun run build:lsp-tools-mcp && bun run build:lsp-daemon && bun run build:codex-plugin && bun build packages/omo-opencode/src/index.ts --outdir dist --target bun --format esm --external zod && bun build packages/omo-opencode/src/tui.ts --outdir dist --target bun --format esm --external @opentui/core --external @opentui/keymap --external @opentui/solid && bun run build:shared-skills-assets && bun run build:node-require-shim && tsc --emitDeclarationOnly && bun build packages/omo-opencode/src/cli/index.ts --outdir dist/cli --target bun --format esm && bun run build:cli-node && bun run build:codex-install && bun run build:schema
+$ bun run --cwd packages/git-bash-mcp build
+$ bun build src/cli.ts --outdir dist --target node --format esm
+Bundled 15 modules in 4ms
+
+  cli.js  19.52 KB  (entry point)
+
+$ npm --prefix packages/lsp-tools-mcp ci && npm --prefix packages/lsp-tools-mcp run build
+
+added 52 packages, and audited 55 packages in 682ms
+
+18 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+
+> @code-yeongyu/lsp-tools-mcp@0.1.0 build
+> node scripts/ensure-core-links.mjs && rm -rf dist && tsc -p tsconfig.build.json --emitDeclarationOnly && bun build src/cli.ts src/mcp.ts src/tools.ts src/request-context.ts src/lsp/manager.ts --outdir dist --target node --format esm
+
+Bundled 51 modules in 6ms
+
+  cli.js               110.14 KB  (entry point)
+  mcp.js               109.64 KB  (entry point)
+  tools.js             101.0 KB   (entry point)
+  request-context.js   490 bytes  (entry point)
+  lsp/manager.js       42.94 KB   (entry point)
+
+$ npm --prefix packages/lsp-daemon ci && npm --prefix packages/lsp-daemon run build
+
+added 52 packages, and audited 55 packages in 516ms
+
+18 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+
+> @code-yeongyu/lsp-daemon@0.1.0 build
+> tsc -p tsconfig.build.json && bun build src/cli.ts src/index.ts --outdir dist --target node --format esm && node scripts/stamp-dist-version.mjs
+
+Bundled 57 modules in 5ms
+
+  cli.js    127.59 KB  (entry point)
+  index.js  123.53 KB  (entry point)
+
+$ npm --prefix packages/omo-codex/plugin ci && bun run --cwd packages/omo-codex/plugin build
+
+added 74 packages, and audited 94 packages in 2s
+
+18 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+$ node scripts/sync-version.mjs && node scripts/sync-hook-status-messages.mjs && node scripts/build-bundled-mcp-runtimes.mjs && node scripts/materialize-shared-upstreams.mjs --strict && node scripts/sync-skills.mjs && node scripts/build-components.mjs
+Synced OMO Codex manifests to version 4.14.0 (0 updated)
+Using bundled lsp-tools-mcp dist
+Using bundled lsp-daemon dist
+Using bundled git-bash-mcp dist
+Cloning into '/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-stats-pagination-parse/packages/shared-skills/upstreams/designpowers'...
+Cloning into '/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-stats-pagination-parse/packages/shared-skills/upstreams/open-design'...
+Cloning into '/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-stats-pagination-parse/packages/shared-skills/upstreams/taste-skill'...
+Cloning into '/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-stats-pagination-parse/packages/shared-skills/upstreams/ui-ux-pro-max'...
+Submodule path 'packages/shared-skills/upstreams/designpowers': checked out 'cb00757da9d554591fa78d27aa1854d60a05c4f7'
+Submodule path 'packages/shared-skills/upstreams/open-design': checked out '6afe7eae156bfa29251a51fd0636649c257f7444'
+Submodule path 'packages/shared-skills/upstreams/taste-skill': checked out '06d6028b5c623016c59ce8536f578e5a1127b499'
+Submodule path 'packages/shared-skills/upstreams/ui-ux-pro-max': checked out 'f32d6a61cdf0bfd57404c45854583fd19ff95088'
+[materialize] wrote 147 frontend reference files from submodules
+Building components/codegraph
+
+> @sisyphuslabs/codex-codegraph@4.14.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/serve.ts --target node --format esm --outfile dist/serve.js && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 31 modules in 9ms
+
+  serve.js  78.39 KB  (entry point)
+
+Bundled 34 modules in 6ms
+
+  cli.js  104.38 KB  (entry point)
+
+Bundling components/codegraph/dist/cli.js
+Bundled 34 modules in 6ms
+
+  cli.js  104.46 KB  (entry point)
+
+Building components/comment-checker
+
+> @code-yeongyu/codex-comment-checker@4.14.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 11 modules in 4ms
+
+  cli.js  19.23 KB  (entry point)
+
+Bundling components/comment-checker/dist/cli.js
+Bundled 11 modules in 4ms
+
+  cli.js  19.40 KB  (entry point)
+
+Building components/git-bash
+
+> @sisyphuslabs/codex-git-bash-hook@4.14.0 build
+> tsc -p tsconfig.build.json
+
+Bundling components/git-bash/dist/cli.js
+Bundled 2 modules in 2ms
+
+  cli.js  5.75 KB  (entry point)
+
+Building components/lazycodex-executor-verify
+
+> @code-yeongyu/codex-lazycodex-executor-verify@4.14.0 build
+> tsc -p tsconfig.build.json
+
+Bundling components/lazycodex-executor-verify/dist/cli.js
+Bundled 5 modules in 3ms
+
+  cli.js  8.26 KB  (entry point)
+
+Building components/rules
+
+> @code-yeongyu/codex-rules@4.14.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 52 modules in 9ms
+
+  cli.js  159.59 KB  (entry point)
+
+Bundling components/rules/dist/cli.js
+Bundled 52 modules in 16ms
+
+  cli.js  159.82 KB  (entry point)
+
+Building components/lsp
+
+> @code-yeongyu/codex-lsp@4.14.0 prebuild
+> node scripts/build-lsp-tools.mjs && node scripts/build-lsp-daemon.mjs
+
+
+> @code-yeongyu/codex-lsp@4.14.0 build
+> node scripts/clean-dist.mjs && tsc -p tsconfig.build.json
+
+Bundling components/lsp/dist/cli.js
+Bundled 6 modules in 5ms
+
+  cli.js  124.76 KB  (entry point)
+
+Building components/telemetry
+
+> @code-yeongyu/codex-telemetry@4.14.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js && bun build src/posthog.ts --target node --format esm --outfile dist/posthog.js
+
+Bundled 78 modules in 20ms
+
+  cli.js  204.83 KB  (entry point)
+
+Bundled 76 modules in 15ms
+
+  posthog.js  202.41 KB  (entry point)
+
+Bundling components/telemetry/dist/cli.js
+Bundled 78 modules in 16ms
+
+  cli.js  204.57 KB  (entry point)
+
+Building components/teammode
+
+> @sisyphuslabs/codex-teammode@4.14.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 2 modules in 4ms
+
+  cli.js  4.18 KB  (entry point)
+
+Bundling components/teammode/dist/cli.js
+Bundled 2 modules in 3ms
+
+  cli.js  4.22 KB  (entry point)
+
+Building components/start-work-continuation
+
+> @code-yeongyu/codex-start-work-continuation@4.14.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 4 modules in 4ms
+
+  cli.js  11.0 KB  (entry point)
+
+Bundling components/start-work-continuation/dist/cli.js
+Bundled 4 modules in 3ms
+
+  cli.js  11.21 KB  (entry point)
+
+Building components/workflow-selector
+
+> @code-yeongyu/codex-workflow-selector@4.14.0 build
+> node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 2 modules in 4ms
+
+  cli.js  9.65 KB  (entry point)
+
+Bundling components/workflow-selector/dist/cli.js
+Bundled 2 modules in 2ms
+
+  cli.js  9.73 KB  (entry point)
+
+Building components/ulw-loop
+
+> @code-yeongyu/codex-ulw-loop@4.14.0 build
+> tsc -p tsconfig.build.json
+
+Bundling components/ulw-loop/dist/cli.js
+Bundled 29 modules in 5ms
+
+  cli.js  112.94 KB  (entry point)
+
+Building components/ultrawork
+
+> @code-yeongyu/codex-ultrawork@4.14.0 build
+> node scripts/sync-directive.mjs && node -e "require('node:fs').rmSync('dist',{recursive:true,force:true})" && bun build src/cli.ts --target node --format esm --outfile dist/cli.js
+
+Bundled 3 modules in 3ms
+
+  cli.js  5.23 KB  (entry point)
+
+Bundling components/ultrawork/dist/cli.js
+Bundled 3 modules in 3ms
+
+  cli.js  5.34 KB  (entry point)
+
+Building components/bootstrap (standalone)
+
+> @sisyphuslabs/codex-bootstrap@4.14.0 build
+> node scripts/build.mjs
+
+Resolving dependencies
+Resolved, downloaded and extracted [2]
+Saved lockfile
+
+  dist/cli.js  120.4kb
+
+⚡ Done in 10ms
+Bundling components/bootstrap/dist/cli.js
+Bundled 43 modules in 5ms
+
+  cli.js  123.91 KB  (entry point)
+
+Bundled 1867 modules in 107ms
+
+  index.js  5.20 MB  (entry point)
+
+Bundled 500 modules in 25ms
+
+  tui.js  1.87 MB  (entry point)
+
+$ bun run build:materialize-frontend && rm -rf dist/skills && cp -R packages/shared-skills/skills dist/skills
+$ node packages/omo-codex/plugin/scripts/materialize-shared-upstreams.mjs --strict
+[materialize] wrote 147 frontend reference files from submodules
+$ bun run script/patch-node-require-shim.ts
+Patched Node/Electron require shim in dist/index.js
+Bundled 841 modules in 61ms
+
+  index.js  2.87 MB  (entry point)
+
+$ bun run script/build-cli-node.ts
+built dist/cli-node (1 output)
+$ bun run script/build-codex-install.ts
+$ bun run script/build-schema.ts
+Generating JSON Schema...
+✓ JSON Schema generated: assets/oh-my-opencode.schema.json
+
++ @types/js-yaml@4.0.9
++ @types/picomatch@4.0.3
++ @typescript/native-preview@7.0.0-dev.20260518.1
++ bun-types@1.3.14
++ typescript@6.0.3
++ @clack/prompts@1.5.0
++ @code-yeongyu/comment-checker@0.8.0
++ @modelcontextprotocol/sdk@1.29.0
++ @opencode-ai/plugin@1.15.13
++ @opencode-ai/sdk@1.15.13
++ @opentui/core@0.2.16
++ @opentui/keymap@0.2.16
++ @opentui/solid@0.2.16
++ commander@14.0.3
++ detect-libc@2.1.2
++ diff@9.0.0
++ js-yaml@4.2.0
++ jsonc-parser@3.3.1
++ picocolors@1.1.1
++ picomatch@4.0.4
++ posthog-node@5.35.12
++ vscode-jsonrpc@8.2.1
++ zod@4.4.3
+
+468 packages installed [87.70s]

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/cli-dry-run.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/cli-dry-run.txt
@@ -1,0 +1,49 @@
+{
+  "dryRun": true,
+  "events": [
+    {
+      "api_key": "dry-run",
+      "event": "omo_download_stats",
+      "distinct_id": "download",
+      "properties": {
+        "$process_person_profile": false,
+        "count": 51430,
+        "package_name": "oh-my-opencode",
+        "source": "npm"
+      }
+    },
+    {
+      "api_key": "dry-run",
+      "event": "omo_download_stats",
+      "distinct_id": "download",
+      "properties": {
+        "$process_person_profile": false,
+        "count": 35370,
+        "package_name": "oh-my-openagent",
+        "source": "npm"
+      }
+    },
+    {
+      "api_key": "dry-run",
+      "event": "omo_download_stats",
+      "distinct_id": "download",
+      "properties": {
+        "$process_person_profile": false,
+        "count": 8933,
+        "package_name": "lazycodex-ai",
+        "source": "npm"
+      }
+    },
+    {
+      "api_key": "dry-run",
+      "event": "omo_download_stats",
+      "distinct_id": "download",
+      "properties": {
+        "$process_person_profile": false,
+        "count": 12615,
+        "package_name": "code-yeongyu/oh-my-openagent",
+        "source": "github_release"
+      }
+    }
+  ]
+}

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/gh-slurp-shape.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/gh-slurp-shape.txt
@@ -1,0 +1,5 @@
+{
+  "pages": 3,
+  "releases": 207,
+  "asset_downloads": 12615
+}

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/git-diff-check.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/git-diff-check.txt
@@ -1,0 +1,1 @@
+PASS: git diff --check reported no whitespace errors

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/git-diff-stat.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/git-diff-stat.txt
@@ -1,0 +1,3 @@
+ script/stats.test.ts | 21 +++++++++++++++++++++
+ script/stats.ts      |  9 +++++++--
+ 2 files changed, 28 insertions(+), 2 deletions(-)

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/git-status-before-commit.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/git-status-before-commit.txt
@@ -1,0 +1,3 @@
+## code-yeongyu/fix-stats-pagination-parse...origin/dev
+ M script/stats.test.ts
+ M script/stats.ts

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/green-bun-test-stats.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/green-bun-test-stats.txt
@@ -1,0 +1,11 @@
+bun test v1.3.14 (0d9b296a)
+
+script/stats.test.ts:
+(pass) download stats automation > #given package and release counts #when collected #then stats use aggregate download sources [1.34ms]
+(pass) download stats automation > #given slurped GitHub release pages #when collected #then stats aggregate every page [0.23ms]
+(pass) download stats automation > #given stats workflow #when inspected #then it is weekly manual and scopes POSTHOG_KEY to send only [0.24ms]
+
+ 3 pass
+ 0 fail
+ 14 expect() calls
+Ran 3 tests across 1 file. [78.00ms]

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/no-excuse-typescript.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/no-excuse-typescript.txt
@@ -1,0 +1,1 @@
+No violations in 2 file(s).

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/red-bun-test-stats.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/red-bun-test-stats.txt
@@ -1,0 +1,29 @@
+bun test v1.3.14 (0d9b296a)
+
+script/stats.test.ts:
+(pass) download stats automation > #given package and release counts #when collected #then stats use aggregate download sources [1.86ms]
+ZodError: [
+  {
+    "expected": "object",
+    "code": "invalid_type",
+    "path": [
+      0
+    ],
+    "message": "Invalid input: expected object, received array"
+  },
+  {
+    "expected": "object",
+    "code": "invalid_type",
+    "path": [
+      1
+    ],
+    "message": "Invalid input: expected object, received array"
+  }
+]
+(fail) download stats automation > #given slurped GitHub release pages #when collected #then stats aggregate every page [0.45ms]
+(pass) download stats automation > #given stats workflow #when inspected #then it is weekly manual and scopes POSTHOG_KEY to send only [0.44ms]
+
+ 2 pass
+ 1 fail
+ 13 expect() calls
+Ran 3 tests across 1 file. [92.00ms]

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/typecheck-script.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/typecheck-script.txt
@@ -1,0 +1,1 @@
+$ tsgo --noEmit -p script/tsconfig.json

--- a/script/stats.test.ts
+++ b/script/stats.test.ts
@@ -31,6 +31,27 @@ describe("download stats automation", () => {
     expect(events.filter((event) => event.properties.source === "npm")).toHaveLength(3)
   })
 
+  test("#given slurped GitHub release pages #when collected #then stats aggregate every page", async () => {
+    // given
+    const stats = await collectDownloadStats({
+      fetchJson: async () => ({ downloads: 1 }),
+      runGhApi: async () => [
+        [{ assets: [{ download_count: 4 }, { download_count: 6 }] }],
+        [{ assets: [{ download_count: 9 }] }],
+      ],
+    })
+
+    // when
+    const githubStat = stats.find((stat) => stat.source === "github_release")
+
+    // then
+    expect(githubStat).toEqual({
+      count: 19,
+      packageName: "code-yeongyu/oh-my-openagent",
+      source: "github_release",
+    })
+  })
+
   test("#given stats workflow #when inspected #then it is weekly manual and scopes POSTHOG_KEY to send only", async () => {
     // given
     const workflow = await readFile(".github/workflows/stats.yml", "utf8")

--- a/script/stats.ts
+++ b/script/stats.ts
@@ -16,6 +16,11 @@ const GitHubAssetSchema = z.object({
 const GitHubReleaseSchema = z.object({
   assets: z.array(GitHubAssetSchema),
 })
+const GitHubReleasesSchema = z.array(GitHubReleaseSchema)
+const GitHubReleasesPayloadSchema = z.union([
+  GitHubReleasesSchema,
+  z.array(GitHubReleasesSchema).transform((pages) => pages.flat()),
+])
 
 type DownloadSource = "npm" | "github_release"
 
@@ -55,7 +60,7 @@ async function defaultFetchJson(url: string): Promise<unknown> {
 }
 
 async function defaultRunGhApi(): Promise<unknown> {
-  const output = await $`gh api repos/${GITHUB_REPOSITORY}/releases --paginate`.text()
+  const output = await $`gh api repos/${GITHUB_REPOSITORY}/releases --paginate --slurp`.text()
   return JSON.parse(output)
 }
 
@@ -71,7 +76,7 @@ async function fetchNpmStat(packageName: string, fetchJson: StatsDeps["fetchJson
 }
 
 function readGitHubReleaseDownloadStat(releasesJson: unknown): DownloadStat {
-  const releases = z.array(GitHubReleaseSchema).parse(releasesJson)
+  const releases = GitHubReleasesPayloadSchema.parse(releasesJson)
   const count = releases.reduce(
     (total, release) =>
       total + release.assets.reduce((assetTotal, asset) => assetTotal + asset.download_count, 0),


### PR DESCRIPTION
## Summary
Fixes release blocker #3 from the 2026-06-29 prepublish heavy review. `script/stats.ts` now invokes GitHub releases with `gh api --paginate --slurp`, then accepts both the previous flat release array shape and the slurped array-of-pages shape before aggregating asset downloads.

## Changes
- Added a regression test for slurped GitHub release pages, using two pages whose asset download counts must aggregate to 19.
- Updated the GitHub releases parser boundary to flatten slurped pages while preserving support for flat release arrays.
- Added evidence under `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/` for RED, GREEN, live CLI dry-run, real GitHub slurp shape, script typecheck, no-excuse TypeScript audit, and diff check.

## QA & Evidence
- **What was tested:** `bun test script/stats.test.ts` before the fix.
  **Observed result:** new slurped-pages test failed with Zod `expected object, received array` for page arrays.
  **Artifact:** `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/red-bun-test-stats.txt`.
  **Why sufficient:** reproduces the blocker at the script aggregation boundary.

- **What was tested:** `bun test script/stats.test.ts` after the fix.
  **Observed result:** 3 tests passed, including the slurped paginated pages regression.
  **Artifact:** `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/green-bun-test-stats.txt`.
  **Why sufficient:** proves the parser now accepts the chosen real pagination shape and preserves existing workflow coverage.

- **What was tested:** `gh api repos/code-yeongyu/oh-my-openagent/releases --paginate --slurp | bun -e '<summarize pages/releases/downloads>'`.
  **Observed result:** live GitHub output slurped to 3 pages / 207 releases / 12615 asset downloads.
  **Artifact:** `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/gh-slurp-shape.txt`.
  **Why sufficient:** confirms the real CLI output shape this fix supports.

- **What was tested:** `bun run script/stats.ts --dry-run`.
  **Observed result:** script emitted four dry-run events; GitHub release event count was 12615, matching the direct slurp probe.
  **Artifact:** `.omo/evidence/20260629-prepublish-blocker-fixes/stats-pagination/cli-dry-run.txt`.
  **Why sufficient:** drives the actual script through npm + GitHub fetch paths without sending PostHog events.

- **What was tested:** `bun run typecheck:script`; TypeScript no-excuse audit for `script/stats.ts` and `script/stats.test.ts`; `git diff --check`.
  **Observed result:** all passed.
  **Artifacts:** `typecheck-script.txt`, `no-excuse-typescript.txt`, `git-diff-check.txt` in the same evidence directory.
  **Why sufficient:** covers script type safety and local diff hygiene for the touched TypeScript files.

## Risks & Residuals
- PostHog upload was intentionally not exercised; `--dry-run` avoids writing analytics events while still proving payload creation.
- Full repository `bun test` and full root `bun run typecheck` were not run because this is a narrow script parser fix; targeted script tests and script typecheck were run.

## Related
- Blocker: `.omo/evidence/20260629-prepublish-heavy-review/final/blockers.md` item 3.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stats parsing for GitHub releases by supporting paginated output from `gh api --paginate --slurp`. This removes the `zod` array/object error and correctly aggregates asset downloads across all pages.

- **Bug Fixes**
  - Parse both flat release arrays and slurped array-of-pages; pages are flattened before aggregation.
  - Switched GitHub call to `--slurp`; stats now count downloads correctly for `code-yeongyu/oh-my-openagent`.
  - Added a regression test to ensure totals aggregate across pages.

<sup>Written for commit 49de91d3c06ab72af3501b374a1798c7bc36191d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

