### PR TITLE
fix(skills): surface frontend visual QA gate early

### DIFF
--- a/packages/omo-opencode/src/features/builtin-skills/frontend/SKILL.md
+++ b/packages/omo-opencode/src/features/builtin-skills/frontend/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: frontend
-description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand."
+description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Completion requires /visual-qa before reporting UI work done unless there is no rendered surface. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand."
 ---
 
 # Frontend
+
+## Non-negotiable completion gate
+
+Before any frontend, web UI, TUI, styling, layout, visual, or design task is reported done, run `/visual-qa` and cite fresh evidence. The only exception is a task with no rendered surface; in that case, explicitly say visual QA is not applicable and why. Do not replace this with a self-inspection, screenshot glance, unit test, or "looks good" statement. This gate is repeated near the top so Codex/LazyCodex retains it even when later routing detail is truncated.
 
 This file is a router, not a rulebook. The rules live in four rulesets under `references/`; your first job is to load the smallest set of files that covers the request, state which you loaded in one sentence, then execute under their guidance. Loading nothing and freestyling produces the generic AI-slop output this skill exists to prevent; loading everything wastes context and creates contradictory instructions.
 

--- a/packages/shared-skills/frontend-skill-contract.test.ts
+++ b/packages/shared-skills/frontend-skill-contract.test.ts
@@ -87,8 +87,11 @@ describe("frontend skill live-URL clone contract", () => {
 
 	test("#given any frontend design task #when defining done #then visual QA is bound and slop animation is forbidden", async () => {
 		const text = await Bun.file(frontendSkillPath).text()
+		const earlyPrompt = text.slice(0, 1400)
 		const axioms = sectionBetween(text, "## Shared axioms", "## When to load something else instead")
 
+		expect(earlyPrompt).toContain("Non-negotiable completion gate")
+		expect(earlyPrompt).toContain("run `/visual-qa`")
 		expect(axioms).toContain("Slop animation")
 		expect(axioms).toContain("hover")
 		expect(axioms.toLowerCase()).toContain("visual-qa")

--- a/packages/shared-skills/skills/frontend/SKILL.md
+++ b/packages/shared-skills/skills/frontend/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: frontend
-description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand."
+description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Completion requires /visual-qa before reporting UI work done unless there is no rendered surface. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand."
 ---
 
 # Frontend
+
+## Non-negotiable completion gate
+
+Before any frontend, web UI, TUI, styling, layout, visual, or design task is reported done, run `/visual-qa` and cite fresh evidence. The only exception is a task with no rendered surface; in that case, explicitly say visual QA is not applicable and why. Do not replace this with a self-inspection, screenshot glance, unit test, or "looks good" statement. This gate is repeated near the top so Codex/LazyCodex retains it even when later routing detail is truncated.
 
 This file is a router, not a rulebook. The rules live in four rulesets under `references/`; your first job is to load the smallest set of files that covers the request, state which you loaded in one sentence, then execute under their guidance. Loading nothing and freestyling produces the generic AI-slop output this skill exists to prevent; loading everything wastes context and creates contradictory instructions.
 

--- a/packages/skills-loader-core/src/features/builtin-skills/frontend/SKILL.md
+++ b/packages/skills-loader-core/src/features/builtin-skills/frontend/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: frontend
-description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand."
+description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Completion requires /visual-qa before reporting UI work done unless there is no rendered surface. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand."
 ---
 
 # Frontend
+
+## Non-negotiable completion gate
+
+Before any frontend, web UI, TUI, styling, layout, visual, or design task is reported done, run `/visual-qa` and cite fresh evidence. The only exception is a task with no rendered surface; in that case, explicitly say visual QA is not applicable and why. Do not replace this with a self-inspection, screenshot glance, unit test, or "looks good" statement. This gate is repeated near the top so Codex/LazyCodex retains it even when later routing detail is truncated.
 
 This file is a router, not a rulebook. The rules live in four rulesets under `references/`; your first job is to load the smallest set of files that covers the request, state which you loaded in one sentence, then execute under their guidance. Loading nothing and freestyling produces the generic AI-slop output this skill exists to prevent; loading everything wastes context and creates contradictory instructions.
 

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/frontend.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/frontend.ts
@@ -3,6 +3,6 @@ import type { BuiltinSkill } from "../types"
 
 export const frontendSkill: BuiltinSkill = {
 	name: "frontend",
-	description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand.",
+	description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Completion requires /visual-qa before reporting UI work done unless there is no rendered surface. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand.",
 	template: loadSharedSkillTemplate("frontend"),
 }


### PR DESCRIPTION
## Summary
- repeat the frontend `/visual-qa` completion gate immediately after the skill title so LazyCodex/Codex sees it before later routing detail can be truncated
- include the completion requirement in the skill description used for discovery/routing
- keep the generated builtin skill copies and TypeScript metadata aligned

Fixes #5838.

## Verification
- `bun install --frozen-lockfile` (postinstall build completed)
- `bun test packages/shared-skills/frontend-skill-contract.test.ts`
- `bun test packages/skills-loader-core/src/features/builtin-skills/skills.test.ts packages/skills-loader-core/src/features/builtin-skills/shared-skill-extraction.test.ts`
- `bun run build:materialize-frontend`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the `/visual-qa` completion gate at the top of the frontend skill and adds it to the description so routing and truncation can’t hide it. Keeps all copies and metadata in sync and adds tests to lock it in. Fixes #5838.

- **Bug Fixes**
  - Repeat “Non-negotiable completion gate” near the top of `SKILL.md` in `packages/omo-opencode`, `packages/shared-skills`, and `packages/skills-loader-core`.
  - Add the requirement to the `description` field and align `packages/skills-loader-core/src/features/builtin-skills/skills/frontend.ts`.
  - Update tests to assert early placement and `/visual-qa` presence.

<sup>Written for commit d7dc8fb2c1e1bb267a830a339c31a2fdc8f5ab1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

