### PR TITLE
fix(omo-codex): invalidate dynamic rules on model switch

### DIFF
--- a/packages/omo-codex/plugin/components/rules/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/rules/src/codex-hook.ts
@@ -190,7 +190,7 @@ export async function runPostToolUseHook(
 		dynamicTargetFingerprints: engine.state.dynamicTargetFingerprints.size,
 		staticDedup: engine.state.staticDedup.size,
 	});
-	const dynamicTargetFingerprints = fingerprintDynamicTargets(input.cwd, targetPaths, config);
+	const dynamicTargetFingerprints = fingerprintDynamicTargets(input.cwd, targetPaths, config, input.model);
 	debugTimer.lap("fingerprint", { fingerprints: dynamicTargetFingerprints.length });
 	const pendingTargetFingerprints = dynamicTargetFingerprints.filter(
 		(target) => engine.state.dynamicTargetFingerprints.get(target.cacheKey) !== target.fingerprint,

--- a/packages/omo-codex/plugin/components/rules/src/dynamic-target-fingerprints.ts
+++ b/packages/omo-codex/plugin/components/rules/src/dynamic-target-fingerprints.ts
@@ -1,12 +1,15 @@
 import { statSync } from "node:fs";
 import { resolve } from "node:path";
-import { isSameOrChildPath, toPosixPath, uniqueStrings } from "./path-utils.js";
-import { createRuleDiscoveryCache, findRuleCandidates } from "@oh-my-opencode/rules-engine/engine";
-import { hashContent } from "@oh-my-opencode/rules-engine/engine";
-import { sortCandidates } from "@oh-my-opencode/rules-engine/engine";
-import { findProjectRoot } from "@oh-my-opencode/rules-engine/engine";
-import { disabledSourcesFromConfig } from "@oh-my-opencode/rules-engine/engine";
 import type { PiRulesConfig, RuleCandidate } from "@oh-my-opencode/rules-engine/engine";
+import {
+	createRuleDiscoveryCache,
+	disabledSourcesFromConfig,
+	findProjectRoot,
+	findRuleCandidates,
+	hashContent,
+	sortCandidates,
+} from "@oh-my-opencode/rules-engine/engine";
+import { isSameOrChildPath, toPosixPath, uniqueStrings } from "./path-utils.js";
 
 export interface DynamicTargetFingerprint {
 	targetPath: string;
@@ -18,6 +21,7 @@ export function fingerprintDynamicTargets(
 	cwd: string,
 	targetPaths: ReadonlyArray<string>,
 	config: PiRulesConfig,
+	model?: string,
 ): DynamicTargetFingerprint[] {
 	const disabledSources = disabledSourcesFromConfig(config);
 	const discoveryCache = createRuleDiscoveryCache();
@@ -34,6 +38,7 @@ export function fingerprintDynamicTargets(
 			targetFile: string;
 			disabledSources?: ReadonlySet<string>;
 			cache: ReturnType<typeof createRuleDiscoveryCache>;
+			model?: string;
 		} = {
 			projectRoot,
 			targetFile: targetPath,
@@ -41,6 +46,9 @@ export function fingerprintDynamicTargets(
 		};
 		if (disabledSources !== undefined) {
 			findOptions.disabledSources = disabledSources;
+		}
+		if (model !== undefined) {
+			findOptions.model = model;
 		}
 		const candidates = findRuleCandidates(findOptions);
 		const candidateFingerprint = sortCandidates(candidates).map(fingerprintCandidate).join("\u0001");
@@ -52,6 +60,7 @@ export function fingerprintDynamicTargets(
 				[
 					"v1",
 					config.enabledSources === "auto" ? "auto" : config.enabledSources.join(","),
+					model ?? "",
 					projectRoot ?? "",
 					cacheKey,
 					candidateFingerprint,

--- a/packages/omo-codex/plugin/components/rules/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/codex-hook.test.ts
@@ -28,6 +28,7 @@ type SessionCache = {
 };
 
 const CLI_PATH = fileURLToPath(new URL("../dist/cli.js", import.meta.url));
+const COMPONENT_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 function runHookCli(input: string, subcommand = "post-tool-use", env: NodeJS.ProcessEnv = {}): Promise<CliResult> {
 	return new Promise((resolve, reject) => {
@@ -68,6 +69,12 @@ const CLAUDE_AND_RULES_ENV = {
 
 const RULES_ONLY_ENV = {
 	CODEX_RULES_ENABLED_SOURCES: ".omo/rules",
+};
+
+const DYNAMIC_BUNDLED_ONLY_ENV = {
+	CODEX_RULES_MODE: "dynamic",
+	CODEX_RULES_ENABLED_SOURCES: "plugin-bundled",
+	PLUGIN_ROOT: COMPONENT_ROOT,
 };
 
 afterEach(() => {
@@ -409,6 +416,31 @@ describe("codex rules hooks", () => {
 		expect(output).toBe("");
 		expect(Object.keys(cachedState.dynamicTargetFingerprints ?? {})).toHaveLength(1);
 		expect(readSessionCache(pluginData).dynamicTargetFingerprints).toEqual(cachedState.dynamicTargetFingerprints);
+	});
+
+	it("#given bundled dynamic rules already injected for gpt-5.5 #when same target switches to gpt-5.6 #then emits the gpt-5.6 rule", async () => {
+		// given
+		const { root, pluginData } = makeTempProject();
+		const filePath = path.join(root, "src", "app.ts");
+		const input = postToolUseInput(root, filePath);
+		const firstOutput = await runPostToolUseHook(input, {
+			pluginDataRoot: pluginData,
+			env: DYNAMIC_BUNDLED_ONLY_ENV,
+		});
+
+		// when
+		const secondOutput = await runPostToolUseHook(
+			{ ...input, model: "gpt-5.6-codex" },
+			{ pluginDataRoot: pluginData, env: DYNAMIC_BUNDLED_ONLY_ENV },
+		);
+
+		// then
+		const firstContext = parseHookOutput(firstOutput).hookSpecificOutput?.additionalContext ?? "";
+		const secondContext = parseHookOutput(secondOutput).hookSpecificOutput?.additionalContext ?? "";
+		expect(firstContext).toContain("based on GPT-5.5");
+		expect(firstContext).not.toContain("based on GPT-5.6");
+		expect(secondContext).toContain("based on GPT-5.6");
+		expect(secondContext).not.toContain("based on GPT-5.5");
 	});
 
 	it("#given default auto sources #when excluded AGENTS.md changes #then PostToolUse fingerprint stays stable", async () => {


### PR DESCRIPTION
## Summary

Fixes the Codex rules dynamic-mode release blocker where a same-session model switch from GPT-5.5 to GPT-5.6 on the same target emitted no second rules context. Dynamic target fingerprints now discover candidates with the active model and include that model in the fingerprint material, so model-gated bundled rules invalidate the per-target cache correctly.

## Changes

- Threads `input.model` into `fingerprintDynamicTargets()` from the rules `PostToolUse` hook.
- Includes the active model in dynamic target fingerprint discovery and hash material.
- Adds a regression that first injects the GPT-5.5 Hephaestus bundled rule, then switches the same session/target to `gpt-5.6-codex` and asserts the GPT-5.6 rule is emitted.

## QA & Evidence

- **Red regression:** `npm test -- test/codex-hook.test.ts -t "same target switches to gpt-5.6"` with the implementation hunk temporarily reversed failed because the second hook output was empty. Artifact: `.omo/evidence/20260710-codex-rules-dynamic-model/01-red-focused-test.txt`.
- **Focused green regression:** same test passed on the final implementation. Artifact: `.omo/evidence/20260710-codex-rules-dynamic-model/02b-green-focused-test-after-format.txt`.
- **Rules component suite:** `npm test` in `packages/omo-codex/plugin/components/rules` passed 30 files / 163 tests. Artifact: `.omo/evidence/20260710-codex-rules-dynamic-model/03b-component-npm-test-after-format.txt`.
- **Rules component typecheck:** `npm run typecheck` passed. Artifact: `.omo/evidence/20260710-codex-rules-dynamic-model/04c-component-typecheck-after-format.txt`.
- **Aggregate prompt surface:** materialized skills with `npm run sync:skills`, then `node --test test/aggregate-skills.test.mjs` passed. Artifacts: `.omo/evidence/20260710-codex-rules-dynamic-model/05-materialize-skills.txt`, `.omo/evidence/20260710-codex-rules-dynamic-model/06-aggregate-skills-test.txt`.
- **Codex gate:** `bun run test:codex` passed 497 tests. Artifact: `.omo/evidence/20260710-codex-rules-dynamic-model/07-test-codex.txt`.
- **Focused hook-unit proof:** compiled rules CLI `hook post-tool-use` was driven twice with isolated `PLUGIN_DATA`, dynamic bundled rules, same session/target, models `gpt-5.5` then `gpt-5.6-codex`; observed `first_has_gpt55=yes` and `second_has_gpt56=yes`. Artifact: `.omo/evidence/20260710-codex-rules-dynamic-model/08b-rules-hook-unit-model-switch-final.txt`.
- **Live Codex QA:** `bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin` passed in isolated `CODEX_HOME` with mock model; observed `hook/completed` for `sessionStart`, `userPromptSubmit`, `stop`, and real `~/.codex/config.toml` unchanged. Artifact: `.omo/evidence/20260710-codex-rules-dynamic-model/10b-codex-qa-app-server-plugin-final.txt`.
- **Hygiene:** touched-file Biome check, no-excuse TypeScript audit, and `git diff --check` passed. Artifacts: `.omo/evidence/20260710-codex-rules-dynamic-model/11b-touched-files-lint.txt`, `.omo/evidence/20260710-codex-rules-dynamic-model/12b-no-excuse-check-after-format.txt`, `.omo/evidence/20260710-codex-rules-dynamic-model/13b-git-diff-check-final.txt`.

## Risks & Residuals

- This intentionally invalidates dynamic target fingerprints when the active model changes. Same-family model slug changes may cause a recheck, but existing dynamic dedup/transcript filtering still prevents duplicate rule emission.
- Full component `npm run lint` still reports package-wide pre-existing import-order/format diagnostics outside this PR's touched files; touched-file Biome check passes. Artifact: `.omo/evidence/20260710-codex-rules-dynamic-model/11-component-lint.txt`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in `omo-codex` where switching models in the same session/target didn’t re-emit rules. Dynamic fingerprints now vary by active model, so bundled rules update correctly after a model change.

- **Bug Fixes**
  - Passes `input.model` into `fingerprintDynamicTargets()` from the PostToolUse hook.
  - Uses the active model in rule discovery and the fingerprint hash to invalidate per-target cache on model switch.
  - Adds a regression test to confirm GPT-5.5 → `gpt-5.6-codex` emits the correct rule.

<sup>Written for commit 4f957b39c9a625c4aa878095433978a74e76c774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

