### PR TITLE
docs(known-issues): note Sisyphus prompt drift

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5578 - Sisyphus prompt reconciliation can shift behavior between turns
+
+- **Affects**: Sisyphus sessions where the configured model family differs from the runtime-selected model family.
+- **Symptom**: Runtime prompt reconciliation can rebuild a large Sisyphus prompt body per request, so adjacent turns may receive materially different instructions. The agent can appear to reverse a prior commitment, such as waiting for a user decision and then proceeding autonomously on the next turn.
+- **Workaround**: For interactive work that depends on stable agent behavior, align the configured Sisyphus model family with the model selected in the TUI, or start a fresh session after changing runtime model family. Avoid switching between GPT and non-GPT Sisyphus routes mid-decision.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5578.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the Sisyphus runtime prompt reconciliation behavior drift reported when configured and runtime model families differ.
- Add a workaround around keeping Sisyphus model family stable for decision-sensitive sessions.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5578

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the Sisyphus prompt reconciliation drift when configured and runtime model families differ (#5578). Added guidance and a workaround to keep agent behavior stable during decision-sensitive sessions.

<sup>Written for commit f67b20aa5bbb6409b5d2519a4e4e13d33c4c2bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

