### PR TITLE
fix(model-core): make network connection errors retryable in fallback patterns

### DIFF
--- a/packages/model-core/src/model-error-classifier.ts
+++ b/packages/model-core/src/model-error-classifier.ts
@@ -38,6 +38,12 @@ const NON_RETRYABLE_ERROR_NAMES = new Set([
  * Message patterns that indicate a retryable error even without a known error name.
  */
 const RETRYABLE_MESSAGE_PATTERNS = [
+  "socket connection",
+  "unable to connect",
+  "cannot connect",
+  "connection was closed",
+  "connection reset",
+  "econnreset",
   "rate_limit",
   "rate limit",
   "usage_limit_reached",

--- a/packages/model-core/src/runtime-fallback-error-classifier.ts
+++ b/packages/model-core/src/runtime-fallback-error-classifier.ts
@@ -24,6 +24,12 @@ export type RuntimeFallbackErrorType =
   | "abort"
 
 export const RUNTIME_FALLBACK_RETRYABLE_ERROR_PATTERNS = [
+  /socket\s+connection/i,
+  /unable\s+to\s+connect/i,
+  /cannot\s+connect/i,
+  /connection\s+(?:was\s+)?closed/i,
+  /connection\s+reset/i,
+  /econnreset/i,
   /rate.?limit/i,
   /too.?many.?requests/i,
   /quota\s+will\s+reset\s+after/i,


### PR DESCRIPTION
## Problem

Network-layer connection errors from providers (e.g. `zai-coding-plan/glm-5.2`) are **not classified as retryable** by either of the two retry gates, so runtime fallback never triggers when they occur. The session stalls and requires manual user input to resume.

Observed error messages that fall through:
- `Cannot connect to API: The socket connection was closed unexpectedly`
- `Unable to connect. Is the computer able to access the url?`
- `fetch failed: ECONNRESET`

In a production deployment, these accounted for **~95 out of ~133** stream errors over a single day — only `overloaded` (which IS already covered) triggered fallback correctly. The rest silently cancelled the worker loop without dispatching the fallback model.

## Root cause

Two independent retry gates both lack coverage for connection-level failures:

1. **`RETRYABLE_MESSAGE_PATTERNS`** in `model-error-classifier.ts` (substring match, used by `isRetryableModelError`) — has `"connection error"` and `"network error"` but **NOT** `"socket connection"`, `"unable to connect"`, `"cannot connect"`, etc.

2. **`RUNTIME_FALLBACK_RETRYABLE_ERROR_PATTERNS`** in `runtime-fallback-error-classifier.ts` (regex match, used by `isRuntimeFallbackRetryableError`) — covers rate limits, quota, `overloaded`, `429/503/529`, but **no connection-level patterns**.

Since neither gate matches, the error is classified as non-retryable → the ultraworker loop cancels → **no fallback model is dispatched** → session halts.

## Fix

Add connection-level patterns to **both** gates so that socket/network connection failures are retryable and trigger runtime fallback to the configured fallback model.

**`model-error-classifier.ts`** — added 6 substring patterns:
`"socket connection"`, `"unable to connect"`, `"cannot connect"`, `"connection was closed"`, `"connection reset"`, `"econnreset"`

**`runtime-fallback-error-classifier.ts`** — added 6 equivalent regex patterns:
`/socket\s+connection/i`, `/unable\s+to\s+connect/i`, `/cannot\s+connect/i`, `/connection\s+(?:was\s+)?closed/i`, `/connection\s+reset/i`, `/econnreset/i`

## Verification

Behavioral test importing `RUNTIME_FALLBACK_RETRYABLE_ERROR_PATTERNS` directly from source (run via `bun`):

| Error message | Before | After |
|---|---|---|
| `...temporarily overloaded` | ✅ retryable | ✅ retryable |
| `Cannot connect to API: socket connection was closed` | ❌ not retried | ✅ retryable |
| `Unable to connect...` | ❌ not retried | ✅ retryable |
| `fetch failed: ECONNRESET` | ❌ not retried | ✅ retryable |
| `Invalid model specified` (negative control) | ❌ not retried | ❌ still not retried |

All 5/5 test cases pass.

## Notes

- Purely additive changes to existing pattern arrays — no behavior change for previously-matching errors.
- The negative control (`Invalid model specified`) confirms business errors remain non-retryable.
- These patterns catch transient infra-level failures where the request likely never reached the model, making retry safe.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make network connection errors retryable so runtime fallback kicks in when a provider drops the stream, preventing stalled sessions.

- **Bug Fixes**
  - Added connection-level patterns to both retry gates in `model-core` so these errors trigger fallback:
    - Substrings: "socket connection", "unable to connect", "cannot connect", "connection was closed", "connection reset", "econnreset"
    - Regexes: equivalent patterns for runtime fallback matching
  - Now covers errors like “Cannot connect to API…”, “Unable to connect…”, and “fetch failed: ECONNRESET”.
  - Verified with behavioral tests; existing matches unchanged and business errors remain non-retryable.

<sup>Written for commit 66a2091cbaa35da209778959bb64064988e8b308. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

