### PR TITLE
fix(ralph-loop): tell Oracle to emit VERIFIED

### DIFF
--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-builder.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-builder.ts
@@ -18,6 +18,7 @@ REQUIRED NOW:
 - Ask Oracle to verify whether the original task is actually complete
 - Include the original task in the Oracle request
 - Explicitly tell Oracle to review skeptically and critically, and to look for reasons the task may still be incomplete or wrong
+- In your Oracle request, explicitly instruct Oracle to end its reply with the exact line <promise>VERIFIED</promise> if and only if the task is genuinely complete and correct, and to omit that token otherwise. The system detects verification solely by this token in Oracle's session, so Oracle MUST be told to emit it.
 - The system will inspect the Oracle session directly for the verification result
 - If Oracle does not verify, continue fixing the task and do not consider it complete
 
@@ -34,6 +35,7 @@ REQUIRED NOW:
 - Do not claim completion early or argue with the failed verification
 - After fixing the remaining issues, request Oracle review again using task(subagent_type="oracle", load_skills=[], run_in_background=false, ...)
 - Include the original task in the Oracle request and tell Oracle to review skeptically and critically
+- In your Oracle request, explicitly instruct Oracle to end its reply with the exact line <promise>VERIFIED</promise> if and only if the task is genuinely complete and correct, and to omit that token otherwise. The system detects verification solely by this token in Oracle's session, so Oracle MUST be told to emit it.
 - Only when the work is ready for review again, output: <promise>{{PROMISE}}</promise>
 
 Original task:

--- a/packages/omo-opencode/src/hooks/ralph-loop/ulw-loop-verification.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/ulw-loop-verification.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { createRalphLoopHook } from "./index"
 import { ULTRAWORK_VERIFICATION_PROMISE } from "./constants"
+import { buildContinuationPrompt, buildVerificationFailurePrompt } from "./continuation-prompt-builder"
 import { clearState, writeState } from "./storage"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import type { RalphLoopState } from "./types"
@@ -51,6 +52,36 @@ describe("ulw-loop verification", () => {
 		}
 		return state
 	}
+
+	function createVerificationState(overrides: Partial<RalphLoopState> = {}): RalphLoopState {
+		return {
+			active: true,
+			completion_promise: "DONE",
+			initial_completion_promise: "DONE",
+			iteration: 2,
+			prompt: "Build API",
+			started_at: new Date().toISOString(),
+			ultrawork: true,
+			verification_pending: true,
+			...overrides,
+		}
+	}
+
+	test("#given verification is pending #when building the Oracle prompt #then it tells Oracle to emit VERIFIED on success", () => {
+		const prompt = buildContinuationPrompt(createVerificationState())
+
+		expect(prompt).toContain("explicitly instruct Oracle to end its reply with the exact line <promise>VERIFIED</promise>")
+		expect(prompt).toContain("if and only if the task is genuinely complete and correct")
+		expect(prompt).toContain("Oracle MUST be told to emit it")
+	})
+
+	test("#given verification failed #when building retry prompt #then it repeats the Oracle VERIFIED token protocol", () => {
+		const prompt = buildVerificationFailurePrompt(createVerificationState({ verification_pending: undefined }))
+
+		expect(prompt).toContain("explicitly instruct Oracle to end its reply with the exact line <promise>VERIFIED</promise>")
+		expect(prompt).toContain("if and only if the task is genuinely complete and correct")
+		expect(prompt).toContain("Oracle MUST be told to emit it")
+	})
 
 	beforeEach(() => {
 		promptCalls = []


### PR DESCRIPTION
## Summary
- tell the main agent to include the `<promise>VERIFIED</promise>` protocol in Oracle verification requests
- repeat the same protocol in the verification-failed retry prompt
- add regression coverage for both prompt builders

Fixes #5839.

## Verification
- `bun test packages/omo-opencode/src/hooks/ralph-loop/ulw-loop-verification.test.ts`
- `bun test packages/omo-opencode/src/hooks/ralph-loop/oracle-verification-detector.test.ts packages/omo-opencode/src/hooks/ralph-loop/completion-promise-detector.test.ts packages/omo-opencode/src/hooks/ralph-loop/ulw-loop-verification.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Oracle verification emits the exact <promise>VERIFIED</promise> token so the system can reliably detect success. Adds the instruction to both the main verification prompt and the retry prompt, with regression tests. Fixes #5839.

- **Bug Fixes**
  - Update `buildContinuationPrompt` to instruct Oracle to end with `<promise>VERIFIED</promise>` only when the task is truly complete.
  - Update `buildVerificationFailurePrompt` to repeat the same protocol on retries.
  - Add regression tests in `ulw-loop-verification.test.ts` covering both prompt builders.

<sup>Written for commit 92841b8444ca568988dc69c89aae7930d8e72fb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

