### PR TITLE
fix(git-bash-mcp): keep stdio transport alive

### DIFF
--- a/packages/git-bash-mcp/src/mcp-startup.test.ts
+++ b/packages/git-bash-mcp/src/mcp-startup.test.ts
@@ -34,6 +34,27 @@ describe("git_bash MCP startup gate", () => {
     // then
     expect(capture.read()).toBe("");
   });
+
+  it("#given Windows host with Git Bash #when Codex starts the stdio server #then idle timeout is disabled across compaction gaps", async () => {
+    // given
+    const capture = captureStdout();
+    const lifecycle: Array<{ readonly event: string; readonly data?: unknown }> = [];
+
+    // when
+    await runMcpStdioServer(Readable.from(['{"jsonrpc":"2.0","id":"init","method":"initialize"}\n']), capture.stdout, {
+      platform: "win32",
+      env: {},
+      exists: () => true,
+      where: () => [],
+      lifecycleLog: (event, data) => {
+        lifecycle.push({ event, data });
+      },
+    });
+
+    // then
+    expect(capture.read()).toContain('"serverInfo":{"name":"git_bash"');
+    expect(lifecycle).toContainEqual({ event: "stdio_started", data: expect.objectContaining({ idle_timeout_ms: 0 }) });
+  });
 });
 
 function captureStdout(): { readonly stdout: Writable; readonly read: () => string } {

--- a/packages/git-bash-mcp/src/mcp.ts
+++ b/packages/git-bash-mcp/src/mcp.ts
@@ -1,6 +1,6 @@
 import type { Readable, Writable } from "node:stream";
 import { errorResponse, isPlainRecord, jsonRpcId, runJsonRpcStdioServer, successResponse } from "@oh-my-opencode/mcp-stdio-core";
-import type { JsonRpcResponse } from "@oh-my-opencode/mcp-stdio-core";
+import type { JsonRpcResponse, McpLifecycleLog } from "@oh-my-opencode/mcp-stdio-core";
 import { resolveGitBash, resolveGitBashForCurrentProcess, type GitBashResolution } from "./git-bash-resolver";
 import { runGitBashCommand, type GitBashRunResult, type RunGitBashCommand } from "./runner";
 
@@ -14,6 +14,7 @@ const EXEC_COMMAND_TIMEOUT_ENV_KEYS = [
 ] as const;
 
 export interface GitBashMcpOptions {
+  readonly lifecycleLog?: McpLifecycleLog;
   readonly platform?: string;
   readonly env?: { readonly [key: string]: string | undefined };
   readonly exists?: (path: string) => boolean;
@@ -66,6 +67,8 @@ export async function runMcpStdioServer(input: Readable, output: Writable, optio
     output,
     handler: handleGitBashMcpRequest,
     handlerOptions: options,
+    idleTimeoutMs: 0,
+    log: options.lifecycleLog,
     parseErrorResponse: () => errorResponse(null, -32601, "Method not found"),
   });
 }


### PR DESCRIPTION
## Summary

Fixes a LazyCodex-owned stale stdio transport path for `git_bash`: when the MCP server is available on Windows, it no longer inherits the shared 10-minute JSON-RPC stdio idle timeout. That idle timeout could leave Codex with a cached tool surface backed by a closed transport after a long compaction/recovery gap.

The change keeps the existing Git Bash tool surface unchanged, adds a lifecycle-log test seam, and pins the server startup behavior at `idle_timeout_ms: 0`.

## Changes

- Disable the Git Bash MCP stdio idle timeout so Codex does not keep a listed `git_bash` tool backed by a server that voluntarily idled itself closed.
- Add a regression test that simulates a Windows host with Git Bash available and asserts the server starts with idle timeout disabled.
- Leave non-Windows and Windows-without-Git-Bash startup behavior unchanged: no protocol noise when the tool should not be exposed.

## QA & Evidence

- **What was tested:** RED focused package test before the production timeout change.
  **Observed result:** The new pin failed because Git Bash MCP started with `idle_timeout_ms: 600000`.
  **Artifact:** `.omo/evidence/20260630-lazycodex-81-mcp-compaction/red-git-bash-idle-timeout-package.txt`
  **Why sufficient:** Demonstrates the pre-fix owned stale-transport risk in the exact MCP server lifecycle.

- **What was tested:** GREEN focused package test after the fix.
  **Observed result:** The new pin passed with `idle_timeout_ms: 0`.
  **Artifact:** `.omo/evidence/20260630-lazycodex-81-mcp-compaction/green-git-bash-idle-timeout-package.txt`
  **Why sufficient:** Proves the regression pin now covers the intended compaction-gap behavior.

- **What was tested:** Full Git Bash MCP package tests, typecheck, and build.
  **Observed result:** 24 tests passed; typecheck and build exited 0.
  **Artifacts:** `.omo/evidence/20260630-lazycodex-81-mcp-compaction/green-git-bash-package-test.txt`, `green-git-bash-typecheck.txt`, `green-git-bash-build.txt`
  **Why sufficient:** Covers the package behavior around tool listing, resolution, command schema, and startup gates.

- **What was tested:** Codex compatibility gate.
  **Observed result:** `bun run test:codex` passed 422 tests.
  **Artifact:** `.omo/evidence/20260630-lazycodex-81-mcp-compaction/green-test-codex.txt`
  **Why sufficient:** Verifies the LazyCodex installer/plugin compatibility suite after changing a bundled MCP runtime.

- **What was tested:** Live isolated Codex app-server smoke with local plugin install and mock model.
  **Observed result:** Plugin hooks completed for `sessionStart`, `userPromptSubmit`, and `stop`; real `~/.codex/config.toml` unchanged.
  **Artifact:** `.omo/evidence/20260630-lazycodex-81-mcp-compaction/app-server-drive-plugin.txt`
  **Why sufficient:** Proves the local LazyCodex plugin still installs and runs in a real Codex app-server session under isolated `CODEX_HOME`.

- **What was tested:** Direct MCP lifecycle smoke simulating Windows Git Bash availability.
  **Observed result:** `idleTimeoutMs: 0`, `exposesRunTool: true`, and two JSON-RPC response lines.
  **Artifact:** `.omo/evidence/20260630-lazycodex-81-mcp-compaction/manual-git-bash-mcp-smoke.txt`
  **Why sufficient:** Drives the changed MCP server surface directly and confirms the transport no longer has an idle close timer while the tool remains exposed.

## Risks & Residuals

- This PR fixes the LazyCodex-owned Git Bash MCP idle-close path. If Codex core itself closes arbitrary stdio MCP transports during compaction and keeps stale tool handles, that broader behavior belongs upstream in Codex's MCP client lifecycle.
- Native Windows TUI smoke was not run from this macOS worktree. Windows-specific behavior is covered by simulated-platform package tests for Git Bash availability and MCP startup.

## Related Issues

Fixes code-yeongyu/lazycodex#81


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the MCP stdio transport alive on Windows to prevent stale `git_bash` tool handles after compaction gaps. We disable the idle timeout (`idleTimeoutMs: 0`), add a lifecycle log seam, and pin the behavior with a regression test; fixes code-yeongyu/lazycodex#81.

- **Bug Fixes**
  - Disable `git_bash` MCP stdio idle timeout on Windows (`idleTimeoutMs: 0`) to avoid closed transports.
  - Add `lifecycleLog` hook and a regression test asserting `idle_timeout_ms: 0`.
  - Leave non-Windows and Windows-without-Git-Bash startup unchanged.

<sup>Written for commit 87cb19479174306bfa2efbe356181ed660a5ff72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

