### PR TITLE
test(release): clean PR 5740 evidence whitespace

### DIFF
--- a/.omo/evidence/20260629-windows-async-test-timeouts/green-root-bun-test.log
+++ b/.omo/evidence/20260629-windows-async-test-timeouts/green-root-bun-test.log
@@ -9425,7 +9425,7 @@ packages/omo-opencode/src/cli/run/events.test.ts:
 (pass) event handling > message.updated with camelCase sessionId sets hasReceivedMeaningfulWork [0.07ms]
 (pass) event handling > message.updated with user role does not set hasReceivedMeaningfulWork [0.08ms]
 
-  ⚙ read_file filePath=/src/index.ts  
+  ⚙ read_file filePath=/src/index.ts
 (pass) event handling > tool.execute sets hasReceivedMeaningfulWork [0.08ms]
 (pass) event handling > tool.execute from different session does not set hasReceivedMeaningfulWork [0.07ms]
 (pass) event handling > session.status with busy type sets mainSessionIdle to false [0.07ms]

--- a/.omo/evidence/20260629-windows-async-test-timeouts/pr-5740-ci-watch.log
+++ b/.omo/evidence/20260629-windows-async-test-timeouts/pr-5740-ci-watch.log
@@ -1,919 +1,919 @@
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-label-pull-request	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+label-pull-request	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-lazycodex-published-smoke	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+lazycodex-published-smoke	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+typecheck (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+build	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+codex-compatibility (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+codex-compatibility (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+test (macos-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+codex-compatibility (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
 
-GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com	
-block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595	
-build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599	
-cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425	
-codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593	
-codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601	
-codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588	
-ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469	
-label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975	
-lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585	
-test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592	
-test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580	
-typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606	
-typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598	
-typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597	
-cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740	
-label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328	
-test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583	
+GitGuardian Security Checks	pass	0	https://dashboard.gitguardian.com
+block-master-pr	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971595
+build	pass	2m11s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971599
+cla	pass	8s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704498/job/83979971425
+codex-compatibility (macos-latest)	pass	2m13s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971593
+codex-compatibility (ubuntu-latest)	pass	2m25s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971601
+codex-compatibility (windows-latest)	pass	5m51s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971588
+ensure-labels	pass	6s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979971469
+label-pull-request	pass	4s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979986975
+lazycodex-published-smoke	pass	21s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971585
+test (macos-latest)	pass	3m35s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971592
+test (ubuntu-latest)	pass	3m31s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971580
+typecheck (macos-latest)	pass	1m44s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971606
+typecheck (ubuntu-latest)	pass	1m30s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971598
+typecheck (windows-latest)	pass	2m56s	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971597
+cubic · AI code reviewer	skipping	1s	https://www.cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5740
+label-issue	skipping	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704495/job/83979987328
+test (windows-latest)	pending	0	https://github.com/code-yeongyu/oh-my-openagent/actions/runs/28349704505/job/83979971583

--- a/.omo/evidence/20260629-windows-async-test-timeouts/red-windows-ci-run-28348775396-filtered.log
+++ b/.omo/evidence/20260629-windows-async-test-timeouts/red-windows-ci-run-28348775396-filtered.log
@@ -1,9 +1,9 @@
 COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 1660-test (windows-latest)	Run tests	2026-06-29T04:35:51.5151464Z (pass) validateOmoConfig > exposes harness ids and codegraph setting applicability metadata
 1661-test (windows-latest)	Run tests	2026-06-29T04:35:51.5163086Z (pass) validateOmoConfig > flags settings used under unsupported harness blocks
-1662-test (windows-latest)	Run tests	2026-06-29T04:35:51.5176428Z 
+1662-test (windows-latest)	Run tests	2026-06-29T04:35:51.5176428Z
 1663-test (windows-latest)	Run tests	2026-06-29T04:35:51.5176852Z ##[endgroup]
-1664-test (windows-latest)	Run tests	2026-06-29T04:35:51.5176984Z 
+1664-test (windows-latest)	Run tests	2026-06-29T04:35:51.5176984Z
 1665-test (windows-latest)	Run tests	2026-06-29T04:35:51.5177271Z ##[group]packages\utils\src\port-utils.test.ts:
 1666-test (windows-latest)	Run tests	2026-06-29T04:35:51.5513421Z (pass) port-utils > #given isPortAvailable > #when a released port is checked #then returns true [31.00ms]
 1667-test (windows-latest)	Run tests	2026-06-29T04:35:51.5829064Z (pass) port-utils > #given isPortAvailable > #when an already bound port is checked #then returns false [32.00ms]
@@ -18,37 +18,37 @@ COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 1676-test (windows-latest)	Run tests	2026-06-29T04:35:53.1337014Z (pass) port-utils > #given getAvailableServerPort > #when the preferred port is blocked #then returns the next port with auto-selection [93.00ms]
 --
 3266-test (windows-latest)	Run tests	2026-06-29T04:37:13.3468193Z (pass) createWebsearchConfig Exa handling > uses unauthenticated Exa URL when EXA_API_KEY is missing [15.00ms]
-3267-test (windows-latest)	Run tests	2026-06-29T04:37:13.3468857Z 
+3267-test (windows-latest)	Run tests	2026-06-29T04:37:13.3468857Z
 3268-test (windows-latest)	Run tests	2026-06-29T04:37:13.3469174Z ##[endgroup]
-3269-test (windows-latest)	Run tests	2026-06-29T04:37:13.3469312Z 
+3269-test (windows-latest)	Run tests	2026-06-29T04:37:13.3469312Z
 3270-test (windows-latest)	Run tests	2026-06-29T04:37:13.3469775Z ##[group]packages\omo-opencode\src\openclaw\gateway-url-validation.test.ts:
-3271-test (windows-latest)	Run tests	2026-06-29T04:37:13.3470457Z 
+3271-test (windows-latest)	Run tests	2026-06-29T04:37:13.3470457Z
 3272-test (windows-latest)	Run tests	2026-06-29T04:37:13.3470855Z ##[endgroup]
-3273-test (windows-latest)	Run tests	2026-06-29T04:37:13.3471053Z 
+3273-test (windows-latest)	Run tests	2026-06-29T04:37:13.3471053Z
 3274:test (windows-latest)	Run tests	2026-06-29T04:37:13.3471728Z ##[group]packages\omo-opencode\src\plugin\build-team-idle-wake-hint-client.test.ts:
 3275-test (windows-latest)	Run tests	2026-06-29T04:37:13.3513880Z (pass) buildTeamIdleWakeHintClient > #given a real-SDK-like session whose promptAsync reads this._client #when the wrapper dispatches the bound method #then the SDK receives the call with _client preserved
 3276-test (windows-latest)	Run tests	2026-06-29T04:37:13.3526980Z (pass) buildTeamIdleWakeHintClient > #given a real-SDK-like session whose status reads this._client #when the wrapper dispatches the bound status #then _client is preserved
 3277-test (windows-latest)	Run tests	2026-06-29T04:37:13.3539473Z (pass) buildTeamIdleWakeHintClient > #given a session without optional methods #when the wrapper is built #then it gracefully exposes undefined entries
 3278-test (windows-latest)	Run tests	2026-06-29T04:37:13.3553282Z (pass) buildTeamIdleWakeHintClient > #given a destructure-without-bind pattern #when promptAsync is invoked via a plain wrapper #then this._client is undefined (historical bug)
-3279-test (windows-latest)	Run tests	2026-06-29T04:37:13.3554351Z 
+3279-test (windows-latest)	Run tests	2026-06-29T04:37:13.3554351Z
 3280-test (windows-latest)	Run tests	2026-06-29T04:37:13.3554669Z ##[endgroup]
-3281-test (windows-latest)	Run tests	2026-06-29T04:37:13.3554823Z 
+3281-test (windows-latest)	Run tests	2026-06-29T04:37:13.3554823Z
 3282-test (windows-latest)	Run tests	2026-06-29T04:37:13.3555239Z ##[group]packages\omo-opencode\src\plugin\chat-headers.test.ts:
 --
-9838-test (windows-latest)	Run tests	2026-06-29T04:38:38.8473233Z 
+9838-test (windows-latest)	Run tests	2026-06-29T04:38:38.8473233Z
 9839-test (windows-latest)	Run tests	2026-06-29T04:38:38.8473612Z ##[endgroup]
-9840-test (windows-latest)	Run tests	2026-06-29T04:38:38.8473790Z 
+9840-test (windows-latest)	Run tests	2026-06-29T04:38:38.8473790Z
 9841-test (windows-latest)	Run tests	2026-06-29T04:38:38.8474364Z ##[group]packages\omo-opencode\src\hooks\atlas\compaction-agent-filter.test.ts:
 9842-test (windows-latest)	Run tests	2026-06-29T04:38:39.0082486Z (pass) atlas hook compaction agent filtering > should inject continuation when the latest message is compaction but the previous agent matches atlas [156.00ms]
-9843-test (windows-latest)	Run tests	2026-06-29T04:38:39.0083481Z 
+9843-test (windows-latest)	Run tests	2026-06-29T04:38:39.0083481Z
 9844-test (windows-latest)	Run tests	2026-06-29T04:38:39.0083839Z ##[endgroup]
-9845-test (windows-latest)	Run tests	2026-06-29T04:38:39.0083992Z 
+9845-test (windows-latest)	Run tests	2026-06-29T04:38:39.0083992Z
 9846:test (windows-latest)	Run tests	2026-06-29T04:38:39.0084598Z ##[group]packages\omo-opencode\src\hooks\atlas\final-wave-approval-gate-regression.test.ts:
 9847-test (windows-latest)	Run tests	2026-06-29T04:38:39.0541664Z (pass) Atlas final-wave approval gate regressions > waits for approval when nested plan checkboxes remain but the only pending top-level task is final-wave [47.00ms]
 9848-test (windows-latest)	Run tests	2026-06-29T04:38:39.1798153Z (pass) Atlas final-wave approval gate regressions > waits for approval after the final parallel reviewer approves before plan checkboxes are updated [125.00ms]
-9849-test (windows-latest)	Run tests	2026-06-29T04:38:39.1799147Z 
+9849-test (windows-latest)	Run tests	2026-06-29T04:38:39.1799147Z
 9850-test (windows-latest)	Run tests	2026-06-29T04:38:39.1799509Z ##[endgroup]
-9851-test (windows-latest)	Run tests	2026-06-29T04:38:39.1799647Z 
+9851-test (windows-latest)	Run tests	2026-06-29T04:38:39.1799647Z
 9852:test (windows-latest)	Run tests	2026-06-29T04:38:39.1800100Z ##[group]packages\omo-opencode\src\hooks\atlas\final-wave-approval-gate.test.ts:
 9853-test (windows-latest)	Run tests	2026-06-29T04:38:39.1903455Z (pass) classifyFinalWaveVerdict > returns approve when the output carries an APPROVE verdict
 9854-test (windows-latest)	Run tests	2026-06-29T04:38:39.1912329Z (pass) classifyFinalWaveVerdict > returns reject when the output carries a REJECT verdict
@@ -62,31 +62,31 @@ COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 9862:test (windows-latest)	Run tests	2026-06-29T04:38:44.2493515Z (fail) Atlas final verification approval gate > pauses for escalation when a final-wave reviewer rejects [5016.00ms]
 9863:test (windows-latest)	Run tests	2026-06-29T04:38:44.2494637Z   ^ this test timed out after 5000ms.
 9864:test (windows-latest)	Run tests	2026-06-29T04:38:44.2826513Z (pass) Atlas final verification approval gate > keeps normal auto-continue instructions for non-final tasks [31.00ms]
-9865-test (windows-latest)	Run tests	2026-06-29T04:38:44.2827050Z 
+9865-test (windows-latest)	Run tests	2026-06-29T04:38:44.2827050Z
 9866-test (windows-latest)	Run tests	2026-06-29T04:38:44.2827342Z ##[endgroup]
-9867-test (windows-latest)	Run tests	2026-06-29T04:38:44.2827461Z 
+9867-test (windows-latest)	Run tests	2026-06-29T04:38:44.2827461Z
 9868-test (windows-latest)	Run tests	2026-06-29T04:38:44.2827823Z ##[group]packages\omo-opencode\src\hooks\atlas\idle-continuation.test.ts:
 9869-test (windows-latest)	Run tests	2026-06-29T04:38:44.2923415Z (pass) scheduleRetry > #given retry timer callback throws #when retry fires #then failure is recorded and retry is rearmed
-9870-test (windows-latest)	Run tests	2026-06-29T04:38:44.2924166Z 
+9870-test (windows-latest)	Run tests	2026-06-29T04:38:44.2924166Z
 9871-test (windows-latest)	Run tests	2026-06-29T04:38:44.2924505Z ##[endgroup]
-9872-test (windows-latest)	Run tests	2026-06-29T04:38:44.2924665Z 
+9872-test (windows-latest)	Run tests	2026-06-29T04:38:44.2924665Z
 --
 12022-test (windows-latest)	Run tests	2026-06-29T04:39:27.5255301Z (pass) createTeamModeStatusInjector > does not inject again when the team mode status was already added
 12023-test (windows-latest)	Run tests	2026-06-29T04:39:27.5266440Z (pass) createTeamModeStatusInjector > does nothing when team mode is disabled
 12024-test (windows-latest)	Run tests	2026-06-29T04:39:27.5277203Z (pass) createTeamModeStatusInjector > does not inject team mode status for punctuation-only prompts
 12025-test (windows-latest)	Run tests	2026-06-29T04:39:27.5287907Z (pass) createTeamModeStatusInjector > does not inject team mode status for synthetic team prompts
 12026-test (windows-latest)	Run tests	2026-06-29T04:39:27.5298417Z (pass) createTeamModeStatusInjector > does not inject team mode status when the team keyword is disabled
-12027-test (windows-latest)	Run tests	2026-06-29T04:39:27.5299597Z 
+12027-test (windows-latest)	Run tests	2026-06-29T04:39:27.5299597Z
 12028-test (windows-latest)	Run tests	2026-06-29T04:39:27.5300060Z ##[endgroup]
-12029-test (windows-latest)	Run tests	2026-06-29T04:39:27.5300279Z 
+12029-test (windows-latest)	Run tests	2026-06-29T04:39:27.5300279Z
 12030:test (windows-latest)	Run tests	2026-06-29T04:39:27.5301140Z ##[group]packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint-delivering-loss.test.ts:
 12031-test (windows-latest)	Run tests	2026-06-29T04:39:28.5892483Z (pass) issue #5101 - pending live delivery must not be silently lost on idle-ack > #given a reserved (.delivering-) message pending injection that never reached the recipient #when the recipient idles #then the message stays recoverable by poll-injection [1063.00ms]
 12032-test (windows-latest)	Run tests	2026-06-29T04:39:30.0439984Z (pass) issue #5101 - pending live delivery must not be silently lost on idle-ack > #given the client cannot read session history #when the recipient idles #then the prior ack-all behavior is preserved (loss-safe fallback unavailable) [1453.00ms]
-12033-test (windows-latest)	Run tests	2026-06-29T04:39:30.0440970Z 
+12033-test (windows-latest)	Run tests	2026-06-29T04:39:30.0440970Z
 12034-test (windows-latest)	Run tests	2026-06-29T04:39:30.0441270Z ##[endgroup]
-12035-test (windows-latest)	Run tests	2026-06-29T04:39:30.0441398Z 
+12035-test (windows-latest)	Run tests	2026-06-29T04:39:30.0441398Z
 12036:test (windows-latest)	Run tests	2026-06-29T04:39:30.0441838Z ##[group]packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint-leader.test.ts:
-12037-test (windows-latest)	Run tests	2026-06-29T04:39:35.1071152Z 
+12037-test (windows-latest)	Run tests	2026-06-29T04:39:35.1071152Z
 12038:test (windows-latest)	Run tests	2026-06-29T04:39:35.1071847Z # Unhandled error between tests
 12039-test (windows-latest)	Run tests	2026-06-29T04:39:35.1072550Z -------------------------------
 12040-test (windows-latest)	Run tests	2026-06-29T04:39:35.1075564Z 200 |       await fileHandle.writeFile(content)
@@ -100,14 +100,14 @@ COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 12050-test (windows-latest)	Run tests	2026-06-29T04:39:35.1087352Z  syscall: "rename",
 12051-test (windows-latest)	Run tests	2026-06-29T04:39:35.1087564Z    errno: -2,
 12052-test (windows-latest)	Run tests	2026-06-29T04:39:35.1087759Z     code: "ENOENT"
-12053-test (windows-latest)	Run tests	2026-06-29T04:39:35.1087883Z 
+12053-test (windows-latest)	Run tests	2026-06-29T04:39:35.1087883Z
 12054-test (windows-latest)	Run tests	2026-06-29T04:39:35.1088310Z       at async atomicWrite (D:\a\oh-my-openagent\oh-my-openagent\packages\team-core\src\team-state-store\locks.ts:205:11)
 12055-test (windows-latest)	Run tests	2026-06-29T04:39:35.1089489Z       at async <anonymous> (D:\a\oh-my-openagent\oh-my-openagent\packages\team-core\src\team-mailbox\send.ts:172:13)
 12056-test (windows-latest)	Run tests	2026-06-29T04:39:35.1090422Z       at async withLock (D:\a\oh-my-openagent\oh-my-openagent\packages\team-core\src\team-state-store\locks.ts:147:18)
 12057-test (windows-latest)	Run tests	2026-06-29T04:39:35.1091247Z       at async sendMessage (D:\a\oh-my-openagent\oh-my-openagent\packages\team-core\src\team-mailbox\send.ts:158:11)
 12058:test (windows-latest)	Run tests	2026-06-29T04:39:35.1092286Z       at async sendCompletionToLead (D:\a\oh-my-openagent\oh-my-openagent\packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint-leader.test.ts:84:9)
 12059:test (windows-latest)	Run tests	2026-06-29T04:39:35.1093838Z       at async <anonymous> (D:\a\oh-my-openagent\oh-my-openagent\packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint-leader.test.ts:126:13)
-12060-test (windows-latest)	Run tests	2026-06-29T04:39:35.1094467Z 
+12060-test (windows-latest)	Run tests	2026-06-29T04:39:35.1094467Z
 12061-test (windows-latest)	Run tests	2026-06-29T04:39:35.1108069Z ##[error]
 12062-test (windows-latest)	Run tests	      at async atomicWrite (D:\a\oh-my-openagent\oh-my-openagent\packages\team-core\src\team-state-store\locks.ts:205:11)
 12063-test (windows-latest)	Run tests	      at async <anonymous> (D:\a\oh-my-openagent\oh-my-openagent\packages\team-core\src\team-mailbox\send.ts:172:13)
@@ -116,18 +116,18 @@ COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 12066:test (windows-latest)	Run tests	      at async sendCompletionToLead (D:\a\oh-my-openagent\oh-my-openagent\packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint-leader.test.ts:84:9)
 12067:test (windows-latest)	Run tests	      at async <anonymous> (D:\a\oh-my-openagent\oh-my-openagent\packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint-leader.test.ts:126:13)
 12068-test (windows-latest)	Run tests	2026-06-29T04:39:35.1115858Z -------------------------------
-12069-test (windows-latest)	Run tests	2026-06-29T04:39:35.1116186Z 
+12069-test (windows-latest)	Run tests	2026-06-29T04:39:35.1116186Z
 12070:test (windows-latest)	Run tests	2026-06-29T04:39:35.1119178Z (fail) createTeamIdleWakeHint leader delivery > #given repeated member completions to an idle leader #when each cycle idles after delivery #then every completion wakes the leader [5062.00ms]
 12071:test (windows-latest)	Run tests	2026-06-29T04:39:35.1120055Z   ^ this test timed out after 5000ms.
-12072-test (windows-latest)	Run tests	2026-06-29T04:39:35.1120253Z 
+12072-test (windows-latest)	Run tests	2026-06-29T04:39:35.1120253Z
 12073-test (windows-latest)	Run tests	2026-06-29T04:39:35.1120508Z ##[endgroup]
-12074-test (windows-latest)	Run tests	2026-06-29T04:39:35.1120631Z 
+12074-test (windows-latest)	Run tests	2026-06-29T04:39:35.1120631Z
 12075:test (windows-latest)	Run tests	2026-06-29T04:39:35.1121149Z ##[group]packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint-pending-delivery-verify.test.ts:
 12076-test (windows-latest)	Run tests	2026-06-29T04:39:36.2419452Z (pass) team idle-wake-hint pending live-delivery verification > unconfirmed pending message (absent from session history) is requeued to inbox, not acked/lost [1125.00ms]
 12077-test (windows-latest)	Run tests	2026-06-29T04:39:37.4735674Z (pass) team idle-wake-hint pending live-delivery verification > confirmed pending message (envelope present in session history) is acked to processed/ [1219.00ms]
-12078-test (windows-latest)	Run tests	2026-06-29T04:39:37.4737246Z 
+12078-test (windows-latest)	Run tests	2026-06-29T04:39:37.4737246Z
 12079-test (windows-latest)	Run tests	2026-06-29T04:39:37.4737802Z ##[endgroup]
-12080-test (windows-latest)	Run tests	2026-06-29T04:39:37.4738038Z 
+12080-test (windows-latest)	Run tests	2026-06-29T04:39:37.4738038Z
 12081:test (windows-latest)	Run tests	2026-06-29T04:39:37.4738812Z ##[group]packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint.test.ts:
 12082:test (windows-latest)	Run tests	2026-06-29T04:39:38.8592573Z (pass) createTeamIdleWakeHint > settles idle before sending the wake hint [1375.00ms]
 12083:test (windows-latest)	Run tests	2026-06-29T04:39:41.1496900Z (pass) createTeamIdleWakeHint > sends a trigger-only wake hint when new unread mail exists [2297.00ms]
@@ -138,29 +138,29 @@ COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 12088:test (windows-latest)	Run tests	2026-06-29T04:39:51.1942939Z (pass) createTeamIdleWakeHint > omits agent and model on the wake-hint promptAsync when the member has none recorded [1500.00ms]
 12089:test (windows-latest)	Run tests	2026-06-29T04:39:56.8036477Z (fail) createTeamIdleWakeHint > acks pending messages on idle, moves files to processed, and clears pending ids [5609.00ms]
 12090:test (windows-latest)	Run tests	2026-06-29T04:39:56.8037630Z   ^ this test timed out after 5000ms.
-12091-test (windows-latest)	Run tests	2026-06-29T04:39:58.0474974Z 
+12091-test (windows-latest)	Run tests	2026-06-29T04:39:58.0474974Z
 12092:test (windows-latest)	Run tests	2026-06-29T04:39:58.0475567Z # Unhandled error between tests
 12093-test (windows-latest)	Run tests	2026-06-29T04:39:58.0475962Z -------------------------------
 12094-test (windows-latest)	Run tests	2026-06-29T04:39:58.0476493Z 518 |         properties: { sessionID: "member-session" },
 12095-test (windows-latest)	Run tests	2026-06-29T04:39:58.0476977Z 519 |       },
 12096-test (windows-latest)	Run tests	2026-06-29T04:39:58.0477181Z 520 |     })
-12097-test (windows-latest)	Run tests	2026-06-29T04:39:58.0477367Z 521 | 
+12097-test (windows-latest)	Run tests	2026-06-29T04:39:58.0477367Z 521 |
 12098-test (windows-latest)	Run tests	2026-06-29T04:39:58.0477563Z 522 |     // then
 12099-test (windows-latest)	Run tests	2026-06-29T04:39:58.0477861Z 523 |     expect(ackSpy).toHaveBeenCalledTimes(1)
 12100-test (windows-latest)	Run tests	2026-06-29T04:39:58.0478177Z                          ^
 12101-test (windows-latest)	Run tests	2026-06-29T04:39:58.0478542Z error: expect(received).toHaveBeenCalledTimes(expected)
-12102-test (windows-latest)	Run tests	2026-06-29T04:39:58.0478900Z 
+12102-test (windows-latest)	Run tests	2026-06-29T04:39:58.0478900Z
 12103-test (windows-latest)	Run tests	2026-06-29T04:39:58.0479081Z Expected number of calls: 1
 12104-test (windows-latest)	Run tests	2026-06-29T04:39:58.0479552Z Received number of calls: 0
-12105-test (windows-latest)	Run tests	2026-06-29T04:39:58.0479709Z 
+12105-test (windows-latest)	Run tests	2026-06-29T04:39:58.0479709Z
 12106:test (windows-latest)	Run tests	2026-06-29T04:39:58.0480287Z       at <anonymous> (D:\a\oh-my-openagent\oh-my-openagent\packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint.test.ts:523:20)
-12107-test (windows-latest)	Run tests	2026-06-29T04:39:58.0480902Z 
+12107-test (windows-latest)	Run tests	2026-06-29T04:39:58.0480902Z
 12108-test (windows-latest)	Run tests	2026-06-29T04:39:58.0483045Z ##[error]Expected number of calls: 1
 12109-test (windows-latest)	Run tests	Received number of calls: 0
-12110-test (windows-latest)	Run tests	
+12110-test (windows-latest)	Run tests
 12111:test (windows-latest)	Run tests	      at <anonymous> (D:\a\oh-my-openagent\oh-my-openagent\packages\omo-opencode\src\hooks\team-session-events\team-idle-wake-hint.test.ts:523:20)
 12112-test (windows-latest)	Run tests	2026-06-29T04:39:58.0485233Z -------------------------------
-12113-test (windows-latest)	Run tests	2026-06-29T04:39:58.0485427Z 
+12113-test (windows-latest)	Run tests	2026-06-29T04:39:58.0485427Z
 12114:test (windows-latest)	Run tests	2026-06-29T04:40:00.7352229Z (pass) createTeamIdleWakeHint > acks pending reserved live-delivery messages on idle [3922.00ms]
 12115:test (windows-latest)	Run tests	2026-06-29T04:40:03.0145412Z (pass) createTeamIdleWakeHint > #given stale idle while pending live delivery is still busy #when idle wake runs #then it keeps the reservation pending [2281.00ms]
 12116:test (windows-latest)	Run tests	2026-06-29T04:40:07.0484640Z (pass) createTeamIdleWakeHint > #given pending live delivery is requeued by session.error #when stale idle handler continues #then it does not ack the requeued message [4032.00ms]
@@ -168,28 +168,28 @@ COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 12118:test (windows-latest)	Run tests	2026-06-29T04:40:14.3788035Z (pass) createTeamIdleWakeHint > acks pending lead messages on idle without sending a wake hint [3500.00ms]
 12119:test (windows-latest)	Run tests	2026-06-29T04:40:15.4885575Z (pass) createTeamIdleWakeHint > sends a wake hint during the spawn race when the registry tracks the fresh member session before disk state persists it [1109.00ms]
 12120:test (windows-latest)	Run tests	2026-06-29T04:40:18.9153190Z (pass) createTeamIdleWakeHint > falls back to disk lookup when the registry points the member session at the wrong teamRunId [3438.00ms]
-12121-test (windows-latest)	Run tests	2026-06-29T04:40:18.9154219Z 
+12121-test (windows-latest)	Run tests	2026-06-29T04:40:18.9154219Z
 12122-test (windows-latest)	Run tests	2026-06-29T04:40:18.9154717Z ##[endgroup]
-12123-test (windows-latest)	Run tests	2026-06-29T04:40:18.9154909Z 
+12123-test (windows-latest)	Run tests	2026-06-29T04:40:18.9154909Z
 12124-test (windows-latest)	Run tests	2026-06-29T04:40:18.9155673Z ##[group]packages\omo-opencode\src\hooks\team-session-events\team-lead-orphan-handler.test.ts:
 12125-test (windows-latest)	Run tests	2026-06-29T04:40:20.7608616Z (pass) createTeamLeadOrphanHandler > #given the deleted session matches the lead #when the orphan handler runs #then it marks the team orphaned and force-deletes the team [1843.00ms]
 12126-test (windows-latest)	Run tests	2026-06-29T04:40:21.8333802Z (pass) createTeamLeadOrphanHandler > #given the registry tracks a fresh lead session before disk state persists it #when the orphan handler runs #then it still marks the team orphaned and force-deletes it [1063.00ms]
 12127-test (windows-latest)	Run tests	2026-06-29T04:40:23.2599964Z (pass) createTeamLeadOrphanHandler > #given the registry points the lead session at the wrong teamRunId #when the orphan handler runs #then it falls back to disk lookup, orphans the correct team, and force-deletes it [1437.00ms]
-12128-test (windows-latest)	Run tests	2026-06-29T04:40:23.2601014Z 
+12128-test (windows-latest)	Run tests	2026-06-29T04:40:23.2601014Z
 12129-test (windows-latest)	Run tests	2026-06-29T04:40:23.2601345Z ##[endgroup]
-12130-test (windows-latest)	Run tests	2026-06-29T04:40:23.2601470Z 
+12130-test (windows-latest)	Run tests	2026-06-29T04:40:23.2601470Z
 12131:test (windows-latest)	Run tests	2026-06-29T04:40:23.2601935Z ##[group]packages\omo-opencode\src\hooks\team-session-events\team-member-error-handler.test.ts:
 12132:test (windows-latest)	Run tests	2026-06-29T04:40:24.5770301Z (pass) createTeamMemberErrorHandler > marks the matching member errored without changing team status [1313.00ms]
 12133:test (windows-latest)	Run tests	2026-06-29T04:40:26.2971643Z (pass) createTeamMemberErrorHandler > marks the member errored during the spawn race when the registry tracks the fresh session before disk state persists it [1719.00ms]
 12134:test (windows-latest)	Run tests	2026-06-29T04:40:31.0367755Z (pass) createTeamMemberErrorHandler > falls back to disk lookup when the registry points the member session at the wrong teamRunId [4750.00ms]
 12135:test (windows-latest)	Run tests	2026-06-29T04:40:36.3066676Z (fail) createTeamMemberErrorHandler > injects a member_error announcement into the lead inbox when a non-lead member errors [5265.00ms]
 12136:test (windows-latest)	Run tests	2026-06-29T04:40:36.3067966Z   ^ this test timed out after 5000ms.
-12137-test (windows-latest)	Run tests	2026-06-29T04:40:36.3080380Z 
+12137-test (windows-latest)	Run tests	2026-06-29T04:40:36.3080380Z
 12138:test (windows-latest)	Run tests	2026-06-29T04:40:36.3080741Z # Unhandled error between tests
 12139-test (windows-latest)	Run tests	2026-06-29T04:40:36.3081297Z -------------------------------
 12140-test (windows-latest)	Run tests	2026-06-29T04:40:36.3082482Z 247 |       },
 12141-test (windows-latest)	Run tests	2026-06-29T04:40:36.3082875Z 248 |     })
