### PR TITLE
[lazycodex-issues] PR75 multi-platform install

### DIFF
--- a/.agents/skills/codex-qa/references/install-verify.md
+++ b/.agents/skills/codex-qa/references/install-verify.md
@@ -10,7 +10,7 @@ contained.
 export CODEX_HOME="$(mktemp -d)/codex"; mkdir -p "$CODEX_HOME"   # must exist first
 export OMO_DISABLE_POSTHOG=1 OMO_CODEX_DISABLE_POSTHOG=1
 export OMO_CODEX_PROJECT="$(mktemp -d)/project"                  # keep project-local cleanup off your tree
-node packages/omo-codex/scripts/install-local.mjs install
+node packages/omo-codex/scripts/install-local.mjs install --platform=codex
 ```
 
 `cqa_install_local_omo` wraps this (logs to `$CQA_HOME_ROOT/install.log`).

--- a/.agents/skills/codex-qa/scripts/lib/common.sh
+++ b/.agents/skills/codex-qa/scripts/lib/common.sh
@@ -116,7 +116,7 @@ cqa_install_local_omo() {
   fi
   local installer="$repo/packages/omo-codex/scripts/install-local.mjs"
   [ -f "$installer" ] || { cqa_fail "installer not found: $installer"; return 1; }
-  node "$installer" install >"$CQA_HOME_ROOT/install.log" 2>&1
+  node "$installer" install --platform=codex >"$CQA_HOME_ROOT/install.log" 2>&1
 }
 
 # Teardown everything the helpers created. Safe to call multiple times.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -706,11 +706,11 @@ jobs:
               mkdir -p "$HOME" "$CODEX_HOME" "$CODEX_LOCAL_BIN_DIR" "$SMOKE_DIR/cwd"
               cd "$SMOKE_DIR/cwd"
               expected_install_output="$(cat <<'EOF'
-npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous
-npx --yes --package oh-my-openagent omo install --platform=claude-code --no-tui
-npx --yes --package oh-my-openagent omo install --platform=gemini --no-tui
-EOF
-)"
+              npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous
+              npx --yes --package oh-my-openagent omo install --platform=claude-code --no-tui
+              npx --yes --package oh-my-openagent omo install --platform=gemini --no-tui
+              EOF
+              )"
 
               if npx_install_output=$(npx -y "$package_spec" --dry-run install --no-tui --codex-autonomous 2>&1) &&
                  npx_doctor_output=$(npx -y "$package_spec" --dry-run doctor 2>&1) &&

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -705,12 +705,18 @@ jobs:
               export CODEX_LOCAL_BIN_DIR="$SMOKE_DIR/bin"
               mkdir -p "$HOME" "$CODEX_HOME" "$CODEX_LOCAL_BIN_DIR" "$SMOKE_DIR/cwd"
               cd "$SMOKE_DIR/cwd"
+              expected_install_output="$(cat <<'EOF'
+npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous
+npx --yes --package oh-my-openagent omo install --platform=claude-code --no-tui
+npx --yes --package oh-my-openagent omo install --platform=gemini --no-tui
+EOF
+)"
 
               if npx_install_output=$(npx -y "$package_spec" --dry-run install --no-tui --codex-autonomous 2>&1) &&
                  npx_doctor_output=$(npx -y "$package_spec" --dry-run doctor 2>&1) &&
-                 [ "$npx_install_output" = "npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous" ] &&
+                 [ "$npx_install_output" = "$expected_install_output" ] &&
                  [ "$npx_doctor_output" = "npx --yes --package oh-my-openagent omo doctor" ] &&
-                 npx -y "$package_spec" install --no-tui --codex-autonomous &&
+                 npx -y "$package_spec" install --platform=codex --no-tui --codex-autonomous &&
                  [ -x "$CODEX_LOCAL_BIN_DIR/omo" ] &&
                  omo_version_output=$("$CODEX_LOCAL_BIN_DIR/omo" --version 2>&1) &&
                  [ "$omo_version_output" = "$OMO_VERSION" ] &&

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -10,10 +10,10 @@ Most users want **Ultimate**. Pick **Light** if you are already invested in Code
 | You want | Run | Lands on disk |
 | :--- | :--- | :--- |
 | Ultimate (OpenCode) | `bunx oh-my-openagent install` (TUI walks you through it) | Plugin registered in `opencode.json`, agent/model config, provider auth |
-| Light (Codex CLI) | `npx lazycodex-ai install` | `~/.codex/plugins/cache/sisyphuslabs/omo/`, stable Codex marketplace snapshot, `~/.codex/config.toml` marketplace/plugin/agent blocks, optional autonomous Codex permissions, component CLIs in `~/.local/bin` |
+| LazyCodex targets | `npx lazycodex-ai install` | Codex Light state plus delegated Claude Code and Gemini target installs; pass `--platform=codex` for Codex only |
 | Both | `bunx oh-my-openagent install --platform=both` | Both of the above |
 
-`lazycodex-ai` defaults to the Codex Light installer and runs through Node/npm. `--platform` on the shared `omo` CLI still defaults to `opencode` (Ultimate). `lazycodex-ai` is the npm/bin alias; `lazycodex` is the GitHub repository that hosts the marketplace bundle. Neither is the Codex marketplace name.
+`lazycodex-ai` runs through Node/npm. Its `install` command targets Codex, Claude Code, and Gemini by default; use `--platform=codex`, `--platform=claude-code`, or `--platform=gemini` to narrow the install, and `--platform=all` or `--all-platforms` to request the default set explicitly. `--platform` on the shared `omo` CLI still defaults to `opencode` (Ultimate). `lazycodex-ai` is the npm/bin alias; `lazycodex` is the GitHub repository that hosts the marketplace bundle. Neither is the Codex marketplace name.
 
 ## For Humans
 
@@ -36,9 +36,11 @@ The Light edition installer asks whether to configure Codex for autonomous full-
 npx lazycodex-ai install
 # non-interactive recommended mode:
 npx lazycodex-ai install --no-tui --codex-autonomous
+# Codex only:
+npx lazycodex-ai install --platform=codex --no-tui --codex-autonomous
 ```
 
