### PR TITLE
feat: default deep to gpt-5.6-terra xhigh and unspecified-low to gpt-5.6-luna xhigh

### DIFF
--- a/.agents/skills/hyperplan/SKILL.md
+++ b/.agents/skills/hyperplan/SKILL.md
@@ -32,10 +32,10 @@ Required categories are `unspecified-low`, `unspecified-high`, `ultrabrain`, and
 
 | Category | Model | Native Mindset | Why This Adversarial Role Fits |
 |----------|-------|----------------|--------------------------------|
-| `unspecified-low` | claude-sonnet-4-6 | Mid-tier, simplicity-leaning, structure-demanding | Pragmatist Skeptic — model bias toward simplicity makes it the natural enemy of over-engineering |
+| `unspecified-low` | gpt-5.6-luna xhigh | Mid-tier, simplicity-leaning, structure-demanding | Pragmatist Skeptic — model bias toward simplicity makes it the natural enemy of over-engineering |
 | `unspecified-high` | claude-opus-4-7 max | High-effort, broad-impact, coordination-aware | Integration Tester — max-tier broad-scope thinking exposes cross-module fragility |
-| `deep` | gpt-5.5 medium | Autonomous, exploration-heavy, evidence-driven | Autonomous Researcher — natural exploration bias attacks unfounded claims |
-| `ultrabrain` | gpt-5.5 xhigh | Hard-logic, simplicity-biased, strategic advisor | Architect Strategist — xhigh reasoning sees structural flaws others miss |
+| `deep` | gpt-5.6-terra xhigh | Autonomous, exploration-heavy, evidence-driven | Autonomous Researcher — natural exploration bias attacks unfounded claims |
+| `ultrabrain` | gpt-5.6-sol xhigh | Hard-logic, simplicity-biased, strategic advisor | Architect Strategist — xhigh reasoning sees structural flaws others miss |
 | `artistry` | gemini-3.1-pro high | Unconventional, pattern-breaking, lateral | Creative Challenger — pattern-breaking bias attacks orthodox thinking |
 
 ### MEMBER 1: `skeptic` (category: `unspecified-low`)

--- a/.opencode/skills/hyperplan/SKILL.md
+++ b/.opencode/skills/hyperplan/SKILL.md
@@ -32,10 +32,10 @@ Required categories are `unspecified-low`, `unspecified-high`, `ultrabrain`, and
 
 | Category | Model | Native Mindset | Why This Adversarial Role Fits |
 |----------|-------|----------------|--------------------------------|
-| `unspecified-low` | claude-sonnet-4-6 | Mid-tier, simplicity-leaning, structure-demanding | Pragmatist Skeptic — model bias toward simplicity makes it the natural enemy of over-engineering |
+| `unspecified-low` | gpt-5.6-luna xhigh | Mid-tier, simplicity-leaning, structure-demanding | Pragmatist Skeptic — model bias toward simplicity makes it the natural enemy of over-engineering |
 | `unspecified-high` | claude-opus-4-7 max | High-effort, broad-impact, coordination-aware | Integration Tester — max-tier broad-scope thinking exposes cross-module fragility |
-| `deep` | gpt-5.5 medium | Autonomous, exploration-heavy, evidence-driven | Autonomous Researcher — natural exploration bias attacks unfounded claims |
-| `ultrabrain` | gpt-5.5 xhigh | Hard-logic, simplicity-biased, strategic advisor | Architect Strategist — xhigh reasoning sees structural flaws others miss |
+| `deep` | gpt-5.6-terra xhigh | Autonomous, exploration-heavy, evidence-driven | Autonomous Researcher — natural exploration bias attacks unfounded claims |
+| `ultrabrain` | gpt-5.6-sol xhigh | Hard-logic, simplicity-biased, strategic advisor | Architect Strategist — xhigh reasoning sees structural flaws others miss |
 | `artistry` | gemini-3.1-pro high | Unconventional, pattern-breaking, lateral | Creative Challenger — pattern-breaking bias attacks orthodox thinking |
 
 ### MEMBER 1: `skeptic` (category: `unspecified-low`)

--- a/docs/examples/coding-focused.jsonc
+++ b/docs/examples/coding-focused.jsonc
@@ -55,7 +55,7 @@
     "quick": { "model": "opencode/gpt-5-nano" },
 
     // Standard coding tasks: good quality, fast
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
+    "unspecified-low": { "model": "openai/gpt-5.6-luna", "variant": "xhigh" },
 
     // Complex refactors: best quality
     "unspecified-high": { "model": "openai/gpt-5.5" },
@@ -64,7 +64,7 @@
     "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
 
     // Deep autonomous work
-    "deep": { "model": "openai/gpt-5.6-sol", "variant": "high" },
+    "deep": { "model": "openai/gpt-5.6-terra", "variant": "xhigh" },
 
     // Architecture decisions
     "ultrabrain": { "model": "openai/gpt-5.6-sol", "variant": "xhigh" },

--- a/docs/examples/default.jsonc
+++ b/docs/examples/default.jsonc
@@ -49,11 +49,11 @@
 
   "categories": {
     "quick": { "model": "opencode/gpt-5-nano" },
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
+    "unspecified-low": { "model": "openai/gpt-5.6-luna", "variant": "xhigh" },
     "unspecified-high": { "model": "anthropic/claude-opus-4-7", "variant": "max" },
     "writing": { "model": "kimi-for-coding/k2p5" },
     "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
-    "deep": { "model": "openai/gpt-5.6-sol", "variant": "high" },
+    "deep": { "model": "openai/gpt-5.6-terra", "variant": "xhigh" },
     "ultrabrain": { "model": "openai/gpt-5.6-sol", "variant": "xhigh" },
   },
 