-12142-test (windows-latest)	Run tests	2026-06-29T04:40:36.3083216Z 249 | 
+12142-test (windows-latest)	Run tests	2026-06-29T04:40:36.3083216Z 249 |
 12143-test (windows-latest)	Run tests	2026-06-29T04:40:36.3084429Z 250 |     // then — lead inbox must contain an announcement about the failed member
 12144-test (windows-latest)	Run tests	2026-06-29T04:40:36.3085588Z 251 |     const leadInboxDir = getInboxDir(resolveBaseDir(config), teamRunId, "lead")
 12145-test (windows-latest)	Run tests	2026-06-29T04:40:36.3086537Z 252 |     const leadInboxEntries = await readdir(leadInboxDir)
@@ -199,19 +199,19 @@ COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 12149-test (windows-latest)	Run tests	2026-06-29T04:40:36.3090837Z  syscall: "scandir",
 12150-test (windows-latest)	Run tests	2026-06-29T04:40:36.3091210Z    errno: -2,
 12151-test (windows-latest)	Run tests	2026-06-29T04:40:36.3091568Z     code: "ENOENT"
-12152-test (windows-latest)	Run tests	2026-06-29T04:40:36.3091805Z 
+12152-test (windows-latest)	Run tests	2026-06-29T04:40:36.3091805Z
 12153:test (windows-latest)	Run tests	2026-06-29T04:40:36.3092952Z       at async <anonymous> (D:\a\oh-my-openagent\oh-my-openagent\packages\omo-opencode\src\hooks\team-session-events\team-member-error-handler.test.ts:252:36)
