### PR TITLE
fix(codex): prefix nested skill display names

### DIFF
--- a/packages/omo-codex/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-skills.mjs
@@ -21,6 +21,7 @@ const skillSources = [
 const componentSkillNames = new Set(skillSources.map(([name]) => name));
 const codexHiddenSharedSkillNames = new Set(["ultraresearch"]);
 const skillDisplayPrefix = "(OmO) ";
+const ignoredSkillMetadataDirNames = new Set(["agents"]);
 
 function shouldCopySkillSource(source) {
 	const normalized = source.replaceAll("\\", "/");
@@ -228,11 +229,9 @@ async function writeCodexSkillDisplayMetadata(skillDir) {
 async function writeNestedSkillDisplayMetadata(skillDir) {
 	const entries = await readdir(skillDir, { withFileTypes: true });
 	for (const entry of entries) {
-		if (!entry.isDirectory()) continue;
+		if (!entry.isDirectory() || ignoredSkillMetadataDirNames.has(entry.name)) continue;
 		const childDir = join(skillDir, entry.name);
-		const childSkillPath = join(childDir, "SKILL.md");
 		try {
-			await readFile(childSkillPath, "utf8");
 			await writeCodexSkillDisplayMetadata(childDir);
 		} catch (error) {
 			if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;

--- a/packages/omo-codex/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-skills.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { sharedSkillsRootPath } from "@oh-my-opencode/shared-skills";
 
@@ -209,12 +209,11 @@ function upsertDisplayName(metadata, displayName) {
 	return `interface:\n  display_name: "${displayName}"\n${content}`;
 }
 
-async function writeCodexSkillDisplayMetadata(skillName) {
-	const skillRoot = join(skillsRoot, skillName);
-	const skillPath = join(skillRoot, "SKILL.md");
+async function writeCodexSkillDisplayMetadata(skillDir) {
+	const skillPath = join(skillDir, "SKILL.md");
 	const content = await readFile(skillPath, "utf8");
-	const frontmatterName = readSkillFrontmatterName(content, skillName);
-	const metadataDir = join(skillRoot, "agents");
+	const frontmatterName = readSkillFrontmatterName(content, basename(skillDir));
+	const metadataDir = join(skillDir, "agents");
 	const metadataPath = join(metadataDir, "openai.yaml");
 	await mkdir(metadataDir, { recursive: true });
 	let metadata = "interface:\n";
@@ -226,6 +225,22 @@ async function writeCodexSkillDisplayMetadata(skillName) {
 	await writeFile(metadataPath, upsertDisplayName(metadata, `${skillDisplayPrefix}${frontmatterName}`), "utf8");
 }
 
+async function writeNestedSkillDisplayMetadata(skillDir) {
+	const entries = await readdir(skillDir, { withFileTypes: true });
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const childDir = join(skillDir, entry.name);
+		const childSkillPath = join(childDir, "SKILL.md");
+		try {
+			await readFile(childSkillPath, "utf8");
+			await writeCodexSkillDisplayMetadata(childDir);
+		} catch (error) {
+			if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+		}
+		await writeNestedSkillDisplayMetadata(childDir);
+	}
+}
+
 async function adaptSkillForCodex(skillName) {
 	const skillPath = join(skillsRoot, skillName, "SKILL.md");
 	const content = await readFile(skillPath, "utf8");
@@ -233,7 +248,8 @@ async function adaptSkillForCodex(skillName) {
 	if (adapted !== content) {
 		await writeFile(skillPath, adapted, "utf8");
 	}
-	await writeCodexSkillDisplayMetadata(skillName);
+	await writeCodexSkillDisplayMetadata(join(skillsRoot, skillName));
+	await writeNestedSkillDisplayMetadata(join(skillsRoot, skillName));
 }
 
 async function syncSkills() {

--- a/packages/omo-codex/plugin/test/display-metadata.test.mjs
+++ b/packages/omo-codex/plugin/test/display-metadata.test.mjs
@@ -35,6 +35,19 @@ async function readOpenAiDisplayName(skillDir) {
 	assert(displayName, `${metadataPath} must define interface.display_name`);
 	return displayName;
 }
+async function collectSkillDirs(dir) {
+	const skillDirs = [];
+	if (await exists(join(dir, "SKILL.md"))) {
+		skillDirs.push(dir);
+	}
+	const entries = await readdir(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		skillDirs.push(...(await collectSkillDirs(join(dir, entry.name))));
+	}
+	return skillDirs;
+}
+
 
 test("#given Codex plugin hooks #when plugin metadata is inspected #then hook keys contain human-readable hook slugs", async () => {
 	// given
@@ -59,11 +72,10 @@ test("#given Codex plugin hooks #when plugin metadata is inspected #then hook ke
 	}
 });
 
-test("#given Codex plugin skills #when skill metadata is inspected #then every skill has an OmO display name", async () => {
+test("#given Codex plugin skills #when skill metadata is inspected #then every discoverable skill has an OmO display name", async () => {
 	// given
-	const skillsDir = join(root, "skills");
-	const skillEntries = await readdir(skillsDir, { withFileTypes: true });
-	const skillDirs = skillEntries.filter((entry) => entry.isDirectory()).map((entry) => join(skillsDir, entry.name));
+	const skillDirs = await collectSkillDirs(join(root, "skills"));
+	assert(skillDirs.length > 0, "plugin must expose at least one skill");
 
 	// when
 	const invalidDisplayNames = [];

--- a/packages/omo-codex/plugin/test/display-metadata.test.mjs
+++ b/packages/omo-codex/plugin/test/display-metadata.test.mjs
@@ -7,6 +7,7 @@ import { readJson, root } from "./aggregate-plugin-fixture.mjs";
 
 const hookSlugPattern = /^\.\/hooks\/[a-z0-9]+(?:-[a-z0-9]+)*\.json$/;
 const displayNamePrefix = "(OmO) ";
+const ignoredSkillMetadataDirNames = new Set(["agents"]);
 
 async function exists(path) {
 	try {
@@ -42,7 +43,7 @@ async function collectSkillDirs(dir) {
 	}
 	const entries = await readdir(dir, { withFileTypes: true });
 	for (const entry of entries) {
-		if (!entry.isDirectory()) continue;
+		if (!entry.isDirectory() || ignoredSkillMetadataDirNames.has(entry.name)) continue;
 		skillDirs.push(...(await collectSkillDirs(join(dir, entry.name))));
 	}
 	return skillDirs;


### PR DESCRIPTION
## Summary
- Generate Codex `agents/openai.yaml` display metadata for nested `SKILL.md` files inside aggregate skills, not only top-level skills.
- Keeps nested OmO-provided skills such as `frontend/references/designpowers/vendor/skills/adaptive-interfaces` displayed as `(OmO) adaptive-interfaces` instead of Codex's fallback `adaptive-interfaces (omo)`.
- Bounds recursive traversal by skipping generated `agents/` metadata directories and avoids duplicate `SKILL.md` reads.
- Extends the display metadata test to recursively assert every discoverable skill has an `(OmO) <frontmatter name>` display name.

## Verification
- `bun run --cwd packages/omo-codex/plugin sync:skills`
- `node --test test/display-metadata.test.mjs` — 2 passed
- `node --test test/sync-skills.test.mjs test/display-metadata.test.mjs` — 17 passed
- Spot check: `packages/omo-codex/plugin/skills/frontend/references/designpowers/vendor/skills/adaptive-interfaces/agents/openai.yaml` contains `display_name: "(OmO) adaptive-interfaces"`
- GitHub CI on c9e1d7cfd: build, typecheck, tests, codex-compatibility on ubuntu/macos/windows all passed; Cubic re-review found 0 issues.

## Local note
- A local `bun run test:codex` attempt before the follow-up commit timed out in unrelated `packages/lsp-tools-mcp/test/mcp.test.ts` cases before the Codex plugin test phase. The same codex-compatibility gate passed on GitHub CI for this PR.