### PR TITLE
perf(omo-opencode): cut default idle-settle/defer waits in slow hook tests

### DIFF
--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/aggressive-truncation-strategy.test.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/aggressive-truncation-strategy.test.ts
@@ -85,7 +85,7 @@ function createAutoCompactState(): AutoCompactState {
 }
 
 async function flushDeferredPrompt(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 600))
+  await new Promise((resolve) => setTimeout(resolve, 60))
 }
 
 describe("runAggressiveTruncationStrategy - pins agent/model/variant on recovered promptAsync", () => {
@@ -117,6 +117,7 @@ describe("runAggressiveTruncationStrategy - pins agent/model/variant on recovere
       truncateAttempt: 0,
       currentTokens: 250_000,
       maxTokens: 200_000,
+      deferPromptMs: 10,
     })
     await flushDeferredPrompt()
 
@@ -150,6 +151,7 @@ describe("runAggressiveTruncationStrategy - pins agent/model/variant on recovere
       truncateAttempt: 0,
       currentTokens: 250_000,
       maxTokens: 200_000,
+      deferPromptMs: 10,
     })
     await flushDeferredPrompt()
 
@@ -175,6 +177,7 @@ describe("runAggressiveTruncationStrategy - pins agent/model/variant on recovere
       truncateAttempt: 0,
       currentTokens: 250_000,
       maxTokens: 200_000,
+      deferPromptMs: 10,
     })
     await flushDeferredPrompt()
 
@@ -204,6 +207,7 @@ describe("runAggressiveTruncationStrategy - pins agent/model/variant on recovere
       truncateAttempt: 0,
       currentTokens: 250_000,
       maxTokens: 200_000,
+      deferPromptMs: 10,
     })
     await flushDeferredPrompt()
 

--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/aggressive-truncation-strategy.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/aggressive-truncation-strategy.ts
@@ -20,6 +20,8 @@ import {
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../shared/prompt-async-gate"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 
+const DEFAULT_DEFER_PROMPT_MS = 500 as const
+
 export async function runAggressiveTruncationStrategy(params: {
   sessionID: string
   autoCompactState: AutoCompactState
@@ -28,6 +30,7 @@ export async function runAggressiveTruncationStrategy(params: {
   truncateAttempt: number
   currentTokens: number
   maxTokens: number
+  deferPromptMs?: number
 }): Promise<{ handled: boolean; nextTruncateAttempt: number }> {
   if (params.truncateAttempt >= TRUNCATE_CONFIG.maxTruncateAttempts) {
     return { handled: false, nextTruncateAttempt: params.truncateAttempt }
@@ -127,7 +130,7 @@ export async function runAggressiveTruncationStrategy(params: {
           error: String(error),
         })
       }
-    }, 500)
+    }, params.deferPromptMs ?? DEFAULT_DEFER_PROMPT_MS)
 
     return { handled: true, nextTruncateAttempt }
   }

--- a/packages/omo-opencode/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
@@ -68,7 +68,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 					},
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		hook.startLoop("session-123", "Keep working", {
 			messageCountAtStart: 0,
@@ -115,7 +115,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 					},
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		hook.startLoop("session-123", "Keep working", {
 			messageCountAtStart: 0,
@@ -161,7 +161,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 					},
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		hook.startLoop("session-123", "Keep working", {
 			messageCountAtStart: 0,
@@ -223,6 +223,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 				},
 			},
 		} as never, {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID): string => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 
@@ -295,6 +296,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 				},
 			},
 		} as never, {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID): string => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 
