### PR TITLE
fix(build): kill the whole process tree when a build step fails

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -1,9 +1,33 @@
 #!/usr/bin/env bun
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { availableParallelism } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const isWindows = process.platform === "win32";
+
+// Detach each child on POSIX so it leads its own process group, letting us SIGKILL the whole
+// group (child + any grandchildren it spawned, e.g. `npm ci` / `bun build` sub-processes) on
+// abort. A plain child.kill() only signals the immediate child, so grandchildren survive and a
+// failed build would otherwise wait out a slow sibling. On Windows there is no process group;
+// killTree falls back to `taskkill /T /F`, which is best-effort tree termination.
+function killTree(child: ReturnType<typeof spawn>): void {
+	const pid = child.pid;
+	if (pid === undefined) return;
+	if (isWindows) {
+		spawnSync("taskkill", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore" });
+		return;
+	}
+	try {
+		process.kill(-pid, "SIGKILL");
+	} catch (error) {
+		// ESRCH => the group is already gone (child exited between the race and this loop); any
+		// other failure (e.g. the child never became a group leader) falls back to a direct kill.
+		if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+			child.kill("SIGKILL");
+		}
+	}
+}
 
 // Every node writes to a disjoint output path, so ordering only matters where one node
 // reads another's output. The three real edges: index -> node-require-shim (patches
@@ -83,10 +107,11 @@ async function runGraph(graph: BuildNode[], env: NodeJS.ProcessEnv) {
 			await Promise.race(running.values());
 		}
 	} catch (error) {
-		// First failure aborts the build; stop the steps still running so they cannot keep
-		// writing artifacts after the build has already failed.
+		// First failure aborts the build; SIGKILL each still-running step's whole process group
+		// so it (and its grandchildren) stops immediately instead of holding the build open until
+		// a slow sibling finishes.
 		for (const child of liveChildren) {
-			child.kill();
+			killTree(child);
 		}
 		await Promise.allSettled(running.values());
 		throw error;
@@ -104,7 +129,10 @@ function runNode(node: BuildNode, env: NodeJS.ProcessEnv, liveChildren?: Set<Ret
 		const child = spawn(node.command, node.args, {
 			cwd: repoRoot,
 			env,
-			shell: process.platform === "win32",
+			shell: isWindows,
+			// POSIX: lead a new process group so killTree can SIGKILL the whole subtree on abort.
+			// Windows has no process groups; taskkill /T handles the tree there.
+			detached: !isWindows,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 		liveChildren?.add(child);


### PR DESCRIPTION
## What

Oracle finding **C-O1**: `script/build.ts`'s failure path (from #5903) called plain `child.kill()`, which sends SIGTERM to the immediate child only. Grandchildren (the `npm ci` / `bun build` sub-processes each node spawns) and any TERM-ignoring child survived, so a failed build waited out slow siblings instead of aborting promptly, and the comment ("so they cannot keep writing artifacts") overstated the guarantee.

This spawns each node **detached** (its own POSIX process group) and adds `killTree()` that SIGKILLs the whole group (`process.kill(-pid, "SIGKILL")`, ESRCH-tolerant, with a direct-kill fallback). Windows has no process groups, so it falls back to `taskkill /PID <pid> /T /F` (best-effort tree kill, documented in the comment). Only the failure path and the spawn flag change; the success path is untouched.

## Why it is safe

`script/build.ts` is the build script, not bundled into any `dist` artifact, and `detached` only changes process-group membership — it does not change what any sub-process writes. So the success-path output is byte-identical.

## QA / evidence (`.omo/evidence/20260706-build-orchestrator-killgroup/`)

- **Byte-identical success path**: full cold build with the new `build.ts` (91s, 2055 files) vs a warm rebuild with the merged dev `build.ts` (14s) -> dist aggregate identical (`91082e52e4b5d564505e1eda91d161e61bbf27007765c5ab637027e8b309ae93`).
- **Oracle repro (mechanism)**: detached spawn + `process.kill(-pid, "SIGKILL")` terminated a `bash -c "sleep 30"` grandchild; close fired at **206ms** (plain `child.kill()` leaves it ~30000ms).
- **Real orchestrator abort**: injected a fast-failing node alongside a 30s slow sibling -> exit 1, wall **34ms**, last stdout line `build: FAILED: build:fast-fail failed with exit code 7`. A surviving sibling would have forced wall >= 30000ms.
- **Guards**: build-chain guard meta-tests 19 pass / 0 fail; `typecheck:script` clean.

## Residual risk

The Windows `taskkill` path is best-effort and was not executed on the macOS QA host (documented, per-platform branch); the success path it does not touch is exercised by CI's windows leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop lingering build subprocesses on failure by killing the entire process tree. Failed builds now exit fast and avoid stray writes.

- **Bug Fixes**
  - POSIX: spawn each step `detached` and on abort send `SIGKILL` to the group with `process.kill(-pid, "SIGKILL")`, falling back to `child.kill("SIGKILL")` if needed.
  - Windows: best-effort tree kill via `taskkill /PID <pid> /T /F`.
  - Only the failure path and spawn flags changed; successful builds are unchanged and outputs remain identical.

<sup>Written for commit 5713f7c625b176da0fdacabf9416fd5066faeba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

