### PR TITLE
fix(auto-slash-command): substitute $SESSION_ID and $TIMESTAMP in command templates

### DIFF
--- a/packages/omo-opencode/src/hooks/auto-slash-command/executor.test.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/executor.test.ts
@@ -1,9 +1,22 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, setSystemTime } from "bun:test"
 import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { _resetForTesting, registerAgentName } from "../../features/claude-code-session-state"
 import { clearCommandLoaderCache } from "../../features/claude-code-command-loader"
+import { loadBuiltinCommands } from "../../features/builtin-commands/commands"
+import { createChatMessageHandler } from "../../plugin/chat-message"
+import { createCommandExecuteBeforeHandler } from "../../plugin/command-execute-before"
+import { createStartWorkHook } from "../start-work"
 import { executeSlashCommand } from "./executor"
+import { createAutoSlashCommandHook } from "./hook"
+import type {
+  AutoSlashCommandHookInput,
+  AutoSlashCommandHookOutput,
+  CommandExecuteBeforeInput,
+  CommandExecuteBeforeOutput,
+} from "./types"
 
 const ENV_KEYS = [
   "CLAUDE_CONFIG_DIR",
@@ -14,6 +27,71 @@ const ENV_KEYS = [
 
 type EnvKey = (typeof ENV_KEYS)[number]
 type EnvSnapshot = Record<EnvKey, string | undefined>
+type TextPart = { readonly text?: string }
+
+const FIXED_TIMESTAMP = "2026-07-16T12:34:56.789Z"
+
+function joinTextParts(parts: readonly TextPart[]): string {
+  return parts.map((part) => part.text ?? "").join("\n")
+}
+
+function createComposedHooks(directory: string) {
+  return {
+    autoSlashCommand: createAutoSlashCommandHook({ skills: [], directory }),
+    startWork: createStartWorkHook(unsafeTestValue<Parameters<typeof createStartWorkHook>[0]>({
+      directory,
+      client: {
+        session: {
+          messages: async () => ({ data: [] }),
+        },
+      },
+    })),
+  }
+}
+
+function createComposedChatMessageHandler(directory: string) {
+  const hooks = createComposedHooks(directory)
+  return createChatMessageHandler({
+    ctx: unsafeTestValue<Parameters<typeof createChatMessageHandler>[0]["ctx"]>({
+      directory,
+      client: {
+        tui: {
+          showToast: async () => {},
+        },
+      },
+    }),
+    pluginConfig: unsafeTestValue<Parameters<typeof createChatMessageHandler>[0]["pluginConfig"]>({}),
+    firstMessageVariantGate: {
+      shouldOverride: () => false,
+      markApplied: () => {},
+    },
+    hooks: unsafeTestValue<Parameters<typeof createChatMessageHandler>[0]["hooks"]>(hooks),
+  })
+}
+
+function createComposedCommandExecuteBeforeHandler(directory: string) {
+  const hooks = createComposedHooks(directory)
+  return createCommandExecuteBeforeHandler({
+    directory,
+    hooks: unsafeTestValue<Parameters<typeof createCommandExecuteBeforeHandler>[0]["hooks"]>(hooks),
+  })
+}
+
+function createChatInput(sessionID: string, messageID: string): AutoSlashCommandHookInput {
+  return {
+    sessionID,
+    messageID,
+    agent: "test-agent",
+    model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+  }
+}
+
+function createChatOutput(text: string): AutoSlashCommandHookOutput {
+  return {
+    message: {},
+    parts: [{ type: "text", text }],
+  }
+}
 
 function writePluginFixture(baseDir: string): void {
   const claudeConfigDir = join(baseDir, "claude-config")
@@ -44,6 +122,7 @@ Execute daplug prompt flow.
 description: Templated prompt from daplug
 ---
 Echo $ARGUMENTS and \${user_message}.
+Session $SESSION_ID at $TIMESTAMP. Keep @missing-reference unchanged.
 `,
   )
   writeFileSync(
@@ -126,6 +205,7 @@ describe("auto-slash command executor plugin dispatch", () => {
   })
 
   afterEach(() => {
+    setSystemTime()
     clearCommandLoaderCache()
     for (const key of ENV_KEYS) {
       const previousValue = envSnapshot[key]
@@ -205,6 +285,7 @@ describe("auto-slash command executor plugin dispatch", () => {
       {
         skills: [],
         pluginsEnabled: true,
+        sessionID: "ses_templated_args",
       },
     )
 
@@ -255,6 +336,76 @@ describe("auto-slash command executor plugin dispatch", () => {
     expect(existsSync(injectionMarker)).toBe(false)
   })
 
+  it("substitutes runtime placeholders once without rewriting user arguments or unresolved file references", async () => {
+    // given
+    const timestamp = "2026-07-16T12:34:56.789Z"
+    const sessionID = "ses_runtime_123"
+    const args = "ship $SESSION_ID $TIMESTAMP $& safely"
+    setSystemTime(new Date(timestamp))
+
+    // when
+    const result = await executeSlashCommand(
+      {
+        command: "daplug:templated",
+        args,
+        raw: `/daplug:templated ${args}`,
+      },
+      {
+        skills: [],
+        pluginsEnabled: true,
+        sessionID,
+      },
+    )
+
+    // then
+    expect(result.success).toBe(true)
+    expect(result.replacementText).toContain(`Echo ${args} and ${args}.`)
+    expect(result.replacementText).toContain(`Session ${sessionID} at ${timestamp}.`)
+    expect(result.replacementText).toContain("Keep @missing-reference unchanged.")
+  })
+
+  it("rejects a session-bound builtin command when the session ID is missing", async () => {
+    // given
+    const parsed = {
+      command: "handoff",
+      args: "",
+      raw: "/handoff",
+    }
+
+    // when
+    const result = await executeSlashCommand(parsed, { skills: [] })
+
+    // then
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to load command "/handoff": Command template requires a session ID',
+    })
+  })
+
+  it("substitutes the exact session ID in handoff session_read instructions", async () => {
+    // given
+    const sessionID = "ses_handoff_exact"
+
+    // when
+    const result = await executeSlashCommand(
+      {
+        command: "handoff",
+        args: "",
+        raw: "/handoff",
+      },
+      {
+        skills: [],
+        sessionID,
+      },
+    )
+
+    // then
+    expect(result.success).toBe(true)
+    expect(result.replacementText).toContain(`session_read({ session_id: "${sessionID}" })`)
+    expect(result.replacementText).not.toContain("$SESSION_ID")
+    expect(result.replacementText).not.toContain("$TIMESTAMP")
+  })
+
   it("renders Atlas as the builtin start-work agent during slash-command execution", async () => {
     // given
 
@@ -267,11 +418,178 @@ describe("auto-slash command executor plugin dispatch", () => {
       },
       {
         skills: [],
+        sessionID: "ses_start_work_test",
       },
     )
 
     // then
     expect(result.success).toBe(true)
     expect(result.replacementText).toContain("**Agent**: atlas")
+  })
+})
+
+describe("auto-slash-command runtime substitution", () => {
+  let testDir: string
+
+  beforeEach(() => {
+    _resetForTesting()
+    registerAgentName("atlas")
+    setSystemTime(new Date(FIXED_TIMESTAMP))
+    testDir = mkdtempSync(join(tmpdir(), "p5984-start-work-composed-"))
+  })
+
+  afterEach(() => {
+    setSystemTime()
+    _resetForTesting()
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it("substitutes each chat session ID without leaking another session", async () => {
+    const hook = createAutoSlashCommandHook({ skills: [] })
+    const firstSessionID = "ses_chat_first"
+    const secondSessionID = "ses_chat_second"
+    const firstOutput = createChatOutput("/handoff first goal")
+    const secondOutput = createChatOutput("/handoff second goal")
+
+    await hook["chat.message"](createChatInput(firstSessionID, "msg-first"), firstOutput)
+    await hook["chat.message"](createChatInput(secondSessionID, "msg-second"), secondOutput)
+
+    expect(firstOutput.parts[0].text).toContain(`session_id: "${firstSessionID}"`)
+    expect(firstOutput.parts[0].text).not.toContain(secondSessionID)
+    expect(secondOutput.parts[0].text).toContain(`session_id: "${secondSessionID}"`)
+    expect(secondOutput.parts[0].text).not.toContain(firstSessionID)
+  })
+
+  it("substitutes the command execution session ID in handoff templates", async () => {
+    const hook = createAutoSlashCommandHook({ skills: [] })
+    const input: CommandExecuteBeforeInput = {
+      command: "handoff",
+      sessionID: "ses_command_handoff",
+      arguments: "continue the audit",
+    }
+    const output: CommandExecuteBeforeOutput = {
+      parts: [{ type: "text", text: "original" }],
+    }
+
+    await hook["command.execute.before"](input, output)
+
+    expect(output.parts[0].text).toContain(`session_id: "${input.sessionID}"`)
+    expect(output.parts[0].text).not.toContain("$SESSION_ID")
+    expect(output.parts[0].text).not.toContain("$TIMESTAMP")
+  })
+
+  const composedSurfaces = [
+    {
+      name: "chat.message",
+      run: async (directory: string, sessionID: string, argumentsText: string) => {
+        const handler = createComposedChatMessageHandler(directory)
+        const output = {
+          message: {},
+          parts: [{ type: "text", text: `/start-work ${argumentsText}` }],
+        }
+        await handler({ sessionID, agent: "sisyphus" }, output)
+        return output.parts
+      },
+    },
+    {
+      name: "command.execute.before",
+      run: async (directory: string, sessionID: string, argumentsText: string) => {
+        const handler = createComposedCommandExecuteBeforeHandler(directory)
+        const output = { parts: [{ type: "text", text: "native command output" }] }
+        await handler({ command: "start-work", sessionID, arguments: argumentsText }, output)
+        return output.parts
+      },
+    },
+  ] as const
+
+  for (const surface of composedSurfaces) {
+    it(`preserves literal runtime-looking arguments through ${surface.name}`, async () => {
+      const sessionID = `ses_${surface.name.replaceAll(".", "_")}`
+      const argumentsText = "literal $SESSION_ID $TIMESTAMP $& $` $'"
+
+      const parts = await surface.run(testDir, sessionID, argumentsText)
+      const text = joinTextParts(parts)
+
+      expect(text).toContain(`<user-request>\n${argumentsText}\n</user-request>`)
+      expect(text).toContain(`**User Arguments**: ${argumentsText}`)
+      expect(text).toContain(
+        `<session-context>\nSession ID: ${sessionID}\nTimestamp: ${FIXED_TIMESTAMP}\n</session-context>`,
+      )
+    })
+
+    it(`preserves session-context-shaped user arguments through ${surface.name}`, async () => {
+      const sessionID = `ses_tag_${surface.name.replaceAll(".", "_")}`
+      const argumentsText = "literal <session-context>user $SESSION_ID at $TIMESTAMP</session-context>"
+
+      const parts = await surface.run(testDir, sessionID, argumentsText)
+      const text = joinTextParts(parts)
+
+      expect(text).toContain(`<user-request>\n${argumentsText}\n</user-request>`)
+      expect(text).toContain(`**User Arguments**: ${argumentsText}`)
+    })
+
+    for (const userInput of [
+      "literal ## Command Instructions then ## User Request with $SESSION_ID $TIMESTAMP $&",
+      "literal <user-request> with $SESSION_ID $TIMESTAMP $&",
+    ]) {
+      it(`substitutes a later raw retry context after hostile user structure on ${surface.name}`, async () => {
+        const firstSessionID = "rendered-session"
+        const retrySessionID = "retry-session"
+        const rendered = await executeSlashCommand(
+          { command: "start-work", args: userInput, raw: `/start-work ${userInput}` },
+          { skills: [], sessionID: firstSessionID },
+        )
+        expect(rendered.success).toBe(true)
+        const rawTemplate = loadBuiltinCommands()["start-work"]?.template ?? ""
+        const hook = createStartWorkHook(unsafeTestValue<Parameters<typeof createStartWorkHook>[0]>({
+          directory: testDir,
+          client: { session: { messages: async () => ({ data: [] }) } },
+        }))
+        const output = {
+          parts: [
+            { type: "text", text: rendered.replacementText ?? "" },
+            { type: "text", text: rawTemplate },
+          ],
+        }
+
+        if (surface.name === "chat.message") {
+          await hook["chat.message"]({ sessionID: retrySessionID }, output)
+        } else {
+          await hook["command.execute.before"]({
+            command: "start-work",
+            sessionID: retrySessionID,
+            arguments: userInput,
+          }, output)
+        }
+
+        expect(output.parts[0].text).toContain(`<user-request>\n${userInput}\n</user-request>`)
+        expect(output.parts[1].text).toContain(`Session ID: opencode:${retrySessionID}`)
+        expect(output.parts[1].text).toMatch(/Timestamp: \d{4}-\d{2}-\d{2}T/)
+        expect(output.parts[1].text).not.toContain("$SESSION_ID")
+        expect(output.parts[1].text).not.toContain("$TIMESTAMP")
+      })
+    }
+  }
+
+  it("substitutes one framework session context split across text parts", async () => {
+    const hook = createStartWorkHook(unsafeTestValue<Parameters<typeof createStartWorkHook>[0]>({
+      directory: testDir,
+      client: { session: { messages: async () => ({ data: [] }) } },
+    }))
+    const prompt = loadBuiltinCommands()["start-work"]?.template ?? ""
+    const splitAt = prompt.indexOf("\nTimestamp:")
+    const output = {
+      parts: [
+        { type: "text", text: prompt.slice(0, splitAt) },
+        { type: "text", text: prompt.slice(splitAt) },
+      ],
+    }
+
+    await hook["chat.message"]({ sessionID: "ses-split-context" }, output)
+
+    expect(output.parts[0].text).toContain("Session ID: opencode:ses-split-context")
+    expect(output.parts[1].text).toMatch(/Timestamp: \d{4}-\d{2}-\d{2}T/)
+    expect(joinTextParts(output.parts)).not.toContain("$SESSION_ID")
+    expect(joinTextParts(output.parts)).not.toContain("$TIMESTAMP")
   })
 })

