### PR TITLE
perf(ci): drop the test job's redundant lsp-daemon build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build vendored lsp-daemon package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-daemon
-
+      # The full install runs the root `prepare` (`bun run build`), whose
+      # `build:lsp-daemon` step already runs `npm ci && npm run build` in
+      # packages/lsp-daemon, so its node_modules and dist exist before the tests.
       - name: Run vendored lsp-daemon tests
         run: npm test
         working-directory: packages/lsp-daemon


### PR DESCRIPTION
## What

Remove the test job's explicit "Build vendored lsp-daemon" step from `.github/workflows/ci.yml`. This is a follow-up to the merged #5890 and removes the last remaining vendored pre-build; ci.yml now has zero explicit "Build vendored ..." steps.

## Why it is redundant

The test job runs `bun install --frozen-lockfile` (no `--ignore-scripts`), which runs the root `prepare` = `bun run build`. That chain includes `build:lsp-daemon`, which is `npm --prefix packages/lsp-daemon ci && npm --prefix packages/lsp-daemon run build`. So after install, `packages/lsp-daemon` already has both its `node_modules` (vitest) and `dist` before the "Run vendored lsp-daemon tests" (`npm test`) step runs.

## QA and evidence

Verified locally (write-up in the branch under `.omo/evidence/20260706-ci-drop-test-lsp-daemon/`):
- Cleaned `packages/lsp-daemon/{node_modules,dist}`, ran `bun install --frozen-lockfile` (full, with prepare). After it, `node_modules/.bin/vitest` and `dist/cli.js` both exist.
- Ran `npm test` in `packages/lsp-daemon` with only that install (no separate build step): 52 tests / 10 files, all passed.
- `actionlint -shellcheck="" .github/workflows/ci.yml`: passes.
- `script/publish-workflow.test.ts` (the workflow-structure meta-test) does not assert the test job's lsp-daemon build, so it stays green.

## Residual risk

The claim "prepare's `npm ci` leaves `node_modules` for the `npm test` step" must hold on all OSes. This PR's matrix run is the proof; watch all three test-OS legs, especially windows.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant `lsp-daemon` build step from the test job in `.github/workflows/ci.yml` to simplify CI and avoid duplicate work. The package is already built during `bun install --frozen-lockfile` via the root `prepare` step.

- **Refactors**
  - Deleted the "Build vendored lsp-daemon package" step; the `prepare` chain (`bun run build` → `build:lsp-daemon` → `npm ci && npm run build` in `packages/lsp-daemon`) covers it.
  - Added a comment in the workflow explaining why the build is unnecessary.

<sup>Written for commit 17ff63ffd3e807b2f1d09e9f9257a11bb4ae5713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

