### PR TITLE
fix(codex): stop exposing designpowers refs as skills

### DIFF
--- a/packages/omo-codex/plugin/test/sync-skills.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills.test.mjs
@@ -55,6 +55,26 @@ test("#given synced aggregate Codex skills #when inspected #then component and s
 	}
 });
 
+test("#given reference-only designpowers frontend files #when synced for Codex #then nested SKILL.md files are not packaged", async () => {
+	// given
+	const frontendReferencesRoot = join(root, "skills", "frontend", "references");
+	const designpowersVendorSkillsRoot = join(frontendReferencesRoot, "designpowers", "vendor", "skills");
+
+	// when
+	const nestedSkillFiles = (await listSkillFiles(frontendReferencesRoot))
+		.map((file) => file.replaceAll("\\", "/"))
+		.filter((file) => file.endsWith("/SKILL.md") || file === "SKILL.md")
+		.sort();
+	const designpowersReferenceFiles = (await listSkillFiles(designpowersVendorSkillsRoot))
+		.map((file) => file.replaceAll("\\", "/"))
+		.filter((file) => file.endsWith("/reference.md"))
+		.sort();
+
+	// then
+	assert.deepEqual(nestedSkillFiles, []);
+	assert.equal(designpowersReferenceFiles.length, 27);
+});
+
 test("#given aggregate Codex skills #when source wiring is inspected #then shared skills are imported from the shared-skills package", async () => {
 	// given
 	const pluginPackageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"));

--- a/packages/omo-codex/src/install/install-codex.test.ts
+++ b/packages/omo-codex/src/install/install-codex.test.ts
@@ -12,6 +12,20 @@ const INSTALL_CODEX_INTEGRATION_TEST_TIMEOUT_MS = process.platform === "win32" ?
 
 const skipAstGrepInstall = async () => ({ kind: "skipped" as const, reason: "test" })
 
+async function listRelativeFiles(root: string, prefix = ""): Promise<string[]> {
+  const entries = await readdir(join(root, prefix), { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const relativePath = prefix.length > 0 ? join(prefix, entry.name) : entry.name
+    if (entry.isDirectory()) {
+      files.push(...(await listRelativeFiles(root, relativePath)))
+    } else {
+      files.push(relativePath.replaceAll("\\", "/"))
+    }
+  }
+  return files.sort()
+}
+
 function formatTomlString(value: string): string {
   return JSON.stringify(value)
 }
@@ -159,6 +173,14 @@ describe("install-codex", () => {
       expect(rootSkillNames).toContain("ulw-plan")
       expect(rootSkillNames).toContain("ulw-loop")
       expect(rootSkillNames).not.toContain("planing-prometheustic")
+      const installedSkillFiles = await listRelativeFiles(join(pluginPath ?? "", "skills"))
+      const nestedReferenceSkillFiles = installedSkillFiles.filter((file) => file.startsWith("frontend/references/") && file.endsWith("/SKILL.md"))
+      const designpowersReferenceFiles = installedSkillFiles.filter((file) =>
+        /^frontend\/references\/designpowers\/vendor\/skills\/[^/]+\/reference\.md$/.test(file)
+      )
+      expect(installedSkillFiles).toContain("frontend/SKILL.md")
+      expect(nestedReferenceSkillFiles).toEqual([])
+      expect(designpowersReferenceFiles).toHaveLength(27)
     }
     expect((await stat(join(pluginPath ?? "", "components", "ultrawork", "skills", "ulw-plan"))).isDirectory()).toBe(true)
     expect((await stat(join(pluginPath ?? "", "components", "ulw-loop", "skills", "ulw-loop"))).isDirectory()).toBe(true)

--- a/packages/shared-skills/materialize-frontend-refs.test.ts
+++ b/packages/shared-skills/materialize-frontend-refs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { parseFrontmatter } from "@oh-my-opencode/utils";
-import { materializeFrontendRefs } from "./scripts/materialize-frontend-refs.mjs";
+import { isSkillMarkdownSourcePath, materializeFrontendRefs } from "./scripts/materialize-frontend-refs.mjs";
 import { brandStems, designpowersThirdPartyRelativePaths, frontendSkillRoot, thirdPartyRelativePaths, uiUxDbScripts } from "./scripts/frontend-refs-manifest.mjs";
 
 type SkillFrontmatter = {
@@ -44,7 +44,7 @@ describe("materialize-frontend-refs", () => {
 		if (result.skipped) return;
 		const failures: string[] = [];
 		for (const relPath of designpowersThirdPartyRelativePaths()) {
-			if (!relPath.endsWith("/SKILL.md")) continue;
+			if (!relPath.endsWith("/reference.md")) continue;
 			const content = await Bun.file(join(frontendSkillRoot, relPath)).text();
 			const parsed = parseFrontmatter<SkillFrontmatter>(content);
 			if (!parsed.hadFrontmatter || parsed.parseError) {
@@ -56,6 +56,24 @@ describe("materialize-frontend-refs", () => {
 			}
 		}
 		expect(failures).toEqual([]);
+	});
+
+	test("materializes designpowers skills as references instead of nested skill entrypoints", () => {
+		if (result.skipped) return;
+		const referencePaths = designpowersThirdPartyRelativePaths().filter((relPath) => relPath.endsWith("/reference.md"));
+		const nestedSkillPaths = designpowersThirdPartyRelativePaths().filter((relPath) => relPath.endsWith("/SKILL.md"));
+
+		expect(referencePaths).toHaveLength(27);
+		expect(nestedSkillPaths).toEqual([]);
+		for (const relPath of referencePaths) {
+			expect(existsSync(join(frontendSkillRoot, relPath))).toBe(true);
+		}
+	});
+
+	test("recognizes upstream skill sources across platform path separators", () => {
+		expect(isSkillMarkdownSourcePath("skills/design-review/SKILL.md")).toBe(true);
+		expect(isSkillMarkdownSourcePath("skills\\design-review\\SKILL.md")).toBe(true);
+		expect(isSkillMarkdownSourcePath("skills/design-review/reference.md")).toBe(false);
 	});
 
 	test("materialized brand reference is verbatim upstream content", async () => {

--- a/packages/shared-skills/provenance-gate.test.ts
+++ b/packages/shared-skills/provenance-gate.test.ts
@@ -65,7 +65,7 @@ describe("DMCA provenance gate", () => {
 		for (const skillName of includedDesignpowersSkills) {
 			const upstream = readFileSync(join(upstreamsRoot, "designpowers", "skills", skillName, "SKILL.md"), "utf8");
 			const materialized = readFileSync(
-				join(frontendSkillRoot, "references", "designpowers", "vendor", "skills", skillName, "SKILL.md"),
+				join(frontendSkillRoot, "references", "designpowers", "vendor", "skills", skillName, "reference.md"),
 				"utf8",
 			);
 			if (normalizeSkillFrontmatter(upstream) !== materialized) mismatches.push(skillName);

--- a/packages/shared-skills/scripts/designpowers-refs-manifest.mjs
+++ b/packages/shared-skills/scripts/designpowers-refs-manifest.mjs
@@ -63,7 +63,7 @@ export function designpowersMaterializeMap() {
 		},
 	};
 	for (const name of includedDesignpowersSkills) {
-		map[`references/designpowers/vendor/skills/${name}/SKILL.md`] = {
+		map[`references/designpowers/vendor/skills/${name}/reference.md`] = {
 			upstream: designpowersUpstreamName,
 			source: `skills/${name}/SKILL.md`,
 		};

--- a/packages/shared-skills/scripts/materialize-frontend-refs.mjs
+++ b/packages/shared-skills/scripts/materialize-frontend-refs.mjs
@@ -20,9 +20,17 @@ export function normalizeSkillFrontmatter(content) {
 	});
 }
 
+export function isSkillMarkdownSourcePath(sourcePath) {
+	const normalizedPath = sourcePath.replaceAll("\\", "/");
+	return normalizedPath === "SKILL.md" || normalizedPath.endsWith("/SKILL.md");
+}
+
 function materializedContent(relTarget, sourcePath) {
 	const content = readFileSync(sourcePath, "utf8");
-	if (relTarget.endsWith("/SKILL.md")) return normalizeSkillFrontmatter(content);
+	const isDesignpowersSkillReference = relTarget.startsWith("references/designpowers/vendor/skills/")
+		&& relTarget.endsWith("/reference.md")
+		&& isSkillMarkdownSourcePath(sourcePath);
+	if (relTarget.endsWith("/SKILL.md") || isDesignpowersSkillReference) return normalizeSkillFrontmatter(content);
 	return content;
 }
 

--- a/packages/shared-skills/skills/frontend/ATTRIBUTION.md
+++ b/packages/shared-skills/skills/frontend/ATTRIBUTION.md
@@ -150,10 +150,11 @@ path-mapped from the designpowers project. It is not committed here; the build
 materializes the selected files from the pinned submodule under
 `packages/shared-skills/upstreams/designpowers`. The materialized set includes the
 upstream `LICENSE`, ten `agents/*.md` role-reference files, and selected
-`skills/*/SKILL.md` files. Bridge/state/router integration skills are intentionally
+`skills/*/SKILL.md` files renamed to `vendor/skills/*/reference.md` so they remain
+reference documents instead of nested skill entrypoints. Bridge/state/router integration skills are intentionally
 excluded; see `frontend/references/designpowers/UPSTREAM.md` for the allowlist and
 exclusion list. Only the allowed frontmatter description quoting normalization described
-above may alter these materialized `SKILL.md` files.
+above may alter these materialized `reference.md` files.
 
 - Source: https://github.com/Owl-Listener/designpowers
 - Pinned upstream commit: cb00757da9d554591fa78d27aa1854d60a05c4f7

--- a/packages/shared-skills/skills/frontend/references/designpowers/EVIDENCE.md
+++ b/packages/shared-skills/skills/frontend/references/designpowers/EVIDENCE.md
@@ -18,6 +18,14 @@ $ find packages/shared-skills/skills/frontend/references/designpowers/vendor/ski
 27
 ```
 
+### Materialized skill reference file count
+
+```sh
+$ find packages/shared-skills/skills/frontend/references/designpowers/vendor/skills -name reference.md | wc -l | tr -d ' '
+27
+$ find packages/shared-skills/skills/frontend/references/designpowers/vendor/skills -name SKILL.md
+```
+
 ### Materialized agent file count
 
 ```sh
@@ -66,7 +74,7 @@ const rawMismatches = [];
 const normalizedMismatches = [];
 for (const name of includedDesignpowersSkills) {
   const upstream = readFileSync(join("packages/shared-skills/upstreams/designpowers/skills", name, "SKILL.md"), "utf8");
-  const materialized = readFileSync(join("packages/shared-skills/skills/frontend/references/designpowers/vendor/skills", name, "SKILL.md"), "utf8");
+  const materialized = readFileSync(join("packages/shared-skills/skills/frontend/references/designpowers/vendor/skills", name, "reference.md"), "utf8");
   if (upstream !== materialized) rawMismatches.push(name);
   if (normalizeSkillFrontmatter(upstream) !== materialized) normalizedMismatches.push(name);
 }
@@ -84,6 +92,6 @@ The 27 raw mismatches are expected frontmatter-only `description:` quoting chang
 ### Excluded-router hard invocation absent
 
 ```sh
-$ for f in packages/shared-skills/skills/frontend/references/designpowers/vendor/skills/*/SKILL.md; do if rg -q 'MUST invoke the `using-designpowers` skill FIRST|invoke the `using-designpowers` skill FIRST' "$f"; then echo "$f"; exit 1; fi; done
+$ for f in packages/shared-skills/skills/frontend/references/designpowers/vendor/skills/*/reference.md; do if rg -q 'MUST invoke the `using-designpowers` skill FIRST|invoke the `using-designpowers` skill FIRST' "$f"; then echo "$f"; exit 1; fi; done
 exit=0
 ```

--- a/packages/shared-skills/skills/frontend/references/designpowers/UPSTREAM.md
+++ b/packages/shared-skills/skills/frontend/references/designpowers/UPSTREAM.md
@@ -14,7 +14,7 @@ The build materializes third-party designpowers files into `packages/shared-skil
 
 - `LICENSE` -> `vendor/LICENSE`
 - `agents/*.md` allowlist -> `vendor/agents/`
-- selected `skills/*/SKILL.md` allowlist -> `vendor/skills/*/SKILL.md`
+- selected `skills/*/SKILL.md` allowlist -> `vendor/skills/*/reference.md`
 
 The materialized `vendor/` directory is ignored in git and included in npm/package output through the frontend skill's `.npmignore` behavior.
 


### PR DESCRIPTION
## Summary
Fixes the LazyCodex issue where the designpowers reference corpus under `omo:frontend` was being shipped as nested `SKILL.md` files, which let Codex discover 27 extra top-level `omo:` skills. The materializer now writes those upstream designpowers skill documents as `vendor/skills/<name>/reference.md` while preserving normalized frontmatter/content.

This keeps `omo:frontend` as the public entrypoint, preserves the reference corpus for frontend guidance, and prevents recursive skill scans from treating designpowers vendor references as standalone skills.

## Changes
- Changed the designpowers frontend reference manifest to target `vendor/skills/*/reference.md` instead of nested `SKILL.md` entrypoints.
- Kept upstream skill frontmatter normalization for those renamed reference files, including Windows-safe source path detection.
- Added shared-skills, Codex aggregate sync, and installer regression coverage for:
  - zero `frontend/references/**/SKILL.md` files,
  - exactly 27 designpowers `reference.md` files,
  - preserved `frontend/SKILL.md` and intentional top-level OMO skills.
- Updated designpowers provenance/reference docs to describe the new reference-only materialization path.

## QA & Evidence
- **What was tested:** Failing-first focused Codex sync regression for nested designpowers `SKILL.md` files.
  **Observed result:** RED artifact listed the 27 nested `SKILL.md` files before the fix; GREEN artifact passed after `reference.md` materialization.
  **Artifact:** `.omo/evidence/20260701-issue98-designpowers-skills/c002-focused-test-red.txt`, `.omo/evidence/20260701-issue98-designpowers-skills/c002-focused-test-green.txt`
  **Why sufficient:** Proves the package-side regression existed and the new assertion catches it.

- **What was tested:** Current shared-skill materialization and provenance tests after adding Windows path coverage.
  **Observed result:** 13 tests passed, including YAML-safe designpowers frontmatter and POSIX/Windows `SKILL.md` source detection.
  **Artifact:** `.omo/evidence/20260701-issue98-designpowers-skills/shared-tests-after-windows-path.txt`
  **Why sufficient:** Covers the materializer behavior and the reviewer-found Windows path edge case.

- **What was tested:** Codex aggregate skill sync focused tests.
  **Observed result:** 16 tests passed; aggregate payload has no nested `frontend/references/**/SKILL.md` files and retains 27 designpowers `reference.md` files.
  **Artifact:** `.omo/evidence/20260701-issue98-designpowers-skills/sync-skills-focused-after-windows-path.txt`
  **Why sufficient:** Covers the shipped Codex plugin skills tree produced by sync.

- **What was tested:** Manual data-surface scan of shared and Codex plugin payloads.
  **Observed result:** shared nested `SKILL.md` count `0`, shared `reference.md` count `27`, Codex nested reference `SKILL.md` count `0`, Codex designpowers `reference.md` count `27`, `frontend/SKILL.md` present.
  **Artifact:** `.omo/evidence/20260701-issue98-designpowers-skills/path-scan-after-windows-path.txt`
  **Why sufficient:** Directly matches the issue #98 verification plan.

- **What was tested:** Isolated Codex install verification via `codex-qa`.
  **Observed result:** plugin cache/config/bin/agent checks passed, `omo@sisyphuslabs` enabled in the isolated home, real `~/.codex/config.toml` unchanged.
  **Artifact:** `.omo/evidence/20260701-issue98-designpowers-skills/codex-qa-install-verify-after-windows-path.txt`
  **Why sufficient:** Proves installer payload lands correctly without polluting the real Codex home.

- **What was tested:** Live Codex app-server turn with local mock model via `codex-qa`.
  **Observed result:** turn completed, mock assistant responded, and plugin hooks fired for `sessionStart`, `userPromptSubmit`, and `stop`; real `~/.codex/config.toml` unchanged.
  **Artifact:** `.omo/evidence/20260701-issue98-designpowers-skills/codex-qa-app-server-after-windows-path.json`
  **Why sufficient:** Satisfies the repo's Codex-connected QA rule by driving a real isolated Codex surface.

- **What was tested:** Full Codex gate.
  **Observed result:** `bun run test:codex` passed with 449 tests.
  **Artifact:** `.omo/evidence/20260701-issue98-designpowers-skills/test-codex-after-windows-path.txt`
  **Why sufficient:** Covers the hermetic Codex compatibility/build/test suite after the fix.

- **What was reviewed:** Final review-work lanes.
  **Observed result:** QA PASS, security PASS, context retry PASS against the correct `code-yeongyu/lazycodex#98`, code-quality retry PASS after fixing the Windows separator blocker.
  **Artifacts:** `.omo/evidence/20260701-issue98-designpowers-skills/review-qa.md`, `review-security.md`, `review-context-retry.md`, `review-code-quality-retry.md`
  **Why sufficient:** Independent review found one blocker, which was fixed and re-reviewed cleanly.

## Risks & Residuals
- The change intentionally renames only the materialized third-party reference copies, not upstream source files or public OMO skill entrypoints.
- A code-quality reviewer left one non-blocking LOW note that the installed-payload assertions could be made even stricter if the fixture ever stops producing root skills; current install evidence and tests execute the branch and pass.
- Evidence files are local `.omo` audit artifacts and are summarized here rather than pasted wholesale to avoid noisy raw logs.

## Related Issues
- Fixes code-yeongyu/lazycodex#98


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop exposing designpowers reference docs as skills by materializing upstream `skills/*/SKILL.md` as `reference.md` under `frontend` vendor refs. This prevents Codex from surfacing 27 unintended top‑level `omo:` skills and keeps `omo:frontend` as the entrypoint. Fixes code-yeongyu/lazycodex#98.

- **Bug Fixes**
  - Materialize designpowers upstream `SKILL.md` to `frontend/references/designpowers/vendor/skills/*/reference.md` with frontmatter normalization.
  - Add `isSkillMarkdownSourcePath` and update materializer to handle Windows/POSIX paths; treat reference targets as normalized content.
  - Update tests in `packages/shared-skills`, `packages/omo-codex` plugin sync, and installer to assert:
    - 0 nested `frontend/references/**/SKILL.md`
    - 27 designpowers `reference.md`
    - `frontend/SKILL.md` remains present
  - Refresh attribution and upstream docs to describe the new reference-only path.

<sup>Written for commit b998fb728de7e542696828c5a9b5ead4b90fad72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

