### PR TITLE
feat(pi-goal): align goal tool contract with codex ext/goal

### DIFF
--- a/packages/pi-goal/AGENTS.md
+++ b/packages/pi-goal/AGENTS.md
@@ -15,7 +15,7 @@ an active goal via hidden continuation prompts (`pi-goal-continuation` custom me
 |------|---------|
 | `src/index.ts` | Extension entry: tools + `/goal` command + session/agent lifecycle + usage accounting |
 | `src/goal/store.ts` | File persistence: read/write/create/update/clear/accountGoalUsage + status transitions |
-| `src/goal/types.ts` | `Goal`, `GoalStatus` (`active\|paused\|budgetLimited\|complete`), store/file/tool types |
+| `src/goal/types.ts` | `Goal`, `GoalStatus` (`active\|paused\|blocked\|budgetLimited\|complete`), store/file/tool types |
 | `src/goal/prompt.ts` | Continuation + budget-limited hidden prompt builders |
 | `src/goal/continuation.ts` | Continuation gating predicates |
 | `src/goal/format.ts` | Tool/UI formatting + tool JSON response snapshots |
@@ -26,6 +26,19 @@ an active goal via hidden continuation prompts (`pi-goal-continuation` custom me
 | `test/` | Vendored characterization suite (bun:test; assertions identical to upstream) |
 | `scripts/qa/drive.mjs` | Live QA driver: real pi CLI in RPC mode, isolated `PI_CODING_AGENT_DIR`, scripted mock provider, `--self-test` |
 | `scripts/qa/mock-provider/` | Self-contained scripted provider extension (no network, no keys) |
+
+## Codex alignment
+
+The goal tool contract is aligned with codex `codex-rs/ext/goal`:
+
+- `update_goal` accepts `complete` and `blocked` (codex `spec.rs` enum); `blocked` is a real,
+  model-settable, non-terminal status (resumable via `/goal resume`).
+- `create_goal` replaces only a `complete` goal and otherwise fails with the codex
+  "unfinished goal" message.
+- Tool/parameter descriptions, the `update_goal` error text, and the completion budget report
+  match codex verbatim; `budgetLimited` is preserved when `paused` or `blocked` is requested.
+- Deliberate deviation: pi omits `usage_limited` (codex sets it from a system
+  `UsageLimitExceeded` turn error, not the model; the Pi harness exposes no such signal).
 
 ## Conventions
 

--- a/packages/pi-goal/scripts/qa/drive.mjs
+++ b/packages/pi-goal/scripts/qa/drive.mjs
@@ -2,9 +2,12 @@
 // Live QA driver: boots the REAL pi coding agent CLI in RPC mode inside an
 // isolated PI_CODING_AGENT_DIR sandbox, loads the vendored pi-goal extension
 // plus a scripted mock provider (no network), and proves the goal tools and
-// continuation wiring work end to end on the real harness:
-// turn 1 creates the goal, the extension queues a hidden continuation prompt,
-// and the continuation-triggered turn 2 marks the goal complete.
+// continuation wiring work end to end on the real harness. Two scenarios:
+//   complete: turn 1 creates the goal, the extension queues a hidden
+//             continuation prompt, and the continuation turn marks it complete.
+//   blocked:  turn 1 creates the goal, and the continuation turn marks it
+//             blocked via update_goal (codex-aligned status).
+// Runs both by default; pass --scenario <complete|blocked> to run one.
 import { spawn } from "node:child_process"
 import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
@@ -18,6 +21,40 @@ const mockProviderEntry = join(scriptDir, "mock-provider", "index.ts")
 const goalExtensionEntry = join(packageRoot, "src", "index.ts")
 const realPiAgentDir = join(homedir(), ".pi", "agent")
 const RUN_TIMEOUT_MILLISECONDS = 120_000
+const CONTINUATION_MARKER = "Continue working toward the active thread goal."
+
+const SCENARIOS = {
+  complete: {
+    objective: "QA: prove pi-goal works on the real pi harness",
+    tokenBudget: 50_000,
+    steps: [
+      {
+        type: "tool_call",
+        name: "create_goal",
+        arguments: { objective: "QA: prove pi-goal works on the real pi harness", token_budget: 50_000 },
+      },
+      { type: "text", text: "goal created, ending this turn" },
+      { type: "tool_call", name: "update_goal", arguments: { status: "complete" } },
+      { type: "text", text: "goal completed, all done" },
+    ],
+    terminalStatus: "complete",
+  },
+  blocked: {
+    objective: "QA: prove the blocked round-trip on the real pi harness",
+    tokenBudget: undefined,
+    steps: [
+      {
+        type: "tool_call",
+        name: "create_goal",
+        arguments: { objective: "QA: prove the blocked round-trip on the real pi harness" },
+      },
+      { type: "text", text: "goal created, ending this turn" },
+      { type: "tool_call", name: "update_goal", arguments: { status: "blocked" } },
+      { type: "text", text: "goal blocked, stopping" },
+    ],
+    terminalStatus: "blocked",
+  },
+}
 
 export function createSandbox() {
   const root = mkdtempSync(join(tmpdir(), "pi-goal-qa-"))
@@ -90,26 +127,8 @@ function readGoalFromSandbox(root) {
   return { file: goalFiles[0], goal: JSON.parse(readFileSync(goalFiles[0], "utf8")).goal }
 }
 
-function runRpcScenario(piBin, sandbox, report) {
-  writeFileSync(
-    join(sandbox.cwd, "mock-script.json"),
-    `${JSON.stringify(
-      {
-        steps: [
-          {
-            type: "tool_call",
-            name: "create_goal",
-            arguments: { objective: "QA: prove pi-goal works on the real pi harness", token_budget: 50_000 },
-          },
-          { type: "text", text: "goal created, ending this turn" },
-          { type: "tool_call", name: "update_goal", arguments: { status: "complete" } },
-          { type: "text", text: "goal completed, all done" },
-        ],
-      },
-      null,
-      2,
-    )}\n`,
-  )
+function runRpcScenario(piBin, sandbox, scenario, scenarioReport) {
+  writeFileSync(join(sandbox.cwd, "mock-script.json"), `${JSON.stringify({ steps: scenario.steps }, null, 2)}\n`)
 
   const child = spawn(
     process.execPath,
@@ -120,23 +139,22 @@ function runRpcScenario(piBin, sandbox, report) {
       stdio: ["pipe", "pipe", "pipe"],
     },
   )
-  report.childPid = child.pid
+  scenarioReport.childPid = child.pid
 
   return new Promise((resolveScenario) => {
     let stdoutBuffer = ""
     let stderrTail = ""
     let agentEndCount = 0
     let settled = false
-
     const timeout = setTimeout(() => finish("timeout"), RUN_TIMEOUT_MILLISECONDS)
 
     function finish(reason) {
       if (settled) return
       settled = true
       clearTimeout(timeout)
-      report.rpcFinishReason = reason
-      report.agentEndCount = agentEndCount
-      report.stderrTail = stderrTail.split("\n").slice(-8).join("\n")
+      scenarioReport.rpcFinishReason = reason
+      scenarioReport.agentEndCount = agentEndCount
+      scenarioReport.stderrTail = stderrTail.split("\n").slice(-8).join("\n")
       child.kill("SIGTERM")
       const killTimeout = setTimeout(() => child.kill("SIGKILL"), 5_000)
       child.once("exit", () => {
@@ -176,13 +194,46 @@ function runRpcScenario(piBin, sandbox, report) {
       if (event.type === "agent_end") {
         agentEndCount += 1
         const { goal } = readGoalFromSandbox(sandbox.root)
-        if (goal?.status === "complete") finish("goal-complete")
-        else if (agentEndCount >= 4) finish("goal-never-completed")
+        if (goal?.status === scenario.terminalStatus) finish(`goal-${scenario.terminalStatus}`)
+        else if (agentEndCount >= 4) finish("terminal-status-never-reached")
       }
     }
 
     child.stdin.write(`${JSON.stringify({ type: "prompt", message: "please create the QA goal" })}\n`)
   })
+}
+
+async function runScenario(piBin, name) {
+  const scenario = SCENARIOS[name]
+  const sandbox = createSandbox()
+  const scenarioReport = {
+    scenario: name,
+    result: "FAIL",
+    reason: undefined,
+    goalStoreFile: undefined,
+    goalAfterRun: undefined,
+    continuationObserved: false,
+    terminalStatusObserved: false,
+    sandboxRoot: sandbox.root,
+  }
+  try {
+    await runRpcScenario(piBin, sandbox, scenario, scenarioReport)
+    const { file, goal } = readGoalFromSandbox(sandbox.root)
+    scenarioReport.goalStoreFile = file
+    scenarioReport.goalAfterRun = goal
+    scenarioReport.continuationObserved = readSandboxText(sandbox.root).includes(CONTINUATION_MARKER)
+    scenarioReport.terminalStatusObserved = goal?.status === scenario.terminalStatus
+
+    const shapeCorrect = goal?.objective === scenario.objective && goal?.tokenBudget === scenario.tokenBudget
+    if (shapeCorrect && scenarioReport.continuationObserved && scenarioReport.terminalStatusObserved) {
+      scenarioReport.result = "PASS"
+    } else {
+      scenarioReport.reason = "assertions-not-satisfied"
+    }
+  } finally {
+    if (scenarioReport.result === "PASS") rmSync(sandbox.root, { recursive: true, force: true })
+  }
+  return scenarioReport
 }
 
 function runSelfTest() {
@@ -195,27 +246,32 @@ function runSelfTest() {
     writeFileSync(join(sandbox.cwd, "probe.json"), "{}")
     if (findGoalStoreFiles(sandbox.root).length !== 0) throw new Error("goal store matcher over-matches")
     if (resolvePiBin() === null) throw new Error("pi binary could not be resolved from the workspace")
+    if (SCENARIOS.blocked.terminalStatus !== "blocked") throw new Error("blocked scenario misconfigured")
     console.log(JSON.stringify({ result: "PASS", mode: "self-test" }))
   } finally {
     rmSync(sandbox.root, { recursive: true, force: true })
   }
 }
 
+function selectedScenarioNames() {
+  const flagIndex = process.argv.indexOf("--scenario")
+  if (flagIndex !== -1 && process.argv[flagIndex + 1]) {
+    const name = process.argv[flagIndex + 1]
+    if (!SCENARIOS[name]) throw new Error(`unknown scenario: ${name}`)
+    return [name]
+  }
+  return Object.keys(SCENARIOS)
+}
+
 async function main() {
   if (process.argv.includes("--self-test")) return runSelfTest()
 
   const beforeDigest = digestDirectory(realPiAgentDir)
-  const sandbox = createSandbox()
   const report = {
     result: "FAIL",
-    reason: undefined,
     piBin: undefined,
-    goalStoreFile: undefined,
-    goalAfterRun: undefined,
-    continuationObserved: false,
-    completionObserved: false,
     realAgentDirUntouched: undefined,
-    sandboxRoot: sandbox.root,
+    scenarios: [],
   }
 
   try {
@@ -227,23 +283,10 @@ async function main() {
     }
     report.piBin = piBin
 
-    await runRpcScenario(piBin, sandbox, report)
-
-    const { file, goal } = readGoalFromSandbox(sandbox.root)
-    report.goalStoreFile = file
-    report.goalAfterRun = goal
-    report.continuationObserved = readSandboxText(sandbox.root).includes(
-      "Continue working toward the active thread goal.",
-    )
-    report.completionObserved = goal?.status === "complete"
-
-    const goalShapeCorrect =
-      goal?.objective === "QA: prove pi-goal works on the real pi harness" && goal?.tokenBudget === 50_000
-    if (goalShapeCorrect && report.continuationObserved && report.completionObserved) {
-      report.result = "PASS"
-    } else {
-      report.reason = "assertions-not-satisfied"
+    for (const name of selectedScenarioNames()) {
+      report.scenarios.push(await runScenario(piBin, name))
     }
+    report.result = report.scenarios.every((scenarioReport) => scenarioReport.result === "PASS") ? "PASS" : "FAIL"
   } finally {
     report.realAgentDirUntouched = digestDirectory(realPiAgentDir) === beforeDigest
     if (report.result === "PASS" && !report.realAgentDirUntouched) {
@@ -251,8 +294,7 @@ async function main() {
       report.reason = "real-pi-agent-dir-mutated"
     }
     console.log(JSON.stringify(report, null, 2))
-    if (report.result === "PASS" || report.result === "SKIP") rmSync(sandbox.root, { recursive: true, force: true })
-    process.exitCode = report.result === "FAIL" ? 1 : 0
+    process.exitCode = report.result === "PASS" || report.result === "SKIP" ? 0 : 1
   }
 }
 

--- a/packages/pi-goal/src/goal/format.ts
+++ b/packages/pi-goal/src/goal/format.ts
@@ -32,6 +32,8 @@ export function goalStatusLabel(status: GoalStatus): string {
 			return "active";
 		case "paused":
 			return "paused";
+		case "blocked":
+			return "blocked";
 		case "budgetLimited":
 			return "limited by budget";
 		case "complete":
@@ -93,11 +95,8 @@ function remainingTokens(goal: Goal | null): number | null {
 
 function completionBudgetReport(goal: Goal | null): string | null {
 	if (goal?.status !== "complete") return null;
-	const parts: string[] = [];
-	if (goal.tokenBudget !== undefined) parts.push(`tokens used: ${goal.tokensUsed} of ${goal.tokenBudget}`);
-	if (goal.timeUsedSeconds > 0) parts.push(`time used: ${goal.timeUsedSeconds} seconds`);
-	if (parts.length === 0) return null;
-	return `Goal achieved. Report final budget usage to the user: ${parts.join("; ")}.`;
+	if (goal.tokenBudget === undefined && goal.timeUsedSeconds <= 0) return null;
+	return "Goal achieved. Report final usage from this tool result's structured goal fields. If `goal.tokenBudget` is present, include token usage from `goal.tokensUsed` and `goal.tokenBudget`. If `goal.timeUsedSeconds` is greater than 0, summarize elapsed time in a concise, human-friendly form appropriate to the response language.";
 }
 
 function formatOneDecimal(value: number): string {

--- a/packages/pi-goal/src/goal/store.ts
+++ b/packages/pi-goal/src/goal/store.ts
@@ -36,8 +36,11 @@ export async function writeGoal(ref: GoalStoreRef, goal: Goal | null): Promise<v
 }
 
 export async function createGoal(ref: GoalStoreRef, objective: string, tokenBudget?: number): Promise<Goal> {
-	if ((await readGoal(ref)) !== null) {
-		throw new GoalAlreadyExistsError("cannot create a new goal because this thread already has a goal");
+	const current = await readGoal(ref);
+	if (current !== null && current.status !== "complete") {
+		throw new GoalAlreadyExistsError(
+			"cannot create a new goal because this thread has an unfinished goal; complete the existing goal first",
+		);
 	}
 
 	const normalizedObjective = validateObjective(objective);
@@ -198,7 +201,9 @@ function statusAfterExplicitStatusUpdate(
 	tokensUsed: number,
 	tokenBudget: number | undefined,
 ): Goal["status"] {
-	if (currentStatus === "budgetLimited" && requestedStatus === "paused") return "budgetLimited";
+	if (currentStatus === "budgetLimited" && (requestedStatus === "paused" || requestedStatus === "blocked")) {
+		return "budgetLimited";
+	}
 	return statusAfterBudgetLimit(requestedStatus, tokensUsed, tokenBudget);
 }
 
@@ -258,7 +263,13 @@ function isGoal(value: unknown): value is Goal {
 }
 
 function isGoalStatus(value: unknown): value is Goal["status"] {
-	return value === "active" || value === "paused" || value === "budgetLimited" || value === "complete";
+	return (
+		value === "active" ||
+		value === "paused" ||
+		value === "blocked" ||
+		value === "budgetLimited" ||
+		value === "complete"
+	);
 }
 
 function isPositiveSafeInteger(value: unknown): value is number {

--- a/packages/pi-goal/src/goal/types.ts
+++ b/packages/pi-goal/src/goal/types.ts
@@ -1,5 +1,5 @@
-export const GOAL_STATUS_VALUES = ["active", "paused", "budgetLimited", "complete"] as const;
-export const COMPLETABLE_GOAL_STATUS_VALUES = ["complete"] as const;
+export const GOAL_STATUS_VALUES = ["active", "paused", "blocked", "budgetLimited", "complete"] as const;
+export const COMPLETABLE_GOAL_STATUS_VALUES = ["complete", "blocked"] as const;
 
 export type GoalStatus = (typeof GOAL_STATUS_VALUES)[number];
 export type CompletableGoalStatus = (typeof COMPLETABLE_GOAL_STATUS_VALUES)[number];

--- a/packages/pi-goal/src/goal/ui.ts
+++ b/packages/pi-goal/src/goal/ui.ts
@@ -54,6 +54,8 @@ export function goalFooterIndicator(goal: Goal): GoalFooterIndicator {
 			return { color, text: usageText === null ? "Pursuing goal" : `Pursuing goal (${usageText})` };
 		case "paused":
 			return { color, text: "Goal paused (/goal resume)" };
+		case "blocked":
+			return { color, text: "Goal blocked (/goal resume)" };
 		case "budgetLimited":
 			return { color, text: usageText === null ? "Goal abandoned" : `Goal unmet (${usageText})` };
 		case "complete":
@@ -170,6 +172,8 @@ function goalStatusUsage(goal: Goal): string | null {
 				: `${formatTokensCompact(goal.tokensUsed)} / ${formatTokensCompact(goal.tokenBudget)}`;
 		case "paused":
 			return null;
+		case "blocked":
+			return null;
 		case "budgetLimited":
 			return goal.tokenBudget === undefined
 				? null
@@ -187,6 +191,8 @@ function goalStatusColor(status: GoalStatus): ThemeColor {
 			return "accent";
 		case "paused":
 			return "muted";
+		case "blocked":
+			return "warning";
 		case "budgetLimited":
 			return "warning";
 		case "complete":

--- a/packages/pi-goal/src/index.ts
+++ b/packages/pi-goal/src/index.ts
@@ -9,6 +9,7 @@ import { parseGoalCommand } from "./goal/command.js";
 import { shouldQueueGoalContinuationAfterAgentEnd, shouldQueueGoalContinuationWhenIdle } from "./goal/continuation.js";
 import { formatGoalForTool, formatGoalToolResponse, goalStatusLabel } from "./goal/format.js";
 import { buildBudgetLimitedPrompt, buildContinuationPrompt } from "./goal/prompt.js";
+import { GoalAlreadyExistsError } from "./goal/errors.js";
 import { accountGoalUsage, clearGoal, createGoal, readGoal, updateGoal } from "./goal/store.js";
 import type { Goal, GoalAccountingMode, GoalStoreRef, TokenUsageSnapshot } from "./goal/types.js";
 import { COMPLETABLE_GOAL_STATUS_VALUES, isRecord } from "./goal/types.js";
@@ -44,28 +45,28 @@ export default function (pi: ExtensionAPI): void {
 		name: "create_goal",
 		label: "Create Goal",
 		description:
-			"Create a goal only when explicitly requested by the user or system/developer instructions; do not infer goals from ordinary tasks.\nSet token_budget only when an explicit token budget is requested. Fails if a goal exists; use update_goal only for status.",
+			"Create a goal only when explicitly requested by the user or system/developer instructions; do not infer goals from ordinary tasks.\nSet token_budget only when an explicit token budget is requested. Fails if an unfinished goal exists; use update_goal only for status.",
 		parameters: Type.Object(
 			{
 				objective: Type.String({
 					description:
-						"Required. The concrete objective to start pursuing. This starts a new active goal only when no goal is currently defined; if a goal already exists, this tool fails.",
+						"Required. The concrete objective to start pursuing. This starts a new active goal when no goal exists or replaces the current goal when it is complete.",
 				}),
 				token_budget: Type.Optional(
-					Type.Integer({ description: "Optional positive token budget for the new active goal." }),
+					Type.Integer({ description: "Positive token budget for the new goal. Omit unless explicitly requested." }),
 				),
 			},
 			{ additionalProperties: false },
 		),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const ref = goalStoreRef(ctx);
-			if ((await readGoal(ref)) !== null) {
-				return toolText(
-					"cannot create a new goal because this thread already has a goal; use update_goal only when the existing goal is complete",
-					true,
-				);
+			let goal: Goal;
+			try {
+				goal = await createGoal(ref, params.objective, params.token_budget);
+			} catch (error) {
+				if (error instanceof GoalAlreadyExistsError) return toolText(error.message, true);
+				throw error;
 			}
-			const goal = await createGoal(ref, params.objective, params.token_budget);
 			beginAgentGoalAccounting(goal);
 			updateGoalUi(ctx, goal);
 			return toolText(formatGoalToolResponse(goal, false));
@@ -76,31 +77,35 @@ export default function (pi: ExtensionAPI): void {
 		name: "update_goal",
 		label: "Update Goal",
 		description:
-			"Update the existing goal.\nUse this tool only to mark the goal achieved.\nSet status to `complete` only when the objective has actually been achieved and no required work remains.\nDo not mark a goal complete merely because its budget is nearly exhausted or because you are stopping work.\nYou cannot use this tool to pause, resume, or budget-limit a goal; those status changes are controlled by the user or system.\nWhen marking a budgeted goal achieved with status `complete`, report the final token usage from the tool result to the user.",
+			"Update the existing goal.\nUse this tool only to mark the goal achieved or genuinely blocked.\nSet status to `complete` only when the objective has actually been achieved and no required work remains.\nSet status to `blocked` only when the same blocking condition has repeated for at least three consecutive goal turns, counting the original/user-triggered turn and any automatic continuations, and the agent cannot make meaningful progress without user input or an external-state change.\nIf the user resumes a goal that was previously marked `blocked`, treat the resumed run as a fresh blocked audit. If the same blocking condition then repeats for at least three consecutive resumed goal turns, set status to `blocked` again.\nOnce the blocked threshold is satisfied, do not keep reporting that you are still blocked while leaving the goal active; set status to `blocked`.\nDo not use `blocked` merely because the work is hard, slow, uncertain, incomplete, or would benefit from clarification.\nDo not mark a goal complete merely because its budget is nearly exhausted or because you are stopping work.\nYou cannot use this tool to pause, resume, budget-limit, or usage-limit a goal; those status changes are controlled by the user or system.\nWhen marking a budgeted goal achieved with status `complete`, report the final token usage from the tool result to the user.",
 		parameters: Type.Object(
 			{
 				status: Type.Union(
 					COMPLETABLE_GOAL_STATUS_VALUES.map((status) => Type.Literal(status)),
 					{
 						description:
-							"Required. Set to complete only when the objective is achieved and no required work remains.",
+							"Required. Set to `complete` only when the objective is achieved and no required work remains. Set to `blocked` only after the same blocking condition has recurred for at least three consecutive goal turns and the agent is at an impasse. After a previously blocked goal is resumed, the resumed run starts a fresh blocked audit.",
 					},
 				),
 			},
 			{ additionalProperties: false },
 		),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			if (params.status !== "complete") {
+			if (params.status !== "complete" && params.status !== "blocked") {
 				return toolText(
-					"update_goal can only mark the existing goal complete; pause, resume, and budget-limited status changes are controlled by the user or system",
+					"update_goal can only mark the existing goal complete or blocked; pause, resume, budget-limited, and usage-limited status changes are controlled by the user or system",
 					true,
 				);
 			}
 			await accountCurrentAgentTurn(ctx, EMPTY_USAGE, "active");
-			const goal = await updateGoal(goalStoreRef(ctx), { status: "complete" });
-			markGoalCompletedThisTurn(goal);
+			const goal = await updateGoal(goalStoreRef(ctx), { status: params.status });
+			if (params.status === "complete") {
+				markGoalCompletedThisTurn(goal);
+			} else {
+				stopAgentGoalAccounting(goal.id);
+			}
 			updateGoalUi(ctx, goal);
-			return toolText(formatGoalToolResponse(goal, true));
+			return toolText(formatGoalToolResponse(goal, params.status === "complete"));
 		},
 	});
 

--- a/packages/pi-goal/test/codex-alignment.test.ts
+++ b/packages/pi-goal/test/codex-alignment.test.ts
@@ -1,0 +1,87 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { accountGoalUsage, createGoal, readGoal, updateGoal } from "../src/goal/store.js";
+import type { TokenUsageSnapshot } from "../src/goal/types.js";
+import type { GoalStoreRef } from "../src/goal/types.js";
+import { GOAL_STATUS_VALUES } from "../src/goal/types.js";
+
+const tempDirs: string[] = [];
+
+async function tempStore(threadId: string): Promise<GoalStoreRef> {
+	const dir = await mkdtemp(join(tmpdir(), "pi-goal-codex-"));
+	tempDirs.push(dir);
+	return { baseDir: dir, threadId };
+}
+
+describe("codex alignment: blocked status", () => {
+	afterEach(async () => {
+		await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+	});
+
+	it("includes blocked in the goal status vocabulary", () => {
+		expect(GOAL_STATUS_VALUES).toContain("blocked");
+	});
+
+	it("marks an active goal blocked and clears its lastStartedAt", async () => {
+		const ref = await tempStore("thread-block");
+		await createGoal(ref, "Pursue the objective");
+
+		const blocked = await updateGoal(ref, { status: "blocked" });
+
+		expect(blocked.status).toBe("blocked");
+		expect(blocked.lastStartedAt).toBeUndefined();
+		expect((await readGoal(ref))?.status).toBe("blocked");
+	});
+
+	it("preserves budgetLimited when a blocked update is requested", async () => {
+		const ref = await tempStore("thread-block-budget");
+		await createGoal(ref, "Budget goal", 10);
+		const overBudget: TokenUsageSnapshot = { input: 20, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 20 };
+		const limited = await accountGoalUsage(ref, overBudget, 0, "active");
+		expect(limited?.status).toBe("budgetLimited");
+
+		const afterBlock = await updateGoal(ref, { status: "blocked" });
+
+		expect(afterBlock.status).toBe("budgetLimited");
+	});
+});
+
+describe("codex alignment: create replaces only a complete goal", () => {
+	afterEach(async () => {
+		await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+	});
+
+	it("replaces a completed goal with a fresh active goal", async () => {
+		const ref = await tempStore("thread-replace-complete");
+		const first = await createGoal(ref, "First objective");
+		await updateGoal(ref, { status: "complete" });
+
+		const replacement = await createGoal(ref, "Second objective");
+
+		expect(replacement.status).toBe("active");
+		expect(replacement.objective).toBe("Second objective");
+		expect(replacement.id).not.toBe(first.id);
+		expect(replacement.tokensUsed).toBe(0);
+	});
+
+	it("rejects creating a goal while an unfinished goal exists with the codex message", async () => {
+		const ref = await tempStore("thread-unfinished");
+		await createGoal(ref, "Active objective");
+
+		await expect(createGoal(ref, "Another objective")).rejects.toThrow(
+			"cannot create a new goal because this thread has an unfinished goal; complete the existing goal first",
+		);
+	});
+
+	it("rejects creating a goal while a blocked goal exists", async () => {
+		const ref = await tempStore("thread-blocked-exists");
+		await createGoal(ref, "Blocked objective");
+		await updateGoal(ref, { status: "blocked" });
+
+		await expect(createGoal(ref, "New objective")).rejects.toThrow("has an unfinished goal");
+	});
+});

--- a/packages/pi-goal/test/extension.test.ts
+++ b/packages/pi-goal/test/extension.test.ts
@@ -108,7 +108,7 @@ describe("pi-goal extension tool contract", () => {
 		expect(toolContract(harness.tool("create_goal"))).toEqual({
 			name: "create_goal",
 			description:
-				"Create a goal only when explicitly requested by the user or system/developer instructions; do not infer goals from ordinary tasks.\nSet token_budget only when an explicit token budget is requested. Fails if a goal exists; use update_goal only for status.",
+				"Create a goal only when explicitly requested by the user or system/developer instructions; do not infer goals from ordinary tasks.\nSet token_budget only when an explicit token budget is requested. Fails if an unfinished goal exists; use update_goal only for status.",
 			parameters: {
 				type: "object",
 				required: ["objective"],
@@ -116,11 +116,11 @@ describe("pi-goal extension tool contract", () => {
 					objective: {
 						type: "string",
 						description:
-							"Required. The concrete objective to start pursuing. This starts a new active goal only when no goal is currently defined; if a goal already exists, this tool fails.",
+							"Required. The concrete objective to start pursuing. This starts a new active goal when no goal exists or replaces the current goal when it is complete.",
 					},
 					token_budget: {
 						type: "integer",
-						description: "Optional positive token budget for the new active goal.",
+						description: "Positive token budget for the new goal. Omit unless explicitly requested.",
 					},
 				},
 				additionalProperties: false,
@@ -129,15 +129,18 @@ describe("pi-goal extension tool contract", () => {
 		expect(toolContract(harness.tool("update_goal"))).toEqual({
 			name: "update_goal",
 			description:
-				"Update the existing goal.\nUse this tool only to mark the goal achieved.\nSet status to `complete` only when the objective has actually been achieved and no required work remains.\nDo not mark a goal complete merely because its budget is nearly exhausted or because you are stopping work.\nYou cannot use this tool to pause, resume, or budget-limit a goal; those status changes are controlled by the user or system.\nWhen marking a budgeted goal achieved with status `complete`, report the final token usage from the tool result to the user.",
+				"Update the existing goal.\nUse this tool only to mark the goal achieved or genuinely blocked.\nSet status to `complete` only when the objective has actually been achieved and no required work remains.\nSet status to `blocked` only when the same blocking condition has repeated for at least three consecutive goal turns, counting the original/user-triggered turn and any automatic continuations, and the agent cannot make meaningful progress without user input or an external-state change.\nIf the user resumes a goal that was previously marked `blocked`, treat the resumed run as a fresh blocked audit. If the same blocking condition then repeats for at least three consecutive resumed goal turns, set status to `blocked` again.\nOnce the blocked threshold is satisfied, do not keep reporting that you are still blocked while leaving the goal active; set status to `blocked`.\nDo not use `blocked` merely because the work is hard, slow, uncertain, incomplete, or would benefit from clarification.\nDo not mark a goal complete merely because its budget is nearly exhausted or because you are stopping work.\nYou cannot use this tool to pause, resume, budget-limit, or usage-limit a goal; those status changes are controlled by the user or system.\nWhen marking a budgeted goal achieved with status `complete`, report the final token usage from the tool result to the user.",
 			parameters: {
 				type: "object",
 				required: ["status"],
 				properties: {
 					status: {
-						anyOf: [{ type: "string", const: "complete" }],
+						anyOf: [
+							{ type: "string", const: "complete" },
+							{ type: "string", const: "blocked" },
+						],
 						description:
-							"Required. Set to complete only when the objective is achieved and no required work remains.",
+							"Required. Set to `complete` only when the objective is achieved and no required work remains. Set to `blocked` only after the same blocking condition has recurred for at least three consecutive goal turns and the agent is at an impasse. After a previously blocked goal is resumed, the resumed run starts a fresh blocked audit.",
 					},
 				},
 				additionalProperties: false,

--- a/packages/pi-goal/test/format.test.ts
+++ b/packages/pi-goal/test/format.test.ts
@@ -42,7 +42,7 @@ describe("goal display formatting", () => {
 			},
 			remainingTokens: 6_750,
 			completionBudgetReport:
-				"Goal achieved. Report final budget usage to the user: tokens used: 3250 of 10000; time used: 75 seconds.",
+				"Goal achieved. Report final usage from this tool result's structured goal fields. If `goal.tokenBudget` is present, include token usage from `goal.tokensUsed` and `goal.tokenBudget`. If `goal.timeUsedSeconds` is greater than 0, summarize elapsed time in a concise, human-friendly form appropriate to the response language.",
 		});
 	});
 });

--- a/packages/pi-goal/test/store.test.ts
+++ b/packages/pi-goal/test/store.test.ts
@@ -34,7 +34,7 @@ describe("goal store", () => {
 		const original = await createGoal(ref, "Original", 10_000);
 
 		await expect(createGoal(ref, "Replacement", 20_000)).rejects.toThrow(
-			"cannot create a new goal because this thread already has a goal",
+			"cannot create a new goal because this thread has an unfinished goal; complete the existing goal first",
 		);
 
 		expect(await readGoal(ref)).toMatchObject({


### PR DESCRIPTION
## Summary
Aligns the vendored `packages/pi-goal` goal tool contract with codex `codex-rs/ext/goal`, per the request to make pi-goal match codex wherever they differ (senpi's builtin goal is a port reference, but its budget removal is senpi's own divergence and is NOT adopted — codex keeps budget, so pi-goal keeps budget and gains the codex deltas). No new package; this changes only `packages/pi-goal`.

## Changes
- **`blocked` status**: added to the vocabulary and made model-settable via `update_goal` (codex `spec.rs` enum `complete|blocked`). It is a non-terminal status (resumable via `/goal resume`); store transitions, `isGoalStatus`, the format label, and the three UI switches handle it.
- **create_goal replace policy**: `create_goal` now replaces only a `complete` goal (fresh id, usage reset) and otherwise fails with the codex message `cannot create a new goal because this thread has an unfinished goal; complete the existing goal first` (codex `insert_thread_goal ... WHERE status='complete'`).
- **Verbatim codex text**: `create_goal`/`update_goal` descriptions, parameter descriptions, the `update_goal` error text (blocked 3-consecutive-turn audit language), and the completion budget report text + condition (`tokenBudget` present OR `timeUsedSeconds > 0`) now match codex `spec.rs`/`tool.rs`.
- **budgetLimited preservation**: preserved when a `paused` or `blocked` update is requested (codex SQL `CASE`).
- **Docs**: `packages/pi-goal/AGENTS.md` gains a Codex alignment section.

Deliberate deviation (documented): pi omits `usage_limited`. In codex that status is set by the system from an `UsageLimitExceeded` turn error, not by the model, and the Pi harness exposes no usage-limit signal to an extension, so it would be dead vocabulary. `update_goal`'s model-settable set is exactly `{complete, blocked}`, matching codex `spec.rs`.

## QA & Evidence
Evidence dir (worktree-local, gitignored): `.omo/evidence/20260706-pi-goal-codex-alignment/`.
- **RED -> GREEN:** `packages/pi-goal/test/codex-alignment.test.ts` fails 0/6 before the change (blocked rejected as invalid status; create neither replaces a complete goal nor rejects with the codex message) — `red-codex-alignment.txt`; passes 6/6 after — `green-codex-alignment.txt`. The full pi-goal suite is 51/51 (the three previously behavior-pinning tests in store/format/extension were updated to the new codex-aligned contract).
- **Manual QA on the REAL harness (the gate):** `node packages/pi-goal/scripts/qa/drive.mjs` runs two scenarios against the real `@mariozechner/pi-coding-agent` v0.73.0 in `--mode rpc` inside isolated `PI_CODING_AGENT_DIR` sandboxes: `complete` (regression: create -> hidden continuation -> `update_goal complete`) and `blocked` (new: create -> hidden continuation -> `update_goal blocked`, persisted goal transitions to `blocked`). Both PASS, real `~/.pi/agent` untouched (`live-pi-harness-qa.json`).
- **Gates:** `bun run typecheck` green across all packages; `bun test packages/pi-goal` 51/51.

## Risks & Residuals
- `blocked` is model-settable but the Pi extension does not auto-block on turn errors the way codex's runtime does (codex has a turn-error -> block system path with no Pi equivalent). Continuation-loop gating on non-clean turn ends is deferred to a follow-up PR (prompt/steering parity) and called out here so the scope is explicit.
- pi-goal is imported by nothing (audit reverse-edge test green), so the main dist build is unaffected.

## Related Issues
Follows the pi-goal/pi-webfetch vendoring PRs; part of the pi-extensions -> monorepo migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `packages/pi-goal` with Codex `codex-rs/ext/goal` to standardize the goal tool. Adds model‑settable `blocked`, enforces Codex’s replace policy in `create_goal`, updates tool copy and budget report, and extends live QA.

- **New Features**
  - `update_goal` now accepts `complete` or `blocked`; `blocked` is non‑terminal and stops accounting until `/goal resume`.
  - `create_goal` replaces only a `complete` goal; otherwise returns Codex error: “cannot create a new goal because this thread has an unfinished goal; complete the existing goal first”.
  - Matched Codex tool/parameter descriptions and `update_goal` error copy; completion budget report now uses Codex text and only appears when `tokenBudget` is set or `timeUsedSeconds` > 0.
  - Preserved `budgetLimited` when `paused` or `blocked` is requested; UI shows `blocked` with appropriate label/color.
  - Docs/tests/QA: added Codex alignment notes to `AGENTS.md`, new `codex-alignment.test.ts`, updated existing tests, and upgraded the live QA driver to named scenarios (`complete`, `blocked`) that run by default with `--scenario` to select.
  - Deliberate deviation: omitted `usage_limited`; `update_goal` remains limited to `{complete, blocked}`.

<sup>Written for commit d8dd02e7b1000e1a847eedb7830c49a49166a886. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

