### PR TITLE
ci(publish): skip pack-time rebuild on the npm publish commands

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -584,6 +584,11 @@ jobs:
 
           jq --arg v "$VERSION" '.optionalDependencies = (.optionalDependencies | to_entries | map(.value = $v) | from_entries)' package.json > tmp.json && mv tmp.json package.json
 
+      # PAYLOAD SOURCE OF TRUTH: this step and "Build Codex plugin components" below produce
+      # every artifact in the published `files` payload. The npm publish steps run with
+      # --ignore-scripts, so they do NOT re-run prepublishOnly/prepack/prepare at pack time.
+      # If these explicit builds are ever removed or reordered, the publishes would ship a
+      # stale or empty dist. Keep them before every publish.
       - name: Build main package
         if: >-
           steps.check.outputs.skip != 'true' ||
@@ -629,9 +634,9 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
         run: |
           if [ -n "$DIST_TAG" ]; then
-            npm publish --access public --provenance --tag "$DIST_TAG" --loglevel verbose
+            npm publish --ignore-scripts --access public --provenance --tag "$DIST_TAG" --loglevel verbose
           else
-            npm publish --access public --provenance --tag latest --loglevel verbose
+            npm publish --ignore-scripts --access public --provenance --tag latest --loglevel verbose
           fi
 
       - name: Publish oh-my-openagent
@@ -653,9 +658,9 @@ jobs:
           ' package.json > tmp.json && mv tmp.json package.json
 
           if [ -n "$DIST_TAG" ]; then
-            npm publish --access public --provenance --tag "$DIST_TAG" --loglevel verbose
+            npm publish --ignore-scripts --access public --provenance --tag "$DIST_TAG" --loglevel verbose
           else
-            npm publish --access public --provenance --tag latest --loglevel verbose
+            npm publish --ignore-scripts --access public --provenance --tag latest --loglevel verbose
           fi
 
       - name: Restore package.json
@@ -683,9 +688,9 @@ jobs:
           ' package.json > tmp.json && mv tmp.json package.json
 
           if [ -n "$DIST_TAG" ]; then
-            npm publish --access public --provenance --tag "$DIST_TAG" --loglevel verbose
+            npm publish --ignore-scripts --access public --provenance --tag "$DIST_TAG" --loglevel verbose
           else
-            npm publish --access public --provenance --tag latest --loglevel verbose
+            npm publish --ignore-scripts --access public --provenance --tag latest --loglevel verbose
           fi
 
       - name: Smoke test published lazycodex-ai

--- a/script/publish-lazycodex-workflow.test.ts
+++ b/script/publish-lazycodex-workflow.test.ts
@@ -111,7 +111,7 @@ describe("LazyCodex publish workflow", () => {
       workflow.includes('https://registry.npmjs.org/lazycodex-ai/${VERSION}')
     const publishesLazycodexNpm = publishLazycodexStep.includes("name: Publish lazycodex-ai") &&
       publishLazycodexStep.includes("if: inputs.publish_lazycodex == true && steps.check-lazycodex.outputs.skip != 'true'") &&
-      publishLazycodexStep.includes("npm publish --access public --provenance --tag latest --loglevel verbose") &&
+      publishLazycodexStep.includes("npm publish --ignore-scripts --access public --provenance --tag latest --loglevel verbose") &&
       !publishLazycodexStep.includes("continue-on-error: true")
     const syncsLazycodexMarketplaceOnStableReleases = workflow.includes("name: Sync LazyCodex Codex marketplace") &&
       syncMarketplaceStep.includes("if: needs.release-metadata.outputs.dist_tag == ''") &&


### PR DESCRIPTION
## What changed

Add `--ignore-scripts` to all 6 `npm publish` commands in `publish.yml`'s `publish-main` job (oh-my-opencode ×2, oh-my-openagent ×2, lazycodex-ai ×2), plus a "PAYLOAD SOURCE OF TRUTH" guard comment above the explicit build step. `publish-platform.yml` is untouched (those are tiny bin/ packages).

## Why

`npm publish` runs `prepublishOnly` (`clean && build:lsp-tools-mcp && build:lsp-daemon && build`) **and** `prepare` (`bun run build`) at pack time — two full rebuilds per publish. In the last release run, each of the oh-my-opencode / oh-my-openagent publish steps spent ~65s of its ~69-70s almost entirely on these rebuilds, not on upload. But `publish-main` already runs explicit **"Build main package"** + **"Build Codex plugin components"** steps that produce the same payload before any publish, so those pack-time rebuilds are pure redundancy.

## Byte-equivalence proof (all three payloads)

With the payload built on disk, compared `npm pack --dry-run` (runs prepack/prepare) vs `npm pack --dry-run --ignore-scripts` (skips them):

| Payload | with-scripts | --ignore-scripts | Result |
| --- | --- | --- | --- |
| oh-my-opencode | 3901 files / 35194689 B | 3901 files / 35194689 B | sorted file list **byte-identical** |
| oh-my-openagent | (name + optionalDeps rewrite) | 3901 files / 35194702 B | same file set; +13 B is the longer embedded package name |
| lazycodex-ai | 590 files / 10516381 B | 590 files / 10516381 B | identical (`scripts={}` makes the flag a no-op there) |

The with-scripts `npm pack --dry-run` took **~16s** (it ran the prepack/prepare rebuild) to produce the identical tarball — that rebuild is exactly what this PR removes.

## Savings (vs both the old build and the R2 build)

Each skipped pack-time rebuild is a full `bun run build`. vs the OLD serial chain (~18-23s warm) the two wrapper publishes were re-running ~2 builds each ≈ the ~115s of pack-time rebuild in `publish-main`; vs the R2 orchestrator (~11s warm) each is cheaper but still redundant. This change removes them entirely, dropping the publish steps toward upload-only.

## Consumer-side

None: the published tarballs are byte-equivalent (file list + size), so every `npm install` consumer of `oh-my-opencode` / `oh-my-openagent` / `lazycodex-ai` receives exactly what they do today.

## Residual risk

The guard comment marks the explicit build steps as the payload source of truth — if a future edit removes/reorders them, publishes would ship stale dist. The publish workflow cannot be run end to end from a branch, so this rests on the tarball-equivalence proof plus actionlint (exit 0). No publish semantics change (dual-publish order, provenance, dist-tag, skip-if-published, name/files rewrites all untouched).

Evidence: `.omo/evidence/20260706-publish-pack-ignore-scripts/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip redundant pack-time rebuilds in the `publish-main` workflow by adding `--ignore-scripts` to all `npm publish` commands. Tarballs for `@oh-my-opencode`, `@oh-my-openagent`, and `lazycodex-ai` are unchanged; publishes run faster.

- **Refactors**
  - Added `--ignore-scripts` to six `npm publish` steps in `.github/workflows/publish.yml`; left `publish-platform.yml` unchanged.
  - Added a guard comment marking the explicit build steps as the payload source of truth (must run before publish).
  - Updated `script/publish-lazycodex-workflow.test.ts` to expect the new `--ignore-scripts` publish command for `lazycodex-ai`.

<sup>Written for commit 0d26c2ac5f595875c541b5e9b184f6e943648758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

