### PR TITLE
fix(ralph-loop): preserve unrelated prompt reservations

### DIFF
--- a/.omo/evidence/20260630-ralph-prompt-gate-full-qa/SUMMARY.md
+++ b/.omo/evidence/20260630-ralph-prompt-gate-full-qa/SUMMARY.md
@@ -1,0 +1,82 @@
+# Ralph prompt-gate QA evidence
+
+## Branch and PR
+
+- Base branch: `dev`
+- Local branch: `dogfood/latest-dev-ralph-fix`
+- Existing PR: <https://github.com/code-yeongyu/oh-my-openagent/pull/5750>
+
+## What changed from the previous PR revision
+
+The updated branch keeps the original Ralph ownership fix and adds the follow-up protections requested by automated review:
+
+- avoids disk-backed loop-state reads for streamed activity unless the activity has a relevant runtime-retry or Ralph-owned prompt-reservation marker;
+- avoids releasing verification-session prompt holds owned by `model-suggestion-retry` or other non-Ralph routes;
+- clears stale Ralph runtime-retry markers without releasing another route's prompt reservation;
+- throttles repeated prompt-gate mismatched-release warnings and bounds the throttle cache.
+
+## Automated gates
+
+- `bun run typecheck`
+  - Result: pass.
+
+- `bun test packages/omo-opencode/src/hooks/ralph-loop packages/utils/src/prompt-async-gate.test.ts --bail`
+  - Result: `210 pass`, `0 fail`.
+
+- `bun test packages/omo-opencode/src/hooks/shared/prompt-async-gate.test.ts packages/omo-opencode/src/hooks/shared/prompt-async-gate-semantic-dedupe-edge.test.ts packages/utils/src/prompt-async-gate*.test.ts --bail`
+  - Result: `95 pass`, `0 fail`.
+
+- `bun run test:codex`
+  - Result: pass; final Node test summary reported `440 pass`, `0 fail`.
+
+- `bun run build`
+  - Result: pass.
+
+- `git diff --check`
+  - Result: pass.
+
+## Full root test suite
+
+- `bun test`
+  - Result: full-suite mode reported `10239 pass`, `2 skip`, `5 fail`.
+  - Failing files:
+    - `packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts`
+    - `packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler-retry.test.ts`
+
+The failing files are outside the changed Ralph/prompt-gate surface and passed when rerun in isolation:
+
+- `bun test packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts`
+  - Result: `7 pass`, `0 fail`.
+
+- `bun test packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler-retry.test.ts`
+  - Result: `3 pass`, `0 fail`.
+
+## OpenCode harness QA
+
+The repo-local `.agents/skills/opencode-qa` scripts were used.
+
+- `bash scripts/lib/common.sh --self-check`
+  - Result: pass.
+
+- `bash scripts/sse-hook-probe.sh --self-test`
+  - Result: pass; observed `server.connected` on the SSE `/event` stream.
+
+- Isolated real-hook probe against `opencode serve` with the repo-local plugin loaded from `packages/omo-opencode/src/index.ts` and a fake OpenAI-compatible provider
+  - Result: pass; observed `message.part.delta` on the SSE `/event` stream for session `ses_0e515b7dbffeqeewkVW1sTyr86`.
+  - Why it matters: `message.part.delta` is the lifecycle event that reaches the changed Ralph `event` hook activity path.
+  - Isolation proof: real OpenCode DB session count was unchanged (`3046 -> 3046`); the generated session lived only in the sandbox DB.
+  - Evidence files: `.omo/evidence/20260630-ralph-prompt-gate-full-qa/real-hook-probe/`.
+
+- `bash scripts/tui-smoke.sh --self-test`
+  - Result: pass; TUI rendered under tmux, the test key sequence reached the composer, and the tmux session was torn down.
+  - Isolation proof: real OpenCode DB session count was unchanged before and after the smoke.
+
+- Isolated local-dist smoke using the built plugin at `dist/index.js` and `opencode agent list --print-logs --log-level DEBUG`
+  - Result: pass, exit 0.
+  - Isolation proof: real OpenCode DB session count was unchanged before and after the smoke.
+  - The sandbox DB had zero sessions after the command.
+  - No `promptAsync reservation release skipped for different source` lines appeared in the smoke stdout/stderr.
+
+## Residual risk
+
+The root suite still has unrelated full-suite/order-dependent failures in this checkout. The failing files pass in isolation and are outside the changed Ralph-loop and prompt-gate files, so this is recorded as pre-existing suite instability rather than a regression from this PR.

--- a/.omo/evidence/20260630-ralph-prompt-gate-full-qa/real-hook-probe/SUMMARY.md
+++ b/.omo/evidence/20260630-ralph-prompt-gate-full-qa/real-hook-probe/SUMMARY.md
@@ -1,0 +1,30 @@
+# Real OpenCode Ralph event-hook probe
+
+## Purpose
+
+Prove that a lifecycle event matching the changed Ralph `event` hook activity path reaches the live OpenCode event surface, not just the SSE self-test `server.connected` plumbing.
+
+## Harness
+
+- Started isolated `opencode serve` with sandboxed `XDG_*` and `HOME`.
+- Loaded the repo-local plugin from `packages/omo-opencode/src/index.ts`.
+- Configured a fake OpenAI-compatible provider from `.agents/skills/opencode-qa/scripts/lib/fake-openai-server.mjs`.
+- Created a sandbox session and sent a `prompt_async` request.
+- Watched `/event?directory=<sandbox>` for `message.part.delta`.
+
+## Result
+
+- Result: pass.
+- First matching event: `{"type":"message.part.delta","sessionID":"ses_0e515b7dbffeqeewkVW1sTyr86"}`.
+- This event type is handled by `getRuntimeRetryActivitySessionID()` and reaches the changed Ralph `event` hook activity path.
+
+## Isolation
+
+- Real OpenCode DB session count: `3046 -> 3046`.
+- Sandbox DB session count: `1`.
+- The generated session lived only in the sandbox DB.
+
+## Captured output artifact
+
+- `redacted-probe-output.txt` contains the command result, isolation receipt, and selected `message.part.delta` SSE event line used to prove the hook-relevant lifecycle event reached the live event surface.
+- Raw server logs were not committed because they are noisy and include transient local ports/paths; the committed artifact preserves the reviewer-relevant output without auth material or private runtime noise.

