### PR TITLE
test(mcp-stdio-core): pin lifecycle log contract

### DIFF
--- a/packages/mcp-stdio-core/src/server.test.ts
+++ b/packages/mcp-stdio-core/src/server.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { PassThrough } from "node:stream"
+import { isPlainRecord } from "./record.js"
 import { successResponse } from "./responses.js"
 import { runJsonRpcStdioServer } from "./server.js"
+import type { McpLifecycleLog } from "./types.js"
+
+type CapturedLogEntry = {
+  readonly event: string
+  readonly fields?: Record<string, boolean | number | string | null>
+}
 
 describe("JSON-RPC stdio server", () => {
   test("#given request handler #when line request arrives #then response is written", async () => {
@@ -21,6 +28,32 @@ describe("JSON-RPC stdio server", () => {
     await server
   })
 
+  test("#given request handler and lifecycle logger #when line request arrives #then request lifecycle logs are emitted", async () => {
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const logs = captureLogs()
+    const received = nextOutput(output)
+    const server = runJsonRpcStdioServer({
+      input,
+      output,
+      log: logs.log,
+      handlerOptions: undefined,
+      handler: async () => successResponse("ok", { acknowledged: true }),
+    })
+
+    input.end('{"jsonrpc":"2.0","id":"ok","method":"ping"}\n')
+
+    expect(await received).toBe('{"jsonrpc":"2.0","id":"ok","result":{"acknowledged":true}}\n')
+    await server
+
+    expect(logs.entries).toEqual([
+      { event: "stdio_started", fields: { cwd: process.cwd(), idle_timeout_ms: 600000 } },
+      { event: "request", fields: { id: "ok", method: "ping" } },
+      { event: "response", fields: { id: "ok", method: "ping", is_error: false } },
+      { event: "stdio_stopped" },
+    ])
+  })
+
   test("#given parse error override #when malformed line arrives #then override response is written", async () => {
     const input = new PassThrough()
     const output = new PassThrough()
@@ -38,7 +71,51 @@ describe("JSON-RPC stdio server", () => {
     expect(await received).toBe('{"jsonrpc":"2.0","id":null,"error":{"code":-32601,"message":"Method not found"}}\n')
     await server
   })
+
+  test("#given lifecycle logger #when malformed line arrives #then parse error log is emitted and response is written", async () => {
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const logs = captureLogs()
+    const received = nextOutput(output)
+    const server = runJsonRpcStdioServer({
+      input,
+      output,
+      log: logs.log,
+      handlerOptions: undefined,
+      handler: async () => undefined,
+    })
+
+    input.end("garbage\n")
+
+    const responseText = await received
+    const response: unknown = JSON.parse(responseText)
+    const error = isPlainRecord(response) ? response["error"] : undefined
+    expect(responseText.endsWith("\n")).toBe(true)
+    expect(isPlainRecord(response) ? response["jsonrpc"] : undefined).toBe("2.0")
+    expect(isPlainRecord(response) ? response["id"] : undefined).toBeNull()
+    expect(isPlainRecord(error) ? error["code"] : undefined).toBe(-32700)
+    expect(isPlainRecord(error) ? error["message"] : undefined).toBe("Parse error")
+    expect(typeof (isPlainRecord(error) ? error["data"] : undefined)).toBe("string")
+    await server
+
+    expect(logs.entries.map((entry) => entry.event)).toEqual(["stdio_started", "parse_error", "stdio_stopped"])
+    expect(logs.entries.filter((entry) => entry.event === "parse_error").map((entry) => entry.fields?.["message"])).toEqual([
+      expect.any(String),
+    ])
+  })
 })
+
+function captureLogs(): { readonly entries: readonly CapturedLogEntry[]; readonly log: McpLifecycleLog } {
+  const entries: CapturedLogEntry[] = []
+  const log: McpLifecycleLog = (event, fields) => {
+    if (fields === undefined) {
+      entries.push({ event })
+      return
+    }
+    entries.push({ event, fields })
+  }
+  return { entries, log }
+}
 
 function nextOutput(output: PassThrough): Promise<string> {
   return new Promise((resolve) => {


### PR DESCRIPTION
## Summary

- Add test coverage for `mcp-stdio-core` lifecycle logging on successful JSON-RPC requests.
- Assert `request` and `response` log fields (`id`, `method`, `is_error`) so the lifecycle log callback can act as a test-grade contract.
- Add malformed JSON coverage that asserts `parse_error` is logged while the JSON-RPC parse-error response is still written.

## Verification

- RED proof: temporarily changed the implementation event from `response` to `response_mismatch`; the new lifecycle assertion failed on the event mismatch.
  - Evidence: `.omo/ulw-loop/mcp-stdio-log-pr-20260701/evidence/red-mutation-lifecycle.txt`
- `bun test packages/mcp-stdio-core/src/server.test.ts --test-name-pattern lifecycle`
  - Evidence: `.omo/ulw-loop/mcp-stdio-log-pr-20260701/evidence/c001-lifecycle-green.txt`
- `bun test packages/mcp-stdio-core/src/server.test.ts --test-name-pattern parse`
  - Evidence: `.omo/ulw-loop/mcp-stdio-log-pr-20260701/evidence/c002-parse-error-green.txt`
- `bun test packages/mcp-stdio-core/src/*.test.ts`
  - Evidence: `.omo/ulw-loop/mcp-stdio-log-pr-20260701/evidence/c003-package-green.txt`
- `bunx tsc --noEmit --project packages/mcp-stdio-core/tsconfig.json`
  - Evidence: `.omo/ulw-loop/mcp-stdio-log-pr-20260701/evidence/typecheck-mcp-stdio-core.txt`
- `git diff --check -- packages/mcp-stdio-core/src/server.test.ts`
  - Evidence: `.omo/ulw-loop/mcp-stdio-log-pr-20260701/evidence/diff-check-server-test.txt`

## QA Notes

This is a test-only change in the leaf `mcp-stdio-core` package. It does not change production code, hook wiring, installer behavior, CLI behavior, telemetry behavior, or runtime MCP server behavior.

Reviewer-readable QA summary was written locally to `.omo/evidence/20260701-mcp-stdio-lifecycle-logs/README.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests in `mcp-stdio-core` to pin the lifecycle logging contract for JSON-RPC over stdio. Verifies the `stdio_started` → `request` → `response` → `stdio_stopped` sequence with `id`, `method`, `is_error`, and that malformed input logs `parse_error` while still returning a valid parse-error response.

<sup>Written for commit 0e00e36198217bc05e032860dc33dee31ec14691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

