### PR TITLE
docs(cleanup): align cleanup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ See [Configuration Documentation](docs/reference/configuration.md).
 - **JSONC Support**: Comments and trailing commas supported
 - **Agents**: Override models, temperatures, prompts, and permissions for any agent
 - **Built-in Skills**: `playwright` (browser automation), `git-master` (atomic commits)
+- **Optional Claude Mem Adapter**: workspace-scoped native memory capability via `skill_mcp`, with non-live smoke verification through `bun run smoke:claude-mem-adapter`
 - **Sisyphus Agent**: Main orchestrator with Prometheus (Planner) and Metis (Plan Consultant)
 - **Background Tasks**: Configure concurrency limits per provider/model
 - **Categories**: Domain-specific task delegation (`visual`, `business-logic`, custom)

--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -320,8 +320,9 @@ Principle-driven, explicit reasoning, deep technical capability. Best for agents
 | -------------------- | ------------------------------------------------------------------------------------------------------------ |
 | **Gemini 3.1 Pro**   | Excels at visual/frontend tasks. Different reasoning style. Default for `visual-engineering` and `artistry`. |
 | **Gemini 3 Flash**   | Fast. Good for doc search and light tasks.                                                                   |
-| **GPT-5.4 Mini Fast** | Default for Explore and Librarian agents. Blazing-fast reasoning-capable mini model. |
-| **MiniMax M3**       | Latest MiniMax flagship. Primary MiniMax fallback in OpenCode Go utility chains, ahead of M2.7. |
+| **DeepSeek V4 Pro**  | Cost-conscious active secondary reasoning and coding. Good for bounded implementation, constrained debugging, tests, and code analysis. |
+| **DeepSeek V4 Flash** | Fast active secondary lane for mechanical edits, repetitive cleanup, boilerplate, simple tests, and predictable maintenance. |
+| **Grok Code Fast 1** | Blazing fast code grep. Default for Explore agent.                                                           |
 | **MiniMax M2.7**     | Fast and smart. Used in OpenCode Go and OpenCode Zen utility fallback chains. |
 | **MiniMax M2.7 Highspeed** | High-speed OpenCode catalog entry used in utility fallback chains that prefer the fastest available MiniMax path. |
 
@@ -359,16 +360,21 @@ You don't need to configure them. The system includes them so it degrades gracef
 
 When agents delegate work, they don't pick a model name — they pick a **category**. The category maps to the right model automatically.
 
