### PR TITLE
fix(codex): reject stale sparkshell prompt surfaces

### DIFF
--- a/packages/omo-codex/plugin/test/aggregate-skills.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-skills.test.mjs
@@ -8,6 +8,7 @@ import {
 	findSpawnAgentCallsWithoutForkContextFalse,
 	root,
 } from "./aggregate-plugin-fixture.mjs";
+import { listSkillFiles } from "./sync-skills-test-support.mjs";
 
 test("#given synced skills with Codex compatibility guidance #when spawn_agent is documented #then invalid role parameters are absent", async () => {
 	const skillsDir = join(root, "skills");
@@ -64,4 +65,26 @@ test("#given long-running orchestration prompts #when waiting on child agents #t
 	}
 
 	assert.deepEqual(missingLivenessGuidance, []);
+});
+
+test("#given packaged Codex prompt surfaces #when inspected #then removed sparkshell guidance is absent", async () => {
+	const promptRoots = [
+		join(root, "skills"),
+		join(root, "components", "rules", "bundled-rules"),
+		join(root, "components", "ultrawork", "agents"),
+		join(root, "components", "ulw-loop", "skills"),
+	];
+	const promptFilePattern = /\.(?:json|md|toml|ya?ml)$/i;
+	const removedSparkshellPattern = /\b(?:sparkshell|spark[-_\s]+shell)\b/i;
+	const matches = [];
+
+	for (const promptRoot of promptRoots) {
+		for (const relativePath of await listSkillFiles(promptRoot)) {
+			if (!promptFilePattern.test(relativePath)) continue;
+			const content = await readFile(join(promptRoot, relativePath), "utf8");
+			if (removedSparkshellPattern.test(content)) matches.push(`${promptRoot}/${relativePath}`);
+		}
+	}
+
+	assert.deepEqual(matches, []);
 });

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5907,7 +5907,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.14.0",
+    version: "4.14.1",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -6880,7 +6880,7 @@ async function existingNonSymlink(path) {
   }
 }
 // packages/omo-codex/src/install/codex-cache-install.ts
-import { cp as cp2, mkdir as mkdir3, readFile as readFile7, rename, rm as rm3 } from "node:fs/promises";
+import { cp as cp2, mkdir as mkdir3, readFile as readFile7, readdir as readdir3, rename, rm as rm3 } from "node:fs/promises";
 import { basename as basename3, dirname as dirname4, join as join11, sep as sep5 } from "node:path";
 
 // packages/omo-codex/src/install/codex-cache-bundled-mcps.ts