-It writes managed Codex Light state to `~/.codex/` and does not touch OpenCode or provider flags. During migration from older Codex plugin installs it may also repair the current project's `.codex/config.toml` if that project has the known `multi_agent_v2` plus legacy `[agents] max_threads` conflict; project-owned `.codex` artifacts are reported, not deleted. Global Codex config will register marketplace `sisyphuslabs` from the local built cache under `~/.codex/plugins/cache/sisyphuslabs`, enable plugin `omo@sisyphuslabs`, and write a valid `[features.multi_agent_v2]` limit table. The installer never enables MultiAgentV2; if it finds an explicit legacy `multi_agent_v2 = false` shorthand, it preserves that disable as table-form `enabled = false`.
+For the Codex target, it writes managed Codex Light state to `~/.codex/` and does not touch OpenCode or provider flags. During migration from older Codex plugin installs it may also repair the current project's `.codex/config.toml` if that project has the known `multi_agent_v2` plus legacy `[agents] max_threads` conflict; project-owned `.codex` artifacts are reported, not deleted. Global Codex config will register marketplace `sisyphuslabs` from the local built cache under `~/.codex/plugins/cache/sisyphuslabs`, enable plugin `omo@sisyphuslabs`, and write a valid `[features.multi_agent_v2]` limit table. The installer never enables MultiAgentV2; if it finds an explicit legacy `multi_agent_v2 = false` shorthand, it preserves that disable as table-form `enabled = false`.
 
 On native Windows Codex installs, the installer discovers Git Bash before writing Codex config. It checks `OMO_CODEX_GIT_BASH_PATH`, standard Git for Windows locations, and then PATH. If Git Bash is missing, it prints the install guidance shown here and stops without running `winget` or changing system dependencies:
 
