### PR TITLE
test(perf): replace blind sleeps in background-agent + cli-run with deterministic signals

### DIFF
--- a/packages/omo-opencode/src/cli/run/poll-for-completion.test.ts
+++ b/packages/omo-opencode/src/cli/run/poll-for-completion.test.ts
@@ -38,6 +38,27 @@ function abortAfter(abortController: AbortController, delayMs: number): void {
   setTimeout(() => abortController.abort(), delayMs)
 }
 
+// Deterministic virtual clock for pollForCompletion. now() reads a mutable
+// counter; sleep() advances it by the requested ms and yields a microtask so
+// the loop's async continuations run without real wall-clock time. `onSleep`
+// lets a test inject state changes (e.g. session goes busy then idle) keyed to
+// virtual elapsed time, preserving the SAME causality the old real-time waits
+// exercised — but deterministically, with no wall-clock race.
+function createVirtualClock(onSleep?: (elapsedMs: number) => void): {
+  now: () => number
+  sleep: (ms: number) => Promise<void>
+} {
+  let currentMs = 0
+  return {
+    now: () => currentMs,
+    sleep: async (ms: number) => {
+      currentMs += ms
+      onSleep?.(currentMs)
+      await Promise.resolve()
+    },
+  }
+}
+
 beforeEach(() => {
   consoleLogSpy = spyOn(console, "log").mockImplementation(() => {})
   consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {})
@@ -100,13 +121,21 @@ describe("pollForCompletion", () => {
     eventState.hasReceivedMeaningfulWork = true
     eventState.currentTool = "task"
     const abortController = new AbortController()
+    // Virtual clock: abort at virtual 100ms — enough poll cycles to prove the
+    // active tool kept blocking completion — without burning real time.
+    const clock = createVirtualClock((elapsedMs) => {
+      if (elapsedMs >= 100) {
+        abortController.abort()
+      }
+    })
 
-    //#when - abort after enough time to verify it didn't exit
-    abortAfter(abortController, 100)
+    //#when
     const result = await pollForCompletion(ctx, eventState, abortController, {
       pollIntervalMs: 10,
       requiredConsecutive: 3,
       minStabilizationMs: 500,
+      now: clock.now,
+      sleep: clock.sleep,
     })
 
     //#then - should be aborted, not completed (tool blocked exit)
@@ -116,21 +145,26 @@ describe("pollForCompletion", () => {
   })
 
   it("resets consecutive counter when session becomes busy between checks", async () => {
-    //#given
+    //#given - session goes busy on the first check, then idle again ~15ms later
     const ctx = createMockContext()
     const eventState = createEventState()
     eventState.mainSessionIdle = true
     eventState.hasReceivedMeaningfulWork = true
     const abortController = new AbortController()
     let todoCallCount = 0
-    let busyInserted = false
+    const busyUntilMs = 15
+    // Virtual clock: flip the session idle again once 15ms of virtual time has
+    // elapsed, mirroring the old setTimeout(15) but deterministically.
+    const clock = createVirtualClock((elapsedMs) => {
+      if (elapsedMs >= busyUntilMs) {
+        eventState.mainSessionIdle = true
+      }
+    })
 
     ;(unsafeTestValue(ctx.client.session)).todo = mock(async () => {
       todoCallCount++
-      if (todoCallCount === 1 && !busyInserted) {
-        busyInserted = true
+      if (todoCallCount === 1) {
         eventState.mainSessionIdle = false
-        setTimeout(() => { eventState.mainSessionIdle = true }, 15)
       }
       return { data: [] }
     })
@@ -142,17 +176,21 @@ describe("pollForCompletion", () => {
     )
 
     //#when
-    const startMs = Date.now()
+    const pollIntervalMs = 10
     const result = await pollForCompletion(ctx, eventState, abortController, {
-      pollIntervalMs: 10,
+      pollIntervalMs,
       requiredConsecutive: 3,
       minStabilizationMs: 10,
+      now: clock.now,
+      sleep: clock.sleep,
     })
-    const elapsedMs = Date.now() - startMs
 
-    //#then - took longer than 3 polls because busy interrupted the streak
+    //#then - completion took longer than the 3-consecutive-poll minimum (30ms)
+    //        because the busy window reset the streak. Same causality as the old
+    //        elapsedMs>30 check, but on the deterministic virtual clock — the
+    //        busy interruption forced at least one extra poll past the minimum.
     expect(result).toBe(0)
-    expect(elapsedMs).toBeGreaterThan(30)
+    expect(clock.now()).toBeGreaterThan(3 * pollIntervalMs)
   })
 
   it("returns 1 on session error", async () => {
@@ -163,12 +201,15 @@ describe("pollForCompletion", () => {
     eventState.mainSessionError = true
     eventState.lastError = "Test error"
     const abortController = new AbortController()
+    const clock = createVirtualClock()
 
-    //#when
+    //#when - errors out via the grace cycles well before any stabilization window
     const result = await pollForCompletion(ctx, eventState, abortController, {
       pollIntervalMs: 10,
       requiredConsecutive: 3,
       minStabilizationMs: 500,
+      now: clock.now,
+      sleep: clock.sleep,
     })
 
     //#then
@@ -316,22 +357,31 @@ describe("pollForCompletion", () => {
   })
 
   it("coerces non-positive stabilization values to default stabilization", async () => {
-    //#given - explicit zero stabilization should still wait for default window
+    //#given - explicit zero stabilization should still wait for the default window
     const ctx = createMockContext()
     const eventState = createEventState()
     eventState.mainSessionIdle = true
     eventState.hasReceivedMeaningfulWork = false
     const abortController = new AbortController()
+    // Virtual clock: abort at virtual 100ms — well before the coerced 1000ms
+    // default window — so completion must NOT have happened by then.
+    const clock = createVirtualClock((elapsedMs) => {
+      if (elapsedMs >= 100) {
+        abortController.abort()
+      }
+    })
 
-    //#when - abort before default 1s window elapses
-    abortAfter(abortController, 100)
+    //#when - minStabilizationMs:0 must coerce to the 1000ms default, so aborting
+    //        at virtual 100ms means the run has not completed early
     const result = await pollForCompletion(ctx, eventState, abortController, {
       pollIntervalMs: 10,
       requiredConsecutive: 1,
       minStabilizationMs: 0,
+      now: clock.now,
+      sleep: clock.sleep,
     })
 
-    //#then - should not complete early
+    //#then - should not complete early (0 coerced to the default 1000ms window)
     expect(result).toBe(130)
   })
 

--- a/packages/omo-opencode/src/cli/run/poll-for-completion.ts
+++ b/packages/omo-opencode/src/cli/run/poll-for-completion.ts
@@ -29,6 +29,10 @@ export interface PollOptions {
   eventWatchdogMs?: number
   secondaryMeaningfulWorkTimeoutMs?: number
   requireMeaningfulWork?: boolean
+  /** Injectable clock (default Date.now). Tests drive a virtual clock to assert timing causality deterministically. */
+  now?: () => number
+  /** Injectable poll delay (default real setTimeout). Tests advance the virtual clock here instead of sleeping. */
+  sleep?: (ms: number) => Promise<void>
 }
 
 export async function pollForCompletion(
@@ -50,14 +54,16 @@ export async function pollForCompletion(
     options.secondaryMeaningfulWorkTimeoutMs ??
     DEFAULT_SECONDARY_MEANINGFUL_WORK_TIMEOUT_MS
   const requireMeaningfulWork = options.requireMeaningfulWork ?? false
+  const now = options.now ?? Date.now
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
   let consecutiveCompleteChecks = 0
   let errorCycleCount = 0
   let firstWorkTimestamp: number | null = null
   let secondaryTimeoutChecked = false
-  const pollStartTimestamp = Date.now()
+  const pollStartTimestamp = now()
 
   while (!abortController.signal.aborted) {
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+    await sleep(pollIntervalMs)
 
     if (abortController.signal.aborted) {
       return 130
@@ -91,7 +97,7 @@ export async function pollForCompletion(
 
     let mainSessionStatus: "idle" | "busy" | "retry" | null = null
     if (eventState.lastEventTimestamp !== null) {
-      const timeSinceLastEvent = Date.now() - eventState.lastEventTimestamp
+      const timeSinceLastEvent = now() - eventState.lastEventTimestamp
       if (timeSinceLastEvent > eventWatchdogMs) {
         console.log(
           pc.yellow(
@@ -108,7 +114,7 @@ export async function pollForCompletion(
           eventState.mainSessionIdle = false
         }
 
-        eventState.lastEventTimestamp = Date.now()
+        eventState.lastEventTimestamp = now()
       }
     }
 
@@ -132,13 +138,13 @@ export async function pollForCompletion(
     }
 
     if (!eventState.hasReceivedMeaningfulWork) {
-      if (Date.now() - pollStartTimestamp < minStabilizationMs) {
+      if (now() - pollStartTimestamp < minStabilizationMs) {
         consecutiveCompleteChecks = 0
         continue
       }
 
       if (requireMeaningfulWork) {
-        if (Date.now() - pollStartTimestamp <= secondaryMeaningfulWorkTimeoutMs) {
+        if (now() - pollStartTimestamp <= secondaryMeaningfulWorkTimeoutMs) {
           consecutiveCompleteChecks = 0
           continue
         }
@@ -155,7 +161,7 @@ export async function pollForCompletion(
         return 1
       }
 
-      if (Date.now() - pollStartTimestamp > secondaryMeaningfulWorkTimeoutMs && !secondaryTimeoutChecked) {
+      if (now() - pollStartTimestamp > secondaryMeaningfulWorkTimeoutMs && !secondaryTimeoutChecked) {
         secondaryTimeoutChecked = true
         const hasActiveWork = await hasActiveSessionWork(ctx)
 
@@ -172,10 +178,10 @@ export async function pollForCompletion(
       }
     } else {
       if (firstWorkTimestamp === null) {
-        firstWorkTimestamp = Date.now()
+        firstWorkTimestamp = now()
       }
 
-      if (Date.now() - firstWorkTimestamp < minStabilizationMs) {
+      if (now() - firstWorkTimestamp < minStabilizationMs) {
         consecutiveCompleteChecks = 0
         continue
       }

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -334,16 +334,41 @@ async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<v
   }
 }
 
-function waitForCoalescedFlush(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 400))
+// Awaits the debounced parent-wake flush to settle by racing the real
+// onScheduledFlushSettled signal against a bounded state poll, so scheduled
+// flushes resolve on the signal (~100ms debounce) and direct-flush flows
+// resolve when their observable settles — replacing blind 400ms sleeps.
+function waitForCoalescedFlush(manager: BackgroundManager, sessionID: string): Promise<void> {
+  return awaitFlushWithFallback(manager, sessionID)
 }
 
 function waitForParentWakeRequeue(manager: BackgroundManager, sessionID: string): Promise<void> {
   return waitUntil(() => getPendingParentWakes(manager).has(sessionID), 600)
 }
 
-function waitForParentWakeErrorSettle(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 260))
+// The late-error requeue tests assert the DISPATCHED wake was cleared (requeued
+// to pending or removed). Poll that observable directly — it becomes true once
+// the async late-error handling settles — instead of blindly sleeping 260ms.
+function waitForParentWakeErrorSettle(manager: BackgroundManager, sessionID: string): Promise<void> {
+  return waitUntil(() => !getDispatchedParentWakes(manager).has(sessionID), 600)
+}
+
+// Capture the settled-flush count at entry (the debounced flush is scheduled but
+// still pending here), then await count > captured — so a settle that lands
+// between this call and registration is not missed. A bounded state-drain covers
+// flows that never schedule a flush (never hangs).
+function awaitFlushWithFallback(manager: BackgroundManager, sessionID: string): Promise<void> {
+  const api = cast<{
+    getScheduledFlushSettledCount: (id: string) => number
+    awaitScheduledFlush: (id: string, sinceCount: number) => Promise<void>
+  }>(manager)
+  const sinceCount = api.getScheduledFlushSettledCount(sessionID)
+  const settled = api.awaitScheduledFlush(sessionID, sinceCount)
+  const drained = waitUntil(
+    () => !getPendingParentWakes(manager).has(sessionID) || getDispatchedParentWakes(manager).has(sessionID),
+    600,
+  )
+  return Promise.race([settled, drained])
 }
 
 function createToastRemoveTaskTracker(): { removeTaskCalls: string[]; resetToastManager: () => void } {
@@ -1879,7 +1904,7 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
     //#when
     await (cast<{ notifyParentSession: (value: BackgroundTask) => Promise<void> }>(manager))
       .notifyParentSession(task)
-    await waitForCoalescedFlush()
+    await waitForCoalescedFlush(manager, "session-parent")
 
     //#then
     expect(capturedBody?.agent).toBe("sisyphus")
@@ -2036,7 +2061,7 @@ describe("BackgroundManager.notifyParentSession - aborted parent", () => {
     //#when
     await (cast<{ notifyParentSession: (task: BackgroundTask) => Promise<void> }>(manager))
       .notifyParentSession(task)
-    await waitForCoalescedFlush()
+    await waitForCoalescedFlush(manager, "session-parent")
 
     //#then
     expect(promptCalled).toBe(true)
@@ -2079,7 +2104,7 @@ describe("BackgroundManager.notifyParentSession - aborted parent", () => {
     //#when
     await (cast<{ notifyParentSession: (task: BackgroundTask) => Promise<void> }>(manager))
       .notifyParentSession(task)
-    await waitForCoalescedFlush()
+    await waitForCoalescedFlush(manager, "session-parent")
 
     //#then
     expect(promptCalled).toBe(true)
@@ -2120,7 +2145,7 @@ describe("BackgroundManager.notifyParentSession - aborted parent", () => {
     //#when
     await (cast<{ notifyParentSession: (task: BackgroundTask) => Promise<void> }>(manager))
       .notifyParentSession(task)
-    await waitForCoalescedFlush()
+    await waitForCoalescedFlush(manager, "session-parent")
 
     //#then
     const pendingWake = getPendingParentWakes(manager).get("session-parent")
@@ -2232,7 +2257,7 @@ describe("BackgroundManager.notifyParentSession - variant propagation", () => {
     //#when
     await (cast<{ notifyParentSession: (task: BackgroundTask) => Promise<void> }>(manager))
       .notifyParentSession(task)
-    await waitForCoalescedFlush()
+    await waitForCoalescedFlush(manager, "session-parent")
 
     //#then
     expect(promptCalls).toHaveLength(1)
@@ -2274,7 +2299,7 @@ describe("BackgroundManager.notifyParentSession - variant propagation", () => {
     //#when
     await (cast<{ notifyParentSession: (task: BackgroundTask) => Promise<void> }>(manager))
       .notifyParentSession(task)
-    await waitForCoalescedFlush()
+    await waitForCoalescedFlush(manager, "session-parent")
 
     //#then
     expect(promptCalls).toHaveLength(1)
@@ -6216,7 +6241,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
         error: { name: "UnknownError", message: "late provider failure" },
       },
     })
-    await waitForParentWakeErrorSettle()
+    await waitForParentWakeErrorSettle(manager, "parent-session-part-wake")
 
     //#then
     expect(promptCalls).toHaveLength(1)
@@ -6292,7 +6317,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
         error: { name: "UnknownError", message: "late provider failure" },
       },
     })
-    await waitForParentWakeErrorSettle()
+    await waitForParentWakeErrorSettle(manager, "parent-session-delta-wake")
 
     //#then
     expect(promptCalls).toHaveLength(1)
@@ -6357,7 +6382,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
         error: { name: "UnknownError", message: "late provider failure" },
       },
     })
-    await waitForParentWakeErrorSettle()
+    await waitForParentWakeErrorSettle(manager, "parent-session-real-delta")
 
     //#then
     expect(promptCalls).toHaveLength(1)
@@ -6424,7 +6449,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
         error: { name: "UnknownError", message: "late provider failure" },
       },
     })
-    await waitForParentWakeErrorSettle()
+    await waitForParentWakeErrorSettle(manager, "parent-session-wake")
 
     //#then
     expect(promptCalls).toHaveLength(1)
@@ -6491,7 +6516,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
       },
     })
     await flushBackgroundNotifications()
-    await waitForParentWakeErrorSettle()
+    await waitForParentWakeErrorSettle(manager, "parent-session-wake")
 
     //#then
     expect(promptCalls).toHaveLength(1)
@@ -6983,7 +7008,7 @@ describe("BackgroundManager.pruneStaleTasksAndNotifications - removes pruned tas
     //#when
     pruneStaleTasksAndNotificationsForTest(manager)
     await flushBackgroundNotifications()
-    await waitForCoalescedFlush()
+    await waitForCoalescedFlush(manager, staleTask.parentSessionId)
 
     //#then
     const retainedTask = getTaskMap(manager).get(staleTask.id)

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -445,7 +445,7 @@ describe("BackgroundManager tmux callback ordering", () => {
         parentSessionId: "ses_parent",
         parentMessageId: "msg_parent",
       })
-      await new Promise((resolve) => setTimeout(resolve, 20))
+      await waitUntil(() => events.includes("session.create") && events.includes("promptAsync"), 600)
 
       //#then
       expect(events).toContain("session.create")
@@ -3611,7 +3611,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
 
       // when
       await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => createCalls.length >= 1, 600)
 
       // then
       expect(createCalls).toHaveLength(1)
@@ -3634,7 +3634,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
 
       // when
       const task = await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task.id)?.status === "running", 600)
 
       // then
       const updatedTask = manager.getTask(task.id)
@@ -3662,7 +3662,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       const task = await manager.launch(input)
       const queuedAt = task.queuedAt
 
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task.id)?.startedAt != null, 600)
 
       // then
       const updatedTask = manager.getTask(task.id)
@@ -3837,7 +3837,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
 
       await manager.launch(input)
       const queuedTask = await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(queuedTask.id) != null, 600)
       expect(manager.getTask(queuedTask.id)?.status).toBe("pending")
 
       // when
@@ -3887,7 +3887,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       }
 
       await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => createAttempts >= 1, 600)
       expect(createAttempts).toBe(1)
 
       // when
@@ -4372,6 +4372,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         type: "session.error",
         properties: { sessionID: internalTask.sessionId, info: { id: internalTask.sessionId } },
       })
+      // monitored: waits for async session.error processing; no single status observable to poll.
       await new Promise((resolve) => setTimeout(resolve, 100))
 
       await expectResolvesDefined(manager.launch(input))
@@ -4424,7 +4425,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
 
       await manager.launch(input)
       const task2 = await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task2.id) != null, 600)
 
       // when
       const cancelled = manager.cancelPendingTask(task2.id)
@@ -4451,7 +4452,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       }
 
       const task = await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task.id)?.status === "running", 600)
 
       // when
       const cancelled = manager.cancelPendingTask(task.id)
@@ -4479,7 +4480,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       await manager.launch(input)
       const task2 = await manager.launch(input)
       const task3 = await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await waitUntil(() => manager.getTask(task3.id) != null, 600)
 
       // when - cancel middle task
       const cancelledTask2 = manager.getTask(task2.id)
@@ -4585,7 +4586,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       // when
       const task1 = await manager.launch(input1)
       const task2 = await manager.launch(input2)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task1.id)?.status === "running" && manager.getTask(task2.id)?.status === "running", 600)
 
       // then - both should be running despite limit of 1 (different keys)
       const updatedTask1 = manager.getTask(task1.id)
