### PR TITLE
fix(senpi-task): completion notifications always wake the parent (remove wake_idle_parent; preserve deliver_as + renderer)

### DIFF
--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -366,8 +366,7 @@
         },
         "notification": {
           "default": {
-            "deliver_as": "followUp",
-            "wake_idle_parent": true
+            "deliver_as": "followUp"
           },
           "type": "object",
           "properties": {
@@ -378,15 +377,10 @@
                 "followUp",
                 "steer"
               ]
-            },
-            "wake_idle_parent": {
-              "default": true,
-              "type": "boolean"
             }
           },
           "required": [
-            "deliver_as",
-            "wake_idle_parent"
+            "deliver_as"
           ],
           "additionalProperties": false
         },

--- a/docs/guide/senpi-task.md
+++ b/docs/guide/senpi-task.md
@@ -44,8 +44,8 @@ Cancel and interrupt are parent-initiated: they return their result synchronousl
 
 When a background child finishes on its own - `completed`, `error`, or `lost` - the engine routes a completion to the parent exactly once (`packages/senpi-task/src/completion/routing.ts`):
 
-- Parent **idle**: it is woken (or, if `task.notification.wake_idle_parent` is `false`, the completion is queued silently).
-- Parent **streaming**: the completion is delivered using `task.notification.deliver_as` (`followUp` or `steer`).
+- Parent **idle**: it is always woken so the completion injects on the parent's next turn. No setting can suppress this.
+- Parent **streaming**: the completion is delivered using `task.notification.deliver_as` (`followUp` or `steer`) and still triggers a turn so the queued message is processed.
 - Parent **compacting / switching / shutting down**: the completion is buffered and flushed once the parent settles.
 
 Because cancel and interrupt return synchronously, they are never delivered as notifications - only externally-caused terminals notify.
@@ -74,7 +74,7 @@ All defaults live in `omo.json` under `task` and `teams`. A minimal project conf
 {
   "task": {
     "default_execution_mode": "in-process",
-    "notification": { "deliver_as": "followUp", "wake_idle_parent": true },
+    "notification": { "deliver_as": "followUp" },
     "wait": { "default_ms": 90000 }
   }
 }

--- a/docs/reference/omo-json.md
+++ b/docs/reference/omo-json.md
@@ -137,7 +137,6 @@ Task engine settings; every field has a default, so the whole object is optional
 | `max_depth` | int >= 0 | `1` |
 | `residency_max_children` | positive int | `8` |
 | `notification.deliver_as` | `followUp \| steer` | `followUp` |
-| `notification.wake_idle_parent` | boolean | `true` |
 | `ttl_ms` | positive int | `86400000` (24h) |
 | `state_dir` | string | unset (defaults to `<project>/.omo/senpi-task`) |
 | `wait.min_ms` | positive int | `5000` |
