### PR TITLE
fix(codex): expose lazycodex ulw cli aliases

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -368,7 +368,7 @@ grep -A2 'omo@sisyphuslabs' ~/.codex/config.toml
 grep -E 'approval_policy|sandbox_mode|network_access' ~/.codex/config.toml
 
 # Component binaries linked?
-ls ~/.local/bin/ | grep -E '^(omo|omo-(comment-checker|git-bash-hook|lsp|rules|start-work-continuation|telemetry|ultrawork|ulw-loop))$'
+ls ~/.local/bin/ | grep -E '^(omo|ulw|ulw-loop|omo-(comment-checker|git-bash-hook|lsp|rules|start-work-continuation|telemetry|ultrawork|ulw-loop))$'
 
 # Codex CLI sees the plugin?
 codex --help
@@ -713,7 +713,7 @@ Skip this section if `--platform=opencode`. Otherwise, the user installed the **
 
 - **Plugin cache:** `~/.codex/plugins/cache/sisyphuslabs/omo/<version>/`
 - **Codex marketplace snapshot:** `~/.codex/.tmp/marketplaces/sisyphuslabs/` (local marketplace metadata and bundled source snapshot)
-- **Component binaries:** `lazycodex-executor-verify`, `omo-comment-checker`, `omo-git-bash-hook`, `omo-lsp`, `omo-rules`, `omo-start-work-continuation`, `omo-telemetry`, `omo-ulw-loop`, `omo-ultrawork` in `~/.local/bin` (or under `$CODEX_LOCAL_BIN_DIR` if set). The top-level `omo` command belongs to the shared oh-my-openagent launcher, not a Codex component.
+- **Component binaries:** `lazycodex-executor-verify`, `omo-comment-checker`, `omo-git-bash-hook`, `omo-lsp`, `omo-rules`, `omo-start-work-continuation`, `omo-telemetry`, `omo-ulw-loop`, `omo-ultrawork`, `ulw`, and `ulw-loop` in `~/.local/bin` (or under `$CODEX_LOCAL_BIN_DIR` if set). The top-level `omo` command belongs to the shared oh-my-openagent launcher, not a Codex component.
 - **Codex agent roles:** `~/.codex/agents/{lazycodex-clone-fidelity-reviewer,lazycodex-code-reviewer,lazycodex-executor,lazycodex-gate-reviewer,lazycodex-qa-executor,explorer,librarian,metis,momus,plan}.toml` copied from the bundled plugin snapshot, so they keep resolving when Codex prunes old plugin-cache versions or temporary marketplace state
 - **Codex config edits:** `~/.codex/config.toml` gained `[features] plugins = true`, `[features] plugin_hooks = true`, `[features.multi_agent_v2] max_concurrent_threads_per_session = 1000`, `[marketplaces.sisyphuslabs]` pointing at `~/.codex/plugins/cache/sisyphuslabs`, `[plugins."omo@sisyphuslabs"]`, plugin MCP policy blocks, SHA256-pinned `[hooks.state."omo@sisyphuslabs:..."]` entries, and optionally autonomous permission settings if accepted. If the installer cannot resolve a CodeGraph-compatible Node runtime, it writes the `codegraph` MCP policy as disabled while leaving `omo@sisyphuslabs` enabled.
 