-| Category | Used For | Default Model | Fallback Chain |
-|---|---|---|---|
-| `visual-engineering` | Frontend, UI, CSS, design | `google/gemini-3.1-pro` (high) | Gemini → `zai-coding-plan/glm-5` → `claude-opus-4-7` (max) → `opencode-go/glm-5.1` → `kimi-for-coding/k2p5` |
-| `artistry` | Creative, novel approaches | `google/gemini-3.1-pro` (high) | Gemini → `claude-opus-4-7` (max) → `gpt-5.5` |
-| `ultrabrain` | Maximum reasoning needed | `openai/gpt-5.5` (xhigh) | GPT-5.5 xhigh → `gemini-3.1-pro` (high) → `claude-opus-4-7` (max) → `opencode-go/glm-5.1` |
-| `deep` | Deep coding, complex logic | `openai/gpt-5.5` (medium) | GPT-5.5 → `claude-opus-4-7` (max) → `gemini-3.1-pro` (high) |
-| `quick` | Simple, fast tasks | `openai/gpt-5.4-mini` | GPT-5.4-mini → `anthropic\|github-copilot\|vercel/claude-haiku-4-5` → `gemini-3-flash` → `opencode-go/minimax-m3` → `opencode-go/minimax-m2.7` → `opencode/gpt-5-nano` |
-| `unspecified-high` | General complex work | `anthropic/claude-opus-4-7` (max) | Opus → `gpt-5.5` (high) → `zai-coding-plan/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5.1` → `opencode/kimi-k2.5` → `moonshotai/kimi-k2.5` |
-| `unspecified-low` | General standard work | `anthropic/claude-sonnet-4-6` | Sonnet → `gpt-5.5-codex` (medium) → `opencode-go/kimi-k2.6` → `google/gemini-3-flash` → `opencode-go/minimax-m3` → `opencode-go/minimax-m2.7` |
-| `writing` | Text, docs, prose | `kimi-for-coding/k2p5` | `gemini-3-flash` → `opencode-go/kimi-k2.6` → `claude-sonnet-4-6` → `opencode-go/minimax-m3` → `opencode-go/minimax-m2.7` |
+| Category             | When Used                  | Fallback Chain                               |
+| -------------------- | -------------------------- | -------------------------------------------- |
+| `visual-engineering` | Frontend, UI, CSS, design  | google\|github-copilot\|opencode/gemini-3.1-pro (high) → zai-coding-plan\|opencode/glm-5 → anthropic\|github-copilot\|opencode/claude-opus-4-6 (max) → opencode-go/glm-5 → kimi-for-coding/k2p5 |
+| `ultrabrain`         | Maximum reasoning needed   | openai\|opencode/gpt-5.4 (xhigh) → google\|github-copilot\|opencode/gemini-3.1-pro (high) → anthropic\|github-copilot\|opencode/claude-opus-4-6 (max) → opencode-go/glm-5 |
+| `deep`               | Deep coding, complex logic | openai\|github-copilot\|venice\|opencode/gpt-5.4 (medium) → anthropic\|github-copilot\|opencode/claude-opus-4-6 (max) → google\|github-copilot\|opencode/gemini-3.1-pro (high) |
+| `artistry`           | Creative, novel approaches | google\|github-copilot\|opencode/gemini-3.1-pro (high) → anthropic\|github-copilot\|opencode/claude-opus-4-6 (max) → openai\|github-copilot\|opencode/gpt-5.4 |
+| `quick`              | Simple, fast tasks         | openai\|github-copilot\|opencode/gpt-5.4-mini → anthropic\|github-copilot\|opencode/claude-haiku-4-5 → google\|github-copilot\|opencode/gemini-3-flash → opencode-go/minimax-m2.7 → opencode/gpt-5-nano |
+| `unspecified-high`   | General complex work       | anthropic\|github-copilot\|opencode/claude-opus-4-6 (max) → openai\|github-copilot\|opencode/gpt-5.4 (high) → zai-coding-plan\|opencode/glm-5 → kimi-for-coding/k2p5 → opencode-go/glm-5 → opencode/kimi-k2.5 → opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix/kimi-k2.5 |
+| `unspecified-low`    | General standard work      | anthropic\|github-copilot\|opencode/claude-sonnet-4-6 → openai\|opencode/gpt-5.3-codex (medium) → opencode-go/kimi-k2.5 → google\|github-copilot\|opencode/gemini-3-flash → opencode-go/minimax-m2.7 |
+| `writing`            | Text, docs, prose          | google\|github-copilot\|opencode/gemini-3-flash → opencode-go/kimi-k2.5 → anthropic\|github-copilot\|opencode/claude-sonnet-4-6 → opencode-go/minimax-m2.7 |
+| `deepseek-pro`       | Secondary reasoning/coding | deepseek/deepseek-v4-pro (high) → deepseek/deepseek-v4-flash (high) → openai/gpt-5.5 (medium) |
+| `deepseek-flash`     | Mechanical/repetitive work | deepseek/deepseek-v4-flash (medium) → deepseek/deepseek-v4-pro (medium) → github-copilot/gpt-5-mini |
+| `secondary-reasoning` | Bounded reasoning         | deepseek/deepseek-v4-pro (high) → openai/gpt-5.5 (medium) |
+| `mechanical-coding`  | Mechanical code edits      | deepseek/deepseek-v4-flash (medium) → deepseek/deepseek-v4-pro (medium) |
+| `bulk-maintenance`   | Repetitive maintenance     | deepseek/deepseek-v4-flash (medium) → deepseek/deepseek-v4-pro (medium) |
 
 See the [Orchestration System Guide](./orchestration.md) for how agents dispatch tasks to categories.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -289,20 +289,7 @@ $env:OMO_CODEX_GIT_BASH_PATH = "C:\Program Files\Git\bin\bash.exe"
 Run with the platform flag and the subscription flags you collected in Step 0:
 
 ```bash
-bunx oh-my-openagent install \
-  --no-tui \
-  --platform=<opencode|codex|both> \
-  [--claude=<yes|no|max20>] \
-  [--gemini=<yes|no>] \
-  [--copilot=<yes|no>] \
-  [--openai=<yes|no>] \
-  [--opencode-zen=<yes|no>] \
-  [--zai-coding-plan=<yes|no>] \
-  [--opencode-go=<yes|no>] \
-  [--kimi-for-coding=<yes|no>] \
-  [--vercel-ai-gateway=<yes|no>] \
-  [--codex-autonomous|--no-codex-autonomous] \
-  [--skip-auth]
+bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --gemini=<yes|no> --copilot=<yes|no> [--openai=<yes|no>] [--opencode-go=<yes|no>] [--opencode-zen=<yes|no>] [--zai-coding-plan=<yes|no>] [--preset foundationstart]
 ```
 
 `--platform` defaults to `opencode` if omitted. Subscription flags only apply when `--platform` is `opencode` or `both`. They are rejected under `--platform=codex` because the Light edition does not write OpenCode model config. `--codex-autonomous` only has an effect when the selected platform includes Codex.
