### PR TITLE
fix(model-core): recognize claude-sonnet-5 as GA 1M-context model (fixes #5788)

### DIFF
--- a/packages/model-core/src/context-limit-resolver.test.ts
+++ b/packages/model-core/src/context-limit-resolver.test.ts
@@ -148,6 +148,24 @@ describe("resolveActualContextLimit", () => {
     })).toBe(1_000_000)
   })
 
+  it("returns GA 1M for claude-sonnet-5 without explicit 1M mode", () => {
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    expect(resolveActualContextLimit("anthropic", "claude-sonnet-5", {
+      anthropicContext1MEnabled: false,
+    })).toBe(1_000_000)
+  })
+
+  it("returns GA 1M for claude-sonnet-5 on google-vertex-anthropic", () => {
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    expect(resolveActualContextLimit("google-vertex-anthropic", "claude-sonnet-5", {
+      anthropicContext1MEnabled: false,
+    })).toBe(1_000_000)
+  })
+
   it("returns GA 1M for claude-opus-4-8", () => {
     delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
     delete process.env[VERTEX_CONTEXT_ENV_KEY]

--- a/packages/model-core/src/context-limit-resolver.ts
+++ b/packages/model-core/src/context-limit-resolver.ts
@@ -26,7 +26,7 @@ function getAnthropicActualLimit(modelCacheState?: ContextLimitModelCacheState):
 
 function hasGA1MContext(modelID: string): boolean {
   return /^claude-(opus|sonnet)-4(?:-|\.)(?:6|7|8)(?:-high)?$/.test(modelID) ||
-    /^claude-(?:fable|mythos)-5$/.test(modelID)
+    /^claude-(?:fable|mythos|sonnet)-5$/.test(modelID)
 }
 
 export function resolveActualContextLimit(


### PR DESCRIPTION
## Summary

`claude-sonnet-5` has a 1M-token context window, but OMO's `hasGA1MContext` gate did not recognize it, so `resolveActualContextLimit` fell back to the 200K default on Anthropic providers and triggered compaction roughly 5x too early.

## Root Cause

[`packages/model-core/src/context-limit-resolver.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/packages/model-core/src/context-limit-resolver.ts#L27-L30) gates the 1M window on two regexes:

```ts
function hasGA1MContext(modelID: string): boolean {
  return /^claude-(opus|sonnet)-4(?:-|\.)(?:6|7|8)(?:-high)?$/.test(modelID) ||
    /^claude-(?:fable|mythos)-5$/.test(modelID)
}
```

`claude-sonnet-5` matches neither: the first branch requires `-4` immediately after `opus|sonnet`, and the 5-generation branch was scoped to `fable|mythos` only. As a result `resolveActualContextLimit("anthropic", "claude-sonnet-5", ...)` returned `DEFAULT_ANTHROPIC_ACTUAL_LIMIT` (200,000) instead of `ANTHROPIC_GA_1M_LIMIT` (1,000,000), on `anthropic`, `google-vertex-anthropic`, and `aws-bedrock-anthropic`.

This is the same class of miss previously fixed for `claude-opus-4-8` (#5070) and for `claude-fable-5` / `claude-mythos-5` (#5188).

## Changes

| File | Change |
|------|--------|
| `packages/model-core/src/context-limit-resolver.ts` | Add `sonnet` to the existing 5-generation alternation: `/^claude-(?:fable\|mythos\|sonnet)-5$/` |
| `packages/model-core/src/context-limit-resolver.test.ts` | Add regression cases for `claude-sonnet-5` on `anthropic` and `google-vertex-anthropic` |

## Reproduction (before fix)

```
155 |     expect(resolveActualContextLimit("anthropic", "claude-sonnet-5", {
157 |     })).toBe(1_000_000)
error: expect(received).toBe(expected)
Expected: 1000000
Received: 200000
(fail) resolveActualContextLimit > returns GA 1M for claude-sonnet-5 without explicit 1M mode
(fail) resolveActualContextLimit > returns GA 1M for claude-sonnet-5 on google-vertex-anthropic
```

## Verification (after fix)

```
(pass) resolveActualContextLimit > returns GA 1M for claude-sonnet-5 without explicit 1M mode
(pass) resolveActualContextLimit > returns GA 1M for claude-sonnet-5 on google-vertex-anthropic
 14 pass
 0 fail
```

## Test

- Regression test: `packages/model-core/src/context-limit-resolver.test.ts` (2 cases added, mirroring the existing fable-5/mythos-5 coverage)
- Related suite: `bun test packages/model-core/` — 286 pass / 0 fail
- Typecheck: `tsgo -p packages/model-core/tsconfig.json --noEmit` — clean (exit 0)

Fixes #5788


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes `claude-sonnet-5` as a GA 1M-context model so `resolveActualContextLimit` returns 1,000,000 (not 200,000) on Anthropic-backed providers. Fixes #5788.

- **Bug Fixes**
  - Expanded `hasGA1MContext` to `/^claude-(?:fable|mythos|sonnet)-5$/` in `packages/model-core/src/context-limit-resolver.ts`.
  - Added regression tests for `anthropic` and `google-vertex-anthropic` in `packages/model-core/src/context-limit-resolver.test.ts`.

<sup>Written for commit 828ef6b3fdad88cb3430d70043374891849e9da3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

