### PR TITLE
docs(cleanup): align cleanup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ See [Configuration Documentation](docs/reference/configuration.md).
 - **JSONC Support**: Comments and trailing commas supported
 - **Agents**: Override models, temperatures, prompts, and permissions for any agent
 - **Built-in Skills**: `playwright` (browser automation), `git-master` (atomic commits)
+- **Optional Claude Mem Adapter**: workspace-scoped native memory capability via `skill_mcp`, with non-live smoke verification through `bun run smoke:claude-mem-adapter`
 - **Sisyphus Agent**: Main orchestrator with Prometheus (Planner) and Metis (Plan Consultant)
 - **Background Tasks**: Configure concurrency limits per provider/model
 - **Categories**: Domain-specific task delegation (`visual`, `business-logic`, custom)

--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -130,6 +130,8 @@ Principle-driven, explicit reasoning, deep technical capability. Best for agents
 | -------------------- | ------------------------------------------------------------------------------------------------------------ |
 | **Gemini 3.1 Pro**   | Excels at visual/frontend tasks. Different reasoning style. Default for `visual-engineering` and `artistry`. |
 | **Gemini 3 Flash**   | Fast. Good for doc search and light tasks.                                                                   |
+| **DeepSeek V4 Pro**  | Cost-conscious active secondary reasoning and coding. Good for bounded implementation, constrained debugging, tests, and code analysis. |
+| **DeepSeek V4 Flash** | Fast active secondary lane for mechanical edits, repetitive cleanup, boilerplate, simple tests, and predictable maintenance. |
 | **Grok Code Fast 1** | Blazing fast code grep. Default for Explore agent.                                                           |
 | **MiniMax M2.7**     | Fast and smart. Used in OpenCode Go and OpenCode Zen utility fallback chains. |
 | **MiniMax M2.7 Highspeed** | High-speed OpenCode catalog entry used in utility fallback chains that prefer the fastest available MiniMax path. |
@@ -177,6 +179,11 @@ When agents delegate work, they don't pick a model name — they pick a **catego
 | `unspecified-high`   | General complex work       | anthropic\|github-copilot\|opencode/claude-opus-4-6 (max) → openai\|github-copilot\|opencode/gpt-5.4 (high) → zai-coding-plan\|opencode/glm-5 → kimi-for-coding/k2p5 → opencode-go/glm-5 → opencode/kimi-k2.5 → opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix/kimi-k2.5 |
 | `unspecified-low`    | General standard work      | anthropic\|github-copilot\|opencode/claude-sonnet-4-6 → openai\|opencode/gpt-5.3-codex (medium) → opencode-go/kimi-k2.5 → google\|github-copilot\|opencode/gemini-3-flash → opencode-go/minimax-m2.7 |
 | `writing`            | Text, docs, prose          | google\|github-copilot\|opencode/gemini-3-flash → opencode-go/kimi-k2.5 → anthropic\|github-copilot\|opencode/claude-sonnet-4-6 → opencode-go/minimax-m2.7 |
+| `deepseek-pro`       | Secondary reasoning/coding | deepseek/deepseek-v4-pro (high) → deepseek/deepseek-v4-flash (high) → openai/gpt-5.5 (medium) |
+| `deepseek-flash`     | Mechanical/repetitive work | deepseek/deepseek-v4-flash (medium) → deepseek/deepseek-v4-pro (medium) → github-copilot/gpt-5-mini |
+| `secondary-reasoning` | Bounded reasoning         | deepseek/deepseek-v4-pro (high) → openai/gpt-5.5 (medium) |
+| `mechanical-coding`  | Mechanical code edits      | deepseek/deepseek-v4-flash (medium) → deepseek/deepseek-v4-pro (medium) |
+| `bulk-maintenance`   | Repetitive maintenance     | deepseek/deepseek-v4-flash (medium) → deepseek/deepseek-v4-pro (medium) |
 
 See the [Orchestration System Guide](./orchestration.md) for how agents dispatch tasks to categories.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -98,7 +98,7 @@ Spawn a subagent to handle installation and report back - to save context.
 Based on user's answers, run the CLI installer with appropriate flags:
 
 ```bash
-bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --gemini=<yes|no> --copilot=<yes|no> [--openai=<yes|no>] [--opencode-go=<yes|no>] [--opencode-zen=<yes|no>] [--zai-coding-plan=<yes|no>]
+bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --gemini=<yes|no> --copilot=<yes|no> [--openai=<yes|no>] [--opencode-go=<yes|no>] [--opencode-zen=<yes|no>] [--zai-coding-plan=<yes|no>] [--preset foundationstart]
 ```
 
 **Examples:**
