### PR TITLE
fix(codex): correct multi-agent version resolution (unknown-model safety + model_catalog_json)

### DIFF
--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-v2-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-v2-guard.mjs
@@ -68,6 +68,15 @@ export function forceDisableMultiAgentV2(config, options = {}) {
 		return normalized;
 	}
 
+	// No model evidence at all (no session model AND no root `model` in
+	// config.toml — Codex Desktop selects the model in the UI): config alone
+	// cannot prove the session is not a GPT-5.6 reserved-schema model, and
+	// writing `enabled = false` would 400 every turn on those sessions
+	// (#6002). Leave the enable state untouched.
+	if (multiAgentVersion == null && !sessionModel && !readRootModel(normalized)) {
+		return normalized;
+	}
+
 	// Unknown catalog entry for an explicit session model: skip force-disable
 	// rather than assume the legacy encrypted-V2 failure mode.
 	if (sessionModel && multiAgentVersion == null) {

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-v2-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-v2-guard.mjs
@@ -107,7 +107,10 @@ export function prefersMultiAgentV2(multiAgentVersion, sessionModel) {
 export function resolveMultiAgentVersionFromConfig(config, options = {}) {
 	const model = normalizeModel(options.sessionModel) || readRootModel(config);
 	if (!model) return null;
-	return resolveMultiAgentVersionForModel(model, options);
+	return resolveMultiAgentVersionForModel(model, {
+		...options,
+		modelsCachePath: options.modelsCachePath?.trim() || readRootModelCatalogPath(config) || undefined,
+	});
 }
 
 /**
@@ -136,6 +139,18 @@ export function readRootModel(config) {
 	const double = config.match(/^\s*model\s*=\s*"([^"]+)"/m);
 	if (double) return double[1];
 	const single = config.match(/^\s*model\s*=\s*'([^']+)'/m);
+	return single?.[1] ?? null;
+}
+
+// Codex documents `model_catalog_json` as a COMPLETE replacement for the
+// fetched models_cache.json (codex-rs/core/src/config/mod.rs load_model_catalog
+// -> load_catalog_json -> ModelsResponse). When set, Codex resolves the model
+// only from that file, so the guard must too — otherwise Codex and the guard
+// disagree on the multi-agent version (lazycodex#120).
+export function readRootModelCatalogPath(config) {
+	const double = config.match(/^\s*model_catalog_json\s*=\s*"([^"]+)"/m);
+	if (double) return double[1];
+	const single = config.match(/^\s*model_catalog_json\s*=\s*'([^']+)'/m);
 	return single?.[1] ?? null;
 }
 

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/subagent-limit-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/subagent-limit-guard.mjs
@@ -1,4 +1,4 @@
-import { prefersMultiAgentV2, resolveMultiAgentVersionFromConfig } from "./multi-agent-v2-guard.mjs";
+import { prefersMultiAgentV2, readRootModel, resolveMultiAgentVersionFromConfig } from "./multi-agent-v2-guard.mjs";
 
 const CODEX_AGENTS_HEADER = "[agents]";
 const CODEX_MULTI_AGENT_V2_HEADER = "[features.multi_agent_v2]";
@@ -11,6 +11,12 @@ const CODEX_SUBAGENT_THREAD_LIMIT = "1000";
  * enabled in config, skip `agents.max_threads` because Codex rejects that key
  * while features.multi_agent_v2 is enabled.
  *
+ * When no model is resolvable at all (no session model and no root `model`
+ * in config.toml — Codex Desktop selects the model in the UI), never
+ * introduce `agents.max_threads`: it hard-fails thread/start on
+ * MultiAgentV2 sessions. An existing cap is still raised in place so the
+ * legacy low-cap repair keeps working and a hand-removed key stays removed.
+ *
  * @param {string} config
  * @param {{ multiAgentVersion?: string | null, sessionModel?: string | null, env?: NodeJS.ProcessEnv, modelsCachePath?: string }} [options]
  */
@@ -22,18 +28,32 @@ export function ensureSubagentConcurrencyLimit(config, options = {}) {
 	const v2Preferred = prefersMultiAgentV2(multiAgentVersion, options.sessionModel) || isMultiAgentV2Enabled(config);
 
 	let result = config;
-	if (!v2Preferred) {
-		result = ensureAgentsMaxThreads(result);
-	} else {
+	if (v2Preferred) {
 		result = removeAgentsMaxThreads(result);
+	} else if (multiAgentVersion == null && !hasModelEvidence(config, options)) {
+		result = raiseExistingAgentsMaxThreads(result);
+	} else {
+		result = ensureAgentsMaxThreads(result);
 	}
 	return ensureMultiAgentV2ThreadLimit(result);
+}
+
+function hasModelEvidence(config, options) {
+	const sessionModel = typeof options.sessionModel === "string" ? options.sessionModel.trim() : "";
+	return sessionModel.length > 0 || readRootModel(config) !== null;
 }
 
 function isMultiAgentV2Enabled(config) {
 	const section = findSection(config, CODEX_MULTI_AGENT_V2_HEADER);
 	if (!section) return false;
 	return /^\s*enabled\s*=\s*true[ \t]*(?:#[^\n]*)?$/m.test(section.text);
+}
+
+function raiseExistingAgentsMaxThreads(config) {
+	const section = findSection(config, CODEX_AGENTS_HEADER);
+	if (!section) return config;
+	if (!/^\s*max_threads\s*=/m.test(section.text)) return config;
+	return replaceOrInsertSetting(config, section, "max_threads", CODEX_SUBAGENT_THREAD_LIMIT);
 }
 
 function ensureAgentsMaxThreads(config) {

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -1179,3 +1179,64 @@ async function canCreateSymlink(type) {
 		return false;
 	}
 }
+
+test("#given model_catalog_json declares a v2 model as v1 #when full migration runs #then keeps the managed disable and max_threads", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-multi-agent-v2-catalog-override-"));
+	const codexHome = join(root, "codex-home");
+	await mkdir(codexHome, { recursive: true });
+	const configPath = join(codexHome, "config.toml");
+	const catalogPath = join(root, "custom-catalog.json");
+	// Codex Desktop user forces gpt-5.6-sol to v1 via an explicit replacement catalog.
+	await writeFile(configPath, [
+		'model = "gpt-5.6-sol"',
+		`model_catalog_json = "${catalogPath}"`,
+		"",
+		"[agents]",
+		"max_threads = 1000",
+		"max_depth = 2",
+		"",
+		"[features.multi_agent_v2]",
+		"enabled = false",
+		"max_concurrent_threads_per_session = 1000",
+		"",
+	].join("\n"));
+	// models_cache.json STILL says v2 (stale), but the explicit catalog wins and says v1.
+	await writeFile(join(codexHome, "models_cache.json"), JSON.stringify({ models: [{ slug: "gpt-5.6-sol", multi_agent_version: "v2" }] }));
+	await writeFile(catalogPath, JSON.stringify({ models: [{ slug: "gpt-5.6-sol", multi_agent_version: "v1" }] }));
+
+	await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json") },
+		cwd: root,
+	});
+
+	const content = await readFile(configPath, "utf8");
+	assert.match(content, /enabled = false/, "explicit v1 catalog must keep the managed disable");
+	assert.match(content, /max_threads = 1000/, "explicit v1 catalog must keep agents.max_threads");
+	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_depth = 2/);
+});
+
+test("#given model_catalog_json declares a model as v2 #when full migration runs #then clears the managed disable", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-multi-agent-v2-catalog-v2-"));
+	const codexHome = join(root, "codex-home");
+	await mkdir(codexHome, { recursive: true });
+	const configPath = join(codexHome, "config.toml");
+	const catalogPath = join(root, "custom-catalog.json");
+	await writeFile(configPath, [
+		'model = "custom-model"',
+		`model_catalog_json = "${catalogPath}"`,
+		"",
+		"[features.multi_agent_v2]",
+		"enabled = false",
+		"",
+	].join("\n"));
+	await writeFile(catalogPath, JSON.stringify({ models: [{ slug: "custom-model", multi_agent_version: "v2" }] }));
+
+	await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json") },
+		cwd: root,
+	});
+
+	const content = await readFile(configPath, "utf8");
+	assert.doesNotMatch(content, /^\s*enabled\s*=\s*false/m, "explicit v2 catalog must clear the disable");
+});

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -756,7 +756,7 @@ test("#given global config with forced multi_agent_v2 #when full migration runs 
 test("#given enabled = true with an inline comment #when forcing disable #then flips to false and preserves the comment", () => {
 	const config = ["[features.multi_agent_v2]", "enabled = true # tuned by me", ""].join("\n");
 
-	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: null });
+	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: "v1" });
 
 	assert.match(result, /^enabled = false # tuned by me$/m);
 	assert.doesNotMatch(result, /enabled = true/);
@@ -767,7 +767,7 @@ test("#given enabled = true with an inline comment #when forcing disable #then f
 test("#given a section header with an inline comment #when forcing disable #then patches in place without duplicating the table", () => {
 	const config = ["[features.multi_agent_v2] # pinned by me", "enabled = true", ""].join("\n");
 
-	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: null });
+	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: "v1" });
 
 	assert.equal((result.match(/\[features\.multi_agent_v2\]/g) ?? []).length, 1);
 	assert.match(result, /enabled = false/);
