### PR TITLE
docs(known-issues): note Sisyphus keyword prompt waste

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5572 - Sisyphus can receive redundant analyze/search keyword prompts
+
+- **Affects**: Sisyphus sessions where user messages repeatedly include analyze/search trigger words.
+- **Symptom**: The keyword detector can inject analyze/search mode prompts that duplicate behavior already present in the Sisyphus system prompt. Repeated trigger words can add avoidable prompt tokens without changing behavior.
+- **Workaround**: In Sisyphus, rely on the default exploration/delegation behavior unless you specifically need a mode keyword. If token budget is tight, avoid repeating generic `analyze`, `search`, `debug`, or equivalent trigger words in every follow-up.
+- **Status**: Open optimization. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5572.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the redundant analyze/search keyword injection concern for Sisyphus sessions.
- Add a token-budget workaround for users who do not need extra mode prompting.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5572

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document a Sisyphus known issue where repeated analyze/search trigger words can inject redundant mode prompts and waste tokens. Adds a workaround to rely on default behavior and avoid repeating generic keywords when token budget is tight; tracked in #5572.

<sup>Written for commit 3db5cf68a6fbc8458b512b524480a00d83512b59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

