### PR TITLE
revert(codex): keep lazycodex install codex-only

### DIFF
--- a/.agents/skills/codex-qa/references/install-verify.md
+++ b/.agents/skills/codex-qa/references/install-verify.md
@@ -10,7 +10,7 @@ contained.
 export CODEX_HOME="$(mktemp -d)/codex"; mkdir -p "$CODEX_HOME"   # must exist first
 export OMO_DISABLE_POSTHOG=1 OMO_CODEX_DISABLE_POSTHOG=1
 export OMO_CODEX_PROJECT="$(mktemp -d)/project"                  # keep project-local cleanup off your tree
-node packages/omo-codex/scripts/install-local.mjs install --platform=codex
+node packages/omo-codex/scripts/install-local.mjs install
 ```
 
 `cqa_install_local_omo` wraps this (logs to `$CQA_HOME_ROOT/install.log`).

--- a/.agents/skills/codex-qa/scripts/lib/common.sh
+++ b/.agents/skills/codex-qa/scripts/lib/common.sh
@@ -116,7 +116,7 @@ cqa_install_local_omo() {
   fi
   local installer="$repo/packages/omo-codex/scripts/install-local.mjs"
   [ -f "$installer" ] || { cqa_fail "installer not found: $installer"; return 1; }
-  node "$installer" install --platform=codex >"$CQA_HOME_ROOT/install.log" 2>&1
+  node "$installer" install >"$CQA_HOME_ROOT/install.log" 2>&1
 }
 
 # Teardown everything the helpers created. Safe to call multiple times.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -705,12 +705,7 @@ jobs:
               export CODEX_LOCAL_BIN_DIR="$SMOKE_DIR/bin"
               mkdir -p "$HOME" "$CODEX_HOME" "$CODEX_LOCAL_BIN_DIR" "$SMOKE_DIR/cwd"
               cd "$SMOKE_DIR/cwd"
-              expected_install_output="$(cat <<'EOF'
-              npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous
-              npx --yes oh-my-openagent@latest install --platform=claude-code --no-tui
-              npx --yes oh-my-openagent@latest install --platform=gemini --no-tui
-              EOF
-              )"
+              expected_install_output="npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous"
               expected_doctor_output_prefix="codex exec "
 
               if npx_install_output=$(npx -y "$package_spec" --dry-run install --no-tui --codex-autonomous 2>&1) &&
@@ -720,7 +715,7 @@ jobs:
                  case "$npx_doctor_output" in *"--sandbox danger-full-access"*) true ;; *) false ;; esac &&
                  case "$npx_doctor_output" in *'Use $omo:lcx-doctor'*) true ;; *) false ;; esac &&
                  case "$npx_doctor_output" in *"--model"*|*"gpt-5.5-codex-mini"*) false ;; *) true ;; esac &&
-                 npx -y "$package_spec" install --platform=codex --no-tui --codex-autonomous &&
+                 npx -y "$package_spec" install --no-tui --codex-autonomous &&
                  [ -x "$CODEX_LOCAL_BIN_DIR/omo" ] &&
                  omo_version_output=$("$CODEX_LOCAL_BIN_DIR/omo" --version 2>&1) &&
                  [ "$omo_version_output" = "$OMO_VERSION" ] &&

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -10,10 +10,10 @@ Most users want **Ultimate**. Pick **Light** if you are already invested in Code
 | You want | Run | Lands on disk |
 | :--- | :--- | :--- |
 | Ultimate (OpenCode) | `bunx oh-my-openagent install` (TUI walks you through it) | Plugin registered in `opencode.json`, agent/model config, provider auth |
-| LazyCodex targets | `npx lazycodex-ai install` | Codex Light state plus delegated Claude Code and Gemini target installs; pass `--platform=codex` for Codex only |
+| Light (Codex CLI) | `npx lazycodex-ai install` | `~/.codex/plugins/cache/sisyphuslabs/omo/`, stable Codex marketplace snapshot, `~/.codex/config.toml` marketplace/plugin/agent blocks, optional autonomous Codex permissions, component CLIs in `~/.local/bin` |
 | Both | `bunx oh-my-openagent install --platform=both` | Both of the above |
 
-`lazycodex-ai` runs through Node/npm. Its `install` command targets Codex, Claude Code, and Gemini by default; use `--platform=codex`, `--platform=claude-code`, or `--platform=gemini` to narrow the install, and `--platform=all` or `--all-platforms` to request the default set explicitly. `--platform` on the shared `omo` CLI still defaults to `opencode` (Ultimate). `lazycodex-ai` is the npm/bin alias; `lazycodex` is the GitHub repository that hosts the marketplace bundle. Neither is the Codex marketplace name.
+`lazycodex-ai` defaults to the Codex Light installer and runs through Node/npm. `--platform` on the shared `omo` CLI still defaults to `opencode` (Ultimate). `lazycodex-ai` is the npm/bin alias; `lazycodex` is the GitHub repository that hosts the marketplace bundle. Neither is the Codex marketplace name.
 
 ## For Humans
 
@@ -36,11 +36,9 @@ The Light edition installer asks whether to configure Codex for autonomous full-
 npx lazycodex-ai install
 # non-interactive recommended mode:
 npx lazycodex-ai install --no-tui --codex-autonomous
-# Codex only:
-npx lazycodex-ai install --platform=codex --no-tui --codex-autonomous
 ```
 
