### PR TITLE
ci(publish): skip prepare build on installs that do not need dist

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -52,7 +52,7 @@ jobs:
           bun-version: "1.3.12"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Validate release inputs
         id: validate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
         working-directory: packages/lsp-tools-mcp
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Type check
         run: bun run typecheck
@@ -132,7 +132,7 @@ jobs:
         working-directory: packages/lsp-tools-mcp
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build vendored lsp-daemon package
         run: npm ci && npm run build
@@ -359,7 +359,7 @@ jobs:
           bun-version: "1.3.12"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Prepare and merge release state before publishing
         id: prepare
@@ -497,7 +497,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Verify platform packages are published
         env:
@@ -800,7 +800,7 @@ jobs:
           bun-version: "1.3.12"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Generate changelog
         run: |


### PR DESCRIPTION
## What changed

Root `package.json` `prepare` runs the full `bun run build` on every `bun install` (no `--ignore-scripts`), so every publish job's "Install dependencies" step silently paid for a full build. This PR adds `--ignore-scripts` to the publish installs whose own steps do not consume those artifacts.

Changed installs:
- `publish.yml`: `typecheck`, `codex-compatibility`, `prepare-release-state`, `publish-main`, `release`
- `publish-platform.yml`: `build`

Deliberately NOT changed:
- `publish.yml` `test` job keeps its full install. Its `bun test` suite includes the Codex installer tests, which need the prepare-built `packages/git-bash-mcp/dist`, `packages/lsp-daemon/dist`, and the codex-plugin component dists. (Same reason `ci.yml`'s test job keeps a full install.)

`package.json` is untouched (Option A).

## Why each flipped job is safe

Every job that gets `--ignore-scripts` either needs no `dist/` at all, or already builds exactly what it ships via an explicit step that stays in place:

- **typecheck**: `bun run typecheck` is `tsgo --noEmit`, no dist.
- **codex-compatibility**: already builds `lsp-tools-mcp` and `lsp-daemon` explicitly around the install, then `bun run test:codex` builds its own codex artifacts.
- **prepare-release-state**: only version-stamps (`sync-version`, `sync-hook-status-messages`, `npm --package-lock-only`), no dist read.
- **publish-platform build**: `bun run build:binaries` writes static launcher shims; it never reads `dist/`.
- **publish-main**: unchanged explicit `bun run build:lsp-tools-mcp && build:lsp-daemon && build` runs right after install.
- **release**: `generate-changelog` is git/GitHub only; the marketplace-sync step keeps its own explicit build chain.

## QA / evidence

Every per-job check was run on a **pristine shallow clone** installed with `--ignore-scripts`, so no warm sub-package artifact could mask a hidden `prepare` dependency (this is the exact trap that produced a red CI run on the sibling ci.yml change). Observed: all target job commands succeed with `dist/` absent; `bun run test:codex` = 456 pass / 0 fail on the pristine clone. actionlint passes (`-shellcheck=""`, exit 0). Evidence + raw logs under `.omo/evidence/20260706-publish-ignore-scripts/`.

## Impact / residual risk

Removes a redundant full build (~30-90s cold) from each affected install. No publish semantics change (dual-publish order, provenance, dist-tag, skip-if-published, marketplace-sync gating all untouched). The publish workflow cannot be run end to end from a branch, so the guarantee rests on the pristine-clone per-job replay plus actionlint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the root prepare build in publish workflows by adding `--ignore-scripts` to installs that don’t need `dist/`. This removes redundant builds and speeds up CI without changing publish behavior.

- **Refactors**
  - Added `--ignore-scripts` to `bun install` in `publish.yml` jobs: `typecheck`, `codex-compatibility`, `prepare-release-state`, `publish-main`, `release`, and in `publish-platform.yml` `build`.
  - Left the `test` job unchanged; it needs prepare-built artifacts.
  - Each updated job either doesn’t read `dist/` or runs its own explicit build; expected savings ~30–90s per affected install.

<sup>Written for commit 904c0184c3115ab6991f2ba4ae07ed30f73c7688. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

