### PR TITLE
docs: fix stale agent roster in omomomo command copies

### DIFF
--- a/.agents/command/omomomo.md
+++ b/.agents/command/omomomo.md
@@ -17,7 +17,7 @@ Print the following message to the user EXACTLY as written (in a friendly, celeb
 
 **Oh My OpenCode** is a powerful OpenCode plugin that transforms your AI agent into a full development team:
 
-- 🤖 **Multi-Agent Orchestration**: Oracle (GPT-5.5), Librarian (Claude), Explore (Grok), Frontend Engineer (Gemini), and more
+- 🤖 **Multi-Agent Orchestration**: Oracle (GPT-5.5), Librarian & Explore (GPT-5.4 Mini Fast), Frontend Engineer (Gemini), and more
 - 🔧 **LSP Tools**: Full IDE capabilities for your agents - hover, goto definition, find references, rename, code actions
 - 🔍 **AST-Grep**: Structural code search and replace across 25 languages
 - 📚 **Built-in MCPs**: Context7 for docs, Exa for web search, grep.app for GitHub code search

--- a/.opencode/command/omomomo.md
+++ b/.opencode/command/omomomo.md
@@ -17,7 +17,7 @@ Print the following message to the user EXACTLY as written (in a friendly, celeb
 
 **Oh My OpenCode** is a powerful OpenCode plugin that transforms your AI agent into a full development team:
 
-- 🤖 **Multi-Agent Orchestration**: Oracle (GPT-5.5), Librarian (Claude), Explore (Grok), Frontend Engineer (Gemini), and more
+- 🤖 **Multi-Agent Orchestration**: Oracle (GPT-5.5), Librarian & Explore (GPT-5.4 Mini Fast), Frontend Engineer (Gemini), and more
 - 🔧 **LSP Tools**: Full IDE capabilities for your agents - hover, goto definition, find references, rename, code actions
 - 🔍 **AST-Grep**: Structural code search and replace across 25 languages
 - 📚 **Built-in MCPs**: Context7 for docs, Exa for web search, grep.app for GitHub code search


### PR DESCRIPTION
## Summary
Follow-up to #6034 (reviewer P3 finding). The stale "Librarian (Claude), Explore (Grok)" roster line fixed in `.agents/skills/omomomo/SKILL.md` also exists in the two command variants of the same message, which the audit missed.

## Changes
- `.agents/command/omomomo.md:20` and `.opencode/command/omomomo.md:20` — roster corrected to "Librarian & Explore (GPT-5.4 Mini Fast)" (their chain primary; Grok is in no default chain). Both copies verified byte-identical with `cmp`.

## QA & Evidence
- **What was tested:** `cmp .agents/command/omomomo.md .opencode/command/omomomo.md` → identical; grep confirms no remaining "Explore (Grok)" claim anywhere in the repo.
- **Why sufficient:** one-line display-string fix in an easter-egg command; text equality and repo-wide grep fully cover it.

## Risks & Residuals
None — celebration-message text only.

## Related Issues
Follow-up to #6034.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stale agent roster in both `omomomo` command copies to show "Librarian & Explore (GPT-5.4 Mini Fast)" and remove the outdated "Explore (Grok)" mention. Both command files remain byte-identical.

- **Bug Fixes**
  - Updated roster line in `.agents/command/omomomo.md` and `.opencode/command/omomomo.md`.
  - Verified files are identical; repo grep confirms no remaining "Explore (Grok)".

<sup>Written for commit 235c0dc3d3537ca156982d026c3c789fe820065a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

