### PR TITLE
docs(known-issues): note session search error serialization

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5854 - `session_search` can report `Error: [object Object]` for CJK queries
+
+- **Affects**: Session-manager search paths when the underlying SDK throws a non-`Error` object, most visibly with CJK or other non-ASCII search terms.
+- **Symptom**: Instead of a useful diagnostic, the tool returns the literal string `Error: [object Object]`, hiding the real SDK or storage-layer failure.
+- **Workaround**: Retry with narrower ASCII search terms when possible, or list candidate sessions first and inspect them with `session_read`. Treat `[object Object]` as an error serialization bug, not as proof that no matching session exists.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5854.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the `session_search` `[object Object]` error serialization gap for CJK/non-ASCII queries.
- Add a workaround that steers users toward ASCII narrowing or `session_list`/`session_read` inspection.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5854

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a known-issues entry documenting that `session_search` can return `Error: [object Object]` for CJK/non-ASCII queries. The note links to #5854 and provides workarounds: try narrower ASCII terms or enumerate with `session_list` and inspect with `session_read`.

<sup>Written for commit 906de92169d4b5e82df8d4898be41652cae7eeea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

