### PR TITLE
docs(known-issues): note ULW loop session id gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5752 - `ulw-loop --session-id` without a value falls back silently
+
+- **Affects**: Codex Light `ulw-loop` CLI usage that passes `--session-id` as a bare flag.
+- **Symptom**: A present-but-valueless `--session-id` can be treated like an omitted flag, so the command falls back to ambient session environment or writes unscoped `.omo/ulw-loop` state instead of failing.
+- **Workaround**: Use `--session-id=<id>` or `--session-id <id>` with a non-empty value whenever explicit scoping matters. Omit the flag entirely only when you intentionally want ambient session detection.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5752.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the `ulw-loop --session-id` valueless flag behavior.
- Add a workaround that distinguishes explicit non-empty session IDs from intentional ambient scoping.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5752

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented a known issue where `ulw-loop --session-id` used without a value is treated as omitted, causing fallback to ambient session or unscoped `.omo/ulw-loop` state. Added guidance to always pass a non-empty session ID when explicit scoping is needed; tracked in #5752.

<sup>Written for commit facd37cf1f51d0a4d07139bfcecaf943b7ce2004. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

