### PR TITLE
test(package-layout): memoize the pack dry-run per file

### DIFF
--- a/script/package-layout-exclusion.test.ts
+++ b/script/package-layout-exclusion.test.ts
@@ -91,7 +91,18 @@ function parsePackedPaths(output: string): Set<string> {
   return packedPaths
 }
 
-async function packDryRunPaths(): Promise<Set<string>> {
+// Both tests pack the SAME tree state: beforeAll writes the fake internal artifacts once, and
+// neither test mutates the tree between packs, so a single dry-run covers both. The cache is
+// populated lazily on the first pack, which only runs inside a test body (after beforeAll), so
+// it never captures the pre-mutation tree.
+let cachedPackDryRunPaths: Promise<Set<string>> | undefined
+
+function packDryRunPaths(): Promise<Set<string>> {
+  cachedPackDryRunPaths ??= runPackDryRun()
+  return cachedPackDryRunPaths
+}
+
+async function runPackDryRun(): Promise<Set<string>> {
   const packProcess = Bun.spawn({
     cmd: ["bun", "pm", "pack", "--dry-run", "--ignore-scripts"],
     cwd: repositoryRoot,

--- a/script/package-layout.test.ts
+++ b/script/package-layout.test.ts
@@ -130,7 +130,16 @@ function parsePackedPaths(output: string): Set<string> {
   return packedPaths
 }
 
-async function packDryRunPaths(): Promise<Set<string>> {
+// Every test here packs the same unmutated tree, and `bun pm pack --dry-run` walks the whole
+// multi-thousand-file payload on each call, so pack once and reuse the result.
+let cachedPackDryRunPaths: Promise<Set<string>> | undefined
+
+function packDryRunPaths(): Promise<Set<string>> {
+  cachedPackDryRunPaths ??= runPackDryRun()
+  return cachedPackDryRunPaths
+}
+
+async function runPackDryRun(): Promise<Set<string>> {
   const packProcess = Bun.spawn({
     cmd: ["bun", "pm", "pack", "--dry-run", "--ignore-scripts"],
     cwd: repositoryRoot,


### PR DESCRIPTION
## What changed

`script/package-layout.test.ts` and `script/package-layout-exclusion.test.ts` each called `bun pm pack --dry-run --ignore-scripts` on **every** `packDryRunPaths()` invocation: 7 calls in the first file, 3 in the second, so 10 full packs of the ~6288-file / 54.7MB payload per suite run. This PR memoizes the pack once per file and reuses the resulting `Set`.

## Why

`bun pm pack --dry-run` walks the whole `files` payload each call. After the taste-skill embedding (#5881) grew that payload by ~678 files, a single pack went from ~1s to ~3.7s, so the 10 redundant packs became the dominant cost in these files. That is the ~+30s suite regression (this pair went 6.21s→23.29s and 2.15s→7.64s, exactly ~10 packs × the grown payload). The redundancy was harmless before; the payload growth exposed it.

## Review conditions

- **(a) Parameterization.** `packDryRunPaths()` takes **no** parameters in either file, so a parameterless module-level memo is correct — no per-input keying needed.
- **(b) Tree mutation vs re-pack.** `package-layout.test.ts` never mutates the tree (only read-only `git ls-files` sits between packs), so all 7 packs are identical. `package-layout-exclusion.test.ts` mutates the tree **once** in `beforeAll` (writes fake internal artifacts + a temporary `package.json`), and then **both** of its tests pack that same mutated state and assert on different subsets — so one shared pack is correct. The cache is populated lazily on the first pack, which only runs inside a test body (after `beforeAll`), so it never captures the pre-mutation tree. No test in either file expects a re-pack to observe a change made after the first pack.

## Observed behavior (QA)

- `package-layout.test.ts`: 8 pass / 0 fail. `package-layout-exclusion.test.ts`: 2 pass / 0 fail (real `bun test` per file, with a full build present so the payload targets exist).
- Timing, warm pack (~0.1s locally): `package-layout.test.ts` 0.65s → 0.18s (7 packs → 1). The saving scales with pack cost: on cold FS or Windows CI (the current critical path) each pack is ~3.7s, so collapsing ~8 redundant packs recovers ~30s there.
- Pack output is deterministic: two repeated packs produce an identical sorted path set (md5 `460f26ca…` == `460f26ca…`), which is why memoizing one result is safe.

Evidence: `.omo/evidence/20260706-memoize-package-layout-pack/`.

## Residual risk

Zero assertion changed; both files stay green. If a future test needs to observe a mid-file tree mutation via a re-pack, it must not reuse the shared cache — the in-file comment documents this constraint.

## Related

The payload growth itself (678 taste-skill files from #5881) is intended product content, surfaced separately as an informational issue for the #5881 owner — not touched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoize the `bun pm pack --dry-run --ignore-scripts` result per test file to remove redundant packs and recover ~30s on cold/CI runs. No assertions changed.

- **Refactors**
  - Cache the dry-run result in `script/package-layout.test.ts` and `script/package-layout-exclusion.test.ts`; `packDryRunPaths()` returns the cached `Set`.
  - Safety: `packDryRunPaths()` is parameterless; both files pack a single tree state (exclusion file mutates in `beforeAll`, cache fills after).
  - Impact: 7→1 and 3→1 packs per file; local warm run 0.65s→0.18s; ~30s saved on Windows CI.

<sup>Written for commit e0bc1d2bf624256fc90d0e94de6ae0ecdce4a571. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