@@ -332,7 +319,10 @@ bunx oh-my-openagent install \
 
 **About the `lazycodex-ai` bin name.** `lazycodex-ai` is the npm package and bin alias for the Codex Light Node installer. `lazycodex` (without the `-ai` suffix) is the GitHub repository that hosts the marketplace bundle. `lazycodex-ai install` does not require Bun. The Codex marketplace name is `sisyphuslabs`, and the plugin name is `omo`.
 
-**What the installer does:**
+- Register the plugin in `opencode.json`
+- Configure agent models based on subscription flags
+- Optionally append FoundationStart startup guidance to the core relay agents when `--preset foundationstart` is used
+- Show which auth steps are needed
 
 | Platform | Writes |
 |----------|--------|
@@ -381,7 +371,65 @@ where bash
 
 If any of these come back empty, re-run `npx lazycodex-ai install` — the installer is idempotent and will recompute hook trust hashes.
 
-### Step 4: Configure authentication
+### FoundationStart preset scope
+
+`--preset foundationstart` is meant for FoundationStart-style workspaces.
+
+Default workspace root:
+
+- `C:\OpenCodeWorkingFolder`
+
+To target a different workspace root, set this before running install:
+
+```bash
+FOUNDATIONSTART_WORKSPACE_ROOT=/path/to/your/workspace
+```
+
+### Maintainer packaged smoke validation
+
+To verify the **packaged** FoundationStart preset path instead of only the workspace implementation, run:
+
+```bash
+bun run smoke:foundationstart-preset
+```
+
+This builds the package, packs it, installs it into a disposable smoke root, runs `install --preset foundationstart`, runs `doctor --json`, and records provenance/report output under:
+
+- `C:\OpenCodeWorkingFolder\simulations\oh-my-openagent-packaged-smoke`
+
+To verify that the **packaged build** also contains the delayed provider-warning behavior and no longer ships the legacy warning text, run:
+
+```bash
+bun run smoke:provider-warning
+```
+
+This reuses the packaged smoke root and writes a second report confirming the installed package contains the delayed-warning state machine and the new warning text, plus focused workspace runtime tests for the same warning path.
+
+### Claude-mem adapter smoke validation
+
+After enabling `claude_mem` in your plugin config, you can run a non-live adapter smoke check:
+
+```bash
+bun run smoke:claude-mem-adapter --output-root "C:\OpenCodeWorkingFolder\.sisyphus\evidence" --windows-path "C:\Temp\Claude Mem Test"
+```
+
+This does **not** require live provider credentials by default. It verifies:
+
+- config parsing
+- workspace-scoped runtime layout
+- capability surface (`search`, `timeline`, `get_observations`)
+- Windows-style path handling
+- degraded-mode launch contract (`launch-required` instead of fake success)
+
+Use this together with:
+
+```bash
+bunx oh-my-opencode doctor
+```
+
+The doctor command checks the host environment/config generally. The dedicated claude-mem smoke command is the precise adapter verification path in wave 1.
+
+### Step 4: Configure Authentication
 
 #### Codex CLI
 

--- a/docs/guide/orchestration.md
+++ b/docs/guide/orchestration.md
@@ -318,15 +318,21 @@ task({ category: "quick", prompt: "..." }); // "Just get it done fast"
 
 ### Delegate-Task Categories
 
