### PR TITLE
fix(omo-codex): keep silent subagents alive

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/directive.md
+++ b/packages/omo-codex/plugin/components/ultrawork/directive.md
@@ -275,11 +275,14 @@ review passes, and `BLOCKED: <reason>` only when it cannot progress.
 Track spawned agent names locally. Use `multi_agent_v1.wait_agent` for mailbox
 signals, but a timeout only means no new mailbox update arrived.
 Treat a running child as alive and keep doing independent root work.
-Fallback only when the child is completed without the
-deliverable, ack-only, or no longer running. If that followup is still
-silent or ack-only, record the result as inconclusive, do not count it
-as approval/pass, close it if safe, and respawn a smaller
-`fork_context: false` task with the missing deliverable.
+Send `TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only
+to a running child when a targeted followup can still recover the lane.
+Fallback only when the child has completed without the deliverable,
+explicitly reported `BLOCKED:`, is no longer running, or responded
+ack-only after a targeted followup. In fallback, record the result as
+inconclusive, do not count it as approval/pass, close it if safe, and
+respawn a smaller `fork_context: false` task with the missing
+deliverable.
 
 # Subagent-dependent transition barrier
 Do not mark an `update_plan` step `completed` while an active child owns
@@ -290,15 +293,15 @@ that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
 A silent wait is not a child-state transition and must not by itself
-trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
-`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
-the child has completed without the deliverable, responded ack-only
-after a targeted followup, explicitly reported `BLOCKED:`, or is no
-longer running. If no final status or completion signal exists, treat
-the child as still active and continue independent root work. Close the
-lane as inconclusive and respawn smaller only after one of those
-non-running or non-delivering states is observed and the deliverable is
-still required.
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. If no final
+status or completion signal exists, treat the child as still active and
+continue independent root work. Send `TASK STILL ACTIVE: return
+<deliverable> or BLOCKED: <reason>` only to a running child when a
+targeted followup can still recover the lane. When the child has
+completed without the deliverable, explicitly reported `BLOCKED:`, is no
+longer running, or responded ack-only after a targeted followup, do not
+send another followup; record the lane as inconclusive and respawn
+smaller only if the deliverable is still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 

--- a/packages/omo-codex/plugin/components/ultrawork/directive.md
+++ b/packages/omo-codex/plugin/components/ultrawork/directive.md
@@ -289,10 +289,16 @@ as inconclusive. Do not generate a plan before spawned research lanes
 that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
-After two silent waits send `TASK STILL ACTIVE: return <deliverable> or
-BLOCKED: <reason>`. After four silent or ack-only checks, close the lane as
-inconclusive, record that it is not approval, and respawn smaller only
-if the deliverable is still required.
+A silent wait is not a child-state transition and must not by itself
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
+`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
+the child has completed without the deliverable, responded ack-only
+after a targeted followup, explicitly reported `BLOCKED:`, or is no
+longer running. If no final status or completion signal exists, treat
+the child as still active and continue independent root work. Close the
+lane as inconclusive and respawn smaller only after one of those
+non-running or non-delivering states is observed and the deliverable is
+still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 

--- a/packages/omo-codex/plugin/components/ultrawork/skills/ultrawork/SKILL.md
+++ b/packages/omo-codex/plugin/components/ultrawork/skills/ultrawork/SKILL.md
@@ -296,10 +296,16 @@ as inconclusive. Do not generate a plan before spawned research lanes
 that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
-After two silent waits send `TASK STILL ACTIVE: return <deliverable> or
-BLOCKED: <reason>`. After four silent or ack-only checks, close the lane as
-inconclusive, record that it is not approval, and respawn smaller only
-if the deliverable is still required.
+A silent wait is not a child-state transition and must not by itself
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
+`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
+the child has completed without the deliverable, responded ack-only
+after a targeted followup, explicitly reported `BLOCKED:`, or is no
+longer running. If no final status or completion signal exists, treat
+the child as still active and continue independent root work. Close the
+lane as inconclusive and respawn smaller only after one of those
+non-running or non-delivering states is observed and the deliverable is
+still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 

--- a/packages/omo-codex/plugin/components/ultrawork/skills/ultrawork/SKILL.md
+++ b/packages/omo-codex/plugin/components/ultrawork/skills/ultrawork/SKILL.md
@@ -282,11 +282,14 @@ review passes, and `BLOCKED: <reason>` only when it cannot progress.
 Track spawned agent names locally. Use `multi_agent_v1.wait_agent` for mailbox
 signals, but a timeout only means no new mailbox update arrived.
 Treat a running child as alive and keep doing independent root work.
