### PR TITLE
perf(codex-build): parallelize component builds

### DIFF
--- a/packages/omo-codex/plugin/scripts/build-components.mjs
+++ b/packages/omo-codex/plugin/scripts/build-components.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import { availableParallelism } from "node:os";
 import { readdir, readFile, writeFile } from "node:fs/promises";
 import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
@@ -11,22 +12,50 @@ const workspaces = Array.isArray(packageJson.workspaces) ? packageJson.workspace
 const workspaceSet = new Set(workspaces);
 const builtinModuleNames = new Set(builtinModules.filter((moduleName) => !moduleName.startsWith("_")));
 
+const workspaceComponents = [];
 for (const workspace of workspaces) {
 	if (typeof workspace !== "string" || !workspace.startsWith("components/")) continue;
 	if (!(await hasBuildScript(workspace))) continue;
-
-	console.log(`Building ${workspace}`);
-	run("npm", ["run", "--workspace", workspace, "build"], root);
-	await bundleCli(workspace);
+	workspaceComponents.push({
+		componentPath: workspace,
+		buildCommand: "npm",
+		buildArgs: ["run", "--workspace", workspace, "build"],
+		buildCwd: root,
+	});
 }
 
+const standaloneComponents = [];
 for (const componentName of await readStandaloneComponentNames()) {
 	const componentPath = `components/${componentName}`;
 	if (!(await hasBuildScript(componentPath))) continue;
+	standaloneComponents.push({
+		componentPath,
+		buildCommand: "npm",
+		buildArgs: ["run", "build"],
+		buildCwd: join(root, componentPath),
+	});
+}
 
