### PR TITLE
fix(#5864): bounded max-defer for pending parent wakes

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -158,6 +158,13 @@ const PARENT_WAKE_TOOL_CALL_DEFER_MAX_MS = 5_000
  */
 const PARENT_WAKE_USER_MESSAGE_IN_PROGRESS_WINDOW_MS = 2_000
 const PARENT_WAKE_SESSION_ACTIVITY_IN_PROGRESS_WINDOW_MS = PARENT_WAKE_TOOL_CALL_DEFER_MAX_MS
+/**
+ * Absolute ceiling after which a pending parent wake is force-flushed as a
+ * reply dispatch even if the parent session stays continuously active (never
+ * emits session.idle). Prevents indefinite defer losing the completion
+ * notification. Well under the 30-min task-inactivity watchdog. See #5864.
+ */
+const PENDING_PARENT_WAKE_MAX_DEFER_MS = 120_000
 
 interface EventProperties {
   sessionID?: string
@@ -318,6 +325,7 @@ export class BackgroundManager {
         failureRequeueWindowMs: PARENT_WAKE_FAILURE_REQUEUE_WINDOW_MS,
         userMessageInProgressWindowMs: PARENT_WAKE_USER_MESSAGE_IN_PROGRESS_WINDOW_MS,
         parentSessionActivityInProgressWindowMs: PARENT_WAKE_SESSION_ACTIVITY_IN_PROGRESS_WINDOW_MS,
+        maxDeferMs: PENDING_PARENT_WAKE_MAX_DEFER_MS,
       },
     )
     this.registerProcessCleanup()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
@@ -16,6 +16,13 @@ export type PendingParentWake = {
   toolCallDeferralStartedAt?: number
   allowEmptyAssistantTurnRetry?: boolean
   noAssistantOutputRetryCount?: number
+  /**
+   * Wall-clock time this wake first entered the pending queue. Used by the
+   * max-defer ceiling (#5864) to force-flush a wake whose parent never emits
+   * `session.idle`. Preserved across merges/requeues so a stream of overlapping
+   * completions cannot reset the clock.
+   */
+  queuedAt?: number
 }
 
 export function resolveParentWakePromptContext(promptContext: ParentWakePromptContext): ParentWakePromptContext {
@@ -45,6 +52,7 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
     ...(wake.noAssistantOutputRetryCount !== undefined
       ? { noAssistantOutputRetryCount: wake.noAssistantOutputRetryCount }
       : {}),
+    ...(wake.queuedAt !== undefined ? { queuedAt: wake.queuedAt } : {}),
   }
 }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -65,9 +65,12 @@ export class ParentWakeFlushRunner {
       // Bounded defer (#5864): the parent never emitted session.idle, so the
       // normal sessionActive / hasRecentActivity / history-defer short-circuits
       // would hold this wake indefinitely. Force a reply-producing dispatch that
-      // also bypasses the prompt-gate status/tool-state checks (forceReplyDispatch)
-      // — otherwise a permanently-busy parent returns {status:"active"} from the
-      // gate and the wake is never delivered. forceNoReply/retainPendingWake stay
+      // bypasses the prompt-gate busy-status check (forceReplyDispatch disables
+      // checkStatus only) — otherwise a permanently-busy parent returns
+      // {status:"active"} from the gate and the wake is never delivered. The
+      // tool-state check (checkToolState) stays enabled so the gate gets a last
+      // chance to reject if the parent's turn became unsafe between the history
+      // check above and the dispatch. forceNoReply/retainPendingWake stay
       // undefined → noReply=false (reply) + pending entry cleared on success.
       // promptAsync's queueBehavior: "defer" serializes against any in-flight
       // turn; if the gate still refuses (reserved/queued), sendParentWakePrompt

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -89,7 +89,25 @@ export class ParentWakeFlushRunner {
       // idle/consumption machinery resumes the wake when the turn settles.
       // This mirrors the normal-path hasRecentParentSessionActivity guard below.
       const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
-      if (this.hasRecentParentSessionActivity(sessionID)) {
+      // Fresh-activity guard: even past the max-defer ceiling, if the parent
+      // has emitted a recent message.part.updated/message.updated event, the
+      // live turn may still be streaming even though session.messages looks
+      // safe/stopped. Forcing a reply-producing dispatch here would inject into
+      // an active turn. Fall back to retained noReply admission — the
+      // idle/consumption machinery resumes the wake when the turn settles.
+      // This mirrors the normal-path hasRecentParentSessionActivity guard below.
+      //
+      // But only on the first admission: once noReplyAdmittedAt is set, the
+      // deposit is already recorded and the wake needs to be *delivered* as a
+      // reply. If we keep returning to this guard on every retry (parent emits
+      // activity every <5s), deferReplyWakeWhileUnsafe returns true and the
+      // wake waits indefinitely — reintroducing #5864's unbounded defer. So
+      // after the first noReply admission, skip this guard and let the
+      // subsequent guards (user-message, history, forceReplyDispatch) decide.
+      if (
+        this.hasRecentParentSessionActivity(sessionID)
+        && latestWake.noReplyAdmittedAt === undefined
+      ) {
         if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
           return
         }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -72,7 +72,31 @@ export class ParentWakeFlushRunner {
       // promptAsync's queueBehavior: "defer" serializes against any in-flight
       // turn; if the gate still refuses (reserved/queued), sendParentWakePrompt
       // requeues (keeping queuedAt) and reschedules, giving bounded retry.
+      //
+      // Exception: if the user just sent a fresh message into the parent session,
+      // a reply-producing dispatch would race their prompt and can crash the
+      // sidecar on Electron/macOS (#4120). In that case, fall back to the same
+      // retained noReply admission the normal path uses — the user's own turn
+      // consumes the deposit without forking a concurrent assistant turn.
       const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
+      if (await this.isUserMessageInProgress(sessionID)) {
+        if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
+          return
+        }
+        await this.sendParentWakePrompt(sessionID, latestWake, {
+          emptyAssistantTurnRetry,
+          toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+          forceNoReply: true,
+          retainPendingWake: latestWake.shouldReply,
+        })
+        log("[background-agent] Recorded admit-only parent wake during max-defer force because user message just arrived:", {
+          sessionID,
+        })
+        if (latestWake.shouldReply) {
+          this.schedulePendingParentWakeFlush(sessionID)
+        }
+        return
+      }
       await this.sendParentWakePrompt(sessionID, latestWake, {
         emptyAssistantTurnRetry,
         toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: false },

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -81,7 +81,32 @@ export class ParentWakeFlushRunner {
       // sidecar on Electron/macOS (#4120). In that case, fall back to the same
       // retained noReply admission the normal path uses — the user's own turn
       // consumes the deposit without forking a concurrent assistant turn.
+      // Fresh-activity guard: even past the max-defer ceiling, if the parent
+      // has emitted a recent message.part.updated/message.updated event, the
+      // live turn may still be streaming even though session.messages looks
+      // safe/stopped. Forcing a reply-producing dispatch here would inject into
+      // an active turn. Fall back to retained noReply admission — the
+      // idle/consumption machinery resumes the wake when the turn settles.
+      // This mirrors the normal-path hasRecentParentSessionActivity guard below.
       const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
+      if (this.hasRecentParentSessionActivity(sessionID)) {
+        if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
+          return
+        }
+        await this.sendParentWakePrompt(sessionID, latestWake, {
+          emptyAssistantTurnRetry,
+          toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+          forceNoReply: true,
+          retainPendingWake: latestWake.shouldReply,
+        })
+        log("[background-agent] Recorded admit-only parent wake during max-defer force because parent session activity is still fresh:", {
+          sessionID,
+        })
+        if (latestWake.shouldReply) {
+          this.schedulePendingParentWakeFlush(sessionID)
+        }
+        return
+      }
       if (await this.isUserMessageInProgress(sessionID)) {
         if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
           return

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -13,6 +13,12 @@ type ParentWakeFlushRunnerDeps = {
   readonly pendingQueue: ParentWakePendingQueue
   readonly dispatchedTracker: ParentWakeDispatchedTracker
   readonly sessionInspector: ParentWakeSessionInspector
+  /**
+   * Absolute ceiling after which a pending wake is force-flushed as a reply
+   * dispatch even if the parent session is still active (#5864). Undefined
+   * preserves the legacy indefinite-defer behavior.
+   */
+  readonly maxDeferMs?: number
 }
 
 export class ParentWakeFlushRunner {
@@ -43,6 +49,35 @@ export class ParentWakeFlushRunner {
       return
     }
     if (await this.dropAdmittedWakeConsumedByParent(sessionID, latestWake)) {
+      return
+    }
+    const maxDeferMs = this.deps.maxDeferMs
+    if (
+      maxDeferMs !== undefined
+      && latestWake.queuedAt !== undefined
+      && Date.now() - latestWake.queuedAt >= maxDeferMs
+    ) {
+      log("[background-agent] Force-flushing parent wake after max-defer ceiling exceeded:", {
+        sessionID,
+        queuedAt: latestWake.queuedAt,
+        maxDeferMs,
+      })
+      // Bounded defer (#5864): the parent never emitted session.idle, so the
+      // normal sessionActive / hasRecentActivity / history-defer short-circuits
+      // would hold this wake indefinitely. Force a reply-producing dispatch that
+      // also bypasses the prompt-gate status/tool-state checks (forceReplyDispatch)
+      // — otherwise a permanently-busy parent returns {status:"active"} from the
+      // gate and the wake is never delivered. forceNoReply/retainPendingWake stay
+      // undefined → noReply=false (reply) + pending entry cleared on success.
+      // promptAsync's queueBehavior: "defer" serializes against any in-flight
+      // turn; if the gate still refuses (reserved/queued), sendParentWakePrompt
+      // requeues (keeping queuedAt) and reschedules, giving bounded retry.
+      const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry,
+        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: false },
+        forceReplyDispatch: true,
+      })
       return
     }
     if (sessionActive) {
@@ -200,6 +235,7 @@ export class ParentWakeFlushRunner {
       readonly toolWaitDecision: ToolWaitDeferralDecision
       readonly forceNoReply?: boolean
       readonly retainPendingWake?: boolean
+      readonly forceReplyDispatch?: boolean
     },
   ): Promise<void> {
     // Mark the dispatch in-flight BEFORE the pending entry is deleted so there is
@@ -221,6 +257,7 @@ export class ParentWakeFlushRunner {
         latestWake,
         ...(options.forceNoReply !== undefined ? { forceNoReply: options.forceNoReply } : {}),
         ...(options.retainPendingWake !== undefined ? { retainPendingWake: options.retainPendingWake } : {}),
+        ...(options.forceReplyDispatch !== undefined ? { forceReplyDispatch: options.forceReplyDispatch } : {}),
         emptyAssistantTurnRetry: options.emptyAssistantTurnRetry,
         toolWaitDecision: options.toolWaitDecision,
         getDispatchedWake: () => this.deps.dispatchedTracker.getWake(sessionID),

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -97,6 +97,35 @@ export class ParentWakeFlushRunner {
         }
         return
       }
+      // History safety: even past the max-defer ceiling, if the parent's
+      // latest assistant turn has an outstanding tool call or unanswered
+      // question, forcing a reply-producing dispatch would fork a concurrent
+      // assistant turn into a turn the history code treats as unsafe. In that
+      // case, fall back to retained noReply admission — the idle/consumption
+      // machinery resumes the wake when the turn settles. This mirrors the
+      // normal-path history deferral at line ~135.
+      const maxDeferHistoryDecision = await this.shouldDeferParentWakeForSessionHistory(
+        sessionID,
+        latestWake,
+      )
+      if (maxDeferHistoryDecision.defer) {
+        if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
+          return
+        }
+        await this.sendParentWakePrompt(sessionID, latestWake, {
+          emptyAssistantTurnRetry,
+          toolWaitDecision: { ...maxDeferHistoryDecision, skipPromptGateToolStateCheck: true },
+          forceNoReply: true,
+          retainPendingWake: latestWake.shouldReply,
+        })
+        log("[background-agent] Held max-defer force-flush because session history is unsafe:", {
+          sessionID,
+        })
+        if (latestWake.shouldReply) {
+          this.schedulePendingParentWakeFlush(sessionID)
+        }
+        return
+      }
       await this.sendParentWakePrompt(sessionID, latestWake, {
         emptyAssistantTurnRetry,
         toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: false },

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
@@ -240,6 +240,54 @@ describe("parent wake max-defer force-flush (#5864)", () => {
     }
   })
 
+  test("#given max-defer force-flush with history safe but gate tool-state sees running tool #then gate blocks and requeues (checkToolState preserved)", async () => {
+    // given: 50ms max-defer ceiling; clock starts at 100_000. The messages
+    // provider is stateful: the first read (isUserMessageInProgress guard)
+    // and second read (shouldDeferParentWakeForSessionHistory) return
+    // SAFE_MESSAGES, but the third read (the prompt gate's checkToolState via
+    // sessionLatestAssistantBlocksInternalPrompt) returns TOOL_CALL_IN_PROGRESS.
+    // This simulates the parent's turn becoming unsafe between the history
+    // check and the gate call. With checkToolState preserved for
+    // forceReplyDispatch, the gate returns {status:"active"} and the wake is
+    // requeued — promptAsync is never called.
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    let messagesCallCount = 0
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => {
+        messagesCallCount++
+        // Read 1: isUserMessageInProgress guard → safe (no user message)
+        // Read 2: shouldDeferParentWakeForSessionHistory → safe (no tool block)
+        // Read 3: prompt gate checkToolState → running tool (turn became unsafe)
+        return messagesCallCount <= 2 ? SAFE_MESSAGES : TOOL_CALL_IN_PROGRESS
+      },
+      maxDeferMs: 50,
+    })
+
+    try {
+      // when: queue a reply-required wake, mark recent activity, advance the
+      // clock past the ceiling, and flush. History reads safe messages first,
+      // so the history safety guard passes. But the gate's checkToolState reads
+      // messages again and sees a running tool call — it returns active and
+      // blocks the dispatch.
+      notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+      notifier.recordParentSessionActivity("parent-1")
+      Date.now = () => 100_060
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: no promptAsync call — the gate blocked the dispatch because the
+      // tool-state check saw an unsafe turn. The pending wake is retained
+      // (requeued by sendParentWakePrompt's gate-refusal path).
+      expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
   test("#given max-defer ceiling not yet elapsed #then does not force-flush (regression guard)", async () => {
     // given: large max-defer ceiling so the ceiling has not elapsed
     const originalDateNow = Date.now

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
@@ -331,6 +331,55 @@ describe("parent wake max-defer force-flush (#5864)", () => {
     }
   })
 
+  test("#given max-defer exceeded with fresh activity but wake already admitted noReply #then force-flushes reply dispatch (bounded defer)", async () => {
+    // given: 50ms max-defer ceiling; clock starts at 100_000. A reply-required
+    // wake is queued and the parent has a fresh activity window. On the first
+    // flush past the ceiling, the fresh-activity guard admits it as noReply
+    // (recording the deposit). On the second flush, the wake already has
+    // noReplyAdmittedAt set — the fresh-activity guard must NOT keep deferring
+    // (that would reintroduce #5864's unbounded wait). Instead it proceeds to
+    // forceReplyDispatch to actually deliver the result.
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      maxDeferMs: 50,
+      parentSessionActivityInProgressWindowMs: 10_000,
+    })
+
+    try {
+      // when: queue a reply-required wake, advance past the ceiling, record
+      // fresh activity, and flush twice. The first flush admits noReply. The
+      // second flush (still past the ceiling, still fresh activity) must
+      // proceed to forceReplyDispatch because noReplyAdmittedAt is set.
+      notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+      Date.now = () => 100_060
+      notifier.recordParentSessionActivity("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+      // First flush: noReply admission
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+      // Advance the clock past the first dispatch's 2s post-dispatch
+      // reservation hold and re-record activity so the fresh-activity guard
+      // is still active on the second flush.
+      Date.now = () => 102_061
+
+      // Second flush: still past the ceiling, still fresh activity, but
+      // noReplyAdmittedAt is set → fresh-activity guard bypassed → forceReplyDispatch
+      notifier.recordParentSessionActivity("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
   test("#given max-defer ceiling not yet elapsed #then does not force-flush (regression guard)", async () => {
     // given: large max-defer ceiling so the ceiling has not elapsed
     const originalDateNow = Date.now

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
@@ -50,6 +50,20 @@ const SAFE_MESSAGES: SessionMessageStub[] = [
   },
 ]
 
+// Latest message is a fresh user prompt (created at "now") — triggers
+// isUserMessageInProgress so the max-defer force path must fall back to
+// retained noReply admission instead of a reply-producing dispatch (#4120).
+const USER_MESSAGE_IN_PROGRESS: SessionMessageStub[] = [
+  {
+    info: { role: "assistant", finish: "stop", time: { created: 90_000 } },
+    parts: [{ type: "text", text: "delegated to background" }],
+  },
+  {
+    info: { role: "user", time: { created: 100_060 } },
+    parts: [{ type: "text", text: "are you done yet?" }],
+  },
+]
+
 function createNotifier(args: {
   sessionStatuses?: Record<string, { type: string }>
   messagesProvider: () => SessionMessageStub[]
@@ -123,6 +137,45 @@ describe("parent wake max-defer force-flush (#5864)", () => {
       expect(promptAsyncCalls).toHaveLength(1)
       expect(promptAsyncCalls[0]?.body.noReply).toBe(false)
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given max-defer exceeded but user message just arrived #then admits noReply retained and keeps the wake queued (#4120 guard)", async () => {
+    // given: 50ms max-defer ceiling; clock starts at 100_000. A reply-required
+    // wake is queued at 100_000 and the parent stays busy/active. After the
+    // ceiling elapses the user sends a fresh prompt into the parent session
+    // (latest message created at "now"), so isUserMessageInProgress() is true.
+    // The max-defer force path must NOT force a reply-producing dispatch
+    // (that would race the user's prompt and can crash the sidecar on
+    // Electron/macOS, #4120). Instead it admits the wake as retained noReply
+    // and keeps the pending entry queued for the user's turn to consume.
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => USER_MESSAGE_IN_PROGRESS,
+      maxDeferMs: 50,
+    })
+
+    try {
+      // when: queue a reply-required wake, mark recent activity, advance the
+      // clock past the ceiling (60ms > 50ms), and flush. The messages provider
+      // returns a fresh user message created at 100_060 (== now), so the
+      // isUserMessageInProgress guard fires inside the max-defer force path.
+      notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+      notifier.recordParentSessionActivity("parent-1")
+      Date.now = () => 100_060
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: a noReply dispatch happened (admit-only, not reply-producing)
+      // and the pending wake is retained for the user's turn to consume.
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
@@ -64,6 +64,24 @@ const USER_MESSAGE_IN_PROGRESS: SessionMessageStub[] = [
   },
 ]
 
+// Latest assistant turn has an outstanding (running) tool call — triggers
+// latestAssistantTurnBlocksInternalPrompt so shouldDeferParentWakeForSessionHistory
+// returns defer:true. The max-defer force path must NOT forceReplyDispatch into
+// this unsafe turn; it admits noReply retained instead.
+const TOOL_CALL_IN_PROGRESS: SessionMessageStub[] = [
+  {
+    info: {
+      role: "assistant",
+      finish: "tool-calls",
+      time: { created: 90_000 },
+    },
+    parts: [
+      { type: "text", text: "let me check" },
+      { type: "tool", state: { status: "running" } },
+    ],
+  },
+]
+
 function createNotifier(args: {
   sessionStatuses?: Record<string, { type: string }>
   messagesProvider: () => SessionMessageStub[]
@@ -173,6 +191,45 @@ describe("parent wake max-defer force-flush (#5864)", () => {
 
       // then: a noReply dispatch happened (admit-only, not reply-producing)
       // and the pending wake is retained for the user's turn to consume.
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given max-defer exceeded but assistant turn has outstanding tool call #then admits noReply retained and keeps the wake queued (history safety)", async () => {
+    // given: 50ms max-defer ceiling; clock starts at 100_000. A reply-required
+    // wake is queued at 100_000 and the parent stays busy/active. After the
+    // ceiling elapses, the parent's latest assistant turn has finish:"tool-calls"
+    // with a running tool part — shouldDeferParentWakeForSessionHistory returns
+    // defer:true. The max-defer force path must NOT forceReplyDispatch into
+    // this unsafe turn (would fork a concurrent assistant turn); it admits
+    // noReply retained instead, and the idle/consumption machinery resumes
+    // when the tool settles.
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => TOOL_CALL_IN_PROGRESS,
+      maxDeferMs: 50,
+    })
+
+    try {
+      // when: queue a reply-required wake, mark recent activity, advance the
+      // clock past the ceiling (60ms > 50ms), and flush. The messages provider
+      // returns an assistant turn with a running tool call, so the history
+      // deferral guard fires inside the max-defer force path.
+      notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+      notifier.recordParentSessionActivity("parent-1")
+      Date.now = () => 100_060
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: a noReply dispatch happened (admit-only, not reply-producing)
+      // and the pending wake is retained for the turn to settle.
       expect(promptAsyncCalls).toHaveLength(1)
       expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { ParentWakeNotifier } from "./parent-wake-notifier"
+import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+
+type PromptAsyncCall = {
+  path: { id: string }
+  body: {
+    noReply?: boolean
+    parts?: unknown[]
+  }
+  query?: {
+    directory: string
+  }
+}
+
+type SessionMessageStub = {
+  info?: {
+    role?: string
+    finish?: string
+    time?: { created?: number; completed?: number }
+    error?: { name?: string }
+  }
+  parts?: Array<{ type?: string; text?: string; synthetic?: boolean; state?: { status?: string } }>
+}
+
+const FINAL_WAKE = [
+  "<system-reminder>",
+  "[BACKGROUND TASK COMPLETED]",
+  "[ALL BACKGROUND TASKS COMPLETE]",
+  "",
+  "**Completed:**",
+  "- `task-a`: task A",
+  "",
+  'Use `background_output(task_id="<id>")` to retrieve each result.',
+  "</system-reminder>",
+].join("\n")
+
+// Assistant-terminated history so hasRecentActivity / history-deferral do not
+// independently block the flush — the only blocker is the busy session status.
+const SAFE_MESSAGES: SessionMessageStub[] = [
+  {
+    info: { role: "user", time: { created: 80_000 } },
+    parts: [{ type: "text", text: "start work" }],
+  },
+  {
+    info: { role: "assistant", finish: "stop", time: { created: 90_000 } },
+    parts: [{ type: "text", text: "delegated to background" }],
+  },
+]
+
+function createNotifier(args: {
+  sessionStatuses?: Record<string, { type: string }>
+  messagesProvider: () => SessionMessageStub[]
+  maxDeferMs?: number
+}): {
+  notifier: ParentWakeNotifier
+  promptAsyncCalls: PromptAsyncCall[]
+} {
+  const promptAsyncCalls: PromptAsyncCall[] = []
+  const client = {
+    session: {
+      messages: async () => ({ data: args.messagesProvider() }),
+      status: async () => ({ data: args.sessionStatuses ?? {} }),
+      promptAsync: async (call: PromptAsyncCall) => {
+        promptAsyncCalls.push(call)
+        return { data: {} }
+      },
+      abort: async () => ({ data: {} }),
+    },
+  } as unknown as ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
+
+  const notifier = new ParentWakeNotifier(
+    {
+      client,
+      directory: "/tmp/test-omo",
+      enqueueNotificationForParent: async (_sessionID, operation) => {
+        await operation()
+      },
+    },
+    {
+      pendingRetryMs: 1_000,
+      acceptedMessageSkewMs: 5_000,
+      toolCallDeferMaxMs: 5_000,
+      failureRequeueWindowMs: 5_000,
+      userMessageInProgressWindowMs: 2_000,
+      ...(args.maxDeferMs !== undefined ? { maxDeferMs: args.maxDeferMs } : {}),
+    },
+  )
+
+  return { notifier, promptAsyncCalls }
+}
+
+afterEach(() => {
+  releaseAllPromptAsyncReservationsForTesting()
+})
+
+describe("parent wake max-defer force-flush (#5864)", () => {
+  test("#given parent stays busy and active past max-defer #then force-flushes a reply dispatch and clears the pending wake", async () => {
+    // given: parent permanently busy, safe history, small max-defer ceiling
+    const originalDateNow = Date.now
+    const queueTime = 100_000
+    Date.now = () => queueTime
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      maxDeferMs: 50,
+    })
+
+    try {
+      // when: queue a reply-required all-complete wake, mark recent activity
+      // (simulating continuous tool calls), then advance the clock past the
+      // max-defer ceiling and flush.
+      notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+      notifier.recordParentSessionActivity("parent-1")
+      Date.now = () => queueTime + 60 // 60ms > 50ms ceiling
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: a reply-producing dispatch happened (the load-bearing assertion —
+      // without the fix the sessionActive branch returns early and no dispatch
+      // occurs) and the pending entry was cleared, not retained.
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(false)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given max-defer ceiling not yet elapsed #then does not force-flush (regression guard)", async () => {
+    // given: large max-defer ceiling so the ceiling has not elapsed
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      maxDeferMs: 50_000,
+    })
+
+    try {
+      // when: queue a reply wake, mark recent activity, flush immediately
+      notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+      notifier.recordParentSessionActivity("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: still deferred — no dispatch, pending wake retained. Guards
+      // against an over-eager force-flush that would interleave on every flush.
+      expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given maxDeferMs undefined #then preserves legacy indefinite-defer behavior", async () => {
+    // given: notifier constructed WITHOUT maxDeferMs (default), parent busy
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => SAFE_MESSAGES,
+    })
+
+    try {
+      // when: queue a reply wake, mark recent activity, advance clock 10s, flush
+      notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+      notifier.recordParentSessionActivity("parent-1")
+      Date.now = () => 110_000
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: no dispatch, pending wake still present — the default is a no-op
+      // and no existing caller's behavior changes.
+      expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { ParentWakeNotifier } from "./parent-wake-notifier"
+import { ParentWakePendingQueue } from "./parent-wake-pending-queue"
+import type { PendingParentWake } from "./parent-wake-dedupe"
 import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
 
 type PromptAsyncCall = {
@@ -180,5 +182,71 @@ describe("parent wake max-defer force-flush (#5864)", () => {
       notifier.shutdown()
       releaseAllPromptAsyncReservationsForTesting()
     }
+  })
+})
+
+describe("parent wake queuedAt preservation across requeue merges (#5864)", () => {
+  test("#given existing wake with newer queuedAt #when older wake requeues into it #then keeps the oldest queuedAt", () => {
+    // given: an existing pending wake queued at T=200 (newer)
+    const originalDateNow = Date.now
+    Date.now = () => 200_000
+    const queue = new ParentWakePendingQueue({
+      pendingRetryMs: 1_000,
+      enqueueNotificationForParent: async (_sessionID, operation) => {
+        await operation()
+      },
+    })
+    try {
+      queue.queueWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+      expect(queue.getWake("parent-1")?.queuedAt).toBe(200_000)
+
+      // when: an older wake (queuedAt=100) is requeued into the existing entry.
+      // Build the requeued wake as an independent literal — do NOT mutate the
+      // queue's existing wake, otherwise the old ??= bug would pass too.
+      const existing = queue.getWake("parent-1")!
+      const requeuedWake: PendingParentWake = {
+        ...existing,
+        queuedAt: 100_000,
+      }
+      Date.now = () => 210_000
+      queue.requeueWake("parent-1", requeuedWake)
+
+      // then: the merged wake keeps the oldest (minimum) queuedAt, not the
+      // newer one — so the max-defer clock still measures time-since-first-queue.
+      // With the old ??= bug, the existing 200_000 would be kept (not overwritten).
+      expect(queue.getWake("parent-1")?.queuedAt).toBe(100_000)
+    } finally {
+      Date.now = originalDateNow
+      queue.shutdown()
+    }
+  })
+
+  test("#given existing wake with older queuedAt #when newer wake requeues into it #then keeps the oldest queuedAt", () => {
+    // given: an existing pending wake queued at T=100 (older)
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const queue = new ParentWakePendingQueue({
+      pendingRetryMs: 1_000,
+      enqueueNotificationForParent: async (_sessionID, operation) => {
+        await operation()
+      },
+    })
+    queue.queueWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    expect(queue.getWake("parent-1")?.queuedAt).toBe(100_000)
+
+    // when: a newer wake (queuedAt=200) is requeued into the existing entry
+    const existing = queue.getWake("parent-1")!
+    const requeuedWake = {
+      ...existing,
+      queuedAt: 200_000,
+    }
+    Date.now = () => 210_000
+    queue.requeueWake("parent-1", requeuedWake)
+
+    // then: the merged wake keeps the older (minimum) queuedAt
+    expect(queue.getWake("parent-1")?.queuedAt).toBe(100_000)
+
+    Date.now = originalDateNow
+    queue.shutdown()
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-max-defer.test.ts
@@ -86,6 +86,7 @@ function createNotifier(args: {
   sessionStatuses?: Record<string, { type: string }>
   messagesProvider: () => SessionMessageStub[]
   maxDeferMs?: number
+  parentSessionActivityInProgressWindowMs?: number
 }): {
   notifier: ParentWakeNotifier
   promptAsyncCalls: PromptAsyncCall[]
@@ -118,6 +119,9 @@ function createNotifier(args: {
       failureRequeueWindowMs: 5_000,
       userMessageInProgressWindowMs: 2_000,
       ...(args.maxDeferMs !== undefined ? { maxDeferMs: args.maxDeferMs } : {}),
+      ...(args.parentSessionActivityInProgressWindowMs !== undefined
+        ? { parentSessionActivityInProgressWindowMs: args.parentSessionActivityInProgressWindowMs }
+        : {}),
     },
   )
 
@@ -280,6 +284,45 @@ describe("parent wake max-defer force-flush (#5864)", () => {
       // tool-state check saw an unsafe turn. The pending wake is retained
       // (requeued by sendParentWakePrompt's gate-refusal path).
       expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given max-defer exceeded but parent has fresh session activity #then admits noReply retained and keeps the wake queued (fresh-activity guard)", async () => {
+    // given: 50ms max-defer ceiling; clock starts at 100_000. A reply-required
+    // wake is queued at 100_000. The parent has a fresh activity window
+    // (parentSessionActivityInProgressWindowMs: 10_000) and
+    // recordParentSessionActivity is called right before flushing — simulating
+    // a live turn streaming (message.part.updated/message.updated events) even
+    // though session.messages looks safe/stopped. The max-defer force path must
+    // NOT forceReplyDispatch into an active turn; it admits noReply retained
+    // instead, and the idle/consumption machinery resumes when the turn settles.
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      maxDeferMs: 50,
+      parentSessionActivityInProgressWindowMs: 10_000,
+    })
+
+    try {
+      // when: queue a reply-required wake, then advance the clock past the
+      // ceiling (60ms > 50ms) and record fresh activity right before flushing.
+      // The fresh-activity guard fires inside the max-defer force path.
+      notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+      Date.now = () => 100_060
+      notifier.recordParentSessionActivity("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: a noReply dispatch happened (admit-only, not reply-producing)
+      // and the pending wake is retained for the turn to settle.
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
     } finally {
       Date.now = originalDateNow

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
@@ -47,4 +47,11 @@ export type ParentWakeNotifierOptions = {
    */
   readonly userMessageInProgressWindowMs: number
   readonly parentSessionActivityInProgressWindowMs?: number
+  /**
+   * Absolute ceiling after which a pending wake is force-flushed as a reply
+   * dispatch even if the parent session is still active. Prevents indefinite
+   * defer when the parent never emits `session.idle` (#5864). When undefined
+   * (the default), behavior is unchanged — wakes defer indefinitely as before.
+   */
+  readonly maxDeferMs?: number
 }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
@@ -66,6 +66,7 @@ export class ParentWakeNotifier {
       pendingQueue: this.pendingQueue,
       dispatchedTracker: this.dispatchedTracker,
       sessionInspector: this.sessionInspector,
+      ...(options.maxDeferMs !== undefined ? { maxDeferMs: options.maxDeferMs } : {}),
     })
   }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -8,6 +8,17 @@ import {
 } from "./parent-wake-dedupe"
 import { unrefTimerHandle } from "./parent-wake-timer-handle"
 
+/**
+ * Returns the oldest (minimum) defined `queuedAt` between two values. Used
+ * during requeue merges to keep the max-defer clock measuring time-since-first
+ * queue, not time-since-last-merge (#5864). If only one is defined, that one
+ * wins; if both are undefined, undefined is returned.
+ */
+function oldestQueuedAt(left: number | undefined, right: number | undefined): number | undefined {
+  if (left === undefined) return right
+  if (right === undefined) return left
+  return Math.min(left, right)
+}
 type ParentWakePendingQueueOptions = {
   readonly pendingRetryMs: number
   readonly enqueueNotificationForParent: (
@@ -83,7 +94,7 @@ export class ParentWakePendingQueue {
       pendingWake.promptContext = latestWake.promptContext
       pendingWake.noReplyAdmittedAt ??= latestWake.noReplyAdmittedAt
       pendingWake.toolCallDeferralStartedAt ??= latestWake.toolCallDeferralStartedAt
-      pendingWake.queuedAt ??= latestWake.queuedAt
+      pendingWake.queuedAt = oldestQueuedAt(pendingWake.queuedAt, latestWake.queuedAt)
       pendingWake.allowEmptyAssistantTurnRetry ||= latestWake.allowEmptyAssistantTurnRetry
       const noAssistantOutputRetryCount = Math.max(
         pendingWake.noAssistantOutputRetryCount ?? 0,

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -68,6 +68,7 @@ export class ParentWakePendingQueue {
       promptContext: resolvedPromptContext,
       notifications: [notification],
       shouldReply,
+      queuedAt: Date.now(),
     })
   }
 
@@ -82,6 +83,7 @@ export class ParentWakePendingQueue {
       pendingWake.promptContext = latestWake.promptContext
       pendingWake.noReplyAdmittedAt ??= latestWake.noReplyAdmittedAt
       pendingWake.toolCallDeferralStartedAt ??= latestWake.toolCallDeferralStartedAt
+      pendingWake.queuedAt ??= latestWake.queuedAt
       pendingWake.allowEmptyAssistantTurnRetry ||= latestWake.allowEmptyAssistantTurnRetry
       const noAssistantOutputRetryCount = Math.max(
         pendingWake.noAssistantOutputRetryCount ?? 0,

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -19,11 +19,16 @@ type ParentWakePromptDispatchInput = {
   readonly forceNoReply?: boolean
   readonly retainPendingWake?: boolean
   /**
-   * When true, bypass the prompt-gate status/tool-state checks and dispatch a
-   * reply-producing prompt even if the parent session is still busy. Used by
-   * the max-defer force-flush (#5864) to deliver a completion notification to
-   * a parent that never emits session.idle. Unlike forceNoReply, this keeps
-   * noReply=false so the orchestrator actually receives the result.
+   * When true, bypass the prompt-gate busy-status check (checkStatus) and
+   * dispatch a reply-producing prompt even if the parent session reports
+   * active/busy. Used by the max-defer force-flush (#5864) to deliver a
+   * completion notification to a parent that never emits session.idle.
+   * Unlike forceNoReply, this keeps noReply=false so the orchestrator
+   * actually receives the result. The tool-state check (checkToolState) is
+   * intentionally NOT bypassed — the history check in ParentWakeFlushRunner
+   * happens before dispatch, but the parent's turn can become unsafe between
+   * that check and the gate call; keeping checkToolState gives the gate a
+   * last chance to reject and requeue.
    */
   readonly forceReplyDispatch?: boolean
   readonly emptyAssistantTurnRetry: boolean
@@ -45,8 +50,7 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
       client: input.client,
       sessionID: input.sessionID,
       checkStatus: input.forceReplyDispatch !== true && input.forceNoReply !== true,
-      checkToolState: input.forceReplyDispatch !== true
-        && input.forceNoReply !== true
+      checkToolState: input.forceNoReply !== true
         && !input.toolWaitDecision.skipPromptGateToolStateCheck,
       source: "background-agent-parent-wake",
       ...(input.emptyAssistantTurnRetry

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -18,6 +18,14 @@ type ParentWakePromptDispatchInput = {
   readonly latestWake: PendingParentWake
   readonly forceNoReply?: boolean
   readonly retainPendingWake?: boolean
+  /**
+   * When true, bypass the prompt-gate status/tool-state checks and dispatch a
+   * reply-producing prompt even if the parent session is still busy. Used by
+   * the max-defer force-flush (#5864) to deliver a completion notification to
+   * a parent that never emits session.idle. Unlike forceNoReply, this keeps
+   * noReply=false so the orchestrator actually receives the result.
+   */
+  readonly forceReplyDispatch?: boolean
   readonly emptyAssistantTurnRetry: boolean
   readonly toolWaitDecision: ToolWaitDeferralDecision
   readonly getDispatchedWake: () => PendingParentWake | undefined
@@ -36,14 +44,16 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
       mode: "async",
       client: input.client,
       sessionID: input.sessionID,
+      checkStatus: input.forceReplyDispatch !== true && input.forceNoReply !== true,
+      checkToolState: input.forceReplyDispatch !== true
+        && input.forceNoReply !== true
+        && !input.toolWaitDecision.skipPromptGateToolStateCheck,
       source: "background-agent-parent-wake",
       ...(input.emptyAssistantTurnRetry
         ? { dedupeKey: createEmptyAssistantTurnRetryDedupeKey(input.latestWake) }
         : {}),
       settleMs: 0,
       queueBehavior: "defer",
-      checkStatus: input.forceNoReply !== true,
-      checkToolState: input.forceNoReply !== true && !input.toolWaitDecision.skipPromptGateToolStateCheck,
       input: {
         path: { id: input.sessionID },
         body: {


### PR DESCRIPTION
## Summary

Fixes #5864.

When a background task completes while its parent (orchestrator) session stays continuously active (back-to-back tool calls, no `session.idle`), the completion notification was queued via `queuePendingParentWake` and **deferred indefinitely**. The only flush path was the `session.idle` event handler — a parent that never goes idle holds the wake until the 30-minute task-inactivity watchdog kills the (already-finished) child. The child has already written its artifact to disk; only the notification is lost.

## Fix

Add an absolute `PENDING_PARENT_WAKE_MAX_DEFER_MS` ceiling (120s). Once a wake has sat in the pending queue longer than this, force-flush it as a **reply-producing** dispatch even if the parent is still busy.

### Changes

- **`queuedAt` timestamp** (`parent-wake-dedupe.ts`, `parent-wake-pending-queue.ts`): track when a wake first entered the pending queue. Preserved across merges/requeues via `oldestQueuedAt()` (min of defined values) so overlapping completions can't reset the ceiling clock — this is load-bearing for the issue's "multiple background tasks dispatched quickly" scenario.

- **`maxDeferMs` option** (`parent-wake-notifier-types.ts`, `parent-wake-notifier.ts`, `parent-wake-flush-runner.ts`): optional ceiling threaded from the manager through the notifier to the flush runner. Default `undefined` → no behavior change for any existing caller.

- **Force-flush short-circuit** (`parent-wake-flush-runner.ts`): in `flushPendingParentWake`, after the `dropAdmittedWakeConsumedByParent` check, if `Date.now() - queuedAt >= maxDeferMs`, force a reply-producing dispatch. Three safety guards run first (each falls back to retained noReply admission instead of forking a concurrent assistant turn):
  1. **Fresh-activity guard** (`hasRecentParentSessionActivity`): if the parent has emitted a recent `message.part.updated`/`message.updated` event, the live turn may still be streaming. Only applies on the first admission (`noReplyAdmittedAt === undefined`) — once the deposit is recorded, the guard is skipped so the wake is eventually delivered as a reply, not re-admitted as noReply forever (bounds the defer against a parent that emits activity every <5s).
  2. **User-message race guard** (`isUserMessageInProgress`): if the user just sent a fresh prompt into the parent session, fall back to retained noReply admission — a reply-producing dispatch would race their prompt and can crash the sidecar on Electron/macOS (#4120).
  3. **History safety guard** (`shouldDeferParentWakeForSessionHistory`): if the parent's latest assistant turn has an outstanding tool call or unanswered question, fall back to retained noReply admission — forcing a reply would fork a concurrent assistant turn into a turn the history code treats as unsafe.
  Only when all three guards pass does `forceReplyDispatch` fire.

- **`forceReplyDispatch` gate bypass** (`parent-wake-prompt-dispatch.ts`): new option that sets `checkStatus: false` only (busy-status bypass); `checkToolState` stays enabled so the gate gets a last chance to reject if the turn became unsafe between the history check and the dispatch. Keeps `noReply: false` so the orchestrator receives the result. Without this, a permanently-busy parent returns `{status:"active"}` from the prompt gate and never receives the dispatch — `forceNoReply` bypasses the gate but produces an admit-only noReply marker, which doesn't deliver the result to the orchestrator's reasoning.

- **Manager wiring** (`manager.ts`): `const PENDING_PARENT_WAKE_MAX_DEFER_MS = 120_000` and wired into the notifier options.

- **Regression tests** (`parent-wake-max-defer.test.ts`): 10 cases (9 bullets — #6 covers two requeue directions):
  1. Force-flushes a reply dispatch after the ceiling with the parent permanently busy + recent activity recorded (the load-bearing assertion — without the fix, `promptAsyncCalls` stays empty).
  2. Does not force-flush before the ceiling elapses (regression guard against over-eager interleaving).
  3. `maxDeferMs` undefined preserves legacy indefinite-defer behavior.
  4. Max-defer exceeded but user message just arrived → admits noReply retained and keeps the wake queued (#4120 guard).
  5. Max-defer exceeded but assistant turn has outstanding tool call → admits noReply retained and keeps the wake queued (history safety).
  6. `queuedAt` preservation across requeue merges (older-into-newer and newer-into-older).
  7. Max-defer force-flush with history safe but gate tool-state sees running tool → gate blocks and requeues (checkToolState preserved).
  8. Max-defer exceeded but parent has fresh session activity → admits noReply retained (fresh-activity guard).
  9. Max-defer exceeded with fresh activity but wake already admitted noReply → force-flushes reply dispatch (bounded defer).

## Verification

- ✅ **New regression tests:** 10/10 pass (`EXIT=0`). Reproduction confirmed: with `maxDeferMs` disabled, case 1 fails (`promptAsyncCalls` empty) — proving the bug exists in the unmodified tree. Cases 4, 5, 7, 8, and 9 verified to fail without their respective guards.
- ✅ **Parent-wake suite** (`packages/omo-opencode/src/features/background-agent/`): 96 pass, 0 fail (`EXIT=0`).
- ✅ **`omo-opencode` package typecheck:** `EXIT=0`.
- ❌ **Root typecheck:** `EXIT=2` — 41 diagnostics in `packages/pi-goal` (missing `@mariozechner/pi-coding-agent` devDependency, likely from incomplete `bun install`). Not attributable to this diff (no changes to `pi-goal`); not baselined against an unmodified tree.
- ❌ **Build:** failed on pre-existing git submodule issue (`open-design` revision missing in `materialize-shared-upstreams`). Unrelated to this fix.
- ❌ **Root test suite:** 23 failures in Codex install/materialization, Codex telemetry bundling, and shared-skill frontend drift. None in `background-agent/` or `prompt-async-gate/`.

## Design notes

- **120s ceiling:** well under the 30-min task-inactivity watchdog, far above normal parent tool-call bursts. One-line constant change if maintainers prefer 60s/180s.
- **Force-flush is reply-producing, not noReply:** the bug is that the orchestrator never *receives* the result. A noReply force-flush would only deposit a passive marker. `promptAsync`'s `queueBehavior: "defer"` + reservation system serializes the injection against any in-flight turn, so "interleaving" means "dispatches as the next turn after the current one finishes," not "crashes the in-flight turn."
- **Safety guards before force-flush:** the fresh-activity, user-message race (#4120), and history safety checks run *inside* the max-defer force path, before `forceReplyDispatch`. If any guard triggers, the wake is admitted as retained noReply and the idle/consumption machinery resumes it when the turn settles — no concurrent assistant turn is forked. The fresh-activity guard only applies on the first admission (`noReplyAdmittedAt === undefined`), so a parent that keeps emitting activity events every <5s still gets the reply delivered on the next flush — the defer is bounded by `maxDeferMs`, not indefinite.
- **Bounded retry:** if the gate still refuses during a force-flush (reserved/queued), `sendParentWakePrompt` requeues (keeping `queuedAt`) and reschedules, giving bounded retry every `pendingRetryMs` (1s).

> Note: PR #1 on the fork (FNDEVVE/oh-my-openagent) is superseded by this upstream PR. Please review this one.

