### PR TITLE
fix(qa): reject empty web terminal captures

### DIFF
--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/README.md
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/README.md
@@ -1,0 +1,48 @@
+# Web Terminal Empty Capture Blocker Fix Evidence
+
+Task: fix blocker #4 from `.omo/evidence/20260629-prepublish-heavy-review/final/blockers.md`: command mode must not exit 0 or report evidence paths when tmux capture is empty or failed.
+
+## Scenario 1: RED regression proof
+- Invocation: `bun test script/web-terminal-visual-qa.test.ts` before the production fix, with a new command-mode empty-capture test temporarily in that file.
+- Binary observable: exit code `1`; failure shows expected exit `1` but helper returned `0`.
+- Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/red-empty-capture-test.log`
+- Receipt: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/red-empty-capture-test.receipt.txt`
+
+## Scenario 2: Focused automated regression tests
+- Invocation: `bun test script/web-terminal-visual-qa.test.ts script/web-terminal-visual-qa-command.test.ts`
+- Binary observable: exit code `0`; 10 tests pass, including `#given command mode captures an empty tmux pane #when rendering #then the helper rejects the evidence`.
+- Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/green-focused-tests.log`
+- Receipt: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/green-focused-tests.receipt.txt`
+
+## Scenario 3: TypeScript script project check
+- Invocation: `bun run typecheck:script`
+- Binary observable: exit code `0`; `tsgo --noEmit -p script/tsconfig.json` passed.
+- Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/typecheck-script.log`
+- Receipt: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/typecheck-script.receipt.txt`
+
+## Scenario 4: Live tmux-backed command success path
+- Invocation: `node script/qa/web-terminal-visual-qa.mjs --title "Live Command QA" --command "printf 'webterm-live-ok\\n'" --source-label "printf live marker" --evidence-dir .omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts --dwell-ms 500 --no-browser`
+- Binary observable: exit code `0`; `terminal.txt` and `terminal-ansi.txt` are each 86 bytes; `terminal.txt` contains `webterm-live-ok` and `[web-terminal-visual-qa exit:0]`.
+- Cleanup receipt: metadata records `tmux kill-session`; `tmux ls` check found no remaining `omo_webterm` session.
+- Artifacts: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal.txt`, `terminal-ansi.txt`, `terminal.html`, `metadata.json`
+- Checks: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-checks.txt`
+- CLI stdout/stderr capture: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-cli.log`
+
+## Scenario 5: Empty tmux capture CLI rejection
+- Invocation: `PATH=<fake-empty-tmux> node script/qa/web-terminal-visual-qa.mjs --title "Empty Command QA" --command "printf 'hidden\\n'" --source-label "fake empty tmux" --evidence-dir .omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-artifacts --dwell-ms 1 --no-browser`
+- Binary observable: helper invocation exits `1`; stderr contains `tmux capture was empty`; no evidence files are written.
+- Cleanup receipt: fake tmux temp dir removed with `rm -rf`; this scenario used no live tmux session.
+- Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-cli.log`
+- Checks: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-checks.txt`
+
+## Scenario 6: File-size and checker hygiene
+- Invocation: pure LOC checks for changed files.
+- Binary observable: `script/qa/web-terminal-visual-qa.mjs` 228, `script/web-terminal-visual-qa.test.ts` 224, `script/web-terminal-visual-qa-command.test.ts` 75; all under the 250 pure LOC ceiling.
+- Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/loc-check.txt`
+- Omitted: `scripts/typescript/check-no-excuse-rules.ts` was not present in this checkout; recorded in `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/no-excuse-checker-unavailable.txt` and substituted `bun run typecheck:script` plus LOC checks.
+
+## Why this is enough
+The RED test proves the pre-fix behavior accepted empty command-mode captures. The new regression test and direct fake-tmux CLI proof cover the blocker path with a non-zero, clear error and no bogus evidence files. The live tmux command proof covers the non-empty success path and confirms artifacts remain non-empty while cleanup completes.
+
+## Residual risk
+PNG capture was intentionally omitted with `--no-browser` because the blocker is command-mode tmux transcript acceptance, not browser rendering. Existing file-replay/browser-render tests remain covered by the focused helper suite.

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-checks.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-checks.txt
@@ -1,0 +1,8 @@
+scenario: command mode rejects empty tmux capture
+invocation: PATH=<fake-empty-tmux> node script/qa/web-terminal-visual-qa.mjs --title "Empty Command QA" --command "printf 'hidden
+'" --source-label "fake empty tmux" --evidence-dir .omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-artifacts --dwell-ms 1 --no-browser
+exit_code: 1
+stderr contains clear error: 1:tmux capture was empty
+artifact files written:
+cleanup: rm -rf /tmp/omo-webterm-empty-fake.V1B4aa; fake tmux temp dir removed: yes
+verdict: passed; empty capture rejected with non-zero exit

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-cli.log
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-cli.log
@@ -1,0 +1,1 @@
+tmux capture was empty

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/green-focused-tests.log
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/green-focused-tests.log
@@ -1,0 +1,20 @@
+bun test v1.3.14 (0d9b296a)
+
+script/web-terminal-visual-qa.test.ts:
+(pass) web terminal visual QA helper > #given a transcript file #when rendering without browser capture #then evidence files and metadata are written [19.68ms]
+(pass) web terminal visual QA helper > #given secret-bearing terminal output #when rendering #then text ansi html and metadata are redacted [18.28ms]
+(pass) web terminal visual QA helper > #given ANSI color and style escapes #when rendering #then HTML preserves terminal styling while text stays plain [18.36ms]
+(pass) web terminal visual QA helper > #given inverse video with default colors #when rendering #then foreground and background swap without filter CSS [18.26ms]
+(pass) web terminal visual QA helper > #given inverse video with explicit colors #when rendering #then foreground and background classes swap [19.79ms]
+(pass) web terminal visual QA helper > #given inverse video is reset #when rendering #then later text uses normal colors [18.27ms]
+(pass) web terminal visual QA helper > #given truecolor and OSC controls #when rendering #then colors are preserved and controls are stripped [18.30ms]
+(pass) web terminal visual QA helper > #given a very long line #when rendering with defaults #then wrapping is enabled and recorded [17.58ms]
+(pass) web terminal visual QA helper > #given help output #when inspecting the helper #then it documents tmux connector and browser evidence [15.81ms]
+
+script/web-terminal-visual-qa-command.test.ts:
+(pass) web terminal visual QA command mode > #given command mode captures an empty tmux pane #when rendering #then the helper rejects the evidence [188.30ms]
+
+ 10 pass
+ 0 fail
+ 72 expect() calls
+Ran 10 tests across 2 files. [421.00ms]

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/green-focused-tests.receipt.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/green-focused-tests.receipt.txt
@@ -1,0 +1,2 @@
+command: bun test script/web-terminal-visual-qa.test.ts script/web-terminal-visual-qa-command.test.ts
+exit_code: 0

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/metadata.json
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/metadata.json
@@ -1,0 +1,29 @@
+{
+  "title": "Live Command QA",
+  "connector": "tmux-backed-pty",
+  "browserCapture": "skipped",
+  "source": {
+    "kind": "command",
+    "label": "printf live marker"
+  },
+  "redaction": {
+    "builtInRules": 7,
+    "literalRules": 0,
+    "regexRules": 0
+  },
+  "wrap": "on",
+  "dimensions": {
+    "cols": 140,
+    "rows": 40,
+    "screenshotWidth": 1268,
+    "screenshotHeight": 840
+  },
+  "cleanup": "cleanup: tmux kill-session -t 'omo_webterm_3726_1782705762730'",
+  "files": {
+    "html": "/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-web-terminal-empty-capture/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal.html",
+    "text": "/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-web-terminal-empty-capture/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal.txt",
+    "ansi": "/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-web-terminal-empty-capture/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal-ansi.txt",
+    "png": null,
+    "metadata": "/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-web-terminal-empty-capture/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/metadata.json"
+  }
+}

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal-ansi.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal-ansi.txt
@@ -1,0 +1,3 @@
+webterm-live-ok
+
+[web-terminal-visual-qa exit:0]

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal.html
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Live Command QA</title>
+<style>
+:root { color-scheme: dark; }
+body { margin: 0; background: #101217; color: #d8dee9; font: 13px/1.35 "SFMono-Regular", "Cascadia Mono", "JetBrains Mono", "Menlo", "Consolas", "Liberation Mono", ui-monospace, monospace; }
+main { min-height: 100vh; box-sizing: border-box; padding: 20px; }
+.terminal { width: min(100%, 140ch); max-width: calc(100vw - 40px); border: 1px solid #3b4452; background: #090b10; box-shadow: 0 20px 80px rgb(0 0 0 / 40%); }
+.bar { display: flex; gap: 8px; align-items: center; padding: 8px 12px; border-bottom: 1px solid #303846; color: #aab7c4; background: #171b22; font-size: 12px; }
+.dot { width: 10px; height: 10px; border-radius: 999px; background: #6b7280; }
+pre { margin: 0; padding: 14px 16px; white-space: pre-wrap; overflow-wrap: anywhere; tab-size: 8; overflow: auto; }
+.ansi-bold { font-weight: 700; }
+.ansi-dim { opacity: 0.72; }
+.ansi-italic { font-style: italic; }
+.ansi-underline { text-decoration: underline; }
+.ansi-strike { text-decoration: line-through; }
+.ansi-fg-black { color: #0c0d10; }
+.ansi-bg-black { background-color: #0c0d10; }
+.ansi-fg-red { color: #ff6b6b; }
+.ansi-bg-red { background-color: #ff6b6b; }
+.ansi-fg-green { color: #51cf66; }
+.ansi-bg-green { background-color: #51cf66; }
+.ansi-fg-yellow { color: #ffd43b; }
+.ansi-bg-yellow { background-color: #ffd43b; }
+.ansi-fg-blue { color: #4dabf7; }
+.ansi-bg-blue { background-color: #4dabf7; }
+.ansi-fg-magenta { color: #d0bfff; }
+.ansi-bg-magenta { background-color: #d0bfff; }
+.ansi-fg-cyan { color: #66d9e8; }
+.ansi-bg-cyan { background-color: #66d9e8; }
+.ansi-fg-white { color: #f1f3f5; }
+.ansi-bg-white { background-color: #f1f3f5; }
+.ansi-fg-bright-black { color: #868e96; }
+.ansi-bg-bright-black { background-color: #868e96; }
+.ansi-fg-bright-red { color: #ff8787; }
+.ansi-bg-bright-red { background-color: #ff8787; }
+.ansi-fg-bright-green { color: #69db7c; }
+.ansi-bg-bright-green { background-color: #69db7c; }
+.ansi-fg-bright-yellow { color: #ffe066; }
+.ansi-bg-bright-yellow { background-color: #ffe066; }
+.ansi-fg-bright-blue { color: #74c0fc; }
+.ansi-bg-bright-blue { background-color: #74c0fc; }
+.ansi-fg-bright-magenta { color: #e599f7; }
+.ansi-bg-bright-magenta { background-color: #e599f7; }
+.ansi-fg-bright-cyan { color: #99e9f2; }
+.ansi-bg-bright-cyan { background-color: #99e9f2; }
+.ansi-fg-bright-white { color: #ffffff; }
+.ansi-bg-bright-white { background-color: #ffffff; }
+</style>
+</head>
+<body><main><section class="terminal"><div class="bar"><span class="dot"></span><strong>Live Command QA</strong></div><pre>webterm-live-ok
+
+[web-terminal-visual-qa exit:0]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</pre></section></main></body>
+</html>

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal.txt
@@ -1,0 +1,3 @@
+webterm-live-ok
+
+[web-terminal-visual-qa exit:0]

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-checks.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-checks.txt
@@ -1,0 +1,10 @@
+scenario: successful live command path produces non-empty tmux-backed evidence
+invocation: node script/qa/web-terminal-visual-qa.mjs --title "Live Command QA" --command "printf 'webterm-live-ok\n'" --source-label "printf live marker" --evidence-dir .omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts --dwell-ms 500 --no-browser
+exit_code: 0
+terminal.txt bytes:       86
+terminal-ansi.txt bytes:       86
+metadata.json bytes:     1351
+marker grep: 1:webterm-live-ok
+exit marker grep: 3:[web-terminal-visual-qa exit:0]
+cleanup metadata:   "cleanup": "cleanup: tmux kill-session -t 'omo_webterm_3726_1782705762730'",
+remaining omo_webterm tmux sessions: none

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-cli.log
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-cli.log
@@ -1,0 +1,9 @@
+web terminal visual QA evidence (live-command-artifacts):
+{
+  "html": "/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-web-terminal-empty-capture/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal.html",
+  "text": "/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-web-terminal-empty-capture/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal.txt",
+  "ansi": "/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-web-terminal-empty-capture/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/terminal-ansi.txt",
+  "png": null,
+  "metadata": "/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-web-terminal-empty-capture/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts/metadata.json"
+}
+cleanup: tmux kill-session -t 'omo_webterm_3726_1782705762730'

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/loc-check.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/loc-check.txt
@@ -1,0 +1,5 @@
+command: pure LOC checks for changed source/test files
+script/qa/web-terminal-visual-qa.mjs: 228
+script/web-terminal-visual-qa.test.ts: 224
+script/web-terminal-visual-qa-command.test.ts: 75
+verdict: all touched files are under 250 pure LOC

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/no-excuse-checker-unavailable.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/no-excuse-checker-unavailable.txt
@@ -1,0 +1,3 @@
+command: find . -path "*check-no-excuse-rules*" -maxdepth 5 -type f
+exit_code: 0
+observed: no checker file found in this checkout; used LOC check plus bun run typecheck:script instead

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/red-empty-capture-test.log
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/red-empty-capture-test.log
@@ -1,0 +1,31 @@
+bun test v1.3.14 (0d9b296a)
+
+script/web-terminal-visual-qa.test.ts:
+(pass) web terminal visual QA helper > #given a transcript file #when rendering without browser capture #then evidence files and metadata are written [20.45ms]
+(pass) web terminal visual QA helper > #given secret-bearing terminal output #when rendering #then text ansi html and metadata are redacted [18.63ms]
+(pass) web terminal visual QA helper > #given ANSI color and style escapes #when rendering #then HTML preserves terminal styling while text stays plain [18.30ms]
+(pass) web terminal visual QA helper > #given inverse video with default colors #when rendering #then foreground and background swap without filter CSS [18.16ms]
+(pass) web terminal visual QA helper > #given inverse video with explicit colors #when rendering #then foreground and background classes swap [19.69ms]
+(pass) web terminal visual QA helper > #given inverse video is reset #when rendering #then later text uses normal colors [18.82ms]
+(pass) web terminal visual QA helper > #given truecolor and OSC controls #when rendering #then colors are preserved and controls are stripped [18.10ms]
+(pass) web terminal visual QA helper > #given a very long line #when rendering with defaults #then wrapping is enabled and recorded [17.73ms]
+(pass) web terminal visual QA helper > #given help output #when inspecting the helper #then it documents tmux connector and browser evidence [16.30ms]
+319 |
+320 |     // when
+321 |     const result = await runCommandWithFakeTmux(fakeTmux)
+322 |
+323 |     // then
+324 |     expect(result.exitCode).toBe(1)
+                                  ^
+error: expect(received).toBe(expected)
+
+Expected: 1
+Received: 0
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/code-yeongyu/fix-web-terminal-empty-capture/script/web-terminal-visual-qa.test.ts:324:29)
+(fail) web terminal visual QA helper > #given command mode captures an empty tmux pane #when rendering #then the helper rejects the evidence [174.16ms]
+
+ 9 pass
+ 1 fail
+ 70 expect() calls
+Ran 10 tests across 1 file. [412.00ms]

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/red-empty-capture-test.receipt.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/red-empty-capture-test.receipt.txt
@@ -1,0 +1,2 @@
+command: bun test script/web-terminal-visual-qa.test.ts
+exit_code: 1

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/typecheck-script.log
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/typecheck-script.log
@@ -1,0 +1,1 @@
+$ tsgo --noEmit -p script/tsconfig.json

--- a/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/typecheck-script.receipt.txt
+++ b/.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/typecheck-script.receipt.txt
@@ -1,0 +1,2 @@
+command: bun run typecheck:script
+exit_code: 0

--- a/script/qa/web-terminal-visual-qa.mjs
+++ b/script/qa/web-terminal-visual-qa.mjs
@@ -180,8 +180,15 @@ function runTmuxCommand(args) {
   const plain = spawnSync("tmux", ["capture-pane", "-p", "-S", "-", "-t", session], { encoding: "utf8" });
   const ansi = spawnSync("tmux", ["capture-pane", "-e", "-p", "-S", "-", "-t", session], { encoding: "utf8" });
   spawnSync("tmux", ["kill-session", "-t", session], { encoding: "utf8" });
+  const plainCapture = plain.status === 0 ? plain.stdout : "";
+  const ansiCapture = ansi.status === 0 ? ansi.stdout : "";
+  const captured = ansiCapture || plainCapture;
+  if (!captured || stripAnsi(captured).trim().length === 0) {
+    const detail = [plain.stderr || plain.stdout, ansi.stderr || ansi.stdout].filter(Boolean).join("; ");
+    throw new Error(`tmux capture was empty${detail ? `: ${detail}` : ""}`);
+  }
   return {
-    ansi: ansi.stdout || plain.stdout,
+    ansi: captured,
     cleanup: `cleanup: tmux kill-session -t ${shellQuote(session)}`,
     connector: "tmux-backed-pty",
   };

--- a/script/web-terminal-visual-qa-command.test.ts
+++ b/script/web-terminal-visual-qa-command.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const helperFilePath = fileURLToPath(new URL("./qa/web-terminal-visual-qa.mjs", import.meta.url))
+
+const tempDirs: string[] = []
+
+function makeTempDir(): string {
+  const path = mkdtempSync(join(tmpdir(), "omo-web-terminal-command-qa-"))
+  tempDirs.push(path)
+  return path
+}
+
+function writeEmptyCaptureTmuxStub(fakeBin: string): void {
+  const fakeTmuxPath = join(fakeBin, "tmux")
+  mkdirSync(fakeBin)
+  writeFileSync(
+    fakeTmuxPath,
+    [
+      "#!/bin/sh",
+      "case \"$1\" in",
+      "  -V) printf 'tmux 3.4\\n'; exit 0 ;;",
+      "  new-session) exit 0 ;;",
+      "  capture-pane) exit 0 ;;",
+      "  kill-session) exit 0 ;;",
+      "esac",
+      "exit 0",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+  writeFileSync(
+    join(fakeBin, "tmux.cmd"),
+    ["@echo off", 'if "%1"=="-V" echo tmux 3.4', "exit /b 0", ""].join("\r\n"),
+    "utf8",
+  )
+  if (process.platform !== "win32") chmodSync(fakeTmuxPath, 0o755)
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe("web terminal visual QA command mode", () => {
+  test("#given command mode captures an empty tmux pane #when rendering #then the helper rejects the evidence", async () => {
+    // given
+    const dir = makeTempDir()
+    const fakeBin = join(dir, "bin")
+    writeEmptyCaptureTmuxStub(fakeBin)
+
+    // when
+    const proc = Bun.spawn({
+      cmd: [
+        process.execPath,
+        helperFilePath,
+        "--title",
+        "Command QA",
+        "--command",
+        "printf visible",
+        "--evidence-dir",
+        dir,
+        "--no-browser",
+        "--dwell-ms",
+        "1",
+      ],
+      env: { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH || ""}` },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [exitCode, stdoutText, stderrText] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+
+    // then
+    expect(exitCode).toBe(1)
+    expect(stderrText).toContain("tmux capture was empty")
+    expect(stdoutText).toBe("")
+  })
+})


### PR DESCRIPTION
## Summary
Fixes release blocker #4 from the prepublish heavy review: `script/qa/web-terminal-visual-qa.mjs` command mode no longer accepts an empty tmux capture as valid evidence. The helper now rejects empty or failed command-mode capture output with a non-zero exit and a clear `tmux capture was empty` error, while preserving the live non-empty command path.

## Changes
- Added a command-mode capture guard after tmux `capture-pane` and before writing artifacts.
- Added a focused command-mode regression test using a fake tmux binary that simulates successful launch/cleanup but empty pane captures.
- Recorded RED, focused test, typecheck, real tmux success, fake empty-capture rejection, LOC, and cleanup evidence under `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/`.

## QA & Evidence
- **RED proof:** `bun test script/web-terminal-visual-qa.test.ts` before the production fix exited `1` because the helper returned `0` for an empty capture. Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/red-empty-capture-test.log`.
- **Focused tests:** `bun test script/web-terminal-visual-qa.test.ts script/web-terminal-visual-qa-command.test.ts` exited `0`; 10 tests passed. Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/green-focused-tests.log`.
- **Typecheck:** `bun run typecheck:script` exited `0`. Artifact: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/typecheck-script.log`.
- **Live tmux proof:** `node script/qa/web-terminal-visual-qa.mjs --title "Live Command QA" --command "printf 'webterm-live-ok\n'" --source-label "printf live marker" --evidence-dir .omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-artifacts --dwell-ms 500 --no-browser` exited `0`; `terminal.txt` and `terminal-ansi.txt` are non-empty and contain both `webterm-live-ok` and `[web-terminal-visual-qa exit:0]`. Checks: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/live-command-checks.txt`.
- **Empty capture CLI proof:** `PATH=<fake-empty-tmux> node script/qa/web-terminal-visual-qa.mjs --title "Empty Command QA" --command "printf 'hidden\n'" --source-label "fake empty tmux" --evidence-dir .omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-artifacts --dwell-ms 1 --no-browser` exited `1`; stderr contains `tmux capture was empty`; no bogus evidence files were written. Checks: `.omo/evidence/20260629-prepublish-blocker-fixes/web-terminal-empty-capture/empty-command-checks.txt`.
- **Cleanup receipts:** live proof metadata records `tmux kill-session` and `tmux ls` found no remaining `omo_webterm` session; fake proof removed its temp tmux directory. Artifacts: `live-command-checks.txt`, `empty-command-checks.txt`.

## Risks & Residuals
PNG/browser capture was omitted with `--no-browser`; this blocker is specifically about accepting empty command-mode tmux transcripts, and existing helper tests still cover rendering/file replay behavior. The new guard treats all-whitespace command captures as invalid evidence, which is intentional for QA transcript integrity.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject empty `tmux` captures in command-mode web-terminal QA to prevent bogus evidence. The CLI now exits non-zero with a clear `tmux capture was empty` error; non-empty captures still succeed and cleanup remains unchanged.

- **Bug Fixes**
  - Added a guard in `script/qa/web-terminal-visual-qa.mjs` to validate `tmux capture-pane` output and throw on empty/whitespace-only results.
  - Added a focused regression test `script/web-terminal-visual-qa-command.test.ts` using a stubbed `tmux` that returns an empty capture.

<sup>Written for commit d30f64c689316d9edf7cc79bb0ea9a8986b1c81e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

