### PR TITLE
fix(build): harden orchestrator failure and output handling

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -45,8 +45,6 @@ const nodes: BuildNode[] = [
 	{ id: "schema", command: "bun", args: ["run", "build:schema"], deps: [] },
 ];
 
-await run();
-
 async function run() {
 	await materializeOnce();
 	const childEnv = { ...process.env, OMO_SKIP_MATERIALIZE: "1" };
@@ -64,30 +62,44 @@ async function runGraph(graph: BuildNode[], env: NodeJS.ProcessEnv) {
 	const limit = Math.max(1, availableParallelism());
 	const pending = new Set(graph.map((node) => node.id));
 	const byId = new Map(graph.map((node) => [node.id, node]));
+	const liveChildren = new Set<ReturnType<typeof spawn>>();
 
-	while (done.size < graph.length) {
-		for (const id of pending) {
-			if (running.size >= limit) break;
-			const node = byId.get(id);
-			if (!node) continue;
-			if (!node.deps.every((dep) => done.has(dep))) continue;
-			pending.delete(id);
-			running.set(id, runNode(node, env).then(() => {
-				running.delete(id);
-				done.add(id);
-			}));
+	try {
+		while (done.size < graph.length) {
+			for (const id of pending) {
+				if (running.size >= limit) break;
+				const node = byId.get(id);
+				if (!node) continue;
+				if (!node.deps.every((dep) => done.has(dep))) continue;
+				pending.delete(id);
+				running.set(id, runNode(node, env, liveChildren).then(() => {
+					running.delete(id);
+					done.add(id);
+				}));
+			}
+			if (running.size === 0) {
+				throw new Error(`build: dependency cycle or unresolved deps among ${[...pending].join(", ")}`);
+			}
+			await Promise.race(running.values());
 		}
-		if (running.size === 0) {
-			throw new Error(`build: dependency cycle or unresolved deps among ${[...pending].join(", ")}`);
+	} catch (error) {
+		// First failure aborts the build; stop the steps still running so they cannot keep
+		// writing artifacts after the build has already failed.
+		for (const child of liveChildren) {
+			child.kill();
 		}
-		await Promise.race(running.values());
+		await Promise.allSettled(running.values());
+		throw error;
 	}
 }
 
-// Buffers each child's stdout/stderr and flushes it as one contiguous block so concurrent
-// steps never interleave, keeping a failing step's output readable. Any non-zero exit
-// rejects, which aborts the build with a non-zero code and a named error.
-function runNode(node: BuildNode, env: NodeJS.ProcessEnv): Promise<void> {
+const MAX_RETAINED_OUTPUT_BYTES = 1024 * 1024;
+
+// Buffers each child's stdout/stderr (tail-capped to keep memory bounded on verbose parallel
+// runs) and flushes it as one contiguous block so concurrent steps never interleave, keeping a
+// failing step's output readable. Any non-zero exit rejects, which aborts the build with a
+// non-zero code and a named error.
+function runNode(node: BuildNode, env: NodeJS.ProcessEnv, liveChildren?: Set<ReturnType<typeof spawn>>): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const child = spawn(node.command, node.args, {
 			cwd: repoRoot,
@@ -95,11 +107,30 @@ function runNode(node: BuildNode, env: NodeJS.ProcessEnv): Promise<void> {
 			shell: process.platform === "win32",
 			stdio: ["ignore", "pipe", "pipe"],
 		});
+		liveChildren?.add(child);
+		let settled = false;
 		const chunks: Buffer[] = [];
-		child.stdout.on("data", (chunk) => chunks.push(chunk));
-		child.stderr.on("data", (chunk) => chunks.push(chunk));
-		child.on("error", (error) => reject(error));
+		let retainedBytes = 0;
+		const retain = (chunk: Buffer) => {
+			chunks.push(chunk);
+			retainedBytes += chunk.length;
+			while (retainedBytes > MAX_RETAINED_OUTPUT_BYTES && chunks.length > 1) {
+				const dropped = chunks.shift();
+				if (dropped !== undefined) retainedBytes -= dropped.length;
+			}
+		};
+		child.stdout.on("data", retain);
+		child.stderr.on("data", retain);
+		child.on("error", (error) => {
+			if (settled) return;
+			settled = true;
+			liveChildren?.delete(child);
+			reject(error);
+		});
 		child.on("close", (status, signal) => {
+			if (settled) return;
+			settled = true;
+			liveChildren?.delete(child);
 			const output = Buffer.concat(chunks).toString("utf8");
 			process.stdout.write(`build:${node.id}\n${output}`);
 			if (status === 0) {
@@ -110,4 +141,14 @@ function runNode(node: BuildNode, env: NodeJS.ProcessEnv): Promise<void> {
 			reject(new Error(`build:${node.id} failed with ${reason}`));
 		});
 	});
+}
+
+try {
+	await run();
+} catch (error) {
+	// Parallel waves interleave sub-build output, so print the failing step as the last
+	// stdout line before exiting non-zero to keep CI failure attribution fast.
+	const message = error instanceof Error ? error.message : String(error);
+	process.stdout.write(`build: FAILED: ${message}\n`);
+	process.exit(1);
 }


### PR DESCRIPTION
## What changed

Four robustness improvements to `script/build.ts` (the parallel build DAG orchestrator merged in #5888). Three are Cubic findings from that PR's review; the fourth is a CI-attribution guard requested by the ci-workflows reviewer.

1. **Kill in-flight children on first failure** (Cubic P1). `runGraph` tracks live children and, on the first step failure, kills the rest and awaits their settle before rethrowing, so no step keeps writing artifacts after the build has already failed.
2. **Bounded per-step output** (Cubic P2). Retained stdout/stderr is tail-capped at 1 MiB, so a verbose parallel run cannot spike memory.
3. **Single-settle guard** (Cubic P2). `runNode`'s `error`/`close` handlers are guarded by a `settled` flag, so a spawn failure (which fires both events) cannot double-settle the promise.
4. **Clean CI failure attribution** (ci-workflows guard). A top-level catch prints `build: FAILED: <step> failed with <reason>` as the **last** stdout line before `process.exit(1)`, so a failing wave stays attributable despite interleaved parallel output. (Each spawned step already prefixes its output with `build:<step>`.)

## QA / evidence

- **Byte-identical build**: hardened vs merged `build.ts`, same worktree, both cold → aggregate `shasum` `6c5680d7…` == `6c5680d7…`. The changes only touch the failure path and output buffering; happy-path output is unchanged.
- **Failure semantics**: an injected failing step exits non-zero, and the last stdout line is exactly `build: FAILED: build:schema failed with exit code 1`.
- **typecheck**: clean.
- **A runtime bug the manual QA caught** (typecheck did not): my first placement of the top-level `try { await run() }` sat *above* the `MAX_RETAINED_OUTPUT_BYTES` const, causing a TDZ `ReferenceError` at runtime. Moved the entry `try/catch` to the end of the module, after all declarations; the smoke build then completed and produced `dist/index.js`.

Evidence: `.omo/evidence/20260706-build-orchestrator-robustness/`.

## Residual risk

Failure propagation is unchanged except that siblings are now stopped and the promise settles exactly once. No payload or publish semantics change.

cc @a415451b285c9c984 (ci-workflows) for the failure-attribution + byte-identical review from the CI-consumer angle, as offered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden the parallel build orchestrator for safer failures and clearer CI logs. Stops in-flight steps on first failure, bounds per-step output memory, and avoids double-settle races.

- **Bug Fixes**
  - `runGraph`: track live children; on first failure, kill others and await settle.
  - Cap retained stdout/stderr per step at 1 MiB (tail) to bound memory use.
  - `runNode`: guard `error`/`close` with a `settled` flag to prevent double-settle.
  - Top-level: print `build: FAILED: <reason>` as the final stdout line before `process.exit(1)` for clear CI attribution.

<sup>Written for commit 35e2d3a752068fb7af7776d327799a9aeed15737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

