### PR TITLE
fix(ulw-plan): normalize ANNOUNCE example delimiter to hyphen in OpenCode flavor

### DIFF
--- a/packages/shared-skills/skills/ulw-plan/SKILL.md
+++ b/packages/shared-skills/skills/ulw-plan/SKILL.md
@@ -19,8 +19,8 @@ Outcome-first: explore a lot, ask few sharp questions - or none, when the intent
 
 After grounding, make ONE judgment, record `intent: clear|unclear` plus `review_required`, **ANNOUNCE both to the user in one line**, then load ONE intent reference (you ALSO read `references/full-workflow.md` for the shared mechanics - see below). The test keys on whether the desired **OUTCOME** is clear, NOT on request length. The announcement is the user's first signal of whether they will be interviewed and whether high-accuracy review is already requested - never skip it.
 
-> "Intent: **CLEAR**, review required — you specified the endpoint and asked for high accuracy. I will ask only the genuine forks, then run the high-accuracy review after approval."
-> "Intent: **UNCLEAR**, review required — 'make auth better' is open-ended and you asked for high accuracy. I will choose best-practice defaults, then run the high-accuracy review automatically."
+> "Intent: **CLEAR**, review required - you specified the endpoint and asked for high accuracy. I will ask only the genuine forks, then run the high-accuracy review after approval."
+> "Intent: **UNCLEAR**, review required - 'make auth better' is open-ended and you asked for high accuracy. I will choose best-practice defaults, then run the high-accuracy review automatically."
 
 - **OVERRIDE - explicit ask wins:** if the user explicitly asks to be questioned or interviewed ("ask me", "interview me", "why aren't you asking me" - in any language), route **CLEAR**, run the interview, and turn the adopt-default filter OFF: the user has claimed the forks, so every surviving one is ASKED, not defaulted. This beats the OUTCOME test below, even on a fuzzy brief.
 - **CLEAR** - the user knows the outcome; the only open items are preferences/tradeoffs the repo cannot answer (genuine owner-decisions). Read **`references/intent-clear.md`**: ask the surviving forks with WHY, run the normal approval gate, and offer high-accuracy review only when `review_required` is false.


### PR DESCRIPTION
## What changed

Two-character follow-up to #5813: the ANNOUNCE example lines in `packages/shared-skills/skills/ulw-plan/SKILL.md` used an em dash (` — `) where the Codex flavor uses a hyphen (` - `).

## Why

Cubic's P3 on #5813 correctly noted the delimiter mismatch contradicts that PR's "drift closed" claim. The repo convention bans em dashes in generated content, so the OpenCode flavor is normalized to the hyphen (not the other way around). After this change the two flavors differ only in intended harness deltas (momus + Codex CLI vs momus + Oracle, Delegation section).

## Observed behavior / QA

- `bun run test:codex`: 449 pass / 0 fail, exit 0 with the change applied.
- Flavor diff audit: every residual diff line between the two SKILL.md copies is a harness delta; `grep` confirms no em/en dashes remain in either copy.

## Residual risk

None beyond #5813; punctuation-only change in prompt text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized the ANNOUNCE example delimiter in the OpenCode flavor of `packages/shared-skills/skills/ulw-plan/SKILL.md` from an em dash to a hyphen to match the Codex flavor and the repo rule banning em dashes in generated content. This closes a small flavor drift in examples with no behavior change.

<sup>Written for commit 25cc57d5ece14b407acf7c552b82fcf78875c5a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