-For the Codex target, it writes managed Codex Light state to `~/.codex/` and does not touch OpenCode or provider flags. During migration from older Codex plugin installs it may also repair the current project's `.codex/config.toml` if that project has the known `multi_agent_v2` plus legacy `[agents] max_threads` conflict; project-owned `.codex` artifacts are reported, not deleted. Global Codex config will register marketplace `sisyphuslabs` from the local built cache under `~/.codex/plugins/cache/sisyphuslabs`, enable plugin `omo@sisyphuslabs`, and write a valid `[features.multi_agent_v2]` limit table. The installer never enables MultiAgentV2; if it finds an explicit legacy `multi_agent_v2 = false` shorthand, it preserves that disable as table-form `enabled = false`.
+It writes managed Codex Light state to `~/.codex/` and does not touch OpenCode or provider flags. During migration from older Codex plugin installs it may also repair the current project's `.codex/config.toml` if that project has the known `multi_agent_v2` plus legacy `[agents] max_threads` conflict; project-owned `.codex` artifacts are reported, not deleted. Global Codex config will register marketplace `sisyphuslabs` from the local built cache under `~/.codex/plugins/cache/sisyphuslabs`, enable plugin `omo@sisyphuslabs`, and write a valid `[features.multi_agent_v2]` limit table. The installer never enables MultiAgentV2; if it finds an explicit legacy `multi_agent_v2 = false` shorthand, it preserves that disable as table-form `enabled = false`.
 
 On Windows, keep the direct `npx lazycodex-ai install ...` form above. Do not rewrite it into an `npx --package` command that launches the `omo install` bin indirectly; that package-manager shape can fail before the installer starts.
 
