### PR TITLE
docs(known-issues): note TUI wake error leak

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5874 - TUI can render transient wake-from-sleep errors in the input area
+
+- **Affects**: TUI sessions that resume after the host sleeps and a sidebar/model metadata fetch fails transiently.
+- **Symptom**: A `Failed to fetch models.dev` error can leak into the main content or input area instead of being routed to a toast or log-only path. The session may still work, but the TUI pane remains visually polluted.
+- **Workaround**: Start a fresh OpenCode session after the machine wakes if the error output appears in the input area. Treat this as a display leak unless the same model fetch error repeats in new sessions.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5874.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the transient TUI wake-from-sleep error rendering leak.
- Add a practical restart/new-session workaround for users who see the pane pollution.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5874

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents a known TUI issue where transient wake-from-sleep errors can appear in the input area, and adds a restart/new-session workaround. Links to issue #5874 so users can track status and avoid confusion from the display leak.

<sup>Written for commit 378a46f3df6eb29a5ab0d5a0562f0639c06a6258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