@@ -328,7 +330,7 @@ bunx oh-my-openagent install \
   bunx oh-my-openagent install --no-tui --platform=opencode --claude=no --openai=no --gemini=no --copilot=no --opencode-go=yes
   ```
 
-**About the `lazycodex-ai` bin name.** `lazycodex-ai` is the npm package and bin alias for the Codex Light Node installer. `lazycodex` (without the `-ai` suffix) is the GitHub repository that hosts the marketplace bundle. `lazycodex-ai install` does not require Bun. The Codex marketplace name is `sisyphuslabs`, and the plugin name is `omo`.
+**About the `lazycodex-ai` bin name.** `lazycodex-ai` is the npm package and bin alias for the LazyCodex Node installer. `lazycodex` (without the `-ai` suffix) is the GitHub repository that hosts the marketplace bundle. `lazycodex-ai install` does not require Bun. The Codex marketplace name is `sisyphuslabs`, and the plugin name is `omo`.
 
 **What the installer does:**
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,7 +14,7 @@ All published packages expose the same compiled CLI with these bin entries:
 - `oh-my-openagent` (preferred name)
 - `oh-my-opencode` (legacy compatibility name)
 - `omo` (short alias, recommended in docs and prompts)
-- `lazycodex-ai` (Light edition shortcut; `lazycodex-ai install` is equivalent to `omo install --platform=codex` unless `--platform` is explicitly overridden)
+- `lazycodex-ai` (Light installer shortcut; `lazycodex-ai install` dispatches the Codex, Claude Code, and Gemini targets by default unless `--platform` is explicitly narrowed)
 
 ## Basic Usage
 
@@ -71,9 +71,9 @@ bunx oh-my-openagent install
 | `--no-codex-autonomous` | Leave existing Codex permission settings unchanged when installing Light or Both |
 | `--skip-auth` | Skip authentication setup hints |
 
-When using the `lazycodex-ai` bin alias, `install` defaults to `--platform=codex`. `lazycodex-ai` is only the npm/bin alias; `lazycodex` is the marketplace repository name. The Codex config uses marketplace `sisyphuslabs` and plugin `omo`, enabled as `omo@sisyphuslabs`, with the marketplace source set to the local built cache under `~/.codex/plugins/cache/sisyphuslabs`.
+When using the published `lazycodex-ai` package, `install` defaults to the LazyCodex agent targets `codex`, `claude-code`, and `gemini`. Pass `--platform=codex`, `--platform=claude-code`, or `--platform=gemini` to install only one target; pass `--platform=all` or `--all-platforms` to request the default set explicitly. The Codex target uses marketplace `sisyphuslabs` and plugin `omo`, enabled as `omo@sisyphuslabs`, with the marketplace source set to the local built cache under `~/.codex/plugins/cache/sisyphuslabs`.
 
-Subscription flags (`--claude`, `--openai`, etc.) only apply when `--platform` is `opencode` or `both`. They are rejected under `--platform=codex` because the Light edition does not write OpenCode model config. `--codex-autonomous` and `--no-codex-autonomous` only affect installs where the selected platform includes Codex.
+On the shared `omo` CLI, `--platform` still means `opencode`, `codex`, or `both`. Subscription flags (`--claude`, `--openai`, etc.) only apply when the shared CLI platform is `opencode` or `both`; they are rejected under `--platform=codex` because the Light edition does not write OpenCode model config. `--codex-autonomous` and `--no-codex-autonomous` only affect installs where the selected target includes Codex, and `lazycodex-ai` filters those Codex-only flags out of non-Codex target commands.
 
 ### Telemetry and opt-out
 

--- a/packages/omo-codex/scripts/install-cli-args.test.mjs
+++ b/packages/omo-codex/scripts/install-cli-args.test.mjs
@@ -13,20 +13,66 @@ test("#given lazycodex install flags #when parsing Node installer argv #then kee
 	// then
 	assert.deepEqual(parsed, {
 		kind: "install",
+		targets: ["codex"],
+		noTui: true,
+		skipAuth: false,
 		autonomousPermissions: true,
 		repoRoot: undefined,
 	});
 });
 
-test("#given unsupported OpenCode platform override #when parsing Node installer argv #then rejects the Bun-backed path", () => {
+test("#given default lazycodex install #when parsing Node installer argv #then targets every supported agent platform", () => {
 	// given
-	const argv = ["install", "--platform=both"];
+	const argv = ["install"];
 
 	// when
-	const parse = () => parseLazyCodexInstallCliArgs(argv);
+	const parsed = parseLazyCodexInstallCliArgs(argv);
 
 	// then
-	assert.throws(parse, /lazycodex-ai installs the Codex Light edition only/);
+	assert.deepEqual(parsed, {
+		kind: "install",
+		targets: ["codex", "claude-code", "gemini"],
+		noTui: false,
+		skipAuth: false,
+		autonomousPermissions: undefined,
+		repoRoot: undefined,
+	});
+});
+
+test("#given all-platform aliases #when parsing Node installer argv #then expands to every supported agent platform", () => {
+	// given
+	const argv = ["install", "--platform=all", "--all-platforms"];
+
+	// when
+	const parsed = parseLazyCodexInstallCliArgs(argv);
+
+	// then
+	assert.deepEqual(parsed, {
+		kind: "install",
+		targets: ["codex", "claude-code", "gemini"],
+		noTui: false,
+		skipAuth: false,
+		autonomousPermissions: undefined,
+		repoRoot: undefined,
+	});
+});
+
+test("#given explicit non-Codex platform override #when parsing Node installer argv #then keeps a single target", () => {
+	// given
+	const argv = ["install", "--platform", "gemini", "--no-tui"];
+
+	// when
+	const parsed = parseLazyCodexInstallCliArgs(argv);
+
+	// then
+	assert.deepEqual(parsed, {
+		kind: "install",
+		targets: ["gemini"],
+		noTui: true,
+		skipAuth: false,
+		autonomousPermissions: undefined,
+		repoRoot: undefined,
+	});
 });
 
 test("#given missing platform value #when parsing Node installer argv #then rejects the incomplete option", () => {
@@ -50,6 +96,9 @@ test("#given repo root equals option #when parsing Node installer argv #then kee
 	// then
 	assert.deepEqual(parsed, {
 		kind: "install",
+		targets: ["codex", "claude-code", "gemini"],
+		noTui: false,
+		skipAuth: false,
 		autonomousPermissions: undefined,
 		repoRoot: "/tmp/project",
 	});
@@ -124,6 +173,7 @@ test("#given dry-run install with codex autonomy flags #when parsing Node instal
 		kind: "command",
 		command: "install",
 		dryRun: true,
+		targets: ["codex", "claude-code", "gemini"],
 		noTui: true,
 		skipAuth: false,
 		autonomousPermissions: true,

--- a/packages/omo-codex/scripts/install-delegated-command.test.mjs
+++ b/packages/omo-codex/scripts/install-delegated-command.test.mjs
@@ -106,6 +106,67 @@ test("#given doctor source-root override #when delegating #then passes it to the
 	assert.doesNotMatch(invocation.args.at(-1), /--source-root/);
 });
 
+test("#given dry-run install without explicit platform #when delegating #then logs every supported agent platform command", async () => {
+	// given
+	const parsed = {
+		kind: "command",
+		command: "install",
+		dryRun: true,
+		targets: ["codex", "claude-code", "gemini"],
+		noTui: true,
+		skipAuth: false,
+		autonomousPermissions: true,
+		repoRoot: undefined,
+		args: [],
+	};
+	const logged = [];
+
+	// when
+	await runDelegatedOmoCommand(parsed, {
+		cwd: "/tmp/project",
+		log: (line) => {
+			logged.push(line);
+		},
+		runCommand: async () => {},
+	});
+
+	// then
+	assert.deepEqual(logged, [
+		"npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous",
+		"npx --yes --package oh-my-openagent omo install --platform=claude-code --no-tui",
+		"npx --yes --package oh-my-openagent omo install --platform=gemini --no-tui",
+	]);
+});
+
+test("#given explicit non-Codex platform plus Codex-only flag #when delegating #then filters the Codex-only flag", async () => {
+	// given
+	const parsed = {
+		kind: "command",
+		command: "install",
+		dryRun: true,
+		targets: ["claude-code"],
+		noTui: true,
+		skipAuth: true,
+		autonomousPermissions: true,
+		repoRoot: undefined,
+		args: [],
+	};
+	const logged = [];
+
+	// when
+	await runDelegatedOmoCommand(parsed, {
+		cwd: "/tmp/project",
+		log: (line) => {
+			logged.push(line);
+		},
+		runCommand: async () => {},
+	});
+
+	// then
+	assert.deepEqual(logged, [
+		"npx --yes --package oh-my-openagent omo install --platform=claude-code --no-tui --skip-auth",
+	]);
+});
 test("#given doctor recursion guard is active #when lazycodex doctor delegates #then rejects before launching Codex", async () => {
 	// given
 	const parsed = { kind: "command", command: "doctor", args: [] };

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -13697,7 +13697,9 @@ function codexMarketplaceSource(marketplaceRoot) {
 }
 
 // packages/omo-codex/src/install/lazycodex-cli-args.ts
-var CODEX_ONLY_ERROR = "lazycodex-ai installs the Codex Light edition only. Use the omo installer for OpenCode or both-platform installs.";
+var LAZYCODEX_INSTALL_TARGETS = ["codex", "claude-code", "gemini"];
+var ALL_PLATFORM_ALIASES = new Set(["all", "all-platforms", "multi", "*"]);
+var LAZYCODEX_INSTALL_TARGET_SET = new Set(LAZYCODEX_INSTALL_TARGETS);
 var PASSTHROUGH_COMMANDS = new Set([
   "doctor",
   "cleanup",
@@ -13709,14 +13711,24 @@ var PASSTHROUGH_COMMANDS = new Set([
 ]);
 function parseLazyCodexInstallCliArgs(argv) {
   const args = [...argv];
-  if (args.length === 0)
-    return { kind: "install", autonomousPermissions: undefined, repoRoot: undefined };
+  if (args.length === 0) {
+    return {
+      kind: "install",
+      targets: [...LAZYCODEX_INSTALL_TARGETS],
+      noTui: false,
+      skipAuth: false,
+      autonomousPermissions: undefined,
+      repoRoot: undefined
+    };
+  }
   let repoRoot;
   let command;
   let dryRun = false;
   let noTui = false;
   let skipAuth = false;
   let autonomousPermissions;
+  let allPlatforms = false;
+  const platforms = [];
   let index = 0;
   while (index < args.length) {
     const arg = args[index];
@@ -13749,10 +13761,19 @@ function parseLazyCodexInstallCliArgs(argv) {
       index += 1;
       continue;
     }
+    if (arg === "--all-platforms") {
+      allPlatforms = true;
+      index += 1;
+      continue;
+    }
     if (arg === "--platform") {
       const platform = readOptionValue(args, index, "--platform");
-      if (platform !== "codex")
-        throw new Error(CODEX_ONLY_ERROR);
+      const parsedPlatform = parseInstallTarget(platform);
+      if (parsedPlatform === "all") {
+        allPlatforms = true;
+      } else {
+        platforms.push(parsedPlatform);
+      }
       index += 2;
       continue;
     }
@@ -13760,8 +13781,12 @@ function parseLazyCodexInstallCliArgs(argv) {
       const platform = arg.slice("--platform=".length);
       if (platform.trim().length === 0)
         throw new Error("--platform requires a value");
-      if (platform !== "codex")
-        throw new Error(CODEX_ONLY_ERROR);
+      const parsedPlatform = parseInstallTarget(platform);
+      if (parsedPlatform === "all") {
+        allPlatforms = true;
+      } else {
+        platforms.push(parsedPlatform);
+      }
       index += 1;
       continue;
     }
@@ -13799,18 +13824,33 @@ function parseLazyCodexInstallCliArgs(argv) {
     }
     throw new Error(`Unsupported lazycodex-ai install option: ${String(arg)}`);
   }
+  const targets = resolveInstallTargets(platforms, allPlatforms);
   if (!dryRun)
-    return { kind: "install", autonomousPermissions, repoRoot };
+    return { kind: "install", targets, noTui, skipAuth, autonomousPermissions, repoRoot };
   return {
     kind: "command",
     command: command ?? "install",
     dryRun,
+    targets,
     noTui,
     skipAuth,
     autonomousPermissions,
     repoRoot,
     args: []
   };
+}
+function parseInstallTarget(platform) {
+  const normalized = platform.trim();
+  if (ALL_PLATFORM_ALIASES.has(normalized))
+    return "all";
+  if (LAZYCODEX_INSTALL_TARGET_SET.has(normalized))
+    return normalized;
+  throw new Error(`Unsupported lazycodex-ai install platform: ${platform} (expected codex, claude-code, gemini, or all)`);
+}
+function resolveInstallTargets(platforms, allPlatforms) {
+  if (allPlatforms || platforms.length === 0)
+    return [...LAZYCODEX_INSTALL_TARGETS];
+  return [...new Set(platforms)];
 }
 function parseUpdateArgs(args, startIndex, initialDryRun, initialRepoRoot) {
   let dryRun = initialDryRun;
@@ -13851,6 +13891,7 @@ function formatLazyCodexInstallHelp() {
   const passthrough = [...PASSTHROUGH_COMMANDS].sort().join(", ");
   return [
     "Usage: lazycodex-ai install [--no-tui] [--codex-autonomous|--no-codex-autonomous] [--repo-root <path>]",
+    "       lazycodex-ai install [--platform codex|claude-code|gemini|all] [--all-platforms]",
     "       lazycodex-ai uninstall [--project <path>]",
     "       lazycodex-ai update [--dry-run] [--repo-root <path>]",
     "       lazycodex-ai doctor [--source-root <path>] [--json|--status|--verbose]",
@@ -13872,34 +13913,55 @@ async function runDelegatedOmoCommand(parsed, options) {
   if (parsed.command === "doctor" && process.env.LAZYCODEX_DOCTOR_LCX_ACTIVE === "1") {
     throw new Error("Refusing recursive lazycodex doctor invocation from inside $omo:lcx-doctor");
   }
-  const invocation = buildDelegatedOmoInvocation(parsed);
+  const invocations = buildDelegatedOmoInvocations(parsed);
   if (parsed.dryRun) {
-    options.log(formatShellCommand(invocation.command, invocation.args));
+    for (const invocation of invocations) {
+      options.log(formatShellCommand(invocation.command, invocation.args));
+    }
     return;
   }
-  const env3 = invocation.delegatesToOmo ? { ...process.env, OMO_INVOCATION_NAME: "omo", ...invocation.env } : { ...process.env, ...invocation.env };
-  await options.runCommand(invocation.command, invocation.args, { cwd: options.cwd, env: env3 });
+  for (const invocation of invocations) {
+    const env3 = invocation.delegatesToOmo ? { ...process.env, OMO_INVOCATION_NAME: "omo", ...invocation.env } : { ...process.env, ...invocation.env };
+    await options.runCommand(invocation.command, invocation.args, { cwd: options.cwd, env: env3 });
+  }
 }
 function buildDelegatedOmoInvocation(parsed) {
+  const invocation = buildDelegatedOmoInvocations(parsed)[0];
+  if (invocation === undefined) {
+    throw new Error("No delegated omo invocation was built");
+  }
+  return invocation;
+}
+function buildDelegatedOmoInvocations(parsed) {
   if (parsed.command === "doctor")
-    return buildLazyCodexDoctorInvocation(parsed.args);
-  const args = ["--yes", "--package", "oh-my-openagent", "omo", parsed.command];
+    return [buildLazyCodexDoctorInvocation(parsed.args)];
   if (parsed.command === "install") {
-    args.push("--platform=codex");
+    const targets = parsed.targets ?? LAZYCODEX_INSTALL_TARGETS;
+    return targets.map((target) => buildInstallInvocation(parsed, target));
+  }
+  const args = ["--yes", "--package", "oh-my-openagent", "omo", parsed.command];
+  if (parsed.command === "cleanup") {
+    args.push("--platform=codex", ...parsed.args);
+  } else {
+    args.push(...parsed.args);
+  }
+  return [{ command: "npx", args, delegatesToOmo: true }];
+}
+function buildInstallInvocation(parsed, target) {
+  const args = ["--yes", "--package", "oh-my-openagent", "omo", parsed.command, `--platform=${target}`];
+  if (parsed.command === "install") {
     if (parsed.noTui)
       args.push("--no-tui");
     if (parsed.skipAuth)
       args.push("--skip-auth");
-    if (parsed.autonomousPermissions !== false)
-      args.push("--codex-autonomous");
-    if (parsed.autonomousPermissions === false)
-      args.push("--no-codex-autonomous");
-    if (parsed.repoRoot)
-      args.push(`--repo-root=${parsed.repoRoot}`);
-  } else if (parsed.command === "cleanup") {
-    args.push("--platform=codex", ...parsed.args);
-  } else {
-    args.push(...parsed.args);
+    if (target === "codex") {
+      if (parsed.autonomousPermissions !== false)
+        args.push("--codex-autonomous");
+      if (parsed.autonomousPermissions === false)
+        args.push("--no-codex-autonomous");
+      if (parsed.repoRoot)
+        args.push(`--repo-root=${parsed.repoRoot}`);
+    }
   }
   return { command: "npx", args, delegatesToOmo: true };
 }
@@ -14297,23 +14359,39 @@ async function runLazyCodexInstallLocalCli(input) {
         input.log(`node ${input.entrypointPath} install --repo-root=${parsed.repoRoot}`);
         return 0;
       }
-      const result2 = await installMarketplaceLocally({
+      const result = await installMarketplaceLocally({
         repoRoot: resolve11(parsed.repoRoot),
         autonomousPermissions: true,
         env: input.env
       });
-      input.log(`Installed ${result2.installed.length} plugin(s) from ${result2.marketplaceName}.`);
+      input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`);
       return 0;
     }
     return runLazyCodexManualUpdate({ env: input.env, dryRun: parsed.dryRun, log: input.log, invokedPath: input.invokedPath });
   }
   const repoRoot = parsed.repoRoot ? resolve11(parsed.repoRoot) : input.defaultRepoRoot;
