### PR TITLE
fix(omo-senpi): wire lsp tool renderers

### DIFF
--- a/packages/omo-senpi/scripts/qa/lsp-renderers.mjs
+++ b/packages/omo-senpi/scripts/qa/lsp-renderers.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, "..", "..")
+const repoRoot = resolve(packageRoot, "..", "..")
+const sourceRoot = join(packageRoot, "src", "components", "lsp", "lsp")
+
+const toolImports = {
+  diagnostics: join(sourceRoot, "tools", "diagnostics.ts"),
+  references: join(sourceRoot, "tools", "find-references.ts"),
+  definition: join(sourceRoot, "tools", "goto-definition.ts"),
+  rename: join(sourceRoot, "tools", "rename.ts"),
+  symbols: join(sourceRoot, "tools", "symbols.ts"),
+}
+
+function usage() {
+  return `lsp-renderers QA
+
+Usage:
+  node packages/omo-senpi/scripts/qa/lsp-renderers.mjs
+  node packages/omo-senpi/scripts/qa/lsp-renderers.mjs --self-test
+`
+}
+
+function findBun() {
+  const configured = process.env.BUN_BIN?.trim()
+  if (configured) return configured
+  return "bun"
+}
+
+function requireSources() {
+  for (const [name, path] of Object.entries(toolImports)) {
+    if (!existsSync(path)) throw new Error(`missing ${name} tool source: ${path}`)
+  }
+}
+
+function importUrl(path) {
+  return pathToFileURL(path).href
+}
+
+function runnerSource() {
+  return `import { lsp_diagnostics } from ${JSON.stringify(importUrl(toolImports.diagnostics))}
+import { lsp_find_references } from ${JSON.stringify(importUrl(toolImports.references))}
+import { lsp_goto_definition } from ${JSON.stringify(importUrl(toolImports.definition))}
+import { lsp_prepare_rename, lsp_rename } from ${JSON.stringify(importUrl(toolImports.rename))}
+import { lsp_symbols } from ${JSON.stringify(importUrl(toolImports.symbols))}
+
+const theme = { fg(_key, text) { return text }, bold(text) { return text } }
+const sampleFile = "/tmp/omo-senpi-lsp/sample.ts"
+const sampleUri = "file:///tmp/omo-senpi-lsp/sample.ts"
+const targetUri = "file:///tmp/omo-senpi-lsp/target.ts"
+const range = (line, character) => ({ start: { line, character }, end: { line, character: character + 5 } })
+const location = (uri, line, character) => ({ uri, range: range(line, character) })
+const diagnostic = { range: range(0, 12), severity: 1, source: "ts", code: "TS2322", message: "Type 'number' is not assignable to type 'string'." }
+const scenarios = [
+  { name: "lsp_diagnostics", tool: lsp_diagnostics, args: { filePath: sampleFile, severity: "error" }, callIncludes: ["lsp_diagnostics", sampleFile, "[error]"], resultIncludes: ["E:1", "1 file"], result: { content: [{ type: "text", text: "error[ts] (TS2322) at 1:12: Type mismatch" }], details: { filePath: sampleFile, severity: "error", mode: "file", diagnostics: [{ file: sampleFile, diagnostic }], totalDiagnostics: 1, truncated: false } } },
+  { name: "lsp_goto_definition", tool: lsp_goto_definition, args: { filePath: sampleFile, line: 1, character: 13 }, callIncludes: ["lsp_goto_definition", sampleFile + ":1:13"], resultIncludes: ["target.ts:4:2"], result: { content: [{ type: "text", text: "/tmp/omo-senpi-lsp/target.ts:4:2" }], details: { filePath: sampleFile, line: 1, character: 13, locations: [location(targetUri, 3, 2)] } } },
+  { name: "lsp_find_references", tool: lsp_find_references, args: { filePath: sampleFile, line: 1, character: 13, includeDeclaration: true }, callIncludes: ["lsp_find_references", sampleFile + ":1:13"], resultIncludes: ["2 references", "2 files"], result: { content: [{ type: "text", text: "/tmp/omo-senpi-lsp/sample.ts:1:13" }], details: { filePath: sampleFile, line: 1, character: 13, references: [location(sampleUri, 0, 13), location(targetUri, 3, 2)], totalReferences: 2, truncated: false } } },
+  { name: "lsp_prepare_rename", tool: lsp_prepare_rename, args: { filePath: sampleFile, line: 1, character: 13 }, callIncludes: ["lsp_prepare_rename", sampleFile + ":1:13"], resultIncludes: ["Rename available"], result: { content: [{ type: "text", text: "Rename available: value" }], details: { filePath: sampleFile, line: 1, character: 13, result: { range: range(0, 13), placeholder: "value" } } } },
+  { name: "lsp_rename", tool: lsp_rename, args: { filePath: sampleFile, line: 1, character: 13, newName: "renamedValue" }, callIncludes: ["lsp_rename", sampleFile + ":1:13", "renamedValue"], resultIncludes: ["Applied 1 edit", "1 file"], result: { content: [{ type: "text", text: "Applied 1 edit to 1 file" }], details: { filePath: sampleFile, line: 1, character: 13, newName: "renamedValue", apply: { success: true, filesModified: [sampleFile], totalEdits: 1, errors: [] }, edit: null } } },
+  { name: "lsp_symbols", tool: lsp_symbols, args: { filePath: sampleFile, scope: "document" }, callIncludes: ["lsp_symbols", "[document]", sampleFile], resultIncludes: ["1 symbol", "document"], result: { content: [{ type: "text", text: "function value at 1:0" }], details: { filePath: sampleFile, scope: "document", symbols: [{ name: "value", kind: 12, range: range(0, 13), selectionRange: range(0, 13) }], totalSymbols: 1, truncated: false } } },
+]
+
+function textOf(value) {
+  return String(value)
+}
+
+function renderScenario(scenario) {
+  if (typeof scenario.tool.renderCall !== "function") throw new Error(scenario.name + " missing renderCall")
+  if (typeof scenario.tool.renderResult !== "function") throw new Error(scenario.name + " missing renderResult")
+  const call = textOf(scenario.tool.renderCall(scenario.args, theme))
+  const result = textOf(scenario.tool.renderResult(scenario.result, { expanded: false }, theme))
+  for (const phrase of scenario.callIncludes) {
+    if (!call.includes(phrase)) throw new Error(scenario.name + " call output missing required phrase: " + phrase)
+  }
+  for (const phrase of scenario.resultIncludes) {
+    if (!result.includes(phrase)) throw new Error(scenario.name + " result output missing required phrase: " + phrase)
+  }
+  return "[" + scenario.name + "]\\ncall: " + call + "\\nresult:\\n" + result
+}
+
+const output = ["custom LSP renderer transcript", ...scenarios.map(renderScenario)].join("\\n\\n")
+const forbidden = ['{"filePath"', '"details":', '"diagnostics":']
+for (const marker of forbidden) {
+  if (output.includes(marker)) throw new Error("renderer output contains raw fallback marker: " + marker)
+}
+const required = [
+  "lsp_diagnostics",
+  "E:1",
+  "1 file",
+  "lsp_goto_definition",
+  "target.ts:4:2",
+  "lsp_find_references",
+  "2 references",
+  "lsp_prepare_rename",
+  "Rename available",
+  "lsp_rename",
+  "Applied 1 edit",
+  "lsp_symbols",
+  "1 symbol",
+]
+for (const phrase of required) {
+  if (!output.includes(phrase)) throw new Error("renderer output missing required phrase: " + phrase)
+}
+console.log(output)
+`
+}
+
+function runSelfTest() {
+  requireSources()
+  const source = runnerSource()
+  if (!source.includes("renderCall")) throw new Error("self-test expected runner to call renderCall")
+  if (!source.includes("renderResult")) throw new Error("self-test expected runner to call renderResult")
+  console.log("SELF-TEST OK")
+}
+
+function runQa() {
+  requireSources()
+  const tmp = mkdtempSync(join(tmpdir(), "omo-senpi-lsp-renderers-"))
+  try {
+    const runnerPath = join(tmp, "runner.ts")
+    writeFileSync(runnerPath, runnerSource(), "utf8")
+    const childEnv = { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? tmp }
+    if (process.env.BUN_INSTALL) childEnv.BUN_INSTALL = process.env.BUN_INSTALL
+    const bun = spawnSync(findBun(), [runnerPath], {
+      cwd: repoRoot,
+      env: childEnv,
+      encoding: "utf8",
+      timeout: 60_000,
+    })
+    if (bun.status !== 0) {
+      process.stderr.write(bun.stderr)
+      process.stdout.write(bun.stdout)
+      throw new Error(`renderer QA runner failed with status ${bun.status ?? "signal " + bun.signal}`)
+    }
+    process.stdout.write(bun.stdout)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function main() {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    process.stdout.write(usage())
+    return
+  }
+  if (process.argv.includes("--self-test")) {
+    runSelfTest()
+    return
+  }
+  runQa()
+}
+
+main()

--- a/packages/omo-senpi/src/components/lsp/lsp-renderers.test.ts
+++ b/packages/omo-senpi/src/components/lsp/lsp-renderers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test"
+
+import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
+import type { ComponentContext, ComponentLogger } from "../../extension/types"
+import { createLspComponent } from "./index"
+import { setServerStatusProvider } from "./lsp/server-resolution"
+import type { ResolvedServer } from "./lsp/types"
+
+const EXPECTED_TOOL_NAMES = [
+  "lsp_diagnostics",
+  "lsp_find_references",
+  "lsp_goto_definition",
+  "lsp_prepare_rename",
+  "lsp_rename",
+  "lsp_symbols",
+] as const
+
+class TestLogger implements ComponentLogger {
+  info(_message: string, _details?: unknown): void {}
+  warn(_message: string, _details?: unknown): void {}
+  error(_message: string, _details?: unknown): void {}
+}
+
+const fakeServer: ResolvedServer = {
+  id: "fake-typescript",
+  command: ["omo-senpi-fake-ls"],
+  extensions: [".ts"],
+  priority: 0,
+}
+
+function registerTools(): FakeExtensionAPI {
+  const pi = new FakeExtensionAPI()
+  const ctx: ComponentContext = {
+    logger: new TestLogger(),
+    config: {
+      getFlag(name) {
+        return pi.getFlag(name)
+      },
+    },
+  }
+  setServerStatusProvider(() => [
+    {
+      id: fakeServer.id,
+      installed: true,
+      extensions: fakeServer.extensions,
+      disabled: false,
+      source: "test",
+      priority: 0,
+      server: fakeServer,
+    },
+  ])
+  createLspComponent().register(pi, ctx)
+  return pi
+}
+
+describe("omo-senpi lsp TUI renderers", () => {
+  it("#given registered LSP tools #when the TUI renders tool activity #then every tool exposes custom call and result renderers", () => {
+    // given / when
+    const pi = registerTools()
+
+    try {
+      // then
+      for (const name of EXPECTED_TOOL_NAMES) {
+        const tool = pi.tools.find((candidate) => candidate["name"] === name)
+        if (!tool) throw new Error(`${name} was not registered`)
+        expect(typeof tool["renderCall"]).toBe("function")
+        expect(typeof tool["renderResult"]).toBe("function")
+      }
+    } finally {
+      setServerStatusProvider(undefined)
+    }
+  })
+})

--- a/packages/omo-senpi/src/components/lsp/lsp/tools/diagnostics.ts
+++ b/packages/omo-senpi/src/components/lsp/lsp/tools/diagnostics.ts
@@ -5,6 +5,7 @@ import { DEFAULT_MAX_DIAGNOSTICS } from "../constants.js";
 import { aggregateDiagnosticsForDirectory } from "../directory-diagnostics.js";
 import { filterDiagnosticsBySeverity, formatDiagnostic } from "../formatters.js";
 import { inferExtensionFromDirectory } from "../infer-extension.js";
+import { renderDiagnosticsCall, renderDiagnosticsResult } from "../renderers-diagnostics.js";
 import { defineTool, Type } from "../schema.js";
 import type { Diagnostic, SeverityFilter } from "../types.js";
 import { handleMissingDependencyError } from "../utils.js";
@@ -101,6 +102,8 @@ export const lsp_diagnostics = defineTool({
 		"Get errors, warnings, and hints from the language server BEFORE running build. " +
 		"Works for both single files and directories - file extension is auto-detected for directories.",
 	parameters: Params,
+	renderCall: renderDiagnosticsCall,
+	renderResult: renderDiagnosticsResult,
 	async execute(
 		_toolCallId: string,
 		rawParams: unknown,

--- a/packages/omo-senpi/src/components/lsp/lsp/tools/find-references.ts
+++ b/packages/omo-senpi/src/components/lsp/lsp/tools/find-references.ts
@@ -1,6 +1,7 @@
 import { withLspClient } from "../client-wrapper.js";
 import { DEFAULT_MAX_REFERENCES } from "../constants.js";
 import { formatLocation } from "../formatters.js";
+import { renderFindReferencesCall, renderFindReferencesResult } from "../renderers-navigation.js";
 import { defineTool, Type } from "../schema.js";
 import type { Location } from "../types.js";
 import { handleMissingDependencyError } from "../utils.js";
@@ -35,6 +36,8 @@ export const lsp_find_references = defineTool({
 	label: "LSP Find References",
 	description: "Find ALL usages/references of a symbol across the entire workspace.",
 	parameters: Params,
+	renderCall: renderFindReferencesCall,
+	renderResult: renderFindReferencesResult,
 	async execute(
 		_toolCallId: string,
 		params: LspFindReferencesParams,

--- a/packages/omo-senpi/src/components/lsp/lsp/tools/goto-definition.ts
+++ b/packages/omo-senpi/src/components/lsp/lsp/tools/goto-definition.ts
@@ -1,5 +1,6 @@
 import { withLspClient } from "../client-wrapper.js";
 import { formatLocation } from "../formatters.js";
+import { renderGotoDefinitionCall, renderGotoDefinitionResult } from "../renderers-navigation.js";
 import { defineTool, Type } from "../schema.js";
 import type { Location, LocationLink } from "../types.js";
 import { handleMissingDependencyError } from "../utils.js";
@@ -30,6 +31,8 @@ export const lsp_goto_definition = defineTool({
 	label: "LSP Goto Definition",
 	description: "Jump to symbol definition. Find WHERE something is defined.",
 	parameters: Params,
+	renderCall: renderGotoDefinitionCall,
+	renderResult: renderGotoDefinitionResult,
 	async execute(
 		_toolCallId: string,
 		params: LspGotoDefinitionParams,

--- a/packages/omo-senpi/src/components/lsp/lsp/tools/rename.ts
+++ b/packages/omo-senpi/src/components/lsp/lsp/tools/rename.ts
@@ -1,5 +1,11 @@
 import { withLspClient } from "../client-wrapper.js";
 import { formatApplyResult, formatPrepareRenameResult } from "../formatters.js";
+import {
+	renderPrepareRenameCall,
+	renderPrepareRenameResult,
+	renderRenameCall,
+	renderRenameResult,
+} from "../renderers-rename.js";
 import { defineTool, Type } from "../schema.js";
 import type { PrepareRenameDefaultBehavior, PrepareRenameResult, Range, WorkspaceEdit } from "../types.js";
 import { handleMissingDependencyError } from "../utils.js";
@@ -53,6 +59,8 @@ export const lsp_prepare_rename = defineTool({
 	label: "LSP Prepare Rename",
 	description: "Check if rename is valid at a given position. Use BEFORE lsp_rename.",
 	parameters: PrepareParams,
+	renderCall: renderPrepareRenameCall,
+	renderResult: renderPrepareRenameResult,
 	async execute(
 		_toolCallId: string,
 		params: LspPositionParams,
@@ -104,6 +112,8 @@ export const lsp_rename = defineTool({
 	description: "Rename symbol across the entire workspace. APPLIES changes to all files.",
 	parameters: RenameParams,
 	executionMode: "sequential",
+	renderCall: renderRenameCall,
+	renderResult: renderRenameResult,
 	async execute(_toolCallId: string, params: LspRenameParams, signal?: AbortSignal, _onUpdate?: unknown, _ctx?: unknown) {
 		try {
 			const edit = await withLspClient<WorkspaceEdit | null>(

--- a/packages/omo-senpi/src/components/lsp/lsp/tools/symbols.ts
+++ b/packages/omo-senpi/src/components/lsp/lsp/tools/symbols.ts
@@ -1,6 +1,7 @@
 import { withLspClient } from "../client-wrapper.js";
 import { DEFAULT_MAX_SYMBOLS } from "../constants.js";
 import { formatDocumentSymbol, formatSymbolInfo } from "../formatters.js";
+import { renderSymbolsCall, renderSymbolsResult } from "../renderers-symbols.js";
 import { defineTool, Type } from "../schema.js";
 import type { DocumentSymbol, SymbolInfo } from "../types.js";
 import { handleMissingDependencyError } from "../utils.js";
@@ -43,6 +44,8 @@ export const lsp_symbols = defineTool({
 		"Get symbols from a file (document) or search across the workspace. " +
 		"Use scope='document' for a file outline, scope='workspace' for project-wide symbol search.",
 	parameters: Params,
+	renderCall: renderSymbolsCall,
+	renderResult: renderSymbolsResult,
 	async execute(
 		_toolCallId: string,
 		params: LspSymbolsParams,


### PR DESCRIPTION
## Summary
Wires the existing OMO Senpi LSP renderer helpers into all six registered LSP tools so the TUI shows compact, tool-specific call/result output instead of the generic fallback.

The behavior was recovered from Claude Code session `d15d20a7-7044-4618-8df9-3ee21880b015`: the installed OMO Senpi plugin already had renderer helper implementations, but the tool definitions did not attach them.

## Changes
- Attach `renderCall` and `renderResult` to `lsp_diagnostics`, `lsp_goto_definition`, `lsp_find_references`, `lsp_prepare_rename`, `lsp_rename`, and `lsp_symbols`.
- Add a focused LSP renderer registration test so every registered LSP tool must expose custom TUI render hooks.
- Add `packages/omo-senpi/scripts/qa/lsp-renderers.mjs`, a deterministic renderer-surface QA driver that invokes each tool's call/result renderers, asserts per-tool call/result phrases, rejects raw fallback JSON markers, and runs the TypeScript runner under a scrubbed child environment.

## QA / Evidence
- Recovered prior-session intent and RED proof: `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260708-lsp-tui/session-read.json`, `user-prompts.txt`, `assistant-text.txt`, and `.omo/evidence/omo-senpi-adapter/lsp-renderers/task-1-red-index-test.log`.
- Focused renderer GREEN proof: `.omo/evidence/omo-senpi-adapter/lsp-renderers/task-1-green-index-test.log`.
- Manual renderer surface QA: `node packages/omo-senpi/scripts/qa/lsp-renderers.mjs`, saved at `.omo/evidence/omo-senpi-adapter/lsp-renderers/lsp-renderers-qa.log`; output includes `E:1`, `1 file`, references, definition, rename, and symbols renderer output with no raw JSON fallback markers.
- Visual terminal QA: `.omo/evidence/omo-senpi-adapter/lsp-renderers/terminal-visual/{terminal.txt,terminal.html,terminal.png,metadata.json}`; regenerated sequentially after an initial blank-artifact review finding.
- Regression gates: `.omo/evidence/omo-senpi-adapter/lsp-renderers/checks.log` covers `build-extension`, `build-extension --check`, `sync-skills`, `embed-directive --check`, focused LSP renderer tests, renderer QA self-test/full run, `tsgo --noEmit -p packages/omo-senpi/tsconfig.json`, and `bun run test:senpi`.
- Final local test result: `bun run test:senpi` passed with `151 pass`, `0 fail`, across 32 files.
- Review gates: QA PASS, security PASS, code-quality rerun PASS, goal-gate rerun APPROVE. Logs/reports are under `.omo/evidence/omo-senpi-adapter/lsp-renderers/` and `.omo/evidence/omo-senpi-adapter/`.

## Risks
- The generated plugin bundle directories are ignored by `packages/omo-senpi/.gitignore`; this PR does not force-add them. `build-extension --check` passed after generation, so the generated output is current for local validation.
- The existing `index.test.ts` file is still oversized, but this PR no longer modifies it after moving the new assertion into `lsp-renderers.test.ts`.
- LSP diagnostics hook repeatedly exited with code `-13` in this worktree, consistent with the recovered handoff; compiler/test gates were used for validation.

## Secret Safety
Evidence logs use synthetic fixture paths and sanitized terminal rendering. The QA child process uses a scrubbed environment and does not read real Senpi auth, tokens, cookies, or API keys.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hooked up custom LSP TUI renderers for all six `omo-senpi` LSP tools, replacing the generic fallback with compact, tool-specific call/result output.

- **Bug Fixes**
  - Wired `renderCall`/`renderResult` for: `lsp_diagnostics`, `lsp_goto_definition`, `lsp_find_references`, `lsp_prepare_rename`, `lsp_rename`, `lsp_symbols`.
  - Added `lsp-renderers.test.ts` to ensure every registered LSP tool exposes custom TUI render hooks.
  - Added `packages/omo-senpi/scripts/qa/lsp-renderers.mjs` to validate per-tool phrases and block raw JSON fallback output.

<sup>Written for commit 8ee0b7deaa6c33daefe1a0d287e3d73032271d51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

