### PR TITLE
fix(runtime-fallback): classify free usage exhaustion (fixes #5815)

### DIFF
--- a/packages/model-core/src/runtime-fallback-error-classifier.ts
+++ b/packages/model-core/src/runtime-fallback-error-classifier.ts
@@ -112,6 +112,7 @@ export function classifyRuntimeFallbackError(error: unknown): RuntimeFallbackErr
     /resource.?exhausted/i.test(message) ||
     /out\s+of\s+credits?/i.test(message) ||
     /payment.?required/i.test(message) ||
+    /free\s+usage\s+exceeded/i.test(message) ||
     /usage\s+limit/i.test(message) ||
     /credit\s+balance.*too\s+low/i.test(message) ||
     /limit\s+exhausted/i.test(message) ||

--- a/packages/omo-opencode/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
@@ -20,6 +20,21 @@ describe("runtime-fallback quota error regressions", () => {
     expect(retryable).toBe(true)
   })
 
+  test("classifies OpenCode Go free usage exhaustion as quota_exceeded", () => {
+    //#given
+    const error = {
+      message: "Free usage exceeded, subscribe to Go",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
+
   test("treats HTTP 402 payment required as fallback-eligible", () => {
     //#given
     const error = { statusCode: 402, message: "Payment Required" }


### PR DESCRIPTION
## Summary
Runtime fallback now treats OpenCode Go free-tier exhaustion (`Free usage exceeded, subscribe to Go`) as a quota exhaustion signal, so the main session can move to the next fallback model instead of staying on the exhausted one.

## Root Cause
`packages/model-core/src/runtime-fallback-error-classifier.ts` already matched quota wording such as `quota exceeded`, `usage quota`, and `usage limit`, but did not match the OpenCode Go wording `Free usage exceeded`. As a result, the OpenCode runtime-fallback wrapper returned `undefined` and the fallback path did not trigger.

## Changes
| File | Change |
|------|--------|
| `packages/model-core/src/runtime-fallback-error-classifier.ts` | Add the OpenCode Go free-usage exhaustion pattern to quota classification. |
| `packages/omo-opencode/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts` | Add regression coverage through the OpenCode runtime-fallback wrapper. |

## Reproduction (before fix)
~~~
Expected: "quota_exceeded"
Received: undefined
(fail) runtime-fallback quota error regressions > classifies OpenCode Go free usage exhaustion as quota_exceeded
~~~

## Verification (after fix)
~~~
(pass) runtime-fallback quota error regressions > classifies OpenCode Go free usage exhaustion as quota_exceeded
12 pass
0 fail
~~~

## Test
- Regression test: `bun test packages/omo-opencode/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts` - 12 pass
- Related suite: `bun test packages/model-core/src/runtime-fallback-error-classifier.test.ts packages/omo-opencode/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts` - 16 pass
- Typecheck: `bun run typecheck` - clean
- Surface driver: OpenCode runtime-fallback wrapper returns `{"type":"quota_exceeded","retryable":true}` for `Free usage exceeded, subscribe to Go`
- Evidence files: `.omo/evidence/20260702-runtime-fallback-free-usage/`

## Notes
`lsp_diagnostics` could not run locally because the LSP daemon was unreachable at `\\.\pipe\omo-lsp-0.1.0-e0572cf2aa1ae539`. The typecheck gate passed.

Fixes #5815


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies the OpenCode Go message “Free usage exceeded, subscribe to Go” as a quota exhaustion so runtime fallback moves to the next model instead of staying on the exhausted one.

- **Bug Fixes**
  - Extend quota detection in `packages/model-core/src/runtime-fallback-error-classifier.ts` to match “free usage exceeded”.
  - Add regression in `packages/omo-opencode/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts` to ensure the wrapper returns `{"type":"quota_exceeded","retryable":true}`.

<sup>Written for commit d6f6275d884943a4a04c7a0f76cc5216bfe800ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

