### PR TITLE
[lazycodex-issues] #89 teammode concurrent add-member

### DIFF
--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/SKILL.md
@@ -80,6 +80,13 @@ space). `{session_id}` is the leader's Codex session id when you can pass it via
 otherwise the script generates a stable handle. Re-running `init` is a safe no-op. Every mutating
 subcommand rewrites `guide.md`, so the manual always matches the current team.
 
+Mutating subcommands take a per-team state lock before reading and rewriting `team.json`. It is
+safe to run independent `add-member`, `bind-thread`, `set-status`, `archive`, `delete`, `guide`,
+and worktree mutation commands concurrently against the same team: they serialize and each command
+reads the latest committed state before writing. If a command reports that team state is locked,
+do not treat the intended mutation as complete; retry after the named command finishes, or inspect
+`.omo/teams/{session_id}/.team.lock/owner.json` if the previous command crashed.
+
 ## Create the team and its threads
 
 1. `init` the team, then `add-member` once per member.

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team-state.mjs
@@ -9,8 +9,9 @@
 // this file stays the state concern only.
 
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 
 export const LENSES = ["area", "ownership", "perspective"];
 export const MEMBER_STATUSES = ["pending", "active", "reported", "blocked", "archived"];
@@ -24,6 +25,8 @@ export function isUnderstaffed(team) {
 // A team dir is a single child of .omo/teams. This pattern alone blocks "/", "\", and a
 // leading "." so ".." and "a/b" can never name a team dir (the escape guard).
 const SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const LOCK_TIMEOUT_MS = Number.parseInt(process.env.OMO_TEAMMODE_LOCK_TIMEOUT_MS ?? "10000", 10);
+const LOCK_RETRY_MS = Number.parseInt(process.env.OMO_TEAMMODE_LOCK_RETRY_MS ?? "25", 10);
 
 function isoNow(now) {
 	return now ?? new Date().toISOString();
@@ -231,6 +234,65 @@ async function lstatOrNull(p) {
 		if (error && error.code === "ENOENT") return null;
 		throw error;
 	});
+}
+
+function positiveIntegerOrFallback(value, fallback) {
+	return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+async function readLockOwner(lockDir) {
+	return readFile(join(lockDir, "owner.json"), "utf8")
+		.then((content) => JSON.parse(content))
+		.catch(() => null);
+}
+
+async function describeLockOwner(lockDir) {
+	const owner = await readLockOwner(lockDir);
+	if (!owner || typeof owner !== "object") return "another team.mjs command";
+	const parts = [];
+	if (owner.command) parts.push(String(owner.command));
+	if (owner.pid) parts.push(`pid ${owner.pid}`);
+	if (owner.createdAt) parts.push(`since ${owner.createdAt}`);
+	return parts.length > 0 ? parts.join(", ") : "another team.mjs command";
+}
+
+export async function withTeamLock(dir, command, fn, options = {}) {
+	const timeoutMs = positiveIntegerOrFallback(options.timeoutMs ?? LOCK_TIMEOUT_MS, 10000);
+	const retryMs = positiveIntegerOrFallback(options.retryMs ?? LOCK_RETRY_MS, 25);
+	const lockDir = join(dir, ".team.lock");
+	const deadline = Date.now() + timeoutMs;
+	let acquired = false;
+	for (;;) {
+		try {
+			await mkdir(lockDir, { mode: 0o700 });
+			acquired = true;
+			await writeFile(
+				join(lockDir, "owner.json"),
+				`${JSON.stringify({ pid: process.pid, command, createdAt: new Date().toISOString() }, null, 2)}\n`,
+				{ encoding: "utf8", flag: "wx" },
+			);
+			break;
+		} catch (error) {
+			if (acquired) {
+				await rm(lockDir, { recursive: true, force: true });
+				throw error;
+			}
+			if (!error || error.code !== "EEXIST") throw error;
+			const st = await lstatOrNull(lockDir);
+			if (st?.isSymbolicLink()) throw new Error(`refused: team lock path is a symlink: ${lockDir}`);
+			if (st && !st.isDirectory()) throw new Error(`refused: team lock path is not a directory: ${lockDir}`);
+			if (Date.now() >= deadline) {
+				const owner = await describeLockOwner(lockDir);
+				throw new Error(`team state is locked by ${owner}; retry after that command completes`);
+			}
+			await delay(Math.min(retryMs, Math.max(1, deadline - Date.now())));
+		}
+	}
+	try {
+		return await fn();
+	} finally {
+		await rm(lockDir, { recursive: true, force: true });
+	}
 }
 
 // Create a directory chain refusing any symlinked component, so team state can never be

--- a/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
+++ b/packages/omo-codex/plugin/components/teammode/skills/teammode/scripts/team.mjs
@@ -35,6 +35,7 @@ import {
 	setMemberStatus,
 	setMemberWorktree,
 	teamExists,
+	withTeamLock,
 	writeGuideAtomic,
 	writeTeamAtomic,
 } from "./team-state.mjs";
@@ -82,57 +83,71 @@ async function persist(team, dir) {
 	await writeGuideAtomic(team, buildGuide(team), dir);
 }
 
+async function mutateTeam(cwd, sessionId, command, fn) {
+	const dir = await assertSafeTeamDir(cwd, sessionId);
+	return withTeamLock(dir, command, async () => {
+		const team = await readTeam(dir);
+		return fn(team, dir);
+	});
+}
+
 const handlers = {
 	async init(cwd, flags) {
 		const teamName = requireFlag(flags, "name");
 		const sessionName = requireFlag(flags, "session-name");
 		const sessionId = typeof flags.session === "string" ? flags.session : `team-${randomUUID().slice(0, 8)}`;
 		const dir = await ensureTeamDir(cwd, sessionId);
-		if (await teamExists(dir)) {
-			process.stdout.write(`exists: ${dir} (left untouched; re-init is a safe no-op)\n`);
-			return;
-		}
-		const team = buildTeam({
-			teamName,
-			sessionName,
-			sessionId,
-			dir,
-			worktreeEnabled: flags.worktree === true,
-			baseBranch: typeof flags["base-branch"] === "string" ? flags["base-branch"] : "dev",
+		await withTeamLock(dir, "init", async () => {
+			if (await teamExists(dir)) {
+				process.stdout.write(`exists: ${dir} (left untouched; re-init is a safe no-op)\n`);
+				return;
+			}
+			const team = buildTeam({
+				teamName,
+				sessionName,
+				sessionId,
+				dir,
+				worktreeEnabled: flags.worktree === true,
+				baseBranch: typeof flags["base-branch"] === "string" ? flags["base-branch"] : "dev",
+			});
+			await persist(team, dir);
+			process.stdout.write(`created: ${dir}\n`);
+			process.stdout.write(`team.json + guide.md written; artifacts/ ready. session id: ${sessionId}\n`);
+			process.stdout.write(`next: add-member --team ${sessionId} --id A --name "<short role>" --focus "<part/ownership/perspective>" --lens area|ownership|perspective --deliverable "<...>"\n`);
 		});
-		await persist(team, dir);
-		process.stdout.write(`created: ${dir}\n`);
-		process.stdout.write(`team.json + guide.md written; artifacts/ ready. session id: ${sessionId}\n`);
-		process.stdout.write(`next: add-member --team ${sessionId} --id A --name "<short role>" --focus "<part/ownership/perspective>" --lens area|ownership|perspective --deliverable "<...>"\n`);
 	},
 
 	async "add-member"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const { dir, team } = await loadTeam(cwd, sessionId);
 		const memberId = requireFlag(flags, "id").trim();
-		addMember(team, {
+		const memberInput = {
 			id: memberId,
 			name: typeof flags.name === "string" ? flags.name : null,
 			focus: requireFlag(flags, "focus"),
 			lens: requireFlag(flags, "lens"),
 			deliverable: typeof flags.deliverable === "string" ? flags.deliverable : "",
 			branch: typeof flags.branch === "string" ? flags.branch : null,
+		};
+		const { team, member } = await mutateTeam(cwd, sessionId, "add-member", async (team, dir) => {
+			addMember(team, memberInput);
+			await persist(team, dir);
+			return { team, member: team.members.find((m) => m.id === memberId) };
 		});
-		await persist(team, dir);
-		const member = team.members.find((m) => m.id === memberId);
 		process.stdout.write(`added member ${memberId} to team ${sessionId}.\n\nSend this as the new thread's first message (title the thread "${member.threadTitle}"):\n---\n${buildMemberPrompt(team, memberId)}\n---\n`);
 	},
 
 	async "bind-thread"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const { dir, team } = await loadTeam(cwd, sessionId);
-		bindThread(team, {
+		const input = {
 			id: requireFlag(flags, "id"),
 			threadId: requireFlag(flags, "thread"),
 			cwd: typeof flags.cwd === "string" ? flags.cwd : null,
 			worktreePath: typeof flags["worktree-path"] === "string" ? flags["worktree-path"] : null,
+		};
+		await mutateTeam(cwd, sessionId, "bind-thread", async (team, dir) => {
+			bindThread(team, input);
+			await persist(team, dir);
 		});
-		await persist(team, dir);
 		process.stdout.write(`bound member ${flags.id} to thread ${flags.thread}.\n`);
 	},
 
@@ -144,25 +159,29 @@ const handlers = {
 
 	async "set-status"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const { dir, team } = await loadTeam(cwd, sessionId);
-		setMemberStatus(team, {
+		const input = {
 			id: requireFlag(flags, "id"),
 			status: requireFlag(flags, "status"),
 			note: typeof flags.note === "string" ? flags.note : "",
+		};
+		await mutateTeam(cwd, sessionId, "set-status", async (team, dir) => {
+			setMemberStatus(team, input);
+			await persist(team, dir);
 		});
-		await persist(team, dir);
 		process.stdout.write(`member ${flags.id} -> ${flags.status}\n`);
 	},
 
 	async "worktree-add"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const { dir, team } = await loadTeam(cwd, sessionId);
-		const member = memberOrThrow(team, requireFlag(flags, "id"));
-		const result = addMemberWorktree(cwd, team, member, {
-			baseBranch: typeof flags["base-branch"] === "string" ? flags["base-branch"] : null,
+		const memberId = requireFlag(flags, "id");
+		const baseBranch = typeof flags["base-branch"] === "string" ? flags["base-branch"] : null;
+		const { member, result } = await mutateTeam(cwd, sessionId, "worktree-add", async (team, dir) => {
+			const member = memberOrThrow(team, memberId);
+			const result = addMemberWorktree(cwd, team, member, { baseBranch });
+			setMemberWorktree(team, { id: member.id, path: result.path, branch: result.branch });
+			await persist(team, dir);
+			return { member, result };
 		});
-		setMemberWorktree(team, { id: member.id, path: result.path, branch: result.branch });
-		await persist(team, dir);
 		const note = result.created ? "" : " (already exists)";
 		const thread = member.threadId
 			? `\nMember thread: ${codexThreadLink(member.threadId)}\nTell that member to: cd "${result.path}"`
@@ -174,11 +193,15 @@ const handlers = {
 
 	async "worktree-remove"(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const { dir, team } = await loadTeam(cwd, sessionId);
-		const member = memberOrThrow(team, requireFlag(flags, "id"));
-		removeMemberWorktree(cwd, team, member, { force: flags.force === true });
-		clearMemberWorktree(team, { id: member.id });
-		await persist(team, dir);
+		const memberId = requireFlag(flags, "id");
+		const force = flags.force === true;
+		const member = await mutateTeam(cwd, sessionId, "worktree-remove", async (team, dir) => {
+			const member = memberOrThrow(team, memberId);
+			removeMemberWorktree(cwd, team, member, { force });
+			clearMemberWorktree(team, { id: member.id });
+			await persist(team, dir);
+			return member;
+		});
 		process.stdout.write(`removed worktree for member ${member.id}\n`);
 	},
 
@@ -208,25 +231,30 @@ const handlers = {
 
 	async archive(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const { dir, team } = await loadTeam(cwd, sessionId);
-		archive(team, {
+		const input = {
 			id: typeof flags.id === "string" ? flags.id : null,
 			note: typeof flags.note === "string" ? flags.note : "",
+		};
+		await mutateTeam(cwd, sessionId, "archive", async (team, dir) => {
+			archive(team, input);
+			await persist(team, dir);
 		});
-		await persist(team, dir);
 		process.stdout.write(flags.id ? `archived member ${flags.id}\n` : `archived team ${sessionId} and closed all members\n`);
 	},
 
 	async delete(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const { dir, team } = await loadTeam(cwd, sessionId);
-		const active = team.members.filter((m) => m.status !== "archived");
-		if (flags.force !== true && (team.status !== "archived" || active.length > 0)) {
-			throw new Error(
-				`refused: team "${sessionId}" is not archived or still has ${active.length} active member(s). Archive first, or pass --force to delete anyway.`,
-			);
-		}
-		await rm(dir, { recursive: true, force: true });
+		const dir = await assertSafeTeamDir(cwd, sessionId);
+		await withTeamLock(dir, "delete", async () => {
+			const team = await readTeam(dir);
+			const active = team.members.filter((m) => m.status !== "archived");
+			if (flags.force !== true && (team.status !== "archived" || active.length > 0)) {
+				throw new Error(
+					`refused: team "${sessionId}" is not archived or still has ${active.length} active member(s). Archive first, or pass --force to delete anyway.`,
+				);
+			}
+			await rm(dir, { recursive: true, force: true });
+		});
 		process.stdout.write(`deleted team state: ${dir}\n`);
 	},
 
@@ -247,9 +275,11 @@ const handlers = {
 
 	async guide(cwd, flags) {
 		const sessionId = requireFlag(flags, "team");
-		const { dir, team } = await loadTeam(cwd, sessionId);
-		await writeGuideAtomic(team, buildGuide(team), dir);
-		process.stdout.write(`${team.paths.guide}\n`);
+		const guidePath = await mutateTeam(cwd, sessionId, "guide", async (team, dir) => {
+			await writeGuideAtomic(team, buildGuide(team), dir);
+			return team.paths.guide;
+		});
+		process.stdout.write(`${guidePath}\n`);
 	},
 };
 

--- a/packages/omo-codex/plugin/test/teammode-safety-fixture.mjs
+++ b/packages/omo-codex/plugin/test/teammode-safety-fixture.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -39,6 +39,46 @@ export function runTeamRaw(cwd, ...args) {
 		cwd,
 		encoding: "utf8",
 		timeout: 10_000,
+	});
+}
+
+export function runTeamRawWithEnv(cwd, env, ...args) {
+	return spawnSync(process.execPath, [teamScript, ...args], {
+		cwd,
+		encoding: "utf8",
+		env: { ...process.env, ...env },
+		timeout: 10_000,
+	});
+}
+
+export function runTeamAsync(cwd, ...args) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [teamScript, ...args], {
+			cwd,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		const timer = setTimeout(() => {
+			child.kill("SIGKILL");
+			reject(new Error(`team.mjs ${args.join(" ")} timed out`));
+		}, 10_000);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.on("error", (error) => {
+			clearTimeout(timer);
+			reject(error);
+		});
+		child.on("close", (status, signal) => {
+			clearTimeout(timer);
+			resolve({ status, signal, stdout, stderr });
+		});
 	});
 }
 

--- a/packages/omo-codex/plugin/test/teammode-safety.test.mjs
+++ b/packages/omo-codex/plugin/test/teammode-safety.test.mjs
@@ -10,7 +10,9 @@ import {
 	createTeamRoot,
 	readTeamJson,
 	runTeam,
+	runTeamAsync,
 	runTeamRaw,
+	runTeamRawWithEnv,
 	symlinkOrSkip,
 	teamDir,
 	teamJsonPath,
@@ -77,6 +79,97 @@ test("#given member A exists #when add-member receives A with trailing space #th
 			team.members.map((member) => member.id),
 			["A"],
 		);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given two add-member commands run concurrently #then both successful mutations are preserved", async () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-concurrent-add-");
+	try {
+		runTeam(tempRoot, "init", "--name", "Concurrent", "--session-name", "Members", "--session", "safe-concurrent-add");
+
+		const [alpha, beta] = await Promise.all([
+			runTeamAsync(
+				tempRoot,
+				"add-member",
+				"--team",
+				"safe-concurrent-add",
+				"--id",
+				"A",
+				"--name",
+				"alpha",
+				"--focus",
+				"alpha",
+				"--lens",
+				"area",
+				"--deliverable",
+				"first",
+			),
+			runTeamAsync(
+				tempRoot,
+				"add-member",
+				"--team",
+				"safe-concurrent-add",
+				"--id",
+				"B",
+				"--name",
+				"beta",
+				"--focus",
+				"beta",
+				"--lens",
+				"perspective",
+				"--deliverable",
+				"second",
+			),
+		]);
+		const team = readTeamJson(tempRoot, "safe-concurrent-add");
+
+		assert.equal(alpha.status, 0, alpha.stderr);
+		assert.equal(beta.status, 0, beta.stderr);
+		assert.deepEqual(
+			team.members.map((member) => member.id).sort(),
+			["A", "B"],
+		);
+		assert.equal(team.log.filter((entry) => entry.event === "add-member").length, 2);
+	} finally {
+		cleanupTeamRoot(tempRoot);
+	}
+});
+
+test("#given another command holds the team lock #when add-member times out #then it fails without mutating team state", () => {
+	const tempRoot = createTeamRoot("omo-codex-teammode-lock-timeout-");
+	try {
+		runTeam(tempRoot, "init", "--name", "Locked", "--session-name", "Members", "--session", "safe-lock-timeout");
+		const lockDir = join(teamDir(tempRoot, "safe-lock-timeout"), ".team.lock");
+		mkdirSync(lockDir);
+		writeFileSync(
+			join(lockDir, "owner.json"),
+			`${JSON.stringify({ command: "held-test", pid: 12345, createdAt: "2026-06-30T00:00:00.000Z" }, null, 2)}\n`,
+		);
+
+		const result = runTeamRawWithEnv(
+			tempRoot,
+			{ OMO_TEAMMODE_LOCK_TIMEOUT_MS: "25", OMO_TEAMMODE_LOCK_RETRY_MS: "5" },
+			"add-member",
+			"--team",
+			"safe-lock-timeout",
+			"--id",
+			"A",
+			"--name",
+			"alpha",
+			"--focus",
+			"alpha",
+			"--lens",
+			"area",
+			"--deliverable",
+			"first",
+		);
+		const team = readTeamJson(tempRoot, "safe-lock-timeout");
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /team state is locked by held-test, pid 12345/);
+		assert.deepEqual(team.members, []);
 	} finally {
 		cleanupTeamRoot(tempRoot);
 	}


### PR DESCRIPTION
## Summary

Fixes code-yeongyu/lazycodex#89 by making teammode state mutations transactional at the process boundary. Mutating `team.mjs` commands now take a per-team lock before reading and rewriting `team.json`, so concurrent `add-member` calls serialize and each command sees the latest committed roster instead of overwriting a peer.

The skill manual now documents that mutators are lock-protected and that a lock-timeout message means the intended mutation did not land and must be retried or inspected.

## Changes

- Added a lock-directory based per-team state lock in `team-state.mjs`, with owner metadata and explicit timeout errors.
- Routed all durable team-state mutators through the lock: `init`, `add-member`, `bind-thread`, `set-status`, worktree mutation, `archive`, `delete`, and `guide` regeneration.
- Added process-level safety tests for concurrent `add-member` preservation and explicit lock-timeout behavior.
- Updated teammode skill guidance so agents know concurrent mutators are serialized and lock failures are not success.

## QA & Evidence

Evidence directory: `.omo/evidence/20260630-teammode-add-member-race/`

- **What was tested:** RED concurrent repro with two real `node team.mjs add-member` processes racing against the same team, repeated 10 times.
  **Observed result:** Before the fix, `lost=10,total=10`; both commands exited 0 but final `team.json` had only one member.
  **Artifact:** `.omo/evidence/20260630-teammode-add-member-race/red-concurrent-add-member.txt`
  **Why sufficient:** Reproduces the exact silent lost-member issue at the shipped CLI surface.

- **What was tested:** GREEN concurrent repro using the same 10-run harness after the lock fix.
  **Observed result:** `lost=0,total=10`; both commands exited 0 and final rosters contained `A,B` every time.
  **Artifact:** `.omo/evidence/20260630-teammode-add-member-race/green-concurrent-add-member.txt`
  **Why sufficient:** Proves successful concurrent add-member commands now preserve both mutations.

- **What was tested:** Manual CLI QA for sequential `init -> add-member A -> add-member B -> status`, plus concurrent `add-member A/B -> status`.
  **Observed result:** Both flows reported `2 member(s)`, persisted `A,B`, and wrote `guide.md`.
  **Artifact:** `.omo/evidence/20260630-teammode-add-member-race/manual-sequential-and-concurrent-qa.txt`
  **Why sufficient:** Covers normal user sequencing and the concurrent user workflow.

- **What was tested:** Adjacent teammode tests.
  **Commands:** `node --test packages/omo-codex/plugin/test/teammode-*.test.mjs`; `bun test test/*.test.ts` from `packages/omo-codex/plugin/components/teammode`.
  **Observed result:** 30 Node teammode tests passed; 4 component hook tests passed.
  **Artifacts:** `.omo/evidence/20260630-teammode-add-member-race/adjacent-teammode-node-tests.txt`, `.omo/evidence/20260630-teammode-add-member-race/component-teammode-hook-test.txt`
  **Why sufficient:** Covers existing safety, guide/status, thread-title, communication, and worktree behavior around teammode.

- **What was tested:** Syntax and Codex compatibility gate.
  **Commands:** `node --check` on both changed scripts; `bun run test:codex`.
  **Observed result:** Syntax checks passed; `bun run test:codex` passed 424 tests.
  **Artifacts:** `.omo/evidence/20260630-teammode-add-member-race/node-check-team-state.txt`, `.omo/evidence/20260630-teammode-add-member-race/node-check-team-script.txt`, `.omo/evidence/20260630-teammode-add-member-race/bun-run-test-codex.txt`
  **Why sufficient:** Covers the hermetic Codex unit/build gate.

- **What was tested:** Codex QA isolation and live plugin smoke.
  **Commands:** `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check`; `bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test`; `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin`.
  **Observed result:** Isolated install passed, app-server turn completed with `sessionStart`, `userPromptSubmit`, and `stop` plugin hooks, and real `~/.codex/config.toml` was unchanged.
  **Artifacts:** `.omo/evidence/20260630-teammode-add-member-race/codex-qa-common-self-check.txt`, `.omo/evidence/20260630-teammode-add-member-race/codex-qa-install-verify.txt`, `.omo/evidence/20260630-teammode-add-member-race/codex-qa-app-server-plugin.json`
  **Why sufficient:** Satisfies the Codex-connected component QA rule with an isolated real Codex run and local plugin install.

## Risks & Residuals

- Locking serializes all state-mutating team commands, including worktree mutations, so a long-running worktree command can make other mutators wait. This is intentional to prevent lost updates; timeout errors are explicit and documented.
- A crashed command can leave `.team.lock`; the timeout error points at `.omo/teams/{session_id}/.team.lock/owner.json` for inspection instead of pretending the mutation succeeded.
- Evidence artifacts omit raw secrets/tokens/auth headers. Temporary QA roots and isolated Codex homes were removed by their harnesses.

## Related Issues

Fixes code-yeongyu/lazycodex#89


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize teammode state mutations with a per-team lock to prevent lost updates during concurrent commands. Fixes #89 where simultaneous add-member calls could overwrite each other; commands now see the latest state or fail fast with a clear lock-timeout.

- **Bug Fixes**
  - Added per-team `.team.lock` and `withTeamLock(...)` in `team-state.mjs` with owner metadata and explicit timeout errors; timeouts configurable via `OMO_TEAMMODE_LOCK_TIMEOUT_MS` and `OMO_TEAMMODE_LOCK_RETRY_MS`.
  - Routed all mutators through the lock: `init`, `add-member`, `bind-thread`, `set-status`, `worktree-add/remove`, `archive`, `delete`, `guide`.
  - Updated `SKILL.md` to document locking and retry guidance; added tests for concurrent add-member preservation and lock-timeout behavior.

<sup>Written for commit 8ef44bd142e25038861e4624f984272e11e708ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