-12154-test (windows-latest)	Run tests	2026-06-29T04:40:36.3094405Z 
+12154-test (windows-latest)	Run tests	2026-06-29T04:40:36.3094405Z
 12155-test (windows-latest)	Run tests	2026-06-29T04:40:36.3097728Z ##[error]
 12156:test (windows-latest)	Run tests	      at async <anonymous> (D:\a\oh-my-openagent\oh-my-openagent\packages\omo-opencode\src\hooks\team-session-events\team-member-error-handler.test.ts:252:36)
 12157-test (windows-latest)	Run tests	2026-06-29T04:40:36.3099628Z -------------------------------
-12158-test (windows-latest)	Run tests	2026-06-29T04:40:36.3100281Z 
+12158-test (windows-latest)	Run tests	2026-06-29T04:40:36.3100281Z
 12159:test (windows-latest)	Run tests	2026-06-29T04:40:40.5646942Z (pass) createTeamMemberErrorHandler > requeues pending live-delivery messages when the recipient session errors before idle ack [4250.00ms]
 12160:test (windows-latest)	Run tests	2026-06-29T04:40:44.1499837Z (pass) createTeamMemberErrorHandler > #given session.error arrives while OpenCode still reports busy #when pending live delivery exists #then it does not requeue a duplicate peer message [3594.00ms]
 12161:test (windows-latest)	Run tests	2026-06-29T04:40:47.4422966Z (pass) createTeamMemberErrorHandler > #given session.error arrives after peer message reached history #when pending live delivery exists #then it does not requeue a duplicate peer message [3297.00ms]
