### PR TITLE
fix(skill): suppress path-alias duplicates from injected description

### DIFF
--- a/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
@@ -36,6 +36,14 @@ function userSkill(name: string, description = "user desc"): SkillInfo {
   })
 }
 
+function opencodeNativeSkill(name: string, description = "opencode native desc"): SkillInfo {
+  const shortName = name.split("/").at(-1) ?? name
+  return makeSkill(name, description, {
+    scope: "config",
+    location: `/opencode/${shortName}.md`,
+  })
+}
+
 function makeCommand(
   name: string,
   description = "command desc",
@@ -268,5 +276,21 @@ describe("formatCombinedDescription with path-alias deduplication", () => {
     expect(result).toContain("\n    <name>/refactor</name>")
     expect(result).toContain("project refactor skill")
     expect(result).toContain("builtin refactor command")
+  })
+
+  it("keeps OpenCode-injected native skills while suppressing shared path aliases", () => {
+    const skills: SkillInfo[] = [
+      sharedSkill("debugging", "full shared debugging"),
+      builtinSharedSkill("debugging", "short debugging wrapper"),
+      opencodeNativeSkill("opencode/customize-opencode", "Qualified OpenCode customize entry"),
+      opencodeNativeSkill("customize-opencode", "Customize OpenCode"),
+    ]
+
+    const result = formatCombinedDescription(skills, [], { includeSkills: true })
+
+    expect(result).toContain("<name>/shared/debugging</name>")
+    expect(result).not.toContain("\n    <name>/debugging</name>")
+    expect(result).toContain("<name>/customize-opencode</name>")
+    expect(result).toContain("Customize OpenCode")
   })
 })

--- a/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
@@ -1,9 +1,46 @@
 import { describe, expect, it } from "bun:test"
 import { deduplicatePathAliasedSkills, formatCombinedDescription } from "./description-formatter"
+import { loadedSkillToInfo } from "./native-skills"
+import type { CommandInfo } from "../slashcommand/types"
 import type { SkillInfo } from "./types"
 