-  const result = await installMarketplaceLocally({
-    repoRoot,
-    autonomousPermissions: parsed.autonomousPermissions,
-    env: input.env
-  });
-  input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`);
+  if (parsed.targets.includes("codex")) {
+    const result = await installMarketplaceLocally({
+      repoRoot,
+      autonomousPermissions: parsed.autonomousPermissions,
+      env: input.env
+    });
+    input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`);
+  }
+  const delegatedTargets = parsed.targets.filter((target) => target !== "codex");
+  if (delegatedTargets.length > 0) {
+    await runDelegatedOmoCommand({
+      kind: "command",
+      command: "install",
+      dryRun: false,
+      targets: delegatedTargets,
+      noTui: parsed.noTui,
+      skipAuth: parsed.skipAuth,
+      autonomousPermissions: parsed.autonomousPermissions,
+      repoRoot: undefined,
+      args: []
+    }, { cwd: input.cwd, log: input.log, runCommand: defaultRunCommand });
+  }
   return 0;
 }
 export {
@@ -14333,6 +14411,7 @@ export {
   installCachedPlugin,
   formatLazyCodexInstallHelp,
   findMissingHookCommandTargets,
+  buildDelegatedOmoInvocations,
   buildDelegatedOmoInvocation,
   assertHookCommandTargets,
   PASSTHROUGH_COMMANDS

--- a/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
+++ b/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
@@ -57,7 +57,7 @@ test("#given lazycodex runs through an npm bin symlink #when running the Node in
 	}
 });
 
