### PR TITLE
docs(known-issues): note background wake defer gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5864 - Background completion wake can defer forever while the parent stays active
+
+- **Affects**: Long-running orchestrator sessions that keep calling tools while background tasks finish.
+- **Symptom**: A background subagent can finish and persist its output, but the parent notification remains queued until the parent emits `session.idle`. If the parent never naturally idles, the task can later appear as a 30-minute inactivity timeout even though the work already landed on disk.
+- **Workaround**: For long orchestrator loops, create explicit turn boundaries after dispatching background work and check `background_output` before re-dispatching the same task. If a task reports an inactivity timeout, inspect its artifact path before assuming the child failed.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5864.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the background parent-wake defer gap for continuously active orchestrator sessions.
- Add a workaround that asks users to create turn boundaries and inspect artifacts before re-dispatching timed-out background tasks.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5864

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented known issue #5864 where background completion notifications can be deferred indefinitely while the parent orchestrator remains active. Added a workaround to add explicit turn boundaries and check saved background output/artifacts before re-dispatching or treating inactivity timeouts as failures.

<sup>Written for commit e11a5d4f8cdbfa7dec38c66e1fbc44a0dc7d4a9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

