### PR TITLE
[lazycodex-issues] #85 companion plugin hook warning

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1039,6 +1039,21 @@ Native Windows Codex installs bundle a `git_bash` MCP server and write `[plugins
 
 The installer discovers Git Bash with `OMO_CODEX_GIT_BASH_PATH`, standard Git for Windows locations, and PATH. If discovery fails, it prints manual install guidance and stops without running `winget` or changing system dependencies. The Light plugin also emits a fixed reminder before the first Codex shell-like `Bash` hook call in a Windows session, and resets that reminder after `PostCompact` so the first post-compaction shell call recommends `git_bash` again.
 
+### Codex Companion Plugin Compatibility
+
+LazyCodex can coexist with other Codex plugins, but if LazyCodex is your primary Codex workflow the `codex@openai-codex` companion plugin adds its own `SessionStart` and `Stop` lifecycle hooks. Those extra hooks can produce confusing Codex hook-failure banners even when the LazyCodex hooks are healthy.
+
+`lazycodex doctor` warns when `omo@sisyphuslabs` is enabled and the companion plugin is enabled, or when stale `[hooks.state."codex@openai-codex:..."]` SessionStart/Stop trust entries remain in `~/.codex/config.toml`. The doctor only reports this condition; it does not disable or delete another plugin for you.
+
+If LazyCodex is the primary workflow, disable the companion plugin explicitly:
+
+```toml
+[plugins."codex@openai-codex"]
+enabled = false
+```
+
+If doctor still warns afterward, remove the stale `[hooks.state."codex@openai-codex:..."]` SessionStart/Stop entries from the Codex config after making your own backup.
+
 ### Provider-Specific
 
 #### Google Auth

--- a/packages/omo-opencode/src/cli/doctor/checks/codex.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/codex.test.ts
@@ -73,6 +73,8 @@ describe("codex doctor checks", () => {
     expect(summary.config.pluginEnabled).toBe(true)
     expect(summary.config.pluginsFeatureEnabled).toBe(true)
     expect(summary.config.pluginHooksFeatureEnabled).toBe(true)
+    expect(summary.config.companionPluginEnabled).toBe(false)
+    expect(summary.config.companionLifecycleHookStateEvents).toEqual([])
     expect(summary.linkedBins).toEqual(["omo", "omo-rules"])
   })
 
@@ -216,8 +218,61 @@ describe("codex doctor checks", () => {
     expect(result.details).toContain("Plugin: omo@4.7.5")
     expect(result.details).toContain("Distribution: lazycodex-ai@4.7.5")
     expect(result.details).toContain("Enabled plugin: omo@sisyphuslabs")
+    expect(result.details).toContain("Companion plugin: none")
     expect(result.details).toContain("Linked bins: omo, omo-rules")
     expect(result.details).toContain("Agents: plan")
+  })
+
+  test("#given LazyCodex is primary and Codex Companion lifecycle hooks are configured #when checking Codex doctor #then warns without disabling anything", async () => {
+    // given
+    const { codexHome, binDir } = await createInstalledCodexHome()
+    await writeFile(
+      join(codexHome, "config.toml"),
+      [
+        "[features]",
+        "plugins = true",
+        "plugin_hooks = true",
+        "",
+        "[marketplaces.sisyphuslabs]",
+        `source = "${join(codexHome, "plugins", "cache", "sisyphuslabs")}"`,
+        "",
+        '[plugins."omo@sisyphuslabs"]',
+        "enabled = true",
+        "",
+        '[plugins."codex@openai-codex"]',
+        "enabled = true",
+        "",
+        '[hooks.state."codex@openai-codex:hooks/hooks.json:session_start:0:0"]',
+        'trusted_hash = "sha256:session"',
+        "",
+        "[hooks.state.'codex@openai-codex:hooks/hooks.json:stop:0:0']",
+        'trusted_hash = "sha256:stop"',
+      ].join("\n"),
+    )
+
+    // when
+    const result = await checkCodex({
+      codexHome,
+      binDir,
+      detectCodexInstallation: async () => ({ found: true, source: "cli", path: "/usr/local/bin/codex" }),
+    })
+    const summary = await gatherCodexSummary({
+      codexHome,
+      binDir,
+      detectCodexInstallation: async () => ({ found: true, source: "cli", path: "/usr/local/bin/codex" }),
+    })
+
+    // then
+    expect(result.status).toBe("warn")
+    expect(summary.config.companionPluginEnabled).toBe(true)
+    expect(summary.config.companionLifecycleHookStateEvents).toEqual(["session_start", "stop"])
+    expect(result.details).toContain("Companion plugin: codex@openai-codex enabled (SessionStart, Stop hook trust)")
+    const issue = result.issues.find((entry) => entry.title === "Codex Companion lifecycle hooks may conflict with LazyCodex")
+    expect(issue).toBeDefined()
+    expect(issue?.severity).toBe("warning")
+    expect(issue?.description).toContain("codex@openai-codex is enabled")
+    expect(issue?.description).toContain("SessionStart, Stop")
+    expect(issue?.fix).toContain('[plugins."codex@openai-codex"] enabled = false')
   })
 
   test("#given a stamped plugin bundle #when gathering Codex summary #then it reports the installer version and stamped state", async () => {

--- a/packages/omo-opencode/src/cli/doctor/checks/codex.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/codex.ts
@@ -5,6 +5,7 @@ import { homedir } from "node:os"
 import { basename, join, resolve } from "node:path"
 import { detectCodexInstallation, type CodexInstallationDetection } from "../../install-codex"
 import { resolveCodexInstallerBinDir } from "../../install-codex/install-codex"
+import { parseHookStateHeaderKey, splitTomlSections } from "../../install-codex/codex-config-toml-sections"
 import { CHECK_IDS, CHECK_NAMES } from "../framework/constants"
 import type { CheckResult, CodexConfigSummary, CodexDoctorSummary, DoctorIssue } from "../framework/types"
 import packageJson from "../../../../package.json" with { type: "json" }
@@ -24,7 +25,9 @@ interface JsonRecord {
 
 const MARKETPLACE_NAME = "sisyphuslabs"
 const PLUGIN_NAME = "omo"
+const COMPANION_PLUGIN_KEY = "codex@openai-codex"
 const DEFAULT_PLUGIN_VERSION = "0.1.0"
+const COMPANION_LIFECYCLE_EVENTS = new Set(["session_start", "stop"])
 const CODEX_BIN_NAMES = [
   "omo",
   "omo-rules",
@@ -81,6 +84,7 @@ export async function checkCodex(deps: CodexDoctorDeps = {}): Promise<CheckResul
       `Distribution: ${summary.packageName ?? "unknown"}@${summary.packageVersion ?? "unknown"}`,
       `Config: ${summary.configPath}`,
       `Enabled plugin: ${summary.config.pluginEnabled ? "omo@sisyphuslabs" : "missing"}`,
+      `Companion plugin: ${formatCompanionPluginStatus(summary.config)}`,
       `Linked bins: ${summary.linkedBins.length > 0 ? summary.linkedBins.join(", ") : "none"}`,
       `Agents: ${summary.agents.length > 0 ? summary.agents.join(", ") : "none"}`,
     ],
@@ -153,6 +157,18 @@ function buildCodexIssues(summary: CodexDoctorSummary): DoctorIssue[] {
       affects: ["hooks"],
     })
   }
+  if (summary.config.pluginEnabled && hasCompanionLifecycleSurface(summary.config)) {
+    issues.push({
+      title: "Codex Companion lifecycle hooks may conflict with LazyCodex",
+      description: [
+        companionLifecycleSurfaceDescription(summary.config),
+        "LazyCodex does not disable other plugins automatically, but when LazyCodex is your primary Codex workflow these extra lifecycle hooks can produce confusing SessionStart/Stop hook failure banners.",
+      ].join(" "),
+      fix: 'If LazyCodex is your primary Codex workflow, set [plugins."codex@openai-codex"] enabled = false and remove stale [hooks.state."codex@openai-codex:..."] SessionStart/Stop entries if the warning remains.',
+      severity: "warning",
+      affects: ["hooks", "plugin compatibility"],
+    })
+  }
   return issues
 }
 
@@ -166,7 +182,15 @@ async function resolveInstalledPluginRoot(codexHome: string): Promise<string | n
 
 async function readCodexConfigSummary(configPath: string): Promise<CodexConfigSummary> {
   if (!existsSync(configPath)) {
-    return { exists: false, marketplaceConfigured: false, pluginEnabled: false, pluginsFeatureEnabled: false, pluginHooksFeatureEnabled: false }
+    return {
+      exists: false,
+      marketplaceConfigured: false,
+      pluginEnabled: false,
+      pluginsFeatureEnabled: false,
+      pluginHooksFeatureEnabled: false,
+      companionPluginEnabled: false,
+      companionLifecycleHookStateEvents: [],
+    }
   }
   const content = await readFile(configPath, "utf8")
   return {
@@ -175,6 +199,8 @@ async function readCodexConfigSummary(configPath: string): Promise<CodexConfigSu
     pluginEnabled: settingEnabled(sectionBody(content, 'plugins."omo@sisyphuslabs"'), "enabled"),
     pluginsFeatureEnabled: featureEnabled(content, "plugins"),
     pluginHooksFeatureEnabled: featureEnabled(content, "plugin_hooks"),
+    companionPluginEnabled: settingEnabled(sectionBody(content, `plugins.${JSON.stringify(COMPANION_PLUGIN_KEY)}`), "enabled"),
+    companionLifecycleHookStateEvents: readCompanionLifecycleHookStateEvents(content),
   }
 }
 
@@ -215,6 +241,72 @@ function featureEnabled(content: string, name: string): boolean {
 
 function settingEnabled(content: string, name: string): boolean {
   return content.includes(`${name} = true`)
+}
+
+function hasCompanionLifecycleSurface(config: CodexConfigSummary): boolean {
+  return config.companionPluginEnabled || config.companionLifecycleHookStateEvents.length > 0
+}
+
+function companionLifecycleSurfaceDescription(config: CodexConfigSummary): string {
+  const states = config.companionLifecycleHookStateEvents
+  const stateText = states.length > 0
+    ? `trusted ${formatCompanionLifecycleEvents(states)} hook state`
+    : "no trusted SessionStart/Stop hook state detected"
+  const pluginText = config.companionPluginEnabled ? `${COMPANION_PLUGIN_KEY} is enabled` : `${COMPANION_PLUGIN_KEY} appears disabled`
+  return `${pluginText}, with ${stateText}.`
+}
+
+function formatCompanionPluginStatus(config: CodexConfigSummary): string {
+  if (config.companionPluginEnabled) {
+    const suffix = config.companionLifecycleHookStateEvents.length > 0
+      ? ` (${formatCompanionLifecycleEvents(config.companionLifecycleHookStateEvents)} hook trust)`
+      : ""
+    return `${COMPANION_PLUGIN_KEY} enabled${suffix}`
+  }
+  if (config.companionLifecycleHookStateEvents.length > 0) {
+    return `stale ${COMPANION_PLUGIN_KEY} ${formatCompanionLifecycleEvents(config.companionLifecycleHookStateEvents)} hook trust`
+  }
+  return "none"
+}
+
+function readCompanionLifecycleHookStateEvents(content: string): readonly string[] {
+  const events = new Set<string>()
+  for (const section of splitTomlSections(content)) {
+    if (section.header === null) continue
+    const key = parseHookStateHeaderKey(section.header)
+    const event = key === null ? null : companionLifecycleEventFromHookStateKey(key)
+    if (event !== null) events.add(event)
+  }
+  return [...events].sort(compareCompanionLifecycleEvents)
+}
+
+function companionLifecycleEventFromHookStateKey(key: string): string | null {
+  if (!key.startsWith(`${COMPANION_PLUGIN_KEY}:`)) return null
+  const eventName = key.split(":").at(-3)
+  return eventName !== undefined && COMPANION_LIFECYCLE_EVENTS.has(eventName) ? eventName : null
+}
+
+function compareCompanionLifecycleEvents(left: string, right: string): number {
+  return companionLifecycleEventOrder(left) - companionLifecycleEventOrder(right)
+}
+
+function companionLifecycleEventOrder(event: string): number {
+  return event === "session_start" ? 0 : event === "stop" ? 1 : 2
+}
+
+function formatCompanionLifecycleEvents(events: readonly string[]): string {
+  return events.map(formatCompanionLifecycleEvent).join(", ")
+}
+
+function formatCompanionLifecycleEvent(event: string): string {
+  switch (event) {
+    case "session_start":
+      return "SessionStart"
+    case "stop":
+      return "Stop"
+    default:
+      return event
+  }
 }
 
 function sectionBody(content: string, sectionName: string): string {

--- a/packages/omo-opencode/src/cli/doctor/format-default.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/format-default.test.ts
@@ -101,6 +101,8 @@ describe("formatDefault", () => {
         pluginEnabled: true,
         pluginsFeatureEnabled: true,
         pluginHooksFeatureEnabled: true,
+        companionPluginEnabled: false,
+        companionLifecycleHookStateEvents: [],
       },
       linkedBins: ["omo"],
       agents: ["plan"],

--- a/packages/omo-opencode/src/cli/doctor/formatter.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/formatter.test.ts
@@ -91,6 +91,8 @@ function createCodexDoctorResult(): DoctorResult {
       pluginEnabled: true,
       pluginsFeatureEnabled: true,
       pluginHooksFeatureEnabled: true,
+      companionPluginEnabled: false,
+      companionLifecycleHookStateEvents: [],
     },
     linkedBins: ["omo", "omo-rules"],
     agents: ["plan"],

--- a/packages/omo-opencode/src/cli/doctor/framework/types.ts
+++ b/packages/omo-opencode/src/cli/doctor/framework/types.ts
@@ -80,6 +80,8 @@ export interface CodexConfigSummary {
   readonly pluginEnabled: boolean
   readonly pluginsFeatureEnabled: boolean
   readonly pluginHooksFeatureEnabled: boolean
+  readonly companionPluginEnabled: boolean
+  readonly companionLifecycleHookStateEvents: readonly string[]
 }
 
 export interface CodexDoctorSummary {


### PR DESCRIPTION
## Summary

Adds a read-only LazyCodex doctor warning for the `codex@openai-codex` companion plugin when LazyCodex is the primary Codex workflow. The warning triggers when the companion plugin is enabled or when stale companion `SessionStart` / `Stop` hook trust entries remain in `~/.codex/config.toml`; it does not disable or delete anything automatically.

## Changes

- Extends the Codex doctor config summary with companion-plugin state and companion lifecycle hook trust detection.
- Surfaces a friendly warning that explains why extra companion lifecycle hooks can cause confusing Codex hook-failure banners and how to disable/clean them manually.
- Adds focused doctor tests for the warning path plus fixture updates for the expanded summary shape.
- Documents the compatibility guidance in the Codex Light configuration reference.

## QA & Evidence

Evidence directory: `.omo/evidence/20260630-issue-85-companion-warning/`

- **What was tested:** RED synthetic doctor function smoke with isolated `CODEX_HOME`, `omo@sisyphuslabs` enabled, `codex@openai-codex` enabled, and companion `session_start` / `stop` hook trust entries.
  **Observed result:** pre-fix doctor returned `status: pass` with `issues: []`, proving the missing warning.
  **Artifact:** `.omo/evidence/20260630-issue-85-companion-warning/red-doctor-synthetic.json`

- **What was tested:** Focused doctor tests.
  **Observed result:** 27 pass, 0 fail.
  **Artifact:** `.omo/evidence/20260630-issue-85-companion-warning/focused-doctor-tests.txt`

- **What was tested:** Manual doctor/config smoke through the actual CLI entrypoint with synthetic `CODEX_HOME` and `CODEX_LOCAL_BIN_DIR`.
  **Observed result:** doctor reports `Companion plugin: codex@openai-codex enabled (SessionStart, Stop hook trust)` and one warning, with 0 failed checks.
  **Artifact:** `.omo/evidence/20260630-issue-85-companion-warning/green-doctor-cli-smoke.txt`

- **What was tested:** `bun run typecheck`, `bun run test:codex`, `bun run build`, and root `bun test`.
  **Observed result:** all exited 0; `test:codex` ended with 422 Node tests passing, and root `bun test` ended with 10216 pass / 2 skip / 0 fail.
  **Artifacts:** `.omo/evidence/20260630-issue-85-companion-warning/typecheck.txt`, `test-codex.txt`, `build.txt`, `bun-test.txt`

## Risks & Residuals

- The warning is intentionally advisory. It detects the known companion plugin key and hook-state shape but leaves all user/plugin configuration unchanged.
- LSP diagnostics are clean for the changed source/type files. The changed Bun test file still shows the repo's existing LSP ambient-type noise for `bun:test` / `node:` imports; `bun run typecheck` passes.

## Related Issues

Fixes code-yeongyu/lazycodex#85


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only doctor warning for the `codex@openai-codex` companion lifecycle hooks when LazyCodex is primary, helping avoid confusing hook-failure banners. Extends the doctor summary and docs; no configuration is changed automatically.

- **New Features**
  - Warns when `omo@sisyphuslabs` is enabled and the `codex@openai-codex` companion is enabled, or when stale `SessionStart`/`Stop` hook trust entries exist in `~/.codex/config.toml`.
  - Shows companion plugin status in doctor output, including detected `SessionStart`/`Stop` trust.
  - Adds focused tests and updates the configuration docs with manual disable/cleanup steps.

<sup>Written for commit af87aaf0b97efb62158c7d82b02230141e18c8b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

