### PR TITLE
feat(agents): add MiMo V2.5 Pro native Sisyphus prompt routing

### DIFF
--- a/packages/model-core/src/agent-model-requirements.ts
+++ b/packages/model-core/src/agent-model-requirements.ts
@@ -9,6 +9,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "max",
       },
       { providers: ["opencode-go", "vercel"], model: "kimi-k2.6" },
+      { providers: ["openrouter", "vercel"], model: "mimo-v2.5-pro" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
       {
         providers: [

--- a/packages/model-core/src/model-family-detectors.ts
+++ b/packages/model-core/src/model-family-detectors.ts
@@ -81,6 +81,11 @@ export function isGlmModel(model: string): boolean {
   return modelName.includes("glm")
 }
 
+export function isMimoModel(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase()
+  return modelName.includes("mimo")
+}
+
 const GEMINI_PROVIDERS = ["google/", "google-vertex/"] as const
 
 export function isGeminiModel(model: string): boolean {

--- a/packages/model-core/src/model-requirements-agents.test.ts
+++ b/packages/model-core/src/model-requirements-agents.test.ts
@@ -17,15 +17,15 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(primary?.variant).toBe("high")
   })
 
-  test("sisyphus keeps opus primary before k2p5, kimi-k2.5, gpt-5.5 medium, and big-pickle", () => {
+  test("sisyphus keeps opus primary before kimi-k2.6, mimo-v2.5-pro, k2p5, kimi-k2.5, gpt-5.5 medium, and big-pickle", () => {
     // given
     const sisyphus = AGENT_MODEL_REQUIREMENTS["sisyphus"]
 
     // when
-    const [primary, second, third, fourth, fifth, sixth, last] = sisyphus.fallbackChain
+    const [primary, second, third, fourth, fifth, sixth, seventh, last] = sisyphus.fallbackChain
 
     // then
-    expect(sisyphus.fallbackChain).toHaveLength(7)
+    expect(sisyphus.fallbackChain).toHaveLength(8)
     expect(sisyphus.requiresAnyModel).toBe(true)
     expect(primary).toEqual({
       providers: ["anthropic", "github-copilot", "opencode", "vercel"],
@@ -33,15 +33,16 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
       variant: "max",
     })
     expect(second).toEqual({ providers: ["opencode-go", "vercel"], model: "kimi-k2.6" })
-    expect(third).toEqual({ providers: ["kimi-for-coding"], model: "k2p5" })
-    expect(fourth?.model).toBe("kimi-k2.5")
-    expect(fifth).toEqual({
+    expect(third).toEqual({ providers: ["openrouter", "vercel"], model: "mimo-v2.5-pro" })
+    expect(fourth).toEqual({ providers: ["kimi-for-coding"], model: "k2p5" })
+    expect(fifth?.model).toBe("kimi-k2.5")
+    expect(sixth).toEqual({
       providers: ["openai", "github-copilot", "opencode", "vercel"],
       model: "gpt-5.5",
       variant: "medium",
     })
-    expect(sixth?.providers[0]).toBe("zai-coding-plan")
-    expect(sixth?.model).toBe("glm-5")
+    expect(seventh?.providers[0]).toBe("zai-coding-plan")
+    expect(seventh?.model).toBe("glm-5")
     expect(last?.providers[0]).toBe("opencode")
     expect(last?.model).toBe("big-pickle")
   })

--- a/packages/omo-opencode/src/agents/sisyphus-agent-factory.test.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-agent-factory.test.ts
@@ -142,6 +142,41 @@ describe("createSisyphusAgent", () => {
     });
   });
 
+  describe("#given a MiMo V2.5 Pro Sisyphus model", () => {
+    test("#when creating the agent #then uses the MiMo-native prompt with bare config", () => {
+      // given
+      const model = "xiaomi/mimo-v2.5-pro";
+
+      // when
+      const agent = createSisyphusAgent(model);
+
+      // then
+      expect(agent.prompt).toContain("running on MiMo V2.5 Pro");
+      expect(agent.prompt).toContain("<mimo_calibration>");
+      expect(agent.prompt).toContain("SEQUENTIAL TOOL CALLS");
+      expect(agent.prompt).toContain("THINKING-TOOL CONFLICT");
+      expect(agent.thinking).toBeUndefined();
+      expect(agent.reasoningEffort).toBeUndefined();
+    });
+
+    test("#when creating the agent with alternate provider naming #then still routes to MiMo variant", () => {
+      // given
+      const models = [
+        "XiaomiMiMo/MiMo-V2.5-Pro",
+        "mimo-v2.5-pro",
+        "opencode-go/mimo-v2-5-pro",
+      ];
+
+      for (const model of models) {
+        // when
+        const agent = createSisyphusAgent(model);
+
+        // then
+        expect(agent.prompt).toContain("running on MiMo V2.5 Pro");
+      }
+    });
+  });
+
   describe("#given a Gemini model", () => {
     test("#when creating the agent #then injects Gemini corrective anchors before constraints", () => {
       // given

--- a/packages/omo-opencode/src/agents/sisyphus-agent-factory.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-agent-factory.ts
@@ -19,6 +19,7 @@ import { buildGpt54SisyphusPrompt } from "./sisyphus/gpt-5-4";
 import { buildGpt55SisyphusPrompt } from "./sisyphus/gpt-5-5";
 import { buildKimiK26SisyphusPrompt } from "./sisyphus/kimi-k2-6";
 import { buildKimiK27SisyphusPrompt } from "./sisyphus/kimi-k2-7";
+import { buildMimoV25ProSisyphusPrompt } from "./sisyphus/mimo-v2-5-pro";
 import type { AgentMode } from "./types";
 import {
   isClaudeFable5Model,
@@ -30,6 +31,7 @@ import {
   isGptNativeSisyphusModel,
   isKimiK2Model,
   isKimiK27Model,
+  isMimoModel,
 } from "./types";
 
 const MODE: AgentMode = "primary";
@@ -50,6 +52,7 @@ export type SisyphusPromptFamily =
   | "claude-opus-4-8"
   | "claude-opus-4-7"
   | "glm-5-2"
+  | "mimo-v2.5-pro"
   | "fallback";
 
 export function resolveSisyphusPromptFamily(model: string): SisyphusPromptFamily {
@@ -61,6 +64,7 @@ export function resolveSisyphusPromptFamily(model: string): SisyphusPromptFamily
   if (isClaudeOpus48Model(model)) return "claude-opus-4-8";
   if (isClaudeOpus47Model(model)) return "claude-opus-4-7";
   if (isGlmModel(model)) return "glm-5-2";
+  if (isMimoModel(model)) return "mimo-v2.5-pro";
   return "fallback";
 }
 
@@ -125,6 +129,12 @@ export function createSisyphusAgent(
         MODE,
         model,
         buildGlm52SisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
+      );
+    case "mimo-v2.5-pro":
+      return buildGlmSisyphusAgentConfig(
+        MODE,
+        model,
+        buildMimoV25ProSisyphusPrompt(model, agents, tools, skills, categories, useTaskSystem),
       );
     case "fallback": {
       const prompt = buildFallbackSisyphusPrompt(

--- a/packages/omo-opencode/src/agents/sisyphus/index.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/index.ts
@@ -26,4 +26,5 @@ export {
 export { buildGpt54SisyphusPrompt } from "./gpt-5-4";
 export { buildGpt55SisyphusPrompt } from "./gpt-5-5";
 export { buildGlm52SisyphusPrompt } from "./glm-5-2";
+export { buildMimoV25ProSisyphusPrompt } from "./mimo-v2-5-pro";
 export { buildKimiK26SisyphusPrompt } from "./kimi-k2-6";

--- a/packages/omo-opencode/src/agents/sisyphus/mimo-v2-5-pro.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/mimo-v2-5-pro.ts
@@ -1,0 +1,219 @@
+import type {
+  AvailableAgent,
+  AvailableTool,
+  AvailableSkill,
+  AvailableCategory,
+} from "../dynamic-agent-prompt-builder";
+import {
+  buildAgentIdentitySection,
+  buildKeyTriggersSection,
+  buildToolSelectionTable,
+  buildExploreSection,
+  buildLibrarianSection,
+  buildDelegationTable,
+  buildCategorySkillsDelegationGuide,
+  buildOracleSection,
+  buildHardBlocksSection,
+  buildAntiPatternsSection,
+  buildAntiDuplicationSection,
+  buildNonClaudePlannerSection,
+  categorizeTools,
+} from "../dynamic-agent-prompt-builder";
+
+function buildMimoTasksSection(useTaskSystem: boolean): string {
+  const noun = useTaskSystem ? "tasks" : "todos";
+  const create = useTaskSystem ? "task_create" : "todowrite";
+  const update = useTaskSystem ? "task_update" : "todowrite";
+  const hook = useTaskSystem ? "TASK CONTINUATION" : "TODO CONTINUATION";
+
+  return `<tasks>
+Use ${noun} for implementation work with two or more real steps, cross-file edits, delegated work, or uncertain scope. Skip tracking for direct answers, pure exploration, and one-step edits.
+
+When tracking: call \`${create}\` before implementation, keep exactly one item \`in_progress\`, and call \`${update}\` the moment an item is done. Never batch completions. If scope changes, revise the list before more edits.
+
+Your ${noun} are tracked by the harness via [SYSTEM REMINDER - ${hook}].
+</tasks>`;
+}
+
+export function buildMimoV25ProSisyphusPrompt(
+  model: string,
+  availableAgents: AvailableAgent[],
+  availableTools: AvailableTool[] = [],
+  availableSkills: AvailableSkill[] = [],
+  availableCategories: AvailableCategory[] = [],
+  useTaskSystem = false,
+): string {
+  const keyTriggers = buildKeyTriggersSection(availableAgents, availableSkills);
+  const toolSelection = buildToolSelectionTable(availableAgents, availableTools, availableSkills);
+  const exploreSection = buildExploreSection(availableAgents);
+  const librarianSection = buildLibrarianSection(availableAgents);
+  const categorySkillsGuide = buildCategorySkillsDelegationGuide(
+    availableCategories,
+    availableSkills,
+  );
+  const delegationTable = buildDelegationTable(availableAgents);
+  const oracleSection = buildOracleSection(availableAgents);
+  const hardBlocks = buildHardBlocksSection();
+  const antiPatterns = buildAntiPatternsSection();
+  const nonClaudePlannerSection = buildNonClaudePlannerSection(model);
+  const tasksSection = buildMimoTasksSection(useTaskSystem);
+
+  const agentIdentity = buildAgentIdentitySection(
+    "Sisyphus",
+    "Powerful AI Agent with orchestration capabilities from OhMyOpenCode",
+  );
+
+  const roleBlock = `<role>
+You are Sisyphus, the OhMyOpenCode orchestration lead, running on MiMo V2.5 Pro.
+
+You are a senior engineer who scales output through specialists. Your job is to understand the user's destination, pick the right route, delegate when that improves the result, verify with real evidence, and stop only when the requested outcome is complete.
+
+Implementation starts only when the current user turn explicitly asks for it with concrete scope. Questions get answers, investigations get findings, and implementation requests get shipped work.
+</role>`;
+
+  const selfKnowledgeBlock = `<self_knowledge>
+You are MiMo V2.5 Pro — a 1T-parameter MoE model post-trained with SFT, domain-specialized RL, and Multi-Teacher On-Policy Distillation (MOPD) for agentic coding. You were explicitly trained for harness awareness: you detect and adapt to the agent framework you run in.
+
+Your training rewards token-efficient trajectories and sustained tool-calling coherence. You can hold 1000+ tool calls in a single session. Trust that prior — lean writing, aggressive intent inference, no redundant loops. The structure here helps you decide faster, not produce ceremony.
+</self_knowledge>`;
+
+  const calibrationBlock = `<mimo_calibration>
+Counter these MiMo V2.5 Pro failure modes explicitly:
+
+1. THINKING-TOOL CONFLICT: when transitioning from reasoning to tool calls, deep thinking can destabilize the output and loop. Reserve deep deliberation for planning, architecture, and subtle debugging BEFORE you issue tool calls. When the next action is a tool call, reason briefly and emit the call — do not deliberate at length and then try to call a tool.
+
+2. SEQUENTIAL TOOL CALLS: you produce one tool call per turn. Do not expect parallel tool calls to batch in a single response. When multiple independent reads or searches are needed, issue them across sequential turns — do not stall waiting to batch them. Plan accordingly: fire the first call now, synthesize on the next turn, fire the next.
+
+3. LATE SAFETY REFUSAL: do not complete a valid reasoning chain and then refuse to output the result. If your reasoning was sound and the task is within scope, output the answer. Wasting compute on reasoning that produces no output is a failure.
+
+4. OVER-EXPLORATION: sufficient context beats complete context. Once you can act correctly, ACT. Do not launch a second search wave to feel safer. Your 1M-token context window means you rarely need to trim — but you also rarely need to read everything.
+
+5. OVER-ASKING: minor decisions are yours. Pick names, defaults, and equivalent approaches; note the choice later. Ask only for scope changes, critical missing information, destructive actions, or external side effects.
+</mimo_calibration>`;
+
+  const outcomeBlock = `<outcome_first>
+Before work, identify three things: destination, constraints, and stopping condition.
+
+- Destination: the user-visible result, not the intermediate task.
+- Constraints: explicit user requirements, codebase patterns, safety, type-safety, and runtime limits.
+- Stopping condition: the evidence that proves the destination is reached.
+
+If the destination is unclear but one simple interpretation is valid, choose it and proceed. If different interpretations change the deliverable, ask one precise question.
+</outcome_first>`;
+
+  const intentBlock = `<intent>
+Classify the CURRENT user message only. Do not carry implementation authorization across turns.
+
+${keyTriggers}
+
+Surface form to routing:
+
+| User says | True intent | You do |
+|---|---|---|
+| "explain", "how does" | understanding | explore enough, then answer |
+| "implement", "add", "create", "write" | implementation | plan, delegate or execute, verify |
+| "look into", "check", "investigate" | investigation | inspect, report findings, wait |
+| "what do you think" | evaluation | judge, propose, wait |
+| "broken", "error", "fix" | root-cause repair | diagnose, fix minimally, verify |
+| "refactor", "improve", "clean up" | open-ended change | assess, propose or use the matching skill |
+
+Say one concise intent line before non-trivial action: "I read this as [type]: [route]." If the answer is already in context, answer instead of re-deriving.
+</intent>`;
+
+  const explorationBlock = `<exploration>
+Use tools for facts. Internal memory is not evidence for file contents, configs, APIs, or current project state.
+
+${toolSelection}
+
+${exploreSection}
+
+${librarianSection}
+
+Issue calls sequentially — one tool per turn. When multiple independent reads or searches are needed, fire the first now and queue the rest for the next turn after synthesis. Do not stall.
+
+Search budget: known file or symbol = direct read/search; unfamiliar local pattern = one sequential wave; external package or API = librarian; architectural risk = Oracle. Stop when sources converge, the target file set is known, or the answer is found.
+
+Fire explore/librarian in the background with [CONTEXT], [GOAL], [DOWNSTREAM], and [REQUEST]. Continue only with non-overlapping work; otherwise end the turn and wait for the completion reminder before calling \`background_output(task_id="bg_...")\`. Use \`task(task_id="ses_...")\` only for follow-ups to the same subagent.
+
+${buildAntiDuplicationSection()}
+</exploration>`;
+
+  const delegationBlock = `<delegation>
+Prefer delegation when a specialist fits, the work spans multiple files, the domain is visual/frontend/security/performance, or the module is unfamiliar. Execute directly only for small, local, fully understood changes.
+
+${categorySkillsGuide}
+
+${nonClaudePlannerSection}
+
+${delegationTable}
+
+Every delegation prompt carries six sections: TASK, EXPECTED OUTCOME, REQUIRED TOOLS, MUST DO, MUST NOT DO, CONTEXT. Make success criteria observable. Vague delegation is rejected work.
+
+After delegation, verify the files and behavior yourself. A subagent report is a lead, not evidence.
+${oracleSection ? `
+${oracleSection}
+` : ""}</delegation>`;
+
+  const executionBlock = `<behavior>
+Implementation loop:
+
+1. Plan the smallest path to the destination. Two or more steps need ${useTaskSystem ? "tasks" : "todos"}; one obvious edit does not.
+2. Match the repo: read configs and similar files before writing. Do not invent style.
+3. Change only what the request requires. Bug fix does not mean refactor. Refactor does not mean feature work.
+4. Use type-safe code. No type suppression, no speculative fallbacks, no helpers for one-off operations, no validation away from trust boundaries.
+5. On failure, read the error, identify the root cause, try a materially different approach, and re-verify. After three failed approaches, stop editing and consult Oracle or ask if Oracle cannot resolve it.
+
+Never revert, delete, push, publish, message, or affect shared systems without explicit approval. Reversible local edits and verification commands are allowed.
+</behavior>`;
+
+  const verificationBlock = `<verification>
+Verification defines done.
+
+- File edit: run \`lsp_diagnostics\` on every changed file.
+- Behavioral change: run adjacent tests or the smallest relevant suite.
+- Buildable project: run the build/typecheck path that covers the touched code.
+- Runnable or user-visible behavior: exercise the real surface: browser for web, interactive_bash for TUI/CLI, curl for HTTP, driver script for libraries.
+- Delegated work: inspect touched files and rerun checks yourself.
+
+Report only evidence from this turn. "Should pass" means unverified. Fix failures caused by your change; name unrelated pre-existing failures without widening scope.
+</verification>`;
+
+  const communicationBlock = `<communication>
+Be terse, concrete, and useful. No flattery, no filler, no narration of routine tool calls.
+
+Progress updates are for meaningful transitions: before exploration, after a load-bearing discovery, before substantial edits, after edits with validation next, or on blockers. Final answers state what changed, where, verification results, and any real residual risk.
+</communication>`;
+
+  const constraintsBlock = `<constraints>
+${hardBlocks}
+
+${antiPatterns}
+</constraints>`;
+
+  return `${agentIdentity}
+${roleBlock}
+
+${selfKnowledgeBlock}
+
+${calibrationBlock}
+
+${outcomeBlock}
+
+${intentBlock}
+
+${explorationBlock}
+
+${delegationBlock}
+
+${executionBlock}
+
+${verificationBlock}
+
+${tasksSection}
+
+${communicationBlock}
+
+${constraintsBlock}`;
+}
+
+export { categorizeTools };

--- a/packages/omo-opencode/src/agents/types.ts
+++ b/packages/omo-opencode/src/agents/types.ts
@@ -13,6 +13,7 @@ import {
   isKimiK2Model,
   isKimiK27Model,
   isMiniMaxModel,
+  isMimoModel,
 } from "@oh-my-opencode/model-core";
 
 export {
@@ -28,6 +29,7 @@ export {
   isKimiK2Model,
   isKimiK27Model,
   isMiniMaxModel,
+  isMimoModel,
 };
 
 const CLAUDE_THINKING_BUDGET_TOKENS = 32000;

--- a/packages/omo-opencode/src/plugin/chat-params.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-params.test.ts
@@ -248,4 +248,103 @@ describe("createChatParamsHandler", () => {
     //#then
     expect(output.maxOutputTokens).toBe(4096)
   })
+
+  test("strips reasoningEffort for openai-compatible providers (issue #5529)", async () => {
+    //#given — gpt-5.5 agent config injects reasoningEffort: "medium", but the provider
+    // is openai-compatible (e.g. local llama.cpp, vLLM, salad-cloud) and OpenAI
+    // rejects requests that combine tools + reasoning_effort on /v1/chat/completions
+    setSessionPromptParams("ses_chat_params_compat", {
+      options: {
+        reasoningEffort: "medium",
+      },
+    })
+
+    const handler = createChatParamsHandler()
+
+    const input = {
+      sessionID: "ses_chat_params_compat",
+      agent: { name: "oracle" },
+      model: {
+        providerID: "salad-cloud",
+        modelID: "gpt-5.5",
+        api: { npm: "@ai-sdk/openai-compatible" },
+      },
+      provider: { id: "salad-cloud" },
+      message: {},
+    }
+
+    const output: ChatParamsOutput = {
+      options: {},
+    }
+
+    //#when
+    await handler(input, output)
+
+    //#then — reasoningEffort must NOT be injected for openai-compatible providers
+    expect(output.options).not.toHaveProperty("reasoningEffort")
+  })
+
+  test("preserves reasoningEffort for native openai provider (issue #5529)", async () => {
+    //#given — same agent config, but native openai provider DOES support it
+    setSessionPromptParams("ses_chat_params_native", {
+      options: {
+        reasoningEffort: "medium",
+      },
+    })
+
+    const handler = createChatParamsHandler()
+
+    const input = {
+      sessionID: "ses_chat_params_native",
+      agent: { name: "oracle" },
+      model: {
+        providerID: "openai",
+        modelID: "gpt-5.5",
+        api: { npm: "@ai-sdk/openai" },
+      },
+      provider: { id: "openai" },
+      message: {},
+    }
+
+    const output: ChatParamsOutput = {
+      options: {},
+    }
+
+    //#when
+    await handler(input, output)
+
+    //#then — native openai provider must keep reasoningEffort
+    expect(output.options.reasoningEffort).toBe("medium")
+  })
+
+  test("preserves reasoningEffort when api.npm is missing (backward compat, issue #5529)", async () => {
+    //#given — when the chat-params hook does not receive api.npm, fall back to
+    // existing behavior and let reasoningEffort through. This preserves backward
+    // compatibility for any plugin/hook that does not forward the api field.
+    setSessionPromptParams("ses_chat_params_legacy", {
+      options: {
+        reasoningEffort: "medium",
+      },
+    })
+
+    const handler = createChatParamsHandler()
+
+    const input = {
+      sessionID: "ses_chat_params_legacy",
+      agent: { name: "oracle" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
+      provider: { id: "openai" },
+      message: {},
+    }
+
+    const output: ChatParamsOutput = {
+      options: {},
+    }
+
+    //#when
+    await handler(input, output)
+
+    //#then — without api.npm, preserve legacy behavior
+    expect(output.options.reasoningEffort).toBe("medium")
+  })
 })

--- a/packages/omo-opencode/src/plugin/chat-params.ts
+++ b/packages/omo-opencode/src/plugin/chat-params.ts
@@ -14,6 +14,7 @@ export type ChatParamsInput = {
 
 type ChatParamsHookInput = ChatParamsInput & {
   rawMessage?: Record<string, unknown>
+  apiNpm?: string
 }
 
 export type ChatParamsOutput = {
@@ -22,6 +23,12 @@ export type ChatParamsOutput = {
   topK?: number
   maxOutputTokens?: number
   options: Record<string, unknown>
+}
+
+const NATIVE_OPENAI_NPM = "@ai-sdk/openai"
+
+function isNativeOpenAIProvider(apiNpm: string | undefined): boolean {
+  return apiNpm === NATIVE_OPENAI_NPM
 }
 
 
@@ -62,6 +69,9 @@ function buildChatParamsInput(raw: unknown): ChatParamsHookInput | null {
   if (typeof modelID !== "string") return null
   if (typeof providerId !== "string") return null
 
+  const api = isRecord(model.api) ? model.api : undefined
+  const apiNpm = api && typeof api.npm === "string" ? api.npm : undefined
+
   return {
     sessionID,
     agent: { name: agentName },
@@ -69,6 +79,7 @@ function buildChatParamsInput(raw: unknown): ChatParamsHookInput | null {
     provider: { id: providerId },
     message,
     rawMessage: message,
+    apiNpm,
   }
 }
 
@@ -143,7 +154,15 @@ export function createChatParamsHandler(_args: {
     normalizedInput.message = normalizedInput.rawMessage as { variant?: string }
 
     if (compatibility.reasoningEffort !== undefined) {
-      output.options.reasoningEffort = compatibility.reasoningEffort
+      if (normalizedInput.apiNpm !== undefined && !isNativeOpenAIProvider(normalizedInput.apiNpm)) {
+        // OpenAI rejects requests that combine tools + reasoning_effort on
+        // /v1/chat/completions (issue #5529). openai-compatible providers and
+        // non-native OpenAI variants may use that endpoint, so drop the
+        // reasoning_effort injection entirely.
+        delete output.options.reasoningEffort
+      } else {
+        output.options.reasoningEffort = compatibility.reasoningEffort
+      }
     } else if ("reasoningEffort" in output.options) {
       delete output.options.reasoningEffort
     }


### PR DESCRIPTION
## Problem

MiMo V2.5 Pro (Xiaomi, 1T-parameter MoE, 42B active, 1M context window) benchmarks at or above Kimi K2.6 and GLM-5.2 on SWE-bench Verified (78.9%) and is competitive with Claude Opus 4.7 on coding tasks. However, it was falling through to the generic fallback prompt with no model-specific calibration, leaving known MiMo failure modes unaddressed.

## Root Cause

`resolveSisyphusPromptFamily()` in `packages/omo-opencode/src/agents/sisyphus-agent-factory.ts` had no detection branch for MiMo models. Any model with "mimo" in its name (e.g. `xiaomi/mimo-v2.5-pro`, `XiaomiMiMo/MiMo-V2.5-Pro`) hit the `"fallback"` case and received the generic Claude-style prompt.

## Fix

Added a native MiMo V2.5 Pro prompt variant with a calibration block targeting 3 critical MiMo-specific quirks identified through research:

### 1. THINKING-TOOL CONFLICT
MiMo's thinking mode can destabilize the thinking-to-tool_use transition, causing infinite text loops that burn ~1M tokens (GitHub issue XiaomiMiMo/MiMo#59). The calibration block instructs Sisyphus to reason briefly before tool calls and reserve deep deliberation for planning/architecture steps that precede tool use.

### 2. SEQUENTIAL TOOL CALLS
MiMo produces one tool call per turn — no parallel tool call support. The exploration section is adjusted to plan sequential tool use across turns instead of stalling to batch independent calls.

### 3. LATE SAFETY REFUSAL
MiMo sometimes completes a valid reasoning chain and then refuses to output the result, wasting compute. The calibration block explicitly counters this behavior.

## Routing

- **Config builder**: `buildGlmSisyphusAgentConfig` (bare config — no `reasoningEffort` since MiMo does not support that API param; no `thinking` config since that is provider-level via `thinking.type: "enabled"/"disabled"`)
- **Detection**: `isMimoModel()` matches "mimo" in model name, covering `xiaomi/mimo-v2.5-pro`, `XiaomiMiMo/MiMo-V2.5-Pro`, `mimo-v2-5-pro`, and any future MiMo variant
- **Prompt family**: `"mimo-v2.5-pro"` — distinct from all other families so the runtime reconciler rebuilds the prompt when the user switches to/from MiMo in the TUI

## TDD Evidence

- **RED**: `createSisyphusAgent("xiaomi/mimo-v2.5-pro")` produced a prompt containing the generic fallback content with no `"running on MiMo V2.5 Pro"` anchor and no `<mimo_calibration>` block.
- **GREEN**: same call now produces a 14,334-char prompt with all 13 sections including the model-specific calibration block.

## Test Results

- `sisyphus-agent-factory.test.ts`: 9/9 pass (including 2 new MiMo test cases)
- Full agents test suite: 345/345 pass (24 files, 972 assertions)
- model-core test suite: 285/285 pass (25 files, 1278 assertions)
- `typecheck:packages`: 0 new errors (3 pre-existing Senpi installer errors, unrelated — confirmed by stashing changes and re-running)
- Both new/modified files compile cleanly (`bun build --no-bundle`)
- `isMimoModel()` verified: correctly detects all 3 provider naming variants, rejects non-MiMo models
- `resolveSisyphusPromptFamily()` verified: MiMo routes to `"mimo-v2.5-pro"`, does not collide with any other family
- Runtime reconciler verified: MiMo recognized as distinct family from GLM (TUI model switch triggers prompt rebuild)

## Files

- `packages/model-core/src/model-family-detectors.ts` (+4/-0) — `isMimoModel()` detector
- `packages/omo-opencode/src/agents/types.ts` (+2/-0) — re-export `isMimoModel`
- `packages/omo-opencode/src/agents/sisyphus/mimo-v2-5-pro.ts` (+203/-0) — new prompt builder with `<mimo_calibration>` block
- `packages/omo-opencode/src/agents/sisyphus/index.ts` (+1/-0) — export builder
- `packages/omo-opencode/src/agents/sisyphus-agent-factory.ts` (+8/-0) — `"mimo-v2.5-pro"` family type, resolver branch, switch case
- `packages/omo-opencode/src/agents/sisyphus-agent-factory.test.ts` (+27/-0) — 2 new test cases

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Sisyphus prompt routing for MiMo V2.5 Pro with a model-calibrated prompt, and promotes it in the Sisyphus fallback chain. Also avoids 400s on OpenAI‑compatible providers by dropping `reasoningEffort` unless using native `@ai-sdk/openai` (or when `api.npm` is missing).

- **New Features**
  - Detects MiMo via `isMimoModel()` and routes to `"mimo-v2.5-pro"`; adds `buildMimoV25ProSisyphusPrompt` with a `<mimo_calibration>` block covering thinking-to-tool conflict, sequential calls, and late safety refusal.
  - Inserts `"mimo-v2.5-pro"` into `AGENT_MODEL_REQUIREMENTS` after `kimi-k2.6` and before `k2p5` (providers: `openrouter`, `vercel`).
  - Uses `buildGlmSisyphusAgentConfig` with a bare config (no `reasoningEffort`, no `thinking`).

- **Bug Fixes**
  - In `packages/omo-opencode/src/plugin/chat-params.ts`, reads `model.api.npm` and drops `reasoningEffort` for OpenAI‑compatible providers; preserves it for native `@ai-sdk/openai` and when `api.npm` is missing. Tests cover all paths.

<sup>Written for commit 1aadbd387e770a26c5f4ed339d1f8c879d8305c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