@@ -332,7 +330,7 @@ bunx oh-my-openagent install \
   bunx oh-my-openagent install --no-tui --platform=opencode --claude=no --openai=no --gemini=no --copilot=no --opencode-go=yes
   ```
 
-**About the `lazycodex-ai` bin name.** `lazycodex-ai` is the npm package and bin alias for the LazyCodex Node installer. `lazycodex` (without the `-ai` suffix) is the GitHub repository that hosts the marketplace bundle. `lazycodex-ai install` does not require Bun. The Codex marketplace name is `sisyphuslabs`, and the plugin name is `omo`.
+**About the `lazycodex-ai` bin name.** `lazycodex-ai` is the npm package and bin alias for the Codex Light Node installer. `lazycodex` (without the `-ai` suffix) is the GitHub repository that hosts the marketplace bundle. `lazycodex-ai install` does not require Bun. The Codex marketplace name is `sisyphuslabs`, and the plugin name is `omo`.
 
 **What the installer does:**
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,7 +14,7 @@ All published packages expose the same compiled CLI with these bin entries:
 - `oh-my-openagent` (preferred name)
 - `oh-my-opencode` (legacy compatibility name)
 - `omo` (short alias, recommended in docs and prompts)
-- `lazycodex-ai` (Light installer shortcut; `lazycodex-ai install` dispatches the Codex, Claude Code, and Gemini targets by default unless `--platform` is explicitly narrowed)
+- `lazycodex-ai` (Light edition shortcut; `lazycodex-ai install` is equivalent to `omo install --platform=codex`; any explicit `--platform` value must be `codex`)
 
 ## Basic Usage
 
@@ -71,9 +71,9 @@ bunx oh-my-openagent install
 | `--no-codex-autonomous` | Leave existing Codex permission settings unchanged when installing Light or Both |
 | `--skip-auth` | Skip authentication setup hints |
 
-When using the published `lazycodex-ai` package, `install` defaults to the LazyCodex agent targets `codex`, `claude-code`, and `gemini`. Pass `--platform=codex`, `--platform=claude-code`, or `--platform=gemini` to install only one target; pass `--platform=all` or `--all-platforms` to request the default set explicitly. The Codex target uses marketplace `sisyphuslabs` and plugin `omo`, enabled as `omo@sisyphuslabs`, with the marketplace source set to the local built cache under `~/.codex/plugins/cache/sisyphuslabs`.
+When using the `lazycodex-ai` bin alias, `install` defaults to `--platform=codex`. `lazycodex-ai` is only the npm/bin alias; `lazycodex` is the marketplace repository name. The Codex config uses marketplace `sisyphuslabs` and plugin `omo`, enabled as `omo@sisyphuslabs`, with the marketplace source set to the local built cache under `~/.codex/plugins/cache/sisyphuslabs`.
 
-On the shared `omo` CLI, `--platform` still means `opencode`, `codex`, or `both`. Subscription flags (`--claude`, `--openai`, etc.) only apply when the shared CLI platform is `opencode` or `both`; they are rejected under `--platform=codex` because the Light edition does not write OpenCode model config. `--codex-autonomous` and `--no-codex-autonomous` only affect installs where the selected target includes Codex, and `lazycodex-ai` filters those Codex-only flags out of non-Codex target commands.
+Subscription flags (`--claude`, `--openai`, etc.) only apply when `--platform` is `opencode` or `both`. They are rejected under `--platform=codex` because the Light edition does not write OpenCode model config. `--codex-autonomous` and `--no-codex-autonomous` only affect installs where the selected platform includes Codex.
 
 ### Telemetry and opt-out
 

--- a/packages/omo-codex/scripts/install-cli-args.test.mjs
+++ b/packages/omo-codex/scripts/install-cli-args.test.mjs
@@ -13,66 +13,20 @@ test("#given lazycodex install flags #when parsing Node installer argv #then kee
 	// then
 	assert.deepEqual(parsed, {
 		kind: "install",
-		targets: ["codex"],
-		noTui: true,
-		skipAuth: false,
 		autonomousPermissions: true,
 		repoRoot: undefined,
 	});
 });
 
-test("#given default lazycodex install #when parsing Node installer argv #then targets every supported agent platform", () => {
+test("#given unsupported OpenCode platform override #when parsing Node installer argv #then rejects the Bun-backed path", () => {
 	// given
-	const argv = ["install"];
+	const argv = ["install", "--platform=both"];
 
 	// when
-	const parsed = parseLazyCodexInstallCliArgs(argv);
+	const parse = () => parseLazyCodexInstallCliArgs(argv);
 
 	// then
-	assert.deepEqual(parsed, {
-		kind: "install",
-		targets: ["codex", "claude-code", "gemini"],
-		noTui: false,
-		skipAuth: false,
-		autonomousPermissions: undefined,
-		repoRoot: undefined,
-	});
-});
-
-test("#given all-platform aliases #when parsing Node installer argv #then expands to every supported agent platform", () => {
-	// given
-	const argv = ["install", "--platform=all", "--all-platforms"];
-
-	// when
-	const parsed = parseLazyCodexInstallCliArgs(argv);
-
-	// then
-	assert.deepEqual(parsed, {
-		kind: "install",
-		targets: ["codex", "claude-code", "gemini"],
-		noTui: false,
-		skipAuth: false,
-		autonomousPermissions: undefined,
-		repoRoot: undefined,
-	});
-});
-
-test("#given explicit non-Codex platform override #when parsing Node installer argv #then keeps a single target", () => {
-	// given
-	const argv = ["install", "--platform", "gemini", "--no-tui"];
-
-	// when
-	const parsed = parseLazyCodexInstallCliArgs(argv);
-
-	// then
-	assert.deepEqual(parsed, {
-		kind: "install",
-		targets: ["gemini"],
-		noTui: true,
-		skipAuth: false,
-		autonomousPermissions: undefined,
-		repoRoot: undefined,
-	});
+	assert.throws(parse, /lazycodex-ai installs the Codex Light edition only/);
 });
 
 test("#given missing platform value #when parsing Node installer argv #then rejects the incomplete option", () => {
@@ -96,9 +50,6 @@ test("#given repo root equals option #when parsing Node installer argv #then kee
 	// then
 	assert.deepEqual(parsed, {
 		kind: "install",
-		targets: ["codex", "claude-code", "gemini"],
-		noTui: false,
-		skipAuth: false,
 		autonomousPermissions: undefined,
 		repoRoot: "/tmp/project",
 	});
@@ -173,7 +124,6 @@ test("#given dry-run install with codex autonomy flags #when parsing Node instal
 		kind: "command",
 		command: "install",
 		dryRun: true,
-		targets: ["codex", "claude-code", "gemini"],
 		noTui: true,
 		skipAuth: false,
 		autonomousPermissions: true,

--- a/packages/omo-codex/scripts/install-delegated-command.test.mjs
+++ b/packages/omo-codex/scripts/install-delegated-command.test.mjs
@@ -145,13 +145,12 @@ test("#given doctor source-root override #when delegating #then passes it to the
 	assert.doesNotMatch(invocation.args.at(-1), /--source-root/);
 });
 
-test("#given dry-run install without explicit platform #when delegating #then logs Windows-safe direct package commands", async () => {
+test("#given dry-run install without explicit platform #when delegating #then logs one Windows-safe Codex install command", async () => {
 	// given
 	const parsed = {
 		kind: "command",
 		command: "install",
 		dryRun: true,
-		targets: ["codex", "claude-code", "gemini"],
 		noTui: true,
 		skipAuth: false,
 		autonomousPermissions: true,
@@ -172,38 +171,6 @@ test("#given dry-run install without explicit platform #when delegating #then lo
 	// then
 	assert.deepEqual(logged, [
 		"npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous",
-		"npx --yes oh-my-openagent@latest install --platform=claude-code --no-tui",
-		"npx --yes oh-my-openagent@latest install --platform=gemini --no-tui",
-	]);
-});
-
-test("#given explicit non-Codex platform plus Codex-only flag #when delegating #then filters the Codex-only flag", async () => {
-	// given
-	const parsed = {
-		kind: "command",
-		command: "install",
-		dryRun: true,
-		targets: ["claude-code"],
-		noTui: true,
-		skipAuth: true,
-		autonomousPermissions: true,
-		repoRoot: undefined,
-		args: [],
-	};
-	const logged = [];
-
-	// when
-	await runDelegatedOmoCommand(parsed, {
-		cwd: "/tmp/project",
-		log: (line) => {
-			logged.push(line);
-		},
-		runCommand: async () => {},
-	});
-
-	// then
-	assert.deepEqual(logged, [
-		"npx --yes oh-my-openagent@latest install --platform=claude-code --no-tui --skip-auth",
 	]);
 });
 test("#given doctor recursion guard is active #when lazycodex doctor delegates #then rejects before launching Codex", async () => {

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -13720,9 +13720,7 @@ function codexMarketplaceSource(marketplaceRoot) {
 }
 
 // packages/omo-codex/src/install/lazycodex-cli-args.ts
-var LAZYCODEX_INSTALL_TARGETS = ["codex", "claude-code", "gemini"];
-var ALL_PLATFORM_ALIASES = new Set(["all", "all-platforms", "multi", "*"]);
-var LAZYCODEX_INSTALL_TARGET_SET = new Set(LAZYCODEX_INSTALL_TARGETS);
+var CODEX_ONLY_ERROR = "lazycodex-ai installs the Codex Light edition only. Use the omo installer for OpenCode or both-platform installs.";
 var PASSTHROUGH_COMMANDS = new Set([
   "doctor",
   "cleanup",
@@ -13734,24 +13732,14 @@ var PASSTHROUGH_COMMANDS = new Set([
 ]);
 function parseLazyCodexInstallCliArgs(argv) {
   const args = [...argv];
-  if (args.length === 0) {
-    return {
-      kind: "install",
-      targets: [...LAZYCODEX_INSTALL_TARGETS],
-      noTui: false,
-      skipAuth: false,
-      autonomousPermissions: undefined,
-      repoRoot: undefined
-    };
-  }
+  if (args.length === 0)
+    return { kind: "install", autonomousPermissions: undefined, repoRoot: undefined };
   let repoRoot;
   let command;
   let dryRun = false;
   let noTui = false;
   let skipAuth = false;
   let autonomousPermissions;
-  let allPlatforms = false;
-  const platforms = [];
   let index = 0;
   while (index < args.length) {
     const arg = args[index];
@@ -13784,19 +13772,10 @@ function parseLazyCodexInstallCliArgs(argv) {
       index += 1;
       continue;
     }
-    if (arg === "--all-platforms") {
-      allPlatforms = true;
-      index += 1;
-      continue;
-    }
     if (arg === "--platform") {
       const platform = readOptionValue(args, index, "--platform");
-      const parsedPlatform = parseInstallTarget(platform);
-      if (parsedPlatform === "all") {
-        allPlatforms = true;
-      } else {
-        platforms.push(parsedPlatform);
-      }
+      if (platform !== "codex")
+        throw new Error(CODEX_ONLY_ERROR);
       index += 2;
       continue;
     }
@@ -13804,12 +13783,8 @@ function parseLazyCodexInstallCliArgs(argv) {
       const platform = arg.slice("--platform=".length);
       if (platform.trim().length === 0)
         throw new Error("--platform requires a value");
-      const parsedPlatform = parseInstallTarget(platform);
-      if (parsedPlatform === "all") {
-        allPlatforms = true;
-      } else {
-        platforms.push(parsedPlatform);
-      }
+      if (platform !== "codex")
+        throw new Error(CODEX_ONLY_ERROR);
       index += 1;
       continue;
     }
@@ -13847,33 +13822,18 @@ function parseLazyCodexInstallCliArgs(argv) {
     }
     throw new Error(`Unsupported lazycodex-ai install option: ${String(arg)}`);
   }
-  const targets = resolveInstallTargets(platforms, allPlatforms);
   if (!dryRun)
-    return { kind: "install", targets, noTui, skipAuth, autonomousPermissions, repoRoot };
+    return { kind: "install", autonomousPermissions, repoRoot };
   return {
     kind: "command",
     command: command ?? "install",
     dryRun,
-    targets,
     noTui,
     skipAuth,
     autonomousPermissions,
     repoRoot,
     args: []
   };
-}
-function parseInstallTarget(platform) {
-  const normalized = platform.trim();
-  if (ALL_PLATFORM_ALIASES.has(normalized))
-    return "all";
-  if (LAZYCODEX_INSTALL_TARGET_SET.has(normalized))
-    return normalized;
-  throw new Error(`Unsupported lazycodex-ai install platform: ${platform} (expected codex, claude-code, gemini, or all)`);
-}
-function resolveInstallTargets(platforms, allPlatforms) {
-  if (allPlatforms || platforms.length === 0)
-    return [...LAZYCODEX_INSTALL_TARGETS];
-  return [...new Set(platforms)];
 }
 function parseUpdateArgs(args, startIndex, initialDryRun, initialRepoRoot) {
   let dryRun = initialDryRun;
@@ -13914,7 +13874,6 @@ function formatLazyCodexInstallHelp() {
   const passthrough = [...PASSTHROUGH_COMMANDS].sort().join(", ");
   return [
     "Usage: lazycodex-ai install [--no-tui] [--codex-autonomous|--no-codex-autonomous] [--repo-root <path>]",
-    "       lazycodex-ai install [--platform codex|claude-code|gemini|all] [--all-platforms]",
     "       lazycodex-ai uninstall [--project <path>]",
     "       lazycodex-ai update [--dry-run] [--repo-root <path>]",
     "       lazycodex-ai doctor [--source-root <path>] [--model <model>] [--json|--status|--verbose]",
@@ -13936,55 +13895,36 @@ async function runDelegatedOmoCommand(parsed, options) {
   if (parsed.command === "doctor" && process.env.LAZYCODEX_DOCTOR_LCX_ACTIVE === "1") {
     throw new Error("Refusing recursive lazycodex doctor invocation from inside $omo:lcx-doctor");
   }
-  const invocations = buildDelegatedOmoInvocations(parsed);
+  const invocation = buildDelegatedOmoInvocation(parsed);
   if (parsed.dryRun) {
-    for (const invocation of invocations) {
-      options.log(formatShellCommand(invocation.command, invocation.args));
-    }
+    options.log(formatShellCommand(invocation.command, invocation.args));
     return;
   }
-  for (const invocation of invocations) {
-    const env3 = invocation.delegatesToOmo ? { ...process.env, OMO_INVOCATION_NAME: "omo", ...invocation.env } : { ...process.env, ...invocation.env };
-    await options.runCommand(invocation.command, invocation.args, { cwd: options.cwd, env: env3 });
-  }
+  const env3 = invocation.delegatesToOmo ? { ...process.env, OMO_INVOCATION_NAME: "omo", ...invocation.env } : { ...process.env, ...invocation.env };
+  await options.runCommand(invocation.command, invocation.args, { cwd: options.cwd, env: env3 });
 }
 function buildDelegatedOmoInvocation(parsed) {
-  const invocation = buildDelegatedOmoInvocations(parsed)[0];
-  if (invocation === undefined) {
-    throw new Error("No delegated omo invocation was built");
-  }
-  return invocation;
-}
-function buildDelegatedOmoInvocations(parsed) {
   if (parsed.command === "doctor")
-    return [buildLazyCodexDoctorInvocation(parsed.args)];
+    return buildLazyCodexDoctorInvocation(parsed.args);
   if (parsed.command === "install") {
-    const targets = parsed.targets ?? LAZYCODEX_INSTALL_TARGETS;
-    return targets.map((target) => buildInstallInvocation(parsed, target));
+    const args2 = ["--yes", "oh-my-openagent@latest", parsed.command, "--platform=codex"];
+    if (parsed.noTui)
+      args2.push("--no-tui");
+    if (parsed.skipAuth)
+      args2.push("--skip-auth");
+    if (parsed.autonomousPermissions !== false)
+      args2.push("--codex-autonomous");
+    if (parsed.autonomousPermissions === false)
+      args2.push("--no-codex-autonomous");
+    if (parsed.repoRoot)
+      args2.push(`--repo-root=${parsed.repoRoot}`);
+    return { command: "npx", args: args2, delegatesToOmo: true };
   }
   const args = ["--yes", "--package", "oh-my-openagent", "omo", parsed.command];
   if (parsed.command === "cleanup") {
     args.push("--platform=codex", ...parsed.args);
   } else {
     args.push(...parsed.args);
-  }
-  return [{ command: "npx", args, delegatesToOmo: true }];
-}
-function buildInstallInvocation(parsed, target) {
-  const args = ["--yes", "oh-my-openagent@latest", parsed.command, `--platform=${target}`];
-  if (parsed.command === "install") {
-    if (parsed.noTui)
-      args.push("--no-tui");
-    if (parsed.skipAuth)
-      args.push("--skip-auth");
-    if (target === "codex") {
-      if (parsed.autonomousPermissions !== false)
-        args.push("--codex-autonomous");
-      if (parsed.autonomousPermissions === false)
-        args.push("--no-codex-autonomous");
-      if (parsed.repoRoot)
-        args.push(`--repo-root=${parsed.repoRoot}`);
-    }
   }
   return { command: "npx", args, delegatesToOmo: true };
 }
@@ -14402,39 +14342,23 @@ async function runLazyCodexInstallLocalCli(input) {
         input.log(`node ${input.entrypointPath} install --repo-root=${parsed.repoRoot}`);
         return 0;
       }
-      const result = await installMarketplaceLocally({
+      const result2 = await installMarketplaceLocally({
         repoRoot: resolve11(parsed.repoRoot),
         autonomousPermissions: true,
         env: input.env
       });
-      input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`);
+      input.log(`Installed ${result2.installed.length} plugin(s) from ${result2.marketplaceName}.`);
       return 0;
     }
     return runLazyCodexManualUpdate({ env: input.env, dryRun: parsed.dryRun, log: input.log, invokedPath: input.invokedPath });
   }
   const repoRoot = parsed.repoRoot ? resolve11(parsed.repoRoot) : input.defaultRepoRoot;