@@ -779,19 +779,19 @@ test("#given an already-guarded commented config #when re-running #then output i
 	const configA = ["[features.multi_agent_v2]", "enabled = true # tuned by me", ""].join("\n");
 	const configB = ["[features.multi_agent_v2] # pinned by me", "enabled = true", ""].join("\n");
 
-	const firstA = forceDisableMultiAgentV2(configA, { multiAgentVersion: null });
-	const rerunA = forceDisableMultiAgentV2(firstA, { multiAgentVersion: null });
+	const firstA = forceDisableMultiAgentV2(configA, { multiAgentVersion: "v1" });
+	const rerunA = forceDisableMultiAgentV2(firstA, { multiAgentVersion: "v1" });
 	assert.equal(rerunA, firstA);
 
-	const firstB = forceDisableMultiAgentV2(configB, { multiAgentVersion: null });
-	const rerunB = forceDisableMultiAgentV2(firstB, { multiAgentVersion: null });
+	const firstB = forceDisableMultiAgentV2(configB, { multiAgentVersion: "v1" });
+	const rerunB = forceDisableMultiAgentV2(firstB, { multiAgentVersion: "v1" });
 	assert.equal(rerunB, firstB);
 });
 
 test("#given user-disabled with an inline comment #when forcing disable #then returns config unchanged", () => {
 	const config = ["[features.multi_agent_v2]", "enabled = false # I turned this off myself", ""].join("\n");
 
-	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: null });
+	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: "v1" });
 
 	assert.equal(result, config);
 });
