### PR TITLE
[lazycodex-issues] #80 doctor source cache reliability

### DIFF
--- a/packages/omo-codex/plugin/test/lcx-bug-skills.test.mjs
+++ b/packages/omo-codex/plugin/test/lcx-bug-skills.test.mjs
@@ -4,11 +4,16 @@ import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const sharedSkillsRoot = join(pluginRoot, "..", "..", "shared-skills");
+
+async function readSkill(name) {
+	return readFile(join(sharedSkillsRoot, "skills", name, "SKILL.md"), "utf8");
+}
 
 test("#given synced lcx-report-bug skill #when inspected #then it files LazyCodex bug issues with generated labels", async () => {
 	// given
-	const skillRoot = join(root, "skills", "lcx-report-bug");
+	const skillRoot = join(sharedSkillsRoot, "skills", "lcx-report-bug");
 
 	// when
 	const skill = await readFile(join(skillRoot, "SKILL.md"), "utf8");
@@ -20,14 +25,14 @@ test("#given synced lcx-report-bug skill #when inspected #then it files LazyCode
 	assert.match(skill, /gh pr create --repo openai\/codex/);
 	assert.doesNotMatch(skill, /gh pr create --repo "\$TARGET_REPO"/);
 	assert.doesNotMatch(skill, /gh pr create --repo code-yeongyu\/lazycodex/);
-	assert.match(interfaceMetadata, /display_name: "\(OmO\) lcx-report-bug"/);
+	assert.match(interfaceMetadata, /display_name: "lcx-report-bug \(omo\)"/);
 	assert.match(interfaceMetadata, /- "lazycodex bug"/);
 	assert.match(interfaceMetadata, /- "openai codex bug"/);
 });
 
 test("#given synced lcx-contribute-bug-fix skill #when inspected #then it delivers LazyCodex fixes as issues and upstream fixes as fork PRs", async () => {
 	// given
-	const skillRoot = join(root, "skills", "lcx-contribute-bug-fix");
+	const skillRoot = join(sharedSkillsRoot, "skills", "lcx-contribute-bug-fix");
 
 	// when
 	const skill = await readFile(join(skillRoot, "SKILL.md"), "utf8");
@@ -40,14 +45,14 @@ test("#given synced lcx-contribute-bug-fix skill #when inspected #then it delive
 	assert.match(skill, /gh pr create --repo openai\/codex/);
 	assert.doesNotMatch(skill, /gh pr create --repo "\$TARGET_REPO"/);
 	assert.doesNotMatch(skill, /gh pr create --repo code-yeongyu\/lazycodex/);
-	assert.match(interfaceMetadata, /display_name: "\(OmO\) lcx-contribute-bug-fix"/);
+	assert.match(interfaceMetadata, /display_name: "lcx-contribute-bug-fix \(omo\)"/);
 	assert.match(interfaceMetadata, /- "contribute a bug fix"/);
 	assert.match(interfaceMetadata, /- "fix bug pr"/);
 });
 
-test("#given synced lcx-doctor skill #when inspected #then it diagnoses installs against latest /tmp sources without mutating them", async () => {
+test("#given synced lcx-doctor skill #when inspected #then it diagnoses installs against latest temp-root sources without mutating them", async () => {
 	// given
-	const skillRoot = join(root, "skills", "lcx-doctor");
+	const skillRoot = join(sharedSkillsRoot, "skills", "lcx-doctor");
 
 	// when
 	const skill = await readFile(join(skillRoot, "SKILL.md"), "utf8");
@@ -55,7 +60,38 @@ test("#given synced lcx-doctor skill #when inspected #then it diagnoses installs
 
 	// then
 	assert.match(skill, /^---\r?\nname: lcx-doctor\r?\n/m);
-	assert.match(interfaceMetadata, /display_name: "\(OmO\) lcx-doctor"/);
+	assert.match(interfaceMetadata, /display_name: "lcx-doctor \(omo\)"/);
 	assert.match(interfaceMetadata, /- "lazycodex doctor"/);
 	assert.match(interfaceMetadata, /- "lazycodex health check"/);
+});
+
+test("#given lcx source-sync skills #when inspected #then source caches are validated before reuse", async () => {
+	// given
+	const skillNames = ["lcx-doctor", "lcx-report-bug", "lcx-contribute-bug-fix"];
+
+	for (const skillName of skillNames) {
+		// when
+		const skill = await readSkill(skillName);
+
+		// then
+		assert.match(skill, /LAZYCODEX_SOURCE_ROOT="\$\{LAZYCODEX_SOURCE_ROOT:-\$\{TMPDIR:-\/tmp\}\/lazycodex-sources\}"/);
+		assert.match(skill, /git -C "\$DEST" rev-parse --is-inside-work-tree/);
+		assert.match(skill, /git -C "\$DEST" config --get remote\.origin\.url/);
+		assert.match(skill, /DEST\.corrupt\.\$\(date \+%Y%m%d%H%M%S\)/);
+		assert.doesNotMatch(skill, /if \[ ! -d "\$DEST\/\.git" \]; then/);
+		assert.doesNotMatch(skill, /sync_latest_source code-yeongyu\/lazycodex \/tmp\/lazycodex-source/);
+		assert.doesNotMatch(skill, /sync_latest_source openai\/codex \/tmp\/openai-codex-source/);
+	}
+});
+
+test("#given lcx-doctor skill #when inspected #then aggregate hook validation follows the current manifest", async () => {
+	// given
+	const skill = await readSkill("lcx-doctor");
+
+	// then
+	assert.match(skill, /\.codex-plugin\/plugin\.json/);
+	assert.match(skill, /manifest declares a `hooks` array/);
+	assert.match(skill, /validate every direct hook path declared by the manifest/);
+	assert.match(skill, /`hooks\/hooks\.json` only when the manifest declares it/);
+	assert.doesNotMatch(skill, /Plugin payload present and non-empty: `hooks\/hooks\.json`/);
 });

--- a/packages/omo-codex/scripts/install-delegated-command.test.mjs
+++ b/packages/omo-codex/scripts/install-delegated-command.test.mjs
@@ -75,9 +75,35 @@ test("#given a dry-run doctor #when delegating #then routes to the Codex LazyCod
 	// then
 	assert.equal(ran, false);
 	assert.match(logged, /^codex exec /);
+	assert.match(logged, /--sandbox danger-full-access/);
+	assert.doesNotMatch(logged, /--sandbox read-only/);
 	assert.match(logged, /Use \$omo:lcx-doctor/);
+	assert.match(logged, /LAZYCODEX_SOURCE_ROOT/);
+	assert.match(logged, /\$\{TMPDIR:-\/tmp\}\/lazycodex-sources/);
 	assert.match(logged, /Requested doctor arguments: --json/);
 	assert.doesNotMatch(logged, /oh-my-openagent omo doctor/);
+});
+
+test("#given doctor source-root override #when delegating #then passes it to the Codex workflow environment", async () => {
+	// given
+	const parsed = { kind: "command", command: "doctor", args: ["--source-root", "/var/tmp/lcx-sources", "--json"] };
+
+	// when
+	const invocation = buildDelegatedOmoInvocation(parsed);
+
+	// then
+	assert.equal(invocation.env?.LAZYCODEX_SOURCE_ROOT, "/var/tmp/lcx-sources");
+	assert.deepEqual(invocation.args.slice(0, 7), [
+		"exec",
+		"--ephemeral",
+		"--sandbox",
+		"danger-full-access",
+		"--skip-git-repo-check",
+		"--cd",
+		".",
+	]);
+	assert.match(invocation.args.at(-1), /Requested doctor arguments: --json/);
+	assert.doesNotMatch(invocation.args.at(-1), /--source-root/);
 });
 
 test("#given doctor recursion guard is active #when lazycodex doctor delegates #then rejects before launching Codex", async () => {

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -13853,6 +13853,7 @@ function formatLazyCodexInstallHelp() {
     "Usage: lazycodex-ai install [--no-tui] [--codex-autonomous|--no-codex-autonomous] [--repo-root <path>]",
     "       lazycodex-ai uninstall [--project <path>]",
     "       lazycodex-ai update [--dry-run] [--repo-root <path>]",
+    "       lazycodex-ai doctor [--source-root <path>] [--json|--status|--verbose]",
     "       lazycodex-ai version",
     "       lazycodex-ai <command> [args...]",
     "",
@@ -13903,21 +13904,23 @@ function buildDelegatedOmoInvocation(parsed) {
   return { command: "npx", args, delegatesToOmo: true };
 }
 function buildLazyCodexDoctorInvocation(doctorArgs) {
+  const doctorOptions = parseLazyCodexDoctorOptions(doctorArgs);
   return {
     command: "codex",
     args: [
       "exec",
       "--ephemeral",
       "--sandbox",
-      "read-only",
+      "danger-full-access",
       "--skip-git-repo-check",
       "--cd",
       ".",
-      buildLazyCodexDoctorPrompt(doctorArgs)
+      buildLazyCodexDoctorPrompt(doctorOptions.args)
     ],
     delegatesToOmo: false,
     env: {
-      LAZYCODEX_DOCTOR_LCX_ACTIVE: "1"
+      LAZYCODEX_DOCTOR_LCX_ACTIVE: "1",
+      ...doctorOptions.sourceRoot === undefined ? {} : { LAZYCODEX_SOURCE_ROOT: doctorOptions.sourceRoot }
     }
   };
 }
@@ -13925,11 +13928,40 @@ function buildLazyCodexDoctorPrompt(doctorArgs) {
   return [
     "Use $omo:lcx-doctor to diagnose this LazyCodex/Codex installation.",
     "This command is already the lazycodex doctor surface; never invoke lazycodex doctor from inside the doctor workflow.",
-    "Sync the latest LazyCodex and OpenAI Codex sources into /tmp, inventory the local installation,",
+    "Use the resolved source root from LAZYCODEX_SOURCE_ROOT when set; otherwise use ${TMPDIR:-/tmp}/lazycodex-sources.",
+    "Validate cached source checkouts before reuse, quarantine corrupt caches, and do not rely on /tmp/lazycodex-source.",
+    "Sync the latest LazyCodex and OpenAI Codex sources there, inventory the local installation,",
     "probe the Codex plugin/cache/hooks/MCP state, and report PASS/WARN/FAIL findings with evidence and remediations.",
     buildDoctorOutputInstruction(doctorArgs),
     doctorArgs.length > 0 ? `Requested doctor arguments: ${doctorArgs.join(" ")}` : "Requested doctor arguments: none"
   ].join(" ");
+}
+function parseLazyCodexDoctorOptions(doctorArgs) {
+  const args = [];
+  let sourceRoot;
+  let index = 0;
+  while (index < doctorArgs.length) {
+    const arg = doctorArgs[index];
+    if (arg === "--source-root") {
+      const value = doctorArgs[index + 1];
+      if (typeof value !== "string" || value.trim().length === 0)
+        throw new Error("--source-root requires a path");
+      sourceRoot = value;
+      index += 2;
+      continue;
+    }
+    if (typeof arg === "string" && arg.startsWith("--source-root=")) {
+      const value = arg.slice("--source-root=".length);
+      if (value.trim().length === 0)
+        throw new Error("--source-root requires a path");
+      sourceRoot = value;
+      index += 1;
+      continue;
+    }
+    args.push(arg);
+    index += 1;
+  }
+  return { args, sourceRoot };
 }
 function buildDoctorOutputInstruction(doctorArgs) {
   if (doctorArgs.includes("--json")) {

--- a/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
+++ b/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
@@ -98,7 +98,10 @@ test("#given dry-run doctor #when running the Node installer entrypoint #then pr
 
 	// then
 	assert.match(output, /^codex exec /);
+	assert.match(output, /--sandbox danger-full-access/);
+	assert.doesNotMatch(output, /--sandbox read-only/);
 	assert.match(output, /Use \$omo:lcx-doctor/);
+	assert.match(output, /\$\{TMPDIR:-\/tmp\}\/lazycodex-sources/);
 	assert.match(output, /Requested doctor arguments: --json/);
 	assert.match(output, /Return exactly one JSON object/);
 	assert.doesNotMatch(output, /oh-my-openagent omo doctor/);

--- a/packages/omo-codex/src/install/lazycodex-cli-args.ts
+++ b/packages/omo-codex/src/install/lazycodex-cli-args.ts
@@ -173,6 +173,7 @@ export function formatLazyCodexInstallHelp(): string {
     "Usage: lazycodex-ai install [--no-tui] [--codex-autonomous|--no-codex-autonomous] [--repo-root <path>]",
     "       lazycodex-ai uninstall [--project <path>]",
     "       lazycodex-ai update [--dry-run] [--repo-root <path>]",
+    "       lazycodex-ai doctor [--source-root <path>] [--json|--status|--verbose]",
     "       lazycodex-ai version",
     "       lazycodex-ai <command> [args...]",
     "",

--- a/packages/omo-codex/src/install/lazycodex-delegated-command.ts
+++ b/packages/omo-codex/src/install/lazycodex-delegated-command.ts
@@ -10,6 +10,11 @@ export type DelegatedOmoInvocation = {
   readonly env?: Readonly<Record<string, string>>
 }
 
+type LazyCodexDoctorOptions = {
+  readonly args: readonly string[]
+  readonly sourceRoot?: string
+}
+
 export async function runDelegatedOmoCommand(
   parsed: LazyCodexDelegatedCommand,
   options: {
@@ -52,21 +57,23 @@ export function buildDelegatedOmoInvocation(parsed: LazyCodexDelegatedCommand): 
 }
 
 function buildLazyCodexDoctorInvocation(doctorArgs: readonly string[]): DelegatedOmoInvocation {
+  const doctorOptions = parseLazyCodexDoctorOptions(doctorArgs)
   return {
     command: "codex",
     args: [
       "exec",
       "--ephemeral",
       "--sandbox",
-      "read-only",
+      "danger-full-access",
       "--skip-git-repo-check",
       "--cd",
       ".",
-      buildLazyCodexDoctorPrompt(doctorArgs),
+      buildLazyCodexDoctorPrompt(doctorOptions.args),
     ],
     delegatesToOmo: false,
     env: {
       LAZYCODEX_DOCTOR_LCX_ACTIVE: "1",
+      ...(doctorOptions.sourceRoot === undefined ? {} : { LAZYCODEX_SOURCE_ROOT: doctorOptions.sourceRoot }),
     },
   }
 }
@@ -75,11 +82,39 @@ function buildLazyCodexDoctorPrompt(doctorArgs: readonly string[]): string {
   return [
     "Use $omo:lcx-doctor to diagnose this LazyCodex/Codex installation.",
     "This command is already the lazycodex doctor surface; never invoke lazycodex doctor from inside the doctor workflow.",
-    "Sync the latest LazyCodex and OpenAI Codex sources into /tmp, inventory the local installation,",
+    "Use the resolved source root from LAZYCODEX_SOURCE_ROOT when set; otherwise use ${TMPDIR:-/tmp}/lazycodex-sources.",
+    "Validate cached source checkouts before reuse, quarantine corrupt caches, and do not rely on /tmp/lazycodex-source.",
+    "Sync the latest LazyCodex and OpenAI Codex sources there, inventory the local installation,",
     "probe the Codex plugin/cache/hooks/MCP state, and report PASS/WARN/FAIL findings with evidence and remediations.",
     buildDoctorOutputInstruction(doctorArgs),
     doctorArgs.length > 0 ? `Requested doctor arguments: ${doctorArgs.join(" ")}` : "Requested doctor arguments: none",
   ].join(" ")
+}
+
+function parseLazyCodexDoctorOptions(doctorArgs: readonly string[]): LazyCodexDoctorOptions {
+  const args: string[] = []
+  let sourceRoot: string | undefined
+  let index = 0
+  while (index < doctorArgs.length) {
+    const arg = doctorArgs[index]
+    if (arg === "--source-root") {
+      const value = doctorArgs[index + 1]
+      if (typeof value !== "string" || value.trim().length === 0) throw new Error("--source-root requires a path")
+      sourceRoot = value
+      index += 2
+      continue
+    }
+    if (typeof arg === "string" && arg.startsWith("--source-root=")) {
+      const value = arg.slice("--source-root=".length)
+      if (value.trim().length === 0) throw new Error("--source-root requires a path")
+      sourceRoot = value
+      index += 1
+      continue
+    }
+    args.push(arg)
+    index += 1
+  }
+  return { args, sourceRoot }
 }
 
 function buildDoctorOutputInstruction(doctorArgs: readonly string[]): string {

--- a/packages/shared-skills/skills/lcx-contribute-bug-fix/SKILL.md
+++ b/packages/shared-skills/skills/lcx-contribute-bug-fix/SKILL.md
@@ -18,7 +18,7 @@ Route ownership the same way as `$lcx-report-bug`, but the deliverable differs b
 
 For `openai/codex`, create a fork PR that includes:
 
-- a focused branch from a fresh `/tmp` clone/worktree
+- a focused branch from a fresh `${TMPDIR:-/tmp}` clone/worktree
 - reproduction logs from before the fix
 - the smallest implementation that fixes the defect
 - verification logs from after the fix
@@ -30,7 +30,7 @@ For `code-yeongyu/lazycodex`, create an issue (never a PR) that includes:
 
 - reproduction logs from before the fix
 - the root cause with source evidence
-- the verified patch as a unified diff, produced and tested in a fresh `/tmp` clone/worktree
+- the verified patch as a unified diff, produced and tested in a fresh `${TMPDIR:-/tmp}` clone/worktree
 - verification logs from after the fix
 - the `lazycodex-generated` label and the footer tag `Tag: lazycodex-generated`
 - cleanup of temporary worktrees and clones
@@ -39,27 +39,58 @@ For `code-yeongyu/lazycodex`, create an issue (never a PR) that includes:
 
 1. Read the user's bug report and identify the affected surface.
 2. Invoke `$omo:debugging` for the investigation. If only unqualified skill names are exposed, invoke `$debugging` and state that it is the OMO debugging skill.
-3. Materialize the latest sources, then decide the target repository. Sync both checkouts on every run and compare them before choosing — a stale checkout routes the fix to the wrong repo:
+3. Materialize the latest sources under `LAZYCODEX_SOURCE_ROOT="${LAZYCODEX_SOURCE_ROOT:-${TMPDIR:-/tmp}/lazycodex-sources}"`, then decide the target repository. Sync both checkouts on every run and compare them before choosing. Validate cached checkouts before reuse so an incomplete `.git` directory cannot route the fix to the wrong repo:
 
 ```bash
+LAZYCODEX_SOURCE_ROOT="${LAZYCODEX_SOURCE_ROOT:-${TMPDIR:-/tmp}/lazycodex-sources}"
+mkdir -p "$LAZYCODEX_SOURCE_ROOT"
+
+valid_source_checkout() {
+  DEST="$1"
+  git -C "$DEST" rev-parse --is-inside-work-tree >/dev/null 2>&1 &&
+    git -C "$DEST" config --get remote.origin.url >/dev/null 2>&1
+}
+
+recover_corrupt_source_checkout() {
+  DEST="$1"
+  if [ -e "$DEST" ] && ! valid_source_checkout "$DEST"; then
+    QUARANTINED="$DEST.corrupt.$(date +%Y%m%d%H%M%S)"
+    mv "$DEST" "$QUARANTINED"
+    echo "Moved corrupt source cache $DEST to $QUARANTINED" >&2
+  fi
+}
+
 sync_latest_source() {
   REPO="$1"; DEST="$2"
-  if [ ! -d "$DEST/.git" ]; then
+  recover_corrupt_source_checkout "$DEST"
+  if [ ! -d "$DEST" ]; then
     gh repo clone "$REPO" "$DEST" -- --depth=1 \
       || git clone --depth=1 "https://github.com/$REPO" "$DEST"
   fi
+  if ! valid_source_checkout "$DEST"; then
+    echo "Source cache $DEST is not a usable git checkout after clone" >&2
+    return 1
+  fi
+  git -C "$DEST" remote set-url origin "https://github.com/$REPO.git" >/dev/null 2>&1 || true
   DEFAULT_BRANCH="$(git -C "$DEST" remote show origin | sed -n '/HEAD branch/s/.*: //p')"
+  if [ -z "$DEFAULT_BRANCH" ]; then
+    DEFAULT_BRANCH="$(git -C "$DEST" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+  fi
+  if [ -z "$DEFAULT_BRANCH" ]; then
+    echo "Could not determine default branch for $REPO in $DEST" >&2
+    return 1
+  fi
   git -C "$DEST" fetch --depth=1 origin "$DEFAULT_BRANCH"
   git -C "$DEST" checkout -B "$DEFAULT_BRANCH" FETCH_HEAD
 }
-sync_latest_source code-yeongyu/lazycodex /tmp/lazycodex-source
-sync_latest_source openai/codex /tmp/openai-codex-source
+sync_latest_source code-yeongyu/lazycodex "$LAZYCODEX_SOURCE_ROOT/lazycodex-source"
+sync_latest_source openai/codex "$LAZYCODEX_SOURCE_ROOT/openai-codex-source"
 ```
-4. Create a fresh temporary clone and branch. Do not modify the user's current repository for the target fix unless the current repository is itself the requested target and the user explicitly asked for local edits.
+4. Create a fresh temporary clone and branch under `${TMPDIR:-/tmp}`. Do not modify the user's current repository for the target fix unless the current repository is itself the requested target and the user explicitly asked for local edits.
 
 ```bash
 TARGET_REPO="code-yeongyu/lazycodex" # or openai/codex
-WORK_ROOT="$(mktemp -d /tmp/lazycodex-fix-XXXXXX)"
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/lazycodex-fix-XXXXXX")"
 gh repo clone "$TARGET_REPO" "$WORK_ROOT/repo" -- --depth=1
 cd "$WORK_ROOT/repo"
 BASE_BRANCH="$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')"
@@ -71,7 +102,7 @@ cd "$WORK_ROOT/worktree"
 
 If `gh` cannot clone, use `git clone --depth=1 "https://github.com/$TARGET_REPO" "$WORK_ROOT/repo"` and continue with the same worktree flow.
 
-5. Reproduce the bug in the worktree through the real surface. Save exact command output to `/tmp/lazycodex-fix-<short-slug>-repro.log`.
+5. Reproduce the bug in the worktree through the real surface. Save exact command output to `${TMPDIR:-/tmp}/lazycodex-fix-<short-slug>-repro.log`.
 6. Write or update a failing regression test before production changes. Confirm it fails for the bug, not for a missing fixture or typo.
 7. Implement the smallest correct fix. Avoid refactors unless the fix cannot be made safely without one.
 8. Run the regression test, adjacent tests, and the smallest real-surface QA command that proves the user-visible behavior changed.
@@ -89,7 +120,7 @@ git log --oneline "origin/$BASE_BRANCH..HEAD"
    - `code-yeongyu/lazycodex`: export the verified patch and write the issue body from the Verified-Fix Issue Template below:
 
 ```bash
-PATCH_FILE="/tmp/lazycodex-fix-<short-slug>.patch"
+PATCH_FILE="${TMPDIR:-/tmp}/lazycodex-fix-<short-slug>.patch"
 git diff "origin/$BASE_BRANCH"..HEAD > "$PATCH_FILE"
 ```
 
@@ -108,7 +139,7 @@ fi
    - `code-yeongyu/lazycodex`: create the verified-fix issue. Never push a branch to this repo and never run `gh pr create` against it:
 
 ```bash
-ISSUE_BODY="/tmp/lazycodex-fix-<short-slug>-issue.md"
+ISSUE_BODY="${TMPDIR:-/tmp}/lazycodex-fix-<short-slug>-issue.md"
 gh issue create --repo code-yeongyu/lazycodex --title "<short fix title>" "${LABEL_ARGS[@]}" --body-file "$ISSUE_BODY"
 ```
 
@@ -184,8 +215,8 @@ Use the bundled script to generate the PR body. Create a JSON file with this sha
 Run:
 
 ```bash
-PR_INPUT="/tmp/lazycodex-fix-<short-slug>-pr.json"
-PR_BODY="/tmp/lazycodex-fix-<short-slug>-pr.md"
+PR_INPUT="${TMPDIR:-/tmp}/lazycodex-fix-<short-slug>-pr.json"
+PR_BODY="${TMPDIR:-/tmp}/lazycodex-fix-<short-slug>-pr.md"
 node "<skill-root>/scripts/create-pr-body.mjs" "$PR_INPUT" "$PR_BODY"
 ```
 

--- a/packages/shared-skills/skills/lcx-contribute-bug-fix/agents/openai.yaml
+++ b/packages/shared-skills/skills/lcx-contribute-bug-fix/agents/openai.yaml
@@ -9,4 +9,4 @@ interface:
     - "lazycodex fix"
     - "omo-codex bug fix"
     - "codex bug fix pr"
-  default_prompt: "Use $lcx-contribute-bug-fix to debug this LazyCodex or Codex bug, work from a fresh /tmp clone and worktree, implement the smallest verified fix, apply the lazycodex-generated label, deliver it (verified-fix issue on code-yeongyu/lazycodex — never a PR there; fork PR only for openai/codex), and clean up."
+  default_prompt: "Use $lcx-contribute-bug-fix to debug this LazyCodex or Codex bug, work from a fresh ${TMPDIR:-/tmp} clone and worktree, implement the smallest verified fix, apply the lazycodex-generated label, deliver it (verified-fix issue on code-yeongyu/lazycodex — never a PR there; fork PR only for openai/codex), and clean up."

--- a/packages/shared-skills/skills/lcx-doctor/SKILL.md
+++ b/packages/shared-skills/skills/lcx-doctor/SKILL.md
@@ -7,37 +7,68 @@ metadata:
 
 # lcx-doctor
 
-You are a LazyCodex install doctor. Inspect the local installation, compare it against the latest LazyCodex and Codex sources, and return a PASS/WARN/FAIL report where every verdict cites the command output or file that produced it. Diagnose only: the only writes you make are under `/tmp`. Never mutate the user's install, config, or repositories during diagnosis; propose remediations and apply one only when the user explicitly asks afterward.
+You are a LazyCodex install doctor. Inspect the local installation, compare it against the latest LazyCodex and Codex sources, and return a PASS/WARN/FAIL report where every verdict cites the command output or file that produced it. Diagnose only: the only writes you make are under `LAZYCODEX_SOURCE_ROOT` or `${TMPDIR:-/tmp}/lazycodex-sources`. Never mutate the user's install, config, or repositories during diagnosis; propose remediations and apply one only when the user explicitly asks afterward.
 
 Use GPT-5.5 style: outcome first, concise, evidence-bound.
 
 ## Required Workflow
 
-1. Materialize the latest sources under `/tmp` first. Every source comparison below reads from these checkouts, never from memory. Re-sync on every run so a cached checkout cannot go stale:
+1. Materialize the latest sources under `LAZYCODEX_SOURCE_ROOT="${LAZYCODEX_SOURCE_ROOT:-${TMPDIR:-/tmp}/lazycodex-sources}"` first. Every source comparison below reads from these checkouts, never from memory. Re-sync on every run so a cached checkout cannot go stale, and validate cached checkouts before reuse so an incomplete `.git` directory cannot poison diagnosis:
 
 ```bash
+LAZYCODEX_SOURCE_ROOT="${LAZYCODEX_SOURCE_ROOT:-${TMPDIR:-/tmp}/lazycodex-sources}"
+mkdir -p "$LAZYCODEX_SOURCE_ROOT"
+
+valid_source_checkout() {
+  DEST="$1"
+  git -C "$DEST" rev-parse --is-inside-work-tree >/dev/null 2>&1 &&
+    git -C "$DEST" config --get remote.origin.url >/dev/null 2>&1
+}
+
+recover_corrupt_source_checkout() {
+  DEST="$1"
+  if [ -e "$DEST" ] && ! valid_source_checkout "$DEST"; then
+    QUARANTINED="$DEST.corrupt.$(date +%Y%m%d%H%M%S)"
+    mv "$DEST" "$QUARANTINED"
+    echo "Moved corrupt source cache $DEST to $QUARANTINED" >&2
+  fi
+}
+
 sync_latest_source() {
   REPO="$1"; DEST="$2"
-  if [ ! -d "$DEST/.git" ]; then
+  recover_corrupt_source_checkout "$DEST"
+  if [ ! -d "$DEST" ]; then
     gh repo clone "$REPO" "$DEST" -- --depth=1 \
       || git clone --depth=1 "https://github.com/$REPO" "$DEST"
   fi
+  if ! valid_source_checkout "$DEST"; then
+    echo "Source cache $DEST is not a usable git checkout after clone" >&2
+    return 1
+  fi
+  git -C "$DEST" remote set-url origin "https://github.com/$REPO.git" >/dev/null 2>&1 || true
   DEFAULT_BRANCH="$(git -C "$DEST" remote show origin | sed -n '/HEAD branch/s/.*: //p')"
+  if [ -z "$DEFAULT_BRANCH" ]; then
+    DEFAULT_BRANCH="$(git -C "$DEST" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+  fi
+  if [ -z "$DEFAULT_BRANCH" ]; then
+    echo "Could not determine default branch for $REPO in $DEST" >&2
+    return 1
+  fi
   git -C "$DEST" fetch --depth=1 origin "$DEFAULT_BRANCH"
   git -C "$DEST" checkout -B "$DEFAULT_BRANCH" FETCH_HEAD
 }
-sync_latest_source code-yeongyu/lazycodex /tmp/lazycodex-source
-sync_latest_source openai/codex /tmp/openai-codex-source
+sync_latest_source code-yeongyu/lazycodex "$LAZYCODEX_SOURCE_ROOT/lazycodex-source"
+sync_latest_source openai/codex "$LAZYCODEX_SOURCE_ROOT/openai-codex-source"
 ```
 
 2. Inventory the installed surface. Resolve `CODEX_HOME` (default `~/.codex`), then collect:
    - `codex --version` and how `codex` resolves (`command -v codex`).
    - Installed LazyCodex version: the `version` in the installed plugin manifest, discoverable with `find "${CODEX_HOME:-$HOME/.codex}/plugins" -path '*/.codex-plugin/plugin.json'`. Installed plugins live under `$CODEX_HOME/plugins/cache/<marketplace>/<name>/<version>/`.
-   - Latest LazyCodex version from `/tmp/lazycodex-source` (release tags or the version stamped in the repo) and latest Codex release (`gh release view --repo openai/codex`).
+   - Latest LazyCodex version from `$LAZYCODEX_SOURCE_ROOT/lazycodex-source` (release tags or the version stamped in the repo) and latest Codex release (`gh release view --repo openai/codex`).
    - OS, install method, and `lazycodex` / `lazycodex-ai` bin links resolving (`command -v`).
-3. Check config and wiring against the latest installer, not against assumptions. Read what the current installer under `/tmp/lazycodex-source` writes (installer sources live in the omo-codex package, e.g. `scripts/install/`), then verify the local equivalents:
+3. Check config and wiring against the latest installer, not against assumptions. Read what the current installer under `$LAZYCODEX_SOURCE_ROOT/lazycodex-source` writes (installer sources live in the omo-codex package, e.g. `scripts/install/`), then verify the local equivalents:
    - `$CODEX_HOME/config.toml` exists and parses; LazyCodex-managed entries match what the latest installer would write.
-   - Plugin payload present and non-empty: `hooks/hooks.json`, `skills/`, `.mcp.json`, components under the installed plugin root.
+   - Plugin payload present and non-empty: read `.codex-plugin/plugin.json`; when that manifest declares a `hooks` array, validate every direct hook path declared by the manifest; require `hooks/hooks.json` only when the manifest declares it; also verify `skills/`, `.mcp.json`, and components under the installed plugin root.
    - Stale project-local leftovers the installer now removes (e.g. `.codex/hooks.json`, `.codex/skills` in the project) are flagged, not deleted.
 4. Probe the real surface. Do not invoke `lazycodex doctor`; this skill is already running inside that doctor workflow, so calling it would recurse. Instead run non-recursive probes directly: `codex --version`, `command -v codex`, the bin-link checks above, config/plugin payload inspections, and a trivial non-interactive Codex invocation that loads the plugin. Capture stderr verbatim; a clean exit with warnings is WARN, not PASS.
 5. Compare for drift. Where installed bundled files differ from the same files at the installed version, or the latest source renamed or removed something the local config still references, record it with both paths.
@@ -67,7 +98,7 @@ sync_latest_source openai/codex /tmp/openai-codex-source
 | Plugin payload wiring | PASS/WARN/FAIL | [evidence] |
 | Bin links / aliases | PASS/WARN/FAIL | [evidence] |
 | Runtime probe | PASS/WARN/FAIL | [evidence] |
-| Drift vs latest source | PASS/WARN/FAIL | [evidence, citing /tmp/lazycodex-source or /tmp/openai-codex-source paths] |
+| Drift vs latest source | PASS/WARN/FAIL | [evidence, citing `$LAZYCODEX_SOURCE_ROOT/lazycodex-source` or `$LAZYCODEX_SOURCE_ROOT/openai-codex-source` paths] |
 
 ### Remediations
 1. [Most important fix first: exact command or config edit, and what it resolves.]
@@ -79,7 +110,7 @@ sync_latest_source openai/codex /tmp/openai-codex-source
 ## Follow-up Routing
 
 - Local misconfiguration or stale install: give the remediation; reinstalling via the standard LazyCodex install command is the default fix for payload drift.
-- Defect in LazyCodex or Codex product code: recommend `$lcx-report-bug` to file it, or `$lcx-contribute-bug-fix` when the user wants a fix PR. Both reuse the `/tmp` checkouts you already synced.
+- Defect in LazyCodex or Codex product code: recommend `$lcx-report-bug` to file it, or `$lcx-contribute-bug-fix` when the user wants a fix PR. Both reuse the source-root checkouts you already synced.
 
 ## Stop Conditions
 
@@ -89,5 +120,5 @@ Do not:
 
 - mutate config, installs, or repositories during diagnosis
 - report a verdict without captured evidence
-- compare against remembered source layout instead of `/tmp/lazycodex-source` and `/tmp/openai-codex-source`
+- compare against remembered source layout instead of `$LAZYCODEX_SOURCE_ROOT/lazycodex-source` and `$LAZYCODEX_SOURCE_ROOT/openai-codex-source`
 - declare healthy while any probe output was never captured

--- a/packages/shared-skills/skills/lcx-doctor/agents/openai.yaml
+++ b/packages/shared-skills/skills/lcx-doctor/agents/openai.yaml
@@ -8,4 +8,4 @@ interface:
     - "codex doctor"
     - "lazycodex install broken"
     - "omo-codex diagnose"
-  default_prompt: "Use $lcx-doctor to sync the latest LazyCodex and Codex sources into /tmp, inventory the local installation, compare versions, config, and wiring against the latest sources, probe the real surface, and report PASS/WARN/FAIL findings with evidence and remediations."
+  default_prompt: "Use $lcx-doctor to sync the latest LazyCodex and Codex sources under LAZYCODEX_SOURCE_ROOT or ${TMPDIR:-/tmp}/lazycodex-sources, inventory the local installation, compare versions, config, and wiring against the latest sources, probe the real surface, and report PASS/WARN/FAIL findings with evidence and remediations."

--- a/packages/shared-skills/skills/lcx-report-bug/SKILL.md
+++ b/packages/shared-skills/skills/lcx-report-bug/SKILL.md
@@ -33,28 +33,59 @@ Create or prepare a GitHub issue or PR that includes:
 
 1. Read the user's bug report and identify the affected surface: LazyCodex installer, Codex plugin, skill, hook, MCP, CLI alias, GitHub marketplace sync, or web/docs.
 2. Invoke `$omo:debugging` for the investigation. If Codex exposes only unqualified skill names in the current session, invoke `$debugging` and state that it is the OMO debugging skill.
-3. Materialize the latest LazyCodex and upstream Codex sources under `/tmp` before deciding ownership. Re-sync on every run so a cached checkout cannot go stale — stale source produces wrong routing and dead line references:
+3. Materialize the latest LazyCodex and upstream Codex sources under `LAZYCODEX_SOURCE_ROOT="${LAZYCODEX_SOURCE_ROOT:-${TMPDIR:-/tmp}/lazycodex-sources}"` before deciding ownership. Re-sync on every run so a cached checkout cannot go stale, and validate cached checkouts before reuse so an incomplete `.git` directory cannot produce wrong routing and dead line references:
 
 ```bash
+LAZYCODEX_SOURCE_ROOT="${LAZYCODEX_SOURCE_ROOT:-${TMPDIR:-/tmp}/lazycodex-sources}"
+mkdir -p "$LAZYCODEX_SOURCE_ROOT"
+
+valid_source_checkout() {
+  DEST="$1"
+  git -C "$DEST" rev-parse --is-inside-work-tree >/dev/null 2>&1 &&
+    git -C "$DEST" config --get remote.origin.url >/dev/null 2>&1
+}
+
+recover_corrupt_source_checkout() {
+  DEST="$1"
+  if [ -e "$DEST" ] && ! valid_source_checkout "$DEST"; then
+    QUARANTINED="$DEST.corrupt.$(date +%Y%m%d%H%M%S)"
+    mv "$DEST" "$QUARANTINED"
+    echo "Moved corrupt source cache $DEST to $QUARANTINED" >&2
+  fi
+}
+
 sync_latest_source() {
   REPO="$1"; DEST="$2"
-  if [ ! -d "$DEST/.git" ]; then
+  recover_corrupt_source_checkout "$DEST"
+  if [ ! -d "$DEST" ]; then
     gh repo clone "$REPO" "$DEST" -- --depth=1 \
       || git clone --depth=1 "https://github.com/$REPO" "$DEST"
   fi
+  if ! valid_source_checkout "$DEST"; then
+    echo "Source cache $DEST is not a usable git checkout after clone" >&2
+    return 1
+  fi
+  git -C "$DEST" remote set-url origin "https://github.com/$REPO.git" >/dev/null 2>&1 || true
   DEFAULT_BRANCH="$(git -C "$DEST" remote show origin | sed -n '/HEAD branch/s/.*: //p')"
+  if [ -z "$DEFAULT_BRANCH" ]; then
+    DEFAULT_BRANCH="$(git -C "$DEST" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+  fi
+  if [ -z "$DEFAULT_BRANCH" ]; then
+    echo "Could not determine default branch for $REPO in $DEST" >&2
+    return 1
+  fi
   git -C "$DEST" fetch --depth=1 origin "$DEFAULT_BRANCH"
   git -C "$DEST" checkout -B "$DEFAULT_BRANCH" FETCH_HEAD
 }
-sync_latest_source code-yeongyu/lazycodex /tmp/lazycodex-source
-sync_latest_source openai/codex /tmp/openai-codex-source
+sync_latest_source code-yeongyu/lazycodex "$LAZYCODEX_SOURCE_ROOT/lazycodex-source"
+sync_latest_source openai/codex "$LAZYCODEX_SOURCE_ROOT/openai-codex-source"
 ```
 4. Follow the debugging skill far enough to gather runtime evidence:
    - form at least three plausible hypotheses
    - run the smallest reproduction that exercises the real surface
    - confirm the root cause by observing the failing state
    - identify the minimal fix path or maintainer action
-5. Compare runtime evidence with both `/tmp/lazycodex-source` and `/tmp/openai-codex-source` before choosing the target repo. Cite exact files, commands, logs, or source paths that support the routing decision.
+5. Compare runtime evidence with both `$LAZYCODEX_SOURCE_ROOT/lazycodex-source` and `$LAZYCODEX_SOURCE_ROOT/openai-codex-source` before choosing the target repo. Cite exact files, commands, logs, or source paths that support the routing decision.
 6. Choose the target repo:
    - Use `code-yeongyu/lazycodex` when the bug is in LazyCodex integration, distribution, bundled plugin code, skills, hooks, MCP wiring, installer behavior, aliases, marketplace sync, docs, or any behavior that disappears in clean upstream Codex.
    - Use `openai/codex` when the bug reproduces in clean upstream Codex without LazyCodex, or the failing behavior comes from Codex CLI core, plugin API contracts, sandboxing, approvals, config loading, or built-in tool behavior.
@@ -110,8 +141,8 @@ Write the issue body in English and keep it direct:
 ## Repository Decision
 - Target repository:
 - Why this belongs there:
-- LazyCodex evidence (runtime + `/tmp/lazycodex-source`):
-- Upstream Codex source evidence from `/tmp/openai-codex-source`:
+- LazyCodex evidence (runtime + `$LAZYCODEX_SOURCE_ROOT/lazycodex-source`):
+- Upstream Codex source evidence from `$LAZYCODEX_SOURCE_ROOT/openai-codex-source`:
 
 ## Reproduction
 1. [Exact command or UI action]
@@ -154,8 +185,8 @@ Use this only when a PR is the right artifact, which is only ever for `openai/co
 ## Repository Decision
 - Target repository:
 - Why this belongs there:
-- LazyCodex evidence (runtime + `/tmp/lazycodex-source`):
-- Upstream Codex source evidence from `/tmp/openai-codex-source`:
+- LazyCodex evidence (runtime + `$LAZYCODEX_SOURCE_ROOT/lazycodex-source`):
+- Upstream Codex source evidence from `$LAZYCODEX_SOURCE_ROOT/openai-codex-source`:
 
 ## Root Cause
 [Confirmed cause. Cite runtime evidence and source paths.]
@@ -178,7 +209,7 @@ Tag: lazycodex-generated
 Prefer `gh`:
 
 ```bash
-ISSUE_BODY="/tmp/lcx-report-bug-$(date +%Y%m%d-%H%M%S).md"
+ISSUE_BODY="${TMPDIR:-/tmp}/lcx-report-bug-$(date +%Y%m%d-%H%M%S).md"
 $EDITOR "$ISSUE_BODY"
 gh issue create --repo "$TARGET_REPO" --title "<clear title>" "${LABEL_ARGS[@]}" --body-file "$ISSUE_BODY"
 ```
@@ -188,7 +219,7 @@ If `$EDITOR` is not usable, write the file with the available file-editing tool,
 For an existing issue:
 
 ```bash
-COMMENT_BODY="/tmp/lcx-report-bug-comment-$(date +%Y%m%d-%H%M%S).md"
+COMMENT_BODY="${TMPDIR:-/tmp}/lcx-report-bug-comment-$(date +%Y%m%d-%H%M%S).md"
 gh issue comment "<issue-number>" --repo "$TARGET_REPO" --body-file "$COMMENT_BODY"
 if [ "${#LABEL_ARGS[@]}" -gt 0 ]; then
   gh issue edit "<issue-number>" --repo "$TARGET_REPO" --add-label lazycodex-generated
@@ -198,7 +229,7 @@ fi
 For a PR from a branch pushed to a fork — `openai/codex` only, never `code-yeongyu/lazycodex`:
 
 ```bash
-PR_BODY="/tmp/lcx-report-bug-pr-$(date +%Y%m%d-%H%M%S).md"
+PR_BODY="${TMPDIR:-/tmp}/lcx-report-bug-pr-$(date +%Y%m%d-%H%M%S).md"
 gh pr create --repo openai/codex --title "<clear title>" "${LABEL_ARGS[@]}" --body-file "$PR_BODY"
 ```
 
@@ -232,6 +263,6 @@ Do not file:
 - a vague issue without reproduction steps
 - an issue that claims a root cause not supported by runtime evidence
 - a duplicate when commenting on an existing issue is enough
-- an issue without checking the latest `/tmp/lazycodex-source` and `/tmp/openai-codex-source` checkouts
+- an issue without checking the latest `$LAZYCODEX_SOURCE_ROOT/lazycodex-source` and `$LAZYCODEX_SOURCE_ROOT/openai-codex-source` checkouts
 - a LazyCodex issue when the bug is proven to reproduce in clean upstream Codex
 - a fix PR without a concrete branch, implemented fix, and verification result

--- a/packages/shared-skills/skills/lcx-report-bug/agents/openai.yaml
+++ b/packages/shared-skills/skills/lcx-report-bug/agents/openai.yaml
@@ -8,4 +8,4 @@ interface:
     - "omo-codex bug"
     - "openai codex bug"
     - "codex upstream issue"
-  default_prompt: "Use $lcx-report-bug to investigate this LazyCodex or Codex bug, compare LazyCodex evidence with /tmp openai/codex source, choose the correct GitHub repo, and file an issue (or, for openai/codex only, a PR — never a PR on code-yeongyu/lazycodex) with reproduction, root cause, fix guidance, and the lazycodex-generated label and footer."
+  default_prompt: "Use $lcx-report-bug to investigate this LazyCodex or Codex bug, compare LazyCodex evidence with sources under LAZYCODEX_SOURCE_ROOT or ${TMPDIR:-/tmp}/lazycodex-sources, choose the correct GitHub repo, and file an issue (or, for openai/codex only, a PR — never a PR on code-yeongyu/lazycodex) with reproduction, root cause, fix guidance, and the lazycodex-generated label and footer."


### PR DESCRIPTION
## Summary

Addresses the source-cache reliability slice of [code-yeongyu/lazycodex#80](https://github.com/code-yeongyu/lazycodex/issues/80) in this source repo. `lazycodex-ai doctor` now launches its lcx workflow with a writable sandbox, supports an explicit `--source-root`, and tells the workflow to use `LAZYCODEX_SOURCE_ROOT` or `${TMPDIR:-/tmp}/lazycodex-sources` instead of hardcoded `/tmp/lazycodex-source` paths.

The shared `lcx-doctor`, `lcx-report-bug`, and `lcx-contribute-bug-fix` helper snippets now validate cached git checkouts before reuse, quarantine corrupt cache directories, recover with a fresh shallow clone, and stop deriving empty default branches from broken `.git` directories. `lcx-doctor` also validates aggregate hook payloads through the current `.codex-plugin/plugin.json` manifest shape instead of always expecting obsolete `hooks/hooks.json`.

## Changes

- Hardened the duplicated `sync_latest_source` workflow in the three lcx skills with `git rev-parse`, `remote.origin.url`, corrupt-cache quarantine, default-branch fallback, and temp-root source paths.
- Updated the generated `lazycodex-ai doctor` delegation path to use `--sandbox danger-full-access`, parse `--source-root`, propagate it as `LAZYCODEX_SOURCE_ROOT`, and strip it from the inner doctor prompt arguments.
- Added contract tests for invalid source-cache reuse, current aggregate hook layout, writable doctor sandboxing, and source-root propagation.
- Regenerated the Node installer bundle at `packages/omo-codex/scripts/install-dist/install-local.mjs`.

## QA & Evidence

- **RED:** Replayed the new contracts against `origin/dev`; old content failed on missing source root/cache validation/manifest/writable sandbox checks. Artifact: `.omo/evidence/20260630-lazycodex-80-doctor-cache/red-origin-dev-contracts.txt`.
- **GREEN lcx contracts:** `node --test packages/omo-codex/plugin/test/lcx-bug-skills.test.mjs`. Artifact: `.omo/evidence/20260630-lazycodex-80-doctor-cache/green-lcx-bug-skills.txt`.
- **GREEN doctor delegation:** `node --test packages/omo-codex/scripts/install-delegated-command.test.mjs packages/omo-codex/scripts/install-local-entrypoint.test.mjs`. Artifact: `.omo/evidence/20260630-lazycodex-80-doctor-cache/green-doctor-delegation.txt`.
- **Codex gate:** `bun run test:codex` passed 425 tests. Artifact: `.omo/evidence/20260630-lazycodex-80-doctor-cache/bun-test-codex.txt`.
- **Codex QA:** `bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test` installed local OMO into an isolated `CODEX_HOME` and confirmed real `~/.codex/config.toml` was unchanged. Artifact: `.omo/evidence/20260630-lazycodex-80-doctor-cache/codex-qa-install-verify.txt`.
- **Manual smoke:** Dry-ran the generated doctor wrapper with `--source-root`, inspected delegated env propagation, created a synthetic corrupt cache with only `.git`, verified quarantine + fresh clone, and removed the temp root. Artifact: `.omo/evidence/20260630-lazycodex-80-doctor-cache/manual-cache-and-doctor-smoke.txt`.
- **Doctor-adjacent checks:** `bun test packages/omo-opencode/src/cli/doctor/checks/codex.test.ts packages/omo-opencode/src/cli/doctor/checks/codex-components.test.ts packages/omo-opencode/src/cli/doctor/doctor-target.test.ts`. Artifact: `.omo/evidence/20260630-lazycodex-80-doctor-cache/opencode-codex-doctor-tests.txt`.
- **Typecheck:** `bun run typecheck`. Artifact: `.omo/evidence/20260630-lazycodex-80-doctor-cache/bun-typecheck.txt`.

## Risks & Residuals

This PR does not move every network-dependent source sync step outside the inner `codex exec`; that remains the larger follow-up for environments where inner Codex networking/DNS differs from the host. It also does not address the separate 4.14.0 packaging/materialization findings or `features.child_agents_md` config stamping from the latest issue comment.

LSP diagnostics are clean on changed source/test files. The generated installer bundle still reports hint-level bundled-dependency noise only; the full typecheck passes.

## Related Issues

- Partial fix for [code-yeongyu/lazycodex#80](https://github.com/code-yeongyu/lazycodex/issues/80)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the doctor workflow’s reliability by validating and repairing source caches, supporting a configurable source root, and running with a writable sandbox. Addresses the source-cache reliability slice of code-yeongyu/lazycodex#80.

- **New Features**
  - `lazycodex-ai doctor` supports `--source-root` (propagated as `LAZYCODEX_SOURCE_ROOT`) and delegates with `--sandbox danger-full-access`.
  - Updated CLI help and doctor prompt to use `${TMPDIR:-/tmp}/lazycodex-sources` as the default source root.

- **Bug Fixes**
  - Hardened source sync in `lcx-doctor`, `lcx-report-bug`, and `lcx-contribute-bug-fix`: validate git checkouts (`git rev-parse`, `remote.origin.url`), quarantine corrupt caches, add default-branch fallbacks, and stop relying on `/tmp/...` hardpaths.
  - Doctor now validates aggregate hooks via `.codex-plugin/plugin.json` (validate declared hook paths; require `hooks/hooks.json` only when declared). Added tests for cache validation, manifest shape, sandboxing, and source-root propagation; regenerated the Node installer bundle.

<sup>Written for commit 88b6399f4898ef4e20fb0c48a3b43c52fc73900d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

