### PR TITLE
fix(opencode): block hidden plan subagent delegation

### DIFF
--- a/packages/omo-opencode/src/tools/delegate-task/coordinator-subagent-guard.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/coordinator-subagent-guard.test.ts
@@ -1,21 +1,34 @@
+/// <reference types="bun-types" />
+
 /**
  * Regression test for issue #4027: coordinator agents must not be selectable as
  * subagent targets via task(). Symmetric guard to PR #4065 (team_create caller
  * eligibility) — this covers the TARGET side of delegation.
  */
-const { describe, test, expect } = require("bun:test")
+import { describe, expect, test } from "bun:test"
 
 import { resolveSubagentExecution } from "./subagent-resolver"
 import { COORDINATOR_AGENT_NAMES } from "./constants"
+import type { AgentInfo } from "./subagent-discovery"
 import type { ExecutorContext } from "./executor-types"
+import type { OpencodeClient } from "./types"
 
-function makeCtx(): ExecutorContext {
+function makeCtx(agents: AgentInfo[] = []): ExecutorContext {
+  const client: OpencodeClient = {
+    app: { agents: async () => ({ data: agents }) },
+    config: { get: async () => ({ data: {} }) },
+    session: {
+      abort: async () => ({}),
+      create: async () => ({ data: { id: "unused" } }),
+      get: async () => ({ data: {} }),
+      messages: async () => ({ data: [] }),
+      status: async () => ({ data: {} }),
+    },
+  }
+
   return {
-    client: {
-      app: { agents: async () => ({ data: [] }) },
-      config: { get: async () => ({ data: {} }) },
-    } as unknown as ExecutorContext["client"],
-    manager: {} as unknown as ExecutorContext["manager"],
+    client,
+    manager: {} as ExecutorContext["manager"],
     directory: "/tmp/test",
   }
 }
@@ -138,6 +151,46 @@ describe("coordinator subagent guard (#4027)", () => {
     expect(result.error).toContain("prometheus")
     expect(result.error).toContain("coordinator agent")
     expect(result.agentToUse).toBe("")
+  })
+
+  test("#given subagent_type=plan resolves to a hidden demoted plan #when resolveSubagentExecution is called from a worker #then the coordinator lane is rejected", async () => {
+    //#given
+    const ctx = makeCtx([{ name: "plan", mode: "subagent", hidden: true }])
+    const args = {
+      subagent_type: "plan",
+      prompt: "plan something",
+      load_skills: [],
+      run_in_background: false,
+      description: "test delegation",
+    }
+
+    //#when
+    const result = await resolveSubagentExecution(args, ctx, "hephaestus", "")
+
+    //#then
+    expect(result.error).toContain("plan")
+    expect(result.error).toContain("coordinator agent")
+    expect(result.error).toContain("Prometheus")
+    expect(result.agentToUse).toBe("")
+  })
+
+  test("#given subagent_type=plan resolves to a visible custom subagent #when resolveSubagentExecution is called from a worker #then the coordinator guard does not reject it", async () => {
+    //#given
+    const ctx = makeCtx([{ name: "plan", mode: "subagent" }])
+    const args = {
+      subagent_type: "plan",
+      prompt: "plan something",
+      load_skills: [],
+      run_in_background: false,
+      description: "test delegation",
+    }
+
+    //#when
+    const result = await resolveSubagentExecution(args, ctx, "hephaestus", "")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.agentToUse).toBe("plan")
   })
 })
 

--- a/packages/omo-opencode/src/tools/delegate-task/subagent-agent-match.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/subagent-agent-match.ts
@@ -100,6 +100,7 @@ export async function resolveSubagentAgentMatch(
     matchedAgent = {
       name: DEFAULT_PLAN_FALLBACK_AGENT,
       mode: "subagent",
+      hidden: true,
     }
   }
 

--- a/packages/omo-opencode/src/tools/delegate-task/subagent-resolver.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/subagent-resolver.ts
@@ -4,6 +4,7 @@ import { log } from "../../shared/logger"
 import { resolveSubagentAgentMatch } from "./subagent-agent-match"
 import { resolveSubagentModel } from "./subagent-model-resolution"
 import { validateSubagentRequest } from "./subagent-request-preflight"
+import { isDemotedPlanAgent } from "./subagent-discovery"
 import type { ResolveSubagentExecutionOptions, ResolveSubagentExecutionResult } from "./subagent-resolution-types"
 
 export type { ResolveSubagentExecutionOptions, ResolveSubagentExecutionResult }
@@ -29,6 +30,14 @@ export async function resolveSubagentExecution(
     }
 
     agentToUse = agentMatch.agentToUse
+    if (isDemotedPlanAgent(agentMatch.matchedAgent)) {
+      return {
+        agentToUse: "",
+        categoryModel: undefined,
+        error: `Cannot delegate to coordinator agent "${agentToUse}" via task(). Hidden plan agents share the Prometheus orchestration lane and must not be used as subagent targets — doing so bypasses the Prometheus coordinator guard. Select a worker agent (e.g., sisyphus-junior via category, hephaestus, oracle) instead.`,
+      }
+    }
+
     const { categoryModel, fallbackChain } = await resolveSubagentModel(agentToUse, agentMatch.matchedAgent, executorCtx)
     return { agentToUse, categoryModel, fallbackChain }
   } catch (error) {


### PR DESCRIPTION
## Summary

- block delegation to OMO's hidden/demoted `plan` agent when a worker reaches it through `task(subagent_type="plan")`
- mark hidden plan fallback matches as hidden so they use the same guard path
- add regression coverage for hidden demoted `plan` rejection while preserving visible custom `plan` subagents

Fixes #5748.

## Verification

- `bun test packages/omo-opencode/src/tools/delegate-task/coordinator-subagent-guard.test.ts`
- `bun test packages/omo-opencode/src/tools/delegate-task/tools.test.ts -t "plan family mutual delegation block"`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-opencode/src/tools/delegate-task/subagent-agent-match.ts packages/omo-opencode/src/tools/delegate-task/subagent-resolver.ts packages/omo-opencode/src/tools/delegate-task/coordinator-subagent-guard.test.ts`
- `bun run typecheck:packages`
- manual Bun resolver probe for hidden demoted `plan` rejection and visible `plan` preservation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks delegation to the hidden/demoted `plan` coordinator via `task(subagent_type="plan")` so workers can’t bypass the Prometheus coordinator guard. Keeps delegation to visible custom `plan` subagents working.

- **Bug Fixes**
  - Reject hidden/demoted `plan` matches in `resolveSubagentExecution` using `isDemotedPlanAgent`.
  - Mark default `plan` fallback as `hidden` to route through the same guard.
  - Add tests for hidden `plan` rejection and visible `plan` acceptance.

<sup>Written for commit 3c442294e24150b5c123f45be6cdc8b37b58d8d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