--- a/packages/omo-codex/plugin/components/ulw-loop/package.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/package.json
@@ -23,7 +23,9 @@
 		"typescript"
 	],
 	"bin": {
-		"omo-ulw-loop": "./dist/cli.js"
+		"omo-ulw-loop": "./dist/cli.js",
+		"ulw": "./dist/cli.js",
+		"ulw-loop": "./dist/cli.js"
 	},
 	"files": [
 		"dist",

--- a/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
@@ -60,10 +60,12 @@ describe("package.json", () => {
 		expect((pkg["engines"] as Record<string, unknown>)["node"]).toBe(">=20.0.0");
 	});
 
-	it("#given package metadata #when bin is inspected #then exposes the omo-ulw-loop binary pointing at dist/cli.js", async () => {
+	it("#given package metadata #when bin is inspected #then exposes the ULW loop binaries pointing at dist/cli.js", async () => {
 		const pkg = await readJson("package.json") as Record<string, unknown>;
 		const bin = pkg["bin"] as Record<string, string>;
 		expect(bin["omo-ulw-loop"]).toBe("./dist/cli.js");
+		expect(bin["ulw"]).toBe("./dist/cli.js");
+		expect(bin["ulw-loop"]).toBe("./dist/cli.js");
 	});
 
 	it("ships the expected files for npm publish", async () => {

--- a/packages/omo-codex/plugin/package-lock.json
+++ b/packages/omo-codex/plugin/package-lock.json
@@ -276,7 +276,9 @@
 			"version": "4.14.0",
 			"license": "MIT",
 			"bin": {
-				"omo-ulw-loop": "dist/cli.js"
+				"omo-ulw-loop": "dist/cli.js",
+				"ulw": "dist/cli.js",
+				"ulw-loop": "dist/cli.js"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.4.16",

--- a/packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs
+++ b/packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs
@@ -40,7 +40,7 @@ async function withBinLinkFixture(run) {
 // Mirrors the Codex marketplace store layout: each plugin version is installed
 // under its own root and old version dirs are deleted on upgrade
 // (core-plugins store.rs), which is why stale bin links MUST be re-pointed.
-async function writeVersionedRoot(root, version, { withRuntimeCli = false } = {}) {
+async function writeVersionedRoot(root, version, { withRuntimeCli = false, withUlwLoopAliases = false } = {}) {
 	const pluginRoot = join(root, "store", "omo", version);
 	await mkdir(join(pluginRoot, ".codex-plugin"), { recursive: true });
 	await writeFile(
@@ -83,6 +83,22 @@ async function writeVersionedRoot(root, version, { withRuntimeCli = false } = {}
 		`${JSON.stringify({ bin: { [COMPONENT_BIN_NAME]: "./dist/cli.js" }, name: "@sisyphuslabs/toolbox" })}\n`,
 	);
 	await writeFile(join(componentRoot, "dist", "cli.js"), "#!/usr/bin/env node\nconsole.log('toolbox');\n");
+	if (withUlwLoopAliases) {
+		const ulwLoopRoot = join(pluginRoot, "components", "ulw-loop");
+		await mkdir(join(ulwLoopRoot, "dist"), { recursive: true });
+		await writeFile(
+			join(ulwLoopRoot, "package.json"),
+			`${JSON.stringify({
+				bin: {
+					"omo-ulw-loop": "./dist/cli.js",
+					ulw: "./dist/cli.js",
+					"ulw-loop": "./dist/cli.js",
+				},
+				name: "@sisyphuslabs/ulw-loop",
+			})}\n`,
+		);
+		await writeFile(join(ulwLoopRoot, "dist", "cli.js"), "#!/usr/bin/env node\nconsole.log('ulw-loop');\n");
+	}
 	if (withRuntimeCli) {
 		await mkdir(join(pluginRoot, "dist", "cli"), { recursive: true });
 		await writeFile(join(pluginRoot, "dist", "cli", "index.js"), "console.log('omo');\n");
@@ -264,5 +280,25 @@ test("#given a payload shipping dist/cli #when the worker setup runs with no bin
 			const shim = await readFile(join(defaultBinDir, `${COMPONENT_BIN_NAME}.cmd`), "utf8");
 			assert.ok(shim.includes(join(pluginRoot, "components", "toolbox", "dist", "cli.js")));
 		}
+	});
+});
+
+test("#given ulw-loop aliases in the plugin payload #when worker setup links bins #then public ULW commands point at the current component without adding SessionStart hooks", async () => {
+	await withBinLinkFixture(async (fixture) => {
+		const pluginRoot = await writeVersionedRoot(fixture.root, "1.0.0", { withUlwLoopAliases: true });
+
+		await runWorkerSetup(setupOptions(fixture, pluginRoot));
+
+		const targets = await symlinkTargets(fixture.binDir);
+		const ulwLoopCli = join(pluginRoot, "components", "ulw-loop", "dist", "cli.js");
+		assert.equal(targets.get("omo-ulw-loop"), ulwLoopCli);
+		assert.equal(targets.get("ulw"), ulwLoopCli);
+		assert.equal(targets.get("ulw-loop"), ulwLoopCli);
+		const hooks = JSON.parse(await readFile(join(pluginRoot, "hooks", "hooks.json"), "utf8"));
+		const sessionStartCommands = hooks.hooks.SessionStart.flatMap((group) => group.hooks)
+			.filter((hook) => hook.type === "command")
+			.map((hook) => hook.command)
+			.filter((command) => command.includes("components/bootstrap/dist/cli.js"));
+		assert.equal(sessionStartCommands.length, 1);
 	});
 });

--- a/packages/omo-codex/plugin/test/component-bin-names.test.mjs
+++ b/packages/omo-codex/plugin/test/component-bin-names.test.mjs
@@ -7,13 +7,13 @@ import { fileURLToPath } from "node:url";
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 
 const EXPECTED_COMPONENT_BINS = new Map([
-	["comment-checker", "omo-comment-checker"],
-	["lsp", "omo-lsp"],
-	["rules", "omo-rules"],
-	["start-work-continuation", "omo-start-work-continuation"],
-	["telemetry", "omo-telemetry"],
-	["ultrawork", "omo-ultrawork"],
-	["ulw-loop", "omo-ulw-loop"],
+	["comment-checker", ["omo-comment-checker"]],
+	["lsp", ["omo-lsp"]],
+	["rules", ["omo-rules"]],
+	["start-work-continuation", ["omo-start-work-continuation"]],
+	["telemetry", ["omo-telemetry"]],
+	["ultrawork", ["omo-ultrawork"]],
+	["ulw-loop", ["omo-ulw-loop", "ulw", "ulw-loop"]],
 ]);
 
 const EXPECTED_USAGE_PREFIXES = new Map([
@@ -29,18 +29,19 @@ async function readJson(relativePath) {
 	return JSON.parse(await readFile(join(root, relativePath), "utf8"));
 }
 
-test("#given aggregate component package metadata #when bin names are inspected #then local component CLIs use the OMO prefix", async () => {
+test("#given aggregate component package metadata #when bin names are inspected #then component CLIs expose documented commands", async () => {
 	// given
 	const components = [...EXPECTED_COMPONENT_BINS.entries()];
 
 	// when
 	const mismatches = [];
-	for (const [component, expectedName] of components) {
+	for (const [component, expectedNames] of components) {
 		const packageJson = await readJson(join("components", component, "package.json"));
 		const bin = packageJson.bin ?? {};
 		const binNames = Object.keys(bin).sort();
-		if (bin[expectedName] !== "./dist/cli.js" || binNames.some((name) => name.startsWith("codex-"))) {
-			mismatches.push({ component, expectedName, bin });
+		const missing = expectedNames.filter((expectedName) => bin[expectedName] !== "./dist/cli.js");
+		if (missing.length > 0 || binNames.some((name) => name.startsWith("codex-"))) {
+			mismatches.push({ component, missing, bin });
 		}
 	}
 

--- a/packages/omo-codex/scripts/install-bin-links.test.mjs
+++ b/packages/omo-codex/scripts/install-bin-links.test.mjs
@@ -247,6 +247,8 @@ test("#given nested component declares reserved omo bin #when linking bins #then
 		bin: {
 			omo: "./dist/cli.js",
 			"omo-ulw-loop": "./dist/cli.js",
+			ulw: "./dist/cli.js",
+			"ulw-loop": "./dist/cli.js",
 		},
 	});
 	await writeFile(join(componentRoot, "dist", "cli.js"), "#!/usr/bin/env node\n");
@@ -255,9 +257,13 @@ test("#given nested component declares reserved omo bin #when linking bins #then
 
 	assert.deepEqual(linked, [
 		{ name: "omo-ulw-loop", path: join(binDir, "omo-ulw-loop"), target: join(componentRoot, "dist", "cli.js") },
+		{ name: "ulw", path: join(binDir, "ulw"), target: join(componentRoot, "dist", "cli.js") },
+		{ name: "ulw-loop", path: join(binDir, "ulw-loop"), target: join(componentRoot, "dist", "cli.js") },
 	]);
 	await assert.rejects(readlink(join(binDir, "omo")));
 	assert.equal(await readlink(join(binDir, "omo-ulw-loop")), join(componentRoot, "dist", "cli.js"));
+	assert.equal(await readlink(join(binDir, "ulw")), join(componentRoot, "dist", "cli.js"));
+	assert.equal(await readlink(join(binDir, "ulw-loop")), join(componentRoot, "dist", "cli.js"));
 });
 
 test("#given stale managed ulw-loop omo symlink #when linking bins #then removes it without touching user-owned omo", async () => {

--- a/packages/omo-codex/src/install/codex-cache.test.ts
+++ b/packages/omo-codex/src/install/codex-cache.test.ts
@@ -296,7 +296,15 @@ describe("codex-cache", () => {
     await writeFile(join(pluginRoot, "package.json"), JSON.stringify({ name: "@scope/omo" }))
     await writeFile(
       join(componentRoot, "package.json"),
-      JSON.stringify({ name: "@scope/ulw-loop", bin: { omo: "dist/cli.js", "omo-ulw-loop": "dist/cli.js" } }),
+      JSON.stringify({
+        name: "@scope/ulw-loop",
+        bin: {
+          omo: "dist/cli.js",
+          "omo-ulw-loop": "dist/cli.js",
+          ulw: "dist/cli.js",
+          "ulw-loop": "dist/cli.js",
+        },
+      }),
     )
     await writeFile(join(componentRoot, "dist", "cli.js"), "#!/usr/bin/env node\n")
 
@@ -304,9 +312,15 @@ describe("codex-cache", () => {
     const linked = await linkCachedPluginBins({ binDir, pluginRoot, platform: "linux" })
 
     // then
-    expect(linked).toEqual([{ name: "omo-ulw-loop", path: join(binDir, "omo-ulw-loop"), target: join(componentRoot, "dist", "cli.js") }])
+    expect(linked).toEqual([
+      { name: "omo-ulw-loop", path: join(binDir, "omo-ulw-loop"), target: join(componentRoot, "dist", "cli.js") },
+      { name: "ulw", path: join(binDir, "ulw"), target: join(componentRoot, "dist", "cli.js") },
+      { name: "ulw-loop", path: join(binDir, "ulw-loop"), target: join(componentRoot, "dist", "cli.js") },
+    ])
     await expect(readlink(join(binDir, "omo"))).rejects.toThrow()
     expect(await readlink(join(binDir, "omo-ulw-loop"))).toBe(join(componentRoot, "dist", "cli.js"))
+    expect(await readlink(join(binDir, "ulw"))).toBe(join(componentRoot, "dist", "cli.js"))
+    expect(await readlink(join(binDir, "ulw-loop"))).toBe(join(componentRoot, "dist", "cli.js"))
   })
 
   test("#given stale managed ulw-loop omo symlink #when linking cached plugin bins #then removes it", async () => {

--- a/packages/omo-codex/src/install/install-codex-test-fixtures.ts
+++ b/packages/omo-codex/src/install/install-codex-test-fixtures.ts
@@ -12,6 +12,8 @@ export const EXPECTED_OMO_COMPONENT_BINS = [
   { name: "omo-start-work-continuation", target: join("components", "start-work-continuation", "dist", "cli.js") },
   { name: "omo-telemetry", target: join("components", "telemetry", "dist", "cli.js") },
   { name: "omo-ulw-loop", target: join("components", "ulw-loop", "dist", "cli.js") },
+  { name: "ulw", target: join("components", "ulw-loop", "dist", "cli.js") },
+  { name: "ulw-loop", target: join("components", "ulw-loop", "dist", "cli.js") },
   { name: "omo-ultrawork", target: join("components", "ultrawork", "dist", "cli.js") },
 ] as const
 
@@ -55,16 +57,20 @@ export async function createRepoWithBuiltComponentBins(
     await createBundledGitBashMcpFixture({ pluginRoot, repoRoot })
   }
 
+  const componentBins = new Map<string, Record<string, string>>()
   for (const entry of EXPECTED_OMO_COMPONENT_BINS) {
     if ("kind" in entry && entry.kind === "runtime-wrapper") continue
     const componentName = entry.target.split(/[\\/]/)[1]
     if (componentName === undefined) throw new Error(`missing component name for ${entry.name}`)
+    const bins = componentBins.get(componentName) ?? {}
+    bins[entry.name] = "./dist/cli.js"
+    componentBins.set(componentName, bins)
+  }
+
+  for (const [componentName, bins] of componentBins) {
     const componentRoot = join(pluginRoot, "components", componentName)
     await mkdir(join(componentRoot, "dist"), { recursive: true })
-    await writeFile(
-      join(componentRoot, "package.json"),
-      JSON.stringify({ name: `@sisyphuslabs/${componentName}`, bin: { [entry.name]: "./dist/cli.js" } }),
-    )
+    await writeFile(join(componentRoot, "package.json"), JSON.stringify({ name: `@sisyphuslabs/${componentName}`, bin: bins }))
     await writeFile(join(componentRoot, "dist", "cli.js"), "#!/usr/bin/env node\n")
   }
 


### PR DESCRIPTION
## Summary
Fixes `code-yeongyu/lazycodex#92`.

The Codex marketplace/root payload now exposes the ULW loop component under the public `ulw` and `ulw-loop` CLI names in addition to the existing `omo-ulw-loop` component name. The session-start/bootstrap bin-link repair path is covered so an installed plugin/root payload links all three names to the current `components/ulw-loop/dist/cli.js` without adding duplicate SessionStart hooks or duplicate ultrawork injection behavior.

## Changes
- Adds `ulw` and `ulw-loop` bin aliases to `packages/omo-codex/plugin/components/ulw-loop/package.json` and the plugin lockfile, all pointing at `./dist/cli.js`.
- Extends component/package contract tests so ULW loop is the only component with documented public aliases while other component bins stay on their OMO-prefixed names.
- Extends installer/cache/bootstrap bin-link tests and fixtures to assert `omo-ulw-loop`, `ulw`, and `ulw-loop` resolve to the current plugin payload CLI, while the bootstrap SessionStart command remains singular.
- Updates the install guide's binary verification list to include `ulw` and `ulw-loop`.

## RED Evidence
- `node --test packages/omo-codex/plugin/test/component-bundled-cli.test.mjs` before the fix: `.omo/evidence/20260630-lazycodex-root-ulw-cli/red-component-bundled-cli-test.txt`
- `node packages/omo-codex/plugin/components/ulw-loop/dist/cli.js ulw-loop help` before the fix: `.omo/evidence/20260630-lazycodex-root-ulw-cli/red-direct-ulw-loop-cli.txt`

## GREEN / QA Evidence
- Build local Codex plugin payload: `bun run build:git-bash-mcp`; `bun run build:codex-plugin`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/build-codex-plugin.txt`
- Focused bin-link contracts: `node --test packages/omo-codex/plugin/test/component-bin-names.test.mjs packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs packages/omo-codex/scripts/install-bin-links.test.mjs`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/green-focused-bin-link-tests.txt`
  - Final rerun artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/final-focused-node-tests.txt` (26 pass)
- Bundled component CLI contract: `node --test packages/omo-codex/plugin/test/component-bundled-cli.test.mjs`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/green-component-bundled-cli-test.txt`
- Direct ULW component CLI: `node packages/omo-codex/plugin/components/ulw-loop/dist/cli.js ulw-loop help`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/green-direct-ulw-loop-cli.txt`
- Installer/cache focused tests: `bun test packages/omo-codex/src/install/lazycodex-install-surface.test.ts packages/omo-codex/src/install/codex-cache.test.ts`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/green-install-surface-cache-tests.txt`
  - Final rerun artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/final-focused-bun-install-tests.txt` (22 pass)
- Duplicate hook/session-start focused regression: `node --test packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs packages/omo-codex/plugin/test/aggregate-hooks.test.mjs --test-name-pattern "ulw-loop does not duplicate ultrawork injection"`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/green-bootstrap-binlinks-test.txt`
- Package/layout publish surfaces: `bun test script/package-layout.test.ts script/publish-lazycodex-workflow.test.ts --bail`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/green-package-publish-tests.txt`
- Marketplace sync/validation surfaces: `bun test script/lazycodex-marketplace-validation.pin.test.ts script/sync-lazycodex-marketplace-root-cli.test.ts script/sync-lazycodex-marketplace.test.ts --bail`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/green-marketplace-sync-tests.txt`
- Full Codex gate: `bun run test:codex`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/test-codex.txt` (423 pass)
- Codex QA install verification: `bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/codex-qa-install-verify.txt`
- First-party live hook QA: `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/codex-qa-app-server-drive.txt`
- Manual isolated install/session-start smoke with temporary `HOME`, `CODEX_HOME`, and `CODEX_LOCAL_BIN_DIR`; then executed `ulw-loop ulw-loop help`, `ulw ulw-loop help`, and `omo-ulw-loop ulw-loop help`
  - Artifact: `.omo/evidence/20260630-lazycodex-root-ulw-cli/manual-isolated-install-ulw-cli.txt`
  - Observed: all three commands resolve to the temp cache's `components/ulw-loop/dist/cli.js`; real `~/.codex/config.toml` checksum unchanged; temp dir removed by trap.

## Risks & Residuals
- Behavior change is limited to package/bin metadata and regression tests; no hook registration path changed.
- Duplicate-response / duplicate wake protections are covered by the new bootstrap assertion, existing aggregate hook duplicate-injection test, full `test:codex`, and app-server hook QA.
- Evidence files are local ignored QA artifacts under `.omo/evidence/20260630-lazycodex-root-ulw-cli/`; they are referenced for reviewer audit but not committed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose public `ulw` and `ulw-loop` CLI aliases for the ULW loop component alongside `omo-ulw-loop`, and ensure all names link to `components/ulw-loop/dist/cli.js`. Prevents duplicate SessionStart hooks during install/upgrade.

- **Bug Fixes**
  - Added `ulw` and `ulw-loop` bins to `packages/omo-codex/plugin/components/ulw-loop/package.json` (and lockfile).
  - Updated installer/cache/bootstrap to link/repair `omo-ulw-loop`, `ulw`, and `ulw-loop` and keep a single SessionStart command.
  - Extended tests for component bin names, bin-link repair, cache installs, and bootstrap to cover aliases and dedupe behavior.
  - Updated install guide to list `ulw` and `ulw-loop` binaries.

<sup>Written for commit a043ccdc2c60a439a3a3ca6f464ad9ce4266b018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

