### PR TITLE
fix(delegate-task): unblock sync tmux readiness

### DIFF
--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+
+function clearRequireCache(modulePath: string): void {
+  const resolvedPath = require.resolve(modulePath)
+  if (require.cache?.[resolvedPath]) {
+    delete require.cache[resolvedPath]
+  }
+}
+
+type PromptDispatchOutcome = "prompt_dispatched" | "timeout"
+
+function timeoutAfter(ms: number): Promise<PromptDispatchOutcome> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve("timeout"), ms)
+  })
+}
+
+describe("executeSyncTask - sync session lifecycle ordering", () => {
+  afterEach(() => {
+    mock.restore()
+    clearRequireCache("./sync-task")
+    const { clearAllDelegatedChildSessionBootstrap } = require("../../shared/delegated-child-session-bootstrap")
+    clearAllDelegatedChildSessionBootstrap()
+  })
+
+  test("#given sync session created callback waits for readiness #when executing sync task #then prompt dispatch is not blocked by the callback", async () => {
+    //#given
+    const mockClient = {
+      session: {
+        create: async () => ({ data: { id: "ignored" } }),
+      },
+    }
+    const { executeSyncTask } = require("./sync-task")
+    let releaseSyncCallback: () => void = () => {}
+    const syncCallbackGate = new Promise<void>((resolve) => {
+      releaseSyncCallback = resolve
+    })
+    let markSyncCallbackStarted: () => void = () => {}
+    const syncCallbackStarted = new Promise<void>((resolve) => {
+      markSyncCallbackStarted = resolve
+    })
+    const onSyncSessionCreated = mock(async (_event: { sessionID: string; parentID: string; title: string }) => {
+      markSyncCallbackStarted()
+      await syncCallbackGate
+    })
+    let markPromptDispatched: () => void = () => {}
+    const promptDispatched = new Promise<void>((resolve) => {
+      markPromptDispatched = resolve
+    })
+    const sendSyncPrompt = mock(async () => {
+      markPromptDispatched()
+      return null
+    })
+    const deps = {
+      createSyncSession: async () => ({ ok: true as const, sessionID: "ses_ready_gate_sync" }),
+      sendSyncPrompt,
+      pollSyncSession: async () => null,
+      fetchSyncResult: async () => ({ ok: true as const, textContent: "Result" }),
+    }
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-123",
+      metadata: () => {},
+    }
+    const mockExecutorCtx = {
+      client: mockClient,
+      directory: "/tmp",
+      onSyncSessionCreated,
+    }
+    const args = {
+      prompt: "test prompt",
+      description: "test task",
+      category: "test",
+      load_skills: [],
+      run_in_background: false,
+      command: null,
+    }
+
+    //#when
+    const resultPromise = executeSyncTask(args, mockCtx, mockExecutorCtx, {
+      sessionID: "parent-session",
+    }, "test-agent", undefined, undefined, undefined, undefined, deps)
+    await syncCallbackStarted
+
+    try {
+      //#then
+      const promptDispatchOutcome = await Promise.race<PromptDispatchOutcome>([
+        promptDispatched.then(() => "prompt_dispatched"),
+        timeoutAfter(250),
+      ])
+      expect(promptDispatchOutcome).toBe("prompt_dispatched")
+      expect(sendSyncPrompt).toHaveBeenCalledTimes(1)
+    } finally {
+      releaseSyncCallback()
+      await resultPromise
+    }
+  })
+})

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
@@ -39,21 +39,18 @@ export async function registerSyncSessionSideEffects(input: {
   })
 
   if (input.executorCtx.onSyncSessionCreated) {
-    log("[task] Invoking onSyncSessionCreated callback", {
+    log("[task] Invoking onSyncSessionCreated callback (fire-and-forget)", {
       sessionID: input.sessionID,
       parentID: input.parentContext.sessionID,
     })
-    try {
-      await input.executorCtx.onSyncSessionCreated({
-        sessionID: input.sessionID,
-        parentID: input.parentContext.sessionID,
-        title: input.args.description,
-      })
-    } catch (error) {
+    void input.executorCtx.onSyncSessionCreated({
+      sessionID: input.sessionID,
+      parentID: input.parentContext.sessionID,
+      title: input.args.description,
+    }).catch((error: unknown) => {
       const message = error instanceof Error ? String(error) : String(error)
       log("[task] onSyncSessionCreated callback failed", { error: message })
-    }
-    await new Promise(resolve => setTimeout(resolve, 200))
+    })
   }
 }
 


### PR DESCRIPTION
Fixes #5608

## What changed

- Added a failing-first regression test for the sync delegate-task ordering contract.
- Changed sync session side-effect registration so `onSyncSessionCreated` runs fire-and-forget with error logging instead of blocking prompt dispatch.
- Removed the old post-callback delay from the sync prompt path.

## Why

The sync path created the child session and then awaited `onSyncSessionCreated`. That callback can wait for the child session to become attachable/busy, but the child prompt is only dispatched later by `runSyncTaskLoop`. Awaiting the callback inverted the order, so the ready gate could not observe `busy` until after it had already timed out.

## Observed behavior

- Red proof: `.omo/evidence/20260704-fix-5608/red-sync-session-lifecycle-test.txt` shows the new regression test failing on the old blocking implementation with `Received: "timeout"`.
- Green proof: `.omo/evidence/20260704-fix-5608/green-sync-session-lifecycle-test.txt` shows the same test passing after the fix.
- Live proof: `.omo/evidence/20260704-fix-5608/live-plugin-log-slice.txt` shows `promptAsync dispatched`, then `session ready` with `status: "busy"` / `waitedMs: 2`, then `pane spawned and tracked`.
- Live completion: `.omo/evidence/20260704-fix-5608/live-fake-llm.log` shows `parent-tool-call`, `child`, and `parent-final`.
- Isolation: `.omo/evidence/20260704-fix-5608/live-isolation-proof.txt` shows the real OpenCode DB session count stayed `21732 -> 21732`.

## QA evidence

- `bun test packages/omo-opencode/src/tools/delegate-task` -> `478 pass`, `0 fail` (`.omo/evidence/20260704-fix-5608/delegate-task-suite.txt`)
- `bun test packages/omo-opencode/src/shared/prompt-async-route-audit.test.ts` -> `10 pass`, `0 fail` (`.omo/evidence/20260704-fix-5608/prompt-async-route-audit.txt`)
- `bun run typecheck` -> passed (`.omo/evidence/20260704-fix-5608/typecheck.txt`)
- `bun run build` -> passed (`.omo/evidence/20260704-fix-5608/build-after-fix.txt`)
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.test.ts` -> `No violations in 2 file(s).`
- `bash .omo/evidence/20260704-fix-5608/run-opencode-sync-tmux-qa.sh` -> isolated `opencode run --format json` with tmux enabled passed (`.omo/evidence/20260704-fix-5608/live-verdict.txt`)

## Residual risk

- Live QA uses a local fake OpenAI Responses server so it can be deterministic and secret-free; it still drives real `opencode run`, the local plugin, the task tool, and tmux pane spawning.
- Existing unrelated generated Codex artifacts were dirty in this worktree from setup/build and were intentionally not included in this PR.
- Existing oversized `sync-task.test.ts` was not refactored because this is a pure mechanical bug fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks sync delegate-task prompt dispatch so tmux readiness works as expected by making `onSyncSessionCreated` non-blocking. Fixes #5608.

- **Bug Fixes**
  - Added a failing-first regression test for sync session lifecycle ordering.
  - Run `onSyncSessionCreated` fire-and-forget with error logging to avoid blocking prompt dispatch.
  - Removed the post-callback artificial delay in the sync path.

<sup>Written for commit 77d69c7ba55b7e3a8ad37a1a8fe532e002196eb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

