### PR TITLE
perf(ci): skip lifecycle scripts on bun install for non-test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build vendored lsp-daemon package
         run: npm ci && npm run build
@@ -202,7 +202,7 @@ jobs:
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build vendored lsp-daemon package
         run: npm ci && npm run build
@@ -247,7 +247,7 @@ jobs:
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run Senpi compatibility tests
         run: bun run test:senpi
@@ -351,7 +351,7 @@ jobs:
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build vendored lsp-daemon package
         run: npm ci && npm run build
@@ -406,7 +406,7 @@ jobs:
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build vendored lsp-daemon package
         run: npm ci && npm run build


### PR DESCRIPTION
## What

Add `--ignore-scripts` to five of the six `bun install --frozen-lockfile` invocations in `.github/workflows/ci.yml`: `typecheck`, `codex-compatibility`, `senpi-compatibility`, `build`, and `auto-commit-schema`. The `test` job is left on the full install (see "Why the test job is excluded").

## Why

The root `package.json` declares `"prepare": "bun run build"` and `"postinstall": "node postinstall.mjs"`. Bun runs both root lifecycle scripts on `bun install --frozen-lockfile`, so these jobs were silently running the entire root build inside their install step. On baseline run `28733980680` the "Install dependencies" step measured 1m12s (ubuntu) to 1m47s (windows) per job. A pure dependency link with a warm cache and `--ignore-scripts` measures about 6s locally.

For these five jobs the build is waste: `typecheck` runs `tsgo` over source, `test:codex` and `test:senpi` build their own artifacts internally, and `build` / `auto-commit-schema` run `bun run build` explicitly after install.

## Why the test job is excluded

A first revision applied `--ignore-scripts` to all six installs. CI run `28746049382` failed all three `test` matrix legs (ubuntu, macos, windows) while every other job passed. Root cause: the root `bun test` suite includes `packages/omo-codex/src/install/*.test.ts` (bunfig ignores only `packages/omo-codex/plugin/**` and `scripts/**`, not `src/`). Those tests drive the real Codex installer, which requires the built `packages/git-bash-mcp/dist`, `packages/lsp-daemon/dist`, and the 11 codex-plugin component dists on disk. `prepare` produced them; `--ignore-scripts` removed them, giving "missing built Git Bash MCP dist" and "Plugin payload is missing 11 hook command target(s)". `test-setup.ts` self-heals only lsp-daemon.

So the `test` job genuinely needs `prepare`'s build and keeps the full install. A follow-up PR can give it an explicit partial build (git-bash-mcp + lsp-daemon + codex-plugin) to recover part of that saving without the unneeded main ESM/tui/schema build.

## Behavior is identical for the five changed jobs

- Coverage, gates, the OS matrix, and every job name are unchanged.
- `build` and `auto-commit-schema` still run `bun run build` explicitly after install.
- `test:codex` and `test:senpi` are self-contained.
- `postinstall.mjs` only warns about opencode version / an optionalDeps platform binary (neither present in CI) and invalidates a cache absent in CI. Skipping it changes nothing.

## QA and evidence

- CI run `28746049382` (the first revision) directly confirms `typecheck` ×3, `codex-compatibility` ×3, `senpi-compatibility` ×3, and `build` all pass with `--ignore-scripts`.
- The test-job failure was reproduced locally: removing `packages/git-bash-mcp/dist` makes `install-codex.test.ts` fail with the exact CI error; restoring the full install fixes it.
- `actionlint -shellcheck="" .github/workflows/ci.yml` (pinned v1.7.10): passes.
- Full write-up in the branch under `.omo/evidence/20260706-ci-ignore-scripts/` (gitignored).

## Residual risk

`--ignore-scripts` also skips dependency-package lifecycle scripts. Bun already blocks untrusted dependency postinstalls by default, and `script/agent/setup.sh` installs this exact way locally. The five changed jobs are confirmed green (four directly in run `28746049382`; `auto-commit-schema` runs only on master push and mirrors the `build` job's explicit `bun run build`). This PR's re-run is the final confirmation.

Post-merge, compare install-step timings against baseline run `28733980680`:

```
gh api repos/code-yeongyu/oh-my-openagent/actions/runs/<RUN_ID>/jobs \
  --jq '.jobs[] | {name, steps: [.steps[] | {name, started_at, completed_at}]}'
```
