### PR TITLE
fix(skills-loader): hermetic HOME resolution for skill/command discovery

### DIFF
--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader.ts
@@ -1,5 +1,5 @@
 import { join } from "path"
-import { homedir } from "os"
+import { getHomeDirectory } from "@oh-my-opencode/utils"
 import { sharedSkillsRootPath } from "@oh-my-opencode/shared-skills"
 import {
   findProjectAgentsSkillDirs,
@@ -59,7 +59,7 @@ export async function loadProjectAgentsSkills(directory?: string): Promise<Recor
   return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()))
 }
 
-export async function loadGlobalAgentsSkills(homeDirectory: string = homedir()): Promise<Record<string, CommandDefinition>> {
+export async function loadGlobalAgentsSkills(homeDirectory: string = getHomeDirectory()): Promise<Record<string, CommandDefinition>> {
   const agentsGlobalDir = join(homeDirectory, ".agents", "skills")
   const skills = await loadSkillsFromDir({ skillsDir: agentsGlobalDir, scope: "user" })
   return skillsToCommandDefinitionRecord(skills)
@@ -195,7 +195,7 @@ export async function discoverProjectAgentsSkills(directory?: string): Promise<L
   return deduplicateSkillsByName(allSkills.flat())
 }
 
-export async function discoverGlobalAgentsSkills(homeDirectory: string = homedir()): Promise<LoadedSkill[]> {
+export async function discoverGlobalAgentsSkills(homeDirectory: string = getHomeDirectory()): Promise<LoadedSkill[]> {
   const agentsGlobalDir = join(homeDirectory, ".agents", "skills")
   return loadSkillsFromDir({ skillsDir: agentsGlobalDir, scope: "user" })
 }

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-template-resolver.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-template-resolver.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
-import { homedir } from "node:os"
 import { join } from "node:path"
+import { getHomeDirectory } from "@oh-my-opencode/utils"
 import { matchSkillByName } from "../../tools/skill/skill-matcher"
 import {
 	findProjectAgentsSkillDirs,
@@ -97,7 +97,7 @@ async function loadConfiguredGitMasterSkill(options?: SkillResolutionOptions): P
 		{ roots: findProjectClaudeSkillDirs(directory), scope: "project" },
 		{ roots: findProjectAgentsSkillDirs(directory), scope: "project" },
 		{ roots: [join(getClaudeConfigDir(), "skills")], scope: "user" },
-		{ roots: [join(homedir(), ".agents", "skills")], scope: "user" },
+		{ roots: [join(getHomeDirectory(), ".agents", "skills")], scope: "user" },
 	]
 
 	for (const group of rootGroups) {

--- a/packages/skills-loader-core/src/shared/claude-config-dir.ts
+++ b/packages/skills-loader-core/src/shared/claude-config-dir.ts
@@ -1,5 +1,5 @@
-import { homedir } from "node:os"
 import { join } from "node:path"
+import { getHomeDirectory } from "@oh-my-opencode/utils"
 
 export function getClaudeConfigDir(): string {
   const envConfigDir = process.env.CLAUDE_CONFIG_DIR
@@ -7,5 +7,5 @@ export function getClaudeConfigDir(): string {
     return envConfigDir
   }
 
-  return join(homedir(), ".claude")
+  return join(getHomeDirectory(), ".claude")
 }

--- a/packages/utils/src/command-executor.ts
+++ b/packages/utils/src/command-executor.ts
@@ -3,3 +3,4 @@ export type { CommandResult, ExecuteHookOptions } from "./command-executor/execu
 
 export { executeCommand } from "./command-executor/execute-command"
 export { resolveCommandsInText } from "./command-executor/resolve-commands-in-text"
+export { getHomeDirectory } from "./command-executor/home-directory"

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,7 +1,8 @@
 /// <reference types="bun-types" />
 import { afterEach, beforeEach, mock } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { existsSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { _resetForTesting as resetClaudeSessionState } from "./packages/omo-opencode/src/features/claude-code-session-state/state"
 import { _resetTaskToastManagerForTesting as resetTaskToastManager } from "./packages/omo-opencode/src/features/task-toast-manager/manager"
@@ -36,6 +37,25 @@ function ensureVendoredLspDaemonBuilt(): void {
   }
 }
 ensureVendoredLspDaemonBuilt()
+
+// Skill/agent/command discovery reads the developer's real HOME (~/.agents/skills,
+// ~/.claude, ~/.config/opencode). A machine with real user skills installed then makes
+// discovery tests pass or fail depending on whose laptop runs them. Point HOME (and
+// USERPROFILE, which os.homedir() reads on Windows) at one empty per-process temp dir so
+// discovery always falls back to the builtins the tests assert on. The discovery code
+// resolves home through getHomeDirectory() (process.env.HOME || USERPROFILE || homedir()),
+// so setting these env vars is sufficient — os.homedir() itself caches the OS home at
+// process start and ignores this mutation. Deliberately NOT setting XDG_* or CLAUDE/OPENCODE
+// config dirs: config-dir tests control those themselves.
+//
+// Applied ONCE at module load, not per-test: the beforeEach env snapshot below captures
+// this hermetic HOME for tests that don't touch it, and the afterEach restore keeps it.
+// A per-test re-application would clobber HOME for suites that set their own HOME in a
+// beforeAll (e.g. openclaw reply-listener daemon tests) and only reset state — not HOME —
+// in their beforeEach, so it must NOT run every test.
+const HERMETIC_HOME = mkdtempSync(join(tmpdir(), "omo-test-home-"))
+process.env.HOME = HERMETIC_HOME
+process.env.USERPROFILE = HERMETIC_HOME
 
 let isGlobalMockCleanup = false
 const { restoreModuleMocks } = installModuleMockLifecycle(mock, {


### PR DESCRIPTION
## What

Routes the three raw `homedir()` sites in skill/command discovery through the existing env-honoring `getHomeDirectory()` helper (`process.env.HOME || process.env.USERPROFILE || homedir()`), exports that helper from the `@oh-my-opencode/utils` barrel, and sandboxes `HOME`+`USERPROFILE` per-process in `test-setup.ts`.

Changed sites in `packages/skills-loader-core`:
- `features/opencode-skill-loader/loader.ts` — `discoverGlobalAgentsSkills` / `loadGlobalAgentsSkills` default param
- `features/opencode-skill-loader/skill-template-resolver.ts` — git-master `~/.agents/skills` root
- `shared/claude-config-dir.ts` — `getClaudeConfigDir()` fallback (matches the claude-code-compat-core copy which already does this)

## Why

Skill/agent/command discovery hardcoded `join(homedir(), ".agents", "skills")` and `join(homedir(), ".claude")`, which **no `CLAUDE_CONFIG_DIR`/`OPENCODE_CONFIG_DIR` override could redirect**. On a dev machine with real skills installed under `~/.agents/skills` (frequently `~/.claude/skills` is a symlink to it), discovered skills shadow the builtins that ~9 discovery tests assert on — so those tests pass or fail depending on whose laptop runs them (CI, with a clean HOME, stays green). This is a real hermeticity gap, and the fix also makes discovery honor an explicitly overridden HOME in production.

### The Bun `os.homedir()` caching proof (why a test-setup preload alone is insufficient)

`os.homedir()` caches the OS home at process start and **ignores runtime `process.env.HOME` mutation**:

```
$ bun -e 'process.env.HOME="/tmp/x"; console.log(require("os").homedir())'
/Users/<real-user>          # NOT /tmp/x
```

CI runs raw `bun test` (ci.yml:115), not `bun run test`, so wrapping an npm script would not cover it. Routing discovery through `getHomeDirectory()` (which reads the env first) is what lets the `test-setup.ts` `HOME`/`USERPROFILE` sandbox actually take effect — for `bun test`, `bun test <file>`, and CI alike.

### Identical outcome for normal launches

In production, `HOME`/`USERPROFILE` are set by the OS to the user's real home, so `getHomeDirectory()` returns exactly what `homedir()` returned before — the resolved path is byte-identical for a normal launch. The only behavior change is that an explicitly overridden `HOME` (tests, sandboxes, containers) is now honored, which is the intended improvement.

## QA / Evidence

**Unit / audits (all green):**
- Full `skills-loader-core` suite: 217/0. Discovery-heavy `omo-opencode` dirs: 295/0. Full `bun run typecheck`: clean.
- `shared-core-extraction-guard`: 3/0. `opencode-coupling-audit` (both pkgs): 4/0. `package-registration-audit`: 6/0. (`skills-loader-core` already declares the `@oh-my-opencode/utils` workspace dep.)
- `test:codex` scope: the codex plugin does not import any changed path; the utils tests the codex gate runs (`jsonc-parser`, `frontmatter`, `execute-hook-command`) pass 46/0, and the barrel export is additive.

**4-state matrix ({dist present/absent} × {real HOME/hermetic HOME}) — all green:**
| | dist absent | dist present |
|---|---|---|
| real HOME (this machine has ~/.agents/skills) | pass | pass |
| hermetic HOME | 89/0 | 89/0 |

**opencode-qa runtime evidence (isolated XDG+HOME sandbox, opencode v1.17.13):**
- Plugin loads cleanly (`opencode models` exit 0 with the freshly-built dist wired via opencode.json).
- Runtime builtin-skill resolution: under sandbox HOME `resolveSkillContentAsync("git-master")` returns the **builtin** (`# Git Master Agent…`); under real HOME (contrast) it returns the developer's real user skill (`## GIT COMMAND PREFIX…`) — the exact flake this fixes.
- Isolation proven: real opencode DB session count unchanged (5751 → 5751).

## Notes

- Deliberately does not set `XDG_*` in the test sandbox — config-dir tests (`opencode-config-dir.test.ts`) control XDG themselves; setting it globally breaks 8 of them.
- The separate `omo-opencode/src/shared/claude-config-dir.ts` copy (used by claude-code hooks, not skill discovery) is intentionally left unchanged — it is not in a flaky path and its test asserts against raw `homedir()`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make skill and command discovery honor `HOME`/`USERPROFILE` so tests and local runs are hermetic and don’t read a developer’s real `~/.agents/skills` or `~/.claude`. This removes discovery flakes and keeps normal behavior unchanged unless `HOME` is explicitly overridden.

- **Bug Fixes**
  - Replaced raw `homedir()` with `getHomeDirectory()` in discovery paths and Claude config fallback.
  - Exported `getHomeDirectory` from `@oh-my-opencode/utils`.
  - Test setup now sets a per-process temp `HOME`/`USERPROFILE` for consistent builtin-skill resolution (no `XDG_*` override).

<sup>Written for commit 5d8f241a0c15ee483dc168e4d5c80d2bc5858fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

