### PR TITLE
docs(known-issues): note hidden plan alias gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5748 - Hidden `plan` alias can bypass the Prometheus coordinator guard
+
+- **Affects**: Worker-agent delegation paths that call `task(subagent_type="plan")` while OMO plan replacement/demotion is enabled.
+- **Symptom**: Direct `task(subagent_type="prometheus")` is blocked as a coordinator target, but the hidden `plan` lane can still be reached from a worker and can receive ULW planning injection. That creates a path into planner/coordinator behavior that the guard was meant to prevent.
+- **Workaround**: Do not call `task(subagent_type="plan")` from worker agents. Route planning through the top-level Prometheus/`@plan` flow, or use normal category delegation for executable worker tasks.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5748.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the hidden `plan` alias path that can bypass the Prometheus coordinator guard.
- Add a workaround steering worker agents away from `task(subagent_type=plan)`.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5748

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document a known issue where a hidden `plan` alias can bypass the Prometheus coordinator guard, and add a workaround steering worker agents away from `task(subagent_type="plan")`. Clarifies impact, symptoms, and mitigation for #5748.

<sup>Written for commit 677baabb32ee5998dd10d84436145caf3a0a4dc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

