### PR TITLE
perf(ci): drop redundant vendored-package build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,6 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - name: Build vendored lsp-tools-mcp package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-tools-mcp
-
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
@@ -144,10 +140,6 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - name: Build vendored lsp-tools-mcp package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-tools-mcp
-
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
@@ -155,10 +147,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Build vendored lsp-daemon package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-daemon
 
       - name: Type check
         run: bun run typecheck
@@ -192,10 +180,6 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - name: Build vendored lsp-tools-mcp package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-tools-mcp
-
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
@@ -203,10 +187,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Build vendored lsp-daemon package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-daemon
 
       - name: Run Codex compatibility tests
         run: bun run test:codex
@@ -341,10 +321,6 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - name: Build vendored lsp-tools-mcp package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-tools-mcp
-
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
@@ -352,10 +328,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Build vendored lsp-daemon package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-daemon
 
       - name: Build
         run: bun run build
@@ -396,10 +368,6 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - name: Build vendored lsp-tools-mcp package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-tools-mcp
-
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
@@ -407,10 +375,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Build vendored lsp-daemon package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-daemon
 
       - name: Build
         run: bun run build

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -180,38 +180,32 @@ describe("test workflows", () => {
     expect(draftReleaseNeedsAllChecks, "Draft release must wait for all root checks and build").toBe(true)
   })
 