@@ -799,7 +799,7 @@ test("#given user-disabled with an inline comment #when forcing disable #then re
 test("#given [features] shorthand true with an inline comment #when forcing disable #then removes the shorthand and appends one disabled table", () => {
 	const config = ["[features]", "plugins = true", "multi_agent_v2 = true # legacy", ""].join("\n");
 
-	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: null });
+	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: "v1" });
 
 	assert.doesNotMatch(result, /^\s*multi_agent_v2\s*=/m);
 	assert.equal((result.match(/\[features\.multi_agent_v2\]/g) ?? []).length, 1);
@@ -816,7 +816,7 @@ test("#given a following section header with an inline comment #when inserting e
 		"",
 	].join("\n");
 
-	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: null });
+	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: "v1" });
 
 	assert.match(result, /\[features\.multi_agent_v2\]\nenabled = false\n/);
 	assert.match(result, /\[mcp_servers\.x\][^\n]*\nenabled = true/);
@@ -1109,6 +1109,47 @@ test("#given config default gpt-5.5 #when full migration gets SessionStart gpt-5
 	assert.deepEqual(result.changed, [configPath]);
 	const content = await readFile(configPath, "utf8");
 	assert.doesNotMatch(content, /^\s*enabled\s*=\s*false/m);
+	assert.doesNotMatch(content, /^\s*max_threads\s*=/m);
+	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+});
+
+test("#given no session model and no root model #when forcing disable #then leaves the enable state untouched", () => {
+	const config = ["[features]", "plugins = true", "", "[features.multi_agent_v2]", "enabled = true", ""].join("\n");
+
+	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: null, sessionModel: null });
+
+	assert.match(result, /enabled = true/);
+	assert.doesNotMatch(result, /enabled = false/);
+	assert.doesNotMatch(result, /openai\/codex#26753/);
+});
+
+test("#given no session model and no root model #when config has no multi_agent_v2 section #then does not append a disable", () => {
+	const config = ["[features]", "plugins = true", ""].join("\n");
+
+	const result = forceDisableMultiAgentV2(config, { multiAgentVersion: null, sessionModel: null });
+
+	assert.equal(result, config);
+	assert.doesNotMatch(result, /\[features\.multi_agent_v2\]/);
+});
+
+test("#given user-modified config without root model #when full non-hook migration runs #then writes no disable and no new agents.max_threads", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-multi-agent-v2-desktop-no-model-"));
+	const codexHome = join(root, "codex-home");
+	await mkdir(codexHome, { recursive: true });
+	const configPath = join(codexHome, "config.toml");
+	// Codex Desktop sessions select the model in the UI; config.toml has no root
+	// `model`, so migration cannot prove the session is not a GPT-5.6
+	// reserved-schema model (#6002).
+	await writeFile(configPath, ['model_reasoning_effort = "high"', "", "[features]", "plugins = true", ""].join("\n"));
+
+	await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json") },
+		cwd: root,
+	});
+
+	const content = await readFile(configPath, "utf8");
+	assert.doesNotMatch(content, /^\s*enabled\s*=\s*false/m);
+	assert.doesNotMatch(content, /openai\/codex#26753/);
 	assert.doesNotMatch(content, /^\s*max_threads\s*=/m);
 	assert.match(content, /max_concurrent_threads_per_session = 1000/);
 });

