### PR TITLE
fix(agents): support Hephaestus on GLM coding providers

### DIFF
--- a/packages/model-core/src/agent-model-requirements.ts
+++ b/packages/model-core/src/agent-model-requirements.ts
@@ -36,8 +36,13 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "gpt-5.5",
         variant: "medium",
       },
+      {
+        providers: ["zai-coding-plan", "opencode", "bailian-coding-plan", "vercel"],
+        model: "glm-5",
+        variant: "medium",
+      },
     ],
-    requiresProvider: ["openai", "github-copilot", "opencode", "vercel"],
+    requiresProvider: ["openai", "github-copilot", "opencode", "vercel", "zai-coding-plan", "bailian-coding-plan"],
     requiresAnyModel: true,
   },
   oracle: {

--- a/packages/model-core/src/model-requirements-agents.test.ts
+++ b/packages/model-core/src/model-requirements-agents.test.ts
@@ -244,7 +244,7 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(bigPickleIndex).toBeGreaterThan(minimaxIndex)
   })
 
-  test("hephaestus supports openai, github-copilot, opencode, and vercel providers", () => {
+  test("hephaestus supports GPT providers plus GLM coding-plan fallback providers", () => {
     // given
     const hephaestus = AGENT_MODEL_REQUIREMENTS["hephaestus"]
 
@@ -254,7 +254,14 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
       "github-copilot",
       "opencode",
       "vercel",
+      "zai-coding-plan",
+      "bailian-coding-plan",
     ])
+    expect(hephaestus.fallbackChain).toContainEqual({
+      providers: ["zai-coding-plan", "opencode", "bailian-coding-plan", "vercel"],
+      model: "glm-5",
+      variant: "medium",
+    })
     expect(hephaestus.requiresProvider).not.toContain("venice")
     expect(hephaestus.fallbackChain[0]?.providers).not.toContain("venice")
     expect(hephaestus.requiresModel).toBeUndefined()

--- a/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
@@ -5,6 +5,7 @@ import {
   getHephaestusPromptSource,
   getHephaestusPrompt,
   createHephaestusAgent,
+  isHephaestusSupportedModel,
   UnsupportedHephaestusModelError,
 } from "./index";
 
@@ -74,6 +75,23 @@ describe("getHephaestusPromptSource", () => {
     expect(source3).toBe("gpt");
   });
 
+  test("returns 'gpt' for GLM coding-plan models", () => {
+    // given
+    const model1 = "zai-coding-plan/glm-5.2";
+    const model2 = "bailian-coding-plan/glm-5";
+    const model3 = "opencode/glm-5.1";
+
+    // when
+    const source1 = getHephaestusPromptSource(model1);
+    const source2 = getHephaestusPromptSource(model2);
+    const source3 = getHephaestusPromptSource(model3);
+
+    // then
+    expect(source1).toBe("gpt");
+    expect(source2).toBe("gpt");
+    expect(source3).toBe("gpt");
+  });
+
   test("throws for generic GPT, unsupported GPT 5.x, non-GPT, and undefined models", () => {
     // given
     const model1 = "openai/gpt-4o";
@@ -95,6 +113,13 @@ describe("getHephaestusPromptSource", () => {
     expect(getSource3).toThrow(UnsupportedHephaestusModelError);
     expect(getSource4).toThrow(UnsupportedHephaestusModelError);
     expect(getSource5).toThrow(UnsupportedHephaestusModelError);
+  });
+
+  test("supports GLM but not unrelated non-GPT models", () => {
+    // given / when / then
+    expect(isHephaestusSupportedModel("zai-coding-plan/glm-5.2")).toBe(true);
+    expect(isHephaestusSupportedModel("anthropic/claude-opus-4-7")).toBe(false);
+    expect(isHephaestusSupportedModel("kimi-for-coding/k2p5")).toBe(false);
   });
 });
 
@@ -151,6 +176,19 @@ describe("getHephaestusPrompt", () => {
     expect(prompt).toContain("Senior Staff Engineer");
     expect(prompt).toContain("KEEP GOING");
     expect(prompt).not.toContain("intent_extraction");
+  });
+
+  test("GLM coding-plan model returns generic deep-worker prompt", () => {
+    // given
+    const model = "zai-coding-plan/glm-5.2";
+
+    // when
+    const prompt = getHephaestusPrompt(model);
+
+    // then
+    expect(prompt).toContain("Senior Staff Engineer");
+    expect(prompt).toContain("KEEP GOING");
+    expect(prompt).toContain("Hephaestus");
   });
 
   test("Claude model is rejected", () => {
@@ -278,6 +316,19 @@ describe("createHephaestusAgent", () => {
     expect(gpt53CodexConfig.permission ?? {}).not.toHaveProperty("apply_patch");
   });
 
+  test("GLM coding-plan model creates Hephaestus config with generic prompt", () => {
+    // given
+    const model = "zai-coding-plan/glm-5.2";
+
+    // when
+    const config = createHephaestusAgent(model);
+
+    // then
+    expect(config.model).toBe(model);
+    expect(config.prompt).toContain("Senior Staff Engineer");
+    expect(config.permission ?? {}).not.toHaveProperty("apply_patch");
+  });
+
   test("useTaskSystem=true produces Task Discipline prompt", () => {
     // given
     const model = "openai/gpt-5.4";
@@ -372,6 +423,37 @@ describe("maybeCreateHephaestusConfig apply_patch permission", () => {
 
       // then
       expect(config).toBeUndefined();
+    });
+  });
+
+  describe("#given GLM coding-plan model with user override", () => {
+    test("#when config is created #then Hephaestus is registered", () => {
+      // given
+      const agentOverrides: AgentOverrides = {
+        hephaestus: {
+          model: "zai-coding-plan/glm-5.2",
+        },
+      };
+      const mergedCategories: Record<string, CategoryConfig> = {};
+
+      // when
+      const config = maybeCreateHephaestusConfig({
+        disabledAgents: [],
+        agentOverrides,
+        availableModels: new Set(["zai-coding-plan/glm-5.2"]),
+        systemDefaultModel: "zai-coding-plan/glm-5.2",
+        isFirstRunNoCache: false,
+        availableAgents: [],
+        availableSkills: [],
+        availableCategories: [],
+        mergedCategories,
+        useTaskSystem: false,
+      });
+
+      // then
+      expect(config).toBeDefined();
+      expect(config?.model).toBe("zai-coding-plan/glm-5.2");
+      expect(config?.variant).toBe("medium");
     });
   });
 

--- a/packages/omo-opencode/src/agents/hephaestus/agent.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "../types";
-import { isGpt5_5Model } from "../types";
+import { isGlmModel, isGpt5_5Model } from "../types";
 import type {
   AvailableAgent,
   AvailableTool,
@@ -26,7 +26,7 @@ export class UnsupportedHephaestusModelError extends Error {
 
   constructor(model: string | undefined) {
     super(
-      `Hephaestus only supports GPT-5.3 Codex, GPT-5.4, and GPT-5.5 models; received ${model ?? "no model"}.`,
+      `Hephaestus only supports GPT-5.3 Codex, GPT-5.4, GPT-5.5, and GLM models; received ${model ?? "no model"}.`,
     );
     this.name = "UnsupportedHephaestusModelError";
     this.model = model;
@@ -40,7 +40,7 @@ function extractModelName(model: string): string {
 export function isHephaestusSupportedModel(model: string | undefined): boolean {
   if (!model) return false;
   const modelName = extractModelName(model);
-  return GPT_5_3_CODEX_RE.test(modelName) || GPT_5_4_RE.test(modelName) || GPT_5_5_RE.test(modelName);
+  return GPT_5_3_CODEX_RE.test(modelName) || GPT_5_4_RE.test(modelName) || GPT_5_5_RE.test(modelName) || isGlmModel(model);
 }
 
 function assertHephaestusSupportedModel(model: string | undefined): void {
@@ -149,7 +149,7 @@ export function createHephaestusAgent(
 
   return {
     description:
-      "Autonomous Deep Worker - goal-oriented execution with GPT Codex. Explores thoroughly before acting, uses explore/librarian agents for comprehensive context, completes tasks end-to-end. Inspired by AmpCode deep mode. (Hephaestus - OhMyOpenCode)",
+      "Autonomous Deep Worker - goal-oriented execution with GPT/GLM coding models. Explores thoroughly before acting, uses explore/librarian agents for comprehensive context, completes tasks end-to-end. Inspired by AmpCode deep mode. (Hephaestus - OhMyOpenCode)",
     mode: MODE,
     model,
     maxTokens: 32000,

--- a/packages/omo-opencode/src/agents/utils.test.ts
+++ b/packages/omo-opencode/src/agents/utils.test.ts
@@ -802,6 +802,25 @@ describe("createBuiltinAgents with requiresProvider gating (hephaestus)", () => 
     }
   })
 
+  test("hephaestus is created when zai-coding-plan provider is connected with a GLM model", async () => {
+    // #given - zai-coding-plan provider has a GLM coding model available
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
+      new Set(["zai-coding-plan/glm-5.2"])
+    )
+
+    try {
+      // #when
+      const agents = await createBuiltinAgents([], {}, undefined, TEST_DEFAULT_MODEL, undefined, undefined, [], {})
+
+      // #then
+      expect(agents.hephaestus).toBeDefined()
+      expect(agents.hephaestus.model).toBe("zai-coding-plan/glm-5.2")
+      expect(agents.hephaestus.variant).toBe("medium")
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   test("hephaestus is created on first run when no availableModels or cache exist", async () => {
     // #given
     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)

--- a/packages/omo-opencode/src/cli/model-fallback.test.ts
+++ b/packages/omo-opencode/src/cli/model-fallback.test.ts
@@ -98,10 +98,13 @@ describe("generateModelConfig", () => {
       // #when generateModelConfig is called
       const result = generateModelConfig(config)
 
-      // #then Bailian is limited to compatible utility routes
+      // #then Bailian is limited to compatible utility routes plus GLM Hephaestus
       expect(result.agents?.librarian?.model).toBe("bailian-coding-plan/qwen3.5-plus")
       expect(result.agents?.explore?.model).toBe("bailian-coding-plan/qwen3.5-plus")
-      expect(result.agents?.hephaestus).toBeUndefined()
+      expect(result.agents?.hephaestus).toEqual({
+        model: "bailian-coding-plan/glm-5",
+        variant: "medium",
+      })
     })
   })
 
@@ -325,7 +328,7 @@ describe("generateModelConfig", () => {
       expect(result.agents?.hephaestus).toBeUndefined()
     })
 
-    test("Hephaestus is omitted when only ZAI is available (no required provider connected)", () => {
+    test("Hephaestus is created when only ZAI coding-plan is available", () => {
       // #given
       const config = createConfig({ hasZaiCodingPlan: true })
 
@@ -333,7 +336,10 @@ describe("generateModelConfig", () => {
       const result = generateModelConfig(config)
 
       // #then
-      expect(result.agents?.hephaestus).toBeUndefined()
+      expect(result.agents?.hephaestus).toEqual({
+        model: "zai-coding-plan/glm-5",
+        variant: "medium",
+      })
     })
   })
 

--- a/packages/omo-opencode/src/hooks/no-hephaestus-non-gpt/hook.ts
+++ b/packages/omo-opencode/src/hooks/no-hephaestus-non-gpt/hook.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { isGptModel } from "../../agents/types"
+import { isHephaestusSupportedModel } from "../../agents/hephaestus"
 import {
   getSessionAgent,
   resolveRegisteredAgentName,
@@ -8,11 +8,11 @@ import {
 import { log } from "../../shared"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
 
-const TOAST_TITLE = "NEVER Use Hephaestus with Non-GPT"
+const TOAST_TITLE = "Unsupported Hephaestus Model"
 const TOAST_MESSAGE = [
-  "Hephaestus is designed exclusively for GPT models.",
-  "Hephaestus is trash without GPT.",
-  "For Claude/Kimi/GLM models, always use Sisyphus.",
+  "Hephaestus is designed for GPT and GLM coding models.",
+  "This model is unsupported for Hephaestus.",
+  "For Claude/Kimi models, always use Sisyphus.",
 ].join("\n")
 type NoHephaestusNonGptHookOptions = {
   allowNonGptModel?: boolean
@@ -51,7 +51,10 @@ export function createNoHephaestusNonGptHook(
       const modelID = input.model?.modelID
       const allowNonGptModel = options?.allowNonGptModel === true
 
-      if (agentKey === "hephaestus" && modelID && !isGptModel(modelID)) {
+      const providerID = input.model?.providerID
+      const modelForSupportCheck = providerID ? `${providerID}/${modelID}` : modelID
+
+      if (agentKey === "hephaestus" && modelID && !isHephaestusSupportedModel(modelForSupportCheck)) {
         showToast(ctx, input.sessionID, allowNonGptModel ? "warning" : "error")
         if (allowNonGptModel) {
           return

--- a/packages/omo-opencode/src/hooks/no-hephaestus-non-gpt/index.test.ts
+++ b/packages/omo-opencode/src/hooks/no-hephaestus-non-gpt/index.test.ts
@@ -45,8 +45,8 @@ describe("no-hephaestus-non-gpt hook", () => {
     expect(output2.message.agent).toBe("sisyphus")
     expect(showToast.mock.calls[0]?.[0]).toMatchObject({
       body: {
-        title: "NEVER Use Hephaestus with Non-GPT",
-        message: expect.stringContaining("Hephaestus is trash without GPT."),
+        title: "Unsupported Hephaestus Model",
+        message: expect.stringContaining("This model is unsupported for Hephaestus."),
         variant: "error",
       },
     })
@@ -75,10 +75,31 @@ describe("no-hephaestus-non-gpt hook", () => {
     expect(output.message.agent).toBeUndefined()
     expect(showToast.mock.calls[0]?.[0]).toMatchObject({
       body: {
-        title: "NEVER Use Hephaestus with Non-GPT",
+        title: "Unsupported Hephaestus Model",
         variant: "warning",
       },
     })
+  })
+
+  test("does not switch agent when hephaestus uses supported GLM model", async () => {
+    // given - hephaestus with GLM coding-plan model
+    const showToast = spyOn({ fn: async (_input: unknown) => ({}) }, "fn")
+    const hook = createNoHephaestusNonGptHook(unsafeTestValue({
+      client: { tui: { showToast } },
+    }))
+
+    const output = createOutput()
+
+    // when - chat.message runs
+    await hook["chat.message"]?.({
+      sessionID: "ses_glm",
+      agent: HEPHAESTUS_DISPLAY,
+      model: { providerID: "zai-coding-plan", modelID: "glm-5.2" },
+    }, output)
+
+    // then - GLM is a supported Hephaestus model and should remain selected
+    expect(showToast).toHaveBeenCalledTimes(0)
+    expect(output.message.agent).toBeUndefined()
   })
 
   test("does not show toast when hephaestus uses gpt model", async () => {


### PR DESCRIPTION
## Summary

Fixes the Hephaestus agent registration path for `zai-coding-plan` / GLM users. Hephaestus now accepts GLM coding models, its model requirements include the GLM coding-plan providers, and the unsupported-model guard no longer switches supported GLM Hephaestus sessions back to Sisyphus.

Fixes #5568

## Changes

- Add a GLM fallback entry for Hephaestus model requirements and include `zai-coding-plan` / `bailian-coding-plan` in the provider gate.
- Extend Hephaestus support checks and prompt routing so GLM coding-plan models use the generic deep-worker prompt.
- Update the Hephaestus guard hook to reject only unsupported models, not all non-GPT models.
- Update CLI model fallback expectations for ZAI/Bailian GLM Hephaestus config.
- Add coverage for GLM fallback requirements, explicit GLM Hephaestus overrides, registration, and guard behavior.

## Verification

Automated:

- `bun test packages/omo-opencode/src/cli/model-fallback.test.ts` -> `50 pass`, `0 fail`
- `bun test packages/model-core/src/model-requirements-agents.test.ts packages/omo-opencode/src/agents/hephaestus/agent.test.ts packages/omo-opencode/src/agents/utils.test.ts packages/omo-opencode/src/hooks/no-hephaestus-non-gpt/index.test.ts` -> `123 pass`, `0 fail`
- `bun test packages/model-core/src/model-requirements-invariants.test.ts packages/model-core/src/model-capabilities.test.ts` -> pass (artifact recorded)
- `bun run typecheck:packages` -> `exit=0`
- `git diff --check` -> clean

Manual QA / harness evidence:

- Evidence directory: `.omo/evidence/20260630-hephaestus-zai-glm-5568/`
- OpenCode `1.17.11` server smoke ran in isolated `XDG_*`, `HOME`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `TEMP`, and `TMP` sandbox directories with a project-local plugin shim importing this branch source.
- Issue scenario smoke used project-local `.opencode/oh-my-openagent.jsonc` with `agents.hephaestus.model = zai-coding-plan/glm-5.2`; `/agent` returned `Hephaestus - Deep Agent` with `model.providerID = zai-coding-plan` and `model.modelID = glm-5.2`.
- SSE `/event` emitted `server.connected`.
- Real OpenCode DB session count stayed unchanged: `3376` before and `3376` after.

Local note: the Bash helper scripts from `opencode-qa` were not usable on this Windows host, so equivalent PowerShell-driven isolated OpenCode server smoke plus `opencode db` receipts were captured.