### PR TITLE
docs(known-issues): note worktree merge status gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5911 - Worktree merge status can ignore dirty filesystem changes
+
+- **Affects**: Agent-managed git worktree handoff and cleanup flows.
+- **Symptom**: A worktree can be reported as already merged when `HEAD` matches the target branch, even though modified, untracked, or ignored task-state files still exist only in the worktree. Treating commit ancestry as the whole truth can make users believe work has been integrated before it has been committed, merged, or cleaned up.
+- **Workaround**: Before deleting a worktree or accepting an "already merged" answer, run `git status --short --untracked-files=all` from the worktree root. If task state may be ignored, also run `git status --short --ignored --untracked-files=all -- .omo` there. Inspect both results, and delete the worktree only after the filesystem is clean or after the remaining changes have been intentionally copied, committed, or discarded.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5911.
+
 ## #5850 - `ulw` planner can fall into native OpenCode plan mode
 
 - **Affects**: Complex `ulw` runs where planning is delegated through a subagent named `plan` while OpenCode's experimental plan mode is enabled.


### PR DESCRIPTION
## Summary
- Document the worktree merge-status false positive where commit ancestry can hide dirty worktree files.
- Add a cleanup-time workaround that checks filesystem state before deleting or accepting a worktree as integrated.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5911

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a known-issues entry for #5911: git worktrees can appear “already merged” based on commit ancestry even when modified, untracked, or ignored task‑state files still exist in the worktree. Workaround: verify with `git status --short --untracked-files=all` and, if task state may be ignored, `git status --short --ignored --untracked-files=all -- .omo`; inspect results and delete the worktree only once it’s clean or changes are intentionally copied, committed, or discarded.

<sup>Written for commit 404da72d20f0dda62e4abc5b279ec1c8d795ded6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

