### PR TITLE
docs(known-issues): add open workaround batch

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -112,6 +112,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Record a `declined` install decision for the missing server with `lsp_install_decision`; future LSP calls collapse to a one-line warning. To share that decision across sessions, set `LSP_TOOLS_MCP_INSTALL_DECISIONS` to a stable decisions-file path.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5260.
 
+## #5810: Session tools can miss history outside the current instance scope
+
+- **Affects**: `session_read`, `session_search`, and `session_list` when OpenCode is launched from a directory whose instance scope excludes older sessions, especially non-git directories on Windows.
+- **Symptom**: `session_info(<id>)` can return metadata for a session while `session_read(<id>)` reports `Session not found`, and `session_list()` shows only a small subset of sessions that exist in the SQLite database.
+- **Workaround**: Use `session_info` first when you know the session id, then relaunch OpenCode from the project directory that owns the historical sessions before using read/search/list. For forensic work, inspect/export the OpenCode DB directly rather than relying on scope-filtered list output.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5810.
+
 ## #5341: `oh-my-opencode` Linux/Windows wrapper can miss platform binaries
 
 - **Affects**: `npm install -g oh-my-opencode@4.10.0` on Linux x64 and Windows x64.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -199,6 +199,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: For work that truly needs a plan, ask for the plan as a first explicit step and wait for it before implementation, or manually stop the parent when it starts executing before the spawned planner returns. Treat background planner output as advisory unless the parent explicitly reports that it read and applied it.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5481.
 
+## #5544 - Session titles can fall back to timestamp names
+
+- **Affects**: Windows OpenCode sessions after ULW/OMO install when title generation fails or receives the wrong prompt text.
+- **Symptom**: Session list entries become generic names such as `New session-2026-06-24T03:24:10.559Z` instead of a short task description.
+- **Workaround**: Check the configured OpenCode title model and fix any `doctor` failure first, especially Bun/UTF-8 errors on Windows. If the session is already created, rename it manually in the OpenCode UI or start a new session with a short first user message before entering `ulw`.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5544.
+
 ## #4722 - Codex hooks can report exit code 1 immediately after install
 
 - **Affects**: LazyCodex / OMO Codex installs where Codex keeps running across a plugin cache/config update.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -220,6 +220,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: If this exact regression appears, downgrade OpenCode to `1.17.9` or use an OMO build that explicitly includes the SDK v2 compatibility wrapper. Do not debug it as a model/provider problem until hook delivery has been confirmed.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5575.
 
+## #5586 - ULW sessions can be titled `ULTRAWORK MODE ENABLED!`
+
+- **Affects**: ULW prompts when title generation sees the injected ultrawork instruction block before the user's task text.
+- **Symptom**: The session title describes the mode banner instead of the actual task, making session history hard to scan.
+- **Workaround**: Start complex work with a short descriptive first sentence before `ulw`, or rename affected sessions manually after creation. If you rely heavily on history search, avoid starting multiple unrelated tasks with identical `ulw` prefixes until title injection ordering is fixed.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5586.
+
 ## #4722 - Codex hooks can report exit code 1 immediately after install
 
 - **Affects**: LazyCodex / OMO Codex installs where Codex keeps running across a plugin cache/config update.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -126,6 +126,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: If you are not using Ralph Loop in that workspace, add `"disabled_hooks": ["ralph-loop"]` to `oh-my-openagent.jsonc`. If a loop is already active, run `/cancel-ralph` before disabling the hook.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5105.
 
+## #5107: Team tmux visualization can silently skip pane creation
+
+- **Affects**: Team mode with `team_mode.tmux_visualization: true` on OpenCode 1.16.2 / OMO 4.8.1 when the TUI uses a dynamic server port.
+- **Symptom**: `team_create` reports an active team, but no tmux panes are spawned, `team_status` has no `tmuxPaneId`, and the only clue is an internal log line saying the OpenCode server is not reachable.
+- **Workaround**: Launch OpenCode with an explicit matching port in both places, for example `OPENCODE_PORT=24096 opencode --port 24096`, then create the team from that session. Treat `removedLayout: true` on delete as a requested-layout flag, not proof that panes existed.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5107.
+
 ## #5025 — OpenCode Desktop loads the plugin but only shows native modes
 
 - **Affects**: OpenCode Desktop on Windows with `oh-my-openagent@4.7.5`.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -133,6 +133,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Keep the parent session active with a short manual follow-up after expected background completion, then ask it to check background task status/output. For critical work, prefer synchronous delegation or explicitly poll task output rather than relying on a single automatic wake.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5804.
 
