### PR TITLE
fix(codex): regenerate installer bundle guards

### DIFF
--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -8663,7 +8663,8 @@ var CODEX_SUBAGENT_THREAD_LIMIT = 1000;
 function ensureCodexMultiAgentV2Config(config, options = {}) {
   const featureFlag = removeFeatureFlagSetting(config, "multi_agent_v2");
   const v2Preferred = options.multiAgentVersion === "v2";
-  const agentsConfig = v2Preferred ? removeAgentsMaxThreads(featureFlag.config) : ensureAgentsMaxThreads(featureFlag.config);
+  const modelKnown = options.multiAgentVersion != null || readRootModel(featureFlag.config) !== null;
+  const agentsConfig = v2Preferred ? removeAgentsMaxThreads(featureFlag.config) : modelKnown ? ensureAgentsMaxThreads(featureFlag.config) : raiseExistingAgentsMaxThreads(featureFlag.config);
   const section = findTomlSection(agentsConfig, CODEX_MULTI_AGENT_V2_HEADER);
   const maxThreadsValue = CODEX_SUBAGENT_THREAD_LIMIT.toString();
   const preserveDisable = featureFlag.value === false && !v2Preferred;
@@ -8688,7 +8689,8 @@ function resolveCodexMultiAgentVersion(config, configPath) {
   const model = readRootModel(config);
   if (model === null)
     return null;
-  const catalogVersion = readCatalogMultiAgentVersion(model, join18(dirname7(configPath), "models_cache.json"));
+  const catalogPath = readRootModelCatalogPath(config) ?? join18(dirname7(configPath), "models_cache.json");
+  const catalogVersion = readCatalogMultiAgentVersion(model, catalogPath);
   if (catalogVersion !== null)
     return catalogVersion;
   return /^gpt-5\.6\b/i.test(model) ? "v2" : null;
@@ -8727,6 +8729,13 @@ function readRootModel(config) {
   const single = config.match(/^\s*model\s*=\s*'([^']+)'/m);
   return single?.[1] ?? null;
 }
+function readRootModelCatalogPath(config) {
+  const double = config.match(/^\s*model_catalog_json\s*=\s*"([^"]+)"/m);
+  if (double !== null)
+    return double[1] ?? null;
+  const single = config.match(/^\s*model_catalog_json\s*=\s*'([^']+)'/m);
+  return single?.[1] ?? null;
+}
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -8756,6 +8765,14 @@ function removeAgentsMaxThreads(config) {
   if (!/^\s*max_threads\s*=/m.test(section.text))
     return config;
   return removeSetting(config, section, "max_threads");
+}
+function raiseExistingAgentsMaxThreads(config) {
+  const section = findTomlSection(config, CODEX_AGENTS_HEADER);
+  if (!section)
+    return config;
+  if (!/^\s*max_threads\s*=/m.test(section.text))
+    return config;
+  return replaceOrInsertSetting(config, section, "max_threads", CODEX_SUBAGENT_THREAD_LIMIT.toString());
 }
 function readBooleanSetting(sectionText, key) {
   const match = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=\\s*(true|false)\\s*(?:#.*)?$`, "m").exec(sectionText);

--- a/packages/omo-codex/scripts/install-generated-bundle.test.mjs
+++ b/packages/omo-codex/scripts/install-generated-bundle.test.mjs
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+
+import { updateCodexConfig } from "./install-dist/install-local.mjs";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const entrypointPath = join(scriptsDir, "install-local.mjs");
@@ -53,3 +56,110 @@ test("#given generated installer output #when importing direct bundle #then comp
 		assert.equal(typeof module[name], "function", `${name} must be exported`);
 	}
 });
