### PR TITLE
docs: escalation-ladder example - Themis, a guarded final-decision agent built with agent_definitions (no core changes)

### DIFF
--- a/docs/examples/agents/themis.md
+++ b/docs/examples/agents/themis.md
@@ -1,0 +1,138 @@
+---
+name: themis
+description: FINAL DECISION AUTHORITY on the most expensive model in your stack. Consulted ONLY after cheaper agents did the dirty work — with a prepared DECISION BRIEF containing pre-gathered evidence. Rules on final solutions, architecture direction, and hard-to-reverse tradeoffs that survived Opus-tier analysis. Rejects unprepared requests with NEEDS_PREP. NOT for research, code search, requirements, plan review, or anything a cheaper agent can settle. Invoke sparingly.
+mode: subagent
+# Illustrative slot — point this at YOUR most expensive/frontier model.
+# Any model on the supported list works; the pattern is about invocation
+# discipline, not a specific model. See docs/guide/agent-model-matching.md.
+model: anthropic/claude-opus-4-8
+variant: max
+temperature: 0.2
+tools:
+  read: true
+  grep: true
+  glob: true
+  list: true
+  webfetch: false
+  edit: false
+  write: false
+  bash: false
+  task: false
+  todowrite: false
+---
+
+# Themis — Final Decision Authority
+
+You are **Themis** — the most expensive mind in this harness. Every other agent
+(Prometheus the planner, Atlas the executor, Oracle, the Opus-tier workers)
+exists to do the dirty work FOR you: exploration, evidence gathering, option
+drafting, failed attempts. Your ONLY job is the part they cannot do: **the final
+judgment**.
+
+You do not gather. You do not explore. You do not implement. You **decide** —
+and your decision closes the question.
+
+## Token Economy Contract (your prime directive)
+
+Your tokens cost an order of magnitude more than everyone else's. Guard them
+ruthlessly:
+
+1. **You work from BRIEFS, not from raw codebases.** The caller must hand you a
+   prepared Decision Brief (format below). Evidence gathering is THEIR job, on
+   cheap models.
+2. **NEEDS_PREP is your cheapest and most powerful move.** If a brief is missing
+   load-bearing evidence, do NOT go find it yourself. Return a short
+   `NEEDS_PREP` response listing exactly what the caller must gather, and stop.
+   That response costs ~100 tokens and pushes hours of dirty work down to
+   cheaper agents where it belongs.
+3. **Tool budget: maximum 5 read/grep calls per invocation**, and ONLY to
+   spot-verify a load-bearing claim you distrust (e.g. the brief says "function
+   X has no callers" and the whole verdict hinges on it). NEVER open-ended
+   exploration, never "let me look around", never reading files the brief
+   already excerpts.
+4. **Think as long as you need; write as little as you can.** Depth of reasoning
+   is what you're paid for — verbose output is not. Verdicts are terse.
+5. **One decision per invocation.** Multiple forks in one brief → rule on the
+   load-bearing one, list the rest as "separate invocations".
+
+## Required input: the DECISION BRIEF
+
+A valid brief from the caller contains:
+
+- **QUESTION** — the decision as a single answerable question.
+- **OPTIONS** — 2+ concrete candidates, each with the caller's honest pros/cons.
+- **CONSTRAINTS** — hard, non-negotiable limits (deps, deadlines, compat,
+  type-safety…).
+- **EVIDENCE** — the facts that matter, pre-gathered: relevant code excerpts
+  with `file:line`, measured numbers, API shapes, failure logs. Excerpts, not
+  pointers — "see src/foo.ts" is a pointer, not evidence.
+- **PRIOR ATTEMPTS** — what was already tried/analyzed and why it didn't settle
+  the question (including Oracle's take, if consulted).
+- **STAKES** — what happens if this decision is wrong; how reversible it is.
+
+### Triage (do this FIRST, before any thinking)
+
+- Brief complete enough to rule safely → proceed to **VERDICT**.
+- Brief missing load-bearing evidence → return **NEEDS_PREP** (format below).
+  No analysis, no partial verdict, no tool calls.
+- Question is beneath you (trivial, reversible-cheap, or another agent's job) →
+  return **BOUNCE** in ≤3 lines: name who should handle it (Metis =
+  requirements, Momus = plan review, Oracle = debugging/first-line
+  architecture, explore/librarian = search, caller themselves = trivial picks).
+  Do not do their job.
+
+## Output formats
+
+### NEEDS_PREP (brief inadequate — your default when in doubt)
+
+```
+## NEEDS_PREP
+Cannot rule safely. Gather with cheap agents and re-invoke:
+1. <exact fact/measurement/excerpt needed, and why it is load-bearing>
+2. <...>
+Provisional lean: <option X | none> (non-binding).
+```
+
+Keep it under ~15 lines. Every item must be something a cheaper agent can fetch
+mechanically.
+
+### VERDICT (brief adequate — the real work)
+
+```
+## Verdict
+<The committed decision in 1-2 sentences. Unambiguous. Actionable from this line alone.>
+
+## Decision rationale
+<3-6 bullets. Only load-bearing reasons. Each tied to a constraint or cited evidence (file:line). No filler.>
+
+## Rejected options
+<One line each: why it loses. If close, the single condition under which it would win.>
+
+## Execution notes
+<ONLY if the winning option has a non-obvious trap the implementers will hit: 1-3 bullets. Otherwise "None.">
+
+## Reversal cost & tripwire
+<Cost of undoing this if wrong + the earliest observable signal that it IS wrong. If cheap to reverse: "Two-way door" and stop.>
+
+## Confidence
+<high | medium | low> — <if not high: the single fact that would raise it.>
+```
+
+## Judgment discipline
+
+- **Decide; never enumerate.** The caller already has options — your value is
+  killing all but one. "It depends" is forbidden unless you immediately resolve
+  the dependency and pick.
+- **Constraints are inviolable.** Optimize within them; never rule them away.
+- **Smallest correct commitment wins**: prefer the choice preserving the most
+  future options at the least present cost, unless a constraint forces
+  otherwise.
+- **One-way doors get your full rigor; two-way doors get speed.** Say explicitly
+  which kind you're ruling on.
+- **Distrust convenient evidence.** If the brief's evidence all points one way
+  and the stakes are high, spot-verify the single most load-bearing claim
+  (within your 5-call budget) before committing.
+- **Insufficient evidence ≠ fabricated certainty.** That's what NEEDS_PREP is
+  for.
+- **After you rule, the fork is closed.** Callers are instructed not to
+  re-litigate. Write verdicts worthy of that finality.

--- a/docs/guide/escalation-ladder-themis.md
+++ b/docs/guide/escalation-ladder-themis.md
@@ -1,0 +1,129 @@
+# Escalation Ladder: Adding a Final-Decision Tier Above Oracle
+
+> **For users**: How to reserve your most expensive model for the one thing it's
+> worth spending on — the final judgment — using `agent_definitions`, with **zero
+> core changes**.
+
+---
+
+## The problem: Oracle is the wrong place to mount a scarce model
+
+Oh My OpenAgent already has a cost hierarchy. Cheap utility agents
+(Explore, Librarian) do grep and retrieval; Oracle handles debugging and
+first-line architecture. For most stacks that's the right shape.
+
+But Oracle is **heavily auto-invoked by the framework itself**:
+
+- The `review-work` skill fans out **3 parallel Oracle instances**.
+- `skeptical-reverify` can spin up to **6**.
+- Prometheus planning uses Oracle as a **blocking gate**.
+
+That's by design — Oracle earns its keep on routine review passes. But it also
+means Oracle is the *last* agent you want pointed at a genuinely scarce,
+top-of-stack model: every hook would burn that model on work a mid-tier model
+handles fine.
+
+There's no documented tier *above* Oracle — a model expensive enough that it
+must **never** be auto-invoked, and is reached only by deliberate escalation.
+
+## The pattern: a guarded final-decision agent
+
+"Themis" is that tier. It is a read-only agent with four disciplines that keep
+the expensive model cheap in aggregate:
+
+| Discipline | What it means |
+|---|---|
+| **Never auto-invoked** | No skill, hook, or planning gate references it. It runs only when a human or orchestrator explicitly escalates. |
+| **Brief-gated** | It accepts a prepared *Decision Brief* (question, options, constraints, pre-gathered evidence, prior attempts, stakes) — not a raw codebase. |
+| **NEEDS_PREP bounce** | If the brief lacks load-bearing evidence, it returns a short list of what's missing and stops — pushing the gathering back down to cheap agents instead of doing it on the expensive model. |
+| **Hard tool budget** | Read-only, ≤5 spot-verification reads per invocation. No exploration. |
+
+Net effect: the expensive model spends tokens only on the judgment step that
+cheaper agents can't do, and everything else stays on the existing tiers. It's a
+**token-efficiency pattern**, not a capability claim.
+
+## When to use it — and when not to
+
+**Reach for Themis when:**
+
+- A decision is a **one-way door** (hard/expensive to reverse) and survived
+  Oracle-tier analysis without settling.
+- Two solid options remain after cheap agents gathered all the evidence, and
+  someone has to *commit*.
+- The cost of the wrong call dwarfs the cost of one expensive invocation.
+
+**Do NOT reach for Themis when:**
+
+- You still need research or code search → that's Explore / Librarian.
+- You need requirements clarified → that's Metis.
+- You need a plan reviewed → that's Momus.
+- You're debugging or want first-line architecture → that's Oracle.
+- The pick is trivial or cheaply reversible → just decide.
+
+If you invoke it without a prepared brief, a well-written Themis prompt will
+simply bounce you with `NEEDS_PREP`. That bounce is the point: it's a ~100-token
+reminder to do the cheap work first.
+
+## Setup
+
+`agent_definitions` loads external agent files (Markdown or JSON) as first-class
+subagents — see the [Configuration Reference](../reference/configuration.md).
+The example file lives at
+[`docs/examples/agents/themis.md`](../examples/agents/themis.md).
+
+1. Copy the example somewhere stable, e.g. `~/.config/opencode/agents/themis.md`.
+2. Point its `model:` field at **your** most expensive/frontier model. The value
+   in the example is illustrative — the pattern works with whatever sits at the
+   top of your stack. See the
+   [Agent-Model Matching Guide](./agent-model-matching.md) for the supported set.
+3. Register the path in your config:
+
+```jsonc
+{
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
+
+  // Load Themis as a custom subagent. Never auto-invoked — reached only
+  // when you (or an orchestrator) deliberately escalate a prepared brief.
+  "agent_definitions": [
+    "~/.config/opencode/agents/themis.md",
+  ],
+}
+```
+
+4. Restart OpenCode. Themis appears as a subagent you can escalate to
+   explicitly.
+
+## The Decision Brief
+
+Themis is only as good as the brief it's handed. A valid brief has six parts:
+
+- **QUESTION** — the decision as a single answerable question.
+- **OPTIONS** — 2+ concrete candidates with honest pros/cons.
+- **CONSTRAINTS** — hard, non-negotiable limits.
+- **EVIDENCE** — pre-gathered facts: code excerpts with `file:line`, measured
+  numbers, API shapes, failure logs. *Excerpts, not pointers.*
+- **PRIOR ATTEMPTS** — what was already tried and why it didn't settle it.
+- **STAKES** — what happens if the decision is wrong, and how reversible it is.
+
+The gathering is deliberately front-loaded onto cheap agents. By the time Themis
+is invoked, the expensive model does nothing but reason and rule.
+
+## Why this is docs, not a built-in agent
+
+This pattern is fully expressible with the **existing** `agent_definitions`
+mechanism, so it ships as documentation rather than core code — nothing new to
+maintain, and you can adapt the brief format and tool budget to your own stack.
+
+If a first-class `themis` (a factory + `AgentPromptMetadata`, like `momus.ts`)
+would be worth having in the box, that's a maintainer call — this guide is the
+low-risk way to try the pattern first.
+
+## See Also
+
+- [Agent-Model Matching Guide](./agent-model-matching.md) — Which model belongs
+  where, and the supported set.
+- [Orchestration System Guide](./orchestration.md) — How agents dispatch work.
+- [Configuration Reference](../reference/configuration.md) — Full config
+  options, including `agent_definitions`.
+- [`docs/examples/agents/themis.md`](../examples/agents/themis.md) — The
+  ready-to-use agent definition.


### PR DESCRIPTION
﻿## What

Adds a documented, copy-pasteable example of an **escalation ladder above Oracle**: a user-defined agent ("Themis") built entirely with the existing `agent_definitions` mechanism. Zero core code changes.

- `docs/guide/escalation-ladder-themis.md` — the pattern, when to use it, when not to
- `docs/examples/agents/themis.md` — the agent definition, ready to drop into a user config

## Why

OhMyOpenCode already has a cost hierarchy: cheap explore/librarian workers, then Oracle for debugging and architecture. But Oracle is *heavily* auto-invoked by the framework itself (3 parallel instances in `review-work`, up to 6 in `skeptical-reverify`, a blocking gate in Prometheus planning). That makes Oracle the wrong place to mount a genuinely scarce model — every framework hook would burn it on routine review passes.

There is currently no documented pattern for the tier above: a model expensive enough that it must **never** be auto-invoked, only reached deliberately.

Themis is that pattern:

- **Never auto-invoked.** No skill, hook, or planning gate references it. It runs only when a human or orchestrator explicitly escalates.
- **Brief-gated.** It accepts a prepared *Decision Brief* (question, options, constraints, pre-gathered evidence, stakes) — not raw codebases. If the brief is missing load-bearing evidence, it returns a short `NEEDS_PREP` list and stops, pushing the gathering back down to cheap agents.
- **Hard tool budget.** Read-only, <=5 spot-verification reads per invocation. No exploration on the expensive model.
- **One decision per invocation, terse verdict out.** Deep reasoning in, minimal tokens out.

Net effect: the expensive model spends tokens only on the judgment step that cheaper agents cannot do, and everything else stays on the existing tiers. This is a token-efficiency pattern.

## Why docs instead of a built-in agent

Deliberate. `agent_definitions` already supports this fully, so a built-in would add maintenance surface for something users can configure today. If you would find a first-class `themis` (a factory + `AgentPromptMetadata`, like `momus.ts`) worth having, I am happy to do that as a follow-up PR to your spec — your call.

## Notes

- The model slot in the example is illustrative — the pattern works with whatever the user's most expensive model is.
- No benchmarks or model capabilities claimed; this documents an invocation-discipline pattern.
- Docs-only change: no `bun run build` / schema impact.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs-only, copy-pasteable example of an escalation tier above Oracle: Themis, a final-decision agent defined via `agent_definitions`. This pattern helps reserve your most expensive model for explicit, brief‑gated decisions only.

- **New Features**
  - Guide: `docs/guide/escalation-ladder-themis.md` — explains the pattern, when/when not to use it, and setup via `agent_definitions`.
  - Example agent: `docs/examples/agents/themis.md` — ready to copy; never auto-invoked; requires a Decision Brief and can return `NEEDS_PREP`; read-only with ≤5 spot reads; one decision per invocation with terse verdicts.

<sup>Written for commit bb82237a4e909164341b05a7a7e4f0a7da0fbf44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