-`task(category="...")` supports these category names in user-facing orchestration:
-
-`visual-engineering`, `artistry`, `ultrabrain`, `deep`, `quick`, `unspecified-low`, `unspecified-high`, `writing`, `quick-rust`, `quick-zig`, `git`
-
-Notes:
-
-- Built-in defaults are defined in `packages/omo-opencode/src/tools/delegate-task/*-categories.ts` and `packages/omo-opencode/src/shared/model-requirements.ts`
-- Projects/users can extend categories via config; additional category names may appear in your session prompt
-- Regardless of category name, category dispatch goes through Sisyphus-Junior
+| Category             | Model                  | When to Use                                                 |
+| -------------------- | ---------------------- | ----------------------------------------------------------- |
+| `visual-engineering` | Gemini 3.1 Pro         | Frontend, UI/UX, design, styling, animation                 |
+| `ultrabrain`         | GPT-5.4 (xhigh)        | Deep logical reasoning, complex architecture decisions      |
+| `artistry`           | Gemini 3.1 Pro (high)  | Highly creative or artistic tasks, novel ideas              |
+| `quick`              | GPT-5.4 Mini           | Trivial tasks - single file changes, typo fixes             |
+| `deep`               | GPT-5.4 (medium)       | Goal-oriented autonomous problem-solving, thorough research |
+| `unspecified-low`    | Claude Sonnet 4.6      | Tasks that don't fit other categories, low effort           |
+| `unspecified-high`   | Claude Opus 4.6 (max)  | Tasks that don't fit other categories, high effort          |
+| `writing`            | Gemini 3 Flash         | Documentation, prose, technical writing                     |
+| `deepseek-pro`       | DeepSeek V4 Pro (high) | Active secondary reasoning and bounded coding               |
+| `deepseek-flash`     | DeepSeek V4 Flash      | Fast mechanical, repetitive, low-risk work                  |
+| `secondary-reasoning` | DeepSeek V4 Pro       | Cost-conscious bounded reasoning and known-module debugging |
+| `mechanical-coding`  | DeepSeek V4 Flash      | Mechanical edits, boilerplate, simple migrations            |
+| `bulk-maintenance`   | DeepSeek V4 Flash      | Repetitive maintenance, cleanup, predictable transforms     |
 
 ### Skills: Domain-Specific Instructions
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -55,20 +55,17 @@ bunx oh-my-openagent install
 ### Options
 
 | Option | Description |
-| --- | --- |
-| `--no-tui` | Run in non-interactive mode (requires all needed options) |
-| `--platform <value>` | Install target edition: `opencode` (Ultimate, default), `codex` (Light), or `both` |
-| `--claude <value>` | Claude subscription: `no`, `yes`, `max20` (Ultimate only) |
-| `--openai <value>` | OpenAI/ChatGPT subscription: `no`, `yes` (Ultimate only) |
-| `--gemini <value>` | Gemini integration: `no`, `yes` (Ultimate only) |
-| `--copilot <value>` | GitHub Copilot subscription: `no`, `yes` (Ultimate only) |
-| `--opencode-zen <value>` | OpenCode Zen access: `no`, `yes` (Ultimate only) |
-| `--zai-coding-plan <value>` | Z.ai Coding Plan subscription: `no`, `yes` (Ultimate only) |
-| `--kimi-for-coding <value>` | Kimi For Coding subscription: `no`, `yes` (Ultimate only) |
-| `--opencode-go <value>` | OpenCode Go subscription: `no`, `yes` (Ultimate only) |
-| `--vercel-ai-gateway <value>` | Vercel AI Gateway: `no`, `yes` (Ultimate only) |
-| `--codex-autonomous` | Configure Codex with `approval_policy = "never"`, `sandbox_mode = "danger-full-access"`, and `network_access = "enabled"` when installing Light or Both |
-| `--no-codex-autonomous` | Leave existing Codex permission settings unchanged when installing Light or Both |
+| ------ | ----------- |
+| `--no-tui` | Run in non-interactive mode without TUI |
+| `--claude <no\|yes\|max20>` | Claude subscription mode |
+| `--openai <no\|yes>` | OpenAI / ChatGPT subscription |
+| `--gemini <no\|yes>` | Gemini integration |
+| `--copilot <no\|yes>` | GitHub Copilot subscription |
+| `--opencode-zen <no\|yes>` | OpenCode Zen access |
+| `--zai-coding-plan <no\|yes>` | Z.ai Coding Plan subscription |
+| `--kimi-for-coding <no\|yes>` | Kimi for Coding subscription |
+| `--opencode-go <no\|yes>` | OpenCode Go subscription |
+| `--preset <name>` | Optional installer preset, currently `foundationstart` (workspace-root configurable via `FOUNDATIONSTART_WORKSPACE_ROOT`) |
 | `--skip-auth` | Skip authentication setup hints |
 
 When using the `lazycodex-ai` bin alias, `install` defaults to `--platform=codex`. `lazycodex-ai` is only the npm/bin alias; `lazycodex` is the marketplace repository name. The Codex config uses marketplace `sisyphuslabs` and plugin `omo`, enabled as `omo@sisyphuslabs`, with the marketplace source set to the local built cache under `~/.codex/plugins/cache/sisyphuslabs`.
