### PR TITLE
fix(cli): warn when a pinned plugin version differs from the running version (fixes #4734)

### DIFF
--- a/packages/omo-opencode/src/cli/get-local-version/formatter.test.ts
+++ b/packages/omo-opencode/src/cli/get-local-version/formatter.test.ts
@@ -1,0 +1,49 @@
+/// <reference path="../../../../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { formatVersionOutput } from "./formatter"
+import type { VersionInfo } from "./types"
+
+describe("formatVersionOutput", () => {
+  test("#given a pinned version equal to the running version #when formatting #then reports the pin without a mismatch warning", () => {
+    // given a pin that matches what is actually running
+    const info: VersionInfo = {
+      currentVersion: "3.16.0",
+      latestVersion: null,
+      isUpToDate: false,
+      isLocalDev: false,
+      isPinned: true,
+      pinnedVersion: "3.16.0",
+      status: "pinned",
+    }
+
+    // when
+    const output = formatVersionOutput(info)
+
+    // then
+    expect(output).toContain("pinned to 3.16.0")
+    expect(output.toLowerCase()).not.toContain("but running")
+  })
+
+  test("#given a pin that differs from the running version #when formatting #then warns the pin does not control the loaded version", () => {
+    // given a config pinned to 3.16.0 while 4.7.5 is actually loaded
+    const info: VersionInfo = {
+      currentVersion: "4.7.5",
+      latestVersion: null,
+      isUpToDate: false,
+      isLocalDev: false,
+      isPinned: true,
+      pinnedVersion: "3.16.0",
+      status: "pinned-mismatch",
+    }
+
+    // when
+    const output = formatVersionOutput(info)
+
+    // then the warning names both the pinned and the actually-running version
+    expect(output).toContain("3.16.0")
+    expect(output).toContain("4.7.5")
+    expect(output.toLowerCase()).toContain("but running")
+  })
+})

--- a/packages/omo-opencode/src/cli/get-local-version/formatter.ts
+++ b/packages/omo-opencode/src/cli/get-local-version/formatter.ts
@@ -48,6 +48,10 @@ export function formatVersionOutput(info: VersionInfo): string {
       lines.push(`  ${SYMBOLS.pin} ${color.magenta(`Version pinned to ${info.pinnedVersion}`)}`)
       lines.push(`  ${color.dim("Update check skipped for pinned versions")}`)
       break
+    case "pinned-mismatch":
+      lines.push(`  ${SYMBOLS.warn} ${color.yellow(`Version pinned to ${info.pinnedVersion} but running ${info.currentVersion}`)}`)
+      lines.push(`  ${color.dim("The pin only skips the update check; it does not control which version OpenCode loads")}`)
+      break
     case "error":
       lines.push(`  ${SYMBOLS.cross} ${color.red("Unable to check for updates")}`)
       lines.push(`  ${color.dim("Network error or npm registry unavailable")}`)

--- a/packages/omo-opencode/src/cli/get-local-version/get-local-version.ts
+++ b/packages/omo-opencode/src/cli/get-local-version/get-local-version.ts
@@ -33,14 +33,16 @@ export async function getLocalVersion(
 
     const pluginInfo = findPluginEntry(directory)
     if (pluginInfo?.isPinned) {
+      const actualVersion = getCachedVersion()
+      const isMismatch = actualVersion !== null && actualVersion !== pluginInfo.pinnedVersion
       const info: VersionInfo = {
-        currentVersion: pluginInfo.pinnedVersion,
+        currentVersion: isMismatch ? actualVersion : pluginInfo.pinnedVersion,
         latestVersion: null,
         isUpToDate: false,
         isLocalDev: false,
         isPinned: true,
         pinnedVersion: pluginInfo.pinnedVersion,
-        status: "pinned",
+        status: isMismatch ? "pinned-mismatch" : "pinned",
       }
 
       console.log(options.json ? formatJsonOutput(info) : formatVersionOutput(info))

--- a/packages/omo-opencode/src/cli/get-local-version/types.ts
+++ b/packages/omo-opencode/src/cli/get-local-version/types.ts
@@ -5,7 +5,7 @@ export interface VersionInfo {
   isLocalDev: boolean
   isPinned: boolean
   pinnedVersion: string | null
-  status: "up-to-date" | "outdated" | "local-dev" | "pinned" | "error" | "unknown"
+  status: "up-to-date" | "outdated" | "local-dev" | "pinned" | "pinned-mismatch" | "error" | "unknown"
 }
 
 export interface GetLocalVersionOptions {


### PR DESCRIPTION
## Summary

`oh-my-openagent get-local-version` printed `Current Version: <pin> [PINNED]` and skipped the update check, but never checked whether the pinned version was actually the one loaded. When a user pinned `oh-my-openagent@3.16.0` in `opencode.json` while OpenCode loaded a different version (e.g. 4.7.5), the command confidently reported `3.16.0 [PINNED]` with no signal that the pin had no effect on the running version. This PR detects that mismatch and warns instead of misreporting.

Fixes #4734.

## Root Cause

In the pinned branch of `get-local-version.ts`, the reported `currentVersion` was set to the **pin string** and the function returned early without ever resolving the actually-loaded version:

```ts
const pluginInfo = findPluginEntry(directory)
if (pluginInfo?.isPinned) {
  const info: VersionInfo = {
    currentVersion: pluginInfo.pinnedVersion, // the PIN, not what is running
    // ...
    status: "pinned",
  }
  console.log(...)
  return 0
}
```

The pin only suppresses the update check; OpenCode itself controls which version is loaded. So a stale pin produced a misleading "you are on 3.16.0" report.

## Changes

| File | Change |
|------|--------|
| `packages/omo-opencode/src/cli/get-local-version/get-local-version.ts` | In the pinned branch, resolve the actually-loaded version via `getCachedVersion()` (already imported) and compare it to the pin. On mismatch, report the real running version with the new `pinned-mismatch` status. |
| `packages/omo-opencode/src/cli/get-local-version/formatter.ts` | Add a `pinned-mismatch` case that warns the pin only skips the update check and does not control which version OpenCode loads. |
| `packages/omo-opencode/src/cli/get-local-version/types.ts` | Add `"pinned-mismatch"` to the `VersionInfo.status` union. |
| `packages/omo-opencode/src/cli/get-local-version/formatter.test.ts` | New regression test (pin == running stays `pinned`; pin != running warns with both versions). |

An exact pin that matches the running version still reports the plain `pinned` status, unchanged.

## Reproduction (before fix)

`get-local-version --json` with `.opencode/opencode.json` pinning `oh-my-openagent@3.16.0` against a 4.14.1 runtime:

```json
{
  "currentVersion": "3.16.0",
  "isPinned": true,
  "pinnedVersion": "3.16.0",
  "status": "pinned"
}
```

The report claims 3.16.0 is current even though a different version is loaded.

## Verification (after fix)

Same reproduction:

```json
{
  "currentVersion": "4.14.1",
  "isPinned": true,
  "pinnedVersion": "3.16.0",
  "status": "pinned-mismatch"
}
```

The CLI text output now reads:

```
[!] Version pinned to 3.16.0 but running 4.14.1
    The pin only skips the update check; it does not control which version OpenCode loads
```

## Test

- Regression: `packages/omo-opencode/src/cli/get-local-version/formatter.test.ts` (2 cases) - goes RED before the formatter case, GREEN after; `bun test` 2 pass / 0 fail.
- Typecheck: `tsgo --noEmit -p packages/omo-opencode/tsconfig.json` - clean (exit 0).

Fixes #4734


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when a pinned plugin version differs from the version actually running in `get-local-version`, preventing false “pinned” reports. Adds a `pinned-mismatch` status that shows both versions. Fixes #4734.

- **Bug Fixes**
  - Compare the pin in `opencode.json` to the actual version via `getCachedVersion()`; on mismatch, report the running version and set status `pinned-mismatch`.
  - Formatter: add `pinned-mismatch` output explaining the pin only skips the update check and doesn’t control which version OpenCode loads.
  - Types: extend `VersionInfo.status` to include `pinned-mismatch`.
  - Tests: add formatter cases for matching pin and mismatch.

<sup>Written for commit 4bdb2a7b5ced2f99213d11d7547916cf1654a1e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

