### PR TITLE
fix(ralph-loop): handle deferred status in handleDetectedCompletion to avoid false-success toast

### DIFF
--- a/packages/omo-opencode/src/hooks/ralph-loop/completion-handler.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/completion-handler.ts
@@ -58,6 +58,13 @@ export async function handleDetectedCompletion(
 			directory,
 			apiTimeoutMs,
 		})
+		if (promptResult.status === "deferred") {
+			log(`[${HOOK_NAME}] Deferred ultrawork verification prompt`, {
+				sessionID,
+				reason: promptResult.reason,
+			})
+			return
+		}
 		if (promptResult.status === "rejected") {
 			log(`[${HOOK_NAME}] Failed to inject ultrawork verification prompt`, {
 				sessionID,

--- a/packages/omo-opencode/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
@@ -694,6 +694,67 @@ describe("ralph-loop dispatch failure invariants", () => {
 		expect(toastCalls.some((toast) => toast.title === "Ralph Loop Failed" && toast.variant === "error")).toBe(true)
 	})
 
+	test("#given ultrawork completion path #when verification prompt injection is deferred #then no toast and no state clear", async () => {
+		// given
+		let cleared = false
+		const loopState = {
+			clear: () => {
+				cleared = true
+				return true
+			},
+			markVerificationPending: (sessionID: string) => ({
+				active: true,
+				iteration: 2,
+				prompt: "Build API",
+				started_at: new Date().toISOString(),
+				session_id: sessionID,
+				completion_promise: ULTRAWORK_VERIFICATION_PROMISE,
+				verification_pending: true,
+			}),
+		}
+
+		await handleDetectedCompletion({
+			directory: testDirectory,
+			project: testDirectory,
+			worktree: testDirectory,
+			serverUrl: "http://localhost:4096",
+			$: async () => ({}),
+			client: {
+				session: {
+					messages: async () => {
+						throw new Error("messages unavailable")
+					},
+					promptAsync: async () => ({}),
+					abort: async () => ({}),
+				},
+				tui: {
+					showToast: (options: { body: { title: string; message: string; variant: string } }) => {
+						toastCalls.push(options.body)
+					},
+				},
+			},
+		} as never, {
+			sessionID: "session-123",
+			state: {
+				active: true,
+				iteration: 2,
+				prompt: "Build API",
+				started_at: new Date().toISOString(),
+				session_id: "session-123",
+				completion_promise: "DONE",
+				ultrawork: true,
+			},
+			loopState,
+			directory: testDirectory,
+			apiTimeoutMs: 5000,
+		})
+
+		// then
+		expect(cleared).toBe(false)
+		expect(toastCalls.some((toast) => toast.title === "ULTRAWORK LOOP")).toBe(false)
+		expect(toastCalls.some((toast) => toast.title === "Ralph Loop Failed")).toBe(false)
+	})
+
 	test("#given reset strategy #when session.create throws #then dispatch failure surfaces", async () => {
 		// given
 		const hook = createRalphLoopHook({


### PR DESCRIPTION
## What changed

`handleDetectedCompletion()` in `packages/omo-opencode/src/hooks/ralph-loop/completion-handler.ts` only branched on the `"rejected"` status returned by `injectContinuationPrompt()`, silently ignoring the `"deferred"` status.

When the prompt-async gate defers the ultrawork verification prompt (e.g. an active reservation or gate conflict returns `{status: "deferred", reason: "active" | "reserved"}`), the handler fell through past both the `rejected` check and the deferred case straight into showing the `"ULTRAWORK LOOP" / "Oracle verification is now required"` success toast — even though the prompt was never actually dispatched to the session.

## Why

This is the same class of bug already handled correctly in two sibling files:
- `verification-failure-handler.ts` (`handleFailedVerification`)
- `iteration-continuation.ts` (`continueIteration`)

Both of those already have a `deferred` branch that logs and returns early without clearing loop state or showing a toast, preserving the pending state for a legitimate retry. `completion-handler.ts` was the one remaining call site missing this branch.

## Fix

Added the `deferred` branch immediately before the existing `rejected` branch, following the exact same pattern:

```ts
if (promptResult.status === "deferred") {
	log(`[${HOOK_NAME}] Deferred ultrawork verification prompt`, {
		sessionID,
		reason: promptResult.reason,
	})
	return
}
if (promptResult.status === "rejected") {
	...
}
```

No `loopState.clear()`, no toast — matches the sibling handlers' semantics for a deferred (not failed, not succeeded) dispatch.

## Test

Added a regression test in `dispatch-failure-invariant.test.ts` (same file as the sibling completion-path tests), using the same "`session.messages` throws" trick from `continuation-prompt-injector.test.ts` to force `injectContinuationPrompt` to return `{status: "deferred", reason: "active"}`. Asserts:
- loop state is **not** cleared (`cleared === false`)
- the `"ULTRAWORK LOOP"` success toast does **not** fire
- the `"Ralph Loop Failed"` toast does **not** fire either (it's neither a success nor a failure — it's deferred)

## Verification

- `bun test packages/omo-opencode/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts` — 13 pass, 0 fail (was 12, added 1)
- `bun run typecheck` — clean
- `bun run build` — clean, schema regenerated with no diff

## Scope

Single-branch addition to one function. Does not touch:
- The non-ultrawork completion branch in the same file
- `loop-state-controller.ts`, `storage.ts`, `prompt-async-gate.ts`
- The `verification_pending` self-heal retry path in `pending-verification-handler.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false success toast in the Ralph Loop when the ultrawork verification prompt is deferred. The handler now respects the `deferred` status, preserving state and avoiding incorrect user feedback.

- Bug Fixes
  - Handle `deferred` result from `injectContinuationPrompt` in `handleDetectedCompletion`, preventing the "ULTRAWORK LOOP" success toast when the prompt isn’t dispatched.
  - Log and return early; do not call `loopState.clear()` and do not show any toast on defer.
  - Add a regression test to ensure state isn’t cleared and no success/error toast fires on deferred.

<sup>Written for commit f2949594bde6b07a3706537b5dcd701014b9b80b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

