### PR TITLE
docs(known-issues): note Bash hook worktree cwd gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5928 - Bash `PreToolUse` hooks can inspect the session repo instead of the active worktree
+
+- **Affects**: Workflows that run project-level Claude-style `PreToolUse` Bash hooks from a secondary git worktree.
+- **Symptom**: The hook input can expose the session or main repository cwd instead of the command's active worktree cwd. Repo-local checks such as `git rev-parse --show-toplevel` then validate the wrong checkout, so a dirty main checkout can block a clean worktree push.
+- **Workaround**: Keep the main session checkout clean before running guarded Bash commands from a worktree. If the hook is user-controlled, prefer deriving the target repository from an explicit command argument or a hook-specific environment variable instead of falling back to `$PWD`.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5928.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the current PreToolUse Bash hook cwd/worktree mismatch as a known issue.
- Add a practical workaround for guarded worktree commands while the runtime behavior remains open.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5928

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented a known issue where Bash `PreToolUse` hooks can use the session repo’s CWD instead of the active worktree, which can make repo checks validate the wrong checkout. Added a brief workaround (keep the session checkout clean or pass the target repo explicitly) and linked the status to #5928.

<sup>Written for commit f8bf5a449f8b2c66a1fb0510b13b0d37eebaebf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

