### PR TITLE
test(ci): stabilize windows test flakes

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/integration.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/integration.test.ts
@@ -131,7 +131,7 @@ describe("team-mode integration", () => {
     expect(delivered.deliveredTo).toEqual(["echo"])
     expect(status.members[0]?.unreadMessages).toBe(1)
     expect(await exists(getRuntimeStateDir(resolveBaseDir(config), runtime.teamRunId))).toBe(false)
-  })
+  }, 15000)
 
   test("C-10.2 runs a 2-member pipeline where worker claims and completes a lead-created task", async () => {
     // given
@@ -155,7 +155,7 @@ describe("team-mode integration", () => {
     expect(claimedTask.owner).toBe("worker")
     expect(completedTasks).toHaveLength(1)
     expect(completedTasks[0]?.subject).toBe("X")
-  })
+  }, 15000)
 
   test("C-10.3 resumes alive teams, orphans dead leads, fails stuck creating teams, and cleans deleting runs", async () => {
     // given

--- a/packages/omo-opencode/src/features/team-mode/team-mailbox/poll.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-mailbox/poll.test.ts
@@ -89,7 +89,7 @@ describe("pollAndBuildInjection", () => {
     // then
     expect(results.filter((result) => result.injected)).toHaveLength(1)
     expect(results.filter((result) => !result.injected)).toHaveLength(7)
-  })
+  }, 15_000)
 
   test("wraps hostile message bodies in a literal peer_message envelope", async () => {
     // given
@@ -153,7 +153,7 @@ describe("pollAndBuildInjection", () => {
     expect(inboxEntries).toContain(`${firstMessageId}.json`)
     expect(inboxEntries).toContain(`${secondMessageId}.json`)
     expect(inboxEntries).not.toContain("processed")
-  })
+  }, 15_000)
 
   test("does not re-inject a pending message on a later turn", async () => {
     // given

--- a/packages/team-core/src/team-mailbox/poll.test.ts
+++ b/packages/team-core/src/team-mailbox/poll.test.ts
@@ -153,7 +153,7 @@ describe("pollAndBuildInjection", () => {
     expect(inboxEntries).toContain(`${firstMessageId}.json`)
     expect(inboxEntries).toContain(`${secondMessageId}.json`)
     expect(inboxEntries).not.toContain("processed")
-  })
+  }, 15_000)
 
   test("does not re-inject a pending message on a later turn", async () => {
     // given

--- a/packages/utils/src/port-utils.test.ts
+++ b/packages/utils/src/port-utils.test.ts
@@ -8,7 +8,6 @@ import { DEFAULT_SERVER_PORT, findAvailablePort, getAvailableServerPort, isPortA
 
 const DEFAULT_HOSTNAME = "127.0.0.1"
 const MAX_PORT_ATTEMPTS = 20
-const EXHAUSTED_PORT_COUNT = MAX_PORT_ATTEMPTS + 1
 const CONTIGUOUS_SEARCH_WINDOW = 256
 const CONTIGUOUS_SEARCH_SEEDS = 8
 
@@ -18,6 +17,11 @@ type TimeoutProbeResult = {
   closeCallCount: number
   isAvailable: boolean
   server: Server | undefined
+}
+
+type BlockedRangeProbeResult = {
+  errorMessage: string | undefined
+  probedPorts: number[]
 }
 
 function getRequiredPropertyDescriptor(target: object, propertyName: string): PropertyDescriptor {
@@ -295,6 +299,51 @@ async function runTimedOutAvailabilityProbe(port: number): Promise<TimeoutProbeR
   }
 }
 
+async function runBlockedRangeAvailabilityProbe(startPort: number): Promise<BlockedRangeProbeResult> {
+  const listenDescriptor = getRequiredPropertyDescriptor(Server.prototype, "listen")
+  const closeDescriptor = getRequiredPropertyDescriptor(Server.prototype, "close")
+  const probedPorts: number[] = []
+  let errorMessage: string | undefined
+
+  Object.defineProperty(Server.prototype, "listen", {
+    configurable: true,
+    value: function listenWithBlockedRange(this: Server, requestedPort: number): Server {
+      if (requestedPort >= startPort && requestedPort < startPort + MAX_PORT_ATTEMPTS) {
+        probedPorts.push(requestedPort)
+        queueMicrotask(() => {
+          this.emit("error", Object.assign(new Error(`mocked port ${requestedPort} unavailable`), { code: "EADDRINUSE" }))
+        })
+        return this
+      }
+
+      queueMicrotask(() => this.emit("listening"))
+      return this
+    },
+  })
+  Object.defineProperty(Server.prototype, "close", {
+    configurable: true,
+    value: function closeMockedServer(this: Server, callback?: (error?: Error) => void): Server {
+      queueMicrotask(() => callback?.())
+      return this
+    },
+  })
+
+  try {
+    try {
+      await findAvailablePort(startPort)
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
+      errorMessage = error.message
+    }
+    return { errorMessage, probedPorts }
+  } finally {
+    Object.defineProperty(Server.prototype, "listen", listenDescriptor)
+    Object.defineProperty(Server.prototype, "close", closeDescriptor)
+  }
+}
+
 describe("port-utils", () => {
   beforeAll(() => {
     trackedServers.clear()
@@ -404,20 +453,12 @@ describe("port-utils", () => {
     })
 
     test("#when every attempted port is blocked #then throws", async () => {
-      const startPort = await findContiguousAvailableStart(EXHAUSTED_PORT_COUNT)
-      await startConsecutiveBlockers(startPort, EXHAUSTED_PORT_COUNT)
+      const startPort = 40_000
 
-      let errorMessage: string | undefined
-      try {
-        await findAvailablePort(startPort)
-      } catch (error) {
-        if (!(error instanceof Error)) {
-          throw error
-        }
-        errorMessage = error.message
-      }
+      const { errorMessage, probedPorts } = await runBlockedRangeAvailabilityProbe(startPort)
 
       expect(errorMessage).toBe(`No available port found in range ${startPort}-${startPort + MAX_PORT_ATTEMPTS - 1}`)
+      expect(probedPorts).toEqual(Array.from({ length: MAX_PORT_ATTEMPTS }, (_, offset) => startPort + offset))
     })
   })
 

--- a/script/sync-lazycodex-marketplace.test.ts
+++ b/script/sync-lazycodex-marketplace.test.ts
@@ -211,7 +211,7 @@ describe("sync-lazycodex-marketplace", () => {
       workflowMissing = error instanceof Error
     }
     expect(workflowMissing).toBe(true)
-  })
+  }, 15_000)
 
   test("#given release version env #when syncing marketplace #then repository payload is stamped with release version", async () => {
     // given


### PR DESCRIPTION
## Summary
Fixes the recent systemic `test (windows-latest)` failures on `dev` by addressing the five known flaky families without skips, retries, or production lock changes.

The timeout failures are slow-but-finishing Windows filesystem/fixture tests hitting Bun's 5000ms per-test default. The port-utils failure is a test setup race caused by closing and immediately rebinding real ports on Windows.

## Root Causes And Fixes
- `packages/omo-opencode/src/features/team-mode/team-mailbox/poll.test.ts`
  - Root cause: the OpenCode copy was missing the explicit 15s timeout already present on the team-core concurrent mailbox test, and the pending-id case does several file-backed mailbox/state operations that can cross Bun's 5s default on Windows.
  - Fix: add 15s per-test timeouts for the concurrent claim and pending-id tests.
- `packages/team-core/src/team-mailbox/poll.test.ts`
  - Root cause: the pending-id file-backed mailbox test can cross Bun's 5s default on Windows under slow fsync/Defender behavior.
  - Fix: add the same 15s timeout used by the neighboring heavy mailbox test.
- `script/sync-lazycodex-marketplace.test.ts`
  - Root cause: the older package payload scenario performs the same heavy fixture write/copy/stat path as adjacent marketplace sync tests and occasionally crosses Bun's default on Windows.
  - Fix: add a 15s per-test timeout to that scenario.
- `packages/omo-opencode/src/features/team-mode/integration.test.ts`
  - Root cause: C-10.1/C-10.2 use file-backed team runtime/tasklist state with real fsync-heavy writes and can exceed Bun's default on Windows, while sibling C-10.3 already had a 15s allowance.
  - Fix: add 15s per-test timeouts to C-10.1 and C-10.2.
- `packages/utils/src/port-utils.test.ts`
  - Root cause: the all-blocked-range test found a contiguous real range, closed it, then immediately rebound blockers. Windows can transiently reject just-closed ports, so setup failed with `EACCES` before `findAvailablePort` was actually tested.
  - Fix: replace that test setup with a deterministic `Server.prototype.listen`/`close` mock that emits `EADDRINUSE` for exactly the attempted range and asserts all 20 attempts were probed.

## Verification
- `bun test packages/utils/src/port-utils.test.ts packages/omo-opencode/src/features/team-mode/team-mailbox/poll.test.ts packages/team-core/src/team-mailbox/poll.test.ts packages/omo-opencode/src/features/team-mode/integration.test.ts script/sync-lazycodex-marketplace.test.ts` -> 42 pass, 0 fail.
- LSP diagnostics on all five changed files -> no diagnostics.
- `bun run typecheck` -> pass.
- `bun run build` -> pass; generated drift from the build was removed before commit.
- `bun test` once locally -> failed only unrelated local shared-skill discovery pollution from `/Users/yeongyu/.agents/skills`; raw output recorded and not used as a green claim.
- OpenCode QA: `common.sh --self-check` and `server-smoke.sh --self-test` passed in an isolated harness.

Evidence artifacts are under `.omo/evidence/20260702-fix-windows-ci-flakiness/`, including raw failed CI logs for runs `28564246225`, `28568276702`, `28509583750`, `28505260701`, and `28560780728`.

## Risk
No production code changed. Remaining risk is that some other Windows-only test not seen in the sampled failures may still be close to Bun's 5s default; this PR fixes the identified failures directly and leaves any broader CI timeout policy for a separate change if CI evidence demands it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Windows CI by fixing five flaky test groups without skips or retries. Increases timeouts for slow file-backed tests and replaces racey port checks with a deterministic mock.

- **Bug Fixes**
  - Set 15s timeouts for heavy tests in `packages/omo-opencode/src/features/team-mode/team-mailbox/poll.test.ts`, `packages/team-core/src/team-mailbox/poll.test.ts`, `packages/omo-opencode/src/features/team-mode/integration.test.ts` (C-10.1, C-10.2), and `script/sync-lazycodex-marketplace.test.ts`.
  - Rewrote `packages/utils/src/port-utils.test.ts` to mock `Server.prototype.listen/close` and emit `EADDRINUSE` for a fixed range, asserting all 20 probes, removing Windows port reuse races.

<sup>Written for commit d98d230096e14d6cbc0b92ddf02dac0df624ce23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

