### PR TITLE
test(flaky): durable fixes for Windows-family timeout flakes + recurrence audit

### DIFF
--- a/packages/omo-opencode/src/dependency-security.test.ts
+++ b/packages/omo-opencode/src/dependency-security.test.ts
@@ -77,8 +77,14 @@ async function findFirstPartyEffectImports(): Promise<string[]> {
       ":(exclude)**/node_modules/**",
       ":(exclude)**/dist/**",
     ],
-    { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" },
+    // Bound the spawn so a slow `git grep -P` on a loaded Windows runner fails
+    // deterministically instead of hanging past the test timeout (the observed flake).
+    { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe", timeout: 60_000 },
   )
+  expect(
+    result.signalCode ?? null,
+    `git grep did not finish within the spawn timeout (signal ${result.signalCode})`,
+  ).toBeNull()
   if (result.exitCode === 1) return []
   expect(result.exitCode, result.stderr.toString()).toBe(0)
   return result.stdout

--- a/packages/omo-opencode/src/hooks/start-work/session-plan-affinity.test.ts
+++ b/packages/omo-opencode/src/hooks/start-work/session-plan-affinity.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
 import { join, win32 } from "node:path"
 import { tmpdir } from "node:os"
 import { findRecentSessionPlanPath } from "./session-plan-affinity"
@@ -10,7 +11,7 @@ type FindRecentSessionPlanPathInput = Parameters<typeof findRecentSessionPlanPat
 
 describe("findRecentSessionPlanPath", () => {
   test("#given session history references omo plan path #when finding recent plan #then returns matching plan", async () => {
-    const directory = join(tmpdir(), "session-plan-affinity-test")
+    const directory = join(tmpdir(), `session-plan-affinity-test-${randomUUID()}`)
     const planPath = join(directory, ".omo", "plans", "foo-bar.md")
     const client = unsafeTestValue<FindRecentSessionPlanPathInput["client"]>({
       session: {


### PR DESCRIPTION
## What

Two durable fixes for the Windows-family timeout flakes surfaced by CI-history mining, plus a recurrence audit of the whole family.

1. **`dependency-security.test.ts`** — the `git grep -P` scan over the tree ran via `Bun.spawnSync` with **no timeout**, so on a loaded Windows runner it could hang past the default test timeout (the observed `[10922ms]` flake, which failed-then-passed on rerun). Bound the spawn to 60s and assert `signalCode` is null so a timeout fails deterministically with a clear message instead of a mystery hang.
2. **`session-plan-affinity.test.ts`** — the tmpdir path used a fixed `session-plan-affinity-test` literal; added a `randomUUID()` suffix so parallel/repeated runs cannot collide. (Precautionary: the path is only string-matched, never written to disk, so there was no actual disk collision — hygiene only. The separate `C:\Users\RUNNER~1\...` literal at line 43 is an intentional Windows short-path test and is left unchanged.)

## Recurrence audit (Root Cause C family)

The 11 Windows-family flakes (team-mailbox `poll`, team-mode `integration` C-10.1/C-10.2, `createTeamIdleWakeHint`, `createTeamMemberErrorHandler`, atlas `final-wave-approval-gate`, `port-utils`, `dependency-security`) were previously remediated by the maintainer. I mined dev CI history since each remediation commit:

| Remediation commit | Landed (UTC) |
|---|---|
| `a099459c5` relax mailbox race timeout | 2026-06-27T17:27Z |
| `b901c7fa9` stabilize integration spawn | 2026-06-28T16:20Z |
| `beb0b0963` relax windows-heavy timeouts | 2026-07-02T10:06Z |
| `d98d23009` mock exhausted port range | 2026-07-02T10:07Z |

**Result: zero recurrence.** The last dev CI failure touching this family was run `28564246225` at **2026-07-02T03:56Z** — *before* the final remediation landed at 10:06Z. Every dev CI run since (2026-07-02T10:29Z through 2026-07-05, ~15 runs) is `success` or `cancelled` (cancelled = superseded push, not failure). So the family is honestly recorded as **remediated, monitored** — no live root-cause left to chase beyond the two durable fixes above.

The `port-utils` "every attempted port is blocked" flake was already converted from real port binding to a mocked exhausted range (`d98d23009`), which is the correct durable pattern.

## QA

- `dependency-security.test.ts` 3/0, `session-plan-affinity.test.ts` 2/0; both stable 10/10 under repeated runs.
- `bun run typecheck` for `omo-opencode`: clean.
- PR CI (this branch) doubles as a Windows-matrix validation run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows CI flakes by adding a 60s timeout to the `git grep -P` spawn and by uniquifying the tmpdir in the session-plan affinity test. Prevents hangs and path collisions; no recurrence seen across the Windows flake family since prior remediations.

- **Bug Fixes**
  - `dependency-security.test.ts`: Bound `Bun.spawnSync` to `timeout: 60_000` and assert `signalCode` is null for deterministic failures instead of hangs.
  - `session-plan-affinity.test.ts`: Append `randomUUID()` to the tmpdir name to avoid parallel/retry collisions.

<sup>Written for commit f790e55a87c91d0b45d129bb904680ff5ca4c3fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

