### PR TITLE
fix(auto-slash-command): remove duplicate user args in formatCommandTemplate

### DIFF
--- a/packages/omo-opencode/src/hooks/auto-slash-command/executor.test.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/executor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { clearCommandLoaderCache } from "../../features/claude-code-command-loader"
@@ -44,6 +44,24 @@ Execute daplug prompt flow.
 description: Templated prompt from daplug
 ---
 Echo $ARGUMENTS and \${user_message}.
+`,
+  )
+  writeFileSync(
+    join(pluginInstallPath, "commands", "special-args.md"),
+    `---
+description: Special argument prompt from daplug
+---
+Echo $ARGUMENTS.
+`,
+  )
+  const userCommandsDir = join(claudeConfigDir, "commands")
+  mkdirSync(userCommandsDir, { recursive: true })
+  writeFileSync(
+    join(userCommandsDir, "plain.md"),
+    `---
+description: Plain user prompt
+---
+Execute the plain prompt.
 `,
   )
 
@@ -194,6 +212,47 @@ describe("auto-slash command executor plugin dispatch", () => {
     expect(result.replacementText).toContain("Echo ship it and ship it.")
     expect(result.replacementText).not.toContain("$ARGUMENTS")
     expect(result.replacementText).not.toContain("${user_message}")
+    expect(result.replacementText).not.toContain("## User Request")
+  })
+
+  it("retains the user request section for command templates without argument placeholders", async () => {
+    const result = await executeSlashCommand(
+      {
+        command: "plain",
+        args: "ship it",
+        raw: "/plain ship it",
+      },
+      {
+        skills: [],
+        pluginsEnabled: true,
+        directory: tempDir,
+      },
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.replacementText).toContain("## User Request\n\nship it")
+  })
+
+  it("preserves special arguments as data when a command template consumes them", async () => {
+    const injectionMarker = join(tempDir, "should-not-exist")
+    const args = `ship @secret.txt $(touch ${injectionMarker}) $HOME`
+
+    const result = await executeSlashCommand(
+      {
+        command: "daplug:special-args",
+        args,
+        raw: `/daplug:special-args ${args}`,
+      },
+      {
+        skills: [],
+        pluginsEnabled: true,
+      },
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.replacementText).toContain(`Echo ${args}.`)
+    expect(result.replacementText).not.toContain("## User Request")
+    expect(existsSync(injectionMarker)).toBe(false)
   })
 
   it("renders Atlas as the builtin start-work agent during slash-command execution", async () => {

--- a/packages/omo-opencode/src/hooks/auto-slash-command/executor.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/executor.ts
@@ -114,7 +114,11 @@ async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<st
     .replace(/\$ARGUMENTS/g, resolvedArguments)
   sections.push(substitutedContent.trim())
 
-  if (args) {
+  if (
+    args &&
+    !resolvedContent.includes("${user_message}") &&
+    !resolvedContent.includes("$ARGUMENTS")
+  ) {
     sections.push("\n\n---\n")
     sections.push("## User Request\n")
     sections.push(args)


### PR DESCRIPTION
## Summary

Prevent auto slash-command prompts from repeating user arguments when the command template already consumes `$ARGUMENTS` or `${user_message}`. Commands without either placeholder keep the trailing `## User Request` section, preserving the existing argument-delivery fallback.

## Changes

- Detect supported argument placeholders in the resolved command template before appending the trailing request section.
- Add failing-first coverage for both placeholder-consuming and no-placeholder command populations.
- Verify file-like and shell-like arguments such as `@secret.txt`, `$(touch marker)`, and `$HOME` remain inert data.
- Keep `$SESSION_ID` / `$TIMESTAMP` runtime-token work out of scope; that remains in PR #5984.

## QA

- `bun test packages/omo-opencode/src/hooks/auto-slash-command/executor.test.ts`: 7 passed, 0 failed, 21 expectations.
- Auto-slash-command hook suite: 69 passed.
- Local pre-build full-suite attempt: 11,603 passed, 3 skipped, 21 failed in generated/payload-dependent Codex installer, package-layout, telemetry-bundle, and path-sensitive config tests; retained as a failed local artifact.
- Exact-head GitHub Actions run `29519402551`: every required Linux, macOS, and Windows test/typecheck/build/Codex/Senpi/published-smoke/security job passed on `97fafb79f285f9dfa3e5b7113d1046c30e967e12`.
- `bun run typecheck`: passed.
- Full build: passed on the exact source tree through a path-neutral wrapper because the mandated team worktree path contains `.omo`, which `sync-skills.mjs` filters.
- Real isolated OpenCode QA: two `opencode run --format json` executions loaded the source plugin, exchanged four requests with a local fake model, created only the sandbox DB, left the host DB session count unchanged at 5751, and completed teardown.

The real OpenCode wire preserves native slash input rather than exposing the plugin-formatted prompt, so duplicate-rendering behavior is asserted by the direct executor test; the real harness proves source-plugin loading, execution, isolation, and cleanup.

## Risk

The conditional is limited to the two placeholders already substituted by this function. Templates without placeholders retain their prior trailing argument placement. No runtime-token substitution behavior is changed.

Closes #6162