@@ -361,7 +363,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 					},
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		hook.startLoop("session-123", "Keep working", {
 			messageCountAtStart: 0,
@@ -721,7 +723,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 					},
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		hook.startLoop("session-123", "Keep working", {
 			messageCountAtStart: 0,

--- a/packages/omo-opencode/src/hooks/ralph-loop/index.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/index.test.ts
@@ -5,7 +5,8 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { createRalphLoopHook } from "./index"
 import { readState, writeState, clearState } from "./storage"
-import type { RalphLoopState } from "./types"
+import type { RalphLoopOptions, RalphLoopState } from "./types"
+import type { PluginInput } from "@opencode-ai/plugin"
 import { parseRalphLoopArguments } from "./command-arguments"
 import { DEFAULT_PROMPT_ASYNC_POST_DISPATCH_HOLD_MS } from "../shared/prompt-async-gate"
 
@@ -15,7 +16,7 @@ describe("ralph-loop", () => {
   let toastCalls: Array<{ title: string; message: string; variant: string }>
   let messagesCalls: Array<{ sessionID: string }>
   let createSessionCalls: Array<{ parentID?: string; title?: string; directory?: string }>
-  let mockSessionMessages: Array<{ info?: { role?: string }; parts?: Array<{ type: string; text?: string }> }>
+  let mockSessionMessages: Array<{ info?: { role?: string; finish?: string }; parts?: Array<{ type: string; text?: string }> }>
   let mockMessagesApiResponseShape: "data" | "array"
 
   function createMockPluginInput(): Parameters<typeof createRalphLoopHook>[0] {
@@ -65,6 +66,13 @@ describe("ralph-loop", () => {
       },
       directory: TEST_DIR,
     } as Parameters<typeof createRalphLoopHook>[0]
+  }
+
+  // Idle settling is a real timed wait; default it to 0 so tests that do not
+  // assert settle timing skip the delay. Callers can still pass an explicit
+  // idleSettleMs to exercise the deferral behavior.
+  function makeHook(ctx: PluginInput, options?: RalphLoopOptions): ReturnType<typeof createRalphLoopHook> {
+    return createRalphLoopHook(ctx, { idleSettleMs: 0, ...options })
   }
 
   beforeEach(() => {
@@ -267,7 +275,7 @@ describe("ralph-loop", () => {
   describe("hook", () => {
     test("should start loop and write state", () => {
       // given - hook instance
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
 
       // when - start loop
       const success = hook.startLoop("session-123", "Build something", {
@@ -288,7 +296,7 @@ describe("ralph-loop", () => {
 
     test("should accept ultrawork option in startLoop", () => {
       // given - hook instance
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
 
       // when - start loop with ultrawork
       hook.startLoop("session-123", "Build something", { ultrawork: true })
@@ -300,7 +308,7 @@ describe("ralph-loop", () => {
 
     test("#given active ultrawork loop #when resumeLoop binds a new session #then prompt is preserved", () => {
       // given
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-old", "Build feature\nwith long prompt", {
         ultrawork: true,
         messageCountAtStart: 8,
@@ -321,7 +329,7 @@ describe("ralph-loop", () => {
 
     test("should handle missing ultrawork option in startLoop", () => {
       // given - hook instance
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
 
       // when - start loop without ultrawork
       hook.startLoop("session-123", "Build something")
@@ -333,7 +341,7 @@ describe("ralph-loop", () => {
 
     test("should inject continuation when loop active and no completion detected", async () => {
       // given - active loop state
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
 
       // when - session goes idle
@@ -358,7 +366,7 @@ describe("ralph-loop", () => {
 
     test("#given synthetic and real idle arrive back-to-back #then only one continuation is injected for the same iteration", async () => {
       // given
-      const hook = createRalphLoopHook(createMockPluginInput(), { idleSettleMs: 0 })
+      const hook = makeHook(createMockPluginInput(), { idleSettleMs: 0 })
       hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
 
       // when
@@ -386,7 +394,7 @@ describe("ralph-loop", () => {
       const originalDateNow = Date.now
       let currentNow = originalDateNow()
       Date.now = () => currentNow
-      const hook = createRalphLoopHook(createMockPluginInput(), { idleSettleMs: 0 })
+      const hook = makeHook(createMockPluginInput(), { idleSettleMs: 0 })
       try {
         hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
 
@@ -422,7 +430,7 @@ describe("ralph-loop", () => {
 
     test("should inject continuation when idle event carries session id in info", async () => {
       // given - active loop state and nested session event shape
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-info-idle", "Build a feature", { maxIterations: 10 })
 
       // when - session goes idle with id under info
@@ -441,7 +449,7 @@ describe("ralph-loop", () => {
 
     test("should settle idle before injecting continuation", async () => {
       // given - active loop state with a configured idle settle delay
-      const hook = createRalphLoopHook(createMockPluginInput(), { idleSettleMs: 25 })
+      const hook = makeHook(createMockPluginInput(), { idleSettleMs: 25 })
       hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
 
       // when - session goes idle
@@ -467,7 +475,7 @@ describe("ralph-loop", () => {
       ctx.client.tui = {
         showToast: () => new Promise(() => {}),
       } as never
-      const hook = createRalphLoopHook(ctx, { idleSettleMs: 0 })
+      const hook = makeHook(ctx, { idleSettleMs: 0 })
       hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
 
       // when - session goes idle
@@ -489,7 +497,7 @@ describe("ralph-loop", () => {
 
     test("should skip continuation when background task is running", async () => {
       // given - active loop state with a running background task
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         backgroundManager: {
           getTasksByParentSession: (sessionID: string) => sessionID === "session-123"
             ? [{ status: "running" }]
@@ -516,7 +524,7 @@ describe("ralph-loop", () => {
 
     test("should stop loop when max iterations reached", async () => {
       // given - loop at max iteration
-      const hook = createRalphLoopHook(createMockPluginInput(), { idleSettleMs: 0 })
+      const hook = makeHook(createMockPluginInput(), { idleSettleMs: 0 })
       hook.startLoop("session-123", "Build something", { maxIterations: 2 })
 
       const state = hook.getState()
@@ -548,7 +556,7 @@ describe("ralph-loop", () => {
 
     test("should cancel loop via cancelLoop", () => {
       // given - active loop
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
       // when - cancel loop
@@ -561,7 +569,7 @@ describe("ralph-loop", () => {
 
     test("should not cancel loop for different session", () => {
       // given - active loop for session-123
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
       // when - try to cancel for different session
@@ -574,7 +582,7 @@ describe("ralph-loop", () => {
 
     test("should continue after non-abort session error", async () => {
       // given - active loop and non-abort session error
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
       await hook.event({
@@ -599,7 +607,7 @@ describe("ralph-loop", () => {
 
     test("should clear state on session deletion", async () => {
       // given - active loop
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
       // when - session deleted
@@ -616,7 +624,7 @@ describe("ralph-loop", () => {
 
     test("should not inject for different session than loop owner", async () => {
       // given - loop owned by session-123
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
       // when - different session goes idle
@@ -645,7 +653,7 @@ describe("ralph-loop", () => {
       writeState(TEST_DIR, state)
 
       // Mock sessionExists to return false for the orphaned session
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         checkSessionExists: async (sessionID: string) => {
           // Orphaned session doesn't exist, current session does
           return sessionID !== "orphaned-session-999"
@@ -680,7 +688,7 @@ describe("ralph-loop", () => {
       writeState(TEST_DIR, state)
 
       // Mock sessionExists to return true for the active session
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         checkSessionExists: async (sessionID: string) => {
           // Original session still exists
           return sessionID === "active-session-123" || sessionID === "new-session-456"
@@ -704,7 +712,7 @@ describe("ralph-loop", () => {
 
     test("should use default config values", () => {
       // given - hook with config
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         config: {
           enabled: true,
           default_max_iterations: 200,
@@ -722,7 +730,7 @@ describe("ralph-loop", () => {
 
     test("should default strategy to continue when not specified", () => {
       // given - hook with no strategy option
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
 
       // when - start loop without strategy
       hook.startLoop("session-123", "Test task")
@@ -734,7 +742,7 @@ describe("ralph-loop", () => {
 
     test("should create new session for reset strategy", async () => {
       // given - hook with reset strategy
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Build a feature", { strategy: "reset" })
 
       // when - session goes idle
@@ -754,7 +762,7 @@ describe("ralph-loop", () => {
 
     test("should not inject when no loop is active", async () => {
       // given - no active loop
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
 
       // when - session goes idle
       await hook.event({
@@ -771,7 +779,7 @@ describe("ralph-loop", () => {
     test("should detect completion promise and stop loop", async () => {
       // given - active loop with transcript containing completion
       const transcriptPath = join(TEST_DIR, "transcript.jsonl")
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "COMPLETE" })
@@ -798,7 +806,7 @@ describe("ralph-loop", () => {
         { info: { role: "user" }, parts: [{ type: "text", text: "Build something" }] },
         { info: { role: "assistant" }, parts: [{ type: "text", text: "I have completed the task. <promise>API_DONE</promise>" }] },
       ]
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "API_DONE" })
@@ -828,7 +836,7 @@ describe("ralph-loop", () => {
         { info: { role: "user" }, parts: [{ type: "text", text: "Build something" }] },
         { info: { role: "assistant" }, parts: [{ type: "text", text: "I have completed the task. <promise>API_DONE</promise>" }] },
       ]
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "API_DONE" })
@@ -873,7 +881,7 @@ describe("ralph-loop", () => {
         },
       })
 
-      const hook = createRalphLoopHook(pluginInput, {
+      const hook = makeHook(pluginInput, {
         getTranscriptPath: () => transcriptPath,
       })
       hook.startLoop("session-123", "Build something", {
@@ -909,7 +917,7 @@ describe("ralph-loop", () => {
           ],
         },
       ]
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
       })
       hook.startLoop("session-123", "Build something", {
@@ -936,7 +944,7 @@ describe("ralph-loop", () => {
 
     test("#given duplicate real idle fires before assistant activity #then loop state is preserved without another prompt", async () => {
       // given - active loop
-      const hook = createRalphLoopHook(createMockPluginInput(), { idleSettleMs: 0 })
+      const hook = makeHook(createMockPluginInput(), { idleSettleMs: 0 })
       hook.startLoop("session-123", "Build feature", { maxIterations: 5 })
 
       // when - duplicate idle events arrive without any intervening activity
@@ -957,7 +965,7 @@ describe("ralph-loop", () => {
       const originalDateNow = Date.now
       let currentNow = originalDateNow()
       Date.now = () => currentNow
-      const hook = createRalphLoopHook(createMockPluginInput(), { idleSettleMs: 0 })
+      const hook = makeHook(createMockPluginInput(), { idleSettleMs: 0 })
       hook.startLoop("session-123", "Build feature", { maxIterations: 5 })
 
       try {
@@ -986,7 +994,7 @@ describe("ralph-loop", () => {
       const originalDateNow = Date.now
       let currentNow = originalDateNow()
       Date.now = () => currentNow
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Build feature", { maxIterations: 5 })
 
       try {
@@ -1012,7 +1020,7 @@ describe("ralph-loop", () => {
 
     test("should include prompt and promise in continuation message", async () => {
       // given - loop with specific prompt and promise
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Create a calculator app", {
         completionPromise: "CALCULATOR_DONE",
         maxIterations: 10,
@@ -1058,7 +1066,7 @@ describe("ralph-loop", () => {
         return originalPromptAsync(opts)
       }
 
-      const hook = createRalphLoopHook(mockInput as Parameters<typeof createRalphLoopHook>[0])
+      const hook = makeHook(mockInput as Parameters<typeof createRalphLoopHook>[0])
       hook.startLoop("session-123", "Build feature", { maxIterations: 10 })
 
       // when - second idle arrives while first idle processing is still in flight
@@ -1081,7 +1089,7 @@ describe("ralph-loop", () => {
 
     test("should clear loop state on user abort (MessageAbortedError)", async () => {
       // given - active loop
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Build something")
       expect(hook.getState()).not.toBeNull()
 
@@ -1102,7 +1110,7 @@ describe("ralph-loop", () => {
 
     test("should NOT set recovery mode on user abort", async () => {
       // given - active loop
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Build something")
 
       // when - user aborts (Ctrl+C)
@@ -1137,7 +1145,7 @@ describe("ralph-loop", () => {
         { info: { role: "assistant" }, parts: [{ type: "text", text: "Nearly there... <promise>DONE</promise>" }] },
         { info: { role: "assistant" }, parts: [{ type: "text", text: "(extra output after promise)" }] },
       ]
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
@@ -1162,7 +1170,7 @@ describe("ralph-loop", () => {
         { info: { role: "assistant" }, parts: [{ type: "text", text: "More work 2" }] },
         { info: { role: "assistant" }, parts: [{ type: "text", text: "More work 3" }] },
       ]
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
@@ -1192,7 +1200,7 @@ describe("ralph-loop", () => {
         })
       }
 
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
@@ -1210,7 +1218,7 @@ describe("ralph-loop", () => {
 
     test("should allow starting new loop while previous loop is active (different session)", async () => {
       // given - active loop in session A
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-A", "First task", { maxIterations: 10 })
       expect(hook.getState()?.session_id).toBe("session-A")
       expect(hook.getState()?.prompt).toBe("First task")
@@ -1244,7 +1252,7 @@ describe("ralph-loop", () => {
       const originalDateNow = Date.now
       let currentNow = originalDateNow()
       Date.now = () => currentNow
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       try {
         hook.startLoop("session-A", "First task", { maxIterations: 10 })
       
@@ -1301,7 +1309,7 @@ Output <promise>DONE</promise> when fully complete`
       })
       writeFileSync(transcriptPath, userEntry + "\n")
 
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
@@ -1332,7 +1340,7 @@ Original task: Build something`
       })
       writeFileSync(transcriptPath, userEntry + "\n")
 
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
@@ -1361,7 +1369,7 @@ Original task: Build something`
       })
       writeFileSync(transcriptPath, toolResultEntry + "\n")
 
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
@@ -1386,7 +1394,7 @@ Original task: Build something`
       mockSessionMessages = [
         { info: { role: "assistant" }, parts: [{ type: "text", text: "No promise here" }] },
       ]
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
@@ -1409,7 +1417,7 @@ Original task: Build something`
     test("should require oracle verification toast for ultrawork completion promise", async () => {
       // given - hook with ultrawork mode and completion in transcript
       const transcriptPath = join(TEST_DIR, "transcript.jsonl")
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
       })
       writeFileSync(transcriptPath, JSON.stringify({ type: "assistant", content: "<promise>DONE</promise>" }) + "\n")
@@ -1444,7 +1452,7 @@ Original task: Build something`
           return { data: mockSessionMessages }
         },
       })
-      const hook = createRalphLoopHook(delayedMock, {
+      const hook = makeHook(delayedMock, {
         getTranscriptPath: () => join(TEST_DIR, "missing-transcript.jsonl"),
         idleSettleMs: 0,
       })
@@ -1475,7 +1483,7 @@ Original task: Build something`
     test("should show regular completion toast when ultrawork disabled", async () => {
       // given - hook without ultrawork
       const transcriptPath = join(TEST_DIR, "transcript.jsonl")
-      const hook = createRalphLoopHook(createMockPluginInput(), {
+      const hook = makeHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
       })
       writeFileSync(transcriptPath, JSON.stringify({ type: "assistant", content: "<promise>DONE</promise>" }) + "\n")
@@ -1490,7 +1498,7 @@ Original task: Build something`
 
     test("should prepend ultrawork to continuation prompt when ultrawork=true", async () => {
       // given - hook with ultrawork mode enabled
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Build API", { ultrawork: true })
 
       // when - session goes idle (continuation triggered)
@@ -1505,7 +1513,7 @@ Original task: Build something`
 
     test("should NOT prepend ultrawork to continuation prompt when ultrawork=false", async () => {
       // given - hook without ultrawork mode
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const hook = makeHook(createMockPluginInput())
       hook.startLoop("session-123", "Build API")
 
       // when - session goes idle (continuation triggered)
@@ -1530,7 +1538,7 @@ Original task: Build something`
           throw new Error("API timeout")
         },
       })
-      const hook = createRalphLoopHook(errorMock, {
+      const hook = makeHook(errorMock, {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
         apiTimeout: 100,
       })


### PR DESCRIPTION
## What changed

Three hook test files spent real wall-clock waiting out default timer durations, with no behavioral reason to wait the full amount. This trims those waits without touching what the tests assert.

- **`hooks/ralph-loop/index.test.ts`** and **`hooks/ralph-loop/dispatch-failure-invariant.test.ts`** — `createRalphLoopHook` applies `idleSettleMs ?? DEFAULT_IDLE_SETTLE_MS` (a 150ms real `sleep` on the idle-continuation path). Most hook builds in these files never overrode it, so nearly every idle test paid 150ms. Non-settle-timing builds now go through `idleSettleMs: 0` (via a small `makeHook` wrapper in `index.test.ts`; via explicit `idleSettleMs: 0` on the 7 call sites in `dispatch-failure-invariant.test.ts`). The tests that specifically assert the settle window keep their explicit values (`25ms` / `50ms`).
- **`hooks/anthropic-context-window-limit-recovery/aggressive-truncation-strategy.ts` (+ test)** — the post-truncation re-dispatch was deferred with a hardcoded `setTimeout(..., 500)`, and the test blind-waited 600ms per test to flush it. The delay is now injectable via an optional `deferPromptMs` param defaulting to a named `DEFAULT_DEFER_PROMPT_MS = 500`. The test passes `deferPromptMs: 10`; the sole production caller (`executor.ts`) does not pass it, so **production keeps the 500ms default — no behavior change outside tests.**

Also widened a pre-existing inline mock type in `index.test.ts` (`mockSessionMessages` now allows the optional `finish` field the tests already assign) to clear an LSP-only false positive; the repo's `tsgo` never flagged it.

## Why

Part of the test-suite speed effort. These three files held ~13s of the local `bun test` wall on default timer waits that the assertions never needed.

## Observed behavior (before → after, all files stay fully green)

| File | Before | After | Tests |
|------|--------|-------|-------|
| ralph-loop/index.test.ts | 8.47s | 0.48s | 60 pass / 0 fail |
| ralph-loop/dispatch-failure-invariant.test.ts | 2.27s | 1.05s | 12 pass / 0 fail |
| aggressive-truncation-strategy.test.ts | 2.48s | 0.31s | 4 pass / 0 fail |
| **total** | **13.22s** | **1.84s** | **~11.4s saved** |

## QA / evidence

- Per-file before/after timings captured (`.omo/evidence/20260706-test-speed/`, local — evidence dir is gitignored per `.local-ignore` convention).
- Regression: `bun test` on `hooks/ralph-loop/` + `hooks/anthropic-context-window-limit-recovery/` → **226 pass / 0 fail across 33 files**.
- Production default-delay path still covered by `executor.test.ts` (14 pass), which does not inject `deferPromptMs`.
- `tsgo --noEmit -p packages/omo-opencode/tsconfig.json` clean.

## Residual risk

Low. Assertions are unchanged; only wait durations were reduced, using values that were already injectable (ralph-loop) or made injectable without changing the production default (aggressive-truncation). The one production caller was checked and does not use the new test-only parameter.

Not touched here (handed to the flaky-test workstream because their remaining cost is a real elapsed-time / absence-confirmation race, not a blind delay): `live-server-route.test.ts` (real `PROBE_ABORT_MS = 1_500` timeout test) and `session-notification.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts unnecessary real-time waits in slow hook tests by bypassing default idle-settle and making a deferral delay configurable. Saves ~11.4s across three files with no behavior changes.

- **Refactors**
  - `hooks/ralph-loop/*.test.ts`: route non-timing builds through `idleSettleMs: 0` via a `makeHook` helper; keep explicit settle values where asserted.
  - `hooks/anthropic-context-window-limit-recovery/aggressive-truncation-strategy.ts`: make the post-truncation re-dispatch delay configurable as `deferPromptMs` (defaults to 500ms); tests pass 10ms; production keeps the default.
  - `hooks/ralph-loop/index.test.ts`: widen `mockSessionMessages` type to allow optional `finish` to clear a false-positive type error.

<sup>Written for commit a6b4924cb21414584cb2dd2ce070fafcac61bb04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Real-harness QA (production hook file)

Because `aggressive-truncation-strategy.ts` is a production hook, ran the `opencode-qa` sandboxed CLI case against the freshly built plugin (opencode v1.17.13, isolated XDG + isolated HOME):

- **Plugin loads with the modified hook registered.** `bun run build` (839 modules); the built `dist/index.js` contains the new code (`deferPromptMs` / `DEFAULT_DEFER_PROMPT_MS`). Booting opencode with that dist wired in shows `[oh-my-openagent] ENTRY - plugin loading`, `[live-server-route] registered`, `[tmux-session-manager] initialized`, with **no plugin-load errors**.
- **Session-count isolation holds.** Real DB session count before = after = 5751 (unchanged); the isolated sandbox got its own empty DB. Sandbox removed on completion.

**Honesty note:** a full model turn was NOT driven end-to-end — the isolated sandbox intentionally carries no provider credentials (copying host auth would break isolation), so `opencode run` reached the model call and timed out. The aggressive-truncation **recovery path itself is unit-covered** (`executor.test.ts` 14/14 exercises the default 500ms path; the strategy unit tests 4/4). Driving a real context-window-limit error E2E is impractical, so the plugin-load proof + that unit coverage is the proportional evidence for a default-unchanged parameter plumb.

Evidence: `.omo/evidence/20260706-test-speed/` (`SUMMARY.md`, `plugin-load-proof.txt`, before/after timings) — local to the worktree, dir is gitignored.