### PR TITLE
fix(opencode): route Bun runtime calls through shims

### DIFF
--- a/packages/omo-opencode/src/features/monitor/process.ts
+++ b/packages/omo-opencode/src/features/monitor/process.ts
@@ -1,9 +1,10 @@
 import { tokenizeCommand } from "../../tools/interactive-bash/tools"
+import { spawn as runtimeSpawn } from "../../shared/bun-spawn-shim"
 
 export type TimerHandle = ReturnType<typeof setTimeout> | number
 
 export interface SpawnDeps {
-  spawn?: typeof Bun.spawn
+  spawn?: SpawnFunction
   setTimer: (fn: () => void, ms: number) => TimerHandle
   clearTimer: (handle: TimerHandle) => void
 }
@@ -15,8 +16,23 @@ export interface MonitoredProcess {
   stderr: ReadableStream<Uint8Array>
 }
 
-type PipeSubprocess = Bun.Subprocess<"ignore", "pipe", "pipe">
 type ExitResult = { code: number | null; signal: string | null }
+interface SpawnedMonitorProcess {
+  readonly exited: Promise<number>
+  readonly stdout: ReadableStream<Uint8Array>
+  readonly stderr: ReadableStream<Uint8Array>
+  readonly pid?: number
+  readonly signalCode?: NodeJS.Signals | null
+}
+
+type SpawnFunction = (argv: readonly string[], options: {
+  readonly cwd?: string
+  readonly env?: Record<string, string>
+  readonly detached: boolean
+  readonly stdin: "ignore"
+  readonly stdout: "pipe"
+  readonly stderr: "pipe"
+}) => SpawnedMonitorProcess
 
 const KILL_GRACE_MS = 5_000
 