+## #5742: ULW loop can create multiple run-continuation files per session
+
+- **Affects**: `/ulw-loop` sessions that write continuation state under `.omo/run-continuation/`.
+- **Symptom**: One visible OpenCode session can generate many continuation files, making it unclear which file represents the active run.
+- **Workaround**: Before deleting anything, identify the current session id and sort `.omo/run-continuation/` by modified time. Archive or move older duplicates out of the active workspace only after the session has ended, then restart the loop from a clean session if state appears inconsistent.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5742.
+
 ## #5790: Completed background results can require a manual follow-up
 
 - **Affects**: Background or parallel investigations where the parent agent promises to wait for the result and then ends the turn.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -83,6 +83,14 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Switch to Prometheus first with the Tab agent selector or `/agent`, ask for the plan there, then run `/start-work` after approval.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4710.
 
+## #4733 - Credit usage can spike after v3 to v4 upgrades
+
+- **Affects**: Anthropic subscription-token users upgrading from the older v3 agent stack to the v4 orchestration stack.
+- **Symptom**: A workload that previously lasted all day can hit Claude session or usage limits within a few hours, even when the user believes the model list stayed the same.
+- **Likely contributors**: Larger v4 system prompts, more explicit orchestration instructions, background delegation, retry/fallback behavior, and feature hooks that did not exist in the same form in v3.
+- **Workaround**: For cost-sensitive sessions, pin cheaper category models, avoid `ulw`/team-mode/background delegation unless needed, and disable optional high-churn hooks or features before long interactive work. Use `opencode models`, `bunx oh-my-openagent doctor`, and provider dashboards to verify the effective model and usage path instead of relying on remembered v3 defaults.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4733.
+
 ## #5050: OpenCode can hang during startup before the plugin runs
 
 - **Affects**: OpenCode 1.16.2 startup with external plugins and cold package caches.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -119,6 +119,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: For one-off trivial prompts, run `opencode --pure` or temporarily disable the plugin for that session.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5120.
 
+## #5187: ChatGPT Plus installs can select API-tier Codex models
+
+- **Affects**: TUI installer runs where the user selects ChatGPT Plus / `--openai=yes`.
+- **Symptom**: Generated category config can map `unspecified-low` and `unspecified-high` to `openai/gpt-5.3-codex`, which then fails for accounts that do not have that API-tier model available even though `doctor` reports the installation as healthy.
+- **Workaround**: Edit `.opencode/oh-my-openagent.jsonc` and move those categories back to a model available through your actual provider set, such as an OpenCode Go Kimi/GLM entry or a supported GPT model visible in `opencode models`. Re-run `bunx oh-my-openagent doctor` after the edit to confirm effective model resolution.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5187.
+
 ## #5105: Ralph Loop can flood logs while child subagents are active
 
 - **Affects**: Sessions with an active Ralph Loop and background child subagents.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -119,6 +119,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Use `session_info` first when you know the session id, then relaunch OpenCode from the project directory that owns the historical sessions before using read/search/list. For forensic work, inspect/export the OpenCode DB directly rather than relying on scope-filtered list output.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5810.
 
+## #5802: `multimodal-looker` can hang on `opencode/mimo-v2.5-free`
+
+- **Affects**: `look_at` / `multimodal-looker` when `agents.multimodal-looker.model` is explicitly set to `opencode/mimo-v2.5-free`.
+- **Symptom**: The delegated image-reading task receives image data but never returns a response or clear timeout. `doctor` can also report the configured model as `unknown`.
+- **Workaround**: Do not use `opencode/mimo-v2.5-free` as the primary multimodal-looker model. Use a known working OpenCode free-tier model such as `opencode/deepseek-v4-flash-free` or `opencode/big-pickle`, then keep `mimo-v2.5-free` out of the primary slot until the model registry/dispatch path is fixed.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5802.
+
 ## #5341: `oh-my-opencode` Linux/Windows wrapper can miss platform binaries
 
 - **Affects**: `npm install -g oh-my-opencode@4.10.0` on Linux x64 and Windows x64.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -234,6 +234,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Use canonical lower-case agent keys in `oh-my-openagent.jsonc` (`sisyphus-junior`, `sisyphus`, `atlas`, etc.) and use display-name settings only for UI labels. After migration, run `bunx oh-my-openagent doctor` and inspect the effective model for `sisyphus-junior`.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5574.
 