--- a/docs/examples/planning-focused.jsonc
+++ b/docs/examples/planning-focused.jsonc
@@ -65,7 +65,7 @@
   "categories": {
     "quick": { "model": "opencode/gpt-5-nano" },
 
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
+    "unspecified-low": { "model": "openai/gpt-5.6-luna", "variant": "xhigh" },
 
     // High-effort planning tasks: maximum reasoning
     "unspecified-high": {
@@ -80,7 +80,7 @@
     "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
 
     // Deep research and analysis
-    "deep": { "model": "openai/gpt-5.6-sol", "variant": "high" },
+    "deep": { "model": "openai/gpt-5.6-terra", "variant": "xhigh" },
 
     // Strategic reasoning
     "ultrabrain": { "model": "openai/gpt-5.6-sol", "variant": "xhigh" },

--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -152,7 +152,7 @@ You don't need every provider. You need the right two.
 | Subscription | Cost | What You Get | Covers |
 |---|---|---|---|
 | **OpenCode Go** | $10/mo | `kimi-k2.5`, `kimi-k2.6`, `glm-5`, `glm-5.2`, `minimax-m2.5`, `minimax-m2.7`, `minimax-m3`, `mimo-v2-pro`, `qwen3.5-plus`, `qwen3.6-plus` | Claude-family alternatives (Kimi, GLM), Gemini-family alternatives (Qwen), utility/retrieval (MiniMax) |
-| **OpenAI Plus/Pro** | $20+/mo | `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.5`, `gpt-5.5-codex`, `gpt-5.6-sol` | GPT-native agents (Hephaestus, Oracle, Momus), GPT fallbacks for model-flexible agents |
+| **OpenAI Plus/Pro** | $20+/mo | `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.5`, `gpt-5.5-codex`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | GPT-native agents (Hephaestus, Oracle, Momus), GPT-5.6 category defaults (`deep`, `ultrabrain`, `unspecified-low`), GPT fallbacks for model-flexible agents |
 
 ### Why this specific combination
 
@@ -205,11 +205,13 @@ Used by: Sisyphus, Atlas, Sisyphus-Junior, Metis (Claude path), Prometheus (prim
 
 ### GPT Family (principle-driven, autonomous)
 
-Used by: Hephaestus, Oracle, Momus, `deep`, `ultrabrain`, `quick`, Prometheus (GPT fallback), Atlas (GPT path).
+Used by: Hephaestus, Oracle, Momus, `deep`, `ultrabrain`, `quick`, `unspecified-low`, Prometheus (GPT fallback), Atlas (GPT path).
 
 | Priority | Model | Provider | Why |
 |---|---|---|---|
-| 1 | `gpt-5.6-sol` (xhigh / high / medium) | `openai`, `vercel` | The GPT-5.6 flagship. New default for Hephaestus (medium), Momus (xhigh), `deep` (high), and `ultrabrain` (xhigh). |
+| 1 | `gpt-5.6-sol` (xhigh / high / medium) | `openai`, `vercel` | The GPT-5.6 flagship. Default for Hephaestus (medium), Momus (xhigh), and `ultrabrain` (xhigh); first fallback for `deep`. |
+| 1 | `gpt-5.6-terra` (xhigh) | `openai`, `vercel` | GPT-5.6 mid-tier. New default for the `deep` category. |
+| 1 | `gpt-5.6-luna` (xhigh) | `openai`, `vercel` | GPT-5.6 light tier. New default for the `unspecified-low` category. |
 | 2 | `gpt-5.5` / `gpt-5.4` (pro / xhigh / high / medium) | `openai`, `github-copilot`, `opencode`, `vercel` | Previous flagship generation; first fallback on providers without GPT-5.6. Hephaestus requires this family. |
 | 3 | `gpt-5.5-codex` | same | Still the deep-coding powerhouse. Kept as an explicit override option. |
 | 3 | **DeepSeek — LIMITED ALTERNATIVE** (`deepseek-v3.2`, `deepseek-chat-v3.1`) | `openrouter/deepseek` | Closest OSS equivalent for autonomous coding behavior. Not wired into default chains — add via `fallback_models`. |
@@ -311,7 +313,9 @@ Principle-driven, explicit reasoning, deep technical capability. Best for agents
 | Model             | Strengths                                                                                       |
 | ----------------- | ----------------------------------------------------------------------------------------------- |
 | **GPT-5.5 Codex** | Deep coding powerhouse. Autonomous exploration. Still available for deep category and explicit overrides. |
-| **GPT-5.6 Sol**   | The GPT-5.6 flagship. Default for Hephaestus (medium) and Momus (xhigh); default for the `deep` / `ultrabrain` categories. |
+| **GPT-5.6 Sol**   | The GPT-5.6 flagship. Default for Hephaestus (medium) and Momus (xhigh); default for the `ultrabrain` category and first fallback for `deep`. |
+| **GPT-5.6 Terra** | GPT-5.6 mid-tier. Default for the `deep` category (xhigh). |
+| **GPT-5.6 Luna**  | GPT-5.6 light tier. Default for the `unspecified-low` category (xhigh). |
 | **GPT-5.5**       | High intelligence, strategic reasoning. Default for Oracle, first fallback for Momus (xhigh) and Hephaestus, and a key fallback for Prometheus / Atlas. |
 | **GPT-5.4 Mini**  | Fast + strong reasoning. Good for lightweight autonomous tasks. Default for quick category. |
 | **GPT-5-Nano**    | Ultra-cheap, fast. Good for simple utility tasks.                                               |
@@ -366,10 +370,10 @@ When agents delegate work, they don't pick a model name — they pick a **catego
 | `visual-engineering` | Frontend, UI, CSS, design | `google/gemini-3.1-pro` (high) | Gemini → `zai-coding-plan/glm-5` → `claude-opus-4-7` (max) → `opencode-go/glm-5.2` → `kimi-for-coding/k2p5` |
 | `artistry` | Creative, novel approaches | `google/gemini-3.1-pro` (high) | Gemini → `claude-opus-4-7` (max) → `gpt-5.5` |
 | `ultrabrain` | Maximum reasoning needed | `openai/gpt-5.6-sol` (xhigh) | `openai\|vercel/gpt-5.6-sol` (xhigh) → `openai\|opencode\|vercel/gpt-5.5` (xhigh) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `opencode-go\|vercel/glm-5.2` |
-| `deep` | Deep coding, complex logic | `openai/gpt-5.6-sol` (high) | `openai\|vercel/gpt-5.6-sol` (high) → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (medium) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `opencode-go\|vercel/kimi-k2.6` → `opencode-go\|vercel/glm-5.2` |
+| `deep` | Deep coding, complex logic | `openai/gpt-5.6-terra` (xhigh) | `openai\|vercel/gpt-5.6-terra` (xhigh) → `openai\|vercel/gpt-5.6-sol` (high) → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (medium) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `opencode-go\|vercel/kimi-k2.6` → `opencode-go\|vercel/glm-5.2` |
 | `quick` | Simple, fast tasks | `openai/gpt-5.4-mini` | GPT-5.4-mini → `anthropic\|github-copilot\|vercel/claude-haiku-4-5` → `gemini-3-flash` → `opencode-go/minimax-m3` → `opencode-go/minimax-m2.7` → `opencode/gpt-5-nano` |
 | `unspecified-high` | General complex work | `anthropic/claude-opus-4-7` (max) | Opus → `gpt-5.5` (high) → `zai-coding-plan/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5.2` → `opencode/kimi-k2.5` → `moonshotai/kimi-k2.5` |
-| `unspecified-low` | General standard work | `anthropic/claude-sonnet-4-6` | `anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6` → `openai\|opencode\|vercel/gpt-5.5` (medium) → `opencode-go\|vercel/kimi-k2.6` → `google\|github-copilot\|opencode\|vercel/gemini-3-flash` → `opencode-go\|vercel/minimax-m3` → `minimax-coding-plan\|minimax-cn-coding-plan/MiniMax-M3` → `opencode-go\|vercel/minimax-m2.7` |
+| `unspecified-low` | General standard work | `openai/gpt-5.6-luna` (xhigh) | `openai\|vercel/gpt-5.6-luna` (xhigh) → `anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6` → `openai\|opencode\|vercel/gpt-5.5` (medium) → `opencode-go\|vercel/kimi-k2.6` → `google\|github-copilot\|opencode\|vercel/gemini-3-flash` → `opencode-go\|vercel/minimax-m3` → `minimax-coding-plan\|minimax-cn-coding-plan/MiniMax-M3` → `opencode-go\|vercel/minimax-m2.7` |
 | `writing` | Text, docs, prose | `kimi-for-coding/k2p5` | `gemini-3-flash` → `opencode-go/kimi-k2.6` → `claude-sonnet-4-6` → `opencode-go/minimax-m3` → `opencode-go/minimax-m2.7` |
 
 See the [Orchestration System Guide](./orchestration.md) for how agents dispatch tasks to categories.
@@ -414,7 +418,7 @@ See the [Orchestration System Guide](./orchestration.md) for how agents dispatch
 
   "categories": {
     "visual-engineering": { "model": "opencode-go/qwen3.6-plus" },  // Qwen as Gemini alt
-    "deep": { "model": "openai/gpt-5.6-sol", "variant": "high" },
+    "deep": { "model": "openai/gpt-5.6-terra", "variant": "xhigh" },
     "ultrabrain": { "model": "openai/gpt-5.6-sol", "variant": "xhigh" },
     "quick": { "model": "openai/gpt-5.4-mini" },
     "unspecified-low": { "model": "opencode-go/kimi-k2.7-code" },
@@ -447,7 +451,7 @@ Highest quality, highest cost. No surprises.
   },
   "categories": {
     "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
-    "deep": { "model": "openai/gpt-5.6-sol", "variant": "high" },
+    "deep": { "model": "openai/gpt-5.6-terra", "variant": "xhigh" },
     "unspecified-high": { "model": "anthropic/claude-opus-4-8", "variant": "max" },
   },
 }

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -542,9 +542,11 @@ Not all models behave the same way. Understanding "similar" families helps you m
 
 | Model             | Provider(s)                      | Notes                                                                                                       |
 | ----------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **GPT-5.6 Sol**   | openai, vercel                   | Preferred when available for Hephaestus, Momus, `deep`, and `ultrabrain`, with role-specific effort levels. |
+| **GPT-5.6 Sol**   | openai, vercel                   | Preferred when available for Hephaestus, Momus, and `ultrabrain`, with role-specific effort levels; first fallback for `deep`. |
+| **GPT-5.6 Terra** | openai, vercel                   | GPT-5.6 mid-tier. Default for the `deep` category (xhigh).                                                 |
+| **GPT-5.6 Luna**  | openai, vercel                   | GPT-5.6 light tier. Default for the `unspecified-low` category (xhigh).                                    |
 | **GPT-5.5-codex** | openai, github-copilot, opencode | Deep coding powerhouse available as an explicit override.                                                  |
-| **GPT-5.5**       | openai, github-copilot, opencode, vercel | Default for Oracle and the first GPT fallback for Hephaestus, Momus, `deep`, and `ultrabrain`.       |
+| **GPT-5.5**       | openai, github-copilot, opencode, vercel | Default for Oracle and the first GPT-5.5-family fallback for Hephaestus, Momus, `deep`, and `ultrabrain`. |
 | **GPT-5.4 Mini**  | openai, github-copilot, opencode, vercel | Fast + strong reasoning. Default for quick category.                                                |
 | **GPT-5-Nano**    | opencode, vercel                 | Ultra-cheap, fast. Good for simple utility tasks.                                                           |
 

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -100,7 +100,7 @@ Use Hephaestus when you need deep architectural reasoning, complex debugging acr
 
 - **Multi-model orchestration.** Pure Codex is single-model. OmO routes different tasks to different models automatically. GPT for deep reasoning. Gemini for frontend. GPT-5.4 Mini for speed. The right brain for the right job.
 - **Background agents.** Fire 5+ agents in parallel. Something Codex simply cannot do. While one agent writes code, another researches patterns, another checks documentation. Like a real dev team.
-- **Category system.** Tasks are routed by intent, not model name. `visual-engineering` gets Gemini. `ultrabrain` prefers GPT-5.6 Sol xhigh through OpenAI or Vercel. `deep` prefers GPT-5.6 Sol high through OpenAI or Vercel. `artistry` gets Gemini. `quick` gets GPT-5.4 Mini. `unspecified-low` gets fast general-purpose models. `unspecified-high` gets Claude Opus. `writing` gets prose-optimized models. No manual juggling.
+- **Category system.** Tasks are routed by intent, not model name. `visual-engineering` gets Gemini. `ultrabrain` prefers GPT-5.6 Sol xhigh through OpenAI or Vercel. `deep` prefers GPT-5.6 Terra xhigh through OpenAI or Vercel. `artistry` gets Gemini. `quick` gets GPT-5.4 Mini. `unspecified-low` prefers GPT-5.6 Luna xhigh. `unspecified-high` gets Claude Opus. `writing` gets prose-optimized models. No manual juggling.
 - **Accumulated wisdom.** Subagents learn from previous results. Conventions discovered in task 1 are passed to task 5. Mistakes made early aren't repeated. The system gets smarter as it works.
 
 ### Prometheus: The Strategic Planner
@@ -195,7 +195,7 @@ You can override specific agents or categories in your config:
     "ultrabrain": { "model": "openai/gpt-5.6-sol", "variant": "xhigh" },
 
     // Autonomous research and execution
-    "deep": { "model": "openai/gpt-5.6-sol", "variant": "high" },
+    "deep": { "model": "openai/gpt-5.6-terra", "variant": "xhigh" },
 
     // Creative and design work
     "artistry": { "model": "google/gemini-3.1-pro", "variant": "high" },

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -101,7 +101,7 @@ Here's a practical starting configuration:
     "quick": { "model": "opencode/gpt-5-nano" },
 
     // unspecified-low - moderate tasks
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
+    "unspecified-low": { "model": "openai/gpt-5.6-luna", "variant": "xhigh" },
 
     // unspecified-high - complex work
     "unspecified-high": { "model": "anthropic/claude-opus-4-7", "variant": "max" },
@@ -301,10 +301,10 @@ Domain-specific model delegation used by the `task()` tool. When Sisyphus delega
 | -------------------- | ------------------------------- | ---------------------------------------------- |
 | `visual-engineering` | `google/gemini-3.1-pro` (high)  | Frontend, UI/UX, design, animation             |
 | `ultrabrain`         | `openai/gpt-5.6-sol` (xhigh)    | Deep logical reasoning, complex architecture   |
-| `deep`               | `openai/gpt-5.6-sol` (high)     | Autonomous problem-solving, thorough research  |
+| `deep`               | `openai/gpt-5.6-terra` (xhigh)  | Autonomous problem-solving, thorough research  |
 | `artistry`           | `google/gemini-3.1-pro` (high)  | Creative/unconventional approaches             |
 | `quick`              | `openai/gpt-5.4-mini`           | Trivial tasks, typo fixes, single-file changes |
-| `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | General tasks, low effort                      |
+| `unspecified-low`    | `openai/gpt-5.6-luna` (xhigh)   | General tasks, low effort                      |
 | `unspecified-high`   | `anthropic/claude-opus-4-7` (max) | General tasks, high effort                   |
 | `writing`            | `kimi-for-coding/k2p5`          | Documentation, prose, technical writing        |
 
@@ -388,10 +388,10 @@ This table documents the first entry of each hardcoded provider fallback chain, 
 | ---------------------- | ------------------- | -------------------------------------------------------------- |
 | **visual-engineering** | `gemini-3.1-pro`    | `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `zai-coding-plan\|opencode/glm-5` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `opencode-go/glm-5.2` → `kimi-for-coding/k2p5` |
 | **ultrabrain**         | `gpt-5.6-sol`       | `openai\|vercel/gpt-5.6-sol (xhigh)` → `openai\|opencode\|vercel/gpt-5.5 (xhigh)` → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro (high)` → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max)` → `opencode-go\|vercel/glm-5.2` |
-| **deep**               | `gpt-5.6-sol`       | `openai\|vercel/gpt-5.6-sol (high)` → `openai\|github-copilot\|opencode\|vercel/gpt-5.5 (medium)` → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max)` → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro (high)` → `opencode-go\|vercel/kimi-k2.6` → `opencode-go\|vercel/glm-5.2` |
+| **deep**               | `gpt-5.6-terra`     | `openai\|vercel/gpt-5.6-terra (xhigh)` → `openai\|vercel/gpt-5.6-sol (high)` → `openai\|github-copilot\|opencode\|vercel/gpt-5.5 (medium)` → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max)` → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro (high)` → `opencode-go\|vercel/kimi-k2.6` → `opencode-go\|vercel/glm-5.2` |
 | **artistry**           | `gemini-3.1-pro`    | `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `openai\|github-copilot\|opencode/gpt-5.5` |
 | **quick**              | `gpt-5.4-mini`      | `openai\|github-copilot\|opencode/gpt-5.4-mini` → `anthropic\|github-copilot\|vercel/claude-haiku-4-5` → `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/minimax-m3` → `opencode-go/minimax-m2.7` → `opencode/gpt-5-nano` |
-| **unspecified-low**    | `claude-sonnet-4-6` | `anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6` → `openai\|opencode\|vercel/gpt-5.5 (medium)` → `opencode-go\|vercel/kimi-k2.6` → `google\|github-copilot\|opencode\|vercel/gemini-3-flash` → `opencode-go\|vercel/minimax-m3` → `minimax-coding-plan\|minimax-cn-coding-plan/MiniMax-M3` → `opencode-go\|vercel/minimax-m2.7` |
+| **unspecified-low**    | `gpt-5.6-luna`      | `openai\|vercel/gpt-5.6-luna (xhigh)` → `anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6` → `openai\|opencode\|vercel/gpt-5.5 (medium)` → `opencode-go\|vercel/kimi-k2.6` → `google\|github-copilot\|opencode\|vercel/gemini-3-flash` → `opencode-go\|vercel/minimax-m3` → `minimax-coding-plan\|minimax-cn-coding-plan/MiniMax-M3` → `opencode-go\|vercel/minimax-m2.7` |
 | **unspecified-high**   | `claude-opus-4-7`   | `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `openai\|github-copilot\|opencode/gpt-5.5 (high)` → `zai-coding-plan\|opencode/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5.2` → `opencode/kimi-k2.5` → `opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix/kimi-k2.5` |
 | **writing**            | `gemini-3-flash`    | `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/kimi-k2.6` → `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `opencode-go/minimax-m3` → `opencode-go/minimax-m2.7` |
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -156,10 +156,10 @@ By combining these two concepts, you can generate optimal agents through `task`.
 | -------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `visual-engineering` | `google/gemini-3.1-pro` (high)  | Frontend, UI/UX, design, styling, animation                                                                                 |
 | `ultrabrain`         | `openai/gpt-5.6-sol` (xhigh)    | Deep logical reasoning, complex architecture decisions requiring extensive analysis                                         |
-| `deep`               | `openai/gpt-5.6-sol` (high)     | Goal-oriented autonomous problem-solving on hairy problems requiring deep research. ONE goal + ONE deliverable per call — multiple goals must fan out as parallel `deep` calls, never bundled into one. |
+| `deep`               | `openai/gpt-5.6-terra` (xhigh)  | Goal-oriented autonomous problem-solving on hairy problems requiring deep research. ONE goal + ONE deliverable per call — multiple goals must fan out as parallel `deep` calls, never bundled into one. |
 | `artistry`           | `google/gemini-3.1-pro` (high)  | Highly creative/artistic tasks, novel ideas                                                                                 |
 | `quick`              | `openai/gpt-5.4-mini`           | Trivial tasks - single file changes, typo fixes, simple modifications                                                       |
-| `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | Tasks that don't fit other categories, low effort required                                                                  |
+| `unspecified-low`    | `openai/gpt-5.6-luna` (xhigh)   | Tasks that don't fit other categories, low effort required                                                                  |
 | `unspecified-high`   | `anthropic/claude-opus-4-7` (max) | Tasks that don't fit other categories, high effort required                                                               |
 | `writing`            | `kimi-for-coding/k2p5`          | Documentation, prose, technical writing                                                                                     |
 

