### PR TITLE
fix(look-at): skip delegation for native vision models

### DIFF
--- a/packages/omo-opencode/src/tools/look-at/AGENTS.md
+++ b/packages/omo-opencode/src/tools/look-at/AGENTS.md
@@ -4,16 +4,17 @@
 
 ## OVERVIEW
 
-14 files. The `look_at` tool delegates image, PDF, and diagram analysis to the `multimodal-looker` subagent. Conditional gate: tool is only registered when `multimodal-looker` is not in `disabled_agents`. Default subagent model: gpt-5.5 medium. This is a summary extractor, not a precise reader.
+14 files. The `look_at` tool delegates image, PDF, and diagram analysis to the `multimodal-looker` subagent only when the current model is not known to support native vision. If the current parent-session model is in the vision-capable model cache, `look_at` skips child-session delegation and tells the caller to use the native `Read` path so the current model can inspect the media directly. Conditional gate: tool is only registered when `multimodal-looker` is not in `disabled_agents`. Default subagent model: gpt-5.5 medium. This is a summary extractor, not a precise reader.
 
 ## EXECUTION FLOW
 
 1. **Args** (`look-at-arguments.ts`) -- normalize `file_path`/`image_data` aliases, validate one-of requirement, reject remote URLs
 2. **Prep** (`look-at-input-preparer.ts`) -- resolve path, detect MIME from extension or Base64 header, convert unsupported images to JPEG
-3. **Spawn** (`look-at-session-runner.ts`) -- create child session with `multimodal-looker` agent, attach file as message part, disable `task`/`call_omo_agent`/`look_at` to prevent recursion
-4. **Poll** (`session-poller.ts`) -- wait until idle (1s interval, 120s timeout)
-5. **Extract** (`assistant-message-extractor.ts`) -- pull latest assistant text from session messages
-6. **Return** -- summary text back to caller
+3. **Native vision check** (`tools.ts`) -- if the current session message model matches the vision-capable cache, skip delegation and return native `Read` guidance
+4. **Spawn** (`look-at-session-runner.ts`) -- otherwise create child session with `multimodal-looker` agent, attach file as message part, disable `task`/`call_omo_agent`/`look_at` to prevent recursion
+5. **Poll** (`session-poller.ts`) -- wait until idle (1s interval, 120s timeout)
+6. **Extract** (`assistant-message-extractor.ts`) -- pull latest assistant text from session messages
+7. **Return** -- summary text back to caller
 
 ## FILE CATALOG
 
@@ -44,7 +45,7 @@ PDFs, screenshots, diagrams -- quick summary extraction. NOT for visual precisio
 
 ## DISTINCTION
 
-This is the TOOL that DELEGATES TO the `multimodal-looker` AGENT. The agent lives in `src/agents/builtin-agents/multimodal-looker.ts`; this tool is the invocation harness.
+This is the TOOL that usually DELEGATES TO the `multimodal-looker` AGENT. The agent lives in `src/agents/builtin-agents/multimodal-looker.ts`; this tool is the invocation harness. Native-vision parent models bypass that delegation path.
 
 ## NOTES
 

