### PR TITLE
fix(ulw-plan): make high-accuracy modifier fire the review gate in any turn

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/SKILL.md
+++ b/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/SKILL.md
@@ -15,9 +15,12 @@ Outcome-first: explore a lot, ask few sharp questions - or none, when the intent
 
 ## INTENT ROUTING - pick ONE intent reference
 
-Before routing, parse review modifiers separately. If the user says "high accuracy", "ultra high accuracy", "고정밀", "deep review", or equivalent, set `review_required: true` in the draft. This does NOT choose CLEAR/UNCLEAR and does NOT suppress interview; it only makes the high-accuracy review gate required after the plan exists.
+**Review modifiers are a gate trigger, not a style cue.** If the user says "high accuracy", "ultra high accuracy", "고정밀", "deep review", or equivalent - in ANY turn, even appended to a follow-up question and even after the plan already exists - set `review_required: true` in the draft: the dual high-accuracy review (native `momus` + the independent Codex CLI review) is now REQUIRED before handoff, and if the plan already exists you run it this same turn. Answering the current question more carefully does NOT satisfy it. This does NOT choose CLEAR/UNCLEAR and does NOT suppress interview.
 
-After grounding, make ONE judgment, record `intent: clear|unclear` plus `review_required`, and load ONE intent reference (you ALSO read `references/full-workflow.md` for the shared mechanics - see below). The test keys on whether the desired **OUTCOME** is clear, NOT on request length.
+After grounding, make ONE judgment, record `intent: clear|unclear` plus `review_required`, **ANNOUNCE both to the user in one line**, then load ONE intent reference (you ALSO read `references/full-workflow.md` for the shared mechanics - see below). The test keys on whether the desired **OUTCOME** is clear, NOT on request length. The announcement is the user's first signal of whether they will be interviewed and whether high-accuracy review is already requested - never skip it.
+
+> "Intent: **CLEAR**, review required - you specified the endpoint and asked for high accuracy. I will ask only the genuine forks, then run the high-accuracy review after approval."
+> "Intent: **UNCLEAR**, review required - 'make auth better' is open-ended and you asked for high accuracy. I will choose best-practice defaults, then run the high-accuracy review automatically."
 
 - **OVERRIDE - explicit ask wins:** if the user explicitly asks to be questioned or interviewed ("ask me", "interview me", "why aren't you asking me" - in any language), route **CLEAR**, run the interview, and turn the adopt-default filter OFF: the user has claimed the forks, so every surviving one is ASKED, not defaulted. This beats the OUTCOME test below, even on a fuzzy brief.
 - **CLEAR** - the user knows the outcome; the only open items are preferences/tradeoffs the repo cannot answer (genuine owner-decisions). Read **`references/intent-clear.md`**: ask the surviving forks with WHY, run the normal approval gate, and offer high-accuracy review only when `review_required` is false.

--- a/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/references/full-workflow.md
+++ b/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/references/full-workflow.md
@@ -36,7 +36,7 @@ Make ONE judgment and follow ONE reference. Review modifiers are not routing sig
 - CLEAR -> `intent-clear.md`: run the **two filters** on every candidate question; ask only surviving forks (owner-decisions), with WHY.
 - UNCLEAR -> `intent-unclear.md`: research maximally, adopt announced best-practice defaults, do not ask the user extra questions.
 
-If a draft/plan already exists and the user asks for high-accuracy review, high-accuracy planning, or to make the plan more accurate, do not reroute from scratch unless the scope changed. Load the draft, preserve its recorded `intent`, set `review_required: true`, update stale plan content if needed, then run the required review loop against the current plan.
+If a draft/plan already exists and the user says a review modifier - even appended to an otherwise unrelated follow-up question - or asks to make the plan more accurate, do not reroute from scratch unless the scope changed. Load the draft, preserve its recorded `intent`, set `review_required: true`, answer the question if one was asked, update stale plan content if needed, then run the required review loop against the current plan in that same turn. A more rigorous answer is not a substitute for the review.
 
 Both paths record `intent`, `review_required`, and decisions to `.omo/drafts/<slug>.md` as they go - long sessions outlive your context, and plan generation reads the draft, not your memory.
 

--- a/packages/omo-codex/plugin/skills/ulw-plan/SKILL.md
+++ b/packages/omo-codex/plugin/skills/ulw-plan/SKILL.md
@@ -15,9 +15,12 @@ Outcome-first: explore a lot, ask few sharp questions - or none, when the intent
 
 ## INTENT ROUTING - pick ONE intent reference
 