@@ -116,6 +116,7 @@ The CLI will:
 
 - Register the plugin in `opencode.json`
 - Configure agent models based on subscription flags
+- Optionally append FoundationStart startup guidance to the core relay agents when `--preset foundationstart` is used
 - Show which auth steps are needed
 
 ### Step 3: Verify Setup
@@ -133,6 +134,64 @@ bunx oh-my-opencode doctor
 ```
 
 This checks system, config, tools, and model resolution, including legacy package name warnings and compatibility-fallback diagnostics.
+
+### FoundationStart preset scope
+
+`--preset foundationstart` is meant for FoundationStart-style workspaces.
+
+Default workspace root:
+
+- `C:\OpenCodeWorkingFolder`
+
+To target a different workspace root, set this before running install:
+
+```bash
+FOUNDATIONSTART_WORKSPACE_ROOT=/path/to/your/workspace
+```
+
+### Maintainer packaged smoke validation
+
+To verify the **packaged** FoundationStart preset path instead of only the workspace implementation, run:
+
+```bash
+bun run smoke:foundationstart-preset
+```
+
+This builds the package, packs it, installs it into a disposable smoke root, runs `install --preset foundationstart`, runs `doctor --json`, and records provenance/report output under:
+
+- `C:\OpenCodeWorkingFolder\simulations\oh-my-openagent-packaged-smoke`
+
+To verify that the **packaged build** also contains the delayed provider-warning behavior and no longer ships the legacy warning text, run:
+
+```bash
+bun run smoke:provider-warning
+```
+
+This reuses the packaged smoke root and writes a second report confirming the installed package contains the delayed-warning state machine and the new warning text, plus focused workspace runtime tests for the same warning path.
+
+### Claude-mem adapter smoke validation
+
+After enabling `claude_mem` in your plugin config, you can run a non-live adapter smoke check:
+
+```bash
+bun run smoke:claude-mem-adapter --output-root "C:\OpenCodeWorkingFolder\.sisyphus\evidence" --windows-path "C:\Temp\Claude Mem Test"
+```
+
+This does **not** require live provider credentials by default. It verifies:
+
+- config parsing
+- workspace-scoped runtime layout
+- capability surface (`search`, `timeline`, `get_observations`)
+- Windows-style path handling
+- degraded-mode launch contract (`launch-required` instead of fake success)
+
+Use this together with:
+
+```bash
+bunx oh-my-opencode doctor
+```
+
+The doctor command checks the host environment/config generally. The dedicated claude-mem smoke command is the precise adapter verification path in wave 1.
 
 ### Step 4: Configure Authentication
 

--- a/docs/guide/orchestration.md
+++ b/docs/guide/orchestration.md
@@ -303,6 +303,11 @@ task({ category: "quick", prompt: "..." }); // "Just get it done fast"
 | `unspecified-low`    | Claude Sonnet 4.6      | Tasks that don't fit other categories, low effort           |
 | `unspecified-high`   | Claude Opus 4.6 (max)  | Tasks that don't fit other categories, high effort          |
 | `writing`            | Gemini 3 Flash         | Documentation, prose, technical writing                     |
+| `deepseek-pro`       | DeepSeek V4 Pro (high) | Active secondary reasoning and bounded coding               |
+| `deepseek-flash`     | DeepSeek V4 Flash      | Fast mechanical, repetitive, low-risk work                  |
+| `secondary-reasoning` | DeepSeek V4 Pro       | Cost-conscious bounded reasoning and known-module debugging |
+| `mechanical-coding`  | DeepSeek V4 Flash      | Mechanical edits, boilerplate, simple migrations            |
+| `bulk-maintenance`   | DeepSeek V4 Flash      | Repetitive maintenance, cleanup, predictable transforms     |
 
 ### Skills: Domain-Specific Instructions
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -56,6 +56,7 @@ bunx oh-my-opencode install
 | `--zai-coding-plan <no\|yes>` | Z.ai Coding Plan subscription |
 | `--kimi-for-coding <no\|yes>` | Kimi for Coding subscription |
 | `--opencode-go <no\|yes>` | OpenCode Go subscription |
+| `--preset <name>` | Optional installer preset, currently `foundationstart` (workspace-root configurable via `FOUNDATIONSTART_WORKSPACE_ROOT`) |
 | `--skip-auth` | Skip authentication setup hints |
 
 ---
@@ -69,6 +70,7 @@ The doctor command detects common issues including:
 - Configuration file validity and JSONC parsing errors
 - Model resolution and fallback chain verification
 - Missing or misconfigured MCP servers
+- General prerequisite validation before running optional adapter smoke checks such as `bun run smoke:claude-mem-adapter`
 ### Usage
 
 ```bash