@@ -121,6 +118,12 @@ The command removes the managed `sisyphuslabs` plugin cache and marketplace snap
 
 Diagnoses your environment and configuration. Checks are grouped into four categories: **System**, **Config**, **Tools**, and **Models**.
 
+The doctor command detects common issues including:
+- Legacy plugin entry references in `opencode.json` (warns when `oh-my-opencode` is still used instead of `oh-my-openagent`)
+- Configuration file validity and JSONC parsing errors
+- Model resolution and fallback chain verification
+- Missing or misconfigured MCP servers
+- General prerequisite validation before running optional adapter smoke checks such as `bun run smoke:claude-mem-adapter`
 ### Usage
 
 ```bash
@@ -140,6 +143,38 @@ bunx oh-my-openagent doctor
 - The current minimum OpenCode version check is `>= 1.4.0`.
 - The doctor command warns when legacy plugin registration (`oh-my-opencode`) is still present in `opencode.json`.
 
+┌──────────────────────────────────────────────────┐
+│  Oh-My-OpenAgent Doctor                           │
+└──────────────────────────────────────────────────┘
+
+System
+  ✓ OpenCode version: 1.0.155 (>= 1.0.150)
+  ✓ Plugin registered in opencode.json
+
+Config
+  ✓ oh-my-opencode.jsonc is valid
+  ✓ Model resolution: all agents have valid fallback chains
+  ⚠ categories.visual-engineering: using default model
+
+Tools
+  ✓ AST-Grep available
+  ✓ LSP servers configured
+
+Models
+  ✓ 11 agents, 8 categories, 0 overrides
+  ⚠ Some configured models rely on compatibility fallback
+
+Summary: 10 passed, 1 warning, 0 failed
+```
+
+For the native `claude-mem` adapter, pair doctor with the dedicated non-live smoke check:
+
+```bash
+bunx oh-my-opencode doctor
+bun run smoke:claude-mem-adapter --output-root "C:\OpenCodeWorkingFolder\.sisyphus\evidence" --windows-path "C:\Temp\Claude Mem Test"
+```
+
+Wave-1 note: doctor is the general host health command; the claude-mem smoke command is the adapter-specific verification path.
 ---
 
 ## run

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -305,8 +305,13 @@ Domain-specific model delegation used by the `task()` tool. When Sisyphus delega
 | `artistry`           | `google/gemini-3.1-pro` (high)  | Creative/unconventional approaches             |
 | `quick`              | `openai/gpt-5.4-mini`           | Trivial tasks, typo fixes, single-file changes |
 | `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | General tasks, low effort                      |
-| `unspecified-high`   | `anthropic/claude-opus-4-7` (max) | General tasks, high effort                   |
-| `writing`            | `kimi-for-coding/k2p5`          | Documentation, prose, technical writing        |
+| `unspecified-high`   | `anthropic/claude-opus-4-6` (max) | General tasks, high effort                   |
+| `writing`            | `google/gemini-3-flash`         | Documentation, prose, technical writing        |
+| `deepseek-pro`       | `deepseek/deepseek-v4-pro` (high) | Active secondary reasoning and coding        |
+| `deepseek-flash`     | `deepseek/deepseek-v4-flash` (medium) | Fast active secondary mechanical lane    |
+| `secondary-reasoning` | `deepseek/deepseek-v4-pro` (high) | Cost-conscious bounded reasoning           |
+| `mechanical-coding`  | `deepseek/deepseek-v4-flash` (medium) | Mechanical code edits and small fixes     |
+| `bulk-maintenance`   | `deepseek/deepseek-v4-flash` (medium) | Repetitive maintenance and cleanup       |
 
 > **Note**: Built-in category defaults are available automatically. User-defined category config merges over the built-in defaults or adds custom categories.
 
@@ -382,7 +387,21 @@ Capability data comes from provider runtime metadata first. OmO also ships bundl
 
 #### Category Provider Chains
 
-This table documents the first entry of each hardcoded provider fallback chain, not the built-in category default shown above. For example, `writing` defaults to `kimi-for-coding/k2p5`, while its provider fallback chain starts with Gemini.
+| Category               | Default Model       | Provider Priority                                              |
+| ---------------------- | ------------------- | -------------------------------------------------------------- |
+| **visual-engineering** | `gemini-3.1-pro`    | `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `zai-coding-plan\|opencode/glm-5` → `anthropic\|github-copilot\|opencode/claude-opus-4-6 (max)` → `opencode-go/glm-5` → `kimi-for-coding/k2p5` |
+| **ultrabrain**         | `gpt-5.4`           | `openai\|opencode/gpt-5.4 (xhigh)` → `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `anthropic\|github-copilot\|opencode/claude-opus-4-6 (max)` → `opencode-go/glm-5` |
+| **deep**               | `gpt-5.4`           | `openai\|github-copilot\|venice\|opencode/gpt-5.4 (medium)` → `anthropic\|github-copilot\|opencode/claude-opus-4-6 (max)` → `google\|github-copilot\|opencode/gemini-3.1-pro (high)` |
+| **artistry**           | `gemini-3.1-pro`    | `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `anthropic\|github-copilot\|opencode/claude-opus-4-6 (max)` → `openai\|github-copilot\|opencode/gpt-5.4` |
+| **quick**              | `gpt-5.4-mini`      | `openai\|github-copilot\|opencode/gpt-5.4-mini` → `anthropic\|github-copilot\|opencode/claude-haiku-4-5` → `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/minimax-m2.7` → `opencode/gpt-5-nano` |
+| **unspecified-low**    | `claude-sonnet-4-6` | `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `openai\|opencode/gpt-5.3-codex (medium)` → `opencode-go/kimi-k2.5` → `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/minimax-m2.7` |
+| **unspecified-high**   | `claude-opus-4-6`   | `anthropic\|github-copilot\|opencode/claude-opus-4-6 (max)` → `openai\|github-copilot\|opencode/gpt-5.4 (high)` → `zai-coding-plan\|opencode/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5` → `opencode/kimi-k2.5` → `opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix/kimi-k2.5` |
+| **writing**            | `gemini-3-flash`    | `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/kimi-k2.5` → `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `opencode-go/minimax-m2.7` |
+| **deepseek-pro**       | `deepseek-v4-pro`   | `deepseek/deepseek-v4-pro (high)` → `deepseek/deepseek-v4-flash (high)` → `openai/gpt-5.5 (medium)` |
+| **deepseek-flash**     | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash (medium)` → `deepseek/deepseek-v4-pro (medium)` → `github-copilot/gpt-5-mini` |
+| **secondary-reasoning** | `deepseek-v4-pro`  | `deepseek/deepseek-v4-pro (high)` → `openai/gpt-5.5 (medium)` |
+| **mechanical-coding**  | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash (medium)` → `deepseek/deepseek-v4-pro (medium)` |
+| **bulk-maintenance**   | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash (medium)` → `deepseek/deepseek-v4-pro (medium)` |
 
 | Category               | Provider Chain Primary | Provider Priority                                           |
 | ---------------------- | ------------------- | -------------------------------------------------------------- |
@@ -628,6 +647,71 @@ Built-in MCPs (enabled by default): `websearch` (Exa AI), `context7` (library do
 ```json
 { "disabled_mcps": ["websearch", "context7", "grep_app", "lsp"] }
 ```
+
+### Claude Mem Adapter
+
+Enable the native `claude-mem` adapter to expose upstream memory tools through the existing `skill_mcp` path.
+
+```jsonc
+{
+  "claude_mem": {
+    "enabled": true,
+    "command": "bunx",
+    "args": ["claude-mem", "mcp"],
+    "data_dir": ".opencode/claude-mem/data",
+    "port": 37777,
+    "auto_start": false,
+    "startup_timeout_ms": 15000,
+    "supported_version_range": "^12.1.0",
+    "env_allowlist": ["ANTHROPIC_API_KEY"],
+    "env_overrides": {}
+  }
+}
+```
+
+Wave-1 behavior:
+
+- Disabled by default.
+- Uses a workspace-scoped runtime/data directory.
+- Exposes only `search`, `timeline`, and `get_observations`.
+- Reuses a healthy runtime on the configured endpoint when present.
+- Degrades cleanly on missing Bun, missing command, unsupported version, invalid data dir, or unhealthy occupied-port collisions.
+
+Wave-1 exclusions:
+
+- no direct Claude hook embedding
+- no per-session memory isolation promise
+- no viewer/admin endpoint exposure
+- no generic multi-provider memory abstraction
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `enabled` | `false` | Enable the adapter for this workspace/config scope |
+| `command` | - | Command used to launch the upstream MCP/runtime boundary |
+| `args` | `[]` | Arguments passed to the command |
+| `cwd` | workspace root | Working directory for the launched process |
+| `port` | `37777` | Expected worker/MCP health endpoint port |
+| `data_dir` | workspace-managed `.opencode/claude-mem/data` | Workspace-scoped runtime state directory |
+| `auto_start` | `false` | Keep false in wave 1 unless you explicitly want immediate startup on first capability demand |
+| `startup_timeout_ms` | `15000` | Time budget for startup/health establishment |
+| `supported_version_range` | `^12.1.0` | Supported upstream `claude-mem` major/range contract |
+| `env_allowlist` | `[]` | Extra env vars allowed into the spawned runtime |
+| `env_overrides` | `{}` | Explicit env overrides passed to the runtime |
+
+Notes:
+
+- `isolation_scope` is fixed to workspace scope in wave 1 and is not user-tunable.
+- Keep `command` explicit when enabling the adapter. The host will not guess an arbitrary external runtime.
+- Paths with spaces are supported; use normal JSON strings, for example `"C:\\Temp\\Claude Mem Test"`.
+
+Validation and smoke verification:
+
+```bash
+bunx oh-my-opencode doctor
+bun run smoke:claude-mem-adapter --output-root "C:\OpenCodeWorkingFolder\.sisyphus\evidence" --windows-path "C:\Temp\Claude Mem Test"
+```
+
+`doctor` validates the host environment/config surface generally. The dedicated adapter smoke command validates the non-live claude-mem wiring and Windows-style path handling.
 
 ### LSP
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -160,8 +160,13 @@ By combining these two concepts, you can generate optimal agents through `task`.
 | `artistry`           | `google/gemini-3.1-pro` (high)  | Highly creative/artistic tasks, novel ideas                                                                                 |
 | `quick`              | `openai/gpt-5.4-mini`           | Trivial tasks - single file changes, typo fixes, simple modifications                                                       |
 | `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | Tasks that don't fit other categories, low effort required                                                                  |