+
+test("#given no root model #when generated bundle updates config #then it does not introduce agents max_threads", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-generated-no-root-model-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(configPath, ['model_reasoning_effort = "high"', "", "[features]", "plugins = false", ""].join("\n"));
+
+	// when
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "debug",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+		pluginNames: ["omo"],
+	});
+
+	// then
+	const config = await readFile(configPath, "utf8");
+	assert.doesNotMatch(config, /^\s*max_threads\s*=/m);
+	assert.match(config, /max_concurrent_threads_per_session = 1000/);
+});
+
+test("#given explicit v1 model_catalog_json and stale models_cache v2 #when generated bundle updates config #then explicit catalog preserves disable and cap", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-generated-catalog-v1-"));
+	const configPath = join(root, "config.toml");
+	const catalogPath = join(root, "custom-catalog.json");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.6-sol"',
+			`model_catalog_json = "${catalogPath}"`,
+			"",
+			"[features]",
+			"multi_agent_v2 = false",
+			"",
+			"[agents]",
+			"max_threads = 16",
+			"",
+		].join("\n"),
+	);
+	await writeFile(catalogPath, JSON.stringify({ models: [{ slug: "gpt-5.6-sol", multi_agent_version: "v1" }] }));
+	await writeFile(join(root, "models_cache.json"), JSON.stringify({ models: [{ slug: "gpt-5.6-sol", multi_agent_version: "v2" }] }));
+
+	// when
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "debug",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+		pluginNames: ["omo"],
+	});
+
+	// then
+	const config = await readFile(configPath, "utf8");
+	const v2Section = sectionText(config, "[features.multi_agent_v2]");
+	assert.match(v2Section, /^enabled = false$/m);
+	assert.match(config, /\[agents\][\s\S]*?max_threads = 1000/);
+	assert.doesNotMatch(config, /max_threads = 16/);
+});
+
+test("#given explicit v2 model_catalog_json and stale models_cache v1 #when generated bundle updates config #then explicit catalog clears managed disable and cap", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-generated-catalog-v2-"));
+	const configPath = join(root, "config.toml");
+	const catalogPath = join(root, "custom-catalog.json");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.6-sol"',
+			`model_catalog_json = "${catalogPath}"`,
+			"",
+			"[features]",
+			"multi_agent_v2 = false",
+			"",
+			"[agents]",
+			"max_threads = 16",
+			"",
+		].join("\n"),
+	);
+	await writeFile(catalogPath, JSON.stringify({ models: [{ slug: "gpt-5.6-sol", multi_agent_version: "v2" }] }));
+	await writeFile(join(root, "models_cache.json"), JSON.stringify({ models: [{ slug: "gpt-5.6-sol", multi_agent_version: "v1" }] }));
+
+	// when
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "debug",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+		pluginNames: ["omo"],
+	});
+
+	// then
+	const config = await readFile(configPath, "utf8");
+	const v2Section = sectionText(config, "[features.multi_agent_v2]");
+	assert.doesNotMatch(v2Section, /^enabled\s*=/m);
+	assert.doesNotMatch(config, /^\s*max_threads\s*=/m);
+	assert.match(v2Section, /max_concurrent_threads_per_session = 1000/);
+});
+
+function sectionText(config, header) {
+	const start = config.indexOf(header);
+	if (start === -1) return "";
+	const afterStart = config.slice(start + header.length);
+	const nextSectionOffset = afterStart.search(/\n\[/);
+	return nextSectionOffset === -1 ? config.slice(start) : config.slice(start, start + header.length + nextSectionOffset);
+}


### PR DESCRIPTION
## Summary
Regenerates the published Codex installer bundle from the current TypeScript source so release artifacts match the MultiAgentV2 guard fixes already on `dev`. Adds generated-bundle regression coverage for the release blocker: no-root-model configs no longer get a new `[agents].max_threads`, explicit `model_catalog_json` v1 preserves the managed disable/cap, and explicit v2 clears/removes them even when `models_cache.json` is stale.

## Changes
- Regenerated `packages/omo-codex/scripts/install-dist/install-local.mjs` via `bun run build:codex-install`.
- Added direct generated-bundle tests in `packages/omo-codex/scripts/install-generated-bundle.test.mjs` for the no-root-model and explicit catalog v1/v2 precedence cases.

## QA & Evidence
- **What was tested:** failing-first generated-bundle test before regeneration: `node --test packages/omo-codex/scripts/install-generated-bundle.test.mjs`.
  **Observed result:** 3/6 failed for the intended stale-bundle behaviors.
  **Artifact:** `.omo/evidence/20260710-codex-installer-bundle-guards/red-install-generated-bundle-node-test.txt`.
  **Why sufficient:** proves the new tests catch the release blocker before the bundle is rebuilt.
- **What was tested:** regenerated bundle: `bun run build:codex-install`.
  **Observed result:** exit 0; diff contains `modelKnown`, `readRootModelCatalogPath`, and `raiseExistingAgentsMaxThreads` in the generated script.
  **Artifact:** `.omo/evidence/20260710-codex-installer-bundle-guards/build-codex-install.txt`.
  **Why sufficient:** proves the committed generated output came from the source build path.
- **What was tested:** focused script/source suites: `node --test ...install-generated-bundle.test.mjs` with related installer script tests, and `bun test packages/omo-codex/src/install/codex-config-toml.test.ts packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts`.
  **Observed result:** script tests 33/33 pass; source tests 28/28 pass.
  **Artifacts:** `.omo/evidence/20260710-codex-installer-bundle-guards/target-script-installer-tests.txt`, `.omo/evidence/20260710-codex-installer-bundle-guards/target-source-installer-tests.txt`.
  **Why sufficient:** covers both the published bundle surface and the typed source surface.
- **What was tested:** Codex QA strict isolation: `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check` and `REPO_ROOT=/Users/yeongyu/local-workspaces/omo-wt/release-codex-installer-bundle bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test`.
  **Observed result:** sandbox cleanup/mock model passed; isolated install found plugin cache, enabled `omo@sisyphuslabs`, linked component bins and agent TOMLs, and real `~/.codex/config.toml` hash was unchanged.
  **Artifacts:** `.omo/evidence/20260710-codex-installer-bundle-guards/codex-qa-common-self-check.txt`, `.omo/evidence/20260710-codex-installer-bundle-guards/codex-qa-install-verify.txt`.
  **Why sufficient:** exercises the local Codex installer in an isolated `CODEX_HOME`.
- **What was tested:** focused real installer scenario: `node packages/omo-codex/scripts/install-local.mjs install` with throwaway `CODEX_HOME`, explicit `model_catalog_json` v2, and stale `models_cache.json` v1.
  **Observed result:** sandbox config had no `features.multi_agent_v2.enabled`, no `agents.max_threads`, retained `max_concurrent_threads_per_session = 1000`, enabled `omo@sisyphuslabs`, and real `~/.codex/config.toml` hash was unchanged.
  **Artifact:** `.omo/evidence/20260710-codex-installer-bundle-guards/focused-real-installer-model-catalog-precedence.txt`.
  **Why sufficient:** proves the stable installer entrypoint plus generated bundle honor `model_catalog_json` before `models_cache.json` outside the unit test runner.
- **What was tested:** canonical Codex gate and hygiene: `bun run test:codex`, `tsgo --noEmit -p packages/omo-codex/tsconfig.json`, `git diff --check`.
  **Observed result:** `test:codex` passed 500/500; typecheck and diff check exited 0.
  **Artifacts:** `.omo/evidence/20260710-codex-installer-bundle-guards/test-codex.txt`, `.omo/evidence/20260710-codex-installer-bundle-guards/typecheck-omo-codex.txt`, `.omo/evidence/20260710-codex-installer-bundle-guards/git-diff-check.txt`.
  **Why sufficient:** covers the required release Codex compatibility gate and local whitespace/type sanity.

Full reviewer-readable evidence ledger: `.omo/evidence/20260710-codex-installer-bundle-guards/evidence.md`.

## Risks & Residuals
- Risk: generated bundle can drift from TypeScript source again. Mitigated by direct generated-bundle behavior tests that fail on the stale artifact.
- Risk: installer surface differs from direct helper tests. Mitigated by the focused real `install-local.mjs install` scenario and Codex QA isolated install verification.
- Residual: `.omo/evidence` is ignored by the repo and remains local evidence, per project convention.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated the Codex installer bundle to sync MultiAgent V2 guard logic with `dev`, and added direct bundle tests to prevent stale artifacts. This fixes incorrect thread-cap behavior and respects explicit `model_catalog_json` over a stale `models_cache.json`.

- **Bug Fixes**
  - No root `model`: do not add `[agents].max_threads`.
  - Prefer `model_catalog_json` path over `models_cache.json` for version resolution.
  - Catalog v1: keep `features.multi_agent_v2` disabled and set `[agents].max_threads = 1000`.
  - Catalog v2: clear `features.multi_agent_v2.enabled` and remove `[agents].max_threads`; keep `max_concurrent_threads_per_session = 1000`.

<sup>Written for commit 0a1fdfa92bc3699851a6d1452b96252b62cb69e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

