### PR TITLE
perf(omo-opencode): zero idle-settle in two more ralph-loop test files

### DIFF
--- a/packages/omo-opencode/src/hooks/ralph-loop/non-abort-error-continuation.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/non-abort-error-continuation.test.ts
@@ -64,7 +64,7 @@ describe("ralph-loop non-abort error continuation", () => {
 					showToast: async () => ({}),
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		hook.startLoop("session-123", "Keep working", {
 			messageCountAtStart: 0,
@@ -118,7 +118,7 @@ describe("ralph-loop non-abort error continuation", () => {
 					showToast: async () => ({}),
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		hook.startLoop("session-123", "Keep ultraworking", {
 			messageCountAtStart: 0,
@@ -177,7 +177,7 @@ describe("ralph-loop non-abort error continuation", () => {
 					showToast: async () => ({}),
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		try {
 			hook.startLoop("session-123", "Keep working", {
@@ -253,7 +253,7 @@ describe("ralph-loop non-abort error continuation", () => {
 					showToast: async () => ({}),
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		try {
 			hook.startLoop("session-123", "Keep working", {
@@ -330,7 +330,7 @@ describe("ralph-loop non-abort error continuation", () => {
 					showToast: async () => ({}),
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		try {
 			hook.startLoop("session-123", "Keep working", {
@@ -407,6 +407,7 @@ describe("ralph-loop non-abort error continuation", () => {
 				},
 			},
 		} as never, {
+			idleSettleMs: 0,
 			backgroundManager: {
 				getTasksByParentSession: (sessionID: string) => sessionID === "session-123"
 					? [{ status: "running" }]
@@ -465,7 +466,7 @@ describe("ralph-loop non-abort error continuation", () => {
 					showToast: async () => ({}),
 				},
 			},
-		} as never)
+		} as never, { idleSettleMs: 0 })
 
 		hook.startLoop("session-123", "Keep working", {
 			messageCountAtStart: 0,

--- a/packages/omo-opencode/src/hooks/ralph-loop/ulw-loop-verification.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/ulw-loop-verification.test.ts
@@ -75,6 +75,7 @@ describe("ulw-loop verification", () => {
 
 		test("#given ulw loop emits DONE #when idle fires #then verification phase starts instead of completing", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -95,6 +96,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given ulw loop is awaiting verification #when VERIFIED appears in oracle session #then loop completes", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -121,6 +123,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given ulw loop is awaiting verification #when oracle session idles with VERIFIED #then loop completes without parent idle", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -147,6 +150,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given ulw loop is awaiting verification #when oracle transcript stores VERIFIED inside tool_result #then loop completes", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -177,6 +181,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given ulw loop is awaiting verification without oracle session #when parent idles again #then loop continues until oracle verifies", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -202,6 +207,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given ulw loop is awaiting oracle verification #when parent idles before VERIFIED arrives #then loop continues instead of waiting", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -250,6 +256,7 @@ describe("ulw-loop verification", () => {
 				},
 			},
 		} as Parameters<typeof createRalphLoopHook>[0], {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -284,6 +291,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given ulw loop without max iterations #when it continues #then it stays unbounded", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -301,6 +309,7 @@ describe("ulw-loop verification", () => {
 			`${JSON.stringify({ type: "assistant", timestamp: "2000-01-01T00:00:00.000Z", content: "old <promise>DONE</promise>" })}\n`,
 		)
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -314,6 +323,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given ulw loop was awaiting verification #when same session starts again #then verification state is overwritten", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -332,6 +342,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given ulw loop was awaiting verification #when different session starts a new ulw loop #then prior verification state is overwritten", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -351,6 +362,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given verification state was overwritten by different ulw loop #when stale oracle session idles #then new loop remains active", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle-old" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -380,6 +392,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given verification state was overwritten by restarted ulw loop #when stale oracle session idles #then restarted loop remains active", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle-old" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -410,6 +423,7 @@ describe("ulw-loop verification", () => {
 
 	test("#given parent session emits VERIFIED #when oracle session is not tracked #then ulw loop completes from parent session evidence", async () => {
 		const hook = createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -447,6 +461,7 @@ describe("ulw-loop verification", () => {
 				},
 			},
 		} as Parameters<typeof createRalphLoopHook>[0], {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -495,6 +510,7 @@ session_id: ses-oracle
 				},
 			},
 		} as Parameters<typeof createRalphLoopHook>[0], {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -541,6 +557,7 @@ session_id: ses-oracle
 				},
 			},
 		} as Parameters<typeof createRalphLoopHook>[0], {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
@@ -581,6 +598,7 @@ session_id: ses-oracle
 				},
 			},
 		} as Parameters<typeof createRalphLoopHook>[0], {
+			idleSettleMs: 0,
 			getTranscriptPath: (sessionID) => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
 		})
 		hook.startLoop("session-123", "Build API", { ultrawork: true })


### PR DESCRIPTION
## What changed

Follow-up to the ralph-loop idle-settle cut, found via the full-suite JUnit timing map (which surfaced two more ralph-loop test files that never overrode the default settle delay). Both are **test-only**.

`createRalphLoopHook` applies `idleSettleMs ?? DEFAULT_IDLE_SETTLE_MS` — a 150ms real `sleep` on the idle-continuation path. These two files build the hook many times with no `idleSettleMs`, so every idle test paid the full 150ms:

- **`ulw-loop-verification.test.ts`** — added `idleSettleMs: 0` to all 18 hook builds.
- **`non-abort-error-continuation.test.ts`** — added `idleSettleMs: 0` to all 7 hook builds.

No test in either file asserts settle timing, so behavior coverage is unchanged.

## Observed behavior (before → after, both green)

| File | Before | After |
|------|--------|-------|
| ulw-loop-verification.test.ts | 4.39s | 3.46s |
| non-abort-error-continuation.test.ts | 2.82s | 0.12s |
| **total** | **7.21s** | **3.58s (~3.6s saved)** |

**Honesty note:** `ulw-loop-verification.test.ts` only dropped ~0.9s because most of its remaining cost is **real `writeFileSync` transcript I/O** (18+ writes) plus per-test hook execution — not blind sleeps. Cutting that further would mean mocking the transcript FS, which is more invasive and behavior-adjacent, so it's deliberately left as-is; this PR only removes the settle delay.

## QA / evidence

- Regression: `bun test packages/omo-opencode/src/hooks/ralph-loop/` → **166 pass / 0 fail across 21 files**.
- `tsgo --noEmit -p packages/omo-opencode/tsconfig.json` clean.
- Evidence: `.omo/evidence/20260706-test-speed/pr2-ralph-more-cuts.txt` (local, gitignored).
- **No production source touched** (test files only), so no real-harness plugin QA is required for this PR — unlike the prior PR which plumbed a production default.

## Residual risk

Very low. Test-only; only the settle wait duration changed; every assertion is unchanged; the whole directory stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `idleSettleMs: 0` in two ralph-loop test files to remove the default 150ms idle-settle sleep from `createRalphLoopHook` builds. Test-only change that speeds up the suite with no behavior change.

- **Performance**
  - `ulw-loop-verification.test.ts`: 4.39s → 3.46s
  - `non-abort-error-continuation.test.ts`: 2.82s → 0.12s
  - ~3.6s total saved across both files (remaining cost is real `writeFileSync` I/O)

<sup>Written for commit 7a6a65a3b15ee88c8a38b9bca21b030e08dcd616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