-function makeSkill(name: string, description = "desc"): SkillInfo {
-  return { name, description, scope: "builtin" }
+function makeSkill(name: string, description = "desc", overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return { name, description, scope: "builtin", ...overrides }
+}
+
+function sharedSkill(name: string, description = "shared desc"): SkillInfo {
+  return makeSkill(`shared/${name}`, description, {
+    scope: "shared",
+    location: `/repo/packages/shared-skills/skills/${name}/SKILL.md`,
+  })
+}
+
+function builtinSharedSkill(name: string, description = "builtin desc"): SkillInfo {
+  return makeSkill(name, description, {
+    scope: "builtin",
+    location: `/repo/packages/shared-skills/skills/${name}`,
+  })
+}
+
+function localSkill(name: string, description = "local desc"): SkillInfo {
+  return makeSkill(name, description, {
+    scope: "project",
+    location: `/repo/.agents/skills/${name}/SKILL.md`,
+  })
+}
+
+function makeCommand(
+  name: string,
+  description = "command desc",
+  overrides: Partial<CommandInfo> = {},
+): CommandInfo {
+  return {
+    name,
+    metadata: { name, description },
+    content: "",
+    scope: "builtin",
+    ...overrides,
+  }
 }
 
 describe("deduplicatePathAliasedSkills", () => {
@@ -18,8 +55,8 @@ describe("deduplicatePathAliasedSkills", () => {
 
   it("suppresses the bare short name when a qualified variant exists", () => {
     const skills = [
-      makeSkill("shared/debugging"),
-      makeSkill("debugging"), // duplicate alias — should be removed
+      sharedSkill("debugging"),
+      builtinSharedSkill("debugging"),
       makeSkill("review-work"),
     ]
     const result = deduplicatePathAliasedSkills(skills)
@@ -28,10 +65,10 @@ describe("deduplicatePathAliasedSkills", () => {
 
   it("handles multiple short-name duplicates in one pass", () => {
     const skills = [
-      makeSkill("shared/debugging"),
-      makeSkill("debugging"),
-      makeSkill("shared/remove-ai-slops"),
-      makeSkill("remove-ai-slops"),
+      sharedSkill("debugging"),
+      builtinSharedSkill("debugging"),
+      sharedSkill("remove-ai-slops"),
+      builtinSharedSkill("remove-ai-slops"),
       makeSkill("review-work"),
     ]
     const result = deduplicatePathAliasedSkills(skills)
@@ -44,8 +81,8 @@ describe("deduplicatePathAliasedSkills", () => {
 
   it("keeps the qualified name even when descriptions differ", () => {
     const skills = [
-      makeSkill("shared/debugging", "canonical description"),
-      makeSkill("debugging", "slightly different description"),
+      sharedSkill("debugging", "canonical description"),
+      builtinSharedSkill("debugging", "slightly different description"),
     ]
     const result = deduplicatePathAliasedSkills(skills)
     expect(result).toHaveLength(1)
@@ -55,8 +92,8 @@ describe("deduplicatePathAliasedSkills", () => {
 
   it("does not suppress a bare name that has no qualified counterpart", () => {
     const skills = [
-      makeSkill("shared/debugging"),
-      makeSkill("review-work"), // no shared/review-work exists
+      sharedSkill("debugging"),
+      makeSkill("review-work"),
     ]
     const result = deduplicatePathAliasedSkills(skills)
     expect(result.map((s) => s.name)).toEqual(["shared/debugging", "review-work"])
@@ -64,26 +101,123 @@ describe("deduplicatePathAliasedSkills", () => {
 
   it("handles deeply nested paths correctly", () => {
     const skills = [
-      makeSkill("org/team/debugging"),
-      makeSkill("debugging"), // should be suppressed
-      makeSkill("team/debugging"), // different qualified path — kept; but short name already suppressed
+      makeSkill("org/team/debugging", "org", { location: "/repo/skills/org/team/debugging/SKILL.md" }),
+      makeSkill("debugging", "org", { location: "/repo/skills/org/team/debugging" }),
+      makeSkill("team/debugging", "team", { location: "/repo/skills/team/debugging/SKILL.md" }),
     ]
     const result = deduplicatePathAliasedSkills(skills)
-    // "debugging" bare name suppressed; both qualified variants kept
     expect(result.map((s) => s.name)).toEqual(["org/team/debugging", "team/debugging"])
+  })
+
+  it("keeps a distinct local bare skill when a shared skill has the same short name", () => {
+    const skills = [
+      sharedSkill("debugging", "shared debugging"),
+      localSkill("debugging", "local debugging"),
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
+      "shared/debugging:shared debugging",
+      "debugging:local debugging",
+    ])
+  })
+
+  it("keeps at least the qualified shared entry for same-source ast-grep aliases", () => {
+    const skills = [
+      sharedSkill("ast-grep", "full ast-grep instructions"),
+      builtinSharedSkill("ast-grep", "short ast-grep wrapper"),
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    expect(result.map((s) => s.name)).toEqual(["shared/ast-grep"])
+    expect(result[0]?.description).toBe("full ast-grep instructions")
+  })
+
+  it("removes shorter builtin aliases for shared-derived refactor skills", () => {
+    const skills = [
+      sharedSkill("refactor", "full refactor instructions"),
+      builtinSharedSkill("refactor", "short refactor wrapper"),
+      sharedSkill("remove-ai-slops", "full cleanup instructions"),
+      builtinSharedSkill("remove-ai-slops", "short cleanup wrapper"),
+      sharedSkill("start-work", "full start-work instructions"),
+      builtinSharedSkill("start-work", "short start-work wrapper"),
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
+      "shared/refactor:full refactor instructions",
+      "shared/remove-ai-slops:full cleanup instructions",
+      "shared/start-work:full start-work instructions",
+    ])
+  })
+
+  it("uses builtin resolvedPath to prove shared-derived aliases have the same source", () => {
+    const shared = sharedSkill("refactor", "full refactor instructions")
+    const builtin = loadedSkillToInfo({
+      name: "refactor",
+      definition: {
+        name: "refactor",
+        description: "short refactor wrapper",
+        template: "",
+      },
+      scope: "builtin",
+      resolvedPath: "/repo/packages/shared-skills/skills/refactor",
+    })
+    const result = deduplicatePathAliasedSkills([shared, builtin])
+    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
+      "shared/refactor:full refactor instructions",
+    ])
   })
 })
 
 describe("formatCombinedDescription with path-alias deduplication", () => {
   it("omits the bare alias from the injected description", () => {
     const skills: SkillInfo[] = [
-      makeSkill("shared/debugging"),
-      makeSkill("debugging"),
+      sharedSkill("debugging"),
+      builtinSharedSkill("debugging"),
       makeSkill("review-work"),
     ]
     const result = formatCombinedDescription(skills, [], { includeSkills: true })
     expect(result).toContain("/shared/debugging")
     expect(result).not.toContain("\n    <name>/debugging</name>")
     expect(result).toContain("/review-work")
+  })
+
+  it("omits shorter shared-derived builtin commands when the shared skill is listed", () => {
+    const skills: SkillInfo[] = [
+      sharedSkill("refactor", "full refactor skill"),
+      sharedSkill("remove-ai-slops", "full cleanup skill"),
+      sharedSkill("start-work", "full start-work skill"),
+    ]
+    const commands: CommandInfo[] = [
+      makeCommand("refactor", "short refactor command"),
+      makeCommand("remove-ai-slops", "short cleanup command"),
+      makeCommand("start-work", "short start-work command"),
+      makeCommand("handoff", "handoff command"),
+    ]
+
+    const result = formatCombinedDescription(skills, commands, { includeSkills: true })
+
+    expect(result).toContain("<name>/shared/refactor</name>")
+    expect(result).toContain("<name>/shared/remove-ai-slops</name>")
+    expect(result).toContain("<name>/shared/start-work</name>")
+    expect(result).not.toContain("\n    <name>/refactor</name>")
+    expect(result).not.toContain("\n    <name>/remove-ai-slops</name>")
+    expect(result).not.toContain("\n    <name>/start-work</name>")
+    expect(result).not.toContain("short refactor command")
+    expect(result).not.toContain("short cleanup command")
+    expect(result).not.toContain("short start-work command")
+    expect(result).toContain("handoff command")
+  })
+
+  it("keeps distinct project commands even when a shared skill has the same short name", () => {
+    const skills: SkillInfo[] = [sharedSkill("refactor", "full refactor skill")]
+    const commands: CommandInfo[] = [
+      makeCommand("refactor", "project refactor command", { scope: "project" }),
+    ]
+
+    const result = formatCombinedDescription(skills, commands, { includeSkills: true })
+
+    expect(result).toContain("<name>/shared/refactor</name>")
+    expect(result).toContain("\n    <name>/refactor</name>")
+    expect(result).toContain("full refactor skill")
+    expect(result).toContain("project refactor command")
   })
 })

--- a/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
@@ -36,11 +36,14 @@ function userSkill(name: string, description = "user desc"): SkillInfo {
   })
 }
 
-function opencodeNativeSkill(name: string, description = "opencode native desc"): SkillInfo {
-  const shortName = name.split("/").at(-1) ?? name
+function opencodeNativeSkill(
+  name: string,
+  description = "opencode native desc",
+  location = "<built-in>",
+): SkillInfo {
   return makeSkill(name, description, {
     scope: "config",
-    location: `/opencode/${shortName}.md`,
+    location,
   })
 }
 
@@ -201,6 +204,38 @@ describe("deduplicatePathAliasedSkills", () => {
     expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
       "shared/start-work:full start-work instructions",
       "start-work:local start-work workflow",
+    ])
+  })
+
+  it("keeps OpenCode native bare skills exposed with built-in sentinel locations", () => {
+    const skills = [
+      opencodeNativeSkill("opencode/customize-opencode", "Qualified OpenCode customize entry"),
+      opencodeNativeSkill("customize-opencode", "Customize OpenCode"),
+    ]
+
+    const result = deduplicatePathAliasedSkills(skills)
+
+    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
+      "opencode/customize-opencode:Qualified OpenCode customize entry",
+      "customize-opencode:Customize OpenCode",
+    ])
+  })
+
+  it("keeps OpenCode native bare skills exposed with legacy /opencode locations", () => {
+    const skills = [
+      opencodeNativeSkill(
+        "opencode/customize-opencode",
+        "Qualified OpenCode customize entry",
+        "/opencode/customize-opencode.md",
+      ),
+      opencodeNativeSkill("customize-opencode", "Customize OpenCode", "/opencode/customize-opencode.md"),
+    ]
+
+    const result = deduplicatePathAliasedSkills(skills)
+
+    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
+      "opencode/customize-opencode:Qualified OpenCode customize entry",
+      "customize-opencode:Customize OpenCode",
     ])
   })
 })

--- a/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
@@ -29,6 +29,13 @@ function localSkill(name: string, description = "local desc"): SkillInfo {
   })
 }
 
+function userSkill(name: string, description = "user desc"): SkillInfo {
+  return makeSkill(name, description, {
+    scope: "user",
+    location: `/home/.agents/skills/${name}/SKILL.md`,
+  })
+}
+
 function makeCommand(
   name: string,
   description = "command desc",
@@ -165,6 +172,29 @@ describe("deduplicatePathAliasedSkills", () => {
       "shared/refactor:full refactor instructions",
     ])
   })
+
+  it("suppresses known shared-derived opencode bare skills even when the wrapper has no location", () => {
+    const skills = [
+      sharedSkill("remove-ai-slops", "full cleanup instructions"),
+      makeSkill("remove-ai-slops", "short cleanup wrapper", { scope: "opencode", location: undefined }),
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
+      "shared/remove-ai-slops:full cleanup instructions",
+    ])
+  })
+
+  it("keeps distinct user bare skills when a shared skill has the same short name", () => {
+    const skills = [
+      sharedSkill("start-work", "full start-work instructions"),
+      userSkill("start-work", "local start-work workflow"),
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
+      "shared/start-work:full start-work instructions",
+      "start-work:local start-work workflow",
+    ])
+  })
 })
 
 describe("formatCombinedDescription with path-alias deduplication", () => {
@@ -219,5 +249,24 @@ describe("formatCombinedDescription with path-alias deduplication", () => {
     expect(result).toContain("\n    <name>/refactor</name>")
     expect(result).toContain("full refactor skill")
     expect(result).toContain("project refactor command")
+  })
+
+  it("keeps builtin commands when the matching qualified skill is not shared-derived", () => {
+    const skills: SkillInfo[] = [
+      makeSkill("project/refactor", "project refactor skill", {
+        scope: "project",
+        location: "/repo/.agents/skills/project/refactor/SKILL.md",
+      }),
+    ]
+    const commands: CommandInfo[] = [
+      makeCommand("refactor", "builtin refactor command"),
+    ]
+
+    const result = formatCombinedDescription(skills, commands, { includeSkills: true })
+
+    expect(result).toContain("<name>/project/refactor</name>")
+    expect(result).toContain("\n    <name>/refactor</name>")
+    expect(result).toContain("project refactor skill")
+    expect(result).toContain("builtin refactor command")
   })
 })

