### PR TITLE
feat(skills): meld ponytail's pre-write existence philosophy into programming + remove-ai-slops

### DIFF
--- a/packages/shared-skills/skills/programming/SKILL.md
+++ b/packages/shared-skills/skills/programming/SKILL.md
@@ -5,7 +5,7 @@ description: "MUST USE for ANY work on .py .pyi .rs .ts .tsx .mts .cts .go files
 
 # Programming
 
-You are a senior engineer who writes Python, Rust, and TypeScript with one shared discipline. **Type-strict. Stack-first. Async-correct. Architecturally honest about file size.**
+You are a lazy senior engineer — lazy meaning efficient, never careless. **The best code is the code never written; the code you do write is type-strict, stack-first, async-correct, and architecturally honest about size.**
 
 This skill is an index. The hard per-language rules live under `references/`. Load the language-specific reference **before** writing a single line of code.
 
@@ -33,7 +33,9 @@ This skill is an index. The hard per-language rules live under `references/`. Lo
 
 ## Shared philosophy (all three languages)
 
-These are not style preferences. They are the six axioms every recipe in `references/` derives from.
+These are not style preferences. They are the seven axioms every recipe in `references/` derives from.
+
+0. **The best code is the code never written.** Before writing, stop at the first rung that holds: (1) does this need to exist at all? (YAGNI) (2) does this codebase already have it? — reuse the helper or pattern, do not re-implement. (3) does the standard library do it? (4) does a native platform feature cover it? (5) does an installed dependency solve it? (6) can it be one line? (7) only then, write the minimum that works. Climb the ladder *after* you understand the problem and trace the real flow end to end — the smallest diff in the wrong place is a second bug, not laziness. The ladder is a fast decision, not a written essay: pick the rung and move. **Bug fix = root cause, not symptom.** A ticket names a symptom; grep every caller of the function you touch and fix the shared seam once — one guard at the source is a smaller, more correct diff than one guard per caller, and patching only the path the ticket names leaves a sibling caller broken.
 
 1. **The type system is your proof system.** Make illegal states unrepresentable. The compiler / type checker is the cheapest test you will ever run. If a bug can be expressed as a type error, it is *required* to be expressed as a type error.
 
@@ -254,7 +256,7 @@ After every code-writing session, answer these out loud (in your reply) before d
 3. **Variant discrimination?** Did I use `if`/`elif`/`else` (or `switch` without `assertNever`, or `match` without `assert_never`) anywhere to discriminate on a tagged type or enum? If yes, rewrite as exhaustive match.
 4. **Escape hatches?** Any `Any`, `# type: ignore`, `unwrap`, `expect` outside `main`/tests, `as` numeric cast, `!`, `@ts-ignore`, `@ts-expect-error`, `#[allow]` on a real warning? If yes, fix the type or document why with a comment.
 5. **Defensive layer?** Any null check, try/except, or `isinstance` guarding a value the type system already proves? If yes, delete.
