### PR TITLE
docs(known-issues): note npm pack payload growth

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5896 - npm pack payload is larger after embedding frontend skill references
+
+- **Affects**: Publish and install paths that package or download the full npm payload.
+- **Symptom**: The packed artifact includes embedded frontend/taste-skill reference material, increasing the unpacked payload size and making `bun pm pack --dry-run --ignore-scripts` noticeably slower than earlier releases.
+- **Workaround**: Treat the larger payload as expected for current releases unless release maintainers decide some embedded reference paths are accidental. When investigating publish slowness, measure pack time separately from test/build time so this payload walk is not mistaken for a runtime regression.
+- **Status**: Informational. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5896.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the current npm pack payload growth caused by embedded frontend/taste-skill references.
- Frame it as an informational packaging note so release investigations do not misclassify it as runtime breakage.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5896

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents known issue #5896: npm pack payload growth from embedded frontend/taste-skill references, affecting publish/install and making `bun pm pack --dry-run --ignore-scripts` slower. Adds a known-issues entry with impact, symptom, workaround, and status to avoid mislabeling it as a runtime regression.

<sup>Written for commit ca7d6770321c069e3f0a98e8df0c1fb33b123c8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