+## #5573 - Background tasks can hang behind incomplete todos
+
+- **Affects**: Background tasks whose subagent creates todos and produces a final answer while one or more todos remain `pending` or `in_progress`.
+- **Symptom**: The parent never receives the completed result because background completion waits for todos to resolve; disabling `todo-continuation-enforcer` can make this worse by removing the recovery prompt.
+- **Workaround**: Do not disable `todo-continuation-enforcer` for background-heavy workflows. In background prompts, add a final instruction to mark every todo completed immediately before emitting the final result, and avoid forcing extra todo usage through skills unless task tracking is essential.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5573.
+
 ## #5548 - ULW continuation can override intentional user-input pauses
 
 - **Affects**: ULW sessions where the agent has unfinished todos but intentionally stops to ask the user for a required decision.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -154,6 +154,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Install through the `oh-my-openagent` package family or use `bunx oh-my-openagent ...` until the wrapper/platform package aliasing is made symmetric. If you already installed the broken wrapper globally, remove it before reinstalling to avoid bin shadowing.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5341.
 
+## #5331: `team_mode.base_dir` does not expand a literal `~`
+
+- **Affects**: Team mode configs that set `"base_dir": "~/.omo"` instead of leaving the field unset/null.
+- **Symptom**: OMO creates a real directory named `~` in the current working directory, with team state under `./~/.omo/...`, rather than writing to the user's home directory.
+- **Workaround**: Use an absolute path for `team_mode.base_dir`, or set it to `null`/remove it so OMO uses its built-in home-directory default. Delete any accidental literal `./~` directories only after confirming they contain no state you still need.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5331.
+
 ## #5120: Sisyphus can loop on simple tasks
 
 - **Affects**: OpenCode 1.17.0 with oh-my-openagent 4.8.1.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -126,6 +126,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Use `session_info` first when you know the session id, then relaunch OpenCode from the project directory that owns the historical sessions before using read/search/list. For forensic work, inspect/export the OpenCode DB directly rather than relying on scope-filtered list output.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5810.
 
+## #5804: Parent session can miss background completion notifications
+
+- **Affects**: Sisyphus sessions that dispatch background work with `task(run_in_background=true)` or `call_omo_agent` and then end the turn saying they are waiting.
+- **Symptom**: The child/background agent completes, but the parent never receives or acts on the wake notification, so the visible session stays stuck until the user manually sends a follow-up such as `continue`.
+- **Workaround**: Keep the parent session active with a short manual follow-up after expected background completion, then ask it to check background task status/output. For critical work, prefer synchronous delegation or explicitly poll task output rather than relying on a single automatic wake.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5804.
+
 ## #5802: `multimodal-looker` can hang on `opencode/mimo-v2.5-free`
 
 - **Affects**: `look_at` / `multimodal-looker` when `agents.multimodal-looker.model` is explicitly set to `opencode/mimo-v2.5-free`.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -206,6 +206,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Check the configured OpenCode title model and fix any `doctor` failure first, especially Bun/UTF-8 errors on Windows. If the session is already created, rename it manually in the OpenCode UI or start a new session with a short first user message before entering `ulw`.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5544.
 
+## #5560 - LSP daemon MCP proxy processes can survive ended sessions
+
+- **Affects**: LSP-backed MCP proxy processes (`cli.js mcp`) after OpenCode sessions end normally or are killed.
+- **Symptom**: Multiple stale `lsp-daemon` proxy processes and language-server children accumulate over days, consuming significant memory even though the original OpenCode sessions are gone.
+- **Workaround**: Periodically inspect process lists for stale `lsp-daemon` / language-server children and terminate orphaned processes after closing OpenCode. If memory pressure appears, restart the editor/terminal session that launched OpenCode so inherited daemon handles are released.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5560.
+
 ## #4722 - Codex hooks can report exit code 1 immediately after install
 
 - **Affects**: LazyCodex / OMO Codex installs where Codex keeps running across a plugin cache/config update.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -192,6 +192,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Use short wait cycles, send one targeted follow-up that asks the child to return a result or `BLOCKED`, then record the child as inconclusive before closing or respawning it. Do not treat repeated wait timeouts as proof that the child finished.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5021.
 