-12162-test (windows-latest)	Run tests	2026-06-29T04:40:47.4423826Z 
+12162-test (windows-latest)	Run tests	2026-06-29T04:40:47.4423826Z
 12163-test (windows-latest)	Run tests	2026-06-29T04:40:47.4424153Z ##[endgroup]
-12164-test (windows-latest)	Run tests	2026-06-29T04:40:47.4424276Z 
+12164-test (windows-latest)	Run tests	2026-06-29T04:40:47.4424276Z
 12165-test (windows-latest)	Run tests	2026-06-29T04:40:47.4424730Z ##[group]packages\omo-opencode\src\hooks\team-session-events\team-member-status-handler.test.ts:
 12166-test (windows-latest)	Run tests	2026-06-29T04:40:51.3248908Z (pass) createTeamMemberStatusHandler > transitions a running member to idle when its session becomes idle [3875.00ms]
 12167-test (windows-latest)	Run tests	2026-06-29T04:40:52.1178367Z (pass) createTeamMemberStatusHandler > leaves an already-idle member untouched on a subsequent session.idle [797.00ms]
@@ -223,8 +223,8 @@ COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 15549-test (windows-latest)	Run tests	2026-06-29T04:41:43.9711834Z (skip) team-mode live tmux smoke > #given a real caller tmux session and two mock members #when createTeamLayout runs #then teammate panes appear in the caller window and cleanup leaves the session intact
 15550-test (windows-latest)	Run tests	2026-06-29T04:41:43.9714153Z (skip) spawnMonitoredProcess real subprocess smoke > #given printf emits two lines #when monitored #then stdout lines arrive and no process group remains
 15551-test (windows-latest)	Run tests	2026-06-29T04:41:43.9716568Z (skip) team-mode live tmux smoke > #given a real caller tmux session and two mock members #when createTeamLayout runs #then teammate panes appear in the caller window and cleanup leaves the session intact