--- a/.omo/evidence/20260630-ralph-prompt-gate-full-qa/real-hook-probe/redacted-probe-output.txt
+++ b/.omo/evidence/20260630-ralph-prompt-gate-full-qa/real-hook-probe/redacted-probe-output.txt
@@ -1,0 +1,22 @@
+Command: bash /tmp/ralph-real-hook-probe.sh
+Working directory: /home/renekris/Development/oh-my-openagent
+
+Terminal result:
+PASS: observed message.part.delta hitting plugin event hook surface
+first_delta={"type":"message.part.delta","sessionID":"ses_0e515b7dbffeqeewkVW1sTyr86"}
+real_db_sessions=3046->3046 sandbox_sessions=1
+
+Isolation receipt, redacted:
+real_db=/home/renekris/.local/share/opencode/opencode.db before=3046
+sandbox=<isolated-xdg>/proj
+session_id=ses_0e515b7dbffeqeewkVW1sTyr86
+after=3046 sandbox_db=<isolated-xdg>/data/opencode/opencode.db sandbox_sessions=1
+
+Selected SSE event stream lines, redacted to the hook-relevant event:
+data: {"type":"message.part.delta","properties":{"sessionID":"ses_0e515b7dbffeqeewkVW1sTyr86","messageID":"msg_f1aea49ce001pmUYLSvknEXgVy","partID":"prt_f1aea5810001og4AjD17s1NXYL","field":"text","delta":"fake response 1"}}
+
+Redactions applied:
+- replaced transient sandbox paths with <isolated-xdg>
+- omitted localhost ports and fake provider plumbing logs
+- omitted unrelated server/SSE lifecycle noise
+- no auth headers, passwords, tokens, or real provider credentials included

--- a/packages/omo-opencode/src/hooks/ralph-loop/event-handler-impl.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/event-handler-impl.ts
@@ -7,15 +7,64 @@ import {
 	getRuntimeRetryActivitySessionID,
 	isAbortError,
 } from "./event-handler-activity"
-import { handleIdleEvent, type EventHandlerRuntime } from "./event-handler-idle"
+import {
+	getVerificationSessionID,
+	handleIdleEvent,
+	matchesLoopSession,
+	type EventHandlerRuntime,
+} from "./event-handler-idle"
 import { handleRuntimeErrorEvent } from "./event-handler-runtime-error"
 import type { RalphLoopEventHandlerOptions } from "./event-handler-types"
-import { releasePromptAsyncReservation } from "../shared/prompt-async-gate"
+import {
+	getPromptReservation,
+	releasePromptAsyncReservation,
+	reservationSourceMatches,
+} from "../shared/prompt-async-gate"
 import { handleDeletedLoopSession, handleErroredLoopSession } from "./session-event-handler"
