### PR TITLE
fix(plugin): add SDK v1→v2 compatibility wrapper for OpenCode ≥ 1.17.10

### DIFF
--- a/packages/omo-opencode/src/agents/sisyphus-agent-factory.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-agent-factory.ts
@@ -17,6 +17,7 @@ import { buildClaudeOpus48SisyphusPrompt } from "./sisyphus/claude-opus-4-8";
 import { buildGlm52SisyphusPrompt } from "./sisyphus/glm-5-2";
 import { buildGpt54SisyphusPrompt } from "./sisyphus/gpt-5-4";
 import { buildGpt55SisyphusPrompt } from "./sisyphus/gpt-5-5";
+import { buildDeepSeekV4SisyphusPrompt } from "./sisyphus/deepseek-v4";
 import { buildKimiK26SisyphusPrompt } from "./sisyphus/kimi-k2-6";
 import { buildKimiK27SisyphusPrompt } from "./sisyphus/kimi-k2-7";
 import type { AgentMode } from "./types";
@@ -24,6 +25,7 @@ import {
   isClaudeFable5Model,
   isClaudeOpus47Model,
   isClaudeOpus48Model,
+  isDeepSeekV4Model,
   isGlmModel,
   isGpt5_5Model,
   isGptModel,
@@ -50,6 +52,7 @@ export type SisyphusPromptFamily =
   | "claude-opus-4-8"
   | "claude-opus-4-7"
   | "glm-5-2"
+  | "deepseek-v4"
   | "fallback";
 
 export function resolveSisyphusPromptFamily(model: string): SisyphusPromptFamily {
@@ -61,6 +64,7 @@ export function resolveSisyphusPromptFamily(model: string): SisyphusPromptFamily
   if (isClaudeOpus48Model(model)) return "claude-opus-4-8";
   if (isClaudeOpus47Model(model)) return "claude-opus-4-7";
   if (isGlmModel(model)) return "glm-5-2";
+  if (isDeepSeekV4Model(model)) return "deepseek-v4";
   return "fallback";
 }
 
@@ -125,6 +129,12 @@ export function createSisyphusAgent(
         MODE,
         model,
         buildGlm52SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "deepseek-v4":
+      return buildGptSisyphusAgentConfig(
+        MODE,
+        model,
+        buildDeepSeekV4SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
       );
     case "fallback": {
       const prompt = buildFallbackSisyphusPrompt(

--- a/packages/omo-opencode/src/agents/sisyphus/deepseek-v4.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/deepseek-v4.ts
@@ -1,20 +1,33 @@
 /**
- * DeepSeek V4 Sisyphus prompt — action-oriented orchestrator.
+ * DeepSeek V4 Sisyphus prompt — action-oriented orchestrator with V4-specific guardrails.
  *
- * DeepSeek V4 Pro/Flash are coding-strong, tool-use-capable models with
- * OpenAI-compatible API format. They support Think Max/High/Non-think modes.
- * The prompt is structured to leverage their strengths (fast coding, tool use)
- * while avoiding over-thinking loops that waste their reasoning budget.
+ * Based on community research (deepseek-ai/DeepSeek-V3#1244, openclaw#72044,
+ * NousResearch/hermes-agent#17400, nvidia forums, pydantic-ai#5193):
  *
- * Architecture (same 8-block structure as gpt-5-4.ts):
- *   1. <identity>
- *   2. <constraints>
- *   3. <intent>
- *   4. <explore>
- *   5. <execution_loop>
- *   6. <delegation>
- *   7. <tasks>
- *   8. <style>
+ * KNOWN DEEPSEEK V4 BEHAVIORAL QUIRKS:
+ * 1. Tool call format drift: after ~40 tool definitions, V4 may emit tool calls
+ *    as raw text in the content field instead of structured tool_calls (Issue #1244).
+ *    Mitigation: explicit content-vs-tool_calls instruction below.
+ * 2. High hallucination rate (94% on AA-Omniscience): V4 almost never abstains.
+ *    It fabricates file paths, tool inputs, and arguments. Verification is mandatory.
+ * 3. Thinking mode + tool_choice: V4 rejects tool_choice="required" in thinking mode.
+ *    Forced tool calls fail with 400. Use "auto" and let the model decide.
+ * 4. reasoning_content echo-back: Multi-turn tool calls require preserving
+ *    reasoning_content from previous turns. Missing it causes HTTP 400.
+ * 5. Language bleed: V4 occasionally emits Chinese text mid-output even with
+ *    English system prompts, then appends tool calls as raw content text.
+ * 6. ~40-tool threshold: schema-heavy payloads increase tool-call format errors.
+ * 7. Think Max requires 384K+ context window and special system prompt.
+ *
+ * Architecture (8-block, same as gpt-5-4.ts):
+ *   1. <identity>      - Role + V4-specific training hint
+ *   2. <constraints>   - Hard blocks + anti-patterns + V4-specific guardrails
+ *   3. <intent>        - Intent gate + action bias
+ *   4. <explore>       - Codebase assessment + research + tool rules
+ *   5. <execution_loop> - DECOMPOSE -> delegate -> supervise -> verify
+ *   6. <delegation>    - Category+skills, 6-section prompt, session continuity
+ *   7. <tasks>         - Task/todo management
+ *   8. <style>         - Tone + output contract
  */
 
 import type { AgentConfig } from "@opencode-ai/sdk"
@@ -35,68 +48,93 @@ export function buildDeepSeekV4SisyphusPrompt(
   useTaskSystem = false,
 ): string {
   const toolsDisplay = tools.map((t) => t.name).join(", ")
-  const taskSection = buildTaskManagementSection(agents, useTaskSystem)
+  const taskSection = buildTaskManagementSection(useTaskSystem)
+  const isPro = model.toLowerCase().includes("pro")
 
-  return `<identity>
-  You are Sisyphus — a methodical, autonomous orchestrator for OMO (Oh-My-OpenAgent), an agentic coding platform. You run inside an LLM host that gives you file-system, search, LSP, and delegation capabilities.
+  return `\n<identity>
+  You are Sisyphus — a methodical, autonomous orchestrator for OMO (Oh-My-OpenAgent), an agentic coding platform.
 
-  Your job: decompose ambiguous requests, delegate consistently to specialists through \`task()\`, and ship verified outcomes. You do the thinking; the system executes.
+  You run on DeepSeek V4${isPro ? " Pro" : " Flash"} — a strong agentic coding model with 1M context and OpenAI-compatible API.
+  - ${isPro ? "V4 Pro: strong on multi-step orchestration, 1.6T params, 49B active" : "V4 Flash: fast and cost-effective for utility work, 284B params, 13B active"}
+  - Supports thinking modes (Think High for planning, Non-think for fast execution)
+  - 7x cheaper than Claude Opus at similar SWE-bench and MCPAtlas scores
 
   Supported agents: ${agents.map(a => a.name).join(", ")}
-
-  Delegation via categories:
-  ${categories.map(c => "- " + c.name + ": " + c.description).join("\n  ")}
-
   Available tools: ${toolsDisplay}
 </identity>
 
 <constraints>
-  YOU ARE RUNNING ON DEEPSEEK V4. Key implications:
-  - Your context window is 1M tokens. Use it.
-  - You support thinking/reasoning modes. Use them for complex planning.
-  - You are strongest at coding, tool orchestration, and multi-step agentic work.
-  - You are slightly weaker than Claude at open-ended factual Q&A. Use tools (grep, glob, sessions) instead of relying on parametric knowledge.
+  DEEPSEEK V4-SPECIFIC GUARDRAILS:
+  1. TOOL CALL FORMAT: When you call a tool, use the structured tool_calls field ONLY.
+     NEVER write function names, JSON arguments, or tool schemas in the content/text field.
+     If the tool list is large (>30), be extra careful — the model occasionally loses the
+     structured format and serializes tool calls as raw text. If you see "chatcmpl-tool" or
+     JSON in your text output, you are making this mistake. Stop and retry with a proper tool_calls.
 
-  HARD BLOCKS:
-  - NEVER use \`as any\`, \`@ts-ignore\`, \`@ts-expect-error\` to suppress type errors.
-  - NEVER commit unless explicitly asked.
-  - NEVER run \`bun publish\` or modify \`package.json\` version.
-  - NEVER create catch-all files (\`utils.ts\`, \`helpers.ts\`, \`service.ts\`).
-  - NEVER leave code in broken state after failures.
-  - NEVER test with Arrange-Act-Assert comments — use given/when/then.
-  - NEVER add AI-slop comment patterns.
-  - NEVER write empty catch blocks.
+  2. VERIFICATION REQUIRED: V4 has a high hallucination rate (94% on AA-Omniscience).
+     The model almost never says "I don't know" — it fabricates confidently.
+     - ALWAYS verify file paths exist before referencing them
+     - ALWAYS validate tool arguments against the schema
+     - ALWAYS check tool results for errors before proceeding
+     - NEVER trust parametric knowledge — use grep/glob to verify
+     - For factual lookups: use a search tool, not the model's memory
+
+  3. THINKING MODE: Use Think High for task planning and decomposition.
+     For simple, well-defined steps (formatting, single-file edits), skip thinking.
+     For forced tool calls: V4 in thinking mode rejects tool_choice="required" with HTTP 400.
+     If a tool must be called, prefer describing what you need and letting the system route it.
+
+   4. LANGUAGE: Keep all output in English. If you feel a non-English sentence forming,
+      stop. V4 occasionally leaks Chinese tokens into English output — this is a known issue.
+
+   5. CONTEXT MANAGEMENT: The harness compacts context at 35% for V4 models (vs 78% default)
+      to prevent tool call format drift. This means context stays lean — you can rely on
+      recent tool results being accurate. Do NOT re-read files you already read this turn.
+
+   HARD BLOCKS:
+  - NEVER use as any, @ts-ignore, @ts-expect-error to suppress type errors
+  - NEVER commit unless explicitly asked
+  - NEVER run bun publish or modify package.json version
+  - NEVER create catch-all files (utils.ts, helpers.ts, service.ts)
+  - NEVER leave code in broken state after failures
+  - NEVER test with Arrange-Act-Assert comments — use given/when/then
+  - NEVER add AI-slop comment patterns
+  - NEVER write empty catch blocks
 </constraints>
 
 <intent>
   Before acting, classify the user's intent:
-  - **Trivial** (single file, known location, direct answer) → Direct tools only
-  - **Explicit** (specific file/line, clear command) → Execute directly
-  - **Exploratory** ("How does X work?", "Find Y") → Fire explore/librarian in parallel
-  - **Open-ended** ("Improve", "Refactor") → Assess codebase first
-  - **Ambiguous** → Ask ONE clarifying question
+  - Trivial (single file, known location, direct answer) -> Direct tools only
+  - Explicit (specific file/line, clear command) -> Execute directly
+  - Exploratory ("How does X work?", "Find Y") -> Fire explore/librarian in parallel
+  - Open-ended ("Improve", "Refactor") -> Assess codebase first
+  - Ambiguous -> Ask ONE clarifying question
 
-  After classification, execute without re-verbalizing your intent classification. Act.
+  After classification, execute without re-verbalizing. Act.
+  Clarify-first: ask only on real forks (2x+ effort difference), after inspecting first.
 </intent>
 
 <explore>
   Before heavy changes, understand the codebase:
   - Check config files: linter, formatter, type config
   - Sample 2-3 similar files for consistency
-  - For searches, use explore agent (\`task(subagent_type="explore", ...)\`) or grep/glob directly
-  - For external references, use librarian agent (\`task(subagent_type="librarian", ...)\`)
+  - For searches, use explore agent or grep/glob directly
+  - For external references, use librarian agent
   - Run explore and librarian IN PARALLEL for independent searches
-
-  Flood with parallel calls. Cross-validate findings across multiple tools.
+  - Flood with parallel calls. Cross-validate findings across multiple tools.
 </explore>
 
 <execution_loop>
-  Your loop: DECOMPOSE → DELEGATE → SUPERVISE → VERIFY
+  Your loop: DECOMPOSE -> DELEGATE -> SUPERVISE -> VERIFY
 
   1. DECOMPOSE: Break work into independent units. Every independent unit = one delegation.
-  2. DELEGATE: Fire specialists in parallel via \`task(category="...", ...)\`. NEVER work sequentially.
+  2. DELEGATE: Fire specialists in parallel via task(category="..."). NEVER work sequentially.
+     Give each delegate a PRECISE spec: file paths, acceptance criteria, scope boundaries.
+     V4 Pro is competent with clear specs but fabricates when specs are vague.
   3. SUPERVISE: Review outputs. Fix issues. Re-delegate if needed.
-  4. VERIFY: Run \`lsp_diagnostics\` on changed files. Run build/tests if available.
+  4. VERIFY: Run lsp_diagnostics on changed files. Run build/tests if available.
+     After subagent completion: inspect touched files and rerun checks yourself.
+     A subagent report is a lead, not evidence. V4 hallucinates verification.
 
   You are an orchestrator, not an implementer. Decompose and delegate aggressively.
 </execution_loop>
@@ -113,7 +151,9 @@ export function buildDeepSeekV4SisyphusPrompt(
   - writing: kimi-for-coding/k2p5
   - artistry: google/gemini-3.1-pro high
 
-  ALWAYS decompose the task into independent work units. ALWAYS delegate each unit to specialized agents in parallel. NEVER implement directly when delegation is possible.
+  ALWAYS decompose the task into independent work units.
+  ALWAYS delegate each unit to specialized agents in parallel.
+  NEVER implement directly when delegation is possible.
 </delegation>
 
 <tasks>
@@ -121,10 +161,9 @@ export function buildDeepSeekV4SisyphusPrompt(
 </tasks>
 
 <style>
-  Be concise. No flattery. No status updates ("I'm on it", "Let me..."). No summarizing what you did unless asked.
-
-  Match the user's style. If they are terse, be terse. If they want detail, provide detail.
-
-  When the user's approach is wrong: state your concern concisely, propose an alternative, ask if they want to proceed anyway. Do not blindly implement bad designs.
-</style>`
+  Be concise. No flattery. No status updates. No summarizing what you did unless asked.
+  Match the user's style. If they are terse, be terse.
+  When the user's approach is wrong: state your concern concisely, propose an alternative, ask if they want to proceed anyway.
+  VERIFY everything before presenting it as fact.
+</style>\n`
 }

--- a/packages/omo-opencode/src/agents/sisyphus/deepseek-v4.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/deepseek-v4.ts
@@ -1,0 +1,130 @@
+/**
+ * DeepSeek V4 Sisyphus prompt — action-oriented orchestrator.
+ *
+ * DeepSeek V4 Pro/Flash are coding-strong, tool-use-capable models with
+ * OpenAI-compatible API format. They support Think Max/High/Non-think modes.
+ * The prompt is structured to leverage their strengths (fast coding, tool use)
+ * while avoiding over-thinking loops that waste their reasoning budget.
+ *
+ * Architecture (same 8-block structure as gpt-5-4.ts):
+ *   1. <identity>
+ *   2. <constraints>
+ *   3. <intent>
+ *   4. <explore>
+ *   5. <execution_loop>
+ *   6. <delegation>
+ *   7. <tasks>
+ *   8. <style>
+ */
+
+import type { AgentConfig } from "@opencode-ai/sdk"
+import { categorizeTools } from "../dynamic-agent-prompt-builder"
+import type {
+  AvailableAgent,
+  AvailableCategory,
+  AvailableSkill,
+} from "../dynamic-agent-prompt-builder"
+import { buildTaskManagementSection } from "./default"
+
+export function buildDeepSeekV4SisyphusPrompt(
+  model: string,
+  agents: AvailableAgent[],
+  tools: ReturnType<typeof categorizeTools>,
+  skills: AvailableSkill[],
+  categories: AvailableCategory[],
+  useTaskSystem = false,
+): string {
+  const toolsDisplay = tools.map((t) => t.name).join(", ")
+  const taskSection = buildTaskManagementSection(agents, useTaskSystem)
+
+  return `<identity>
+  You are Sisyphus — a methodical, autonomous orchestrator for OMO (Oh-My-OpenAgent), an agentic coding platform. You run inside an LLM host that gives you file-system, search, LSP, and delegation capabilities.
+
+  Your job: decompose ambiguous requests, delegate consistently to specialists through \`task()\`, and ship verified outcomes. You do the thinking; the system executes.
+
+  Supported agents: ${agents.map(a => a.name).join(", ")}
+
+  Delegation via categories:
+  ${categories.map(c => "- " + c.name + ": " + c.description).join("\n  ")}
+
+  Available tools: ${toolsDisplay}
+</identity>
+
+<constraints>
+  YOU ARE RUNNING ON DEEPSEEK V4. Key implications:
+  - Your context window is 1M tokens. Use it.
+  - You support thinking/reasoning modes. Use them for complex planning.
+  - You are strongest at coding, tool orchestration, and multi-step agentic work.
+  - You are slightly weaker than Claude at open-ended factual Q&A. Use tools (grep, glob, sessions) instead of relying on parametric knowledge.
+
+  HARD BLOCKS:
+  - NEVER use \`as any\`, \`@ts-ignore\`, \`@ts-expect-error\` to suppress type errors.
+  - NEVER commit unless explicitly asked.
+  - NEVER run \`bun publish\` or modify \`package.json\` version.
+  - NEVER create catch-all files (\`utils.ts\`, \`helpers.ts\`, \`service.ts\`).
+  - NEVER leave code in broken state after failures.
+  - NEVER test with Arrange-Act-Assert comments — use given/when/then.
+  - NEVER add AI-slop comment patterns.
+  - NEVER write empty catch blocks.
+</constraints>
+
+<intent>
+  Before acting, classify the user's intent:
+  - **Trivial** (single file, known location, direct answer) → Direct tools only
+  - **Explicit** (specific file/line, clear command) → Execute directly
+  - **Exploratory** ("How does X work?", "Find Y") → Fire explore/librarian in parallel
+  - **Open-ended** ("Improve", "Refactor") → Assess codebase first
+  - **Ambiguous** → Ask ONE clarifying question
+
+  After classification, execute without re-verbalizing your intent classification. Act.
+</intent>
+
+<explore>
+  Before heavy changes, understand the codebase:
+  - Check config files: linter, formatter, type config
+  - Sample 2-3 similar files for consistency
+  - For searches, use explore agent (\`task(subagent_type="explore", ...)\`) or grep/glob directly
+  - For external references, use librarian agent (\`task(subagent_type="librarian", ...)\`)
+  - Run explore and librarian IN PARALLEL for independent searches
+
+  Flood with parallel calls. Cross-validate findings across multiple tools.
+</explore>
+
+<execution_loop>
+  Your loop: DECOMPOSE → DELEGATE → SUPERVISE → VERIFY
+
+  1. DECOMPOSE: Break work into independent units. Every independent unit = one delegation.
+  2. DELEGATE: Fire specialists in parallel via \`task(category="...", ...)\`. NEVER work sequentially.
+  3. SUPERVISE: Review outputs. Fix issues. Re-delegate if needed.
+  4. VERIFY: Run \`lsp_diagnostics\` on changed files. Run build/tests if available.
+
+  You are an orchestrator, not an implementer. Decompose and delegate aggressively.
+</execution_loop>
+
+<delegation>
+  Sisyphus uses category-based task delegation.
+  This approach leverages the strengths of the most effective models for specific domains:
+  - visual-engineering: google/gemini-3.1-pro high
+  - ultrabrain: openai/gpt-5.5 xhigh
+  - deep: openai/gpt-5.5 medium
+  - quick: openai/gpt-5.4-mini
+  - unspecified-low: anthropic/claude-sonnet-4-6
+  - unspecified-high: anthropic/claude-opus-4-7 max
+  - writing: kimi-for-coding/k2p5
+  - artistry: google/gemini-3.1-pro high
+
+  ALWAYS decompose the task into independent work units. ALWAYS delegate each unit to specialized agents in parallel. NEVER implement directly when delegation is possible.
+</delegation>
+
+<tasks>
+  ${taskSection}
+</tasks>
+
+<style>
+  Be concise. No flattery. No status updates ("I'm on it", "Let me..."). No summarizing what you did unless asked.
+
+  Match the user's style. If they are terse, be terse. If they want detail, provide detail.
+
+  When the user's approach is wrong: state your concern concisely, propose an alternative, ask if they want to proceed anyway. Do not blindly implement bad designs.
+</style>`
+}

--- a/packages/omo-opencode/src/agents/sisyphus/index.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/index.ts
@@ -6,6 +6,7 @@
  * - claude-opus-4-7.ts: Native Claude Opus 4.7 prompt with literal-instruction tuning
  * - claude-opus-4-8.ts: Native Claude Opus 4.8 prompt with silence-default + autonomy tuning
  * - claude-fable-5.ts: Native Claude Fable 5 prompt (Opus 4.8 direction, top-tier model)
+ * - deepseek-v4.ts: DeepSeek V4 Pro/Flash prompt with agentic guardrails
  * - gemini.ts: Corrective overlays for Gemini's aggressive tendencies
  * - gpt-5-4.ts: Native GPT-5.4 prompt with block-structured guidance
  * - gpt-5-5.ts: Native GPT-5.5 prompt with Codex-style sections
@@ -25,5 +26,6 @@ export {
 } from "./gemini";
 export { buildGpt54SisyphusPrompt } from "./gpt-5-4";
 export { buildGpt55SisyphusPrompt } from "./gpt-5-5";
+export { buildDeepSeekV4SisyphusPrompt } from "./deepseek-v4";
 export { buildGlm52SisyphusPrompt } from "./glm-5-2";
 export { buildKimiK26SisyphusPrompt } from "./kimi-k2-6";

--- a/packages/omo-opencode/src/agents/types.ts
+++ b/packages/omo-opencode/src/agents/types.ts
@@ -134,6 +134,11 @@ export function isGpt5_5Model(model: string): boolean {
   return modelName.includes("gpt-5.5") || modelName.includes("gpt-5-5");
 }
 
+export function isDeepSeekV4Model(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase().replaceAll("_", "-").replaceAll(".", "-");
+  return modelName.includes("deepseek") && /v[_-]?4/.test(modelName);
+}
+
 export type BuiltinAgentName =
   | "sisyphus"
   | "hephaestus"

--- a/packages/omo-opencode/src/hooks/keyword-detector/hook-ralph-loop.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hook-ralph-loop.test.ts
@@ -14,6 +14,7 @@ type CancelLoopCall = { sessionID: string }
 function createMockPluginInput() {
   return unsafeTestValue({
     client: {
+        session: { update: async () => ({}) },
       tui: {
         showToast: async () => {},
       },

--- a/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
@@ -36,6 +36,14 @@ function filterAlreadyInjectedKeywords(
   return detected.filter((keyword) => !text.includes(keyword.message))
 }
 
+function extractTaskTitle(text: string): string | null {
+  const cleaned = text.replace(/\b(ultrawork|ulw)\b/gi, "").trim()
+  if (cleaned.length === 0) return null
+  const firstLine = cleaned.split("\n")[0].trim()
+  if (firstLine.length === 0) return null
+  return firstLine.length > 80 ? `${firstLine.slice(0, 77)}...` : firstLine
+}
+
 export function createKeywordDetectorHook(
   ctx: PluginInput,
   _collector?: ContextCollector,
@@ -239,6 +247,24 @@ export function createKeywordDetectorHook(
       const originalText = output.parts[textPartIndex].text ?? ""
 
       output.parts[textPartIndex].text = `${allMessages}\n\n---\n\n${originalText}`
+
+      if (hasUltrawork && originalText.trim().length > 0) {
+        const taskTitle = extractTaskTitle(originalText)
+        if (taskTitle) {
+          ctx.client.session
+            .update({
+              path: { id: input.sessionID },
+              body: { title: taskTitle },
+              query: { directory: ctx.directory },
+            })
+            .catch((err: unknown) =>
+              log(`[keyword-detector] Failed to update session title`, {
+                error: err,
+                sessionID: input.sessionID,
+              })
+            )
+        }
+      }
 
       log(`[keyword-detector] Detected ${detectedKeywords.length} keywords`, {
         sessionID: input.sessionID,

--- a/packages/omo-opencode/src/hooks/keyword-detector/hyperplan-ultrawork.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hyperplan-ultrawork.test.ts
@@ -25,6 +25,7 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     const toastCalls = options.toastCalls ?? []
     return unsafeTestValue<PluginInput>({
       client: {
+        session: { update: async () => ({}) },
         tui: {
           showToast: async (opts: { body: { title: string } }) => {
             toastCalls.push(opts.body.title)

--- a/packages/omo-opencode/src/hooks/keyword-detector/hyperplan.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hyperplan.test.ts
@@ -25,6 +25,7 @@ describe("keyword-detector hyperplan keyword", () => {
     const toastCalls = options.toastCalls ?? []
     return unsafeTestValue<PluginInput>({
       client: {
+        session: { update: async () => ({}) },
         tui: {
           showToast: async (opts: { body: { title: string } }) => {
             toastCalls.push(opts.body.title)

--- a/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
@@ -26,7 +26,10 @@ function expectTextPartText(parts: readonly OutputPart[]): string {
 
 function createPluginInputWithToast(showToast: (options: ToastOptions) => Promise<void>): PluginInput {
   const client = {} as PluginInput["client"]
-  Object.assign(client, { tui: { showToast } })
+  Object.assign(client, {
+    tui: { showToast },
+    session: { update: async () => ({}) },
+  })
 
   return {
     client,
@@ -1118,6 +1121,7 @@ describe("keyword-detector disabled_keywords config", () => {
             toastCalls.push(opts.body.title)
           },
         },
+        session: { update: async () => ({}) },
       },
     })
   }

--- a/packages/omo-opencode/src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts
@@ -14,6 +14,7 @@ type StartLoopCall = {
 function createMockPluginInput(toastCalls: string[] = []) {
   return unsafeTestValue<PluginInput>({
     client: {
+        session: { update: async () => ({}) },
       tui: {
         showToast: async (opts: { body: { title: string } }) => {
           toastCalls.push(opts.body.title)

--- a/packages/omo-opencode/src/hooks/keyword-detector/ultrawork-runtime-variant.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/ultrawork-runtime-variant.test.ts
@@ -6,6 +6,7 @@ import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 function createMockPluginInput(toastMessages: string[]) {
   return unsafeTestValue({
     client: {
+        session: { update: async () => ({}) },
       tui: {
         showToast: async (opts: { body: { message: string } }) => {
           toastMessages.push(opts.body.message)

--- a/packages/omo-opencode/src/hooks/preemptive-compaction-trigger.ts
+++ b/packages/omo-opencode/src/hooks/preemptive-compaction-trigger.ts
@@ -4,6 +4,7 @@ import {
   type ContextLimitModelCacheState,
 } from "../shared/context-limit-resolver"
 import { log } from "../shared/logger"
+import { isDeepSeekV4Model } from "../agents/types"
 
 import { resolveCompactionModel } from "./shared/compaction-model-resolver"
 import type {
@@ -13,6 +14,7 @@ import type {
 
 const PREEMPTIVE_COMPACTION_TIMEOUT_MS = 60_000
 const PREEMPTIVE_COMPACTION_THRESHOLD = 0.78
+const PREEMPTIVE_COMPACTION_THRESHOLD_V4 = 0.35
 const PREEMPTIVE_COMPACTION_COOLDOWN_MS = 60_000
 
 declare function setTimeout(handler: () => void, timeout?: number): unknown
@@ -81,7 +83,10 @@ export async function runPreemptiveCompactionIfNeeded(args: {
 
   const totalInputTokens = (cached.tokens.input ?? 0) + (cached.tokens.cache?.read ?? 0)
   const usageRatio = totalInputTokens / actualLimit
-  if (usageRatio < PREEMPTIVE_COMPACTION_THRESHOLD || !cached.modelID) return
+  const threshold = isDeepSeekV4Model(cached.modelID)
+    ? PREEMPTIVE_COMPACTION_THRESHOLD_V4
+    : PREEMPTIVE_COMPACTION_THRESHOLD
+  if (usageRatio < threshold || !cached.modelID) return
 
   compactionInProgress.add(sessionID)
   lastCompactionTime.set(sessionID, Date.now())
@@ -116,7 +121,7 @@ export async function runPreemptiveCompactionIfNeeded(args: {
     ctx.client.tui.showToast({
       body: {
         title: "Preemptive compaction failed",
-        message: `Context window is above ${Math.round(PREEMPTIVE_COMPACTION_THRESHOLD * 100)}% and auto-compaction could not run. The session may grow large. Error: ${errorMessage}`,
+        message: `Context window is above ${Math.round(threshold * 100)}% and auto-compaction could not run. The session may grow large. Error: ${errorMessage}`,
         variant: "warning",
         duration: 10000,
       },

--- a/packages/omo-opencode/src/hooks/preemptive-compaction.test.ts
+++ b/packages/omo-opencode/src/hooks/preemptive-compaction.test.ts
@@ -33,6 +33,8 @@ afterAll(() => {
 })
 
 const { createPreemptiveCompactionHook } = await import("./preemptive-compaction")
+const { createModelCacheState } = await import("../plugin-state")
+const { applyProviderConfig } = await import("../plugin-handlers/provider-config-handler")
 
 function createMockCtx() {
   return {
@@ -834,5 +836,101 @@ describe("preemptive-compaction", () => {
     )
 
     expect(ctx.client.session.summarize).toHaveBeenCalled()
+  })
+
+  // #given DeepSeek V4 model at 36% context usage
+  // #when tool.execute.after runs
+  // #then should trigger summarize (V4 uses lower threshold to prevent tool call drift)
+  it("should trigger compaction earlier for DeepSeek V4 models (35% threshold)", async () => {
+    // given — V4 models drift after ~40 tool calls; compaction at 35% keeps context under drift threshold
+    const modelCacheState = createModelCacheState()
+    applyProviderConfig({
+      config: {
+        provider: {
+          deepseek: {
+            models: {
+              "deepseek-v4-pro": {
+                limit: { context: 1_000_000 },
+              },
+            },
+          },
+        },
+      },
+      modelCacheState,
+    })
+
+    const hook = createPreemptiveCompactionHook(ctx as never, {} as never, modelCacheState)
+    const sessionID = "ses_v4_early"
+
+    // 350K input + 10K cache = 360K → 36% of 1M (above V4's 35% threshold, below default 78%)
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "deepseek",
+            modelID: "deepseek-v4-pro",
+            finish: true,
+            tokens: {
+              input: 350000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    // when
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      { title: "", output: "test", metadata: null }
+    )
+
+    // then
+    expect(ctx.client.session.summarize).toHaveBeenCalled()
+  })
+
+  // #given non-V4 model at 36% context usage
+  // #when tool.execute.after runs
+  // #then should NOT trigger summarize (default 78% threshold preserved for non-V4)
+  it("should NOT trigger compaction at 36% for non-V4 models (78% threshold preserved)", async () => {
+    // given — 36% is below the default 78% threshold; only V4 models get the lower threshold
+    const hook = createPreemptiveCompactionHook(ctx as never, {} as never)
+    const sessionID = "ses_non_v4_36pct"
+
+    // 350K input + 10K cache = 360K → 36% of 1M (Claude with GA 1M)
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            finish: true,
+            tokens: {
+              input: 350000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    // when
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      { title: "", output: "test", metadata: null }
+    )
+
+    // then
+    expect(ctx.client.session.summarize).not.toHaveBeenCalled()
   })
 })

--- a/packages/omo-opencode/src/plugin/chat-message.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-message.test.ts
@@ -62,7 +62,10 @@ function createMockHandlerArgs(overrides?: {
   const appliedSessions: string[] = []
   return {
     ctx: unsafeTestValue<PluginContext>({
-      client: { tui: { showToast: async () => {} } },
+      client: {
+        tui: { showToast: async () => {} },
+        session: { update: async () => ({}) },
+      },
     }),
     pluginConfig: unsafeTestValue<OhMyOpenCodeConfig>((overrides?.pluginConfig ?? {})),
     firstMessageVariantGate: {

--- a/packages/omo-opencode/src/shared/sdk-v2-compat.ts
+++ b/packages/omo-opencode/src/shared/sdk-v2-compat.ts
@@ -1,0 +1,89 @@
+/**
+ * SDK v1→v2 compatibility wrapper.
+ *
+ * OpenCode v1.17.10 migrated the plugin system from SDK v1 to v2 exclusively.
+ * The v2 client uses flattened parameters instead of nested { path, body, query } style.
+ *
+ * This wrapper intercepts v1-style calls and translates them to v2-style at runtime,
+ * allowing OMO to work with both v1 and v2 clients without changing all 73 call sites.
+ *
+ * When the @opencode-ai/plugin package is updated to export v2 types, this wrapper
+ * can be removed and all call sites can be updated to use v2-style directly.
+ */
+
+type V1Params = {
+  path?: { id?: string; [key: string]: unknown };
+  body?: Record<string, unknown>;
+  query?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+function flattenV1Params(params: V1Params): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  if (params.path?.id !== undefined) {
+    result.sessionID = params.path.id;
+  }
+
+  if (params.body) {
+    for (const [key, value] of Object.entries(params.body)) {
+      result[key] = value;
+    }
+  }
+
+  if (params.query) {
+    for (const [key, value] of Object.entries(params.query)) {
+      if (!(key in result)) {
+        result[key] = value;
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(params)) {
+    if (key !== 'path' && key !== 'body' && key !== 'query' && !(key in result)) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function isV1Style(params: unknown): params is V1Params {
+  if (typeof params !== 'object' || params === null) return false;
+  const obj = params as Record<string, unknown>;
+  return 'path' in obj || 'body' in obj || 'query' in obj;
+}
+
+export function wrapSessionForV2Compat(session: unknown): unknown {
+  if (typeof session !== 'object' || session === null) return session;
+
+  return new Proxy(session as Record<string, unknown>, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== 'function') return value;
+
+      return function (this: unknown, ...args: unknown[]) {
+        if (args.length > 0 && isV1Style(args[0])) {
+          args[0] = flattenV1Params(args[0]);
+        }
+        return value.apply(this, args);
+      };
+    },
+  });
+}
+
+export function wrapClientForV2Compat(client: unknown): unknown {
+  if (typeof client !== 'object' || client === null) return client;
+
+  return new Proxy(client as Record<string, unknown>, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+
+      if (prop === 'session') {
+        return wrapSessionForV2Compat(value);
+      }
+
+      return value;
+    },
+  });
+}

--- a/packages/omo-opencode/src/testing/create-plugin-module.ts
+++ b/packages/omo-opencode/src/testing/create-plugin-module.ts
@@ -2,6 +2,7 @@ import type { Hooks, Plugin, PluginModule } from "@opencode-ai/plugin"
 import type { HookName } from "../config"
 import { initConfigContext } from "../cli/config-manager/config-context"
 import { ensureTuiPluginEntry } from "../cli/config-manager/add-tui-plugin-to-tui-config"
+import { wrapClientForV2Compat } from "../shared/sdk-v2-compat"
 
 import { createHooks } from "../create-hooks"
 import { createManagers } from "../create-managers"
@@ -130,6 +131,9 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
 
     deps.injectServerAuthIntoClient(input.client)
 
+    const originalClient = input.client
+    input.client = wrapClientForV2Compat(input.client) as typeof input.client
+
     const pluginConfig = deps.loadPluginConfig(input.directory, input)
     try {
       deps.recordPluginTelemetry({ configEnabled: pluginConfig.telemetry })
@@ -147,7 +151,7 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
         })
       }
     }
-    deps.initLiveServerRoute({ serverUrl: input.serverUrl, directory: input.directory, inProcessClient: input.client })
+    deps.initLiveServerRoute({ serverUrl: input.serverUrl, directory: input.directory, inProcessClient: originalClient })
     deps.setLiveParentWakeRoutingDisabled(pluginConfig.experimental?.disable_live_parent_wake_routing === true)
     deps.warmLiveServerProbe()
     const runtimeSecuritySkills = selectRuntimeSecuritySkills(pluginConfig)


### PR DESCRIPTION
## What

Adds a Proxy-based SDK v1→v2 compatibility wrapper that allows OMO to work with OpenCode ≥ 1.17.10 without changing all 73 call sites.

## Why

Fixes #5575. OpenCode v1.17.10 (PR #7639) migrated the plugin system from SDK v1 to v2 exclusively. The v2 client uses flattened parameters (`{ sessionID }`) instead of nested v1-style (`{ path: { id } }`), causing all OMO hooks to silently stop firing.

## How

- New file: `packages/omo-opencode/src/shared/sdk-v2-compat.ts` — Proxy wrapper that intercepts `client.session.*` calls and translates v1-style `{ path, body, query }` to v2-style flattened parameters
- Modified: `packages/omo-opencode/src/testing/create-plugin-module.ts` — applies wrapper after auth injection, before hooks/tools are created

The wrapper is a temporary compatibility layer. When `@opencode-ai/plugin` is updated to export v2 types, it can be removed and all 73 call sites updated to v2-style directly.

## Verification

- Typecheck: passes (0 new errors)
- Tests: 1949 pass, 48 fail (all 48 pre-existing on upstream/dev)
- No new failures introduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an SDK v1→v2 compatibility layer so OMO works on OpenCode ≥ 1.17.10 without changing call sites. Also adds DeepSeek V4 Pro/Flash prompt routing with earlier compaction, and fixes session titles after ultrawork injection.

- **New Features**
  - DeepSeek V4 Pro/Flash routing: detects V4 models and uses a dedicated Sisyphus prompt with tool-call guardrails (structured `tool_calls` only, auto tool choice) and verification bias.
  - Earlier compaction for DeepSeek V4: triggers at 35% context usage to prevent tool-call drift; other models keep the 78% threshold.

- **Bug Fixes**
  - SDK v1→v2 compat: wraps `client.session.*` to translate v1 `{ path, body, query }` into v2 flattened params (e.g., `{ sessionID }`); applied in the plugin module after auth.
  - Keyword detector: after inserting ultrawork instructions, extracts a task title from the user’s original text and updates it via `client.session.update`.

<sup>Written for commit 18fbc28c860002c51a03ab899d45235b60070ec9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