--- a/packages/omo-opencode/src/hooks/auto-slash-command/executor.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/executor.ts
@@ -17,6 +17,15 @@ interface SkillCommandInfo {
 
 type CommandInfo = DiscoveredCommandInfo | SkillCommandInfo
 
+const COMMAND_TEMPLATE_VARIABLE_PATTERN = /\$\{user_message\}|\$ARGUMENTS|\$SESSION_ID|\$TIMESTAMP/g
+
+class MissingCommandSessionIDError extends Error {
+  constructor() {
+    super("Command template requires a session ID")
+    this.name = "MissingCommandSessionIDError"
+  }
+}
+
 function skillToCommandInfo(skill: LoadedSkill): SkillCommandInfo {
   return {
     name: skill.name,
@@ -41,6 +50,7 @@ export interface ExecutorOptions {
   enabledPluginsOverride?: Record<string, boolean>
   agent?: string
   directory?: string
+  sessionID?: string
 }
 
 
@@ -75,7 +85,28 @@ async function findCommand(commandName: string, options?: ExecutorOptions): Prom
   ) ?? null
 }
 
-async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<string> {
+function substituteCommandTemplate(content: string, args: string, sessionID: string | undefined): string {
+  if (content.includes("$SESSION_ID") && !sessionID) {
+    throw new MissingCommandSessionIDError()
+  }
+
+  const timestamp = new Date().toISOString()
+  return content.replace(COMMAND_TEMPLATE_VARIABLE_PATTERN, (variable) => {
+    switch (variable) {
+      case "${user_message}":
+      case "$ARGUMENTS":
+        return args
+      case "$SESSION_ID":
+        return sessionID ?? ""
+      case "$TIMESTAMP":
+        return timestamp
+      default:
+        return variable
+    }
+  })
+}
+
+async function formatCommandTemplate(cmd: CommandInfo, args: string, sessionID?: string): Promise<string> {
   const sections: string[] = []
 
   sections.push(`# /${cmd.name} Command\n`)
@@ -108,10 +139,7 @@ async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<st
   const commandDir = cmd.path ? dirname(cmd.path) : process.cwd()
   const withFileRefs = await resolveFileReferencesInText(content, commandDir)
   const resolvedContent = await resolveCommandsInText(withFileRefs)
-  const resolvedArguments = args
-  const substitutedContent = resolvedContent
-    .replace(/\$\{user_message\}/g, resolvedArguments)
-    .replace(/\$ARGUMENTS/g, resolvedArguments)
+  const substitutedContent = substituteCommandTemplate(resolvedContent, args, sessionID)
   sections.push(substitutedContent.trim())
 
   if (
@@ -153,7 +181,7 @@ export async function executeSlashCommand(parsed: ParsedSlashCommand, options?: 
   }
 
   try {
-    const template = await formatCommandTemplate(command, parsed.args)
+    const template = await formatCommandTemplate(command, parsed.args, options?.sessionID)
     return {
       success: true,
       replacementText: template,

--- a/packages/omo-opencode/src/hooks/auto-slash-command/hook.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/hook.ts
@@ -131,6 +131,7 @@ export function createAutoSlashCommandHook(options?: AutoSlashCommandHookOptions
       const executionOptions: ExecutorOptions = {
         ...executorOptions,
         agent: input.agent,
+        sessionID: input.sessionID,
       }
 
       const result = await executeSlashCommand(parsed, executionOptions)
@@ -189,6 +190,7 @@ export function createAutoSlashCommandHook(options?: AutoSlashCommandHookOptions
       const executionOptions: ExecutorOptions = {
         ...executorOptions,
         agent: input.agent,
+        sessionID: input.sessionID,
       }
 
       const result = await executeSlashCommand(parsed, executionOptions)

--- a/packages/omo-opencode/src/hooks/start-work/start-work-hook.ts
+++ b/packages/omo-opencode/src/hooks/start-work/start-work-hook.ts
@@ -19,6 +19,11 @@ import { findRecentSessionPlanPath } from "./session-plan-affinity"
 export const HOOK_NAME = "start-work" as const
 const START_WORK_TEMPLATE_MARKER = "You are starting an Atlas work session."
 const CONTEXT_INFO_MARKER = "<!-- omo-start-work-context -->"
+const COMMAND_INSTRUCTION_OPEN = "<command-instruction>"
+const COMMAND_INSTRUCTION_CLOSE = "</command-instruction>"
+const SESSION_CONTEXT_OPEN = "<session-context>"
+const SESSION_CONTEXT_CLOSE = "</session-context>"
+const RUNTIME_PLACEHOLDER_PATTERN = /\$SESSION_ID|\$TIMESTAMP/g
 
 interface StartWorkHookInput {
   sessionID: string
@@ -34,6 +39,101 @@ interface StartWorkCommandExecuteBeforeInput {
 interface StartWorkHookOutput {
   message?: Record<string, unknown>
   parts: Array<{ type: string; text?: string }>
+}
+
+type TextPart = StartWorkHookOutput["parts"][number]
+
+interface TextEntry {
+  readonly part: TextPart
+  readonly text: string
+  readonly start: number
+  readonly end: number
+}
+
+interface TextRange {
+  readonly start: number
+  readonly end: number
+}
+
+function findFrameworkSessionContextRanges(text: string): readonly TextRange[] {
+  const ranges: TextRange[] = []
+  let searchFrom = 0
+
+  while (searchFrom < text.length) {
+    const markerIndex = text.indexOf(START_WORK_TEMPLATE_MARKER, searchFrom)
+    if (markerIndex < 0) break
+
+    const instructionOpen = text.lastIndexOf(COMMAND_INSTRUCTION_OPEN, markerIndex)
+    const instructionBodyStart = instructionOpen + COMMAND_INSTRUCTION_OPEN.length
+    const instructionClose = text.indexOf(
+      COMMAND_INSTRUCTION_CLOSE,
+      markerIndex + START_WORK_TEMPLATE_MARKER.length,
+    )
+    if (
+      instructionOpen < searchFrom
+      || instructionClose < 0
+      || text.slice(instructionBodyStart, markerIndex).trim() !== ""
+    ) {
+      searchFrom = markerIndex + START_WORK_TEMPLATE_MARKER.length
+      continue
+    }
+
+    const instructionEnd = instructionClose + COMMAND_INSTRUCTION_CLOSE.length
+    const contextOpen = text.indexOf(SESSION_CONTEXT_OPEN, instructionEnd)
+    if (contextOpen < 0 || text.slice(instructionEnd, contextOpen).trim() !== "") {
+      searchFrom = instructionEnd
+      continue
+    }
+
+    const contextBodyStart = contextOpen + SESSION_CONTEXT_OPEN.length
+    const contextClose = text.indexOf(SESSION_CONTEXT_CLOSE, contextBodyStart)
+    if (contextClose < 0) {
+      searchFrom = contextBodyStart
+      continue
+    }
+
+    ranges.push({ start: contextBodyStart, end: contextClose })
+    searchFrom = contextClose + SESSION_CONTEXT_CLOSE.length
+  }
+
+  return ranges
+}
+
+function substituteSessionContextPlaceholders(
+  parts: TextPart[],
+  sessionId: string,
+  timestamp: string,
+): void {
+  let offset = 0
+  const entries: TextEntry[] = []
+  for (const part of parts) {
+    if (part.type !== "text" || !part.text) continue
+    entries.push({ part, text: part.text, start: offset, end: offset + part.text.length })
+    offset += part.text.length
+  }
+
+  const combinedText = entries.map((entry) => entry.text).join("")
+  const ranges = findFrameworkSessionContextRanges(combinedText)
+
+  for (const entry of entries) {
+    let cursor = 0
+    let substituted = ""
+    for (const range of ranges) {
+      const overlapStart = Math.max(entry.start, range.start)
+      const overlapEnd = Math.min(entry.end, range.end)
+      if (overlapStart >= overlapEnd) continue
+
+      const localStart = overlapStart - entry.start
+      const localEnd = overlapEnd - entry.start
+      substituted += entry.text.slice(cursor, localStart)
+      substituted += entry.text.slice(localStart, localEnd).replace(
+        RUNTIME_PLACEHOLDER_PATTERN,
+        (placeholder) => placeholder === "$SESSION_ID" ? sessionId : timestamp,
+      )
+      cursor = localEnd
+    }
+    entry.part.text = substituted + entry.text.slice(cursor)
+  }
 }
 
 function resolveWorktreeContext(
@@ -111,18 +211,15 @@ export function createStartWorkHook(ctx: PluginInput) {
       preferredPlanPath,
     })
 
-    // Substitute placeholders across every text part: on an error-retry path
-    // OpenCode may re-issue the original template alongside the already-
-    // processed text, leaving a second <session-context> block with un-
-    // substituted $SESSION_ID / $TIMESTAMP literals (#4480).
+    // Substitute placeholders in every raw session-context region: on an
+    // error-retry path OpenCode may re-issue the original template alongside
+    // the already-processed text (#4480).
     let firstTextIdx = -1
     let contextAlreadyInjected = false
+    substituteSessionContextPlaceholders(output.parts, sessionId, timestamp)
     for (let i = 0; i < output.parts.length; i++) {
       const part = output.parts[i]
       if (part.type !== "text" || !part.text) continue
-      part.text = part.text
-        .replace(/\$SESSION_ID/g, sessionId)
-        .replace(/\$TIMESTAMP/g, timestamp)
       if (part.text.includes(CONTEXT_INFO_MARKER)) {
         contextAlreadyInjected = true
       }


### PR DESCRIPTION
## Problem

Slash-command templates could emit literal `$SESSION_ID` and `$TIMESTAMP` values. `/handoff` then asked the agent to read a session named `$SESSION_ID`, and `/start-work` retry paths could leave raw runtime placeholders in framework-owned session context.

## Fix

- Substitute `${user_message}`, `$ARGUMENTS`, `$SESSION_ID`, and `$TIMESTAMP` in one atomic template pass so replacement metacharacters and runtime-looking user input remain data.
- Pass the exact OpenCode session ID through both `chat.message` and `command.execute.before`.
- Fail clearly when a session-bound template is executed without a session ID.
- Restrict start-work retry substitution to the framework-owned `<session-context>` immediately following the exact builtin start-work command marker.
- Preserve P5983 conditional trailing-request behavior and P5988 unresolved-file-reference behavior.

## QA And Evidence

- Focused runtime-template regression: **21 passed, 0 failed, 75 assertions**.
- Broader affected suites covering chat/native hooks, start-work, builtin commands, leak guards, and unresolved file references: **227 passed, 0 failed, 516 assertions**.
- `bun run typecheck`: passed.
- Runtime bundle from `packages/omo-opencode/src/index.ts`: passed.
- Full `packages/omo-opencode` suite: **8268 passed, 1 skipped, 2 host-config-dependent unrelated failures**. The exact failing loader test passes **12/12** with isolated `HOME` and XDG roots, without changing product code.
- Real isolated OpenCode drove builtin `/start-work` through both the native command endpoint and `chat.message` against the local plugin/runtime bundle. Both requests proved exact per-session IDs, ISO timestamps, literal `$SESSION_ID`/`$TIMESTAMP`/`$&` preservation in user sections, `@missing-reference` preservation, and start-work context injection.
- Host OpenCode DB remained unchanged at **5751 -> 5751**. QA PIDs, ports, temp roots, and tmux socket directories were all removed.
- OpenCode common self-check, SSE self-test, TUI self-test, and bounded authenticated server smoke passed.
- Independent exact-diff review: **APPROVE**.

## Risk

The change is limited to four auto-slash-command/start-work source and test files. User content is never recursively reprocessed after insertion, and retry compatibility substitution is marker-scoped to framework-owned context.

Fixes #5977
