### PR TITLE
perf(omo-opencode): lower plugin_load_timeout_ms in config-handler timeout test

### DIFF
--- a/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.test.ts
@@ -1354,7 +1354,7 @@ describe("config-handler plugin loading error boundary (#1559)", () => {
       () => new Promise(() => {})
     )
     const pluginConfig = createPluginConfig({
-      experimental: { plugin_load_timeout_ms: 100 },
+      experimental: { plugin_load_timeout_ms: 10 },
     })
     const config: Record<string, unknown> = {
       model: "anthropic/claude-opus-4-7",


### PR DESCRIPTION
## What changed

One of three oracle-proposed A-R1 batch cuts (the only clean one — the other two were dropped, see below).

`config-handler.test.ts` "returns empty defaults when loadAllPluginComponents times out" mocks the loader as a never-resolving promise and asserts only that the timeout **fires** (empty defaults returned) — the `100ms` value itself is never asserted. `plugin_load_timeout_ms` is config-injectable, so lowering it to `10ms` tests identical behavior faster.

## Observed behavior

| File | Before (isolated) | After (3-run avg) | Tests |
|------|-------------------|-------------------|-------|
| config-handler.test.ts | 303ms | 205ms | 52 pass / 0 fail |

~95ms saved. Test-only, no production source touched, `tsgo` clean.

## Batch outcome (the other two dropped, per "drop non-clean with a note")

- **unstable-agent-babysitter:94 (idleSettleMs:50) — DROPPED.** The test asserts `Date.now() - startedAt >= 45` — it specifically verifies the 50ms settle elapsed. Zeroing breaks the assertion; the injectable-clock alternative is a virtual-clock rewrite, which exceeds the blind-delay/injectable-default discipline.
- **delegate-task/tools.test.ts:769 (setTimeout(20)) — DROPPED.** The 20ms > 10ms poll gap is load-bearing: it ensures the wait-for-session poll runs at least one cycle before the session appears. Lowering it risks the test no longer exercising the wait path.

Evidence: `.omo/evidence/20260706-test-speed/round4-batch.txt`.

## Residual risk

Very low. Test-only; only the injected timeout duration changed; the timeout-fired behavior and all assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the config-handler timeout test by lowering the injected `plugin_load_timeout_ms` from 100ms to 10ms. The test only asserts that a timeout fires and returns empty defaults, so behavior is unchanged; ~95ms faster and test-only.

<sup>Written for commit f8c2aeda13814bea6d7da73e0584ee3ae9102b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