@@ -29,11 +45,11 @@ function killProcessGroup(pid: number, signal: NodeJS.Signals | 0): void {
 }
 
 function spawnDetachedProcess(
-  argv: string[],
+  argv: readonly string[],
   opts: { cwd?: string; env?: Record<string, string> },
-  spawn: typeof Bun.spawn,
-): PipeSubprocess {
-  return spawn<"ignore", "pipe", "pipe">(argv, {
+  spawn: SpawnFunction,
+): SpawnedMonitorProcess {
+  return spawn(argv, {
     cwd: opts.cwd,
     env: opts.env,
     detached: true,
@@ -52,7 +68,7 @@ export function spawnMonitoredProcess(
     throw new Error("Cannot spawn an empty monitor command")
   }
 
-  const subprocess = spawnDetachedProcess(argv, opts, deps.spawn ?? Bun.spawn)
+  const subprocess = spawnDetachedProcess(argv, opts, deps.spawn ?? runtimeSpawn)
   let actualExited = false
   let publicExitSettled = false
   let watchdogTimer: TimerHandle | undefined
@@ -86,11 +102,15 @@ export function spawnMonitoredProcess(
   function kill(signal: NodeJS.Signals = "SIGTERM"): void {
     if (actualExited) return
 
-    killProcessGroup(subprocess.pid, signal)
+    if (subprocess.pid !== undefined) {
+      killProcessGroup(subprocess.pid, signal)
+    }
     if (graceTimer === undefined) {
       graceTimer = deps.setTimer(() => {
         if (!actualExited) {
-          killProcessGroup(subprocess.pid, "SIGKILL")
+          if (subprocess.pid !== undefined) {
+            killProcessGroup(subprocess.pid, "SIGKILL")
+          }
         }
       }, KILL_GRACE_MS)
     }
@@ -106,7 +126,7 @@ export function spawnMonitoredProcess(
     actualExited = true
     clearWatchdog()
     clearGraceTimer()
-    settlePublicExit({ code, signal: subprocess.signalCode })
+    settlePublicExit({ code, signal: subprocess.signalCode ?? null })
   }).catch((error) => {
     void error
     actualExited = true

--- a/packages/omo-opencode/src/hooks/comment-checker/cli.ts
+++ b/packages/omo-opencode/src/hooks/comment-checker/cli.ts
@@ -1,4 +1,5 @@
 import { spawn } from "../../shared/bun-spawn-shim"
+import { bunWhich } from "../../shared/bun-which-shim"
 import { join } from "path"
 import { existsSync } from "fs"
 import * as fs from "fs"
@@ -25,7 +26,7 @@ function getBinaryName(): string {
   return process.platform === "win32" ? "comment-checker.exe" : "comment-checker"
 }
 
-export function resolveCommentCheckerPathFromPath(binaryName: string, which: (binary: string) => string | null = Bun.which): string | null {
+export function resolveCommentCheckerPathFromPath(binaryName: string, which: (binary: string) => string | null = bunWhich): string | null {
   try {
     return which(binaryName)
   } catch (error) {

--- a/packages/omo-opencode/src/shared/opencode-adapter-bun-runtime-audit.test.ts
+++ b/packages/omo-opencode/src/shared/opencode-adapter-bun-runtime-audit.test.ts
@@ -5,6 +5,8 @@ import path from "node:path"
 
 const RAW_BUN_RUNTIME_API_RE =
   /(?<![.$\w])Bun\.(spawn|spawnSync|file|write|which|hash|serve|readableStreamToText)\b/g
+const RAW_BUN_MODULE_RE =
+  /\b(?:from\s*["']bun:[^"']+["']|import\s*\(\s*["']bun:[^"']+["']\s*\)|require\s*\(\s*["']bun:[^"']+["']\s*\))/g
 const APPROVED_BUN_SHIM_RE = /^bun-[a-z0-9-]+-shim\.ts$/
 
 function repoRootFrom(start: string): string {
@@ -56,6 +58,8 @@ function isAuditedProductionSource(filePath: string): boolean {
     && !basename.endsWith(".d.ts")
     && !basename.endsWith(".test.ts")
     && !basename.endsWith(".smoke.ts")
+    && !basename.endsWith("test-support.ts")
+    && !basename.endsWith("-test-fixture.ts")
     && !basename.endsWith(".fixture.ts")
     && !basename.endsWith(".fixtures.ts")
     && !APPROVED_BUN_SHIM_RE.test(basename)
@@ -108,12 +112,17 @@ function isTypeOnlyBunReference(line: string, position: number): boolean {
   return /\btypeof\s+$/.test(line.slice(0, position))
 }
 
+function isTypeOnlyBunModuleReference(line: string, position: number): boolean {
+  const prefix = line.slice(0, position)
+  return /\b(?:type\s+\w+\s*=\s*|typeof\s+)$/.test(prefix)
+}
+
 function formatOffender(filePath: string, lineNumber: number, apiName: string): string {
   return `${relativeAdapterPath(filePath)}:${lineNumber} uses ${apiName}`
 }
 
 describe("OpenCode adapter Bun runtime audit", () => {
-  test("#given production adapter source #when audited #then raw Bun runtime APIs are shimmed", async () => {
+  test("#given production adapter source #when audited #then raw Bun runtime APIs and modules are shimmed", async () => {
     // Given
     const files = await listAdapterSourceFiles(OPENCODE_SRC_DIR)
     const offenders: string[] = []
@@ -138,6 +147,20 @@ describe("OpenCode adapter Bun runtime audit", () => {
             || isInsideStringLiteral(line, match.index)
             || isLineComment(line, match.index)
             || isTypeOnlyBunReference(line, match.index)
+          ) {
+            continue
+          }
+
+          offenders.push(formatOffender(filePath, lineIndex + 1, match[0]))
+        }
+
+        RAW_BUN_MODULE_RE.lastIndex = 0
+        for (const match of line.matchAll(RAW_BUN_MODULE_RE)) {
+          if (
+            match.index === undefined
+            || isLineComment(line, match.index)
+            || isInsideStringLiteral(line, match.index)
+            || isTypeOnlyBunModuleReference(line, match.index)
           ) {
             continue
           }

--- a/packages/omo-opencode/src/shared/opencode-adapter-bun-runtime-audit.test.ts
+++ b/packages/omo-opencode/src/shared/opencode-adapter-bun-runtime-audit.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync } from "node:fs"
+import { readdir, readFile } from "node:fs/promises"
+import path from "node:path"
+
+const RAW_BUN_RUNTIME_API_RE =
+  /(?<![.$\w])Bun\.(spawn|spawnSync|file|write|which|hash|serve|readableStreamToText)\b/g
+const APPROVED_BUN_SHIM_RE = /^bun-[a-z0-9-]+-shim\.ts$/
+
+function repoRootFrom(start: string): string {
+  let dir = start
+  for (;;) {
+    if (existsSync(path.join(dir, "bun.lock")) || existsSync(path.join(dir, ".git"))) {
+      return dir
+    }
+
+    const parent = path.dirname(dir)
+    if (parent === dir) {
+      throw new Error("repo root sentinel not found")
+    }
+    dir = parent
+  }
+}
+
+const WORKSPACE_ROOT = repoRootFrom(import.meta.dir)
+const OPENCODE_SRC_DIR = path.join(WORKSPACE_ROOT, "packages", "omo-opencode", "src")
+
+async function listAdapterSourceFiles(directory: string): Promise<string[]> {
+  let entries: Awaited<ReturnType<typeof readdir>>
+  try {
+    entries = await readdir(directory, { withFileTypes: true })
+  } catch {
+    return []
+  }
+
+  const nestedFiles = await Promise.all(entries.map(async (entry) => {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      return listAdapterSourceFiles(entryPath)
+    }
+    if (entry.isFile() && isAuditedProductionSource(entryPath)) {
+      return [entryPath]
+    }
+    return []
+  }))
+
+  return nestedFiles.flat()
+}
+
+function isAuditedProductionSource(filePath: string): boolean {
+  const basename = path.basename(filePath)
+  const relativePath = relativeAdapterPath(filePath)
+
+  return (
+    basename.endsWith(".ts")
+    && !basename.endsWith(".d.ts")
+    && !basename.endsWith(".test.ts")
+    && !basename.endsWith(".smoke.ts")
+    && !basename.endsWith(".fixture.ts")
+    && !basename.endsWith(".fixtures.ts")
+    && !APPROVED_BUN_SHIM_RE.test(basename)
+    && !relativePath.includes("/__tests__/")
+    && !relativePath.includes("/fixtures/")
+    && !relativePath.includes("/test-fixtures/")
+  )
+}
+
+function relativeAdapterPath(filePath: string): string {
+  return path.relative(WORKSPACE_ROOT, filePath).split(path.sep).join("/")
+}
+
+function isInsideStringLiteral(line: string, position: number): boolean {
+  let quote: "'" | '"' | "`" | null = null
+  let escaped = false
+
+  for (let index = 0; index < position; index += 1) {
+    const char = line.charAt(index)
+
+    if (escaped) {
+      escaped = false
+      continue
+    }
+
+    if (quote !== null && char === "\\") {
+      escaped = true
+      continue
+    }
+
+    if (char === "'" || char === '"' || char === "`") {
+      if (quote === char) {
+        quote = null
+      } else if (quote === null) {
+        quote = char
+      }
+    }
+  }
+
+  return quote !== null
+}
+
+function isLineComment(line: string, position: number): boolean {
+  const prefix = line.slice(0, position)
+  const commentStart = prefix.indexOf("//")
+  return commentStart !== -1 && !isInsideStringLiteral(prefix, commentStart)
+}
+
+function isTypeOnlyBunReference(line: string, position: number): boolean {
+  return /\btypeof\s+$/.test(line.slice(0, position))
+}
+
+function formatOffender(filePath: string, lineNumber: number, apiName: string): string {
+  return `${relativeAdapterPath(filePath)}:${lineNumber} uses ${apiName}`
+}
+
+describe("OpenCode adapter Bun runtime audit", () => {
+  test("#given production adapter source #when audited #then raw Bun runtime APIs are shimmed", async () => {
+    // Given
+    const files = await listAdapterSourceFiles(OPENCODE_SRC_DIR)
+    const offenders: string[] = []
+
+    // When
+    for (const filePath of files) {
+      const contents = await readFile(filePath, "utf8")
+      let insideBlockComment = false
+
+      for (const [lineIndex, line] of contents.split("\n").entries()) {
+        const trimmed = line.trimStart()
+
+        if (insideBlockComment || trimmed.startsWith("/*")) {
+          insideBlockComment = !trimmed.includes("*/")
+          continue
+        }
+
+        RAW_BUN_RUNTIME_API_RE.lastIndex = 0
+        for (const match of line.matchAll(RAW_BUN_RUNTIME_API_RE)) {
+          if (
+            match.index === undefined
+            || isInsideStringLiteral(line, match.index)
+            || isLineComment(line, match.index)
+            || isTypeOnlyBunReference(line, match.index)
+          ) {
+            continue
+          }
+
+          offenders.push(formatOffender(filePath, lineIndex + 1, match[0]))
+        }
+      }
+    }
+
+    // Then
+    expect(
+      offenders.sort(),
+      `Expected production OpenCode adapter source to use shared Bun runtime shims.\n${offenders.join("\n")}`,
+    ).toEqual([])
+  }, 20_000)
+})


### PR DESCRIPTION
## Summary

This closes a source-level regression gap in the same Bun-runtime compatibility class as issue #3824. Two OpenCode adapter paths had drifted back to raw `Bun.*` defaults in TypeScript source, so this PR routes them through the existing runtime shims and adds an audit test to catch future raw Bun runtime API or raw `bun:*` module use before the bundle check.

Issue #3824 was broadly fixed by #3964, which eliminated raw Bun globals and also handled the `bun:sqlite` loader hazard for OpenCode Desktop/Electron. This PR is intentionally narrower: it fixes the fresh source-level `Bun.spawn` / `Bun.which` regressions found on current `dev`, while extending the source audit so the #3964 class does not silently drift back in adapter production code.

## Changes

- Routes monitor process spawning through `bun-spawn-shim` instead of defaulting directly to `Bun.spawn`.
- Routes comment-checker PATH resolution through `bun-which-shim` instead of defaulting directly to `Bun.which`.
- Adds `opencode-adapter-bun-runtime-audit.test.ts`, which scans production OpenCode adapter source and fails on raw `Bun.spawn`, `Bun.spawnSync`, `Bun.file`, `Bun.write`, `Bun.which`, `Bun.hash`, `Bun.serve`, `Bun.readableStreamToText`, or raw `bun:*` module imports/requires outside approved test/fixture/shim-safe contexts.

## QA & Evidence

- **What was tested:** failing-first source audit for raw Bun runtime API use.
  **Observed result:** failed before the fix on `features/monitor/process.ts` and `hooks/comment-checker/cli.ts`.
  **Artifact:** `.omo/evidence/20260708-issue-3824-bun-runtime/red-test.txt`.
  **Why sufficient:** proves the regression test targeted the actual issue-specific source offenders before the implementation change.

- **What was tested:** green audit and focused monitor/comment-checker tests.
  **Observed result:** audit passed; focused suite passed 16 tests.
  **Artifacts:** `.omo/evidence/20260708-issue-3824-bun-runtime/green-audit-test.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/green-audit-test-v2.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/green-focused-tests.txt`.
  **Why sufficient:** covers the changed source paths and the source-level guard for both raw Bun globals and raw `bun:*` loader imports.

- **What was tested:** full local pre-push gates.
  **Observed result:** `bun run typecheck`, `bun test`, and `bun run build` all exited 0 before and after the audit expansion; full test suite reported 11146 pass, 2 skip, 0 fail on both runs.
  **Artifacts:** `.omo/evidence/20260708-issue-3824-bun-runtime/prepush-typecheck.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/prepush-bun-test.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/prepush-build.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/prepush-typecheck-v2.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/prepush-bun-test-v2.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/prepush-build-v2.txt`.
  **Why sufficient:** matches the repository pre-push gate expected by the PR workflow.

- **What was tested:** built bundle and Node/OpenCode real harness compatibility.
  **Observed result:** existing dist bundle Bun-globals test passed; `node --input-type=module` imported `dist/index.js`; raw `Bun.*` search found no bundle matches; isolated `opencode debug config --print-logs` loaded this local plugin without `Bun is not defined`, left the real opencode session count unchanged, and cleaned up its sandbox.
  **Artifacts:** `.omo/evidence/20260708-issue-3824-bun-runtime/dist-bundle-tests.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/node-import-smoke.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/dist-raw-bun-rg.txt`, `.omo/evidence/20260708-issue-3824-bun-runtime/opencode-local-plugin-load.txt`.
  **Why sufficient:** exercises the user-visible OpenCode plugin load path in the installed CLI with isolated XDG state.

## Risks & Residuals

The audit intentionally uses lexical scanning rather than a full parser, so it is conservative and allowlists test/fixture/shim locations. That is acceptable here because the risk is direct production-source references to a small known set of `Bun.*` runtime APIs or raw `bun:*` module imports.

The audit allows type-only `bun:*` references and the existing string-hidden deferred `bun:sqlite` import pattern because Node's ESM loader cannot see those at parse time. Static imports and direct dynamic imports remain banned.

Build regenerated unrelated Codex distribution files locally; those were restored and are not included in this PR.

## Related Issues

Refs #3824
