### PR TITLE
perf(omo-opencode): make session-create retry delay injectable for tests

### DIFF
--- a/packages/omo-opencode/src/cli/run/session-resolver.test.ts
+++ b/packages/omo-opencode/src/cli/run/session-resolver.test.ts
@@ -81,7 +81,7 @@ describe("resolveSession", () => {
     })
 
     // when
-    const result = await resolveSession({ client: mockClient, directory })
+    const result = await resolveSession({ client: mockClient, directory, retryDelayMs: 1 })
 
     // then
     expect(result).toBe("new-session-id")
@@ -107,7 +107,7 @@ describe("resolveSession", () => {
     })
 
     // when
-    const result = await resolveSession({ client: mockClient, directory })
+    const result = await resolveSession({ client: mockClient, directory, retryDelayMs: 1 })
 
     // then
     expect(result).toBe("retried-session-id")
@@ -134,7 +134,7 @@ describe("resolveSession", () => {
     })
 
     // when
-    const result = resolveSession({ client: mockClient, directory })
+    const result = resolveSession({ client: mockClient, directory, retryDelayMs: 1 })
 
     // then
     await Promise.resolve(
@@ -154,7 +154,7 @@ describe("resolveSession", () => {
     })
 
     // when
-    const result = resolveSession({ client: mockClient, directory })
+    const result = resolveSession({ client: mockClient, directory, retryDelayMs: 1 })
 
     // then
     await Promise.resolve(

--- a/packages/omo-opencode/src/cli/run/session-resolver.ts
+++ b/packages/omo-opencode/src/cli/run/session-resolver.ts
@@ -10,8 +10,10 @@ export async function resolveSession(options: {
   client: OpencodeClient
   sessionId?: string
   directory: string
+  retryDelayMs?: number
 }): Promise<string> {
   const { client, sessionId, directory } = options
+  const retryDelayMs = options.retryDelayMs ?? SESSION_CREATE_RETRY_DELAY_MS
 
   if (sessionId) {
     const res = await client.session.get({
@@ -42,7 +44,7 @@ export async function resolveSession(options: {
       console.error(pc.dim(`  Error: ${serializeError(res.error)}`))
 
       if (attempt < SESSION_CREATE_MAX_RETRIES) {
-        const delay = SESSION_CREATE_RETRY_DELAY_MS * attempt
+        const delay = retryDelayMs * attempt
         console.log(pc.dim(`  Retrying in ${delay}ms...`))
         await new Promise((resolve) => setTimeout(resolve, delay))
       }
@@ -60,7 +62,7 @@ export async function resolveSession(options: {
     )
 
     if (attempt < SESSION_CREATE_MAX_RETRIES) {
-      const delay = SESSION_CREATE_RETRY_DELAY_MS * attempt
+      const delay = retryDelayMs * attempt
       console.log(pc.dim(`  Retrying in ${delay}ms...`))
       await new Promise((resolve) => setTimeout(resolve, delay))
     }


### PR DESCRIPTION
## What changed

Round-2 timing cut found by mining the full-suite JUnit map. `session-resolver.test.ts` was the 2nd-slowest file in the whole suite (7.2s) purely because it waited out real retry backoff.

`resolveSession` retried session creation with a hardcoded `SESSION_CREATE_RETRY_DELAY_MS = 1000` (`delay = 1000 * attempt`). The "retries session creation on failure" test slept 1000ms and "throws after all retries exhausted" slept 1000 + 2000 = 3000ms of real time.

Added an optional `retryDelayMs` to `resolveSession`'s options (default unchanged at the existing 1000ms const), threaded into both delay sites. The test passes `retryDelayMs: 1`. The one production caller (`runner.ts`) does **not** pass it, so production keeps the 1000ms backoff — no behavior change.

## Observed behavior

| File | Before | After | Tests |
|------|--------|-------|-------|
| session-resolver.test.ts | 7.23s | 0.24s | 6 pass / 0 fail |

~7s saved — the single largest per-file cut in the effort so far.

## QA / evidence

- Retry + exhaustion paths remain fully unit-covered (6/6, including the retry and all-retries-exhausted cases).
- `tsgo --noEmit -p packages/omo-opencode/tsconfig.json` clean.
- **opencode-qa** (production source touched): built the plugin, booted opencode in an isolated XDG+HOME sandbox — log shows `[oh-my-openagent] ENTRY - plugin loading` + `[live-server-route] registered`, no plugin-load errors; `dist/index.js` carries `retryDelayMs`. Isolation: real DB session count 5751 before = 5751 after.
- Evidence: `.omo/evidence/20260706-test-speed/round2-session-resolver.txt` + `round2-plugin-load-proof.txt` (local, gitignored).

**Honesty note:** a full `omo run` model turn was not driven E2E — the sandbox has no provider credentials (copying host auth would break isolation). The retry logic is a CLI helper fully covered by unit tests, so the load proof + unit coverage is the proportional evidence for a default-unchanged parameter plumb (same discipline as the prior merged PR).

## Residual risk

Low. Default backoff unchanged in production; only the test-injected delay changed; every assertion is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the session creation retry delay injectable in `omo-opencode` to speed up tests without changing production behavior. Added optional `retryDelayMs` to `resolveSession` (default 1000ms); tests set it to 1ms, cutting `session-resolver.test.ts` from 7.23s to 0.24s.

<sup>Written for commit 59b2864aec62beb0e4c1aa03de0dc412f8ed3305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

