### PR TITLE
perf(ci): skip the bun cache on Windows for --ignore-scripts jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # Skip the bun cache on Windows: its restore (~60-80s) costs more than a
+      # cold `--ignore-scripts` install (~20s). Keep it on Linux/macOS where the
+      # restore is cheap. The test job (full install) keeps the cache everywhere.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -179,7 +183,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # Skip the bun cache on Windows: its restore (~60-80s) costs more than a
+      # cold `--ignore-scripts` install (~20s). Keep it on Linux/macOS where the
+      # restore is cheap. The test job (full install) keeps the cache everywhere.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -220,7 +228,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # Skip the bun cache on Windows: its restore (~60-80s) costs more than a
+      # cold `--ignore-scripts` install (~20s). Keep it on Linux/macOS where the
+      # restore is cheap. The test job (full install) keeps the cache everywhere.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -320,7 +332,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # Skip the bun cache on Windows: its restore (~60-80s) costs more than a
+      # cold `--ignore-scripts` install (~20s). Keep it on Linux/macOS where the
+      # restore is cheap. The test job (full install) keeps the cache everywhere.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -367,7 +383,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # Skip the bun cache on Windows: its restore (~60-80s) costs more than a
+      # cold `--ignore-scripts` install (~20s). Keep it on Linux/macOS where the
+      # restore is cheap. The test job (full install) keeps the cache everywhere.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}


### PR DESCRIPTION
## What

Skip the bun install cache on Windows for the `--ignore-scripts` jobs (typecheck, codex-compatibility, senpi-compatibility, plus build and auto-commit-schema which are ubuntu-only so the guard is a no-op there). The `test` job's cache is unchanged (it runs the full install where the cache still helps).

## Why (measured on run 28747724541)

On Windows, the `actions/cache` restore of `~/.bun/install/cache` takes 61-76s, while the `--ignore-scripts` install it speeds up takes only 17-19s:

| job (windows) | cache restore | install |
| --- | --- | --- |
| typecheck | 61s | 18s |
| codex-compatibility | 69s | 19s |
| senpi-compatibility | 76s | 17s |

The ~92MB cache's Windows extraction is the bottleneck, not download bandwidth. Skipping it and doing a cold `bun install --ignore-scripts` should be net-faster on Windows.

## This PR is the trial

The change is the measurement. After CI runs, compare this PR's Windows install-step time (cold, no cache) against the ~60-76s restore + 17-19s install baseline. Net-positive if cold install < ~60s. Linux/macOS keep the cache (cheap restore there).

## QA

- `actionlint -shellcheck=""`: passes.
- The `test` job's cache is verified unguarded (keeps the cache on every OS).
- Coverage, gates, and job names unchanged.
- Evidence: `.omo/evidence/20260706-ci-windows-cache-drop/`.

## Residual risk

If a cold Windows install download is unexpectedly slow, the 3 Windows legs could show no gain; the run's install-step timing decides. Trivially revertible (drop the `if:` guard).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip restoring the Bun cache on Windows for `--ignore-scripts` CI jobs to reduce runtime. Linux/macOS still use the cache; the full-install `test` job keeps it on all OSes.

<sup>Written for commit 7af6c6660f080b67538dccd5476a458b5c1455b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