-Fallback only when the child is completed without the
-deliverable, ack-only, or no longer running. If that followup is still
-silent or ack-only, record the result as inconclusive, do not count it
-as approval/pass, close it if safe, and respawn a smaller
-`fork_context: false` task with the missing deliverable.
+Send `TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only
+to a running child when a targeted followup can still recover the lane.
+Fallback only when the child has completed without the deliverable,
+explicitly reported `BLOCKED:`, is no longer running, or responded
+ack-only after a targeted followup. In fallback, record the result as
+inconclusive, do not count it as approval/pass, close it if safe, and
+respawn a smaller `fork_context: false` task with the missing
+deliverable.
 
 # Subagent-dependent transition barrier
 Do not mark an `update_plan` step `completed` while an active child owns
@@ -297,15 +300,15 @@ that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
 A silent wait is not a child-state transition and must not by itself
-trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
-`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
-the child has completed without the deliverable, responded ack-only
-after a targeted followup, explicitly reported `BLOCKED:`, or is no
-longer running. If no final status or completion signal exists, treat
-the child as still active and continue independent root work. Close the
-lane as inconclusive and respawn smaller only after one of those
-non-running or non-delivering states is observed and the deliverable is
-still required.
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. If no final
+status or completion signal exists, treat the child as still active and
+continue independent root work. Send `TASK STILL ACTIVE: return
+<deliverable> or BLOCKED: <reason>` only to a running child when a
+targeted followup can still recover the lane. When the child has
+completed without the deliverable, explicitly reported `BLOCKED:`, is no
+longer running, or responded ack-only after a targeted followup, do not
+send another followup; record the lane as inconclusive and respawn
+smaller only if the deliverable is still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 

--- a/packages/omo-codex/plugin/components/ultrawork/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/codex-hook.test.ts
@@ -222,6 +222,25 @@ describe("codex ultrawork hook", () => {
 		expect(directive).toMatch(/Treat child status as a progress signal/);
 	});
 
