### PR TITLE
docs(known-issues): note provider status bar gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5904 - TUI status bar does not show the active provider prefix
+
+- **Affects**: Multi-provider setups where the same model name is available through more than one provider.
+- **Symptom**: The TUI status bar can show only the model name, such as `claude-opus-4-7`, without the provider prefix. After runtime fallback or manual model changes, users must open the model picker to tell whether the active route is `opencode/`, `anthropic/`, an OpenAI-compatible provider, or a local provider.
+- **Workaround**: When provider identity matters, use the model picker or logs to confirm the full `provider/model` route before starting a long run. Keep provider-specific display names or notes in your project config until a persistent status-bar provider indicator exists.
+- **Status**: Open enhancement. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5904.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the current TUI limitation where the status bar omits the active provider prefix.
- Add a user-facing workaround for confirming the full provider/model route before long runs.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5904

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents a known TUI issue where the status bar only shows the model name and hides the provider prefix. Adds a simple workaround to confirm the full provider/model route before long runs; refs #5904.

<sup>Written for commit 170f1bcb843301a50de18f5da296e2387dd1fa3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