-15552-test (windows-latest)	Run tests	2026-06-29T04:41:43.9717904Z 
-15553-test (windows-latest)	Run tests	2026-06-29T04:41:43.9717919Z 
+15552-test (windows-latest)	Run tests	2026-06-29T04:41:43.9717904Z
+15553-test (windows-latest)	Run tests	2026-06-29T04:41:43.9717919Z
 15554-test (windows-latest)	Run tests	2026-06-29T04:41:43.9718058Z 4 tests failed:
 15555:test (windows-latest)	Run tests	2026-06-29T04:41:43.9719013Z (fail) Atlas final verification approval gate > pauses for escalation when a final-wave reviewer rejects [5016.00ms]
 15556:test (windows-latest)	Run tests	2026-06-29T04:41:43.9720033Z   ^ this test timed out after 5000ms.
@@ -234,7 +234,7 @@ COMMAND: gh run view 28348775396 --log-failed filtered to failing test files
 15560:test (windows-latest)	Run tests	2026-06-29T04:41:43.9725427Z   ^ this test timed out after 5000ms.
 15561:test (windows-latest)	Run tests	2026-06-29T04:41:43.9726522Z (fail) createTeamMemberErrorHandler > injects a member_error announcement into the lead inbox when a non-lead member errors [5265.00ms]
 15562:test (windows-latest)	Run tests	2026-06-29T04:41:43.9727494Z   ^ this test timed out after 5000ms.
