### PR TITLE
fix(codex): clarify CodeGraph includeCode contract

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -2589,6 +2589,9 @@ class CodegraphBridgeStdioError extends Error {
     this.streamName = streamName;
   }
 }
+var CODEGRAPH_NODE_DESCRIPTION = "Inspect one named symbol or file. In symbol mode, includeCode=true includes leaf-symbol source when available. Container symbols such as classes, interfaces, structs, enums, modules, and namespaces return structural outlines with member lists by design. For container source, request a specific member symbol or use file mode with symbolsOnly=false plus offset/limit.";
+var CODEGRAPH_NODE_INCLUDE_CODE_DESCRIPTION = "Symbol mode: include leaf-symbol source when available. Container symbols such as classes, interfaces, structs, enums, modules, and namespaces intentionally return structural outlines with members; request a specific member symbol or use file mode with symbolsOnly=false plus offset/limit for source.";
+var CODEGRAPH_CONTAINER_OUTLINE_GUIDANCE = "Container symbols intentionally return structural outlines with members. For source, request a specific member symbol or call codegraph_node in file mode with symbolsOnly=false plus offset/limit around the symbol location.";
 async function runBridgedCodegraphProcess(command, args, options) {
   const invocation = resolveServeProcessInvocation(command, args);
   const child = spawn2(invocation.command, invocation.args, {
@@ -2602,7 +2605,7 @@ async function runBridgedCodegraphProcess(command, args, options) {
     throw new CodegraphBridgeStdioError("stdin");
   if (childOutput === null)
     throw new CodegraphBridgeStdioError("stdout");
-  const responseModes = new Map;
+  const pendingResponses = new Map;
   let defaultResponseMode = "framed";
   const childExit = new Promise((resolveExit, reject) => {
     child.once("error", reject);
@@ -2615,10 +2618,10 @@ async function runBridgedCodegraphProcess(command, args, options) {
     });
   });
   const bridgeDone = Promise.all([
-    forwardClientToCodegraph(options.input, childInput, responseModes, (mode) => {
+    forwardClientToCodegraph(options.input, childInput, pendingResponses, (mode) => {
       defaultResponseMode = mode;
     }),
-    forwardCodegraphToClient(childOutput, options.output, responseModes, () => defaultResponseMode)
+    forwardCodegraphToClient(childOutput, options.output, pendingResponses, () => defaultResponseMode)
   ]);
   const destroyChildPipes = () => {
     childInput.destroy();
@@ -2627,7 +2630,7 @@ async function runBridgedCodegraphProcess(command, args, options) {
   childExit.then(destroyChildPipes, destroyChildPipes);
   return Promise.race([childExit, bridgeDone.then(() => childExit)]);
 }
-async function forwardClientToCodegraph(input, childInput, responseModes, setDefaultResponseMode) {
+async function forwardClientToCodegraph(input, childInput, pendingResponses, setDefaultResponseMode) {
   for await (const message of readStdioJsonRpcMessages(input)) {
     if (message.kind === "parse_error") {
       continue;
@@ -2635,23 +2638,29 @@ async function forwardClientToCodegraph(input, childInput, responseModes, setDef
     const responseMode = message.responseMode;
     setDefaultResponseMode(responseMode);
     const key = responseModeKey(message.payload);
-    if (key !== null)
-      responseModes.set(key, responseMode);
+    if (key !== null) {
+      pendingResponses.set(key, {
+        method: jsonRpcMethod(message.payload),
+        responseMode,
+        toolName: jsonRpcToolName(message.payload)
+      });
+    }
     await writeLine(childInput, JSON.stringify(message.payload));
   }
   childInput.end();
 }
-async function forwardCodegraphToClient(childOutput, output, responseModes, defaultResponseMode) {
+async function forwardCodegraphToClient(childOutput, output, pendingResponses, defaultResponseMode) {
   for await (const message of readStdioJsonRpcMessages(childOutput)) {
     if (message.kind === "parse_error") {
       writeStdioJsonRpcResponse(output, errorResponse(null, -32700, "Parse error", message.message), defaultResponseMode());
       continue;
     }
     const key = responseModeKey(message.payload);
-    const responseMode = key === null ? defaultResponseMode() : responseModes.get(key) ?? defaultResponseMode();
+    const pendingResponse = key === null ? undefined : pendingResponses.get(key);
+    const responseMode = pendingResponse?.responseMode ?? defaultResponseMode();
     if (key !== null)
-      responseModes.delete(key);
-    writeStdioJsonRpcResponse(output, message.payload, responseMode);
+      pendingResponses.delete(key);
+    writeStdioJsonRpcResponse(output, clarifyCodegraphResponse(message.payload, pendingResponse), responseMode);
   }
 }
 function responseModeKey(payload) {
@@ -2659,6 +2668,110 @@ function responseModeKey(payload) {
     return null;
   const id = jsonRpcId(payload["id"]);
   return `${typeof id}:${String(id)}`;
+}
+function jsonRpcMethod(payload) {
+  if (!isPlainRecord(payload))
+    return null;
+  const method = payload["method"];
+  return typeof method === "string" ? method : null;
+}
+function jsonRpcToolName(payload) {
+  if (jsonRpcMethod(payload) !== "tools/call" || !isPlainRecord(payload))
+    return null;
+  const params = payload["params"];
+  if (!isPlainRecord(params))
+    return null;
+  const name = params["name"];
+  return typeof name === "string" ? name : null;
+}
+function clarifyCodegraphResponse(payload, pendingResponse) {
+  if (pendingResponse?.method === "tools/list")
+    return clarifyCodegraphToolsList(payload);
+  if (pendingResponse?.method === "tools/call" && pendingResponse.toolName === "codegraph_node") {
+    return clarifyCodegraphNodeCallResult(payload);
+  }
+  return payload;
+}
+function clarifyCodegraphToolsList(payload) {
+  if (!isPlainRecord(payload))
+    return payload;
+  const result = payload["result"];
+  if (!isPlainRecord(result) || !Array.isArray(result["tools"]))
+    return payload;
+  let changed = false;
+  const tools = result["tools"].map((tool) => {
+    if (!isPlainRecord(tool) || tool["name"] !== "codegraph_node")
+      return tool;
+    if (!hasCodegraphNodeContractMetadata(tool))
+      return tool;
+    changed = true;
+    return clarifyCodegraphNodeTool(tool);
+  });
+  if (!changed)
+    return payload;
+  return { ...payload, result: { ...result, tools } };
+}
+function clarifyCodegraphNodeTool(tool) {
+  const clarified = {
+    ...tool,
+    description: CODEGRAPH_NODE_DESCRIPTION
+  };
+  const inputSchema = tool["inputSchema"];
+  if (isPlainRecord(inputSchema))
+    clarified["inputSchema"] = clarifyCodegraphNodeInputSchema(inputSchema);
+  return clarified;
+}
+function hasCodegraphNodeContractMetadata(tool) {
+  if (typeof tool["description"] === "string")
+    return true;
+  const inputSchema = tool["inputSchema"];
+  if (!isPlainRecord(inputSchema))
+    return false;
+  const properties = inputSchema["properties"];
+  return isPlainRecord(properties) && isPlainRecord(properties["includeCode"]);
+}
+function clarifyCodegraphNodeInputSchema(inputSchema) {
+  const properties = inputSchema["properties"];
+  if (!isPlainRecord(properties))
+    return inputSchema;
+  const includeCode = properties["includeCode"];
+  if (!isPlainRecord(includeCode))
+    return inputSchema;
+  return {
+    ...inputSchema,
+    properties: {
+      ...properties,
+      includeCode: {
+        ...includeCode,
+        description: CODEGRAPH_NODE_INCLUDE_CODE_DESCRIPTION
+      }
+    }
+  };
+}
+function clarifyCodegraphNodeCallResult(payload) {
+  if (!isPlainRecord(payload))
+    return payload;
+  const result = payload["result"];
+  if (!isPlainRecord(result) || !Array.isArray(result["content"]))
+    return payload;
+  let changed = false;
+  const content = result["content"].map((item) => {
+    if (!isPlainRecord(item) || item["type"] !== "text" || typeof item["text"] !== "string")
+      return item;
+    const text = clarifyContainerOutlineGuidance(item["text"]);
+    if (text === item["text"])
+      return item;
+    changed = true;
+    return { ...item, text };
+  });
+  if (!changed)
+    return payload;
+  return { ...payload, result: { ...result, content } };
+}
+function clarifyContainerOutlineGuidance(text) {
+  if (!text.includes("Structural outline only"))
+    return text;
+  return text.replace(/Structural outline only[^\n]*(?:\n[^\n]*(?:Read|read)[^\n]*)?/g, CODEGRAPH_CONTAINER_OUTLINE_GUIDANCE);
 }
 async function writeLine(output, line) {
   if (output.write(`${line}

--- a/packages/omo-codex/plugin/components/codegraph/dist/serve.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/serve.js
@@ -2022,6 +2022,9 @@ class CodegraphBridgeStdioError extends Error {
     this.streamName = streamName;
   }
 }
+var CODEGRAPH_NODE_DESCRIPTION = "Inspect one named symbol or file. In symbol mode, includeCode=true includes leaf-symbol source when available. Container symbols such as classes, interfaces, structs, enums, modules, and namespaces return structural outlines with member lists by design. For container source, request a specific member symbol or use file mode with symbolsOnly=false plus offset/limit.";
+var CODEGRAPH_NODE_INCLUDE_CODE_DESCRIPTION = "Symbol mode: include leaf-symbol source when available. Container symbols such as classes, interfaces, structs, enums, modules, and namespaces intentionally return structural outlines with members; request a specific member symbol or use file mode with symbolsOnly=false plus offset/limit for source.";
+var CODEGRAPH_CONTAINER_OUTLINE_GUIDANCE = "Container symbols intentionally return structural outlines with members. For source, request a specific member symbol or call codegraph_node in file mode with symbolsOnly=false plus offset/limit around the symbol location.";
 async function runBridgedCodegraphProcess(command, args, options) {
   const invocation = resolveServeProcessInvocation(command, args);
   const child = spawn(invocation.command, invocation.args, {
@@ -2035,7 +2038,7 @@ async function runBridgedCodegraphProcess(command, args, options) {
     throw new CodegraphBridgeStdioError("stdin");
   if (childOutput === null)
     throw new CodegraphBridgeStdioError("stdout");
-  const responseModes = new Map;
+  const pendingResponses = new Map;
   let defaultResponseMode = "framed";
   const childExit = new Promise((resolveExit, reject) => {
     child.once("error", reject);
@@ -2048,10 +2051,10 @@ async function runBridgedCodegraphProcess(command, args, options) {
     });
   });
   const bridgeDone = Promise.all([
-    forwardClientToCodegraph(options.input, childInput, responseModes, (mode) => {
+    forwardClientToCodegraph(options.input, childInput, pendingResponses, (mode) => {
       defaultResponseMode = mode;
     }),
-    forwardCodegraphToClient(childOutput, options.output, responseModes, () => defaultResponseMode)
+    forwardCodegraphToClient(childOutput, options.output, pendingResponses, () => defaultResponseMode)
   ]);
   const destroyChildPipes = () => {
     childInput.destroy();
@@ -2060,7 +2063,7 @@ async function runBridgedCodegraphProcess(command, args, options) {
   childExit.then(destroyChildPipes, destroyChildPipes);
   return Promise.race([childExit, bridgeDone.then(() => childExit)]);
 }
-async function forwardClientToCodegraph(input, childInput, responseModes, setDefaultResponseMode) {
+async function forwardClientToCodegraph(input, childInput, pendingResponses, setDefaultResponseMode) {
   for await (const message of readStdioJsonRpcMessages(input)) {
     if (message.kind === "parse_error") {
       continue;
@@ -2068,23 +2071,29 @@ async function forwardClientToCodegraph(input, childInput, responseModes, setDef
     const responseMode = message.responseMode;
     setDefaultResponseMode(responseMode);
     const key = responseModeKey(message.payload);
-    if (key !== null)
-      responseModes.set(key, responseMode);
+    if (key !== null) {
+      pendingResponses.set(key, {
+        method: jsonRpcMethod(message.payload),
+        responseMode,
+        toolName: jsonRpcToolName(message.payload)
+      });
+    }
     await writeLine(childInput, JSON.stringify(message.payload));
   }
   childInput.end();
 }
-async function forwardCodegraphToClient(childOutput, output, responseModes, defaultResponseMode) {
+async function forwardCodegraphToClient(childOutput, output, pendingResponses, defaultResponseMode) {
   for await (const message of readStdioJsonRpcMessages(childOutput)) {
     if (message.kind === "parse_error") {
       writeStdioJsonRpcResponse(output, errorResponse(null, -32700, "Parse error", message.message), defaultResponseMode());
       continue;
     }
     const key = responseModeKey(message.payload);
-    const responseMode = key === null ? defaultResponseMode() : responseModes.get(key) ?? defaultResponseMode();
+    const pendingResponse = key === null ? undefined : pendingResponses.get(key);
+    const responseMode = pendingResponse?.responseMode ?? defaultResponseMode();
     if (key !== null)
-      responseModes.delete(key);
-    writeStdioJsonRpcResponse(output, message.payload, responseMode);
+      pendingResponses.delete(key);
+    writeStdioJsonRpcResponse(output, clarifyCodegraphResponse(message.payload, pendingResponse), responseMode);
   }
 }
 function responseModeKey(payload) {
@@ -2092,6 +2101,110 @@ function responseModeKey(payload) {
     return null;
   const id = jsonRpcId(payload["id"]);
   return `${typeof id}:${String(id)}`;
+}
+function jsonRpcMethod(payload) {
+  if (!isPlainRecord(payload))
+    return null;
+  const method = payload["method"];
+  return typeof method === "string" ? method : null;
+}
+function jsonRpcToolName(payload) {
+  if (jsonRpcMethod(payload) !== "tools/call" || !isPlainRecord(payload))
+    return null;
+  const params = payload["params"];
+  if (!isPlainRecord(params))
+    return null;
+  const name = params["name"];
+  return typeof name === "string" ? name : null;
+}
+function clarifyCodegraphResponse(payload, pendingResponse) {
+  if (pendingResponse?.method === "tools/list")
+    return clarifyCodegraphToolsList(payload);
+  if (pendingResponse?.method === "tools/call" && pendingResponse.toolName === "codegraph_node") {
+    return clarifyCodegraphNodeCallResult(payload);
+  }
+  return payload;
+}
+function clarifyCodegraphToolsList(payload) {
+  if (!isPlainRecord(payload))
+    return payload;
+  const result = payload["result"];
+  if (!isPlainRecord(result) || !Array.isArray(result["tools"]))
+    return payload;
+  let changed = false;
+  const tools = result["tools"].map((tool) => {
+    if (!isPlainRecord(tool) || tool["name"] !== "codegraph_node")
+      return tool;
+    if (!hasCodegraphNodeContractMetadata(tool))
+      return tool;
+    changed = true;
+    return clarifyCodegraphNodeTool(tool);
+  });
+  if (!changed)
+    return payload;
+  return { ...payload, result: { ...result, tools } };
+}
+function clarifyCodegraphNodeTool(tool) {
+  const clarified = {
+    ...tool,
+    description: CODEGRAPH_NODE_DESCRIPTION
+  };
+  const inputSchema = tool["inputSchema"];
+  if (isPlainRecord(inputSchema))
+    clarified["inputSchema"] = clarifyCodegraphNodeInputSchema(inputSchema);
+  return clarified;
+}
+function hasCodegraphNodeContractMetadata(tool) {
+  if (typeof tool["description"] === "string")
+    return true;
+  const inputSchema = tool["inputSchema"];
+  if (!isPlainRecord(inputSchema))
+    return false;
+  const properties = inputSchema["properties"];
+  return isPlainRecord(properties) && isPlainRecord(properties["includeCode"]);
+}
+function clarifyCodegraphNodeInputSchema(inputSchema) {
+  const properties = inputSchema["properties"];
+  if (!isPlainRecord(properties))
+    return inputSchema;
+  const includeCode = properties["includeCode"];
+  if (!isPlainRecord(includeCode))
+    return inputSchema;
+  return {
+    ...inputSchema,
+    properties: {
+      ...properties,
+      includeCode: {
+        ...includeCode,
+        description: CODEGRAPH_NODE_INCLUDE_CODE_DESCRIPTION
+      }
+    }
+  };
+}
+function clarifyCodegraphNodeCallResult(payload) {
+  if (!isPlainRecord(payload))
+    return payload;
+  const result = payload["result"];
+  if (!isPlainRecord(result) || !Array.isArray(result["content"]))
+    return payload;
+  let changed = false;
+  const content = result["content"].map((item) => {
+    if (!isPlainRecord(item) || item["type"] !== "text" || typeof item["text"] !== "string")
+      return item;
+    const text = clarifyContainerOutlineGuidance(item["text"]);
+    if (text === item["text"])
+      return item;
+    changed = true;
+    return { ...item, text };
+  });
+  if (!changed)
+    return payload;
+  return { ...payload, result: { ...result, content } };
+}
+function clarifyContainerOutlineGuidance(text) {
+  if (!text.includes("Structural outline only"))
+    return text;
+  return text.replace(/Structural outline only[^\n]*(?:\n[^\n]*(?:Read|read)[^\n]*)?/g, CODEGRAPH_CONTAINER_OUTLINE_GUIDANCE);
 }
 async function writeLine(output, line) {
   if (output.write(`${line}

--- a/packages/omo-codex/plugin/components/codegraph/src/mcp-bridge.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/mcp-bridge.ts
@@ -20,6 +20,21 @@ class CodegraphBridgeStdioError extends Error {
 	}
 }
 
+interface PendingClientResponse {
+	readonly method: string | null;
+	readonly responseMode: StdioJsonRpcResponseMode;
+	readonly toolName: string | null;
+}
+
+const CODEGRAPH_NODE_DESCRIPTION =
+	"Inspect one named symbol or file. In symbol mode, includeCode=true includes leaf-symbol source when available. Container symbols such as classes, interfaces, structs, enums, modules, and namespaces return structural outlines with member lists by design. For container source, request a specific member symbol or use file mode with symbolsOnly=false plus offset/limit.";
+
+const CODEGRAPH_NODE_INCLUDE_CODE_DESCRIPTION =
+	"Symbol mode: include leaf-symbol source when available. Container symbols such as classes, interfaces, structs, enums, modules, and namespaces intentionally return structural outlines with members; request a specific member symbol or use file mode with symbolsOnly=false plus offset/limit for source.";
+
+const CODEGRAPH_CONTAINER_OUTLINE_GUIDANCE =
+	"Container symbols intentionally return structural outlines with members. For source, request a specific member symbol or call codegraph_node in file mode with symbolsOnly=false plus offset/limit around the symbol location.";
+
 export async function runBridgedCodegraphProcess(
 	command: string,
 	args: readonly string[],
@@ -36,7 +51,7 @@ export async function runBridgedCodegraphProcess(
 	if (childInput === null) throw new CodegraphBridgeStdioError("stdin");
 	if (childOutput === null) throw new CodegraphBridgeStdioError("stdout");
 
-	const responseModes = new Map<string, StdioJsonRpcResponseMode>();
+	const pendingResponses = new Map<string, PendingClientResponse>();
 	let defaultResponseMode: StdioJsonRpcResponseMode = "framed";
 	const childExit = new Promise<number>((resolveExit, reject) => {
 		child.once("error", reject);
@@ -49,10 +64,10 @@ export async function runBridgedCodegraphProcess(
 		});
 	});
 	const bridgeDone = Promise.all([
-		forwardClientToCodegraph(options.input, childInput, responseModes, (mode) => {
+		forwardClientToCodegraph(options.input, childInput, pendingResponses, (mode) => {
 			defaultResponseMode = mode;
 		}),
-		forwardCodegraphToClient(childOutput, options.output, responseModes, () => defaultResponseMode),
+		forwardCodegraphToClient(childOutput, options.output, pendingResponses, () => defaultResponseMode),
 	]);
 	const destroyChildPipes = (): void => {
 		childInput.destroy();
@@ -65,7 +80,7 @@ export async function runBridgedCodegraphProcess(
 async function forwardClientToCodegraph(
 	input: Readable,
 	childInput: Writable,
-	responseModes: Map<string, StdioJsonRpcResponseMode>,
+	pendingResponses: Map<string, PendingClientResponse>,
 	setDefaultResponseMode: (mode: StdioJsonRpcResponseMode) => void,
 ): Promise<void> {
 	for await (const message of readStdioJsonRpcMessages(input)) {
@@ -75,7 +90,13 @@ async function forwardClientToCodegraph(
 		const responseMode = message.responseMode;
 		setDefaultResponseMode(responseMode);
 		const key = responseModeKey(message.payload);
-		if (key !== null) responseModes.set(key, responseMode);
+		if (key !== null) {
+			pendingResponses.set(key, {
+				method: jsonRpcMethod(message.payload),
+				responseMode,
+				toolName: jsonRpcToolName(message.payload),
+			});
+		}
 		await writeLine(childInput, JSON.stringify(message.payload));
 	}
 	childInput.end();
@@ -84,7 +105,7 @@ async function forwardClientToCodegraph(
 async function forwardCodegraphToClient(
 	childOutput: Readable,
 	output: Writable,
-	responseModes: Map<string, StdioJsonRpcResponseMode>,
+	pendingResponses: Map<string, PendingClientResponse>,
 	defaultResponseMode: () => StdioJsonRpcResponseMode,
 ): Promise<void> {
 	for await (const message of readStdioJsonRpcMessages(childOutput)) {
@@ -93,9 +114,10 @@ async function forwardCodegraphToClient(
 			continue;
 		}
 		const key = responseModeKey(message.payload);
-		const responseMode = key === null ? defaultResponseMode() : (responseModes.get(key) ?? defaultResponseMode());
-		if (key !== null) responseModes.delete(key);
-		writeStdioJsonRpcResponse(output, message.payload, responseMode);
+		const pendingResponse = key === null ? undefined : pendingResponses.get(key);
+		const responseMode = pendingResponse?.responseMode ?? defaultResponseMode();
+		if (key !== null) pendingResponses.delete(key);
+		writeStdioJsonRpcResponse(output, clarifyCodegraphResponse(message.payload, pendingResponse), responseMode);
 	}
 }
 
@@ -103,6 +125,101 @@ function responseModeKey(payload: unknown): string | null {
 	if (!isPlainRecord(payload) || !("id" in payload)) return null;
 	const id = jsonRpcId(payload["id"]);
 	return `${typeof id}:${String(id)}`;
+}
+
+function jsonRpcMethod(payload: unknown): string | null {
+	if (!isPlainRecord(payload)) return null;
+	const method = payload["method"];
+	return typeof method === "string" ? method : null;
+}
+
+function jsonRpcToolName(payload: unknown): string | null {
+	if (jsonRpcMethod(payload) !== "tools/call" || !isPlainRecord(payload)) return null;
+	const params = payload["params"];
+	if (!isPlainRecord(params)) return null;
+	const name = params["name"];
+	return typeof name === "string" ? name : null;
+}
+
+function clarifyCodegraphResponse(payload: unknown, pendingResponse: PendingClientResponse | undefined): unknown {
+	if (pendingResponse?.method === "tools/list") return clarifyCodegraphToolsList(payload);
+	if (pendingResponse?.method === "tools/call" && pendingResponse.toolName === "codegraph_node") {
+		return clarifyCodegraphNodeCallResult(payload);
+	}
+	return payload;
+}
+
+function clarifyCodegraphToolsList(payload: unknown): unknown {
+	if (!isPlainRecord(payload)) return payload;
+	const result = payload["result"];
+	if (!isPlainRecord(result) || !Array.isArray(result["tools"])) return payload;
+
+	let changed = false;
+	const tools = result["tools"].map((tool) => {
+		if (!isPlainRecord(tool) || tool["name"] !== "codegraph_node") return tool;
+		if (!hasCodegraphNodeContractMetadata(tool)) return tool;
+		changed = true;
+		return clarifyCodegraphNodeTool(tool);
+	});
+	if (!changed) return payload;
+	return { ...payload, result: { ...result, tools } };
+}
+
+function clarifyCodegraphNodeTool(tool: Record<string, unknown>): Record<string, unknown> {
+	const clarified: Record<string, unknown> = {
+		...tool,
+		description: CODEGRAPH_NODE_DESCRIPTION,
+	};
+	const inputSchema = tool["inputSchema"];
+	if (isPlainRecord(inputSchema)) clarified["inputSchema"] = clarifyCodegraphNodeInputSchema(inputSchema);
+	return clarified;
+}
+
+function hasCodegraphNodeContractMetadata(tool: Record<string, unknown>): boolean {
+	if (typeof tool["description"] === "string") return true;
+	const inputSchema = tool["inputSchema"];
+	if (!isPlainRecord(inputSchema)) return false;
+	const properties = inputSchema["properties"];
+	return isPlainRecord(properties) && isPlainRecord(properties["includeCode"]);
+}
+
+function clarifyCodegraphNodeInputSchema(inputSchema: Record<string, unknown>): Record<string, unknown> {
+	const properties = inputSchema["properties"];
+	if (!isPlainRecord(properties)) return inputSchema;
+	const includeCode = properties["includeCode"];
+	if (!isPlainRecord(includeCode)) return inputSchema;
+	return {
+		...inputSchema,
+		properties: {
+			...properties,
+			includeCode: {
+				...includeCode,
+				description: CODEGRAPH_NODE_INCLUDE_CODE_DESCRIPTION,
+			},
+		},
+	};
+}
+
+function clarifyCodegraphNodeCallResult(payload: unknown): unknown {
+	if (!isPlainRecord(payload)) return payload;
+	const result = payload["result"];
+	if (!isPlainRecord(result) || !Array.isArray(result["content"])) return payload;
+
+	let changed = false;
+	const content = result["content"].map((item) => {
+		if (!isPlainRecord(item) || item["type"] !== "text" || typeof item["text"] !== "string") return item;
+		const text = clarifyContainerOutlineGuidance(item["text"]);
+		if (text === item["text"]) return item;
+		changed = true;
+		return { ...item, text };
+	});
+	if (!changed) return payload;
+	return { ...payload, result: { ...result, content } };
+}
+
+function clarifyContainerOutlineGuidance(text: string): string {
+	if (!text.includes("Structural outline only")) return text;
+	return text.replace(/Structural outline only[^\n]*(?:\n[^\n]*(?:Read|read)[^\n]*)?/g, CODEGRAPH_CONTAINER_OUTLINE_GUIDANCE);
 }
 
 async function writeLine(output: Writable, line: string): Promise<void> {

--- a/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge.test.ts
@@ -93,6 +93,90 @@ describe("runCodegraphServe MCP protocol bridge", () => {
 			rmSync(tempRoot, { recursive: true, force: true });
 		}
 	});
+
+	it("#given old upstream codegraph_node metadata and container outline guidance #when bridging #then it exposes the corrected LazyCodex contract", async () => {
+		// given
+		const tempRoot = mkdtempSync(join(tmpdir(), "omo-codegraph-contract-"));
+		const projectRoot = join(tempRoot, "project");
+		const fakeCodegraph = join(tempRoot, "codegraph-contract-fake.cjs");
+		const childLog = join(tempRoot, "child.log");
+		const input = new PassThrough();
+		const output = new PassThrough();
+		let stdout = "";
+		output.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString("utf8");
+		});
+
+		try {
+			mkdirSync(projectRoot, { recursive: true });
+			writeFakeContractCodegraph(fakeCodegraph);
+
+			const run = runCodegraphServe({
+				cwd: tempRoot,
+				env: {
+					CODEGRAPH_ALLOW_UNSAFE_NODE: "1",
+					CODEGRAPH_FAKE_LOG: childLog,
+					OMO_CODEGRAPH_BIN: fakeCodegraph,
+					OMO_CODEGRAPH_PROJECT_CWD: projectRoot,
+					PATH: process.env["PATH"],
+				},
+				nodeVersion: "22.14.0",
+				buildEnv: () => ({}),
+				resolve: () => ({ argsPrefix: [], command: fakeCodegraph, exists: true, source: "env" }),
+				stderr: { write: () => undefined },
+				stdin: input,
+				stdout: output,
+			});
+
+			// when
+			input.end([
+				frameMcpRequest({
+					id: 1,
+					method: "tools/list",
+					params: {},
+				}),
+				frameMcpRequest({
+					id: 2,
+					method: "tools/call",
+					params: {
+						arguments: { includeCode: true, symbol: "JsonlMCP" },
+						name: "codegraph_node",
+					},
+				}),
+			].join(""));
+			const exitCode = await run;
+
+			// then
+			expect(exitCode).toBe(0);
+			const bodies = parseMcpBodies(stdout);
+			const tools = arrayProperty(recordProperty(recordValue(bodies[0]), "result"), "tools");
+			const nodeTool = findTool(tools, "codegraph_node");
+			const searchTool = findTool(tools, "codegraph_search");
+			expect(stringProperty(nodeTool, "description")).toContain("Container symbols");
+			expect(stringProperty(nodeTool, "description")).toContain("file mode");
+			expect(stringProperty(nodeTool, "description")).not.toContain("verbatim source");
+			expect(stringProperty(nodeTool, "description")).not.toContain("full body");
+			expect(
+				stringProperty(
+					recordProperty(recordProperty(recordProperty(nodeTool, "inputSchema"), "properties"), "includeCode"),
+					"description",
+				),
+			).toBe(
+				"Symbol mode: include leaf-symbol source when available. Container symbols such as classes, interfaces, structs, enums, modules, and namespaces intentionally return structural outlines with members; request a specific member symbol or use file mode with symbolsOnly=false plus offset/limit for source.",
+			);
+			expect(searchTool).toEqual({ description: "search stays unchanged", name: "codegraph_search" });
+
+			const callResult = recordProperty(recordValue(bodies[1]), "result");
+			const text = stringProperty(recordValue(arrayProperty(callResult, "content")[0]), "text");
+			expect(text).toContain("Container symbols intentionally return structural outlines");
+			expect(text).toContain("specific member symbol");
+			expect(text).toContain("file mode");
+			expect(text).toContain("symbolsOnly=false");
+			expect(text).not.toContain("Read tool");
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
 });
 
 function writeFakeNewlineCodegraph(filePath: string): void {
@@ -111,6 +195,32 @@ function writeFakeNewlineCodegraph(filePath: string): void {
 			"  }",
 			"  if (request.method === 'tools/list') {",
 			"    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { tools: [{ name: 'codegraph_search' }, { name: 'codegraph_node' }, { name: 'codegraph_explore' }, { name: 'codegraph_callers' }] } }) + '\\n');",
+			"  }",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(filePath, 0o755);
+}
+
+function writeFakeContractCodegraph(filePath: string): void {
+	writeFileSync(
+		filePath,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"const readline = require('node:readline');",
+			"fs.writeFileSync(process.env.CODEGRAPH_FAKE_LOG, `cwd=${process.cwd()}\\n`);",
+			"const rl = readline.createInterface({ input: process.stdin });",
+			"rl.on('line', (line) => {",
+			"  const request = JSON.parse(line);",
+			"  if (request.method === 'tools/list') {",
+			"    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { tools: [",
+			"      { name: 'codegraph_search', description: 'search stays unchanged' },",
+			"      { name: 'codegraph_node', description: 'ONE SYMBOL you can name - its location, signature, verbatim source (includeCode=true) and caller/callee trail in one call', inputSchema: { type: 'object', properties: { includeCode: { type: 'boolean', description: \"Symbol mode: include the symbol's full body (default: false).\" }, symbol: { type: 'string' } } } }",
+			"    ] } }) + '\\n');",
+			"  }",
+			"  if (request.method === 'tools/call') {",
+			"    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { content: [{ type: 'text', text: 'JsonlMCP\\nMembers (7)\\nStructural outline only. For full source, use the Read tool on this file or request a member.' }] } }) + '\\n');",
 			"  }",
 			"});",
 		].join("\n"),
@@ -143,4 +253,35 @@ function parseMcpBodies(transcript: string): readonly unknown[] {
 		cursor = bodyStart + length;
 	}
 	return bodies;
+}
+
+function findTool(tools: readonly unknown[], name: string): Record<string, unknown> {
+	for (const tool of tools) {
+		const record = recordValue(tool);
+		if (record["name"] === name) return record;
+	}
+	throw new Error(`Missing tool ${name}`);
+}
+
+function arrayProperty(record: Record<string, unknown>, key: string): readonly unknown[] {
+	const value = record[key];
+	if (!Array.isArray(value)) throw new Error(`Expected ${key} to be an array`);
+	return value;
+}
+
+function recordProperty(record: Record<string, unknown>, key: string): Record<string, unknown> {
+	return recordValue(record[key]);
+}
+
+function stringProperty(record: Record<string, unknown>, key: string): string {
+	const value = record[key];
+	if (typeof value !== "string") throw new Error(`Expected ${key} to be a string`);
+	return value;
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error("Expected record value");
+	}
+	return value as Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
Fixes code-yeongyu/lazycodex#87 by making the LazyCodex CodeGraph MCP bridge expose an accurate `codegraph_node` `includeCode` contract. Container symbols still return structural outlines, but the tool description, `includeCode` schema text, and structural-outline guidance now say that explicitly and point agents to specific member symbols or file mode with `symbolsOnly=false` plus `offset`/`limit` for source.

## Changes
- Patch the CodeGraph MCP bridge to remember the originating MCP request and selectively clarify `tools/list` metadata for `codegraph_node`.
- Clarify `codegraph_node` structural-outline `tools/call` text so it no longer recommends raw `Read` first.
- Add a bridge regression test with a fake upstream CodeGraph child that emits the old stale contract and container-outline output.
- Rebuild the checked-in CodeGraph component runtime bundles.

## QA & Evidence
- **RED contract mismatch:** `bun test ./test/serve-mcp-bridge.test.ts` from `packages/omo-codex/plugin/components/codegraph` before the bridge patch.
  - Observed: failed because `codegraph_node` description still said `verbatim source (includeCode=true)`.
  - Artifact: `.omo/evidence/20260630-codegraph-include-code/red-bridge-contract.txt`
- **CodeGraph component build:** `npm --prefix packages/omo-codex/plugin/components/codegraph run build`.
  - Observed: build exited 0 and regenerated `dist/serve.js` + `dist/cli.js`.
  - Artifact: `.omo/evidence/20260630-codegraph-include-code/codegraph-build.txt`
- **CodeGraph component tests:** `npm --prefix packages/omo-codex/plugin/components/codegraph test`.
  - Observed: 47 pass, 0 fail.
  - Artifact: `.omo/evidence/20260630-codegraph-include-code/green-codegraph-tests.txt`
- **CodeGraph typecheck:** `npm --prefix packages/omo-codex/plugin/components/codegraph run typecheck`.
  - Observed: exited 0.
  - Artifact: `.omo/evidence/20260630-codegraph-include-code/codegraph-typecheck.txt`
- **Manual MCP smoke:** built `packages/omo-codex/plugin/components/codegraph/dist/serve.js` driven over framed stdio with a fake CodeGraph child emitting the old schema and structural-outline output.
  - Observed: corrected schema/description includes container-outline language, call text recommends member/file mode, and no corrected output mentions `Read tool`.
  - Artifact: `.omo/evidence/20260630-codegraph-include-code/manual-mcp-smoke.txt`
- **Codex gate:** `bun run test:codex`.
  - Observed: 422 pass, 0 fail.
  - Artifact: `.omo/evidence/20260630-codegraph-include-code/test-codex.txt`
- **Isolated Codex app-server QA:** `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin`.
  - Observed: isolated local install completed a mock-model turn; `sessionStart`, `userPromptSubmit`, and `stop` hooks fired; real `~/.codex/config.toml` unchanged.
  - Artifact: `.omo/evidence/20260630-codegraph-include-code/codex-app-server-drive.json`

## Risks & Residuals
- This is a local bridge compatibility shim, not an upstream CodeGraph behavior change. It intentionally preserves current container-outline behavior and only corrects the public MCP contract/guidance.
- The text rewrite is scoped to `codegraph_node` `tools/call` responses containing `Structural outline only`, plus `tools/list` metadata for `codegraph_node`.

## Related Issues
Fixes code-yeongyu/lazycodex#87

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the `codegraph_node` `includeCode` contract in the CodeGraph MCP bridge so container symbols are documented as structural-only and source guidance is correct. Fixes code-yeongyu/lazycodex#87 and leaves other tools unchanged.

- **Bug Fixes**
  - Track pending MCP requests (method/tool/response mode) and rewrite `tools/list` and `tools/call` only for `codegraph_node`.
  - Update tool description and `includeCode` schema; replace container-outline "Read tool" advice with member/file guidance using `symbolsOnly=false` and `offset`/`limit`.
  - Add a regression test against old upstream metadata/output and rebuild the component bundles.

<sup>Written for commit 4cf383c5b7170ae910434cd2ebe63e2be193e97e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