--- a/packages/omo-codex/plugin/test/subagent-limit-migration.test.mjs
+++ b/packages/omo-codex/plugin/test/subagent-limit-migration.test.mjs
@@ -75,3 +75,35 @@ test("#given gpt-5.6 session model with no models_cache #when migrating #then do
 	assert.match(content, /max_depth = 4/);
 	assert.match(content, /max_concurrent_threads_per_session = 1000/);
 });
+
+test("#given config without any model #when migrating #then does not introduce agents.max_threads", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-no-model-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		['model_reasoning_effort = "high"', "", "[agents]", "max_depth = 4", ""].join("\n"),
+	);
+
+	await migrateConfigFile(configPath, { env: { CODEX_HOME: root } });
+
+	const content = await readFile(configPath, "utf8");
+	assert.doesNotMatch(content, /^\s*max_threads\s*=/m);
+	assert.match(content, /max_depth = 4/);
+	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+});
+
+test("#given config without any model but an existing low cap #when migrating #then still raises the existing cap", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-no-model-raise-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		['model_reasoning_effort = "high"', "", "[agents]", "max_threads = 6", "max_depth = 4", ""].join("\n"),
+	);
+
+	await migrateConfigFile(configPath, { env: { CODEX_HOME: root } });
+
+	const content = await readFile(configPath, "utf8");
+	assert.match(content, /max_threads = 1000/);
+	assert.doesNotMatch(content, /max_threads = 6/);
+	assert.match(content, /max_depth = 4/);
+});

--- a/packages/omo-codex/src/install/codex-config-toml.test.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.test.ts
@@ -822,3 +822,35 @@ describe("codex-config-toml", () => {
   })
 
 })