@@ -4612,7 +4613,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       // when
       const task1 = await manager.launch(input)
       const task2 = await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task1.id)?.status === "running", 600)
 
       // then - same key should respect limit
       const updatedTask1 = manager.getTask(task1.id)
@@ -4649,7 +4650,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       // when
       const task1 = await manager.launch(input1)
       const task2 = await manager.launch(input2)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task1.id)?.status === "running" && manager.getTask(task2.id)?.status === "running", 600)
 
       // then - different models should run in parallel
       const updatedTask1 = manager.getTask(task1.id)
@@ -4686,7 +4687,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       // when
       const task1 = await manager.launch(input1)
       const task2 = await manager.launch(input2)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task1.id)?.status === "running", 600)
 
       // then
       const updatedTask1 = manager.getTask(task1.id)
@@ -4728,7 +4729,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       // when
       const task1 = await manager.launch(input1)
       const task2 = await manager.launch(input2)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task1.id)?.status === "running", 600)
 
       // then
       const updatedTask1 = manager.getTask(task1.id)
@@ -4779,7 +4780,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       await manager.launch(input1)
       await manager.launch(input2)
       const task3 = await manager.launch(input3)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task3.id) != null, 600)
 
       // when
       const cancelled = await manager.cancelTask(task3.id, { abortSession: false, skipNotification: true })