--- a/packages/omo-opencode/src/tools/look-at/tools.test.ts
+++ b/packages/omo-opencode/src/tools/look-at/tools.test.ts
@@ -307,6 +307,50 @@ describe("look-at tool", () => {
   })
 
   describe("createLookAt model passthrough", () => {
+    test("#given current model supports native vision #when look_at executes #then it skips multimodal-looker delegation", async () => {
+      setVisionCapableModelsCache(new Map([["openai/gpt-5.5", { providerID: "openai", modelID: "gpt-5.5" }]]))
+
+      const createSession = mock(async () => {
+        throw new Error("look_at should not create a multimodal-looker session")
+      })
+
+      const mockClient = {
+        session: {
+          messages: async () => ({
+            data: [
+              {
+                id: "parent-message",
+                info: {
+                  role: "assistant",
+                  model: { providerID: "openai", modelID: "gpt-5.5" },
+                  time: { created: 1 },
+                },
+              },
+            ],
+          }),
+          get: async () => ({ data: { directory: "/project" } }),
+          create: createSession,
+          prompt: async () => ({}),
+        },
+      }
+
+      const tool = createLookAt(unsafeTestValue({
+        client: mockClient,
+        directory: "/project",
+      }))
+
+      const result = await tool.execute(
+        { file_path: "/test/file.png", goal: "analyze image" },
+        createToolContext(),
+      )
+
+      expect(createSession).not.toHaveBeenCalled()
+      expect(result).toContain("native vision")
+      expect(result).toContain("Read")
+      expect(result).toContain("/test/file.png")
+      expect(result).not.toContain("multimodal-looker")
+    })
+
     // given multimodal-looker agent has resolved model info
     // when LookAt tool executed
     // then model info should be passed to sync prompt

--- a/packages/omo-opencode/src/tools/look-at/tools.ts
+++ b/packages/omo-opencode/src/tools/look-at/tools.ts
@@ -7,8 +7,89 @@ import { normalizeArgs, validateArgs } from "./look-at-arguments"
 import { prepareLookAtInput } from "./look-at-input-preparer"
 import { runLookAtSession } from "./look-at-session-runner"
 import { getMissingLookAtFilePath } from "./missing-file-error"
+import { normalizeSDKResponse } from "../../shared"
+import { readVisionCapableModelsCache } from "../../shared/vision-capable-models-cache"
 
 export { normalizeArgs, validateArgs } from "./look-at-arguments"
+
+type CurrentModelInfo = {
+  providerID: string
+  modelID: string
+}
+
+type SDKMessageWithModel = {
+  id?: string
+  info?: {
+    model?: {
+      providerID?: string
+      modelID?: string
+    }
+    providerID?: string
+    modelID?: string
+    time?: {
+      created?: number
+    }
+  }
+}
+
+function readMessageModel(message: SDKMessageWithModel): CurrentModelInfo | null {
+  const providerID = message.info?.model?.providerID ?? message.info?.providerID
+  const modelID = message.info?.model?.modelID ?? message.info?.modelID
+  if (!providerID || !modelID) {
+    return null
+  }
+  return { providerID, modelID }
+}
+
+async function resolveCurrentModel(ctx: PluginInput, sessionID: string, messageID: string): Promise<CurrentModelInfo | null> {
+  try {
+    const response = await ctx.client.session.messages({ path: { id: sessionID } })
+    const messages = normalizeSDKResponse(response, [] as SDKMessageWithModel[])
+    const exactMessage = messages.find((message) => message.id === messageID)
+    const exactModel = exactMessage ? readMessageModel(exactMessage) : null
+    if (exactModel) {
+      return exactModel
+    }
+
+    const sortedMessages = [...messages].sort((left, right) => {
+      const leftTime = left.info?.time?.created ?? Number.NEGATIVE_INFINITY
+      const rightTime = right.info?.time?.created ?? Number.NEGATIVE_INFINITY
+      if (leftTime !== rightTime) return rightTime - leftTime
+      return (right.id ?? "").localeCompare(left.id ?? "")
+    })
+
+    for (const message of sortedMessages) {
+      const model = readMessageModel(message)
+      if (model) {
+        return model
+      }
+    }
+  } catch (error) {
+    log("[look_at] Failed to resolve current model for native vision check:", error)
+  }
+  return null
+}
+
+function isVisionCapableModel(model: CurrentModelInfo | null, visionCapableModels = readVisionCapableModelsCache()): model is CurrentModelInfo {
+  if (!model) {
+    return false
+  }
+  return visionCapableModels.some((candidate) =>
+    candidate.providerID === model.providerID && candidate.modelID === model.modelID
+  )
+}
+
+function buildNativeVisionGuidance(args: LookAtArgs, model: CurrentModelInfo): string {
+  const filePaths = args.file_paths ?? (args.file_path ? [args.file_path] : [])
+  const imageDataCount = (args.image_data_list ?? (args.image_data ? [args.image_data] : [])).length
+  const filePathText = filePaths.length > 0
+    ? `Use the Read tool directly on ${filePaths.map((filePath) => `"${filePath}"`).join(", ")} so ${model.providerID}/${model.modelID} can inspect the media with native vision.`
+    : `Attach or paste the image directly in the current conversation so ${model.providerID}/${model.modelID} can inspect it with native vision.`
+  const clipboardText = imageDataCount > 0 && filePaths.length > 0
+    ? "\nFor pasted clipboard images, attach or paste them directly in the current conversation instead of delegating through look_at."
+    : ""
+  return `Skipped look_at delegation because the current model supports native vision.\n\n${filePathText}${clipboardText}\n\nGoal: ${args.goal}`
+}
 
 export function createLookAt(ctx: PluginInput): ToolDefinition {
   return tool({
@@ -38,6 +119,15 @@ export function createLookAt(ctx: PluginInput): ToolDefinition {
       log(`[look_at] Analyzing ${sourceDescription}, goal: ${args.goal}`)
 
       try {
+        const visionCapableModels = readVisionCapableModelsCache()
+        if (visionCapableModels.length > 0) {
+          const currentModel = await resolveCurrentModel(ctx, toolContext.sessionID, toolContext.messageID)
+          if (isVisionCapableModel(currentModel, visionCapableModels)) {
+            log(`[look_at] Skipping multimodal-looker delegation because ${currentModel.providerID}/${currentModel.modelID} supports native vision`)
+            return buildNativeVisionGuidance(args, currentModel)
+          }
+        }
+
         return await runLookAtSession({
           ctx,
           toolContext,


### PR DESCRIPTION
## Summary
- skip `look_at` child-session delegation when the parent session's current model is known to support native vision
- return native `Read` guidance for file paths / pasted images so the current model can inspect media directly
- keep existing `multimodal-looker` fallback behavior for non-vision or unknown current models
- update the look-at local AGENTS notes to document the native-vision bypass

Fixes #4624.

## Verification
- `bun test packages/omo-opencode/src/tools/look-at/tools.test.ts --timeout 30000`
- `bun test packages/omo-opencode/src/tools/look-at --timeout 30000`
- `bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json`
- `git diff --check`
- OpenCode QA evidence under `.omo/evidence/20260630-look-at-native-vision-4624/`:
  - isolated `opencode serve` using local source plugin
  - `/global/health` healthy on OpenCode 1.17.11
  - `/doc` returned 156 paths
  - `/agent` included OMO agents including Sisyphus and `multimodal-looker`
  - real OpenCode DB session count unchanged: 3376 -> 3376

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `multimodal-looker` delegation in `look_at` when the current session model supports native vision and return native `Read` guidance so the parent model inspects media directly. Keeps the existing fallback for non‑vision or unknown models (Fixes #4624).

- **Bug Fixes**
  - Detect current model from session messages and check a vision-capable model cache.
  - Skip child session and return `Read` instructions for files or pasted images; otherwise use `multimodal-looker`.
  - Update `AGENTS.md` and add a test asserting the native‑vision passthrough.

<sup>Written for commit 12658450b1404c8f4b5779c2e5c7adfff1c25500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

