### PR TITLE
fix(rules): limit Hephaestus truncation exemption

### DIFF
--- a/packages/rules-engine/src/engine/formatter.test.ts
+++ b/packages/rules-engine/src/engine/formatter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+
+import { formatStaticBlock } from "./formatter.js";
+import type { LoadedRule, MatchReason, RuleSource } from "./types.js";
+
+describe("engine formatStaticBlock", () => {
+	it("#given a project rule under a hephaestus directory #when formatting under a 200 byte budget #then it keeps normal order and truncates the body", () => {
+		// given
+		const tailMarker = "PROJECT_HEPHAESTUS_TAIL_SENTINEL";
+		const alphaRule = loadedRule({
+			path: "/repo/.omo/rules/alpha.md",
+			relativePath: ".omo/rules/alpha.md",
+			body: "Alpha guidance.",
+		});
+		const projectHephaestusRule = loadedRule({
+			path: "/repo/.omo/rules/hephaestus/large.md",
+			relativePath: ".omo/rules/hephaestus/large.md",
+			body: `Project Hephaestus rule ${"H".repeat(600)} ${tailMarker}`,
+		});
+
+		// when
+		const block = formatStaticBlock([alphaRule, projectHephaestusRule], {
+			maxRuleChars: 120,
+			maxResultChars: 200,
+		});
+
+		// then
+		expect(block).toContain("Alpha guidance.");
+		expect(block).toContain("Project Hephaestus rule");
+		expect(block.indexOf("Alpha guidance.") < block.indexOf("Project Hephaestus rule")).toBe(true);
+		expect(block).not.toContain(tailMarker);
+		expect(block).toContain("[Truncated. Full: .omo/rules/hephaestus/large.md]");
+	});
+});
+
+function loadedRule(input: {
+	readonly body: string;
+	readonly path: string;
+	readonly relativePath: string;
+	readonly source?: RuleSource;
+	readonly matchReason?: MatchReason;
+}): LoadedRule {
+	return {
+		path: input.path,
+		realPath: input.path,
+		source: input.source ?? ".omo/rules",
+		distance: 0,
+		isGlobal: false,
+		isSingleFile: true,
+		relativePath: input.relativePath,
+		frontmatter: {},
+		body: input.body,
+		contentHash: input.relativePath,
+		matchReason: input.matchReason ?? "single-file",
+	};
+}

--- a/packages/rules-engine/src/engine/truncator.test.ts
+++ b/packages/rules-engine/src/engine/truncator.test.ts
@@ -22,6 +22,8 @@ describe("engine isNeverTruncatedRule", () => {
 		it("#when checked #then they remain truncatable", () => {
 			expect(isNeverTruncatedRule("bundled-rules/windows-git-bash.md")).toBe(false);
 			expect(isNeverTruncatedRule(".omo/rules/typescript.md")).toBe(false);
+			expect(isNeverTruncatedRule(".omo/rules/hephaestus/large.md")).toBe(false);
+			expect(isNeverTruncatedRule("bundled-rules/hephaestus/future.md")).toBe(false);
 		});
 	});
 

--- a/packages/rules-engine/src/engine/truncator.ts
+++ b/packages/rules-engine/src/engine/truncator.ts
@@ -10,18 +10,19 @@ type BudgetResult = BudgetRule & {
 	truncated: boolean;
 };
 