-test("#given dry-run install flags #when running the Node installer entrypoint #then prints delegated autonomous codex install command", () => {
+test("#given dry-run install flags #when running the Node installer entrypoint #then prints every supported agent platform command", () => {
 	// given
 	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
 
@@ -69,7 +69,14 @@ test("#given dry-run install flags #when running the Node installer entrypoint #
 	).trim();
 
 	// then
-	assert.equal(output, "npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous");
+	assert.equal(
+		output,
+		[
+			"npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous",
+			"npx --yes --package oh-my-openagent omo install --platform=claude-code --no-tui",
+			"npx --yes --package oh-my-openagent omo install --platform=gemini --no-tui",
+		].join("\n"),
+	);
 });
 
 test("#given dry-run install opt-out #when running the Node installer entrypoint #then preserves existing Codex permission settings", () => {
@@ -84,7 +91,29 @@ test("#given dry-run install opt-out #when running the Node installer entrypoint
 	).trim();
 
 	// then
-	assert.equal(output, "npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --no-codex-autonomous");
+	assert.equal(
+		output,
+		[
+			"npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --no-codex-autonomous",
+			"npx --yes --package oh-my-openagent omo install --platform=claude-code --no-tui",
+			"npx --yes --package oh-my-openagent omo install --platform=gemini --no-tui",
+		].join("\n"),
+	);
+});
+
+test("#given explicit dry-run platform #when running the Node installer entrypoint #then prints only that platform command", () => {
+	// given
+	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
+
+	// when
+	const output = execFileSync(
+		process.execPath,
+		[scriptPath, "--dry-run", "install", "--platform=gemini", "--no-tui", "--codex-autonomous"],
+		{ encoding: "utf8" },
+	).trim();
+
+	// then
+	assert.equal(output, "npx --yes --package oh-my-openagent omo install --platform=gemini --no-tui");
 });
 
 test("#given dry-run doctor #when running the Node installer entrypoint #then prints Codex LazyCodex doctor workflow command", () => {

--- a/packages/omo-codex/scripts/install-local.mjs
+++ b/packages/omo-codex/scripts/install-local.mjs
@@ -59,6 +59,7 @@ export const installMarketplaceLocally = generatedInstaller.installMarketplaceLo
 export const resolveCodexInstallerBinDir = generatedInstaller.resolveCodexInstallerBinDir;
 export const PASSTHROUGH_COMMANDS = generatedInstaller.PASSTHROUGH_COMMANDS;
 export const buildDelegatedOmoInvocation = generatedInstaller.buildDelegatedOmoInvocation;
+export const buildDelegatedOmoInvocations = generatedInstaller.buildDelegatedOmoInvocations;
 export const formatLazyCodexInstallHelp = generatedInstaller.formatLazyCodexInstallHelp;
 export const parseLazyCodexInstallCliArgs = generatedInstaller.parseLazyCodexInstallCliArgs;
 export const runDelegatedOmoCommand = generatedInstaller.runDelegatedOmoCommand;

--- a/packages/omo-codex/src/install/install-local-cli.ts
+++ b/packages/omo-codex/src/install/install-local-cli.ts
@@ -17,7 +17,7 @@ export { stampGitBashMcpEnv } from "./codex-git-bash-mcp-env"
 export { assertHookCommandTargets, findMissingHookCommandTargets } from "./codex-hook-targets"
 export { repairNearestProjectLocalCodexArtifacts } from "./codex-project-local-cleanup"
 export { PASSTHROUGH_COMMANDS, formatLazyCodexInstallHelp, parseLazyCodexInstallCliArgs } from "./lazycodex-cli-args"
-export { buildDelegatedOmoInvocation, runDelegatedOmoCommand } from "./lazycodex-delegated-command"
+export { buildDelegatedOmoInvocation, buildDelegatedOmoInvocations, runDelegatedOmoCommand } from "./lazycodex-delegated-command"
 
 export async function installMarketplaceLocally(options: CodexInstallOptions = {}): Promise<CodexInstallResult> {
   return runCodexInstaller(options)
@@ -73,11 +73,31 @@ export async function runLazyCodexInstallLocalCli(input: {
   }
 
   const repoRoot = parsed.repoRoot ? resolve(parsed.repoRoot) : input.defaultRepoRoot
-  const result = await installMarketplaceLocally({
-    repoRoot,
-    autonomousPermissions: parsed.autonomousPermissions,
-    env: input.env,
-  })
-  input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`)
+  if (parsed.targets.includes("codex")) {
+    const result = await installMarketplaceLocally({
+      repoRoot,
+      autonomousPermissions: parsed.autonomousPermissions,
+      env: input.env,
+    })
+    input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`)
+  }
+
+  const delegatedTargets = parsed.targets.filter((target) => target !== "codex")
+  if (delegatedTargets.length > 0) {
+    await runDelegatedOmoCommand(
+      {
+        kind: "command",
+        command: "install",
+        dryRun: false,
+        targets: delegatedTargets,
+        noTui: parsed.noTui,
+        skipAuth: parsed.skipAuth,
+        autonomousPermissions: parsed.autonomousPermissions,
+        repoRoot: undefined,
+        args: [],
+      },
+      { cwd: input.cwd, log: input.log, runCommand: defaultRunCommand },
+    )
+  }
   return 0
 }

--- a/packages/omo-codex/src/install/lazycodex-cli-args.ts
+++ b/packages/omo-codex/src/install/lazycodex-cli-args.ts
@@ -1,4 +1,9 @@
-const CODEX_ONLY_ERROR = "lazycodex-ai installs the Codex Light edition only. Use the omo installer for OpenCode or both-platform installs."
+export const LAZYCODEX_INSTALL_TARGETS = ["codex", "claude-code", "gemini"] as const
+
+export type LazyCodexInstallTarget = (typeof LAZYCODEX_INSTALL_TARGETS)[number]
+
+const ALL_PLATFORM_ALIASES = new Set(["all", "all-platforms", "multi", "*"])
+const LAZYCODEX_INSTALL_TARGET_SET = new Set<string>(LAZYCODEX_INSTALL_TARGETS)
 
 export const PASSTHROUGH_COMMANDS: ReadonlySet<string> = new Set([
   "doctor",
@@ -11,13 +16,21 @@ export const PASSTHROUGH_COMMANDS: ReadonlySet<string> = new Set([
 ] as const)
 
 export type LazyCodexInstallCliArgs =
-  | { readonly kind: "install"; readonly autonomousPermissions: boolean | undefined; readonly repoRoot: string | undefined }
+  | {
+      readonly kind: "install"
+      readonly targets: readonly LazyCodexInstallTarget[]
+      readonly noTui: boolean
+      readonly skipAuth: boolean
+      readonly autonomousPermissions: boolean | undefined
+      readonly repoRoot: string | undefined
+    }
   | { readonly kind: "help" }
   | { readonly kind: "version" }
   | {
       readonly kind: "command"
       readonly command: string
       readonly dryRun: boolean
+      readonly targets?: readonly LazyCodexInstallTarget[]
       readonly noTui?: boolean
       readonly skipAuth?: boolean
       readonly autonomousPermissions?: boolean
@@ -28,7 +41,16 @@ export type LazyCodexInstallCliArgs =
 
 export function parseLazyCodexInstallCliArgs(argv: readonly string[]): LazyCodexInstallCliArgs {
   const args = [...argv]
-  if (args.length === 0) return { kind: "install", autonomousPermissions: undefined, repoRoot: undefined }
+  if (args.length === 0) {
+    return {
+      kind: "install",
+      targets: [...LAZYCODEX_INSTALL_TARGETS],
+      noTui: false,
+      skipAuth: false,
+      autonomousPermissions: undefined,
+      repoRoot: undefined,
+    }
+  }
 
   let repoRoot: string | undefined
   let command: "install" | undefined
@@ -36,6 +58,8 @@ export function parseLazyCodexInstallCliArgs(argv: readonly string[]): LazyCodex
   let noTui = false
   let skipAuth = false
   let autonomousPermissions: boolean | undefined
+  let allPlatforms = false
+  const platforms: LazyCodexInstallTarget[] = []
   let index = 0
   while (index < args.length) {
     const arg = args[index]
@@ -66,16 +90,31 @@ export function parseLazyCodexInstallCliArgs(argv: readonly string[]): LazyCodex
       index += 1
       continue
     }
+    if (arg === "--all-platforms") {
+      allPlatforms = true
+      index += 1
+      continue
+    }
     if (arg === "--platform") {
       const platform = readOptionValue(args, index, "--platform")
-      if (platform !== "codex") throw new Error(CODEX_ONLY_ERROR)
+      const parsedPlatform = parseInstallTarget(platform)
+      if (parsedPlatform === "all") {
+        allPlatforms = true
+      } else {
+        platforms.push(parsedPlatform)
+      }
       index += 2
       continue
     }
     if (typeof arg === "string" && arg.startsWith("--platform=")) {
       const platform = arg.slice("--platform=".length)
       if (platform.trim().length === 0) throw new Error("--platform requires a value")
-      if (platform !== "codex") throw new Error(CODEX_ONLY_ERROR)
+      const parsedPlatform = parseInstallTarget(platform)
+      if (parsedPlatform === "all") {
+        allPlatforms = true
+      } else {
+        platforms.push(parsedPlatform)
+      }
       index += 1
       continue
     }
@@ -112,18 +151,37 @@ export function parseLazyCodexInstallCliArgs(argv: readonly string[]): LazyCodex
     throw new Error(`Unsupported lazycodex-ai install option: ${String(arg)}`)
   }
 
-  if (!dryRun) return { kind: "install", autonomousPermissions, repoRoot }
+  const targets = resolveInstallTargets(platforms, allPlatforms)
+  if (!dryRun) return { kind: "install", targets, noTui, skipAuth, autonomousPermissions, repoRoot }
 
   return {
     kind: "command",
     command: command ?? "install",
     dryRun,
+    targets,
     noTui,
     skipAuth,
     autonomousPermissions,
     repoRoot,
     args: [],
   }
+}
+
+function parseInstallTarget(platform: string): LazyCodexInstallTarget | "all" {
+  const normalized = platform.trim()
+  if (ALL_PLATFORM_ALIASES.has(normalized)) return "all"
+  if (LAZYCODEX_INSTALL_TARGET_SET.has(normalized)) return normalized as LazyCodexInstallTarget
+  throw new Error(
+    `Unsupported lazycodex-ai install platform: ${platform} (expected codex, claude-code, gemini, or all)`,
+  )
+}
+
+function resolveInstallTargets(
+  platforms: readonly LazyCodexInstallTarget[],
+  allPlatforms: boolean,
+): readonly LazyCodexInstallTarget[] {
+  if (allPlatforms || platforms.length === 0) return [...LAZYCODEX_INSTALL_TARGETS]
+  return [...new Set(platforms)]
 }
 
 function parseUpdateArgs(
@@ -171,6 +229,7 @@ export function formatLazyCodexInstallHelp(): string {
   const passthrough = [...PASSTHROUGH_COMMANDS].sort().join(", ")
   return [
     "Usage: lazycodex-ai install [--no-tui] [--codex-autonomous|--no-codex-autonomous] [--repo-root <path>]",
+    "       lazycodex-ai install [--platform codex|claude-code|gemini|all] [--all-platforms]",
     "       lazycodex-ai uninstall [--project <path>]",
     "       lazycodex-ai update [--dry-run] [--repo-root <path>]",
     "       lazycodex-ai doctor [--source-root <path>] [--json|--status|--verbose]",

--- a/packages/omo-codex/src/install/lazycodex-delegated-command.ts
+++ b/packages/omo-codex/src/install/lazycodex-delegated-command.ts
@@ -1,5 +1,5 @@
 import type { RunCommand } from "./types"
-import type { LazyCodexInstallCliArgs } from "./lazycodex-cli-args"
+import { LAZYCODEX_INSTALL_TARGETS, type LazyCodexInstallTarget, type LazyCodexInstallCliArgs } from "./lazycodex-cli-args"
 
 export type LazyCodexDelegatedCommand = Extract<LazyCodexInstallCliArgs, { readonly kind: "command" }>
 
@@ -26,32 +26,59 @@ export async function runDelegatedOmoCommand(
   if (parsed.command === "doctor" && process.env.LAZYCODEX_DOCTOR_LCX_ACTIVE === "1") {
     throw new Error("Refusing recursive lazycodex doctor invocation from inside $omo:lcx-doctor")
   }
-  const invocation = buildDelegatedOmoInvocation(parsed)
+  const invocations = buildDelegatedOmoInvocations(parsed)
   if (parsed.dryRun) {
-    options.log(formatShellCommand(invocation.command, invocation.args))
+    for (const invocation of invocations) {
+      options.log(formatShellCommand(invocation.command, invocation.args))
+    }
     return
   }
-  const env = invocation.delegatesToOmo
-    ? { ...process.env, OMO_INVOCATION_NAME: "omo", ...invocation.env }
-    : { ...process.env, ...invocation.env }
-  await options.runCommand(invocation.command, invocation.args, { cwd: options.cwd, env })
+  for (const invocation of invocations) {
+    const env = invocation.delegatesToOmo
+      ? { ...process.env, OMO_INVOCATION_NAME: "omo", ...invocation.env }
+      : { ...process.env, ...invocation.env }
+    await options.runCommand(invocation.command, invocation.args, { cwd: options.cwd, env })
+  }
 }
 
 export function buildDelegatedOmoInvocation(parsed: LazyCodexDelegatedCommand): DelegatedOmoInvocation {
-  if (parsed.command === "doctor") return buildLazyCodexDoctorInvocation(parsed.args)
+  const invocation = buildDelegatedOmoInvocations(parsed)[0]
+  if (invocation === undefined) {
+    throw new Error("No delegated omo invocation was built")
+  }
+  return invocation
+}
+
+export function buildDelegatedOmoInvocations(parsed: LazyCodexDelegatedCommand): readonly DelegatedOmoInvocation[] {
+  if (parsed.command === "doctor") return [buildLazyCodexDoctorInvocation(parsed.args)]
+
+  if (parsed.command === "install") {
+    const targets = parsed.targets ?? LAZYCODEX_INSTALL_TARGETS
+    return targets.map((target) => buildInstallInvocation(parsed, target))
+  }
 
   const args = ["--yes", "--package", "oh-my-openagent", "omo", parsed.command]
-  if (parsed.command === "install") {
-    args.push("--platform=codex")
-    if (parsed.noTui) args.push("--no-tui")
-    if (parsed.skipAuth) args.push("--skip-auth")
-    if (parsed.autonomousPermissions !== false) args.push("--codex-autonomous")
-    if (parsed.autonomousPermissions === false) args.push("--no-codex-autonomous")
-    if (parsed.repoRoot) args.push(`--repo-root=${parsed.repoRoot}`)
-  } else if (parsed.command === "cleanup") {
+  if (parsed.command === "cleanup") {
     args.push("--platform=codex", ...parsed.args)
   } else {
     args.push(...parsed.args)
+  }
+  return [{ command: "npx", args, delegatesToOmo: true }]
+}
+
+function buildInstallInvocation(
+  parsed: LazyCodexDelegatedCommand,
+  target: LazyCodexInstallTarget,
+): DelegatedOmoInvocation {
+  const args = ["--yes", "--package", "oh-my-openagent", "omo", parsed.command, `--platform=${target}`]
+  if (parsed.command === "install") {
+    if (parsed.noTui) args.push("--no-tui")
+    if (parsed.skipAuth) args.push("--skip-auth")
+    if (target === "codex") {
+      if (parsed.autonomousPermissions !== false) args.push("--codex-autonomous")
+      if (parsed.autonomousPermissions === false) args.push("--no-codex-autonomous")
+      if (parsed.repoRoot) args.push(`--repo-root=${parsed.repoRoot}`)
+    }
   }
   return { command: "npx", args, delegatesToOmo: true }
 }

--- a/script/publish-lazycodex-workflow.test.ts
+++ b/script/publish-lazycodex-workflow.test.ts
@@ -299,10 +299,13 @@ describe("LazyCodex publish workflow", () => {
       smokeStep.includes('export CODEX_LOCAL_BIN_DIR="$SMOKE_DIR/bin"')
     const assertsDryRunRouting = smokeStep.includes('npx -y "$package_spec" --dry-run install --no-tui --codex-autonomous') &&
       smokeStep.includes('npx -y "$package_spec" --dry-run doctor') &&
+      smokeStep.includes('expected_install_output="$(cat <<\'EOF\'') &&
       smokeStep.includes("npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous") &&
+      smokeStep.includes("npx --yes --package oh-my-openagent omo install --platform=claude-code --no-tui") &&
+      smokeStep.includes("npx --yes --package oh-my-openagent omo install --platform=gemini --no-tui") &&
       smokeStep.includes("npx --yes --package oh-my-openagent omo doctor")
     const installsRealPackageAndVerifiesOmoBin =
-      smokeStep.includes('npx -y "$package_spec" install --no-tui --codex-autonomous') &&
+      smokeStep.includes('npx -y "$package_spec" install --platform=codex --no-tui --codex-autonomous') &&
       smokeStep.includes('[ -x "$CODEX_LOCAL_BIN_DIR/omo" ]') &&
       smokeStep.includes('omo_version_output=$("$CODEX_LOCAL_BIN_DIR/omo" --version 2>&1)') &&
       smokeStep.includes('[ "$omo_version_output" = "$OMO_VERSION" ]') &&


### PR DESCRIPTION
## Summary
Ports the closed LazyCodex PR [code-yeongyu/lazycodex#75](https://github.com/code-yeongyu/lazycodex/pull/75) into the upstream OmO source tree. That PR was closed by automation because LazyCodex source changes now land through `code-yeongyu/oh-my-openagent`, specifically `packages/omo-codex`.

`lazycodex-ai install` now defaults to the LazyCodex target set `codex`, `claude-code`, and `gemini`; explicit `--platform=<target>` narrows to one target; `--platform=all` / `--all-platforms` expand to the default set; and Codex-only flags are filtered out of non-Codex delegated commands.

## Changes
- Adds LazyCodex target parsing in `packages/omo-codex/src/install/lazycodex-cli-args.ts`, including `codex`, `claude-code`, `gemini`, `all`, `all-platforms`, `multi`, and `*` handling.
- Updates delegated install command construction to emit one command per target and to keep `--codex-autonomous`, `--no-codex-autonomous`, and `--repo-root` on Codex only.
- Updates the local Node installer entrypoint and regenerated `packages/omo-codex/scripts/install-dist/install-local.mjs` bundle.
- Updates published LazyCodex smoke expectations so the dry-run asserts all three default target commands while the real install smoke stays explicitly Codex-scoped.
- Documents the new LazyCodex target behavior in `docs/guide/installation.md` and `docs/reference/cli.md`.
- Updates `codex-qa` install verification to call `install --platform=codex` explicitly, so Codex-only QA does not accidentally invoke the new all-target default.

## QA & Evidence
Evidence folder: `.omo/evidence/20260630-pr75-multi-platform-install/`

- **Original PR review:** `gh pr view 75 --repo code-yeongyu/lazycodex --json title,state,body,comments,files,headRefName,baseRefName,url`; `gh pr diff 75 --repo code-yeongyu/lazycodex --color=never`.
  - **Observed:** PR #75 changed the thin LazyCodex wrapper to default to Codex, Claude Code, and Gemini target commands, preserve explicit single-target installs, add all-platform aliases, and filter Codex-only flags.
- **RED tests:** Node installer tests were run before implementation.
  - **Artifact:** `.omo/evidence/20260630-pr75-multi-platform-install/red-node-installer-tests.txt`
- **Focused green Node tests:** `node --test packages/omo-codex/scripts/install-cli-args.test.mjs packages/omo-codex/scripts/install-delegated-command.test.mjs packages/omo-codex/scripts/install-local-entrypoint.test.mjs`
  - **Observed:** 43 pass, 0 fail.
  - **Artifact:** `.omo/evidence/20260630-pr75-multi-platform-install/node-installer-tests-final.txt`
- **Publish workflow routing test:** `bun test script/publish-lazycodex-workflow.test.ts`
  - **Observed:** 6 pass, 0 fail.
  - **Artifact:** `.omo/evidence/20260630-pr75-multi-platform-install/workflow-routing-test-final.txt`
- **Repo-level checks:** `bun run typecheck`; `bun run build`; `/Users/yeongyu/DevelopmentTools/go/bin/actionlint -color -shellcheck=""`; earlier full `bun test`.
  - **Observed:** typecheck passed; build passed; full test suite passed with 10215 pass, 2 skip, 0 fail across 1258 files.
  - **Artifacts:** `.omo/evidence/20260630-pr75-multi-platform-install/typecheck-final.txt`, `.omo/evidence/20260630-pr75-multi-platform-install/build-final.txt`, `.omo/evidence/20260630-pr75-multi-platform-install/actionlint-final.txt`, `.omo/evidence/20260630-pr75-multi-platform-install/bun-test.txt`
- **Manual LazyCodex dry-runs:**
  - `node packages/omo-codex/scripts/install-local.mjs --dry-run install --no-tui --codex-autonomous`
  - `node packages/omo-codex/scripts/install-local.mjs --dry-run install --platform=gemini --no-tui --codex-autonomous`
  - `node packages/omo-codex/scripts/install-local.mjs --dry-run install --platform=all --no-tui`
  - **Observed:** default and `all` emit Codex, Claude Code, and Gemini commands; explicit Gemini emits one command and drops the Codex-only flag.
  - **Artifacts:** `.omo/evidence/20260630-pr75-multi-platform-install/manual-dry-run-default-multi.txt`, `.omo/evidence/20260630-pr75-multi-platform-install/manual-dry-run-explicit-gemini.txt`, `.omo/evidence/20260630-pr75-multi-platform-install/manual-dry-run-platform-all.txt`
- **Codex QA:** `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check`; `bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test`
  - **Observed:** isolated `CODEX_HOME` proof passed; local plugin cache/config/bin/agent TOMLs were verified; real `~/.codex/config.toml` shasum was unchanged.
  - **Artifacts:** `.omo/evidence/20260630-pr75-multi-platform-install/codex-qa-common-self-check.txt`, `.omo/evidence/20260630-pr75-multi-platform-install/codex-qa-install-verify.txt`

## Risks & Residuals
- This is a faithful upstream port of the wrapper-level behavior from LazyCodex PR #75. The current shared `omo` CLI still owns the implementation/validation of downstream install target names, and this PR does not invent new first-party Claude Code or Gemini installer internals beyond the delegated command contract from the original PR.
- Non-Codex target behavior was proven at the LazyCodex wrapper/dry-run level. The real harness install QA is Codex-scoped through `codex-qa`, because that is the first-party installer surface currently present under `packages/omo-codex`.
- Raw secret-bearing logs, auth headers, launchd env, and real config contents were not copied into evidence.