-| `unspecified-high`   | `anthropic/claude-opus-4-7` (max) | Tasks that don't fit other categories, high effort required                                                               |
-| `writing`            | `kimi-for-coding/k2p5`          | Documentation, prose, technical writing                                                                                     |
+| `unspecified-high`   | `anthropic/claude-opus-4-6` (max) | Tasks that don't fit other categories, high effort required                                                               |
+| `writing`            | `google/gemini-3-flash`         | Documentation, prose, technical writing                                                                                     |
+| `deepseek-pro`       | `deepseek/deepseek-v4-pro` (high) | Active secondary reasoning and coding for bounded implementation, constrained debugging, tests, and analysis               |
+| `deepseek-flash`     | `deepseek/deepseek-v4-flash` (medium) | Fast active secondary lane for repetitive, mechanical, low-risk, or high-volume work                                  |
+| `secondary-reasoning` | `deepseek/deepseek-v4-pro` (high) | Cost-conscious reasoning for bounded problems, known-module debugging, and planned implementation                         |
+| `mechanical-coding`  | `deepseek/deepseek-v4-flash` (medium) | Mechanical edits, simple migrations, formatting, rename sweeps, boilerplate, and small fixes                          |
+| `bulk-maintenance`   | `deepseek/deepseek-v4-flash` (medium) | Repetitive hygiene, documentation cleanup, lint-style edits, generated small tests, and batch transforms              |
 
 ### Usage
 

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/AGENTS.md
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/AGENTS.md
@@ -6,6 +6,12 @@
 
 ~2110 LOC across 19 files. Provides Claude Code settings.json compatibility layer. Parses CC permission rules and maps CC hooks (PreToolUse, PostToolUse) to OpenCode hooks.
 