-15563-test (windows-latest)	Run tests	2026-06-29T04:41:43.9727756Z 
+15563-test (windows-latest)	Run tests	2026-06-29T04:41:43.9727756Z
 15564-test (windows-latest)	Run tests	2026-06-29T04:41:43.9727874Z  10277 pass
 15565-test (windows-latest)	Run tests	2026-06-29T04:41:43.9728139Z  11 skip
 15566-test (windows-latest)	Run tests	2026-06-29T04:41:43.9728378Z  4 fail

--- a/.omo/evidence/20260629-windows-async-test-timeouts/whitespace-fix-verification.md
+++ b/.omo/evidence/20260629-windows-async-test-timeouts/whitespace-fix-verification.md
@@ -1,0 +1,37 @@
+# Whitespace Fix Verification
+
+## Scope
+
+Changed only committed evidence artifacts under `.omo/evidence/20260629-windows-async-test-timeouts/`.
+
+## Commands
+
+```console
+$ git diff --check v4.13.0
+```
+
+Result: exit 0, no output.
+
+```console
+$ git diff --check v4.13.0..HEAD
+```
+
+Result after commit: exit 0, no output.
+
+```console
+$ git diff --check -- .omo/evidence/20260629-windows-async-test-timeouts
+```
+
+Result: exit 0, no output.
+
+```console
+$ git diff --name-status origin/dev..HEAD
+M	.omo/evidence/20260629-windows-async-test-timeouts/green-root-bun-test.log
+M	.omo/evidence/20260629-windows-async-test-timeouts/pr-5740-ci-watch.log
+M	.omo/evidence/20260629-windows-async-test-timeouts/red-windows-ci-run-28348775396-filtered.log
+A	.omo/evidence/20260629-windows-async-test-timeouts/whitespace-fix-verification.md
+```
+
+## Why This Is Enough
+
+The regression is a release-blocking `git diff --check` failure in committed evidence logs. The verification exercises the same whitespace checker against the release range with the working-tree fix applied, and the name-status check proves no product or test source changed.


