### PR TITLE
fix(background-agent): bound incomplete todo completion wait

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -6705,6 +6705,69 @@ describe("BackgroundManager.handleEvent - session.error", () => {
     manager.shutdown()
   })
 
+  test("completes task on session.idle after incomplete-todo grace expires", async () => {
+    //#given
+    const realDateNow = Date.now
+    const baseNow = realDateNow()
+    const sessionID = "ses-idle-incomplete-todos-grace"
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "assistant" },
+              parts: [{ type: "text", text: "valid result" }],
+            },
+          ],
+        }),
+        todo: async () => ({
+          data: [{ id: "todo-1", content: "stale todo", status: "in_progress", priority: "high" }],
+        }),
+      },
+    }
+
+    const manager = new BackgroundManager({ pluginContext: createPluginInput(client) })
+    stubNotifyParentSession(manager)
+
+    const task = createMockTask({
+      id: "task-idle-incomplete-todos-grace",
+      sessionId: sessionID,
+      parentSessionId: "parent-session",
+      parentMessageId: "msg-idle-grace",
+      description: "task with stale incomplete todos",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(baseNow - (MIN_IDLE_TIME_MS + 10)),
+    })
+    getTaskMap(manager).set(task.id, task)
+
+    try {
+      Date.now = () => baseNow
+
+      //#when
+      manager.handleEvent({ type: "session.idle", properties: { sessionID } })
+      await flushBackgroundNotifications()
+
+      //#then - todo-continuation gets the initial grace chance
+      expect(task.status).toBe("running")
+
+      //#when - the task is still idle with valid output after the grace window
+      Date.now = () => baseNow + 30_001
+      manager.handleEvent({ type: "session.idle", properties: { sessionID } })
+      await flushBackgroundNotifications()
+
+      //#then
+      expect(task.status).toBe("completed")
+      expect(task.completedAt).toBeDefined()
+    } finally {
+      Date.now = realDateNow
+      manager.shutdown()
+    }
+  })
+
   test("retry path releases current concurrency slot and prefers current provider in fallback entry", async () => {
     //#given
     const manager = createBackgroundManager()
@@ -7631,6 +7694,68 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
     expect(todoCallCount).toBe(1)
 
     manager.shutdown()
+  })
+
+  test("should complete idle polling task after incomplete-todo grace expires", async () => {
+    //#given
+    const realDateNow = Date.now
+    const baseNow = realDateNow()
+    const sessionID = "session-polling-incomplete-todos-grace"
+    const client = {
+      session: {
+        status: async () => ({ data: { [sessionID]: { type: "idle" } } }),
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "assistant" },
+              parts: [{ type: "text", text: "valid result" }],
+            },
+          ],
+        }),
+        todo: async () => ({
+          data: [{ id: "todo-1", content: "stale todo", status: "in_progress", priority: "high" }],
+        }),
+      },
+    }
+    const manager = new BackgroundManager({ pluginContext: createPluginInput(client) })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-polling-incomplete-todos-grace",
+      sessionId: sessionID,
+      parentSessionId: "parent-session",
+      parentMessageId: "msg-1",
+      description: "idle polling task with stale todos",
+      prompt: "test",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(baseNow - (MIN_IDLE_TIME_MS + 10)),
+    }
+    getTaskMap(manager).set(task.id, task)
+
+    try {
+      Date.now = () => baseNow
+
+      //#when
+      await manager["pollRunningTasks"]()
+
+      //#then - todo-continuation gets the initial grace chance
+      expect(task.status).toBe("running")
+
+      //#when - polling observes the same idle task after the grace window
+      Date.now = () => baseNow + 30_001
+      await manager["pollRunningTasks"]()
+
+      //#then
+      expect(task.status).toBe("completed")
+      expect(task.completedAt).toBeDefined()
+    } finally {
+      Date.now = realDateNow
+      manager.shutdown()
+    }
   })
 })
 

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -149,6 +149,7 @@ const PENDING_PARENT_WAKE_RETRY_MS = 1_000
 const PENDING_PARENT_WAKE_DEBOUNCE_MS = 100
 const PARENT_WAKE_ACCEPTED_MESSAGE_SKEW_MS = 5_000
 const PARENT_WAKE_TOOL_CALL_DEFER_MAX_MS = 5_000
