### PR TITLE
Add Aside frontend design reference

### DIFF
--- a/packages/omo-opencode/src/features/builtin-skills/frontend/SKILL.md
+++ b/packages/omo-opencode/src/features/builtin-skills/frontend/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: frontend
-description: "MUST USE for ANY frontend, web UI, UX, or visual work — building, styling, or redesigning pages/components, React project setup, performance audits, design QA. Routes four rulesets: design (anti-slop taste router over 12 taste skills + 69 brand DESIGN.md refs — Apple, Stripe, Linear, Notion, Vercel, Claude, Nike — plus React dev tooling gate: react-grab, react-scan, react-doctor), perfection (Lighthouse 100 in every category via real Playwright Chromium audits, NEVER the lighthouse CLI, never by weakening UX), ui-ux-db (searchable 50+ styles, 97 palettes, 57 font pairings, 99 UX guidelines), designpowers (design operating layer, personas, accessibility, critique, debt, handoff, and role-reference guidance). Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, taste, premium, luxury, minimal, brutalist, Awwwards, anti-slop, polish, DESIGN.md, mockup, react setup, react-scan, react-doctor, lighthouse, performance, Core Web Vitals, LCP, CLS, INP, SEO, accessibility, a11y, WCAG, audit my site, make this faster, color palette, font pairing, looks generic, make it pretty, like X brand."
+description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand."
 ---
 
 # Frontend
 
 This file is a router, not a rulebook. The rules live in four rulesets under `references/`; your first job is to load the smallest set of files that covers the request, state which you loaded in one sentence, then execute under their guidance. Loading nothing and freestyling produces the generic AI-slop output this skill exists to prevent; loading everything wastes context and creates contradictory instructions.
+
+**The bar is not clean-and-correct — it is work a senior designer at Linear, Stripe, or Supabase would ship.** Correct-but-flat is a failure, not a finish. Protect the surface as hard as you protect the build: design is a first-class deliverable, not a one-shot decision you lock and walk away from.
 
 ## Phase 0 — Route (before any UI work)
 
@@ -22,15 +24,16 @@ This file is a router, not a rulebook. The rules live in four rulesets under `re
 
 Every implementation must choose one of these branches before UI code changes:
 
-1. **Greenfield or fresh setup:** if the user gave no concrete visual reference, use `references/design/_INDEX.md` to shortlist 2-3 plausible Layer B references, then deeply load exactly one Layer A style skill and one Layer B brand/design-system reference; use `open-design` only when the curated set has no fit. Treat those references as source material, not mood labels: extract tokens, layout grammar, component anatomy, interaction states, motion, and taste decisions into `DESIGN.md`, then recombine them into project-specific primitives. Customize for the user's product and content, but do not freestyle past the selected references; never copy logos, trademarked assets, or brand-specific copy. Define Section 5 primitives with variants, default/hover/active/focus/disabled/loading/empty/error states, accessibility, and motion before code. Build them first in a component showcase or state harness; each primitive and required state must pass mobile/tablet/desktop visual QA before product screens.
-2. **Existing project with `DESIGN.md` or a component system:** read it, follow it, and update it before implementation only when the requested work needs a new token, primitive, state, motion rule, accessibility constraint, or accepted debt.
-3. **Existing project with UI but no `DESIGN.md` and no reusable component layer:** STOP and ask the user one focused question: should you preserve the current look with copy-nearby styling, or extract a real `DESIGN.md` plus reusable components before continuing? Do not silently choose.
+1. **Concrete visual reference:** if the user supplies a screenshot, generated mockup, Stitch/Imagen output, Figma export, overview, or annotated reference packet, treat it as the visual contract. Load `references/design/image-to-code-skill.md` plus the relevant design/perfection files, extract the reference's exact tokens, layout geometry, copy, spacing, states, and responsive intent into `DESIGN.md`, then implement reusable primitives against that contract. Final QA must run `/visual-qa` in reference-fidelity mode: compare the actual UI against the reference packet pixel-by-pixel and verify the code is an extensible design-system implementation, not a screenshot-matched one-off.
+2. **Greenfield or fresh setup:** if the user gave no concrete visual reference, use `references/design/_INDEX.md` to shortlist 2-3 plausible Layer B references, then deeply load exactly one Layer A style skill and one Layer B brand/design-system reference; use `open-design` only when the curated set has no fit. Treat those references as source material, not mood labels: extract tokens, layout grammar, component anatomy, interaction states, motion, and taste decisions into `DESIGN.md`, then recombine them into project-specific primitives. Customize for the user's product and content, but do not freestyle past the selected references; never copy logos, trademarked assets, or brand-specific copy. Define Section 5 primitives with variants, default/hover/active/focus/disabled/loading/empty/error states, accessibility, and motion before code. Build them first in a component showcase or state harness; each primitive and required state must pass mobile/tablet/desktop visual QA before product screens.
+3. **Existing project with `DESIGN.md` or a component system:** read it, follow it, and update it before implementation only when the requested work needs a new token, primitive, state, motion rule, accessibility constraint, accepted debt, or reference-fidelity requirement.
+4. **Existing project with UI but no `DESIGN.md` and no reusable component layer:** STOP and ask the user one focused question: should you preserve the current look with copy-nearby styling, or extract a real `DESIGN.md` plus reusable components before continuing? Do not silently choose.
 
 When `references/designpowers/README.md` is loaded for implementation, redesign, or design-system work, feed its personas, accessibility, critique, debt, handoff, and role-reference guidance into the branch above. The resulting `DESIGN.md` is the implementation contract: tokens, typography, spacing, primitives, motion, responsive behavior, accessibility constraints, and accepted debt must be named there before code uses them. Verify component primitives, states, and final screens with real visual QA evidence; pass design-system decisions, implementation evidence, and unresolved debt into `/review-work` for significant implementation work.
 
 ## Ruleset 1 — design (`references/design/`)
 
-The reference library has one architecture file, 12 taste skills (Layer A — *how to execute*), and 69 brand design systems (Layer B — *what it should look like*). Most non-trivial tasks load **one Layer A + one Layer B**. `README.md` carries the full routing flow, stacking rules, anti-patterns, and the mandatory browser-based Design QA phase; `_INDEX.md` catalogs all 81 files with mood-to-brand mappings — read it whenever routing is not obvious from the tables below.
+The reference library has one architecture file, 12 taste skills (Layer A — *how to execute*), and 70 brand design systems (Layer B — *what it should look like*). Most non-trivial tasks load **one Layer A + one Layer B**. `README.md` carries the full routing flow, stacking rules, anti-patterns, and the mandatory browser-based Design QA phase; `_INDEX.md` catalogs all 83 files with mood-to-brand mappings — read it whenever routing is not obvious from the tables below.
 
 ### Layer 0 — architecture
 
@@ -42,11 +45,11 @@ The reference library has one architecture file, 12 taste skills (Layer A — *h
 
 | File | Read when the user says… |
 |---|---|
-| `taste-skill.md` | Nothing style-specific — "make a good UI". The default all-rounder. |
-| `gpt-tasteskill.md` | "Awwwards-tier", "wow factor", "cinematic", "scroll-triggered", or `taste-skill` results felt too safe. |
+| `taste-skill.md` | Neutral or operational UI with no surface ambition — internal tools, dashboards, "just make it usable". The safe default; do NOT settle here when the brief signals glossy / premium / startup-grade craft. |
+| `gpt-tasteskill.md` | "Awwwards-tier", "wow factor", "cinematic", "scroll-triggered" marketing/landing experiences. |
 | `minimalist-skill.md` | "minimal", "clean", "Notion-like", "Linear-like", "editorial". |
 | `brutalist-skill.md` | "brutalist", "raw", "Swiss", "experimental", "anti-design". |
-| `soft-skill.md` | "premium", "luxury", "calm", "expensive", "spa", "boutique", "elegant". |
+| `soft-skill.md` | "premium", "luxury", "calm", "expensive", "elegant", AND glossy / glassy / liquid-glass / startup-grade product surfaces — pair with a high-craft Layer B (`supabase`, `linear.app`, `vercel`, `stripe`). |
 | `redesign-skill.md` | Improving EXISTING UI — "this looks bad", "fix the design". Audit-first workflow; never use on greenfield. |
 | `image-to-code-skill.md` | "Generate the design first, then code it." Pair with one imagegen file below. |
 | `output-skill.md` | Stacks on any style skill when output is incomplete — placeholders, `// TODO`, half-done components. |
