### PR TITLE
fix(opencode): check session existence by id

### DIFF
--- a/packages/omo-opencode/src/tools/session-manager/sdk-storage.ts
+++ b/packages/omo-opencode/src/tools/session-manager/sdk-storage.ts
@@ -19,7 +19,7 @@ function throwOnNonFallbackableSdkError(response: unknown): void {
 
 const SDK_TRANSIENT_RETRY_ATTEMPTS = 3
 
-// session_read issues two SDK calls (session.list for existence + session.messages),
+// session_read checks existence and then reads messages through SDK calls,
 // so a single transient HTTP failure on either call would fall back to file storage,
 // which does not exist for pure-sqlite sessions and surfaces a false "Session not found".
 // Retry only on transient/unavailable errors; semantic errors (e.g. "session not found")
@@ -63,9 +63,8 @@ export async function getSdkAllSessions(client: PluginInput["client"]): Promise<
 }
 
 export async function sdkSessionExists(client: PluginInput["client"], sessionID: string): Promise<boolean> {
-  const response = await fetchSdkResponse(() => client.session.list())
-  const sessions = normalizeSDKResponse(response, [] as Array<{ id?: string }>)
-  return sessions.some((session) => session.id === sessionID)
+  const messages = await getSdkSessionMessages(client, sessionID)
+  return messages.length > 0
 }
 
 export async function getSdkSessionMessages(

--- a/packages/omo-opencode/src/tools/session-manager/storage-fallback.test.ts
+++ b/packages/omo-opencode/src/tools/session-manager/storage-fallback.test.ts
@@ -222,22 +222,39 @@ describe("session-manager storage fallback", () => {
     expect(todos[0].content).toBe("Fallback todo")
   })
 
-  test("#given unreachable SDK list error #when sessionExists runs #then falls back to file existence", async () => {
+  test("#given unreachable SDK messages error #when sessionExists runs #then falls back to file existence", async () => {
     createSessionMessage("ses_file", "msg_001", 1_000)
-    mockClient.session.list.mockImplementation(() => Promise.reject(createSdkUnavailableError("ETIMEDOUT while connecting")))
+    mockClient.session.messages.mockImplementation(() => Promise.reject(createSdkUnavailableError("ETIMEDOUT while connecting")))
 
     const exists = await storage.sessionExists("ses_file")
 
     expect(exists).toBe(true)
   })
 
-  test("#given empty SDK session list #when sessionExists runs #then falls back to file existence", async () => {
+  test("#given empty SDK messages response #when sessionExists runs #then falls back to file existence", async () => {
     createSessionMessage("ses_file", "msg_001", 1_000)
-    mockClient.session.list.mockImplementation(() => Promise.resolve({ data: [] }))
+    mockClient.session.messages.mockImplementation(() => Promise.resolve({ data: [] }))
 
     const exists = await storage.sessionExists("ses_file")
 
     expect(exists).toBe(true)
+  })
+
+  test("#given session is absent from scoped SDK list but messages are readable by id #when sessionExists runs #then confirms existence by id", async () => {
+    mockClient.session.list.mockImplementation(() => Promise.resolve({ data: [] }))
+    mockClient.session.messages.mockImplementation((request: { path: { id: string } }) => {
+      expect(request.path.id).toBe("ses_sqlite_scoped_out")
+      return Promise.resolve({
+        data: [
+          { info: { id: "msg_sdk", role: "user", time: { created: 1_000 } }, parts: [] },
+        ],
+      })
+    })
+
+    const exists = await storage.sessionExists("ses_sqlite_scoped_out")
+
+    expect(exists).toBe(true)
+    expect(mockClient.session.messages).toHaveBeenCalledWith({ path: { id: "ses_sqlite_scoped_out" } })
   })
 
   test("#given semantic SDK error #when readSessionMessages runs #then rethrows instead of hiding bug", async () => {
@@ -246,13 +263,15 @@ describe("session-manager storage fallback", () => {
     await expect(storage.readSessionMessages("ses_missing")).rejects.toThrow("session not found")
   })
 
-  test("#given SDK list fails transiently then recovers #when sessionExists runs #then retries SDK and avoids false-negative file fallback", async () => {
-    // given a pure-sqlite session present in the SDK but absent from file storage
+  test("#given SDK messages fail transiently then recover #when sessionExists runs #then retries SDK and avoids false-negative file fallback", async () => {
+    // given a pure-sqlite session present by SDK id lookup but absent from file storage
     let attempts = 0
-    mockClient.session.list.mockImplementation(() => {
+    mockClient.session.messages.mockImplementation(() => {
       attempts += 1
       if (attempts === 1) return Promise.reject(createSdkUnavailableError("fetch failed"))
-      return Promise.resolve({ data: [{ id: "ses_sqlite_only" }] })
+      return Promise.resolve({
+        data: [{ info: { id: "msg_sdk", role: "user", time: { created: 5_000 } }, parts: [] }],
+      })
     })
 
     // when sessionExists hits a single transient SDK failure


### PR DESCRIPTION
## Summary
- Switch sqlite SDK sessionExists from scoped session.list() enumeration to by-id session.messages() lookup.
- Preserve fallback/retry behavior by reusing the existing SDK message fetch path.
- Add a regression where a session is missing from the scoped list but readable by id.

## Scope
- Addresses the session_read/sessionExists false-negative from #5810.
- Leaves session_list/session_search enumeration scope policy unchanged.
- Empty-but-existing sqlite sessions still behave like existing getSessionInfo/read semantics and fall back when no messages are returned.

## Verification
- bun test packages/omo-opencode/src/tools/session-manager/storage-fallback.test.ts packages/omo-opencode/src/tools/session-manager/storage.test.ts
- bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false negatives in `sessionExists` by checking existence via `session.messages` for a given ID instead of enumerating `session.list`. Addresses Linear #5810 and preserves retry/fallback behavior.

- **Bug Fixes**
  - Use by-id `session.messages` to confirm existence and avoid scoped-list gaps.
  - Retry on transient SDK errors; fall back to file existence if messages are unreachable or empty (matches current read semantics).
  - Add tests for scoped-out sessions readable by ID and transient-retry flow.

<sup>Written for commit 57f06493489b236add01fa8d77f4cebf622b3076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

