### PR TITLE
fix(omo-opencode): bound parent wake defer

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { ParentWakeNotifier } from "./parent-wake-notifier"
+import {
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "../../hooks/shared/prompt-async-gate"
+
+type PromptAsyncCall = {
+  path: { id: string }
+  body: {
+    noReply?: boolean
+    parts?: unknown[]
+  }
+  query?: {
+    directory: string
+  }
+}
+
+type SessionMessageStub = {
+  info?: {
+    role?: string
+    finish?: string
+    time?: { created?: number; completed?: number }
+  }
+  parts?: Array<{ type?: string; text?: string; synthetic?: boolean; state?: { status?: string } }>
+}
+
+const FINAL_WAKE = [
+  "<system-reminder>",
+  "[BACKGROUND TASK COMPLETED]",
+  "[ALL BACKGROUND TASKS COMPLETE]",
+  "",
+  "**Completed:**",
+  "- `task-a`: task A",
+  "",
+  'Use `background_output(task_id="<id>")` to retrieve each result.',
+  "</system-reminder>",
+].join("\n")
+
+const BLOCKED_MESSAGES: SessionMessageStub[] = [
+  {
+    info: { role: "user", time: { created: 80_000 } },
+    parts: [{ type: "text", text: "start work" }],
+  },
+  {
+    info: { role: "assistant", finish: "tool-calls", time: { created: 99_500 } },
+    parts: [{ type: "tool", state: { status: "running" } }],
+  },
+]
+
+const SAFE_MESSAGES: SessionMessageStub[] = [
+  {
+    info: { role: "user", time: { created: 80_000 } },
+    parts: [{ type: "text", text: "start work" }],
+  },
+  {
+    info: { role: "assistant", finish: "stop", time: { created: 90_000 } },
+    parts: [{ type: "text", text: "delegated to background" }],
+  },
+]
+
+function createNotifier(args: {
+  sessionStatuses: Record<string, { type: string }>
+  messagesProvider: () => SessionMessageStub[]
+}): {
+  notifier: ParentWakeNotifier
+  promptAsyncCalls: PromptAsyncCall[]
+} {
+  const promptAsyncCalls: PromptAsyncCall[] = []
+  const client = createOpencodeClient({ baseUrl: "http://127.0.0.1:1" })
+  Object.assign(client.session, {
+    messages: async () => ({ data: args.messagesProvider() }),
+    status: async () => ({ data: args.sessionStatuses }),
+    promptAsync: async (call: PromptAsyncCall) => {
+      promptAsyncCalls.push(call)
+      return { data: {} }
+    },
+    abort: async () => ({ data: {} }),
+  })
+
+  const notifier = new ParentWakeNotifier(
+    {
+      client,
+      directory: "/tmp/test-omo",
+      enqueueNotificationForParent: async (_sessionID, operation) => {
+        await operation()
+      },
+    },
+    {
+      pendingRetryMs: 1_000,
+      acceptedMessageSkewMs: 5_000,
+      toolCallDeferMaxMs: 5_000,
+      failureRequeueWindowMs: 5_000,
+      userMessageInProgressWindowMs: 2_000,
+    },
+  )
+
+  return { notifier, promptAsyncCalls }
+}
+
+function queueAgedWake(notifier: ParentWakeNotifier): void {
+  notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+  const wake = notifier.getPendingParentWakes().get("parent-1")
+  if (!wake) {
+    throw new Error("expected pending wake")
+  }
+  wake.queuedAt = Date.now() - 120_000
+}
+
+function releaseParentWakeHold(sessionID: string): void {
+  releasePromptAsyncReservation(sessionID, "test:simulate-expired-parent-wake-hold", {
+    reservedBy: "background-agent-parent-wake",
+  })
+}
+
+afterEach(() => {
+  releaseAllPromptAsyncReservationsForTesting()
+})
+
+describe("parent wake active defer ceiling", () => {
+  test("#given safe history and aged wake while parent is busy #then it dispatches a reply", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => SAFE_MESSAGES,
+    })
+    queueAgedWake(notifier)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).not.toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      notifier.shutdown()
+    }
+  })
+
+  test("#given retained noReply wake ages while parent is busy #then it does not force a reply", async () => {
+    // given
+    const originalDateNow = Date.now
+    let now = 100_000
+    Date.now = () => now
+    const sessionStatuses: Record<string, { type: string }> = { "parent-1": { type: "idle" } }
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses,
+      messagesProvider: () => BLOCKED_MESSAGES,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeDefined()
+
+      // when
+      now = 220_000
+      sessionStatuses["parent-1"] = { type: "busy" }
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+    }
+  })
+
+  test("#given fresh user message and aged wake while parent is busy #then it admits noReply", async () => {
+    // given
+    const originalDateNow = Date.now
+    const now = 220_000
+    Date.now = () => now
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => [
+        ...SAFE_MESSAGES,
+        {
+          info: { role: "user", time: { created: now - 100 } },
+          parts: [{ type: "text", text: "real user follow-up" }],
+        },
+      ],
+    })
+    queueAgedWake(notifier)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+    }
+  })
+
+  test("#given blocked tool history and aged wake while parent is busy #then it admits noReply", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => BLOCKED_MESSAGES,
+    })
+    queueAgedWake(notifier)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+    } finally {
+      notifier.shutdown()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
@@ -63,6 +63,7 @@ const SAFE_MESSAGES: SessionMessageStub[] = [
 function createNotifier(args: {
   sessionStatuses: Record<string, { type: string }>
   messagesProvider: () => SessionMessageStub[]
+  parentActivityWindowMs?: number
 }): {
   notifier: ParentWakeNotifier
   promptAsyncCalls: PromptAsyncCall[]
@@ -93,6 +94,7 @@ function createNotifier(args: {
       toolCallDeferMaxMs: 5_000,
       failureRequeueWindowMs: 5_000,
       userMessageInProgressWindowMs: 2_000,
+      parentSessionActivityInProgressWindowMs: args.parentActivityWindowMs,
     },
   )
 
@@ -178,6 +180,41 @@ describe("parent wake active defer ceiling", () => {
     }
   })
 
+  test("#given retained noReply wake and fresh activity exceed active ceiling #then it dispatches once safe", async () => {
+    // given
+    const originalDateNow = Date.now
+    let now = 100_000
+    Date.now = () => now
+    const sessionStatuses: Record<string, { type: string }> = { "parent-1": { type: "idle" } }
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses,
+      messagesProvider: () => SAFE_MESSAGES,
+      parentActivityWindowMs: 180_000,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    notifier.recordParentSessionActivity("parent-1")
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-1")
+      now = 220_000
+      sessionStatuses["parent-1"] = { type: "busy" }
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      notifier.recordParentSessionActivity("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls[1]?.body.noReply).not.toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+    }
+  })
+
   test("#given fresh user message and aged wake while parent is busy #then it admits noReply", async () => {
     // given
     const originalDateNow = Date.now
@@ -227,6 +264,30 @@ describe("parent wake active defer ceiling", () => {
       expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
       expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+    } finally {
+      notifier.shutdown()
+    }
+  })
+
+  test("#given prompt gate sees blocked tool state after active ceiling #then reply stays queued", async () => {
+    // given
+    let messageLoads = 0
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => {
+        messageLoads += 1
+        return messageLoads >= 3 ? BLOCKED_MESSAGES : SAFE_MESSAGES
+      },
+    })
+    queueAgedWake(notifier)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
     } finally {
       notifier.shutdown()
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -1,6 +1,7 @@
 import { tmpdir } from "node:os"
 import { afterEach, describe, expect, test } from "bun:test"
 import type { PluginInput } from "@opencode-ai/plugin"
+import { createOpencodeClient } from "@opencode-ai/sdk"
 import { BackgroundManager } from "./manager"
 import type { BackgroundTask } from "./types"
 import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
@@ -19,6 +20,7 @@ type PromptAsyncCall = {
 type PendingParentWakeForTest = {
   notifications: string[]
   shouldReply: boolean
+  queuedAt?: number
 }
 
 let managerUnderTest: BackgroundManager | undefined
@@ -52,23 +54,23 @@ function createManager(sessionStatuses: Record<string, { type: string }>): {
   promptAsyncCalls: PromptAsyncCall[]
 } {
   const promptAsyncCalls: PromptAsyncCall[] = []
-  const client = {
-    session: {
-      messages: async () => [],
-      status: async () => ({ data: sessionStatuses }),
-      prompt: async () => ({}),
-      promptAsync: async (call: PromptAsyncCall) => {
-        promptAsyncCalls.push(call)
-        return {}
-      },
-      abort: async () => ({}),
+  const client = createOpencodeClient({ baseUrl: "http://127.0.0.1:1" })
+  Object.assign(client.session, {
+    messages: async () => [],
+    status: async () => ({ data: sessionStatuses }),
+    prompt: async () => ({}),
+    promptAsync: async (call: PromptAsyncCall) => {
+      promptAsyncCalls.push(call)
+      return {}
     },
-  }
+    abort: async () => ({}),
+  })
   const ctx: PluginInput = {
-    client: client as PluginInput["client"],
+    client,
     project: {} as PluginInput["project"],
     directory: tmpdir(),
     worktree: tmpdir(),
+    experimental_workspace: { register: () => {} },
     serverUrl: new URL("http://localhost"),
     $: {} as PluginInput["$"],
   }
@@ -132,6 +134,38 @@ describe("BackgroundManager parent wake active turn events", () => {
     // then
     expect(promptAsyncCalls).toHaveLength(0)
     expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+  })
+
+  test("#when active parent turn keeps a reply wake past the defer ceiling #then the wake is dispatched", async () => {
+    // given
+    const sessionStatuses: Record<string, { type: string }> = {
+      "parent-1": { type: "busy" },
+    }
+    const { manager, promptAsyncCalls } = createManager(sessionStatuses)
+    managerUnderTest = manager
+    const task = createTask({
+      id: "task-a",
+      parentSessionId: "parent-1",
+      description: "task A",
+      status: "completed",
+      completedAt: new Date("2026-05-20T14:19:14.625Z"),
+    })
+    getTasks(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+    await notifyParentSessionForTest(manager, task)
+    const pendingWake = getPendingParentWakes(manager).get("parent-1")
+    if (!pendingWake) {
+      throw new Error("expected pending wake after active parent notification")
+    }
+    pendingWake.queuedAt = Date.now() - 120_000
+
+    // when
+    await flushPendingParentWakeForTest(manager, "parent-1")
+
+    // then
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).not.toBe(true)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 
   test("#when duplicate background completions overlap an active parent turn #then one coalesced wake stays queued", async () => {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -136,38 +136,6 @@ describe("BackgroundManager parent wake active turn events", () => {
     expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
   })
 
-  test("#when active parent turn keeps a reply wake past the defer ceiling #then the wake is dispatched", async () => {
-    // given
-    const sessionStatuses: Record<string, { type: string }> = {
-      "parent-1": { type: "busy" },
-    }
-    const { manager, promptAsyncCalls } = createManager(sessionStatuses)
-    managerUnderTest = manager
-    const task = createTask({
-      id: "task-a",
-      parentSessionId: "parent-1",
-      description: "task A",
-      status: "completed",
-      completedAt: new Date("2026-05-20T14:19:14.625Z"),
-    })
-    getTasks(manager).set(task.id, task)
-    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
-    await notifyParentSessionForTest(manager, task)
-    const pendingWake = getPendingParentWakes(manager).get("parent-1")
-    if (!pendingWake) {
-      throw new Error("expected pending wake after active parent notification")
-    }
-    pendingWake.queuedAt = Date.now() - 120_000
-
-    // when
-    await flushPendingParentWakeForTest(manager, "parent-1")
-
-    // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).not.toBe(true)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
-  })
-
   test("#when duplicate background completions overlap an active parent turn #then one coalesced wake stays queued", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
@@ -11,6 +11,7 @@ export type PendingParentWake = {
   promptContext: ParentWakePromptContext
   notifications: string[]
   shouldReply: boolean
+  queuedAt?: number
   dispatchedAt?: number
   noReplyAdmittedAt?: number
   toolCallDeferralStartedAt?: number
@@ -34,6 +35,7 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
     promptContext,
     notifications: [...wake.notifications],
     shouldReply: wake.shouldReply,
+    ...(wake.queuedAt !== undefined ? { queuedAt: wake.queuedAt } : {}),
     ...(wake.dispatchedAt !== undefined ? { dispatchedAt: wake.dispatchedAt } : {}),
     ...(wake.noReplyAdmittedAt !== undefined ? { noReplyAdmittedAt: wake.noReplyAdmittedAt } : {}),
     ...(wake.toolCallDeferralStartedAt !== undefined

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -15,6 +15,8 @@ type ParentWakeFlushRunnerDeps = {
   readonly sessionInspector: ParentWakeSessionInspector
 }
 
+const PENDING_PARENT_WAKE_MAX_ACTIVE_DEFER_MS = 60_000
+
 export class ParentWakeFlushRunner {
   constructor(private readonly deps: ParentWakeFlushRunnerDeps) {}
 
@@ -45,7 +47,20 @@ export class ParentWakeFlushRunner {
     if (await this.dropAdmittedWakeConsumedByParent(sessionID, latestWake)) {
       return
     }
+    const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
     if (sessionActive) {
+      if (this.shouldForceDispatchAfterActiveDefer(latestWake)) {
+        await this.sendParentWakePrompt(sessionID, latestWake, {
+          emptyAssistantTurnRetry,
+          toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+          skipPromptGateStatusCheck: true,
+        })
+        log("[background-agent] Sent parent wake after active-session defer ceiling:", {
+          sessionID,
+          queuedAgeMs: this.getQueuedAgeMs(latestWake),
+        })
+        return
+      }
       this.schedulePendingParentWakeFlush(sessionID)
       log("[background-agent] Deferred parent wake because parent session is active:", {
         sessionID,
@@ -72,7 +87,6 @@ export class ParentWakeFlushRunner {
       return
     }
 
-    const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
     const toolWaitDecision = await this.shouldDeferParentWakeForSessionHistory(sessionID, latestWake)
     if (toolWaitDecision.defer) {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
@@ -200,6 +214,7 @@ export class ParentWakeFlushRunner {
       readonly toolWaitDecision: ToolWaitDeferralDecision
       readonly forceNoReply?: boolean
       readonly retainPendingWake?: boolean
+      readonly skipPromptGateStatusCheck?: boolean
     },
   ): Promise<void> {
     // Mark the dispatch in-flight BEFORE the pending entry is deleted so there is
@@ -221,6 +236,9 @@ export class ParentWakeFlushRunner {
         latestWake,
         ...(options.forceNoReply !== undefined ? { forceNoReply: options.forceNoReply } : {}),
         ...(options.retainPendingWake !== undefined ? { retainPendingWake: options.retainPendingWake } : {}),
+        ...(options.skipPromptGateStatusCheck !== undefined
+          ? { skipPromptGateStatusCheck: options.skipPromptGateStatusCheck }
+          : {}),
         emptyAssistantTurnRetry: options.emptyAssistantTurnRetry,
         toolWaitDecision: options.toolWaitDecision,
         getDispatchedWake: () => this.deps.dispatchedTracker.getWake(sessionID),
@@ -237,6 +255,14 @@ export class ParentWakeFlushRunner {
 
   private async isSessionActive(sessionID: string): Promise<boolean> {
     return isOpenCodeSessionActive(this.deps.notifierDeps.client, sessionID)
+  }
+
+  private shouldForceDispatchAfterActiveDefer(wake: PendingParentWake): boolean {
+    return wake.shouldReply && this.getQueuedAgeMs(wake) >= PENDING_PARENT_WAKE_MAX_ACTIVE_DEFER_MS
+  }
+
+  private getQueuedAgeMs(wake: PendingParentWake): number {
+    return Date.now() - (wake.queuedAt ?? Date.now())
   }
 
   private hasRecentParentSessionActivity(sessionID: string): boolean {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -57,7 +57,7 @@ export class ParentWakeFlushRunner {
       return
     }
 
-    if (this.hasRecentParentSessionActivity(sessionID)) {
+    if (!forceDispatchAfterActiveDefer && this.hasRecentParentSessionActivity(sessionID)) {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -48,19 +48,8 @@ export class ParentWakeFlushRunner {
       return
     }
     const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
-    if (sessionActive) {
-      if (this.shouldForceDispatchAfterActiveDefer(latestWake)) {
-        await this.sendParentWakePrompt(sessionID, latestWake, {
-          emptyAssistantTurnRetry,
-          toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-          skipPromptGateStatusCheck: true,
-        })
-        log("[background-agent] Sent parent wake after active-session defer ceiling:", {
-          sessionID,
-          queuedAgeMs: this.getQueuedAgeMs(latestWake),
-        })
-        return
-      }
+    const forceDispatchAfterActiveDefer = sessionActive && this.shouldForceDispatchAfterActiveDefer(latestWake)
+    if (sessionActive && !forceDispatchAfterActiveDefer) {
       this.schedulePendingParentWakeFlush(sessionID)
       log("[background-agent] Deferred parent wake because parent session is active:", {
         sessionID,
@@ -154,7 +143,14 @@ export class ParentWakeFlushRunner {
     await this.sendParentWakePrompt(sessionID, latestWake, {
       emptyAssistantTurnRetry,
       toolWaitDecision: finalToolWaitDecision,
+      ...(forceDispatchAfterActiveDefer ? { skipPromptGateStatusCheck: true } : {}),
     })
+    if (forceDispatchAfterActiveDefer) {
+      log("[background-agent] Sent parent wake after active-session defer ceiling:", {
+        sessionID,
+        queuedAgeMs: this.getQueuedAgeMs(latestWake),
+      })
+    }
   }
 
   schedulePendingParentWakeFlush(sessionID: string, delayMs?: number): void {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -48,9 +48,11 @@ export class ParentWakePendingQueue {
     promptContext: ParentWakePromptContext,
     shouldReply: boolean,
   ): void {
+    const now = Date.now()
     const resolvedPromptContext = resolveParentWakePromptContext(promptContext)
     const pendingWake = this.pendingParentWakes.get(sessionID)
     if (pendingWake) {
+      pendingWake.queuedAt ??= now
       const mergedNotifications = mergeParentWakeNotifications(pendingWake.notifications, notification)
       const notificationsChanged = mergedNotifications.length !== pendingWake.notifications.length
         || mergedNotifications.some((merged, index) => merged !== pendingWake.notifications[index])
@@ -68,12 +70,17 @@ export class ParentWakePendingQueue {
       promptContext: resolvedPromptContext,
       notifications: [notification],
       shouldReply,
+      queuedAt: now,
     })
   }
 
   requeueWake(sessionID: string, latestWake: PendingParentWake): void {
+    const now = Date.now()
     const pendingWake = this.pendingParentWakes.get(sessionID)
     if (pendingWake) {
+      const existingQueuedAt = pendingWake.queuedAt ?? now
+      const latestQueuedAt = latestWake.queuedAt ?? now
+      pendingWake.queuedAt = Math.min(existingQueuedAt, latestQueuedAt)
       pendingWake.notifications = pendingWake.notifications.reduce(
         (notifications, notification) => mergeParentWakeNotifications(notifications, notification),
         [...latestWake.notifications],
@@ -92,7 +99,9 @@ export class ParentWakePendingQueue {
       }
       return
     }
-    this.pendingParentWakes.set(sessionID, cloneParentWake(latestWake))
+    const clonedWake = cloneParentWake(latestWake)
+    clonedWake.queuedAt ??= now
+    this.pendingParentWakes.set(sessionID, clonedWake)
   }
 
   scheduleFlush(sessionID: string, operation: () => Promise<void>, delayMs?: number): void {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -18,6 +18,7 @@ type ParentWakePromptDispatchInput = {
   readonly latestWake: PendingParentWake
   readonly forceNoReply?: boolean
   readonly retainPendingWake?: boolean
+  readonly skipPromptGateStatusCheck?: boolean
   readonly emptyAssistantTurnRetry: boolean
   readonly toolWaitDecision: ToolWaitDeferralDecision
   readonly getDispatchedWake: () => PendingParentWake | undefined
@@ -42,7 +43,7 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
         : {}),
       settleMs: 0,
       queueBehavior: "defer",
-      checkStatus: input.forceNoReply !== true,
+      checkStatus: input.forceNoReply !== true && input.skipPromptGateStatusCheck !== true,
       checkToolState: input.forceNoReply !== true && !input.toolWaitDecision.skipPromptGateToolStateCheck,
       input: {
         path: { id: input.sessionID },


### PR DESCRIPTION
## Summary

- Add a bounded active-session defer ceiling for reply-required background parent wakes.
- Track when each pending parent wake was first queued and preserve that timestamp through merge/requeue paths.
- After a reply-required wake has waited at least 60s while the parent remains active, allow one reply-producing wake through the active/fresh-activity loop while preserving retained noReply, user-message, and tool-history safety guards.
- Keep normal active-turn deferral before the ceiling and preserve live-listener routing for OpenCode serve topology.

Fixes #5864.
Refs #5569, #5790.

## Why

The Discord report says that after all background tasks complete, OpenCode/ULW does not continue by itself and needs a manual nudge. The related GitHub issues describe the same parent-wake family: a reply-required parent wake is persisted, but no assistant turn starts. The missing case on current `dev` was a continuously active/busy parent session: every retry saw the parent as active or freshly active, requeued the reply-required wake, and could defer forever.

## Changes

- Add `queuedAt` to pending parent wakes and preserve it through clone, merge, and requeue paths.
- Add a 60s active-session defer ceiling for reply-required wakes.
- Route over-ceiling wakes through the existing safety checks first, then skip only the final prompt-gate status check for the reply dispatch.
- Bypass the fresh parent-activity noReply admission only after the active defer ceiling has elapsed, so a retained all-complete wake cannot loop forever on fresh activity.
- Add focused regression coverage for the ceiling and its safety guardrails.

## QA / Evidence

Evidence directory: `.omo/evidence/20260709-ulw-resume/` (local, ignored by git by repo policy).

- `active-defer-ceiling-after-guardrail-fix.log`: focused active-defer suite passed, `6 pass`, `0 fail`; covers fresh parent activity after retained noReply and blocked tool-state after the ceiling.
- `targeted-tests-after-fresh-activity-fix.log`: targeted parent-wake/live-route suite passed, `92 pass`, `0 fail`.
- `typecheck-after-fresh-activity-fix.log`: `bun run typecheck` passed.
- `test-senpi-after-fresh-activity-fix.log`: `bun run test:senpi` passed, `151 pass`, `0 fail`.
- `serve-wake-split-after-fresh-activity-fix.log`: isolated OpenCode serve + fake model harness returned `RESULT=FIXED`, `terminal_stops=1`, `child_task_sessions=1`, `route_live_dispatch=true`, and real DB count unchanged (`5751 -> 5751`).
- `manual-qa-after-fresh-activity-fix.log`: direct retained-wake fresh-activity driver observed `{"promptAsyncCalls":2,"firstNoReply":true,"secondNoReply":false,"pendingWakeRemaining":false}` and `MANUAL_QA_PASS`.
- `diff-check-after-fresh-activity-fix.log`: `git diff --check` clean.
- `no-excuse-after-fresh-activity-fix.log`: changed fresh-fix files contain no forbidden TypeScript/test escape hatches.

## Risk

The over-ceiling path is deliberately narrow: it applies only to reply-required wakes after 60s of active-session deferral. Retained noReply, fresh user-message, and blocked tool-history cases still admit noReply or keep the wake queued instead of forcing a reply. The isolated serve probe covers the live-listener route so this does not regress the OpenCode serve split topology.