-	console.log(`Building ${componentPath} (standalone)`);
-	run("npm", ["run", "build"], join(root, componentPath));
-	await bundleCli(componentPath);
+const tasks = [...workspaceComponents, ...standaloneComponents];
+const concurrency = Math.max(1, Math.min(tasks.length, availableParallelism()));
+await runTasksWithConcurrency(tasks, concurrency);
+
+async function runTasksWithConcurrency(items, limit) {
+	let nextIndex = 0;
+	const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+		while (true) {
+			const index = nextIndex;
+			nextIndex += 1;
+			if (index >= items.length) return;
+			await buildComponent(items[index]);
+		}
+	});
+	await Promise.all(workers);
+}
+
+async function buildComponent(task) {
+	await runCaptured(task.buildCommand, task.buildArgs, task.buildCwd, `Building ${task.componentPath}`);
+	await bundleCli(task.componentPath);
 }
 
 async function readStandaloneComponentNames() {
@@ -51,19 +80,36 @@ async function hasBuildScript(relativePath) {
 async function bundleCli(workspace) {
 	const entry = join(root, workspace, "src", "cli.ts");
 	const output = join(root, workspace, "dist", "cli.js");
-	console.log(`Bundling ${workspace}/dist/cli.js`);
-	run("bun", ["build", entry, "--target", "node", "--format", "esm", "--outfile", output], root);
+	await runCaptured("bun", ["build", entry, "--target", "node", "--format", "esm", "--outfile", output], root, `Bundling ${workspace}/dist/cli.js`);
 	await normalizeBuiltinImports(output);
 }
 
-function run(command, args, cwd) {
-	const result = spawnSync(command, args, {
-		cwd,
-		shell: process.platform === "win32",
-		stdio: "inherit",
+// Buffers each child's stdout/stderr and flushes it as one contiguous block so
+// concurrent builds never interleave, keeping a failing component's output readable.
+function runCaptured(command, args, cwd, label) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd,
+			shell: process.platform === "win32",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const chunks = [];
+		child.stdout.on("data", (chunk) => chunks.push(chunk));
+		child.stderr.on("data", (chunk) => chunks.push(chunk));
+		child.on("error", (error) => reject(error));
+		child.on("close", (status, signal) => {
+			const output = Buffer.concat(chunks).toString("utf8");
+			process.stdout.write(`${label}\n${output}`);
+			if (status === 0) {
+				resolve();
+				return;
+			}
+			const reason = signal ? `signal ${signal}` : `exit code ${status}`;
+			const error = new Error(`${label} failed with ${reason}`);
+			error.exitCode = status ?? 1;
+			reject(error);
+		});
 	});
-	if (result.error !== undefined) throw result.error;
-	if (result.status !== 0) process.exit(result.status ?? 1);
 }
 
 async function normalizeBuiltinImports(output) {

--- a/packages/omo-codex/plugin/test/install-time-build-runtime.test.mjs
+++ b/packages/omo-codex/plugin/test/install-time-build-runtime.test.mjs
@@ -14,7 +14,7 @@ test("#given aggregate build scripts #when inspected #then component CLIs are bu
 	const componentBuildScript = buildComponentsScript;
 
 	// then
-	assert.match(componentBuildScript, /run\("bun", \["build", entry, "--target", "node", "--format", "esm", "--outfile", output\]/);
+	assert.match(componentBuildScript, /"bun", \["build", entry, "--target", "node", "--format", "esm", "--outfile", output\]/);
 	assert.doesNotMatch(componentBuildScript, /\bbun\s+run\b/);
 });
 


### PR DESCRIPTION
## What changed

`packages/omo-codex/plugin/scripts/build-components.mjs` built the ~12 Codex plugin components in a serial `for...of` loop, each running `npm run build` followed by a `bun build` bundle step. This is the dominant cost inside `build:codex-plugin` (which is itself ~46% of a warm `bun run build`). This PR runs the components through a bounded-concurrency pool sized to `availableParallelism()` instead.

## Why it is safe

Each component writes only its own `components/<name>/dist`, so the builds are independent and build ordering cannot affect the output. Two behaviors are preserved deliberately:

- **No garbled output under concurrency.** Each child's stdout and stderr are buffered and flushed as one contiguous block, so parallel builds never interleave.
- **Fail-fast with readable errors.** A failing component still fails the whole build with a non-zero exit and a clear, component-named error (verified by injecting a syntax error into one component).

The `install-time-build-runtime` shape-guard test asserted the literal wrapper name `run("bun", ...)`. The refactor renamed that wrapper, so the assertion was loosened to match the preserved bun-bundling invariant (`"bun", ["build", entry, "--target", "node", ...]`) regardless of the wrapper function name. The Windows-shell and `bun run` guards are unchanged.

## Observed behavior (QA)

- **Byte-identical output.** Aggregate and per-component `shasum` of all `components/*/dist` are identical between the old serial script and the new parallel script, across warm, repeated, and cold (`rm node_modules` + fresh `npm ci`) builds. Aggregate `6ef14a98856cb5d18596b38eb3dc70d02b0157e2`, 100 files, before and after.
- **Speed.** Local `build-components` dropped from ~10.0s to ~2.7s (~3.5x). The same step runs in CI `publish-main` and in `codex-compatibility` across three OSes, so the saving compounds there.
- **Failure semantics.** Injected error produced exit code 1 with a contiguous, readable, component-named error block.
- **`bun run test:codex`: 456 pass, 0 fail.**
- **codex-qa first-party proofs:** `install-verify.sh --self-test` and `app-server-drive.sh --self-test` both PASS, and both assert the real `~/.codex/config.toml` shasum is unchanged (isolated temp `CODEX_HOME`).

Evidence recorded under `.omo/evidence/20260706-parallel-component-build/` (WHAT TESTED / OBSERVED / WHY ENOUGH / OMITTED plus raw logs).

## Residual risk

Build ordering is now nondeterministic, but with per-component isolated output directories that cannot change results; confirmed empirically by the repeated identical hashes. No publish-workflow semantics are touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized Codex plugin component builds using a bounded pool sized to `availableParallelism()`, cutting `build-components` from ~10s to ~2.7s while keeping outputs byte‑identical and failure behavior unchanged.

- **Refactors**
  - Replaced the serial loop with a worker pool for both workspace and standalone components; each task runs `npm run build` and then bundles the CLI with `bun build`.
  - Added buffered stdout/stderr per task to avoid interleaved logs; preserve fail-fast with clear, component-labeled errors.
  - Loosened the install-time guard to assert the `bun build` invocation shape independent of the wrapper function name.

<sup>Written for commit eaf3260285338c8d58b4417248c5ee2fa3f73921. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