+## Migration status
+
+- This module remains an internal compatibility shim during the ChatGPT/Codex-first migration.
+- Public/default-facing discovery now prefers generic `code-hooks` paths and aliases.
+- Do not rename or remove this module until compatibility aliases and downstream callers are proven stable.
+
 ## WHAT IT DOES
 
 1. Parses Claude Code `settings.json` permission format

--- a/packages/omo-opencode/src/tools/AGENTS.md
+++ b/packages/omo-opencode/src/tools/AGENTS.md
@@ -47,7 +47,7 @@ Tools registered via [`createToolRegistry()`](../plugin/tool-registry.ts) in `sr
 | `team_status` | Full team run status (members, tasks, mailbox) |
 | `team_list` | List declared + active teams |
 
-## DELEGATION CATEGORIES (built-in 8)
+## DELEGATION CATEGORIES (built-in 13)
 
 `task` (delegate) selects model by category. Default category models live in provider-specific files under `src/tools/delegate-task/` and aggregate via `BUILTIN_CATEGORIES` in `builtin-categories.ts`. Authoritative fallback chains in [`src/shared/model-requirements.ts`](../shared/model-requirements.ts) `CATEGORY_MODEL_REQUIREMENTS`.
 
@@ -61,6 +61,11 @@ Tools registered via [`createToolRegistry()`](../plugin/tool-registry.ts) in `sr
 | `unspecified-low` | anthropic/claude-sonnet-4-6 | anthropic-categories.ts | Moderate effort fallback |
 | `unspecified-high` | anthropic/claude-opus-4-7 (variant: max) | anthropic-categories.ts | High effort fallback |
 | `writing` | kimi-for-coding/k2p5 (default) → gemini-3-flash (first fallback) | kimi-categories.ts | Documentation, prose |
