### PR TITLE
[lazycodex-issues] OpenCode user skill tool loading

### DIFF
--- a/.omo/evidence/20260630-opencode-skill-loading/QA-REPORT.md
+++ b/.omo/evidence/20260630-opencode-skill-loading/QA-REPORT.md
@@ -1,0 +1,25 @@
+# OpenCode Skill Loading QA
+
+## What Was Tested
+
+- Started `opencode serve` 1.17.8 in the `opencode-qa` isolated XDG sandbox.
+- Created normal-path skills under isolated project `.agents/skills`, project `.claude/skills`, isolated OpenCode config `skills/`, and isolated home `.agents/skills`.
+- Called the real OpenCode `GET /skill?directory=<isolated-project>` endpoint.
+- Invoked OmO's patched native-skill adapter plus `skill` tool against that live endpoint.
+- Invoked the delegate skill resolver with the same native-skill accessor.
+
+## What Was Observed
+
+- `opencode-health.json`: server reported `healthy: true`, version `1.17.8`.
+- `opencode-skills.filtered.json`: OpenCode returned `customize-opencode`, `user-normal-skill`, `claude-normal-skill`, `config-normal-skill`, and `global-normal-skill`.
+- `omo-skill-tool-output.json`: OmO loaded `user-normal-skill` through the `skill` tool and loaded `global-normal-skill` through delegate skill resolution.
+- `manual-qa.log`: live DB session count stayed `5737` before and after, proving the run did not write to the real OpenCode DB.
+
+## Why It Is Enough
+
+This drives the reported path at the boundary that was broken: OpenCode owns normal-path skill discovery and exposes it through `app.skills`; OmO now adapts that live endpoint into the existing `skill` and `task` native-skill surfaces.
+
+## What Was Omitted
+
+- The raw `/skill` response was not kept because it includes the full built-in `customize-opencode` body with token/auth placeholder examples. The filtered JSON keeps the names, locations, descriptions, and content previews needed for review.
+- The temporary server password and Authorization header were never written to evidence.

--- a/.omo/evidence/20260630-opencode-skill-loading/manual-qa.log
+++ b/.omo/evidence/20260630-opencode-skill-loading/manual-qa.log
@@ -1,0 +1,13 @@
+Manual QA: OpenCode native skill loading through OmO skill surfaces
+Started: 2026-06-30T05:04:23Z
+opencode_version: 1.17.8
+real_db_path: /Users/yeongyu/.local/share/opencode/opencode.db
+real_db_sessions_before: 5737
+isolated_server_url: http://127.0.0.1:50820
+isolated_project: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/oqa-xdg.XXXXXX.sBooluwiGL/proj
+isolated_home: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/oqa-xdg.XXXXXX.sBooluwiGL/home
+isolated_xdg_config: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/oqa-xdg.XXXXXX.sBooluwiGL/config
+real_db_sessions_after: 5737
+real_db_isolation: unchanged
+bun_skill_tool_exit: 0
+Finished: 2026-06-30T05:04:24Z

--- a/.omo/evidence/20260630-opencode-skill-loading/omo-skill-tool-output.json
+++ b/.omo/evidence/20260630-opencode-skill-loading/omo-skill-tool-output.json
@@ -1,0 +1,15 @@
+{
+  "nativeSkillNames": [
+    "claude-normal-skill",
+    "config-normal-skill",
+    "customize-opencode",
+    "global-normal-skill",
+    "user-normal-skill"
+  ],
+  "skillToolLoadedUserSkill": true,
+  "skillToolBaseDirectory": "/private/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/oqa-xdg.XXXXXX.sBooluwiGL/proj/.agents/skills/user-normal-skill",
+  "delegateLoadedGlobalSkill": true,
+  "permissionPatterns": [
+    "user-normal-skill"
+  ]
+}

--- a/.omo/evidence/20260630-opencode-skill-loading/opencode-health.json
+++ b/.omo/evidence/20260630-opencode-skill-loading/opencode-health.json
@@ -1,0 +1,4 @@
+{
+  "healthy": true,
+  "version": "1.17.8"
+}

