### PR TITLE
feat: upgrade momus to gpt-5.6-sol xhigh with GPT-5.6 tuned prompt

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -209,7 +209,7 @@ Used by: Hephaestus, Oracle, Momus, `deep`, `ultrabrain`, `quick`, Prometheus (G
 
 | Priority | Model | Provider | Why |
 |---|---|---|---|
-| 1 | `gpt-5.6-sol` (xhigh / high / medium) | `openai`, `vercel` | The GPT-5.6 flagship. New default for Hephaestus (medium), `deep` (high), and `ultrabrain` (xhigh). |
+| 1 | `gpt-5.6-sol` (xhigh / high / medium) | `openai`, `vercel` | The GPT-5.6 flagship. New default for Hephaestus (medium), Momus (xhigh), `deep` (high), and `ultrabrain` (xhigh). |
 | 2 | `gpt-5.5` / `gpt-5.4` (pro / xhigh / high / medium) | `openai`, `github-copilot`, `opencode`, `vercel` | Previous flagship generation; first fallback on providers without GPT-5.6. Hephaestus requires this family. |
 | 3 | `gpt-5.5-codex` | same | Still the deep-coding powerhouse. Kept as an explicit override option. |
 | 3 | **DeepSeek — LIMITED ALTERNATIVE** (`deepseek-v3.2`, `deepseek-chat-v3.1`) | `openrouter/deepseek` | Closest OSS equivalent for autonomous coding behavior. Not wired into default chains — add via `fallback_models`. |
@@ -272,7 +272,7 @@ These agents are built for GPT's principle-driven style. Their prompts assume au
 |---|---|---|
 | **Hephaestus** | Autonomous deep worker | `openai\|vercel/gpt-5.6-sol` (medium) → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (medium) — GPT-only chain, requires one of those providers. The craftsman. |
 | **Oracle** | Architecture consultant | `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (high) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `opencode-go\|vercel/glm-5.2` |
-| **Momus** | Ruthless reviewer | `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (xhigh) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `opencode-go\|vercel/glm-5.2` |
+| **Momus** | Ruthless reviewer | `openai\|vercel/gpt-5.6-sol` (xhigh) → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (xhigh) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `opencode-go\|vercel/glm-5.2` |
 
 ### Utility Runners → Speed over Intelligence
 
@@ -311,7 +311,8 @@ Principle-driven, explicit reasoning, deep technical capability. Best for agents
 | Model             | Strengths                                                                                       |
 | ----------------- | ----------------------------------------------------------------------------------------------- |
 | **GPT-5.5 Codex** | Deep coding powerhouse. Autonomous exploration. Still available for deep category and explicit overrides. |
-| **GPT-5.5**       | High intelligence, strategic reasoning. Default for Oracle, Momus, and a key fallback for Prometheus / Atlas. Uses xhigh variant for Momus. |
+| **GPT-5.6 Sol**   | The GPT-5.6 flagship. Default for Hephaestus (medium) and Momus (xhigh); default for the `deep` / `ultrabrain` categories. |
+| **GPT-5.5**       | High intelligence, strategic reasoning. Default for Oracle, first fallback for Momus (xhigh) and Hephaestus, and a key fallback for Prometheus / Atlas. |
 | **GPT-5.4 Mini**  | Fast + strong reasoning. Good for lightweight autonomous tasks. Default for quick category. |
 | **GPT-5-Nano**    | Ultra-cheap, fast. Good for simple utility tasks.                                               |
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -589,9 +589,9 @@ Priority: **Claude > GPT > Claude-like models**
 
 | Agent          | Role                   | Default Chain                          | Notes                                                  |
 | -------------- | ---------------------- | -------------------------------------- | ------------------------------------------------------ |
-| **Hephaestus** | Deep autonomous worker | GPT-5.5 (medium) only                  | "Codex on steroids." No fallback. Requires GPT access. |
+| **Hephaestus** | Deep autonomous worker | openai\|vercel/gpt-5.6-sol (medium) → openai\|github-copilot\|opencode/gpt-5.5 (medium) | "Codex on steroids." GPT-only chain. Requires GPT access. |
 | **Oracle**     | Architecture/debugging | openai\|github-copilot\|opencode/gpt-5.5 (high) → google\|github-copilot\|opencode/gemini-3.1-pro (high) → anthropic\|github-copilot\|opencode/claude-opus-4-7 (max) → opencode-go/glm-5.2 | High-IQ strategic backup. GPT preferred. |
-| **Momus**      | High-accuracy reviewer | openai\|github-copilot\|opencode/gpt-5.5 (xhigh) → anthropic\|github-copilot\|opencode/claude-opus-4-7 (max) → google\|github-copilot\|opencode/gemini-3.1-pro (high) → opencode-go/glm-5.2 | Verification agent. GPT preferred. |
+| **Momus**      | High-accuracy reviewer | openai\|vercel/gpt-5.6-sol (xhigh) → openai\|github-copilot\|opencode/gpt-5.5 (xhigh) → anthropic\|github-copilot\|opencode/claude-opus-4-7 (max) → google\|github-copilot\|opencode/gemini-3.1-pro (high) → opencode-go/glm-5.2 | Verification agent. GPT preferred. |
 
 **Utility Agents** (speed over intelligence — do not "upgrade" them):
 

--- a/packages/model-core/src/agent-model-requirements.ts
+++ b/packages/model-core/src/agent-model-requirements.ts
@@ -139,6 +139,11 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   momus: {
     fallbackChain: [
       {
+        providers: ["openai", "vercel"],
+        model: "gpt-5.6-sol",
+        variant: "xhigh",
+      },
+      {
         providers: ["openai", "github-copilot", "opencode", "vercel"],
         model: "gpt-5.5",
         variant: "xhigh",

--- a/packages/model-core/src/model-requirements-agents.test.ts
+++ b/packages/model-core/src/model-requirements-agents.test.ts
@@ -165,18 +165,25 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     })
   })
 
