### PR TITLE
fix(tui): sanitize sidebar poll error logs (fixes #5874)

### DIFF
--- a/packages/omo-opencode/src/tui.test.ts
+++ b/packages/omo-opencode/src/tui.test.ts
@@ -5,9 +5,9 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import type { TuiPluginApi, TuiPluginMeta, TuiSlotPlugin } from "@opencode-ai/plugin/tui"
+import type { TuiSlotPlugin } from "@opencode-ai/plugin/tui"
 
-import tuiModule, { handleTuiPollError } from "./tui"
+import { formatTuiPollErrorForLog, handleTuiPollError, startTuiSidebar } from "./tui"
 
 type SolidNode = {
   readonly tag: string
@@ -89,7 +89,7 @@ describe("TUI sidebar polling", () => {
     } satisfies SidebarApiForTest
 
     // when
-    await tuiModule.tui(api as unknown as TuiPluginApi, undefined, {} as TuiPluginMeta)
+    await startTuiSidebar(api)
 
     // then
     expect(calls).toEqual(["register", "render"])
@@ -115,6 +115,26 @@ describe("TUI sidebar polling", () => {
 
     // then
     expect(reportedErrors).toEqual([pollError])
+  })
+
+  it("#given a poll Error with a large cause #when the log payload is formatted #then only stable text fields are retained", () => {
+    // given
+    const pollError = new Error("Failed to fetch models.dev", {
+      cause: {
+        statusText: "socket closed",
+        rawOutput: "x".repeat(1024),
+      },
+    })
+
+    // when
+    const payload = formatTuiPollErrorForLog(pollError)
+
+    // then
+    expect(payload).toEqual({
+      name: "Error",
+      message: "Failed to fetch models.dev",
+    })
+    expect("cause" in payload).toBe(false)
   })
 
   it("#given a non-Error throw during polling #when the poll error handler runs #then the value is rethrown", () => {

--- a/packages/omo-opencode/src/tui.ts
+++ b/packages/omo-opencode/src/tui.ts
@@ -29,6 +29,26 @@ type RegisterSidebarContentSlotInput<Node> = {
   readonly renderSidebar: () => Node
 }
 
+type TuiSidebarApi = {
+  readonly state: {
+    readonly path: {
+      readonly directory: string
+    }
+  }
+  readonly theme: {
+    readonly current: Record<string, unknown>
+  }
+  readonly slots: {
+    readonly register: (registration: SidebarSlotRegistration<unknown>) => string
+  }
+  readonly renderer: {
+    readonly requestRender: () => void
+  }
+  readonly lifecycle: {
+    readonly onDispose: (dispose: () => void) => () => void
+  }
+}
+
 function registerSidebarContentSlot<Node>({
   registerSlot,
   requestRender,
@@ -67,6 +87,11 @@ function materializeNode<Node>(node: ViewNode, solid: SolidRuntime<Node>): Node 
 }
 
 type RosterResolver = (directory: string) => RosterRow[]
+type TuiPollErrorLogPayload = {
+  readonly name: string
+  readonly message: string
+}
+
 type PluginValidation = {
   readonly valid: boolean
   readonly messages: readonly string[]
@@ -103,9 +128,17 @@ async function readView(directory: string): Promise<SidebarView> {
   })
 }
 
+export function formatTuiPollErrorForLog(error: Error): TuiPollErrorLogPayload {
+  return {
+    name: error.name,
+    message: error.message,
+  }
+}
+
 export function handleTuiPollError(
   error: unknown,
-  reportPollError: (error: Error) => void = (pollError) => log("[tui-sidebar] polling failed", { error: pollError }),
+  reportPollError: (error: Error) => void = (pollError) =>
+    log("[tui-sidebar] polling failed", formatTuiPollErrorForLog(pollError)),
 ): void {
   if (error instanceof Error) {
     reportPollError(error)
@@ -114,67 +147,76 @@ export function handleTuiPollError(
   throw error
 }
 
-const module: TuiPluginModule = {
-  id: "oh-my-openagent:tui",
-  tui: async (api) => {
-    const solid = await import("@opentui/solid").catch(() => null)
-    if (!solid) {
+export async function startTuiSidebar(api: TuiSidebarApi): Promise<void> {
+  const solid = await import("@opentui/solid").catch((error) => {
+    if (error instanceof Error) return null
+    throw error
+  })
+  if (!solid) {
+    return
+  }
+
+  const directory = api.state.path.directory
+  if ((await loadPluginValidation(directory)).config.tui?.sidebar?.enabled === false) {
+    return
+  }
+
+  let currentView = await readView(directory)
+  let currentKey = viewKey(currentView)
+  let disposed = false
+  let inFlight = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  registerSidebarContentSlot({
+    registerSlot: (registration) => {
+      api.slots.register(registration)
+    },
+    requestRender: () => {
+      api.renderer.requestRender()
+    },
+    renderSidebar: () => materialize(buildViewNodes(currentView, api.theme.current), solid),
+  })
+
+  const schedule = (): void => {
+    timer = setTimeout(tick, POLL_INTERVAL_MS)
+  }
+
+  const tick = async (): Promise<void> => {
+    if (disposed || inFlight) {
+      if (!disposed) schedule()
       return
     }
-
-    const directory = api.state.path.directory
-    if ((await loadPluginValidation(directory)).config.tui?.sidebar?.enabled === false) {
-      return
-    }
-
-    let currentView = await readView(directory)
-    let currentKey = viewKey(currentView)
-    let disposed = false
-    let inFlight = false
-    let timer: ReturnType<typeof setTimeout> | null = null
-
-    registerSidebarContentSlot({
-      registerSlot: (registration) => {
-        api.slots.register(registration)
-      },
-      requestRender: () => {
+    inFlight = true
+    try {
+      const nextView = await readView(directory)
+      const nextKey = viewKey(nextView)
+      if (nextKey !== currentKey) {
+        currentView = nextView
+        currentKey = nextKey
         api.renderer.requestRender()
-      },
-      renderSidebar: () => materialize(buildViewNodes(currentView, api.theme.current), solid),
-    })
-
-    const schedule = (): void => {
-      timer = setTimeout(tick, POLL_INTERVAL_MS)
-    }
-
-    const tick = async (): Promise<void> => {
-      if (disposed || inFlight) {
-        if (!disposed) schedule()
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        handleTuiPollError(error)
         return
       }
-      inFlight = true
-      try {
-        const nextView = await readView(directory)
-        const nextKey = viewKey(nextView)
-        if (nextKey !== currentKey) {
-          currentView = nextView
-          currentKey = nextKey
-          api.renderer.requestRender()
-        }
-      } catch (error) {
-        handleTuiPollError(error)
-      } finally {
-        inFlight = false
-        if (!disposed) schedule()
-      }
+      throw error
+    } finally {
+      inFlight = false
+      if (!disposed) schedule()
     }
+  }
 
-    schedule()
-    api.lifecycle.onDispose(() => {
-      disposed = true
-      if (timer) clearTimeout(timer)
-    })
-  },
+  schedule()
+  api.lifecycle.onDispose(() => {
+    disposed = true
+    if (timer) clearTimeout(timer)
+  })
+}
+
+const module: TuiPluginModule = {
+  id: "oh-my-openagent:tui",
+  tui: async (api) => startTuiSidebar(api),
 }
 
 export default module


### PR DESCRIPTION
## Summary
- Sanitize the default TUI sidebar poll error log payload to stable `{ name, message }` fields instead of passing the raw `Error` object through the logger.
- Export a narrow `startTuiSidebar` helper so the focused test can drive sidebar startup without casting the OpenCode TUI API.
- Add a regression test that an `Error` with a large `cause` does not include `cause` in the log payload.

Fixes #5874.

## Verification
- `bun test packages/omo-opencode/src/tui.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-opencode/src/tui.ts packages/omo-opencode/src/tui.test.ts`
- `bun run typecheck:packages`
- `git diff --check origin/dev..HEAD`
- Evidence recorded locally under `.omo/evidence/20260706-tui-poll-error-5874/`.

## QA note
- Ran the required `opencode-qa` TUI path as far as this Windows host allows. The common self-check and TUI smoke are blocked here by missing `tmux` and `jq`; Docker fallback is also unavailable (`docker: command not found`).
- Full OpenCode tmux TUI smoke remains the residual pre-merge QA gap for a host with `tmux` and `jq`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize TUI sidebar poll error logs to emit only {name, message} instead of the raw Error, preventing large cause payloads from leaking. Also expose a small `startTuiSidebar` helper and add a regression test; fixes #5874.

- **Bug Fixes**
  - `handleTuiPollError` now logs via `formatTuiPollErrorForLog`, sending `{ name, message }` only.
  - Keeps rethrow for non-Error values.
  - Adds a test that ensures `cause` is not included in log payloads.

- **Refactors**
  - Extracts sidebar startup to `startTuiSidebar` for focused tests without casting `@opencode-ai/plugin/tui` types.
  - Handles missing `@opentui/solid` by returning early.

<sup>Written for commit 9907d877e16d55a9de5cbc8177efbc395c250739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