--- a/.omo/evidence/20260630-opencode-skill-loading/opencode-qa-common-self-check.txt
+++ b/.omo/evidence/20260630-opencode-skill-loading/opencode-qa-common-self-check.txt
@@ -1,0 +1,8 @@
+PASS: dependencies present (opencode sqlite3 curl jq tmux)
+PASS: oqa_db_path -> /Users/yeongyu/.local/share/opencode/opencode.db
+PASS: oqa_sql_escape quotes single quotes
+PASS: oqa_free_port -> 51184
+PASS: isolated XDG sandbox auto-removed on exit (/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/oqa-xdg.XXXXXX.bPj1DIeLkJ)
+PASS: isolated HOME points inside sandbox
+PASS: isolated HOME preserves HOME-based opencode shim
+PASS: common.sh self-check

--- a/.omo/evidence/20260630-opencode-skill-loading/opencode-skills.filtered.json
+++ b/.omo/evidence/20260630-opencode-skill-loading/opencode-skills.filtered.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "claude-normal-skill",
+    "description": "Skill from project .claude normal path",
+    "location": "/private/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/oqa-xdg.XXXXXX.sBooluwiGL/proj/.claude/skills/claude-normal-skill/SKILL.md",
+    "content_preview": "CLAUDE_NORMAL_SKILL_BODY_FROM_PROJECT_CLAUDE\n"
+  },
+  {
+    "name": "config-normal-skill",
+    "description": "Skill from isolated OpenCode config skills path",
+    "location": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/oqa-xdg.XXXXXX.sBooluwiGL/config/opencode/skills/config-normal-skill/SKILL.md",
+    "content_preview": "CONFIG_NORMAL_SKILL_BODY_FROM_XDG_CONFIG\n"
+  },
+  {
+    "name": "customize-opencode",
+    "description": "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself.",
+    "location": "<built-in>",
+    "content_preview": "<!--\n  Built-in skill. Name and description are registered in code at\n  packages/core/src/plugin/skill.ts\n  and CUSTOMIZ"
+  },
+  {
+    "name": "global-normal-skill",
+    "description": "Skill from isolated HOME .agents normal path",
+    "location": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/oqa-xdg.XXXXXX.sBooluwiGL/home/.agents/skills/global-normal-skill/SKILL.md",
+    "content_preview": "GLOBAL_NORMAL_SKILL_BODY_FROM_HOME_AGENTS\n"
+  },
+  {
+    "name": "user-normal-skill",
+    "description": "User skill from project .agents normal path",
+    "location": "/private/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/oqa-xdg.XXXXXX.sBooluwiGL/proj/.agents/skills/user-normal-skill/SKILL.md",
+    "content_preview": "USER_NORMAL_SKILL_BODY_FROM_PROJECT_AGENTS\n"
+  }
+]

--- a/packages/omo-opencode/src/plugin/runtime-skill-resolver.test.ts
+++ b/packages/omo-opencode/src/plugin/runtime-skill-resolver.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from "bun:test"
-import { createRuntimeSkillsResolver, type RuntimeHostSkills } from "./runtime-skill-resolver"
+import { describe, it, expect, mock } from "bun:test"
+import { createNativeSkillsAccessor, createRuntimeSkillsResolver, type RuntimeHostSkills } from "./runtime-skill-resolver"
 import type { LoadedSkill } from "../features/opencode-skill-loader/types"