--- a/packages/model-core/src/category-model-requirements.ts
+++ b/packages/model-core/src/category-model-requirements.ts
@@ -47,6 +47,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       {
         providers: ["openai", "vercel"],
+        model: "gpt-5.6-terra",
+        variant: "xhigh",
+      },
+      {
+        providers: ["openai", "vercel"],
         model: "gpt-5.6-sol",
         variant: "high",
       },
@@ -108,6 +113,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   "unspecified-low": {
     fallbackChain: [
+      {
+        providers: ["openai", "vercel"],
+        model: "gpt-5.6-luna",
+        variant: "xhigh",
+      },
       {
         providers: ["anthropic", "github-copilot", "opencode", "vercel"],
         model: "claude-sonnet-4-6",

--- a/packages/model-core/src/model-capabilities/supplemental-entries.ts
+++ b/packages/model-core/src/model-capabilities/supplemental-entries.ts
@@ -32,6 +32,38 @@ export const SUPPLEMENTAL_MODEL_CAPABILITIES: Record<string, ModelCapabilitiesSn
 			output: 128000,
 		},
 	},
+	"gpt-5.6-terra": {
+		id: "gpt-5.6-terra",
+		family: "gpt-mini",
+		reasoning: true,
+		temperature: false,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image", "pdf"],
+			output: ["text"],
+		},
+		limit: {
+			context: 1050000,
+			input: 922000,
+			output: 128000,
+		},
+	},
+	"gpt-5.6-luna": {
+		id: "gpt-5.6-luna",
+		family: "gpt-nano",
+		reasoning: true,
+		temperature: false,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image", "pdf"],
+			output: ["text"],
+		},
+		limit: {
+			context: 1050000,
+			input: 922000,
+			output: 128000,
+		},
+	},
 	"gpt-5.5": {
 		id: "gpt-5.5",
 		family: "gpt",

--- a/packages/model-core/src/model-requirements-categories.test.ts
+++ b/packages/model-core/src/model-requirements-categories.test.ts
@@ -18,22 +18,24 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     expect(secondary?.variant).toBe("xhigh")
   })
 
