### PR TITLE
fix(runtime-fallback): preserve manual model selection

### DIFF
--- a/packages/omo-opencode/src/hooks/runtime-fallback/event-handler.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/event-handler.test.ts
@@ -274,4 +274,60 @@ describe("createEventHandler", () => {
     expect(created?.currentModel).toBe("openai/gpt-5.5-codex")
     expect(typeof created?.currentModel).toBe("string")
   })
+  it("#given session.created uses a fallback-listed manual model #when an agent has a preferred model #then the manual model is not treated as active fallback (#5816)", async () => {
+    const sessionID = "session-manual-model"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      agents: {
+        sisyphus: {
+          model: "provider-a/model-a",
+          fallback_models: ["provider-b/model-b"],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    await handler({
+      event: {
+        type: "session.created",
+        properties: {
+          info: { id: sessionID, agent: "sisyphus", model: "provider-b/model-b" },
+        },
+      },
+    })
+
+    const created = deps.sessionStates.get(sessionID)
+    expect(created?.originalModel).toBe("provider-b/model-b")
+    expect(created?.currentModel).toBe("provider-b/model-b")
+    expect(created?.fallbackIndex).toBe(-1)
+  })
+
+  it("#given session.created follows an already pending fallback #when the event fires #then existing fallback state is preserved", async () => {
+    const sessionID = "session-pending-fallback"
+    const deps = createDeps()
+    const state = createFallbackState("provider-a/model-a")
+    state.currentModel = "provider-b/model-b"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "provider-b/model-b"
+    deps.sessionStates.set(sessionID, state)
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    await handler({
+      event: {
+        type: "session.created",
+        properties: { info: { id: sessionID, model: "provider-b/model-b" } },
+      },
+    })
+
+    const preserved = deps.sessionStates.get(sessionID)
+    expect(preserved?.originalModel).toBe("provider-a/model-a")
+    expect(preserved?.currentModel).toBe("provider-b/model-b")
+    expect(preserved?.fallbackIndex).toBe(0)
+    expect(preserved?.pendingFallbackModel).toBe("provider-b/model-b")
+    expect(deps.sessionLastAccess.has(sessionID)).toBe(true)
+  })
 })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/event-handler.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/event-handler.ts
@@ -32,22 +32,6 @@ function resolveEventModel(props: Record<string, unknown> | undefined): string |
   return undefined
 }
 
-function resolvePreferredSessionModel(
-  sessionID: string,
-  agent: string | undefined,
-  pluginConfig: HookDeps["pluginConfig"],
-): string | undefined {
-  const agentConfig = agent && pluginConfig?.agents
-    ? pluginConfig.agents[agent]
-    : undefined
-  if (typeof agentConfig?.model === "string") return agentConfig.model
-
-  const category = typeof agentConfig?.category === "string"
-    ? agentConfig.category
-    : SessionCategoryRegistry.get(sessionID)
-  const categoryModel = category ? pluginConfig?.categories?.[category]?.model : undefined
-  return typeof categoryModel === "string" ? categoryModel : undefined
-}
 
 export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   const { config, pluginConfig, sessionStates, sessionLastAccess, sessionRetryInFlight, sessionAwaitingFallbackResult, sessionFallbackTimeouts, sessionStatusRetryKeys } = deps
@@ -71,26 +55,18 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
     const sessionInfo = props ? props.info : undefined
     const sessionRecord = isRuntimeFallbackRecord(sessionInfo) ? sessionInfo : undefined
     const sessionModel = sessionRecord?.["model"]
-    const sessionAgent = sessionRecord?.["agent"]
+
     const model = normalizeModelToCanonicalString(sessionModel)
-    const agent = typeof sessionAgent === "string"
-      ? sessionAgent
-      : props && typeof props.agent === "string"
-        ? props.agent
-        : undefined
 
     if (sessionID && model) {
       log(`[${HOOK_NAME}] Session created with model`, { sessionID, model })
-      const preferredModel = resolvePreferredSessionModel(sessionID, agent, pluginConfig)
-      const fallbackIndex = preferredModel && preferredModel !== model
-        ? getFallbackModelsForSession(sessionID, agent, pluginConfig).indexOf(model)
-        : -1
-      const state = createFallbackState(fallbackIndex >= 0 && preferredModel ? preferredModel : model)
-      if (fallbackIndex >= 0) {
-        state.currentModel = model
-        state.fallbackIndex = fallbackIndex
+
+      if (sessionStates.has(sessionID)) {
+        sessionLastAccess.set(sessionID, Date.now())
+        return
       }
-      sessionStates.set(sessionID, state)
+
+      sessionStates.set(sessionID, createFallbackState(model))
       sessionLastAccess.set(sessionID, Date.now())
     }
   }

--- a/packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts
@@ -2641,7 +2641,7 @@ describe("runtime-fallback", () => {
       expect(output.message.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
     })
 
-    test("should restore configured primary when reopened on a configured fallback model", async () => {
+    test("should keep a user-selected configured fallback model instead of restoring the configured primary", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false, restore_primary_after_cooldown: true }),
         pluginConfig: createMockPluginConfigWithCategoryModel(
@@ -2666,7 +2666,7 @@ describe("runtime-fallback", () => {
       }
       await hook["chat.message"]?.({ sessionID, model: { providerID: "openai", modelID: "gpt-5.4" } }, output)
 
-      expect(output.message.model).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-5" })
+      expect(output.message.model).toBeUndefined()
     })
 
     test("should notify when fallback occurs", async () => {


### PR DESCRIPTION
## Summary
- stop `session.created` from bootstrapping a fallback-active state just because the created model is listed in an agent/category fallback list
- preserve an already pending fallback state when a retry-created session arrives
- update regression coverage for manually selected fallback-listed models

Fixes #5816.

## Verification
- `bun test packages/omo-opencode/src/hooks/runtime-fallback/event-handler.test.ts packages/omo-opencode/src/hooks/runtime-fallback/chat-message-handler.test.ts packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves manual model selection on session start and stops auto-activating fallback when the selected model is on a configured fallback list. Also keeps an in-flight fallback state when a session is re-created. Fixes #5816.

- **Bug Fixes**
  - `session.created` no longer marks a user-selected fallback-listed model as active fallback; we initialize with that model and `fallbackIndex = -1`.
  - If a session is re-created during a pending fallback, we keep the existing fallback state and only refresh last-access.

<sup>Written for commit 2e2f3590946b7e8f176436aabb26c583074baeed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