+import type { SkillLoadOptions } from "../tools/skill/types"
+
+import { unsafeTestValue } from "../../../../test-support/unsafe-test-value"
 
 function skill(name: string, mcp?: Record<string, unknown>): LoadedSkill {
   return {
@@ -120,5 +123,146 @@ describe("createRuntimeSkillsResolver", () => {
 
     // then
     expect(result).toBe(base)
+  })
+})
+
+describe("createNativeSkillsAccessor", () => {
+  it("#given current OpenCode exposes app.skills #when native skills are loaded #then normal OpenCode skills are returned", async () => {
+    const appSkills = mock(async (_parameters: unknown) => ({
+      data: [
+        {
+          name: "customize-opencode",
+          location: "<built-in>",
+          content: "Use OpenCode config schemas.",
+        },
+        {
+          name: "project-skill",
+          description: "Project skill from .agents",
+          location: "/tmp/project/.agents/skills/project-skill/SKILL.md",
+          content: "Project skill body",
+        },
+      ],
+    }))
+
+    const nativeSkills = createNativeSkillsAccessor(unsafeTestValue({
+      directory: "/tmp/project",
+      client: { app: { skills: appSkills } },
+    }))
+
+    expect(nativeSkills).toBeDefined()
+    expect(await nativeSkills?.all()).toEqual([
+      {
+        name: "customize-opencode",
+        description: "",
+        location: "<built-in>",
+        content: "Use OpenCode config schemas.",
+      },
+      {
+        name: "project-skill",
+        description: "Project skill from .agents",
+        location: "/tmp/project/.agents/skills/project-skill/SKILL.md",
+        content: "Project skill body",
+      },
+    ])
+    expect(await nativeSkills?.get("project-skill")).toEqual({
+      name: "project-skill",
+      description: "Project skill from .agents",
+      location: "/tmp/project/.agents/skills/project-skill/SKILL.md",
+      content: "Project skill body",
+    })
+    expect(await nativeSkills?.dirs()).toEqual(["/tmp/project/.agents/skills/project-skill"])
+    expect(appSkills.mock.calls[0]?.[0]).toEqual({ directory: "/tmp/project" })
+  })
+
+  it("#given app.skills needs the generated SDK query shape #when direct loading has no data #then it falls back to query.directory", async () => {
+    const appSkills = mock(async (parameters: unknown) => {
+      if (parameters && typeof parameters === "object" && "query" in parameters) {
+        return {
+          data: [{
+            name: "query-shape-skill",
+            description: "Older generated SDK shape",
+            location: "/tmp/project/.opencode/skills/query-shape-skill/SKILL.md",
+            content: "Query shape body",
+          }],
+        }
+      }
+      return { data: [] }
+    })
+
+    const nativeSkills = createNativeSkillsAccessor(unsafeTestValue({
+      directory: "/tmp/project",
+      client: { app: { skills: appSkills } },
+    }))
+
+    expect(await nativeSkills?.all()).toEqual([{
+      name: "query-shape-skill",
+      description: "Older generated SDK shape",
+      location: "/tmp/project/.opencode/skills/query-shape-skill/SKILL.md",
+      content: "Query shape body",
+    }])
+    expect(appSkills.mock.calls[1]?.[0]).toEqual({ query: { directory: "/tmp/project" } })
+  })
+
+  it("#given app.skills throws #when native skills are loaded #then it degrades to an empty accessor result", async () => {
+    const appSkills = mock(async () => {
+      throw new Error("skill endpoint unavailable")
+    })
+
+    const nativeSkills = createNativeSkillsAccessor(unsafeTestValue({
+      directory: "/tmp/project",
+      client: { app: { skills: appSkills } },
+    }))
+
+    expect(await nativeSkills?.all()).toEqual([])
+    expect(await nativeSkills?.get("missing")).toBeUndefined()
+    expect(await nativeSkills?.dirs()).toEqual([])
+  })
+
+  it("#given a legacy PluginInput.skills accessor #when native skills are requested #then it is preferred over app.skills", async () => {
+    const legacySkills: NonNullable<SkillLoadOptions["nativeSkills"]> = {
+      all() {
+        return [{
+          name: "legacy-skill",
+          description: "Legacy native skill",
+          location: "/tmp/legacy/skills/legacy-skill/SKILL.md",
+          content: "Legacy body",
+        }]
+      },
+      get(name: string) {
+        return name === "legacy-skill"
+          ? {
+            name: "legacy-skill",
+            description: "Legacy native skill",
+            location: "/tmp/legacy/skills/legacy-skill/SKILL.md",
+            content: "Legacy body",
+          }
+          : undefined
+      },
+      dirs() {
+        return ["/tmp/legacy/skills/legacy-skill"]
+      },
+    }
+    const appSkills = mock(async () => ({
+      data: [{
+        name: "app-skill",
+        description: "App skill",
+        location: "/tmp/app/skills/app-skill/SKILL.md",
+        content: "App body",
+      }],
+    }))
+
+    const nativeSkills = createNativeSkillsAccessor(unsafeTestValue({
+      directory: "/tmp/project",
+      client: { app: { skills: appSkills } },
+      skills: legacySkills,
+    }))
+
+    expect(await nativeSkills?.all()).toEqual([{
+      name: "legacy-skill",
+      description: "Legacy native skill",
+      location: "/tmp/legacy/skills/legacy-skill/SKILL.md",
+      content: "Legacy body",
+    }])
+    expect(appSkills).not.toHaveBeenCalled()
   })
 })

