### PR TITLE
fix(codex): prune stale plugin cache versions

### DIFF
--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5907,7 +5907,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.15.0",
+    version: "4.15.1",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -7716,6 +7716,23 @@ async function pruneMarketplacePluginCaches(input) {
   const remainingEntries = await readCacheEntryNames(cacheRoot);
   if (remainingEntries.length === 0) {
     await rm5(cacheRoot, { recursive: true, force: true });
+  }
+}
+async function pruneMarketplacePluginVersions(input) {
+  const cacheRoot = join13(input.codexHome, "plugins", "cache", input.marketplaceName);
+  if (!await fileExistsStrict(cacheRoot))
+    return;
+  for (const plugin of input.plugins) {
+    const pluginRoot = join13(cacheRoot, plugin.name);
+    if (!await fileExistsStrict(pluginRoot))
+      continue;
+    const keepVersions = new Set([plugin.version]);
+    const entries = await readCacheEntries(pluginRoot);
+    for (const entry of entries) {
+      if (keepVersions.has(entry.name))
+        continue;
+      await rm5(join13(pluginRoot, entry.name), { recursive: true, force: true });
+    }
   }
 }
 async function readCacheEntries(path) {
@@ -13788,6 +13805,7 @@ async function runCodexInstaller(options = {}) {
     marketplaceName: marketplace.name,
     keepPluginNames: marketplace.plugins.map((plugin) => plugin.name)
   });