+const NEVER_TRUNCATED_RULE_PATHS = new Set([
+	"bundled-rules/hephaestus.md",
+	"bundled-rules/hephaestus/gpt-5.5.md",
+	"bundled-rules/hephaestus/gpt-5.6.md",
+]);
+
 function truncationNotice(relativePath: string): string {
 	return TRUNCATION_NOTICE.replace("{path}", relativePath);
 }
 
 export function isNeverTruncatedRule(relativePath: string): boolean {
-	const normalized = relativePath.replace(/\\/g, "/");
-	const segments = normalized.split("/").filter((segment) => segment.length > 0);
-	const filename = segments.at(-1) ?? normalized;
-	if (filename.toLowerCase() === "hephaestus.md") {
-		return true;
-	}
-	return segments.at(-2)?.toLowerCase() === "hephaestus";
+	const normalized = relativePath.replace(/\\/g, "/").toLowerCase();
+	return NEVER_TRUNCATED_RULE_PATHS.has(normalized);
 }
 
 function safeSliceEnd(body: string, end: number): number {


### PR DESCRIPTION
## Summary
Fixes the release-blocker where any user/project rule inside a `hephaestus/` directory inherited the bundled Hephaestus never-truncate and first-order treatment. The rules engine now only exempts the supported bundled baselines: `bundled-rules/hephaestus.md`, `bundled-rules/hephaestus/gpt-5.5.md`, and `bundled-rules/hephaestus/gpt-5.6.md`.

## Changes
- Added a negative rules-engine regression for `.omo/rules/hephaestus/large.md` under a 200 byte budget, proving it keeps normal order after another project rule and truncates with the read-full marker.
- Replaced the broad `parent directory === hephaestus` predicate with an exact normalized bundled-path allowlist.
- Extended direct truncator assertions so project hephaestus paths and unsupported bundled hephaestus variants remain truncatable while packaged variants stay full-body.

## QA & Evidence
- **What was tested:** Red regression before the fix: `cd packages/rules-engine && bun test src/engine/formatter.test.ts`.
  **Observed result:** Failed because `Alpha guidance.` was dropped and the project hephaestus tail survived the 200 byte budget.
  **Artifact:** `.omo/evidence/20260710-hephaestus-rule-truncation/red-rules-engine-formatter-test.txt`.
  **Why sufficient:** Reproduces blocker 1's ordering and overflow symptoms.

- **What was tested:** Focused rules-engine tests: `cd packages/rules-engine && bun test src/engine/formatter.test.ts src/engine/truncator.test.ts`.
  **Observed result:** 6 pass, 15 assertions.
  **Artifact:** `.omo/evidence/20260710-hephaestus-rule-truncation/rules-engine-focused-tests.txt`.
  **Why sufficient:** Covers the fixed negative path and preserves bundled baseline behavior.

- **What was tested:** Full rules-engine suite from repo root and typecheck.
  **Observed result:** 37 pass / 0 fail; `tsgo --noEmit -p tsconfig.json` passed.
  **Artifacts:** `.omo/evidence/20260710-hephaestus-rule-truncation/rules-engine-root-tests.txt`, `.omo/evidence/20260710-hephaestus-rule-truncation/rules-engine-typecheck.txt`.
  **Why sufficient:** Covers shared engine regressions beyond the new case.

- **What was tested:** Codex rules component formatter consumer and OpenCode rules-injector shared-package smoke.
  **Observed result:** Codex formatter test passed 9 tests; OpenCode matcher/finder smoke passed.
  **Artifacts:** `.omo/evidence/20260710-hephaestus-rule-truncation/codex-rules-component-formatter-test.txt`, `.omo/evidence/20260710-hephaestus-rule-truncation/opencode-rules-injector-shared-smoke.txt`.
  **Why sufficient:** Covers the direct Codex formatter consumer and shared package resolution from OpenCode.

- **What was tested:** Codex gates: `bun run test:codex`, `codex-qa` self-check, and `codex-qa` app-server `--plugin`.
  **Observed result:** `test:codex` passed; Codex QA used isolated `CODEX_HOME`, left real `~/.codex/config.toml` unchanged, completed a mock-model app-server turn, and observed plugin hook notifications for `sessionStart` and `userPromptSubmit`.
  **Artifacts:** `.omo/evidence/20260710-hephaestus-rule-truncation/test-codex.txt`, `.omo/evidence/20260710-hephaestus-rule-truncation/codex-qa-self-check.txt`, `.omo/evidence/20260710-hephaestus-rule-truncation/codex-qa-app-server-plugin.json`.
  **Why sufficient:** Satisfies the required isolated real Codex harness proof for Codex-connected rules behavior.

- **What was tested:** Runtime `formatStaticBlock` probe, no-excuse scan, and `git diff --check`.
  **Observed result:** Non-bundled project hephaestus rule: alpha present, alpha before project, project tail absent, truncation marker present. Bundled GPT-5.6 rule: tail present, no truncation marker. No no-excuse violations. `git diff --check` clean.
  **Artifacts:** `.omo/evidence/20260710-hephaestus-rule-truncation/rules-engine-runtime-probe.json`, `.omo/evidence/20260710-hephaestus-rule-truncation/no-excuse-check.txt`, `.omo/evidence/20260710-hephaestus-rule-truncation/git-diff-check.txt`.
  **Why sufficient:** Gives a direct reviewer-readable binary observable for the exact blocker scenario.

## Risks & Residuals
- The allowlist is intentionally narrow. Future bundled Hephaestus variants must be added explicitly if they should be never-truncated.
- Evidence omits raw temporary Codex home contents and secret-bearing environment/log surfaces; the helper output records isolation and hook results without credentials.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a release-blocker by limiting Hephaestus “never truncate” to exact bundled baselines. Project rules under `hephaestus/` now keep normal order and truncate correctly.

- **Bug Fixes**
  - In `rules-engine` truncator, replaced directory check with an allowlist: `bundled-rules/hephaestus.md`, `bundled-rules/hephaestus/gpt-5.5.md`, `bundled-rules/hephaestus/gpt-5.6.md`.
  - Added formatter regression test for `.omo/rules/hephaestus/large.md` under a 200-byte budget to assert order, truncation marker, and tail removal.
  - Extended truncator tests to ensure project `hephaestus` and unsupported bundled variants remain truncatable.

<sup>Written for commit 882c2284c5e5f2abeb2ec5fd93c5ad5fc1310296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