-  test("deep has gpt-5.6-sol high as primary before gpt-5.5 medium", () => {
+  test("deep has gpt-5.6-terra xhigh as primary before gpt-5.6-sol high", () => {
     // given
     const deep = CATEGORY_MODEL_REQUIREMENTS["deep"]
 
     // when
-    const [primary, secondary] = deep.fallbackChain
+    const [primary, secondary, third] = deep.fallbackChain
 
     // then
-    expect(deep.fallbackChain.length).toBeGreaterThan(1)
-    expect(primary?.variant).toBe("high")
-    expect(primary?.model).toBe("gpt-5.6-sol")
+    expect(deep.fallbackChain.length).toBeGreaterThan(2)
+    expect(primary?.variant).toBe("xhigh")
+    expect(primary?.model).toBe("gpt-5.6-terra")
     expect(primary?.providers).toContain("openai")
     expect(primary?.providers).not.toContain("venice")
-    expect(secondary?.model).toBe("gpt-5.5")
-    expect(secondary?.variant).toBe("medium")
-    expect(secondary?.providers).toContain("github-copilot")
+    expect(secondary?.model).toBe("gpt-5.6-sol")
+    expect(secondary?.variant).toBe("high")
+    expect(third?.model).toBe("gpt-5.5")
+    expect(third?.variant).toBe("medium")
+    expect(third?.providers).toContain("github-copilot")
   })
 
   test("visual-engineering keeps gemini, glm, opus, opencode-go, and k2p5 fallback order", () => {
@@ -73,17 +75,20 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     expect(secondary?.providers).toContain("anthropic")
   })
 
-  test("unspecified-low has claude-sonnet-4-6 as primary", () => {
+  test("unspecified-low has gpt-5.6-luna xhigh as primary before claude-sonnet-4-6", () => {
     // given
     const unspecifiedLow = CATEGORY_MODEL_REQUIREMENTS["unspecified-low"]
 
     // when
-    const primary = unspecifiedLow.fallbackChain[0]
+    const [primary, secondary] = unspecifiedLow.fallbackChain
 
     // then
-    expect(unspecifiedLow.fallbackChain.length).toBeGreaterThan(0)
-    expect(primary?.model).toBe("claude-sonnet-4-6")
-    expect(primary?.providers[0]).toBe("anthropic")
+    expect(unspecifiedLow.fallbackChain.length).toBeGreaterThan(1)
+    expect(primary?.model).toBe("gpt-5.6-luna")
+    expect(primary?.variant).toBe("xhigh")
+    expect(primary?.providers[0]).toBe("openai")
+    expect(secondary?.model).toBe("claude-sonnet-4-6")
+    expect(secondary?.providers[0]).toBe("anthropic")
   })
 
   test("unspecified-high keeps opus primary before gpt-5.5 high", () => {

--- a/packages/omo-opencode/src/cli/config-manager/generate-omo-config.test.ts
+++ b/packages/omo-opencode/src/cli/config-manager/generate-omo-config.test.ts
@@ -164,9 +164,13 @@ describe("generateOmoConfig - model fallback system", () => {
         variant: "medium",
       },
     ])
-    expect(categories.deep.model).toBe("openai/gpt-5.6-sol")
-    expect(categories.deep.variant).toBe("high")
+    expect(categories.deep.model).toBe("openai/gpt-5.6-terra")
+    expect(categories.deep.variant).toBe("xhigh")
     expect(categories.deep.fallback_models).toEqual([
+      {
+        model: "openai/gpt-5.6-sol",
+        variant: "high",
+      },
       {
         model: "openai/gpt-5.5",
         variant: "medium",

--- a/packages/omo-opencode/src/tools/AGENTS.md
+++ b/packages/omo-opencode/src/tools/AGENTS.md
@@ -55,10 +55,10 @@ Tools registered via [`createToolRegistry()`](../plugin/tool-registry.ts) in `sr
 |----------|---------------|-------------|--------|
 | `visual-engineering` | google/gemini-3.1-pro (variant: high) | google-categories.ts | Frontend, UI/UX |
 | `ultrabrain` | openai/gpt-5.6-sol (variant: xhigh) | openai-categories.ts | Hard logic / heavy reasoning |
-| `deep` | openai/gpt-5.6-sol (variant: high) | openai-categories.ts | Autonomous multi-step problem-solving |
+| `deep` | openai/gpt-5.6-terra (variant: xhigh) | openai-categories.ts | Autonomous multi-step problem-solving |
 | `artistry` | google/gemini-3.1-pro (variant: high) | google-categories.ts | Creative / unconventional approaches |
 | `quick` | openai/gpt-5.4-mini | openai-categories.ts | Trivial single-file changes |
-| `unspecified-low` | anthropic/claude-sonnet-4-6 | anthropic-categories.ts | Moderate effort fallback |
+| `unspecified-low` | openai/gpt-5.6-luna (variant: xhigh) | openai-categories.ts | Moderate effort fallback |
 | `unspecified-high` | anthropic/claude-opus-4-7 (variant: max) | anthropic-categories.ts | High effort fallback |
 | `writing` | kimi-for-coding/k2p5 (default) → gemini-3-flash (first fallback) | kimi-categories.ts | Documentation, prose |
 

--- a/packages/omo-opencode/src/tools/delegate-task/anthropic-categories.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/anthropic-categories.ts
@@ -1,28 +1,5 @@
 import type { BuiltinCategoryDefinition } from "./builtin-category-definition"
 
-const UNSPECIFIED_LOW_CATEGORY_PROMPT_APPEND = `<Category_Context>
-You are working on tasks that don't fit specific categories but require moderate effort.
-
-<Selection_Gate>
-BEFORE selecting this category, VERIFY ALL conditions:
-1. Task does NOT fit: quick (trivial), visual-engineering (UI), ultrabrain (deep logic), artistry (creative), writing (docs)
-2. Task requires more than trivial effort but is NOT system-wide
-3. Scope is contained within a few files/modules
-
-If task fits ANY other category, DO NOT select unspecified-low.
-This is NOT a default choice - it's for genuinely unclassifiable moderate-effort work.
-</Selection_Gate>
-</Category_Context>
-
-<Caller_Warning>
-THIS CATEGORY USES A MID-TIER MODEL (claude-sonnet-4-6).
-
-**PROVIDE CLEAR STRUCTURE:**
-1. MUST DO: Enumerate required actions explicitly
-2. MUST NOT DO: State forbidden actions to prevent scope creep
-3. EXPECTED OUTPUT: Define concrete success criteria
-</Caller_Warning>`
-
 const UNSPECIFIED_HIGH_CATEGORY_PROMPT_APPEND = `<Category_Context>
 You are working on tasks that don't fit specific categories but require substantial effort.
 
@@ -39,12 +16,6 @@ If task is unclassifiable but moderate-effort, use unspecified-low instead.
 </Category_Context>`
 
 export const ANTHROPIC_CATEGORIES: BuiltinCategoryDefinition[] = [
-  {
-    name: "unspecified-low",
-    config: { model: "anthropic/claude-sonnet-4-6" },
-    description: "Tasks that don't fit other categories, low effort required",
-    promptAppend: UNSPECIFIED_LOW_CATEGORY_PROMPT_APPEND,
-  },
   {
     name: "unspecified-high",
     config: { model: "anthropic/claude-opus-4-7", variant: "max" },

--- a/packages/omo-opencode/src/tools/delegate-task/openai-categories.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/openai-categories.ts
@@ -124,6 +124,29 @@ EXPECTED OUTPUT:
 If your prompt lacks this structure, REWRITE IT before delegating.
 </Caller_Warning>`
 
+const UNSPECIFIED_LOW_CATEGORY_PROMPT_APPEND = `<Category_Context>
+You are working on tasks that don't fit specific categories but require moderate effort.
+
+<Selection_Gate>
+BEFORE selecting this category, VERIFY ALL conditions:
+1. Task does NOT fit: quick (trivial), visual-engineering (UI), ultrabrain (deep logic), artistry (creative), writing (docs)
+2. Task requires more than trivial effort but is NOT system-wide
+3. Scope is contained within a few files/modules
+
+If task fits ANY other category, DO NOT select unspecified-low.
+This is NOT a default choice - it's for genuinely unclassifiable moderate-effort work.
+</Selection_Gate>
+</Category_Context>
+
+<Caller_Warning>
+THIS CATEGORY USES A LIGHTWEIGHT MODEL (gpt-5.6-luna).
+
+**PROVIDE CLEAR STRUCTURE:**
+1. MUST DO: Enumerate required actions explicitly
+2. MUST NOT DO: State forbidden actions to prevent scope creep
+3. EXPECTED OUTPUT: Define concrete success criteria
+</Caller_Warning>`
+
 export const OPENAI_CATEGORIES: BuiltinCategoryDefinition[] = [
   {
     name: "ultrabrain",
@@ -133,7 +156,7 @@ export const OPENAI_CATEGORIES: BuiltinCategoryDefinition[] = [
   },
   {
     name: "deep",
-    config: { model: "openai/gpt-5.6-sol", variant: "high" },
+    config: { model: "openai/gpt-5.6-terra", variant: "xhigh" },
     description: "Goal-oriented autonomous problem-solving on hairy problems requiring deep research. ONE goal + ONE deliverable per call — multiple goals must fan out as parallel `deep` calls, never bundled into one.",
     promptAppend: DEEP_CATEGORY_PROMPT_APPEND,
     resolvePromptAppend: resolveDeepCategoryPromptAppend,
@@ -143,5 +166,11 @@ export const OPENAI_CATEGORIES: BuiltinCategoryDefinition[] = [
     config: { model: "openai/gpt-5.4-mini" },
     description: "Trivial tasks - single file changes, typo fixes, simple modifications",
     promptAppend: QUICK_CATEGORY_PROMPT_APPEND,
+  },
+  {
+    name: "unspecified-low",
+    config: { model: "openai/gpt-5.6-luna", variant: "xhigh" },
+    description: "Tasks that don't fit other categories, low effort required",
+    promptAppend: UNSPECIFIED_LOW_CATEGORY_PROMPT_APPEND,
   },
 ]

--- a/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
@@ -181,8 +181,8 @@ describe("sisyphus-task", () => {
 
       // when / #then
       expect(category).toBeDefined()
-      expect(category.model).toBe("openai/gpt-5.6-sol")
-      expect(category.variant).toBe("high")
+      expect(category.model).toBe("openai/gpt-5.6-terra")
+      expect(category.variant).toBe("xhigh")
     })
 
     test("unspecified-high category uses claude-opus-4-7 max as primary", () => {
@@ -3778,7 +3778,7 @@ describe("sisyphus-task", () => {
       
       // then - default model from DEFAULT_CATEGORIES is used
       const category = expectResolvedCategoryConfig(resolved)
-      expect(category.config.model).toBe("anthropic/claude-sonnet-4-6")
+      expect(category.config.model).toBe("openai/gpt-5.6-luna")
     })
 
     test("category built-in model takes precedence over inheritedModel for builtin category", () => {

--- a/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
@@ -3779,6 +3779,7 @@ describe("sisyphus-task", () => {
       // then - default model from DEFAULT_CATEGORIES is used
       const category = expectResolvedCategoryConfig(resolved)
       expect(category.config.model).toBe("openai/gpt-5.6-luna")
+      expect(category.config.variant).toBe("xhigh")
     })
 
     test("category built-in model takes precedence over inheritedModel for builtin category", () => {

--- a/packages/senpi-task/src/category/__snapshots__/resolve-category.test.ts.snap
+++ b/packages/senpi-task/src/category/__snapshots__/resolve-category.test.ts.snap
@@ -32,8 +32,8 @@ exports[`builtin category defaults #given ported builtin defaults #when snapshot
   {
     "name": "deep",
     "config": {
-      "model": "openai/gpt-5.6-sol",
-      "variant": "high"
+      "model": "openai/gpt-5.6-terra",
+      "variant": "xhigh"
     },
     "description": "Goal-oriented autonomous problem-solving on hairy problems requiring deep research. ONE goal + ONE deliverable per call — multiple goals must fan out as parallel \`deep\` calls, never bundled into one.",
     "promptAppend": "<Category_Context>\\nYou are working on GOAL-ORIENTED AUTONOMOUS tasks.\\n\\nYou are NOT an interactive assistant. You are an autonomous problem-solver.\\n\\nBEFORE making ANY changes:\\n1. Silently explore the codebase extensively (5-15 minutes of reading is normal)\\n2. Read related files, trace dependencies, understand the full context\\n3. Build a complete mental model of the problem space\\n4. Do not ask clarifying questions - the goal is already defined\\n\\nYou receive a GOAL. When the goal includes numbered steps or phases, treat them as one atomic task broken into sub-steps, not as separate independent tasks. Figure out HOW to achieve it yourself. Thorough research before any action.\\n\\nSub-steps of ONE goal = execute all steps as phases of one atomic task.\\nGenuinely independent tasks = flag and refuse, require separate delegations.\\n\\nApproach: explore extensively, understand deeply, then act decisively. Prefer comprehensive solutions over quick patches. If the goal is unclear, make reasonable assumptions and proceed.\\n\\nMinimal status updates. Focus on results, not play-by-play. Report completion with summary of changes.\\n</Category_Context>"
@@ -49,10 +49,11 @@ exports[`builtin category defaults #given ported builtin defaults #when snapshot
   {
     "name": "unspecified-low",
     "config": {
-      "model": "anthropic/claude-sonnet-4-6"
+      "model": "openai/gpt-5.6-luna",
+      "variant": "xhigh"
     },
     "description": "Tasks that don't fit other categories, low effort required",
-    "promptAppend": "<Category_Context>\\nYou are working on tasks that don't fit specific categories but require moderate effort.\\n\\n<Selection_Gate>\\nBEFORE selecting this category, VERIFY ALL conditions:\\n1. Task does NOT fit: quick (trivial), visual-engineering (UI), ultrabrain (deep logic), artistry (creative), writing (docs)\\n2. Task requires more than trivial effort but is NOT system-wide\\n3. Scope is contained within a few files/modules\\n\\nIf task fits ANY other category, DO NOT select unspecified-low.\\nThis is NOT a default choice - it's for genuinely unclassifiable moderate-effort work.\\n</Selection_Gate>\\n</Category_Context>\\n\\n<Caller_Warning>\\nTHIS CATEGORY USES A MID-TIER MODEL (claude-sonnet-4-6).\\n\\n**PROVIDE CLEAR STRUCTURE:**\\n1. MUST DO: Enumerate required actions explicitly\\n2. MUST NOT DO: State forbidden actions to prevent scope creep\\n3. EXPECTED OUTPUT: Define concrete success criteria\\n</Caller_Warning>"
+    "promptAppend": "<Category_Context>\\nYou are working on tasks that don't fit specific categories but require moderate effort.\\n\\n<Selection_Gate>\\nBEFORE selecting this category, VERIFY ALL conditions:\\n1. Task does NOT fit: quick (trivial), visual-engineering (UI), ultrabrain (deep logic), artistry (creative), writing (docs)\\n2. Task requires more than trivial effort but is NOT system-wide\\n3. Scope is contained within a few files/modules\\n\\nIf task fits ANY other category, DO NOT select unspecified-low.\\nThis is NOT a default choice - it's for genuinely unclassifiable moderate-effort work.\\n</Selection_Gate>\\n</Category_Context>\\n\\n<Caller_Warning>\\nTHIS CATEGORY USES A LIGHTWEIGHT MODEL (gpt-5.6-luna).\\n\\n**PROVIDE CLEAR STRUCTURE:**\\n1. MUST DO: Enumerate required actions explicitly\\n2. MUST NOT DO: State forbidden actions to prevent scope creep\\n3. EXPECTED OUTPUT: Define concrete success criteria\\n</Caller_Warning>"
   },
   {
     "name": "unspecified-high",

--- a/packages/senpi-task/src/category/anthropic-categories.ts
+++ b/packages/senpi-task/src/category/anthropic-categories.ts
@@ -1,29 +1,6 @@
 import type { BuiltinCategoryDefinition } from "./types"
 
 // Ported from packages/omo-opencode/src/tools/delegate-task/anthropic-categories.ts.
-const UNSPECIFIED_LOW_CATEGORY_PROMPT_APPEND = `<Category_Context>
-You are working on tasks that don't fit specific categories but require moderate effort.
-
-<Selection_Gate>
-BEFORE selecting this category, VERIFY ALL conditions:
-1. Task does NOT fit: quick (trivial), visual-engineering (UI), ultrabrain (deep logic), artistry (creative), writing (docs)
-2. Task requires more than trivial effort but is NOT system-wide
-3. Scope is contained within a few files/modules
-
-If task fits ANY other category, DO NOT select unspecified-low.
-This is NOT a default choice - it's for genuinely unclassifiable moderate-effort work.
-</Selection_Gate>
-</Category_Context>
-
-<Caller_Warning>
-THIS CATEGORY USES A MID-TIER MODEL (claude-sonnet-4-6).
-
-**PROVIDE CLEAR STRUCTURE:**
-1. MUST DO: Enumerate required actions explicitly
-2. MUST NOT DO: State forbidden actions to prevent scope creep
-3. EXPECTED OUTPUT: Define concrete success criteria
-</Caller_Warning>`
-
 const UNSPECIFIED_HIGH_CATEGORY_PROMPT_APPEND = `<Category_Context>
 You are working on tasks that don't fit specific categories but require substantial effort.
 
@@ -40,12 +17,6 @@ If task is unclassifiable but moderate-effort, use unspecified-low instead.
 </Category_Context>`
 
 export const ANTHROPIC_CATEGORIES = [
-  {
-    name: "unspecified-low",
-    config: { model: "anthropic/claude-sonnet-4-6" },
-    description: "Tasks that don't fit other categories, low effort required",
-    promptAppend: UNSPECIFIED_LOW_CATEGORY_PROMPT_APPEND,
-  },
   {
     name: "unspecified-high",
     config: { model: "anthropic/claude-opus-4-7", variant: "max" },

--- a/packages/senpi-task/src/category/fallback-chains.ts
+++ b/packages/senpi-task/src/category/fallback-chains.ts
@@ -18,6 +18,7 @@ export const CATEGORY_FALLBACK_CHAINS: Readonly<Record<string, readonly Delegate
     { providers: ["opencode-go", "vercel"], model: "glm-5.2" },
   ],
   deep: [
+    { providers: ["openai", "vercel"], model: "gpt-5.6-terra", variant: "xhigh" },
     { providers: ["openai", "vercel"], model: "gpt-5.6-sol", variant: "high" },
     { providers: ["openai", "github-copilot", "opencode", "vercel"], model: "gpt-5.5", variant: "medium" },
     { providers: ["anthropic", "github-copilot", "opencode", "vercel"], model: "claude-opus-4-7", variant: "max" },
@@ -42,6 +43,7 @@ export const CATEGORY_FALLBACK_CHAINS: Readonly<Record<string, readonly Delegate
     { providers: ["opencode", "vercel"], model: "gpt-5-nano" },
   ],
   "unspecified-low": [
+    { providers: ["openai", "vercel"], model: "gpt-5.6-luna", variant: "xhigh" },
     { providers: ["anthropic", "github-copilot", "opencode", "vercel"], model: "claude-sonnet-4-6" },
     { providers: ["openai", "opencode", "vercel"], model: "gpt-5.5", variant: "medium" },
     { providers: ["opencode-go", "vercel"], model: "kimi-k2.6" },

--- a/packages/senpi-task/src/category/openai-categories.ts
+++ b/packages/senpi-task/src/category/openai-categories.ts
@@ -135,6 +135,29 @@ EXPECTED OUTPUT:
 If your prompt lacks this structure, REWRITE IT before delegating.
 </Caller_Warning>`
 
+const UNSPECIFIED_LOW_CATEGORY_PROMPT_APPEND = `<Category_Context>
+You are working on tasks that don't fit specific categories but require moderate effort.
+
+<Selection_Gate>
+BEFORE selecting this category, VERIFY ALL conditions:
+1. Task does NOT fit: quick (trivial), visual-engineering (UI), ultrabrain (deep logic), artistry (creative), writing (docs)
+2. Task requires more than trivial effort but is NOT system-wide
+3. Scope is contained within a few files/modules
+
+If task fits ANY other category, DO NOT select unspecified-low.
+This is NOT a default choice - it's for genuinely unclassifiable moderate-effort work.
+</Selection_Gate>
+</Category_Context>
+
+<Caller_Warning>
+THIS CATEGORY USES A LIGHTWEIGHT MODEL (gpt-5.6-luna).
+
+**PROVIDE CLEAR STRUCTURE:**
+1. MUST DO: Enumerate required actions explicitly
+2. MUST NOT DO: State forbidden actions to prevent scope creep
+3. EXPECTED OUTPUT: Define concrete success criteria
+</Caller_Warning>`
+
 export const OPENAI_CATEGORIES = [
   {
     name: "ultrabrain",
@@ -144,7 +167,7 @@ export const OPENAI_CATEGORIES = [
   },
   {
     name: "deep",
-    config: { model: "openai/gpt-5.6-sol", variant: "high" },
+    config: { model: "openai/gpt-5.6-terra", variant: "xhigh" },
     description: "Goal-oriented autonomous problem-solving on hairy problems requiring deep research. ONE goal + ONE deliverable per call — multiple goals must fan out as parallel `deep` calls, never bundled into one.",
     promptAppend: DEEP_CATEGORY_PROMPT_APPEND,
     resolvePromptAppend: resolveDeepCategoryPromptAppend,
@@ -154,5 +177,11 @@ export const OPENAI_CATEGORIES = [
     config: { model: "openai/gpt-5.4-mini" },
     description: "Trivial tasks - single file changes, typo fixes, simple modifications",
     promptAppend: QUICK_CATEGORY_PROMPT_APPEND,
+  },
+  {
+    name: "unspecified-low",
+    config: { model: "openai/gpt-5.6-luna", variant: "xhigh" },
+    description: "Tasks that don't fit other categories, low effort required",
+    promptAppend: UNSPECIFIED_LOW_CATEGORY_PROMPT_APPEND,
   },
 ] satisfies readonly BuiltinCategoryDefinition[]


### PR DESCRIPTION
## Summary

Rolls the GPT-5.6 tier split into the category defaults: `deep` now recommends `openai/gpt-5.6-terra` (xhigh) first, `unspecified-low` recommends `openai/gpt-5.6-luna` (xhigh) first, and `ultrabrain` keeps `openai/gpt-5.6-sol` (xhigh). Previous defaults are preserved as the next fallback entries, so setups without GPT-5.6 access resolve exactly as before.

## Changes

- **model-core (routing source of truth)** — `category-model-requirements.ts` prepends `gpt-5.6-terra` (xhigh) to the `deep` chain and `gpt-5.6-luna` (xhigh) to the `unspecified-low` chain, `openai|vercel` providers, prior primaries (`gpt-5.6-sol` high / `claude-sonnet-4-6`) retained as fallbacks. `supplemental-entries.ts` registers terra/luna capability entries with specs verified against models.dev (context 1050000 / input 922000 / output 128000, text+image+pdf input, families gpt-mini / gpt-nano). Category tests updated to pin the new chain heads.
- **omo-opencode (builtin `task` categories)** — `deep` builtin default bumped to `openai/gpt-5.6-terra` xhigh; `unspecified-low` moved from `anthropic-categories.ts` to `openai-categories.ts` (file naming convention = default model provider) with `openai/gpt-5.6-luna` xhigh and an updated caller warning. Delegate-task category table in `tools/AGENTS.md` refreshed.
- **senpi-task (mirror)** — `fallback-chains.ts` and builtin category defaults mirrored 1:1 with model-core/omo-opencode; resolve-category snapshot regenerated.
- **docs & examples** — agent-model-matching, installation, configuration, features, overview, three example jsonc configs, and the hyperplan skill roster table (`.agents`/`.opencode` copies kept byte-identical) reflect the new defaults.

Intentional non-goals: no config migration is added — PR #6021 removed entry-scoped migrations to preserve explicit user pins; existing configs keep their pinned models and pick the new defaults up on installer regeneration. `ultrabrain` untouched (already sol xhigh). omo-codex agent TOMLs untouched (separate surface with its own defaults).

## QA & Evidence

Full evidence file: `.omo/evidence/gpt-5-6-category-defaults-qa.md` (worktree, `.omo` is gitignored — contents reproduced here).

- **What was tested:** real installer CLI (`node bin/oh-my-opencode.js install --no-tui --platform=opencode ...`) in isolated `HOME`/`XDG_CONFIG_HOME`, three provider scenarios.
  - **Claude+OpenAI:** generated `oh-my-openagent.json` has `deep` = terra xhigh (fallbacks sol high → gpt-5.5 medium → opus max), `unspecified-low` = luna xhigh (fallbacks sonnet → gpt-5.5 medium), `ultrabrain` = sol xhigh. PASS.
  - **Claude-only:** `deep`/`ultrabrain` = opus max, `unspecified-low` = sonnet — identical to pre-change degradation; no GPT pin forced on non-GPT configs. PASS.
  - **OpenAI-only:** all three categories route to terra/sol/luna xhigh with GPT-5.5 fallbacks. PASS.
- **What was tested:** runtime builtin defaults (`DEFAULT_CATEGORIES` from `delegate-task/builtin-categories`) — the table the `task` tool uses with no user config. Observed terra/sol/luna xhigh. PASS.
- **What was tested:** terra/luna capability specs cross-checked against models.dev `api.json` (openai, vercel, llmgateway providers agree). Supplemental entries mirror those values exactly.
- **Automated:** `bun test packages/model-core packages/senpi-task packages/utils` → 1217 pass / 0 fail; `bun test packages/omo-opencode` → 8206 pass / 1 skip / 0 fail; `bun run typecheck` → exit 0; `bun run build` → exit 0.
- **Why sufficient:** the installer scenarios cover the three availability shapes that decide category primaries (mixed, no-OpenAI, OpenAI-only), and the builtin-defaults check covers the no-config runtime path; together they exercise every surface this PR touches.

## Risks & Residuals

- **Users without GPT-5.6 in their catalog:** mitigated — old primaries remain as immediate fallbacks in every touched chain (Scenario 2 evidence).
- **Mirror drift between model-core / senpi-task / omo-opencode:** mitigated — all three updated in lockstep in this PR; snapshot test pins the mirror.
- **Existing user configs:** accepted — intentionally not migrated (repo policy after #3777/#4527/#6021); new defaults apply to fresh installs and installer regeneration only.

## Related Issues

Follows the rollout pattern of #6010 (momus → gpt-5.6-sol xhigh) and #6012.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates category defaults to GPT-5.6 tiers: `deep` now prefers `openai/gpt-5.6-terra` (xhigh) and `unspecified-low` prefers `openai/gpt-5.6-luna` (xhigh). `ultrabrain` stays on `openai/gpt-5.6-sol` (xhigh); prior defaults remain as fallbacks.

- New Features
  - `model-core`: prepends `gpt-5.6-terra` (xhigh) to `deep` and `gpt-5.6-luna` (xhigh) to `unspecified-low`; adds terra/luna capability entries; updates category tests.
  - `omo-opencode`: moves `unspecified-low` to `openai/gpt-5.6-luna` (xhigh) and bumps `deep` to `openai/gpt-5.6-terra` (xhigh); updates caller warning and `AGENTS.md`; strengthens delegate default test to assert the xhigh variant.
  - `senpi-task`: mirrors the new defaults and fallback chains; refreshes snapshot.
  - Docs/examples: updates guides and example configs to the new defaults.

- Migration
  - No migration needed. Existing configs keep pinned models; new installs or regenerated configs pick up the new defaults.

<sup>Written for commit 54a375c64332ecf72ce3907e35e3d4a185d978b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