@@ -7445,6 +7445,7 @@ async function installCachedPlugin(input) {
     await removeCachedManagedNpmBinShims(tempPath);
     if (input.buildSource === false)
       await maybeRunNpmSyncSkills(tempPath, input.runCommand);
+    await assertNoRemovedSparkshellPromptReferences(tempPath);
     await rewriteCachedMcpManifest(tempPath, input.sourcePath);
     await rewriteCachedManifestRoot(tempPath, tempPath, targetPath);
     await assertHookCommandTargets(tempPath);
@@ -7523,6 +7524,55 @@ function shouldCopyPluginPath(path, root) {
   const parts = relative4.split(sep5);
   return !parts.some((part) => part === ".git" || part === "node_modules");
 }
+var removedSparkshellReferencePattern = /\b(?:sparkshell|spark[-_\s]+shell)\b/i;
+var removedSparkshellPromptSurfaceDirs = new Set([".codex-plugin", "agents", "bundled-rules", "hooks", "skills"]);
+var removedSparkshellPromptSurfaceFiles = new Set(["directive.md", "plugin.json"]);
+var removedSparkshellTextFilePattern = /\.(?:json|md|toml|ya?ml)$/i;
+async function assertNoRemovedSparkshellPromptReferences(pluginRoot) {
+  for (const filePath of await listRemovedSparkshellPromptSurfaceFiles(pluginRoot, "")) {
+    const content = await readFile7(join11(pluginRoot, filePath), "utf8");
+    if (!removedSparkshellReferencePattern.test(content))
+      continue;
+    throw new Error(`removed sparkshell reference found in Codex plugin prompt surface: ${filePath}`);
+  }
+}
+async function listRemovedSparkshellPromptSurfaceFiles(pluginRoot, relativeDirectory) {
+  const directory = relativeDirectory === "" ? pluginRoot : join11(pluginRoot, relativeDirectory);
+  const entries = await readdir3(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const relativePath = relativeDirectory === "" ? entry.name : join11(relativeDirectory, entry.name);
+    if (entry.isDirectory()) {
+      if (shouldDescendIntoRemovedSparkshellPromptSurface(relativePath)) {
+        files.push(...await listRemovedSparkshellPromptSurfaceFiles(pluginRoot, relativePath));
+      }
+      continue;
+    }
+    if (shouldCheckRemovedSparkshellPromptFile(relativePath))
+      files.push(relativePath);
+  }
+  return files.sort();
+}
+function shouldDescendIntoRemovedSparkshellPromptSurface(relativePath) {
+  const parts = relativePath.split(sep5);
+  if (parts.some((part) => part === ".git" || part === "dist" || part === "node_modules"))
+    return false;
+  if (parts[0] === "components") {
+    if (parts.length <= 2)
+      return true;
+    return removedSparkshellPromptSurfaceDirs.has(parts[2]);
+  }
+  return removedSparkshellPromptSurfaceDirs.has(parts[0]);
+}
+function shouldCheckRemovedSparkshellPromptFile(relativePath) {
+  if (!removedSparkshellTextFilePattern.test(relativePath))
+    return false;
+  const parts = relativePath.split(sep5);
+  const fileName = parts.at(-1) ?? "";
+  if (parts[0] === "components" && parts.length === 3)
+    return removedSparkshellPromptSurfaceFiles.has(fileName);
+  return removedSparkshellPromptSurfaceDirs.has(parts[0]);
+}
 async function copyRootRuntimeDists(input) {
   const repoRoot = repoRootForCodexPluginSource(input.sourcePath);
   if (repoRoot === null)
@@ -7547,7 +7597,7 @@ function repoRootForCodexPluginSource(sourcePath) {
   return dirname4(packagesRoot);
 }
 // packages/omo-codex/src/install/codex-cache-prune.ts
-import { lstat as lstat4, readdir as readdir3, rm as rm4, stat as stat3 } from "node:fs/promises";
+import { lstat as lstat4, readdir as readdir4, rm as rm4, stat as stat3 } from "node:fs/promises";
 import { join as join12 } from "node:path";
 async function pruneMarketplaceCache(input) {
   const cacheRoot = join12(input.codexHome, "plugins", "cache", input.marketplaceName);
@@ -7575,11 +7625,11 @@ async function pruneMarketplacePluginCaches(input) {
 }
 async function readCacheEntries(path) {
   const emptyEntries = [];
-  return readCacheRoot(path, () => readdir3(path, { withFileTypes: true }), emptyEntries);
+  return readCacheRoot(path, () => readdir4(path, { withFileTypes: true }), emptyEntries);
 }
 async function readCacheEntryNames(path) {
   const emptyNames = [];
-  return readCacheRoot(path, () => readdir3(path), emptyNames);
+  return readCacheRoot(path, () => readdir4(path), emptyNames);
 }
 async function readCacheRoot(path, readEntries, fallback) {
   try {
@@ -8741,7 +8791,7 @@ function toCodexResolution(resolution) {
 }
 
 // packages/omo-codex/src/install/link-cached-plugin-agents.ts
-import { copyFile, lstat as lstat7, mkdir as mkdir6, readFile as readFile13, readdir as readdir4, rm as rm6, writeFile as writeFile6 } from "node:fs/promises";
+import { copyFile, lstat as lstat7, mkdir as mkdir6, readFile as readFile13, readdir as readdir5, rm as rm6, writeFile as writeFile6 } from "node:fs/promises";
 import { basename as basename5, join as join19 } from "node:path";
 
 // packages/omo-codex/src/install/retired-managed-agent-purge.ts
@@ -8809,7 +8859,7 @@ async function capturePreservedAgentReasoning(input) {
   if (!await exists4(agentsDir))
     return new Map;
   const preserved = new Map;
-  const agentEntries = await readdir4(agentsDir, { withFileTypes: true });
+  const agentEntries = await readdir5(agentsDir, { withFileTypes: true });
   for (const entry of agentEntries) {
     if (!entry.name.endsWith(".toml"))
       continue;
@@ -8827,7 +8877,7 @@ async function capturePreservedAgentServiceTier(input) {
   if (!await exists4(agentsDir))
     return new Map;
   const preserved = new Map;
-  const agentEntries = await readdir4(agentsDir, { withFileTypes: true });
+  const agentEntries = await readdir5(agentsDir, { withFileTypes: true });
   for (const entry of agentEntries) {
     if (!entry.name.endsWith(".toml"))
       continue;
@@ -8884,7 +8934,7 @@ async function discoverBundledAgents(pluginRoot) {
   const componentsRoot = join19(pluginRoot, "components");
   if (!await exists4(componentsRoot))
     return [];
-  const componentEntries = await readdir4(componentsRoot, { withFileTypes: true });
+  const componentEntries = await readdir5(componentsRoot, { withFileTypes: true });
   const agents = [];
   for (const entry of componentEntries) {
     if (!entry.isDirectory())
@@ -8892,7 +8942,7 @@ async function discoverBundledAgents(pluginRoot) {
     const agentsRoot = join19(componentsRoot, entry.name, "agents");
     if (!await exists4(agentsRoot))
       continue;
-    const agentEntries = await readdir4(agentsRoot, { withFileTypes: true });
+    const agentEntries = await readdir5(agentsRoot, { withFileTypes: true });
     for (const file2 of agentEntries) {
       if (!file2.isFile() || !file2.name.endsWith(".toml"))
         continue;
@@ -9199,7 +9249,7 @@ function shouldCopyMarketplaceSourcePath(path, root) {
 }
 
 // packages/omo-codex/src/install/lazycodex-version-stamp.ts
-import { readdir as readdir5, readFile as readFile15, writeFile as writeFile8 } from "node:fs/promises";
+import { readdir as readdir6, readFile as readFile15, writeFile as writeFile8 } from "node:fs/promises";
 import { join as join22 } from "node:path";
 async function readDistributionManifest(repoRoot) {
   try {
@@ -9292,7 +9342,7 @@ async function stampHookStatusMessages(path, version) {
 async function stampComponentVersions(input) {
   let entries;
   try {
-    entries = await readdir5(join22(input.pluginRoot, "components"));
+    entries = await readdir6(join22(input.pluginRoot, "components"));
   } catch (error) {
     if (error instanceof Error)
       return;
@@ -9555,7 +9605,7 @@ function formatUnknownError(error) {
 }
 
 // packages/omo-codex/src/install/lsp-daemon-reaper.ts
-import { readFile as readFile17, readdir as readdir6, rm as rm8 } from "node:fs/promises";
+import { readFile as readFile17, readdir as readdir7, rm as rm8 } from "node:fs/promises";
 import { connect } from "node:net";
 import { join as join24 } from "node:path";
 async function reapLspDaemons(codexHome, deps = {}) {
@@ -9565,7 +9615,7 @@ async function reapLspDaemons(codexHome, deps = {}) {
   const reaped = [];
   let entries;
   try {
-    entries = await readdir6(daemonRoot);
+    entries = await readdir7(daemonRoot);
   } catch {
     return reaped;
   }

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -7569,8 +7569,11 @@ function shouldCheckRemovedSparkshellPromptFile(relativePath) {
     return false;
   const parts = relativePath.split(sep5);
   const fileName = parts.at(-1) ?? "";
-  if (parts[0] === "components" && parts.length === 3)
-    return removedSparkshellPromptSurfaceFiles.has(fileName);
+  if (parts[0] === "components") {
+    if (parts.length === 3)
+      return removedSparkshellPromptSurfaceFiles.has(fileName);
+    return parts.length > 3 && removedSparkshellPromptSurfaceDirs.has(parts[2]);
+  }
   return removedSparkshellPromptSurfaceDirs.has(parts[0]);
 }
 async function copyRootRuntimeDists(input) {

--- a/packages/omo-codex/src/install/codex-cache-install.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, readFile, rename, rm } from "node:fs/promises"
+import { cp, mkdir, readFile, readdir, rename, rm } from "node:fs/promises"
 import { basename, dirname, join, sep } from "node:path"
 import { copyBundledMcpRuntimeDists } from "./codex-cache-bundled-mcps"
 import { removeCachedManagedNpmBinShims } from "./codex-cache-bins"
@@ -36,6 +36,7 @@ export async function installCachedPlugin(input: {
     await maybeRunNpmInstall(tempPath, input.runCommand, ["ci", "--omit=dev"])
     await removeCachedManagedNpmBinShims(tempPath)
     if (input.buildSource === false) await maybeRunNpmSyncSkills(tempPath, input.runCommand)
+    await assertNoRemovedSparkshellPromptReferences(tempPath)
     await rewriteCachedMcpManifest(tempPath, input.sourcePath)
     await rewriteCachedManifestRoot(tempPath, tempPath, targetPath)
     await assertHookCommandTargets(tempPath)
@@ -111,6 +112,54 @@ function shouldCopyPluginPath(path: string, root: string): boolean {
   if (relative === "") return true
   const parts = relative.split(sep)
   return !parts.some((part) => part === ".git" || part === "node_modules")
+}
+
+const removedSparkshellReferencePattern = /\b(?:sparkshell|spark[-_\s]+shell)\b/i
+const removedSparkshellPromptSurfaceDirs = new Set([".codex-plugin", "agents", "bundled-rules", "hooks", "skills"])
+const removedSparkshellPromptSurfaceFiles = new Set(["directive.md", "plugin.json"])
+const removedSparkshellTextFilePattern = /\.(?:json|md|toml|ya?ml)$/i
+
+async function assertNoRemovedSparkshellPromptReferences(pluginRoot: string): Promise<void> {
+  for (const filePath of await listRemovedSparkshellPromptSurfaceFiles(pluginRoot, "")) {
+    const content = await readFile(join(pluginRoot, filePath), "utf8")
+    if (!removedSparkshellReferencePattern.test(content)) continue
+    throw new Error(`removed sparkshell reference found in Codex plugin prompt surface: ${filePath}`)
+  }
+}
+
+async function listRemovedSparkshellPromptSurfaceFiles(pluginRoot: string, relativeDirectory: string): Promise<readonly string[]> {
+  const directory = relativeDirectory === "" ? pluginRoot : join(pluginRoot, relativeDirectory)
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const relativePath = relativeDirectory === "" ? entry.name : join(relativeDirectory, entry.name)
+    if (entry.isDirectory()) {
+      if (shouldDescendIntoRemovedSparkshellPromptSurface(relativePath)) {
+        files.push(...(await listRemovedSparkshellPromptSurfaceFiles(pluginRoot, relativePath)))
+      }
+      continue
+    }
+    if (shouldCheckRemovedSparkshellPromptFile(relativePath)) files.push(relativePath)
+  }
+  return files.sort()
+}
+
+function shouldDescendIntoRemovedSparkshellPromptSurface(relativePath: string): boolean {
+  const parts = relativePath.split(sep)
+  if (parts.some((part) => part === ".git" || part === "dist" || part === "node_modules")) return false
+  if (parts[0] === "components") {
+    if (parts.length <= 2) return true
+    return removedSparkshellPromptSurfaceDirs.has(parts[2])
+  }
+  return removedSparkshellPromptSurfaceDirs.has(parts[0])
+}
+
+function shouldCheckRemovedSparkshellPromptFile(relativePath: string): boolean {
+  if (!removedSparkshellTextFilePattern.test(relativePath)) return false
+  const parts = relativePath.split(sep)
+  const fileName = parts.at(-1) ?? ""
+  if (parts[0] === "components" && parts.length === 3) return removedSparkshellPromptSurfaceFiles.has(fileName)
+  return removedSparkshellPromptSurfaceDirs.has(parts[0])
 }
 
 async function copyRootRuntimeDists(input: { readonly pluginRoot: string; readonly sourcePath: string }): Promise<void> {

--- a/packages/omo-codex/src/install/codex-cache-install.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.ts
@@ -158,7 +158,10 @@ function shouldCheckRemovedSparkshellPromptFile(relativePath: string): boolean {
   if (!removedSparkshellTextFilePattern.test(relativePath)) return false
   const parts = relativePath.split(sep)
   const fileName = parts.at(-1) ?? ""
-  if (parts[0] === "components" && parts.length === 3) return removedSparkshellPromptSurfaceFiles.has(fileName)
+  if (parts[0] === "components") {
+    if (parts.length === 3) return removedSparkshellPromptSurfaceFiles.has(fileName)
+    return parts.length > 3 && removedSparkshellPromptSurfaceDirs.has(parts[2])
+  }
   return removedSparkshellPromptSurfaceDirs.has(parts[0])
 }
 

--- a/packages/omo-codex/src/install/codex-cache.test.ts
+++ b/packages/omo-codex/src/install/codex-cache.test.ts
@@ -178,6 +178,32 @@ describe("codex-cache", () => {
     expect(await readFile(join(installed.path, "package-lock.json"), "utf8")).toBe(lockfile)
   })
 
+  test("#given stale sparkshell guidance in prompt surfaces #when caching plugin #then cache promotion is rejected", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-sparkshell-"))
+    const codexHome = join(root, "codex-home")
+    const sourceRoot = join(root, "plugin")
+    await mkdir(join(sourceRoot, "skills", "ulw-loop", "references"), { recursive: true })
+    await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }))
+    await writeFile(
+      join(sourceRoot, "skills", "ulw-loop", "references", "full-workflow.md"),
+      "After compaction, run `omo sparkshell cat .omo/ulw-loop/ledger.jsonl` first.\n",
+    )
+
+    // when / then
+    await expect(
+      installCachedPlugin({
+        codexHome,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async () => undefined,
+      }),
+    ).rejects.toThrow(/removed sparkshell/i)
+    await expect(stat(join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0"))).rejects.toThrow()
+  })
+
   test("#given existing cache #when npm install fails #then previous active cache is preserved", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-install-fail-"))

--- a/packages/omo-codex/src/install/codex-cache.test.ts
+++ b/packages/omo-codex/src/install/codex-cache.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, test } from "bun:test"
 import { realpathSync } from "node:fs"
 import { mkdir, mkdtemp, readdir, readFile, readlink, rename, stat, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { basename, join, relative, sep } from "node:path"
+import { basename, dirname, join, relative, sep } from "node:path"
 import { installCachedPlugin, linkCachedPluginBins, rewriteCachedMcpManifest } from "./codex-cache"
 
 describe("codex-cache", () => {
@@ -202,6 +202,39 @@ describe("codex-cache", () => {
       }),
     ).rejects.toThrow(/removed sparkshell/i)
     await expect(stat(join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0"))).rejects.toThrow()
+  })
+
+  test("#given stale sparkshell guidance in component prompt surfaces #when caching plugin #then cache promotion is rejected", async () => {
+    // given
+    const promptCases = [
+      join("components", "ulw-loop", "agents", "planner.toml"),
+      join("components", "ulw-loop", "bundled-rules", "rules.md"),
+      join("components", "ulw-loop", "hooks", "session-start.json"),
+      join("components", "ulw-loop", "skills", "ulw-loop", "references", "full-workflow.md"),
+    ]
+
+    for (const promptCase of promptCases) {
+      const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-component-sparkshell-"))
+      const codexHome = join(root, "codex-home")
+      const sourceRoot = join(root, "plugin")
+      const stalePrompt = join(sourceRoot, promptCase)
+      await mkdir(dirname(stalePrompt), { recursive: true })
+      await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }))
+      await writeFile(stalePrompt, "After compaction, run `omo sparkshell cat .omo/ulw-loop/ledger.jsonl` first.\n")
+
+      // when / then
+      await expect(
+        installCachedPlugin({
+          codexHome,
+          marketplaceName: "debug",
+          name: "omo",
+          sourcePath: sourceRoot,
+          version: "0.1.0",
+          runCommand: async () => undefined,
+        }),
+      ).rejects.toThrow(/removed sparkshell/i)
+      await expect(stat(join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0"))).rejects.toThrow()
+    }
   })
 
   test("#given existing cache #when npm install fails #then previous active cache is preserved", async () => {


### PR DESCRIPTION
## Summary
This PR prevents removed `sparkshell` guidance from being promoted into the Codex plugin cache again. The current source prompt surfaces were already clean, but an installed 4.14.0 cache still contained stale `omo sparkshell cat .omo/ulw-loop/ledger.jsonl` guidance in the ulw-loop skill, which explains why the removed feature could still appear in live usage.

The installer now scans Codex prompt surfaces before cache promotion and rejects any removed sparkshell reference. The aggregate prompt-surface test also keeps generated packaged prompts clean.

## Changes
- Add an install-time guard in the Codex cache installer that scans plugin prompt surfaces before promoting a new cache directory.
- Cover the stale ulw-loop skill reference with a focused cache install test that proves the bad cache is rejected and not promoted.
- Add an aggregate packaged prompt-surface scan so generated Codex skill/rule/agent surfaces stay sparkshell-free.
- Regenerate the packaged Node installer bundle so published install paths carry the same guard.

## QA & Evidence
- **What was tested:** Pre-fix investigation of source vs installed cache prompt surfaces.
  **Observed result:** Current source prompt surfaces had no live sparkshell guidance; installed `~/.codex/plugins/cache/sisyphuslabs/omo/4.14.0` still had stale ulw-loop guidance.
  **Artifacts:** `.omo/evidence/20260630-sparkshell-residual-calls/pre-fix-sparkshell-rg.txt`, `.omo/evidence/20260630-sparkshell-residual-calls/pre-fix-sparkshell-targeted-rg.txt`
  **Why sufficient:** Identifies the residual call path as stale installed/generated prompt material rather than a current runtime route.

- **What was tested:** Focused cache installer guard.
  **Observed result:** RED failed before the guard; GREEN rejects stale `skills/ulw-loop/references/full-workflow.md` guidance and preserves cache promotion safety.
  **Artifacts:** `.omo/evidence/20260630-sparkshell-residual-calls/red-codex-cache-sparkshell-guard.txt`, `.omo/evidence/20260630-sparkshell-residual-calls/green-codex-cache-focused-v2.txt`
  **Why sufficient:** Covers the exact recurrence path where stale prompt text would enter the installed Codex cache.

- **What was tested:** Generated packaged prompt surfaces.
  **Observed result:** Aggregate prompt-surface scan passes; post-fix prompt-surface scan reports `matchCount: 0`.
  **Artifacts:** `.omo/evidence/20260630-sparkshell-residual-calls/green-aggregate-sparkshell-scan-v2.txt`, `.omo/evidence/20260630-sparkshell-residual-calls/post-fix-prompt-surface-scan.txt`
  **Why sufficient:** Prevents generated skill/rule/agent prompts from silently reintroducing removed sparkshell guidance.

- **What was tested:** Codex QA with isolated install and app-server hook proof.
  **Observed result:** Isolated installed cache scan reports `matchCount: 0`; real `~/.codex/config.toml` stayed unchanged; app-server proof fired `sessionStart`, `userPromptSubmit`, and `stop` hooks.
  **Artifacts:** `.omo/evidence/20260630-sparkshell-residual-calls/codex-qa-install-and-cache-summary-v2.txt`, `.omo/evidence/20260630-sparkshell-residual-calls/codex-qa-app-server-drive-plugin.json`
  **Why sufficient:** Drives the real Codex plugin surface in isolation while proving the user Codex home was not mutated.

- **What was tested:** Codex package gates.
  **Observed result:** `tsgo --noEmit -p packages/omo-codex/tsconfig.json` passed; `bun run test:codex` passed.
  **Artifacts:** `.omo/evidence/20260630-sparkshell-residual-calls/typecheck-omo-codex.txt`, `.omo/evidence/20260630-sparkshell-residual-calls/test-codex.txt`
  **Why sufficient:** Confirms installer/package compatibility and the repo-mandated Codex gate after regenerating the installer bundle.

## Risks & Residuals
- The guard intentionally scans Codex prompt surfaces only, not arbitrary package metadata or dependency lockfiles. This avoids false positives while covering the user-visible guidance paths that can reach Codex sessions.
- Existing already-installed stale caches are explained by this PR but not automatically deleted by it; reinstall/update will receive the clean generated prompt surfaces and the new guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks promotion of stale `sparkshell` guidance into the Codex plugin cache by scanning prompt surfaces (including component prompts) during install. Fixes residual prompts from older 4.14.0 caches and ships via the regenerated installer.

- **Bug Fixes**
  - Extend install-time guard to scan top-level and `components/*/{agents,bundled-rules,hooks,skills}` prompt surfaces; reject any `sparkshell` references.
  - Add tests covering component prompt cases and keep packaged skills/rules/agents sparkshell-free.
  - Regenerate installer bundle; bump `@oh-my-opencode/omo-codex` to `4.14.1`.

- **Migration**
  - Existing stale caches are not auto-removed; update/reinstall to receive the clean prompts and guard.

<sup>Written for commit 2ec93c5c47c1f4cd9991d57c44c3b9a39bba06c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

