### PR TITLE
fix(omo-opencode): verify live listener session affinity before routing parent wakes

### DIFF
--- a/packages/omo-opencode/src/shared/live-server-route-probe.test.ts
+++ b/packages/omo-opencode/src/shared/live-server-route-probe.test.ts
@@ -30,7 +30,10 @@ describe("live-server-route probe endpoint", () => {
     //#when
     await resolveDispatchClient(inProcessClient, "ses_probe_endpoint")
 
-    //#then
-    expect(fetchedUrls).toEqual(["http://127.0.0.1:4096/global/health"])
+    //#then — health probe first, then per-session affinity verification (#5569)
+    expect(fetchedUrls).toEqual([
+      "http://127.0.0.1:4096/global/health",
+      "http://127.0.0.1:4096/session/ses_probe_endpoint",
+    ])
   })
 })

--- a/packages/omo-opencode/src/shared/live-server-route.test.ts
+++ b/packages/omo-opencode/src/shared/live-server-route.test.ts
@@ -50,6 +50,10 @@ function makeNeverResolvingFetch(): {
   return { fetch: fake as unknown as typeof fetch, callCount: () => calls }
 }
 
+function countHealthProbes(urls: readonly string[]): number {
+  return urls.filter((url) => url.includes("/global/health")).length
+}
+
 const FAKE_SERVER_URL = new URL("http://127.0.0.1:19999")
 
 const fakeInProcessClient = { _marker: "in-process" } as unknown
