### PR TITLE
fix(tmux-core): quote attach command arguments

### DIFF
--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/pane-command.test.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/pane-command.test.ts
@@ -1,5 +1,42 @@
 import { describe, expect, it } from "bun:test"
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { buildTmuxAttachCommand, buildTmuxPlaceholderCommand } from "./pane-command"
+
+function createFakeOpencodeBin(tempDir: string): string {
+  const binDir = join(tempDir, "bin")
+  const opencodePath = join(binDir, "opencode")
+  mkdirSync(binDir, { recursive: true })
+  writeFileSync(
+    opencodePath,
+    [
+      "#!/bin/sh",
+      "index=0",
+      "for arg in \"$@\"; do",
+      "  printf '%s\\t%s\\n' \"$index\" \"$arg\"",
+      "  index=$((index + 1))",
+      "done",
+    ].join("\n"),
+  )
+  chmodSync(opencodePath, 0o755)
+  return binDir
+}
+
+function runCommandWithFakeOpencode(command: string, binDir: string): readonly string[] {
+  const result = Bun.spawnSync(["/bin/sh", "-c", command], {
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    },
+  })
+  expect(result.exitCode).toBe(0)
+  return result.stdout
+    .toString()
+    .trim()
+    .split("\n")
+    .map((line) => line.split("\t").slice(1).join("\t"))
+}
 
 describe("buildTmuxAttachCommand", () => {
   it("uses /bin/sh instead of inheriting SHELL", () => {
@@ -15,11 +52,25 @@ describe("buildTmuxAttachCommand", () => {
     }
   })
 
-  it("escapes serverUrl shell metacharacters", () => {
-    const cmd = buildTmuxAttachCommand("http://localhost:3000$(whoami);rm -rf /", "ses_abc123")
-    expect(cmd).toContain("\\$")
-    expect(cmd).toContain("\\;")
-    expect(cmd).not.toMatch(/[^\\];\s*rm/)
+  it("#given serverUrl shell metacharacters #when generated command runs through the shell #then serverUrl stays one literal argument", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omo tmux command "))
+
+    try {
+      const binDir = createFakeOpencodeBin(tempDir)
+      const serverUrl = "http://localhost:3000$(whoami);rm -rf /"
+      const cmd = buildTmuxAttachCommand(serverUrl, "ses_abc123")
+
+      expect(runCommandWithFakeOpencode(cmd, binDir)).toEqual([
+        "attach",
+        serverUrl,
+        "--session",
+        "ses_abc123",
+        "--dir",
+        process.cwd(),
+      ])
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 
   it("escapes session id shell metacharacters", () => {

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/pane-command.test.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/pane-command.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { buildTmuxAttachCommand, buildTmuxPlaceholderCommand } from "./pane-command"
 
+const itWithUnixShell = it.skipIf(process.platform === "win32")
+
 function createFakeOpencodeBin(tempDir: string): string {
   const binDir = join(tempDir, "bin")
   const opencodePath = join(binDir, "opencode")
@@ -52,26 +54,29 @@ describe("buildTmuxAttachCommand", () => {
     }
   })
 
-  it("#given serverUrl shell metacharacters #when generated command runs through the shell #then serverUrl stays one literal argument", () => {
-    const tempDir = mkdtempSync(join(tmpdir(), "omo tmux command "))
+  itWithUnixShell(
+    "#given serverUrl shell metacharacters #when generated command runs through the shell #then serverUrl stays one literal argument",
+    () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "omo tmux command "))
 
-    try {
-      const binDir = createFakeOpencodeBin(tempDir)
-      const serverUrl = "http://localhost:3000$(whoami);rm -rf /"
-      const cmd = buildTmuxAttachCommand(serverUrl, "ses_abc123")
+      try {
+        const binDir = createFakeOpencodeBin(tempDir)
+        const serverUrl = "http://localhost:3000$(whoami);rm -rf /"
+        const cmd = buildTmuxAttachCommand(serverUrl, "ses_abc123")
 
-      expect(runCommandWithFakeOpencode(cmd, binDir)).toEqual([
-        "attach",
-        serverUrl,
-        "--session",
-        "ses_abc123",
-        "--dir",
-        process.cwd(),
-      ])
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true })
-    }
-  })
+        expect(runCommandWithFakeOpencode(cmd, binDir)).toEqual([
+          "attach",
+          serverUrl,
+          "--session",
+          "ses_abc123",
+          "--dir",
+          process.cwd(),
+        ])
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true })
+      }
+    },
+  )
 
   it("escapes session id shell metacharacters", () => {
     const cmd = buildTmuxAttachCommand("http://localhost:3000", 'ses_abc"$(whoami)"')

--- a/packages/tmux-core/src/tmux-utils/pane-command.test.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-command.test.ts
@@ -1,5 +1,42 @@
 import { describe, expect, it } from "bun:test"
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { buildTmuxAttachCommand, buildTmuxPlaceholderCommand } from "./pane-command"
+
+function createFakeOpencodeBin(tempDir: string): string {
+  const binDir = join(tempDir, "bin")
+  const opencodePath = join(binDir, "opencode")
+  mkdirSync(binDir, { recursive: true })
+  writeFileSync(
+    opencodePath,
+    [
+      "#!/bin/sh",
+      "index=0",
+      "for arg in \"$@\"; do",
+      "  printf '%s\\t%s\\n' \"$index\" \"$arg\"",
+      "  index=$((index + 1))",
+      "done",
+    ].join("\n"),
+  )
+  chmodSync(opencodePath, 0o755)
+  return binDir
+}
+
+function runCommandWithFakeOpencode(command: string, binDir: string): readonly string[] {
+  const result = Bun.spawnSync(["/bin/sh", "-c", command], {
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    },
+  })
+  expect(result.exitCode).toBe(0)
+  return result.stdout
+    .toString()
+    .trim()
+    .split("\n")
+    .map((line) => line.split("\t").slice(1).join("\t"))
+}
 
 describe("buildTmuxAttachCommand", () => {
   it("uses /bin/sh instead of inheriting SHELL", () => {
@@ -15,17 +52,54 @@ describe("buildTmuxAttachCommand", () => {
     }
   })
 
-  it("escapes serverUrl shell metacharacters", () => {
-    const cmd = buildTmuxAttachCommand("http://localhost:3000$(whoami);rm -rf /", "ses_abc123")
-    expect(cmd).toContain("\\$")
-    expect(cmd).toContain("\\;")
-    expect(cmd).not.toMatch(/[^\\];\s*rm/)
+  it("#given serverUrl shell metacharacters #when generated command runs through the shell #then serverUrl stays one literal argument", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omo tmux command "))
+
+    try {
+      const binDir = createFakeOpencodeBin(tempDir)
+      const serverUrl = "http://localhost:3000$(whoami);rm -rf /"
+      const cmd = buildTmuxAttachCommand(serverUrl, "ses_abc123")
+
+      expect(runCommandWithFakeOpencode(cmd, binDir)).toEqual([
+        "attach",
+        serverUrl,
+        "--session",
+        "ses_abc123",
+        "--dir",
+        process.cwd(),
+      ])
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 
   it("escapes session id shell metacharacters", () => {
     const cmd = buildTmuxAttachCommand("http://localhost:3000", 'ses_abc"$(whoami)"')
     expect(cmd).toContain('\\"')
     expect(cmd).toContain("\\$")
+  })
+
+  it("#given directory path contains spaces #when generated command runs through the shell #then directory stays one argument", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omo tmux command "))
+    const directory = join(tempDir, "Mobile Documents", "project")
+
+    try {
+      mkdirSync(directory, { recursive: true })
+      const binDir = createFakeOpencodeBin(tempDir)
+
+      const command = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123", directory)
+
+      expect(runCommandWithFakeOpencode(command, binDir)).toEqual([
+        "attach",
+        "http://localhost:3000",
+        "--session",
+        "ses_abc123",
+        "--dir",
+        directory,
+      ])
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/tmux-core/src/tmux-utils/pane-command.test.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-command.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { buildTmuxAttachCommand, buildTmuxPlaceholderCommand } from "./pane-command"
 
+const itWithUnixShell = it.skipIf(process.platform === "win32")
+
 function createFakeOpencodeBin(tempDir: string): string {
   const binDir = join(tempDir, "bin")
   const opencodePath = join(binDir, "opencode")
@@ -52,26 +54,29 @@ describe("buildTmuxAttachCommand", () => {
     }
   })
 
-  it("#given serverUrl shell metacharacters #when generated command runs through the shell #then serverUrl stays one literal argument", () => {
-    const tempDir = mkdtempSync(join(tmpdir(), "omo tmux command "))
+  itWithUnixShell(
+    "#given serverUrl shell metacharacters #when generated command runs through the shell #then serverUrl stays one literal argument",
+    () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "omo tmux command "))
 
-    try {
-      const binDir = createFakeOpencodeBin(tempDir)
-      const serverUrl = "http://localhost:3000$(whoami);rm -rf /"
-      const cmd = buildTmuxAttachCommand(serverUrl, "ses_abc123")
+      try {
+        const binDir = createFakeOpencodeBin(tempDir)
+        const serverUrl = "http://localhost:3000$(whoami);rm -rf /"
+        const cmd = buildTmuxAttachCommand(serverUrl, "ses_abc123")
 
-      expect(runCommandWithFakeOpencode(cmd, binDir)).toEqual([
-        "attach",
-        serverUrl,
-        "--session",
-        "ses_abc123",
-        "--dir",
-        process.cwd(),
-      ])
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true })
-    }
-  })
+        expect(runCommandWithFakeOpencode(cmd, binDir)).toEqual([
+          "attach",
+          serverUrl,
+          "--session",
+          "ses_abc123",
+          "--dir",
+          process.cwd(),
+        ])
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true })
+      }
+    },
+  )
 
   it("escapes session id shell metacharacters", () => {
     const cmd = buildTmuxAttachCommand("http://localhost:3000", 'ses_abc"$(whoami)"')
@@ -79,28 +84,31 @@ describe("buildTmuxAttachCommand", () => {
     expect(cmd).toContain("\\$")
   })
 
-  it("#given directory path contains spaces #when generated command runs through the shell #then directory stays one argument", () => {
-    const tempDir = mkdtempSync(join(tmpdir(), "omo tmux command "))
-    const directory = join(tempDir, "Mobile Documents", "project")
+  itWithUnixShell(
+    "#given directory path contains spaces #when generated command runs through the shell #then directory stays one argument",
+    () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "omo tmux command "))
+      const directory = join(tempDir, "Mobile Documents", "project")
 
-    try {
-      mkdirSync(directory, { recursive: true })
-      const binDir = createFakeOpencodeBin(tempDir)
+      try {
+        mkdirSync(directory, { recursive: true })
+        const binDir = createFakeOpencodeBin(tempDir)
 
-      const command = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123", directory)
+        const command = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123", directory)
 
-      expect(runCommandWithFakeOpencode(command, binDir)).toEqual([
-        "attach",
-        "http://localhost:3000",
-        "--session",
-        "ses_abc123",
-        "--dir",
-        directory,
-      ])
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true })
-    }
-  })
+        expect(runCommandWithFakeOpencode(command, binDir)).toEqual([
+          "attach",
+          "http://localhost:3000",
+          "--session",
+          "ses_abc123",
+          "--dir",
+          directory,
+        ])
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true })
+      }
+    },
+  )
 })
 
 describe("buildTmuxPlaceholderCommand", () => {

--- a/packages/tmux-core/src/tmux-utils/pane-command.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-command.ts
@@ -2,10 +2,18 @@ import { shellEscapeForDoubleQuotedCommand } from "@oh-my-opencode/utils"
 
 const TMUX_COMMAND_SHELL = "/bin/sh"
 
+function shellQuoteForNestedCommand(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+    .replace(/\\/g, "\\\\")
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`")
+    .replace(/"/g, '\\"')
+}
+
 export function buildTmuxAttachCommand(serverUrl: string, sessionId: string, directory: string = process.cwd()): string {
-  const escapedUrl = shellEscapeForDoubleQuotedCommand(serverUrl)
-  const escapedSessionId = shellEscapeForDoubleQuotedCommand(sessionId)
-  const escapedDirectory = shellEscapeForDoubleQuotedCommand(directory || process.cwd())
+  const escapedUrl = shellQuoteForNestedCommand(serverUrl)
+  const escapedSessionId = shellQuoteForNestedCommand(sessionId)
+  const escapedDirectory = shellQuoteForNestedCommand(directory || process.cwd())
   return `${TMUX_COMMAND_SHELL} -c "opencode attach ${escapedUrl} --session ${escapedSessionId} --dir ${escapedDirectory}"`
 }
 


### PR DESCRIPTION
## Summary
Fixes #5596.

`buildTmuxAttachCommand` now wraps each `opencode attach` argument for the inner `/bin/sh -c` command so `--dir` values with spaces remain one argv item when a tmux subagent pane is focused. This is a mechanical quoting fix; it does not change the pane lifecycle or user-facing behavior beyond making the existing attach command survive spaced paths.

## Changes
- Quote `serverUrl`, `sessionId`, and `directory` as inner-shell arguments while preserving the existing `/bin/sh -c "..."` tmux command shape.
- Add a failing-first `tmux-core` regression that executes the generated command through a real shell with a fake `opencode` and asserts a spaced directory arrives as one argument.
- Strengthen the core and OpenCode adapter shim metacharacter tests to assert literal argv behavior instead of the previous escape spelling.
- Guard the Unix `/bin/sh` argv-execution tests on Windows, where the generated tmux command is not runnable because `/bin/sh` is absent.

## Observed Behavior
- Before the product fix, the new regression failed because the fake `opencode` received the spaced directory split into multiple arguments.
- After the fix, `bun test packages/tmux-core` passed with `75 pass, 0 fail`.
- After aligning the adapter shim test, `bun test packages/omo-opencode/src/shared/tmux/tmux-utils/pane-command.test.ts packages/tmux-core` passed with `81 pass, 0 fail`.
- A scratch tmux session executing the generated command shape captured argument `5` as the complete spaced directory and exited `0`.
- Windows CI initially failed only because the new argv-level tests tried to spawn `/bin/sh` on `windows-latest`; after guarding those Unix shell execution tests, the focused suite still passes locally with `81 pass, 0 fail`.

## QA & Evidence
- **Failing-first regression:** `bun test packages/tmux-core` before product changes. Observed the new test fail on word-splitting. Artifact: `.omo/evidence/20260704-fix-5596/bun-test-tmux-core-red.txt`.
- **Green regression:** `bun test packages/tmux-core` after the fix. Observed `75 pass, 0 fail`. Artifacts: `.omo/evidence/20260704-fix-5596/bun-test-tmux-core-green.txt`, `.omo/evidence/20260704-fix-5596/bun-test-tmux-core-final.txt`.
- **Adapter CI fix iteration:** `bun test packages/omo-opencode/src/shared/tmux/tmux-utils/pane-command.test.ts packages/tmux-core`. Observed `81 pass, 0 fail`. Artifact: `.omo/evidence/20260704-fix-5596/bun-test-tmux-core-adapter-final.txt`.
- **Windows CI guard iteration:** same focused test command after guarding Unix shell execution tests on `win32`. Observed `81 pass, 0 fail`. Artifacts: `.omo/evidence/20260704-fix-5596/ci-test-windows-failed.log`, `.omo/evidence/20260704-fix-5596/bun-test-tmux-core-windows-guard-final.txt`.
- **Type safety:** `bun run typecheck` exited 0 before and after the adapter shim test fix and after the Windows guard. Artifacts: `.omo/evidence/20260704-fix-5596/typecheck.txt`, `.omo/evidence/20260704-fix-5596/typecheck-after-adapter-test-fix.txt`, `.omo/evidence/20260704-fix-5596/typecheck-after-windows-guard-final.txt`.
- **Real tmux proof:** scratch tmux session with fake `opencode` and spaced temp `--dir`. Observed full path at argv index `5`; scratch session and temp directory cleaned up. Artifacts: `.omo/evidence/20260704-fix-5596/tmux-live-proof.txt`, `.omo/evidence/20260704-fix-5596/tmux-live-proof-pane.txt`.
- **OpenCode QA mapping:** `opencode-qa` common harness self-check and TUI smoke. Observed isolated XDG cleanup, TUI render under tmux, tmux teardown, and unchanged real DB session count. Artifacts: `.omo/evidence/20260704-fix-5596/opencode-qa-common-self-check.txt`, `.omo/evidence/20260704-fix-5596/opencode-qa-tui-smoke.txt`, `.omo/evidence/20260704-fix-5596/opencode-qa-tui-smoke-after-adapter-test-fix.txt`, `.omo/evidence/20260704-fix-5596/opencode-qa-common-self-check-after-windows-guard.txt`, `.omo/evidence/20260704-fix-5596/opencode-qa-tui-smoke-after-windows-guard.txt`.

## Bootstrap Note
`bash script/agent/setup.sh` was run before code work. After dependency install it failed during the build substep because local file-protocol submodules are disallowed in this worktree; the focused test suite, typecheck, tmux proof, and opencode QA checks above were run successfully afterward.

## Risks & Residuals
- No live provider-backed `opencode attach` session was used. The failing issue is shell argument integrity, so the tmux proof substitutes a fake `opencode` that prints argv and avoids provider/server dependencies.
- Setup left unrelated submodule working-tree dirtiness under `packages/shared-skills/upstreams/*`; those files were not staged or committed.

