### PR TITLE
fix(codex): preserve generated skill guidance

### DIFF
--- a/packages/omo-codex/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-skills.mjs
@@ -50,12 +50,17 @@ This skill may include examples copied from the OpenCode harness. In Codex, do n
 
 Role-specific behavior must be described in a self-contained \`message\`. Use \`fork_context: false\` to start the child with only the initial prompt (no parent history); use \`fork_context: true\` only when full parent history is truly required. Include any required conversation context, files, diffs, constraints, and requested skill names directly in the spawned agent's \`message\`. OMO installs these selectable agent roles into \`~/.codex/agents/\`: \`explorer\`, \`librarian\`, \`plan\`, \`momus\`, \`metis\`, \`lazycodex-code-reviewer\`, \`lazycodex-qa-executor\`, and \`lazycodex-gate-reviewer\` - pass the matching name as \`agent_type\` so the child gets that role's model and instructions. If the spawn tool exposes no \`agent_type\` parameter, omit it and describe the role inside \`message\`. If a code block below conflicts with this section, this section wins.
 
+On \`multi_agent_v2\` sessions the same \`agent_type\` applies (the OMO installer exposes it) with \`fork_turns\` instead of \`fork_context\`. If a code block below conflicts with this section, this section wins.
+
+When translating \`load_skills=[...]\`, include the requested skill names in the spawned agent's \`message\`. If a code block below conflicts with this section, this section wins.
+
 For work likely to exceed one wait cycle, require the child to send \`WORKING: <task> - <current phase>\` before long passes and \`BLOCKED: <reason>\` only when progress stops. A \`multi_agent_v1.wait_agent\` timeout only means no new mailbox update arrived. Treat a running child as alive. Fallback only when the child is completed without the deliverable, ack-only after followup, explicitly \`BLOCKED:\`, or no longer running.
 
 `;
 
 const codexCompatibilityEndMarkers = [
 	"For work likely to exceed one wait cycle, require the child to send `WORKING: <task> - <current phase>` before long passes and `BLOCKED: <reason>` only when progress stops. A `multi_agent_v1.wait_agent` timeout only means no new mailbox update arrived. Treat a running child as alive. Fallback only when the child is completed without the deliverable, ack-only after followup, explicitly `BLOCKED:`, or no longer running.\n\n",
+	"On `multi_agent_v2` sessions the same `agent_type` applies (the OMO installer exposes it) with `fork_turns` instead of `fork_context`. If a code block below conflicts with this section, this section wins.\n\n",
 	"Role-specific behavior must be described in a self-contained `message`. Use `fork_context: false` to start the child with only the initial prompt (no parent history); use `fork_context: true` only when full parent history is truly required. Include any required conversation context, files, diffs, constraints, and requested skill names directly in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.\n\n",
 	"When translating `load_skills=[...]`, include the requested skill names in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.\n\n",
 	"When translating `load_skills=[...]`, name the skills inside the spawned agent's `message`. If a code block below conflicts with this section, this section wins.\n\n",

--- a/packages/omo-codex/plugin/skills/init-deep/SKILL.md
+++ b/packages/omo-codex/plugin/skills/init-deep/SKILL.md
@@ -18,6 +18,10 @@ This skill may include examples copied from the OpenCode harness. In Codex, do n
 
 Role-specific behavior must be described in a self-contained `message`. Use `fork_context: false` to start the child with only the initial prompt (no parent history); use `fork_context: true` only when full parent history is truly required. Include any required conversation context, files, diffs, constraints, and requested skill names directly in the spawned agent's `message`. OMO installs these selectable agent roles into `~/.codex/agents/`: `explorer`, `librarian`, `plan`, `momus`, `metis`, `lazycodex-code-reviewer`, `lazycodex-qa-executor`, and `lazycodex-gate-reviewer` - pass the matching name as `agent_type` so the child gets that role's model and instructions. If the spawn tool exposes no `agent_type` parameter, omit it and describe the role inside `message`. If a code block below conflicts with this section, this section wins.
 
+On `multi_agent_v2` sessions the same `agent_type` applies (the OMO installer exposes it) with `fork_turns` instead of `fork_context`. If a code block below conflicts with this section, this section wins.
+
+When translating `load_skills=[...]`, include the requested skill names in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.
+
 For work likely to exceed one wait cycle, require the child to send `WORKING: <task> - <current phase>` before long passes and `BLOCKED: <reason>` only when progress stops. A `multi_agent_v1.wait_agent` timeout only means no new mailbox update arrived. Treat a running child as alive. Fallback only when the child is completed without the deliverable, ack-only after followup, explicitly `BLOCKED:`, or no longer running.
 
 # /init-deep

--- a/packages/omo-codex/plugin/test/sync-skills-orchestration.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills-orchestration.test.mjs
@@ -28,6 +28,11 @@ function patternFromParts(parts, flags) {
 	return new RegExp(parts.join(""), flags);
 }
 
+const multiAgentV2RoleGuidance =
+	"On `multi_agent_v2` sessions the same `agent_type` applies (the OMO installer exposes it) with `fork_turns` instead of `fork_context`.";
+const loadSkillsGuidance =
+	"When translating `load_skills=[...]`, include the requested skill names in the spawned agent's `message`.";
+
 test("#given synced aggregate Codex skills #when they contain OpenCode orchestration examples #then Codex tool compatibility guidance is injected", async () => {
 	// given
 	const opencodeOnlyToolPattern = /\b(?:call_omo_agent|background_output|team_[a-z_]+|task)\s*\(/;
@@ -45,6 +50,8 @@ test("#given synced aggregate Codex skills #when they contain OpenCode orchestra
 			compatibilityIndex < content.search(opencodeOnlyToolPattern),
 			`${skillName} must explain Codex tool translation before OpenCode-only examples`,
 		);
+		assert.ok(content.includes(multiAgentV2RoleGuidance), `${skillName} missing multi_agent_v2 role guidance`);
+		assert.ok(content.includes(loadSkillsGuidance), `${skillName} missing load_skills guidance`);
 	}
 });
 
@@ -81,7 +88,7 @@ task(category="quick", prompt="verify")
 	assert.ok(compatibilityIndex < firstToolIndex);
 	assert.equal(adapted.match(/## Codex Harness Tool Compatibility/g)?.length, 1);
 	assert.doesNotMatch(adapted, /Older variant guidance/);
-	assert.doesNotMatch(adapted, /When translating `load_skills=\[\.\.\.\]`/);
+	assert.doesNotMatch(adapted, /name the skills inside the spawned agent's `message`/);
 	assert.match(adapted, /\n---\n\n## Next Section/);
 });
 
@@ -143,6 +150,25 @@ call_omo_agent(subagent_type="explore", prompt="inspect")
 	assert.match(adapted, /multi_agent_v1\.wait_agent/);
 	assert.doesNotMatch(adapted, /task_name/);
 	assert.doesNotMatch(adapted, /Obsolete generated compatibility prose/);
+});
+
+test("#given generated Codex compatibility guidance #when adapting a skill #then multi-agent role and load_skills guidance are both present", () => {
+	// given
+	const content = `---
+name: example
+---
+
+# Example Skill
+
+task(subagent_type="oracle", load_skills=["debugging"], prompt="verify")
+`;
+
+	// when
+	const adapted = insertCodexCompatibilityGuidance(content);
+
+	// then
+	assert.ok(adapted.includes(multiAgentV2RoleGuidance));
+	assert.ok(adapted.includes(loadSkillsGuidance));
 });
 
 test("#given generated guidance before a template export #when adapting a skill #then the export wrapper is preserved", () => {

--- a/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
@@ -43,6 +43,7 @@ export const componentSkillSources = [
 
 const codexCompatibilityEndMarkers = [
 	"For work likely to exceed one wait cycle, require the child to send `WORKING: <task> - <current phase>` before long passes and `BLOCKED: <reason>` only when progress stops. A `multi_agent_v1.wait_agent` timeout only means no new mailbox update arrived. Treat a running child as alive. Fallback only when the child is completed without the deliverable, ack-only after followup, explicitly `BLOCKED:`, or no longer running.\n\n",
+	"On `multi_agent_v2` sessions the same `agent_type` applies (the OMO installer exposes it) with `fork_turns` instead of `fork_context`. If a code block below conflicts with this section, this section wins.\n\n",
 	"Role-specific behavior must be described in a self-contained `message`. Use `fork_context: false` to start the child with only the initial prompt (no parent history); use `fork_context: true` only when full parent history is truly required. Include any required conversation context, files, diffs, constraints, and requested skill names directly in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.\n\n",
 	"When translating `load_skills=[...]`, include the requested skill names in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.\n\n",
 	"When translating `load_skills=[...]`, name the skills inside the spawned agent's `message`. If a code block below conflicts with this section, this section wins.\n\n",


### PR DESCRIPTION
## Summary

Generated Codex skill payloads now keep the current multi-agent compatibility guidance when OpenCode-oriented skills are synced into the Codex plugin. This fixes the release blocker where packaged aggregate skills could omit `multi_agent_v2` / `fork_turns` instructions and the canonical `load_skills` translation note.

## Changes

- Updated the Codex skill sync transformer so generated compatibility sections include `multi_agent_v2` role guidance with `fork_turns`, plus canonical `load_skills=[...]` translation guidance.
- Refreshed the tracked generated `init-deep` skill payload so the packaged copy reflects the new generated section.
- Extended the sync-skill orchestration tests to require the new generated guidance in aggregate Codex skills and to keep stale wording from surviving replacement.

## QA & Evidence

- **What was tested:** `node packages/omo-codex/plugin/scripts/sync-skills.mjs`, then grep the generated `packages/omo-codex/plugin/skills/ulw-research/SKILL.md` payload.
  **Observed result:** Generated `ulw-research` includes `multi_agent_v2`, `fork_turns`, `fork_context`, and `load_skills` guidance.
  **Artifact:** `.omo/evidence/20260629-ulw-research-drift/generated-ulw-research-guidance.txt`
  **Why sufficient:** Proves the release-blocking generated payload now carries the missing Codex compatibility instructions.

- **What was tested:** `node --test packages/omo-codex/plugin/test/sync-skills-orchestration.test.mjs packages/omo-codex/plugin/test/sync-skills.test.mjs packages/omo-codex/plugin/test/ulw-research-skill-contract.test.mjs`
  **Observed result:** 43/43 focused sync and skill contract tests passed.
  **Artifact:** `.omo/evidence/20260629-ulw-research-drift/focused-sync-tests.txt`
  **Why sufficient:** Pins the generator behavior and guards against stale generated compatibility prose.

- **What was tested:** Codex QA install verification with isolated `CODEX_HOME`.
  **Observed result:** Sandbox install passed and the real `~/.codex/config.toml` remained unchanged.
  **Artifact:** `.omo/evidence/20260629-ulw-research-drift/codex-install-verify.txt`
  **Why sufficient:** Covers the mandatory Codex plugin install path without touching the real user config.

- **What was tested:** `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin`
  **Observed result:** Real `codex app-server` ran with an isolated `CODEX_HOME` and mock model; plugin hooks completed for `sessionStart`, `userPromptSubmit`, and `stop`.
  **Artifact:** `.omo/evidence/20260629-ulw-research-drift/codex-app-server-drive.json`
  **Why sufficient:** Provides first-party live Codex harness proof for the plugin path.

- **What was tested:** `bun run test:codex`
  **Observed result:** 422/422 tests passed.
  **Artifact:** `.omo/evidence/20260629-ulw-research-drift/test-codex.txt`
  **Why sufficient:** Covers the hermetic Codex unit gate.

- **What was tested:** `bun run typecheck`
  **Observed result:** Passed.
  **Artifact:** `.omo/evidence/20260629-ulw-research-drift/typecheck.txt`
  **Why sufficient:** Covers TypeScript correctness across the workspace.

- **What was tested:** `bun run build`
  **Observed result:** Passed.
  **Artifact:** `.omo/evidence/20260629-ulw-research-drift/build.txt`
  **Why sufficient:** Covers packaged build output generation.

- **What was tested:** `bun test`
  **Observed result:** 10290 passed, 2 skipped, 0 failed.
  **Artifact:** `.omo/evidence/20260629-ulw-research-drift/bun-test.txt`
  **Why sufficient:** Covers the full Bun test suite for unrelated regressions.

## Risks & Residuals

The change is limited to generated compatibility prose and sync tests. The main residual risk is future drift between generated guidance and packaged aggregate payloads; the added tests now assert the guidance exists in synced aggregate skills and that stale wording is removed.

## Related Issues

Release blocker from pre-publish review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Codex skill compatibility guidance during sync so aggregate skills keep required multi-agent notes. Fixes missing `multi_agent_v2`/`fork_turns` and `load_skills` instructions that blocked release.

- **Bug Fixes**
  - Updated the skill sync transformer to include `multi_agent_v2` role guidance with `fork_turns` and the canonical `load_skills=[...]` translation note, and to drop stale variants.
  - Refreshed the generated `init-deep` skill payload to include the new guidance.
  - Added orchestration tests to assert the guidance is present in synced skills and prevent regressions.

<sup>Written for commit 6f4655b5dfb21062e8923646d67c16b5dcc08041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

