### PR TITLE
docs(known-issues): note team member wake gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5657 - Team members can stop waking after their first idle response
+
+- **Affects**: Team Mode runs with several members receiving messages concurrently.
+- **Symptom**: Members can show unread messages in `team_status`, but never wake to process them after initial idle/completed transitions. `team_send_message` delivery only proves the inbox file was written; it does not prove the member consumed the message.
+- **Workaround**: Monitor `team_status` for unread counts that keep increasing while member output stays unchanged. If a member is stuck, restart the affected team/member or redistribute the task rather than repeatedly sending more messages to the same unread mailbox.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5657.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the Team Mode member wake gap where unread messages can pile up without being processed.
- Add a workaround around monitoring `team_status` and restarting/reassigning stuck members instead of repeatedly sending more messages.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5657

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented known issue #5657: in Team Mode, some members can stop waking after their first idle/completed transition, leaving unread messages unprocessed. Added a workaround to monitor `team_status` and restart or reassign stuck members instead of resending messages.

<sup>Written for commit c5474bd426cabec2a514e2c6f9a7eb96afaf539f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

