### PR TITLE
feat(shared-skills): cross-language logging methodology for the programming skill + debugging bridge

### DIFF
--- a/packages/shared-skills/skills/debugging/references/methodology/06-fix.md
+++ b/packages/shared-skills/skills/debugging/references/methodology/06-fix.md
@@ -98,6 +98,12 @@ Run the full test suite for the affected package (not just the one new test). Ex
 
 If they don't, your "fix" broke something else. Back to Phase 6 with the new failure as evidence — usually it means the mechanism you thought you fixed was load-bearing for some other code path you didn't know about, and the "broken" test is actually pointing at a better understanding of the system.
 
+### 5. Close the observability gap
+
+If diagnosis burned extra rounds *because state was invisible* — no log line told you which branch ran, what the value was, whether the fallback engaged — that invisibility is a defect adjacent to the bug, and this is the one moment where adding a log line is NOT "just in case": this session is the evidence that the line earns its place. Ship the fix WITH that line, written to the standard of the `programming` skill's `references/logging.md` — level chosen by consumer, placed at the decision point, data in fields not interpolation, through the project's designated logger. If the project deliberately does not log, respect that and skip this step.
+
+This does not soften the artifact rule: every temporary `print` / `dbg!` / `console.log` planted *during* diagnosis stays journaled and gets scrubbed in Phase 9. The triage is the consumer test — a line whose ongoing consumer you can name is part of the fix; a line that only served today's session is an artifact.
+
 ### Update the journal
 
 ```markdown

--- a/packages/shared-skills/skills/programming/SKILL.md
+++ b/packages/shared-skills/skills/programming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: programming
-description: "MUST USE for ANY work on .py .pyi .rs .ts .tsx .mts .cts .go files. One philosophy: strict types, modern stacks (Pydantic v2 / serde+thiserror / Zod / gin+sqlc+pgx+slog), modern toolchains (uv+basedpyright+ruff / cargo+clippy+miri / Bun+Biome+tsc / gofumpt+golangci-lint v2+nilaway+go-race), parse-don't-validate, exhaustive match, typed errors, no any/unwrap/panic, 250 LOC ceiling, TDD. Routes to references/{python,rust,typescript,rust-ub,go}/. Triggers: write/edit Python/Rust/TypeScript/Go code, new project, gin server, bubbletea TUI, CJK IME, connect-go RPC, sqlc pgx, branded ids, exhaustive match, unsafe Rust, miri, oversized file, refactor, TDD, e2e test, arena, allocator, bumpalo, const fn, const generics, comptime, zero-alloc, bitfield, repr, scopeguard, errdefer, Zig-like, zerocopy, packed struct."
+description: "MUST USE for ANY work on .py .pyi .rs .ts .tsx .mts .cts .go files. One philosophy: strict types, modern stacks (Pydantic v2 / serde+thiserror / Zod / gin+sqlc+pgx+slog), modern toolchains (uv+basedpyright+ruff / cargo+clippy+miri / Bun+Biome+tsc / gofumpt+golangci-lint v2+nilaway+go-race), parse-don't-validate, exhaustive match, typed errors, no any/unwrap/panic, 250 LOC ceiling, TDD, consumer-routed logging. Routes to references/{python,rust,typescript,rust-ub,go}/ + references/logging.md. Triggers: write/edit Python/Rust/TypeScript/Go code, new project, gin server, bubbletea TUI, CJK IME, connect-go RPC, sqlc pgx, branded ids, exhaustive match, unsafe Rust, miri, oversized file, refactor, TDD, e2e test, logging, log levels, structured logging, observability, arena, allocator, bumpalo, const fn, const generics, comptime, zero-alloc, bitfield, repr, scopeguard, errdefer, Zig-like, zerocopy, packed struct."
 ---
 
 # Programming
@@ -216,6 +216,14 @@ Naming variables, functions, or flags by the **absence** of a quality (`isNotVal
 
 ---
 
