### PR TITLE
docs(known-issues): note parent wake turn gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5569 - Reply-required parent wake may persist without starting a new turn
+
+- **Affects**: Background-task completion flows where the final all-complete wake is written into the parent session.
+- **Symptom**: The parent session can receive a `[BACKGROUND TASK COMPLETED] [ALL BACKGROUND TASKS COMPLETE]` internal wake without `OMO_INTERNAL_NOREPLY`, but no assistant/model turn starts until the user sends another message.
+- **Workaround**: If background tasks appear complete and the parent stays silent, send a short manual follow-up such as `continue`, then ask the parent to call `background_output` for each completed task. Confirm the wake exists before re-dispatching the same work.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5569.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the reply-required parent wake gap where an all-complete background wake is persisted but no assistant turn starts.
- Add a workaround around sending a short follow-up and retrieving `background_output` before re-dispatching work.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5569

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented known issue #5569: after all background tasks complete, a reply-required parent wake may persist without starting a new assistant turn. Adds a workaround to send a short follow-up and fetch `background_output` before re-dispatching work in `docs/reference/known-issues.md`.

<sup>Written for commit 868eaead7db31a72544518de4a4423e48d5d2bb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

