### PR TITLE
test(bunfig): ignore built dist/ test copies in discovery

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,6 +1,6 @@
 [test]
 preload = ["./test-setup.ts"]
-pathIgnorePatterns = ["packages/web/**", "packages/lsp-tools-mcp/**", "packages/lsp-daemon/**", "packages/omo-codex/plugin/**", "packages/omo-codex/scripts/**", "packages/shared-skills/upstreams/**"]
+pathIgnorePatterns = ["dist/**", "packages/web/**", "packages/lsp-tools-mcp/**", "packages/lsp-daemon/**", "packages/omo-codex/plugin/**", "packages/omo-codex/scripts/**", "packages/shared-skills/upstreams/**"]
 
 [loader]
 ".md" = "text"


### PR DESCRIPTION
## What

Adds `dist/**` to `bunfig.toml` `pathIgnorePatterns` so `bun test` no longer discovers built test copies under the gitignored `dist/` directory.

## Why

`bun test` at the repo root discovers `.test.ts` files wherever they land, including built copies under `dist/skills/visual-qa/scripts/` produced by the shared-skills build. When `dist/` is stale relative to source, the dist copy of a test fails while the source copy passes — so the pass/fail outcome depends purely on whether `dist/` was last rebuilt. That is a build-state flake: a full-suite run on a clean checkout, on a checkout after `bun run build`, and on a checkout after `bun run clean` can each discover a different set of tests.

Observed in a baseline run: `visual-qa skill prompt contract > ...falls back to agent-browser` failed from `dist/skills/visual-qa/scripts/skill-prompt-contract.test.ts` (a stale dist copy asserting `bun add -g agent-browser`) while the source copy asserting `npm install -g agent-browser` passed.

## Zero coverage lost (verified)

All 7 test files under `dist/skills/visual-qa/scripts/` have a 1:1 source-of-truth copy under `packages/shared-skills/skills/visual-qa/scripts/`:

```
ansi.test.ts  cli.test.ts  east-asian-width.test.ts  image-diff.test.ts
png-decode.test.ts  skill-prompt-contract.test.ts  tui-grid.test.ts
```

Those source copies are NOT in `pathIgnorePatterns` (only `packages/shared-skills/upstreams/**` is), so they remain discovered. Confirmed the source `skill-prompt-contract.test.ts` still runs (16 tests, 0 fail).

The build job's `dist-bundle-*.test.ts` step (`packages/omo-opencode/src/shared/dist-bundle-bun-globals.test.ts` and `dist-bundle-prompt-content.test.ts`) is source-located under `packages/omo-opencode/src/shared/`, so it is unaffected by this ignore.

## QA

- Verified with `dist/` present (7 dist test files): explicitly targeting a dist test path now yields zero discovered tests; the source copy still runs 16 tests green.
- One-line, test-config-only change; no production code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignored built test copies in `dist/` during `bun test` discovery by adding `dist/**` to `bunfig.toml` `pathIgnorePatterns`. This removes build-state flakes from stale dist artifacts; all source tests still run, so coverage is unchanged.

<sup>Written for commit 277dd05ddf8a316e3d97fae7a7df804c34e27453. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

