### PR TITLE
docs(known-issues): note Qwen capability label gap

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -2,6 +2,13 @@
 
 Tracks bugs that are present in the current release but have been intentionally deferred. Each entry should explain the symptom, the history, any workaround, and the planned resolution.
 
+## #5516 - Custom Qwen models can report capabilities as unknown
+
+- **Affects**: Custom OpenAI-compatible providers serving Qwen-family models that are not present in the bundled model-capabilities snapshot.
+- **Symptom**: `omo doctor` can warn that configured models rely on compatibility fallback and show `[capabilities: unknown]`, even when the provider supplies enough runtime metadata for the model to work.
+- **Workaround**: Configure practical runtime fields such as `tool_call`, `reasoning`, and `limit` in the provider definition where supported, then treat the `unknown` doctor label as diagnostic noise unless runtime tool use actually fails.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5516.
+
 ## #4184 - Custom provider models without `limit` do not auto-compact
 
 - **Affects**: OpenAI-compatible custom providers whose models are written to `opencode.json` without a `limit` block.


### PR DESCRIPTION
## Summary
- Document the diagnostic gap where custom Qwen-family models can show `[capabilities: unknown]`.
- Add a workaround around configuring runtime fields and treating the label as diagnostic noise when runtime behavior works.

## QA / Evidence
- `git diff --check` -> passed.
- Docs-only change under `docs/reference/known-issues.md`; no OpenCode or Codex adapter code touched, so harness QA is not required.

Refs #5516

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented a known issue where custom Qwen-family models can show [capabilities: unknown] in `omo doctor` even when they work. Adds a workaround: set runtime fields like `tool_call`, `reasoning`, and `limit`, and treat the label as noise unless tool use fails (refs #5516).

<sup>Written for commit 25c52c69a07e75461f5345602ff633299fc9639a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