@@ -120,6 +122,15 @@ Models
 
 Summary: 10 passed, 1 warning, 0 failed
 ```
+
+For the native `claude-mem` adapter, pair doctor with the dedicated non-live smoke check:
+
+```bash
+bunx oh-my-opencode doctor
+bun run smoke:claude-mem-adapter --output-root "C:\OpenCodeWorkingFolder\.sisyphus\evidence" --windows-path "C:\Temp\Claude Mem Test"
+```
+
+Wave-1 note: doctor is the general host health command; the claude-mem smoke command is the adapter-specific verification path.
 ---
 
 ## run

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -295,6 +295,11 @@ Domain-specific model delegation used by the `task()` tool. When Sisyphus delega
 | `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | General tasks, low effort                      |
 | `unspecified-high`   | `anthropic/claude-opus-4-6` (max) | General tasks, high effort                   |
 | `writing`            | `google/gemini-3-flash`         | Documentation, prose, technical writing        |
+| `deepseek-pro`       | `deepseek/deepseek-v4-pro` (high) | Active secondary reasoning and coding        |
+| `deepseek-flash`     | `deepseek/deepseek-v4-flash` (medium) | Fast active secondary mechanical lane    |
+| `secondary-reasoning` | `deepseek/deepseek-v4-pro` (high) | Cost-conscious bounded reasoning           |
+| `mechanical-coding`  | `deepseek/deepseek-v4-flash` (medium) | Mechanical code edits and small fixes     |
+| `bulk-maintenance`   | `deepseek/deepseek-v4-flash` (medium) | Repetitive maintenance and cleanup       |
 
 > **Note**: Built-in defaults only apply if the category is present in your config. Otherwise the system default model is used.
 
@@ -378,6 +383,11 @@ Capability data comes from provider runtime metadata first. OmO also ships bundl
 | **unspecified-low**    | `claude-sonnet-4-6` | `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `openai\|opencode/gpt-5.3-codex (medium)` → `opencode-go/kimi-k2.5` → `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/minimax-m2.7` |
 | **unspecified-high**   | `claude-opus-4-6`   | `anthropic\|github-copilot\|opencode/claude-opus-4-6 (max)` → `openai\|github-copilot\|opencode/gpt-5.4 (high)` → `zai-coding-plan\|opencode/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5` → `opencode/kimi-k2.5` → `opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix/kimi-k2.5` |
 | **writing**            | `gemini-3-flash`    | `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/kimi-k2.5` → `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `opencode-go/minimax-m2.7` |
