### PR TITLE
feat(shared-skills): complete the taste-skill (tasteskill.dev) embedding in the frontend skill

### DIFF
--- a/packages/omo-opencode/src/features/builtin-skills/frontend/SKILL.md
+++ b/packages/omo-opencode/src/features/builtin-skills/frontend/SKILL.md
@@ -56,7 +56,7 @@ The reference library has one architecture file, 12 taste skills (Layer A — *h
 | `redesign-skill.md` | Improving EXISTING UI — "this looks bad", "fix the design". Audit-first workflow; never use on greenfield. |
 | `image-to-code-skill.md` | "Generate the design first, then code it." Pair with one imagegen file below. |
 | `output-skill.md` | Stacks on any style skill when output is incomplete — placeholders, `// TODO`, half-done components. |
-| `stitch-skill.md` | Stacks on any style skill for Google Stitch compatibility or a `DESIGN.md` doc export. |
+| `stitch-skill.md` | Stacks on any style skill for Google Stitch compatibility or a `DESIGN.md` doc export. A complete worked export ships as `stitch-design-example.md`. |
 | `imagegen-frontend-web.md` / `imagegen-frontend-mobile.md` / `imagegen-brandkit.md` | Image-only output (mockup, app-screen concepts, brand board). These NEVER write code — switch to `image-to-code-skill.md` if code is wanted. |
 
 ### Layer B — brand design systems (orthogonal to Layer A; stack freely)

--- a/packages/shared-skills/materialize-frontend-refs.test.ts
+++ b/packages/shared-skills/materialize-frontend-refs.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseFrontmatter } from "@oh-my-opencode/utils";
 import { isSkillMarkdownSourcePath, materializeFrontendRefs } from "./scripts/materialize-frontend-refs.mjs";
