### PR TITLE
docs(installation): note community model tools

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -233,18 +233,6 @@ Map their answer to:
 
 **MUST STRONGLY WARN, WHEN USER SAID THEY DON'T HAVE CLAUDE SUBSCRIPTION, SISYPHUS AGENT MIGHT NOT WORK IDEALLY.**
 
-#### Optional: community model-management tools
-
-Community tools such as the experimental [oh-my-openagent VS Code extension](https://github.com/andersou/oh-my-openagent-vscode-extension) can make agent model selection easier to inspect and edit. Treat them as configuration frontends: they should write the same `oh-my-openagent.jsonc` / `oh-my-opencode.jsonc` fields documented here, not a separate runtime integration.
-
-After using any external UI to change models:
-
-1. Review the generated JSONC before restarting OpenCode.
-2. Run `bunx oh-my-openagent doctor` to confirm the effective model for each agent/category.
-3. Keep provider credentials and API keys in the provider auth flow or environment, not in shared project config.
-
-If an external tool shows a model that OMO later skips, the source of truth is still the model-matching and registration logic in this repository. Use the [Agent Model Matching](./agent-model-matching.md) guide to check whether the selected model family is supported for that agent.
-
 ### Step 1: Prerequisites
 
 #### For platform `opencode` or `both`
@@ -638,6 +626,20 @@ If the user wants to override which model an agent uses, edit the plugin config 
 **Lower-risk overrides** (compatible behavior): Sisyphus Opus → Sonnet/Kimi K2.6/GLM 5; Prometheus Opus → GPT-5.5 (same prompt, different model); Atlas Kimi K2.6 → Sonnet/GPT-5.5 (auto-switch).
 
 **Dangerous overrides** (no prompt support): Sisyphus → older GPT models (only 5.4/5.5 have dedicated GPT paths); Hephaestus → Claude (built for Codex); Explore → Opus (massive cost waste); Librarian → Opus (same).
+
+#### Optional: community model-management tools
+
+The independently maintained, experimental [oh-my-openagent VS Code extension](https://github.com/andersou/oh-my-openagent-vscode-extension) can edit user-level model assignments. It is a third-party configuration frontend, not an OMO runtime component; the OMO project does not maintain or support it, and compatibility is not guaranteed.
+
+Use external tools only with the canonical `oh-my-openagent.jsonc` fields described in [Configuration](../reference/configuration.md). Check which file the tool changed: a nearer project `.opencode/oh-my-openagent.jsonc` overrides user-level settings, and a coexisting legacy `oh-my-opencode.jsonc` is ignored when the canonical file exists.
+
+After using an external UI to change models:
+
+1. Review the generated JSONC before restarting OpenCode.
+2. Run `bunx oh-my-openagent doctor --verbose` to inspect its diagnostic model-resolution view. This does not replace checking nearer project config or runtime registration and model-matching rules.
+3. Keep provider credentials and API keys in the provider auth flow or environment, not in shared project config.
+
+If an external tool shows a model that OMO later skips, the source of truth is still the model-matching and registration logic in this repository. Use the [Agent Model Matching](./agent-model-matching.md) guide to check whether the selected model family is supported for that agent.
 
 #### Provider resolution
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -233,6 +233,18 @@ Map their answer to:
 
 **MUST STRONGLY WARN, WHEN USER SAID THEY DON'T HAVE CLAUDE SUBSCRIPTION, SISYPHUS AGENT MIGHT NOT WORK IDEALLY.**
 
+#### Optional: community model-management tools
+
+Community tools such as the experimental [oh-my-openagent VS Code extension](https://github.com/andersou/oh-my-openagent-vscode-extension) can make agent model selection easier to inspect and edit. Treat them as configuration frontends: they should write the same `oh-my-openagent.jsonc` / `oh-my-opencode.jsonc` fields documented here, not a separate runtime integration.
+
+After using any external UI to change models:
+
+1. Review the generated JSONC before restarting OpenCode.
+2. Run `bunx oh-my-openagent doctor` to confirm the effective model for each agent/category.
+3. Keep provider credentials and API keys in the provider auth flow or environment, not in shared project config.
+
+If an external tool shows a model that OMO later skips, the source of truth is still the model-matching and registration logic in this repository. Use the [Agent Model Matching](./agent-model-matching.md) guide to check whether the selected model family is supported for that agent.
+
 ### Step 1: Prerequisites
 
 #### For platform `opencode` or `both`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -55,7 +55,7 @@ User config loads first. Project configs are discovered by walking from the work
 
 **Security note:** `mcp_env_allowlist` is user-only. Walked configs cannot extend it.
 
-**Rename compatibility:** The published package and CLI binary remain `oh-my-opencode`. OpenCode plugin registration prefers `oh-my-openagent`, while legacy `oh-my-opencode` entries and config basenames still load during the transition. Config detection checks `oh-my-opencode` before `oh-my-openagent`, so if both plugin config basenames exist in the same directory, the legacy `oh-my-opencode.*` file currently wins.
+**Rename compatibility:** OpenCode plugin registration and new config writes prefer `oh-my-openagent`, while legacy `oh-my-opencode` entries and config basenames still load during the transition. If both plugin config basenames exist in the same directory, the canonical `oh-my-openagent.*` file wins; update the canonical file only.
 JSONC supports `// line comments`, `/* block comments */`, and trailing commas.
 
 Enable schema autocomplete:


### PR DESCRIPTION
## Summary
- Document how community model-management tools should be treated: configuration frontends, not separate runtime integrations.
- Link the experimental VS Code extension from the discussion issue with clear verification and credential-safety guidance.
- Point users back to `doctor` and the agent model-matching guide as the source of truth for effective model resolution.

Closes #5346.

## Verification
- `bun install --cwd packages/web --frozen-lockfile`
- `node .\scripts\generate-docs-content.mjs` from `packages/web`
- `bun run --cwd packages/web type-check`
- `git diff --check`

Docs-only change; OpenCode/Codex harness QA not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that community model tools are third‑party configuration frontends (not runtime integrations), fulfilling #5346. Adds the experimental `oh-my-openagent` VS Code extension link, a `bunx oh-my-openagent doctor --verbose` check, reminders to review JSONC and keep credentials out of shared config, and updates config precedence: project `.opencode/oh-my-openagent.jsonc` overrides user-level; canonical `oh-my-openagent.*` beats legacy `oh-my-opencode.*` (update the canonical file only); use the Agent Model Matching guide as the source of truth.

<sup>Written for commit 7dee0188269d660a3c929bab22df5b1322c4288d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