-6. **Helpers for one-off?** Any function, class, or trait introduced for a single caller that will never get a second caller? If yes, inline.
+6. **Helpers for one-off?** Any function, class, or trait introduced for a single caller that will never get a second caller? If yes, inline — axiom 0 should have caught it pre-write; this is the backstop.
 7. **Tests?** Is the behavior I just introduced locked by a test that would fail if I revert this commit?
 8. **Parameter bloat?** Any function I wrote or modified that takes more than 3 parameters — or smuggles them through a dict/kwargs/`...args`/throwaway options object? If yes, group related params into a typed value object. See [Smell 2](references/code-smells.md#smell-2--function-with-more-than-3-parameters).
 9. **Redundant verification?** Did I perform a destructive action (delete, remove, clear) and then immediately re-query to "confirm" it worked? Did I call a setter then a getter to "verify"? If yes, delete the verification — the operation's contract IS the proof. See [Smell 3](references/code-smells.md#smell-3--redundant-verification-after-a-destructive-action).

--- a/packages/shared-skills/skills/remove-ai-slops/SKILL.md
+++ b/packages/shared-skills/skills/remove-ai-slops/SKILL.md
@@ -30,6 +30,7 @@ The agent looks for these nine categories. The first three are stylistic, the ne
 2. **Over-defensive code** — null checks for guaranteed values, try/except around code that cannot raise, isinstance checks for statically typed params, default values for required params, backward-compat shims, redundant validation duplicated at multiple layers, **broad exception catching** (`except Exception`/`except BaseException` in Python, empty `catch {}` or `catch (e) { console.error(e) }` without narrowing in TypeScript/JavaScript).
    - KEEP: validation at system boundaries (user input, external APIs), I/O error handling, nullable DB fields. Top-level boundary catch-all (CLI `main()`, HTTP handler) with explicit logging + re-raise is acceptable.
    - REFACTOR: `except Exception` → catch the specific exception you expect. Empty `catch {}` → add `instanceof` narrowing or re-throw. `catch (e) { log(e) }` → narrow with `instanceof`, handle known cases, re-throw unknown.
+   - PROOF REQUIRED: before deleting any validation or error handling at a trust boundary, Phase 2 must include an **adversarial** regression (malformed or hostile input) that fails if the guard is removed. No adversarial test → the guard stays. Redundant defense to remove is a duplicate of a check that already runs *inside* the boundary; a guard with no proof of redundancy is load-bearing.
 
 3. **Excessive complexity** — deep nesting (>3 levels), nested ternaries, complex boolean expressions (combine 4+ predicates), long parameter lists (>5 args without a struct/dataclass/object), god functions (>50 lines doing many things), overly clever one-liners that sacrifice readability, `if/elif/else` chains for type/enum/literal discrimination (must be `match/case` + `assert_never`), `object` used as a type annotation (must be `Protocol`, `TypeVar`, or explicit union).
    - KEEP: established complexity patterns in this codebase, performance-critical hot paths that intentionally use a complex idiom. `if/else` for boolean conditions and range checks (not variant discrimination).
@@ -126,21 +127,36 @@ For each in-scope source file:
 
 If you cannot establish a green baseline (e.g., test runner is broken), STOP and report. Do not proceed with cleanup on unverified ground.
 
-### Phase 3: Cleanup plan
+### Phase 3: Cleanup plan — existence first, then smells
 
-Produce an explicit plan **before** spawning the removal agents:
+The largest, safest deletion is code that should not have existed. **Before categorizing smells, run the deletion ladder on each changed unit:**
+
+- **Delete entirely** — the behavior is not needed (YAGNI, speculative, dead on arrival).
+- **Reuse** — an existing helper or pattern in this repo already does it; replace the reimplementation with a call to it.
+- **Platform / stdlib / native / dependency** — the language stdlib, the runtime, or an already-installed dependency already does it (a hand-rolled date picker → `<input type="date">`, a custom query parser → `URLSearchParams`, a bespoke debounce → the util already imported).
+- **Simplify in place** — it must exist; make it smaller.
+
+Only code that lands on **Simplify in place** proceeds to the smell categories. This turns the pass from "find smells to trim" into "first decide whether the code should exist, then trim what survives." One function replaced by a platform call is a bigger, safer win than any in-place cleanup — and it needs no per-line smell analysis.
+
+For a diff that **fixes a bug**, grep the callers of every shared function it touches. Prefer one root-cause fix at the shared seam over repeated guards at each caller — a per-caller patch that leaves a sibling caller broken is a partial fix, not a cleanup.
+
+Then produce an explicit plan **before** spawning the removal agents:
 
 ```
 File: src/foo.py
+  Ladder: 2 units simplify-in-place; 1 unit delete (native <input> replaces custom picker)
   Categories: dead code, excessive complexity, performance
   Order: dead code → complexity → performance
   Risk: medium (touches caching layer)
 
 File: src/bar.py
+  Ladder: all simplify-in-place
   Categories: obvious comments, over-defensive
   Order: comments → defensive
   Risk: low
 ```
+
+**Intentional shortcuts:** if the plan deliberately keeps a bounded simplification (a naive scan fine under N rows, a global lock, an O(n²) path), mark it in-code with a `debt:` comment naming the ceiling and the upgrade trigger (in omo, prefix with `// @allow` so the comment-checker treats it as intentional), and list it under "Remaining Risks / Deferred" in the report. That section is the debt ledger — a simplification with a known ceiling and no marker is indistinguishable from a bug.
 
 Order rule (safest → riskiest): comments → dead code → defensive → duplication → complexity → abstraction/boundary → performance → tests → oversized-modules. This minimizes blast radius of any one change.
 
@@ -170,13 +186,9 @@ task(
   prompt="""
 Remove AI slops from: {file_path}
 
-In addition to your default categories (obvious comments, over-defensive code, spaghetti nesting), also evaluate these categories:
-- Excessive complexity: god functions, long parameter lists, complex booleans, nested ternaries
-- Needless abstraction: pass-through wrappers, single-use helpers, speculative indirection
-- Boundary violations: wrong-layer imports, leaky responsibilities, hidden coupling
-- Dead code: unused imports, unreachable branches, stale flags, debug leftovers
-- Duplication: copy-paste branches, redundant helpers
-- Performance equivalences: O(n²)→O(n) via set lookup, hoist computation out of loops, eager→lazy collections, batch redundant calls, cache repeated len()/length
+First run the deletion ladder from Phase 3 on this file (delete entirely / reuse existing repo code / platform-stdlib-native / simplify in place); only code that must exist proceeds to smell removal.
+
+Then evaluate EVERY category defined in this skill's "Categories (what counts as slop)" section, applying that section's KEEP and REFACTOR rules verbatim — the Categories section you have loaded is canonical, do not work from a restated subset.
 
 Apply changes in this order (safest → riskiest): comments → dead code → defensive → duplication → complexity → abstraction/boundary → performance → oversized-modules.
 
@@ -251,18 +263,19 @@ Behavior Lock:
   - Baseline status: GREEN
 
 Cleanup Plan:
-  - path/to/file1.ts: [dead code → complexity → performance]
-  - path/to/file2.py: [comments → defensive]
+  - path/to/file1.ts: [ladder: 1 delete (native) + simplify-in-place] → [dead code → complexity → performance]
+  - path/to/file2.py: [ladder: all simplify-in-place] → [comments → defensive]
 
-Per-File Results:
+Per-File Results (each cut shows what replaces it):
   path/to/file1.ts
-    - Dead code: 3 removed (lines X-Y, A-B, C)
+    - Ladder/delete: custom DatePicker (48 lines) → <input type="date"> (native), flatpickr import removed
+    - Dead code: 3 removed (lines X-Y, A-B, C) → nothing (unreachable)
     - Excessive complexity: 1 simplified (nested ternary at L42 → if/else)
     - Performance: 1 (line N: list scan → set lookup, O(n²)→O(n), behavior identical)
     - Skipped (preserved): 2 (defensive null check at boundary; commented WHY at L88)
 
   path/to/file2.py
-    - Obvious comments: 5 removed
+    - Obvious comments: 5 removed → nothing
     - Over-defensive: 1 simplified (redundant isinstance on typed param)
 
 Quality Gates:
@@ -280,8 +293,14 @@ Critical Review:
 Issues Found & Fixed:
   - [None] OR [Issue description → Fix applied]
 
-Remaining Risks / Deferred:
+Net Impact:
+  - LOC: -74 (removed 91, added 17)
+  - Dependencies: -1 (flatpickr removed; native <input type="date"> used)
+  - Files deleted: 1 (src/date-picker-wrapper.ts — platform-native replacement)
+
+Remaining Risks / Deferred (this section is the debt ledger):
   - [None] OR [e.g., "boundary violation in module X flagged but not refactored — needs human judgment"]
+  - `debt:` markers kept this pass: [None] OR [file:line — ceiling → upgrade trigger]
 
 Final Status: CLEAN | ISSUES FIXED | REQUIRES ATTENTION
 ```


### PR DESCRIPTION
## Summary

Two shared skills gain the one thing ponytail (`DietrichGebert/ponytail`) has and we lacked: a **pre-write "should this code exist at all?" gate**. `programming` taught how to write code well but always presumed code would be written; `remove-ai-slops` was strong at "find a smell, trim it" but never asked whether the code should exist. This PR reframes both around "the best code is the code never written" — melding ponytail's philosophy in our own voice, **not copying ponytail's files**. Markdown skill-TEXT only; no code, hooks, config, or runtime behavior changes.

Basis: a prior GPT-5.5 analysis (codex thread `019f1b0c`) comparing the two, plus ponytail pinned at `16f6cbf`. Edits follow the `prompt-engineering` skill's discipline — reframe/replace at the source, defend growth — rather than appending checklists. Net: `programming` +2 lines, `remove-ai-slops` +19 (with 18 deletions from a de-dup).

## Changes

**`programming/SKILL.md`** (`a3bb87e`)
- Opening identity reframed to "lazy senior engineer — efficient, never careless; the best code is the code never written" (replacement, net-neutral).
- New **axiom 0** above the existing six: a 7-rung pre-write existence ladder (YAGNI → reuse → stdlib → native → dependency → one-line → minimum), explicitly "a fast decision, not a written essay" so it stays cheap on terse reasoning models since this ships cross-harness. Folds in "**bug fix = root cause, not symptom**" + caller sweep.
- Post-write loop Q6 now points back at axiom 0 as the backstop (ties pre/post, no redundant deletion — the helper checks remain valid post-write catches).

**`remove-ai-slops/SKILL.md`** (`5b23476`)
- **Phase 3 reframed** "existence first, then smells": run a deletion ladder (delete entirely / reuse / platform-stdlib-native / simplify-in-place) before categorizing; only survivors get smell analysis. This subsumes reinvented-stdlib cases, so **no new category** was added.
- Category 2: **adversarial regression required** before deleting any trust-boundary guard (closes the one safety gap ponytail's own benchmark flagged).
- Bugfix **caller sweep** rule; **`debt:` marker** + the existing "Remaining Risks / Deferred" section formalized as the debt ledger; **deletion accounting** (what replaces each cut + net LOC/deps) in the report.
- Phase 4 worker prompt: the restated category list (drift-prone duplicate of the canonical Categories section) replaced with a reference to it — one canonical definition.

## QA & Evidence

Scope reaches the Codex Light edition (shared skills sync into the Codex plugin), so this ran the `codex-qa` isolated landing proof. Evidence: `.omo/evidence/20260701-ponytail-melding-skills/` (gitignored; summary below).

- **What was tested:** codex sync-adaptation + no-drift tests (`node --test .../sync-skills*.test.mjs`) after `sync:skills`.
  **Observed:** 24 pass / 0 fail — includes "generated copies have no hand-authored drift", singular `## Codex Harness Tool Compatibility` header, and the eager-payload budget. **Artifact:** rerun inline + `install-verify.txt`.
- **What was tested:** shared-skills parse + packaging + builtin-skill structure, both editions (`bun test shared-skills-package.test.ts + builtin-skills/skills.test.ts x2`).
  **Observed:** 45 pass / 0 fail — every skill (incl. these two) parses, packages, keeps valid structure. This also covers the OpenCode loader path.
- **What was tested:** real isolated install (`codex-qa install-verify.sh --keep`, `REPO_ROOT=<worktree>`, mock model), then grep the LANDED skill bytes in the isolated `CODEX_HOME`.
  **Observed:** install PASS (plugin cache `4.14.2`, `omo@sisyphuslabs` enabled, 9 bins + agent TOMLs linked). Both skills landed with **every** edited marker; Codex compat header count = **1**; removed duplicate category list count = **0**. **Artifact:** `landing-proof.txt`.
- **Isolation:** real `~/.codex/config.toml` shasum `b03493d4…` **identical before/after** (`real-home-shasum-{before,after}.txt` + install-verify's own assertion). Isolated home removed after grep.

## Risks & Residuals

- **Cross-harness token cost** (GPT-5.5 can burn thinking tokens deliberating each rung): mitigated by phrasing the ladder as a fast decision rule ("not a written essay"), per the GPT-5.5 prompting guide.
- **`debt:` marker vs comment-checker**: the skill instructs prefixing with `// @allow` so the comment-checker treats it as intentional. Accepted; no code comments introduced by this PR.
- Worktree-only infra noise during QA (frontend submodule checkout, a regenerated `codegraph/dist/serve.js`) was reverted and is **not** in the diff — only the two `SKILL.md` files are committed.

## Related

Melds philosophy from `DietrichGebert/ponytail` @ `16f6cbf` (inspiration, not vendored).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pre-write existence ladder to `programming` and `remove-ai-slops`, aligning both around “the best code is the code never written.” Coding and cleanup now default to delete/reuse/platform-first, with safer deletions and clearer debt tracking.

- **Refactors**
  - `programming`: added Axiom 0 (7‑rung pre-write ladder: YAGNI → reuse → stdlib → native → dependency → one‑line → minimum), reframed identity, and tied post‑write check back to Axiom 0; bug fixes prioritize root cause with a caller sweep.
  - `remove-ai-slops`: Phase 3 is existence‑first using the same ladder; only survivors get smell analysis; require adversarial regression before removing trust‑boundary guards; prefer shared‑seam fixes over per‑caller guards; added `debt:` marker and "Remaining Risks / Deferred" as a debt ledger with deletion accounting (replacement + net LOC/deps); worker prompt now references the canonical Categories section.

<sup>Written for commit 5b2347694d1b27985b81e8a0ee7d8963bc1ce1e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