+
+const RALPH_LOOP_PROMPT_RESERVATION_SOURCE = "ralph-loop" as const
+const RALPH_LOOP_PROMPT_RESERVATION_PREFIX = "ralph-loop:" as const
 
 type RalphLoopEvent = {
 	readonly type: string
 	readonly properties?: unknown
+}
+
+function hasRalphOwnedPromptReservation(sessionID: string): boolean {
+	const reservation = getPromptReservation(sessionID)
+	return reservation !== undefined
+		&& reservationSourceMatches(
+			reservation.source,
+			RALPH_LOOP_PROMPT_RESERVATION_SOURCE,
+			RALPH_LOOP_PROMPT_RESERVATION_PREFIX,
+		)
+}
+
+function releaseRalphPromptReservation(sessionID: string): void {
+	releasePromptAsyncReservation(sessionID, RALPH_LOOP_PROMPT_RESERVATION_SOURCE, {
+		reservedBy: RALPH_LOOP_PROMPT_RESERVATION_SOURCE,
+		reservedByPrefix: RALPH_LOOP_PROMPT_RESERVATION_PREFIX,
+	})
+}
+
+function clearRuntimeRetryActivity(
+	runtime: EventHandlerRuntime,
+	sessionID: string,
+	options: { readonly releaseReservation: boolean },
+): void {
+	runtime.runtimeErrorRetriedSessions.delete(sessionID)
+	if (options.releaseReservation) {
+		releaseRalphPromptReservation(sessionID)
+	}
+	runtime.recentHandledSyntheticIdleAt.delete(sessionID)
+}
+
+function forgetNonLoopRuntimeRetryActivity(
+	runtime: EventHandlerRuntime,
+	sessionID: string,
+): void {
+	runtime.runtimeErrorRetriedSessions.delete(sessionID)
+	runtime.recentHandledSyntheticIdleAt.delete(sessionID)
 }
 
 export function createRalphLoopEventHandlerImpl(
@@ -32,9 +81,37 @@ export function createRalphLoopEventHandlerImpl(
 		const props = isRecord(event.properties) ? event.properties : undefined
 		const runtimeRetryActivitySessionID = getRuntimeRetryActivitySessionID(event.type, props)
 		if (runtimeRetryActivitySessionID) {
-			runtime.runtimeErrorRetriedSessions.delete(runtimeRetryActivitySessionID)
-			releasePromptAsyncReservation(runtimeRetryActivitySessionID, "ralph-loop")
-			runtime.recentHandledSyntheticIdleAt.delete(runtimeRetryActivitySessionID)
+			const hasRuntimeRetryMarker = runtime.runtimeErrorRetriedSessions.has(runtimeRetryActivitySessionID)
+			const hasRalphReservation = hasRalphOwnedPromptReservation(runtimeRetryActivitySessionID)
+			if (!hasRuntimeRetryMarker && !hasRalphReservation) {
+				return
+			}
+
+			const state = options.loopState.getState()
+			if (!state?.active) {
+				if (hasRuntimeRetryMarker || hasRalphReservation) {
+					clearRuntimeRetryActivity(runtime, runtimeRetryActivitySessionID, {
+						releaseReservation: hasRalphReservation,
+					})
+				}
+				return
+			}
+
+			const verificationSessionID = getVerificationSessionID(state)
+			const match = matchesLoopSession(state, runtimeRetryActivitySessionID, verificationSessionID)
+			if (!match.parent && !match.verification) {
+				forgetNonLoopRuntimeRetryActivity(runtime, runtimeRetryActivitySessionID)
+				return
+			}
+			if (hasRuntimeRetryMarker) {
+				clearRuntimeRetryActivity(runtime, runtimeRetryActivitySessionID, {
+					releaseReservation: hasRalphReservation,
+				})
+			} else if (hasRalphReservation) {
+				clearRuntimeRetryActivity(runtime, runtimeRetryActivitySessionID, {
+					releaseReservation: true,
+				})
+			}
 		}
 
 		if (event.type === "session.idle") {

--- a/packages/omo-opencode/src/hooks/ralph-loop/ralph-loop-event-handler-characterization.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/ralph-loop-event-handler-characterization.test.ts
@@ -1,8 +1,16 @@
 /// <reference path="../../../../../bun-test.d.ts" />
 
+import { existsSync, mkdtempSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { afterEach, describe, expect, test } from "bun:test"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
-import { releaseAllPromptAsyncReservationsForTesting, releasePromptAsyncReservation } from "../shared/prompt-async-gate"
+import { _flushForTesting, _resetLoggerForTesting, _setLoggerForTesting } from "../../shared/logger"
+import {
+	dispatchInternalPrompt,
+	releaseAllPromptAsyncReservationsForTesting,
+	releasePromptAsyncReservation,
+} from "../shared/prompt-async-gate"
 import { latestUserMessageIsInProgress } from "./event-handler-activity"
 import { createRalphLoopEventHandler } from "./ralph-loop-event-handler"
 import type { IterationCommitExpectation, RalphLoopState } from "./types"
@@ -15,6 +23,7 @@ type PromptCall = {
 describe("ralph-loop event handler characterization", () => {
 	afterEach(() => {
 		releaseAllPromptAsyncReservationsForTesting()
+		_resetLoggerForTesting()
 	})
 
 	test("#given synthetic idle already continued the loop #when matching real idle follows immediately #then Ralph injects only once", async () => {
@@ -204,5 +213,519 @@ describe("ralph-loop event handler characterization", () => {
 			{ iteration: 2, sessionID: "session-123" },
 		])
 		expect(state?.iteration).toBe(3)
+	})
+
+	test("#given runtime retry marker but another route owns the reservation #when retried activity arrives #then Ralph clears only its marker", async () => {
+		// given
+		const logDir = mkdtempSync(join(tmpdir(), "ralph-loop-runtime-marker-"))
+		const logFile = join(logDir, "oh-my-opencode.log")
+		_setLoggerForTesting({ filePath: logFile })
+		let state: RalphLoopState | null = {
+			active: true,
+			iteration: 1,
+			max_iterations: 5,
+			completion_promise: "DONE",
+			started_at: new Date().toISOString(),
+			prompt: "Keep working",
+			session_id: "session-123",
+		}
+		const promptCalls: PromptCall[] = []
+		const client = unsafeTestValue({
+			session: {
+				messages: async () => ({ data: [] }),
+				promptAsync: async (input: {
+					readonly path: { readonly id: string }
+					readonly body: { readonly parts: readonly [{ readonly text: string }] }
+				}) => {
+					promptCalls.push({
+						sessionID: input.path.id,
+						text: input.body.parts[0].text,
+					})
+					return {}
+				},
+			},
+		})
+		const handler = createRalphLoopEventHandler(unsafeTestValue({ client }), {
+			directory: "/tmp/ralph-loop-event-handler-characterization",
+			apiTimeoutMs: 5000,
+			idleSettleMs: 0,
+			getTranscriptPath: () => undefined,
+			loopState: {
+				getState: () => state,
+				clear: () => {
+					state = null
+					return true
+				},
+				incrementIteration: () => {
+					if (!state) return null
+					state = { ...state, iteration: state.iteration + 1 }
+					return state
+				},
+				setSessionID: (sessionID: string) => {
+					if (!state) return null
+					state = { ...state, session_id: sessionID }
+					return state
+				},
+				markVerificationPending: () => state,
+				setVerificationSessionID: () => state,
+				restartAfterFailedVerification: () => state,
+				clearVerificationState: () => state,
+			},
+		})
+
+		await handler({
+			event: {
+				type: "session.error",
+				properties: {
+					sessionID: "session-123",
+					error: { name: "RuntimeError" },
+				},
+			},
+		})
+		expect(releasePromptAsyncReservation("session-123", "ralph-loop")).toBe(true)
+		const reservation = await dispatchInternalPrompt({
+			mode: "async",
+			client,
+			sessionID: "session-123",
+			source: "model-suggestion-retry",
+			settleMs: 0,
+			postDispatchHoldMs: 10_000,
+			input: {
+				path: { id: "session-123" },
+				body: {
+					parts: [{ type: "text", text: "retry through another route" }],
+				},
+			},
+		})
+
+		// when
+		await handler({
+			event: { type: "message.part.delta", properties: { sessionID: "session-123" } },
+		})
+		_flushForTesting()
+		const logContent = existsSync(logFile) ? readFileSync(logFile, "utf8") : ""
+		const releasedByOwner = releasePromptAsyncReservation("session-123", "model-suggestion-retry")
+
+		// then
+		expect(reservation.status).toBe("dispatched")
+		expect(releasedByOwner).toBe(true)
+		expect(logContent).not.toContain("promptAsync reservation release skipped for different source")
+		expect(promptCalls).toHaveLength(2)
+	})
+
+	test("#given runtime retry marker but Ralph state is inactive #when retried activity arrives #then stale marker is cleared", async () => {
+		// given
+		let state: RalphLoopState | null = {
+			active: true,
+			iteration: 1,
+			max_iterations: 5,
+			completion_promise: "DONE",
+			started_at: new Date().toISOString(),
+			prompt: "Keep working",
+			session_id: "session-123",
+		}
+		const promptCalls: PromptCall[] = []
+		const client = unsafeTestValue({
+			session: {
+				messages: async () => ({ data: [] }),
+				promptAsync: async (input: {
+					readonly path: { readonly id: string }
+					readonly body: { readonly parts: readonly [{ readonly text: string }] }
+				}) => {
+					promptCalls.push({
+						sessionID: input.path.id,
+						text: input.body.parts[0].text,
+					})
+					return {}
+				},
+			},
+		})
+		const handler = createRalphLoopEventHandler(unsafeTestValue({ client }), {
+			directory: "/tmp/ralph-loop-event-handler-characterization",
+			apiTimeoutMs: 5000,
+			idleSettleMs: 0,
+			getTranscriptPath: () => undefined,
+			loopState: {
+				getState: () => state,
+				clear: () => {
+					state = null
+					return true
+				},
+				incrementIteration: () => {
+					if (!state) return null
+					state = { ...state, iteration: state.iteration + 1 }
+					return state
+				},
+				setSessionID: (sessionID: string) => {
+					if (!state) return null
+					state = { ...state, session_id: sessionID }
+					return state
+				},
+				markVerificationPending: () => state,
+				setVerificationSessionID: () => state,
+				restartAfterFailedVerification: () => state,
+				clearVerificationState: () => state,
+			},
+		})
+
+		await handler({
+			event: {
+				type: "session.error",
+				properties: {
+					sessionID: "session-123",
+					error: { name: "RuntimeError" },
+				},
+			},
+		})
+		state = null
+
+		// when
+		await handler({
+			event: { type: "message.part.delta", properties: { sessionID: "session-123" } },
+		})
+		state = {
+			active: true,
+			iteration: 2,
+			max_iterations: 5,
+			completion_promise: "DONE",
+			started_at: new Date().toISOString(),
+			prompt: "Keep working",
+			session_id: "session-123",
+		}
+		await handler({
+			event: { type: "session.idle", properties: { sessionID: "session-123" } },
+		})
+
+		// then
+		expect(promptCalls).toHaveLength(2)
+		expect(state?.iteration).toBe(3)
+	})
+
+	test("#given child session has a retry reservation #when unrelated child activity arrives #then Ralph does not attempt to release it", async () => {
+		// given
+		const logDir = mkdtempSync(join(tmpdir(), "ralph-loop-scope-"))
+		const logFile = join(logDir, "oh-my-opencode.log")
+		_setLoggerForTesting({ filePath: logFile })
+		let getStateCalls = 0
+		let state: RalphLoopState | null = {
+			active: true,
+			iteration: 1,
+			max_iterations: 5,
+			completion_promise: "DONE",
+			started_at: new Date().toISOString(),
+			prompt: "Keep working",
+			session_id: "parent-session",
+		}
+		const promptCalls: PromptCall[] = []
+		const client = unsafeTestValue({
+			session: {
+				messages: async () => ({ data: [] }),
+				promptAsync: async (input: {
+					readonly path: { readonly id: string }
+					readonly body: { readonly parts: readonly [{ readonly text: string }] }
+				}) => {
+					promptCalls.push({
+						sessionID: input.path.id,
+						text: input.body.parts[0].text,
+					})
+					return {}
+				},
+			},
+		})
+		const handler = createRalphLoopEventHandler(unsafeTestValue({ client }), {
+			directory: "/tmp/ralph-loop-event-handler-characterization",
+			apiTimeoutMs: 5000,
+			idleSettleMs: 0,
+			getTranscriptPath: () => undefined,
+			loopState: {
+				getState: () => {
+					getStateCalls++
+					return state
+				},
+				clear: () => {
+					state = null
+					return true
+				},
+				incrementIteration: () => state,
+				setSessionID: (sessionID: string) => {
+					if (!state) return null
+					state = { ...state, session_id: sessionID }
+					return state
+				},
+				markVerificationPending: () => state,
+				setVerificationSessionID: () => state,
+				restartAfterFailedVerification: () => state,
+				clearVerificationState: () => state,
+			},
+		})
+		const reservation = await dispatchInternalPrompt({
+			mode: "async",
+			client,
+			sessionID: "child-session",
+			source: "model-suggestion-retry",
+			settleMs: 0,
+			postDispatchHoldMs: 10_000,
+			input: {
+				path: { id: "child-session" },
+				body: {
+					parts: [{ type: "text", text: "retry child" }],
+				},
+			},
+		})
+
+		// when
+		await handler({
+			event: { type: "message.part.delta", properties: { sessionID: "child-session" } },
+		})
+		_flushForTesting()
+		const logContent = existsSync(logFile) ? readFileSync(logFile, "utf8") : ""
+		const releasedByOwner = releasePromptAsyncReservation("child-session", "model-suggestion-retry")
+
+		// then
+		expect(reservation.status).toBe("dispatched")
+		expect(getStateCalls).toBe(0)
+		expect(releasedByOwner).toBe(true)
+		expect(logContent).not.toContain("promptAsync reservation release skipped for different source")
+		expect(promptCalls).toHaveLength(1)
+	})
+
+	test("#given verification session is owned by model suggestion retry #when verification activity arrives #then Ralph leaves that hold alone", async () => {
+		// given
+		const logDir = mkdtempSync(join(tmpdir(), "ralph-loop-verification-"))
+		const logFile = join(logDir, "oh-my-opencode.log")
+		_setLoggerForTesting({ filePath: logFile })
+		let getStateCalls = 0
+		let state: RalphLoopState | null = {
+			active: true,
+			iteration: 1,
+			max_iterations: 5,
+			completion_promise: "DONE",
+			started_at: new Date().toISOString(),
+			prompt: "Keep working",
+			session_id: "parent-session",
+			verification_pending: true,
+			verification_session_id: "verification-session",
+		}
+		const client = unsafeTestValue({
+			session: {
+				messages: async () => ({ data: [] }),
+				promptAsync: async () => ({}),
+			},
+		})
+		const handler = createRalphLoopEventHandler(unsafeTestValue({ client }), {
+			directory: "/tmp/ralph-loop-event-handler-characterization",
+			apiTimeoutMs: 5000,
+			idleSettleMs: 0,
+			getTranscriptPath: () => undefined,
+			loopState: {
+				getState: () => {
+					getStateCalls++
+					return state
+				},
+				clear: () => {
+					state = null
+					return true
+				},
+				incrementIteration: () => state,
+				setSessionID: (sessionID: string) => {
+					if (!state) return null
+					state = { ...state, session_id: sessionID }
+					return state
+				},
+				markVerificationPending: () => state,
+				setVerificationSessionID: () => state,
+				restartAfterFailedVerification: () => state,
+				clearVerificationState: () => state,
+			},
+		})
+		const reservation = await dispatchInternalPrompt({
+			mode: "async",
+			client,
+			sessionID: "verification-session",
+			source: "model-suggestion-retry",
+			settleMs: 0,
+			postDispatchHoldMs: 10_000,
+			input: {
+				path: { id: "verification-session" },
+				body: {
+					parts: [{ type: "text", text: "verify" }],
+				},
+			},
+		})
+
+		// when
+		await handler({
+			event: { type: "message.part.updated", properties: { sessionID: "verification-session" } },
+		})
+		_flushForTesting()
+		const logContent = existsSync(logFile) ? readFileSync(logFile, "utf8") : ""
+		const releasedByOwner = releasePromptAsyncReservation("verification-session", "model-suggestion-retry")
+
+		// then
+		expect(reservation.status).toBe("dispatched")
+		expect(getStateCalls).toBe(0)
+		expect(releasedByOwner).toBe(true)
+		expect(logContent).not.toContain("promptAsync reservation release skipped for different source")
+	})
+
+	test("#given verification session has a Ralph reservation #when verification activity arrives #then Ralph may release it", async () => {
+		// given
+		let state: RalphLoopState | null = {
+			active: true,
+			iteration: 1,
+			max_iterations: 5,
+			completion_promise: "DONE",
+			started_at: new Date().toISOString(),
+			prompt: "Keep working",
+			session_id: "parent-session",
+			verification_pending: true,
+			verification_session_id: "verification-session",
+		}
+		const promptCalls: PromptCall[] = []
+		const client = unsafeTestValue({
+			session: {
+				messages: async () => ({ data: [] }),
+				promptAsync: async (input: {
+					readonly path: { readonly id: string }
+					readonly body: { readonly parts: readonly [{ readonly text: string }] }
+				}) => {
+					promptCalls.push({
+						sessionID: input.path.id,
+						text: input.body.parts[0].text,
+					})
+					return {}
+				},
+			},
+		})
+		const handler = createRalphLoopEventHandler(unsafeTestValue({ client }), {
+			directory: "/tmp/ralph-loop-event-handler-characterization",
+			apiTimeoutMs: 5000,
+			idleSettleMs: 0,
+			getTranscriptPath: () => undefined,
+			loopState: {
+				getState: () => state,
+				clear: () => {
+					state = null
+					return true
+				},
+				incrementIteration: () => state,
+				setSessionID: (sessionID: string) => {
+					if (!state) return null
+					state = { ...state, session_id: sessionID }
+					return state
+				},
+				markVerificationPending: () => state,
+				setVerificationSessionID: () => state,
+				restartAfterFailedVerification: () => state,
+				clearVerificationState: () => state,
+			},
+		})
+		const reservation = await dispatchInternalPrompt({
+			mode: "async",
+			client,
+			sessionID: "verification-session",
+			source: "ralph-loop",
+			settleMs: 0,
+			postDispatchHoldMs: 10_000,
+			input: {
+				path: { id: "verification-session" },
+				body: {
+					parts: [{ type: "text", text: "verify" }],
+				},
+			},
+		})
+
+		// when
+		await handler({
+			event: { type: "message.part.updated", properties: { sessionID: "verification-session" } },
+		})
+		const releasedAfterHandler = releasePromptAsyncReservation("verification-session", "ralph-loop")
+
+		// then
+		expect(reservation.status).toBe("dispatched")
+		expect(releasedAfterHandler).toBe(false)
+		expect(promptCalls).toHaveLength(1)
+	})
+
+	test("#given child subagent activity with a non-Ralph prompt hold #when Ralph observes the event #then it ignores the child session without mismatch spam", async () => {
+		// given
+		let state: RalphLoopState | null = {
+			active: true,
+			iteration: 1,
+			max_iterations: 5,
+			completion_promise: "DONE",
+			started_at: new Date().toISOString(),
+			prompt: "Keep working",
+			session_id: "parent-session",
+		}
+		const logFilePath = join(mkdtempSync(join(tmpdir(), "ralph-child-activity-")), "omo.log")
+		_setLoggerForTesting({ filePath: logFilePath, maxSizeBytes: 1024 * 1024, maxBackups: 1 })
+		const promptCalls: PromptCall[] = []
+		const client = unsafeTestValue({
+			session: {
+				messages: async () => ({ data: [] }),
+				promptAsync: async (input: {
+					readonly path: { readonly id: string }
+					readonly body: { readonly parts: readonly [{ readonly text: string }] }
+				}) => {
+					promptCalls.push({
+						sessionID: input.path.id,
+						text: input.body.parts[0].text,
+					})
+					return {}
+				},
+			},
+		})
+		const handler = createRalphLoopEventHandler(unsafeTestValue({ client }), {
+			directory: "/tmp/ralph-loop-event-handler-characterization",
+			apiTimeoutMs: 5000,
+			idleSettleMs: 0,
+			getTranscriptPath: () => undefined,
+			loopState: {
+				getState: () => state,
+				clear: () => {
+					state = null
+					return true
+				},
+				incrementIteration: () => state,
+				setSessionID: (sessionID: string) => {
+					if (!state) return null
+					state = { ...state, session_id: sessionID }
+					return state
+				},
+				markVerificationPending: () => state,
+				setVerificationSessionID: () => state,
+				restartAfterFailedVerification: () => state,
+				clearVerificationState: () => state,
+			},
+		})
+		const reservation = await dispatchInternalPrompt({
+			mode: "async",
+			client,
+			sessionID: "child-explore-session",
+			source: "model-suggestion-retry",
+			settleMs: 0,
+			postDispatchHoldMs: 10_000,
+			input: {
+				path: { id: "child-explore-session" },
+				body: {
+					parts: [{ type: "text", text: "retry child" }],
+				},
+			},
+		})
+
+		// when
+		await handler({
+			event: { type: "message.part.updated", properties: { sessionID: "child-explore-session" } },
+		})
+		_flushForTesting()
+		const releasedByOwner = releasePromptAsyncReservation("child-explore-session", "model-suggestion-retry")
+		const logText = existsSync(logFilePath) ? readFileSync(logFilePath, "utf8") : ""
+
+		// then
+		expect(reservation.status).toBe("dispatched")
+		expect(releasedByOwner).toBe(true)
+		expect(promptCalls).toHaveLength(1)
+		expect(logText).not.toContain("promptAsync reservation release skipped for different source")
 	})
 })

--- a/packages/utils/src/prompt-async-gate.test.ts
+++ b/packages/utils/src/prompt-async-gate.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
 
+import { configureSharedSubunitLogger } from "./logger"
 import {
+  _getDifferentSourceReleaseLogThrottleSizeForTesting,
   _setPromptGateMessagesFetchTimeoutMsForTesting,
   dispatchInternalPrompt,
   releaseAllPromptAsyncReservationsForTesting,
@@ -22,6 +24,7 @@ async function waitForPromise<T>(promise: Promise<T>, label: string): Promise<T>
 describe("dispatchInternalPrompt", () => {
   afterEach(() => {
     // then
+    configureSharedSubunitLogger(undefined)
     _setPromptGateMessagesFetchTimeoutMsForTesting(undefined)
     releaseAllPromptAsyncReservationsForTesting()
   })
@@ -362,6 +365,7 @@ describe("dispatchInternalPrompt", () => {
 describe("dispatchInternalPrompt shared gate behavior", () => {
   afterEach(() => {
     // then
+    configureSharedSubunitLogger(undefined)
     _setPromptGateMessagesFetchTimeoutMsForTesting(undefined)
     releaseAllPromptAsyncReservationsForTesting()
   })
@@ -1135,6 +1139,86 @@ describe("dispatchInternalPrompt shared gate behavior", () => {
     expect(first.status).toBe("dispatched")
     expect(second).toEqual({ status: "queued", queuedBy: "team-live-delivery", position: 1 })
     expect(promptCalls).toBe(1)
+  })
+
+  test("#given repeated mismatched release attempts #when the same route spams release #then mismatch logs are throttled", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 1_000
+    const logs: Array<{ readonly message: string; readonly data?: unknown }> = []
+    configureSharedSubunitLogger((message, data) => logs.push({ message, data }))
+    const client = {
+      session: {
+        promptAsync: async () => ({}),
+      },
+    }
+
+    try {
+      const first = await dispatchInternalPrompt({
+        mode: "async",
+        client,
+        sessionID: "ses_throttle_mismatch_release",
+        input: {
+          path: { id: "ses_throttle_mismatch_release" },
+          body: { parts: [{ type: "text", text: "hold" }] },
+        },
+        source: "model-suggestion-retry",
+        settleMs: 0,
+      })
+
+      // when
+      const firstRelease = releasePromptAsyncReservation("ses_throttle_mismatch_release", "ralph-loop")
+      const secondRelease = releasePromptAsyncReservation("ses_throttle_mismatch_release", "ralph-loop")
+      Date.now = () => 31_001
+      const thirdReleaseAfterThrottleWindow = releasePromptAsyncReservation("ses_throttle_mismatch_release", "ralph-loop")
+      const ownerRelease = releasePromptAsyncReservation("ses_throttle_mismatch_release", "model-suggestion-retry")
+
+      // then
+      const mismatchLogs = logs.filter((entry) => entry.message.includes("release skipped for different source"))
+      expect(first.status).toBe("dispatched")
+      expect(firstRelease).toBe(false)
+      expect(secondRelease).toBe(false)
+      expect(thirdReleaseAfterThrottleWindow).toBe(false)
+      expect(ownerRelease).toBe(true)
+      expect(mismatchLogs).toHaveLength(2)
+    } finally {
+      Date.now = originalDateNow
+    }
+  })
+
+  test("#given many unique mismatched release attempts #when the throttle cache fills #then old entries are pruned", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 10_000
+    const client = {
+      session: {
+        promptAsync: async () => ({}),
+      },
+    }
+
+    try {
+      // when
+      for (let index = 0; index < 1_100; index += 1) {
+        const sessionID = `ses_throttle_bound_${index}`
+        await dispatchInternalPrompt({
+          mode: "async",
+          client,
+          sessionID,
+          input: {
+            path: { id: sessionID },
+            body: { parts: [{ type: "text", text: "hold" }] },
+          },
+          source: "model-suggestion-retry",
+          settleMs: 0,
+        })
+        releasePromptAsyncReservation(sessionID, "ralph-loop")
+      }
+
+      // then
+      expect(_getDifferentSourceReleaseLogThrottleSizeForTesting()).toBeLessThanOrEqual(1_024)
+    } finally {
+      Date.now = originalDateNow
+    }
   })
 
   test("#given a route family promptAsync hold #when the same family aborts another source #then the reservation is released", async () => {

--- a/packages/utils/src/prompt-async-gate.ts
+++ b/packages/utils/src/prompt-async-gate.ts
@@ -58,6 +58,11 @@ export {
   _setPromptGateMessagesFetchTimeoutMsForTesting,
 } from "./prompt-async-gate/timing"
 
+export {
+  getPromptReservation,
+  reservationSourceMatches,
+} from "./prompt-async-gate/reservations"
+
 export type {
   InternalPromptDispatchArgs,
   InternalPromptDispatchMode,
@@ -69,6 +74,54 @@ export type {
 type ObjectPathPromptInput = {
   readonly path?: { readonly id?: string } | string
   readonly [key: string]: unknown
+}
+
+const DIFFERENT_SOURCE_RELEASE_LOG_THROTTLE_MS = 30_000
+const DIFFERENT_SOURCE_RELEASE_LOG_MAX_ENTRIES = 1_024
+const differentSourceReleaseLogTimes = new Map<string, number>()
+
+function pruneDifferentSourceReleaseLogTimes(now: number): void {
+  for (const [key, loggedAt] of differentSourceReleaseLogTimes) {
+    if (now - loggedAt >= DIFFERENT_SOURCE_RELEASE_LOG_THROTTLE_MS) {
+      differentSourceReleaseLogTimes.delete(key)
+    }
+  }
+
+  const overflowCount = differentSourceReleaseLogTimes.size - DIFFERENT_SOURCE_RELEASE_LOG_MAX_ENTRIES
+  if (overflowCount <= 0) {
+    return
+  }
+
+  let removedCount = 0
+  for (const key of differentSourceReleaseLogTimes.keys()) {
+    differentSourceReleaseLogTimes.delete(key)
+    removedCount += 1
+    if (removedCount >= overflowCount) {
+      return
+    }
+  }
+}
+
+export function _getDifferentSourceReleaseLogThrottleSizeForTesting(): number {
+  return differentSourceReleaseLogTimes.size
+}
+
+function shouldLogDifferentSourceRelease(
+  sessionID: string,
+  source: string,
+  reservedBy: string,
+  now = Date.now(),
+): boolean {
+  pruneDifferentSourceReleaseLogTimes(now)
+
+  const key = `${sessionID}\u0000${source}\u0000${reservedBy}`
+  const lastLoggedAt = differentSourceReleaseLogTimes.get(key)
+  if (lastLoggedAt !== undefined && now - lastLoggedAt < DIFFERENT_SOURCE_RELEASE_LOG_THROTTLE_MS) {
+    return false
+  }
+  differentSourceReleaseLogTimes.set(key, now)
+  pruneDifferentSourceReleaseLogTimes(now)
+  return true
 }
 
 function hasObjectSessionPath(input: unknown): input is ObjectPathPromptInput & { readonly path: { readonly id: string } } {
@@ -301,6 +354,7 @@ export function releaseAllPromptAsyncReservationsForTesting(): void {
   clearPromptQueueStateForTesting()
   clearRecentPromptDispatchesForTesting()
   resetPromptGateTimingForTesting()
+  differentSourceReleaseLogTimes.clear()
 }
 
 export function isInternalPromptDispatchAccepted(result: InternalPromptDispatchResult): boolean {
@@ -319,11 +373,13 @@ export function releasePromptAsyncReservation(
 
   const expectedSource = options?.reservedBy ?? source
   if (!reservationSourceMatches(existing.source, expectedSource, options?.reservedByPrefix)) {
-    log("[prompt-async-gate] promptAsync reservation release skipped for different source", {
-      sessionID,
-      source,
-      reservedBy: existing.source,
-    })
+    if (shouldLogDifferentSourceRelease(sessionID, source, existing.source)) {
+      log("[prompt-async-gate] promptAsync reservation release skipped for different source", {
+        sessionID,
+        source,
+        reservedBy: existing.source,
+      })
+    }
     return false
   }
 


### PR DESCRIPTION
## Summary

Fixes Ralph-loop activity cleanup so prompt reservations are only released for sessions and reservation sources Ralph actually owns.

Before this change, child/subagent or verification-session activity could make Ralph attempt to release a prompt hold owned by another route, producing repeated `promptAsync reservation release skipped for different source` warnings during Ralph/ULW workflows. The updated branch also avoids doing disk-backed loop-state reads for unrelated streamed activity and bounds the shared prompt-gate mismatch log throttle.

## Changes

- Scope Ralph runtime-retry activity cleanup to active Ralph-owned parent or verification sessions.
- Check cheap in-memory runtime-retry and prompt-reservation ownership before falling back to disk-backed loop state.
- Release only prompt reservations owned by `ralph-loop` / `ralph-loop:*`; preserve holds owned by `model-suggestion-retry` and delegate-task routes.
- Clear stale Ralph runtime-retry markers without releasing another route's prompt reservation.
- Add a bounded throttle for repeated prompt-gate mismatched-release logs.
- Add characterization coverage for unrelated child activity, non-Ralph-owned verification activity, Ralph-owned verification activity, stale runtime markers, and bounded prompt-gate mismatch logging.

## QA & Evidence

- **What was tested:** Focused Ralph loop + prompt-gate regression surface.
  **Observed result:** `bun test packages/omo-opencode/src/hooks/ralph-loop packages/utils/src/prompt-async-gate.test.ts --bail` reported `209 pass`, `0 fail`.
  **Artifact:** `.omo/evidence/20260630-ralph-prompt-gate-full-qa/SUMMARY.md`
  **Why sufficient:** Covers the changed Ralph event-handler paths plus prompt-gate reservation behavior.

- **What was tested:** Mirrored/shared prompt-gate import surfaces.
  **Observed result:** `bun test packages/omo-opencode/src/hooks/shared/prompt-async-gate.test.ts packages/omo-opencode/src/hooks/shared/prompt-async-gate-semantic-dedupe-edge.test.ts packages/utils/src/prompt-async-gate*.test.ts --bail` reported `95 pass`, `0 fail`.
  **Artifact:** `.omo/evidence/20260630-ralph-prompt-gate-full-qa/SUMMARY.md`
  **Why sufficient:** Confirms both the utils implementation and OpenCode shared re-export surfaces remain compatible.

- **What was tested:** Typecheck.
  **Observed result:** `bun run typecheck` passed.
  **Artifact:** `.omo/evidence/20260630-ralph-prompt-gate-full-qa/SUMMARY.md`
  **Why sufficient:** Covers workspace TypeScript correctness after the branch was rebased.

- **What was tested:** Build.
  **Observed result:** `bun run build` passed.
  **Artifact:** `.omo/evidence/20260630-ralph-prompt-gate-full-qa/SUMMARY.md`
  **Why sufficient:** Confirms the built OpenCode plugin entrypoint and generated declarations/schema still build.

- **What was tested:** Codex compatibility gate.
  **Observed result:** `bun run test:codex` passed; final Node test summary reported `440 pass`, `0 fail`.
  **Artifact:** `.omo/evidence/20260630-ralph-prompt-gate-full-qa/SUMMARY.md`
  **Why sufficient:** This change is OpenCode-side, but the shared workspace gate still passed.

- **What was tested:** OpenCode harness QA via `.agents/skills/opencode-qa`.
  **Observed result:** `common.sh --self-check`, `sse-hook-probe.sh --self-test`, and `tui-smoke.sh --self-test` all passed. TUI smoke proved the real OpenCode DB session count stayed unchanged before/after. A separate isolated local-dist smoke loaded `dist/index.js`, exited 0, kept the real DB count unchanged, left the sandbox DB with zero sessions, and produced no `promptAsync reservation release skipped for different source` lines.
  **Artifact:** `.omo/evidence/20260630-ralph-prompt-gate-full-qa/SUMMARY.md`
  **Why sufficient:** Drives the real OpenCode QA harness and proves isolation for the plugin-connected change.

- **What was tested:** Root test suite.
  **Observed result:** `bun test` reported `10239 pass`, `2 skip`, `5 fail`. The failing files are outside this PR's changed surface and passed when rerun in isolation:
  - `bun test packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts` -> `7 pass`, `0 fail`.
  - `bun test packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler-retry.test.ts` -> `3 pass`, `0 fail`.
  **Artifact:** `.omo/evidence/20260630-ralph-prompt-gate-full-qa/SUMMARY.md`
  **Why sufficient:** Records the current full-suite instability and shows the failures are isolated from the Ralph/prompt-gate change.

## Risks & Residuals

- The main behavior risk is accidentally suppressing legitimate Ralph/ULW retry cleanup. This is covered by parent-session, verification-session, stale-marker, unrelated-child, and Ralph-owned reservation tests.
- Full root `bun test` is not globally green in this checkout. The failing files pass in isolation and are outside the changed Ralph-loop/prompt-gate files, so this PR treats them as pre-existing full-suite/order-dependent instability rather than a regression from this change.
- The prompt-gate throttle only suppresses repeated mismatch logs. It does not change the ownership check: mismatched releases still return `false`.

## Automated Checks

```bash
bun run typecheck
bun test packages/omo-opencode/src/hooks/ralph-loop packages/utils/src/prompt-async-gate.test.ts --bail
bun test packages/omo-opencode/src/hooks/shared/prompt-async-gate.test.ts packages/omo-opencode/src/hooks/shared/prompt-async-gate-semantic-dedupe-edge.test.ts packages/utils/src/prompt-async-gate*.test.ts --bail
bun run test:codex
bun run build
bun test
```

## Related Issues

Related: #5105