+  await pruneMarketplacePluginVersions({ codexHome, marketplaceName: marketplace.name, plugins: installed });
   for (const legacyMarketplaceName of legacyCacheMarketplaces(marketplace.name)) {
     await pruneMarketplacePluginCaches({
       codexHome,

--- a/packages/omo-codex/src/install/codex-cache-prune.test.ts
+++ b/packages/omo-codex/src/install/codex-cache-prune.test.ts
@@ -1,0 +1,52 @@
+/// <reference path="../../../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readdir, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pruneMarketplacePluginVersions } from "./codex-cache"
+
+describe("codex-cache prune", () => {
+  test("#given multiple cached plugin versions #when pruning plugin versions #then only the installed version remains", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-version-prune-"))
+    const codexHome = join(root, "codex-home")
+    const pluginRoot = join(codexHome, "plugins", "cache", "sisyphuslabs", "omo")
+    await mkdir(join(pluginRoot, "4.12.1"), { recursive: true })
+    await mkdir(join(pluginRoot, "4.15.0"), { recursive: true })
+    await mkdir(join(pluginRoot, "4.15.1"), { recursive: true })
+    await writeFile(join(pluginRoot, "4.15.1", "package.json"), "{}")
+
+    // when
+    await pruneMarketplacePluginVersions({
+      codexHome,
+      marketplaceName: "sisyphuslabs",
+      plugins: [{ name: "omo", version: "4.15.1" }],
+    })
+
+    // then
+    expect(await readdir(pluginRoot)).toEqual(["4.15.1"])
+    expect((await stat(join(pluginRoot, "4.15.1", "package.json"))).isFile()).toBe(true)
+  })
+
+  test("#given temp and backup cache siblings #when pruning plugin versions #then installer-owned working directories are removed", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-working-prune-"))
+    const codexHome = join(root, "codex-home")
+    const pluginRoot = join(codexHome, "plugins", "cache", "sisyphuslabs", "omo")
+    await mkdir(join(pluginRoot, ".backup-4.15.1-100-200"), { recursive: true })
+    await mkdir(join(pluginRoot, ".tmp-4.15.1-100-201"), { recursive: true })
+    await mkdir(join(pluginRoot, "4.15.1"), { recursive: true })
+
+    // when
+    await pruneMarketplacePluginVersions({
+      codexHome,
+      marketplaceName: "sisyphuslabs",
+      plugins: [{ name: "omo", version: "4.15.1" }],
+    })
+
+    // then
+    expect(await readdir(pluginRoot)).toEqual(["4.15.1"])
+  })
+})

--- a/packages/omo-codex/src/install/codex-cache-prune.ts
+++ b/packages/omo-codex/src/install/codex-cache-prune.ts
@@ -34,6 +34,25 @@ export async function pruneMarketplacePluginCaches(input: {
   }
 }
 
+export async function pruneMarketplacePluginVersions(input: {
+  readonly codexHome: string
+  readonly marketplaceName: string
+  readonly plugins: readonly { readonly name: string; readonly version: string }[]
+}): Promise<void> {
+  const cacheRoot = join(input.codexHome, "plugins", "cache", input.marketplaceName)
+  if (!(await fileExistsStrict(cacheRoot))) return
+  for (const plugin of input.plugins) {
+    const pluginRoot = join(cacheRoot, plugin.name)
+    if (!(await fileExistsStrict(pluginRoot))) continue
+    const keepVersions = new Set([plugin.version])
+    const entries = await readCacheEntries(pluginRoot)
+    for (const entry of entries) {
+      if (keepVersions.has(entry.name)) continue
+      await rm(join(pluginRoot, entry.name), { recursive: true, force: true })
+    }
+  }
+}
+
 async function readCacheEntries(path: string): Promise<readonly Dirent<string>[]> {
   const emptyEntries: readonly Dirent<string>[] = []
   return readCacheRoot(path, () => readdir(path, { withFileTypes: true }), emptyEntries)

--- a/packages/omo-codex/src/install/codex-cache.ts
+++ b/packages/omo-codex/src/install/codex-cache.ts
@@ -1,4 +1,4 @@
 export { linkCachedPluginBins, linkRootRuntimeBin } from "./codex-cache-bins"
 export { installCachedPlugin } from "./codex-cache-install"
 export { rewriteCachedMcpManifest, type RewriteCachedMcpManifestOptions } from "./codex-cache-mcp-manifest"
-export { pruneMarketplaceCache, pruneMarketplacePluginCaches } from "./codex-cache-prune"
+export { pruneMarketplaceCache, pruneMarketplacePluginCaches, pruneMarketplacePluginVersions } from "./codex-cache-prune"

--- a/packages/omo-codex/src/install/index.ts
+++ b/packages/omo-codex/src/install/index.ts
@@ -12,7 +12,14 @@ export { runCodexInstaller } from "./install-codex"
 export { detectCodexInstallation, formatCodexInstallationWarning } from "./codex-installation-detection"
 export { cleanupCodexLight, cleanupCodexLightConfigText } from "./codex-cleanup"
 export { readMarketplace, readPluginManifest, resolvePluginSource, validatePathSegment } from "./codex-marketplace"
-export { installCachedPlugin, linkCachedPluginBins, linkRootRuntimeBin, pruneMarketplaceCache, rewriteCachedMcpManifest } from "./codex-cache"
+export {
+  installCachedPlugin,
+  linkCachedPluginBins,
+  linkRootRuntimeBin,
+  pruneMarketplaceCache,
+  pruneMarketplacePluginVersions,
+  rewriteCachedMcpManifest,
+} from "./codex-cache"
 export {
   findNewestCachedCodexComponentCli,
   resolveCachedCodexComponentCliPath,

--- a/packages/omo-codex/src/install/install-codex-cache-prune.test.ts
+++ b/packages/omo-codex/src/install/install-codex-cache-prune.test.ts
@@ -1,0 +1,34 @@
+/// <reference path="../../../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { runCodexInstaller } from "./install-codex"
+
+const skipAstGrepInstall = async () => ({ kind: "skipped" as const, reason: "test" })
+
+describe("install-codex cache pruning", () => {
+  test("#given an old cached omo version #when installing current omo #then the installer prunes the stale version", async () => {
+    // given
+    const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-cache-prune-home-"))
+    const binDir = await mkdtemp(join(tmpdir(), "omo-codex-cache-prune-bin-"))
+    const oldVersionCacheRoot = join(codexHome, "plugins", "cache", "sisyphuslabs", "omo", "0.0.1")
+    await mkdir(oldVersionCacheRoot, { recursive: true })
+    await writeFile(join(oldVersionCacheRoot, "package.json"), JSON.stringify({ name: "@scope/omo-old", version: "0.0.1" }))
+
+    // when
+    const result = await runCodexInstaller({
+      codexHome,
+      binDir,
+      repoRoot: process.cwd(),
+      astGrepInstaller: skipAstGrepInstall,
+      runCommand: async () => undefined,
+    })
+
+    // then
+    expect((await stat(result.installed[0]?.path ?? "")).isDirectory()).toBe(true)
+    await expect(stat(oldVersionCacheRoot)).rejects.toThrow()
+  }, { timeout: 20_000 })
+})

--- a/packages/omo-codex/src/install/install-codex.ts
+++ b/packages/omo-codex/src/install/install-codex.ts
@@ -1,7 +1,7 @@
 import { join, resolve } from "node:path"
 import { existsSync } from "node:fs"
 import { homedir } from "node:os"
-import { installCachedPlugin, linkCachedPluginBins, linkRootRuntimeBin, pruneMarketplaceCache, pruneMarketplacePluginCaches } from "./codex-cache"
+import { installCachedPlugin, linkCachedPluginBins, linkRootRuntimeBin, pruneMarketplaceCache, pruneMarketplacePluginCaches, pruneMarketplacePluginVersions } from "./codex-cache"
 import { writeCachedMarketplaceManifest } from "./codex-cached-marketplace-manifest"
 import { shouldBuildSourcePackages } from "./codex-package-layout"
 import { updateCodexConfig } from "./codex-config-toml"
@@ -152,6 +152,7 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
     marketplaceName: marketplace.name,
     keepPluginNames: marketplace.plugins.map((plugin) => plugin.name),
   })
+  await pruneMarketplacePluginVersions({ codexHome, marketplaceName: marketplace.name, plugins: installed })
   for (const legacyMarketplaceName of legacyCacheMarketplaces(marketplace.name)) {
     await pruneMarketplacePluginCaches({
       codexHome,


### PR DESCRIPTION
## Summary
- add `pruneMarketplacePluginVersions` to remove stale cached version directories under each installed marketplace plugin
- run the version prune after successful Codex plugin install, so only the installed version remains
- cover the helper and installer path with Bun tests, and refresh the generated local installer bundle

## Validation
- `bun test packages/omo-codex/src/install/codex-cache-prune.test.ts packages/omo-codex/src/install/install-codex-cache-prune.test.ts packages/omo-codex/src/install/install-codex.test.ts --bail`
- `./node_modules/.bin/tsgo --noEmit -p packages/omo-codex/tsconfig.json`
- `PATH="/opt/homebrew/bin:$PATH" bun run test:codex`
- isolated `CODEX_HOME` local install QA: old cached versions `4.12.1` and `4.15.0` were pruned, only `4.15.1` remained; real `~/.codex/config.toml` hash stayed unchanged; tmux `codex exec` returned `QA_OK`

Note: an initial `bun run test:codex` using `/usr/bin/python3` failed because that Python lacks `tomllib`; rerunning with Homebrew Python on PATH passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes stale cached plugin versions after Codex plugin installs so only the installed version remains, reducing disk usage and avoiding conflicts.

- **Bug Fixes**
  - Added `pruneMarketplacePluginVersions` to remove old version directories per plugin.
  - Runs immediately after a successful install via `runCodexInstaller`.
  - Cleans up installer temp/backup cache dirs in plugin cache.
  - Refreshed installer dist; `@oh-my-opencode/omo-codex` now reports `4.15.1`.
  - Added Bun tests for the prune helper and installer flow.

<sup>Written for commit 4fb867e5687f1446718afa4c9dcf8c8c278b1e5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

