### PR TITLE
Guard LazyCodex hook CLI payloads

### DIFF
--- a/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
@@ -87,6 +87,26 @@ test("#given aggregate PostCompact hooks #when hooks are inspected #then LSP dia
 	assert.equal(lspPostCompactHooks[0]?.handler.statusMessage, "(OmO) Resetting LSP Diagnostics Cache");
 });
 
+test("#given aggregate hook commands #when inspected #then every plugin-root command target exists", async () => {
+	// given
+	const commandHooks = await readAggregateCommandHooks();
+
+	// when
+	const missingTargets = [];
+	for (const hook of commandHooks) {
+		for (const command of [hook.handler.command, hook.handler.commandWindows]) {
+			if (typeof command !== "string") continue;
+			for (const match of command.matchAll(/\$\{PLUGIN_ROOT\}([\\/][^"'\s]+)/g)) {
+				const target = match[1].replaceAll("\\", "/").replace(/^\//, "");
+				if (!(await exists(target))) missingTargets.push(`${hookLocation(hook)} -> ${target}`);
+			}
+		}
+	}
+
+	// then
+	assert.deepEqual(missingTargets, []);
+});
+
 test("#given aggregate hook commands #when inspected #then every command exposes a Codex status message", async () => {
 	// given
 	// when

--- a/script/sync-lazycodex-marketplace.test.ts
+++ b/script/sync-lazycodex-marketplace.test.ts
@@ -62,6 +62,28 @@ async function writePluginFixture(sourceRoot: string, options: WritePluginFixtur
           ],
         },
       ],
+      Stop: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: 'node "${PLUGIN_ROOT}/components/start-work-continuation/dist/cli.js" hook stop',
+              statusMessage: "LazyCodex(1.2.3): Checking Start-Work Continuation",
+            },
+          ],
+        },
+      ],
+      UserPromptSubmit: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: 'node "${PLUGIN_ROOT}/components/ulw-loop/dist/cli.js" hook user-prompt-submit',
+              statusMessage: "LazyCodex(1.2.3): Checking Ulw-Loop Steering",
+            },
+          ],
+        },
+      ],
     },
   })
   await writeJson(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "bootstrap", "hooks", "hooks.json"), {
@@ -107,6 +129,13 @@ async function writePluginFixture(sourceRoot: string, options: WritePluginFixtur
   await writeFile(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "lsp", "dist", "cli.js"), "#!/usr/bin/env node\n")
   await mkdir(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "comment-checker", "dist"), { recursive: true })
   await writeFile(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "comment-checker", "dist", "cli.js"), "#!/usr/bin/env node\n")
+  await mkdir(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "start-work-continuation", "dist"), { recursive: true })
+  await writeFile(
+    join(sourceRoot, "packages", "omo-codex", "plugin", "components", "start-work-continuation", "dist", "cli.js"),
+    "#!/usr/bin/env node\n",
+  )
+  await mkdir(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "ulw-loop", "dist"), { recursive: true })
+  await writeFile(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "ulw-loop", "dist", "cli.js"), "#!/usr/bin/env node\n")
   await mkdir(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "bootstrap", "dist"), { recursive: true })
   await writeFile(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "bootstrap", "dist", "cli.js"), "#!/usr/bin/env node\n")
   await mkdir(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "bootstrap", "scripts"), { recursive: true })
@@ -166,6 +195,10 @@ describe("sync-lazycodex-marketplace", () => {
     expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "git-bash-mcp", "dist", "cli.js"))).isFile()).toBe(true)
     expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "lsp-tools-mcp", "dist", "cli.js"))).isFile()).toBe(true)
     expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "lsp-daemon", "dist", "cli.js"))).isFile()).toBe(true)
+    expect(
+      (await stat(join(lazycodexRoot, "plugins", "omo", "components", "start-work-continuation", "dist", "cli.js"))).isFile(),
+    ).toBe(true)
+    expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "ulw-loop", "dist", "cli.js"))).isFile()).toBe(true)
     await expectPathMissing(join(lazycodexRoot, "plugins", "omo", "node_modules"))
     await expectPathMissing(join(lazycodexRoot, "plugins", "omo", ".ulw"))
     await expectPathMissing(join(lazycodexRoot, "plugins", "omo", ".claude"))


### PR DESCRIPTION
## Problem

This is the upstream replacement for code-yeongyu/lazycodex#112 ("Fix missing marketplace hook CLI payloads"), which I first opened against `code-yeongyu/lazycodex`. That repository is generated from `oh-my-openagent`, so the fix belongs here under the Codex implementation and marketplace sync path.

The original LazyCodex PR addressed code-yeongyu/lazycodex#108: the generated `omo@sisyphuslabs` marketplace payload declared hooks/bins for:

- `plugins/omo/components/start-work-continuation/dist/cli.js`
- `plugins/omo/components/ulw-loop/dist/cli.js`

but those generated CLI files were missing from the checked-in LazyCodex marketplace payload. That can leave marketplace installs with dangling hook targets after update or repair.

## What the original LazyCodex PR changed

The closed LazyCodex PR directly edited the generated marketplace repository by:

- adding the generated `dist/cli.js` payload files for `start-work-continuation` and `ulw-loop`;
- removing those components' local `dist/` ignores so the generated files could be tracked in the LazyCodex repo;
- adding an aggregate hook regression test that fails when a `${PLUGIN_ROOT}/...` command target is missing.

## Upstream version of the fix

This PR keeps the generated payload source-of-truth in `oh-my-openagent` instead:

- extends the LazyCodex marketplace sync fixture to include the exact `start-work-continuation` and `ulw-loop` hook CLI targets;
- asserts that a synced LazyCodex marketplace payload contains both generated CLI files;
- adds an aggregate OMO Codex hook guard that verifies every `${PLUGIN_ROOT}` command target, including Windows command targets, exists after the plugin build.

This guards the source sync path that produces the LazyCodex repo instead of committing generated artifacts directly to LazyCodex.

Related: code-yeongyu/lazycodex#108, code-yeongyu/lazycodex#112.

## Verification

- `bun install` (ran the repository postinstall/build chain, including `bun run --cwd packages/omo-codex/plugin build`)
- `bun test script/sync-lazycodex-marketplace.test.ts`
- `node --test packages/omo-codex/plugin/test/aggregate-hooks.test.mjs`
- `node --check packages/omo-codex/plugin/components/start-work-continuation/dist/cli.js && node --check packages/omo-codex/plugin/components/ulw-loop/dist/cli.js`
- actual sync smoke via `bun run script/sync-lazycodex-marketplace.ts "$PWD" <tmp>` and `stat` checks for both generated LazyCodex payload CLI paths
- `bun test script/package-layout.test.ts script/publish-lazycodex-workflow.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `omo-codex` hook CLI payloads so marketplace sync always includes required CLI files and no hooks point to missing targets. Adds tests and a guard to validate all ${PLUGIN_ROOT} command paths, including Windows variants.

- **Bug Fixes**
  - Added sync fixture entries for `start-work-continuation` and `ulw-loop` CLI hooks.
  - Assert the synced payload contains both `dist/cli.js` files.
  - Added an aggregate hook guard test that verifies every ${PLUGIN_ROOT} command (and Windows command) resolves to an existing file after build.

<sup>Written for commit bd937929278f300bc9c0c18d719c8f53b03afe69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

