### PR TITLE
feat(omo-senpi): report live tool hook status labels to senpi

### DIFF
--- a/packages/omo-senpi/src/components/comment-checker/comment-checker.test.ts
+++ b/packages/omo-senpi/src/components/comment-checker/comment-checker.test.ts
@@ -62,6 +62,46 @@ describe("omo-senpi comment-checker component", () => {
     ])
   })
 
+  it("#given a context with updateToolHookStatus #when the check runs #then the live status label is reported once", async () => {
+    // given
+    const cwd = createTempCwd()
+    const { pi, calls } = await registerWithFakeRunner()
+    const statuses: string[] = []
+    const context = {
+      ...createContext(cwd),
+      updateToolHookStatus(message: string) {
+        statuses.push(message)
+      },
+    }
+
+    // when
+    await pi.dispatch("tool_result", createToolResultEvent(), context)
+
+    // then
+    expect(calls).toHaveLength(1)
+    expect(statuses).toEqual(["(OmO) Checking Comments"])
+  })
+
+  it("#given a non-mutation tool result #when tool_result dispatches #then no live status is reported", async () => {
+    // given
+    const cwd = createTempCwd()
+    const { pi, calls } = await registerWithFakeRunner()
+    const statuses: string[] = []
+    const context = {
+      ...createContext(cwd),
+      updateToolHookStatus(message: string) {
+        statuses.push(message)
+      },
+    }
+
+    // when
+    await pi.dispatch("tool_result", createToolResultEvent({ toolName: "bash" }), context)
+
+    // then
+    expect(calls).toHaveLength(0)
+    expect(statuses).toEqual([])
+  })
+
   it("#given successful edit result #when tool_result dispatches #then runner receives the right absolute path", async () => {
     // given
     const cwd = createTempCwd()

--- a/packages/omo-senpi/src/components/comment-checker/component.ts
+++ b/packages/omo-senpi/src/components/comment-checker/component.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, resolve } from "node:path"
 
+import { reportToolHookStatus } from "../../extension/tool-hook-status"
 import type { ComponentContext, OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types"
 import { COMMENT_CHECKER_FEEDBACK_HEADER } from "./constants"
 import { parseToolResultContext, parseToolResultEvent, toHookInput } from "./hook-input"
@@ -66,6 +67,7 @@ export function createCommentCheckerComponent(options: CommentCheckerComponentOp
           return undefined
         }
 
+        reportToolHookStatus(eventContext, "(OmO) Checking Comments")
         const result = await check({
           binaryPath: resolvedBinaryPath,
           hookInput: toHookInput(event, toolContext, absolutePath),

--- a/packages/omo-senpi/src/components/lsp/index.test.ts
+++ b/packages/omo-senpi/src/components/lsp/index.test.ts
@@ -230,6 +230,60 @@ describe("omo-senpi lsp component", () => {
     expect(widgetCalls).toEqual([{ key: "omo-senpi-lsp", content: undefined, placement: "belowEditor" }])
   })
 
+  it("#given a context with updateToolHookStatus #when post-edit diagnostics run #then the live status label is reported", async () => {
+    // given
+    const statuses: string[] = []
+    const event = {
+      type: "tool_result",
+      toolCallId: "write-1",
+      toolName: "write",
+      input: { path: "src/clean.ts" },
+      content: [{ type: "text", text: "Wrote file successfully." }],
+      isError: false,
+    }
+
+    // when
+    await handlePostEditDiagnosticsToolResult(
+      event,
+      {
+        updateToolHookStatus(message: string) {
+          statuses.push(message)
+        },
+      },
+      async () => "No diagnostics found",
+    )
+
+    // then
+    expect(statuses).toEqual(["(OmO) Checking LSP Diagnostics"])
+  })
+
+  it("#given a non-mutation tool result #when the post-edit handler runs #then no live status is reported", async () => {
+    // given
+    const statuses: string[] = []
+    const event = {
+      type: "tool_result",
+      toolCallId: "bash-1",
+      toolName: "bash",
+      input: { command: "ls" },
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    }
+
+    // when
+    await handlePostEditDiagnosticsToolResult(
+      event,
+      {
+        updateToolHookStatus(message: string) {
+          statuses.push(message)
+        },
+      },
+      async () => "No diagnostics found",
+    )
+
+    // then
+    expect(statuses).toEqual([])
+  })
+
   it("#given post-edit diagnostics are clean #when a write tool result arrives #then no diagnostics are injected", async () => {
     // given
     const event = {

--- a/packages/omo-senpi/src/components/lsp/index.ts
+++ b/packages/omo-senpi/src/components/lsp/index.ts
@@ -1,9 +1,11 @@
+import { reportToolHookStatus } from "../../extension/tool-hook-status";
 import type { ComponentContext, OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types";
 import { getConfigNotices } from "./lsp/config-loader.js";
 import { disposeDefaultLspManager, getLspManager } from "./lsp/manager-default.js";
 import {
 	appendPostEditDiagnostics,
 	POST_EDIT_DIAGNOSTICS_WIDGET_KEY,
+	shouldRunPostEditDiagnostics,
 	syncPostEditDiagnosticsWidget,
 	type DiagnosticsRunner,
 	type ToolResultLike,
@@ -92,6 +94,9 @@ export async function handlePostEditDiagnosticsToolResult(
 	runDiagnostics: DiagnosticsRunner = runLspDiagnosticsForPostEdit,
 ): Promise<ToolResultHandlerResult | undefined> {
 	if (!isToolResultLike(event)) return undefined;
+	if (shouldRunPostEditDiagnostics(event)) {
+		reportToolHookStatus(ctx, "(OmO) Checking LSP Diagnostics");
+	}
 	const result = await appendPostEditDiagnostics(event, runDiagnostics);
 	syncPostEditDiagnosticsWidget((key, content, options) => {
 		if (isWidgetContext(ctx)) {

--- a/packages/omo-senpi/src/components/lsp/lsp/post-edit-diagnostics.ts
+++ b/packages/omo-senpi/src/components/lsp/lsp/post-edit-diagnostics.ts
@@ -30,11 +30,15 @@ interface DiagnosticBlock {
 	diagnostics: string;
 }
 
+export function shouldRunPostEditDiagnostics(event: ToolResultLike): boolean {
+	return !event.isError && MUTATION_TOOL_NAMES.has(event.toolName);
+}
+
 export async function appendPostEditDiagnostics(
 	event: ToolResultLike,
 	runDiagnostics: DiagnosticsRunner,
 ): Promise<PostEditDiagnosticsResult | undefined> {
-	if (event.isError || !MUTATION_TOOL_NAMES.has(event.toolName)) return undefined;
+	if (!shouldRunPostEditDiagnostics(event)) return undefined;
 
 	const filePaths = extractMutatedFilePaths(event);
 	if (filePaths.length === 0) return undefined;

--- a/packages/omo-senpi/src/extension/tool-hook-status.ts
+++ b/packages/omo-senpi/src/extension/tool-hook-status.ts
@@ -1,0 +1,6 @@
+export function reportToolHookStatus(eventContext: unknown, statusMessage: string): void {
+  if (typeof eventContext !== "object" || eventContext === null) return
+  const update = Reflect.get(eventContext, "updateToolHookStatus")
+  if (typeof update !== "function") return
+  Reflect.apply(update, eventContext, [statusMessage])
+}


### PR DESCRIPTION
## Summary

Senpi's TUI hook status row showed a generic `Running PostToolUse hook: running omo` for every omo-senpi `tool_result` handler, so users could not tell which component was working or what it was doing. Senpi now exposes an optional `ctx.updateToolHookStatus()` on tool event contexts (code-yeongyu/senpi#106); this PR makes the comment-checker and lsp components report their identity through it.

Before: `Running PostToolUse hook: running omo (2s)`
After: `Running PostToolUse hook: (OmO) Checking LSP Diagnostics (1s)` / `(OmO) Checking Comments`

The labels reuse the exact wording the retired hooks-JSON install flow already shipped as `statusMessage`.

## Changes

- `src/extension/tool-hook-status.ts` (new): `reportToolHookStatus()` — feature-detects `updateToolHookStatus` on the unknown event context, so it is a safe no-op on senpi builds without the API.
- `comment-checker`: reports `(OmO) Checking Comments` right before invoking the binary (only when the check actually runs).
- `lsp`: exports `shouldRunPostEditDiagnostics()` from post-edit-diagnostics and reports `(OmO) Checking LSP Diagnostics` only for mutation tool results that will run diagnostics.

## QA / Evidence

Evidence dir: `.omo/evidence/20260704-senpi-live-hook-status/` (gitignored per repo config; README.md there has the full what/observed/why-enough breakdown).

- **Unit (failing-first)**: 4 new bun tests captured RED then GREEN — exact label reported once per running check and no report for non-mutation tool results, for both components. Pre-existing tests pass contexts *without* the method, proving the older-senpi no-op path.
- **Gate**: `npx tsgo --noEmit -p packages/omo-senpi/tsconfig.json` clean; `bun run test:senpi` 94 pass (build extension + skills sync + directive check + tests).
- **Live TUI**: drove senpi from source (branch with the new API) in tmux inside an isolated sandbox (`SENPI_CODING_AGENT_DIR` at temp, `PI_OFFLINE=1`, localhost fake model), with the locally built plugin installed via sandbox settings. A scripted `write` tool call produced `Running PostToolUse hook: (OmO) Checking LSP Diagnostics (1s)` live (`frames.txt`, `hook-lines.txt`). The comment-checker window is <150 ms, so its label is pinned by the deterministic unit tests instead of a timing-dependent screenshot.
- Isolation: real `~/.senpi/agent/auth.json` sha256 asserted unchanged; tmux session and sandbox torn down (receipt in script output).

## Risks

- On released senpi (no API), `reportToolHookStatus` is a no-op — covered by all pre-existing component tests whose contexts lack the method.
- Label text is static and secret-free; no user input flows into it.

## Secret safety

No secret-bearing logs. QA used a localhost fake model server with an inline mock key; no real provider credentials were read or written.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show specific live hook status labels in Senpi’s TUI for `omo-senpi`, replacing the generic “running omo.” Comment checker and LSP now report clear, per-action messages.

- **New Features**
  - Added `reportToolHookStatus()` to safely call optional `ctx.updateToolHookStatus` (no-op on older Senpi).
  - `comment-checker`: reports "(OmO) Checking Comments" when the check runs.
  - `lsp`: reports "(OmO) Checking LSP Diagnostics" only for mutation tool results; exported `shouldRunPostEditDiagnostics()` to gate execution.
  - Added targeted tests for labels and backward compatibility.

<sup>Written for commit a1efded420196b83ecf9bf4dfd237025c15b0e39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

