### PR TITLE
fix(opencode): keep ultrawork sticky per session

### DIFF
--- a/packages/omo-opencode/src/features/claude-code-session-state/state.ts
+++ b/packages/omo-opencode/src/features/claude-code-session-state/state.ts
@@ -5,6 +5,7 @@ export const syncSubagentSessions = new Set<string>()
 export const handedBackSyncSessions = new Set<string>()
 
 let _mainSessionID: string | undefined
+const ultraworkActivatedSessions = new Set<string>()
 
 export function setMainSession(id: string | undefined) {
   _mainSessionID = id
@@ -12,6 +13,14 @@ export function setMainSession(id: string | undefined) {
 
 export function getMainSessionID(): string | undefined {
   return _mainSessionID
+}
+
+export function markUltraworkSessionActive(sessionID: string): void {
+  ultraworkActivatedSessions.add(sessionID)
+}
+
+export function isUltraworkSessionActive(sessionID: string | undefined): boolean {
+  return typeof sessionID === "string" && ultraworkActivatedSessions.has(sessionID)
 }
 
 const registeredAgentNames = new Set<string>()
@@ -80,6 +89,7 @@ export function _resetForTesting(): void {
   syncSubagentSessions.clear()
   handedBackSyncSessions.clear()
   sessionAgentMap.clear()
+  ultraworkActivatedSessions.clear()
   registeredAgentNames.clear()
   registeredAgentAliases.clear()
 }

--- a/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
@@ -4,6 +4,8 @@ import type { KeywordDetectorConfig } from "../../config/schema/keyword-detector
 import {
   getMainSessionID,
   getSessionAgent,
+  isUltraworkSessionActive,
+  markUltraworkSessionActive,
   subagentSessions,
 } from "../../features/claude-code-session-state"
 import type { ContextCollector } from "../../features/context-injector"
@@ -117,29 +119,42 @@ export function createKeywordDetectorHook(
       const mainSessionID = getMainSessionID()
       const isNonMainSession = mainSessionID && input.sessionID !== mainSessionID
 
+      let stickyUltraworkContinuation = false
+
       if (detectedKeywords.length === 0) {
-        if (defaultMode?.ultrawork && !isNonMainSession && !defaultModeUltraworkInjectedSessions.has(input.sessionID)) {
-          defaultModeUltraworkInjectedSessions.add(input.sessionID)
+        const stickyUltraworkKeyword =
+          !isPlannerAgent(currentAgent) && isUltraworkSessionActive(input.sessionID)
+            ? detectKeywordsWithType("ultrawork", currentAgent, modelID, disabledKeywords, enabledExpansions)
+              .find((k) => k.type === "ultrawork")
+            : undefined
 
-          log(`[keyword-detector] Default ultrawork mode auto-activated (injected via system prompt)`, { sessionID: input.sessionID })
+        if (stickyUltraworkKeyword) {
+          detectedKeywords = [stickyUltraworkKeyword]
+          stickyUltraworkContinuation = true
+        } else {
+          if (defaultMode?.ultrawork && !isNonMainSession && !defaultModeUltraworkInjectedSessions.has(input.sessionID)) {
+            defaultModeUltraworkInjectedSessions.add(input.sessionID)
 
-          ctx.client.tui
-            .showToast({
-              body: {
-                title: "Ultrawork Mode Activated",
-                message: "Default ultrawork mode enabled. All agents at your disposal.",
-                variant: "success" as const,
-                duration: 3000,
-              },
-            })
-            .catch((err) =>
-              log(`[keyword-detector] Failed to show toast`, {
-                error: err,
-                sessionID: input.sessionID,
+            log(`[keyword-detector] Default ultrawork mode auto-activated (injected via system prompt)`, { sessionID: input.sessionID })
+
+            ctx.client.tui
+              .showToast({
+                body: {
+                  title: "Ultrawork Mode Activated",
+                  message: "Default ultrawork mode enabled. All agents at your disposal.",
+                  variant: "success" as const,
+                  duration: 3000,
+                },
               })
-            )
+              .catch((err) =>
+                log(`[keyword-detector] Failed to show toast`, {
+                  error: err,
+                  sessionID: input.sessionID,
+                })
+              )
+          }
+          return
         }
-        return
       }
 
       if (isNonMainSession) {
@@ -163,32 +178,37 @@ export function createKeywordDetectorHook(
 
       const hasUltrawork = detectedKeywords.some((k) => k.type === "ultrawork")
       if (hasUltrawork) {
-        const runtimeVariant = getRuntimeVariant(input, output.message)
-        const isRuntimeMax = runtimeVariant === "max"
+        markUltraworkSessionActive(input.sessionID)
 
-        log(`[keyword-detector] Ultrawork mode activated`, {
-          sessionID: input.sessionID,
-          runtimeVariant,
-        })
+        if (stickyUltraworkContinuation) {
+          log(`[keyword-detector] Ultrawork mode continued`, { sessionID: input.sessionID })
+        } else {
+          const runtimeVariant = getRuntimeVariant(input, output.message)
+          const isRuntimeMax = runtimeVariant === "max"
 
-        ctx.client.tui
-          .showToast({
-            body: {
-              title: "Ultrawork Mode Activated",
-              message: isRuntimeMax
-                ? "Maximum precision engaged. All agents at your disposal."
-                : "Runtime variant preserved. All agents at your disposal.",
-              variant: "success" as const,
-              duration: 3000,
-            },
+          log(`[keyword-detector] Ultrawork mode activated`, {
+            sessionID: input.sessionID,
+            runtimeVariant,
           })
-          .catch((err) =>
-            log(`[keyword-detector] Failed to show toast`, {
-              error: err,
-              sessionID: input.sessionID,
-            })
-          )
 
+          ctx.client.tui
+            .showToast({
+              body: {
+                title: "Ultrawork Mode Activated",
+                message: isRuntimeMax
+                  ? "Maximum precision engaged. All agents at your disposal."
+                  : "Runtime variant preserved. All agents at your disposal.",
+                variant: "success" as const,
+                duration: 3000,
+              },
+            })
+            .catch((err) =>
+              log(`[keyword-detector] Failed to show toast`, {
+                error: err,
+                sessionID: input.sessionID,
+              })
+            )
+        }
       }
 
       const hasHyperplan = detectedKeywords.some((k) => k.type === "hyperplan")

--- a/packages/omo-opencode/src/hooks/keyword-detector/ultrawork-sticky-session.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/ultrawork-sticky-session.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+
+import { createKeywordDetectorHook } from "./index"
+import { _resetForTesting, setMainSession, subagentSessions } from "../../features/claude-code-session-state"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+
+function createMockPluginInput(toastCalls: string[] = []) {
+  return unsafeTestValue<PluginInput>({
+    client: {
+      tui: {
+        showToast: async (opts: { body: { title: string } }) => {
+          toastCalls.push(opts.body.title)
+        },
+      },
+    },
+  })
+}
+
+function createOutput(text: string) {
+  return {
+    message: {} as Record<string, unknown>,
+    parts: [{ type: "text", text }],
+  }
+}
+
+describe("keyword-detector ultrawork sticky session", () => {
+  beforeEach(() => {
+    _resetForTesting()
+    setMainSession("main-session")
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+  })
+
+  test("#given a session activated by ulw #when a follow-up omits the keyword #then ultrawork prompt is still injected", async () => {
+    const toastCalls: string[] = []
+    const hook = createKeywordDetectorHook(createMockPluginInput(toastCalls))
+
+    const firstOutput = createOutput("ulw refactor the auth module")
+    await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, firstOutput)
+
+    const followUpOutput = createOutput("and also add error handling")
+    await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, followUpOutput)
+
+    expect(firstOutput.parts[0]?.text).toContain("ULTRAWORK MODE ENABLED!")
+    expect(followUpOutput.parts[0]?.text).toContain("ULTRAWORK MODE ENABLED!")
+    expect(followUpOutput.parts[0]?.text).toContain("and also add error handling")
+    expect(toastCalls).toEqual(["Ultrawork Mode Activated"])
+  })
+
+  test("#given a fresh session without ulw activation #when a message has no keyword #then it remains unchanged", async () => {
+    const hook = createKeywordDetectorHook(createMockPluginInput())
+    const output = createOutput("and also add error handling")
+
+    await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, output)
+
+    expect(output.parts[0]?.text).toBe("and also add error handling")
+  })
+
+  test("#given a session activated by ulw then marked as a background task #when a follow-up omits the keyword #then sticky injection is suppressed", async () => {
+    const hook = createKeywordDetectorHook(createMockPluginInput())
+
+    const firstOutput = createOutput("ulw refactor the auth module")
+    await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, firstOutput)
+    subagentSessions.add("main-session")
+
+    const followUpOutput = createOutput("and also add error handling")
+    await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, followUpOutput)
+
+    expect(followUpOutput.parts[0]?.text).toBe("and also add error handling")
+  })
+})

--- a/packages/omo-opencode/src/plugin/ultrawork-model-override.test.ts
+++ b/packages/omo-opencode/src/plugin/ultrawork-model-override.test.ts
@@ -58,6 +58,7 @@ describe("detectUltrawork", () => {
 
 describe("resolveUltraworkOverride", () => {
   beforeEach(async () => {
+    sessionStateModule._resetForTesting()
     await loadFreshUltraworkModelOverrideModule()
   })
 
@@ -88,6 +89,21 @@ describe("resolveUltraworkOverride", () => {
 
     //#then
     expect(result).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-7", variant: "max" })
+  })
+
+  test("should keep resolving override on keyword-less follow-up after session activation", () => {
+    //#given
+    const config = createConfig("sisyphus", { model: "anthropic/claude-opus-4-7", variant: "max" })
+    const activationOutput = createOutput("ulw refactor the auth module")
+    const followUpOutput = createOutput("and also add error handling")
+
+    //#when
+    const activation = resolveUltraworkOverride(config, "sisyphus", activationOutput, "ses_ulw")
+    const followUp = resolveUltraworkOverride(config, "sisyphus", followUpOutput, "ses_ulw")
+
+    //#then
+    expect(activation).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-7", variant: "max" })
+    expect(followUp).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-7", variant: "max" })
   })
 
   test("should return null when no keyword detected", () => {
@@ -242,6 +258,7 @@ describe("applyUltraworkModelOverrideOnMessage", () => {
   let dbOverrideSpy: ReturnType<typeof spyOn>
 
   beforeEach(async () => {
+    sessionStateModule._resetForTesting()
     logSpy = spyOn(sharedModule, "log")
     logSpy.mockImplementation(() => {})
     dbOverrideSpy = spyOn(dbOverrideModule, "scheduleDeferredModelOverride")
@@ -250,6 +267,7 @@ describe("applyUltraworkModelOverrideOnMessage", () => {
   })
 
   afterEach(() => {
+    sessionStateModule._resetForTesting()
     logSpy?.mockRestore()
     dbOverrideSpy?.mockRestore()
   })

--- a/packages/omo-opencode/src/plugin/ultrawork-model-override.ts
+++ b/packages/omo-opencode/src/plugin/ultrawork-model-override.ts
@@ -1,6 +1,6 @@
 import type { OhMyOpenCodeConfig } from "../config"
 import type { AgentOverrides } from "../config/schema/agent-overrides"
-import { getSessionAgent } from "../features/claude-code-session-state"
+import { getSessionAgent, isUltraworkSessionActive, markUltraworkSessionActive } from "../features/claude-code-session-state"
 import { log } from "../shared"
 import { getAgentConfigKey } from "../shared/agent-display-names"
 import { scheduleDeferredModelOverride } from "./ultrawork-db-model-override"
@@ -67,7 +67,11 @@ export function resolveUltraworkOverride(
   sessionID?: string,
 ): UltraworkOverrideResult | null {
   const promptText = extractPromptText(output.parts)
-  if (!detectUltrawork(promptText)) return null
+  const hasUltraworkKeyword = detectUltrawork(promptText)
+  if (hasUltraworkKeyword && sessionID) {
+    markUltraworkSessionActive(sessionID)
+  }
+  if (!hasUltraworkKeyword && !isUltraworkSessionActive(sessionID)) return null
 
   const messageAgentName =
     typeof output.message["agent"] === "string" ? (output.message["agent"] as string) : undefined


### PR DESCRIPTION
## Summary
- Track keyword-activated ULW sessions so follow-up messages without `ulw`/`ultrawork` still receive the ultrawork prompt.
- Reuse the same session activation state for ultrawork model/variant override follow-ups.
- Preserve existing guards for planner/non-OMO/background sessions and avoid repeat activation toasts on sticky follow-ups.

Fixes #5806.

## Scope
- No disable/toggle mechanism is added; this matches the current issue fix and leaves explicit deactivation semantics for a follow-up.
- Hyperplan-ultrawork combo behavior is unchanged.

## Verification
- bun test packages/omo-opencode/src/hooks/keyword-detector/hook-ralph-loop.test.ts packages/omo-opencode/src/hooks/keyword-detector/hyperplan-ultrawork.test.ts packages/omo-opencode/src/hooks/keyword-detector/hyperplan.test.ts packages/omo-opencode/src/hooks/keyword-detector/index.test.ts packages/omo-opencode/src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts packages/omo-opencode/src/hooks/keyword-detector/ultrawork-runtime-variant.test.ts packages/omo-opencode/src/hooks/keyword-detector/ultrawork-sticky-session.test.ts packages/omo-opencode/src/plugin/ultrawork-model-override.test.ts
- bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json
