### PR TITLE
fix(test): make omo plugin tests portable on Windows

### DIFF
--- a/packages/omo-codex/plugin/package.json
+++ b/packages/omo-codex/plugin/package.json
@@ -27,6 +27,6 @@
 		"check": "npm run build && npm test",
 		"sync:hooks": "node scripts/sync-hook-status-messages.mjs",
 		"sync:skills": "node scripts/sync-skills.mjs",
-		"test": "node --test test/*.test.mjs"
+		"test": "node scripts/run-node-test-files.mjs"
 	}
 }

--- a/packages/omo-codex/plugin/scripts/run-node-test-files.mjs
+++ b/packages/omo-codex/plugin/scripts/run-node-test-files.mjs
@@ -1,0 +1,14 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const testFiles = readdirSync("test")
+	.filter((file) => file.endsWith(".test.mjs"))
+	.sort()
+	.map((file) => join("test", file));
+
+const result = spawnSync(process.execPath, ["--test", ...testFiles], {
+	stdio: "inherit",
+});
+
+process.exit(result.status ?? 1);

--- a/packages/omo-codex/plugin/scripts/run-node-test-files.mjs
+++ b/packages/omo-codex/plugin/scripts/run-node-test-files.mjs
@@ -2,12 +2,13 @@ import { spawnSync } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
+const testArgs = process.argv.slice(2);
 const testFiles = readdirSync("test")
 	.filter((file) => file.endsWith(".test.mjs"))
 	.sort()
 	.map((file) => join("test", file));
 
-const result = spawnSync(process.execPath, ["--test", ...testFiles], {
+const result = spawnSync(process.execPath, ["--test", ...testArgs, ...testFiles], {
 	stdio: "inherit",
 });
 

--- a/packages/omo-codex/plugin/test/aggregate-build.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-build.test.mjs
@@ -21,7 +21,7 @@ test("#given aggregate plugin build script #when inspected #then generated asset
 	);
 	assert.match(buildScript, /^node scripts\/sync-version\.mjs &&/);
 	assert.match(buildScript, /materialize-shared-upstreams\.mjs --strict && node scripts\/sync-skills\.mjs/);
-	assert.equal(testScript, "node --test test/*.test.mjs");
+	assert.equal(testScript, "node scripts/run-node-test-files.mjs");
 	assert(packageJson.workspaces.includes("components/ultrawork"));
 	assert.doesNotMatch(packageText, /\bpython3?\b|ultrawork-detector\.py/);
 });

--- a/packages/omo-codex/plugin/test/run-node-test-files.test.mjs
+++ b/packages/omo-codex/plugin/test/run-node-test-files.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+
+import { root } from "./aggregate-plugin-fixture.mjs";
+
+test("#given extra node test arguments #when aggregate test wrapper runs #then forwards them to node", async () => {
+	// given
+	const fixtureRoot = await mkdtemp(join(tmpdir(), "omo-node-test-wrapper-"));
+	const fixtureTestRoot = join(fixtureRoot, "test");
+	const reportPath = join(fixtureRoot, "node-test-report.xml");
+	await mkdir(fixtureTestRoot);
+	await writeFile(
+		join(fixtureTestRoot, "argument-forwarding.test.mjs"),
+		[
+			'import assert from "node:assert/strict";',
+			'import test from "node:test";',
+			'test("selected wrapper case", () => assert.equal(1, 1));',
+			'test("unselected wrapper case", () => assert.fail("test-name-pattern was not forwarded"));',
+		].join("\n"),
+	);
+	const childEnv = { ...process.env };
+	delete childEnv.NODE_TEST_CONTEXT;
+	let result;
+	let report = "";
+
+	// when
+	try {
+		result = spawnSync(
+			process.execPath,
+			[
+				join(root, "scripts", "run-node-test-files.mjs"),
+				"--test-name-pattern",
+				"^selected wrapper case$",
+				"--test-reporter=junit",
+				"--test-reporter-destination",
+				reportPath,
+			],
+			{ cwd: fixtureRoot, encoding: "utf8", env: childEnv },
+		);
+		report = result.status === 0 ? await readFile(reportPath, "utf8") : "";
+	} finally {
+		await rm(fixtureRoot, { recursive: true, force: true });
+	}
+
+	// then
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(report, /<testcase name="selected wrapper case"/);
+	assert.match(report, /message="test name does not match pattern"/);
+	assert.match(report, /<!-- fail 0 -->/);
+});


### PR DESCRIPTION
## Summary

- retargets the Windows test-portability fix from the first LazyCodex PR, which was auto-closed because LazyCodex changes land here
- replaces `node --test test/*.test.mjs` in `packages/omo-codex/plugin` with a small Node runner that enumerates top-level `.test.mjs` files without relying on shell glob expansion
- updates the aggregate build-script contract test to guard the new portable test command

Original LazyCodex PR: https://github.com/code-yeongyu/lazycodex/pull/107

## Verification

- RED before this change, from `packages/omo-codex/plugin`: `npm test` failed with `Could not find ...\test\*.test.mjs`
- `node --test test\aggregate-build.test.mjs` from `packages/omo-codex/plugin`: 2 pass, 0 fail
- `git diff --check`

## Note

With the glob issue fixed, `npm test` from `packages/omo-codex/plugin` now reaches the broader suite on Windows. That broader suite is still red in this checkout: 194 pass, 34 fail. The visible failures are unrelated synced-skill/shared package artifacts and generated CLI expectations, including missing `plugin\skills\ulw-loop\...` files and missing `@oh-my-opencode/shared-skills` imports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `packages/omo-codex/plugin` tests portable on Windows by replacing the shell-glob test command with a Node runner that enumerates test files and forwards Node test args. Fixes `npm test` failures and keeps support for `--test` flags (e.g., reporter and filters).

- **Bug Fixes**
  - Add `scripts/run-node-test-files.mjs` to find top-level `.test.mjs` files and invoke Node with `--test`, forwarding extra args.
  - Update `package.json` test script to `node scripts/run-node-test-files.mjs`.
  - Update tests: assert the new test command and add coverage for arg forwarding (e.g., `--test-name-pattern`, `--test-reporter`).

<sup>Written for commit 8a812fef320598bc9b1939d69cac18a6febdefec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