-  if (parsed.targets.includes("codex")) {
-    const result = await installMarketplaceLocally({
-      repoRoot,
-      autonomousPermissions: parsed.autonomousPermissions,
-      env: input.env
-    });
-    input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`);
-  }
-  const delegatedTargets = parsed.targets.filter((target) => target !== "codex");
-  if (delegatedTargets.length > 0) {
-    await runDelegatedOmoCommand({
-      kind: "command",
-      command: "install",
-      dryRun: false,
-      targets: delegatedTargets,
-      noTui: parsed.noTui,
-      skipAuth: parsed.skipAuth,
-      autonomousPermissions: parsed.autonomousPermissions,
-      repoRoot: undefined,
-      args: []
-    }, { cwd: input.cwd, log: input.log, runCommand: defaultRunCommand });
-  }
+  const result = await installMarketplaceLocally({
+    repoRoot,
+    autonomousPermissions: parsed.autonomousPermissions,
+    env: input.env
+  });
+  input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`);
   return 0;
 }
 export {
@@ -14454,7 +14378,6 @@ export {
   installCachedPlugin,
   formatLazyCodexInstallHelp,
   findMissingHookCommandTargets,
-  buildDelegatedOmoInvocations,
   buildDelegatedOmoInvocation,
   assertHookCommandTargets,
   PASSTHROUGH_COMMANDS

--- a/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
+++ b/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
@@ -57,7 +57,7 @@ test("#given lazycodex runs through an npm bin symlink #when running the Node in
 	}
 });
 