+| `deepseek-pro` | deepseek/deepseek-v4-pro (variant: high) | delegate-task/ | Active secondary reasoning and coding |
+| `deepseek-flash` | deepseek/deepseek-v4-flash (variant: medium) | delegate-task/ | Mechanical/repetitive work |
+| `secondary-reasoning` | deepseek/deepseek-v4-pro (variant: high) | delegate-task/ | Bounded reasoning |
+| `mechanical-coding` | deepseek/deepseek-v4-flash (variant: medium) | delegate-task/ | Mechanical code edits |
+| `bulk-maintenance` | deepseek/deepseek-v4-flash (variant: medium) | delegate-task/ | Repetitive maintenance |
 
 User-defined categories declared in `categories: { ... }` config override and extend this set.
 


### PR DESCRIPTION
Supersedes #5824 due to conflicts with current dev. Original branch was based on an older dev snapshot and was conflicting.

Same scope as original: 9 docs-only paths updating agent model matching, installation guide, orchestration, CLI reference, configuration, features, and AGENTS.md files with deepseek categories, FoundationStart preset, and claude-mem adapter documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates documentation to align with v2 cleanup: adds DeepSeek task categories, updates installer flow to `oh-my-opencode` with a FoundationStart preset, and documents the native `claude_mem` adapter with smoke checks and doctor guidance.

- **New Features**
  - Agent categories: added `deepseek-pro`, `deepseek-flash`, `secondary-reasoning`, `mechanical-coding`, `bulk-maintenance`; updated defaults and provider fallback chains across guides and config (built-ins now 13). Moved `writing` default to `google/gemini-3-flash`.
  - Installer: switched examples to `bunx oh-my-opencode install` and added `--preset foundationstart` (configurable via `FOUNDATIONSTART_WORKSPACE_ROOT`). Included packaged smoke validations: `bun run smoke:foundationstart-preset` and `bun run smoke:provider-warning`.
  - Claude Mem adapter: documented optional native `claude_mem` via `skill_mcp`, workspace-scoped runtime, and non-live smoke check: `bun run smoke:claude-mem-adapter --output-root ... --windows-path ...`. Added README bullet and full config block with defaults.
  - CLI reference: simplified `install` flags, documented `--preset`, and expanded `doctor` coverage (legacy plugin warnings, model chain checks, MCP verification). Example doctor output included; pairing with `claude-mem` smoke command shown.
  - Orchestration: updated category table to reflect new DeepSeek lanes and usage guidance.
  - Internal docs: noted migration status for `claude-code-hooks` shim; updated tools docs to show 13 built-in categories.

<sup>Written for commit 49dd3359fbc9f3ba4657a02206c6d083f63f987a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