@@ -4809,9 +4810,9 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         parentMessageId: "parent-message",
       }
 
-      await manager.launch(input)
+      const task1 = await manager.launch(input)
       const task2 = await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task1.id)?.status === "running", 600)
 
       // when
       const pendingTask = manager.getTask(task2.id)
@@ -4842,7 +4843,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
 
       // when
       const task = await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await waitUntil(() => manager.getTask(task.id)?.status === "running", 600)
 
       // then
       const runningTask = manager.getTask(task.id)
@@ -4873,6 +4874,9 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
 
       const queuedAt = task2.queuedAt!
 
+      // monitored: this test asserts real elapsed time between queuedAt and startedAt
+      // (both from real Date.now()) and manually completes a sibling task mid-flow, so
+      // its blind waits let real time pass and are kept intentionally.
       await new Promise(resolve => setTimeout(resolve, 50))
 
       const tasks = Array.from(getTaskMap(manager).values())
@@ -4882,6 +4886,9 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         getConcurrencyManager(manager).release(runningTask.concurrencyKey)
       }
 
+      // monitored: this assertion needs REAL time to elapse between queuedAt and
+      // startedAt (both from real Date.now()); a poll that resolves instantly can
+      // land them in the same millisecond, so a short blind wait is required here.
       await new Promise(resolve => setTimeout(resolve, 100))
 
       // then
