### PR TITLE
fix(delegate-task): remove duplicate `<available_skills>` injection from task() subagent system prompts

### DIFF
--- a/packages/omo-opencode/src/tools/delegate-task/native-skill-prompt-filter.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/native-skill-prompt-filter.test.ts
@@ -28,14 +28,6 @@ function nativeSkill(name: string, description: string): NativeSkillEntry {
   }
 }
 
-function requireSkillContent(value: string | undefined): string {
-  expect(value).toBeDefined()
-  if (value === undefined) {
-    throw new Error("Expected captured delegate skill content")
-  }
-  return value
-}
-
 describe("createDelegateTask native skill prompt filtering", () => {
   afterEach(() => {
     mock.restore()
@@ -43,7 +35,7 @@ describe("createDelegateTask native skill prompt filtering", () => {
     releaseAllPromptAsyncReservationsForTesting()
   })
 
-  it("#given disabled and protected native skills #when delegate system content is built #then hostile native descriptions are excluded", async () => {
+  it("#given native skills and a non-plan target #when delegate system content is built #then native descriptions are omitted", async () => {
     // given
     __setTimingConfig({
       POLL_INTERVAL_MS: 10,
@@ -167,12 +159,7 @@ describe("createDelegateTask native skill prompt filtering", () => {
     )
 
     // then
-    const skillContent = requireSkillContent(capturedLaunch?.skillContent)
-    expect(skillContent).toContain("safe-native-skill")
-    expect(skillContent).toContain("Safe native guidance")
-    expect(skillContent).not.toContain("blocked-native-skill")
-    expect(skillContent).not.toContain("BLOCKED_NATIVE_PROMPT_INJECTION")
-    expect(skillContent).not.toContain("DISABLED_SHARED_ALIAS_INJECTION")
-    expect(skillContent).not.toContain("IGNORE_ALL_PRIOR_INSTRUCTIONS")
+    expect(capturedLaunch).toBeDefined()
+    expect(capturedLaunch?.skillContent).toBeUndefined()
   })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/prompt-builder.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/prompt-builder.test.ts
@@ -20,7 +20,7 @@ import type { AvailableSkill, AvailableCategory } from "../../agents/dynamic-age
 describe("prompt-builder", () => {
   describe("buildSystemContent", () => {
     describe("#given non-plan agent with availableSkills", () => {
-      test("#when availableSkills contains project-level skills #then system content includes available_skills section", () => {
+      test("#when availableSkills contains project-level skills #then system content omits skill list section", () => {
         // given
         const availableSkills: AvailableSkill[] = [
           { name: "git-master", description: "Git workflow automation", location: "plugin" },
@@ -38,12 +38,10 @@ describe("prompt-builder", () => {
         })
 
         // then
-        expect(result).toBeDefined()
-        expect(result).toContain("my-project-skill")
-        expect(result).toContain("git-master")
+        expect(result).toBeUndefined()
       })
 
-      test("#when agent is explore #then system content includes available_skills section", () => {
+      test("#when agent is explore #then system content omits skill list section", () => {
         // given
         const availableSkills: AvailableSkill[] = [
           { name: "review-work", description: "Review code quality", location: "project" },
@@ -56,8 +54,7 @@ describe("prompt-builder", () => {
         })
 
         // then
-        expect(result).toBeDefined()
-        expect(result).toContain("review-work")
+        expect(result).toBeUndefined()
       })
 
       test("#when availableSkills is empty #then system content does not include available_skills section", () => {
@@ -102,7 +99,7 @@ describe("prompt-builder", () => {
     })
 
     describe("#given non-plan agent with agentsContext override", () => {
-      test("#when agentsContext is provided #then it takes precedence and skills section is appended", () => {
+      test("#when agentsContext is provided #then it is preserved without appending skills section", () => {
         // given
         const availableSkills: AvailableSkill[] = [
           { name: "deploy-skill", description: "Deployment automation", location: "project" },
@@ -118,14 +115,14 @@ describe("prompt-builder", () => {
         // then
         expect(result).toBeDefined()
         expect(result).toContain("Custom agent context here")
-        expect(result).toContain("deploy-skill")
+        expect(result).not.toContain("deploy-skill")
       })
     })
   })
 })
 
 describe("buildSystemContent — nativeSkillInfos merging", () => {
-  test("#given a nativeSkill name not in availableSkills #when block is built #then native name appears", () => {
+  test("#given plan agent and a nativeSkill name not in availableSkills #when block is built #then native name appears", () => {
     // given
     const availableSkills: AvailableSkill[] = [
       { name: "omo-skill", description: "From OMO disk", location: "project" },
@@ -136,19 +133,20 @@ describe("buildSystemContent — nativeSkillInfos merging", () => {
 
     // when
     const result = buildSystemContent({
-      agentName: "explore",
+      agentName: "plan",
       availableSkills,
       nativeSkillInfos,
     })
 
     // then
     expect(result).toBeDefined()
+    expect(result).toContain("AVAILABLE SKILLS")
     expect(result).toContain("omo-skill")
     expect(result).toContain("test-driven-development")
     expect(result).toContain("TDD discipline")
   })
 
-  test("#given a name in BOTH availableSkills AND nativeSkillInfos #when block is built #then OMO description wins", () => {
+  test("#given plan agent and a name in BOTH availableSkills AND nativeSkillInfos #when block is built #then OMO description wins", () => {
     // given
     const availableSkills: AvailableSkill[] = [
       { name: "shared", description: "omo-version-of-shared", location: "project" },
@@ -159,7 +157,7 @@ describe("buildSystemContent — nativeSkillInfos merging", () => {
 
     // when
     const result = buildSystemContent({
-      agentName: "explore",
+      agentName: "plan",
       availableSkills,
       nativeSkillInfos,
     })
@@ -170,7 +168,25 @@ describe("buildSystemContent — nativeSkillInfos merging", () => {
     expect(result).not.toContain("native-version-of-shared")
   })
 
-  test("#given empty availableSkills and a nativeSkillInfo #when block is built #then native skill renders", () => {
+  test("#given plan agent with empty availableSkills and a nativeSkillInfo #when block is built #then native skill renders", () => {
+    // given
+    const nativeSkillInfos = [
+      { name: "brainstorming", description: "Use before any creative work", location: "/fake/SKILL.md" },
+    ]
+
+    // when
+    const result = buildSystemContent({
+      agentName: "plan",
+      availableSkills: [],
+      nativeSkillInfos,
+    })
+
+    // then
+    expect(result).toBeDefined()
+    expect(result).toContain("brainstorming")
+  })
+
+  test("#given non-plan agent and a nativeSkillInfo #when block is built #then native skill is omitted", () => {
     // given
     const nativeSkillInfos = [
       { name: "brainstorming", description: "Use before any creative work", location: "/fake/SKILL.md" },
@@ -184,7 +200,6 @@ describe("buildSystemContent — nativeSkillInfos merging", () => {
     })
 
     // then
-    expect(result).toBeDefined()
-    expect(result).toContain("brainstorming")
+    expect(result).toBeUndefined()
   })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/prompt-builder.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/prompt-builder.ts
@@ -37,22 +37,6 @@ function mergeNativeIntoAvailable(
   return merged
 }
 
-function buildAvailableSkillsSection(skills: AvailableSkill[]): string {
-  if (skills.length === 0) {
-    return ""
-  }
-
-  const rows = skills
-    .map((s) => `- \`${s.name}\`: ${s.description || s.name}`)
-    .join("\n")
-
-  return `<available_skills>
-Skills provide specialized instructions. Load via load_skills parameter when delegating tasks.
-
-${rows}
-</available_skills>`
-}
-
 function usesFreeOrLocalModel(model: { providerID: string; modelID: string; variant?: string } | undefined): boolean {
   if (!model) {
     return false
@@ -91,14 +75,7 @@ export function buildSystemContent(input: BuildSystemContentInput): string | und
     ? buildPlanAgentSystemPrepend(availableCategories, effectiveAvailableSkills)
     : ""
 
-  const skillsSection = !isPlan
-    ? buildAvailableSkillsSection(effectiveAvailableSkills)
-    : ""
-
-  const baseAgentsContext = agentsContext ?? planAgentPrepend
-  const effectiveAgentsContext = !isPlan && skillsSection
-    ? [baseAgentsContext, skillsSection].filter(Boolean).join("\n\n")
-    : baseAgentsContext
+  const effectiveAgentsContext = agentsContext ?? planAgentPrepend
 
   const effectiveMaxPromptTokens = maxPromptTokens
     ?? (usesFreeOrLocalModel(model) ? FREE_OR_LOCAL_PROMPT_TOKEN_LIMIT : undefined)

--- a/packages/omo-opencode/src/tools/delegate-task/types.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/types.ts
@@ -136,6 +136,5 @@ export interface BuildSystemContentInput {
   agentName?: string
   availableCategories?: AvailableCategory[]
   availableSkills?: AvailableSkill[]
-  /** OpenCode native skill list to merge into the <available_skills> block. */
   nativeSkillInfos?: { name: string; description: string; location: string }[]
 }


### PR DESCRIPTION
## Summary

* Stop injecting the oMo-generated `<available_skills>` section into system prompts for sub-agents called through the `task()` tool.
* This duplicate injection was causing unnecessary context usage: roughly 6,000 extra tokens from oMo-provided skills alone, and even more when user-defined skills were present.
* At the moment, all necessary skill information is already included in the `description` of the `skill` tool, so injecting another oMo-generated `<available_skills>` section into the system prompt is unnecessary. This appears to be leftover behavior from an older implementation path.
* The `AVAILABLE SKILLS` table for the `plan` agent is preserved.
* The skill body injection path through `load_skills[]` is also preserved.

## Changes

### Core Implementation

* **`packages/omo-opencode/src/tools/delegate-task/prompt-builder.ts`**

  * Removed `buildAvailableSkillsSection()`, which generated the non-plan-agent `<available_skills>` XML section.
  * Removed the `skillsSection` generation and append path from `buildSystemContent()` for non-plan agents.
  * Kept `mergeNativeIntoAvailable()` for the `plan` agent's `AVAILABLE SKILLS` table.
  * Simplified `effectiveAgentsContext` calculation to `agentsContext ?? planAgentPrepend`.

### Type Definitions

* **`packages/omo-opencode/src/tools/delegate-task/types.ts`**

  * Removed the outdated JSDoc comment on `BuildSystemContentInput.nativeSkillInfos` that referred to merging into an `<available_skills>` block.
  * Kept the field itself because it is still used for the `plan` agent path.

### Test Updates

* **`packages/omo-opencode/src/tools/delegate-task/prompt-builder.test.ts`**

  * Updated tests to verify that non-plan agents such as `sisyphus-junior` and `explore` no longer include skill lists in system content.
  * Added coverage to verify that the `plan` agent (`agentName: "plan"`) still preserves the `AVAILABLE SKILLS` table and native skill merge behavior.
  * Updated the `agentsContext` test to verify that provided agent context is preserved without appending a skill section.
  * All 10 tests pass.

* **`packages/omo-opencode/src/tools/delegate-task/native-skill-prompt-filter.test.ts`**

  * Updated the test to verify that native skill descriptions are not included in system content for a non-plan target such as `explore`.
  * All 1 test passes.

## QA & Evidence

<!-- For each command or manual QA action: what was tested, what you observed, where the saved artifact/log lives, and why that evidence is sufficient. Link sanitized artifacts under .omo/evidence/ when applicable. Do not paste raw secret-bearing logs, env dumps, tokens, auth headers, or private credentials. -->

- **What was tested:** <!-- command or surface driven -->
  **Observed result:** <!-- actual result -->
  **Artifact:** <!-- saved sanitized artifact/log path -->
  **Why sufficient:** <!-- covered behavior or risk -->

## Risks & Residuals

### Unit Tests

* **What was tested:** Unit tests for the changed files and related skill resolution paths.

  **Observed result:**

  * `prompt-builder.test.ts`: 10 pass, 0 fail, 23 `expect()` calls
  * `native-skill-prompt-filter.test.ts`: 1 pass, 0 fail
  * `skill-resolver.test.ts`: 14 pass, verifying that the `load_skills` resolution path still works
  * `skill-context-shared-skill.test.ts`: 19 pass, verifying that shared skill integration still works
  * `tools.test.ts`: 133 pass, 0 fail

  **Why sufficient:** These tests verify that duplicate skill injection is removed for non-plan agents while the `plan` agent path remains intact.

### Build Verification

* **What was tested:** Build through `bun install`.

  **Observed result:** Build succeeded. `bun run build` is executed internally.

  **Why sufficient:** TypeScript type checking and build verification passed.

### LSP Diagnostics

* **What was tested:** LSP diagnostics for the four changed files.

  **Observed result:** No error diagnostics in any changed file. Biome still reports an `organizeImports` hint, but import auto-sorting was intentionally avoided to keep this PR minimal.

  **Why sufficient:** There are no type errors. The remaining diagnostic is only a non-functional import ordering suggestion, and this PR intentionally avoids unrelated formatting diffs.

### Real OpenCode QA

* **What was tested:** After building locally, I called the `librarian` sub-agent through the `task()` tool and captured the actual API request payload through a proxy.

  **Observed result:**

  * The `librarian` sub-agent call succeeded.

  * The sub-agent returned a normal response.

  * Inspecting the captured JSON payload showed:

    * **Before this fix:** two `<available_skills>` tag sections were present.
    * **After this fix:** only one `<available_skills>` tag section remained.

  * The duplicated oMo-generated `<available_skills>` section, which started with the following text, was fully removed:

    ```text
    Skills provide specialized instructions. Load via load_skills parameter when delegating tasks.
    ```

  * The removed section used a Markdown list format and contained duplicated skill names and descriptions.

  **Artifact:** Locally captured JSON payload. Not externally shareable.

  **Why sufficient:** This confirms at the actual API request level that the duplicate injection is gone in a real OpenCode environment.

### Review Work

* **What was tested:** A 5-lane parallel review equivalent to `shared/review-work`.

  **Observed result:** All 5 lanes passed.

  * Goal & Constraint Verification: PASS — requirements are satisfied.
  * QA Execution: PASS — test coverage is sufficient.
  * Code Quality: PASS — no blocking issues found.
  * Security: PASS — no new security risks found.
  * Context Mining: PASS — no missed requirements found.

  **Why sufficient:** The change was reviewed from multiple angles and no blocking issue was found.

## Risks & Residuals

### Residual Risks

1. **OpenCode upstream `<available_skills>` injection**

   * **Conclusion:** mitigated
   * **Reason:** The duplicate oMo-generated section has been removed, but the OpenCode-upstream `<available_skills>` section remains. This is separate from the `skill` tool description and is outside the scope of this PR. Real payload inspection confirmed that only one `<available_skills>` section remains after this change.

2. **`nativeSkillInfos` is still generated in the non-plan path in `tools.ts`**

   * **Conclusion:** accepted
   * **Reason:** `buildPromptNativeSkillInfos()` still runs for non-plan agent calls and creates `nativeSkillInfos`, but `buildSystemContent()` no longer consumes it for non-plan agents. This is now dead work for non-plan agents, but the path is preserved because it is still needed for the `plan` agent's `AVAILABLE SKILLS` table. This can be cleaned up separately in a future PR.
   * **Evidence:** `packages/omo-opencode/src/tools/delegate-task/tools.ts:107, 118, 192, 215`

3. **`AVAILABLE SKILLS` reinjection in the plan continuation path**

   * **Conclusion:** not applicable
   * **Reason:** The continuation-path `buildSystemContent()` call at `tools.ts:113` does not pass `agentName`, so the `AVAILABLE SKILLS` table is not reinjected when continuing a plan session. This is existing behavior and remains unchanged by this PR. It should be fine as long as the existing session context is preserved.
   * **Evidence:** `packages/omo-opencode/src/tools/delegate-task/tools.ts:113-119`

### Mitigated Risk

* **Context usage:** Removing the duplicate injection saves roughly 6,000 tokens from oMo-provided skills alone, and more when user-defined skills are present.

## Automated Checks

### Commands Run

```bash
# Build
bun install  # internally runs bun run build

# Tests
bun test packages/omo-opencode/src/tools/delegate-task/prompt-builder.test.ts
bun test packages/omo-opencode/src/tools/delegate-task/native-skill-prompt-filter.test.ts
bun test packages/omo-opencode/src/tools/delegate-task/skill-resolver.test.ts
bun test packages/omo-opencode/src/plugin/skill-context-shared-skill.test.ts

# LSP diagnostics
# Checked these files:
# - packages/omo-opencode/src/tools/delegate-task/prompt-builder.ts
# - packages/omo-opencode/src/tools/delegate-task/prompt-builder.test.ts
# - packages/omo-opencode/src/tools/delegate-task/native-skill-prompt-filter.test.ts
# - packages/omo-opencode/src/tools/delegate-task/types.ts

# Git diff check
git diff --check -- packages/omo-opencode/src/tools/delegate-task/prompt-builder.ts packages/omo-opencode/src/tools/delegate-task/prompt-builder.test.ts packages/omo-opencode/src/tools/delegate-task/native-skill-prompt-filter.test.ts packages/omo-opencode/src/tools/delegate-task/types.ts
```

### Commands Not Run

* `bun test` full suite: not run. Only related tests were run.

  **Reason:** This change is limited to the `delegate-task` path, so related tests and LSP diagnostics were considered sufficient.

## Related Issues

Closes #5999

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate `<available_skills>` injection for sub-agents called via `task()`, keeping only the `plan` agent’s `AVAILABLE SKILLS` table. This cuts prompt size by ~6k tokens and relies on `skill` tool descriptions and `load_skills` for skill info.

- **Bug Fixes**
  - Removed non-`plan` `<available_skills>` generation in `delegate-task`; non-plan system prompts no longer add skill lists or native skill descriptions.
  - Kept `plan` agent table and native-skill merge; simplified context handling to `agentsContext ?? planAgentPrepend`.
  - Updated tests to verify omission for non-plan agents and retention for `plan`; cleaned up an outdated JSDoc in `types`.

<sup>Written for commit 7265aeacb7068a6c674c4f42b78cdab9fdc8a0dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

