### PR TITLE
ci(publish): pin npm to 11.18.0 to fix provenance sigstore crash

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -294,7 +294,7 @@ jobs:
 
       - name: Upgrade npm for trusted publishing (>=11.5.1)
         if: steps.check.outputs.skip_all != 'true' && steps.download.outcome == 'success'
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Strip token auth from .npmrc to force OIDC
         if: steps.check.outputs.skip_all != 'true' && steps.download.outcome == 'success'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -494,7 +494,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for trusted publishing (>=11.5.1)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## Summary
The v4.16.1 publish run failed on **all 12 platform publish legs** with `npm error Cannot find module 'sigstore'` during `npm publish --provenance`. Root cause: the workflows do `npm install -g npm@latest`, and the current `@latest` is **npm 12.0.0**, which crashes on the provenance path (missing `sigstore`). Nothing was published (all packages still 4.16.0; no tag/release), so this is a clean unblock.

## Changes
- `publish.yml` + `publish-platform.yml`: pin the trusted-publishing npm upgrade from `npm@latest` → `npm@11.18.0` (latest known-good 11.x; ships `sigstore`, satisfies the ≥11.5.1 trusted-publishing requirement).

## QA & Evidence
- **Diagnosis:** `npm view npm version` = `12.0.0`; failing run 29004818356 logs show `MODULE_NOT_FOUND: Cannot find module 'sigstore'` on every leg, identically (systemic, not transient).
- **Fix rationale:** 11.18.0 predates the 12.0.0 regression and still meets ≥11.5.1. Two-line change, CI-config only, no package code touched.
- **Why sufficient:** the only failing step was the provenance publish under npm 12.0.0; pinning to a sigstore-bearing npm removes that exact failure.

## Risks & Residuals
- CI-only change; no runtime/package impact. Follow-up: revisit `@latest` once npm 12.x fixes the provenance/sigstore packaging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `npm` to `11.18.0` in publish workflows to fix provenance failures caused by `npm` `12.0.0` missing `sigstore`. Restores `npm publish --provenance` and unblocks releases.

- **Bug Fixes**
  - Replace `npm install -g npm@latest` with `npm install -g npm@11.18.0` in `.github/workflows/publish.yml` and `.github/workflows/publish-platform.yml`.
  - `11.18.0` includes `sigstore` and meets the ≥11.5.1 trusted publishing requirement; CI-only change.

<sup>Written for commit 8289997114c9f44d90a919acbbc1f1d604f96946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