@@ -4923,7 +4930,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         expect(task.id).toMatch(/^bg_/)
       })
 
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await waitUntil(() => tasks.filter(t => manager.getTask(t.id)?.status === "running").length >= 5, 600)
 
       const updatedTasks = tasks.map(t => manager.getTask(t.id))
       const runningCount = updatedTasks.filter(t => t?.status === "running").length
@@ -6612,7 +6619,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
     })
     await flushBackgroundNotifications()
     manager.handleEvent({ type: "session.idle", properties: { sessionID } })
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await waitUntil(() => task.status === "completed", 600)
 
     //#then
     expect(task.status).toBe("completed")
@@ -6661,7 +6668,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
       type: "session.idle",
       properties: { info: { id: sessionID } },
     })
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await waitUntil(() => task.status === "completed", 600)
 
     //#then
     expect(task.status).toBe("completed")
@@ -7230,7 +7237,7 @@ describe("BackgroundManager.handleEvent - early session.idle deferral", () => {
 
       //#then - idle should be deferred (not dropped), and task should eventually complete
       expect(task.status).toBe("running")
-      await new Promise((resolve) => setTimeout(resolve, 220))
+      await waitUntil(() => task.status === "completed", 600)
       expect(task.status).toBe("completed")
       expect(messagesCalls).toEqual([sessionID])
     } finally {
@@ -7280,7 +7287,7 @@ describe("BackgroundManager.handleEvent - early session.idle deferral", () => {
     manager.handleEvent({ type: "session.idle", properties: { sessionID } })
 
     //#then - should be processed immediately
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await waitUntil(() => task.status === "completed", 600)
     expect(task.status).toBe("completed")
 
     manager.shutdown()
@@ -7650,7 +7657,7 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
     manager.handleEvent({ type: "session.idle", properties: { sessionID } })
 
     //#then - task completes without refetching session.messages
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await waitUntil(() => task.status === "completed", 600)
     expect(task.status).toBe("completed")
     expect(messagesCallCount).toBe(0)
     expect(todoCallCount).toBe(1)
@@ -7700,7 +7707,7 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
       parentSessionId: "parent-session-2",
       parentMessageId: "msg-2",
     })
-    await new Promise((resolve) => setTimeout(resolve, 60))
+    await waitUntil(() => getTaskMap(manager).has(task.id) && !completionTimers.has(task.id), 600)
 
     //#then
     expect(getTaskMap(manager).has(task.id)).toBe(true)
@@ -8097,7 +8104,7 @@ describe("BackgroundManager - tool permission spread order", () => {
       //#when
       await (cast<{ startTask: (item: { task: BackgroundTask; input: import("./types").LaunchInput }) => Promise<void> }>(manager))
         .startTask({ task, input })
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      await waitUntil(() => promptCalls.length >= 2, 600)
 
       //#then
       expect(promptCalls).toHaveLength(2)

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -280,6 +280,8 @@ export class BackgroundManager {
   private loggedSessionStatusUnavailable = false
   readonly taskHistory = new TaskHistory()
   private cachedCircuitBreakerSettings?: CircuitBreakerSettings
+  private readonly scheduledFlushSettledCounts = new Map<string, number>()
+  private readonly scheduledFlushSettledWaiters = new Map<string, Array<() => void>>()
 
   constructor(config: BackgroundManagerConfig) {
     const { pluginContext, ...options } = config
@@ -307,7 +309,7 @@ export class BackgroundManager {
         directory: this.directory,
         enqueueNotificationForParent: this.enqueueNotificationForParent.bind(this),
         onPendingWakeRequeued: (sessionID) => this.updateBackgroundTaskMarker(sessionID),
-        onScheduledFlushSettled: (sessionID) => this.updateBackgroundTaskMarker(sessionID),
+        onScheduledFlushSettled: (sessionID) => this.recordScheduledFlushSettled(sessionID),
       },
       {
         pendingRetryMs: PENDING_PARENT_WAKE_RETRY_MS,
@@ -2792,6 +2794,48 @@ The task was re-queued on a fallback model after a retryable failure.
   private async isSessionActive(sessionID: string): Promise<boolean> {
     const resolved = await resolveDispatchClient(this.client, sessionID)
     return isOpenCodeSessionActive(resolved.client as Parameters<typeof isOpenCodeSessionActive>[0], sessionID)
+  }
+
+  private recordScheduledFlushSettled(sessionID: string): void {
+    this.updateBackgroundTaskMarker(sessionID)
+    this.scheduledFlushSettledCounts.set(sessionID, (this.scheduledFlushSettledCounts.get(sessionID) ?? 0) + 1)
+    const waiters = this.scheduledFlushSettledWaiters.get(sessionID)
+    if (waiters && waiters.length > 0) {
+      this.scheduledFlushSettledWaiters.set(sessionID, [])
+      for (const waiter of waiters) {
+        waiter()
+      }
+    }
+  }
+
+  /**
+   * Test-only: monotonic count of scheduled parent-wake flushes that have settled
+   * for this session (the real onScheduledFlushSettled signal). Capture this
+   * BEFORE triggering a flush, then awaitScheduledFlush(sessionID, captured) so a
+   * settle that races between trigger and await is not missed.
+   */
+  getScheduledFlushSettledCount(sessionID: string): number {
+    return this.scheduledFlushSettledCounts.get(sessionID) ?? 0
+  }
+
+  /**
+   * Test-only: resolves once the settled-flush count for this session exceeds
+   * `sinceCount` (captured before the flush was triggered). Deterministic — no
+   * blind sleep past the debounce, and no registration-after-settle race.
+   */
+  awaitScheduledFlush(sessionID: string, sinceCount: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const arm = (): void => {
+        if ((this.scheduledFlushSettledCounts.get(sessionID) ?? 0) > sinceCount) {
+          resolve()
+          return
+        }
+        const waiters = this.scheduledFlushSettledWaiters.get(sessionID) ?? []
+        waiters.push(arm)
+        this.scheduledFlushSettledWaiters.set(sessionID, waiters)
+      }
+      arm()
+    })
   }
 
   private queuePendingParentWake(

--- a/packages/omo-opencode/src/features/team-mode/integration.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/integration.test.ts
@@ -131,7 +131,7 @@ describe("team-mode integration", () => {
     expect(delivered.deliveredTo).toEqual(["echo"])
     expect(status.members[0]?.unreadMessages).toBe(1)
     expect(await exists(getRuntimeStateDir(resolveBaseDir(config), runtime.teamRunId))).toBe(false)
-  }, 15000)
+  }, 30000)
 
   test("C-10.2 runs a 2-member pipeline where worker claims and completes a lead-created task", async () => {
     // given
@@ -155,7 +155,7 @@ describe("team-mode integration", () => {
     expect(claimedTask.owner).toBe("worker")
     expect(completedTasks).toHaveLength(1)
     expect(completedTasks[0]?.subject).toBe("X")
-  }, 15000)
+  }, 30000)
 
   test("C-10.3 resumes alive teams, orphans dead leads, fails stuck creating teams, and cleans deleting runs", async () => {
     // given
@@ -180,7 +180,7 @@ describe("team-mode integration", () => {
     expect((await loadRuntimeState(deadRuntime.teamRunId, config)).status).toBe("orphaned")
     expect((await loadRuntimeState(stuckRuntime.teamRunId, config)).status).toBe("failed")
     expect(await exists(getRuntimeStateDir(resolveBaseDir(config), deletingRuntime.teamRunId))).toBe(false)
-  }, 15000)
+  }, 30000)
 
   test("C-10.5 end-to-end: createTeamRun persists category-aware routing and team_send_message reapplies it on promptAsync", async () => {
     // given - a 2-member team; resolveMemberMock returns agentToUse + model per member


### PR DESCRIPTION
## What

Test-speed + race-hardening across background-agent + cli-run + team-mode, one commit per mechanism. Folds in the 3 oracle-audit blockers (A-R2, B-R1, B-O1).

1. **manager.test.ts** — await the real parent-wake flush-settle signal (settle counter) instead of blind sleeps, AND replace ~23 more blind `launch→setTimeout→assert` waits with `waitUntil` polls.
2. **cli/run/poll-for-completion.test.ts** — inject a virtual clock so the busy-delay causality is deterministic virtual time.
3. **team-mode/integration.test.ts** — bump test timeouts above the production lock-wait deadline.

## (1a) manager: real settle signal via a monotonic counter

`onScheduledFlushSettled(sessionID)` fires in a `finally` after the debounced flush (every outcome). Made test-observable with a **per-session monotonic settle counter**: `recordScheduledFlushSettled` still calls `updateBackgroundTaskMarker` first (production byte-identical), then bumps the counter and drains waiters. Tests capture `getScheduledFlushSettledCount(session)` **before** triggering the flush, then `awaitScheduledFlush(session, sinceCount)` resolves once the count exceeds it (self-rearming waiter) — no registration-after-settle race, no debounce change, no source seam, zero touch to the 114 direct constructions.

**Design-history delta (honest):** the design assumed one flush-completion signal; the 12 blind-wait sites actually split into **two classes** — *coalesced-flush* sites await the settle counter (raced against a bounded pending/dispatched state-drain), *late-error-requeue* sites call `flushPendingParentWake` directly (no scheduled signal) and poll the `getDispatchedParentWakes`-cleared observable.

## (1b) manager: blind launch-wait conversions (oracle A-R2)

Beyond the 7 flush sites, ~30 more blind `setTimeout` waits (17×50ms + 4×100ms + smaller) followed `launch(...) → setTimeout → assert status/createCalls/timers`. Converted to `waitUntil(predicate, 600)` keyed on each test's exact observable, with **per-site-correct predicates** (concurrency-limited tests wait for task1 running while task2 stays pending, etc.). Verified NO `waitUntil` hits its timeout fallback (instrumented + checked). **Kept as documented-monitored blind waits:** the session.error-processing wait (no single status observable) and the queuedAt-vs-startedAt timestamp test (asserts real elapsed time between queue and start + manually completes a sibling task, so a poll that resolves instantly can collapse the timestamps to the same millisecond).

manager.test.ts 7.85s → 5.05s, 191/0, stable 20/20 under 4x CPU load.

## (2) poll-for-completion: injectable virtual clock

`now?: () => number` + `sleep?: (ms) => Promise<void>` on `PollOptions` (default `Date.now` + real `setTimeout` → production byte-identical). Timing tests drive a deterministic virtual clock; the busy-interruption property (was `elapsedMs > 30`, a race) is preserved as `clock.now() > 3 * pollInterval`. **One test keeps the REAL 1000ms default window** as the default-path guard. 2.24s → 1.95s, 20/0, stable 20/20 under load.

## (3) team-mode integration timeout (oracle B-O1)

`integration.test.ts` set the bun test-timeout to 15000ms == the production `LOCK_WAIT_TIMEOUT_MS` (locks.ts:29) — the two deadlines race on a slow runner. Bumped the 3 test timeouts to 30000ms so the harness deadline strictly dominates and a real lock-wait failure surfaces as the product error, not a harness kill.

## Explicitly NOT touched (verified, documented)

- **parent-wake-* (5 files):** verified already race-free `waitUntil` state-polls; cost is the real 100ms debounce, not deletable blind sleeps. No action.
- **messaging.test.ts:** no blind sleeps; 4.17s is real `withLock`/`atomicWrite` fs I/O (fs-lock family, recurrence-audited = zero recurrence). No action.
- **reply-listener.test.ts:** untouched; keeps its `beforeAll` HOME ordering.

## Windows-family recurrence audit (oracle B-R1)

Evidence artifact written: `.omo/evidence/20260706-windows-flake-recurrence/AUDIT.md` (+ raw query data). The 11 Windows-family flakes were remediated by 4 maintainer commits (a099459c5, b901c7fa9, beb0b0963, d98d23009). Since the latest remediation (2026-07-02T10:07Z): 19 success, 18 cancelled (superseded pushes), **0 failures**, 0 attempt>1 reruns; last family failure predates remediation. Honest close: "remediated; no recurrence observed across 19 completed dev CI runs + loop-1 local 0-fail; monitoring continues" — the 18 cancelled runs are a stated per-test monitoring gap, not proof-of-never-recur.

## QA / Evidence

- manager 20/20 + poll-for-completion 20/20 under 4x CPU load; no `waitUntil` timeout-fallback hits.
- Full `bun test packages/omo-opencode/` ordering run: **8123 pass, 0 fail**.
- prompt-async invariant suites green (route-audit + mock-lifecycle-audit, 11/0). `bun run typecheck` clean. Rebased onto latest dev.