-test("#given dry-run install flags #when running the Node installer entrypoint #then prints every supported agent platform command", () => {
+test("#given dry-run install flags #when running the Node installer entrypoint #then prints delegated autonomous codex install command", () => {
 	// given
 	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
 
@@ -69,14 +69,7 @@ test("#given dry-run install flags #when running the Node installer entrypoint #
 	).trim();
 
 	// then
-	assert.equal(
-		output,
-		[
-			"npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous",
-			"npx --yes oh-my-openagent@latest install --platform=claude-code --no-tui",
-			"npx --yes oh-my-openagent@latest install --platform=gemini --no-tui",
-		].join("\n"),
-	);
+	assert.equal(output, "npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous");
 });
 
 test("#given dry-run install opt-out #when running the Node installer entrypoint #then preserves existing Codex permission settings", () => {
@@ -91,29 +84,21 @@ test("#given dry-run install opt-out #when running the Node installer entrypoint
 	).trim();
 
 	// then
-	assert.equal(
-		output,
-		[
-			"npx --yes oh-my-openagent@latest install --platform=codex --no-tui --no-codex-autonomous",
-			"npx --yes oh-my-openagent@latest install --platform=claude-code --no-tui",
-			"npx --yes oh-my-openagent@latest install --platform=gemini --no-tui",
-		].join("\n"),
-	);
+	assert.equal(output, "npx --yes oh-my-openagent@latest install --platform=codex --no-tui --no-codex-autonomous");
 });
 
-test("#given explicit dry-run platform #when running the Node installer entrypoint #then prints only that platform command", () => {
+test("#given explicit non-Codex dry-run platform #when running the Node installer entrypoint #then rejects it", () => {
 	// given
 	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
 
-	// when
-	const output = execFileSync(
-		process.execPath,
-		[scriptPath, "--dry-run", "install", "--platform=gemini", "--no-tui", "--codex-autonomous"],
-		{ encoding: "utf8" },
-	).trim();
-
-	// then
-	assert.equal(output, "npx --yes oh-my-openagent@latest install --platform=gemini --no-tui");
+	// when/then
+	assert.throws(
+		() =>
+			execFileSync(process.execPath, [scriptPath, "--dry-run", "install", "--platform=gemini", "--no-tui"], {
+				encoding: "utf8",
+			}),
+		/lazycodex-ai installs the Codex Light edition only/,
+	);
 });
 
 test("#given dry-run doctor #when running the Node installer entrypoint #then prints Codex LazyCodex doctor workflow command", () => {

--- a/packages/omo-codex/scripts/install-local.mjs
+++ b/packages/omo-codex/scripts/install-local.mjs
@@ -59,7 +59,6 @@ export const installMarketplaceLocally = generatedInstaller.installMarketplaceLo
 export const resolveCodexInstallerBinDir = generatedInstaller.resolveCodexInstallerBinDir;
 export const PASSTHROUGH_COMMANDS = generatedInstaller.PASSTHROUGH_COMMANDS;
 export const buildDelegatedOmoInvocation = generatedInstaller.buildDelegatedOmoInvocation;
-export const buildDelegatedOmoInvocations = generatedInstaller.buildDelegatedOmoInvocations;
 export const formatLazyCodexInstallHelp = generatedInstaller.formatLazyCodexInstallHelp;
 export const parseLazyCodexInstallCliArgs = generatedInstaller.parseLazyCodexInstallCliArgs;
 export const runDelegatedOmoCommand = generatedInstaller.runDelegatedOmoCommand;

--- a/packages/omo-codex/src/install/install-local-cli.ts
+++ b/packages/omo-codex/src/install/install-local-cli.ts
@@ -17,7 +17,7 @@ export { stampGitBashMcpEnv } from "./codex-git-bash-mcp-env"
 export { assertHookCommandTargets, findMissingHookCommandTargets } from "./codex-hook-targets"
 export { repairNearestProjectLocalCodexArtifacts } from "./codex-project-local-cleanup"
 export { PASSTHROUGH_COMMANDS, formatLazyCodexInstallHelp, parseLazyCodexInstallCliArgs } from "./lazycodex-cli-args"
-export { buildDelegatedOmoInvocation, buildDelegatedOmoInvocations, runDelegatedOmoCommand } from "./lazycodex-delegated-command"
+export { buildDelegatedOmoInvocation, runDelegatedOmoCommand } from "./lazycodex-delegated-command"
 
 export async function installMarketplaceLocally(options: CodexInstallOptions = {}): Promise<CodexInstallResult> {
   return runCodexInstaller(options)
@@ -73,31 +73,11 @@ export async function runLazyCodexInstallLocalCli(input: {
   }
 
   const repoRoot = parsed.repoRoot ? resolve(parsed.repoRoot) : input.defaultRepoRoot
-  if (parsed.targets.includes("codex")) {
-    const result = await installMarketplaceLocally({
-      repoRoot,
-      autonomousPermissions: parsed.autonomousPermissions,
-      env: input.env,
-    })
-    input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`)
-  }
-
-  const delegatedTargets = parsed.targets.filter((target) => target !== "codex")
-  if (delegatedTargets.length > 0) {
-    await runDelegatedOmoCommand(
-      {
-        kind: "command",
-        command: "install",
-        dryRun: false,
-        targets: delegatedTargets,
-        noTui: parsed.noTui,
-        skipAuth: parsed.skipAuth,
-        autonomousPermissions: parsed.autonomousPermissions,
-        repoRoot: undefined,
-        args: [],
-      },
-      { cwd: input.cwd, log: input.log, runCommand: defaultRunCommand },
-    )
-  }
+  const result = await installMarketplaceLocally({
+    repoRoot,
+    autonomousPermissions: parsed.autonomousPermissions,
+    env: input.env,
+  })
+  input.log(`Installed ${result.installed.length} plugin(s) from ${result.marketplaceName}.`)
   return 0
 }

--- a/packages/omo-codex/src/install/lazycodex-cli-args.ts
+++ b/packages/omo-codex/src/install/lazycodex-cli-args.ts
@@ -1,9 +1,4 @@
-export const LAZYCODEX_INSTALL_TARGETS = ["codex", "claude-code", "gemini"] as const
-
-export type LazyCodexInstallTarget = (typeof LAZYCODEX_INSTALL_TARGETS)[number]
-
-const ALL_PLATFORM_ALIASES = new Set(["all", "all-platforms", "multi", "*"])
-const LAZYCODEX_INSTALL_TARGET_SET = new Set<string>(LAZYCODEX_INSTALL_TARGETS)
+const CODEX_ONLY_ERROR = "lazycodex-ai installs the Codex Light edition only. Use the omo installer for OpenCode or both-platform installs."
 
 export const PASSTHROUGH_COMMANDS: ReadonlySet<string> = new Set([
   "doctor",
@@ -16,21 +11,13 @@ export const PASSTHROUGH_COMMANDS: ReadonlySet<string> = new Set([
 ] as const)
 
 export type LazyCodexInstallCliArgs =
-  | {
-      readonly kind: "install"
-      readonly targets: readonly LazyCodexInstallTarget[]
-      readonly noTui: boolean
-      readonly skipAuth: boolean
-      readonly autonomousPermissions: boolean | undefined
-      readonly repoRoot: string | undefined
-    }
+  | { readonly kind: "install"; readonly autonomousPermissions: boolean | undefined; readonly repoRoot: string | undefined }
   | { readonly kind: "help" }
   | { readonly kind: "version" }
   | {
       readonly kind: "command"
       readonly command: string
       readonly dryRun: boolean
-      readonly targets?: readonly LazyCodexInstallTarget[]
       readonly noTui?: boolean
       readonly skipAuth?: boolean
       readonly autonomousPermissions?: boolean
@@ -41,16 +28,7 @@ export type LazyCodexInstallCliArgs =
 
 export function parseLazyCodexInstallCliArgs(argv: readonly string[]): LazyCodexInstallCliArgs {
   const args = [...argv]
-  if (args.length === 0) {
-    return {
-      kind: "install",
-      targets: [...LAZYCODEX_INSTALL_TARGETS],
-      noTui: false,
-      skipAuth: false,
-      autonomousPermissions: undefined,
-      repoRoot: undefined,
-    }
-  }
+  if (args.length === 0) return { kind: "install", autonomousPermissions: undefined, repoRoot: undefined }
 
   let repoRoot: string | undefined
   let command: "install" | undefined
@@ -58,8 +36,6 @@ export function parseLazyCodexInstallCliArgs(argv: readonly string[]): LazyCodex
   let noTui = false
   let skipAuth = false
   let autonomousPermissions: boolean | undefined
-  let allPlatforms = false
-  const platforms: LazyCodexInstallTarget[] = []
   let index = 0
   while (index < args.length) {
     const arg = args[index]
@@ -90,31 +66,16 @@ export function parseLazyCodexInstallCliArgs(argv: readonly string[]): LazyCodex
       index += 1
       continue
     }
-    if (arg === "--all-platforms") {
-      allPlatforms = true
-      index += 1
-      continue
-    }
     if (arg === "--platform") {
       const platform = readOptionValue(args, index, "--platform")
-      const parsedPlatform = parseInstallTarget(platform)
-      if (parsedPlatform === "all") {
-        allPlatforms = true
-      } else {
-        platforms.push(parsedPlatform)
-      }
+      if (platform !== "codex") throw new Error(CODEX_ONLY_ERROR)
       index += 2
       continue
     }
     if (typeof arg === "string" && arg.startsWith("--platform=")) {
       const platform = arg.slice("--platform=".length)
       if (platform.trim().length === 0) throw new Error("--platform requires a value")
-      const parsedPlatform = parseInstallTarget(platform)
-      if (parsedPlatform === "all") {
-        allPlatforms = true
-      } else {
-        platforms.push(parsedPlatform)
-      }
+      if (platform !== "codex") throw new Error(CODEX_ONLY_ERROR)
       index += 1
       continue
     }
@@ -151,37 +112,18 @@ export function parseLazyCodexInstallCliArgs(argv: readonly string[]): LazyCodex
     throw new Error(`Unsupported lazycodex-ai install option: ${String(arg)}`)
   }
 
-  const targets = resolveInstallTargets(platforms, allPlatforms)
-  if (!dryRun) return { kind: "install", targets, noTui, skipAuth, autonomousPermissions, repoRoot }
+  if (!dryRun) return { kind: "install", autonomousPermissions, repoRoot }
 
   return {
     kind: "command",
     command: command ?? "install",
     dryRun,
-    targets,
     noTui,
     skipAuth,
     autonomousPermissions,
     repoRoot,
     args: [],
   }
-}
-
-function parseInstallTarget(platform: string): LazyCodexInstallTarget | "all" {
-  const normalized = platform.trim()
-  if (ALL_PLATFORM_ALIASES.has(normalized)) return "all"
-  if (LAZYCODEX_INSTALL_TARGET_SET.has(normalized)) return normalized as LazyCodexInstallTarget
-  throw new Error(
-    `Unsupported lazycodex-ai install platform: ${platform} (expected codex, claude-code, gemini, or all)`,
-  )
-}
-
-function resolveInstallTargets(
-  platforms: readonly LazyCodexInstallTarget[],
-  allPlatforms: boolean,
-): readonly LazyCodexInstallTarget[] {
-  if (allPlatforms || platforms.length === 0) return [...LAZYCODEX_INSTALL_TARGETS]
-  return [...new Set(platforms)]
 }
 
 function parseUpdateArgs(
@@ -229,7 +171,6 @@ export function formatLazyCodexInstallHelp(): string {
   const passthrough = [...PASSTHROUGH_COMMANDS].sort().join(", ")
   return [
     "Usage: lazycodex-ai install [--no-tui] [--codex-autonomous|--no-codex-autonomous] [--repo-root <path>]",
-    "       lazycodex-ai install [--platform codex|claude-code|gemini|all] [--all-platforms]",
     "       lazycodex-ai uninstall [--project <path>]",
     "       lazycodex-ai update [--dry-run] [--repo-root <path>]",
     "       lazycodex-ai doctor [--source-root <path>] [--model <model>] [--json|--status|--verbose]",

--- a/packages/omo-codex/src/install/lazycodex-delegated-command.ts
+++ b/packages/omo-codex/src/install/lazycodex-delegated-command.ts
@@ -1,5 +1,5 @@
 import type { RunCommand } from "./types"
-import { LAZYCODEX_INSTALL_TARGETS, type LazyCodexInstallTarget, type LazyCodexInstallCliArgs } from "./lazycodex-cli-args"
+import type { LazyCodexInstallCliArgs } from "./lazycodex-cli-args"
 
 export type LazyCodexDelegatedCommand = Extract<LazyCodexInstallCliArgs, { readonly kind: "command" }>
 
@@ -27,35 +27,28 @@ export async function runDelegatedOmoCommand(
   if (parsed.command === "doctor" && process.env.LAZYCODEX_DOCTOR_LCX_ACTIVE === "1") {
     throw new Error("Refusing recursive lazycodex doctor invocation from inside $omo:lcx-doctor")
   }
-  const invocations = buildDelegatedOmoInvocations(parsed)
+  const invocation = buildDelegatedOmoInvocation(parsed)
   if (parsed.dryRun) {
-    for (const invocation of invocations) {
-      options.log(formatShellCommand(invocation.command, invocation.args))
-    }
+    options.log(formatShellCommand(invocation.command, invocation.args))
     return
   }
-  for (const invocation of invocations) {
-    const env = invocation.delegatesToOmo
-      ? { ...process.env, OMO_INVOCATION_NAME: "omo", ...invocation.env }
-      : { ...process.env, ...invocation.env }
-    await options.runCommand(invocation.command, invocation.args, { cwd: options.cwd, env })
-  }
+  const env = invocation.delegatesToOmo
+    ? { ...process.env, OMO_INVOCATION_NAME: "omo", ...invocation.env }
+    : { ...process.env, ...invocation.env }
+  await options.runCommand(invocation.command, invocation.args, { cwd: options.cwd, env })
 }
 
 export function buildDelegatedOmoInvocation(parsed: LazyCodexDelegatedCommand): DelegatedOmoInvocation {
-  const invocation = buildDelegatedOmoInvocations(parsed)[0]
-  if (invocation === undefined) {
-    throw new Error("No delegated omo invocation was built")
-  }
-  return invocation
-}
-
-export function buildDelegatedOmoInvocations(parsed: LazyCodexDelegatedCommand): readonly DelegatedOmoInvocation[] {
-  if (parsed.command === "doctor") return [buildLazyCodexDoctorInvocation(parsed.args)]
+  if (parsed.command === "doctor") return buildLazyCodexDoctorInvocation(parsed.args)
 
   if (parsed.command === "install") {
-    const targets = parsed.targets ?? LAZYCODEX_INSTALL_TARGETS
-    return targets.map((target) => buildInstallInvocation(parsed, target))
+    const args = ["--yes", "oh-my-openagent@latest", parsed.command, "--platform=codex"]
+    if (parsed.noTui) args.push("--no-tui")
+    if (parsed.skipAuth) args.push("--skip-auth")
+    if (parsed.autonomousPermissions !== false) args.push("--codex-autonomous")
+    if (parsed.autonomousPermissions === false) args.push("--no-codex-autonomous")
+    if (parsed.repoRoot) args.push(`--repo-root=${parsed.repoRoot}`)
+    return { command: "npx", args, delegatesToOmo: true }
   }
 
   const args = ["--yes", "--package", "oh-my-openagent", "omo", parsed.command]
@@ -63,23 +56,6 @@ export function buildDelegatedOmoInvocations(parsed: LazyCodexDelegatedCommand):
     args.push("--platform=codex", ...parsed.args)
   } else {
     args.push(...parsed.args)
-  }
-  return [{ command: "npx", args, delegatesToOmo: true }]
-}
-
-function buildInstallInvocation(
-  parsed: LazyCodexDelegatedCommand,
-  target: LazyCodexInstallTarget,
-): DelegatedOmoInvocation {
-  const args = ["--yes", "oh-my-openagent@latest", parsed.command, `--platform=${target}`]
-  if (parsed.command === "install") {
-    if (parsed.noTui) args.push("--no-tui")
-    if (parsed.skipAuth) args.push("--skip-auth")
-    if (target === "codex") {
-      if (parsed.autonomousPermissions !== false) args.push("--codex-autonomous")
-      if (parsed.autonomousPermissions === false) args.push("--no-codex-autonomous")
-      if (parsed.repoRoot) args.push(`--repo-root=${parsed.repoRoot}`)
-    }
   }
   return { command: "npx", args, delegatesToOmo: true }
 }

--- a/script/publish-lazycodex-workflow.test.ts
+++ b/script/publish-lazycodex-workflow.test.ts
@@ -318,18 +318,18 @@ describe("LazyCodex publish workflow", () => {
       smokeStep.includes('export CODEX_LOCAL_BIN_DIR="$SMOKE_DIR/bin"')
     const assertsDryRunRouting = smokeStep.includes('npx -y "$package_spec" --dry-run install --no-tui --codex-autonomous') &&
       smokeStep.includes('npx -y "$package_spec" --dry-run doctor') &&
-      smokeStep.includes('expected_install_output="$(cat <<\'EOF\'') &&
+      smokeStep.includes('expected_install_output="npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous"') &&
       smokeStep.includes('expected_doctor_output_prefix="codex exec ') &&
       smokeStep.includes("npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous") &&
-      smokeStep.includes("npx --yes oh-my-openagent@latest install --platform=claude-code --no-tui") &&
-      smokeStep.includes("npx --yes oh-my-openagent@latest install --platform=gemini --no-tui") &&
       smokeStep.includes('case "$npx_doctor_output" in "$expected_doctor_output_prefix"*) true ;; *) false ;; esac') &&
       smokeStep.includes('case "$npx_doctor_output" in *"--sandbox danger-full-access"*) true ;; *) false ;; esac') &&
       smokeStep.includes("Use $omo:lcx-doctor") &&
       smokeStep.includes('case "$npx_doctor_output" in *"--model"*|*"gpt-5.5-codex-mini"*) false ;; *) true ;; esac') &&
-      !smokeStep.includes("npx --yes --package oh-my-openagent omo install")
+      !smokeStep.includes("npx --yes --package oh-my-openagent omo install") &&
+      !smokeStep.includes("--platform=claude-code") &&
+      !smokeStep.includes("--platform=gemini")
     const installsRealPackageAndVerifiesOmoBin =
-      smokeStep.includes('npx -y "$package_spec" install --platform=codex --no-tui --codex-autonomous') &&
+      smokeStep.includes('npx -y "$package_spec" install --no-tui --codex-autonomous') &&
       smokeStep.includes('[ -x "$CODEX_LOCAL_BIN_DIR/omo" ]') &&
       smokeStep.includes('omo_version_output=$("$CODEX_LOCAL_BIN_DIR/omo" --version 2>&1)') &&
       smokeStep.includes('[ "$omo_version_output" = "$OMO_VERSION" ]') &&


### PR DESCRIPTION
## Summary

Reverts #5766 / merge commit `4e159fa422b9a60fa0b6e01211b761e4cd48d101`.

`lazycodex-ai` is a Codex Light installer surface. It should not install Claude Code or Gemini targets by default, and explicit non-Codex `--platform` values are rejected again with a Codex-only error. The Windows-safe direct package dry-run shape from the later installer hardening is preserved for the Codex target:

```text
npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous
```

Original source item: `code-yeongyu/lazycodex#75` by `@neulketing` (`Install all supported agent platforms by default`). That PR has no linked closing issue.

## QA

- `bun run build:codex-install`
- `node --test packages/omo-codex/scripts/install-cli-args.test.mjs packages/omo-codex/scripts/install-delegated-command.test.mjs packages/omo-codex/scripts/install-local-entrypoint.test.mjs packages/omo-codex/scripts/install-generated-bundle.test.mjs` — 46 pass
- `bun test script/publish-lazycodex-workflow.test.ts` — 6 pass / 51 expects
- Manual dry-run smoke:
  - `node packages/omo-codex/scripts/install-local.mjs --dry-run install --no-tui --codex-autonomous` prints only the Codex install command
  - `node packages/omo-codex/scripts/install-local.mjs --dry-run install --platform=gemini --no-tui` rejects with the Codex-only error
  - `node packages/omo-codex/scripts/install-local.mjs --dry-run doctor --json` routes through `codex exec ... $omo:lcx-doctor`

## Note

`bun install --frozen-lockfile` triggered this repo's `prepare` build and stopped in shared-skill submodule materialization because local `file://` submodule transport is disabled in this worktree. The dependency links were created; the targeted installer build and tests above passed after that.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts multi-platform installs in `lazycodex-ai`; the installer is Codex Light only again. Non-Codex `--platform` values now error, and dry-run prints a single Codex install command.

- **Refactors**
  - Default `lazycodex-ai install` targets Codex only; `--platform` must be `codex`.
  - Simplified delegation to a single `npx oh-my-openagent@latest install --platform=codex` call; removed multi-target logic and helpers.
  - Kept Windows-safe dry-run output for Codex: `npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous`.
  - Updated CLI help, docs, workflow smoke test, and tests to remove Claude Code/Gemini paths.

- **Migration**
  - Use `npx lazycodex-ai install` (optionally `--no-tui --codex-autonomous`) for Codex Light.
  - Scripts with `--platform=codex` still work but are no longer required.
  - For Claude Code or Gemini installs, use `oh-my-openagent`/`omo` outside `lazycodex-ai`.

<sup>Written for commit 376b9e9b6675dfe4897350072f0121829802e792. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