+| **deepseek-pro**       | `deepseek-v4-pro`   | `deepseek/deepseek-v4-pro (high)` → `deepseek/deepseek-v4-flash (high)` → `openai/gpt-5.5 (medium)` |
+| **deepseek-flash**     | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash (medium)` → `deepseek/deepseek-v4-pro (medium)` → `github-copilot/gpt-5-mini` |
+| **secondary-reasoning** | `deepseek-v4-pro`  | `deepseek/deepseek-v4-pro (high)` → `openai/gpt-5.5 (medium)` |
+| **mechanical-coding**  | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash (medium)` → `deepseek/deepseek-v4-pro (medium)` |
+| **bulk-maintenance**   | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash (medium)` → `deepseek/deepseek-v4-pro (medium)` |
 
 Run `bunx oh-my-opencode doctor --verbose` to see effective model resolution for your config.
 
@@ -602,6 +612,71 @@ Built-in MCPs (enabled by default): `websearch` (Exa AI), `context7` (library do
 ```json
 { "disabled_mcps": ["websearch", "context7", "grep_app"] }
 ```
+
+### Claude Mem Adapter
+
+Enable the native `claude-mem` adapter to expose upstream memory tools through the existing `skill_mcp` path.
+
+```jsonc
+{
+  "claude_mem": {
+    "enabled": true,
+    "command": "bunx",
+    "args": ["claude-mem", "mcp"],
+    "data_dir": ".opencode/claude-mem/data",
+    "port": 37777,
+    "auto_start": false,
+    "startup_timeout_ms": 15000,
+    "supported_version_range": "^12.1.0",
+    "env_allowlist": ["ANTHROPIC_API_KEY"],
+    "env_overrides": {}
+  }
+}
+```
+
+Wave-1 behavior:
+
+- Disabled by default.
+- Uses a workspace-scoped runtime/data directory.
+- Exposes only `search`, `timeline`, and `get_observations`.
+- Reuses a healthy runtime on the configured endpoint when present.
+- Degrades cleanly on missing Bun, missing command, unsupported version, invalid data dir, or unhealthy occupied-port collisions.
+
+Wave-1 exclusions:
+
+- no direct Claude hook embedding
+- no per-session memory isolation promise
+- no viewer/admin endpoint exposure
+- no generic multi-provider memory abstraction
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `enabled` | `false` | Enable the adapter for this workspace/config scope |
+| `command` | - | Command used to launch the upstream MCP/runtime boundary |
+| `args` | `[]` | Arguments passed to the command |
+| `cwd` | workspace root | Working directory for the launched process |
+| `port` | `37777` | Expected worker/MCP health endpoint port |
+| `data_dir` | workspace-managed `.opencode/claude-mem/data` | Workspace-scoped runtime state directory |
+| `auto_start` | `false` | Keep false in wave 1 unless you explicitly want immediate startup on first capability demand |
+| `startup_timeout_ms` | `15000` | Time budget for startup/health establishment |
+| `supported_version_range` | `^12.1.0` | Supported upstream `claude-mem` major/range contract |
+| `env_allowlist` | `[]` | Extra env vars allowed into the spawned runtime |
+| `env_overrides` | `{}` | Explicit env overrides passed to the runtime |
+
+Notes:
+
+- `isolation_scope` is fixed to workspace scope in wave 1 and is not user-tunable.
+- Keep `command` explicit when enabling the adapter. The host will not guess an arbitrary external runtime.
+- Paths with spaces are supported; use normal JSON strings, for example `"C:\\Temp\\Claude Mem Test"`.
+
+Validation and smoke verification:
+
+```bash
+bunx oh-my-opencode doctor
+bun run smoke:claude-mem-adapter --output-root "C:\OpenCodeWorkingFolder\.sisyphus\evidence" --windows-path "C:\Temp\Claude Mem Test"
+```
+
+`doctor` validates the host environment/config surface generally. The dedicated adapter smoke command validates the non-live claude-mem wiring and Windows-style path handling.
 
 ### LSP
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -117,6 +117,11 @@ By combining these two concepts, you can generate optimal agents through `task`.
 | `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | Tasks that don't fit other categories, low effort required                                                                  |
 | `unspecified-high`   | `anthropic/claude-opus-4-6` (max) | Tasks that don't fit other categories, high effort required                                                               |
 | `writing`            | `google/gemini-3-flash`         | Documentation, prose, technical writing                                                                                     |
+| `deepseek-pro`       | `deepseek/deepseek-v4-pro` (high) | Active secondary reasoning and coding for bounded implementation, constrained debugging, tests, and analysis               |
+| `deepseek-flash`     | `deepseek/deepseek-v4-flash` (medium) | Fast active secondary lane for repetitive, mechanical, low-risk, or high-volume work                                  |
+| `secondary-reasoning` | `deepseek/deepseek-v4-pro` (high) | Cost-conscious reasoning for bounded problems, known-module debugging, and planned implementation                         |
+| `mechanical-coding`  | `deepseek/deepseek-v4-flash` (medium) | Mechanical edits, simple migrations, formatting, rename sweeps, boilerplate, and small fixes                          |
+| `bulk-maintenance`   | `deepseek/deepseek-v4-flash` (medium) | Repetitive hygiene, documentation cleanup, lint-style edits, generated small tests, and batch transforms              |
 
 ### Usage
 

