### PR TITLE
feat(senpi-task): completions steer into the running turn and batch into one injection

### DIFF
--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -364,26 +364,6 @@
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
         },
-        "notification": {
-          "default": {
-            "deliver_as": "followUp"
-          },
-          "type": "object",
-          "properties": {
-            "deliver_as": {
-              "default": "followUp",
-              "type": "string",
-              "enum": [
-                "followUp",
-                "steer"
-              ]
-            }
-          },
-          "required": [
-            "deliver_as"
-          ],
-          "additionalProperties": false
-        },
         "ttl_ms": {
           "default": 86400000,
           "type": "integer",
@@ -467,7 +447,6 @@
         "default_concurrency",
         "max_depth",
         "residency_max_children",
-        "notification",
         "ttl_ms",
         "wait",
         "team"

--- a/docs/guide/senpi-task.md
+++ b/docs/guide/senpi-task.md
@@ -45,7 +45,7 @@ Cancel and interrupt are parent-initiated: they return their result synchronousl
 When a background child finishes on its own - `completed`, `error`, or `lost` - the engine routes a completion to the parent exactly once (`packages/senpi-task/src/completion/routing.ts`):
 
 - Parent **idle**: it is always woken so the completion injects on the parent's next turn. No setting can suppress this.
-- Parent **streaming**: the completion is delivered using `task.notification.deliver_as` (`followUp` or `steer`) and still triggers a turn so the queued message is processed.
+- Parent **streaming**: the completion is steered into the running turn at the next tool-call boundary. Multiple notifications that become ready in the same batch window (about 200ms) are combined into one injection.
 - Parent **compacting / switching / shutting down**: the completion is buffered and flushed once the parent settles.
 
 Because cancel and interrupt return synchronously, they are never delivered as notifications - only externally-caused terminals notify.
@@ -74,7 +74,6 @@ All defaults live in `omo.json` under `task` and `teams`. A minimal project conf
 {
   "task": {
     "default_execution_mode": "in-process",
-    "notification": { "deliver_as": "followUp" },
     "wait": { "default_ms": 90000 }
   }
 }

--- a/docs/reference/omo-json.md
+++ b/docs/reference/omo-json.md
@@ -136,7 +136,6 @@ Task engine settings; every field has a default, so the whole object is optional
 | `model_concurrency` | record<string, positive int> | unset |
 | `max_depth` | int >= 0 | `1` |
 | `residency_max_children` | positive int | `8` |
-| `notification.deliver_as` | `followUp \| steer` | `followUp` |
 | `ttl_ms` | positive int | `86400000` (24h) |
 | `state_dir` | string | unset (defaults to `<project>/.omo/senpi-task`) |
 | `wait.min_ms` | positive int | `5000` |
@@ -146,7 +145,7 @@ Task engine settings; every field has a default, so the whole object is optional
 | `team.max_parallel_members` | int 1..8 | `4` |
 | `team.max_wall_clock_minutes` | positive int | `120` |
 
-`state_dir` defaults to `<project_dir>/.omo/senpi-task` when unset (`packages/senpi-task/src/store/state-dir.ts`). `notification` controls how a child completion reaches an idle or streaming parent; see the completion routing table in [`packages/senpi-task/AGENTS.md`](../../packages/senpi-task/AGENTS.md).
+`state_dir` defaults to `<project_dir>/.omo/senpi-task` when unset (`packages/senpi-task/src/store/state-dir.ts`). Completion delivery is not configurable: every child completion is batched with any other ready notifications and steered into the parent's running turn at the next tool-call boundary; see the completion routing table in [`packages/senpi-task/AGENTS.md`](../../packages/senpi-task/AGENTS.md).
 
 ### `teams`
 
@@ -180,7 +179,6 @@ Each member shares a base (`name` matching `^[a-z0-9-]+$`, optional `cwd`, `work
   "task": {
     "default_execution_mode": "in-process",
     "default_concurrency": 4,
-    "notification": { "deliver_as": "followUp" },
     "wait": { "default_ms": 90000 }
   },
   "categories": {

--- a/packages/omo-config-core/src/schema/task.ts
+++ b/packages/omo-config-core/src/schema/task.ts
@@ -1,9 +1,5 @@
 import * as z from "zod"
 
-export const OmoTaskNotificationSchema = z.object({
-  deliver_as: z.enum(["followUp", "steer"]).default("followUp"),
-}).strict()
-
 export const OmoTaskWaitSchema = z.object({
   min_ms: z.number().int().positive().default(5000),
   default_ms: z.number().int().positive().default(60000),
@@ -23,7 +19,6 @@ export const OmoTaskSettingsSchema = z.object({
   model_concurrency: z.record(z.string(), z.number().int().positive()).optional(),
   max_depth: z.number().int().nonnegative().default(1),
   residency_max_children: z.number().int().positive().default(8),
-  notification: OmoTaskNotificationSchema.default({ deliver_as: "followUp" }),
   ttl_ms: z.number().int().positive().default(86400000),
   state_dir: z.string().optional(),
   wait: OmoTaskWaitSchema.default({ min_ms: 5000, default_ms: 60000, max_ms: 600000 }),

--- a/packages/omo-senpi/src/components/task/engine.ts
+++ b/packages/omo-senpi/src/components/task/engine.ts
@@ -88,11 +88,10 @@ export function composeTaskEngine(deps: ComposeTaskEngineDeps): TaskEngine {
     ...(settings.state_dir !== undefined && { task: { state_dir: settings.state_dir } }),
   })
 
-  const parentNotifier = createParentNotifier(deps.pi, deps.coordinator)
+  const parentNotifier = createParentNotifier(deps.pi, deps.coordinator, () => runtime.parentState().kind === "streaming")
   const notifier = createCompletionNotifier({
     notifier: parentNotifier,
     store: baseStore,
-    config: settings.notification,
   })
 
   let managerRef: TaskManager | undefined

--- a/packages/omo-senpi/src/components/task/index.test.ts
+++ b/packages/omo-senpi/src/components/task/index.test.ts
@@ -36,6 +36,7 @@ const TASK_EVENTS = [
   "session_shutdown",
   "model_select",
   "before_agent_start",
+  "agent_end",
 ]
 const TASK_COMMANDS = ["task-kill", "tasks"]
 

--- a/packages/omo-senpi/src/components/task/index.ts
+++ b/packages/omo-senpi/src/components/task/index.ts
@@ -120,7 +120,7 @@ function registerTaskTools(pi: SenpiExtensionAPI, engine: TaskEngine): void {
 // only on the lead (current) session; the manager's shared-tool filter strips the whole team_* family
 // from member children, and only the pre-scoped member team_send_message is re-added (see team-service).
 function registerTeamTools(pi: SenpiExtensionAPI, ctx: ComponentContext, engine: TaskEngine): () => Promise<void> {
-  const leadNotifier = createTeamMessageNotifier(pi, ctx.idleCoordinator)
+  const leadNotifier = createTeamMessageNotifier(pi, ctx.idleCoordinator, () => engine.runtime.parentState().kind === "streaming")
   const serviceDeps = {
     manager: engine.manager,
     runtime: engine.runtime,
@@ -204,6 +204,21 @@ export function wireEventBridge(
   pi.on("model_select", (_payload, eventCtx) => {
     engine.runtime.captureFrom(asLiveContext(eventCtx))
     statusUi.scheduleSync()
+  })
+
+  // Idle-edge drain: when the parent's turn ends, everything collected in the batch window is
+  // delivered NOW as one combined steer, before senpi's print mode can decide the session is over
+  // (the 200ms collect timer alone would race a -p exit and lose the wake - live-driver proven).
+  // Deferred one microtask so a ulw-loop continuation enqueued by its own agent_end handler on the
+  // same edge joins the same injection instead of racing it.
+  pi.on("agent_end", (_payload, eventCtx) => {
+    engine.runtime.captureFrom(asLiveContext(eventCtx))
+    const coordinator = ctx.idleCoordinator
+    if (coordinator === undefined) return undefined
+    queueMicrotask(() => {
+      coordinator.flushOnIdle()
+    })
+    return undefined
   })
 
   pi.on("before_agent_start", (_payload, eventCtx) => {

--- a/packages/omo-senpi/src/components/task/parent-notifier.test.ts
+++ b/packages/omo-senpi/src/components/task/parent-notifier.test.ts
@@ -28,108 +28,131 @@ function fakePi(): SenpiExtensionAPI & { readonly sent: SentMessage[]; readonly 
   }
 }
 
-function coordinatorCapturing(delivered: { content: string; deliverAs: "steer" | "followUp" }[]): IdleInjectionCoordinator {
-  return new IdleInjectionCoordinator((content, options) => delivered.push({ content, deliverAs: options.deliverAs }))
+type Delivered = { content: string; deliverAs: "steer" | "followUp" }
+
+// A manually-driven flush scheduler stands in for the production batch-window timer so the tests
+// control exactly when the deferred flush runs (everything enqueued before it batches together).
+function coordinatorWithManualFlush(delivered: Delivered[]): { coordinator: IdleInjectionCoordinator; runFlush: () => void } {
+  let pending: (() => void) | undefined
+  const coordinator = new IdleInjectionCoordinator(
+    (content, options) => delivered.push({ content, deliverAs: options.deliverAs }),
+    { scheduleFlush: (flush) => { pending = flush } },
+  )
+  return {
+    coordinator,
+    runFlush: () => {
+      pending?.()
+      pending = undefined
+    },
+  }
 }
 
 const completionDetails = [
   { task_id: "st_1", name: "worker", status: "completed" as const, duration_ms: 10, final_response_head: "ok", continuation_hint: "continue" },
 ]
 
-describe("createParentNotifier idle vs streaming routing", () => {
-  test("#given an idle wake (triggerTurn, no deliverAs) #when enqueued #then it routes through the coordinator and collapses", () => {
+function completionMessage(taskId: string) {
+  return {
+    customType: "senpi-task.completion" as const,
+    content: `${taskId} completed`,
+    display: false,
+    details: [{ ...completionDetails[0]!, task_id: taskId }],
+    triggerTurn: true,
+  }
+}
+
+describe("createParentNotifier batched steer delivery", () => {
+  test("#given one completion #when enqueued #then it defers through the coordinator and flushes as ONE steer", () => {
     // given
-    const delivered: { content: string; deliverAs: "steer" | "followUp" }[] = []
-    const coordinator = coordinatorCapturing(delivered)
+    const delivered: Delivered[] = []
+    const { coordinator, runFlush } = coordinatorWithManualFlush(delivered)
     const pi = fakePi()
-    const notifier = createParentNotifier(pi, coordinator)
+    const notifier = createParentNotifier(pi, coordinator, () => true)
 
-    // when: a wake completion carries triggerTurn:true and NO deliverAs (the idle-edge arbitration path)
-    notifier.enqueue({
-      customType: "senpi-task.completion",
-      content: "st_1 completed",
-      display: false,
-      details: completionDetails,
-      triggerTurn: true,
-    })
+    // when: the parent is STREAMING, so the completion collects in the batch window
+    notifier.enqueue(completionMessage("st_1"))
 
-    // then: it is arbitrated by the coordinator (one followUp injection), NOT delivered directly
+    // then nothing delivers synchronously (the batch window is open)
+    expect(delivered).toHaveLength(0)
+    expect(pi.sent).toHaveLength(0)
+
+    // when the batch window closes
+    runFlush()
+
+    // then exactly one steer injection carries the completion
     expect(delivered).toHaveLength(1)
     expect(delivered[0]?.content).toContain("st_1 completed")
-    expect(delivered[0]?.deliverAs).toBe("followUp")
-    expect(pi.sent).toHaveLength(0)
+    expect(delivered[0]?.deliverAs).toBe("steer")
     expect(pi.userSent).toHaveLength(0)
   })
 
-  test("#given a streaming completion (triggerTurn AND deliverAs:steer) #when enqueued #then it delivers DIRECTLY via the renderer channel with steer preserved", () => {
+  test("#given two near-simultaneous completions #when the batch window closes #then BOTH arrive in ONE steer injection", () => {
     // given
-    const delivered: { content: string; deliverAs: "steer" | "followUp" }[] = []
-    const coordinator = coordinatorCapturing(delivered)
+    const delivered: Delivered[] = []
+    const { coordinator, runFlush } = coordinatorWithManualFlush(delivered)
     const pi = fakePi()
-    const notifier = createParentNotifier(pi, coordinator)
+    const notifier = createParentNotifier(pi, coordinator, () => true)
 
-    // when: a STREAMING completion now carries BOTH triggerTurn:true AND the configured deliverAs
-    notifier.enqueue({
-      customType: "senpi-task.completion",
-      content: "st_1 completed",
-      display: false,
-      details: completionDetails,
-      triggerTurn: true,
-      deliverAs: "steer",
-    })
+    // when two children complete inside the same batch window (streaming parent)
+    notifier.enqueue(completionMessage("st_1"))
+    notifier.enqueue(completionMessage("st_2"))
+    runFlush()
 
-    // then: it bypasses the coordinator and goes straight to the rich custom-message channel
-    expect(delivered).toHaveLength(0)
-    expect(pi.userSent).toHaveLength(0)
-    expect(pi.sent).toHaveLength(1)
-    // and: the configured deliver_as (steer) survives, and triggerTurn rides along
-    expect(pi.sent[0]?.options).toMatchObject({ deliverAs: "steer", triggerTurn: true })
-    // and: the senpi-task.completion renderer applies (custom message shape, not a plain user message)
-    expect(pi.sent[0]?.message.customType).toBe("senpi-task.completion")
-    expect(pi.sent[0]?.message.details).toEqual(completionDetails)
+    // then the parent receives exactly ONE steer carrying both notifications
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.deliverAs).toBe("steer")
+    expect(delivered[0]?.content).toContain("st_1 completed")
+    expect(delivered[0]?.content).toContain("st_2 completed")
   })
 
-  test("#given a streaming completion with deliverAs:followUp #when enqueued #then it delivers directly with followUp preserved", () => {
+  test("#given a re-enqueue of the same completion #when the batch window closes #then the key dedupes to one entry", () => {
     // given
-    const delivered: { content: string; deliverAs: "steer" | "followUp" }[] = []
-    const coordinator = coordinatorCapturing(delivered)
-    const pi = fakePi()
-    const notifier = createParentNotifier(pi, coordinator)
+    const delivered: Delivered[] = []
+    const { coordinator, runFlush } = coordinatorWithManualFlush(delivered)
+    const notifier = createParentNotifier(fakePi(), coordinator, () => true)
 
-    // when
-    notifier.enqueue({
-      customType: "senpi-task.completion",
-      content: "st_1 completed",
-      display: false,
-      details: completionDetails,
-      triggerTurn: true,
-      deliverAs: "followUp",
-    })
+    // when the engine's sync-throw retry re-enqueues the same message (streaming parent)
+    notifier.enqueue(completionMessage("st_1"))
+    notifier.enqueue(completionMessage("st_1"))
+    runFlush()
 
-    // then
-    expect(delivered).toHaveLength(0)
-    expect(pi.sent).toHaveLength(1)
-    expect(pi.sent[0]?.options).toMatchObject({ deliverAs: "followUp", triggerTurn: true })
-    expect(pi.sent[0]?.message.customType).toBe("senpi-task.completion")
+    // then it never double-injects
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.content.match(/st_1 completed/g)).toHaveLength(1)
   })
 
-  test("#given no coordinator is wired #when an idle wake enqueues #then it falls back to the direct renderer channel", () => {
+  test("#given an IDLE parent #when two completions land in the same tick #then one microtask steer carries both", async () => {
+    // given: no manual scheduler - the idle path flushes itself on the next microtask
+    const delivered: Delivered[] = []
+    const coordinator = new IdleInjectionCoordinator(
+      (content, options) => delivered.push({ content, deliverAs: options.deliverAs }),
+    )
+    const notifier = createParentNotifier(fakePi(), coordinator, () => false)
+
+    // when both completions land in the same tick
+    notifier.enqueue(completionMessage("st_1"))
+    notifier.enqueue(completionMessage("st_2"))
+    expect(delivered).toHaveLength(0)
+    await Promise.resolve()
+
+    // then delivery is immediate (no exit race in print mode) and still batched into ONE steer
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.deliverAs).toBe("steer")
+    expect(delivered[0]?.content).toContain("st_1 completed")
+    expect(delivered[0]?.content).toContain("st_2 completed")
+  })
+
+  test("#given no coordinator is wired #when a completion enqueues #then it falls back to a direct steer on the renderer channel", () => {
     // given
     const pi = fakePi()
     const notifier = createParentNotifier(pi)
 
     // when
-    notifier.enqueue({
-      customType: "senpi-task.completion",
-      content: "st_1 completed",
-      display: false,
-      details: completionDetails,
-      triggerTurn: true,
-    })
+    notifier.enqueue(completionMessage("st_1"))
 
-    // then: with no arbiter, the wake still reaches the parent through the rich channel
+    // then the completion still steers into the running turn through the rich channel
     expect(pi.sent).toHaveLength(1)
-    expect(pi.sent[0]?.options).toMatchObject({ triggerTurn: true })
+    expect(pi.sent[0]?.options).toMatchObject({ triggerTurn: true, deliverAs: "steer" })
     expect(pi.sent[0]?.message.customType).toBe("senpi-task.completion")
   })
 })

--- a/packages/omo-senpi/src/components/task/parent-notifier.ts
+++ b/packages/omo-senpi/src/components/task/parent-notifier.ts
@@ -7,26 +7,28 @@ import type { SenpiExtensionAPI } from "../../extension/types"
 export const TASK_COMPLETION_MESSAGE_TYPE = "senpi-task.completion"
 
 /**
- * Adapt the engine's synchronous ParentNotifier.enqueue seam onto senpi delivery. Only an IDLE-edge
- * wake (triggerTurn:true AND deliverAs === undefined) routes through the idle-injection coordinator, so
- * a completion wake and a pending ulw-loop continuation on the same idle edge collapse to ONE injection
- * (the Oracle arbitration blocker). A STREAMING completion carries triggerTurn:true AND a deliverAs; it
- * is mid-turn, not on an idle edge, so it must NOT be arbitrated - it delivers directly through the rich
- * custom-message channel so the senpi-task.completion renderer applies and the configured deliver_as
- * (steer|followUp) is honored. Silent-queue completions (no triggerTurn) also stay on that channel.
+ * Adapt the engine's synchronous ParentNotifier.enqueue seam onto senpi delivery. EVERY delivered
+ * completion routes through the shared idle-injection coordinator with a DEFERRED flush, so all
+ * notifications that become ready within the batch window (multiple children completing near-
+ * simultaneously, a pending ulw-loop continuation, team lead-messages) collapse into exactly ONE
+ * injection steered into the running turn at the next tool-call boundary. Without a coordinator
+ * (composition seam absent) it falls back to a direct steer through the rich custom-message channel.
  * senpi swallows async delivery errors, so a synchronous throw here surfaces as the engine's failure.
  */
-export function createParentNotifier(pi: SenpiExtensionAPI, coordinator?: IdleInjectionCoordinator): ParentNotifier {
+export function createParentNotifier(
+  pi: SenpiExtensionAPI,
+  coordinator?: IdleInjectionCoordinator,
+  isStreaming?: () => boolean,
+): ParentNotifier {
   return {
     enqueue(message: ParentNotifierMessage): void {
-      if (message.triggerTurn === true && message.deliverAs === undefined && coordinator !== undefined) {
+      if (coordinator !== undefined) {
         coordinator.enqueue({ key: injectionKey(message), source: "task-completion", content: message.content })
-        coordinator.flushOnIdle()
+        // Mid-turn: collect in the batch window (the agent_end drain backstops a turn that ends first).
+        // Idle: flush on the next microtask so same-tick completions batch but delivery is immediate.
+        if (isStreaming?.() === true) coordinator.scheduleFlush()
+        else coordinator.flushSoon()
         return
-      }
-      const options: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" } = {
-        ...(message.triggerTurn !== undefined && { triggerTurn: message.triggerTurn }),
-        ...(message.deliverAs !== undefined && { deliverAs: message.deliverAs }),
       }
       pi.sendMessage(
         {
@@ -35,7 +37,7 @@ export function createParentNotifier(pi: SenpiExtensionAPI, coordinator?: IdleIn
           display: message.display,
           details: message.details,
         },
-        options,
+        { triggerTurn: true, deliverAs: "steer" },
       )
     },
   }

--- a/packages/omo-senpi/src/components/task/session-transition-bridge.test.ts
+++ b/packages/omo-senpi/src/components/task/session-transition-bridge.test.ts
@@ -123,7 +123,7 @@ describe("createSessionTransitionBridge buffered-completion round trip", () => {
     const runtime = new TaskRuntimeContext("/project")
     const store = fakeStore(completedRecord("session-a"))
     const notifier = capturingNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: { deliver_as: "followUp" } })
+    const completion = createCompletionNotifier({ notifier, store })
     const bridge = createSessionTransitionBridge({ runtime, notifier: completion })
 
     // when the session enters compaction and a background terminal arrives
@@ -149,7 +149,7 @@ describe("createSessionTransitionBridge buffered-completion round trip", () => {
     const runtime = new TaskRuntimeContext("/project")
     const store = fakeStore(completedRecord("session-a"))
     const notifier = capturingNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: { deliver_as: "followUp" } })
+    const completion = createCompletionNotifier({ notifier, store })
     const bridge = createSessionTransitionBridge({ runtime, notifier: completion })
 
     // when a switch begins and a completion buffers
@@ -172,7 +172,7 @@ describe("createSessionTransitionBridge buffered-completion round trip", () => {
     const runtime = new TaskRuntimeContext("/project")
     const store = fakeStore(completedRecord("session-a"))
     const notifier = capturingNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: { deliver_as: "followUp" } })
+    const completion = createCompletionNotifier({ notifier, store })
     const bridge = createSessionTransitionBridge({ runtime, notifier: completion })
 
     // when

--- a/packages/omo-senpi/src/components/task/team-message-notifier.test.ts
+++ b/packages/omo-senpi/src/components/task/team-message-notifier.test.ts
@@ -24,26 +24,37 @@ function fakePi(): SenpiExtensionAPI & { readonly sent: SentMessage[] } {
   }
 }
 
-function deferredCoordinator(delivered: string[]): { coordinator: IdleInjectionCoordinator; runDeferred: () => void } {
+type Delivered = { content: string; deliverAs: "steer" | "followUp" }
+
+function deferredCoordinator(delivered: Delivered[]): { coordinator: IdleInjectionCoordinator; runDeferred: () => void } {
   let pending: (() => void) | undefined
-  const coordinator = new IdleInjectionCoordinator((content) => delivered.push(content), {
-    scheduleFlush: (flush) => {
-      pending = flush
+  const coordinator = new IdleInjectionCoordinator(
+    (content, options) => delivered.push({ content, deliverAs: options.deliverAs }),
+    {
+      scheduleFlush: (flush) => {
+        pending = flush
+      },
     },
-  })
-  return { coordinator, runDeferred: () => pending?.() }
+  )
+  return {
+    coordinator,
+    runDeferred: () => {
+      pending?.()
+      pending = undefined
+    },
+  }
 }
 
 describe("team-message notifier + shared idle coordinator", () => {
-  test("#given a lead message and a completion on one idle edge #when both wake #then exactly one injection", () => {
+  test("#given a lead message and a completion in one batch window #when flushed #then exactly one steer injection", () => {
     // given
-    const delivered: string[] = []
+    const delivered: Delivered[] = []
     const { coordinator, runDeferred } = deferredCoordinator(delivered)
     const pi = fakePi()
-    const teamNotifier = createTeamMessageNotifier(pi, coordinator)
-    const completionNotifier = createParentNotifier(pi, coordinator)
+    const teamNotifier = createTeamMessageNotifier(pi, coordinator, () => true)
+    const completionNotifier = createParentNotifier(pi, coordinator, () => true)
 
-    // when: the team lead-message wake enqueues + defers, then the completion wake flushes synchronously
+    // when: both become ready inside the same batch window
     teamNotifier.enqueue({ customType: "senpi-task.team-message", content: "beta: shipped", display: false, from: "beta", messageId: "m1", triggerTurn: true })
     completionNotifier.enqueue({
       customType: "senpi-task.completion",
@@ -53,22 +64,26 @@ describe("team-message notifier + shared idle coordinator", () => {
       triggerTurn: true,
     })
 
-    // then: the synchronous completion flush drains BOTH into one injection
-    expect(delivered).toHaveLength(1)
-    expect(delivered[0]).toContain("st_1 completed")
-    expect(delivered[0]).toContain("beta: shipped")
+    // then: nothing delivers until the window closes
+    expect(delivered).toHaveLength(0)
 
-    // and: the deferred team flush finds an empty queue and no-ops
+    // when the batch window closes
     runDeferred()
+
+    // then: ONE steer injection carries both, in deterministic completion-first order
     expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.deliverAs).toBe("steer")
+    expect(delivered[0]?.content).toContain("st_1 completed")
+    expect(delivered[0]?.content).toContain("beta: shipped")
+    expect(delivered[0]?.content.indexOf("st_1 completed")).toBeLessThan(delivered[0]?.content.indexOf("beta: shipped") ?? -1)
     expect(pi.sent).toHaveLength(0)
   })
 
   test("#given the same lead message enqueued twice (retry) #when flushed #then it injects once", () => {
     // given
-    const delivered: string[] = []
+    const delivered: Delivered[] = []
     const { coordinator, runDeferred } = deferredCoordinator(delivered)
-    const teamNotifier = createTeamMessageNotifier(fakePi(), coordinator)
+    const teamNotifier = createTeamMessageNotifier(fakePi(), coordinator, () => true)
     const wake = { customType: "senpi-task.team-message", content: "beta: done", display: false, from: "beta", messageId: "m1", triggerTurn: true } as const
 
     // when: the engine's enqueue-with-retry double-fires the SAME message id
@@ -81,39 +96,36 @@ describe("team-message notifier + shared idle coordinator", () => {
     expect(delivered).toHaveLength(1)
   })
 
-  test("#given a streaming (non-wake) lead message #when enqueued #then it routes to the rich renderer channel, not the coordinator", () => {
-    // given
-    const delivered: string[] = []
-    const { coordinator } = deferredCoordinator(delivered)
+  test("#given a streaming lead message #when enqueued #then it also batches through the coordinator as steer", () => {
+    // given: a streaming lead delivery carries triggerTurn like every delivered notification
+    const delivered: Delivered[] = []
+    const { coordinator, runDeferred } = deferredCoordinator(delivered)
     const pi = fakePi()
-    const teamNotifier = createTeamMessageNotifier(pi, coordinator)
+    const teamNotifier = createTeamMessageNotifier(pi, coordinator, () => true)
 
     // when
-    teamNotifier.enqueue({ customType: "senpi-task.team-message", content: "beta: fyi", display: false, from: "beta", messageId: "m2", deliverAs: "followUp" })
+    teamNotifier.enqueue({ customType: "senpi-task.team-message", content: "beta: steering", display: false, from: "beta", messageId: "m3", triggerTurn: true })
+    runDeferred()
 
-    // then
-    expect(coordinator.pendingCount()).toBe(0)
-    expect(pi.sent).toHaveLength(1)
-    expect(pi.sent[0]?.message.customType).toBe("senpi-task.team-message")
-    expect(pi.sent[0]?.options).toMatchObject({ deliverAs: "followUp" })
+    // then: the coordinator steers the injection; nothing bypasses the batch
+    expect(pi.sent).toHaveLength(0)
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]?.deliverAs).toBe("steer")
+    expect(delivered[0]?.content).toContain("beta: steering")
   })
 
-  test("#given a streaming lead message carrying BOTH triggerTurn and deliverAs:steer #when enqueued #then it delivers directly via the renderer with steer preserved, not the coordinator", () => {
-    // given: the engine now stamps a streaming lead message with triggerTurn:true AND the configured deliverAs
-    const delivered: string[] = []
-    const { coordinator } = deferredCoordinator(delivered)
+  test("#given no coordinator is wired #when a lead message enqueues #then it falls back to a direct steer on the renderer channel", () => {
+    // given
     const pi = fakePi()
-    const teamNotifier = createTeamMessageNotifier(pi, coordinator)
+    const teamNotifier = createTeamMessageNotifier(pi)
 
     // when
-    teamNotifier.enqueue({ customType: "senpi-task.team-message", content: "beta: steering", display: false, from: "beta", messageId: "m3", triggerTurn: true, deliverAs: "steer" })
+    teamNotifier.enqueue({ customType: "senpi-task.team-message", content: "beta: fyi", display: false, from: "beta", messageId: "m2", triggerTurn: true })
 
-    // then: it bypasses the idle-edge arbiter and reaches the rich channel with steer + triggerTurn intact
-    expect(coordinator.pendingCount()).toBe(0)
-    expect(delivered).toHaveLength(0)
+    // then
     expect(pi.sent).toHaveLength(1)
     expect(pi.sent[0]?.message.customType).toBe("senpi-task.team-message")
-    expect(pi.sent[0]?.message.details).toEqual({ from: "beta", messageId: "m3" })
-    expect(pi.sent[0]?.options).toMatchObject({ deliverAs: "steer", triggerTurn: true })
+    expect(pi.sent[0]?.message.details).toEqual({ from: "beta", messageId: "m2" })
+    expect(pi.sent[0]?.options).toMatchObject({ triggerTurn: true, deliverAs: "steer" })
   })
 })

--- a/packages/omo-senpi/src/components/task/team-message-notifier.ts
+++ b/packages/omo-senpi/src/components/task/team-message-notifier.ts
@@ -8,32 +8,30 @@ export const TEAM_MESSAGE_MESSAGE_TYPE = "senpi-task.team-message"
 
 /**
  * Adapt the team messaging engine's synchronous LeadMessageNotifier.enqueue seam onto senpi delivery.
- * Only an IDLE-edge wake (triggerTurn:true AND deliverAs === undefined) routes through the SHARED
- * idle-injection coordinator so a team lead-message wake and a task-completion wake landing on the same
- * idle edge collapse to ONE injection (the completion path enqueues + flushOnIdle synchronously; this
- * path enqueues + schedules a deferred flush, which the synchronous flush drains first). The coordinator
- * dedupes on the message id, so the enqueue is all-or-nothing under the engine's retry: a re-enqueue of
- * the same message never double-injects. A STREAMING lead message carries triggerTurn:true AND a
- * deliverAs; it is mid-turn, not on an idle edge, so it delivers DIRECTLY through the rich custom-message
- * channel so the senpi-task.team-message renderer applies and the configured deliver_as survives.
- * Silent-queue deliveries (no triggerTurn) also stay on that channel. senpi swallows async delivery
- * errors, so a synchronous throw here surfaces to the engine as a failed lead delivery.
+ * EVERY delivered lead-message routes through the SHARED idle-injection coordinator with a DEFERRED
+ * flush, so lead messages, task completions, and a pending ulw-loop continuation that become ready in
+ * the same batch window collapse into exactly ONE injection steered into the running turn at the next
+ * tool-call boundary. The coordinator dedupes on the message id, so the enqueue stays all-or-nothing
+ * under the engine's retry: re-enqueueing the same message never double-injects. Without a coordinator
+ * it falls back to a direct steer through the rich custom-message channel. senpi swallows async
+ * delivery errors, so a synchronous throw here surfaces to the engine as a failed lead delivery.
  */
-export function createTeamMessageNotifier(pi: SenpiExtensionAPI, coordinator?: IdleInjectionCoordinator): LeadMessageNotifier {
+export function createTeamMessageNotifier(
+  pi: SenpiExtensionAPI,
+  coordinator?: IdleInjectionCoordinator,
+  isStreaming?: () => boolean,
+): LeadMessageNotifier {
   return {
     enqueue(message: LeadTeamMessage): void {
-      if (message.triggerTurn === true && message.deliverAs === undefined && coordinator !== undefined) {
+      if (coordinator !== undefined) {
         coordinator.enqueue({ key: `team-message:${message.messageId}`, source: "team-message", content: message.content })
-        coordinator.scheduleFlush()
+        if (isStreaming?.() === true) coordinator.scheduleFlush()
+        else coordinator.flushSoon()
         return
-      }
-      const options: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" } = {
-        ...(message.triggerTurn !== undefined && { triggerTurn: message.triggerTurn }),
-        ...(message.deliverAs !== undefined && { deliverAs: message.deliverAs }),
       }
       pi.sendMessage(
         { customType: message.customType, content: message.content, display: message.display, details: { from: message.from, messageId: message.messageId } },
-        options,
+        { triggerTurn: true, deliverAs: "steer" },
       )
     },
   }

--- a/packages/omo-senpi/src/components/task/team-service.ts
+++ b/packages/omo-senpi/src/components/task/team-service.ts
@@ -118,7 +118,6 @@ export function createTeamService(deps: TeamServiceDeps): TeamToolsService {
         config,
         delivery,
         leadNotifier: deps.leadNotifier,
-        notificationConfig: deps.settings.notification,
         parentState: () => deps.runtime.parentState(),
         ...(deps.now !== undefined ? { now: deps.now } : {}),
         ...(deps.newMessageId !== undefined ? { newMessageId: deps.newMessageId } : {}),

--- a/packages/omo-senpi/src/extension/compose.ts
+++ b/packages/omo-senpi/src/extension/compose.ts
@@ -79,9 +79,15 @@ export function composeOmoSenpiExtension(
     // Install the capture registry and idle coordinator BEFORE the component loop so every component
     // (lsp registers earlier than task) has its tools captured and shares one injection arbiter.
     const captureRegistry = installToolCaptureRegistry(pi)
-    const idleCoordinator = new IdleInjectionCoordinator((content, options) => {
-      pi.sendUserMessage(content, options)
-    })
+    // The 200ms batch window: every delivered notification (completions, team messages, the ulw
+    // continuation) defers its flush through this timer, so everything that becomes ready within the
+    // window collapses into ONE steer injection instead of N separate ones.
+    const idleCoordinator = new IdleInjectionCoordinator(
+      (content, options) => {
+        pi.sendUserMessage(content, options)
+      },
+      { scheduleFlush: (flush) => void setTimeout(flush, 200) },
+    )
 
     const ctx: ComponentContext = {
       logger,

--- a/packages/omo-senpi/src/extension/idle-injection-coordinator.test.ts
+++ b/packages/omo-senpi/src/extension/idle-injection-coordinator.test.ts
@@ -27,7 +27,7 @@ describe("IdleInjectionCoordinator", () => {
     expect(collapsed).toBe(2)
     expect(calls).toHaveLength(1)
     expect(calls[0]?.content).toBe("task st_1 completed\n\ncontinue the run")
-    expect(calls[0]?.options).toEqual({ deliverAs: "followUp" })
+    expect(calls[0]?.options).toEqual({ deliverAs: "steer" })
   })
 
   it("#given repeated continuation enqueues #when flushed #then they collapse to one keyed injection", () => {

--- a/packages/omo-senpi/src/extension/idle-injection-coordinator.ts
+++ b/packages/omo-senpi/src/extension/idle-injection-coordinator.ts
@@ -28,16 +28,19 @@ const SOURCE_RANK: Readonly<Record<IdleInjectionSource, number>> = {
 }
 
 /**
- * The single injection queue for one idle edge. Task completion wakes and the ulw-loop continuation
- * both enqueue here; flushOnIdle collapses everything pending into exactly ONE sendUserMessage so the
- * parent never receives two competing wakes on the same idle edge (the Oracle arbitration blocker).
- * comment-checker's tool_result transform is intentionally NOT routed here.
+ * The single injection queue for the parent session. EVERY delivered notification (task completions,
+ * team lead-messages, the ulw-loop continuation) enqueues here; a deferred flush collapses everything
+ * that became ready within the batch window into exactly ONE injection, steered into the running turn
+ * at the next tool-call boundary (unconditional batched-steer contract: N ready notifications never
+ * produce N separate injections). comment-checker's tool_result transform is intentionally NOT routed
+ * here.
  */
 export class IdleInjectionCoordinator {
   readonly #deliver: IdleInjectionDelivery
   readonly #pending = new Map<string, IdleInjection>()
   readonly #scheduleFlush: FlushScheduler
   #flushScheduled = false
+  #soonScheduled = false
 
   constructor(deliver: IdleInjectionDelivery, options: IdleInjectionCoordinatorOptions = {}) {
     this.#deliver = deliver
@@ -61,6 +64,18 @@ export class IdleInjectionCoordinator {
     })
   }
 
+  // Immediate coalesced flush for an IDLE parent: a microtask is soon enough to land the steer before
+  // senpi's print mode can decide the session is over (the windowed timer is not - live-driver proven),
+  // while still batching every notification that becomes ready in the same tick into one injection.
+  flushSoon(): void {
+    if (this.#soonScheduled) return
+    this.#soonScheduled = true
+    queueMicrotask(() => {
+      this.#soonScheduled = false
+      this.flushOnIdle()
+    })
+  }
+
   pendingCount(): number {
     return this.#pending.size
   }
@@ -73,7 +88,7 @@ export class IdleInjectionCoordinator {
     )
     const collapsed = ordered.length
     this.#pending.clear()
-    this.#deliver(ordered.map((injection) => injection.content).join("\n\n"), { deliverAs: "followUp" })
+    this.#deliver(ordered.map((injection) => injection.content).join("\n\n"), { deliverAs: "steer" })
     return collapsed
   }
 }

--- a/packages/senpi-task/AGENTS.md
+++ b/packages/senpi-task/AGENTS.md
@@ -47,7 +47,7 @@ The Senpi-coupled engine behind the `omo-senpi` task component: a durable task s
 
 ### Completion routing table (`completion/routing.ts`)
 
-`shouldNotifyStatus` fires only for externally-caused terminals `completed`/`error`/`lost` (`routing.ts:4`); parent-initiated cancel/interrupt return synchronously in the tool result and never push. `routeCompletion` maps parent state to an action: `idle` -> `wake` unconditionally (no setting may suppress it), `streaming` -> `deliver_streaming` using `deliver_as` (`followUp` | `steer`) with `triggerTurn` also stamped so the queued message still fires a turn, and `compacting`/`session_switching`/`session_shutdown` -> `buffer` until the parent settles (`routing.ts:12`).
+`shouldNotifyStatus` fires only for externally-caused terminals `completed`/`error`/`lost` (`routing.ts:4`); parent-initiated cancel/interrupt return synchronously in the tool result and never push. `routeCompletion` maps parent state to an action: `idle` -> `wake` and `streaming` -> `deliver_streaming`, both delivered unconditionally (no setting may suppress, delay, or split them - the omo-senpi coordinator batches every notification ready in the same window into ONE injection steered into the running turn at the next tool-call boundary), and `compacting`/`session_switching`/`session_shutdown` -> `buffer` until the parent settles (`routing.ts:12`).
 
 ## EXECUTION MODES
 

--- a/packages/senpi-task/src/__adversarial__/chaos-harness.ts
+++ b/packages/senpi-task/src/__adversarial__/chaos-harness.ts
@@ -134,7 +134,7 @@ export function buildHarness(options: ChaosHarnessOptions): ChaosHarness {
     destruction,
   })
   const parentNotifier = makeNotifier(store, observations)
-  const notifier = createCompletionNotifier({ notifier: parentNotifier, store, config: config.notification })
+  const notifier = createCompletionNotifier({ notifier: parentNotifier, store })
 
   return {
     manager,

--- a/packages/senpi-task/src/completion/index.ts
+++ b/packages/senpi-task/src/completion/index.ts
@@ -11,7 +11,6 @@ export type {
   DeliveredDecision,
   FlushInput,
   FlushResult,
-  NotificationConfig,
   NotifyResult,
   ParentNotifier,
   ParentNotifierMessage,

--- a/packages/senpi-task/src/completion/notifier-buffer-dedupe.test.ts
+++ b/packages/senpi-task/src/completion/notifier-buffer-dedupe.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from "bun:test"
 
 import { createCompletionNotifier } from "./notifier"
-import type { NotificationConfig, ParentNotifier, ParentNotifierMessage, ParentState } from "./types"
+import type { ParentNotifier, ParentNotifierMessage, ParentState } from "./types"
 import type { TaskRecord } from "../state"
 import type { PersistedTaskEvent } from "../store"
 
-const wakeConfig: NotificationConfig = { deliver_as: "followUp" }
 
 function bufferedRecord(): TaskRecord {
   return {
@@ -46,7 +45,7 @@ describe("completion notifier buffered dedupe (W1-V F5)", () => {
     // given a compacting parent so both notifyTerminal calls route to the buffer
     const record = bufferedRecord()
     const { notifier: parent, calls } = fakeNotifier()
-    const notifier = createCompletionNotifier({ notifier: parent, store: fakeStore(record), config: wakeConfig })
+    const notifier = createCompletionNotifier({ notifier: parent, store: fakeStore(record) })
     const compacting: ParentState = { kind: "compacting" }
 
     // when notifyTerminal fires twice for the same terminal (task,epoch) before a flush

--- a/packages/senpi-task/src/completion/notifier.test.ts
+++ b/packages/senpi-task/src/completion/notifier.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from "bun:test"
 
 import { createCompletionNotifier } from "./notifier"
-import type { NotificationConfig, ParentNotifier, ParentNotifierMessage, ParentState } from "./types"
+import type { ParentNotifier, ParentNotifierMessage, ParentState } from "./types"
 import type { TaskRecord } from "../state"
 import type { PersistedTaskEvent } from "../store"
 
-const wakeConfig: NotificationConfig = { deliver_as: "followUp" }
 
 function baseRecord(overrides: Partial<TaskRecord> = {}): TaskRecord {
   return {
@@ -70,7 +69,7 @@ describe("createCompletionNotifier - exactly-once epoch contract", () => {
     const record = baseRecord()
     const { store, replaced } = fakeStore([record])
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
 
     // when
     const first = completion.notifyTerminal({ record, parentState: { kind: "idle" }, runInBackground: true })
@@ -88,7 +87,7 @@ describe("createCompletionNotifier - exactly-once epoch contract", () => {
     const record = baseRecord({ notification: { run_epoch: 1, notified_epoch: 0 } })
     const { store, replaced } = fakeStore([record])
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
 
     // when
     const result = completion.notifyTerminal({ record, parentState: { kind: "idle" }, runInBackground: true })
@@ -104,7 +103,7 @@ describe("createCompletionNotifier - exactly-once epoch contract", () => {
     const record = baseRecord({ notification: { run_epoch: 0, notified_epoch: 0 } })
     const { store } = fakeStore([record])
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
 
     // when
     const result = completion.notifyTerminal({ record, parentState: { kind: "idle" }, runInBackground: true })
@@ -121,7 +120,7 @@ describe("createCompletionNotifier - gating", () => {
     const record = baseRecord()
     const { store } = fakeStore([record])
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
 
     // when
     const result = completion.notifyTerminal({ record, parentState: { kind: "idle" }, runInBackground: false })
@@ -137,7 +136,7 @@ describe("createCompletionNotifier - gating", () => {
     const interrupted = baseRecord({ status: "interrupted", final_response: undefined })
     const { store } = fakeStore([cancelled])
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
 
     // when
     const cancelResult = completion.notifyTerminal({ record: cancelled, parentState: { kind: "idle" }, runInBackground: true })
@@ -154,7 +153,7 @@ describe("createCompletionNotifier - gating", () => {
     const record = baseRecord({ status: "running", final_response: undefined })
     const { store } = fakeStore([record])
     const { notifier } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
 
     // when
     const result = completion.notifyTerminal({ record, parentState: { kind: "idle" }, runInBackground: true })
@@ -165,37 +164,36 @@ describe("createCompletionNotifier - gating", () => {
 })
 
 describe("createCompletionNotifier - routing table", () => {
-  function route(parentState: ParentState, config: NotificationConfig) {
+  function route(parentState: ParentState) {
     const record = baseRecord()
     const { store } = fakeStore([record])
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config })
+    const completion = createCompletionNotifier({ notifier, store })
     const result = completion.notifyTerminal({ record, parentState, runInBackground: true })
     return { result, calls, completion }
   }
 
   test("#given idle parent #when delivered #then triggerTurn payload recorded unconditionally", () => {
     // when
-    const { result, calls } = route({ kind: "idle" }, { deliver_as: "followUp" })
+    const { result, calls } = route({ kind: "idle" })
 
     // then an idle parent always wakes with a triggerTurn payload
     expect(result).toEqual({ kind: "delivered", decision: "wake" })
     expect(calls[0]?.triggerTurn).toBe(true)
   })
 
-  test("#given streaming parent #when delivered #then followUp deliverAs and triggerTurn are set", () => {
+  test("#given streaming parent #when delivered #then triggerTurn payload recorded for the batched steer", () => {
     // when
-    const { result, calls } = route({ kind: "streaming" }, { deliver_as: "followUp" })
+    const { result, calls } = route({ kind: "streaming" })
 
-    // then a streaming completion queues as followUp AND guarantees a turn
+    // then a streaming completion also guarantees a turn; the adapter steers the batched injection
     expect(result).toEqual({ kind: "delivered", decision: "deliver_streaming" })
-    expect(calls[0]?.deliverAs).toBe("followUp")
     expect(calls[0]?.triggerTurn).toBe(true)
   })
 
   test("#given compacting parent #when notified #then buffered without delivery", () => {
     // when
-    const { result, calls } = route({ kind: "compacting" }, wakeConfig)
+    const { result, calls } = route({ kind: "compacting" })
 
     // then
     expect(result).toEqual({ kind: "buffered", reason: "compacting" })
@@ -204,7 +202,7 @@ describe("createCompletionNotifier - routing table", () => {
 
   test("#given session_switching parent #when notified #then buffered without delivery", () => {
     // when
-    const { result, calls } = route({ kind: "session_switching" }, wakeConfig)
+    const { result, calls } = route({ kind: "session_switching" })
 
     // then
     expect(result).toEqual({ kind: "buffered", reason: "session_switching" })
@@ -219,7 +217,7 @@ describe("createCompletionNotifier - buffering, flush, batching", () => {
     const second = baseRecord({ task_id: "st_bbbb", name: "two" })
     const { store, replaced } = fakeStore([first, second])
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
     completion.notifyTerminal({ record: first, parentState: { kind: "compacting" }, runInBackground: true })
     completion.notifyTerminal({ record: second, parentState: { kind: "compacting" }, runInBackground: true })
 
@@ -239,7 +237,7 @@ describe("createCompletionNotifier - buffering, flush, batching", () => {
     const record = baseRecord()
     const { store, events, replaced } = fakeStore([record])
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
     completion.notifyTerminal({ record, parentState: { kind: "session_shutdown" }, runInBackground: true })
 
     // when
@@ -257,7 +255,7 @@ describe("createCompletionNotifier - buffering, flush, batching", () => {
     const record = baseRecord()
     const { store } = fakeStore([record])
     const { notifier } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
 
     // when
     const flush = completion.flushBuffered({ sessionId: "parent-session", replaced: false })
@@ -273,7 +271,7 @@ describe("createCompletionNotifier - notifier failure contract", () => {
     const record = baseRecord()
     const { store, replaced } = fakeStore([record])
     const { notifier, calls } = fakeNotifier(1)
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
 
     // when
     const result = completion.notifyTerminal({ record, parentState: { kind: "idle" }, runInBackground: true })
@@ -289,7 +287,7 @@ describe("createCompletionNotifier - notifier failure contract", () => {
     const record = baseRecord()
     const { store, events, replaced } = fakeStore([record])
     const { notifier, calls } = fakeNotifier(2)
-    const completion = createCompletionNotifier({ notifier, store, config: wakeConfig })
+    const completion = createCompletionNotifier({ notifier, store })
 
     // when
     const result = completion.notifyTerminal({ record, parentState: { kind: "idle" }, runInBackground: true })

--- a/packages/senpi-task/src/completion/notifier.ts
+++ b/packages/senpi-task/src/completion/notifier.ts
@@ -39,7 +39,7 @@ export function createCompletionNotifier(deps: CompletionNotifierDeps): Completi
     if (record.notification.notified_epoch >= epoch) return { kind: "skipped", reason: "already-notified" }
 
     const details = buildCompletionDetails(record, request.tokens === undefined ? {} : { tokens: request.tokens })
-    const decision = routeCompletion(request.parentState, deps.config)
+    const decision = routeCompletion(request.parentState)
     if (decision.kind === "buffer") {
       pushBuffered(buffered, record.parent_session_id, { task_id: record.task_id, epoch, details })
       return { kind: "buffered", reason: decision.reason }
@@ -85,16 +85,16 @@ export function createCompletionNotifier(deps: CompletionNotifierDeps): Completi
   return { notifyTerminal, flushBuffered, bufferedCount }
 }
 
-// A streaming completion queues as the configured deliverAs AND stamps triggerTurn:true so the parent
-// is guaranteed to take a turn to process it once the current turn ends (senpi sendMessage accepts
-// triggerTurn + deliverAs together). A wake completion (idle parent) fires the turn directly.
+// Every delivered notification stamps triggerTurn:true; the omo-senpi adapter routes it through the
+// idle-injection coordinator, which batches ALL ready notifications into ONE injection steered into
+// the running turn at the next tool-call boundary (unconditional-steer contract).
 function buildDeliveryMessage(
   details: readonly CompletionDetails[],
   decision: Exclude<RoutingDecision, { kind: "buffer" }>,
 ): ParentNotifierMessage {
+  void decision
   const base = buildCompletionMessage(details)
-  if (decision.kind === "wake") return { ...base, triggerTurn: true }
-  return { ...base, deliverAs: decision.deliverAs, triggerTurn: true }
+  return { ...base, triggerTurn: true }
 }
 
 function deliveredDecision(decision: Exclude<RoutingDecision, { kind: "buffer" }>): DeliveredDecision {

--- a/packages/senpi-task/src/completion/routing.test.ts
+++ b/packages/senpi-task/src/completion/routing.test.ts
@@ -1,36 +1,29 @@
 import { describe, expect, test } from "bun:test"
 
 import { routeCompletion, shouldNotifyStatus } from "./routing"
-import type { NotificationConfig, ParentState } from "./types"
-
-const wakeConfig: NotificationConfig = { deliver_as: "followUp" }
-const steerConfig: NotificationConfig = { deliver_as: "steer" }
+import type { ParentState } from "./types"
 
 describe("routeCompletion", () => {
-  test("#given idle parent #when routed #then always wakes regardless of config", () => {
+  test("#given idle parent #when routed #then always wakes with no config to consult", () => {
     // given
     const state: ParentState = { kind: "idle" }
 
     // when
-    const followUp = routeCompletion(state, wakeConfig)
-    const steer = routeCompletion(state, steerConfig)
+    const decision = routeCompletion(state)
 
-    // then an idle parent unconditionally wakes; there is no silent-queue path
-    expect(followUp).toEqual({ kind: "wake" })
-    expect(steer).toEqual({ kind: "wake" })
+    // then an idle parent unconditionally wakes; there is no silent-queue path and no knob
+    expect(decision).toEqual({ kind: "wake" })
   })
 
-  test("#given streaming parent #when routed #then delivered with configured deliver_as", () => {
+  test("#given streaming parent #when routed #then delivered into the running turn", () => {
     // given
     const state: ParentState = { kind: "streaming" }
 
     // when
-    const followUp = routeCompletion(state, wakeConfig)
-    const steer = routeCompletion(state, steerConfig)
+    const decision = routeCompletion(state)
 
-    // then
-    expect(followUp).toEqual({ kind: "deliver_streaming", deliverAs: "followUp" })
-    expect(steer).toEqual({ kind: "deliver_streaming", deliverAs: "steer" })
+    // then delivery timing is not configurable: the adapter steers the batched injection
+    expect(decision).toEqual({ kind: "deliver_streaming" })
   })
 
   test("#given compacting parent #when routed #then buffered with compacting reason", () => {
@@ -38,7 +31,7 @@ describe("routeCompletion", () => {
     const state: ParentState = { kind: "compacting" }
 
     // when
-    const decision = routeCompletion(state, wakeConfig)
+    const decision = routeCompletion(state)
 
     // then
     expect(decision).toEqual({ kind: "buffer", reason: "compacting" })
@@ -49,7 +42,7 @@ describe("routeCompletion", () => {
     const state: ParentState = { kind: "session_switching" }
 
     // when
-    const decision = routeCompletion(state, wakeConfig)
+    const decision = routeCompletion(state)
 
     // then
     expect(decision).toEqual({ kind: "buffer", reason: "session_switching" })
@@ -60,7 +53,7 @@ describe("routeCompletion", () => {
     const state: ParentState = { kind: "session_shutdown" }
 
     // when
-    const decision = routeCompletion(state, wakeConfig)
+    const decision = routeCompletion(state)
 
     // then
     expect(decision).toEqual({ kind: "buffer", reason: "session_shutdown" })

--- a/packages/senpi-task/src/completion/routing.ts
+++ b/packages/senpi-task/src/completion/routing.ts
@@ -1,5 +1,5 @@
 import type { TaskStatus } from "../state"
-import type { NotificationConfig, ParentState, RoutingDecision } from "./types"
+import type { ParentState, RoutingDecision } from "./types"
 
 const notifyingStatuses = new Set<TaskStatus>(["completed", "error", "lost"])
 
@@ -9,16 +9,15 @@ export function shouldNotifyStatus(status: TaskStatus): boolean {
   return notifyingStatuses.has(status)
 }
 
-// An idle parent ALWAYS wakes: a completed background child's notification must unconditionally reach
-// the parent's next turn, with no config able to suppress it. A streaming parent delivers with the
-// configured deliver_as (and the notifier also stamps triggerTurn so the queued message still fires a
-// turn). Transient transitions buffer and flush with triggerTurn on the next session_start/idle edge.
-export function routeCompletion(parentState: ParentState, config: NotificationConfig): RoutingDecision {
+// Delivery is unconditional: an idle parent ALWAYS wakes and a streaming parent ALWAYS receives the
+// notification steered into its running turn at the next tool-call boundary - no config can suppress,
+// delay, or split it. Transient transitions buffer and flush on the next session_start/idle edge.
+export function routeCompletion(parentState: ParentState): RoutingDecision {
   switch (parentState.kind) {
     case "idle":
       return { kind: "wake" }
     case "streaming":
-      return { kind: "deliver_streaming", deliverAs: config.deliver_as }
+      return { kind: "deliver_streaming" }
     case "compacting":
       return { kind: "buffer", reason: "compacting" }
     case "session_switching":

--- a/packages/senpi-task/src/completion/types.ts
+++ b/packages/senpi-task/src/completion/types.ts
@@ -1,12 +1,6 @@
 import type { TaskRecord, TaskStatus } from "../state"
 import type { PersistedTaskEvent } from "../store"
 
-// Resolved from omo.json task.notification (config-core OmoTaskNotificationSchema). Kept structural so
-// this module stays harness-neutral; the omo-senpi composition (todo 17) feeds the parsed config.
-export type NotificationConfig = {
-  readonly deliver_as: "steer" | "followUp"
-}
-
 export type TransitionReason = "compacting" | "session_switching" | "session_shutdown"
 
 // The live parent-session state the completion push routes against (Metis #3 five-state machine).
@@ -19,7 +13,7 @@ export type ParentState =
 
 export type RoutingDecision =
   | { readonly kind: "wake" }
-  | { readonly kind: "deliver_streaming"; readonly deliverAs: "steer" | "followUp" }
+  | { readonly kind: "deliver_streaming" }
   | { readonly kind: "buffer"; readonly reason: TransitionReason }
 
 export type CompletionDetails = {
@@ -34,13 +28,14 @@ export type CompletionDetails = {
 
 // Structurally compatible with senpi sendMessage(Pick<CustomMessage,"customType"|"content"|"display"|
 // "details">, {triggerTurn, deliverAs}). One message carries one or many completions (batching).
+// Delivery is UNCONDITIONAL STEER: every delivered notification triggers a turn and steers into the
+// running turn at the next tool-call boundary; the adapter batches all ready messages into ONE steer.
 export type ParentNotifierMessage = {
   readonly customType: "senpi-task.completion"
   readonly content: string
   readonly display: boolean
   readonly details: readonly CompletionDetails[]
   readonly triggerTurn?: boolean
-  readonly deliverAs?: "steer" | "followUp"
 }
 
 // SYNCHRONOUS enqueue seam. senpi pi.sendMessage returns void and swallows async delivery errors, so
@@ -58,7 +53,6 @@ export type CompletionNotifierStore = {
 export type CompletionNotifierDeps = {
   readonly notifier: ParentNotifier
   readonly store: CompletionNotifierStore
-  readonly config: NotificationConfig
 }
 
 export type CompletionRequest = {

--- a/packages/senpi-task/src/completion/unconditional-wake.test.ts
+++ b/packages/senpi-task/src/completion/unconditional-wake.test.ts
@@ -2,14 +2,13 @@ import { describe, expect, test } from "bun:test"
 
 import { createCompletionNotifier } from "./notifier"
 import { routeCompletion } from "./routing"
-import type { NotificationConfig, ParentNotifier, ParentNotifierMessage, ParentState } from "./types"
+import type { ParentNotifier, ParentNotifierMessage, ParentState } from "./types"
 import type { TaskRecord } from "../state"
 import type { PersistedTaskEvent } from "../store"
 
-// Product-owner invariant: a completed background child's notification MUST unconditionally reach the
-// parent's next turn. No config may suppress it. These tests pin that there is no waiting-forever path.
-const config: NotificationConfig = { deliver_as: "followUp" }
-const steerConfig: NotificationConfig = { deliver_as: "steer" }
+// Product-owner invariant: a completed background child's notification MUST unconditionally steer into
+// the parent's running turn at the next tool-call boundary, and multiple ready notifications batch into
+// ONE injection. No config may suppress, delay, or split it - the deliver_as knob no longer exists.
 
 function baseRecord(overrides: Partial<TaskRecord> = {}): TaskRecord {
   return {
@@ -52,7 +51,7 @@ describe("unconditional wake", () => {
     const state: ParentState = { kind: "idle" }
 
     // when routed
-    const decision = routeCompletion(state, config)
+    const decision = routeCompletion(state)
 
     // then it wakes, never queues silently
     expect(decision).toEqual({ kind: "wake" })
@@ -62,7 +61,7 @@ describe("unconditional wake", () => {
     // given
     const record = baseRecord()
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store: fakeStore(record), config })
+    const completion = createCompletionNotifier({ notifier, store: fakeStore(record) })
 
     // when
     const result = completion.notifyTerminal({ record, parentState: { kind: "idle" }, runInBackground: true })
@@ -73,18 +72,17 @@ describe("unconditional wake", () => {
     expect(calls[0]?.triggerTurn).toBe(true)
   })
 
-  test("#given a streaming parent #when a background child completes #then delivery carries triggerTurn and deliverAs", () => {
+  test("#given a streaming parent #when a background child completes #then delivery carries triggerTurn for the batched steer", () => {
     // given
     const record = baseRecord()
     const { notifier, calls } = fakeNotifier()
-    const completion = createCompletionNotifier({ notifier, store: fakeStore(record), config: steerConfig })
+    const completion = createCompletionNotifier({ notifier, store: fakeStore(record) })
 
     // when
     const result = completion.notifyTerminal({ record, parentState: { kind: "streaming" }, runInBackground: true })
 
-    // then a streaming completion queues as the configured deliverAs AND guarantees a turn
+    // then a streaming completion also guarantees a turn; the adapter steers the batched injection
     expect(result).toEqual({ kind: "delivered", decision: "deliver_streaming" })
-    expect(calls[0]?.deliverAs).toBe("steer")
     expect(calls[0]?.triggerTurn).toBe(true)
   })
 })

--- a/packages/senpi-task/src/index.ts
+++ b/packages/senpi-task/src/index.ts
@@ -194,7 +194,6 @@ export type {
   DeliveredDecision,
   FlushInput,
   FlushResult,
-  NotificationConfig,
   NotifyResult,
   ParentNotifier,
   ParentNotifierMessage,

--- a/packages/senpi-task/src/team/messaging/deliver-lead.test.ts
+++ b/packages/senpi-task/src/team/messaging/deliver-lead.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, test } from "bun:test"
 
-import type { NotificationConfig, ParentState } from "../../completion"
+import type { ParentState } from "../../completion"
 import { deliverToLead } from "./deliver-lead"
 import { buildTeamMessage } from "./message"
 import { FakeLeadNotifier } from "./__fixtures__/messaging-fakes"
-
-const CONFIG: NotificationConfig = { deliver_as: "followUp" }
 
 function leadMessage() {
   return buildTeamMessage(
@@ -23,7 +21,6 @@ describe("deliverToLead", () => {
     const result = deliverToLead({
       message: leadMessage(),
       parentState: { kind: "idle" },
-      notificationConfig: CONFIG,
       notifier,
     })
 
@@ -51,13 +48,11 @@ member alpha needs a decision
     const result = deliverToLead({
       message: leadMessage(),
       parentState: { kind: "streaming" },
-      notificationConfig: { deliver_as: "steer" },
       notifier,
     })
 
-    // then a streaming lead delivery both steers AND guarantees a turn
+    // then a streaming lead delivery also guarantees a turn; the adapter steers the batched injection
     expect(result).toEqual({ kind: "delivered", decision: "deliver_streaming" })
-    expect(notifier.enqueued[0]?.deliverAs).toBe("steer")
     expect(notifier.enqueued[0]?.triggerTurn).toBe(true)
   })
 
@@ -73,7 +68,6 @@ member alpha needs a decision
     const result = deliverToLead({
       message: leadMessage(),
       parentState: { kind } as ParentState,
-      notificationConfig: CONFIG,
       notifier,
     })
 
@@ -90,7 +84,6 @@ member alpha needs a decision
     const result = deliverToLead({
       message: leadMessage(),
       parentState: { kind: "idle" },
-      notificationConfig: CONFIG,
       notifier,
     })
 
@@ -107,7 +100,6 @@ member alpha needs a decision
     const result = deliverToLead({
       message: leadMessage(),
       parentState: { kind: "idle" },
-      notificationConfig: CONFIG,
       notifier,
     })
 

--- a/packages/senpi-task/src/team/messaging/deliver-lead.ts
+++ b/packages/senpi-task/src/team/messaging/deliver-lead.ts
@@ -1,25 +1,25 @@
 import { routeCompletion } from "../../completion"
-import type { NotificationConfig, ParentState } from "../../completion"
+import type { ParentState } from "../../completion"
 import { buildPeerMessageEnvelope } from "./message"
 import type { LeadDeliveryResult, LeadMessageNotifier, LeadTeamMessage, Message } from "./types"
 
 export type DeliverToLeadInput = {
   readonly message: Message
   readonly parentState: ParentState
-  readonly notificationConfig: NotificationConfig
   readonly notifier: LeadMessageNotifier
 }
 
 /**
  * Routes a member->lead message through the SAME parent-state machine the completion push uses (todo
- * 11): an idle lead ALWAYS wakes (no config may suppress it), a streaming lead delivers with the
- * configured `deliverAs` AND stamps triggerTurn so the queued message still fires a turn, and a
- * mid-transition parent (compacting / switching / shutdown) buffers WITHOUT enqueue for the omo-senpi
- * coordinator to flush later. Enqueue is a synchronous fire-and-forget seam; only a sync throw is
- * observable, so a single retry is attempted before reporting failure (mirrors the completion notifier).
+ * 11): an idle OR streaming lead ALWAYS receives the message steered into its next tool-call boundary
+ * (no config may suppress or delay it; the omo-senpi coordinator batches everything ready into ONE
+ * steer), and a mid-transition parent (compacting / switching / shutdown) buffers WITHOUT enqueue for
+ * the omo-senpi coordinator to flush later. Enqueue is a synchronous fire-and-forget seam; only a sync
+ * throw is observable, so a single retry is attempted before reporting failure (mirrors the completion
+ * notifier).
  */
 export function deliverToLead(input: DeliverToLeadInput): LeadDeliveryResult {
-  const decision = routeCompletion(input.parentState, input.notificationConfig)
+  const decision = routeCompletion(input.parentState)
   if (decision.kind === "buffer") return { kind: "buffered", reason: decision.reason }
 
   const message = buildLeadMessage(input.message, decision)
@@ -40,8 +40,8 @@ function buildLeadMessage(
     from: message.from,
     messageId: message.messageId,
   }
-  if (decision.kind === "wake") return { ...base, triggerTurn: true }
-  return { ...base, deliverAs: decision.deliverAs, triggerTurn: true }
+  void decision
+  return { ...base, triggerTurn: true }
 }
 
 function enqueueWithRetry(notifier: LeadMessageNotifier, message: LeadTeamMessage): boolean {

--- a/packages/senpi-task/src/team/messaging/send.test.ts
+++ b/packages/senpi-task/src/team/messaging/send.test.ts
@@ -2,7 +2,6 @@ import { existsSync } from "node:fs"
 import { join } from "node:path"
 import { afterEach, describe, expect, test } from "bun:test"
 
-import type { NotificationConfig } from "../../completion"
 import { writeMemberTaskMap } from "../member-map"
 import { ensureTeamRuntimeDirs, resolveTeamMemberInboxDir, resolveTeamRuntimeDirs, teamStorageBaseDir } from "../storage"
 import { toTeamCoreConfig } from "../runtime-config"
@@ -19,7 +18,6 @@ import {
 import { taskSettings } from "../__fixtures__/runtime-fakes"
 
 const TEAM_RUN_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
-const NOTIFICATION: NotificationConfig = { deliver_as: "followUp" }
 
 afterEach(() => {
   cleanupMessagingTmp()
@@ -46,7 +44,6 @@ function deps(
     config,
     delivery,
     leadNotifier,
-    notificationConfig: NOTIFICATION,
     parentState: () => ({ kind: "idle" as const }),
   }
 }

--- a/packages/senpi-task/src/team/messaging/send.ts
+++ b/packages/senpi-task/src/team/messaging/send.ts
@@ -29,7 +29,6 @@ export async function sendTeamMessage(
     const lead = deliverToLead({
       message,
       parentState: deps.parentState(),
-      notificationConfig: deps.notificationConfig,
       notifier: deps.leadNotifier,
     })
     return { kind: "to_lead", messageId: message.messageId, lead }

--- a/packages/senpi-task/src/team/messaging/types.ts
+++ b/packages/senpi-task/src/team/messaging/types.ts
@@ -1,6 +1,6 @@
 import type { Message } from "@oh-my-opencode/team-core/types"
 
-import type { NotificationConfig, ParentState, TransitionReason } from "../../completion"
+import type { ParentState, TransitionReason } from "../../completion"
 import type { TaskRecord } from "../../state"
 import type { SendOutcome } from "../../steering"
 import type { StateDirConfig } from "../../store"
@@ -40,7 +40,6 @@ export type LeadTeamMessage = {
   readonly from: string
   readonly messageId: string
   readonly triggerTurn?: boolean
-  readonly deliverAs?: "steer" | "followUp"
 }
 
 // SYNCHRONOUS enqueue seam (same failure contract as the completion notifier): the only observable
@@ -63,7 +62,6 @@ export type MessagingEngineDeps = {
   readonly config: TeamCoreConfig
   readonly delivery: MessagingDeliveryPort
   readonly leadNotifier: LeadMessageNotifier
-  readonly notificationConfig: NotificationConfig
   // The lead's live session state at send time, resolved lazily so the member-direction path never
   // pays for it. Feeds the SAME parent-state routing machine the completion push uses (todo 11).
   readonly parentState: () => ParentState


### PR DESCRIPTION
## What changed

Follow-up to #5969 (unconditional wake), completing the product-owner delivery contract for senpi-task completion notifications:

- **Always steer**: a completed background child's notification injects into the parent's RUNNING turn at the next tool-call boundary (senpi steer semantics), never as an after-the-turn followUp. The `task.notification.deliver_as` knob is removed along with its schema/docs surface — no setting can delay, suppress, or split delivery.
- **Always batch**: every notification that becomes ready in the same window — multiple child completions, team lead-messages, a pending ulw-loop continuation — is combined into ONE steered injection (deterministic completion-first order). N near-simultaneous completions never produce N separate wakes.
- Delivery is parent-state aware, with each branch derived from a live-driver failure:
  - **idle** → coalesced microtask flush: immediate delivery. A windowed timer alone loses the wake to senpi print-mode exit — the live driver showed the run shutting down with the wake still sitting in the 200ms timer and the revived child being torn down mid-run.
  - **streaming** → 200ms collect window, steered at the next tool boundary (this is the batch window).
  - **turn-end (`agent_end`)** → synchronous drain backstop, one-microtask deferred so a same-edge ulw-loop continuation joins the same injection.

## QA / evidence

- Unit: 712 pass / 0 fail across senpi-task + omo-senpi + omo-config-core; typecheck ×3 exit 0; `bun run test:senpi` full gate green; bundle 510KB ≤ 700,000; schema freshness + docs link audit green (regenerated `assets/omo.schema.json`).
- New regression tests: idle same-tick batching (2 completions → 1 steer), streaming window batching, cross-source completion+team batching with ordering, retry dedupe, no-coordinator direct-steer fallback, `agent_end` wiring.
- Live on real senpi 2026.7.5-2 (isolated sandbox, mock provider, no keys): task-e2e **10/10 PASS** including `unconditional_wake`, `followup_revive`, and the full store-signature arc (`running → completed → revived → completed → disposed → destroyed`); real `~/.senpi` credentials byte-unchanged; 0 leaked pids. Evidence with failure archaeology under `.omo/evidence/senpi-task/fix-batched-steer/` in the orchestration worktree.

## Residual risk

- The 200ms streaming collect window is a fixed constant; if senpi's steer pickup granularity changes, revisit. Two completions arriving in different windows while streaming deliver as two steers (by design — the window bounds latency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always-steered, batched completion delivery for `senpi-task`: background task completions and team lead messages now steer into the parent’s running turn and coalesce into a single injection. The `task.notification.deliver_as` setting is removed.

- **New Features**
  - Always steer: every delivered notification injects at the next tool-call boundary.
  - Always batch: notifications ready in the same window combine into one injection, with deterministic completion-first order and key-based dedupe.
  - Parent-state aware delivery:
    - Idle: microtask flush for immediate, coalesced delivery.
    - Streaming: 200ms collect window, then steer.
    - Turn end (`agent_end`): synchronous drain (one microtask deferred) to flush the window before idle.
  - Shared idle-injection coordinator across `omo-senpi`; direct-steer fallback if no coordinator is available.

- **Migration**
  - Remove `task.notification` (and `deliver_as`) from `omo.json` and any references in code/docs.
  - Types and params removed:
    - `NotificationConfig` and `deliverAs` on notifier messages.
    - `createCompletionNotifier` no longer accepts a `config` argument.
  - All delivered notifications now steer; there is no `followUp` mode or setting to delay or split delivery.

<sup>Written for commit 58c6773a08b9f8cd2d46a0459e4460db082512ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