+	it("#given directive #when wait_agent is silent #then timeout counters never close running children", () => {
+		// given
+		const payload = {
+			hook_event_name: "UserPromptSubmit",
+			prompt: "ulw",
+		};
+
+		// when
+		const output = runUserPromptSubmitHook(payload, { skillFilePath: null });
+		const parsed = parseHookOutput(output);
+
+		// then
+		const directive = parsed.hookSpecificOutput.additionalContext;
+		expect(directive).toMatch(/A silent wait is not a child-state transition/);
+		expect(directive).toMatch(/must not by itself\s+trigger `TASK STILL ACTIVE`/);
+		expect(directive).not.toMatch(/After two silent waits/);
+		expect(directive).not.toMatch(/After four silent/);
+	});
+
 	it("#given directive #when inspected #then hardens Codex subagent assignment ambiguity", () => {
 		// given
 		const payload = {

--- a/packages/omo-codex/plugin/components/ultrawork/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/codex-hook.test.ts
@@ -237,8 +237,17 @@ describe("codex ultrawork hook", () => {
 		const directive = parsed.hookSpecificOutput.additionalContext;
 		expect(directive).toMatch(/A silent wait is not a child-state transition/);
 		expect(directive).toMatch(/must not by itself\s+trigger `TASK STILL ACTIVE`/);
+		expect(directive).toMatch(/TASK STILL ACTIVE:[\s\S]*only to a running child/);
+		expect(directive).toMatch(/explicitly reported `BLOCKED:`/);
+		expect(directive).toMatch(/do not\s+send another followup/);
 		expect(directive).not.toMatch(/After two silent waits/);
 		expect(directive).not.toMatch(/After four silent/);
+		expect(directive).not.toMatch(
+			/Fallback only when the child is completed without the\s+deliverable, ack-only, or no longer running/,
+		);
+		expect(directive).not.toMatch(
+			/TASK STILL ACTIVE:[^\n]*only when\s*\n\s*the child has completed without the deliverable/,
+		);
 	});
 
 	it("#given directive #when inspected #then hardens Codex subagent assignment ambiguity", () => {

--- a/packages/omo-codex/plugin/components/ulw-loop/directive.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/directive.md
@@ -275,11 +275,14 @@ review passes, and `BLOCKED: <reason>` only when it cannot progress.
 Track spawned agent names locally. Use `multi_agent_v1.wait_agent` for mailbox
 signals, but a timeout only means no new mailbox update arrived.
 Treat a running child as alive and keep doing independent root work.
-Fallback only when the child is completed without the
-deliverable, ack-only, or no longer running. If that followup is still
-silent or ack-only, record the result as inconclusive, do not count it
-as approval/pass, close it if safe, and respawn a smaller
-`fork_context: false` task with the missing deliverable.
+Send `TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only
+to a running child when a targeted followup can still recover the lane.
+Fallback only when the child has completed without the deliverable,
+explicitly reported `BLOCKED:`, is no longer running, or responded
+ack-only after a targeted followup. In fallback, record the result as
+inconclusive, do not count it as approval/pass, close it if safe, and
+respawn a smaller `fork_context: false` task with the missing
+deliverable.
 
 # Subagent-dependent transition barrier
 Do not mark an `update_plan` step `completed` while an active child owns
@@ -290,15 +293,15 @@ that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
 A silent wait is not a child-state transition and must not by itself
-trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
-`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
-the child has completed without the deliverable, responded ack-only
-after a targeted followup, explicitly reported `BLOCKED:`, or is no
-longer running. If no final status or completion signal exists, treat
-the child as still active and continue independent root work. Close the
-lane as inconclusive and respawn smaller only after one of those
-non-running or non-delivering states is observed and the deliverable is
-still required.
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. If no final
+status or completion signal exists, treat the child as still active and
+continue independent root work. Send `TASK STILL ACTIVE: return
+<deliverable> or BLOCKED: <reason>` only to a running child when a
+targeted followup can still recover the lane. When the child has
+completed without the deliverable, explicitly reported `BLOCKED:`, is no
+longer running, or responded ack-only after a targeted followup, do not
+send another followup; record the lane as inconclusive and respawn
+smaller only if the deliverable is still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 

--- a/packages/omo-codex/plugin/components/ulw-loop/directive.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/directive.md
@@ -289,10 +289,16 @@ as inconclusive. Do not generate a plan before spawned research lanes
 that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
-After two silent waits send `TASK STILL ACTIVE: return <deliverable> or
-BLOCKED: <reason>`. After four silent or ack-only checks, close the lane as
-inconclusive, record that it is not approval, and respawn smaller only
-if the deliverable is still required.
+A silent wait is not a child-state transition and must not by itself
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
+`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
+the child has completed without the deliverable, responded ack-only
+after a targeted followup, explicitly reported `BLOCKED:`, or is no
+longer running. If no final status or completion signal exists, treat
+the child as still active and continue independent root work. Close the
+lane as inconclusive and respawn smaller only after one of those
+non-running or non-delivering states is observed and the deliverable is
+still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 

--- a/packages/prompts-core/prompts/ultrawork/codex.md
+++ b/packages/prompts-core/prompts/ultrawork/codex.md
@@ -275,11 +275,14 @@ review passes, and `BLOCKED: <reason>` only when it cannot progress.
 Track spawned agent names locally. Use `multi_agent_v1.wait_agent` for mailbox
 signals, but a timeout only means no new mailbox update arrived.
 Treat a running child as alive and keep doing independent root work.
-Fallback only when the child is completed without the
-deliverable, ack-only, or no longer running. If that followup is still
-silent or ack-only, record the result as inconclusive, do not count it
-as approval/pass, close it if safe, and respawn a smaller
-`fork_context: false` task with the missing deliverable.
+Send `TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only
+to a running child when a targeted followup can still recover the lane.
+Fallback only when the child has completed without the deliverable,
+explicitly reported `BLOCKED:`, is no longer running, or responded
+ack-only after a targeted followup. In fallback, record the result as
+inconclusive, do not count it as approval/pass, close it if safe, and
+respawn a smaller `fork_context: false` task with the missing
+deliverable.
 
 # Subagent-dependent transition barrier
 Do not mark an `update_plan` step `completed` while an active child owns
@@ -290,15 +293,15 @@ that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
 A silent wait is not a child-state transition and must not by itself
-trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
-`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
-the child has completed without the deliverable, responded ack-only
-after a targeted followup, explicitly reported `BLOCKED:`, or is no
-longer running. If no final status or completion signal exists, treat
-the child as still active and continue independent root work. Close the
-lane as inconclusive and respawn smaller only after one of those
-non-running or non-delivering states is observed and the deliverable is
-still required.
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. If no final
+status or completion signal exists, treat the child as still active and
+continue independent root work. Send `TASK STILL ACTIVE: return
+<deliverable> or BLOCKED: <reason>` only to a running child when a
+targeted followup can still recover the lane. When the child has
+completed without the deliverable, explicitly reported `BLOCKED:`, is no
+longer running, or responded ack-only after a targeted followup, do not
+send another followup; record the lane as inconclusive and respawn
+smaller only if the deliverable is still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 

--- a/packages/prompts-core/prompts/ultrawork/codex.md
+++ b/packages/prompts-core/prompts/ultrawork/codex.md
@@ -289,10 +289,16 @@ as inconclusive. Do not generate a plan before spawned research lanes
 that feed the plan have returned or been closed as inconclusive.
 Do not write the final answer, PR handoff, or completion summary while
 active child agents remain open. Use short `multi_agent_v1.wait_agent` cycles.
-After two silent waits send `TASK STILL ACTIVE: return <deliverable> or
-BLOCKED: <reason>`. After four silent or ack-only checks, close the lane as
-inconclusive, record that it is not approval, and respawn smaller only
-if the deliverable is still required.
+A silent wait is not a child-state transition and must not by itself
+trigger `TASK STILL ACTIVE`, `close_agent`, or a respawn. Send
+`TASK STILL ACTIVE: return <deliverable> or BLOCKED: <reason>` only when
+the child has completed without the deliverable, responded ack-only
+after a targeted followup, explicitly reported `BLOCKED:`, or is no
+longer running. If no final status or completion signal exists, treat
+the child as still active and continue independent root work. Close the
+lane as inconclusive and respawn smaller only after one of those
+non-running or non-delivering states is observed and the deliverable is
+still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 


### PR DESCRIPTION
## Summary

Ports the fix from the first LazyCodex PR into the upstream Codex implementation under `packages/omo-codex`.

Original LazyCodex PR: https://github.com/code-yeongyu/lazycodex/pull/106

That PR was automatically closed because LazyCodex is generated from this repository. The bot asked for the equivalent change to be opened here against `packages/omo-codex`.

## Problem

The Codex ultrawork directive contains contradictory subagent liveness guidance.

Earlier guidance says `multi_agent_v1.wait_agent` timeouts are mailbox-only: a timeout means no new child message arrived, not that the child stopped working.

The later transition barrier contradicted that by telling the parent to:

- send `TASK STILL ACTIVE` after two silent waits
- close the lane as inconclusive after four silent or ack-only checks
- respawn a smaller child if the deliverable was still required

That can interrupt legitimate long-running child agents. The parent sees silence, treats it as a stale lane, and replaces or closes the child even though it may still be reading, testing, or reviewing.

## Fix

- Treat a silent wait as a non-state transition.
- Do not let silence alone trigger `TASK STILL ACTIVE`, `close_agent`, or respawn.
- Only follow up / close / respawn after an actual non-delivering state:
  - child completed without the deliverable
  - child responded ack-only after a targeted follow-up
  - child explicitly reported `BLOCKED:`
  - child is no longer running
- Update the source prompt in `packages/prompts-core/prompts/ultrawork/codex.md`.
- Keep the Codex component directive, bundled ultrawork skill, and ulw-loop directive in sync.
- Add a regression test against generated Codex hook output so the silent-wait counters cannot come back unnoticed.

## Verification

Passing:

```text
npm --prefix packages/omo-codex/plugin/components/ultrawork test -- test/codex-hook.test.ts test/directive-source.test.ts
# 2 files passed, 16 tests passed

npm --prefix packages/omo-codex/plugin/components/ulw-loop test -- test/ultrawork-directive.test.ts
# 1 file passed, 7 tests passed

npm --prefix packages/omo-codex/plugin/components/ultrawork test
# 5 files passed, 31 tests passed

npm --prefix packages/omo-codex/plugin/components/ultrawork run typecheck
npm --prefix packages/omo-codex/plugin/components/ultrawork run lint
npm --prefix packages/omo-codex/plugin/components/ulw-loop run typecheck
npm --prefix packages/omo-codex/plugin/components/ulw-loop run lint
# all passed

git diff --check
# passed
```

Limited by local Windows shell:

```text
npm --prefix packages/omo-codex/plugin/components/ulw-loop test
# The related ultrawork-directive test passed.
# Full suite is blocked locally by existing Windows shell assumptions:
# - spawn npm ENOENT
# - spawn /bin/sh ENOENT
# - POSIX path expectations in test/paths.test.ts

bun run test:codex
# Could not complete locally.
# First run failed before tests because workspace deps were missing.
# After attempting bun install, install/build failed because build:lsp-tools-mcp uses rm -rf and this Windows shell has no rm command.
```

Local evidence summary was recorded at `.omo/evidence/20260703-subagent-liveness/verification.md` in the working tree, but it is ignored by `.gitignore` and is not included in this PR diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep silent subagents alive by removing timeout-driven transitions and aligning fallback policy so silence never triggers `TASK STILL ACTIVE`, close, or respawn. Syncs directives across `omo-codex` and `prompts-core`, and adds a regression test.

- **Bug Fixes**
  - Treat silent `wait_agent` timeouts as non-state transitions; continue independent work without auto follow-ups.
  - Send `TASK STILL ACTIVE` only to a running child when a targeted follow-up can recover the lane.
  - Fallback only after explicit non-delivering states (completed without deliverable, ack-only after targeted follow-up, `BLOCKED:`, or not running); record as inconclusive, do not send another follow-up, and respawn smaller only if needed.
  - Remove “two silent waits/four checks” counters and sync text in `ultrawork` directive, `skills/ultrawork/SKILL.md`, and `ulw-loop`, plus `prompts-core/prompts/ultrawork/codex.md`.
  - Add a hook-level regression test to ensure silent waits never close or respawn children and that the old counters are gone.

<sup>Written for commit d88124cc040cfc18b5247f7a8bd0355242513722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