--- a/src/hooks/claude-code-hooks/AGENTS.md
+++ b/src/hooks/claude-code-hooks/AGENTS.md
@@ -6,6 +6,12 @@
 
 ~2110 LOC across 19 files. Provides Claude Code settings.json compatibility layer. Parses CC permission rules and maps CC hooks (PreToolUse, PostToolUse) to OpenCode hooks.
 
+## Migration status
+
+- This module remains an internal compatibility shim during the ChatGPT/Codex-first migration.
+- Public/default-facing discovery now prefers generic `code-hooks` paths and aliases.
+- Do not rename or remove this module until compatibility aliases and downstream callers are proven stable.
+
 ## WHAT IT DOES
 
 1. Parses Claude Code `settings.json` permission format

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -23,7 +23,7 @@
 |------|---------|------------|
 | `task` | `createDelegateTask` | description, prompt, category, subagent_type, run_in_background, session_id, load_skills, command |
 
-**8 Built-in Categories**: visual-engineering, ultrabrain, deep, artistry, quick, unspecified-low, unspecified-high, writing
+**13 Built-in Categories**: visual-engineering, ultrabrain, deep, artistry, quick, unspecified-low, unspecified-high, writing, deepseek-pro, deepseek-flash, secondary-reasoning, mechanical-coding, bulk-maintenance
 
 ### Agent Invocation (1)
 
@@ -99,6 +99,11 @@
 | unspecified-low | claude-sonnet-4-6 | Moderate effort |
 | unspecified-high | claude-opus-4-6 max | High effort |
 | writing | gemini-3-flash | Documentation |
+| deepseek-pro | deepseek-v4-pro high | Active secondary reasoning/coding |
+| deepseek-flash | deepseek-v4-flash medium | Fast mechanical lane |
+| secondary-reasoning | deepseek-v4-pro high | Bounded secondary reasoning |
+| mechanical-coding | deepseek-v4-flash medium | Mechanical code edits |
+| bulk-maintenance | deepseek-v4-flash medium | Repetitive maintenance |
 
 ## HOW TO ADD A TOOL
 


### PR DESCRIPTION
# Summary

Docs-only cleanup slice from the verified dirty-worktree cleanup queue (Wave F1–F4, final approval).

## Changed Scope

9 docs-only paths, segmented into 3 owning slices:

### Slice 10a — Docs structure (5 paths)
- \docs/guide/agent-model-matching.md\
- \docs/guide/installation.md\
- \docs/guide/orchestration.md\
- \docs/reference/cli.md\
- \docs/reference/features.md\

### Slice 10b — Configuration docs (2 paths)
- \docs/reference/configuration.md\
- \ssets/oh-my-opencode.schema.json\

### Slice 10c — Repository root (2 paths)
- \README.md\
- \in/platform.d.ts\

## Testing & Evidence

- Repo-local \un run\ commands validated against \package.json\ scripts.
- Scratch/evidence artifacts stored under \.sisyphus/evidence/dirty-worktree-cleanup/\ — not included in production docs.
- Final Wave (F1–F4) approved the overall cleanup plan.

## Notes

- No source code changes — docs-only.
- Independent from other cleanup slices; no merge conflicts expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns docs with new DeepSeek task categories, the `--preset foundationstart` installer flow, and the optional `claude-mem` adapter and smoke checks; no source changes.

- **New Features**
  - Added DeepSeek categories with defaults and fallbacks: `deepseek-pro`, `deepseek-flash`, `secondary-reasoning`, `mechanical-coding`, `bulk-maintenance` (guides, orchestration, configuration, features, tools).
  - Installer: new `--preset foundationstart` and `FOUNDATIONSTART_WORKSPACE_ROOT`, plus packaged validation via `bun run smoke:foundationstart-preset` and `bun run smoke:provider-warning`.
  - Optional `claude-mem` adapter: README callout; config docs for workspace-scoped runtime via `skill_mcp`, capabilities, and clean degradation; non-live `bun run smoke:claude-mem-adapter` paired with `bunx oh-my-opencode doctor`.
  - CLI docs: `install --preset` flag and doctor notes for running adapter smoke checks.
  - Added migration note for `src/hooks/claude-code-hooks/AGENTS.md`; expanded built-in category list in tools docs.

<sup>Written for commit 7a9d900cb2b5a9a2e734dc605f0ab5d6f20577fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