@@ -128,7 +132,11 @@ describe("live-server-route", () => {
   describe("resolveDispatchClient — 200 probe → live + client cached", () => {
     test("#given probe returns 200 #when resolveDispatchClient called twice #then returns live route and caches same client object", async () => {
       //#given
-      const { fetch: fakeFetch, callCount } = makeFakeFetch([{ ok: true, status: 200 }])
+      const seenUrls: string[] = []
+      const fakeFetch = (async (url: RequestInfo | URL) => {
+        seenUrls.push(String(url))
+        return { ok: true, status: 200 } as Response
+      }) as unknown as typeof fetch
       _setFetchImplementationForTesting(fakeFetch)
       initLiveServerRoute({ serverUrl: FAKE_SERVER_URL, directory: "/tmp/test", inProcessClient: fakeInProcessClient })
       _setLiveClientForTesting(fakeLiveClient)
@@ -137,12 +145,12 @@ describe("live-server-route", () => {
       const result1 = await resolveDispatchClient(fakeInProcessClient, "ses_live1")
       const result2 = await resolveDispatchClient(fakeInProcessClient, "ses_live2")
 
-      //#then
+      //#then — one health probe; per-session affinity probes are separate
       expect(result1.route).toBe("live")
       expect(result1.client).toBe(fakeLiveClient)
       expect(result2.route).toBe("live")
       expect(result2.client).toBe(fakeLiveClient)
-      expect(callCount()).toBe(1)
+      expect(countHealthProbes(seenUrls)).toBe(1)
     })
   })
 
@@ -196,9 +204,13 @@ describe("live-server-route", () => {
   })
 
   describe("resolveDispatchClient — TTL: second resolve within 60s skips re-fetch", () => {
-    test("#given two sequential resolves within TTL #when resolveDispatchClient called twice #then fetch is called only once", async () => {
+    test("#given two sequential resolves within TTL #when resolveDispatchClient called twice #then the health probe fires only once", async () => {
       //#given
-      const { fetch: fakeFetch, callCount } = makeFakeFetch([{ ok: true, status: 200 }, { ok: true, status: 200 }])
+      const seenUrls: string[] = []
+      const fakeFetch = (async (url: RequestInfo | URL) => {
+        seenUrls.push(String(url))
+        return { ok: true, status: 200 } as Response
+      }) as unknown as typeof fetch
       _setFetchImplementationForTesting(fakeFetch)
       _setLiveClientForTesting(fakeLiveClient)
       initLiveServerRoute({ serverUrl: FAKE_SERVER_URL, directory: "/tmp/test", inProcessClient: fakeInProcessClient })
@@ -208,16 +220,16 @@ describe("live-server-route", () => {
       await resolveDispatchClient(fakeInProcessClient, "ses_ttl2")
 
       //#then
-      expect(callCount()).toBe(1)
+      expect(countHealthProbes(seenUrls)).toBe(1)
     })
   })
 
   describe("resolveDispatchClient — shared in-flight: concurrent resolves trigger ONE fetch", () => {
     test("#given two concurrent resolveDispatchClient calls #when both start simultaneously #then only one fetch is triggered", async () => {
       //#given
-      let fetchCalls = 0
-      const sharedFetch = async (_url: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
-        fetchCalls++
+      const seenUrls: string[] = []
+      const sharedFetch = async (url: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+        seenUrls.push(String(url))
         await new Promise<void>((r) => setTimeout(r, 50))
         return { ok: true, status: 200 } as Response
       }
@@ -231,7 +243,7 @@ describe("live-server-route", () => {
         resolveDispatchClient(fakeInProcessClient, "ses_concurrent_b"),
       ])
       //#then
-      expect(fetchCalls).toBe(1)
+      expect(countHealthProbes(seenUrls)).toBe(1)
       expect(r1.route).toBe("live")
       expect(r2.route).toBe("live")
     })
@@ -346,13 +358,14 @@ describe("live-server-route", () => {
       expect(result).toBeUndefined()
     })
 
-    test("#given a registered client with a fresh available probe #when tryResolveDispatchClientSync called #then it returns the live route synchronously", async () => {
-      //#given
+    test("#given a fresh probe and verified session affinity #when tryResolveDispatchClientSync called #then it returns the live route synchronously", async () => {
+      //#given — the async path verifies session affinity; the sync fast path may
+      // only serve sessions with cached affinity evidence (#5569)
       const { fetch: fakeFetch } = makeFakeFetch([{ ok: true, status: 200 }])
       _setFetchImplementationForTesting(fakeFetch)
       initLiveServerRoute({ serverUrl: FAKE_SERVER_URL, directory: "/tmp/sync", inProcessClient: fakeInProcessClient })
       _setLiveClientForTesting(fakeLiveClient)
-      await resolveDispatchClient(fakeInProcessClient, "ses_sync_warm")
+      await resolveDispatchClient(fakeInProcessClient, "ses_sync_fresh")
 
       //#when
       const result = tryResolveDispatchClientSync(fakeInProcessClient, "ses_sync_fresh")
@@ -406,6 +419,107 @@ describe("live-server-route", () => {
       //#when / then — must not throw, must not return a promise that callers must await
       const result = warmLiveServerProbe()
       expect(result).toBeUndefined()
+    })
+  })
+
+  describe("session affinity", () => {
+    function makeUrlAwareFakeFetch(handler: (url: string) => FakeFetchResponse): {
+      fetch: typeof fetch
+      urls: () => string[]
+    } {
+      const seen: string[] = []
+      const fake = async (url: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+        const asString = String(url)
+        seen.push(asString)
+        const resp = handler(asString)
+        return { ok: resp.ok, status: resp.status } as Response
+      }
+      return { fetch: fake as unknown as typeof fetch, urls: () => [...seen] }
+    }
+
+    test("#given healthy listener that does not own the session #when resolving dispatch client #then falls back to in-process", async () => {
+      //#given — health probe succeeds but the listener 404s the target session
+      const { fetch: fakeFetch, urls } = makeUrlAwareFakeFetch((url) => {
+        if (url.includes("/global/health")) return { ok: true, status: 200 }
+        return { ok: false, status: 404 }
+      })
+      _setFetchImplementationForTesting(fakeFetch)
+      initLiveServerRoute({ serverUrl: FAKE_SERVER_URL, directory: "/tmp/test", inProcessClient: fakeInProcessClient })
+
+      //#when
+      const result = await resolveDispatchClient(fakeInProcessClient, "ses_not_owned")
+
+      //#then — wake must not vanish into a listener that has no such session (#5569)
+      expect(result.route).toBe("in-process")
+      expect(result.reason).toBe("affinity")
+      expect(urls().some((url) => url.includes("/session/ses_not_owned"))).toBe(true)
+    })
+
+    test("#given listener that owns the session #when resolving twice #then routes live and caches the affinity probe", async () => {
+      //#given
+      const { fetch: fakeFetch, urls } = makeUrlAwareFakeFetch(() => ({ ok: true, status: 200 }))
+      _setFetchImplementationForTesting(fakeFetch)
+      initLiveServerRoute({ serverUrl: FAKE_SERVER_URL, directory: "/tmp/test", inProcessClient: fakeInProcessClient })
+
+      //#when
+      const first = await resolveDispatchClient(fakeInProcessClient, "ses_owned")
+      const second = await resolveDispatchClient(fakeInProcessClient, "ses_owned")
+
+      //#then
+      expect(first.route).toBe("live")
+      expect(second.route).toBe("live")
+      const affinityProbes = urls().filter((url) => url.includes("/session/ses_owned"))
+      expect(affinityProbes.length).toBe(1)
+    })
+
+    test("#given transient non-404 affinity failure #when resolving dispatch client #then keeps live routing (status quo)", async () => {
+      //#given — a 500 on the session probe must not force in-process (would reintroduce runner-split in serve topology)
+      const { fetch: fakeFetch } = makeUrlAwareFakeFetch((url) => {
+        if (url.includes("/global/health")) return { ok: true, status: 200 }
+        return { ok: false, status: 500 }
+      })
+      _setFetchImplementationForTesting(fakeFetch)
+      initLiveServerRoute({ serverUrl: FAKE_SERVER_URL, directory: "/tmp/test", inProcessClient: fakeInProcessClient })
+
+      //#when
+      const result = await resolveDispatchClient(fakeInProcessClient, "ses_transient")
+
+      //#then
+      expect(result.route).toBe("live")
+    })
+
+    test("#given fresh health probe but unknown session affinity #when sync resolution runs #then defers to the async path", async () => {
+      //#given — availability is warm but the session was never affinity-checked
+      const { fetch: fakeFetch } = makeUrlAwareFakeFetch(() => ({ ok: true, status: 200 }))
+      _setFetchImplementationForTesting(fakeFetch)
+      initLiveServerRoute({ serverUrl: FAKE_SERVER_URL, directory: "/tmp/test", inProcessClient: fakeInProcessClient })
+      await resolveDispatchClient(fakeInProcessClient, "ses_warm")
+
+      //#when — a different session with no cached affinity
+      const syncResult = tryResolveDispatchClientSync(fakeInProcessClient, "ses_unknown_affinity")
+
+      //#then — sync path must not claim live without affinity evidence
+      expect(syncResult).toBeUndefined()
+    })
+
+    test("#given cached negative affinity #when sync resolution runs #then returns in-process without refetching", async () => {
+      //#given
+      const { fetch: fakeFetch, urls } = makeUrlAwareFakeFetch((url) => {
+        if (url.includes("/global/health")) return { ok: true, status: 200 }
+        return { ok: false, status: 404 }
+      })
+      _setFetchImplementationForTesting(fakeFetch)
+      initLiveServerRoute({ serverUrl: FAKE_SERVER_URL, directory: "/tmp/test", inProcessClient: fakeInProcessClient })
+      await resolveDispatchClient(fakeInProcessClient, "ses_cached_missing")
+      const fetchCountAfterAsync = urls().length
+
+      //#when
+      const syncResult = tryResolveDispatchClientSync(fakeInProcessClient, "ses_cached_missing")
+
+      //#then
+      expect(syncResult?.route).toBe("in-process")
+      expect(syncResult?.reason).toBe("affinity")
+      expect(urls().length).toBe(fetchCountAfterAsync)
     })
   })
 })

--- a/packages/omo-opencode/src/shared/live-server-route.ts
+++ b/packages/omo-opencode/src/shared/live-server-route.ts
@@ -8,11 +8,17 @@ export const LIVE_ROUTE_UNAVAILABLE_LOG = "[live-server-route] route unavailable
 
 const PROBE_TTL_MS = 60_000
 const PROBE_ABORT_MS = 1_500
+const AFFINITY_TTL_MS = 60_000
 
 type RouteResult = {
   client: unknown
   route: "live" | "in-process"
-  reason: "identity" | "flag" | "child" | "unavailable" | "live"
+  reason: "identity" | "flag" | "child" | "unavailable" | "live" | "affinity"
+}
+
+type SessionAffinityEntry = {
+  owned: boolean
+  timestamp: number
 }
 
 type RouteRegistration = {
@@ -22,6 +28,8 @@ type RouteRegistration = {
   probeTimestamp: number
   inFlightProbe: Promise<boolean> | undefined
   warnedOnce: boolean
+  sessionAffinity: Map<string, SessionAffinityEntry>
+  inFlightAffinity: Map<string, Promise<boolean | undefined>>
 }
 
 const registrations = new Map<unknown, RouteRegistration>()
@@ -66,6 +74,8 @@ export function initLiveServerRoute(opts: {
     probeTimestamp: 0,
     inFlightProbe: undefined,
     warnedOnce: false,
+    sessionAffinity: new Map(),
+    inFlightAffinity: new Map(),
   }
   registrations.set(opts.inProcessClient, registration)
   lastRegistration = registration
@@ -126,6 +136,81 @@ async function probe(registration: RouteRegistration): Promise<boolean> {
     registration.probeTimestamp = Date.now()
     return false
   }
+}
+
+// A healthy `/global/health` only proves SOME listener answers on the
+// registered URL — not that it is the instance owning the target session.
+// Dispatching a parent wake to a listener that does not own the session
+// silently drops the wake and the parent never continues (#5569). Before
+// trusting the live route for a session, confirm the listener can actually
+// resolve it. Only a definite 404 demotes the route: transient failures keep
+// the live route so serve-topology runner-split protection is not lost.
+async function probeSessionAffinity(registration: RouteRegistration, sessionID: string): Promise<boolean | undefined> {
+  if (!registration.serverUrl) {
+    return undefined
+  }
+
+  const probeUrl = new URL(`/session/${sessionID}`, registration.serverUrl)
+  const authHeader = getServerBasicAuthHeader()
+  const headers: Record<string, string> = authHeader ? { Authorization: authHeader } : {}
+
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), PROBE_ABORT_MS)
+    let response: Response
+    try {
+      response = await getFetch()(probeUrl, { headers, signal: controller.signal })
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (response.ok) {
+      setSessionAffinity(registration, sessionID, true)
+      return true
+    }
+    if (response.status === 404) {
+      setSessionAffinity(registration, sessionID, false)
+      log("[live-server-route] live listener does not own session; falling back to in-process client", { sessionID })
+      return false
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+function setSessionAffinity(registration: RouteRegistration, sessionID: string, owned: boolean): void {
+  const now = Date.now()
+  for (const [key, entry] of registration.sessionAffinity) {
+    if (now - entry.timestamp >= AFFINITY_TTL_MS) {
+      registration.sessionAffinity.delete(key)
+    }
+  }
+  registration.sessionAffinity.set(sessionID, { owned, timestamp: now })
+}
+
+function getFreshSessionAffinity(registration: RouteRegistration, sessionID: string): boolean | undefined {
+  const entry = registration.sessionAffinity.get(sessionID)
+  if (!entry || Date.now() - entry.timestamp >= AFFINITY_TTL_MS) {
+    return undefined
+  }
+  return entry.owned
+}
+
+async function resolveSessionAffinity(registration: RouteRegistration, sessionID: string): Promise<boolean | undefined> {
+  const cached = getFreshSessionAffinity(registration, sessionID)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  let inFlight = registration.inFlightAffinity.get(sessionID)
+  if (!inFlight) {
+    inFlight = probeSessionAffinity(registration, sessionID).finally(() => {
+      registration.inFlightAffinity.delete(sessionID)
+    })
+    registration.inFlightAffinity.set(sessionID, inFlight)
+  }
+  return inFlight
 }
 
 function getFreshProbeAvailability(registration: RouteRegistration): boolean | undefined {
@@ -191,6 +276,16 @@ export function tryResolveDispatchClientSync(client: unknown, sessionID: string)
     return { client, route: "in-process", reason: "unavailable" }
   }
 
+  const cachedAffinity = getFreshSessionAffinity(registration, sessionID)
+  if (cachedAffinity === undefined) {
+    // No affinity evidence yet — defer to the async path so the listener is
+    // verified to own this session before a wake is trusted to it (#5569).
+    return undefined
+  }
+  if (!cachedAffinity) {
+    return { client, route: "in-process", reason: "affinity" }
+  }
+
   const resolvedLiveClient = getOrBuildLiveClient(registration)
   if (!resolvedLiveClient) {
     return { client, route: "in-process", reason: "unavailable" }
@@ -212,6 +307,11 @@ export async function resolveDispatchClient(client: unknown, sessionID: string):
   const isAvailable = await resolveAvailability(registration)
   if (!isAvailable) {
     return { client, route: "in-process", reason: "unavailable" }
+  }
+
+  const affinity = await resolveSessionAffinity(registration, sessionID)
+  if (affinity === false) {
+    return { client, route: "in-process", reason: "affinity" }
   }
 
   const resolvedLiveClient = getOrBuildLiveClient(registration)
@@ -260,6 +360,7 @@ export function markLiveRouteUnavailable(reason: string): void {
   for (const registration of registrations.values()) {
     registration.available = false
     registration.probeTimestamp = Date.now()
+    registration.sessionAffinity.clear()
   }
   log(`[live-server-route] marked unavailable: ${reason}`)
 }

--- a/packages/utils/src/prompt-async-gate/route-resolver.ts
+++ b/packages/utils/src/prompt-async-gate/route-resolver.ts
@@ -6,7 +6,7 @@ export const LIVE_ROUTE_UNAVAILABLE_LOG = "[live-server-route] route unavailable
 export type PromptDispatchRouteResult = {
   readonly client: unknown
   readonly route: "live" | "in-process"
-  readonly reason: "identity" | "flag" | "child" | "unavailable" | "live"
+  readonly reason: "identity" | "flag" | "child" | "unavailable" | "live" | "affinity"
 }
 
 export type PromptDispatchRouteResolver = {


### PR DESCRIPTION
## Summary

Parent wakes dispatched through the live-server route could vanish when the registered listener URL answered `/global/health` but did not actually own the target session (stale registration / another instance on the port). The `promptAsync` appeared to succeed, no assistant loop ever started, and the parent session sat silent until a manual "continue" — the residual root cause documented in #5569 after the defer-ceiling fix (#5994) landed.

The live route now verifies session affinity: before trusting the live listener for a session, it GETs `/session/{id}` on that listener. A definite 404 demotes that session's dispatches to the in-process client; transient failures (5xx/network/timeout) keep the live route so the serve-topology runner-split protection from the live-listener design is not regressed. Results are cached per session for 60s with deduped in-flight probes, and the sync fast path only serves sessions with cached affinity evidence.

## Changes

- `packages/omo-opencode/src/shared/live-server-route.ts`: per-session affinity probe + TTL cache + in-flight dedupe; new `"affinity"` route reason; `markLiveRouteUnavailable` clears affinity caches; sync fast path defers to async when affinity is unknown.
- `packages/utils/src/prompt-async-gate/route-resolver.ts`: `PromptDispatchRouteResult.reason` union extended with `"affinity"`.
- Tests: 5 new affinity tests (not-owned fallback, owned+cache, transient keeps live, sync defers on unknown, sync serves cached negative); existing probe-URL/fetch-count/sync-fast-path pins updated to the new policy (health-probe counts asserted URL-filtered).

## QA & Evidence

Evidence bundle (worktree-local, gitignored): `.omo/evidence/20260710-live-route-session-affinity/` — `summary.md` maps artifacts to criteria.

- **What was tested:** RED→GREEN unit proof. 4 new tests captured failing on base (`01-red.txt`: wrong-session listener was routed "live"), 31/31 after the fix (`02-green.txt`).
  **Why sufficient:** pins the full routing decision table (owned / not-owned / transient / sync-cache arms).
- **What was tested:** real-surface QA against a REAL isolated `opencode serve` (v1.17.13, XDG sandbox): created a real session, drove `resolveDispatchClient` over real HTTP.
  **Observed:** not-owned session → `{route: "in-process", reason: "affinity"}`; owned session → `{route: "live"}`. `QA_RESULT=PASS` (`03-real-server-affinity-qa.txt`); cleanup receipt with real-DB before/after count 21841 == 21841 (`04-cleanup-receipt.txt`).
- **What was tested:** full serve-topology E2E via the opencode-qa skill's `serve-wake-split-probe.sh --expect fixed` with the plugin loaded from this branch's source and a local fake LLM (no real API).
  **Observed:** `RESULT=FIXED`, `route_live_dispatch=true`, `terminal_stops=1`, `child_task_sessions=1`, `plugin_inits=1` — the parent-wake pipeline still dispatches via the live listener end-to-end with the affinity check active (`wake-split-probe/`).
- **Gates:** root `bun test` 11206 pass / 0 fail; `bun run typecheck` clean; `bun run build` OK.

## Risks & Residuals

- First dispatch per session adds one bounded (1.5s abort) GET to the live listener; cached for 60s. Accepted for wake-delivery correctness.
- Transient affinity errors intentionally keep live routing — a wrong listener that errors (rather than 404s) is not demoted; mitigated by the existing `isPreSendConnectionFailure` handling and `markLiveRouteUnavailable`.
- Affinity flapping within the 60s TTL is possible in pathological setups; bounded by TTL.

## Related Issues

Addresses the residual live-route root cause in #5569 (family: #5790, #5804).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost parent wakes by verifying the live listener actually owns the session before routing. Falls back to the in‑process client when the listener reports a definite 404, preventing silent drops.

- **Bug Fixes**
  - `omo-opencode`: Verify session affinity via GET `/session/{id}` before routing. 404 → route `in-process` with reason `"affinity"`; transient errors keep `live`.
  - Cache per-session affinity for 60s with in‑flight dedupe; cleared by `markLiveRouteUnavailable`.
  - Sync resolver serves `live` only with cached affinity; otherwise defers. Cached negative affinity returns `in-process` without refetch.
  - `utils`: Extend `PromptDispatchRouteResult.reason` to include `"affinity"`.

<sup>Written for commit bcb1e095348c57b180e20d8e95373c7a9ed15c2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