-Before routing, parse review modifiers separately. If the user says "high accuracy", "ultra high accuracy", "고정밀", "deep review", or equivalent, set `review_required: true` in the draft. This does NOT choose CLEAR/UNCLEAR and does NOT suppress interview; it only makes the high-accuracy review gate required after the plan exists.
+**Review modifiers are a gate trigger, not a style cue.** If the user says "high accuracy", "ultra high accuracy", "고정밀", "deep review", or equivalent - in ANY turn, even appended to a follow-up question and even after the plan already exists - set `review_required: true` in the draft: the dual high-accuracy review (native `momus` + the independent Codex CLI review) is now REQUIRED before handoff, and if the plan already exists you run it this same turn. Answering the current question more carefully does NOT satisfy it. This does NOT choose CLEAR/UNCLEAR and does NOT suppress interview.
 
-After grounding, make ONE judgment, record `intent: clear|unclear` plus `review_required`, and load ONE intent reference (you ALSO read `references/full-workflow.md` for the shared mechanics - see below). The test keys on whether the desired **OUTCOME** is clear, NOT on request length.
+After grounding, make ONE judgment, record `intent: clear|unclear` plus `review_required`, **ANNOUNCE both to the user in one line**, then load ONE intent reference (you ALSO read `references/full-workflow.md` for the shared mechanics - see below). The test keys on whether the desired **OUTCOME** is clear, NOT on request length. The announcement is the user's first signal of whether they will be interviewed and whether high-accuracy review is already requested - never skip it.
+
+> "Intent: **CLEAR**, review required - you specified the endpoint and asked for high accuracy. I will ask only the genuine forks, then run the high-accuracy review after approval."
+> "Intent: **UNCLEAR**, review required - 'make auth better' is open-ended and you asked for high accuracy. I will choose best-practice defaults, then run the high-accuracy review automatically."
 
 - **OVERRIDE - explicit ask wins:** if the user explicitly asks to be questioned or interviewed ("ask me", "interview me", "why aren't you asking me" - in any language), route **CLEAR**, run the interview, and turn the adopt-default filter OFF: the user has claimed the forks, so every surviving one is ASKED, not defaulted. This beats the OUTCOME test below, even on a fuzzy brief.
 - **CLEAR** - the user knows the outcome; the only open items are preferences/tradeoffs the repo cannot answer (genuine owner-decisions). Read **`references/intent-clear.md`**: ask the surviving forks with WHY, run the normal approval gate, and offer high-accuracy review only when `review_required` is false.

--- a/packages/shared-skills/skills/ulw-plan/SKILL.md
+++ b/packages/shared-skills/skills/ulw-plan/SKILL.md
@@ -15,7 +15,7 @@ Outcome-first: explore a lot, ask few sharp questions - or none, when the intent
 
 ## INTENT ROUTING - pick ONE intent reference
 
-Before routing, parse review modifiers separately. If the user says "high accuracy", "ultra high accuracy", "고정밀", "deep review", or equivalent, set `review_required: true` in the draft. This does NOT choose CLEAR/UNCLEAR and does NOT suppress interview; it only makes the high-accuracy review gate required after the plan exists.
+**Review modifiers are a gate trigger, not a style cue.** If the user says "high accuracy", "ultra high accuracy", "고정밀", "deep review", or equivalent - in ANY turn, even appended to a follow-up question and even after the plan already exists - set `review_required: true` in the draft: the dual high-accuracy review (native `momus` + the independent Oracle review) is now REQUIRED before handoff, and if the plan already exists you run it this same turn. Answering the current question more carefully does NOT satisfy it. This does NOT choose CLEAR/UNCLEAR and does NOT suppress interview.
 
 After grounding, make ONE judgment, record `intent: clear|unclear` plus `review_required`, **ANNOUNCE both to the user in one line**, then load ONE intent reference (you ALSO read `references/full-workflow.md` for the shared mechanics - see below). The test keys on whether the desired **OUTCOME** is clear, NOT on request length. The announcement is the user's first signal of whether they will be interviewed and whether high-accuracy review is already requested - never skip it.
 

--- a/packages/shared-skills/skills/ulw-plan/references/full-workflow.md
+++ b/packages/shared-skills/skills/ulw-plan/references/full-workflow.md
@@ -36,7 +36,7 @@ Make ONE judgment and follow ONE reference. Review modifiers are not routing sig
 - CLEAR -> `intent-clear.md`: run the **two filters** on every candidate question; ask only surviving forks (owner-decisions), with WHY.
 - UNCLEAR -> `intent-unclear.md`: research maximally, adopt announced best-practice defaults, do not ask the user extra questions.
 