### PR DESCRIPTION
## Summary

This PR removes trailing whitespace from the committed PR #5740 evidence artifacts that were making `git diff --check v4.13.0..origin/dev` fail after merge. It is intentionally artifact-only: no product source, test source, config, or generated schema files changed.

## Changes

- Sanitized trailing spaces/tabs in `.omo/evidence/20260629-windows-async-test-timeouts/green-root-bun-test.log`.
- Sanitized trailing spaces/tabs in `.omo/evidence/20260629-windows-async-test-timeouts/pr-5740-ci-watch.log`.
- Sanitized trailing spaces/tabs in `.omo/evidence/20260629-windows-async-test-timeouts/red-windows-ci-run-28348775396-filtered.log`.
- Added `.omo/evidence/20260629-windows-async-test-timeouts/whitespace-fix-verification.md` with the verification record.

## QA & Evidence

- **What was tested:** `git diff --check v4.13.0..HEAD`
- **Observed result:** exit 0, no output.
- **Artifact:** `.omo/evidence/20260629-windows-async-test-timeouts/whitespace-fix-verification.md`
- **Why sufficient:** This is the same release-range whitespace gate that was blocking publish, now evaluated against this PR's `HEAD`.

- **What was tested:** `git diff --name-status origin/dev..HEAD`
- **Observed result:** only files under `.omo/evidence/20260629-windows-async-test-timeouts/` are listed.
- **Artifact:** `.omo/evidence/20260629-windows-async-test-timeouts/whitespace-fix-verification.md`
- **Why sufficient:** Confirms the PR is scoped to the committed evidence artifact directory and does not edit product/test source.

## Risks & Residuals

Risk is limited to artifact text formatting. No runtime code or tests changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes trailing whitespace from PR #5740 evidence logs so `git diff --check` passes and the release is unblocked. Only committed evidence files changed; no source or tests touched.

- **Bug Fixes**
  - Trim trailing spaces/tabs in three logs under `.omo/evidence/20260629-windows-async-test-timeouts/`.
  - Add `.omo/evidence/20260629-windows-async-test-timeouts/whitespace-fix-verification.md` with the verification results.

<sup>Written for commit 8a26efd3ff6eb36145632cd5058cd719d3a93af0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

