### PR TITLE
fix(codex): route doctor through Windows cmd shim

### DIFF
--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -6431,7 +6431,7 @@ function whereCommand(command) {
   }
 }
 // packages/omo-codex/src/install/codex-process.ts
-var WINDOWS_CMD_SHIM_COMMANDS = new Set(["npm", "npx"]);
+var WINDOWS_CMD_SHIM_COMMANDS = new Set(["codex", "npm", "npx"]);
 function resolveRunCommandInvocation(command, args, platform = process.platform) {
   if (platform !== "win32" || !WINDOWS_CMD_SHIM_COMMANDS.has(command.toLowerCase())) {
     return { command, args: [...args] };

--- a/packages/omo-codex/src/install/codex-process.test.ts
+++ b/packages/omo-codex/src/install/codex-process.test.ts
@@ -19,6 +19,21 @@ describe("codex-process", () => {
     })
   })
 
+  test("#given Windows codex command #when resolving run command invocation #then uses cmd shim", () => {
+    // given
+    const command = "codex"
+    const args = ["exec", "doctor"] as const
+
+    // when
+    const invocation = resolveRunCommandInvocation(command, args, "win32")
+
+    // then
+    expect(invocation).toEqual({
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", "codex.cmd", "exec", "doctor"],
+    })
+  })
+
   test("#given non-Windows npm command #when resolving run command invocation #then preserves direct execution", () => {
     // given
     const command = "npm"

--- a/packages/omo-codex/src/install/codex-process.ts
+++ b/packages/omo-codex/src/install/codex-process.ts
@@ -1,7 +1,7 @@
 import { spawn } from "../../../omo-opencode/src/shared/bun-spawn-shim"
 import type { RunCommand } from "./types"
 
-const WINDOWS_CMD_SHIM_COMMANDS = new Set(["npm", "npx"])
+const WINDOWS_CMD_SHIM_COMMANDS = new Set(["codex", "npm", "npx"])
 
 export type RunCommandInvocation = {
   readonly command: string


### PR DESCRIPTION
## Problem

On Windows, `lazycodex-ai doctor` delegates to `codex exec`, but npm-installed CLIs commonly surface as `.cmd` shims. The LazyCodex installer command runner only routed `npm` and `npx` through `cmd.exe /d /s /c <name>.cmd`, so the doctor path could try to spawn `codex` directly instead of `codex.cmd`.

## Fix

- Include `codex` in the Windows cmd-shim handling for the Codex installer command runner.
- Add a regression test for `resolveRunCommandInvocation("codex", ["exec", "doctor"], "win32")`.
- Regenerate `packages/omo-codex/scripts/install-dist/install-local.mjs` with `bun run build:codex-install`.

## Verification

- RED: `bun test packages/omo-codex/src/install/codex-process.test.ts` failed before the production change because the Windows `codex` invocation stayed direct (`command: "codex"`).
- GREEN: `bun test packages/omo-codex/src/install/codex-process.test.ts` passed after the fix (`4 pass`).
- Generated bundle: `bun run build:codex-install` regenerated the installer bundle and the generated allowlist includes `codex`.
- Script tests: `node --test packages/omo-codex/scripts/install-generated-bundle.test.mjs packages/omo-codex/scripts/install-delegated-command.test.mjs` passed (`9 pass`).
- Typecheck: `bun run --cwd packages/omo-codex typecheck` passed.
- Real-surface proof: drove the generated installer CLI export with a fake `codex.cmd` first on `PATH`; `lazycodex doctor --json` invoked the shim and captured `codex.cmd exec --ephemeral --sandbox read-only ... Requested doctor arguments: --json`.
- Isolated install QA: `CODEX_HOME` and `CODEX_LOCAL_BIN_DIR` pointed at a temp directory, `node packages/omo-codex/scripts/install-local.mjs install --no-tui --codex-autonomous` installed `omo@sisyphuslabs`, and the real `~/.codex/config.toml` hash was unchanged.

Note: a broader focused Bun subset including packaged/Linux-simulation installer tests hit existing Windows symlink `EPERM` failures unrelated to this change; the new codex-process test passed in that same run.

## Risk

Narrow Windows CLI spawn path. Existing `npm` and `npx` behavior is preserved; non-Windows `codex` execution remains direct.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows execution of `lazycodex-ai doctor` by routing `codex` through the `.cmd` shim (`cmd.exe /d /s /c codex.cmd`). This prevents direct `codex` spawns and makes the doctor command reliable on Windows.

- **Bug Fixes**
  - Route `codex` via the Windows cmd shim by adding it to the allowlist in the installer runner.
  - Add a regression test for the Windows invocation and regenerate the installer bundle.

<sup>Written for commit 0763b7d18f67b5a85ef2fde20f03b48a61891adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