--- a/packages/omo-opencode/src/plugin/runtime-skill-resolver.ts
+++ b/packages/omo-opencode/src/plugin/runtime-skill-resolver.ts
@@ -1,7 +1,30 @@
+import { dirname, isAbsolute } from "node:path"
+
 import type { LoadedSkill } from "../features/opencode-skill-loader/types"
+import type { SkillLoadOptions } from "../tools/skill/types"
 import type { PluginContext } from "./types"
 
 export type RuntimeHostSkills = { paths?: string[]; urls?: string[] }
+type NativeSkillAccessor = NonNullable<SkillLoadOptions["nativeSkills"]>
+type NativeSkillEntry = Awaited<ReturnType<NativeSkillAccessor["all"]>>[number]
+type AppSkillCallParameters =
+  | { readonly directory?: string }
+  | { readonly query: { readonly directory?: string } }
+
+function isObject(value: unknown): value is object {
+  return typeof value === "object" && value !== null
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+}
+
+function isRuntimeHostSkills(value: unknown): value is RuntimeHostSkills {
+  if (!isObject(value)) return false
+  const paths = Reflect.get(value, "paths")
+  const urls = Reflect.get(value, "urls")
+  return (paths === undefined || isStringArray(paths)) && (urls === undefined || isStringArray(urls))
+}
 
 /**
  * Read `skills` from opencode's merged runtime config via the plugin client.
@@ -20,14 +43,111 @@ export async function readRuntimeHostSkills(
 ): Promise<RuntimeHostSkills | undefined> {
   try {
     const result = await client.config.get()
-    const skills = (result as { data?: { skills?: unknown } }).data?.skills
-    if (skills && typeof skills === "object") {
-      return skills as RuntimeHostSkills
-    }
-  } catch {
-    // Fall back to base skills in the caller.
+    const data = isObject(result) ? Reflect.get(result, "data") : undefined
+    const skills = isObject(data) ? Reflect.get(data, "skills") : undefined
+    if (isRuntimeHostSkills(skills)) return skills
+  } catch (error) {
+    if (!(error instanceof Error)) return undefined
   }
   return undefined
+}
+
+function hasFunction(value: object, name: string): boolean {
+  return typeof Reflect.get(value, name) === "function"
+}
+
+function isNativeSkillAccessor(value: unknown): value is NativeSkillAccessor {
+  return isObject(value) && hasFunction(value, "all") && hasFunction(value, "get") && hasFunction(value, "dirs")
+}
+
+function nativeSkillEntry(value: unknown): NativeSkillEntry | undefined {
+  if (!isObject(value)) return undefined
+  const name = Reflect.get(value, "name")
+  const description = Reflect.get(value, "description")
+  const location = Reflect.get(value, "location")
+  const content = Reflect.get(value, "content")
+  if (typeof name !== "string" || typeof location !== "string" || typeof content !== "string") return undefined
+  return {
+    name,
+    description: typeof description === "string" ? description : "",
+    location,
+    content,
+  }
+}
+
+function nativeSkillEntries(response: unknown): NativeSkillEntry[] {
+  if (!isObject(response)) return []
+  const data = Reflect.get(response, "data")
+  if (!Array.isArray(data)) return []
+  return data.flatMap((entry) => {
+    const skill = nativeSkillEntry(entry)
+    return skill ? [skill] : []
+  })
+}
+
+function createAppSkillLoader(
+  client: PluginContext["client"],
+): ((parameters: AppSkillCallParameters) => Promise<NativeSkillEntry[]>) | undefined {
+  if (!isObject(client)) return undefined
+  const app = Reflect.get(client, "app")
+  if (!isObject(app)) return undefined
+  const skills = Reflect.get(app, "skills")
+  if (typeof skills !== "function") return undefined
+  return async (parameters) => {
+    const response: unknown = await Reflect.apply(skills, app, [parameters])
+    return nativeSkillEntries(response)
+  }
+}
+
+function legacyNativeSkills(ctx: PluginContext): NativeSkillAccessor | undefined {
+  const skills = Reflect.get(ctx, "skills")
+  return isNativeSkillAccessor(skills) ? skills : undefined
+}
+
+async function loadAppSkills(args: {
+  readonly load: (parameters: AppSkillCallParameters) => Promise<NativeSkillEntry[]>
+  readonly directory: string
+}): Promise<NativeSkillEntry[]> {
+  try {
+    const direct = await args.load({ directory: args.directory })
+    if (direct.length > 0) return direct
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
+  }
+  try {
+    return await args.load({ query: { directory: args.directory } })
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
+    return []
+  }
+}
+
+function skillDirs(skills: readonly NativeSkillEntry[]): string[] {
+  const dirs = new Set<string>()
+  for (const skill of skills) {
+    if (isAbsolute(skill.location)) dirs.add(dirname(skill.location))
+  }
+  return Array.from(dirs)
+}
+
+export function createNativeSkillsAccessor(ctx: PluginContext): NativeSkillAccessor | undefined {
+  const legacy = legacyNativeSkills(ctx)
+  if (legacy) return legacy
+
+  const load = createAppSkillLoader(ctx.client)
+  if (!load) return undefined
+
+  const all = () => loadAppSkills({ load, directory: ctx.directory })
+
+  return {
+    all,
+    async get(name: string) {
+      return (await all()).find((skill) => skill.name === name)
+    },
+    async dirs() {
+      return skillDirs(await all())
+    },
+  }
 }
 
 /**

--- a/packages/omo-opencode/src/plugin/tool-registry-core-tools.test.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-core-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test"
 import { tool } from "@opencode-ai/plugin"
+import type { DelegateTaskToolOptions } from "../tools/delegate-task/types"
 import type { SkillLoadOptions } from "../tools/skill/types"
 import type { ToolRegistryFactories } from "./tool-registry-factories"
 
@@ -14,17 +15,20 @@ const fakeTool = tool({
   },
 })
 
-function createFactories(createSkillTool: (options: SkillLoadOptions) => typeof fakeTool): ToolRegistryFactories {
+function createFactories(args: {
+  readonly createSkillTool: (options: SkillLoadOptions) => typeof fakeTool
+  readonly createDelegateTask?: (options: DelegateTaskToolOptions) => typeof fakeTool
+}): ToolRegistryFactories {
   return {
     createBackgroundTools: () => ({}),
     createCallOmoAgent: () => fakeTool,
     createLookAt: () => fakeTool,
     createSkillMcpTool: () => fakeTool,
-    createSkillTool,
+    createSkillTool: args.createSkillTool,
     createGrepTools: () => ({}),
     createGlobTools: () => ({}),
     createSessionManagerTools: () => ({}),
-    createDelegateTask: () => fakeTool,
+    createDelegateTask: args.createDelegateTask ?? (() => fakeTool),
     discoverCommandsSync: () => [],
     interactive_bash: fakeTool,
     createTaskCreateTool: () => fakeTool,
@@ -72,11 +76,72 @@ describe("#given disabled native skills in the registry skill context", () => {
         disabledSkills,
       },
       availableCategories: [],
-      factories: createFactories(createSkillTool),
+      factories: createFactories({ createSkillTool }),
     })
 
     // then
     expect(createSkillTool).toHaveBeenCalledTimes(1)
     expect(createSkillTool.mock.calls[0]?.[0].disabledSkills).toBe(disabledSkills)
+  })
+
+  test("#given current OpenCode exposes skills through the app skill endpoint #when core tools register the skill tool #then the skill tool can load native skills", async () => {
+    // given
+    const createSkillTool = mock((options: SkillLoadOptions) => fakeTool)
+    const createDelegateTask = mock((options: DelegateTaskToolOptions) => fakeTool)
+    const appSkills = mock(async () => ({
+      data: [
+        {
+          name: "customize-opencode",
+          description: "Built-in OpenCode config skill",
+          location: "<built-in>",
+          content: "Use OpenCode config schemas.",
+        },
+      ],
+    }))
+
+    // when
+    createCoreTools({
+      ctx: unsafeTestValue({
+        directory: "/tmp/project",
+        client: {
+          app: {
+            skills: appSkills,
+          },
+        },
+      }),
+      pluginConfig: unsafeTestValue({
+        disabled_agents: ["multimodal-looker"],
+      }),
+      managers: unsafeTestValue({
+        backgroundManager: {},
+        tmuxSessionManager: {},
+        skillMcpManager: {},
+        modelFallbackControllerAccessor: {},
+      }),
+      skillContext: {
+        mergedSkills: [],
+        availableSkills: [],
+        browserProvider: "playwright",
+        disabledSkills: new Set(),
+      },
+      availableCategories: [],
+      factories: createFactories({ createSkillTool, createDelegateTask }),
+    })
+
+    // then
+    const nativeSkills = createSkillTool.mock.calls[0]?.[0].nativeSkills
+    const delegateNativeSkills = createDelegateTask.mock.calls[0]?.[0].nativeSkills
+    expect(nativeSkills).toBeDefined()
+    expect(delegateNativeSkills).toBe(nativeSkills)
+    const loaded = await nativeSkills?.all()
+    expect(appSkills).toHaveBeenCalledWith({ directory: "/tmp/project" })
+    expect(loaded).toEqual([
+      {
+        name: "customize-opencode",
+        description: "Built-in OpenCode config skill",
+        location: "<built-in>",
+        content: "Use OpenCode config schemas.",
+      },
+    ])
   })
 })

--- a/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
@@ -1,5 +1,4 @@
 import type { ToolDefinition } from "@opencode-ai/plugin"
-import type { SkillLoadOptions } from "../tools/skill/types"
 import type { AvailableCategory } from "../agents/dynamic-agent-prompt-builder"
 import type { OhMyOpenCodeConfig } from "../config"
 import type { Managers } from "../create-managers"
@@ -12,7 +11,7 @@ import * as openclawRuntimeDispatch from "../openclaw/runtime-dispatch"
 import { log } from "../shared"
 import { getSisyphusJuniorModelOverride } from "./tool-registry-team-tools"
 import { createSkillContext } from "./skill-context"
-import { createRuntimeSkillsResolver, readRuntimeHostSkills } from "./runtime-skill-resolver"
+import { createNativeSkillsAccessor, createRuntimeSkillsResolver, readRuntimeHostSkills } from "./runtime-skill-resolver"
 
 export function createCoreTools(args: {
   readonly ctx: PluginContext
@@ -35,6 +34,7 @@ export function createCoreTools(args: {
   const isMultimodalLookerEnabled = !(pluginConfig.disabled_agents ?? []).some(
     (agent) => agent.toLowerCase() === "multimodal-looker",
   )
+  const nativeSkills = createNativeSkillsAccessor(ctx)
   const delegateTask = factories.createDelegateTask({
     manager: managers.backgroundManager,
     client: ctx.client,
@@ -48,7 +48,7 @@ export function createCoreTools(args: {
     teamModeEnabled: pluginConfig.team_mode?.enabled ?? false,
     availableCategories,
     availableSkills: skillContext.availableSkills,
-    nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
+    nativeSkills,
     sisyphusAgentConfig: pluginConfig.sisyphus_agent,
     syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
     modelFallbackControllerAccessor: managers.modelFallbackControllerAccessor,
@@ -109,7 +109,7 @@ export function createCoreTools(args: {
     browserProvider: skillContext.browserProvider,
     disabledSkills: skillContext.disabledSkills,
     teamModeEnabled: pluginConfig.team_mode?.enabled ?? false,
-    nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
+    nativeSkills,
     pluginsEnabled: pluginConfig.claude_code?.plugins ?? true,
     enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
     includeSkillsInDescription: true,


### PR DESCRIPTION
## Summary

Fixes OmO/OpenCode skill-tool loading for normal OpenCode skills that are not OmO-owned. Current OpenCode exposes built-in/default/user skills through the `app.skills` endpoint, but OmO was still only looking for the older `PluginInput.skills` accessor, so `skill` and delegated `load_skills` could miss skills that OpenCode itself had discovered.

The fix adds a compatibility native-skill accessor that prefers the legacy `ctx.skills` shape when present, otherwise adapts `ctx.client.app.skills({ directory })` into OmO's existing native-skill interface. The same accessor is now passed to both the OmO `skill` tool and `task` delegate path.

## Source Evidence

Primary OpenCode source checked during the investigation was upstream `opencode-ai/opencode` at commit `451876b`:

- `packages/opencode/src/skill/index.ts`: OpenCode scans project/global `.claude/skills`, `.agents/skills`, OpenCode config `skill(s)` dirs, configured `skills.paths`/`skills.urls`, and built-in `customize-opencode`.
- `packages/opencode/src/server/routes/instance/httpapi/handlers/instance.ts`: `GET /skill` returns `skill.all()`.
- `packages/opencode/src/server/routes/instance/httpapi/groups/instance.ts`: `/skill` is exposed as `app.skills`.
- `packages/opencode/src/tool/skill.ts`: native OpenCode `skill` tool loads from `Skill.Service`.
- Installed SDK `@opencode-ai/sdk@1.15.13` exposes v2 `client.app.skills({ directory })` in `dist/v2/gen/sdk.gen.d.ts`.

The temporary upstream clone used for investigation was removed after the fix.

## Changes

- Added `createNativeSkillsAccessor()` in `packages/omo-opencode/src/plugin/runtime-skill-resolver.ts`.
- Normalizes `app.skills` responses into OmO native skill entries, including optional descriptions, built-in locations, `get()`, and `dirs()` support.
- Supports both current direct SDK shape `{ directory }` and older generated SDK query shape `{ query: { directory } }`.
- Keeps legacy `ctx.skills` compatibility and prefers it when available.
- Wires the accessor once in `createCoreTools()` and shares it between `skill` and `task`.
- Adds focused regression coverage for endpoint-backed native skills, fallback behavior, failure fallback, legacy preference, and registry wiring.

## Tests

- `bun test packages/omo-opencode/src/plugin/runtime-skill-resolver.test.ts packages/omo-opencode/src/plugin/tool-registry-core-tools.test.ts`
- `bun test packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts packages/omo-opencode/src/tools/delegate-task/skill-resolver.test.ts packages/omo-opencode/src/plugin/skill-context-shared-skill.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-opencode/src/plugin/runtime-skill-resolver.ts packages/omo-opencode/src/plugin/runtime-skill-resolver.test.ts packages/omo-opencode/src/plugin/tool-registry-core-tools.ts packages/omo-opencode/src/plugin/tool-registry-core-tools.test.ts`
- `bun run --cwd packages/omo-opencode typecheck`
- `git diff --check`

## Manual QA & Evidence

Evidence is committed under `.omo/evidence/20260630-opencode-skill-loading/`.

- `.omo/evidence/20260630-opencode-skill-loading/opencode-qa-common-self-check.txt`: `opencode-qa` helper dependencies and isolated XDG cleanup self-check passed.
- `.omo/evidence/20260630-opencode-skill-loading/manual-qa.log`: isolated `opencode serve` 1.17.8 run; live DB session count stayed `5737` before and after.
- `.omo/evidence/20260630-opencode-skill-loading/opencode-health.json`: real server health check returned healthy.
- `.omo/evidence/20260630-opencode-skill-loading/opencode-skills.filtered.json`: real `/skill` endpoint returned built-in `customize-opencode`, project `.agents`, project `.claude`, isolated config, and isolated home `.agents` skills.
- `.omo/evidence/20260630-opencode-skill-loading/omo-skill-tool-output.json`: OmO `skill` tool loaded `user-normal-skill`, and delegate skill resolution loaded `global-normal-skill` through the same native accessor.
- `.omo/evidence/20260630-opencode-skill-loading/QA-REPORT.md`: what was tested, observed, why it is sufficient, and what was omitted.

## Risks & Residuals

- The adapter intentionally does not duplicate OpenCode skill discovery rules; OpenCode remains the source of truth via `/skill`.
- If a future SDK changes the `app.skills` response shape, the adapter degrades to an empty native skill list instead of breaking tool registration; tests cover the current and older request shapes.
- Full root `bun run build` was not run because the touched package has a targeted typecheck and the full build runs unrelated cross-package packaging/npm-ci work. Coordinator can decide if they want that heavier gate before merge.

Coordinator will review/QA and decide merge; this PR should not be merged by this lane.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenCode native skill loading in OmO by using the OpenCode `app.skills` endpoint when legacy `ctx.skills` isn’t available. Restores loading for normal user and built-in skills in both the `skill` tool and delegated task path.

- **Bug Fixes**
  - Added `createNativeSkillsAccessor()` that prefers legacy `ctx.skills`, otherwise adapts `client.app.skills({ directory })` to OmO’s native skill shape.
  - Supports both `{ directory }` and `{ query: { directory } }` request shapes from `@opencode-ai/sdk`.
  - Normalizes entries (name, description, location, content) and provides `all()`, `get()`, `dirs()`.
  - Wired once in `createCoreTools()` and shared by `skill` and `delegate-task`.
  - Safe fallback: endpoint errors or shape changes return an empty list instead of breaking tool registration.
  - Added focused tests and QA evidence validating live endpoint loading and legacy preference.

<sup>Written for commit 76050162ef80780a431b0feac6079257a168f1f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

