### PR TITLE
fix(ulw-loop): require a value for explicit --session-id (fixes #5752)

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/src/cli-commands.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/cli-commands.ts
@@ -39,8 +39,8 @@ export async function ulwLoopCommand(argv: readonly string[]): Promise<number> {
 	const rest = argv.slice(1);
 	const repoRoot = process.cwd();
 	const json = hasFlag(rest, "--json");
-	const scope = commandScope(rest);
 	try {
+		const scope = commandScope(rest);
 		if (!isUlwLoopSubcommand(command)) {
 			if (json) {
 				printJsonError(
@@ -94,7 +94,22 @@ function unhandledSubcommand(command: never): never {
 	throw new UlwLoopError(`Unhandled ulw-loop subcommand: ${String(command)}.`, "ULW_LOOP_SUBCOMMAND_UNHANDLED");
 }
 
+const SESSION_ID_FLAG = "--session-id";
+
+function sessionIdFlagPresent(argv: readonly string[]): boolean {
+	return hasFlag(argv, SESSION_ID_FLAG) || argv.some((arg) => arg.startsWith(`${SESSION_ID_FLAG}=`));
+}
+
 function commandScope(argv: readonly string[]): UlwLoopScope | undefined {
-	const sessionId = readValue(argv, "--session-id") ?? resolveUlwLoopSessionIdFromEnv();
+	if (sessionIdFlagPresent(argv)) {
+		const sessionId = readValue(argv, SESSION_ID_FLAG)?.trim();
+		if (!sessionId) {
+			throw new UlwLoopError(`${SESSION_ID_FLAG} requires a non-empty value.`, "ULW_LOOP_SESSION_ID_REQUIRED", {
+				details: { flag: SESSION_ID_FLAG },
+			});
+		}
+		return { sessionId };
+	}
+	const sessionId = resolveUlwLoopSessionIdFromEnv();
 	return sessionId === null ? undefined : { sessionId };
 }

--- a/packages/omo-codex/plugin/components/ulw-loop/test/cli-create-goals.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/cli-create-goals.test.ts
@@ -169,4 +169,20 @@ describe("ulwLoopCommand create-goals", () => {
 
 		expect(await readFile(join(testDir, ".omo/ulw-loop/manual-456/goals.json"), "utf8")).toContain("Manual scoped");
 	});
+
+	it("#given a valueless --session-id #when creating goals #then it fails and writes no plan", async () => {
+		const code = await ulwLoopCommand(["create-goals", "--session-id", "--brief", "- Alpha"]);
+
+		expect(code).toBe(1);
+		expect(err.join("")).toContain("--session-id requires a non-empty value");
+		await expect(readFile(join(testDir, ".omo/ulw-loop/goals.json"), "utf8")).rejects.toThrow();
+	});
+
+	it("#given an empty --session-id= #when creating goals #then it fails and writes no plan", async () => {
+		const code = await ulwLoopCommand(["create-goals", "--session-id=", "--brief", "- Alpha"]);
+
+		expect(code).toBe(1);
+		expect(err.join("")).toContain("--session-id requires a non-empty value");
+		await expect(readFile(join(testDir, ".omo/ulw-loop/goals.json"), "utf8")).rejects.toThrow();
+	});
 });


### PR DESCRIPTION
## Summary

`ulw-loop` accepted `--session-id` **without a value** and silently fell back to the ambient session env or the unscoped default, so a user who meant to isolate state could write a plan into the wrong scope with no signal. An explicit `--session-id` (or `--session-id=`) now requires a non-empty value; only an omitted flag falls back to env.

Fixes #5752.

## Root Cause

`commandScope()` resolved the scope with a nullish coalesce:

```ts
function commandScope(argv: readonly string[]): UlwLoopScope | undefined {
  const sessionId = readValue(argv, "--session-id") ?? resolveUlwLoopSessionIdFromEnv();
  return sessionId === null ? undefined : { sessionId };
}
```

`readValue()` returns `undefined` **both** when the flag is absent **and** when it is present without a value (`--session-id` followed by another flag, or `--session-id=`). So a present-but-valueless flag was indistinguishable from an omitted flag and fell through to `resolveUlwLoopSessionIdFromEnv()` / unscoped.

## Changes

| File | Change |
|------|--------|
| `packages/omo-codex/plugin/components/ulw-loop/src/cli-commands.ts` | Detect when `--session-id` / `--session-id=` is present and require a trimmed non-empty value (throw `ULW_LOOP_SESSION_ID_REQUIRED` otherwise); only an absent flag falls back to env. Move the `commandScope()` call inside `ulwLoopCommand()`'s try/catch so the rejection is reported through the normal error path (text and `--json`) and returns a non-zero exit instead of escaping the function. |
| `packages/omo-codex/plugin/components/ulw-loop/test/cli-create-goals.test.ts` | Regression tests: valueless `--session-id` and empty `--session-id=` both exit non-zero and write no plan. |

## Reproduction (before fix)

Valueless `--session-id` with session env cleared (the issue's repro):

```
$ bun src/cli.ts create-goals --session-id --goal x --criteria y
ulw-loop plan created: 1 goal(s)
brief: .omo/ulw-loop/brief.md
goals: .omo/ulw-loop/goals.json
ledger: .omo/ulw-loop/ledger.jsonl
exit=0                      # silently created an UNSCOPED plan
```

## Verification (after fix)

```
[A valueless --session-id]   exit=1  files=0   "--session-id requires a non-empty value."
[B empty   --session-id=  ]   exit=1  files=0
[C valid   --session-id foo]  exit=0  -> .omo/ulw-loop/foo/goals.json
[D ambient CODEX_SESSION_ID]  exit=0  -> .omo/ulw-loop/ambient-1/goals.json   (env fallback preserved)
[E no flag, no env        ]   exit=0  -> .omo/ulw-loop/goals.json             (unchanged)
```

## Test

- Regression: `test/cli-create-goals.test.ts` (2 new cases) - `vitest --run` 7 pass / 0 fail for that file
- Typecheck: `tsc --noEmit` - clean (exit 0)
- Note: a few pre-existing Windows-only failures in `paths.test.ts` / `package-smoke.test.ts` / `cli-entrypoint.test.ts` are unrelated to this change and reproduce on `dev` with the change stashed.

Fixes #5752


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`ulw-loop` now requires a non-empty value when `--session-id` is provided, preventing accidental writes to the wrong scope. Only an omitted flag falls back to env/default. Fixes #5752.

- **Bug Fixes**
  - Treat present-but-empty `--session-id`/`--session-id=` as errors (`ULW_LOOP_SESSION_ID_REQUIRED`).
  - Call `commandScope()` inside `ulwLoopCommand()` try/catch to surface errors and exit non-zero (supports `--json`).
  - Added regression tests: valueless and empty `--session-id` fail and write no plan.

<sup>Written for commit f2ed3b10e67fbd3723198b9198c3af2e22b9eb3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

