### PR TITLE
perf(ci): trial skipping the bun cache on all Windows jobs (multi-run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # TRIAL: skip the bun cache on Windows, where the ~92MB restore measured
+      # 43-82s (variable) — comparable to or worse than a cold install. The
+      # matrix run measures cold Windows install vs the restore+warm-install path.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -139,7 +143,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # TRIAL: skip the bun cache on Windows, where the ~92MB restore measured
+      # 43-82s (variable) — comparable to or worse than a cold install. The
+      # matrix run measures cold Windows install vs the restore+warm-install path.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -179,7 +187,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # TRIAL: skip the bun cache on Windows, where the ~92MB restore measured
+      # 43-82s (variable) — comparable to or worse than a cold install. The
+      # matrix run measures cold Windows install vs the restore+warm-install path.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -220,7 +232,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # TRIAL: skip the bun cache on Windows, where the ~92MB restore measured
+      # 43-82s (variable) — comparable to or worse than a cold install. The
+      # matrix run measures cold Windows install vs the restore+warm-install path.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -320,7 +336,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # TRIAL: skip the bun cache on Windows, where the ~92MB restore measured
+      # 43-82s (variable) — comparable to or worse than a cold install. The
+      # matrix run measures cold Windows install vs the restore+warm-install path.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
@@ -367,7 +387,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
-      - uses: actions/cache@v5
+      # TRIAL: skip the bun cache on Windows, where the ~92MB restore measured
+      # 43-82s (variable) — comparable to or worse than a cold install. The
+      # matrix run measures cold Windows install vs the restore+warm-install path.
+      - if: runner.os != 'Windows'
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}


### PR DESCRIPTION
## What

Trial: guard `actions/cache@v5` with `if: runner.os != 'Windows'` on all cache-using jobs, so every Windows matrix leg (test, typecheck, codex-compatibility, senpi-compatibility) installs cold. Linux/macOS keep the cache. This expands the earlier #5894 trial to include the test job, per flaky-hunter's request, and measures across multiple runs to beat the variance.

## Why (new data)

The Windows bun-cache restore (~92MB) is high-variance and expensive: measured 43s, 61-76s, and 82s across recent runs. For the `--ignore-scripts` jobs the install it speeds up is only ~17-19s, so the restore alone exceeds the whole install. The test job (full install ~103s) also pays the same 43-82s restore.

## This is a multi-run trial

The decision needs 2-3 runs to average the variance. Criterion (flaky-hunter): keep the drop only if cold Windows install beats restore + warm install on average, per job; revert otherwise. The decision table is in the branch evidence and gets filled from the trial runs. I will re-run this workflow 1-2 more times and report the averaged per-job Windows install-step deltas before recommending merge or close.

## QA

- `actionlint -shellcheck=""`: passes.
- Pure per-OS conditional on the cache step; coverage, gates, and job names unchanged.
- Evidence + decision table: `.omo/evidence/20260706-ci-windows-cache-trial-v2/`.

## Residual risk

Removing the cache exposes the Windows install to registry-tail-risk (a 108s cold-install sample appeared in #5894). If cold install is slower or higher-variance than restore+warm on average, revert. Trivially revertible.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily skip `actions/cache@v5` on Windows for all bun-installing CI jobs (test, typecheck, codex-compatibility, senpi-compatibility) to see if cold installs outperform the slow, high-variance cache restore; Linux and macOS keep the cache. Run multiple times and keep only if Windows cold install beats restore + warm install on average.

<sup>Written for commit 0962ef1aa9748991acbfa09534bf22f1f5cee9ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

