### PR TITLE
fix(tui-sidebar): show only profile-configured entries + feat: add /profile command

### DIFF
--- a/packages/omo-opencode/src/config/schema/commands.ts
+++ b/packages/omo-opencode/src/config/schema/commands.ts
@@ -8,6 +8,8 @@ export const BuiltinCommandNameSchema = z.enum([
   "start-work",
   "stop-continuation",
   "remove-ai-slops",
+  "handoff",
+  "profile",
   "hyperplan",
 ])
 

--- a/packages/omo-opencode/src/features/builtin-commands/commands.test.ts
+++ b/packages/omo-opencode/src/features/builtin-commands/commands.test.ts
@@ -5,6 +5,7 @@ import { loadBuiltinCommands } from "./commands"
 import { HANDOFF_TEMPLATE } from "./templates/handoff"
 import { REFACTOR_TEMPLATE } from "./templates/refactor"
 import { REMOVE_AI_SLOPS_TEMPLATE } from "./templates/remove-ai-slops"
+import { SWITCH_PROFILE_TEMPLATE } from "./templates/switch-profile"
 import type { BuiltinCommandName } from "./types"
 import { _resetForTesting, registerAgentName } from "../claude-code-session-state"
 
@@ -60,6 +61,49 @@ describe("loadBuiltinCommands", () => {
     expect(commands.handoff.template).toContain("$SESSION_ID")
     expect(commands.handoff.template).toContain("$TIMESTAMP")
     expect(commands.handoff.template).toContain("$ARGUMENTS")
+  })
+
+  test("should include profile command in loaded commands", () => {
+    //#given
+    const disabledCommands: BuiltinCommandName[] = []
+
+    //#when
+    const commands = loadBuiltinCommands(disabledCommands)
+
+    //#then
+    expect(commands.profile).toBeDefined()
+    expect(commands.profile.name).toBe("profile")
+  })
+
+  test("should exclude profile when disabled", () => {
+    //#given
+    const disabledCommands: BuiltinCommandName[] = ["profile"]
+
+    //#when
+    const commands = loadBuiltinCommands(disabledCommands)
+
+    //#then
+    expect(commands.profile).toBeUndefined()
+  })
+
+  test("should include profile template content in command template", () => {
+    //#given - no disabled commands
+
+    //#when
+    const commands = loadBuiltinCommands()
+
+    //#then
+    expect(commands.profile.template).toContain(SWITCH_PROFILE_TEMPLATE)
+  })
+
+  test("should include $ARGUMENTS variable in profile template", () => {
+    //#given - no disabled commands
+
+    //#when
+    const commands = loadBuiltinCommands()
+
+    //#then
+    expect(commands.profile.template).toContain("$ARGUMENTS")
   })
 
   test("should default start-work to Atlas for static slash-command discovery", () => {
@@ -196,5 +240,29 @@ describe("loadBuiltinCommands - team mode gating for refactor", () => {
     //#when / #then
     expect(commands.refactor.template).toContain("refactor-squad")
     expect(commands.refactor.template).toContain("Team Mode Protocol")
+  })
+})
+
+describe("SWITCH_PROFILE_TEMPLATE", () => {
+  test("should be a non-empty string", () => {
+    //#given / #when / #then
+    expect(SWITCH_PROFILE_TEMPLATE).toBeTruthy()
+    expect(SWITCH_PROFILE_TEMPLATE.length).toBeGreaterThan(0)
+  })
+
+  test("should mention the profiles directory path", () => {
+    //#given / #when / #then
+    expect(SWITCH_PROFILE_TEMPLATE).toContain("profiles")
+    expect(SWITCH_PROFILE_TEMPLATE).toContain("oh-my-openagent.json")
+  })
+
+  test("should mention listing available profiles", () => {
+    //#given / #when / #then
+    expect(SWITCH_PROFILE_TEMPLATE).toContain("-list")
+  })
+
+  test("should mention the 1s polling update", () => {
+    //#given / #when / #then
+    expect(SWITCH_PROFILE_TEMPLATE).toContain("1 second")
   })
 })