--- a/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test"
+import { deduplicatePathAliasedSkills, formatCombinedDescription } from "./description-formatter"
+import type { SkillInfo } from "./types"
+
+function makeSkill(name: string, description = "desc"): SkillInfo {
+  return { name, description, scope: "builtin" }
+}
+
+describe("deduplicatePathAliasedSkills", () => {
+  it("keeps all skills when there are no path-alias duplicates", () => {
+    const skills = [makeSkill("debugging"), makeSkill("review-work"), makeSkill("git-master")]
+    expect(deduplicatePathAliasedSkills(skills).map((s) => s.name)).toEqual([
+      "debugging",
+      "review-work",
+      "git-master",
+    ])
+  })
+
+  it("suppresses the bare short name when a qualified variant exists", () => {
+    const skills = [
+      makeSkill("shared/debugging"),
+      makeSkill("debugging"), // duplicate alias — should be removed
+      makeSkill("review-work"),
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    expect(result.map((s) => s.name)).toEqual(["shared/debugging", "review-work"])
+  })
+
+  it("handles multiple short-name duplicates in one pass", () => {
+    const skills = [
+      makeSkill("shared/debugging"),
+      makeSkill("debugging"),
+      makeSkill("shared/remove-ai-slops"),
+      makeSkill("remove-ai-slops"),
+      makeSkill("review-work"),
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    expect(result.map((s) => s.name)).toEqual([
+      "shared/debugging",
+      "shared/remove-ai-slops",
+      "review-work",
+    ])
+  })
+
+  it("keeps the qualified name even when descriptions differ", () => {
+    const skills = [
+      makeSkill("shared/debugging", "canonical description"),
+      makeSkill("debugging", "slightly different description"),
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe("shared/debugging")
+    expect(result[0]?.description).toBe("canonical description")
+  })
+
+  it("does not suppress a bare name that has no qualified counterpart", () => {
+    const skills = [
+      makeSkill("shared/debugging"),
+      makeSkill("review-work"), // no shared/review-work exists
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    expect(result.map((s) => s.name)).toEqual(["shared/debugging", "review-work"])
+  })
+
+  it("handles deeply nested paths correctly", () => {
+    const skills = [
+      makeSkill("org/team/debugging"),
+      makeSkill("debugging"), // should be suppressed
+      makeSkill("team/debugging"), // different qualified path — kept; but short name already suppressed
+    ]
+    const result = deduplicatePathAliasedSkills(skills)
+    // "debugging" bare name suppressed; both qualified variants kept
+    expect(result.map((s) => s.name)).toEqual(["org/team/debugging", "team/debugging"])
+  })
+})
+
+describe("formatCombinedDescription with path-alias deduplication", () => {
+  it("omits the bare alias from the injected description", () => {
+    const skills: SkillInfo[] = [
+      makeSkill("shared/debugging"),
+      makeSkill("debugging"),
+      makeSkill("review-work"),
+    ]
+    const result = formatCombinedDescription(skills, [], { includeSkills: true })
+    expect(result).toContain("/shared/debugging")
+    expect(result).not.toContain("\n    <name>/debugging</name>")
+    expect(result).toContain("/review-work")
+  })
+})

--- a/packages/omo-opencode/src/tools/skill/description-formatter.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.ts
@@ -65,6 +65,11 @@ function normalizeSkillLocation(location: string | undefined): string | undefine
   return normalized.toLowerCase()
 }
 
+function isOpenCodeInjectedNativeSkill(skill: SkillInfo): boolean {
+  const location = skill.location?.replaceAll("\\", "/").toLowerCase()
+  return location?.startsWith("/opencode/") ?? false
+}
+
 function hasSameSource(qualified: SkillInfo, bare: SkillInfo): boolean {
   const qualifiedLocation = normalizeSkillLocation(qualified.location)
   const bareLocation = normalizeSkillLocation(bare.location)
@@ -109,6 +114,7 @@ export function deduplicatePathAliasedSkills(skills: SkillInfo[]): SkillInfo[] {
     if (skill.name.includes("/")) return true
     const qualifiedMatches = qualifiedByShortName.get(normalizeSkillName(skill.name))
     if (!qualifiedMatches) return true
+    if (isOpenCodeInjectedNativeSkill(skill)) return true
     if (qualifiedMatches.some((qualified) => hasSameSource(qualified, skill))) return false
     if (qualifiedMatches.some((qualified) => isSuppressibleSharedDerivedBareSkill(
       qualified,

--- a/packages/omo-opencode/src/tools/skill/description-formatter.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.ts
@@ -71,6 +71,30 @@ function hasSameSource(qualified: SkillInfo, bare: SkillInfo): boolean {
   return Boolean(qualifiedLocation && bareLocation && qualifiedLocation === bareLocation)
 }
 
+function hasSharedSkillSource(skill: SkillInfo, shortName: string): boolean {
+  const location = normalizeSkillLocation(skill.location)
+  return location?.endsWith(`/shared-skills/skills/${shortName}`) ?? false
+}
+
+function isSharedDerivedQualifiedSkill(skill: SkillInfo, shortName: string): boolean {
+  if (!skill.name.includes("/")) return false
+  if (normalizeSkillName(shortSkillName(skill.name)) !== shortName) return false
+  if (skill.scope === "shared") return true
+
+  return hasSharedSkillSource(skill, shortName)
+}
+
+function isSuppressibleSharedDerivedBareSkill(
+  qualified: SkillInfo,
+  bare: SkillInfo,
+  shortName: string,
+): boolean {
+  if (!isSharedDerivedQualifiedSkill(qualified, shortName)) return false
+  if (bare.scope !== "builtin" && bare.scope !== "opencode") return false
+  if (hasSharedSkillSource(bare, shortName)) return true
+  return bare.location === undefined && SHARED_DERIVED_BUILTIN_COMMANDS.has(shortName)
+}
+
 export function deduplicatePathAliasedSkills(skills: SkillInfo[]): SkillInfo[] {
   const qualifiedByShortName = new Map<string, SkillInfo[]>()
   for (const skill of skills) {
@@ -86,6 +110,13 @@ export function deduplicatePathAliasedSkills(skills: SkillInfo[]): SkillInfo[] {
     const qualifiedMatches = qualifiedByShortName.get(normalizeSkillName(skill.name))
     if (!qualifiedMatches) return true
     if (qualifiedMatches.some((qualified) => hasSameSource(qualified, skill))) return false
+    if (qualifiedMatches.some((qualified) => isSuppressibleSharedDerivedBareSkill(
+      qualified,
+      skill,
+      normalizeSkillName(skill.name),
+    ))) {
+      return false
+    }
     return true
   })
 }
@@ -96,10 +127,7 @@ function shouldSuppressBuiltinCommandAlias(command: CommandInfo, skills: SkillIn
   const normalizedCommandName = normalizeSkillName(command.name)
   if (!SHARED_DERIVED_BUILTIN_COMMANDS.has(normalizedCommandName)) return false
 
-  return skills.some((skill) => {
-    if (!skill.name.includes("/")) return false
-    return normalizeSkillName(shortSkillName(skill.name)) === normalizedCommandName
-  })
+  return skills.some((skill) => isSharedDerivedQualifiedSkill(skill, normalizedCommandName))
 }
 
 function deduplicateCommandsForPathAliasedSkills(

--- a/packages/omo-opencode/src/tools/skill/description-formatter.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.ts
@@ -42,12 +42,43 @@ function formatSlashCommand(command: CommandInfo): string {
   return lines.join("\n")
 }
 
+/**
+ * Removes path-alias duplicates from a skill list before injection.
+ *
+ * When the same logical skill is registered under both a qualified path
+ * (e.g. `shared/debugging`) and a bare short name (`debugging`), only the
+ * qualified name is kept in the description.  The execution-time matcher in
+ * `skill-matcher.ts` already resolves bare short names to their qualified
+ * counterpart, so callers do not lose the ability to invoke the skill by its
+ * short name — they just won't see the redundant alias in the tool description.
+ */
+export function deduplicatePathAliasedSkills(skills: SkillInfo[]): SkillInfo[] {
+  // Build a set of all short names (last path segment) that also have a
+  // qualified (multi-segment) variant in the list.
+  const qualifiedShortNames = new Set<string>()
+  for (const skill of skills) {
+    const parts = skill.name.split("/")
+    if (parts.length > 1) {
+      const shortName = parts[parts.length - 1]
+      if (shortName) qualifiedShortNames.add(shortName)
+    }
+  }
+
+  // Suppress bare entries whose name exactly matches a qualified short name.
+  return skills.filter((skill) => {
+    if (!skill.name.includes("/") && qualifiedShortNames.has(skill.name)) {
+      return false
+    }
+    return true
+  })
+}
+
 export function formatCombinedDescription(
   skills?: SkillInfo[],
   commands?: CommandInfo[],
   options: CombinedDescriptionOptions = {}
 ): string {
-  const availableSkills = options.includeSkills ? skills ?? [] : []
+  const availableSkills = options.includeSkills ? deduplicatePathAliasedSkills(skills ?? []) : []
   const availableCommands = commands ?? []
 
   if (availableSkills.length === 0 && availableCommands.length === 0) {

--- a/packages/omo-opencode/src/tools/skill/description-formatter.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.ts
@@ -7,6 +7,8 @@ interface CombinedDescriptionOptions {
   includeSkills?: boolean
 }
 
+const SHARED_DERIVED_BUILTIN_COMMANDS = new Set(["refactor", "remove-ai-slops", "start-work"])
+
 function formatSkillCommand(skill: SkillInfo): string {
   const lines = [
     "  <command>",
@@ -42,35 +44,69 @@ function formatSlashCommand(command: CommandInfo): string {
   return lines.join("\n")
 }
 
-/**
- * Removes path-alias duplicates from a skill list before injection.
- *
- * When the same logical skill is registered under both a qualified path
- * (e.g. `shared/debugging`) and a bare short name (`debugging`), only the
- * qualified name is kept in the description.  The execution-time matcher in
- * `skill-matcher.ts` already resolves bare short names to their qualified
- * counterpart, so callers do not lose the ability to invoke the skill by its
- * short name — they just won't see the redundant alias in the tool description.
- */
+function shortSkillName(name: string): string {
+  const parts = name.split("/")
+  return parts[parts.length - 1] ?? name
+}
+
+function normalizeSkillName(name: string): string {
+  return name.toLowerCase()
+}
+
+function normalizeSkillLocation(location: string | undefined): string | undefined {
+  if (!location) return undefined
+  let normalized = location.replaceAll("\\", "/").replace(/\/+$/, "")
+  const lower = normalized.toLowerCase()
+  if (lower.endsWith("/skill.md")) {
+    normalized = normalized.slice(0, -"/SKILL.md".length)
+  } else if (lower.endsWith(".md")) {
+    normalized = normalized.slice(0, normalized.lastIndexOf("/"))
+  }
+  return normalized.toLowerCase()
+}
+
+function hasSameSource(qualified: SkillInfo, bare: SkillInfo): boolean {
+  const qualifiedLocation = normalizeSkillLocation(qualified.location)
+  const bareLocation = normalizeSkillLocation(bare.location)
+  return Boolean(qualifiedLocation && bareLocation && qualifiedLocation === bareLocation)
+}
+
 export function deduplicatePathAliasedSkills(skills: SkillInfo[]): SkillInfo[] {
-  // Build a set of all short names (last path segment) that also have a
-  // qualified (multi-segment) variant in the list.
-  const qualifiedShortNames = new Set<string>()
+  const qualifiedByShortName = new Map<string, SkillInfo[]>()
   for (const skill of skills) {
-    const parts = skill.name.split("/")
-    if (parts.length > 1) {
-      const shortName = parts[parts.length - 1]
-      if (shortName) qualifiedShortNames.add(shortName)
-    }
+    if (!skill.name.includes("/")) continue
+    const shortName = normalizeSkillName(shortSkillName(skill.name))
+    const matches = qualifiedByShortName.get(shortName) ?? []
+    matches.push(skill)
+    qualifiedByShortName.set(shortName, matches)
   }
 
-  // Suppress bare entries whose name exactly matches a qualified short name.
   return skills.filter((skill) => {
-    if (!skill.name.includes("/") && qualifiedShortNames.has(skill.name)) {
-      return false
-    }
+    if (skill.name.includes("/")) return true
+    const qualifiedMatches = qualifiedByShortName.get(normalizeSkillName(skill.name))
+    if (!qualifiedMatches) return true
+    if (qualifiedMatches.some((qualified) => hasSameSource(qualified, skill))) return false
     return true
   })
+}
+
+function shouldSuppressBuiltinCommandAlias(command: CommandInfo, skills: SkillInfo[]): boolean {
+  if (command.scope !== "builtin") return false
+  if (command.name.includes("/")) return false
+  const normalizedCommandName = normalizeSkillName(command.name)
+  if (!SHARED_DERIVED_BUILTIN_COMMANDS.has(normalizedCommandName)) return false
+
+  return skills.some((skill) => {
+    if (!skill.name.includes("/")) return false
+    return normalizeSkillName(shortSkillName(skill.name)) === normalizedCommandName
+  })
+}
+
+function deduplicateCommandsForPathAliasedSkills(
+  commands: CommandInfo[],
+  skills: SkillInfo[],
+): CommandInfo[] {
+  return commands.filter((command) => !shouldSuppressBuiltinCommandAlias(command, skills))
 }
 
 export function formatCombinedDescription(
@@ -79,7 +115,7 @@ export function formatCombinedDescription(
   options: CombinedDescriptionOptions = {}
 ): string {
   const availableSkills = options.includeSkills ? deduplicatePathAliasedSkills(skills ?? []) : []
-  const availableCommands = commands ?? []
+  const availableCommands = deduplicateCommandsForPathAliasedSkills(commands ?? [], availableSkills)
 
   if (availableSkills.length === 0 && availableCommands.length === 0) {
     if ((skills?.length ?? 0) > 0) {

--- a/packages/omo-opencode/src/tools/skill/description-formatter.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.ts
@@ -66,8 +66,9 @@ function normalizeSkillLocation(location: string | undefined): string | undefine
 }
 
 function isOpenCodeInjectedNativeSkill(skill: SkillInfo): boolean {
+  if (skill.scope !== "config") return false
   const location = skill.location?.replaceAll("\\", "/").toLowerCase()
-  return location?.startsWith("/opencode/") ?? false
+  return location === "<built-in>" || (location?.startsWith("/opencode/") ?? false)
 }
 
 function hasSameSource(qualified: SkillInfo, bare: SkillInfo): boolean {

--- a/packages/omo-opencode/src/tools/skill/native-skills.ts
+++ b/packages/omo-opencode/src/tools/skill/native-skills.ts
@@ -15,7 +15,7 @@ export function loadedSkillToInfo(skill: LoadedSkill): SkillInfo {
   return {
     name: skill.name,
     description: skill.definition.description || "",
-    location: skill.path,
+    location: skill.path ?? skill.resolvedPath,
     scope: skill.scope,
     license: skill.license,
     compatibility: skill.compatibility,

--- a/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
+++ b/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
@@ -813,6 +813,65 @@ describe("skill tool - nativeSkills integration", () => {
     expect(tool.description).toContain("native-visible-skill")
   })
 
+  it("keeps OpenCode-injected native skills in the description while suppressing shared path aliases", () => {
+    //#given
+    const sharedDebuggingSkill: LoadedSkill = {
+      name: "shared/debugging",
+      path: "/repo/packages/shared-skills/skills/debugging/SKILL.md",
+      resolvedPath: "/repo/packages/shared-skills/skills/debugging",
+      definition: {
+        name: "shared/debugging",
+        description: "Full shared debugging instructions",
+        template: "Full shared debugging body",
+      },
+      scope: "shared",
+    }
+    const bareDebuggingAlias: LoadedSkill = {
+      name: "debugging",
+      path: "/repo/packages/shared-skills/skills/debugging",
+      resolvedPath: "/repo/packages/shared-skills/skills/debugging",
+      definition: {
+        name: "debugging",
+        description: "Short debugging wrapper",
+        template: "Short debugging body",
+      },
+      scope: "builtin",
+    }
+    const tool = createSkillTool({
+      skills: [sharedDebuggingSkill, bareDebuggingAlias],
+      includeSkillsInDescription: true,
+      nativeSkills: {
+        all() {
+          return [
+            {
+              name: "opencode/customize-opencode",
+              description: "Qualified OpenCode customize entry",
+              location: "/opencode/customize-opencode.md",
+              content: "Qualified OpenCode customize body",
+            },
+            {
+              name: "customize-opencode",
+              description: "Customize OpenCode",
+              location: "/opencode/customize-opencode.md",
+              content: "Customize OpenCode body",
+            },
+          ]
+        },
+        get() { return undefined },
+        dirs() { return [] },
+      },
+    })
+
+    //#when
+    const description = tool.description
+
+    //#then
+    expect(description).toContain("<name>/shared/debugging</name>")
+    expect(description).not.toContain("\n    <name>/debugging</name>")
+    expect(description).toContain("<name>/customize-opencode</name>")
+    expect(description).toContain("Customize OpenCode")
+  })
+
   it("merges native skills exposed by PluginInput.skills.all()", async () => {
     //#given
     const tool = createSkillTool({

--- a/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
+++ b/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
@@ -846,13 +846,13 @@ describe("skill tool - nativeSkills integration", () => {
             {
               name: "opencode/customize-opencode",
               description: "Qualified OpenCode customize entry",
-              location: "/opencode/customize-opencode.md",
+              location: "<built-in>",
               content: "Qualified OpenCode customize body",
             },
             {
               name: "customize-opencode",
               description: "Customize OpenCode",
-              location: "/opencode/customize-opencode.md",
+              location: "<built-in>",
               content: "Customize OpenCode body",
             },
           ]


### PR DESCRIPTION
## Problem

When shared skills are enabled via `skills.paths`, the same skill can appear under both a qualified path name (e.g. `shared/debugging`) and a bare short name (`debugging`). Both variants were being injected into the skill tool description, causing ~3,500 tokens of redundant context per session.

Raised by @cpt9617 in the Sisyphus Labs Discord, with @typeey also confirming the direction.

## Root Cause

`formatCombinedDescription` received the full merged skill list without any path-alias deduplication. The description-level deduplication only checked exact name matches, so `debugging` and `shared/debugging` were treated as separate entries.

## Fix

Added `deduplicatePathAliasedSkills()` to `description-formatter.ts` which filters out any bare name that already has a qualified multi-segment counterpart in the list:

- `shared/debugging` is kept (canonical, qualified)
- `debugging` is suppressed (redundant alias)

The execution-time `matchSkillByName` in `skill-matcher.ts` already resolves bare short names via its `shortNameMatches` logic, so callers retain full invocation compatibility (`skill(name="debugging")` still works) without the description cost.

## What changes

- `src/tools/skill/description-formatter.ts` — new `deduplicatePathAliasedSkills()` helper, applied inside `formatCombinedDescription`
- `src/tools/skill/description-formatter.test.ts` — 7 new unit tests covering happy path, multiple duplicates, description drift, no-counterpart, and deeply nested paths

## Test results

```
50 pass, 0 fail
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses path-aliased duplicates in the skill tool description by keeping qualified names (e.g. `shared/debugging`) and dropping redundant bare aliases and shared‑derived builtin command aliases. Cuts tokens while preserving how skills and commands are invoked.

- **Bug Fixes**
  - Deduplicate skills by filtering bare names that have a qualified counterpart from the same source (via normalized location/`resolvedPath`).
  - Suppress builtin aliases `refactor`, `remove-ai-slops`, `start-work` only when a shared‑derived skill exists for that short name.
  - Preserve OpenCode native skill aliases (`config` scope with `<built-in>` or `/opencode/*`) and distinct project/user skills; keep builtin commands when the qualified skill isn’t shared‑derived.

<sup>Written for commit f078fd89effb107d545721f11b454bf03d58593b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

