### PR TITLE
fix(release): stamp omo-senpi version in lockstep with root

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -410,13 +410,15 @@ jobs:
           jq --arg v "$VERSION" '.optionalDependencies = (.optionalDependencies | to_entries | map(.value = $v) | from_entries)' package.json > tmp.json && mv tmp.json package.json
 
           node packages/omo-codex/plugin/scripts/sync-version.mjs
+          jq --arg v "$VERSION" '.version = $v' packages/omo-senpi/package.json > tmp.json && mv tmp.json packages/omo-senpi/package.json
+          node packages/omo-senpi/plugin/scripts/sync-version.mjs
           node packages/omo-codex/plugin/scripts/sync-hook-status-messages.mjs
           npm --prefix packages/omo-codex/plugin install --package-lock-only --ignore-scripts --no-audit --fund=false
           bun install --lockfile-only
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add package.json packages/oh-my-opencode-*/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/package-lock.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
+          git add package.json packages/oh-my-opencode-*/package.json packages/omo-senpi/package.json packages/omo-senpi/plugin/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/package-lock.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
           git diff --cached --quiet || git commit -m "release: v${VERSION}"
           git push --force-with-lease origin "HEAD:${RELEASE_BRANCH}"
 
@@ -868,6 +870,8 @@ jobs:
           jq --arg v "$VERSION" '.optionalDependencies = (.optionalDependencies | to_entries | map(.value = $v) | from_entries)' package.json > tmp.json && mv tmp.json package.json
 
           node packages/omo-codex/plugin/scripts/sync-version.mjs
+          jq --arg v "$VERSION" '.version = $v' packages/omo-senpi/package.json > tmp.json && mv tmp.json packages/omo-senpi/package.json
+          node packages/omo-senpi/plugin/scripts/sync-version.mjs
           node packages/omo-codex/plugin/scripts/sync-hook-status-messages.mjs
           npm --prefix packages/omo-codex/plugin install --package-lock-only --ignore-scripts --no-audit --fund=false
           bun install --lockfile-only
@@ -879,7 +883,7 @@ jobs:
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add package.json packages/oh-my-opencode-*/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/package-lock.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
+          git add package.json packages/oh-my-opencode-*/package.json packages/omo-senpi/package.json packages/omo-senpi/plugin/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/package-lock.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
           git diff --cached --quiet || git commit -m "release: v${VERSION}"
 
       - name: Create release tag

--- a/packages/omo-senpi/package.json
+++ b/packages/omo-senpi/package.json
@@ -1,48 +1,48 @@
 {
-	"name": "@oh-my-opencode/omo-senpi",
-	"version": "4.16.0",
-	"type": "module",
-	"private": true,
-	"description": "Senpi harness adapter for oh-my-openagent.",
-	"exports": {
-		".": {
-			"types": "./src/index.ts",
-			"import": "./src/index.ts"
-		},
-		"./install": {
-			"types": "./src/install/index.ts",
-			"import": "./src/install/index.ts"
-		},
-		"./extension": {
-			"types": "./src/index.ts",
-			"import": "./src/index.ts"
-		}
-	},
-	"types": "./src/index.ts",
-	"scripts": {
-		"typecheck": "tsgo --noEmit -p tsconfig.json",
-		"test": "bun test src/**/*.test.ts"
-	},
-	"dependencies": {
-		"@oh-my-opencode/utils": "workspace:*",
-		"@oh-my-opencode/comment-checker-core": "workspace:*",
-		"@oh-my-opencode/telemetry-core": "workspace:*",
-		"@oh-my-opencode/prompts-core": "workspace:*",
-		"@oh-my-opencode/senpi-task": "workspace:*",
-		"@oh-my-opencode/omo-config-core": "workspace:*",
-		"@oh-my-opencode/delegate-core": "workspace:*",
-		"@oh-my-opencode/team-core": "workspace:*",
-		"vscode-jsonrpc": "^8.2.1"
-	},
-	"peerDependencies": {
-		"@code-yeongyu/senpi": "2026.7.5-2"
-	},
-	"peerDependenciesMeta": {
-		"@code-yeongyu/senpi": {
-			"optional": true
-		}
-	},
-	"devDependencies": {
-		"@code-yeongyu/senpi": "2026.7.5-2"
-	}
+  "name": "@oh-my-opencode/omo-senpi",
+  "version": "4.16.1",
+  "type": "module",
+  "private": true,
+  "description": "Senpi harness adapter for oh-my-openagent.",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./install": {
+      "types": "./src/install/index.ts",
+      "import": "./src/install/index.ts"
+    },
+    "./extension": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "test": "bun test src/**/*.test.ts"
+  },
+  "dependencies": {
+    "@oh-my-opencode/utils": "workspace:*",
+    "@oh-my-opencode/comment-checker-core": "workspace:*",
+    "@oh-my-opencode/telemetry-core": "workspace:*",
+    "@oh-my-opencode/prompts-core": "workspace:*",
+    "@oh-my-opencode/senpi-task": "workspace:*",
+    "@oh-my-opencode/omo-config-core": "workspace:*",
+    "@oh-my-opencode/delegate-core": "workspace:*",
+    "@oh-my-opencode/team-core": "workspace:*",
+    "vscode-jsonrpc": "^8.2.1"
+  },
+  "peerDependencies": {
+    "@code-yeongyu/senpi": "2026.7.5-2"
+  },
+  "peerDependenciesMeta": {
+    "@code-yeongyu/senpi": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@code-yeongyu/senpi": "2026.7.5-2"
+  }
 }