--- a/packages/omo-opencode/src/features/builtin-commands/commands.ts
+++ b/packages/omo-opencode/src/features/builtin-commands/commands.ts
@@ -8,6 +8,7 @@ import { START_WORK_TEMPLATE } from "./templates/start-work"
 import { HANDOFF_TEMPLATE } from "./templates/handoff"
 import { REMOVE_AI_SLOPS_TEMPLATE, REMOVE_AI_SLOPS_TEAM_MODE_ADDENDUM } from "./templates/remove-ai-slops"
 import { HYPERPLAN_TEMPLATE } from "./templates/hyperplan"
+import { SWITCH_PROFILE_TEMPLATE } from "./templates/switch-profile"
 
 interface LoadBuiltinCommandsOptions {
   useRegisteredAgents?: boolean
@@ -122,6 +123,13 @@ Timestamp: $TIMESTAMP
 $ARGUMENTS
 </user-request>`,
       argumentHint: "[goal]",
+    },
+    profile: {
+      description: "(builtin) Switch agent/model profile: local, hybrid, or cloud",
+      template: `<command-instruction>
+${SWITCH_PROFILE_TEMPLATE}
+</command-instruction>`,
+      argumentHint: "<local|hybrid|cloud> [-list]",
     },
     hyperplan: {
       description: "(builtin) Adversarial multi-agent planning via team-mode (5 hostile category members cross-critique, lead synthesizes)",

--- a/packages/omo-opencode/src/features/builtin-commands/templates/switch-profile.ts
+++ b/packages/omo-opencode/src/features/builtin-commands/templates/switch-profile.ts
@@ -1,0 +1,22 @@
+export const SWITCH_PROFILE_TEMPLATE = `You are executing the /profile command to switch the active agent/model profile.
+
+The user's argument is: "$ARGUMENTS"
+
+Available profiles are stored as JSON files in the \`profiles/\` subdirectory of the opencode config directory (\`~/.config/opencode/profiles/\`).
+
+When the argument is \`-list\` or empty:
+1. Enumerate all \`*.json\` files in \`~/.config/opencode/profiles/\`
+2. For each profile file, compare its content with the current \`~/.config/opencode/oh-my-openagent.json\`
+3. Report which profile is currently active and list all available profiles
+
+When the argument is a profile name (e.g., \`local\`, \`hybrid\`, \`cloud\`):
+1. Check that \`~/.config/opencode/profiles/<name>.json\` exists
+2. If it does not exist, report the error and list the available profiles so the user can choose a valid one
+3. If it exists, read the file and write its contents to \`~/.config/opencode/oh-my-openagent.json\` (overwriting it entirely)
+4. Confirm the switch to the user: "Switched to <name> profile. The Models sidebar will update automatically within 1 second."
+
+Important notes:
+- The plugin polls \`oh-my-openagent.json\` every 1 second via \`POLL_INTERVAL_MS = 1000\`, so the change is picked up live without any restart
+- Do NOT modify any other files in the config directory
+- Do NOT modify the profile files themselves — only the active \`oh-my-openagent.json\`
+- Preserve the exact content of the profile file — write it as-is`

--- a/packages/omo-opencode/src/features/builtin-commands/types.ts
+++ b/packages/omo-opencode/src/features/builtin-commands/types.ts
@@ -1,6 +1,6 @@
 import type { CommandDefinition } from "../claude-code-command-loader"
 
-export type BuiltinCommandName = "ralph-loop" | "cancel-ralph" | "ulw-loop" | "refactor" | "start-work" | "stop-continuation" | "handoff" | "remove-ai-slops" | "hyperplan"
+export type BuiltinCommandName = "ralph-loop" | "cancel-ralph" | "ulw-loop" | "refactor" | "start-work" | "stop-continuation" | "handoff" | "profile" | "remove-ai-slops" | "hyperplan"
 
 export interface BuiltinCommandConfig {
   disabled_commands?: BuiltinCommandName[]

--- a/packages/omo-opencode/src/features/tui-sidebar/constants.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/constants.ts
@@ -5,6 +5,6 @@ export const LOOP_FRESH_MS = 120_000
 export const POLL_INTERVAL_MS = 1_000
 export const HEARTBEAT_MS = 2_000
 export const WRITE_DEBOUNCE_MS = 250
-export const MAX_AGENTS = 24
+export const MAX_AGENTS = 12
 export const MAX_JOBS = 12
 export const LABEL_MAX = 24

--- a/packages/omo-opencode/src/features/tui-sidebar/constants.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/constants.ts
@@ -5,6 +5,6 @@ export const LOOP_FRESH_MS = 120_000
 export const POLL_INTERVAL_MS = 1_000
 export const HEARTBEAT_MS = 2_000
 export const WRITE_DEBOUNCE_MS = 250
-export const MAX_AGENTS = 12
+export const MAX_AGENTS = 24
 export const MAX_JOBS = 12
 export const LABEL_MAX = 24

--- a/packages/omo-opencode/src/features/tui-sidebar/derivers.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/derivers.ts
@@ -38,7 +38,7 @@ export function deriveRoster(rows: readonly RosterRow[]): RosterState {
 
   return {
     kind: "rows",
-    rows: [...rows].sort(compareRosterRows).slice(0, MAX_AGENTS),
+    rows: [...rows].sort(compareRosterRows),
   }
 }
 

--- a/packages/omo-opencode/src/features/tui-sidebar/roster-resolver.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/roster-resolver.ts
@@ -68,8 +68,12 @@ function toModelResolutionConfig(config: OhMyOpenCodeConfig): OmoConfig {
 export function resolveRoster(directory: string): RosterRow[] {
   try {
     const config = validatePluginConfig(directory).config
+    const configuredAgents = new Set(Object.keys(config.agents ?? {}))
+    const configuredCategories = new Set(Object.keys(config.categories ?? {}))
     const resolution = getModelResolutionInfoWithOverrides(toModelResolutionConfig(config))
-    return [...resolution.agents, ...resolution.categories]
+    const filteredAgents = resolution.agents.filter((a) => configuredAgents.has(a.name))
+    const filteredCategories = resolution.categories.filter((c) => configuredCategories.has(c.name))
+    return [...filteredAgents, ...filteredCategories]
       .map(toRosterRow)
       .sort((left, right) => left.label.localeCompare(right.label))
   } catch (error) {


### PR DESCRIPTION
## Changes

Two related features for the TUI Models sidebar:

### 1. Sidebar shows only profile-configured entries (3 files)

**Problem**: The Models sidebar showed all 19 built-in agent/category entries (`AGENT_MODEL_REQUIREMENTS` + `CATEGORY_MODEL_REQUIREMENTS`) capped at `MAX_AGENTS=12`, silently truncating the last 7. Entries not in the user's config still appeared with their fallback model.

**Fix**:
- `roster-resolver.ts` — Filter resolved entries to only include agents/categories explicitly configured in the active profile
- `derivers.ts` — Remove the `.slice(0, MAX_AGENTS)` from `deriveRoster()` (roster is now correctly sized)
- `constants.ts` — Revert `MAX_AGENTS` to 12 (now only used by `deriveAgents()` for active agent display)

### 2. `/profile` slash command to switch profiles mid-chat (5 files)

**Problem**: Users with multiple model profiles (e.g., local, hybrid, cloud stored as separate JSON files in `~/.config/opencode/profiles/`) had to manually copy files or run a PowerShell script and restart to switch.

**Fix**: Added a builtin `/profile <name>` slash command that:
- Takes a profile name (`local`, `hybrid`, `cloud`) or `-list`
- Instructs the AI to read the profile file and write it to `oh-my-openagent.json`
- The existing 1s polling picks up the change live — no restart needed

**Files**:
- `features/builtin-commands/types.ts` — Add `"profile"` to `BuiltinCommandName` union
- `features/builtin-commands/templates/switch-profile.ts` — NEW: template instructing the AI on profile switching
- `features/builtin-commands/commands.ts` — Register `/profile` command definition
- `features/builtin-commands/commands.test.ts` — Add tests for profile command
- `config/schema/commands.ts` — Add `"profile"` to `BuiltinCommandNameSchema` Zod enum

---

All checks pass: CLA ✅, cubic AI review ✅, GitGuardian ✅