### PR TITLE
ci(publish-platform): raise publish max-parallel 2 to 6

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -202,7 +202,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 2
+      # Each matrix leg is an independent OIDC-provenance npm publish with no shared
+      # state; the build matrix above already runs all 12 legs concurrently. 6 keeps
+      # a conservative margin against npm burst limits while roughly halving the
+      # publish wall time versus the previous value of 2.
+      max-parallel: 6
       matrix:
         platform: [darwin-arm64, darwin-x64, darwin-x64-baseline, linux-x64, linux-x64-baseline, linux-arm64, linux-x64-musl, linux-x64-musl-baseline, linux-arm64-musl, windows-x64, windows-x64-baseline, windows-arm64]
     steps:


### PR DESCRIPTION
## What changed

`.github/workflows/publish-platform.yml`: the `publish` job's `strategy.max-parallel` goes from `2` to `6`, with an in-file comment recording the rationale.

## Why

The publish job runs a 12-platform matrix of independent npm publishes. At `max-parallel: 2` they drip out two at a time, spending ~120s of wall time on publish alone (observed 146s including scheduler gaps in the latest release run). Each leg is an independent npm publish using per-job OIDC provenance with no shared state, and the sibling `build` matrix in the same file already runs all 12 legs concurrently without issue.

The value `2` was introduced in `8e19ffdce` when the build/publish jobs were split for OIDC provenance. That commit documents OIDC and artifact reuse, not any npm rate-limit or 429 incident, and there is no such incident anywhere in the repo history. It is an undocumented conservative default.

## Impact

Greedy wall-time model over the latest release run's 12 publish legs (mean 20.2s each): ~121s at `max-parallel: 2` to ~43s at `max-parallel: 6`. Expected saving ~80-100s off the release critical path.

## Residual risk

`6` is deliberately conservative rather than the full `12`, keeping a margin against npm burst limits. The publish workflow cannot be run end to end from a branch, so this rests on past-run timing plus the fact that the build matrix already runs 12-wide. No publish semantics (dual-publish order, provenance, dist-tag, skip-if-published) are touched.

## QA

actionlint passes (CI's `-shellcheck=""` invocation), exit 0. Evidence: `.omo/evidence/20260706-publish-parallel/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the publish job’s `strategy.max-parallel` from 2 to 6 in `.github/workflows/publish-platform.yml` to speed up the 12-platform npm publish. This cuts publish wall time from ~120s to ~40–60s, saving ~80–100s on the release critical path.

<sup>Written for commit 2e928c205cd36aac3c1cc55001201e23109c7525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