-import { brandStems, designpowersThirdPartyRelativePaths, frontendSkillRoot, thirdPartyRelativePaths, uiUxDbScripts } from "./scripts/frontend-refs-manifest.mjs";
+import { brandStems, designpowersThirdPartyRelativePaths, frontendSkillRoot, tasteSkillArtifactFiles, thirdPartyRelativePaths, uiUxDbScripts, upstreamsRoot } from "./scripts/frontend-refs-manifest.mjs";
 
 type SkillFrontmatter = {
 	readonly name?: unknown
@@ -74,6 +74,17 @@ describe("materialize-frontend-refs", () => {
 		expect(isSkillMarkdownSourcePath("skills/design-review/SKILL.md")).toBe(true);
 		expect(isSkillMarkdownSourcePath("skills\\design-review\\SKILL.md")).toBe(true);
 		expect(isSkillMarkdownSourcePath("skills/design-review/reference.md")).toBe(false);
+	});
+
+	test("materializes every taste-skill artifact byte-identical to its upstream source", () => {
+		if (result.skipped) return;
+		// given the non-SKILL.md taste-skill artifacts (the stitch worked-example DESIGN.md)
+		for (const [fileName, source] of Object.entries(tasteSkillArtifactFiles)) {
+			const upstream = readFileSync(join(upstreamsRoot, "taste-skill", source), "utf8");
+			const materialized = readFileSync(join(frontendSkillRoot, "references", "design", fileName), "utf8");
+			// then the artifact ships verbatim - no frontmatter normalization applies to non-SKILL.md sources
+			expect(materialized).toBe(upstream);
+		}
 	});
 
 	test("materialized brand reference is verbatim upstream content", async () => {

--- a/packages/shared-skills/scripts/frontend-refs-manifest.d.mts
+++ b/packages/shared-skills/scripts/frontend-refs-manifest.d.mts
@@ -7,6 +7,7 @@ export const upstreamsRoot: string;
 export const designOriginals: readonly string[];
 export const brandStems: readonly string[];
 export const tasteSkillFiles: Record<string, string>;
+export const tasteSkillArtifactFiles: Record<string, string>;
 export const uiUxDbFileRenames: Record<string, string>;
 export const uiUxDbScripts: readonly string[];
 

--- a/packages/shared-skills/scripts/frontend-refs-manifest.mjs
+++ b/packages/shared-skills/scripts/frontend-refs-manifest.mjs
@@ -41,6 +41,12 @@ export const tasteSkillFiles = {
 	"imagegen-brandkit.md": "skills/brandkit/SKILL.md",
 };
 
+// Non-SKILL.md taste-skill artifact: upstream ships stitch-skill with a worked
+// example of the DESIGN.md document that skill exports.
+export const tasteSkillArtifactFiles = {
+	"stitch-design-example.md": "skills/stitch-skill/DESIGN.md",
+};
+
 export const uiUxDbFileRenames = {
 	"data/web-interface.csv": "data/app-interface.csv",
 };
@@ -94,6 +100,9 @@ export function designMaterializeMap() {
 		};
 	}
 	for (const [fileName, source] of Object.entries(tasteSkillFiles)) {
+		map[`references/design/${fileName}`] = { upstream: "taste-skill", source };
+	}
+	for (const [fileName, source] of Object.entries(tasteSkillArtifactFiles)) {
 		map[`references/design/${fileName}`] = { upstream: "taste-skill", source };
 	}
 	return map;

--- a/packages/shared-skills/skills/frontend/ATTRIBUTION.md
+++ b/packages/shared-skills/skills/frontend/ATTRIBUTION.md
@@ -68,12 +68,15 @@ The taste-skill files and image-generation skills under `frontend/references/des
 `imagegen-brandkit.md`) are path-mapped copies of the per-skill `SKILL.md` files from the
 taste-skill project (each `skills/<name>/SKILL.md` is renamed to
 `references/design/<name>.md`; `imagegen-brandkit.md` maps from `skills/brandkit/SKILL.md`).
+`stitch-design-example.md` is a path-mapped verbatim copy of `skills/stitch-skill/DESIGN.md`,
+the worked example of the design-system document that the stitch skill exports.
 They are not committed here; the build materializes them from the pinned submodule under
 `packages/shared-skills/upstreams/taste-skill`. Only the allowed frontmatter description
 quoting normalization described above may alter these materialized `SKILL.md` files.
 
 - Source: https://github.com/Leonxlnx/taste-skill
-- Pinned upstream commit: 06d6028b5c623016c59ce8536f578e5a1127b499
+- Official site: https://www.tasteskill.dev/
+- Pinned upstream commit: b17742737e796305d829b3ad39eda3add0d79060
 
 ```
 MIT License

--- a/packages/shared-skills/skills/frontend/SKILL.md
+++ b/packages/shared-skills/skills/frontend/SKILL.md
@@ -56,7 +56,7 @@ The reference library has one architecture file, 12 taste skills (Layer A — *h
 | `redesign-skill.md` | Improving EXISTING UI — "this looks bad", "fix the design". Audit-first workflow; never use on greenfield. |
 | `image-to-code-skill.md` | "Generate the design first, then code it." Pair with one imagegen file below. |
 | `output-skill.md` | Stacks on any style skill when output is incomplete — placeholders, `// TODO`, half-done components. |
-| `stitch-skill.md` | Stacks on any style skill for Google Stitch compatibility or a `DESIGN.md` doc export. |
+| `stitch-skill.md` | Stacks on any style skill for Google Stitch compatibility or a `DESIGN.md` doc export. A complete worked export ships as `stitch-design-example.md`. |
 | `imagegen-frontend-web.md` / `imagegen-frontend-mobile.md` / `imagegen-brandkit.md` | Image-only output (mockup, app-screen concepts, brand board). These NEVER write code — switch to `image-to-code-skill.md` if code is wanted. |
 
 ### Layer B — brand design systems (orthogonal to Layer A; stack freely)

--- a/packages/shared-skills/skills/frontend/references/design/README.md
+++ b/packages/shared-skills/skills/frontend/references/design/README.md
@@ -157,7 +157,7 @@ Triggers: "generate a mockup image", "create a brand kit board", "design referen
 
 Triggers: "Google Stitch", "compatible with Stitch", "also write a DESIGN.md", "give me the design as a doc".
 
-**Action:** Add `stitch-skill.md` on top of whatever you loaded in Steps 1–4.
+**Action:** Add `stitch-skill.md` on top of whatever you loaded in Steps 1–4. For the shape of a finished export, see the worked example in `stitch-design-example.md`.
 
 ### Step 7 — The agent has been lazy
 

--- a/packages/shared-skills/skills/frontend/references/design/_INDEX.md
+++ b/packages/shared-skills/skills/frontend/references/design/_INDEX.md
@@ -33,7 +33,7 @@ From [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill).
 | `minimalist-skill.md` | Editorial product UI inspired by Notion/Linear. Restrained monochrome palette, crisp structure, generous whitespace. | The user says "minimal", "clean", "Notion-style", "Linear-style", "editorial", "boring is good", "remove decoration". |
 | `brutalist-skill.md` | BETA. Mechanical visual language. Swiss typography, sharp contrast, raw structure, experimental composition. | The user says "brutalist", "raw", "Swiss", "experimental", "industrial", "unstyled", "anti-design". |
 | `output-skill.md` | Pushes for complete output: no placeholder comments, no `// TODO`, no skipped implementation, no half-done components. | Stack on top of any other skill when the agent has been lazy or the user complains "you keep leaving things undone". Do not use alone. |
-| `stitch-skill.md` | Google Stitch-compatible semantic design rules. Includes the extra DESIGN.md export format. | The user is working with Google Stitch, or explicitly wants Stitch-format output, or wants a DESIGN.md alongside the code. |
+| `stitch-skill.md` | Google Stitch-compatible semantic design rules. Includes the extra DESIGN.md export format; a complete worked export ships alongside as `stitch-design-example.md`. | The user is working with Google Stitch, or explicitly wants Stitch-format output, or wants a DESIGN.md alongside the code. |
 
 ### Image-generation skills (do NOT write code, only produce reference imagery)
 

--- a/packages/skills-loader-core/src/features/builtin-skills/frontend/SKILL.md
+++ b/packages/skills-loader-core/src/features/builtin-skills/frontend/SKILL.md
@@ -56,7 +56,7 @@ The reference library has one architecture file, 12 taste skills (Layer A — *h
 | `redesign-skill.md` | Improving EXISTING UI — "this looks bad", "fix the design". Audit-first workflow; never use on greenfield. |
 | `image-to-code-skill.md` | "Generate the design first, then code it." Pair with one imagegen file below. |
 | `output-skill.md` | Stacks on any style skill when output is incomplete — placeholders, `// TODO`, half-done components. |
-| `stitch-skill.md` | Stacks on any style skill for Google Stitch compatibility or a `DESIGN.md` doc export. |
+| `stitch-skill.md` | Stacks on any style skill for Google Stitch compatibility or a `DESIGN.md` doc export. A complete worked export ships as `stitch-design-example.md`. |
 | `imagegen-frontend-web.md` / `imagegen-frontend-mobile.md` / `imagegen-brandkit.md` | Image-only output (mockup, app-screen concepts, brand board). These NEVER write code — switch to `image-to-code-skill.md` if code is wanted. |
 
 ### Layer B — brand design systems (orthogonal to Layer A; stack freely)


### PR DESCRIPTION
## Summary

[tasteskill.dev](https://www.tasteskill.dev/) (the "Anti-Slop Frontend Framework", GitHub `Leonxlnx/taste-skill`) was already integrated into the frontend skill by the DMCA submodule reshape (#5472): a pinned submodule under `packages/shared-skills/upstreams/taste-skill` materializes 12 of its 13 skills into `references/design/` at build time. An audit against today's upstream found three residual gaps; this PR closes them. After this PR the frontend skill carries everything tasteskill.dev ships except the deliberately excluded legacy `taste-skill-v1` (superseded by v2 under the same install name) and the repo-index `llms.txt`.

## Changes

- **Upstream pin bump** (`upstreams/taste-skill` gitlink + `ATTRIBUTION.md`): moves the pin 3 commits to upstream `main` tip `b177427`. Verified via `git log --stat`: those commits touch only README/sponsor assets, zero `skills/` content — so no materialized file body changes.
- **New materialized artifact** (`scripts/frontend-refs-manifest.mjs`, `.d.mts`, `materialize-frontend-refs.test.ts`): `skills/stitch-skill/DESIGN.md` — the only taste-skill content that spans a second file beside `SKILL.md`, a complete worked example of the design-system document the stitch skill exports — now materializes as `references/design/stitch-design-example.md` (147 → 148 files). A new test pins it byte-identical to the upstream source. The file is covered by the existing `references/design/*.md` gitignore rule, so the DMCA zero-committed-copies model is unchanged.
- **Routing + attribution docs** (`SKILL.md`, `references/design/_INDEX.md`, `references/design/README.md`, `ATTRIBUTION.md`): the stitch rows/steps now point at the worked example, and ATTRIBUTION cites the official site (tasteskill.dev) beside the GitHub source and documents the new path mapping.

## QA & Evidence

Evidence dir: `.omo/evidence/20260706-tasteskill-embedding/` (local, per repo convention).

- **What was tested:** `materialize-frontend-refs.mjs --strict` before/after the manifest change. **Observed:** 147 → 148 files written; `cmp` proves `stitch-design-example.md` is byte-identical to `upstreams/taste-skill/skills/stitch-skill/DESIGN.md`. **Why sufficient:** the materialize pipeline is the exact surface both editions build from; byte-identity is additionally pinned by the new test.
- **What was tested:** `script/update-frontend-upstreams.mjs --check`. **Observed:** all 4 ATTRIBUTION pins match live submodule HEADs (taste-skill now `b177427`). **Why sufficient:** this is the provenance gate CI enforces via `provenance-gate.test.ts`.
- **What was tested:** `bun test packages/shared-skills/` at HEAD. **Observed:** 85 pass / 0 fail (provenance gate, third-party manifest partition, materialize suite incl. the new byte-identity test, frontend skill contract). 
- **What was tested:** OpenCode-side packaging/parse gate (`packages/omo-opencode/src/shared-skills-package.test.ts`). **Observed:** 3 pass / 0 fail — the modified frontend SKILL.md parses and ships.
- **What was tested:** Codex-side landing — `packages/omo-codex/plugin/scripts/sync-skills.mjs`, then inspection of the synced copy. **Observed:** `plugin/skills/frontend/references/design/stitch-design-example.md` lands byte-identical; all 4 routing docs carry the reference in the synced copy. `bun run test:codex` passes (exit 0).
- **What was tested:** `bun run typecheck` (tsgo, all workspaces). **Observed:** exit 0.

## Risks & Residuals

- **Materialized-content regression from the pin bump:** none possible — the 3 upstream commits touch no `skills/` path (verified by diff stat), and the materialize byte-identity tests would catch any drift. Mitigated.
- **DMCA/provenance posture:** unchanged — the new artifact is materialized-only (gitignored), verbatim, MIT-attributed with the mapping documented. Mitigated by `provenance-gate.test.ts` + `frontend-thirdparty-manifest.test.ts`, both green.
- **Deliberate exclusions:** `taste-skill-v1` (legacy, superseded by v2) and `skills/llms.txt` (upstream's own index; our SKILL.md router serves that role) stay out. Accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the `tasteskill.dev` embedding by shipping the stitch DESIGN.md worked example and wiring it into the frontend skill. Adds a byte-identity test and bumps the `taste-skill` submodule pin.

- **New Features**
  - Materialize `skills/stitch-skill/DESIGN.md` as `references/design/stitch-design-example.md`; manifest and test ensure byte-identical content.
  - Update routing docs (`SKILL.md` in shared + checked-in copies, `references/design/README.md`, `references/design/_INDEX.md`) to reference the worked example.
  - Refresh `ATTRIBUTION.md` with the official site and the new path mapping.

- **Dependencies**
  - Bump `packages/shared-skills/upstreams/taste-skill` to `b177427` in `Leonxlnx/taste-skill` (README/sponsor-only upstream changes; no `skills/` diffs).

<sup>Written for commit 84e1864c1461f2ecdf965c5967108635062b0cab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

