### PR TITLE
docs(known-issues): note manual model override gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5816 - Manual model selection can be reset by runtime fallback state
+
+- **Affects**: OpenCode sessions where an OMO agent has an explicit configured model and the user manually selects another model from that agent's fallback list.
+- **Symptom**: The manually selected model can be used for the current message and then be interpreted as an active fallback, causing the next message to be forced back to the agent-configured model.
+- **Workaround**: For sessions where manual model choice must persist, temporarily adjust the agent's configured model/fallback list or use an agent path without an explicit model override. After changing model routing, start a fresh session so runtime fallback state is rebuilt from the intended baseline.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5816.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the runtime-fallback state gap where manual model selection can be reset to the agent configured model.
- Add a workaround for sessions that need a manually selected model to persist.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5816

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a known-issues entry for #5816 explaining that manual model selection can revert to the agent’s configured model due to runtime fallback. Includes a simple workaround to keep the chosen model persistent.

<sup>Written for commit a39f8b4219cbe68626bd6209f8ec25136f2a7e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

