### PR TITLE
[lazycodex-issues] #90 LSP hook daemon packaging

### DIFF
--- a/packages/lsp-daemon/src/ensure-daemon.ts
+++ b/packages/lsp-daemon/src/ensure-daemon.ts
@@ -11,6 +11,7 @@ import type { DaemonPaths } from "./paths.js";
 const PROBE_TIMEOUT_MS = 500;
 const DEFAULT_READY_TIMEOUT_MS = 5_000;
 const DEFAULT_POLL_INTERVAL_MS = 100;
+const CODEX_LSP_DAEMON_CLI_ENV = "CODEX_LSP_DAEMON_CLI";
 
 export class DaemonUnreachableError extends Error {
 	constructor(socketPath: string) {
@@ -97,7 +98,7 @@ export function spawnDaemonProcess(paths: DaemonPaths): void {
 	mkdirSync(dirname(paths.log), { recursive: true });
 	const logFd = openSync(paths.log, "a");
 	try {
-		const cliPath = fileURLToPath(new URL("./cli.js", import.meta.url));
+		const cliPath = resolveDaemonCliPath();
 		const child = spawn(execPath, [cliPath, "daemon"], {
 			detached: true,
 			stdio: ["ignore", logFd, logFd],
@@ -106,6 +107,12 @@ export function spawnDaemonProcess(paths: DaemonPaths): void {
 	} finally {
 		closeSync(logFd);
 	}
+}
+
+export function resolveDaemonCliPath(env: NodeJS.ProcessEnv = process.env): string {
+	const override = env[CODEX_LSP_DAEMON_CLI_ENV]?.trim();
+	if (override) return override;
+	return fileURLToPath(new URL("./cli.js", import.meta.url));
 }
 
 export function defaultEnsureDaemonDeps(): EnsureDaemonDeps {
@@ -118,8 +125,7 @@ export function defaultEnsureDaemonDeps(): EnsureDaemonDeps {
 		spawnDaemon: (paths) => spawnDaemonProcess(paths),
 		sleep: (ms) =>
 			new Promise((resolve) => {
-				const timer = setTimeout(resolve, ms);
-				timer.unref?.();
+				setTimeout(resolve, ms);
 			}),
 		now: () => Date.now(),
 	};

--- a/packages/lsp-daemon/src/paths.ts
+++ b/packages/lsp-daemon/src/paths.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 const requireFromHere = createRequire(import.meta.url);
 
 const MAX_SOCKET_PATH_LENGTH = 100;
+const CODEX_LSP_DAEMON_VERSION_ENV = "CODEX_LSP_DAEMON_VERSION";
 
 export interface DaemonPaths {
 	version: string;
@@ -38,7 +39,7 @@ export function daemonBaseDir(env: NodeJS.ProcessEnv = process.env): string {
 
 export function daemonPaths(
 	env: NodeJS.ProcessEnv = process.env,
-	version: string = resolveDaemonVersion(),
+	version: string = resolveDaemonVersionFromEnv(env) ?? resolveDaemonVersion(),
 ): DaemonPaths {
 	const dir = join(daemonBaseDir(env), `v${version}`);
 	return {
@@ -49,6 +50,11 @@ export function daemonPaths(
 		pid: join(dir, "daemon.pid"),
 		log: join(dir, "daemon.log"),
 	};
+}
+
+export function resolveDaemonVersionFromEnv(env: NodeJS.ProcessEnv = process.env): string | null {
+	const version = env[CODEX_LSP_DAEMON_VERSION_ENV]?.trim();
+	return version && version.length > 0 ? version : null;
 }
 
 function resolveSocketPath(dir: string, version: string): string {

--- a/packages/lsp-daemon/test/ensure-daemon.test.ts
+++ b/packages/lsp-daemon/test/ensure-daemon.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { DaemonUnreachableError, type EnsureDaemonDeps, ensureDaemonRunning } from "../src/ensure-daemon.js";
+import {
+	DaemonUnreachableError,
+	type EnsureDaemonDeps,
+	ensureDaemonRunning,
+	resolveDaemonCliPath,
+} from "../src/ensure-daemon.js";
 import type { LockHandle } from "../src/lock.js";
 import { daemonPaths } from "../src/paths.js";
 
@@ -47,6 +52,16 @@ function makeHarness(config: { probeQueue: boolean[]; lockAvailable: boolean; on
 }
 
 describe("ensureDaemonRunning", () => {
+	it("#given explicit daemon CLI env #when resolving spawn target #then uses that path", () => {
+		expect(resolveDaemonCliPath({ CODEX_LSP_DAEMON_CLI: "/tmp/omo-lsp-daemon-cli.js" })).toBe(
+			"/tmp/omo-lsp-daemon-cli.js",
+		);
+	});
+
+	it("#given blank daemon CLI env #when resolving spawn target #then falls back to bundled cli", () => {
+		expect(resolveDaemonCliPath({ CODEX_LSP_DAEMON_CLI: "  " })).toMatch(/cli\.js$/);
+	});
+
 	it("#given daemon already reachable #when ensure #then does not lock or spawn", async () => {
 		const { deps, counts } = makeHarness({ probeQueue: [true], lockAvailable: true });
 		await ensureDaemonRunning(PATHS, deps);

--- a/packages/lsp-daemon/test/paths.test.ts
+++ b/packages/lsp-daemon/test/paths.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { daemonBaseDir, daemonPaths, resolveDaemonVersion } from "../src/paths.js";
+import { daemonBaseDir, daemonPaths, resolveDaemonVersion, resolveDaemonVersionFromEnv } from "../src/paths.js";
 
 const stampScript = fileURLToPath(new URL("../scripts/stamp-dist-version.mjs", import.meta.url));
 const packageManifest = JSON.parse(
@@ -41,6 +41,12 @@ describe("daemon paths", () => {
 		expect(paths.pid).toBe(join("/d", "v1.2.3", "daemon.pid"));
 	});
 
+	it("#given daemon version env #when daemonPaths resolves version #then uses it for socket coordination", () => {
+		const paths = daemonPaths({ CODEX_LSP_DAEMON_DIR: "/d", CODEX_LSP_DAEMON_VERSION: "7.8.9" });
+		expect(paths.version).toBe("7.8.9");
+		expect(paths.dir).toBe(join("/d", "v7.8.9"));
+	});
+
 	it("#given a very long base dir #when daemonPaths #then falls back to a short tmp socket", () => {
 		const longDir = `/${"x".repeat(120)}`;
 		const paths = daemonPaths({ CODEX_LSP_DAEMON_DIR: longDir }, "1.0.0");
@@ -55,6 +61,14 @@ describe("daemon paths", () => {
 });
 
 describe("resolveDaemonVersion injection", () => {
+	it("#given daemon version env #when resolving env version #then trims and returns it", () => {
+		expect(resolveDaemonVersionFromEnv({ CODEX_LSP_DAEMON_VERSION: " 7.8.9 " })).toBe("7.8.9");
+	});
+
+	it("#given blank daemon version env #when resolving env version #then returns null", () => {
+		expect(resolveDaemonVersionFromEnv({ CODEX_LSP_DAEMON_VERSION: "  " })).toBeNull();
+	});
+
 	it("#given injected require returning a version for ./package.json #when resolving version #then returns the sibling-first result", () => {
 		const fake = (id: string): unknown => {
 			if (id === "./package.json") return { version: "9.9.9" };

--- a/packages/omo-codex/plugin/components/lsp/src/cli.ts
+++ b/packages/omo-codex/plugin/components/lsp/src/cli.ts
@@ -1,12 +1,9 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { createRequire } from "node:module";
 import { argv, execPath, stderr } from "node:process";
 
 import { runPostCompactHookCli, runPostToolUseHookCli } from "./codex-hook-cli.js";
-
-const require = createRequire(import.meta.url);
-const PACKAGE_LSP_MCP_CLI = "@code-yeongyu/lsp-daemon/dist/cli.js";
+import { resolveLspDaemonCliPath } from "./daemon-cli-path.js";
 
 async function main(): Promise<void> {
 	const [command = "mcp", subcommand = ""] = argv.slice(2);
@@ -35,7 +32,7 @@ main().catch((error: unknown) => {
 });
 
 async function runPackageLspMcpCli(): Promise<void> {
-	const cliPath = require.resolve(PACKAGE_LSP_MCP_CLI);
+	const cliPath = resolveLspDaemonCliPath();
 	const child = spawn(execPath, [cliPath, "mcp"], { stdio: "inherit" });
 	await new Promise<void>((resolve, reject) => {
 		child.once("error", reject);

--- a/packages/omo-codex/plugin/components/lsp/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/lsp/src/codex-hook.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 
 import { callDiagnosticsViaDaemon, currentRequestContext } from "@code-yeongyu/lsp-daemon";
 
+import { ensureLspDaemonCliEnv } from "./daemon-cli-path.js";
 import {
 	isLspDaemonUnreachableDiagnostics,
 	isUnavailableLspDiagnostics,
@@ -60,6 +61,7 @@ const CONTEXT_PRESSURE_MARKERS = [
 ] as const;
 
 export async function runLspDiagnosticsText(filePath: string): Promise<string> {
+	ensureLspDaemonCliEnv();
 	const result = await callDiagnosticsViaDaemon(filePath, { context: currentRequestContext() });
 	return result.content.map((block) => block.text).join("\n");
 }

--- a/packages/omo-codex/plugin/components/lsp/src/daemon-cli-path.ts
+++ b/packages/omo-codex/plugin/components/lsp/src/daemon-cli-path.ts
@@ -1,0 +1,65 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const requireFromHere = createRequire(import.meta.url);
+
+const PACKAGE_LSP_DAEMON_CLI = "@code-yeongyu/lsp-daemon/dist/cli.js";
+const CODEX_LSP_DAEMON_CLI_ENV = "CODEX_LSP_DAEMON_CLI";
+const CODEX_LSP_DAEMON_VERSION_ENV = "CODEX_LSP_DAEMON_VERSION";
+
+interface LspDaemonCliResolution {
+	cliPath: string;
+	version: string | null;
+}
+
+export function ensureLspDaemonCliEnv(env: NodeJS.ProcessEnv = process.env): void {
+	const configuredCli = env[CODEX_LSP_DAEMON_CLI_ENV]?.trim();
+	const resolution = configuredCli ? resolveConfiguredLspDaemonCli(configuredCli) : resolveLspDaemonCli();
+	if (!configuredCli) env[CODEX_LSP_DAEMON_CLI_ENV] = resolution.cliPath;
+	if (!env[CODEX_LSP_DAEMON_VERSION_ENV]?.trim() && resolution.version !== null) {
+		env[CODEX_LSP_DAEMON_VERSION_ENV] = resolution.version;
+	}
+}
+
+export function resolveLspDaemonCliPath(): string {
+	return resolveLspDaemonCli().cliPath;
+}
+
+function resolveLspDaemonCli(): LspDaemonCliResolution {
+	const packageCli = resolvePackageLspDaemonCliPath();
+	if (packageCli !== null) return resolveConfiguredLspDaemonCli(packageCli);
+	const bundledCli = fileURLToPath(new URL("../../lsp-daemon/dist/cli.js", import.meta.url));
+	if (existsSync(bundledCli)) return resolveConfiguredLspDaemonCli(bundledCli);
+	return resolveConfiguredLspDaemonCli(bundledCli);
+}
+
+function resolvePackageLspDaemonCliPath(): string | null {
+	try {
+		return requireFromHere.resolve(PACKAGE_LSP_DAEMON_CLI);
+	} catch {
+		return null;
+	}
+}
+
+function resolveConfiguredLspDaemonCli(cliPath: string): LspDaemonCliResolution {
+	return {
+		cliPath,
+		version: readDaemonPackageVersion(cliPath),
+	};
+}
+
+function readDaemonPackageVersion(cliPath: string): string | null {
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(join(dirname(cliPath), "package.json"), "utf8"));
+		if (isRecord(parsed) && typeof parsed["version"] === "string" && parsed["version"].length > 0) {
+			return parsed["version"];
+		}
+	} catch {}
+	return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
@@ -15,6 +15,7 @@ describe("plugin package metadata", () => {
 		const hooksJson = readHooksJson("hooks/hooks.json");
 		const mcpJson = readMcpJson(".mcp.json");
 		const cliSource = readTextFile("src/cli.ts");
+		const daemonCliPathSource = readTextFile("src/daemon-cli-path.ts");
 		const codexHookCliSource = readTextFile("src/codex-hook-cli.ts");
 		const codexHookSource = readTextFile("src/codex-hook.ts");
 		const sourceFiles = listDirectoryEntries("src");
@@ -43,8 +44,12 @@ describe("plugin package metadata", () => {
 		expect(lspServer?.command).toBe("node");
 		expect(lspServer?.args).toEqual(["../../../../lsp-daemon/dist/cli.js", "mcp"]);
 		expect(cliSource).not.toContain("./lazy-lsp-mcp.js");
-		expect(cliSource).toContain("@code-yeongyu/lsp-daemon/dist/cli.js");
+		expect(cliSource).toContain("resolveLspDaemonCliPath");
+		expect(daemonCliPathSource).toContain("@code-yeongyu/lsp-daemon/dist/cli.js");
+		expect(daemonCliPathSource).toContain("../../lsp-daemon/dist/cli.js");
+		expect(daemonCliPathSource).toContain("CODEX_LSP_DAEMON_VERSION");
 		expect(cliSource).not.toContain("../../../../../lsp-daemon/dist/cli.js");
+		expect(codexHookSource).toContain("ensureLspDaemonCliEnv");
 		expect(codexHookCliSource).toContain("@code-yeongyu/lsp-daemon");
 		expect(codexHookSource).toContain("@code-yeongyu/lsp-daemon");
 		expect(codexHookCliSource).not.toContain("../../../../../lsp-daemon");

--- a/packages/omo-codex/plugin/test/component-bundled-cli.test.mjs
+++ b/packages/omo-codex/plugin/test/component-bundled-cli.test.mjs
@@ -158,12 +158,15 @@ test("#given bundled LSP hook CLI in installed layout #when diagnostics run #the
 			timeout: HOOK_CLI_TEST_TIMEOUT_MS,
 		});
 
-		assert.equal(result.status, 0, `stderr: ${result.stderr}`);
-		assert.equal(result.stderr, "");
+		const daemonInvocations = existsSync(invocationLog) ? readFileSync(invocationLog, "utf8") : "";
+		const failureContext = `stdout: ${result.stdout}\nstderr: ${result.stderr}\ndaemon log: ${daemonInvocations}`;
+		assert.equal(result.status, 0, failureContext);
+		assert.equal(result.stderr, "", failureContext);
+		assert.notEqual(result.stdout, "", failureContext);
 		const parsed = JSON.parse(result.stdout);
 		assert.equal(parsed.decision, "block");
 		assert.match(parsed.reason, /error\[fake\] \(1\) at 1:1: Missing fake symbol\./);
-		assert.deepEqual(readFileSync(invocationLog, "utf8").trim().split("\n").map(JSON.parse), [["daemon"]]);
+		assert.deepEqual(daemonInvocations.trim().split("\n").map(JSON.parse), [["daemon"]]);
 		assert.equal(existsSync(join(daemonDir, "v0.1.0", "daemon.log")), true);
 	} finally {
 		rmSync(tempRoot, { recursive: true, force: true });
@@ -339,9 +342,13 @@ function writeFakeLspDaemonCli(path) {
 			"const dir = join(baseDir, versionDirName);",
 			'const naturalSocket = join(dir, "daemon.sock");',
 			'const digest = createHash("sha256").update(dir).digest("hex").slice(0, 16);',
-			"const socketPath = naturalSocket.length < 100 ? naturalSocket : join(tmpdir(), `omo-lsp-${version}-${digest}.sock`);",
-			"mkdirSync(dirname(socketPath), { recursive: true });",
-			"try { unlinkSync(socketPath); } catch {}",
+			"const socketPath = process.platform === \"win32\"",
+			"\t? `\\\\\\\\.\\\\pipe\\\\omo-lsp-${version}-${digest}`",
+			"\t: naturalSocket.length < 100 ? naturalSocket : join(tmpdir(), `omo-lsp-${version}-${digest}.sock`);",
+			"if (process.platform !== \"win32\") {",
+			"\tmkdirSync(dirname(socketPath), { recursive: true });",
+			"\ttry { unlinkSync(socketPath); } catch {}",
+			"}",
 			"const server = createServer((socket) => {",
 			'\tlet raw = "";',
 			'\tsocket.setEncoding("utf8");',

--- a/packages/omo-codex/plugin/test/component-bundled-cli.test.mjs
+++ b/packages/omo-codex/plugin/test/component-bundled-cli.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -120,6 +120,51 @@ test("#given representative component hook payloads #when executed through dist 
 			assert.equal(result.stderr, "", `${hookCase.name} stderr`);
 			hookCase.assertOutput(result.stdout);
 		}
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+test("#given bundled LSP hook CLI in installed layout #when diagnostics run #then it spawns sibling daemon target", () => {
+	const tempRoot = mkdtempSync(join(tmpdir(), "omo-codex-lsp-installed-"));
+	try {
+		const lspDist = join(tempRoot, "components", "lsp", "dist");
+		const daemonDist = join(tempRoot, "components", "lsp-daemon", "dist");
+		const daemonDir = join(tempRoot, "daemon");
+		const invocationLog = join(tempRoot, "fake-daemon-invocations.jsonl");
+		mkdirSync(lspDist, { recursive: true });
+		mkdirSync(daemonDist, { recursive: true });
+		mkdirSync(join(tempRoot, "src"), { recursive: true });
+		writeFileSync(join(tempRoot, "package.json"), JSON.stringify({ type: "module" }));
+		writeFileSync(join(lspDist, "cli.js"), readFileSync(componentCliPath("lsp"), "utf8"));
+		writeFileSync(join(daemonDist, "package.json"), JSON.stringify({ type: "module", version: "0.1.0" }));
+		writeFakeLspDaemonCli(join(daemonDist, "cli.js"));
+		const editedFile = join(tempRoot, "src", "broken.c");
+		writeFileSync(editedFile, "int main(void) { return missing_symbol; }\n");
+
+		const result = spawnSync(process.execPath, [join(lspDist, "cli.js"), "hook", "post-tool-use"], {
+			cwd: tempRoot,
+			encoding: "utf8",
+			env: hookEnv(tempRoot, {
+				CODEX_LSP_DAEMON_DIR: daemonDir,
+				FAKE_LSP_DAEMON_LOG: invocationLog,
+			}),
+			input: JSON.stringify({
+				session_id: "bundled-lsp-hook",
+				tool_name: "Edit",
+				tool_input: { file_path: editedFile },
+				tool_response: { ok: true },
+			}),
+			timeout: HOOK_CLI_TEST_TIMEOUT_MS,
+		});
+
+		assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+		assert.equal(result.stderr, "");
+		const parsed = JSON.parse(result.stdout);
+		assert.equal(parsed.decision, "block");
+		assert.match(parsed.reason, /error\[fake\] \(1\) at 1:1: Missing fake symbol\./);
+		assert.deepEqual(readFileSync(invocationLog, "utf8").trim().split("\n").map(JSON.parse), [["daemon"]]);
+		assert.equal(existsSync(join(daemonDir, "v0.1.0", "daemon.log")), true);
 	} finally {
 		rmSync(tempRoot, { recursive: true, force: true });
 	}
@@ -274,6 +319,52 @@ function smokeImportComponent(component, event) {
 	} finally {
 		rmSync(tempRoot, { recursive: true, force: true });
 	}
+}
+
+function writeFakeLspDaemonCli(path) {
+	writeFileSync(
+		path,
+		[
+			"#!/usr/bin/env node",
+			'import { createHash } from "node:crypto";',
+			'import { appendFileSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";',
+			'import { tmpdir } from "node:os";',
+			'import { dirname, join } from "node:path";',
+			'import { createServer } from "node:net";',
+			"",
+			"appendFileSync(process.env.FAKE_LSP_DAEMON_LOG, `${JSON.stringify(process.argv.slice(2))}\\n`);",
+			"const baseDir = process.env.CODEX_LSP_DAEMON_DIR;",
+			'const versionDirName = readdirSync(baseDir).find((entry) => entry.startsWith("v")) ?? "v0";',
+			"const version = versionDirName.slice(1);",
+			"const dir = join(baseDir, versionDirName);",
+			'const naturalSocket = join(dir, "daemon.sock");',
+			'const digest = createHash("sha256").update(dir).digest("hex").slice(0, 16);',
+			"const socketPath = naturalSocket.length < 100 ? naturalSocket : join(tmpdir(), `omo-lsp-${version}-${digest}.sock`);",
+			"mkdirSync(dirname(socketPath), { recursive: true });",
+			"try { unlinkSync(socketPath); } catch {}",
+			"const server = createServer((socket) => {",
+			'\tlet raw = "";',
+			'\tsocket.setEncoding("utf8");',
+			'\tsocket.on("data", (chunk) => {',
+			"\t\traw += chunk;",
+			'\t\tif (!raw.includes("\\n")) return;',
+			"\t\tconst request = JSON.parse(raw.trim());",
+			"\t\tconst response = {",
+			'\t\t\tjsonrpc: "2.0",',
+			"\t\t\tid: request.id,",
+			"\t\t\tresult: {",
+			'\t\t\t\tcontent: [{ type: "text", text: "error[fake] (1) at 1:1: Missing fake symbol." }],',
+			"\t\t\t},",
+			"\t\t};",
+			'\t\tsocket.end(`${JSON.stringify(response)}\\n`);',
+			"\t\tserver.close(() => process.exit(0));",
+			"\t});",
+			"});",
+			"server.listen(socketPath);",
+			"setTimeout(() => process.exit(1), 10000).unref();",
+			"",
+		].join("\n"),
+	);
 }
 
 function hookEnv(tempRoot, extraEnv = {}) {

--- a/packages/omo-opencode/src/tools/task/task-update.test.ts
+++ b/packages/omo-opencode/src/tools/task/task-update.test.ts
@@ -1,18 +1,10 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { existsSync, rmSync, mkdirSync } from "fs"
+import { mkdtempSync, rmSync } from "fs"
+import { tmpdir } from "os"
 import { join } from "path"
 import type { TaskObject } from "./types"
 import { createTaskUpdateTool } from "./task-update"
 
-const TEST_STORAGE = ".test-task-update-tool"
-const TEST_DIR = join(process.cwd(), TEST_STORAGE)
-const TEST_CONFIG = {
-  sisyphus: {
-    tasks: {
-      storage_path: TEST_STORAGE,
-    },
-  },
-}
 const TEST_SESSION_ID = "test-session-123"
 const TEST_ABORT_CONTROLLER = new AbortController()
 const TEST_CONTEXT = {
@@ -24,26 +16,28 @@ const TEST_CONTEXT = {
 
 describe("task_update tool", () => {
   let tool: ReturnType<typeof createTaskUpdateTool>
+  let testDir = ""
 
   beforeEach(() => {
-    if (existsSync(TEST_STORAGE)) {
-      rmSync(TEST_STORAGE, { recursive: true, force: true })
-    }
-    mkdirSync(TEST_DIR, { recursive: true })
-    tool = createTaskUpdateTool(TEST_CONFIG)
+    testDir = mkdtempSync(join(tmpdir(), "omo-task-update-"))
+    tool = createTaskUpdateTool({
+      sisyphus: {
+        tasks: {
+          storage_path: testDir,
+        },
+      },
+    })
   })
 
   afterEach(() => {
-    if (existsSync(TEST_STORAGE)) {
-      rmSync(TEST_STORAGE, { recursive: true, force: true })
-    }
+    rmSync(testDir, { recursive: true, force: true })
   })
 
   describe("update action", () => {
     test("updates task subject when provided", async () => {
       //#given
       const taskId = "T-test-123"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Original subject",
@@ -72,7 +66,7 @@ describe("task_update tool", () => {
     test("updates task description when provided", async () => {
       //#given
       const taskId = "T-test-124"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Test subject",
@@ -99,7 +93,7 @@ describe("task_update tool", () => {
     test("updates task status when provided", async () => {
       //#given
       const taskId = "T-test-125"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Test subject",
@@ -120,13 +114,14 @@ describe("task_update tool", () => {
       const result = JSON.parse(resultStr)
 
       //#then
+      expect(result).toHaveProperty("task")
       expect(result.task.status).toBe("in_progress")
     })
 
     test("additively appends to blocks array without replacing", async () => {
       //#given
       const taskId = "T-test-126"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Test subject",
@@ -156,7 +151,7 @@ describe("task_update tool", () => {
     test("avoids duplicate blocks when adding", async () => {
       //#given
       const taskId = "T-test-127"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Test subject",
@@ -185,7 +180,7 @@ describe("task_update tool", () => {
     test("additively appends to blockedBy array without replacing", async () => {
       //#given
       const taskId = "T-test-128"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Test subject",
@@ -215,7 +210,7 @@ describe("task_update tool", () => {
     test("merges metadata without replacing entire object", async () => {
       //#given
       const taskId = "T-test-129"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Test subject",
@@ -251,7 +246,7 @@ describe("task_update tool", () => {
     test("deletes metadata keys when set to null", async () => {
       //#given
       const taskId = "T-test-130"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Test subject",
@@ -287,7 +282,7 @@ describe("task_update tool", () => {
     test("updates activeForm when provided", async () => {
       //#given
       const taskId = "T-test-131"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Test subject",
@@ -314,7 +309,7 @@ describe("task_update tool", () => {
     test("updates owner when provided", async () => {
       //#given
       const taskId = "T-test-132"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Test subject",
@@ -371,7 +366,7 @@ describe("task_update tool", () => {
     test("persists changes to file storage", async () => {
       //#given
       const taskId = "T-test-133"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Original subject",
@@ -399,7 +394,7 @@ describe("task_update tool", () => {
     test("updates multiple fields in single call", async () => {
       //#given
       const taskId = "T-test-134"
-      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const taskPath = join(testDir, `${taskId}.json`)
       const initialTask: TaskObject = {
         id: taskId,
         subject: "Original subject",


### PR DESCRIPTION
## Summary

Fixes the LazyCodex LSP hook packaging failure reported in code-yeongyu/lazycodex#90. The bundled `components/lsp/dist/cli.js hook post-tool-use` no longer cold-starts itself as `daemon`; it resolves the real packaged `lsp-daemon` CLI, shares the daemon package version with the inlined client, and waits for daemon readiness in short-lived hook processes.

## Changes

- Added `CODEX_LSP_DAEMON_CLI` and `CODEX_LSP_DAEMON_VERSION` coordination in `packages/lsp-daemon`, so bundled clients and spawned daemon processes agree on the executable and socket directory.
- Added a Codex LSP component resolver that works in both repository `node_modules` layout and installed-plugin sibling layout (`components/lsp-daemon/dist/cli.js`). The hook path sets the daemon env before collecting diagnostics, and `omo-lsp mcp` delegates through the same resolver.
- Added a bundled CLI regression that copies the built LSP CLI into an installed-plugin-shaped temp tree, runs `hook post-tool-use`, asserts blocking diagnostics, and proves the spawned daemon target/version path.
- Follow-up after Windows CI: made the fake installed daemon use the same Windows named-pipe endpoint as `packages/lsp-daemon`, and hardened the regression to include stdout/stderr/fake-daemon logs before parsing hook JSON.

## QA & Evidence

Evidence directory: `.omo/evidence/20260630-lsp-daemon-hook/`

- **RED reproduction:** built the pre-fix bundled LSP CLI and drove `node packages/omo-codex/plugin/components/lsp/dist/cli.js hook post-tool-use` against a broken C fixture.
  - Observed: direct module emitted `decision:"block"` with `missing_symbol`; bundled CLI exited `0` with empty stdout/stderr; daemon log contained `Usage: omo-lsp`.
  - Artifacts: `red-summary.txt`, `red-direct-stdout.json`, `red-bundled-stdout.txt`, `red-bundled-stderr.txt`, `red-daemon-logs.txt`.

- **Focused tests:**
  - `npm --prefix packages/lsp-daemon test` -> 52 passed.
  - `npm --prefix packages/omo-codex/plugin/components/lsp test` -> component suite passed.
  - `bun run --cwd packages/omo-codex/plugin build` -> rebuilt bundled LSP CLI.
  - `node --test packages/omo-codex/plugin/test/component-bundled-cli.test.mjs` -> 8 passed.
  - Artifacts: `green-focused-summary.txt`, `green-lsp-daemon-test.txt`, `green-codex-lsp-component-test.txt`, `green-codex-plugin-build.txt`, `green-component-bundled-cli-test.txt`.

- **Manual hook CLI smoke:** drove the fixed bundled hook CLI against a real broken C file with `clangd`, using isolated daemon/plugin/home dirs.
  - Observed: hook stdout contained blocking JSON with `missing_symbol`; stderr empty; daemon log had zero `Usage: omo-lsp` lines.
  - MCP mode smoke: `node packages/omo-codex/plugin/components/lsp/dist/cli.js mcp` responded to MCP `initialize` with `serverInfo.name:"lsp"`.
  - Artifacts: `green-manual-summary.txt`, `green-bundled-hook-stdout.json`, `green-bundled-hook-stderr.txt`, `green-daemon-logs.txt`, `green-mcp-smoke.txt`.

- **Codex gate and isolated live QA:**
  - `bun run test:codex` -> 423 passed.
  - `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check` -> PASS, real `~/.codex/config.toml` unchanged.
  - `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` -> app-server turn completed against mock model; observed plugin hooks for `sessionStart`, `userPromptSubmit`, and `stop`; real `~/.codex/config.toml` unchanged.
  - Artifacts: `green-test-codex.txt`, `codex-qa-common-self-check.txt`, `codex-qa-app-server-plugin.txt`.

- **Windows CI follow-up:**
  - Inspected failed `codex-compatibility (windows-latest)` job `84199953604` from run `28416343264`.
  - `node --test packages/omo-codex/plugin/test/component-bundled-cli.test.mjs` -> 8 passed after making the fake daemon named-pipe aware.
  - `bun run test:codex` -> 423 passed after the follow-up.
  - Artifacts: `windows-regression-focused-after-fix.txt`, `test-codex-after-windows-fix.txt`.

## Risks & Residuals

- The daemon launch env names are internal to the packaged LSP hook path. Risk is bounded by daemon unit tests, the bundled installed-layout regression, and the real hook CLI smoke.
- The app-server QA warning about project-local trust is expected in the isolated temporary `CODEX_HOME`; the script still observed plugin hook completion and real home immutability.

## Related Issues

- Fixes https://github.com/code-yeongyu/lazycodex/issues/90

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LSP hook packaging so the bundled CLI resolves and spawns the real `@code-yeongyu/lsp-daemon` CLI from packaged or bundled locations, shares its version via env, and waits for readiness. Restores blocking diagnostics for packaged installs and MCP mode. Fixes code-yeongyu/lazycodex#90.

- **Bug Fixes**
  - Respect `CODEX_LSP_DAEMON_CLI` when spawning; added a daemon-side CLI resolver and wired it into `ensure-daemon`.
  - Version coordination via `CODEX_LSP_DAEMON_VERSION`: daemon paths read it; the plugin reads the daemon package version and sets the env automatically.
  - Added a plugin resolver that finds the daemon CLI in `node_modules` or sibling `components/lsp-daemon`; hook and `mcp` paths use it and set env.
  - Regression test emulates an installed layout, verifies the sibling daemon target, versioned socket/log, and blocking diagnostics; made cross-platform.
  - Isolated `task_update` tests with per-test temp storage on Windows to fix a flaky missing-`task` result; product code unchanged.

<sup>Written for commit d3dd50636778d2bbc18fe2e72a0bc0131a7d0129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Follow-up: Windows `task_update` Test After Rebase

After the leader rebase to `48f00c5090cea1badbc58ace2ca6a782f6d82868`, Windows `test (windows-latest)` failed in run `28417200927`, job `84202515007`. The only failing test was `task_update tool > update action > updates task status when provided`; the log showed the tool response had no `task` field.

Fix: isolated `packages/omo-opencode/src/tools/task/task-update.test.ts` storage per test with a unique absolute temp dir, removing fixed-directory lock/cleanup interference on Windows. LSP product code is unchanged in this follow-up.

Evidence directory: `.omo/evidence/20260630-task-update-windows/`

- `bun test packages/omo-opencode/src/tools/task/task-update.test.ts -t "updates task status when provided"` -> 1 passed, 13 filtered.
- `bun test packages/omo-opencode/src/tools/task` -> 100 passed.
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check` -> PASS.
- Artifacts: `focused-status-test.txt`, `task-tool-package-tests.txt`, `opencode-qa-common-self-check.txt`, `QA-SUMMARY.md`.
