### PR TITLE
fix(doctor): guard tui.json tuple plugin entries in TUI plugin check (fixes #5786)

### DIFF
--- a/packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.test.ts
@@ -26,6 +26,14 @@ function writeTuiConfig(plugins: string[]): void {
   )
 }
 
+function writeTuiConfigRaw(plugins: unknown[]): void {
+  writeFileSync(
+    join(testConfigDir, "tui.json"),
+    JSON.stringify({ plugin: plugins }, null, 2) + "\n",
+    "utf-8",
+  )
+}
+
 function createPackageJson(packageName: string, exportsValue: Record<string, unknown> = { ".": "./dist/index.js" }): string {
   return JSON.stringify({ name: packageName, exports: exportsValue }, null, 2) + "\n"
 }
@@ -80,6 +88,22 @@ describe("tui-plugin-config check", () => {
     expect(result.status).toBe("pass")
     expect(result.issues).toHaveLength(0)
     expect(result.name).toBe("TUI Plugin")
+  })
+
+  it("passes when tui.json pairs our entry with a tuple third-party plugin entry", async () => {
+    //#given opencode.json has the server entry, the installed package exports ./tui,
+    //#      and tui.json has our string entry plus a valid tuple plugin entry
+    //#      of the form [pathOrPackage, options]
+    writeInstalledPackage(PLUGIN_NAME, { ".": "./dist/index.js", "./tui": "./dist/tui.js" })
+    writeOpenCodeConfig([PLUGIN_NAME])
+    writeTuiConfigRaw([PLUGIN_NAME, ["./local-tui-plugin.tsx", { label: "custom" }]])
+
+    //#when running the check
+    const result = await checkTuiPluginConfig()
+
+    //#then the tuple entry is ignored and our string entry still registers the plugin
+    expect(result.status).toBe("pass")
+    expect(result.issues).toHaveLength(0)
   })
 
   it("passes after ensureTuiPluginEntry adds the missing package TUI entry", async () => {

--- a/packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.ts
@@ -140,7 +140,7 @@ export function detectServerPluginRegistration(): ServerPluginInfo {
 
   try {
     const parsed = parseJsonc<OpenCodeConfigShape>(readFileSync(configPath, "utf-8"))
-    const plugins = parsed.plugin ?? []
+    const plugins = (parsed.plugin ?? []).filter((entry): entry is string => typeof entry === "string")
     const serverEntry = plugins.find(isServerPluginEntry)
     return {
       registered: serverEntry !== undefined,
@@ -172,7 +172,7 @@ export function detectTuiPluginRegistration(): TuiPluginInfo {
 
   try {
     const parsed = parseJsonc<TuiConfigShape>(readFileSync(tuiJsonPath, "utf-8"))
-    const plugins = parsed.plugin ?? []
+    const plugins = (parsed.plugin ?? []).filter((entry): entry is string => typeof entry === "string")
     return {
       registered: plugins.some(isTuiPluginEntry),
       configPath: tuiJsonPath,


### PR DESCRIPTION
## Summary

`omo doctor` falsely reported `TUI plugin entry missing from tui.json` whenever `tui.json` contained a valid `"oh-my-openagent"` entry alongside a tuple plugin entry such as `["./plugin.tsx", { ... }]`. The tuple made a doctor predicate throw a `TypeError`, which the broad `try/catch` swallowed into an all-false registration state.

## Root Cause

`detectTuiPluginRegistration()` and `detectServerPluginRegistration()` in [`tui-plugin-config.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.ts) fed the raw parsed `plugin` array into predicates typed `(entry: string)` that call `String.startsWith`:

```ts
const plugins = parsed.plugin ?? []
return {
  registered: plugins.some(isTuiPluginEntry),
  hasNamedTuiEntry: plugins.some(isNamedTuiPluginEntry),  // <- throws on a tuple entry
  ...
}
```

OpenCode plugin config accepts tuple entries of the form `[pathOrPackage, options]`. When `tui.json` holds `["oh-my-openagent", ["./local.tsx", { ... }]]`, `.some(isNamedTuiPluginEntry)` iterates past the string entry, reaches the tuple, calls `entry.startsWith(...)` on an array, and throws `TypeError: entry.startsWith is not a function`. The surrounding `catch` treats that as an absent registration and returns `registered: false`, so doctor emits the misleading missing-entry warning.

## Changes

| File | Change |
|------|--------|
| `packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.ts` | Filter the parsed `plugin` array to strings before evaluating predicates, in both `detectTuiPluginRegistration()` and `detectServerPluginRegistration()` |
| `packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.test.ts` | Add a regression case where `tui.json` pairs the package entry with a tuple plugin entry |

The fix reuses the exact guard already used by `pluginEntries()` in [`add-tui-plugin-to-tui-config.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/packages/omo-opencode/src/cli/config-manager/add-tui-plugin-to-tui-config.ts#L49): `.filter((entry): entry is string => typeof entry === "string")`.

## Reproduction (before fix)

```
104 |     //#then the tuple entry is ignored and our string entry still registers the plugin
error: expect(received).toBe(expected)
Expected: "pass"
Received: "warn"
(fail) tui-plugin-config check > passes when tui.json pairs our entry with a tuple third-party plugin entry
```

## Verification (after fix)

```
(pass) tui-plugin-config check > passes when tui.json pairs our entry with a tuple third-party plugin entry
 14 pass
 0 fail
```

## Test

- Regression test: `packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.test.ts` (1 case added)
- Related suite: `bun test packages/omo-opencode/src/cli/doctor/` — 158 pass. The single `spawn-with-timeout` failure ("returns stdout and exit code") is a pre-existing Windows subprocess flake that reproduces identically on unmodified `dev`, unrelated to this change.
- Typecheck: `tsgo -p packages/omo-opencode/tsconfig.json --noEmit` — clean (exit 0)

Fixes #5786


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false “TUI plugin entry missing from tui.json” warning in `omo doctor` when `tui.json` includes tuple plugin entries. We now ignore tuple entries during checks so valid `oh-my-openagent` registrations pass.

- **Bug Fixes**
  - Filter plugin arrays to strings in `detectTuiPluginRegistration()` and `detectServerPluginRegistration()` to avoid calling string methods on tuples.
  - Added a regression test for a mixed config: `["oh-my-openagent", ["./local-tui-plugin.tsx", { ... }]]`.

<sup>Written for commit f56b615c30238d8a874cc57c25cb9711eac4fd57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