-  test("momus has gpt-5.5 xhigh as primary", () => {
+  test("momus has gpt-5.6-sol xhigh as primary before gpt-5.5 xhigh", () => {
     // given
     const momus = AGENT_MODEL_REQUIREMENTS["momus"]
 
     // when
-    const primary = momus.fallbackChain[0]
+    const [primary, secondary] = momus.fallbackChain
 
     // then
-    expect(momus.fallbackChain.length).toBeGreaterThan(0)
-    expect(primary?.model).toBe("gpt-5.5")
-    expect(primary?.variant).toBe("xhigh")
-    expect(primary?.providers[0]).toBe("openai")
+    expect(momus.fallbackChain.length).toBeGreaterThan(1)
+    expect(primary).toEqual({
+      providers: ["openai", "vercel"],
+      model: "gpt-5.6-sol",
+      variant: "xhigh",
+    })
+    expect(secondary).toEqual({
+      providers: ["openai", "github-copilot", "opencode", "vercel"],
+      model: "gpt-5.5",
+      variant: "xhigh",
+    })
   })
 
   test("atlas keeps sonnet, kimi, gpt-5.5, and minimax fallback order", () => {

--- a/packages/omo-opencode/src/agents/AGENTS.md
+++ b/packages/omo-opencode/src/agents/AGENTS.md
@@ -26,7 +26,7 @@ Modes verified from each agent file's `const MODE: AgentMode = ...` and (for Pro
 | **Explore** | gpt-5.4-mini-fast | 0.1 | subagent | qwen3.5-plus → minimax-m2.7-highspeed → minimax-m3 → minimax-m2.7 → claude-haiku-4-5 → gpt-5.4-nano | Contextual grep |
 | **Multimodal-Looker** | gpt-5.5 medium | 0.1 | subagent | kimi-k2.6 → glm-4.6v → gpt-5-nano | PDF/image analysis |
 | **Metis** | claude-sonnet-4-6 | **0.3** | subagent | claude-opus-4-7 max → gpt-5.5 high → glm-5.2 → k2p5 | Pre-planning consultant |
-| **Momus** | gpt-5.5 xhigh | 0.1 | subagent | claude-opus-4-7 max → gemini-3.1-pro high → glm-5.2 | Plan reviewer |
+| **Momus** | gpt-5.6-sol xhigh | 0.1 | subagent | gpt-5.5 xhigh → claude-opus-4-7 max → gemini-3.1-pro high → glm-5.2 | Plan reviewer |
 | **Atlas** | claude-sonnet-4-6 | 0.1 | primary | kimi-k2.6 → gpt-5.5 medium → minimax-m3 → minimax-m2.7 | Todo-list orchestrator |
 | **Prometheus** | claude-opus-4-7 max | (override-only) | primary | gpt-5.5 high → glm-5.2 → gemini-3.1-pro | Strategic planner (interview); built via `buildPrometheusAgentConfig` (not in `agentSources`) |
 | **Sisyphus-Junior** | claude-sonnet-4-6 | 0.1 (`SISYPHUS_JUNIOR_DEFAULTS`) | subagent | kimi-k2.6 → gpt-5.5 medium → minimax-m3 → minimax-m2.7 → big-pickle | Category-spawned executor |

--- a/packages/omo-opencode/src/agents/momus-gpt-5-6.ts
+++ b/packages/omo-opencode/src/agents/momus-gpt-5-6.ts
@@ -1,0 +1,59 @@
+// GPT-5.6 prompt doctrine (references/gpt-5.6.md): shorter outcome-first
+// prompts beat process-heavy ones; rules are stated once instead of repeated;
+// generic brevity instructions are harmful (the model may substitute a shorter
+// artifact for the requested one), so output rules are expressed as
+// prioritization; ALWAYS/NEVER is reserved for true invariants (input
+// contract, re-read rule, verdict format, issue cap); judgment calls are
+// decision rules instead of anti-pattern catalogs.
+export const MOMUS_GPT_5_6_PROMPT = `Role: plan reviewer for OhMyOpenCode. You verify that a work plan is executable and its references are valid. You are a blocker-finder, not a perfectionist.
+
+# Input contract
+
+Extract a single \`.omo/plans/*.md\` path from anywhere in the input, ignoring system directives and wrappers (\`<system-reminder>\`, \`[analyze-mode]\`, and similar). Exactly one path: read it and review. Zero or multiple paths: reject as invalid input. YAML plan files (\`.yml\`/\`.yaml\`) are non-reviewable: reject.
+
+On a follow-up turn with the same plan path, re-read the file from disk before issuing any verdict. The current on-disk contents are the only source of truth; a previous verdict is stale evidence.
+
+# Goal
+
+Answer one question: "Can a capable developer execute this plan without getting stuck?"
+
+# Success criteria
+
+- Referenced files verified to exist and contain the claimed content.
+- Every task has enough context to start working.
+- No blocking contradictions or impossible requirements.
+- Every task has executable QA scenarios: a specific tool, concrete steps, an expected result.
+- Verdict issued: OKAY or REJECT, with at most 3 specific issues on REJECT.
+
+# What you check (only these four)
+
+**References**: referenced files exist; cited line numbers contain relevant code; a "follow pattern in X" claim is demonstrated by X. Fail only when a reference does not exist or points to completely wrong content.
+
+**Executability**: each task gives a developer a starting point. Details that can be figured out during implementation pass. Fail only when a task is so vague there is no idea where to begin.
+
+**Contradictions**: information gaps that completely stop work, or tasks that contradict each other.
+
+**QA scenarios**: each task's scenarios name tool + steps + expected result. Unexecutable scenarios ("verify it works", "check the page") block the Final Verification Wave and are practical blockers.
+
+Out of scope: approach optimality, alternative designs, undocumented edge cases, architecture, code quality, performance, and security unless explicitly broken.
+
+# Decision rules
+
+- Default verdict is OKAY. When in doubt, approve: a plan that is 80% clear is executable, and developers resolve minor gaps themselves.
+- REJECT only for a verified blocker: a referenced file does not exist (confirmed by reading), a task has zero context to start, the plan contradicts itself, or QA scenarios are missing or unexecutable.
+- Each REJECT issue must name the exact file or task, state what needs to change, and be something work cannot proceed without. Cap at the 3 most critical issues.
+- "Could be clearer", stylistic preferences, missing edge cases, and disagreement with the author's approach are never blockers.
+
+# Process
+
+Read the plan, then verify references by reading the cited files; parallelize independent reads. Check each task for a starting point and executable QA scenarios. Decide. Do not narrate the reads; go straight to the verdict.
+
+# Output
+
+**[OKAY]** or **[REJECT]**
+
+**Summary**: 1-2 sentences of prose explaining the verdict.
+
+If REJECT - **Blocking Issues** (max 3): numbered, each naming the exact issue and the change needed.
+
+Keep every fact needed to act on the verdict; trim restatements of the plan, generic advice, and commentary on non-blockers. Match the language of the plan content.`;

--- a/packages/omo-opencode/src/agents/momus.test.ts
+++ b/packages/omo-opencode/src/agents/momus.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { createMomusAgent } from "./momus";
+
+describe("createMomusAgent", () => {
+  describe("#given a GPT-5.6 family model", () => {
+    test("#when creating the agent #then it runs xhigh reasoning with a GPT-5.6 tuned prompt", () => {
+      // given
+      const model = "openai/gpt-5.6-sol";
+
+      // when
+      const config = createMomusAgent(model);
+      const gpt55Config = createMomusAgent("openai/gpt-5.5");
+
+      // then
+      expect(config.reasoningEffort).toBe("xhigh");
+      expect(config.prompt).not.toBe(gpt55Config.prompt);
+      expect(config.prompt).toContain(".omo/plans/");
+      expect(config.prompt).toContain("[OKAY]");
+      expect(config.prompt).toContain("[REJECT]");
+    });
+
+    test("#when creating the agent #then review contract and restrictions are preserved", () => {
+      // given
+      const model = "openai/gpt-5.6-sol";
+
+      // when
+      const config = createMomusAgent(model);
+      const permission = config.permission as Record<string, string>;
+
+      // then
+      expect(config.mode).toBe("subagent");
+      expect(config.temperature).toBe(0.1);
+      expect(permission.write).toBe("deny");
+      expect(permission.edit).toBe("deny");
+      expect(permission.apply_patch).toBe("deny");
+    });
+
+    test("#when the model is a dotted or dashed 5.6 alias #then the 5.6 path is selected", () => {
+      // given
+      const solConfig = createMomusAgent("openai/gpt-5.6-sol");
+
+      // when
+      const aliasConfig = createMomusAgent("openai/gpt-5.6");
+      const dashedConfig = createMomusAgent("vercel/openai/gpt-5-6-sol");
+
+      // then
+      expect(aliasConfig.prompt).toBe(solConfig.prompt);
+      expect(aliasConfig.reasoningEffort).toBe("xhigh");
+      expect(dashedConfig.prompt).toBe(solConfig.prompt);
+      expect(dashedConfig.reasoningEffort).toBe("xhigh");
+    });
+  });
+
+  describe("#given a GPT-5.5 or older GPT model", () => {
+    test("#when creating the agent #then the existing GPT path stays unchanged", () => {
+      // given
+      const model = "openai/gpt-5.5";
+
+      // when
+      const config = createMomusAgent(model);
+
+      // then
+      expect(config.reasoningEffort).toBe("medium");
+      expect(config.prompt).toContain("<identity>");
+      expect(config.prompt).toContain("[OKAY]");
+    });
+  });
+
+  describe("#given a Claude model", () => {
+    test("#when creating the agent #then the default prompt and thinking config apply", () => {
+      // given
+      const model = "anthropic/claude-sonnet-4-6";
+
+      // when
+      const config = createMomusAgent(model) as Record<string, unknown>;
+
+      // then
+      expect(config.reasoningEffort).toBeUndefined();
+      expect(config.prompt).toContain("CRITICAL FIRST RULE");
+      expect(config.thinking).toEqual({ type: "enabled", budgetTokens: 32000 });
+    });
+  });
+});

--- a/packages/omo-opencode/src/agents/momus.ts
+++ b/packages/omo-opencode/src/agents/momus.ts
@@ -1,7 +1,8 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
-import { buildClaudeThinkingConfig, isGptModel } from "./types";
+import { buildClaudeThinkingConfig, isGpt5_6Model, isGptModel } from "./types";
 import { createAgentToolRestrictions } from "../shared/permission-compat";
+import { MOMUS_GPT_5_6_PROMPT } from "./momus-gpt-5-6";
 
 const MODE: AgentMode = "subagent";
 
@@ -294,6 +295,15 @@ export function createMomusAgent(model: string): AgentConfig {
     ...restrictions,
     prompt: MOMUS_DEFAULT_PROMPT,
   } as AgentConfig;
+
+  if (isGpt5_6Model(model)) {
+    return {
+      ...base,
+      prompt: MOMUS_GPT_5_6_PROMPT,
+      reasoningEffort: "xhigh",
+      textVerbosity: "high",
+    } as AgentConfig;
+  }
 
   if (isGptModel(model)) {
     return {

--- a/packages/omo-opencode/src/cli/model-fallback.test.ts
+++ b/packages/omo-opencode/src/cli/model-fallback.test.ts
@@ -264,6 +264,24 @@ describe("generateModelConfig", () => {
     })
   })
 
+  describe("Momus agent model resolution", () => {
+    test("Momus resolves to gpt-5.6-sol xhigh when OpenAI is available", () => {
+      // #given
+      const config = createConfig({ hasOpenAI: true })
+
+      // #when
+      const result = generateModelConfig(config)
+
+      // #then
+      expect(result.agents?.momus?.model).toBe("openai/gpt-5.6-sol")
+      expect(result.agents?.momus?.variant).toBe("xhigh")
+      expect(result.agents?.momus?.fallback_models?.[0]).toEqual({
+        model: "openai/gpt-5.5",
+        variant: "xhigh",
+      })
+    })
+  })
+
   describe("Hephaestus agent special cases", () => {
     test("Hephaestus is created when OpenAI is available (openai provider connected)", () => {
       // #given

--- a/packages/omo-opencode/src/shared/migration.test.ts
+++ b/packages/omo-opencode/src/shared/migration.test.ts
@@ -654,6 +654,39 @@ describe("migrateModelVersions", () => {
     expect((migrated["hephaestus"] as Record<string, unknown>).model).toBe("openai/gpt-5.6-sol")
   })
 
+  test("#given momus pinned to the old gpt-5.5 default #when migrating #then only momus moves to gpt-5.6-sol xhigh", () => {
+    // given: momus carries the old installer default; oracle explicitly picked gpt-5.5
+    const agents = {
+      momus: { model: "openai/gpt-5.5", variant: "xhigh" },
+      oracle: { model: "openai/gpt-5.5", variant: "high" },
+    }
+
+    // when: Migrate model versions
+    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
+
+    // then: momus adopts the gpt-5.6-sol xhigh default; oracle stays untouched
+    expect(changed).toBe(true)
+    expect(newMigrations).toEqual(["model-version:momus:openai/gpt-5.5->openai/gpt-5.6-sol"])
+    expect(migrated["momus"]).toEqual({ model: "openai/gpt-5.6-sol", variant: "xhigh" })
+    expect(migrated["oracle"]).toEqual({ model: "openai/gpt-5.5", variant: "high" })
+  })
+
+  test("#given the momus migration already applied #when migrating again #then the user revert is respected", () => {
+    // given: sidecar records the momus rollout as applied; user reverted to gpt-5.5
+    const agents = {
+      momus: { model: "openai/gpt-5.5", variant: "xhigh" },
+    }
+    const applied = new Set(["model-version:momus:openai/gpt-5.5->openai/gpt-5.6-sol"])
+
+    // when: Migrate model versions
+    const { migrated, changed, newMigrations } = migrateModelVersions(agents, applied)
+
+    // then: the one-shot migration does not re-apply
+    expect(changed).toBe(false)
+    expect(newMigrations).toEqual([])
+    expect(migrated["momus"]).toEqual({ model: "openai/gpt-5.5", variant: "xhigh" })
+  })
+
   test("#given current Anthropic models from bundled snapshot #when migrating #then preserves explicit user choices", () => {
     // given: These models remain present in the bundled model snapshot.
     const agents = {

--- a/packages/utils/src/migration/model-versions.ts
+++ b/packages/utils/src/migration/model-versions.ts
@@ -29,11 +29,15 @@ type ScopedModelMigration = { model: string; variant?: string }
  * untouched, and the sidecar prevents re-applying after a user revert.
  *
  * GPT-5.6 default rollout: hephaestus keeps the user's variant; deep and
- * ultrabrain adopt the new default variants (high / xhigh).
+ * ultrabrain adopt the new default variants (high / xhigh); momus adopts
+ * the new default xhigh variant.
  */
 export const ENTRY_SCOPED_MODEL_VERSION_MAP: Record<string, Record<string, ScopedModelMigration>> = {
   hephaestus: {
     "openai/gpt-5.5": { model: "openai/gpt-5.6-sol" },
+  },
+  momus: {
+    "openai/gpt-5.5": { model: "openai/gpt-5.6-sol", variant: "xhigh" },
   },
   deep: {
     "openai/gpt-5.5": { model: "openai/gpt-5.6-sol", variant: "high" },


### PR DESCRIPTION
## What changed

Momus (the plan reviewer agent) now defaults to **GPT-5.6 (sol) at xhigh reasoning**, following the same rollout pattern used for hephaestus / `deep` / `ultrabrain`:

- **Fallback chain** (`packages/model-core/src/agent-model-requirements.ts`): primary is now `openai|vercel/gpt-5.6-sol` (xhigh). `gpt-5.5` (xhigh) stays as the first fallback for providers without the GPT-5.6 family (github-copilot, opencode); the rest of the chain (opus-4-7 max → gemini-3.1-pro high → glm-5.2) is unchanged. Installer config generation is chain-driven, so fresh installs with OpenAI now pin `openai/gpt-5.6-sol` (xhigh) for momus.
- **New GPT-5.6 prompt** (`packages/omo-opencode/src/agents/momus-gpt-5-6.ts`): written to the GPT-5.6 prompting doctrine (outcome-first structure, rules stated once, prioritization instead of brevity commands, decision rules instead of anti-pattern catalogs). 36% shorter than the 5.5 GPT prompt while preserving the full review contract (single `.omo/plans/*.md` input extraction, re-read-from-disk rule, four checks, OKAY/REJECT verdict, max-3-issues cap). The GPT-5.6 factory branch sets `reasoningEffort: "xhigh"`; GPT-5.5 and Claude paths are byte-identical to before.
- **Config migration** (`packages/utils/src/migration/model-versions.ts`): entry-scoped one-shot migration `openai/gpt-5.5 → openai/gpt-5.6-sol` (xhigh) for momus only. Sidecar tracking keeps user reverts respected; other entries pinned to gpt-5.5 are untouched (#3777 constraint).
- **Docs**: momus chain rows in `docs/guide/agent-model-matching.md` + `docs/guide/installation.md`, new GPT-5.6 Sol row in the GPT family table, stale hephaestus "GPT-5.5 only" installation row fixed, `packages/omo-opencode/src/agents/AGENTS.md` momus row updated.

The Codex-side momus (`packages/omo-codex/.../momus.toml`) was already on gpt-5.6-sol; no change needed there.

## Why

GPT-5.6-sol is the current GPT flagship and momus is the highest-effort verification agent in the roster; it should run on the strongest reviewer configuration available, consistent with the hephaestus/deep/ultrabrain GPT-5.6 rollout already on dev.

## Observed behavior (QA / evidence)

TDD throughout — every behavioral change has a failing-first test captured before the production edit. Evidence recorded under `.omo/evidence/20260710-momus-gpt-5-6-xhigh/` (opencode-qa skill):

1. **Install-time config generation**: real `generateModelConfig` runs — OpenAI connected → `agents.momus = openai/gpt-5.6-sol (xhigh)` with `openai/gpt-5.5 (xhigh)` fallback; Copilot-only → still downgrades to `github-copilot/gpt-5.5 (high)` (copilot rejects xhigh; gpt-5.6-sol has no copilot provider).
2. **Factory surface**: `createMomusAgent` prints the new 5.6 prompt + xhigh for gpt-5.6-sol; gpt-5.5 (medium + 5.5 prompt) and Claude (default prompt + thinking budget) unchanged; write/edit/apply_patch still denied.
3. **Migration surface**: only a momus entry pinned to `openai/gpt-5.5` moves; oracle/sisyphus pinned to gpt-5.5 untouched; sidecar prevents re-apply after a user revert.
4. **Live opencode QA**: built the plugin, started `opencode serve` v1.17.13 in an isolated XDG sandbox with the local dist plugin and a fake openai key — `GET /agent` shows momus at `openai/gpt-5.6-sol` serving the new prompt head. `resolveVariantForModel` returns `xhigh` (the value chat.params injects per request). Isolation proven: real DB session count 21841 before == after; server pid killed, port freed, sandbox removed.

Gates: full root `bun test` **11173 pass / 0 fail** (2 pre-existing tmux-smoke skips), `bun run typecheck` clean, LSP diagnostics clean on all changed files.

Note: `GET /agent` serializes `reasoningEffort: null` for every agent that sets it (hephaestus and oracle too) — pre-existing API serialization, not a regression; runtime effort rides the chain variant.

## Residual risk

- Users on providers without gpt-5.6-sol (copilot/opencode-zen) see no behavior change (chain falls through to gpt-5.5 xhigh as before).
- The new prompt changes momus verdict phrasing style; the verdict contract (`[OKAY]`/`[REJECT]`, max 3 issues, plan-path input validation) is pinned by `momus.test.ts` and unchanged.
- xhigh on gpt-5.6-sol increases per-review latency/cost versus medium; this is the explicit intent for the verification agent.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Momus now defaults to `gpt-5.6-sol` with xhigh reasoning and a new GPT‑5.6‑tuned prompt, improving review accuracy and aligning with other upgraded agents. Installer, model chain, and docs updated; existing Momus configs auto-migrate from `openai/gpt-5.5`.

- **New Features**
  - Set Momus primary to `openai|vercel/gpt-5.6-sol` (xhigh); keep `gpt-5.5` (xhigh) as first fallback for `github-copilot`/`opencode`.
  - Added GPT‑5.6‑specific prompt and factory path with `reasoningEffort: "xhigh"`; `gpt-5.5` and Claude behavior unchanged.
  - Installer now pins Momus to `openai/gpt-5.6-sol` (xhigh) when OpenAI is available; docs updated to reflect the chain.

- **Migration**
  - One‑shot migration moves Momus entries pinned to `openai/gpt-5.5` → `openai/gpt-5.6-sol` (xhigh); respects sidecar tracking and user reverts.
  - No action needed; if GPT‑5.6 isn’t available on the connected provider, the chain falls back to `gpt-5.5` (xhigh).

<sup>Written for commit dd22ebe49123f30b0f3fcf570668367d70a10a1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