+
+  test("#given model_catalog_json declares a v2 family model as v1 #when updating config #then keeps agents.max_threads", async () => {
+    // given: Codex documents model_catalog_json as a complete replacement for
+    // models_cache.json (codex-rs load_model_catalog). A user forcing gpt-5.6-sol
+    // to v1 via that catalog must keep the v1 thread cap (lazycodex#120).
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-model-catalog-override-"))
+    const configPath = join(root, "config.toml")
+    const catalogPath = join(root, "custom-catalog.json")
+    await writeFile(configPath, [
+      'model = "gpt-5.6-sol"',
+      `model_catalog_json = "${catalogPath}"`,
+      "",
+      "[features]",
+      "multi_agent_v2 = false",
+      "",
+    ].join("\n"))
+    await writeFile(catalogPath, JSON.stringify({ models: [{ slug: "gpt-5.6-sol", multi_agent_version: "v1" }] }))
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content).toContain("max_threads = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+  })

--- a/packages/omo-codex/src/install/codex-config-toml.test.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.test.ts
@@ -533,6 +533,30 @@ describe("codex-config-toml", () => {
     expect(content).toContain("max_concurrent_threads_per_session = 1000")
   })
 
+  test("#given user-modified config without root model #when updating config #then does not introduce agents.max_threads", async () => {
+    // given: Codex Desktop selects the model in the UI; a user-modified config
+    // (reasoning profile not applied) keeps no root model, so the installer
+    // cannot prove the session is not a GPT-5.6 V2 model that rejects
+    // agents.max_threads at thread/start (#6002).
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-no-model-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(configPath, ['model_reasoning_effort = "high"', "", "[features]", "plugins = false", ""].join("\n"))
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content).not.toMatch(/^\s*max_threads\s*=/m)
+    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+  })
+
   test("#given managed agent role sections #when updating config #then preserves role config while raising only root agents max_threads", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-role-section-"))

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
@@ -80,7 +80,8 @@ export function ensureCodexMultiAgentV2Config(
 export function resolveCodexMultiAgentVersion(config: string, configPath: string): CodexMultiAgentVersion {
   const model = readRootModel(config)
   if (model === null) return null
-  const catalogVersion = readCatalogMultiAgentVersion(model, join(dirname(configPath), "models_cache.json"))
+  const catalogPath = readRootModelCatalogPath(config) ?? join(dirname(configPath), "models_cache.json")
+  const catalogVersion = readCatalogMultiAgentVersion(model, catalogPath)
   if (catalogVersion !== null) return catalogVersion
   return /^gpt-5\.6\b/i.test(model) ? "v2" : null
 }
@@ -113,6 +114,13 @@ function readRootModel(config: string): string | null {
   const double = config.match(/^\s*model\s*=\s*"([^"]+)"/m)
   if (double !== null) return double[1] ?? null
   const single = config.match(/^\s*model\s*=\s*'([^']+)'/m)
+  return single?.[1] ?? null
+}
+
+function readRootModelCatalogPath(config: string): string | null {
+  const double = config.match(/^\s*model_catalog_json\s*=\s*"([^"]+)"/m)
+  if (double !== null) return double[1] ?? null
+  const single = config.match(/^\s*model_catalog_json\s*=\s*'([^']+)'/m)
   return single?.[1] ?? null
 }
 

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
@@ -26,6 +26,12 @@ export type CodexMultiAgentVersion = "v1" | "v2" | null
  * the legacy `[features]` boolean shorthand (a config-level disable
  * mismatches the reserved `collaboration.spawn_agent` schema on some Codex
  * versions - oh-my-openagent#6002 / #6008).
+ *
+ * When config.toml names no root model at all (Codex Desktop selects the
+ * model in the UI), the installer never introduces `agents.max_threads`:
+ * Codex rejects that key at thread/start while MultiAgentV2 is active. An
+ * existing cap is still raised in place so the legacy low-cap repair keeps
+ * working and a hand-removed key stays removed.
  */
 export function ensureCodexMultiAgentV2Config(
   config: string,
@@ -33,9 +39,12 @@ export function ensureCodexMultiAgentV2Config(
 ): string {
   const featureFlag = removeFeatureFlagSetting(config, "multi_agent_v2")
   const v2Preferred = options.multiAgentVersion === "v2"
+  const modelKnown = options.multiAgentVersion != null || readRootModel(featureFlag.config) !== null
   const agentsConfig = v2Preferred
     ? removeAgentsMaxThreads(featureFlag.config)
-    : ensureAgentsMaxThreads(featureFlag.config)
+    : modelKnown
+      ? ensureAgentsMaxThreads(featureFlag.config)
+      : raiseExistingAgentsMaxThreads(featureFlag.config)
   const section = findTomlSection(agentsConfig, CODEX_MULTI_AGENT_V2_HEADER)
   const maxThreadsValue = CODEX_SUBAGENT_THREAD_LIMIT.toString()
   const preserveDisable = featureFlag.value === false && !v2Preferred
@@ -140,6 +149,13 @@ function removeAgentsMaxThreads(config: string): string {
   if (!section) return config
   if (!/^\s*max_threads\s*=/m.test(section.text)) return config
   return removeSetting(config, section, "max_threads")
+}
+
+function raiseExistingAgentsMaxThreads(config: string): string {
+  const section = findTomlSection(config, CODEX_AGENTS_HEADER)
+  if (!section) return config
+  if (!/^\s*max_threads\s*=/m.test(section.text)) return config
+  return replaceOrInsertSetting(config, section, "max_threads", CODEX_SUBAGENT_THREAD_LIMIT.toString())
 }
 
 function readBooleanSetting(sectionText: string, key: string): boolean | null {


### PR DESCRIPTION
## Summary

Two gaps in the OMO multi-agent version resolver (the code that decides whether a Codex session is V1 or V2) caused config-tug-of-war breakage:

1. **Unknown-model recurrence (#6002).** Codex Desktop picks the model in the UI, so config.toml often has no root model. The guards resolved multiAgentVersion = null from a model-less config and then ran the legacy force-disable path anyway — writing enabled = false and/or agents.max_threads = 1000 on every installer/auto-update/migrate-CLI run. The disable 400s every turn on GPT-5.6 (collaboration.spawn_agent reserved-schema), and agents.max_threads is rejected at thread/start while V2 is active. Users had to hand-edit and pray no migration re-ran — the post-#6004 "still broken on 4.16.1/4.16.2" reports.

2. **model_catalog_json ignored (code-yeongyu/lazycodex#120).** Codex documents model_catalog_json as a COMPLETE replacement for models_cache.json. A user forcing gpt-5.6-sol to v1 via that catalog had Codex resolve v1 but the OMO guards read models_cache.json (still v2) and cleared the managed disable/max_threads the user needed.

This PR fixes the resolver in both the plugin migration and the TypeScript installer: skip the force-disable / agents.max_threads introduction when no model is resolvable at all, and prefer model_catalog_json over models_cache.json when set.

## Changes

- multi-agent-v2-guard.mjs: no-model skip in forceDisableMultiAgentV2; new readRootModelCatalogPath; resolveMultiAgentVersionFromConfig prefers it.
- subagent-limit-guard.mjs: new raiseExistingAgentsMaxThreads (no-model branch); v1/v2 paths unchanged.
- codex-multi-agent-v2-config.ts (installer): no-model agents.max_threads safety mirror; resolveCodexMultiAgentVersion prefers model_catalog_json.
- Tests: RED then GREEN no-model cases (plugin + installer); new model_catalog_json v1-override and v2 cases (plugin + installer); 6 legacy TOML-mechanics tests updated to explicit multiAgentVersion v1 so they keep exercising the legacy-disable path under the new no-model policy.

## QA and Evidence

Evidence: .omo/evidence/20260710-multi-agent-unknown-model/ (summary.md).

- RED then GREEN: 01-red.txt model-less config force-disabled + max_threads added on base; 03-green-all.txt plugin 54/0 + installer 26/0; full bun run test:codex exit 0; bun run typecheck exit 0.
- Hermetic migration dry-run (dry-run.mjs / 04-hermetic-dry-run.txt): real migrateCodexConfig() against a temp CODEX_HOME for 4 configs — user-modified-no-model (no disable, no max_threads), gpt-5.4 v1 (cap raised, disable kept), gpt-5.6-sol v2 (disable cleared, max_threads dropped), model_catalog_json v1-override of a v2 model (disable kept). DRY_RUN=PASS.
- install-verify (05-install-verify.txt, codex-qa skill): local omo installs into isolated CODEX_HOME, 9 component bins + agent TOMLs linked; real ~/.codex/config.toml sha unchanged (7394c5ec == 7394c5ec).

## Risks and Residuals

- An empty config (no reasoning settings) still receives the default v1 profile (sets root model = gpt-5.5), so it keeps getting max_threads = 1000 — intended for fresh v1 installs. The fix targets user-modified configs with no root model.
- model_catalog_json paths are read as-is (Codex requires absolute paths there anyway); on a lookup miss inside an explicit catalog the resolver returns null (no fallback to models_cache.json), matching Codex complete-replacement semantics.

## Related Issues

Addresses the post-#6004 recurrence of #6002. Fixes code-yeongyu/lazycodex#120. Related: lazycodex#118.
