### PR TITLE
perf(ci): skip the bun cache on Windows for ignore-scripts jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # On Windows the ~/.bun cache restore (61-76s for a ~92MB payload) costs more
+      # than the ignore-scripts install it speeds up (17-19s), so skip it there and
+      # let the install download cold. Keep the cache on Linux and macOS.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -179,7 +183,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # On Windows the ~/.bun cache restore (61-76s for a ~92MB payload) costs more
+      # than the ignore-scripts install it speeds up (17-19s), so skip it there and
+      # let the install download cold. Keep the cache on Linux and macOS.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -220,7 +228,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # On Windows the ~/.bun cache restore (61-76s for a ~92MB payload) costs more
+      # than the ignore-scripts install it speeds up (17-19s), so skip it there and
+      # let the install download cold. Keep the cache on Linux and macOS.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}


### PR DESCRIPTION
## What

Add `if: runner.os != 'Windows'` to the `actions/cache@v5` step in the three matrix jobs that install with `--ignore-scripts`: `typecheck`, `codex-compatibility`, `senpi-compatibility`. Windows skips the cache and installs cold; Linux and macOS keep it. The `test` job (full install) and the ubuntu-only `build` / `auto-commit-schema` jobs are unchanged.

## Why

After the `--ignore-scripts` and vendored-build-prune work landed, those three windows jobs install in 17-19s. But the `~/.bun/install/cache` restore takes 61-76s on windows for the ~92MB payload (slow windows extraction, not download bandwidth). So on windows the cache now costs more than the install it is meant to speed up.

Measured on the post-prune runs:

| windows job | cache restore | install (`--ignore-scripts`) |
| --- | --- | --- |
| typecheck | 61s | 18s |
| codex-compatibility | 69s | 19s |
| senpi-compatibility | 76s | 17s |

## This is a measurement trial

The CI run on this PR measures the cold windows `bun install --ignore-scripts` (no cache) for these three jobs. If the cold install is faster than the ~61-76s cache-restore path it replaces, the change is a net win; if not, it gets reverted. `bun install --frozen-lockfile` is deterministic with or without the cache, so coverage and behavior are identical either way.

## QA and evidence

- Change scoped to the 3 target jobs only; test/build/auto-commit-schema cache steps untouched (verified per-job).
- `actionlint -shellcheck="" .github/workflows/ci.yml`: passes.
- Write-up + decision criteria in the branch under `.omo/evidence/20260706-ci-windows-cache-trial/`.

## Verification after merge

```
gh api repos/code-yeongyu/oh-my-openagent/actions/runs/<RUN_ID>/jobs \
  --jq '.jobs[] | select(.name | test("windows")) | {name, steps: [.steps[] | select(.name | test("cache|Install")) | {name, started_at, completed_at}]}'
```

Confirm the windows typecheck/codex/senpi jobs have no cache-restore step and note the new cold install time.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the `actions/cache@v5` Bun cache restore on Windows for the `typecheck`, `codex-compatibility`, and `senpi-compatibility` jobs that run `bun install --ignore-scripts`, keeping the cache on Linux and macOS. Trial to cut CI time: Windows cache restore takes 61–76s for ~92MB, while a cold install takes 17–19s; other jobs (`test`, `build`, `auto-commit-schema`) are unchanged.

<sup>Written for commit 39c0eb92d012ce1bb9e419001403d47345676451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