-  test("prepares lsp-tools-mcp before Codex compatibility tests", () => {
+  test("runs Codex compatibility tests with Node available for the self-built MCP runtimes", () => {
     const workflow = readFileSync(ciWorkflowPath, "utf8")
     const codexCompatibilityJob = sliceWorkflowSection(workflow, "  codex-compatibility:", "  lazycodex-published-smoke:")
 
     const hasNodeSetup = codexCompatibilityJob.includes('node-version: "24"')
-    const buildsLspToolsMcp =
-      codexCompatibilityJob.includes("name: Build vendored lsp-tools-mcp package") &&
-      codexCompatibilityJob.includes("working-directory: packages/lsp-tools-mcp") &&
-      codexCompatibilityJob.indexOf("name: Build vendored lsp-tools-mcp package") <
-        codexCompatibilityJob.indexOf("name: Run Codex compatibility tests")
+    // `bun run test:codex` builds lsp-tools-mcp and lsp-daemon itself (see the
+    // "builds bundled MCP runtimes before Codex compatibility tests" test), so the
+    // job no longer needs an explicit pre-build step.
+    const runsCodexTests = codexCompatibilityJob.includes("run: bun run test:codex")
 
     expect(hasNodeSetup, "Codex compatibility must setup Node for MCP package builds").toBe(true)
-    expect(buildsLspToolsMcp, "Codex compatibility must build lsp-tools-mcp before bun run test:codex").toBe(true)
+    expect(runsCodexTests, "Codex compatibility must run bun run test:codex").toBe(true)
   })
 
-  test("sets up Bun before vendored lsp-tools-mcp builds", () => {
+  test("sets up Bun before vendored lsp-tools-mcp builds in publish workflow jobs", () => {
     // #given
-    const ciWorkflow = readFileSync(ciWorkflowPath, "utf8")
+    // ci.yml no longer pre-builds lsp-tools-mcp in any job: typecheck/codex/build
+    // dropped it as redundant (typecheck needs no build; test:codex and bun run
+    // build self-build it), and the test job's full install rebuilds it via prepare.
+    // publish.yml still pre-builds it, so the ordering guard still applies there.
     const publishWorkflow = readFileSync(publishWorkflowPath, "utf8")
-    const ciTestJob = sliceWorkflowSection(ciWorkflow, "  test:", "  typecheck:")
-    const ciTypecheckJob = sliceWorkflowSection(ciWorkflow, "  typecheck:", "  codex-compatibility:")
-    const ciCodexCompatibilityJob = sliceWorkflowSection(ciWorkflow, "  codex-compatibility:", "  lazycodex-published-smoke:")
-    const ciBuildJob = sliceWorkflowSection(ciWorkflow, "  build:", "  draft-release:")
     const publishTestJob = sliceWorkflowSection(publishWorkflow, "  test:", "  typecheck:")
     const publishTypecheckJob = sliceWorkflowSection(publishWorkflow, "  typecheck:", "  codex-compatibility:")
     const publishCodexCompatibilityJob = sliceWorkflowSection(publishWorkflow, "  codex-compatibility:", "  preflight-trust:")
 
     // #then
-    expectBunSetupBeforeLspToolsBuild(ciTestJob, "CI test job")
-    expectBunSetupBeforeLspToolsBuild(ciTypecheckJob, "CI typecheck job")
-    expectBunSetupBeforeLspToolsBuild(ciCodexCompatibilityJob, "CI Codex compatibility job")
-    expectBunSetupBeforeLspToolsBuild(ciBuildJob, "CI build job")
     expectBunSetupBeforeLspToolsBuild(publishTestJob, "publish test job")
     expectBunSetupBeforeLspToolsBuild(publishTypecheckJob, "publish typecheck job")
     expectBunSetupBeforeLspToolsBuild(publishCodexCompatibilityJob, "publish Codex compatibility job")


### PR DESCRIPTION
## What

Remove six redundant "Build vendored ..." steps from `.github/workflows/ci.yml` (36 lines deleted). This is the "verified step prunes" follow-up to PR #5877 (which added `--ignore-scripts` to five jobs).

Per job:
- `typecheck`: removed both vendored builds.
- `codex-compatibility`: removed both.
- `build`: removed both.
- `auto-commit-schema`: removed both.
- `test`: removed the lsp-tools-mcp pre-build only; kept the lsp-daemon build and its `npm test`.
- `senpi-compatibility`: unchanged (never had vendored builds).

## Why

Each removed step rebuilt `lsp-tools-mcp` or `lsp-daemon` in a job that either already builds them another way or does not need them:
- `typecheck` references neither vendored package (its scripts run `tsgo` over source).
- `test:codex` already runs `build:lsp-tools-mcp` and `build:lsp-daemon` internally.
- `bun run build` (used by `build` and `auto-commit-schema`) already builds both, and in the right order: `build:lsp-tools-mcp` (step 2, with its own `npm ci`) runs before `build:codex-plugin` (step 4), which reuses lsp-tools-mcp's `node_modules`.
- The `test` job keeps the lsp-daemon build and `npm test` for real coverage; only the lsp-tools-mcp pre-build is dropped, and the full install's build rebuilds it. `test-setup.ts:ensureVendoredLspDaemonBuilt()` also self-heals lsp-daemon if its `dist/cli.js` is missing.

## QA and evidence

Verified locally with vendored `dist/` and `node_modules` removed (write-up in the branch under `.omo/evidence/20260706-ci-prune-vendored-builds/`, gitignored):
- `bun run typecheck`: exit 0.
- `bun run build`: exit 0, produced `dist/index.js`, `dist/index.d.ts`, and both vendored dists.
- `test:codex` build prefix: exit 0, produced both vendored dists.
- Workspace lifecycle grep: no workspace package declares an install-time lifecycle script, so `--ignore-scripts` is safe tree-wide.
- `actionlint -shellcheck="" .github/workflows/ci.yml`: passes.

## Behavior is identical

No coverage, gate, OS matrix, or job name changed. The removed steps were duplication. This PR's matrix run is the final proof.

## Residual risk

`build` and `auto-commit-schema` now rely on `bun run build`'s internal ordering (lsp-tools-mcp before codex-plugin). Verified correct from a clean state locally; the matrix run confirms it on all OSes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed six redundant vendored build steps for `lsp-tools-mcp` and `lsp-daemon` in `.github/workflows/ci.yml` to cut duplication and speed up CI. Updated workflow meta-tests to reflect the new CI shape; behavior, coverage, and gates are unchanged.

- **Refactors**
  - Pruned "Build vendored ..." in `typecheck`, `codex-compatibility`, `build`, and `auto-commit-schema`; kept the `lsp-daemon` build/tests in `test`.
  - `script/publish-workflow.test.ts`: stop expecting CI pre-builds; assert Node is set up and `bun run test:codex` runs; keep Bun-before-`lsp-tools-mcp` ordering checks only for `publish.yml`.
  - CI now relies on existing flows: `bun run build` builds both in order; `test:codex` builds both internally; `typecheck` doesn’t use vendored packages.

<sup>Written for commit 29d32f4c745ab473c9ea1c1deb05601c1df5e813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