-If a draft/plan already exists and the user asks for high-accuracy review, high-accuracy planning, or to make the plan more accurate, do not reroute from scratch unless the scope changed. Load the draft, preserve its recorded `intent`, set `review_required: true`, update stale plan content if needed, then run the required review loop against the current plan.
+If a draft/plan already exists and the user says a review modifier - even appended to an otherwise unrelated follow-up question - or asks to make the plan more accurate, do not reroute from scratch unless the scope changed. Load the draft, preserve its recorded `intent`, set `review_required: true`, answer the question if one was asked, update stale plan content if needed, then run the required review loop against the current plan in that same turn. A more rigorous answer is not a substitute for the review.
 
 Both paths record `intent`, `review_required`, and decisions to `.omo/drafts/<slug>.md` as they go - long sessions outlive your context, and plan generation reads the draft, not your memory.
 


### PR DESCRIPTION
## What changed

The ulw-plan review-modifier rule ("high accuracy" / "ultra high accuracy" / "고정밀" / "deep review") is rewritten from a routing-time flag parse into a standing, any-turn gate trigger, in both harness flavors:

- `packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/SKILL.md` (Codex canonical; synced copy `plugin/skills/ulw-plan/SKILL.md` regenerated via `sync-skills.mjs`)
- `packages/shared-skills/skills/ulw-plan/SKILL.md` (OpenCode flavor)
- both flavors' `references/full-workflow.md` Phase 2 "plan already exists" clause

The new wording states, at the trigger site, that the modifier requires the dual high-accuracy review (native `momus` + the independent Codex CLI / Oracle review) in ANY turn - even appended to an unrelated follow-up question, even after the plan already exists - to be run that same turn, and that answering the question more rigorously does not substitute for the review. The "ANNOUNCE `review_required` in one line" commitment device, previously only in the OpenCode flavor, is ported into the Codex flavor (drift closed).

## Why

Real failure, captured in Codex thread `019f1c43-1c9c-7f40-8547-743c127843fb` (ulw-plan 4.14.2, gpt-5.5): the user appended "high accuracy" to a follow-up question after the plan existed. The model's own reasoning shows it treated the token as an answer-quality adjective ("플랜을 그대로 믿지 않고 대조해서 답할게") and did not spawn momus; the review only ran one turn later after the user explicitly said "high accuracy 는 momus 소환해야하잖아".

Root cause is prompt framing, not model capability: the old rule said "**Before routing**, parse review modifiers... it only makes the... gate required **after the plan exists**", which reads as a routing-turn-only instruction, and the only named action was setting a flag whose consumer lives in a second-tier reference file. Both gpt-5.5 (outcome-first, resolves ambiguous tokens to their plain-English meaning) and Opus 4.7/4.8 (literal scope-following, conservative subagent spawning) under-fire on that framing, so one fix covers both flavors.

## Observed behavior / QA

- `bun run test:codex`: **449 pass / 0 fail, exit 0** (hermetic Codex gate: installer, config migration, plugin component + sync-skills orchestration suites).
- `codex-qa` `install-verify.sh --keep`: **PASS** in an isolated `CODEX_HOME` (plugin cache present, `omo@sisyphuslabs` enabled, component bins + agent TOMLs linked) with the real `~/.codex/config.toml` shasum asserted unchanged.
- Landing proof: inside the isolated install, the packaged `skills/ulw-plan/SKILL.md` carries the new gate-trigger line (L18) and the ported ANNOUNCE device (L20), `references/full-workflow.md` carries the same-turn clause (L39), and the old framing is absent.
- Baseline attribution: 5 local skills-loader test failures are byte-identical on clean `dev` without this change (38/5 both sides) - pre-existing environment artifacts, not a regression.

Evidence bundle: `.omo/evidence/20260702-ulw-plan-high-accuracy-trigger/` (README + install-verify.log + landing-proof.log + test-codex.log + baseline-attribution.log; local evidence dir, gitignored by design).

## Residual risk

Prompt-text change only; no code paths touched. The behavioral claim (momus fires on the first "high accuracy" mention mid-session) is ultimately provable only in a live gpt-5.5 session; the wording was derived from the captured failure trace and applies the same fix shape validated live in PR #5407 (prompt-competition fix). If live behavior still under-fires, the next lever is the intent-clear/unclear references, not more SKILL.md text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make “high accuracy” and similar modifiers a standing gate in `ulw-plan`, triggering the required dual review on any turn and running it in the same turn if a plan already exists. Also add a one-line announcement of `intent` and `review_required` to the Codex flavor to align both harnesses.

- **Bug Fixes**
  - Treat review modifiers as a gate trigger, not a style cue: set `review_required: true` on any turn, including after a plan exists.
  - Update workflow: when a modifier appears mid-session, answer the follow-up if any, then run the dual review that same turn (`momus` + independent Codex CLI/Oracle); a careful answer is not a substitute.
  - Sync wording across Codex and OpenCode SKILLs and references; port the one-line `intent`/`review_required` announcement to Codex.

<sup>Written for commit f839a68697444b048fb12a45dac6753981934760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