--- a/packages/omo-senpi/plugin/package.json
+++ b/packages/omo-senpi/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-yeongyu/omo-senpi",
-  "version": "4.16.0",
+  "version": "4.16.1",
   "private": true,
   "description": "OMO Senpi adapter packaged as one local-path Pi package.",
   "type": "module",


### PR DESCRIPTION
## Summary
The v4.16.1 publish run failed the `omo-senpi` plugin-manifest **lockstep test** (`Expected: "4.16.1"`, got 4.16.0), blocking the release. Root cause: `prepare-release-state` stamps root + `oh-my-opencode-*` + `omo-codex` manifests but **never bumps `packages/omo-senpi`**, so after any version bump omo-senpi falls out of lockstep with root.

## Changes
- **Workflow** (`publish.yml`): wire omo-senpi stamping into BOTH the `prepare-release-state` and the `release` re-stamp blocks — bump `packages/omo-senpi/package.json` to `$VERSION` and run its own `sync-version.mjs` (propagates to the plugin manifest), plus add both manifests to the release `git add` list.
- **Manifests**: bump `packages/omo-senpi/package.json` and `packages/omo-senpi/plugin/package.json` to `4.16.1` to restore lockstep and unblock v4.16.1.

## QA & Evidence
- **Before:** `bun test packages/omo-senpi/src/plugin-manifest.test.ts packages/omo-senpi/src/package-shape.test.ts` → 2 fail (version mismatch 4.16.0 vs root 4.16.1).
- **After (this branch, deps linked):** same command → **6 pass / 0 fail / 29 expect() calls**.
- **YAML:** `publish.yml` parses cleanly (bun `yaml.parse`).
- **Why sufficient:** reproduces the exact CI failure and shows the version bump + workflow wiring resolves it; the workflow change prevents recurrence on future bumps.

## Risks & Residuals
- Release-workflow-only + version manifests; no runtime/package-code change. omo-senpi is a private package (not npm-published), so this only affects the in-repo lockstep contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release workflow to keep `@oh-my-opencode/omo-senpi` in lockstep with the root version, unblocking v4.16.1 by resolving the plugin-manifest test failure. Also bumps both `omo-senpi` manifests to `4.16.1` to restore consistency.

- **Bug Fixes**
  - Update `.github/workflows/publish.yml` to stamp `packages/omo-senpi/package.json` with `$VERSION` and run `packages/omo-senpi/plugin/scripts/sync-version.mjs` in both prepare and release steps.
  - Add `packages/omo-senpi/package.json` and `packages/omo-senpi/plugin/package.json` to the release `git add` set.
  - Bump `@oh-my-opencode/omo-senpi` and `@code-yeongyu/omo-senpi` to `4.16.1`; plugin-manifest lockstep test now passes.

<sup>Written for commit 2f6d99fd25db56ac0e8a6f89074ce598a348ada1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