@@ -55,7 +58,7 @@ The reference library has one architecture file, 12 taste skills (Layer A — *h
 
 ### Layer B — brand design systems (orthogonal to Layer A; stack freely)
 
-When the user names a brand or site — "Linear-style", "like Stripe's landing" — load `references/design/<brand>.md` as the token source of truth (palette, type scale, components, do/don'ts). Coverage includes `apple` `stripe` `linear.app` `notion` `vercel` `claude` `figma` `airbnb` `nike` `tesla` `spotify` `raycast` `revolut` and ~56 more; the full list with mood shortcuts is in `_INDEX.md`. Extract the tokens and apply them to the project's own content — never copy logos or trademarked imagery. If the named brand is missing, fall back to a Layer A mood match or the `open-design` skill.
+When the user names a brand or site — "Linear-style", "like Stripe's landing", "Aside-style browser agent" — load `references/design/<brand>.md` as the token source of truth (palette, type scale, components, do/don'ts). Coverage includes `aside` `apple` `stripe` `linear.app` `notion` `vercel` `claude` `figma` `airbnb` `nike` `tesla` `spotify` `raycast` `revolut` and ~56 more; the full list with mood shortcuts is in `_INDEX.md`. Extract the tokens and apply them to the project's own content — never copy logos or trademarked imagery. If the named brand is missing, fall back to a Layer A mood match or the `open-design` skill.
 
 ### React dev tooling
 
@@ -99,9 +102,11 @@ Domains: `product` `style` `typography` `color` `landing` `chart` `ux` `react` `
 | Request | Load |
 |---|---|
 | "Build a landing page" (no direction given) | `design/README.md` + `design/_INDEX.md` shortlist → exactly one Layer B reference + `design/taste-skill.md` + `perfection/README.md` |
+| "Aside-style AI browser / browser agent page" | `design/README.md` + `design/aside.md` + `design/taste-skill.md` + `perfection/README.md` |
 | "Linear-style landing page" | `design/README.md` + `design/linear.app.md` + `design/taste-skill.md` + `perfection/README.md` |
 | "Premium SaaS hero like Stripe" | `design/README.md` + `design/stripe.md` + `design/soft-skill.md` + `perfection/README.md` |
 | "Improve this existing dashboard" | `design/README.md` + `design/redesign-skill.md` + `perfection/README.md` |
+| "Build this screenshot / Imagen mock / Stitch output exactly" | `design/README.md` + `design/image-to-code-skill.md` + `perfection/README.md` + `/visual-qa` reference-fidelity mode |
 | "Audit my site" / "make this page faster" | `perfection/README.md` (+ `perfection/react-perf-tooling.md` if React) |
 | "Mockup image of a fintech app" — no code | `design/imagegen-frontend-mobile.md` (+ a Layer B brand if named) |
 | "What palette/fonts fit a wellness brand?" | `ui-ux-db/README.md` → search CLI |
@@ -111,7 +116,8 @@ Domains: `product` `style` `typography` `color` `landing` `chart` `ux` `react` `
 ## Shared axioms (all four rulesets agree — apply always)
 
 - **No design system = no UI work.** `DESIGN.md` exists before components do; every color, font size, and spacing value traces back to a token in it.
-- **Never weaken UX to buy points.** No dropping animations, hiding content, or simplifying interactions for a score or a deadline.
+- **Concrete reference = contract.** When a screenshot, generated mockup, overview, or annotated reference exists, the implementation must match its pixels, copy, component structure, and responsive intent unless the user explicitly accepts a deviation.
+- **Never weaken UX OR flatten the surface to buy points.** No dropping animations, hiding content, simplifying interactions, or replacing rendered/lit material with flat fills and flat geometric primitives for a Lighthouse score or a deadline. Hit 100 AND keep the surface dimensional — both, or neither.
 - **No emojis as icons.** SVG icon sets only (Lucide, Heroicons, Radix, Phosphor).
 - **GPU-composited animation only** — `transform`, `opacity`, `filter`; never animate layout properties.
 - **Verify in a real browser before declaring done.** Screenshots at 375 / 768 / 1280px; hover, focus, loading, empty, and error states all exercised.
@@ -120,7 +126,7 @@ Domains: `product` `style` `typography` `color` `landing` `chart` `ux` `react` `
 
 | Situation | Load |
 |---|---|
-| Brand/style not among the 69 in `references/design/`, or the user says "Open Design" | `open-design` skill — the local nexu-io/open-design library (137+ design skills, 150+ design systems) |
+| Brand/style not among the 70 in `references/design/`, or the user says "Open Design" | `open-design` skill — the local nexu-io/open-design library (137+ design skills, 150+ design systems) |
 | Driving a browser for the Design QA phase | `agent-browser` skill |
 | Pure TypeScript/logic work with zero visual surface | `programming` skill alone — this skill adds nothing there |
 

--- a/packages/shared-skills/AGENTS.md
+++ b/packages/shared-skills/AGENTS.md
@@ -37,7 +37,7 @@ upstreams/{open-design,taste-skill,ui-ux-pro-max,designpowers}   # pinned submod
 ```
 
 - The materialized files are GITIGNORED (`skills/frontend/.gitignore`) so they are never committed; a `skills/frontend/.npmignore` overrides that `.gitignore` for npm pack so the materialized refs DO ship. The lazycodex marketplace sync is a raw file copy and ships whatever is on disk after the plugin build materialized it.
-- The §4 project-original design docs (`README.md`, `_INDEX.md`, `design-system-architecture.md`, `react-dev-tooling-skill.md`) and all of `references/perfection/*` stay committed (un-ignored in `.gitignore`).
+- The §5 project-original design docs (`README.md`, `_INDEX.md`, `aside.md`, `design-system-architecture.md`, `react-dev-tooling-skill.md`) and all of `references/perfection/*` stay committed (un-ignored in `.gitignore`).
 - ATTRIBUTION pins each upstream's SHA (`Pinned upstream commit:`); `script/update-frontend-upstreams.mjs` bumps the submodules + rewrites the pins (`--check` verifies pins == submodule HEAD, no network). `provenance-gate.test.ts` fails CI if any third-party path is committed, the materialize set is missing, or a pin drifts. `materialize-frontend-refs.test.ts` covers the allowed `SKILL.md` description quoting normalization.
 - Submodule init is non-fatal ONLY in `script/agent/setup.sh` (offline devs get a working tree minus brand refs); the plugin build chain runs it `--strict` so CI/publish ship a complete package.
 

--- a/packages/shared-skills/frontend-skill-contract.test.ts
+++ b/packages/shared-skills/frontend-skill-contract.test.ts
@@ -32,3 +32,22 @@ describe("frontend skill concrete-reference contract", () => {
 		expect(axioms).toContain("pixels, copy, component structure, and responsive intent")
 	})
 })
+
+describe("frontend skill Aside reference contract", () => {
+	test("#given an Aside-style AI browser brief #when routing design references #then Aside is discoverable and provenance-backed", async () => {
+		const skillText = await Bun.file(frontendSkillPath).text()
+		const indexText = await Bun.file(new URL("./skills/frontend/references/design/_INDEX.md", import.meta.url)).text()
+		const designReadmeText = await Bun.file(new URL("./skills/frontend/references/design/README.md", import.meta.url)).text()
+		const asideText = await Bun.file(new URL("./skills/frontend/references/design/aside.md", import.meta.url)).text()
+
+		expect(skillText).toContain("design/aside.md")
+		expect(skillText).toContain("Aside-style AI browser")
+		expect(indexText).toContain("`aside.md`")
+		expect(indexText).toContain("AI browser / agentic browser / product-app launch")
+		expect(designReadmeText).toContain("Aside-style browser agent")
+		expect(asideText).toContain("## Provenance")
+		expect(asideText).toContain("https://aside.com/")
+		expect(asideText).toContain("JCodesMore/ai-website-cloner-template")
+		expect(asideText).toContain("Do not treat this file as a license to copy")
+	})
+})

--- a/packages/shared-skills/scripts/frontend-refs-manifest.mjs
+++ b/packages/shared-skills/scripts/frontend-refs-manifest.mjs
@@ -10,6 +10,7 @@ export const upstreamsRoot = join(sharedSkillsRoot, "upstreams");
 export const designOriginals = [
 	"README.md",
 	"_INDEX.md",
+	"aside.md",
 	"design-system-architecture.md",
 	"react-dev-tooling-skill.md",
 ];

--- a/packages/shared-skills/skills/frontend/.gitignore
+++ b/packages/shared-skills/skills/frontend/.gitignore
@@ -1,12 +1,12 @@
 # Frontend third-party references are materialized at build time from the
 # submodules under packages/shared-skills/upstreams/ (DMCA-safe: the repo holds
 # zero third-party copies; the build/npm-pack materializes them into the
-# published package). Keep the section-4 project-original files committed.
+# published package). Keep the section-5 project-original files committed.
 
 # Brand + taste-skill design references (open-design, taste-skill upstreams).
 references/design/*.md
 
-# Project-original design docs (ATTRIBUTION section 4) stay committed.
+# Project-original design docs (ATTRIBUTION section 5) stay committed.
 !references/design/README.md
 !references/design/_INDEX.md
 !references/design/aside.md

--- a/packages/shared-skills/skills/frontend/.gitignore
+++ b/packages/shared-skills/skills/frontend/.gitignore
@@ -9,6 +9,7 @@ references/design/*.md
 # Project-original design docs (ATTRIBUTION section 4) stay committed.
 !references/design/README.md
 !references/design/_INDEX.md
+!references/design/aside.md
 !references/design/design-system-architecture.md
 !references/design/react-dev-tooling-skill.md
 

--- a/packages/shared-skills/skills/frontend/ATTRIBUTION.md
+++ b/packages/shared-skills/skills/frontend/ATTRIBUTION.md
@@ -186,10 +186,16 @@ SOFTWARE.
 
 ## 5. Project-original files
 
-`frontend/SKILL.md`, `frontend/references/design/README.md`, `_INDEX.md`,
+`frontend/SKILL.md`, `frontend/references/design/README.md`, `_INDEX.md`, `aside.md`,
 `design-system-architecture.md`, `react-dev-tooling-skill.md`,
 `frontend/references/perfection/README.md`, `react-perf-tooling.md`, and
 `frontend/scripts/perfection/lighthouse-audit.py` are original to this project and require
 no third-party attribution. The perfection docs and script only invoke third-party tools
 (react-scan, react-doctor, react-grab, playwright-lighthouse, lighthouse, chrome-launcher)
 at runtime; no source from those tools is vendored, so their licenses are not carried here.
+
+`frontend/references/design/aside.md` is a project-original synthesis from live browser
+capture evidence and a local reconnaissance run following the MIT-licensed
+`JCodesMore/ai-website-cloner-template` workflow; it is not copied from Aside or from the
+template. Aside names, trademarks, product text, and visual assets remain the property of
+their respective owners and are referenced only for descriptive design-analysis purposes.

--- a/packages/shared-skills/skills/frontend/SKILL.md
+++ b/packages/shared-skills/skills/frontend/SKILL.md
@@ -33,7 +33,7 @@ When `references/designpowers/README.md` is loaded for implementation, redesign,
 
 ## Ruleset 1 — design (`references/design/`)
 
-The reference library has one architecture file, 12 taste skills (Layer A — *how to execute*), and 69 brand design systems (Layer B — *what it should look like*). Most non-trivial tasks load **one Layer A + one Layer B**. `README.md` carries the full routing flow, stacking rules, anti-patterns, and the mandatory browser-based Design QA phase; `_INDEX.md` catalogs all 81 files with mood-to-brand mappings — read it whenever routing is not obvious from the tables below.
+The reference library has one architecture file, 12 taste skills (Layer A — *how to execute*), and 70 brand design systems (Layer B — *what it should look like*). Most non-trivial tasks load **one Layer A + one Layer B**. `README.md` carries the full routing flow, stacking rules, anti-patterns, and the mandatory browser-based Design QA phase; `_INDEX.md` catalogs all 83 files with mood-to-brand mappings — read it whenever routing is not obvious from the tables below.
 
 ### Layer 0 — architecture
 
@@ -58,7 +58,7 @@ The reference library has one architecture file, 12 taste skills (Layer A — *h
 
 ### Layer B — brand design systems (orthogonal to Layer A; stack freely)
 
-When the user names a brand or site — "Linear-style", "like Stripe's landing" — load `references/design/<brand>.md` as the token source of truth (palette, type scale, components, do/don'ts). Coverage includes `apple` `stripe` `linear.app` `notion` `vercel` `claude` `figma` `airbnb` `nike` `tesla` `spotify` `raycast` `revolut` and ~56 more; the full list with mood shortcuts is in `_INDEX.md`. Extract the tokens and apply them to the project's own content — never copy logos or trademarked imagery. If the named brand is missing, fall back to a Layer A mood match or the `open-design` skill.
+When the user names a brand or site — "Linear-style", "like Stripe's landing", "Aside-style browser agent" — load `references/design/<brand>.md` as the token source of truth (palette, type scale, components, do/don'ts). Coverage includes `aside` `apple` `stripe` `linear.app` `notion` `vercel` `claude` `figma` `airbnb` `nike` `tesla` `spotify` `raycast` `revolut` and ~56 more; the full list with mood shortcuts is in `_INDEX.md`. Extract the tokens and apply them to the project's own content — never copy logos or trademarked imagery. If the named brand is missing, fall back to a Layer A mood match or the `open-design` skill.
 
 ### React dev tooling
 
@@ -102,6 +102,7 @@ Domains: `product` `style` `typography` `color` `landing` `chart` `ux` `react` `
 | Request | Load |
 |---|---|
 | "Build a landing page" (no direction given) | `design/README.md` + `design/_INDEX.md` shortlist → exactly one Layer B reference + `design/taste-skill.md` + `perfection/README.md` |
+| "Aside-style AI browser / browser agent page" | `design/README.md` + `design/aside.md` + `design/taste-skill.md` + `perfection/README.md` |
 | "Linear-style landing page" | `design/README.md` + `design/linear.app.md` + `design/taste-skill.md` + `perfection/README.md` |
 | "Premium SaaS hero like Stripe" | `design/README.md` + `design/stripe.md` + `design/soft-skill.md` + `perfection/README.md` |
 | "Improve this existing dashboard" | `design/README.md` + `design/redesign-skill.md` + `perfection/README.md` |
@@ -125,7 +126,7 @@ Domains: `product` `style` `typography` `color` `landing` `chart` `ux` `react` `
 
 | Situation | Load |
 |---|---|
-| Brand/style not among the 69 in `references/design/`, or the user says "Open Design" | `open-design` skill — the local nexu-io/open-design library (137+ design skills, 150+ design systems) |
+| Brand/style not among the 70 in `references/design/`, or the user says "Open Design" | `open-design` skill — the local nexu-io/open-design library (137+ design skills, 150+ design systems) |
 | Driving a browser for the Design QA phase | `agent-browser` skill |
 | Pure TypeScript/logic work with zero visual surface | `programming` skill alone — this skill adds nothing there |
 

--- a/packages/shared-skills/skills/frontend/references/design/README.md
+++ b/packages/shared-skills/skills/frontend/references/design/README.md
@@ -16,9 +16,9 @@ Two things ship flat most often, and both read as "clean but generic": the **her
 The library lives flat in this directory (`references/design/`, max depth 1) and has two conceptual layers, and **most non-trivial tasks load one from each layer**:
 
 - **Layer A — taste skills (12 files):** how to execute. Discipline, motion physics, spacing rules, anti-slop guardrails, output completeness. Filenames end in `-skill.md` or start with `imagegen-`.
-- **Layer B — design systems (69 files):** what it should look like. Concrete color/type/component tokens for one specific brand aesthetic. Filenames are brand names (`claude.md`, `notion.md`, `stripe.md`, …).
+- **Layer B — design systems (70 files):** what it should look like. Concrete color/type/component tokens for one specific brand aesthetic. Filenames are brand names (`aside.md`, `claude.md`, `notion.md`, `stripe.md`, ...).
 
-A combined directory of all 81 reference files is at `_INDEX.md`. **Read that index before loading anything** unless the routing is obvious — it has the full mood-mapping and stacking rules in one place.
+A combined directory of all 83 reference files is at `_INDEX.md`. **Read that index before loading anything** unless the routing is obvious — it has the full mood-mapping and stacking rules in one place.
 
 ## Open Design Library
 
@@ -94,7 +94,7 @@ Run through this in order and stop at the first match. Do not skip — earlier r
 
 ### Step 1 — Did the user name a specific brand or site?
 
-Phrasings: "make it look like Linear", "Stripe-style buttons", "Notion-feel sidebar", "like {brand}'s landing page", or pasting a screenshot of a known brand site.
+Phrasings: "make it look like Linear", "Stripe-style buttons", "Notion-feel sidebar", "Aside-style browser agent", "like {brand}'s landing page", or pasting a screenshot of a known brand site.
 
 **Action:** Open `_INDEX.md`, find the brand under "Layer B — Design Systems", then load `<brand>.md`. Use it as the project's design system source of truth (color hex values, type scale, component specs, do/don'ts).
 
@@ -201,6 +201,7 @@ Once references are loaded, before writing any UI code:
 | User asks for... | Load these |
 |---|---|
 | "Build me a landing page" (no other info) | `_INDEX.md` shortlist → exactly one Layer B reference + `taste-skill.md` |
+| "Build me an Aside-style AI browser / agent page" | `aside.md` + `taste-skill.md` |
 | "Build me a Linear-style landing page" | `linear.app.md` + `taste-skill.md` |
 | "Make it Notion-like and minimal" | `notion.md` + `minimalist-skill.md` |
 | "Premium SaaS hero, like Stripe" | `stripe.md` + `soft-skill.md` |

--- a/packages/shared-skills/skills/frontend/references/design/_INDEX.md
+++ b/packages/shared-skills/skills/frontend/references/design/_INDEX.md
@@ -54,7 +54,7 @@ From [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill).
 
 ## Layer B — Design Systems (70)
 
-From [VoltAgent/awesome-design-md](https://github.com/VoltAgent/awesome-design-md), based on [Google Stitch DESIGN.md format](https://stitch.withgoogle.com/docs/design-md/overview/). Each file captures one website's complete visual language: color palette, typography, components, layout principles, depth, do/don't, responsive behavior, and an agent prompt guide.
+Most Layer B files are materialized from [VoltAgent/awesome-design-md](https://github.com/VoltAgent/awesome-design-md), based on [Google Stitch DESIGN.md format](https://stitch.withgoogle.com/docs/design-md/overview/). Project-original entries such as `aside.md` are listed here only when `ATTRIBUTION.md` and `frontend-refs-manifest.mjs` mark them as original. Each file captures one website's complete visual language: color palette, typography, components, layout principles, depth, do/don't, responsive behavior, and an agent prompt guide.
 
 ### How to use
 
@@ -79,7 +79,7 @@ Each file ships with: visual theme, hex color palette + semantic roles, full typ
 | `voltagent.md` | AI agent framework. Void-black canvas, emerald accent, terminal-native. |
 | `x.ai.md` | Elon Musk's AI lab. Stark monochrome, futuristic minimalism. |
 
-### Developer Tools & IDEs (9)
+### Developer Tools & IDEs (8)
 
 | File | Aesthetic |
 |---|---|

--- a/packages/shared-skills/skills/frontend/references/design/_INDEX.md
+++ b/packages/shared-skills/skills/frontend/references/design/_INDEX.md
@@ -3,7 +3,7 @@
 All reference files live flat in this directory. Three layers:
 - **Layer 0 — design system architecture** (1 file): the mandatory gate. Defines `DESIGN.md` structure, creation workflow, validation rules. Always loaded by Phase 0 when no design system exists.
 - **Layer A — taste skills** (12 files): how to execute. Discipline, motion, spacing, anti-slop, output completeness.
-- **Layer B — design systems** (69 files): what it should look like. Brand-specific color/type/component tokens.
+- **Layer B — design systems** (70 files): what it should look like. Brand-specific color/type/component tokens.
 
 **Phase 0 runs first** (check/create `DESIGN.md`), then most non-trivial tasks load **one Layer A + one Layer B** together. See the routing flow in the sibling `README.md`.
 
@@ -52,7 +52,7 @@ From [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill).
 
 ---
 
-## Layer B — Design Systems (71)
+## Layer B — Design Systems (70)
 
 From [VoltAgent/awesome-design-md](https://github.com/VoltAgent/awesome-design-md), based on [Google Stitch DESIGN.md format](https://stitch.withgoogle.com/docs/design-md/overview/). Each file captures one website's complete visual language: color palette, typography, components, layout principles, depth, do/don't, responsive behavior, and an agent prompt guide.
 
@@ -79,10 +79,11 @@ Each file ships with: visual theme, hex color palette + semantic roles, full typ
 | `voltagent.md` | AI agent framework. Void-black canvas, emerald accent, terminal-native. |
 | `x.ai.md` | Elon Musk's AI lab. Stark monochrome, futuristic minimalism. |
 
-### Developer Tools & IDEs (8)
+### Developer Tools & IDEs (9)
 
 | File | Aesthetic |
 |---|---|
+| `aside.md` | AI browser agent. Bright product-app marketing, custom display type, soft squircle controls, browser-product framing. |
 | `cursor.md` | AI-first code editor. Sleek dark interface, gradient accents. |
 | `expo.md` | React Native platform. Dark theme, tight letter-spacing, code-centric. |
 | `lovable.md` | AI full-stack builder. Playful gradients, friendly dev aesthetic. |
@@ -183,6 +184,7 @@ Each file ships with: visual theme, hex color palette + semantic roles, full typ
 - **"Brutal / Swiss / industrial"** → `nike.md`, `bugatti.md`, `vodafone.md`
 - **"Dark cinematic"** → `runwayml.md`, `elevenlabs.md`, `superhuman.md`, `shopify.md`
 - **"Terminal / developer-native"** → `vercel.md`, `warp.md`, `voltagent.md`, `ollama.md`
+- **"AI browser / agentic browser / product-app launch"** → `aside.md`, `raycast.md`, `superhuman.md`
 - **"Warm / approachable / soft"** → `airbnb.md`, `notion.md`, `intercom.md`, `mastercard.md`
 - **"Data-dense / dashboard"** → `sentry.md`, `kraken.md`, `posthog.md`, `clickhouse.md`
 - **"Bold / sporty / monochrome punch"** → `nike.md`, `uber.md`, `tesla.md`, `binance.md`

--- a/packages/shared-skills/skills/frontend/references/design/aside.md
+++ b/packages/shared-skills/skills/frontend/references/design/aside.md
@@ -7,7 +7,7 @@
 
 This reference is derived from a live capture of `https://aside.com/` on 2026-06-30, plus a reconnaissance pass following `JCodesMore/ai-website-cloner-template` at commit `8dd9cb47dde0d49fec06ee1d69bedd04840f3c95`.
 
-Evidence artifacts for the source capture were written under `.omo/evidence/20260630-aside-frontend-reference/`:
+Reviewer-run evidence artifacts for the source capture were written under `.omo/evidence/20260630-aside-frontend-reference/`:
 
 - `aside-live-extraction.json`
 - `aside-home.png`
@@ -16,13 +16,27 @@ Evidence artifacts for the source capture were written under `.omo/evidence/2026
 - `cloner-tablet-768.png`
 - `cloner-mobile-390.png`
 
+Those `.omo/evidence` files are local review artifacts, not shipped package assets. Downstream agents should recapture the live site when fidelity to the current Aside page matters. This file carries the stable, reviewer-visible digest from that capture.
+
+### Reviewer-Visible Capture Digest
+
+- **Source page:** `https://aside.com/`
+- **Source metadata:** title indicated a browser built to do real work; description framed it as a browser that completes complex work across sites, accounts, and history.
+- **Template source:** `JCodesMore/ai-website-cloner-template` at commit `8dd9cb47dde0d49fec06ee1d69bedd04840f3c95`; the template was used as a local reconnaissance workflow, not copied into this repo.
+- **Screenshots captured:** live page at 1440px wide; reconstructed reconnaissance screenshots at 1440px, 768px, and 390px widths.
+- **Page topology:** compact nav, centered hero, sky/cloud hero wash, large browser-product frame, explanatory intro band, capability sections, benchmark tabs, password/security sections, blue closing CTA band, dense footer.
+- **Extracted type signals:** `displayFont` for hero and section display; Geist for body/UI; Geist Mono available for technical specimens.
+- **Extracted scale signals:** H1 around 48px / 52px with slight negative tracking; body 16px / 24px; UI labels around 14px / 20px.
+- **Extracted surface signals:** white page canvas, ink text around `#090b0c`, soft gray controls around `#f5f5f5`, black-opacity dividers, pill trust badge, rounded/squircle CTA buttons, product-frame shadows.
+- **Responsive observations:** desktop preserves full nav and large browser frame; tablet narrows the product frame; mobile crops/stacks the frame while keeping the hero and CTA visible.
+
 Do not treat this file as a license to copy Aside's logo, product screenshots, copy, or proprietary assets. Use it as a token and layout reference for original AI-browser, agent-workflow, and product-app surfaces.
 
 ## 1. Visual Theme & Atmosphere
 
-Aside's current site reads as a bright, high-confidence product application rather than a dark developer landing page. The canvas is mostly white with hairline black dividers, dense product UI, and large custom display headlines. It feels closer to a native app launch page than a SaaS template: crisp, controlled, and built around the promise that the browser itself can do real work.
+Aside's current site reads as a bright, high-confidence product application rather than a dark developer landing page. The canvas is mostly white with hairline black dividers, dense product UI, large custom display headlines, and pale sky-blue atmospheric bands in the hero and final CTA. It feels closer to a native app launch page than a SaaS template: crisp, controlled, and built around the promise that the browser itself can do real work.
 
-The signature move is the contrast between calm white space and dense browser-product framing. The page opens with a centered hero, a small Y Combinator trust pill, and a large browser/app visual. Below that, sections use full-width bands, thin separators, and app-like capability cards instead of decorative feature-card grids. The tone is practical and confident: precise controls, product screenshots, benchmark pills, password/memory/security stories, and compact navigation.
+The signature move is the contrast between calm white space, a gentle cloud-like blue wash, and dense browser-product framing. The page opens with a centered hero, a small Y Combinator trust pill, and a large browser/app visual. Below that, sections use full-width bands, thin separators, and app-like capability cards instead of decorative feature-card grids. The tone is practical and confident: precise controls, product screenshots, benchmark pills, password/memory/security stories, and compact navigation.
 
 Rounded elements should feel like soft squircles, not generic `rounded-2xl` blobs. Live capture shows very large pill radii for trust badges and hero CTAs, medium squircle radii around compact action buttons, and square rhythm for structural section boundaries. Depth is created by product frames, soft shadows, white/black opacity borders, and layered screenshot surfaces, not by colorful background decoration.
 
@@ -46,6 +60,8 @@ Rounded elements should feel like soft squircles, not generic `rounded-2xl` blob
 ### Accent Use
 
 Aside's live capture does not rely on one dominant neon accent. Accents come from product imagery, benchmark pills, subtle icon color, and carefully placed dark controls. If a project needs a brand color, keep it secondary to the black/white/gray product-app system and apply it only to small signals.
+
+The current page does use pale cyan/sky-blue atmosphere in large image-backed bands. Treat that as an optional Aside signature for AI-browser launches: soft, airy, and product-framing, not a generic blue gradient background.
 
 ## 3. Typography Rules
 
@@ -152,7 +168,7 @@ This is the key Aside-inspired primitive.
 - Use hairline borders and product-frame shadows as the primary elevation language.
 - Prefer subtle neutral shadow over colored glows.
 - Layer product screenshots or UI panels to create depth.
-- Keep broad backgrounds flat white unless a product visual needs a light atmospheric wash.
+- Keep broad backgrounds flat white unless a product visual, hero, or closing CTA needs the current Aside-like pale sky-blue atmospheric wash.
 
 ### Motion
 
@@ -184,7 +200,7 @@ Every primitive must define default, hover, active, focus-visible, disabled, loa
 - Don't copy Aside's logo, text, screenshots, or proprietary product assets.
 - Don't replace the product-browser focal object with flat geometric decoration.
 - Don't make the page a purple-blue gradient SaaS layout.
-- Don't use sky blue as a giant primary CTA color unless the actual project brand calls for it.
+- Don't use saturated sky blue as a giant primary CTA color; if using Aside's current atmosphere, keep it pale, cloud-like, and subordinate to the product frame.
 - Don't over-round every component equally; distinguish pills, squircles, and structural edges.
 - Don't hide visual QA behind tests. Aside-like work needs screenshots at mobile, tablet, and desktop widths.
 

--- a/packages/shared-skills/skills/frontend/references/design/aside.md
+++ b/packages/shared-skills/skills/frontend/references/design/aside.md
@@ -1,0 +1,193 @@
+# Design System Inspired by Aside
+
+> Category: Developer Tools & IDEs
+> AI browser agent. Bright product-app marketing, custom display type, soft squircle controls, agent-browser product framing.
+
+## Provenance
+
+This reference is derived from a live capture of `https://aside.com/` on 2026-06-30, plus a reconnaissance pass following `JCodesMore/ai-website-cloner-template` at commit `8dd9cb47dde0d49fec06ee1d69bedd04840f3c95`.
+
+Evidence artifacts for the source capture were written under `.omo/evidence/20260630-aside-frontend-reference/`:
+
+- `aside-live-extraction.json`
+- `aside-home.png`
+- `cloner-output-summary.md`
+- `cloner-desktop-1440.png`
+- `cloner-tablet-768.png`
+- `cloner-mobile-390.png`
+
+Do not treat this file as a license to copy Aside's logo, product screenshots, copy, or proprietary assets. Use it as a token and layout reference for original AI-browser, agent-workflow, and product-app surfaces.
+
+## 1. Visual Theme & Atmosphere
+
+Aside's current site reads as a bright, high-confidence product application rather than a dark developer landing page. The canvas is mostly white with hairline black dividers, dense product UI, and large custom display headlines. It feels closer to a native app launch page than a SaaS template: crisp, controlled, and built around the promise that the browser itself can do real work.
+
+The signature move is the contrast between calm white space and dense browser-product framing. The page opens with a centered hero, a small Y Combinator trust pill, and a large browser/app visual. Below that, sections use full-width bands, thin separators, and app-like capability cards instead of decorative feature-card grids. The tone is practical and confident: precise controls, product screenshots, benchmark pills, password/memory/security stories, and compact navigation.
+
+Rounded elements should feel like soft squircles, not generic `rounded-2xl` blobs. Live capture shows very large pill radii for trust badges and hero CTAs, medium squircle radii around compact action buttons, and square rhythm for structural section boundaries. Depth is created by product frames, soft shadows, white/black opacity borders, and layered screenshot surfaces, not by colorful background decoration.
+
+## 2. Color Palette & Roles
+
+### Core Canvas
+
+- **White** (`#ffffff`): primary page background. Use for the main canvas and broad content bands.
+- **Ink Black** (`lab(2.93655 -0.435196 -0.608262)`, approximate `#090b0c`): primary text. Use this instead of pure black when possible.
+- **Soft Gray Surface** (`lab(96.52 -0.0000298023 0.0000119209)`, approximate `#f5f5f5`): rounded control and panel surface.
+- **Hairline Divider** (`rgba(0,0,0,0.06)`): section borders and subtle containment.
+- **Muted Text** (`#737373` to `#a1a1a1` range): captions, footer links, secondary product explanations.
+
+### Action Surfaces
+
+- **Primary Button Surface**: light gray or ink-inverted depending on context. Use compact contrast instead of saturated brand color.
+- **Primary Button Text**: ink black on light controls; white on dark controls.
+- **Hover Surface**: slightly darker neutral fill with 150ms color/background/border transition.
+- **Focus Ring**: neutral gray ring. Keep it visible against white and soft gray.
+
+### Accent Use
+
+Aside's live capture does not rely on one dominant neon accent. Accents come from product imagery, benchmark pills, subtle icon color, and carefully placed dark controls. If a project needs a brand color, keep it secondary to the black/white/gray product-app system and apply it only to small signals.
+
+## 3. Typography Rules
+
+### Font Family
+
+- **Display**: Aside custom display font exposed in capture as `displayFont`, fallback display sans.
+- **Body / UI**: Geist, fallback sans.
+- **Mono**: Geist Mono for code, benchmark labels, and technical specimens.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---:|---:|---:|---:|---|
+| Hero Display | displayFont | 48px | 400 | 52px | -0.48px | Primary H1 |
+| Section Display | displayFont | 36px-48px | 400-500 | 1.08-1.15 | tight | Major section claims |
+| Card Title | displayFont or Geist | 24px-30px | 500 | 1.2 | normal/tight | Product capability cards |
+| Body | Geist | 16px | 400 | 24px | normal | General explanation |
+| UI Label | Geist | 14px | 500 | 20px | normal | Nav, buttons, menu labels |
+| Pill/Caption | Geist | 12px-14px | 500-550 | 1.3 | slight | Badges, metadata, benchmarks |
+
+### Principles
+
+- Use the display font for the claim, not for every word on the page.
+- Keep body copy plain, readable, and product-focused.
+- Favor medium weights over bold weights; the brand voice is confident but not shouty.
+- Avoid negative letter-spacing outside display text. The router's global rule against viewport-scaled font sizing still applies.
+
+## 4. Component Stylings
+
+### Navigation
+
+- Top navigation is compact and product-app-like.
+- Logo at left, grouped menu buttons/links in the center, download CTA at right.
+- Nav labels use Geist 14px/500 with short 150ms color/background transitions.
+- Dropdown triggers can be text buttons with no visible border until hover.
+- Mobile should collapse to icon/hamburger controls with the same neutral/squircle treatment.
+
+### Hero Trust Pill
+
+- Pill radius: full pill, visually continuous.
+- Border/fill: very subtle neutral contrast against white.
+- Text: 12px-14px Geist, medium weight.
+- Content: use as a trust or provenance signal, not a decorative chip pile.
+
+### Primary CTA
+
+- Shape: pill for hero CTA, medium squircle for standard nav/action buttons.
+- Height: 36px compact nav, 44px hero/mobile.
+- Padding: generous horizontal padding for hero; compact in nav.
+- Motion: 150ms background/color/border transition; pressed state can scale to 0.97.
+- Icon: use SVG icon from the app's icon library; do not use emoji.
+
+### Product Browser Frame
+
+This is the key Aside-inspired primitive.
+
+- Large product/browser mockup below or near the hero claim.
+- Use a real screenshot, generated bitmap, or carefully built UI surface. Do not substitute flat rectangles.
+- Contain with soft border, rounded/squircle corners, and restrained shadow.
+- Internal chrome should show real browser/app affordances: sidebar, tabs, compact controls, content panels.
+- The frame can overflow and crop at mobile widths, but the focal content must remain legible.
+
+### Capability Sections
+
+- Full-width horizontal bands separated by `border-b border-black/6` style dividers.
+- Section structure: one major claim, one explanatory block, one app-like visual or metric module.
+- Avoid three generic feature cards unless the product genuinely has three peer capabilities.
+- Link rows and "Learn more" controls stay quiet and text-forward.
+
+### Benchmark Pills / Tabs
+
+- Medium squircle radius around compact tabs.
+- Neutral backgrounds with dark text.
+- Hover/active states should be visible through fill, border, or text contrast.
+- Useful for agent benchmarks, model comparisons, task modes, and product states.
+
+## 5. Layout Principles
+
+### Structure
+
+- Full page uses stacked bands rather than isolated floating cards.
+- Hero centers the brand claim and then gives the product visual real space.
+- Sections often span full width with internal max-width constraints.
+- Footer is link-dense and calm, with grouped columns.
+
+### Spacing
+
+- Outer page padding: 8px mobile, 16px desktop.
+- Hero vertical rhythm: generous, but not editorially sparse; the product visual arrives quickly.
+- Section padding: 56px-96px depending on density.
+- Dense UI inside product frames can use 8px-16px rhythm.
+
+### Responsive Behavior
+
+- Desktop: full nav, large browser/product visual, multi-column footer.
+- Tablet: preserve product framing but reduce visual width and section padding.
+- Mobile: collapse nav, make hero text more compact, crop or stack the product frame deliberately.
+- Avoid horizontal overflow; if a browser mockup is wider than the viewport, scale or crop from a stable container.
+
+## 6. Depth, Motion & Interaction
+
+### Depth
+
+- Use hairline borders and product-frame shadows as the primary elevation language.
+- Prefer subtle neutral shadow over colored glows.
+- Layer product screenshots or UI panels to create depth.
+- Keep broad backgrounds flat white unless a product visual needs a light atmospheric wash.
+
+### Motion
+
+- Use short transitions for controls: color, background-color, border-color, opacity, transform.
+- Keep motion in the 150ms-200ms range with standard cubic-bezier easing.
+- Product demos may use scroll or time-based state changes, but document the interaction model in `DESIGN.md` before building.
+- Animate transform/opacity/filter only.
+
+### Interaction States
+
+Every primitive must define default, hover, active, focus-visible, disabled, loading, empty, and error states before implementation. Aside-like surfaces are quiet, so missing states are obvious.
+
+## 7. Do's and Don'ts
+
+### Do
+
+- Do use a bright canvas with crisp ink typography for the current Aside-inspired look.
+- Do use a custom display face or distinctive display substitute for hero and section claims.
+- Do preserve the product-browser frame as the memorable focal object.
+- Do use soft squircle or pill corners intentionally by component role.
+- Do build dense, useful product UI inside the hero visual.
+- Do use thin black-opacity dividers to make sections feel engineered.
+- Do keep CTA colors neutral and high contrast.
+- Do cite live screenshots or extracted design tokens when claiming Aside fidelity.
+
+### Don't
+
+- Don't resurrect the older dark-only Aside reference without checking the live site.
+- Don't copy Aside's logo, text, screenshots, or proprietary product assets.
+- Don't replace the product-browser focal object with flat geometric decoration.
+- Don't make the page a purple-blue gradient SaaS layout.
+- Don't use sky blue as a giant primary CTA color unless the actual project brand calls for it.
+- Don't over-round every component equally; distinguish pills, squircles, and structural edges.
+- Don't hide visual QA behind tests. Aside-like work needs screenshots at mobile, tablet, and desktop widths.
+
+## Agent Prompt
+
+When building an Aside-inspired surface, first create or update `DESIGN.md` with: bright white product-app atmosphere, display/body/mono font roles, ink/neutral token ramp, squircle/pill component rules, a product-browser focal primitive, dense capability bands, and responsive crop/scale behavior for the product frame. Use original content and assets. Verify with screenshots at 375px, 768px, and 1280px or wider, and compare against the live-reference evidence before declaring visual fidelity.

--- a/packages/skills-loader-core/src/features/builtin-skills/frontend/SKILL.md
+++ b/packages/skills-loader-core/src/features/builtin-skills/frontend/SKILL.md
@@ -33,7 +33,7 @@ When `references/designpowers/README.md` is loaded for implementation, redesign,
 
 ## Ruleset 1 — design (`references/design/`)
 
-The reference library has one architecture file, 12 taste skills (Layer A — *how to execute*), and 69 brand design systems (Layer B — *what it should look like*). Most non-trivial tasks load **one Layer A + one Layer B**. `README.md` carries the full routing flow, stacking rules, anti-patterns, and the mandatory browser-based Design QA phase; `_INDEX.md` catalogs all 81 files with mood-to-brand mappings — read it whenever routing is not obvious from the tables below.
+The reference library has one architecture file, 12 taste skills (Layer A — *how to execute*), and 70 brand design systems (Layer B — *what it should look like*). Most non-trivial tasks load **one Layer A + one Layer B**. `README.md` carries the full routing flow, stacking rules, anti-patterns, and the mandatory browser-based Design QA phase; `_INDEX.md` catalogs all 83 files with mood-to-brand mappings — read it whenever routing is not obvious from the tables below.
 
 ### Layer 0 — architecture
 
@@ -58,7 +58,7 @@ The reference library has one architecture file, 12 taste skills (Layer A — *h
 
 ### Layer B — brand design systems (orthogonal to Layer A; stack freely)
 
-When the user names a brand or site — "Linear-style", "like Stripe's landing" — load `references/design/<brand>.md` as the token source of truth (palette, type scale, components, do/don'ts). Coverage includes `apple` `stripe` `linear.app` `notion` `vercel` `claude` `figma` `airbnb` `nike` `tesla` `spotify` `raycast` `revolut` and ~56 more; the full list with mood shortcuts is in `_INDEX.md`. Extract the tokens and apply them to the project's own content — never copy logos or trademarked imagery. If the named brand is missing, fall back to a Layer A mood match or the `open-design` skill.
+When the user names a brand or site — "Linear-style", "like Stripe's landing", "Aside-style browser agent" — load `references/design/<brand>.md` as the token source of truth (palette, type scale, components, do/don'ts). Coverage includes `aside` `apple` `stripe` `linear.app` `notion` `vercel` `claude` `figma` `airbnb` `nike` `tesla` `spotify` `raycast` `revolut` and ~56 more; the full list with mood shortcuts is in `_INDEX.md`. Extract the tokens and apply them to the project's own content — never copy logos or trademarked imagery. If the named brand is missing, fall back to a Layer A mood match or the `open-design` skill.
 
 ### React dev tooling
 
@@ -102,6 +102,7 @@ Domains: `product` `style` `typography` `color` `landing` `chart` `ux` `react` `
 | Request | Load |
 |---|---|
 | "Build a landing page" (no direction given) | `design/README.md` + `design/_INDEX.md` shortlist → exactly one Layer B reference + `design/taste-skill.md` + `perfection/README.md` |
+| "Aside-style AI browser / browser agent page" | `design/README.md` + `design/aside.md` + `design/taste-skill.md` + `perfection/README.md` |
 | "Linear-style landing page" | `design/README.md` + `design/linear.app.md` + `design/taste-skill.md` + `perfection/README.md` |
 | "Premium SaaS hero like Stripe" | `design/README.md` + `design/stripe.md` + `design/soft-skill.md` + `perfection/README.md` |
 | "Improve this existing dashboard" | `design/README.md` + `design/redesign-skill.md` + `perfection/README.md` |
@@ -125,7 +126,7 @@ Domains: `product` `style` `typography` `color` `landing` `chart` `ux` `react` `
 
 | Situation | Load |
 |---|---|
-| Brand/style not among the 69 in `references/design/`, or the user says "Open Design" | `open-design` skill — the local nexu-io/open-design library (137+ design skills, 150+ design systems) |
+| Brand/style not among the 70 in `references/design/`, or the user says "Open Design" | `open-design` skill — the local nexu-io/open-design library (137+ design skills, 150+ design systems) |
 | Driving a browser for the Design QA phase | `agent-browser` skill |
 | Pure TypeScript/logic work with zero visual surface | `programming` skill alone — this skill adds nothing there |
 


### PR DESCRIPTION
## Summary

Adds a provenance-backed Aside design reference to the shared frontend skill and routes Aside-style AI browser briefs to it. The reference is based on fresh live capture of https://aside.com/ plus a local reconnaissance run using `JCodesMore/ai-website-cloner-template`, with explicit guidance not to copy Aside assets, logos, screenshots, or product text.

The verification-loop fix also syncs the checked-in frontend builtin SKILL artifacts used by OpenCode/skills-loader extraction tests, so the shared source and packaged artifacts stay byte-equivalent.

## Changes

- Adds `references/design/aside.md` as a project-original design-system synthesis for bright AI-browser/product-app surfaces.
- Updates frontend routing docs so Aside is listed under Developer Tools & IDEs and the quick routes recognize Aside-style browser agent briefs.
- Adds reviewer-visible capture digest details in `aside.md` so PR reviewers can audit the local capture without needing ignored `.omo` artifacts in the diff.
- Updates the shared-skills provenance manifest, `.gitignore`, and attribution notes so the new original file stays committed while third-party references remain gated.
- Adds a focused frontend contract test that proves Aside is discoverable and provenance-backed.
- Syncs `packages/skills-loader-core/src/features/builtin-skills/frontend/SKILL.md` and `packages/omo-opencode/src/features/builtin-skills/frontend/SKILL.md` with the shared frontend skill source.

## QA & Evidence

- **Live source capture:** drove `https://aside.com/` in Chromium/Playwright and captured design extraction plus screenshots. Artifacts: `.omo/evidence/20260630-aside-frontend-reference/aside-live-extraction.json`, `aside-home.png`.
- **Template reconnaissance:** cloned `JCodesMore/ai-website-cloner-template` at `8dd9cb47dde0d49fec06ee1d69bedd04840f3c95`, installed/built it, ran the Aside clone/reference workflow, and removed the temp clone. Artifacts: `.omo/evidence/20260630-aside-frontend-reference/cloner-run.log`, `cloner-output-summary.md`, `cloner-desktop-1440.png`, `cloner-tablet-768.png`, `cloner-mobile-390.png`, `npm-install.log`, `npm-build.log`.
- **Focused shared-skill tests:** `bun test packages/shared-skills/frontend-skill-contract.test.ts packages/shared-skills/frontend-thirdparty-manifest.test.ts packages/shared-skills/materialize-frontend-refs.test.ts packages/shared-skills/provenance-gate.test.ts packages/skills-loader-core/src/features/builtin-skills/shared-skill-extraction.test.ts packages/omo-opencode/src/features/builtin-skills/shared-skill-extraction.test.ts` passed with 23 tests / 0 failures. Artifact: `.omo/evidence/20260630-aside-frontend-reference/focused-tests-after-artifact-sync.log`.
- **Full local test gate:** `bun test` passed with 10,235 tests / 0 failures / 2 skipped. Artifact: `.omo/evidence/20260630-aside-frontend-reference/root-bun-test-after-artifact-sync.log`.
- **Contract grep:** verified Aside routing/discoverability/provenance strings in the skill docs. Artifact: `.omo/evidence/20260630-aside-frontend-reference/docs-grep.log`.
- **Diff hygiene:** `git diff --check origin/dev...HEAD` passed.

## Risks & Residuals

- This is docs/test/shared-skill reference work only; it does not touch OpenCode or Codex runtime hooks, installers, tools, agents, or package execution paths.
- Main risk is provenance/licensing drift. Mitigated by keeping the reference as project-original synthesis, updating attribution/manifest gates, adding contract/provenance tests, and including a reviewer-visible capture digest.
