### PR TITLE
fix(config): preserve explicit GPT-5.5 pins

### DIFF
--- a/packages/omo-opencode/src/shared/migration.test.ts
+++ b/packages/omo-opencode/src/shared/migration.test.ts
@@ -632,59 +632,23 @@ describe("migrateModelVersions", () => {
     expect(sisyphus.temperature).toBe(0.1)
   })
 
-  test("#given a config with explicit gpt-5.5 (#3777) #when migrating #then only entry-scoped defaults move", () => {
-    // given: sisyphus explicitly picked gpt-5.5; hephaestus carries the old installer default
-    const agents = {
-      sisyphus: { model: "openai/gpt-5.5", variant: "medium" },
-      hephaestus: {
-        model: "openai/gpt-5.5",
-        fallback_models: [{ model: "openai/gpt-5.5" }],
-      },
-    }
-
-    // when: Migrate model versions
-    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
-
-    // then: global gpt-5.5 rewrites stay forbidden (#3777); only the scoped
-    // hephaestus default rollout applies, one-shot and revertible via sidecar
-    expect(changed).toBe(true)
-    expect(newMigrations).toEqual(["model-version:hephaestus:openai/gpt-5.5->openai/gpt-5.6-sol"])
-    expect(MODEL_VERSION_MAP["openai/gpt-5.5"]).toBeUndefined()
-    expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe("openai/gpt-5.5")
-    expect((migrated["hephaestus"] as Record<string, unknown>).model).toBe("openai/gpt-5.6-sol")
-  })
-
-  test("#given momus pinned to the old gpt-5.5 default #when migrating #then only momus moves to gpt-5.6-sol xhigh", () => {
-    // given: momus carries the old installer default; oracle explicitly picked gpt-5.5
-    const agents = {
+  test("#given explicit gpt-5.5 pins on current entries (#3777) #when migrating #then preserves every user choice", () => {
+    // given: current agent and category entries explicitly select gpt-5.5
+    const configs = {
+      hephaestus: { model: "openai/gpt-5.5", variant: "medium" },
       momus: { model: "openai/gpt-5.5", variant: "xhigh" },
-      oracle: { model: "openai/gpt-5.5", variant: "high" },
+      deep: { model: "openai/gpt-5.5", variant: "medium" },
+      ultrabrain: { model: "openai/gpt-5.5", variant: "xhigh" },
     }
 
     // when: Migrate model versions
-    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
+    const { migrated, changed, newMigrations } = migrateModelVersions(configs)
 
-    // then: momus adopts the gpt-5.6-sol xhigh default; oracle stays untouched
-    expect(changed).toBe(true)
-    expect(newMigrations).toEqual(["model-version:momus:openai/gpt-5.5->openai/gpt-5.6-sol"])
-    expect(migrated["momus"]).toEqual({ model: "openai/gpt-5.6-sol", variant: "xhigh" })
-    expect(migrated["oracle"]).toEqual({ model: "openai/gpt-5.5", variant: "high" })
-  })
-
-  test("#given the momus migration already applied #when migrating again #then the user revert is respected", () => {
-    // given: sidecar records the momus rollout as applied; user reverted to gpt-5.5
-    const agents = {
-      momus: { model: "openai/gpt-5.5", variant: "xhigh" },
-    }
-    const applied = new Set(["model-version:momus:openai/gpt-5.5->openai/gpt-5.6-sol"])
-
-    // when: Migrate model versions
-    const { migrated, changed, newMigrations } = migrateModelVersions(agents, applied)
-
-    // then: the one-shot migration does not re-apply
+    // then: current models remain user-selectable and no entry name implies provenance
     expect(changed).toBe(false)
     expect(newMigrations).toEqual([])
-    expect(migrated["momus"]).toEqual({ model: "openai/gpt-5.5", variant: "xhigh" })
+    expect(MODEL_VERSION_MAP["openai/gpt-5.5"]).toBeUndefined()
+    expect(migrated).toEqual(configs)
   })
 
   test("#given current Anthropic models from bundled snapshot #when migrating #then preserves explicit user choices", () => {
@@ -860,65 +824,6 @@ describe("migrateModelVersions", () => {
     expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
   })
 
-  test("migrates hephaestus gpt-5.5 pin to gpt-5.6-sol preserving variant", () => {
-    // given: hephaestus pinned to the previous default, oracle pinned to the same model
-    const agents = {
-      hephaestus: { model: "openai/gpt-5.5", variant: "medium" },
-      oracle: { model: "openai/gpt-5.5", variant: "high" },
-    }
-
-    // when
-    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
-
-    // then: only hephaestus moves; oracle's pin is untouched
-    expect(changed).toBe(true)
-    expect(newMigrations).toEqual(["model-version:hephaestus:openai/gpt-5.5->openai/gpt-5.6-sol"])
-    const hephaestus = migrated["hephaestus"] as Record<string, unknown>
-    expect(hephaestus.model).toBe("openai/gpt-5.6-sol")
-    expect(hephaestus.variant).toBe("medium")
-    const oracle = migrated["oracle"] as Record<string, unknown>
-    expect(oracle.model).toBe("openai/gpt-5.5")
-  })
-
-  test("migrates deep and ultrabrain gpt-5.5 pins to gpt-5.6-sol with new default variants", () => {
-    // given: categories pinned to the previous defaults
-    const categories = {
-      deep: { model: "openai/gpt-5.5", variant: "medium" },
-      ultrabrain: { model: "openai/gpt-5.5", variant: "xhigh" },
-    }
-
-    // when
-    const { migrated, changed, newMigrations } = migrateModelVersions(categories)
-
-    // then
-    expect(changed).toBe(true)
-    expect(newMigrations).toEqual([
-      "model-version:deep:openai/gpt-5.5->openai/gpt-5.6-sol",
-      "model-version:ultrabrain:openai/gpt-5.5->openai/gpt-5.6-sol",
-    ])
-    const deep = migrated["deep"] as Record<string, unknown>
-    expect(deep.model).toBe("openai/gpt-5.6-sol")
-    expect(deep.variant).toBe("high")
-    const ultrabrain = migrated["ultrabrain"] as Record<string, unknown>
-    expect(ultrabrain.model).toBe("openai/gpt-5.6-sol")
-    expect(ultrabrain.variant).toBe("xhigh")
-  })
-
-  test("skips already-applied scoped migration so user reverts stick", () => {
-    // given: user reverted hephaestus back to gpt-5.5 after the migration ran once
-    const agents = {
-      hephaestus: { model: "openai/gpt-5.5", variant: "medium" },
-    }
-    const appliedMigrations = new Set(["model-version:hephaestus:openai/gpt-5.5->openai/gpt-5.6-sol"])
-
-    // when
-    const { migrated, changed, newMigrations } = migrateModelVersions(agents, appliedMigrations)
-
-    // then
-    expect(changed).toBe(false)
-    expect(newMigrations).toHaveLength(0)
-    expect((migrated["hephaestus"] as Record<string, unknown>).model).toBe("openai/gpt-5.5")
-  })
 })
 
 describe("migrateConfigFile _migrations tracking", () => {

--- a/packages/utils/src/migration/model-versions.ts
+++ b/packages/utils/src/migration/model-versions.ts
@@ -18,35 +18,6 @@ export const MODEL_VERSION_MAP: Record<string, string> = {
   "anthropic/claude-opus-4-4": "anthropic/claude-opus-4-7",
 }
 
-type ScopedModelMigration = { model: string; variant?: string }
-
-/**
- * Entry-scoped migrations: applied only when a specific agent/category entry
- * is pinned to the old model. Unlike MODEL_VERSION_MAP this may move entries
- * off a still-selectable model, because it narrowly retargets entries whose
- * pinned value matches the PREVIOUS built-in default (typically written by the
- * installer, not chosen by hand). Other entries pinned to the same model are
- * untouched, and the sidecar prevents re-applying after a user revert.
- *
- * GPT-5.6 default rollout: hephaestus keeps the user's variant; deep and
- * ultrabrain adopt the new default variants (high / xhigh); momus adopts
- * the new default xhigh variant.
- */
-export const ENTRY_SCOPED_MODEL_VERSION_MAP: Record<string, Record<string, ScopedModelMigration>> = {
-  hephaestus: {
-    "openai/gpt-5.5": { model: "openai/gpt-5.6-sol" },
-  },
-  momus: {
-    "openai/gpt-5.5": { model: "openai/gpt-5.6-sol", variant: "xhigh" },
-  },
-  deep: {
-    "openai/gpt-5.5": { model: "openai/gpt-5.6-sol", variant: "high" },
-  },
-  ultrabrain: {
-    "openai/gpt-5.5": { model: "openai/gpt-5.6-sol", variant: "xhigh" },
-  },
-}
-
 const CURRENT_USER_SELECTABLE_MODELS = new Set([
   "anthropic/claude-opus-4-5",
   "anthropic/claude-opus-4-6",
@@ -55,10 +26,6 @@ const CURRENT_USER_SELECTABLE_MODELS = new Set([
 
 function migrationKey(oldModel: string, newModel: string): string {
   return `model-version:${oldModel}->${newModel}`
-}
-
-function scopedMigrationKey(entry: string, oldModel: string, newModel: string): string {
-  return `model-version:${entry}:${oldModel}->${newModel}`
 }
 
 export function migrateModelVersions(
@@ -72,28 +39,6 @@ export function migrateModelVersions(
   for (const [key, value] of Object.entries(configs)) {
     if (value && typeof value === "object" && !Array.isArray(value)) {
       const config = value as Record<string, unknown>
-      const scopedMigration =
-        typeof config.model === "string"
-          ? ENTRY_SCOPED_MODEL_VERSION_MAP[key]?.[config.model]
-          : undefined
-      if (scopedMigration && typeof config.model === "string") {
-        const oldModel = config.model
-        const mKey = scopedMigrationKey(key, oldModel, scopedMigration.model)
-
-        if (appliedMigrations?.has(mKey)) {
-          migrated[key] = value
-          continue
-        }
-
-        migrated[key] = {
-          ...config,
-          model: scopedMigration.model,
-          ...(scopedMigration.variant ? { variant: scopedMigration.variant } : {}),
-        }
-        changed = true
-        newMigrations.push(mKey)
-        continue
-      }
       if (
         typeof config.model === "string" &&
         !CURRENT_USER_SELECTABLE_MODELS.has(config.model) &&


### PR DESCRIPTION
## Summary

Preserve explicit GPT-5.5 model selections during OpenCode config migration. The GPT-5.6 rollout had inferred that named agent/category entries were installer-owned defaults, but the config contains no provenance that can distinguish those values from user choices.

## Changes

- Remove entry-scoped GPT-5.5 to GPT-5.6 rewrites for `hephaestus`, `momus`, `deep`, and `ultrabrain`.
- Keep the existing retired-model migration path unchanged.
- Add a regression covering all four current entries and asserting no migration record is created.

## QA & Evidence

- **What was tested:** `bun test packages/omo-opencode/src/shared/migration.test.ts`
- **Observed result:** 89 passed, 0 failed.
- **Why sufficient:** Covers current-model preservation plus existing retired-model and migration-sidecar behavior.

- **What was tested:** `bun run typecheck:packages`
- **Observed result:** Passed all package TypeScript projects.
- **Why sufficient:** Confirms the utility export removal and OpenCode consumers remain type-safe.

- **What was tested:** Real `opencode run --format json` with this worktree's local plugin, an isolated XDG/HOME sandbox, a local fake OpenAI server, and explicit GPT-5.5 pins for all four entries.
- **Observed result:** Full turn completed with `TUI_NOREG_OK`; config SHA-256 stayed `3d5593cd487c09c15ad55e5a242b46daa222c3b8fbf9a444da3a1490ef8b3cc4`; all pins remained GPT-5.5; no migration sidecar appeared; real OpenCode session count stayed 21,841 before and after.
- **Artifact:** `.omo/evidence/20260710-preserve-explicit-gpt55-pins/live-run-final/README.txt` in the task worktree.
- **Why sufficient:** Exercises the production plugin startup and config migration path while proving isolation from the user's real database.

## Risks & Residuals

- Existing configs that were generated by an older installer will no longer be auto-retargeted to GPT-5.6 because they are indistinguishable from explicit user pins. Omitted model settings still receive the new built-in GPT-5.6 defaults.
- No schema or API break.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves explicit GPT-5.5 pins during OpenCode config migration. Removes entry-scoped GPT-5.6 rollouts so user-selected models stay unchanged; only omitted settings adopt the new GPT-5.6 defaults.

- **Bug Fixes**
  - Removed entry-scoped GPT-5.5 → GPT-5.6 rewrites for `hephaestus`, `momus`, `deep`, and `ultrabrain`.
  - Kept retired-model migration via `MODEL_VERSION_MAP` unchanged.
  - Added regression test to ensure no migration records are created and explicit pins are preserved.

<sup>Written for commit bdf7bb49fb89e51bf142c30812ab8ea5dc2c60d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