+## LOGGING — CROSS-CUTTING RULES
+
+Logging is part of the code you ship, and it has iron rules of its own: levels chosen by naming the consumer (never by severity vibes), placement at decision points (never inside helpers), stable messages with structured fields — and, above everything else, **the project's existing practice wins: a project with a designated logger gets that logger and nothing else, and a project that does not log does not get logging uninvited.**
+
+**Read [`references/logging.md`](references/logging.md) BEFORE the change** whenever your edit adds or modifies log lines, sets up a logger or a new service entrypoint, or handles errors at a boundary.
+
+---
+
 ## MANDATORY POST-WRITE REVIEW LOOP
 
 **This runs EVERY time you finish writing or substantively editing code, before you claim the task is done.** No exceptions.
@@ -261,6 +269,7 @@ After every code-writing session, answer these out loud (in your reply) before d
 8. **Parameter bloat?** Any function I wrote or modified that takes more than 3 parameters — or smuggles them through a dict/kwargs/`...args`/throwaway options object? If yes, group related params into a typed value object. See [Smell 2](references/code-smells.md#smell-2--function-with-more-than-3-parameters).
 9. **Redundant verification?** Did I perform a destructive action (delete, remove, clear) and then immediately re-query to "confirm" it worked? Did I call a setter then a getter to "verify"? If yes, delete the verification — the operation's contract IS the proof. See [Smell 3](references/code-smells.md#smell-3--redundant-verification-after-a-destructive-action).
 10. **Negative naming?** Any variable, function, or flag named by the absence of a quality (`isNotValid`, `noErrors`, `DisableX`) when a positive name (`isValid`, `isClean`, `EnableX`) would work? If yes, rename to positive form and invert the branch. See [Smell 4](references/code-smells.md#smell-4--negative-form-names-and-conditions).
+11. **Logging?** If I touched log lines, logger setup, or error boundaries: did I follow the project's existing practice (including its absence)? Is every new line leveled by its consumer, placed at a decision point, and message-stable with data in fields? See [`references/logging.md`](references/logging.md).
 
 **If any answer fails, fix it before declaring done.** This loop is the difference between "the code compiles" and "the code is correct."
 

--- a/packages/shared-skills/skills/programming/references/logging.md
+++ b/packages/shared-skills/skills/programming/references/logging.md
@@ -1,0 +1,91 @@
+# Logging — Cross-Language Methodology
+
+Every log line has exactly two legitimate readers: the operator reconstructing an incident and the developer reproducing a bug. A line that serves neither is cost — storage, noise, and attention stolen from the lines that matter. Everything below derives from that.
+
+This reference is deliberately stack-agnostic. It never tells you which logging library to use — the ecosystem table in SKILL.md owns stack defaults, and the project's existing practice overrides everything (Rule 0).
+
+---
+
+## Rule 0 — Discover the project's practice before emitting anything
+
+**BEFORE adding a single log line, find out how this project logs.** Grep for the logger initialization, a wrapper module, prior art in sibling files, and the project's agent docs (AGENTS.md / CLAUDE.md).
+
+| What you find | Required behavior |
+|---|---|
+| A designated logger or wrapper | Use it exactly — its levels, its field conventions, its error-passing shape. Copy the call shape of the nearest well-written call site, not your habit. |
+| A logging lib you like better | Irrelevant. NEVER introduce a second logging framework into a project that already has one. |
+| Raw `console.*` / `print` culture | Follow it for user-facing CLI output. For diagnostics, propose structured logging in your reply — do not unilaterally convert the project. |
+| **No logging at all** (library, small CLI, script) | **Respect the absence.** A library that suddenly logs is a behavior change its consumers never asked for; a 40-line script does not need a logging framework. If logging would genuinely help, say so in your reply — add it only when the user asks or the task itself is about observability. |
+
+Bypassing the project's designated logger with a bare `console.log` / `print` "just for this one line" is the logging equivalent of `as any`: it escapes every contract the project set up — stage routing, formatting, redaction, shipping.
+
+Serialization contracts (reserved field names, argument order, the key an Error must be passed under) are project knowledge. Discover the contract from the logger config and existing call sites; if the project's agent docs do not record it, record what you found there as part of your change.
+
+## Greenfield — when you own the setup
+
+A new service earns exactly this much logging infrastructure, and no more:
+
+1. **One init module.** Callers import a ready logger; only the init module knows the stage. No call site ever checks `NODE_ENV`-style vars to decide how to log.
+2. **Stage split by environment.** Dev = human-readable (pretty, colorized). Prod = structured, machine-parseable (JSON to stdout). Same logger API on both — the stage changes the sink and format, never the call sites.
+3. **Level threshold per stage.** Dev = `debug`, prod = `info`, overridable with a `LOG_LEVEL`-style env var.
+4. **The stack's standard structured logger** (the ecosystem table in SKILL.md names the default) — never a hand-rolled one.
+5. **Error-serialization proof.** Before trusting error logging, pass a real Error/exception through the PROD formatter once and assert the output preserves type, message, and stack. Every structured-logging stack has a reserved-key contract, and violating it typically produces an empty `{}` where the stack trace should have been — discovered during the incident. This is a one-line test; write it at setup time and the whole bug class is dead permanently.
+
+## Choosing the level — consumer, not severity
+
+**A level is a routing decision, not a severity vibe. Choose it by naming who consumes the line and what they do about it. If you cannot name the consumer, do not emit the line.**
+
+| Level | Consumer and action | The line earns this level when |
+|---|---|---|
+| `error` | Alerting wakes a human NOW | **The service failed** at a user-visible operation and cannot recover on its own. |
+| `warn` | Reviewed in batch — dashboards, weekly triage | The request SUCCEEDED but took an abnormal path: retry needed, fallback engaged, degraded mode, suspicious data. |
+| `info` | Read during an incident to reconstruct the timeline | A state transition without which the request's story does not reconstruct: session/job/connection created, completed, destroyed. |
+| `debug` | The developer reproducing locally | Detailed tracing. **Does not exist in prod.** |
+
+Two corollaries that get violated constantly:
+
+- **`error` means the SERVICE failed, not the request.** A 4xx is the client's mistake handled correctly — that is `warn` at most, `info` for routine misses. Reserve `error` for 5xx-class outcomes: the service could not do its job. Log 4xx as `error` and the alert channel drowns in noise from every crawler probing `/wp-admin`; a drowned alert channel is equivalent to no alerting.
+- **A failure logged at `info` is invisible.** If the message says "failed", the level is `warn` or `error` — never `info`.
+
+## Placement — log decisions, not work
+
+Log where the system decides something, not where it does something:
+
+- **Boundaries** — request in / response out, calls to external systems (and their failures).
+- **State transitions** — create / complete / destroy of sessions, jobs, connections.
+- **Decision points** — retry chosen, fallback engaged, cache bypassed, degraded mode entered.
+- **The one place an error is finally handled.**
+
+Never log inside pure functions, utilities, or private helpers — callers with context log outcomes; internals stay silent. Two mechanical rules:
+
+- **One event, one line.** Log-and-rethrow at every layer turns one incident into five look-alike incidents. Log where the error is handled; layers that only propagate stay silent.
+- **Mechanical logging belongs to middleware.** Request/response logging is wired once at the framework layer, never hand-assembled per handler. High-volume zero-signal paths (health probes, metrics scrapes) are excluded there as data — an exclusion set — not as scattered `if` statements.
+
+**No speculative logs.** "Might need it later" is not a consumer. A log line earns its place through evidence: a debugging session that burned rounds because this state was invisible (see the debugging bridge below), an incident postmortem, an alert that needs the field.
+
+## The line contract
+
+- **The message is a stable, grep-able constant; data goes in fields.** `logger.warn({orderId, attempt}, "payment retry")` — never `` `retrying payment for ${orderId}` ``. An interpolated message cannot be counted, aggregated, or alerted on.
+- **Correlation or it did not happen.** Request-scoped lines carry the trace/request id; entity-scoped lines carry the entity id. A line you cannot join to its request is noise during the only moments logs matter.
+- **Name events semantically** (`session.destroy`, `payment.fallback`), never positionally ("Step 3"). Step numbers couple the log stream to today's call structure; the first refactor makes them lie.
+- **No secrets.** Tokens, credentials, session cookies, and PII never enter a log line; URLs are sanitized (strip or redact query params like `token`, `key`) before logging. A leaked log is a leaked credential.
+- **The logging path may not break the program.** If a log call can itself fail (serializing exotic state, a wrapper that touches I/O), that failure is caught, downgraded to a `warn` through a channel that cannot fail, and the operation continues. An empty catch around logging is still an empty catch.
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails |
+|---|---|
+| `console.*` / `print` bypassing the project's designated logger | Escapes stage routing, redaction, and shipping — invisible in prod |
+| Introducing a logging framework to a project that has none | Uninvited behavior change; Rule 0 violation |
+| 4xx logged as `error` | Alert noise buries real pages |
+| Log-and-rethrow at every layer | One incident looks like five |
+| Variables interpolated into the message string | Un-aggregatable, un-alertable |
+| "Might need it later" logs | No consumer → pure cost |
+| Debug-time prints promoted to permanent `info` | Narration, not state transitions |
+| Trusting Error serialization without the proof | `error: {}` in prod, discovered during the incident |
+
+## Debugging bridge — how logs earn their place
+
+When a `debugging`-skill session takes extra rounds *because state was invisible* — no line told you which branch ran, what the value was, whether the fallback engaged — that invisibility is a defect adjacent to the bug. **The fix ships with the log line that would have made diagnosis one round**: placed at a decision point, leveled by consumer, fields not interpolation, through the project's designated logger.
+
+The inverse also holds: every temporary `print` / `dbg!` / `console.log` planted *during* diagnosis is a debug artifact and gets scrubbed at cleanup. The triage between the two is the consumer test — a line whose ongoing consumer you can name is part of the fix; a line that only served today's session is an artifact.


### PR DESCRIPTION
## Summary

The `programming` skill now teaches logging as a first-class discipline: a new cross-language reference (`references/logging.md`) defines when to log, at which level, and where — so any session that loads the skill produces well-placed, well-leveled, structured logs by default. The reference is deliberately **library-agnostic** (stack defaults remain in the existing SKILL.md ecosystem table) and leads with a discovery gate: **the project's existing practice wins, including the absence of logging** — a project without logging does not get logging uninvited. The `debugging` skill's fix phase gains a matching bridge so logs earn their place through evidence instead of speculation.

## Changes

- **`programming/references/logging.md` (new)** — the methodology, organized as decision rules:
  - *Rule 0 — discovery gate*: find the project's designated logger/wrapper first and follow its contract exactly; never introduce a second logging framework; never bypass with `console.*`/`print`; **respect a project that deliberately does not log** (suggest, don't add).
  - *Greenfield setup*: one init module, env-driven stage split (dev pretty / prod structured JSON), `LOG_LEVEL` override, and an **error-serialization proof** — pass a real Error through the prod formatter once and assert type/message/stack survive (kills the `error: {}`-in-prod bug class at setup time).
  - *Levels by consumer, not severity*: error = alert wakes a human (service failed, 5xx — never 4xx); warn = batch review (succeeded but abnormal); info = incident timeline reconstruction; debug = dev-only. "Can't name the consumer → don't emit."
  - *Placement*: boundaries, state transitions, decision points, the one place an error is handled; one event = one line (no log-and-rethrow); mechanical logging owned by middleware with noise paths excluded as data; no speculative logs.
  - *Line contract*: stable grep-able message + data in fields, correlation ids, semantic event names, no secrets, logging failures never break the program.
- **`programming/SKILL.md`** — minimal routing hook (new short section before the review loop), review-loop item 11 (logging self-check), and description trigger words (`logging`, `log levels`, `structured logging`, `observability`). Description stays at 925/1024 chars with the Codex display prefix.
- **`debugging/references/methodology/06-fix.md`** — Phase 7 step 5 "Close the observability gap": when diagnosis burned rounds because state was invisible, the fix ships with that log line (to the logging.md standard); temporary diagnosis prints remain artifacts scrubbed in Phase 9. Resolves the tension between "no speculative logs" and "logs should serve debugging" with a fact-gated rule.

## QA & Evidence

Evidence dir (local, gitignored per `.omo/*`): `.omo/evidence/20260704-programming-logging-skill/`

- **What was tested:** OpenCode loader landing — drove the real `skills-loader-core` `getSkillByName("programming")` API + `sharedSkillsRootPath()` resolution.
  **Observed:** skill discovered (scope `shared`), description triggers present, body routes to `references/logging.md`, review item 11 present, reference resolves at the served path with the respect-absence rule and zero library names, debugging bridge present (PROOF 1–8 all true).
  **Artifact:** `opencode-loader-landing-proof.log` + `landing-proof.ts`.
  **Why sufficient:** exercises the exact code path OpenCode uses to serve shared skills at runtime.
- **What was tested:** Codex gate — `bun run test:codex` in the worktree (after `git -c protocol.file.allow=always submodule update --init` for the known fresh-worktree submodule transport gotcha).
  **Observed:** exit 0; final plugin suite 456 pass / 0 fail.
  **Artifact:** `test-codex.log`.
  **Why sufficient:** hermetic unit gate covering installer, config migration, and the full plugin component suite including `sync-skills`.
- **What was tested:** Codex landing, twice — (a) synced copies under `plugin/skills/` after the gate's sync run; (b) `.agents/skills/codex-qa/scripts/install-verify.sh --keep` installing the local build into an **isolated `CODEX_HOME`**, then asserting the installed plugin cache contents.
  **Observed:** new reference, SKILL.md hook, description triggers, and debugging bridge present in both the synced copy (PROOF C1–C4) and the installed cache (PROOF C5–C7); `install-verify` PASS; **real `~/.codex/config.toml` shasum unchanged** (`26a5250…`); isolated home removed afterwards.
  **Artifacts:** `codex-sync-landing-proof.log`, `codex-install-verify.log`.
  **Why sufficient:** proves the change lands on the real Codex install surface without touching the host.
- **What was tested:** regression — scoped `bun test` over `shared-skills-package.test.ts`, `features/builtin-skills/` (SKILL.md byte-pin extraction), and `markdown-link-audit.test.ts`; plus `packages/skills-loader-core`.
  **Observed:** 55 pass / 0 fail scoped; loader-core 215 pass / 2 fail where the identical 2 failures reproduce on clean dev at the same base commit `db0e80c7d` (pre-existing git-master template drift, untouched by this PR).
  **Artifacts:** `bun-test-opencode-scoped.log`, `loader-core-worktree.log`, `loader-core-baseline-dev-db0e80c7d.log`.
  **Why sufficient:** every content pin that could regress from skill-text edits is covered, and the only failures are proven pre-existing.

## Risks & Residuals

- **Byte-pin regressions** (debugging SKILL.md is pinned to a TS mirror): mitigated — only `references/06-fix.md` was edited; extraction tests green.
- **Codex 1024-char description cap**: mitigated — 925 chars including the `(OmO) ` prefix, asserted in evidence.
- **Prompt effectiveness** (does the model actually follow the new rules): not machine-assertable; accepted as design-review territory. The reference is decision-rule shaped throughout, which is the form both Claude and GPT-5.5 sessions follow reliably in this repo's experience.
- **Build byproducts** regenerated by `test:codex` (`codegraph/dist/serve.js`, `install-dist/install-local.mjs`) were restored and are not part of this PR.

## Related Issues

None — follow-up from the arbiter logging-methodology review discussion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-language logging methodology to the `programming` skill and links it to the `debugging` skill, so sessions produce consistent, consumer-routed, structured logs. Respects each project's existing practice (including no logging) and includes a greenfield setup recipe with an error-serialization proof.

- New Features
  - Added `programming/references/logging.md`: Rule 0 discovery gate (follow the project's logger or respectfully skip), consumer-based levels, decision-point placement, stable message + structured fields, and greenfield setup (single init, dev pretty/prod JSON, `LOG_LEVEL` override, error-serialization proof).
  - Updated `programming/SKILL.md`: routing hook to the logging reference, new review item for logging, and trigger words (logging, log levels, structured logging, observability).
  - Bridged `debugging` fix phase: “Close the observability gap” — ship the one log line that diagnosis proved necessary; temporary prints remain artifacts and are scrubbed later.

<sup>Written for commit 62f66680f8be219efcc78703bf40d14cf46f3b4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

