### PR TITLE
Fix teammode archive ambiguity guidance

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -68,7 +68,7 @@ node "<skill-root>/scripts/team.mjs" set-status   --team <session_id> --id A --s
 node "<skill-root>/scripts/team.mjs" worktree-add    --team <session_id> --id A [--base-branch <branch>]
 node "<skill-root>/scripts/team.mjs" worktree-remove --team <session_id> --id A [--force]
 node "<skill-root>/scripts/team.mjs" integrate       --team <session_id> [--id A]
-node "<skill-root>/scripts/team.mjs" archive      --team <session_id> [--id A]
+node "<skill-root>/scripts/team.mjs" archive      --team <session_id> [--id A] [--note "<...>"]
 node "<skill-root>/scripts/team.mjs" delete       --team <session_id> [--force]
 node "<skill-root>/scripts/team.mjs" status       --team <session_id>
 ```
@@ -183,12 +183,17 @@ result against that todo's acceptance criteria before you integrate.
 
 DISBAND the team the moment it is no longer needed. A team exists only to do its work; once that
 work is done, or the user no longer wants it, do not leave it lying around - archive every member,
-then delete the team state. A finished team that is never disbanded is a leak.
+then delete the team state only after archival evidence is clean or preserved. A finished team that
+is never disbanded is a leak.
 
 - `archive` closes the team: notify each active member, copy anything useful into `artifacts/`,
-  archive each member thread with `codex_app.set_thread_archived`, then `archive` flips the team
-  and all members to archived. If a thread-archive tool is unavailable, record that in the team log
-  and tell the user - never pretend a member was archived.
+  then try to archive each member thread with `codex_app.set_thread_archived`. Treat Codex App
+  failures such as "Ambiguous Codex thread id" or a thread id that is ambiguous across hosts as an
+  app-thread archival blocker, not as a team-state blocker: record the failure in the team log,
+  tell the user which member thread was not proven archived, and continue the team-state archive
+  with `archive --note "<blocker>"`. Never pretend a member thread was archived. Do not delete the
+  team state after an app-thread archival blocker unless the evidence has been copied elsewhere or
+  the user explicitly accepts that evidence loss.
 - `delete` removes `.omo/teams/{session_id}` and refuses while the team is unarchived or any member
   is still active unless `--force`.
 - When the work wraps up, land it the way the user asked: `integrate --team <id>` for a direct merge

--- a/packages/omo-codex/plugin/test/teammode-archive-ambiguity.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-archive-ambiguity.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { root } from "./aggregate-plugin-fixture.mjs";
+import { cleanupTeamRoot, createTeamRoot, readTeamJson, runTeam } from "./teammode-safety-fixture.mjs";
+
+const teammodeSkillPath = join("components", "teammode", "skills", "teammode", "SKILL.md");
+
+test("#given Codex App thread ids can be ambiguous across hosts #when archive guidance is read #then it separates app-thread archival from team-state archival", () => {
+	const body = readFileSync(join(root, teammodeSkillPath), "utf8");
+
+	assert.match(
+		body,
+		/Ambiguous Codex thread id|ambiguous across hosts/i,
+		"archive guidance must name the Codex App multi-host ambiguity failure instead of only saying the archive tool is unavailable",
+	);
+	assert.match(
+		body,
+		/app-thread archival blocker/i,
+		"archive guidance must classify ambiguous app-thread ids as app-thread archival blockers",
+	);
+	assert.match(
+		body,
+		/record .*team log/i,
+		"archive guidance must require a durable team-log record when app-thread archival cannot be proven",
+	);
+	assert.match(
+		body,
+		/continue .*team-state archive/i,
+		"archive guidance must let the team-state archive proceed after recording the app-thread archival blocker",
+	);
+	assert.match(
+		body,
+		/archive --note/i,
+		"archive guidance must route ambiguous app-thread archive blockers into archive --note evidence",
+	);
+	assert.match(
+		body,
+		/Do not delete/i,
+		"archive guidance must keep evidence available until ambiguous app-thread archival is resolved",
+	);
+});
+
+test("#given app-thread archival is blocked by an ambiguous id #when archive runs with a note #then team state is archived and keeps the blocker in the log", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-archive-ambiguity-");
+	try {
+		runTeam(tempRoot, "init", "--name", "ArchiveQA", "--session-name", "cleanup", "--session", "archive-ambiguity");
+		runTeam(
+			tempRoot,
+			"add-member",
+			"--team",
+			"archive-ambiguity",
+			"--id",
+			"A",
+			"--name",
+			"local",
+			"--focus",
+			"local host member",
+			"--lens",
+			"area",
+			"--deliverable",
+			"local notes",
+		);
+		runTeam(
+			tempRoot,
+			"add-member",
+			"--team",
+			"archive-ambiguity",
+			"--id",
+			"B",
+			"--name",
+			"remote",
+			"--focus",
+			"remote host member",
+			"--lens",
+			"perspective",
+			"--deliverable",
+			"remote notes",
+		);
+		runTeam(tempRoot, "bind-thread", "--team", "archive-ambiguity", "--id", "A", "--thread", "duplicate-thread-id");
+		runTeam(tempRoot, "bind-thread", "--team", "archive-ambiguity", "--id", "B", "--thread", "remote-thread-id");
+
+		const blocker = "app-thread archive blocker: Ambiguous Codex thread id duplicate-thread-id; matching hosts: local, remote-ssh-discovered:m5";
+		runTeam(tempRoot, "archive", "--team", "archive-ambiguity", "--note", blocker);
+		const team = readTeamJson(tempRoot, "archive-ambiguity");
+
+		assert.equal(team.status, "archived");
+		assert.deepEqual(
+			team.members.map((member) => member.status),
+			["archived", "archived"],
+		);
+		assert.equal(
+			team.log.some((entry) => entry.event === "archive" && entry.detail === blocker),
+			true,
+			"team log must preserve the app-thread archival blocker after durable team-state archival",
+		);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});


### PR DESCRIPTION
## Summary

Fixes code-yeongyu/lazycodex#82 by clarifying the Codex teammode archive path when `codex_app.set_thread_archived` rejects a member thread id as ambiguous across hosts. The guidance now treats that as an app-thread archival blocker, records it, reports the unproven member thread, and still allows durable team-state archival through `archive --note` so evidence is preserved.

## Changes

- Updates the leader-facing teammode skill archive instructions to name `Ambiguous Codex thread id` / ambiguous-across-host failures and separate app-thread archive proof from durable team-state archival.
- Documents `archive --note` in the command synopsis so the blocker has an explicit evidence-preserving path.
- Adds a regression test that fails on the old guidance and verifies `team.mjs archive --note` archives team state while retaining the blocker in the team log.

## QA & Evidence

- **What was tested:** RED regression with `node --test packages/omo-codex/plugin/test/teammode-archive-ambiguity.test.mjs` before updating the skill guidance.
  **Observed result:** Failed on missing ambiguous-thread guidance; the existing `archive --note` state behavior passed.
  **Artifact:** `.omo/evidence/20260630-archive-ambiguity/red-teammode-archive-ambiguity.log`
  **Why sufficient:** Proves the test captures the exact issue #82 guidance gap before the fix.

- **What was tested:** GREEN teammode archive and adjacent safety/communication/title suites.
  **Observed result:** 19 pass / 0 fail.
  **Artifact:** `.omo/evidence/20260630-archive-ambiguity/green-teammode-adjacent.log`
  **Why sufficient:** Covers the new behavior plus adjacent teammode guidance and state safety contracts.

- **What was tested:** Sync-skill contract tests.
  **Observed result:** 24 pass / 0 fail, including generated component-skill drift checks.
  **Artifact:** `.omo/evidence/20260630-archive-ambiguity/sync-skills-tests.log`
  **Why sufficient:** Confirms the component skill remains the source of truth for generated Codex skill packaging.

- **What was tested:** Manual `team.mjs` archive smoke with a synthetic ambiguous thread-id blocker passed through `archive --note`.
  **Observed result:** `status` showed the team and both members archived; `team.json` retained the blocker as the final archive log entry.
  **Artifact:** `.omo/evidence/20260630-archive-ambiguity/manual-team-archive-smoke.log`
  **Why sufficient:** Drives the documented recovery path through the real teammode script surface.

- **What was tested:** Isolated local install into sandboxed `CODEX_HOME` / `CODEX_LOCAL_BIN_DIR` with telemetry disabled.
  **Observed result:** Installed `skills/teammode/SKILL.md` contained the new ambiguous-thread guidance and the real `~/.codex/config.toml` checksum was unchanged.
  **Artifact:** `.omo/evidence/20260630-archive-ambiguity/isolated-install-skill-guidance.log`
  **Why sufficient:** Proves the local build propagates the updated skill to the installed Codex plugin surface without touching the real Codex config.

- **What was tested:** Full Codex compatibility gate: `bun run test:codex`.
  **Observed result:** 424 pass / 0 fail.
  **Artifact:** `.omo/evidence/20260630-archive-ambiguity/test-codex.log`
  **Why sufficient:** Covers broader Codex installer, package, component, and plugin regression risk.

Evidence index: `.omo/evidence/20260630-archive-ambiguity/README.md`

## Risks & Residuals

- This PR changes guidance and tests only; `team.mjs archive --note` already supported the durable-state behavior and is now regression-covered.
- No raw secrets, auth headers, tokens, or private logs were included in evidence.

## Related Issues

Fixes code-yeongyu/lazycodex#82


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies teammode archive guidance when `codex_app.set_thread_archived` rejects a member thread id as ambiguous across hosts. Documents `archive --note` to allow team-state archival while preserving evidence, and adds a regression test to ensure the blocker is logged (fixes code-yeongyu/lazycodex#82).

<sup>Written for commit 5d3d1f4ba15926a65a0757574b227b3f4cf1dba9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