+## #4722 - Codex hooks can report exit code 1 immediately after install
+
+- **Affects**: LazyCodex / OMO Codex installs where Codex keeps running across a plugin cache/config update.
+- **Symptom**: Codex shows `SessionStart hook (failed)` or `UserPromptSubmit hook (failed)` with `hook exited with code 1`, but the visible saved hook output may not identify which OMO component failed.
+- **Workaround**: Re-run `npx --yes lazycodex-ai@latest install --no-tui --skip-auth`, start a fresh Codex session, and confirm no hook failure banner appears. If failures persist, manually replay the registered OMO hook commands with minimal Codex-shaped JSON payloads so the failing component can be separated from unrelated global hooks.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4722.
+
 ## #3303 - Windows OpenCode proxy install can fail before OMO loads
 
 - **Affects**: Windows OpenCode installs behind an HTTP(S) proxy, especially first startup paths that ask OpenCode to fetch `oh-my-openagent@latest`.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -133,6 +133,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Keep the parent session active with a short manual follow-up after expected background completion, then ask it to check background task status/output. For critical work, prefer synchronous delegation or explicitly poll task output rather than relying on a single automatic wake.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5804.
 
+## #5790: Completed background results can require a manual follow-up
+
+- **Affects**: Background or parallel investigations where the parent agent promises to wait for the result and then ends the turn.
+- **Symptom**: The background work may finish successfully, but no final answer is delivered into the original conversation until the user asks whether the result came back.
+- **Workaround**: Ask the parent to record the task ids before waiting, then send one follow-up after the expected completion window asking it to read those task outputs and summarize. For long-running work, prefer explicit task status checks over assuming the parent will proactively resume.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5790.
+
 ## #5802: `multimodal-looker` can hang on `opencode/mimo-v2.5-free`
 
 - **Affects**: `look_at` / `multimodal-looker` when `agents.multimodal-looker.model` is explicitly set to `opencode/mimo-v2.5-free`.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -234,6 +234,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Use canonical lower-case agent keys in `oh-my-openagent.jsonc` (`sisyphus-junior`, `sisyphus`, `atlas`, etc.) and use display-name settings only for UI labels. After migration, run `bunx oh-my-openagent doctor` and inspect the effective model for `sisyphus-junior`.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5574.
 
+## #5548 - ULW continuation can override intentional user-input pauses
+
+- **Affects**: ULW sessions where the agent has unfinished todos but intentionally stops to ask the user for a required decision.
+- **Symptom**: A continuation prompt can push the model to proceed without the user's answer, causing it to invent defaults or make decisions that should have stayed with the user.
+- **Workaround**: When asking ULW to do work that needs human confirmation, explicitly require `BLOCKED awaiting user input` and no further action until the answer arrives. For sensitive approval workflows, use a normal interactive prompt or disable the continuation hook for that session rather than relying on ULW autonomy.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5548.
+
 ## #4722 - Codex hooks can report exit code 1 immediately after install
 
 - **Affects**: LazyCodex / OMO Codex installs where Codex keeps running across a plugin cache/config update.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -168,6 +168,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Before relying on multi-member activation, run a one-member smoke team and verify a reply reaches the lead. If replies do not appear, fall back to a parent-driven workflow with explicit `team_task_*` state checks or use the last known working version for team-mode-heavy runs.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5317.
 
+## #5288: Synchronous plan tasks can remain visible as running
+
+- **Affects**: `task(subagent_type="plan", run_in_background=false, ...)` routed through the delegate-task sync wrapper.
+- **Symptom**: The plan text is returned, but the visible `Plan Task` item remains running because child/background helper state can keep the wrapper alive.
+- **Workaround**: Prefer the normal `@plan` / Prometheus flow for planning, or invoke the planner directly through the agent surface instead of wrapping it as a synchronous `task(subagent_type="plan")`. If the UI already shows a stale running plan task after output is available, treat the returned plan text as authoritative and avoid waiting on the stale wrapper.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5288.
+
 ## #5120: Sisyphus can loop on simple tasks
 
 - **Affects**: OpenCode 1.17.0 with oh-my-openagent 4.8.1.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -227,6 +227,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Start complex work with a short descriptive first sentence before `ulw`, or rename affected sessions manually after creation. If you rely heavily on history search, avoid starting multiple unrelated tasks with identical `ulw` prefixes until title injection ordering is fixed.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5586.
 