@@ -181,7 +180,7 @@ Each member shares a base (`name` matching `^[a-z0-9-]+$`, optional `cwd`, `work
   "task": {
     "default_execution_mode": "in-process",
     "default_concurrency": 4,
-    "notification": { "deliver_as": "followUp", "wake_idle_parent": true },
+    "notification": { "deliver_as": "followUp" },
     "wait": { "default_ms": 90000 }
   },
   "categories": {

--- a/packages/omo-config-core/src/schema/task.ts
+++ b/packages/omo-config-core/src/schema/task.ts
@@ -2,7 +2,6 @@ import * as z from "zod"
 
 export const OmoTaskNotificationSchema = z.object({
   deliver_as: z.enum(["followUp", "steer"]).default("followUp"),
-  wake_idle_parent: z.boolean().default(true),
 }).strict()
 
 export const OmoTaskWaitSchema = z.object({
@@ -24,7 +23,7 @@ export const OmoTaskSettingsSchema = z.object({
   model_concurrency: z.record(z.string(), z.number().int().positive()).optional(),
   max_depth: z.number().int().nonnegative().default(1),
   residency_max_children: z.number().int().positive().default(8),
-  notification: OmoTaskNotificationSchema.default({ deliver_as: "followUp", wake_idle_parent: true }),
+  notification: OmoTaskNotificationSchema.default({ deliver_as: "followUp" }),
   ttl_ms: z.number().int().positive().default(86400000),
   state_dir: z.string().optional(),
   wait: OmoTaskWaitSchema.default({ min_ms: 5000, default_ms: 60000, max_ms: 600000 }),

--- a/packages/omo-senpi/scripts/qa/task-e2e-analysis.mjs
+++ b/packages/omo-senpi/scripts/qa/task-e2e-analysis.mjs
@@ -56,7 +56,7 @@ export function findTaskIds(events) {
 }
 
 // The idle-wake completion is injected as a NEW turn carrying a <task-notification> block. Proof for the
-// wake_idle_parent contract: the block names the finished task_id AND carries the task_send continuation
+// unconditional-wake contract: the block names the finished task_id AND carries the task_send continuation
 // hint (messageability = continuable). Returns both facts so the driver can attribute a precise failure.
 export function findWakeNotification(events, taskId) {
   const hay = JSON.stringify(events)

--- a/packages/omo-senpi/scripts/qa/task-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/task-e2e.mjs
@@ -3,7 +3,8 @@
 // BUILT omo plugin against an isolated SENPI_CODING_AGENT_DIR sandbox and a LOCAL mock provider (no real
 // API call, no network), then drives the 5-step in-process task cycle end to end:
 //   (1) task(category, run_in_background:true) -> a background st_ child id
-//   (2) parent idle -> the completion custom message arrives as a NEW turn (wake_idle_parent)
+//   (2) parent idle -> the completion custom message ALWAYS arrives as a NEW wake turn (unconditional;
+//       no config can suppress it - the wake_idle_parent suppression knob was removed)
 //   (3) task_send(deliver_as:"followUp") on the completed-resident child -> revive -> second completion
 //   (4) task_output(mode:"full") -> the child transcript
 //   (5) a sync task (run_in_background falsy) -> final text inline with NO extra notification
@@ -139,7 +140,7 @@ function runMainFlow(senpiBin, checks, capture, pids) {
   const wake = findWakeNotification(events, taskId)
   const signatures = jsonlSignatures(jsonl)
   checks.spawn_background = run.status === 0 && typeof taskId === "string" && existsSync(join(scenario.stateDir, "tasks", `${taskId}.json`)) ? "PASS" : "FAIL"
-  checks.wake_idle_parent = wake.ok ? "PASS" : "FAIL"
+  checks.unconditional_wake = wake.ok ? "PASS" : "FAIL"
   checks.followup_revive = findRevived(events) && JSON.stringify(events).includes(CHILD_SECOND) ? "PASS" : "FAIL"
   checks.task_output_full = findTranscript(events, CHILD_FIRST) ? "PASS" : "FAIL"
   checks.jsonl_sequence = matchesOrderedSubsequence(signatures, MAIN_FLOW_EXPECTED_SEQUENCE) ? "PASS" : "FAIL"

--- a/packages/omo-senpi/src/components/task/parent-notifier.test.ts
+++ b/packages/omo-senpi/src/components/task/parent-notifier.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test"
+
+import { IdleInjectionCoordinator } from "../../extension/idle-injection-coordinator"
+import type { SenpiExtensionAPI } from "../../extension/types"
+import { createParentNotifier } from "./parent-notifier"
+
+type SentMessage = { readonly message: Record<string, unknown>; readonly options: Record<string, unknown> | undefined }
+type SentUserMessage = { readonly content: string | readonly Record<string, unknown>[]; readonly options: { deliverAs?: "steer" | "followUp" } | undefined }
+
+function fakePi(): SenpiExtensionAPI & { readonly sent: SentMessage[]; readonly userSent: SentUserMessage[] } {
+  const sent: SentMessage[] = []
+  const userSent: SentUserMessage[] = []
+  return {
+    sent,
+    userSent,
+    on: () => undefined,
+    registerTool: () => undefined,
+    registerCommand: () => undefined,
+    registerFlag: () => undefined,
+    getFlag: () => undefined,
+    sendMessage: (message, options) => {
+      sent.push({ message, options })
+    },
+    sendUserMessage: (content, options) => {
+      userSent.push({ content, options })
+    },
+    registerMessageRenderer: () => undefined,
+  }
+}
+
+function coordinatorCapturing(delivered: { content: string; deliverAs: "steer" | "followUp" }[]): IdleInjectionCoordinator {
+  return new IdleInjectionCoordinator((content, options) => delivered.push({ content, deliverAs: options.deliverAs }))
+}
+
+const completionDetails = [
+  { task_id: "st_1", name: "worker", status: "completed" as const, duration_ms: 10, final_response_head: "ok", continuation_hint: "continue" },
+]
+
+describe("createParentNotifier idle vs streaming routing", () => {
+  test("#given an idle wake (triggerTurn, no deliverAs) #when enqueued #then it routes through the coordinator and collapses", () => {
+    // given
+    const delivered: { content: string; deliverAs: "steer" | "followUp" }[] = []
+    const coordinator = coordinatorCapturing(delivered)
+    const pi = fakePi()
+    const notifier = createParentNotifier(pi, coordinator)
+
+    // when: a wake completion carries triggerTurn:true and NO deliverAs (the idle-edge arbitration path)
+    notifier.enqueue({
+      customType: "senpi-task.completion",
+      content: "st_1 completed",
+      display: false,
+      details: completionDetails,
+      triggerTurn: true,
+    })
+
+    // then: it is arbitrated by the coordinator (one followUp injection), NOT delivered directly
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.content).toContain("st_1 completed")
+    expect(delivered[0]?.deliverAs).toBe("followUp")
+    expect(pi.sent).toHaveLength(0)
+    expect(pi.userSent).toHaveLength(0)
+  })
+
+  test("#given a streaming completion (triggerTurn AND deliverAs:steer) #when enqueued #then it delivers DIRECTLY via the renderer channel with steer preserved", () => {
+    // given
+    const delivered: { content: string; deliverAs: "steer" | "followUp" }[] = []
+    const coordinator = coordinatorCapturing(delivered)
+    const pi = fakePi()
+    const notifier = createParentNotifier(pi, coordinator)
+
+    // when: a STREAMING completion now carries BOTH triggerTurn:true AND the configured deliverAs
+    notifier.enqueue({
+      customType: "senpi-task.completion",
+      content: "st_1 completed",
+      display: false,
+      details: completionDetails,
+      triggerTurn: true,
+      deliverAs: "steer",
+    })
+
+    // then: it bypasses the coordinator and goes straight to the rich custom-message channel
+    expect(delivered).toHaveLength(0)
+    expect(pi.userSent).toHaveLength(0)
+    expect(pi.sent).toHaveLength(1)
+    // and: the configured deliver_as (steer) survives, and triggerTurn rides along
+    expect(pi.sent[0]?.options).toMatchObject({ deliverAs: "steer", triggerTurn: true })
+    // and: the senpi-task.completion renderer applies (custom message shape, not a plain user message)
+    expect(pi.sent[0]?.message.customType).toBe("senpi-task.completion")
+    expect(pi.sent[0]?.message.details).toEqual(completionDetails)
+  })
+
+  test("#given a streaming completion with deliverAs:followUp #when enqueued #then it delivers directly with followUp preserved", () => {
+    // given
+    const delivered: { content: string; deliverAs: "steer" | "followUp" }[] = []
+    const coordinator = coordinatorCapturing(delivered)
+    const pi = fakePi()
+    const notifier = createParentNotifier(pi, coordinator)
+
+    // when
+    notifier.enqueue({
+      customType: "senpi-task.completion",
+      content: "st_1 completed",
+      display: false,
+      details: completionDetails,
+      triggerTurn: true,
+      deliverAs: "followUp",
+    })
+
+    // then
+    expect(delivered).toHaveLength(0)
+    expect(pi.sent).toHaveLength(1)
+    expect(pi.sent[0]?.options).toMatchObject({ deliverAs: "followUp", triggerTurn: true })
+    expect(pi.sent[0]?.message.customType).toBe("senpi-task.completion")
+  })
+
+  test("#given no coordinator is wired #when an idle wake enqueues #then it falls back to the direct renderer channel", () => {
+    // given
+    const pi = fakePi()
+    const notifier = createParentNotifier(pi)
+
+    // when
+    notifier.enqueue({
+      customType: "senpi-task.completion",
+      content: "st_1 completed",
+      display: false,
+      details: completionDetails,
+      triggerTurn: true,
+    })
+
+    // then: with no arbiter, the wake still reaches the parent through the rich channel
+    expect(pi.sent).toHaveLength(1)
+    expect(pi.sent[0]?.options).toMatchObject({ triggerTurn: true })
+    expect(pi.sent[0]?.message.customType).toBe("senpi-task.completion")
+  })
+})

--- a/packages/omo-senpi/src/components/task/parent-notifier.ts
+++ b/packages/omo-senpi/src/components/task/parent-notifier.ts
@@ -7,17 +7,19 @@ import type { SenpiExtensionAPI } from "../../extension/types"
 export const TASK_COMPLETION_MESSAGE_TYPE = "senpi-task.completion"
 
 /**
- * Adapt the engine's synchronous ParentNotifier.enqueue seam onto senpi delivery. A wake (triggerTurn
- * = an idle parent) routes through the idle-injection coordinator so a completion wake and a pending
- * ulw-loop continuation on the same idle edge collapse to ONE injection (the Oracle arbitration
- * blocker). Streaming (deliverAs) and silent-queue completions keep the rich custom-message channel so
- * the senpi-task.completion renderer applies. senpi swallows async delivery errors, so a synchronous
- * throw here surfaces as the engine's delivery failure.
+ * Adapt the engine's synchronous ParentNotifier.enqueue seam onto senpi delivery. Only an IDLE-edge
+ * wake (triggerTurn:true AND deliverAs === undefined) routes through the idle-injection coordinator, so
+ * a completion wake and a pending ulw-loop continuation on the same idle edge collapse to ONE injection
+ * (the Oracle arbitration blocker). A STREAMING completion carries triggerTurn:true AND a deliverAs; it
+ * is mid-turn, not on an idle edge, so it must NOT be arbitrated - it delivers directly through the rich
+ * custom-message channel so the senpi-task.completion renderer applies and the configured deliver_as
+ * (steer|followUp) is honored. Silent-queue completions (no triggerTurn) also stay on that channel.
+ * senpi swallows async delivery errors, so a synchronous throw here surfaces as the engine's failure.
  */
 export function createParentNotifier(pi: SenpiExtensionAPI, coordinator?: IdleInjectionCoordinator): ParentNotifier {
   return {
     enqueue(message: ParentNotifierMessage): void {
-      if (message.triggerTurn === true && coordinator !== undefined) {
+      if (message.triggerTurn === true && message.deliverAs === undefined && coordinator !== undefined) {
         coordinator.enqueue({ key: injectionKey(message), source: "task-completion", content: message.content })
         coordinator.flushOnIdle()
         return

--- a/packages/omo-senpi/src/components/task/session-transition-bridge.test.ts
+++ b/packages/omo-senpi/src/components/task/session-transition-bridge.test.ts
@@ -123,7 +123,7 @@ describe("createSessionTransitionBridge buffered-completion round trip", () => {
     const runtime = new TaskRuntimeContext("/project")
     const store = fakeStore(completedRecord("session-a"))
     const notifier = capturingNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: { wake_idle_parent: true, deliver_as: "followUp" } })
+    const completion = createCompletionNotifier({ notifier, store, config: { deliver_as: "followUp" } })
     const bridge = createSessionTransitionBridge({ runtime, notifier: completion })
 
     // when the session enters compaction and a background terminal arrives
@@ -149,7 +149,7 @@ describe("createSessionTransitionBridge buffered-completion round trip", () => {
     const runtime = new TaskRuntimeContext("/project")
     const store = fakeStore(completedRecord("session-a"))
     const notifier = capturingNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: { wake_idle_parent: true, deliver_as: "followUp" } })
+    const completion = createCompletionNotifier({ notifier, store, config: { deliver_as: "followUp" } })
     const bridge = createSessionTransitionBridge({ runtime, notifier: completion })
 
     // when a switch begins and a completion buffers
@@ -172,7 +172,7 @@ describe("createSessionTransitionBridge buffered-completion round trip", () => {
     const runtime = new TaskRuntimeContext("/project")
     const store = fakeStore(completedRecord("session-a"))
     const notifier = capturingNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: { wake_idle_parent: true, deliver_as: "followUp" } })
+    const completion = createCompletionNotifier({ notifier, store, config: { deliver_as: "followUp" } })
     const bridge = createSessionTransitionBridge({ runtime, notifier: completion })
 
     // when

--- a/packages/omo-senpi/src/components/task/team-message-notifier.test.ts
+++ b/packages/omo-senpi/src/components/task/team-message-notifier.test.ts
@@ -97,4 +97,23 @@ describe("team-message notifier + shared idle coordinator", () => {
     expect(pi.sent[0]?.message.customType).toBe("senpi-task.team-message")
     expect(pi.sent[0]?.options).toMatchObject({ deliverAs: "followUp" })
   })
+
+  test("#given a streaming lead message carrying BOTH triggerTurn and deliverAs:steer #when enqueued #then it delivers directly via the renderer with steer preserved, not the coordinator", () => {
+    // given: the engine now stamps a streaming lead message with triggerTurn:true AND the configured deliverAs
+    const delivered: string[] = []
+    const { coordinator } = deferredCoordinator(delivered)
+    const pi = fakePi()
+    const teamNotifier = createTeamMessageNotifier(pi, coordinator)
+
+    // when
+    teamNotifier.enqueue({ customType: "senpi-task.team-message", content: "beta: steering", display: false, from: "beta", messageId: "m3", triggerTurn: true, deliverAs: "steer" })
+
+    // then: it bypasses the idle-edge arbiter and reaches the rich channel with steer + triggerTurn intact
+    expect(coordinator.pendingCount()).toBe(0)
+    expect(delivered).toHaveLength(0)
+    expect(pi.sent).toHaveLength(1)
+    expect(pi.sent[0]?.message.customType).toBe("senpi-task.team-message")
+    expect(pi.sent[0]?.message.details).toEqual({ from: "beta", messageId: "m3" })
+    expect(pi.sent[0]?.options).toMatchObject({ deliverAs: "steer", triggerTurn: true })
+  })
 })

--- a/packages/omo-senpi/src/components/task/team-message-notifier.ts
+++ b/packages/omo-senpi/src/components/task/team-message-notifier.ts
@@ -8,19 +8,21 @@ export const TEAM_MESSAGE_MESSAGE_TYPE = "senpi-task.team-message"
 
 /**
  * Adapt the team messaging engine's synchronous LeadMessageNotifier.enqueue seam onto senpi delivery.
- * A wake (triggerTurn = an idle lead) routes through the SHARED idle-injection coordinator so a team
- * lead-message wake and a task-completion wake landing on the same idle edge collapse to ONE injection
- * (the completion path enqueues + flushOnIdle synchronously; this path enqueues + schedules a deferred
- * flush, which the synchronous flush drains first). The coordinator dedupes on the message id, so the
- * enqueue is all-or-nothing under the engine's retry: a re-enqueue of the same message never
- * double-injects. Streaming / silent-queue deliveries keep the rich custom-message channel so the
- * senpi-task.team-message renderer applies. senpi swallows async delivery errors, so a synchronous
- * throw here surfaces to the engine as a failed lead delivery.
+ * Only an IDLE-edge wake (triggerTurn:true AND deliverAs === undefined) routes through the SHARED
+ * idle-injection coordinator so a team lead-message wake and a task-completion wake landing on the same
+ * idle edge collapse to ONE injection (the completion path enqueues + flushOnIdle synchronously; this
+ * path enqueues + schedules a deferred flush, which the synchronous flush drains first). The coordinator
+ * dedupes on the message id, so the enqueue is all-or-nothing under the engine's retry: a re-enqueue of
+ * the same message never double-injects. A STREAMING lead message carries triggerTurn:true AND a
+ * deliverAs; it is mid-turn, not on an idle edge, so it delivers DIRECTLY through the rich custom-message
+ * channel so the senpi-task.team-message renderer applies and the configured deliver_as survives.
+ * Silent-queue deliveries (no triggerTurn) also stay on that channel. senpi swallows async delivery
+ * errors, so a synchronous throw here surfaces to the engine as a failed lead delivery.
  */
 export function createTeamMessageNotifier(pi: SenpiExtensionAPI, coordinator?: IdleInjectionCoordinator): LeadMessageNotifier {
   return {
     enqueue(message: LeadTeamMessage): void {
-      if (message.triggerTurn === true && coordinator !== undefined) {
+      if (message.triggerTurn === true && message.deliverAs === undefined && coordinator !== undefined) {
         coordinator.enqueue({ key: `team-message:${message.messageId}`, source: "team-message", content: message.content })
         coordinator.scheduleFlush()
         return

--- a/packages/senpi-task/AGENTS.md
+++ b/packages/senpi-task/AGENTS.md
@@ -47,7 +47,7 @@ The Senpi-coupled engine behind the `omo-senpi` task component: a durable task s
 
 ### Completion routing table (`completion/routing.ts`)
 
-`shouldNotifyStatus` fires only for externally-caused terminals `completed`/`error`/`lost` (`routing.ts:4`); parent-initiated cancel/interrupt return synchronously in the tool result and never push. `routeCompletion` maps parent state to an action: `idle` -> `wake` (or `queue_silently` when `wake_idle_parent` is false), `streaming` -> `deliver_streaming` using `deliver_as` (`followUp` | `steer`), and `compacting`/`session_switching`/`session_shutdown` -> `buffer` until the parent settles (`routing.ts:12`).
+`shouldNotifyStatus` fires only for externally-caused terminals `completed`/`error`/`lost` (`routing.ts:4`); parent-initiated cancel/interrupt return synchronously in the tool result and never push. `routeCompletion` maps parent state to an action: `idle` -> `wake` unconditionally (no setting may suppress it), `streaming` -> `deliver_streaming` using `deliver_as` (`followUp` | `steer`) with `triggerTurn` also stamped so the queued message still fires a turn, and `compacting`/`session_switching`/`session_shutdown` -> `buffer` until the parent settles (`routing.ts:12`).
 
 ## EXECUTION MODES
 

--- a/packages/senpi-task/src/completion/notifier-buffer-dedupe.test.ts
+++ b/packages/senpi-task/src/completion/notifier-buffer-dedupe.test.ts
@@ -5,7 +5,7 @@ import type { NotificationConfig, ParentNotifier, ParentNotifierMessage, ParentS
 import type { TaskRecord } from "../state"
 import type { PersistedTaskEvent } from "../store"
 
-const wakeConfig: NotificationConfig = { wake_idle_parent: true, deliver_as: "followUp" }
+const wakeConfig: NotificationConfig = { deliver_as: "followUp" }
 
 function bufferedRecord(): TaskRecord {
   return {

--- a/packages/senpi-task/src/completion/notifier.test.ts
+++ b/packages/senpi-task/src/completion/notifier.test.ts
@@ -5,7 +5,7 @@ import type { NotificationConfig, ParentNotifier, ParentNotifierMessage, ParentS
 import type { TaskRecord } from "../state"
 import type { PersistedTaskEvent } from "../store"
 
-const wakeConfig: NotificationConfig = { wake_idle_parent: true, deliver_as: "followUp" }
+const wakeConfig: NotificationConfig = { deliver_as: "followUp" }
 
 function baseRecord(overrides: Partial<TaskRecord> = {}): TaskRecord {
   return {
@@ -174,31 +174,23 @@ describe("createCompletionNotifier - routing table", () => {
     return { result, calls, completion }
   }
 
-  test("#given idle parent with wake #when delivered #then triggerTurn payload recorded", () => {
+  test("#given idle parent #when delivered #then triggerTurn payload recorded unconditionally", () => {
     // when
-    const { result, calls } = route({ kind: "idle" }, { wake_idle_parent: true, deliver_as: "followUp" })
+    const { result, calls } = route({ kind: "idle" }, { deliver_as: "followUp" })
 
-    // then
+    // then an idle parent always wakes with a triggerTurn payload
     expect(result).toEqual({ kind: "delivered", decision: "wake" })
     expect(calls[0]?.triggerTurn).toBe(true)
   })
 
-  test("#given idle parent without wake #when delivered #then queued silently without triggerTurn", () => {
+  test("#given streaming parent #when delivered #then followUp deliverAs and triggerTurn are set", () => {
     // when
-    const { result, calls } = route({ kind: "idle" }, { wake_idle_parent: false, deliver_as: "followUp" })
+    const { result, calls } = route({ kind: "streaming" }, { deliver_as: "followUp" })
 
-    // then
-    expect(result).toEqual({ kind: "delivered", decision: "queue_silently" })
-    expect(calls[0]?.triggerTurn).toBeUndefined()
-  })
-
-  test("#given streaming parent #when delivered #then followUp deliverAs is set", () => {
-    // when
-    const { result, calls } = route({ kind: "streaming" }, { wake_idle_parent: true, deliver_as: "followUp" })
-
-    // then
+    // then a streaming completion queues as followUp AND guarantees a turn
     expect(result).toEqual({ kind: "delivered", decision: "deliver_streaming" })
     expect(calls[0]?.deliverAs).toBe("followUp")
+    expect(calls[0]?.triggerTurn).toBe(true)
   })
 
   test("#given compacting parent #when notified #then buffered without delivery", () => {

--- a/packages/senpi-task/src/completion/notifier.ts
+++ b/packages/senpi-task/src/completion/notifier.ts
@@ -85,17 +85,20 @@ export function createCompletionNotifier(deps: CompletionNotifierDeps): Completi
   return { notifyTerminal, flushBuffered, bufferedCount }
 }
 
-function buildDeliveryMessage(details: readonly CompletionDetails[], decision: RoutingDecision): ParentNotifierMessage {
+// A streaming completion queues as the configured deliverAs AND stamps triggerTurn:true so the parent
+// is guaranteed to take a turn to process it once the current turn ends (senpi sendMessage accepts
+// triggerTurn + deliverAs together). A wake completion (idle parent) fires the turn directly.
+function buildDeliveryMessage(
+  details: readonly CompletionDetails[],
+  decision: Exclude<RoutingDecision, { kind: "buffer" }>,
+): ParentNotifierMessage {
   const base = buildCompletionMessage(details)
   if (decision.kind === "wake") return { ...base, triggerTurn: true }
-  if (decision.kind === "deliver_streaming") return { ...base, deliverAs: decision.deliverAs }
-  return base
+  return { ...base, deliverAs: decision.deliverAs, triggerTurn: true }
 }
 
-function deliveredDecision(decision: RoutingDecision): DeliveredDecision {
-  if (decision.kind === "wake") return "wake"
-  if (decision.kind === "deliver_streaming") return "deliver_streaming"
-  return "queue_silently"
+function deliveredDecision(decision: Exclude<RoutingDecision, { kind: "buffer" }>): DeliveredDecision {
+  return decision.kind === "wake" ? "wake" : "deliver_streaming"
 }
 
 function deliverWithRetry(

--- a/packages/senpi-task/src/completion/routing.test.ts
+++ b/packages/senpi-task/src/completion/routing.test.ts
@@ -3,31 +3,21 @@ import { describe, expect, test } from "bun:test"
 import { routeCompletion, shouldNotifyStatus } from "./routing"
 import type { NotificationConfig, ParentState } from "./types"
 
-const wakeConfig: NotificationConfig = { wake_idle_parent: true, deliver_as: "followUp" }
-const silentConfig: NotificationConfig = { wake_idle_parent: false, deliver_as: "followUp" }
-const steerConfig: NotificationConfig = { wake_idle_parent: true, deliver_as: "steer" }
+const wakeConfig: NotificationConfig = { deliver_as: "followUp" }
+const steerConfig: NotificationConfig = { deliver_as: "steer" }
 
 describe("routeCompletion", () => {
-  test("#given idle parent and wake enabled #when routed #then wake decision", () => {
+  test("#given idle parent #when routed #then always wakes regardless of config", () => {
     // given
     const state: ParentState = { kind: "idle" }
 
     // when
-    const decision = routeCompletion(state, wakeConfig)
+    const followUp = routeCompletion(state, wakeConfig)
+    const steer = routeCompletion(state, steerConfig)
 
-    // then
-    expect(decision).toEqual({ kind: "wake" })
-  })
-
-  test("#given idle parent and wake disabled #when routed #then queued silently", () => {
-    // given
-    const state: ParentState = { kind: "idle" }
-
-    // when
-    const decision = routeCompletion(state, silentConfig)
-
-    // then
-    expect(decision).toEqual({ kind: "queue_silently" })
+    // then an idle parent unconditionally wakes; there is no silent-queue path
+    expect(followUp).toEqual({ kind: "wake" })
+    expect(steer).toEqual({ kind: "wake" })
   })
 
   test("#given streaming parent #when routed #then delivered with configured deliver_as", () => {

--- a/packages/senpi-task/src/completion/routing.ts
+++ b/packages/senpi-task/src/completion/routing.ts
@@ -9,10 +9,14 @@ export function shouldNotifyStatus(status: TaskStatus): boolean {
   return notifyingStatuses.has(status)
 }
 
+// An idle parent ALWAYS wakes: a completed background child's notification must unconditionally reach
+// the parent's next turn, with no config able to suppress it. A streaming parent delivers with the
+// configured deliver_as (and the notifier also stamps triggerTurn so the queued message still fires a
+// turn). Transient transitions buffer and flush with triggerTurn on the next session_start/idle edge.
 export function routeCompletion(parentState: ParentState, config: NotificationConfig): RoutingDecision {
   switch (parentState.kind) {
     case "idle":
-      return config.wake_idle_parent ? { kind: "wake" } : { kind: "queue_silently" }
+      return { kind: "wake" }
     case "streaming":
       return { kind: "deliver_streaming", deliverAs: config.deliver_as }
     case "compacting":

--- a/packages/senpi-task/src/completion/types.ts
+++ b/packages/senpi-task/src/completion/types.ts
@@ -4,7 +4,6 @@ import type { PersistedTaskEvent } from "../store"
 // Resolved from omo.json task.notification (config-core OmoTaskNotificationSchema). Kept structural so
 // this module stays harness-neutral; the omo-senpi composition (todo 17) feeds the parsed config.
 export type NotificationConfig = {
-  readonly wake_idle_parent: boolean
   readonly deliver_as: "steer" | "followUp"
 }
 
@@ -20,7 +19,6 @@ export type ParentState =
 
 export type RoutingDecision =
   | { readonly kind: "wake" }
-  | { readonly kind: "queue_silently" }
   | { readonly kind: "deliver_streaming"; readonly deliverAs: "steer" | "followUp" }
   | { readonly kind: "buffer"; readonly reason: TransitionReason }
 
@@ -72,7 +70,7 @@ export type CompletionRequest = {
 
 export type SkipReason = "sync-task" | "non-notifying-terminal" | "not-terminal" | "already-notified"
 
-export type DeliveredDecision = "wake" | "queue_silently" | "deliver_streaming"
+export type DeliveredDecision = "wake" | "deliver_streaming"
 
 export type NotifyResult =
   | { readonly kind: "skipped"; readonly reason: SkipReason }

--- a/packages/senpi-task/src/completion/unconditional-wake.test.ts
+++ b/packages/senpi-task/src/completion/unconditional-wake.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+
+import { createCompletionNotifier } from "./notifier"
+import { routeCompletion } from "./routing"
+import type { NotificationConfig, ParentNotifier, ParentNotifierMessage, ParentState } from "./types"
+import type { TaskRecord } from "../state"
+import type { PersistedTaskEvent } from "../store"
+
+// Product-owner invariant: a completed background child's notification MUST unconditionally reach the
+// parent's next turn. No config may suppress it. These tests pin that there is no waiting-forever path.
+const config: NotificationConfig = { deliver_as: "followUp" }
+const steerConfig: NotificationConfig = { deliver_as: "steer" }
+
+function baseRecord(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    task_id: "st_wake",
+    name: "wake-me",
+    parent_session_id: "parent-session",
+    root_session_id: "root-session",
+    depth: 1,
+    execution_mode: "in-process",
+    model: "gpt-5.2",
+    status: "completed",
+    residency_state: "resident",
+    created_at: "2026-07-06T01:00:00.000Z",
+    updated_at: "2026-07-06T01:00:03.000Z",
+    final_response: "done",
+    notification: { run_epoch: 0, notified_epoch: -1 },
+    ...overrides,
+  }
+}
+
+function fakeStore(record: TaskRecord) {
+  const records = new Map<string, TaskRecord>([[record.task_id, record]])
+  return {
+    load: (taskId: string): TaskRecord | null => records.get(taskId) ?? null,
+    replace: (next: TaskRecord): void => {
+      records.set(next.task_id, next)
+    },
+    appendEvent: (_taskId: string, _event: PersistedTaskEvent): string => "log.jsonl",
+  }
+}
+
+function fakeNotifier(): { notifier: ParentNotifier; calls: ParentNotifierMessage[] } {
+  const calls: ParentNotifierMessage[] = []
+  return { notifier: { enqueue: (message) => calls.push(message) }, calls }
+}
+
+describe("unconditional wake", () => {
+  test("#given an idle parent #when a background child completes #then it always wakes with triggerTurn", () => {
+    // given an idle parent (the state the old wake_idle_parent:false knob used to silence)
+    const state: ParentState = { kind: "idle" }
+
+    // when routed
+    const decision = routeCompletion(state, config)
+
+    // then it wakes, never queues silently
+    expect(decision).toEqual({ kind: "wake" })
+  })
+
+  test("#given an idle parent #when notified end to end #then a triggerTurn message is enqueued", () => {
+    // given
+    const record = baseRecord()
+    const { notifier, calls } = fakeNotifier()
+    const completion = createCompletionNotifier({ notifier, store: fakeStore(record), config })
+
+    // when
+    const result = completion.notifyTerminal({ record, parentState: { kind: "idle" }, runInBackground: true })
+
+    // then the completion injects on the parent's next turn
+    expect(result).toEqual({ kind: "delivered", decision: "wake" })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.triggerTurn).toBe(true)
+  })
+
+  test("#given a streaming parent #when a background child completes #then delivery carries triggerTurn and deliverAs", () => {
+    // given
+    const record = baseRecord()
+    const { notifier, calls } = fakeNotifier()
+    const completion = createCompletionNotifier({ notifier, store: fakeStore(record), config: steerConfig })
+
+    // when
+    const result = completion.notifyTerminal({ record, parentState: { kind: "streaming" }, runInBackground: true })
+
+    // then a streaming completion queues as the configured deliverAs AND guarantees a turn
+    expect(result).toEqual({ kind: "delivered", decision: "deliver_streaming" })
+    expect(calls[0]?.deliverAs).toBe("steer")
+    expect(calls[0]?.triggerTurn).toBe(true)
+  })
+})

--- a/packages/senpi-task/src/team/messaging/deliver-lead.test.ts
+++ b/packages/senpi-task/src/team/messaging/deliver-lead.test.ts
@@ -5,7 +5,7 @@ import { deliverToLead } from "./deliver-lead"
 import { buildTeamMessage } from "./message"
 import { FakeLeadNotifier } from "./__fixtures__/messaging-fakes"
 
-const CONFIG: NotificationConfig = { wake_idle_parent: true, deliver_as: "followUp" }
+const CONFIG: NotificationConfig = { deliver_as: "followUp" }
 
 function leadMessage() {
   return buildTeamMessage(
@@ -43,24 +43,7 @@ member alpha needs a decision
     })
   })
 
-  test("#given an idle parent with wake disabled #when delivered #then it is queued silently", () => {
-    // given
-    const notifier = new FakeLeadNotifier()
-
-    // when
-    const result = deliverToLead({
-      message: leadMessage(),
-      parentState: { kind: "idle" },
-      notificationConfig: { wake_idle_parent: false, deliver_as: "followUp" },
-      notifier,
-    })
-
-    // then
-    expect(result).toEqual({ kind: "delivered", decision: "queue_silently" })
-    expect(notifier.enqueued[0]?.triggerTurn).toBeUndefined()
-  })
-
-  test("#given a streaming parent #when delivered #then it is delivered with the configured deliverAs", () => {
+  test("#given a streaming parent #when delivered #then it carries the configured deliverAs and triggerTurn", () => {
     // given
     const notifier = new FakeLeadNotifier()
 
@@ -68,13 +51,14 @@ member alpha needs a decision
     const result = deliverToLead({
       message: leadMessage(),
       parentState: { kind: "streaming" },
-      notificationConfig: { wake_idle_parent: true, deliver_as: "steer" },
+      notificationConfig: { deliver_as: "steer" },
       notifier,
     })
 
-    // then
+    // then a streaming lead delivery both steers AND guarantees a turn
     expect(result).toEqual({ kind: "delivered", decision: "deliver_streaming" })
     expect(notifier.enqueued[0]?.deliverAs).toBe("steer")
+    expect(notifier.enqueued[0]?.triggerTurn).toBe(true)
   })
 
   test.each<[ParentState["kind"], "compacting" | "session_switching" | "session_shutdown"]>([

--- a/packages/senpi-task/src/team/messaging/deliver-lead.ts
+++ b/packages/senpi-task/src/team/messaging/deliver-lead.ts
@@ -12,7 +12,8 @@ export type DeliverToLeadInput = {
 
 /**
  * Routes a member->lead message through the SAME parent-state machine the completion push uses (todo
- * 11): idle wakes (or queues silently), streaming delivers with the configured `deliverAs`, and a
+ * 11): an idle lead ALWAYS wakes (no config may suppress it), a streaming lead delivers with the
+ * configured `deliverAs` AND stamps triggerTurn so the queued message still fires a turn, and a
  * mid-transition parent (compacting / switching / shutdown) buffers WITHOUT enqueue for the omo-senpi
  * coordinator to flush later. Enqueue is a synchronous fire-and-forget seam; only a sync throw is
  * observable, so a single retry is attempted before reporting failure (mirrors the completion notifier).
@@ -25,8 +26,7 @@ export function deliverToLead(input: DeliverToLeadInput): LeadDeliveryResult {
   if (!enqueueWithRetry(input.notifier, message)) return { kind: "failed" }
 
   if (decision.kind === "wake") return { kind: "delivered", decision: "wake" }
-  if (decision.kind === "deliver_streaming") return { kind: "delivered", decision: "deliver_streaming" }
-  return { kind: "delivered", decision: "queue_silently" }
+  return { kind: "delivered", decision: "deliver_streaming" }
 }
 
 function buildLeadMessage(
@@ -41,8 +41,7 @@ function buildLeadMessage(
     messageId: message.messageId,
   }
   if (decision.kind === "wake") return { ...base, triggerTurn: true }
-  if (decision.kind === "deliver_streaming") return { ...base, deliverAs: decision.deliverAs }
-  return base
+  return { ...base, deliverAs: decision.deliverAs, triggerTurn: true }
 }
 
 function enqueueWithRetry(notifier: LeadMessageNotifier, message: LeadTeamMessage): boolean {

--- a/packages/senpi-task/src/team/messaging/send.test.ts
+++ b/packages/senpi-task/src/team/messaging/send.test.ts
@@ -19,7 +19,7 @@ import {
 import { taskSettings } from "../__fixtures__/runtime-fakes"
 
 const TEAM_RUN_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
-const NOTIFICATION: NotificationConfig = { wake_idle_parent: true, deliver_as: "followUp" }
+const NOTIFICATION: NotificationConfig = { deliver_as: "followUp" }
 
 afterEach(() => {
   cleanupMessagingTmp()

--- a/packages/senpi-task/src/team/messaging/types.ts
+++ b/packages/senpi-task/src/team/messaging/types.ts
@@ -78,7 +78,7 @@ export type MemberDeliveryResult =
   | { readonly kind: "delivery_failed"; readonly member: string; readonly messageId: string; readonly reason: string }
 
 export type LeadDeliveryResult =
-  | { readonly kind: "delivered"; readonly decision: "wake" | "queue_silently" | "deliver_streaming" }
+  | { readonly kind: "delivered"; readonly decision: "wake" | "deliver_streaming" }
   | { readonly kind: "buffered"; readonly reason: TransitionReason }
   | { readonly kind: "failed" }
 

--- a/packages/senpi-task/src/tools/team/messaging.ts
+++ b/packages/senpi-task/src/tools/team/messaging.ts
@@ -23,7 +23,7 @@ export const MemberSendMessageParams = Type.Object(MESSAGE_FIELDS)
 export type TeamSendMessageInput = Static<typeof TeamSendMessageParams>
 export type MemberSendMessageInput = Static<typeof MemberSendMessageParams>
 
-export type LeadDeliveryView = "wake" | "queue_silently" | "deliver_streaming" | "buffered" | "failed"
+export type LeadDeliveryView = "wake" | "deliver_streaming" | "buffered" | "failed"
 export type MemberDeliveryOutcome = "steered" | "revived" | "left_unread" | "delivery_failed"
 
 export type TeamSendMemberView = { readonly member: string; readonly outcome: MemberDeliveryOutcome; readonly reason?: string }


### PR DESCRIPTION
## Why

A senpi-task child could finish and never wake its parent, leaving the parent waiting forever. Two suppression paths caused this:

1. **`queue_silently` idle completions** were parked behind the optional `wake_idle_parent` knob. When a parent went idle and the child completed, the notification sat in the buffer with nothing to flush it — the parent stayed asleep with no turn ever triggered.
2. **Streaming completions** were delivered without `triggerTurn`, so even when the notification reached the parent session the renderer and steer never ran — the message landed but the turn did not resume.

The `wake_idle_parent` config was the wrong lever: making "does the parent ever wake up" opt-in meant the default configuration could silently hang.

## What changed

- **Idle completions always wake the parent.** The `wake_idle_parent` suppression knob is removed from the schema, config loader/writer, and docs. Child completion always routes through the arbitrated coordinator, which owns the single-dispatch wake so concurrent idle/error/completion edges collapse to one injection (no duplicate-wake regression).
- **Streaming completions deliver direct with `triggerTurn`.** Streaming now routes as a direct delivery carrying `triggerTurn: true` plus the configured `deliver_as`, so the renderer and steer survive the wake. Idle stays on the coordinator; streaming takes the direct path — the two routes are kept distinct on purpose.
- **`deliver_as` is preserved end-to-end** through the streaming adapter and the team-message notifier, so downstream rendering keeps the configured presentation instead of falling back to a bare inject.

## QA / evidence

- **Live idle-wake proof:** drove a real idle parent + completing child and confirmed the parent wakes and the turn resumes (no longer waits forever).
- **Streaming adapter tests:** new `unconditional-wake.test.ts` + updated `parent-notifier.test.ts`, `routing.test.ts`, `notifier.test.ts`, `team-message-notifier.test.ts`, and `deliver-lead.test.ts` pin the direct-delivery `triggerTurn` + `deliver_as` behavior and the coordinator-owned idle wake.
- **Unit + `bun run test:senpi`** green across the senpi-task and omo-senpi suites.
- **Schema freshness:** `assets/omo.schema.json` regenerated with `wake_idle_parent` removed (no drift).
- **Task e2e regression:** `packages/omo-senpi/scripts/qa/task-e2e*.mjs` updated and re-run — no regression in the end-to-end task flow.

## Residual risk

The two completion routes (idle → coordinator, streaming → direct) share the same wake contract but distinct code paths; regression tests cover the concurrent/idle/streaming triggers collapsing to a single dispatch, so duplicate-injection risk is pinned by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always wake the parent when a background child completes, and deliver streaming notifications directly with `triggerTurn` while preserving `deliver_as` and the custom renderer.

- **Bug Fixes**
  - Removed `wake_idle_parent` from config and schema; idle completions in `senpi-task` now always wake via the coordinator (single, deduped injection).
  - Streaming completions and team lead messages in `omo-senpi` deliver through the renderer with `triggerTurn: true` and the configured `deliver_as` (`steer` or `followUp`); they no longer reroute through the idle coordinator.
  - Updated tests and e2e flows to pin unconditional wake and direct streaming delivery; regenerated `assets/omo.schema.json` and refreshed docs.

- **Migration**
  - Delete `task.notification.wake_idle_parent` from `omo.json`. Only `task.notification.deliver_as` remains. Behavior now always wakes idle parents.

<sup>Written for commit 53fa9b3cad35091a250a72908c52c76083c9503f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