+const INCOMPLETE_TODO_COMPLETION_GRACE_MS = 30_000
 /**
  * Window during which a freshly-arrived user message in the parent session
  * causes a queued parent-wake to defer instead of dispatching. Mitigates the
@@ -272,6 +273,7 @@ export class BackgroundManager {
   private parentWakeTextDeltaBuffers: Map<string, string> = new Map()
   private observedOutputSessions: Set<string> = new Set()
   private observedIncompleteTodosBySession: Map<string, boolean> = new Map()
+  private incompleteTodoCompletionBlockedAtByTask: Map<string, number> = new Map()
   private rootDescendantCounts: Map<string, number>
   private preStartDescendantReservations: Set<string>
   private enableParentSessionNotifications: boolean
@@ -429,6 +431,7 @@ export class BackgroundManager {
   }
 
   private removeTask(task: BackgroundTask): void {
+    this.clearIncompleteTodoCompletionBlock(task)
     this.archiveCompletedTask(task)
     archiveBackgroundTask(task)
     this.tasks.delete(task.id)
@@ -1546,6 +1549,43 @@ The fallback retry session is now created and can be inspected directly.
     this.observedIncompleteTodosBySession.delete(sessionID)
   }
 
+  private clearIncompleteTodoCompletionBlock(task: Pick<BackgroundTask, "id">): void {
+    this.incompleteTodoCompletionBlockedAtByTask.delete(task.id)
+  }
+
+  private shouldDeferForIncompleteTodos(
+    task: BackgroundTask,
+    sessionID: string,
+    source: string,
+  ): boolean {
+    const now = Date.now()
+    const blockedAt = this.incompleteTodoCompletionBlockedAtByTask.get(task.id)
+    if (blockedAt === undefined) {
+      this.incompleteTodoCompletionBlockedAtByTask.set(task.id, now)
+      log("[background-agent] Starting incomplete-todo completion grace:", {
+        taskId: task.id,
+        sessionID,
+        source,
+        graceMs: INCOMPLETE_TODO_COMPLETION_GRACE_MS,
+      })
+      return true
+    }
+
+    const elapsedMs = now - blockedAt
+    if (elapsedMs < INCOMPLETE_TODO_COMPLETION_GRACE_MS) {
+      return true
+    }
+
+    log("[background-agent] Incomplete-todo completion grace expired; allowing completion:", {
+      taskId: task.id,
+      sessionID,
+      source,
+      elapsedMs,
+      graceMs: INCOMPLETE_TODO_COMPLETION_GRACE_MS,
+    })
+    return false
+  }
+
   private messageUpdatedInfoHasParentWakeOutput(info: Record<string, unknown>, role: unknown): boolean {
     if (role === "tool") {
       return true
@@ -1798,6 +1838,12 @@ The fallback retry session is now created and can be inspected directly.
         return status !== "completed" && status !== "cancelled"
       })
       this.observedIncompleteTodosBySession.set(sessionID, hasIncompleteTodos)
+      if (!hasIncompleteTodos) {
+        const resolved = this.resolveTaskAttemptBySession(sessionID)
+        if (resolved?.isCurrent) {
+          this.clearIncompleteTodoCompletionBlock(resolved.task)
+        }
+      }
       return
     }
 
@@ -1818,6 +1864,7 @@ The fallback retry session is now created and can be inspected directly.
         idleDeferralTimers: this.idleDeferralTimers,
         validateSessionHasOutput: (id) => this.validateSessionHasOutput(id),
         checkSessionTodos: (id) => this.checkSessionTodos(id),
+        shouldDeferForIncompleteTodos: (task, id, source) => this.shouldDeferForIncompleteTodos(task, id, source),
         tryCompleteTask: (task, source) => this.tryCompleteTask(task, source),
         emitIdleEvent: (sessionID) => this.handleEvent({ type: "session.idle", properties: { sessionID } }),
       })
@@ -1985,6 +2032,7 @@ The fallback retry session is now created and can be inspected directly.
     if (task.rootSessionId) {
       this.unregisterRootDescendant(task.rootSessionId)
     }
+    this.clearIncompleteTodoCompletionBlock(task)
     this.taskHistory.record(task.parentSessionId, {
       id: task.id,
       sessionID: task.sessionId,
@@ -2099,6 +2147,7 @@ The fallback retry session is now created and can be inspected directly.
     if (task.rootSessionId) {
       this.unregisterRootDescendant(task.rootSessionId)
     }
+    this.clearIncompleteTodoCompletionBlock(task)
     this.taskHistory.record(task.parentSessionId, { id: task.id, sessionID: task.sessionId, agent: task.agent, description: task.description, status: "error", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
 
     if (task.concurrencyKey) {
@@ -2187,6 +2236,7 @@ The task was re-queued on a fallback model after a retryable failure.
       )
     }
     if (retried && previousSessionID) {
+      this.clearIncompleteTodoCompletionBlock(task)
       this.clearSessionOutputObserved(previousSessionID)
       this.clearSessionTodoObservation(previousSessionID)
       clearDelegatedChildSessionBootstrap(previousSessionID)
@@ -2414,6 +2464,7 @@ The task was re-queued on a fallback model after a retryable failure.
     if (wasRunning && task.rootSessionId) {
       this.unregisterRootDescendant(task.rootSessionId)
     }
+    this.clearIncompleteTodoCompletionBlock(task)
     this.taskHistory.record(task.parentSessionId, { id: task.id, sessionID: task.sessionId, agent: task.agent, description: task.description, status: "cancelled", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
 
     if (task.concurrencyKey) {
@@ -2547,6 +2598,7 @@ The task was re-queued on a fallback model after a retryable failure.
       if (task.rootSessionId) {
         this.unregisterRootDescendant(task.rootSessionId)
       }
+      this.clearIncompleteTodoCompletionBlock(task)
 
       removeTaskToastTracking(task.id)
 
@@ -2906,6 +2958,7 @@ The task was re-queued on a fallback model after a retryable failure.
     if (task.rootSessionId) {
       this.unregisterRootDescendant(task.rootSessionId)
     }
+    this.clearIncompleteTodoCompletionBlock(task)
     this.taskHistory.record(task.parentSessionId, { id: task.id, sessionID: task.sessionId, agent: task.agent, description: task.description, status: "error", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
     if (task.concurrencyKey) {
       this.concurrencyManager.release(task.concurrencyKey)
@@ -3047,7 +3100,7 @@ The task was re-queued on a fallback model after a retryable failure.
           if (task.status !== "running") continue
 
           const hasIncompleteTodos = await this.checkSessionTodos(sessionID)
-          if (hasIncompleteTodos) {
+          if (hasIncompleteTodos && this.shouldDeferForIncompleteTodos(task, sessionID, completionSource)) {
             log("[background-agent] Task has incomplete todos via polling, waiting:", task.id)
             continue
           }

--- a/packages/omo-opencode/src/features/background-agent/session-idle-event-handler.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-idle-event-handler.test.ts
@@ -310,6 +310,28 @@ describe("handleSessionIdleBackgroundEvent", () => {
       expect(tryCompleteTask).not.toHaveBeenCalled()
     })
 
+    it("#when incomplete todos no longer defer completion #then should complete task", async () => {
+      //#given
+      const task = createRunningTask()
+      const tryCompleteTask = mock(() => Promise.resolve(true))
+
+      //#when
+      handleSessionIdleBackgroundEvent({
+        properties: { sessionID: task.sessionId! },
+        findBySession: () => task,
+        idleDeferralTimers: new Map(),
+        validateSessionHasOutput: () => Promise.resolve(true),
+        checkSessionTodos: () => Promise.resolve(true),
+        shouldDeferForIncompleteTodos: () => false,
+        tryCompleteTask,
+        emitIdleEvent: () => {},
+      })
+
+      //#then
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      expect(tryCompleteTask).toHaveBeenCalledWith(task, "session.idle event")
+    })
+
     it("#when task status changes during validation #then should not complete task", async () => {
       //#given
       const task = createRunningTask()

--- a/packages/omo-opencode/src/features/background-agent/session-idle-event-handler.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-idle-event-handler.ts
@@ -9,6 +9,7 @@ export function handleSessionIdleBackgroundEvent(args: {
   idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>>
   validateSessionHasOutput: (sessionID: string) => Promise<boolean>
   checkSessionTodos: (sessionID: string) => Promise<boolean>
+  shouldDeferForIncompleteTodos?: (task: BackgroundTask, sessionID: string, source: string) => boolean
   tryCompleteTask: (task: BackgroundTask, source: string) => Promise<boolean>
   emitIdleEvent: (sessionID: string) => void
 }): void {
@@ -18,6 +19,7 @@ export function handleSessionIdleBackgroundEvent(args: {
     idleDeferralTimers,
     validateSessionHasOutput,
     checkSessionTodos,
+    shouldDeferForIncompleteTodos,
     tryCompleteTask,
     emitIdleEvent,
   } = args
@@ -76,7 +78,8 @@ export function handleSessionIdleBackgroundEvent(args: {
         return
       }
 
-      if (hasIncompleteTodos) {
+      const completionSource = "session.idle event"
+      if (hasIncompleteTodos && (shouldDeferForIncompleteTodos?.(task, sessionID, completionSource) ?? true)) {
         log("[background-agent] Task has incomplete todos, waiting for todo-continuation:", task.id)
         return
       }
@@ -89,7 +92,7 @@ export function handleSessionIdleBackgroundEvent(args: {
         return
       }
 
-      await tryCompleteTask(task, "session.idle event")
+      await tryCompleteTask(task, completionSource)
     })
     .catch((err) => {
       log("[background-agent] Error in session.idle handler:", err)


### PR DESCRIPTION
## Summary
- Fixes #5573.
- Adds a bounded 30s grace window when a background task is idle with valid assistant output but still has incomplete todos, so todo-continuation gets an initial chance to resume work without letting stale todo state hang the task indefinitely.
- Applies the same grace decision to both `session.idle` completion and polling completion, and clears the grace state when tasks finish, fail, cancel, retry, or todos become complete.

## Verification
- `bun test packages/omo-opencode/src/features/background-agent/session-idle-event-handler.test.ts packages/omo-opencode/src/features/background-agent/manager.test.ts` (208 pass, 0 fail)
- `bun run typecheck:packages`
- `git diff --check`

## OpenCode QA evidence
- Evidence directory: `.omo/evidence/20260629-bg-task-incomplete-todos-5573/`
- `strict-qa-final-audit.txt` records the Windows PowerShell fallback for `opencode-qa` Case B because host `bash` resolves to a broken WSL shim and Git Bash was unavailable.
- Strict sandbox proof: `HOME`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `XDG_*`, and `OPENCODE_CONFIG_DIR` all pointed under the evidence sandbox.
- Runtime proof captured: `/global/health` healthy, `/doc` exposes 156 paths, unauthenticated `/session` returns 401, SSE emits `server.connected`, `/agent` includes OMO agents, no duplicate plugin warning, and real OpenCode DB count remained unchanged before/after (`3368`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents background tasks from hanging when a session is idle with valid output but still has incomplete todos by adding a 30s grace window before allowing completion. Applies to both `session.idle` events and polling, addressing Linear #5573.

- **Bug Fixes**
  - Add a per-task 30s grace timer that starts when incomplete todos are first detected.
  - Use the same defer/complete logic in `session.idle` handling and the polling path.
  - Clear the grace state when todos resolve or when tasks complete, error, cancel, retry, or are removed.

<sup>Written for commit 5b056c65501ce728cf4ff4cc79f11f6a9c956bea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