+## #5574 - Agent config rewrites can confuse Sisyphus-Junior overrides
+
+- **Affects**: Configs that use display-style keys such as `Sisyphus-Junior` instead of canonical config keys such as `sisyphus-junior`.
+- **Symptom**: OMO rewrites the config and creates a backup, but the effective model/category override can appear to apply to the wrong name, causing Sisyphus-Junior to fall back to a cheaper/default model.
+- **Workaround**: Use canonical lower-case agent keys in `oh-my-openagent.jsonc` (`sisyphus-junior`, `sisyphus`, `atlas`, etc.) and use display-name settings only for UI labels. After migration, run `bunx oh-my-openagent doctor` and inspect the effective model for `sisyphus-junior`.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5574.
+
 ## #4722 - Codex hooks can report exit code 1 immediately after install
 
 - **Affects**: LazyCodex / OMO Codex installs where Codex keeps running across a plugin cache/config update.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -112,6 +112,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Record a `declined` install decision for the missing server with `lsp_install_decision`; future LSP calls collapse to a one-line warning. To share that decision across sessions, set `LSP_TOOLS_MCP_INSTALL_DECISIONS` to a stable decisions-file path.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5260.
 
+## #5341: `oh-my-opencode` Linux/Windows wrapper can miss platform binaries
+
+- **Affects**: `npm install -g oh-my-opencode@4.10.0` on Linux x64 and Windows x64.
+- **Symptom**: Running `oh-my-opencode --version` exits with `Platform binary not installed` because the wrapper looks for `oh-my-opencode-linux-x64` / `oh-my-opencode-windows-x64`, while the published platform packages for those targets use the `oh-my-openagent-*` family.
+- **Workaround**: Install through the `oh-my-openagent` package family or use `bunx oh-my-openagent ...` until the wrapper/platform package aliasing is made symmetric. If you already installed the broken wrapper globally, remove it before reinstalling to avoid bin shadowing.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5341.
+
 ## #5120: Sisyphus can loop on simple tasks
 
 - **Affects**: OpenCode 1.17.0 with oh-my-openagent 4.8.1.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -91,6 +91,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: For cost-sensitive sessions, pin cheaper category models, avoid `ulw`/team-mode/background delegation unless needed, and disable optional high-churn hooks or features before long interactive work. Use `opencode models`, `bunx oh-my-openagent doctor`, and provider dashboards to verify the effective model and usage path instead of relying on remembered v3 defaults.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4733.
 
+## #4734 - Version pins can report one version while another build loads
+
+- **Affects**: OpenCode plugin entries pinned as `oh-my-openagent@<version>` when package cache resolution still serves a newer installed build.
+- **Symptom**: The version checker says the plugin is pinned, for example to `3.16.0`, but the session header shows a newer running version such as `4.7.5`.
+- **Workaround**: Treat the session header and loaded package cache as the source of truth. Clear the OpenCode package cache for `oh-my-openagent@latest` / pinned entries, reinstall the exact package version, and re-open OpenCode before relying on a downgrade to reduce usage or behavior changes.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4734.
+
 ## #5050: OpenCode can hang during startup before the plugin runs
 
 - **Affects**: OpenCode 1.16.2 startup with external plugins and cold package caches.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -213,6 +213,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Periodically inspect process lists for stale `lsp-daemon` / language-server children and terminate orphaned processes after closing OpenCode. If memory pressure appears, restart the editor/terminal session that launched OpenCode so inherited daemon handles are released.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5560.
 
+## #5575 - OpenCode 1.17.10+ can stop dispatching OMO hooks
+
+- **Affects**: OMO versions still wired to OpenCode's older plugin hook shape when run on OpenCode 1.17.10 or newer.
+- **Symptom**: The plugin loads without an obvious crash, but session lifecycle hooks stop firing, subagent completion reminders do not reach the parent, and delegated work can look permanently stuck.
+- **Workaround**: If this exact regression appears, downgrade OpenCode to `1.17.9` or use an OMO build that explicitly includes the SDK v2 compatibility wrapper. Do not debug it as a model/provider problem until hook delivery has been confirmed.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5575.
+
 ## #4722 - Codex hooks can report exit code 1 immediately after install
 
 - **Affects**: LazyCodex / OMO Codex installs where Codex keeps running across a plugin cache/config update.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -98,6 +98,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: If the hang happens before `/tmp/oh-my-opencode.log` gets a plugin entry, avoid the npm resolver path by using an absolute `file://` plugin path or by pre-populating the OpenCode package cache. If logs point to a malformed or locked `opencode.db`, back up and remove `~/.local/share/opencode/opencode.db*`; OpenCode recreates it on next start, but local session history is lost.
 - **Status**: Open. The npm resolver timeout belongs upstream in OpenCode; tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5050.
 
