### PR TITLE
fix(omo-codex): fail on unreadable config.toml instead of overwriting it (fixes #5751)

### DIFF
--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -8523,8 +8523,12 @@ function readBooleanSetting(sectionText, key) {
 async function updateCodexConfig(input) {
   await mkdir5(dirname6(input.configPath), { recursive: true });
   let config = "";
-  if (await exists(input.configPath))
+  try {
     config = await readFile10(input.configPath, "utf8");
+  } catch (error) {
+    if (!(isNodeErrorWithCode(error) && error.code === "ENOENT"))
+      throw error;
+  }
   const pluginSet = new Set(input.pluginNames);
   for (const legacyMarketplaceName of legacyMarketplaceNames(input.marketplaceName)) {
     config = removeMarketplaceBlock(config, legacyMarketplaceName);
@@ -8559,16 +8563,6 @@ async function updateCodexConfig(input) {
   await writeFileAtomic(input.configPath, `${config.trimEnd()}
 `);
 }
-async function exists(path) {
-  try {
-    await readFile10(path, "utf8");
-    return true;
-  } catch (error) {
-    if (error instanceof Error)
-      return false;
-    return false;
-  }
-}
 
 // packages/omo-codex/src/install/codex-hook-trust.ts
 import { createHash } from "node:crypto";
@@ -8588,7 +8582,7 @@ var EVENT_LABELS = new Map([
 ]);
 async function trustedHookStatesForPlugin(input) {
   const manifestPath = join17(input.pluginRoot, ".codex-plugin", "plugin.json");
-  if (!await exists2(manifestPath))
+  if (!await exists(manifestPath))
     return [];
   const manifest = JSON.parse(await readFile11(manifestPath, "utf8"));
   if (!isPlainRecord(manifest))
@@ -8596,7 +8590,7 @@ async function trustedHookStatesForPlugin(input) {
   const states = [];
   for (const hookPath of hookManifestPaths2(manifest.hooks)) {
     const hooksPath = join17(input.pluginRoot, hookPath);
-    if (!await exists2(hooksPath))
+    if (!await exists(hooksPath))
       continue;
     const parsed = JSON.parse(await readFile11(hooksPath, "utf8"));
     if (!isPlainRecord(parsed) || !isPlainRecord(parsed.hooks))
@@ -8679,7 +8673,7 @@ function canonicalJson(value) {
 function stripDotSlash2(value) {
   return value.startsWith("./") ? value.slice(2) : value;
 }
-async function exists2(path) {
+async function exists(path) {
   try {
     await readFile11(path, "utf8");
     return true;
@@ -8738,11 +8732,11 @@ var RETIRED_MANAGED_AGENT_FILES = [
 ];
 async function purgeRetiredManagedAgentFiles(input) {
   const agentsDir = join18(input.codexHome, "agents");
-  if (!await exists3(agentsDir))
+  if (!await exists2(agentsDir))
     return;
   for (const retiredAgent of RETIRED_MANAGED_AGENT_FILES) {
     const agentPath = join18(agentsDir, retiredAgent.fileName);
-    if (!await exists3(agentPath))
+    if (!await exists2(agentPath))
       continue;
     const agentStat = await lstat6(agentPath);
     if (agentStat.isDirectory() && !agentStat.isSymbolicLink())
@@ -8765,7 +8759,7 @@ async function readTextIfExists(path) {
     throw error;
   }
 }
-async function exists3(path) {
+async function exists2(path) {
   try {
     await lstat6(path);
     return true;
@@ -8785,7 +8779,7 @@ function nodeErrorCode(error) {
 var MANIFEST_FILE = ".installed-agents.json";
 async function capturePreservedAgentReasoning(input) {
   const agentsDir = join19(input.codexHome, "agents");
-  if (!await exists4(agentsDir))
+  if (!await exists3(agentsDir))
     return new Map;
   const preserved = new Map;
   const agentEntries = await readdir4(agentsDir, { withFileTypes: true });
@@ -8803,7 +8797,7 @@ async function capturePreservedAgentReasoning(input) {
 }
 async function capturePreservedAgentServiceTier(input) {
   const agentsDir = join19(input.codexHome, "agents");
-  if (!await exists4(agentsDir))
+  if (!await exists3(agentsDir))
     return new Map;
   const preserved = new Map;
   const agentEntries = await readdir4(agentsDir, { withFileTypes: true });
@@ -8861,7 +8855,7 @@ async function restorePreservedServiceTier(input) {
 }
 async function discoverBundledAgents(pluginRoot) {
   const componentsRoot = join19(pluginRoot, "components");
-  if (!await exists4(componentsRoot))
+  if (!await exists3(componentsRoot))
     return [];
   const componentEntries = await readdir4(componentsRoot, { withFileTypes: true });
   const agents = [];
@@ -8869,7 +8863,7 @@ async function discoverBundledAgents(pluginRoot) {
     if (!entry.isDirectory())
       continue;
     const agentsRoot = join19(componentsRoot, entry.name, "agents");
-    if (!await exists4(agentsRoot))
+    if (!await exists3(agentsRoot))
       continue;
     const agentEntries = await readdir4(agentsRoot, { withFileTypes: true });
     for (const file2 of agentEntries) {
@@ -8886,7 +8880,7 @@ async function replaceWithCopy(linkPath, target) {
   await copyFile(target, linkPath);
 }
 async function prepareReplacement(linkPath) {
-  if (!await exists4(linkPath))
+  if (!await exists3(linkPath))
     return;
   const entryStat = await lstat7(linkPath);
   if (entryStat.isDirectory() && !entryStat.isSymbolicLink()) {
@@ -9005,7 +8999,7 @@ function parseJsonString(value) {
     return null;
   }
 }
-async function exists4(path) {
+async function exists3(path) {
   try {
     await lstat7(path);
     return true;
@@ -9419,7 +9413,7 @@ async function findProjectLocalCodexConfigs(startDirectory, codexHome) {
         configPathsFromCwd.push(configPath);
       }
     }
-    if (await exists5(join23(current, ".git"))) {
+    if (await exists4(join23(current, ".git"))) {
       return configPathsFromCwd.length === 0 ? null : {
         projectRoot: current,
         configPaths: [...configPathsFromCwd].reverse(),
@@ -9500,7 +9494,7 @@ async function maybeLstat(path) {
     throw error;
   }
 }
-async function exists5(path) {
+async function exists4(path) {
   return await maybeLstat(path) !== null;
 }
 function nodeErrorCode3(error) {

--- a/packages/omo-codex/src/install/codex-config-toml.test.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.test.ts
@@ -4,7 +4,7 @@
 // allow: SIZE_OK - Codex TOML writer coverage shares parser/fixture helpers across migration edge cases; this release adds config regressions and future edits should split by table family.
 
 import { describe, expect, test } from "bun:test"
-import { lstat, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises"
+import { chmod, lstat, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { updateCodexConfig } from "./codex-config-toml"
@@ -709,5 +709,51 @@ describe("codex-config-toml", () => {
     expect(content).toContain('[agents."review.agent"]')
     expect(content).toContain('config_file = "./agents/review.agent.toml"')
   })
+
+  test("#given a config path that exists but cannot be read as a file #when updating config #then surfaces the read error instead of overwriting from an empty config", async () => {
+    // given a config path that exists but is not a readable file (a directory makes readFile throw EISDIR cross-platform)
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-unreadable-dir-"))
+    const configPath = join(root, "config.toml")
+    await mkdir(configPath)
+    await writeFile(join(configPath, "keep.txt"), "user data")
+
+    // when updating config
+    // then the read error surfaces instead of overwriting from an empty config
+    await expect(
+      updateCodexConfig({
+        configPath,
+        repoRoot: "/repo/packages/omo-codex",
+        marketplaceName: "debug",
+        marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+        pluginNames: ["omo"],
+      }),
+    ).rejects.toThrow("EISDIR")
+  })
+
+  test.skipIf(process.platform === "win32")(
+    "#given an existing config file that cannot be read #when updating config #then rejects and preserves the original file",
+    async () => {
+      // given an existing config.toml that cannot be read (POSIX write-only permission)
+      const root = await mkdtemp(join(tmpdir(), "omo-codex-config-unreadable-file-"))
+      const configPath = join(root, "config.toml")
+      const original = '[user]\nimportant = "keep"\n'
+      await writeFile(configPath, original)
+      await chmod(configPath, 0o200)
+
+      // when updating config
+      // then it rejects and preserves the original content
+      await expect(
+        updateCodexConfig({
+          configPath,
+          repoRoot: "/repo/packages/omo-codex",
+          marketplaceName: "debug",
+          marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+          pluginNames: ["omo"],
+        }),
+      ).rejects.toThrow()
+      await chmod(configPath, 0o600)
+      expect(await readFile(configPath, "utf8")).toBe(original)
+    },
+  )
 
 })

--- a/packages/omo-codex/src/install/codex-config-toml.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile } from "node:fs/promises"
 import { dirname } from "node:path"
+import { isNodeErrorWithCode } from "./codex-cache-fs"
 import { ensureAgentConfig, removeStaleManagedAgentBlocks } from "./codex-config-agents"
 import { writeFileAtomic } from "./codex-config-atomic-write"
 import { ensureFeatureEnabled } from "./codex-config-features"
@@ -35,7 +36,11 @@ export async function updateCodexConfig(input: {
 }): Promise<void> {
   await mkdir(dirname(input.configPath), { recursive: true })
   let config = ""
-  if (await exists(input.configPath)) config = await readFile(input.configPath, "utf8")
+  try {
+    config = await readFile(input.configPath, "utf8")
+  } catch (error) {
+    if (!(isNodeErrorWithCode(error) && error.code === "ENOENT")) throw error
+  }
 
   const pluginSet = new Set(input.pluginNames)
   for (const legacyMarketplaceName of legacyMarketplaceNames(input.marketplaceName)) {
@@ -72,14 +77,4 @@ export async function updateCodexConfig(input: {
   }
 
   await writeFileAtomic(input.configPath, `${config.trimEnd()}\n`)
-}
-
-async function exists(path: string): Promise<boolean> {
-  try {
-    await readFile(path, "utf8")
-    return true
-  } catch (error) {
-    if (error instanceof Error) return false
-    return false
-  }
 }


### PR DESCRIPTION
## Summary

The omo-codex installer could **overwrite an existing `config.toml` when the file exists but cannot be read**. `updateCodexConfig()` now reads the config directly and only treats a genuinely-absent file (`ENOENT`) as empty; any other read error is re-thrown before a single byte is written.

Fixes #5751.

## Root Cause

`updateCodexConfig()` probed for an existing config with a local `exists()` helper:

```ts
let config = ""
if (await exists(input.configPath)) config = await readFile(input.configPath, "utf8")
// ...
async function exists(path: string): Promise<boolean> {
  try { await readFile(path, "utf8"); return true }
  catch (error) { if (error instanceof Error) return false; return false }
}
```

`exists()` swallowed **every** `readFile()` error and returned `false`. A present-but-unreadable `config.toml` (`EACCES`/`EPERM`, or any non-`ENOENT` read failure) was therefore treated as absent, so the function started from an empty config and `writeFileAtomic()` replaced the user's file, dropping its contents.

## Changes

| File | Change |
|------|--------|
| `packages/omo-codex/src/install/codex-config-toml.ts` | Read the config directly; catch only `ENOENT` (use empty config), re-throw all other read errors before any write. Remove the now-unused `exists()` helper. Reuses the existing `isNodeErrorWithCode` guard from `codex-cache-fs`. |
| `packages/omo-codex/src/install/codex-config-toml.test.ts` | Two regression tests: a cross-platform case (an unreadable path surfaces the read error instead of overwriting) and a POSIX `chmod 0o200` case asserting the original file is preserved. |

Net source change: `+6 / -9` (one import, the read guard, minus the dead helper).

## Reproduction (before fix)

The new test against the unmodified code shows the installer reaches `writeFileAtomic` and **attempts to overwrite** the existing path:

```
).rejects.toThrow("EISDIR")
error: expect(received).toThrow(expected)
Expected substring: "EISDIR"
Received message: "EPERM: operation not permitted, rename
'...\.tmp-config.toml-7968-...' -> '...\config.toml'"
(fail) codex-config-toml > ...surfaces the read error instead of overwriting from an empty config
```

`chmod` cannot make a file unreadable on Windows, so the unreadable case is exercised cross-platform via a directory `config.toml` (so `readFile` throws `EISDIR`), plus a POSIX `chmod 0o200` test that is skipped on Windows.

## Verification (after fix)

```
(pass) codex-config-toml > ...surfaces the read error instead of overwriting from an empty config
(skip) codex-config-toml > ...rejects and preserves the original file   # POSIX-only chmod case
 22 pass
 1 skip
 0 fail
Ran 23 tests across 1 file.
```

## Test

- Regression: `packages/omo-codex/src/install/codex-config-toml.test.ts` (2 new cases) - 22 pass / 1 skip (POSIX-only `chmod` case) / 0 fail
- Typecheck: `tsgo --noEmit -p packages/omo-codex/tsconfig.json` - clean (exit 0)

Fixes #5751

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the `omo-codex` installer from overwriting an existing `config.toml` when the file exists but can’t be read. `updateCodexConfig()` now treats only `ENOENT` as “missing” and fails fast on other read errors. Fixes #5751.

- **Bug Fixes**
  - Read the config directly; catch only `ENOENT`, re-throw all other read errors before any write.
  - Removed the `exists()` probe that swallowed read errors and caused unintended overwrites.
  - Regenerated the bundled installer at `scripts/install-dist/install-local.mjs` so the fix is used when the dist bundle is present; the old `exists()` path is removed.
  - Added regression tests for unreadable paths (cross‑platform) and POSIX `chmod` to ensure the original file is preserved.

<sup>Written for commit dc8ae70aba6536eafb32808c8b0029b399d4b560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