+## #5072: Blank TUI when the external plugin is enabled globally
+
+- **Affects**: OpenCode 1.16.2 on macOS when `oh-my-openagent@latest` is loaded from global `opencode.jsonc`.
+- **Symptom**: The TUI opens to a blank screen and logs stop around `service=plugin path=oh-my-openagent@latest loading plugin`; disabling plugins restores normal startup.
+- **Workaround**: Temporarily remove the plugin from global config, then retry with a pinned plugin version or a project-local plugin entry so the failing config can be isolated. Start with `opencode --log-level DEBUG .` and compare logs with `plugin: []` before assuming provider or terminal rendering is at fault.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5072.
+
 ## #5260: Background tasks can wait on an LSP install decision
 
 - **Affects**: Background tasks that call LSP tools when the language server is not installed.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -161,6 +161,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Use an absolute path for `team_mode.base_dir`, or set it to `null`/remove it so OMO uses its built-in home-directory default. Delete any accidental literal `./~` directories only after confirming they contain no state you still need.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5331.
 
+## #5317: `team_send_message` replies can disappear after team activation
+
+- **Affects**: Team-mode workflows on the reported 4.10.0 path where leads send activation checks to members immediately after `team_create`.
+- **Symptom**: `team_send_message` reports successful delivery, but member acknowledgements never appear in the lead transcript or status flow, leaving the lead unable to confirm that members are alive.
+- **Workaround**: Before relying on multi-member activation, run a one-member smoke team and verify a reply reaches the lead. If replies do not appear, fall back to a parent-driven workflow with explicit `team_task_*` state checks or use the last known working version for team-mode-heavy runs.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5317.
+
 ## #5120: Sisyphus can loop on simple tasks
 
 - **Affects**: OpenCode 1.17.0 with oh-my-openagent 4.8.1.

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -192,6 +192,13 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Workaround**: Use short wait cycles, send one targeted follow-up that asks the child to return a result or `BLOCKED`, then record the child as inconclusive before closing or respawning it. Do not treat repeated wait timeouts as proof that the child finished.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5021.
 
+## #5481 - LazyCodex can continue without consuming a spawned planner result
+
+- **Affects**: LazyCodex `ulw` flows that spawn a planner/research subagent while the parent keeps executing.
+- **Symptom**: The planner continues spending high-effort tokens, but the main agent proceeds with its own plan and never incorporates the planner output.
+- **Workaround**: For work that truly needs a plan, ask for the plan as a first explicit step and wait for it before implementation, or manually stop the parent when it starts executing before the spawned planner returns. Treat background planner output as advisory unless the parent explicitly reports that it read and applied it.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5481.
+
 ## #4722 - Codex hooks can report exit code 1 immediately after install
 
 - **Affects**: LazyCodex / OMO Codex installs where Codex keeps running across a plugin cache/config update.


### PR DESCRIPTION
## Summary
- Add a documentation-only batch of known issue entries and practical workarounds in `docs/reference/known-issues.md`.
- Group open runtime/reporting gaps without changing adapter behavior.
- Reference related open issues without closing them, because this PR documents current behavior rather than fixing the underlying bugs.

## QA / Evidence
- `node .\scripts\generate-docs-content.mjs` from `packages/web` -> docs content already current with 9 HTML-compiled docs.
- `bun run --cwd packages/web type-check` -> passed.
- `git diff --check upstream/dev...HEAD` -> passed.
- Docs-only change; no files under `packages/omo-opencode/` or `packages/omo-codex/` were touched, so `opencode-qa` / `codex-qa` harness evidence is not required for this PR.

Refs #4733 #5072 #5107 #5187 #5341 #5810 #5802 #4734 #4722 #5481 #5544 #5560 #5575 #5586 #5574 #5548 #5573 #5804 #5790 #5331 #5317 #5288 #5742

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs-only batch of known issues with practical workarounds in `docs/reference/known-issues.md`.

Covers OpenCode/`oh-my-openagent` v4 areas like credit spikes after v3→v4 upgrades, plugin startup/blank TUI, team tmux port mismatches, model/version-pin mismatches, multimodal hangs, background task wakeups/todo stalls, ULW title/continuation quirks, LSP process leaks, and Windows/Linux install/path gaps; no runtime changes.

<sup>Written for commit 7e19943e55e79447d9830358235e4efe0f3aa732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

