### PR TITLE
feat(ulw-loop): Stop-hook auto-resume and spawn guards (fan-out cap + gate-artifact preflight)

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -731,7 +731,7 @@ Skip this section if `--platform=opencode`. Otherwise, the user installed the **
 | `git-bash` | TypeScript + MCP | `PreToolUse` (`Bash`), `PostCompact`, MCP server | On Windows, exposes `git_bash`; reminds Codex before the first shell-like call and again after compaction |
 | `lsp` | TypeScript + MCP | MCP server + post-edit hooks | Exposes LSP diagnostics, navigation, symbols, rename via MCP |
 | `ultrawork` | TypeScript | `UserPromptSubmit` keyword detector | Detects `ulw`/`ultrawork` keyword; the installer links bundled Codex agent TOMLs into `$CODEX_HOME/agents` |
-| `ulw-loop` | TypeScript | Durable orchestration via `.omo/ulw-loop/` | Multi-goal orchestration with evidence audit trail |
+| `ulw-loop` | TypeScript | `UserPromptSubmit`, `PreToolUse`, `Stop` | Multi-goal orchestration with evidence audit trail, spawn guards, and Stop-hook auto-resume via `.omo/ulw-loop/` |
 | `start-work-continuation` | TypeScript | `Stop`, `SubagentStop` | Continues `.omo/boulder.json` start-work plans when Codex pauses at a stop boundary |
 | `telemetry` | TypeScript | `SessionStart` | Emits anonymous daily active telemetry when enabled |
 

--- a/packages/omo-codex/README.md
+++ b/packages/omo-codex/README.md
@@ -19,7 +19,7 @@ Codex harness adapter for **oh-my-openagent**. Brings the OMO experience (rules 
 - `lsp` (TypeScript + LSP MCP) - exposes LSP diagnostics, navigation, symbols, rename via MCP + post-edit hooks.
 - `git-bash` (TypeScript + Git Bash MCP) - exposes the Windows-only `git_bash` MCP and reminds Codex on the first shell-like call, including the first one after compaction.
 - `ultrawork` (TypeScript) - keyword detector (`ulw` / `ultrawork`) that injects the full ultrawork directive; bundled agent TOML files are installed into `CODEX_HOME/agents`.
-- `ulw-loop` (TypeScript) - durable multi-goal orchestration backed by `.omo/ulw-loop/` evidence audit.
+- `ulw-loop` (TypeScript) - durable multi-goal orchestration backed by `.omo/ulw-loop/` evidence audit; `PreToolUse` spawn guards (fan-out cap + gate-artifact preflight) and a `Stop` auto-resume hook.
 - `start-work-continuation` (TypeScript) - `Stop` / `SubagentStop` continuation hook for `.omo/boulder.json` start-work plans.
 - `telemetry` (TypeScript) - anonymous daily active telemetry hook.
 

--- a/packages/omo-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/omo-codex/plugin/.codex-plugin/plugin.json
@@ -30,6 +30,7 @@
 		"./hooks/user-prompt-submit-checking-ulw-loop-steering.json",
 		"./hooks/pre-tool-use-recommending-git-bash-mcp.json",
 		"./hooks/pre-tool-use-enforcing-unlimited-goal-budget.json",
+		"./hooks/pre-tool-use-guarding-ulw-loop-spawns.json",
 		"./hooks/post-tool-use-checking-comments.json",
 		"./hooks/post-tool-use-checking-lsp-diagnostics.json",
 		"./hooks/post-tool-use-checking-codegraph-init-guidance.json",

--- a/packages/omo-codex/plugin/.codex-plugin/plugin.json
+++ b/packages/omo-codex/plugin/.codex-plugin/plugin.json
@@ -39,6 +39,7 @@
 		"./hooks/post-compact-resetting-project-rule-cache.json",
 		"./hooks/post-compact-resetting-lsp-diagnostics-cache.json",
 		"./hooks/stop-checking-start-work-continuation.json",
+		"./hooks/stop-checking-ulw-loop-resume.json",
 		"./hooks/subagent-stop-checking-start-work-continuation.json",
 		"./hooks/subagent-stop-verifying-lazycodex-executor-evidence.json"
 	],

--- a/packages/omo-codex/plugin/components/ulw-loop/AGENTS.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/AGENTS.md
@@ -45,4 +45,4 @@ Conventions for human contributors and AI agents working on this repository.
 ## Build and Hooks
 
 - Build output goes to `dist/`.
-- `hooks/hooks.json` runs `node ${PLUGIN_ROOT}/dist/cli.js hook user-prompt-submit --with-ultrawork`.
+- `hooks/hooks.json` wires `hook user-prompt-submit --with-ultrawork` (UserPromptSubmit), `hook pre-tool-use` (create_goal budget), `hook pre-tool-use-spawn` (spawn guards), and `hook stop` (auto-resume).

--- a/packages/omo-codex/plugin/components/ulw-loop/CHANGELOG.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [0.1.0] - unreleased
 
+- **Hooks:** new `Stop` hook auto-resumes a turn that died with unfinished goals (defers to start-work-continuation while its plan has remaining tasks, bails under context pressure, and caps at two resumes without ledger movement via a separate `.stuck` marker). New `PreToolUse` spawn guard adds a per-session fan-out cap (`OMO_SPAWN_FANOUT_LIMIT`, default 60) and denies final gate-reviewer spawns while the reviewer artifacts the gate audits are missing.
+
 - **Memory:** steering ledger entries no longer embed the full plan four times (`before`/`after` at both the audit and entry level). Accepted steers now record a compact `UlwLoopSteeringPlanSnapshot` (plan counters + only the goals the mutation touched), shrinking a measured real-world entry from 189KB to 7.8KB (~24x) and ending quadratic `ledger.jsonl` growth over long runs.
 - **Memory:** steering dedup (`--idempotency-key` / `promptSignature`) streams the ledger line-by-line with a substring pre-filter instead of `JSON.parse`-ing every entry into memory; dedup returns strip legacy full-plan `before`/`after` payloads from re-surfaced audits. `readSteeringLedgerEntries` streams too.
 - **Memory:** `withUlwLoopMutationLock` no longer retains the mutation result (full plan/audit) per `(repo, scope)` in its module-level lock map; settled gates self-evict, so long-lived embedders stop accumulating entries.

--- a/packages/omo-codex/plugin/components/ulw-loop/README.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/README.md
@@ -27,9 +27,11 @@ The final quality gate parsed by `checkpoint` validates `codeReview`, `manualQa`
 
 This directory is a component of the aggregate `@sisyphuslabs/omo-codex-plugin` root. Plugin discovery (`.codex-plugin/plugin.json`) is owned by that aggregate root, not by this component. The component ships:
 
-- `hooks/hooks.json` registering two hooks:
+- `hooks/hooks.json` registering four hooks:
   - `UserPromptSubmit` -> `node "${PLUGIN_ROOT}/dist/cli.js" hook user-prompt-submit --with-ultrawork`
   - `PreToolUse` matching `^create_goal$` -> `node "${PLUGIN_ROOT}/dist/cli.js" hook pre-tool-use`
+  - `PreToolUse` matching the spawn tool tokens -> `node "${PLUGIN_ROOT}/dist/cli.js" hook pre-tool-use-spawn` (fan-out cap + gate-artifact preflight)
+  - `Stop` -> `node "${PLUGIN_ROOT}/dist/cli.js" hook stop` (auto-resume with a two-strike no-progress cap)
 - `skills/ulw-loop/` for the bundled `ulw-loop` skill.
 - `bin.omo-ulw-loop` -> `dist/cli.js` for standalone CLI invocation.
 

--- a/packages/omo-codex/plugin/components/ulw-loop/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/hooks/hooks.json
@@ -23,6 +23,17 @@
 						"statusMessage": "(OmO 4.16.3) Enforcing Unlimited Ulw-Loop Budget"
 					}
 				]
+			},
+			{
+				"matcher": "^(spawn_agent|collaborationspawn_agent|collaboration\\.spawn_agent)$",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook pre-tool-use-spawn",
+						"timeout": 5,
+						"statusMessage": "(OmO 4.16.3) Guarding Ulw-Loop Spawns"
+					}
+				]
 			}
 		],
 		"Stop": [

--- a/packages/omo-codex/plugin/components/ulw-loop/hooks/hooks.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/hooks/hooks.json
@@ -24,6 +24,18 @@
 					}
 				]
 			}
+		],
+		"Stop": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"${PLUGIN_ROOT}/dist/cli.js\" hook stop",
+						"timeout": 10,
+						"statusMessage": "(OmO 4.16.3) Checking Ulw-Loop Resume"
+					}
+				]
+			}
 		]
 	}
 }

--- a/packages/omo-codex/plugin/components/ulw-loop/src/cli.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { isUlwLoopSubcommand, ulwLoopCommand } from "./cli-commands.js";
 import { runPreToolUseGoalBudgetGuardCli, runUlwLoopHookCli } from "./codex-hook.js";
+import { runStopResumeHookCli } from "./stop-resume-hook.js";
 
 const TOP_LEVEL_HELP =
 	"Usage:\n  omo ulw-loop <subcommand> [args]\n  omo hook user-prompt-submit [--with-ultrawork]  (Codex UserPromptSubmit hook)\n  omo help | --help | -h                          (this message)\n\nRun `omo ulw-loop help` for ulw-loop subcommands.\n";
@@ -23,6 +24,10 @@ async function main(): Promise<number> {
 		}
 		if (sub === "pre-tool-use") {
 			await runPreToolUseGoalBudgetGuardCli(process.stdin, process.stdout);
+			return 0;
+		}
+		if (sub === "stop") {
+			await runStopResumeHookCli(process.stdin, process.stdout);
 			return 0;
 		}
 		process.stderr.write(`[omo] unknown hook subcommand: ${sub ?? "(none)"}\n`);

--- a/packages/omo-codex/plugin/components/ulw-loop/src/cli.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { isUlwLoopSubcommand, ulwLoopCommand } from "./cli-commands.js";
 import { runPreToolUseGoalBudgetGuardCli, runUlwLoopHookCli } from "./codex-hook.js";
+import { runSpawnGuardCli } from "./spawn-guard.js";
 import { runStopResumeHookCli } from "./stop-resume-hook.js";
 
 const TOP_LEVEL_HELP =
@@ -28,6 +29,10 @@ async function main(): Promise<number> {
 		}
 		if (sub === "stop") {
 			await runStopResumeHookCli(process.stdin, process.stdout);
+			return 0;
+		}
+		if (sub === "pre-tool-use-spawn") {
+			await runSpawnGuardCli(process.stdin, process.stdout);
 			return 0;
 		}
 		process.stderr.write(`[omo] unknown hook subcommand: ${sub ?? "(none)"}\n`);

--- a/packages/omo-codex/plugin/components/ulw-loop/src/spawn-guard.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/spawn-guard.ts
@@ -1,0 +1,140 @@
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { PreToolUsePayload } from "./codex-hook.js";
+import { parsePreToolUsePayload } from "./codex-hook.js";
+import { isFinalRunCompletionCandidate } from "./goal-status.js";
+import { ulwLoopAttemptEvidenceDir, ulwLoopDir } from "./paths.js";
+import type { UlwLoopPlan } from "./types.js";
+
+// spawn_agent = v1; collaborationspawn_agent = the delimiter-free flattened v2
+// hook token from codex-rs hook_names.rs; collaboration.spawn_agent = the
+// dotted token observed live in the task-1 probe (hook-tool-tokens.txt).
+const SPAWN_TOOL_TOKENS = new Set(["spawn_agent", "collaborationspawn_agent", "collaboration.spawn_agent"]);
+const DEFAULT_FANOUT_LIMIT = 60;
+const GATE_MESSAGE_PATTERN = /lazycodex-gate-reviewer|final gate review/i;
+
+export function applySpawnGuards(payload: PreToolUsePayload): string {
+	if (payload.hook_event_name !== "PreToolUse" || !SPAWN_TOOL_TOKENS.has(payload.tool_name)) return "";
+	const stateDir = ulwLoopDir(payload.cwd, { sessionId: payload.session_id });
+	const plan = readPlan(join(stateDir, "goals.json"));
+	if (plan === null) return "";
+	const fanOutDenial = consumeFanOutBudget(stateDir);
+	if (fanOutDenial !== null) return deny(fanOutDenial);
+	const missingArtifact = missingGateArtifact(payload, plan);
+	if (missingArtifact !== null)
+		return deny(`spawn code-review + QA first; gate audits their artifacts: missing ${missingArtifact}`);
+	return "";
+}
+
+export async function runSpawnGuardCli(stdin: NodeJS.ReadableStream, stdout: NodeJS.WritableStream): Promise<void> {
+	try {
+		const chunks: Buffer[] = [];
+		for await (const chunk of stdin) chunks.push(Buffer.from(chunk));
+		const payload = parsePreToolUsePayload(Buffer.concat(chunks).toString("utf8"));
+		if (payload === null) return;
+		const output = applySpawnGuards(payload);
+		if (output.length > 0) stdout.write(output);
+	} catch (error) {
+		if (error instanceof Error) return;
+	}
+}
+
+// Per-session spawn counter; depth/lineage tracking is descoped — this is a
+// total-volume backstop against fan-out explosions, not a recursion tracker.
+function consumeFanOutBudget(stateDir: string): string | null {
+	const counterPath = join(stateDir, "spawn-count.json");
+	const count = readCount(counterPath) + 1;
+	writeFileSync(counterPath, JSON.stringify({ count }));
+	const limit = fanOutLimit();
+	if (count <= limit) return null;
+	return `ulw-loop spawn fan-out cap reached (${count}/${limit}). Consolidate work into the agents already running, or raise OMO_SPAWN_FANOUT_LIMIT if this volume is intentional.`;
+}
+
+function missingGateArtifact(payload: PreToolUsePayload, plan: UlwLoopPlan): string | null {
+	if (!isGateReviewerSpawn(payload.tool_input)) return null;
+	const goal = plan.goals.find((candidate) => isFinalRunCompletionCandidate(plan, candidate));
+	if (goal === undefined || goal.status === "complete") return null;
+	if (!goal.successCriteria.every((criterion) => criterion.status === "pass")) return null;
+	const scope = { sessionId: payload.session_id } as const;
+	if (plan.evidenceLayoutVersion === 2) {
+		const attemptDir = ulwLoopAttemptEvidenceDir(goal.id, goal.attempt, scope);
+		for (const name of [`${goal.id}-code-review.md`, `${goal.id}-manual-qa.md`]) {
+			const relative = `${attemptDir}/${name}`;
+			if (!isNonEmptyFile(join(payload.cwd, relative))) return relative;
+		}
+		return null;
+	}
+	const flatReport = `.omo/evidence/${goal.id}-code-review.md`;
+	if (!isNonEmptyFile(join(payload.cwd, flatReport))) return flatReport;
+	// v1 manual-QA approximation: any other non-empty evidence file counts.
+	if (!hasOtherEvidenceFile(join(payload.cwd, ".omo", "evidence"), `${goal.id}-code-review.md`))
+		return `.omo/evidence/<any manual-QA artifact besides ${goal.id}-code-review.md>`;
+	return null;
+}
+
+function isGateReviewerSpawn(toolInput: unknown): boolean {
+	if (typeof toolInput !== "object" || toolInput === null) return false;
+	const record = toolInput as Record<string, unknown>;
+	const agentType = record["agent_type"];
+	if (typeof agentType === "string") return agentType === "lazycodex-gate-reviewer";
+	const message = record["message"];
+	return typeof message === "string" && GATE_MESSAGE_PATTERN.test(message);
+}
+
+function deny(reason: string): string {
+	return `${JSON.stringify({
+		hookSpecificOutput: {
+			hookEventName: "PreToolUse",
+			permissionDecision: "deny",
+			permissionDecisionReason: reason,
+			additionalContext: reason,
+		},
+	})}\n`;
+}
+
+function fanOutLimit(): number {
+	const raw = process.env["OMO_SPAWN_FANOUT_LIMIT"];
+	if (raw === undefined) return DEFAULT_FANOUT_LIMIT;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_FANOUT_LIMIT;
+}
+
+function isNonEmptyFile(path: string): boolean {
+	try {
+		return existsSync(path) && statSync(path).size > 0;
+	} catch (error) {
+		if (error instanceof Error) return false;
+		throw error;
+	}
+}
+
+function hasOtherEvidenceFile(evidenceDir: string, excludedName: string): boolean {
+	try {
+		return readdirSync(evidenceDir).some(
+			(name) => name !== excludedName && isNonEmptyFile(join(evidenceDir, name)),
+		);
+	} catch (error) {
+		if (error instanceof Error) return false;
+		throw error;
+	}
+}
+
+function readCount(counterPath: string): number {
+	try {
+		const parsed = JSON.parse(readFileSync(counterPath, "utf8")) as Record<string, unknown>;
+		return typeof parsed["count"] === "number" && parsed["count"] >= 0 ? parsed["count"] : 0;
+	} catch (error) {
+		if (error instanceof Error) return 0;
+		throw error;
+	}
+}
+
+function readPlan(goalsPath: string): UlwLoopPlan | null {
+	try {
+		return JSON.parse(readFileSync(goalsPath, "utf8")) as UlwLoopPlan;
+	} catch (error) {
+		if (error instanceof Error) return null;
+		throw error;
+	}
+}

--- a/packages/omo-codex/plugin/components/ulw-loop/src/spawn-guard.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/spawn-guard.ts
@@ -111,9 +111,7 @@ function isNonEmptyFile(path: string): boolean {
 
 function hasOtherEvidenceFile(evidenceDir: string, excludedName: string): boolean {
 	try {
-		return readdirSync(evidenceDir).some(
-			(name) => name !== excludedName && isNonEmptyFile(join(evidenceDir, name)),
-		);
+		return readdirSync(evidenceDir).some((name) => name !== excludedName && isNonEmptyFile(join(evidenceDir, name)));
 	} catch (error) {
 		if (error instanceof Error) return false;
 		throw error;

--- a/packages/omo-codex/plugin/components/ulw-loop/src/stop-resume-hook.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/stop-resume-hook.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 
-import { ulwLoopDir } from "./paths.js";
+import { normalizeUlwLoopSessionId, ulwLoopDir } from "./paths.js";
 import type { UlwLoopItem, UlwLoopPlan } from "./types.js";
 
 // Turn-death recovery only: Codex emits Stop when a turn ends, so a run that
@@ -10,15 +10,29 @@ import type { UlwLoopItem, UlwLoopPlan } from "./types.js";
 
 const RESUME_CAP = 2;
 
+// Mirrors start-work-continuation's context-pressure bail-out: injecting a
+// resume directive into an already-overflowing context makes things worse.
+const CONTEXT_PRESSURE_MARKERS = [
+	"context compacted",
+	"context_length_exceeded",
+	"skill descriptions were shortened",
+	"context_too_large",
+	"codex ran out of room in the model's context window",
+	"your input exceeds the context window",
+	"long threads and multiple compactions",
+] as const;
+
 interface StopPayload {
 	readonly session_id: string;
 	readonly cwd: string;
+	readonly transcript_path: string;
 	readonly stop_hook_active: boolean;
 }
 
 export function runStopResumeHook(input: unknown): string {
 	const payload = parseStopPayload(input);
 	if (payload === null || payload.stop_hook_active) return "";
+	if (transcriptShowsContextPressure(payload.transcript_path)) return "";
 	if (boulderContinuationWillFire(payload.cwd, payload.session_id)) return "";
 	const stateDir = ulwLoopDir(payload.cwd, { sessionId: payload.session_id });
 	const plan = readPlan(join(stateDir, "goals.json"));
@@ -26,13 +40,14 @@ export function runStopResumeHook(input: unknown): string {
 	const goal = resumableGoal(plan);
 	if (goal === undefined) return "";
 	if (!consumeResumeBudget(stateDir, goal.id)) return "";
-	return JSON.stringify({ decision: "block", reason: renderResumeDirective(plan, goal, payload.session_id) });
+	const output: { decision: "block"; reason: string } = {
+		decision: "block",
+		reason: renderResumeDirective(plan, goal, payload.session_id),
+	};
+	return JSON.stringify(output);
 }
 
-export async function runStopResumeHookCli(
-	stdin: NodeJS.ReadableStream,
-	stdout: NodeJS.WritableStream,
-): Promise<void> {
+export async function runStopResumeHookCli(stdin: NodeJS.ReadableStream, stdout: NodeJS.WritableStream): Promise<void> {
 	try {
 		const chunks: Buffer[] = [];
 		for await (const chunk of stdin) chunks.push(Buffer.from(chunk));
@@ -70,7 +85,9 @@ function consumeResumeBudget(stateDir: string, goalId: string): boolean {
 }
 
 function renderResumeDirective(plan: UlwLoopPlan, goal: UlwLoopItem, sessionId: string): string {
-	const option = plan.goalsPath.includes(`/${sessionId}/`) ? ` --session-id ${sessionId}` : "";
+	const normalized = normalizeUlwLoopSessionId(sessionId);
+	const option =
+		normalized !== null && plan.goalsPath.includes(`/${normalized}/`) ? ` --session-id ${normalized}` : "";
 	return [
 		`The ulw-loop run in this session still has unfinished goals (next: ${goal.id} — ${goal.title}).`,
 		"The turn ended before the loop completed. Resume it now:",
@@ -118,18 +135,53 @@ function boulderContinuationWillFire(cwd: string, sessionId: string): boolean {
 	try {
 		const raw = JSON.parse(readFileSync(join(cwd, ".omo", "boulder.json"), "utf8")) as Record<string, unknown>;
 		const works = raw["works"];
-		if (typeof works !== "object" || works === null) return false;
-		return Object.values(works).some((work) => {
+		// The flat legacy shape has no works map: the top level is the single work.
+		const entries = typeof works === "object" && works !== null ? Object.values(works) : [raw];
+		return entries.some((work) => {
 			if (typeof work !== "object" || work === null) return false;
 			const entry = work as Record<string, unknown>;
 			const sessionIds = Array.isArray(entry["session_ids"]) ? entry["session_ids"] : [];
 			const continuable = entry["status"] === "active" || entry["status"] === "paused";
-			return continuable && sessionIds.includes(`codex:${sessionId}`);
+			return continuable && sessionIds.includes(`codex:${sessionId}`) && boulderPlanHasRemainingTask(cwd, entry);
 		});
 	} catch (error) {
 		if (error instanceof Error) return false;
 		throw error;
 	}
+}
+
+function transcriptShowsContextPressure(transcriptPath: string): boolean {
+	try {
+		const transcript = readFileSync(transcriptPath, "utf8").toLowerCase();
+		return CONTEXT_PRESSURE_MARKERS.some((marker) => transcript.includes(marker));
+	} catch (error) {
+		if (error instanceof Error) return false;
+		throw error;
+	}
+}
+
+// start-work-continuation only fires while its plan checklist has remaining
+// items; a boulder work whose plan is exhausted (or unreadable) leaves the
+// Stop event to this hook.
+function boulderPlanHasRemainingTask(cwd: string, entry: Record<string, unknown>): boolean {
+	const activePlan = entry["active_plan"];
+	if (typeof activePlan !== "string" || activePlan.trim().length === 0) return false;
+	const planPath = isAbsolute(activePlan) ? activePlan : join(cwd, activePlan);
+	const worktree = entry["worktree_path"];
+	const candidates =
+		typeof worktree === "string" && worktree.trim().length > 0 && !isAbsolute(activePlan)
+			? [join(isAbsolute(worktree) ? worktree : join(cwd, worktree), activePlan), planPath]
+			: [planPath];
+	for (const candidate of candidates) {
+		try {
+			return readFileSync(candidate, "utf8")
+				.split(/\r?\n/)
+				.some((line) => line.startsWith("- [ ] "));
+		} catch (error) {
+			if (!(error instanceof Error)) throw error;
+		}
+	}
+	return false;
 }
 
 function parseStopPayload(value: unknown): StopPayload | null {
@@ -150,6 +202,7 @@ function parseStopPayload(value: unknown): StopPayload | null {
 	return {
 		session_id: record["session_id"] as string,
 		cwd: record["cwd"] as string,
+		transcript_path: record["transcript_path"] as string,
 		stop_hook_active: record["stop_hook_active"] as boolean,
 	};
 }

--- a/packages/omo-codex/plugin/components/ulw-loop/src/stop-resume-hook.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/stop-resume-hook.ts
@@ -1,0 +1,155 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { ulwLoopDir } from "./paths.js";
+import type { UlwLoopItem, UlwLoopPlan } from "./types.js";
+
+// Turn-death recovery only: Codex emits Stop when a turn ends, so a run that
+// dies mid-turn (crash, kill, context blowup before any Stop) never reaches
+// this handler. Mid-turn stalls are out of scope by design.
+
+const RESUME_CAP = 2;
+
+interface StopPayload {
+	readonly session_id: string;
+	readonly cwd: string;
+	readonly stop_hook_active: boolean;
+}
+
+export function runStopResumeHook(input: unknown): string {
+	const payload = parseStopPayload(input);
+	if (payload === null || payload.stop_hook_active) return "";
+	if (boulderContinuationWillFire(payload.cwd, payload.session_id)) return "";
+	const stateDir = ulwLoopDir(payload.cwd, { sessionId: payload.session_id });
+	const plan = readPlan(join(stateDir, "goals.json"));
+	if (plan === null || plan.aggregateCompletion?.status === "complete") return "";
+	const goal = resumableGoal(plan);
+	if (goal === undefined) return "";
+	if (!consumeResumeBudget(stateDir, goal.id)) return "";
+	return JSON.stringify({ decision: "block", reason: renderResumeDirective(plan, goal, payload.session_id) });
+}
+
+export async function runStopResumeHookCli(
+	stdin: NodeJS.ReadableStream,
+	stdout: NodeJS.WritableStream,
+): Promise<void> {
+	try {
+		const chunks: Buffer[] = [];
+		for await (const chunk of stdin) chunks.push(Buffer.from(chunk));
+		const output = runStopResumeHook(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+		if (output.length > 0) stdout.write(output);
+	} catch (error) {
+		if (error instanceof Error) return;
+	}
+}
+
+function resumableGoal(plan: UlwLoopPlan): UlwLoopItem | undefined {
+	const active = plan.goals.find((goal) => goal.id === plan.activeGoalId);
+	if (active !== undefined && isResumableStatus(active.status)) return active;
+	return plan.goals.find((goal) => isResumableStatus(goal.status));
+}
+
+function isResumableStatus(status: UlwLoopItem["status"]): boolean {
+	return status === "pending" || status === "in_progress";
+}
+
+// Two-strike cap keyed on ledger movement: an unchanged ledger.jsonl line
+// count across resumes means the loop is not progressing. The stuck marker is
+// a separate file — a ledger append would change the count and self-reset.
+function consumeResumeBudget(stateDir: string, goalId: string): boolean {
+	const ledgerLineCount = countLedgerLines(join(stateDir, "ledger.jsonl"));
+	const counterPath = join(stateDir, `auto-resume-${goalId}.json`);
+	const previous = readCounter(counterPath);
+	const count = previous !== null && previous.ledgerLineCount === ledgerLineCount ? previous.count : 0;
+	if (count >= RESUME_CAP) {
+		writeFileSync(join(stateDir, `auto-resume-${goalId}.stuck`), `no ledger progress after ${count} resumes\n`);
+		return false;
+	}
+	writeFileSync(counterPath, JSON.stringify({ count: count + 1, ledgerLineCount }));
+	return true;
+}
+
+function renderResumeDirective(plan: UlwLoopPlan, goal: UlwLoopItem, sessionId: string): string {
+	const option = plan.goalsPath.includes(`/${sessionId}/`) ? ` --session-id ${sessionId}` : "";
+	return [
+		`The ulw-loop run in this session still has unfinished goals (next: ${goal.id} — ${goal.title}).`,
+		"The turn ended before the loop completed. Resume it now:",
+		`1. Run \`omo ulw-loop status${option} --json\` to reload the plan, the active goal, and currentAttemptDir.`,
+		"2. Continue the active goal's remaining success criteria, recording evidence with record-evidence.",
+		`3. Checkpoint through \`omo ulw-loop checkpoint${option}\` when the goal's criteria are proven.`,
+		"If the loop is genuinely blocked on the user, checkpoint the goal as blocked with the reason instead.",
+	].join("\n");
+}
+
+function readPlan(goalsPath: string): UlwLoopPlan | null {
+	try {
+		return JSON.parse(readFileSync(goalsPath, "utf8")) as UlwLoopPlan;
+	} catch (error) {
+		if (error instanceof Error) return null;
+		throw error;
+	}
+}
+
+function countLedgerLines(ledgerPath: string): number {
+	try {
+		return readFileSync(ledgerPath, "utf8").split("\n").filter(Boolean).length;
+	} catch (error) {
+		if (error instanceof Error) return 0;
+		throw error;
+	}
+}
+
+function readCounter(counterPath: string): { count: number; ledgerLineCount: number } | null {
+	try {
+		if (!existsSync(counterPath)) return null;
+		const parsed = JSON.parse(readFileSync(counterPath, "utf8")) as Record<string, unknown>;
+		if (typeof parsed["count"] !== "number" || typeof parsed["ledgerLineCount"] !== "number") return null;
+		return { count: parsed["count"], ledgerLineCount: parsed["ledgerLineCount"] };
+	} catch (error) {
+		if (error instanceof Error) return null;
+		throw error;
+	}
+}
+
+// Local ~10-LOC approximation of start-work-continuation's boulder check (no
+// cross-component import allowed): any continuable work for this session means
+// that hook owns the Stop event, so this one stays silent.
+function boulderContinuationWillFire(cwd: string, sessionId: string): boolean {
+	try {
+		const raw = JSON.parse(readFileSync(join(cwd, ".omo", "boulder.json"), "utf8")) as Record<string, unknown>;
+		const works = raw["works"];
+		if (typeof works !== "object" || works === null) return false;
+		return Object.values(works).some((work) => {
+			if (typeof work !== "object" || work === null) return false;
+			const entry = work as Record<string, unknown>;
+			const sessionIds = Array.isArray(entry["session_ids"]) ? entry["session_ids"] : [];
+			const continuable = entry["status"] === "active" || entry["status"] === "paused";
+			return continuable && sessionIds.includes(`codex:${sessionId}`);
+		});
+	} catch (error) {
+		if (error instanceof Error) return false;
+		throw error;
+	}
+}
+
+function parseStopPayload(value: unknown): StopPayload | null {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	const optionalMessage = record["last_assistant_message"];
+	const valid =
+		record["hook_event_name"] === "Stop" &&
+		typeof record["session_id"] === "string" &&
+		typeof record["turn_id"] === "string" &&
+		typeof record["transcript_path"] === "string" &&
+		typeof record["cwd"] === "string" &&
+		typeof record["model"] === "string" &&
+		typeof record["permission_mode"] === "string" &&
+		typeof record["stop_hook_active"] === "boolean" &&
+		(optionalMessage === undefined || typeof optionalMessage === "string");
+	if (!valid) return null;
+	return {
+		session_id: record["session_id"] as string,
+		cwd: record["cwd"] as string,
+		stop_hook_active: record["stop_hook_active"] as boolean,
+	};
+}

--- a/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
@@ -194,6 +194,7 @@ describe("source LOC budget", () => {
 		const files = [
 			"src/types.ts", "src/paths.ts", "src/plan-io.ts", "src/plan-crud.ts", "src/goal-status.ts",
 			"src/evidence.ts", "src/quality-gate.ts", "src/quality-gate-verdicts.ts", "src/checkpoint.ts", "src/review-blockers.ts",
+			"src/stop-resume-hook.ts", "src/spawn-guard.ts",
 			"src/steering.ts", "src/codex-goal-instruction.ts", "src/codex-goal-snapshot.ts", "src/codex-hook.ts",
 			"src/cli.ts", "src/cli-arg-parser.ts", "src/cli-output.ts", "src/cli-steering.ts", "src/cli-commands.ts",
 		];

--- a/packages/omo-codex/plugin/components/ulw-loop/test/spawn-guard.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/spawn-guard.test.ts
@@ -1,0 +1,228 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { PreToolUsePayload } from "../src/codex-hook.ts";
+import { applySpawnGuards } from "../src/spawn-guard.ts";
+
+let workDir: string;
+let originalLimit: string | undefined;
+
+beforeEach(async () => {
+	workDir = await mkdtemp(join(tmpdir(), "ulw-spawn-guard-"));
+	originalLimit = process.env["OMO_SPAWN_FANOUT_LIMIT"];
+	delete process.env["OMO_SPAWN_FANOUT_LIMIT"];
+});
+
+afterEach(async () => {
+	if (originalLimit === undefined) delete process.env["OMO_SPAWN_FANOUT_LIMIT"];
+	else process.env["OMO_SPAWN_FANOUT_LIMIT"] = originalLimit;
+	await rm(workDir, { recursive: true, force: true });
+});
+
+function payload(toolName: string, toolInput: Record<string, unknown>): PreToolUsePayload {
+	return {
+		hook_event_name: "PreToolUse",
+		session_id: "s1",
+		turn_id: "t1",
+		transcript_path: null,
+		cwd: workDir,
+		model: "gpt-5.6-sol",
+		permission_mode: "default",
+		tool_name: toolName,
+		tool_use_id: "tu1",
+		tool_input: toolInput,
+	};
+}
+
+function sessionDir(): string {
+	return join(workDir, ".omo", "ulw-loop", "s1");
+}
+
+function criterion(id: string): Record<string, unknown> {
+	return {
+		id,
+		scenario: `scenario ${id}`,
+		userModel: "happy",
+		expectedEvidence: "evidence",
+		capturedEvidence: "captured",
+		status: "pass",
+		capturedAt: "2026-07-11T00:00:00.000Z",
+	};
+}
+
+function writeGoals(planOverrides: Record<string, unknown> = {}): void {
+	mkdirSync(sessionDir(), { recursive: true });
+	writeFileSync(
+		join(sessionDir(), "goals.json"),
+		JSON.stringify({
+			version: 1,
+			createdAt: "2026-07-11T00:00:00.000Z",
+			updatedAt: "2026-07-11T00:00:00.000Z",
+			briefPath: ".omo/ulw-loop/s1/brief.md",
+			goalsPath: ".omo/ulw-loop/s1/goals.json",
+			ledgerPath: ".omo/ulw-loop/s1/ledger.jsonl",
+			codexGoalMode: "aggregate",
+			goals: [
+				{
+					id: "g1",
+					title: "Final goal",
+					objective: "Final goal",
+					status: "in_progress",
+					successCriteria: [criterion("C001"), criterion("C002")],
+					attempt: 1,
+					createdAt: "2026-07-11T00:00:00.000Z",
+					updatedAt: "2026-07-11T00:00:00.000Z",
+				},
+			],
+			activeGoalId: "g1",
+			...planOverrides,
+		}),
+	);
+}
+
+function deny(output: string): { permissionDecision: string; permissionDecisionReason: string } {
+	return JSON.parse(output).hookSpecificOutput;
+}
+
+describe("applySpawnGuards fan-out cap", () => {
+	it("#given spawns under the limit #when guarded #then allows and counts", () => {
+		writeGoals();
+
+		expect(applySpawnGuards(payload("spawn_agent", { message: "scan" }))).toBe("");
+
+		const counter = JSON.parse(readFileSync(join(sessionDir(), "spawn-count.json"), "utf8"));
+		expect(counter.count).toBe(1);
+	});
+
+	it("#given the env limit exceeded #when guarded #then denies naming count/limit", () => {
+		writeGoals();
+		process.env["OMO_SPAWN_FANOUT_LIMIT"] = "3";
+
+		expect(applySpawnGuards(payload("spawn_agent", { message: "scan" }))).toBe("");
+		expect(applySpawnGuards(payload("spawn_agent", { message: "scan" }))).toBe("");
+		expect(applySpawnGuards(payload("spawn_agent", { message: "scan" }))).toBe("");
+		const fourth = applySpawnGuards(payload("spawn_agent", { message: "scan" }));
+
+		const output = deny(fourth);
+		expect(output.permissionDecision).toBe("deny");
+		expect(output.permissionDecisionReason).toContain("4/3");
+	});
+
+	it("#given no ulw-loop session state #when guarded #then no-ops without counting", () => {
+		expect(applySpawnGuards(payload("spawn_agent", { message: "scan" }))).toBe("");
+	});
+
+	it("#given a non-spawn tool #when guarded #then no-ops", () => {
+		writeGoals();
+
+		expect(applySpawnGuards(payload("create_goal", { objective: "x" }))).toBe("");
+	});
+
+	it("#given the observed dotted v2 token #when guarded #then it counts too", () => {
+		writeGoals();
+		process.env["OMO_SPAWN_FANOUT_LIMIT"] = "1";
+
+		expect(applySpawnGuards(payload("collaboration.spawn_agent", { message: "scan" }))).toBe("");
+		const second = applySpawnGuards(payload("collaborationspawn_agent", { message: "scan" }));
+
+		expect(deny(second).permissionDecisionReason).toContain("2/1");
+	});
+});
+
+describe("applySpawnGuards gate-artifact guard", () => {
+	it("#given a gate spawn by agent_type without artifacts #when guarded #then denies naming the missing path", () => {
+		writeGoals();
+
+		const output = applySpawnGuards(
+			payload("collaborationspawn_agent", { agent_type: "lazycodex-gate-reviewer", message: "final gate review" }),
+		);
+
+		const parsed = deny(output);
+		expect(parsed.permissionDecision).toBe("deny");
+		expect(parsed.permissionDecisionReason).toContain("missing");
+		expect(parsed.permissionDecisionReason).toContain("g1-code-review.md");
+	});
+
+	it("#given a gate spawn identified by message only #when guarded #then still denies", () => {
+		writeGoals();
+
+		const output = applySpawnGuards(payload("spawn_agent", { message: "run the FINAL GATE REVIEW now" }));
+
+		expect(deny(output).permissionDecision).toBe("deny");
+	});
+
+	it("#given v1 artifacts on disk #when the gate spawns #then allows", () => {
+		writeGoals();
+		mkdirSync(join(workDir, ".omo", "evidence"), { recursive: true });
+		writeFileSync(join(workDir, ".omo", "evidence", "g1-code-review.md"), "report\n");
+		writeFileSync(join(workDir, ".omo", "evidence", "g1-manual-qa.md"), "matrix\n");
+
+		const output = applySpawnGuards(
+			payload("spawn_agent", { agent_type: "lazycodex-gate-reviewer", message: "final gate review" }),
+		);
+
+		expect(output).toBe("");
+	});
+
+	it("#given a v2 plan #when the gate spawns without attempt-dir artifacts #then denies naming the attempt path", () => {
+		writeGoals({ evidenceLayoutVersion: 2 });
+		mkdirSync(join(workDir, ".omo", "evidence"), { recursive: true });
+		writeFileSync(join(workDir, ".omo", "evidence", "g1-code-review.md"), "stale flat report\n");
+
+		const output = applySpawnGuards(
+			payload("spawn_agent", { agent_type: "lazycodex-gate-reviewer", message: "final gate review" }),
+		);
+
+		expect(deny(output).permissionDecisionReason).toContain(".omo/evidence/ulw/s1/g1/a1/g1-code-review.md");
+	});
+
+	it("#given a v2 plan with attempt-dir artifacts #when the gate spawns #then allows", () => {
+		writeGoals({ evidenceLayoutVersion: 2 });
+		const attemptDir = join(workDir, ".omo", "evidence", "ulw", "s1", "g1", "a1");
+		mkdirSync(attemptDir, { recursive: true });
+		writeFileSync(join(attemptDir, "g1-code-review.md"), "report\n");
+		writeFileSync(join(attemptDir, "g1-manual-qa.md"), "matrix\n");
+
+		const output = applySpawnGuards(
+			payload("spawn_agent", { agent_type: "lazycodex-gate-reviewer", message: "final gate review" }),
+		);
+
+		expect(output).toBe("");
+	});
+
+	it("#given the final goal's criteria are not all pass #when the gate spawns #then no-ops", () => {
+		writeGoals({
+			goals: [
+				{
+					id: "g1",
+					title: "Final goal",
+					objective: "Final goal",
+					status: "in_progress",
+					successCriteria: [criterion("C001"), { ...criterion("C002"), status: "pending" }],
+					attempt: 1,
+					createdAt: "2026-07-11T00:00:00.000Z",
+					updatedAt: "2026-07-11T00:00:00.000Z",
+				},
+			],
+		});
+
+		const output = applySpawnGuards(
+			payload("spawn_agent", { agent_type: "lazycodex-gate-reviewer", message: "final gate review" }),
+		);
+
+		expect(output).toBe("");
+	});
+
+	it("#given a non-gate reviewer spawn #when artifacts are missing #then never denies on the artifact rule", () => {
+		writeGoals();
+
+		const output = applySpawnGuards(
+			payload("spawn_agent", { agent_type: "lazycodex-code-reviewer", message: "review the diff" }),
+		);
+
+		expect(output).toBe("");
+	});
+});

--- a/packages/omo-codex/plugin/components/ulw-loop/test/stop-resume-hook.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/stop-resume-hook.test.ts
@@ -1,0 +1,147 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { runStopResumeHook } from "../src/stop-resume-hook.ts";
+
+let workDir: string;
+
+beforeEach(async () => {
+	workDir = await mkdtemp(join(tmpdir(), "ulw-stop-resume-"));
+});
+
+afterEach(async () => {
+	await rm(workDir, { recursive: true, force: true });
+});
+
+function stopPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		hook_event_name: "Stop",
+		session_id: "s1",
+		turn_id: "t1",
+		transcript_path: join(workDir, "transcript.jsonl"),
+		cwd: workDir,
+		model: "gpt-5.6-sol",
+		permission_mode: "default",
+		stop_hook_active: false,
+		...overrides,
+	};
+}
+
+function sessionDir(): string {
+	return join(workDir, ".omo", "ulw-loop", "s1");
+}
+
+function writeGoals(goals: readonly Record<string, unknown>[], planOverrides: Record<string, unknown> = {}): void {
+	mkdirSync(sessionDir(), { recursive: true });
+	writeFileSync(
+		join(sessionDir(), "goals.json"),
+		JSON.stringify({
+			version: 1,
+			createdAt: "2026-07-11T00:00:00.000Z",
+			updatedAt: "2026-07-11T00:00:00.000Z",
+			briefPath: ".omo/ulw-loop/s1/brief.md",
+			goalsPath: ".omo/ulw-loop/s1/goals.json",
+			ledgerPath: ".omo/ulw-loop/s1/ledger.jsonl",
+			codexGoalMode: "aggregate",
+			goals,
+			...planOverrides,
+		}),
+	);
+	writeFileSync(join(sessionDir(), "ledger.jsonl"), "");
+	writeFileSync(join(workDir, "transcript.jsonl"), "");
+}
+
+function pendingGoal(id = "g1", status = "pending"): Record<string, unknown> {
+	return {
+		id,
+		title: `Goal ${id}`,
+		objective: `Objective ${id}`,
+		status,
+		successCriteria: [],
+		attempt: 1,
+		createdAt: "2026-07-11T00:00:00.000Z",
+		updatedAt: "2026-07-11T00:00:00.000Z",
+	};
+}
+
+describe("runStopResumeHook", () => {
+	it("#given a pending goal #when the turn stops #then blocks with a resume directive", () => {
+		writeGoals([pendingGoal()]);
+
+		const output = runStopResumeHook(stopPayload());
+
+		const parsed = JSON.parse(output);
+		expect(parsed.decision).toBe("block");
+		expect(parsed.reason).toContain("omo ulw-loop status");
+	});
+
+	it("#given stop_hook_active #when the hook runs #then no-ops", () => {
+		writeGoals([pendingGoal()]);
+
+		expect(runStopResumeHook(stopPayload({ stop_hook_active: true }))).toBe("");
+	});
+
+	it("#given a malformed payload #when the hook runs #then no-ops", () => {
+		writeGoals([pendingGoal()]);
+
+		expect(runStopResumeHook({ hook_event_name: "Stop" })).toBe("");
+	});
+
+	it("#given an active boulder work for the session #when the hook runs #then defers to start-work-continuation", () => {
+		writeGoals([pendingGoal()]);
+		mkdirSync(join(workDir, ".omo"), { recursive: true });
+		writeFileSync(
+			join(workDir, ".omo", "boulder.json"),
+			JSON.stringify({ works: { w1: { session_ids: ["codex:s1"], status: "active" } } }),
+		);
+
+		expect(runStopResumeHook(stopPayload())).toBe("");
+	});
+
+	it("#given no ulw-loop state #when the hook runs #then no-ops", () => {
+		expect(runStopResumeHook(stopPayload())).toBe("");
+	});
+
+	it("#given all goals complete #when the hook runs #then no-ops", () => {
+		writeGoals([pendingGoal("g1", "complete"), pendingGoal("g2", "complete")]);
+
+		expect(runStopResumeHook(stopPayload())).toBe("");
+	});
+
+	it("#given blocked and failed goals only #when the hook runs #then no-ops", () => {
+		writeGoals([pendingGoal("g1", "blocked"), pendingGoal("g2", "failed")]);
+
+		expect(runStopResumeHook(stopPayload())).toBe("");
+	});
+
+	it("#given a static ledger #when the hook fires three times #then caps after two and marks stuck", () => {
+		writeGoals([pendingGoal()]);
+
+		const first = runStopResumeHook(stopPayload());
+		const second = runStopResumeHook(stopPayload());
+		const third = runStopResumeHook(stopPayload());
+
+		expect(JSON.parse(first).decision).toBe("block");
+		expect(JSON.parse(second).decision).toBe("block");
+		expect(third).toBe("");
+		const counter = JSON.parse(readFileSync(join(sessionDir(), "auto-resume-g1.json"), "utf8"));
+		expect(counter.count).toBe(2);
+		expect(existsSync(join(sessionDir(), "auto-resume-g1.stuck"))).toBe(true);
+		expect(readFileSync(join(sessionDir(), "ledger.jsonl"), "utf8")).toBe("");
+	});
+
+	it("#given ledger movement between stops #when the hook fires again #then the cap resets", () => {
+		writeGoals([pendingGoal()]);
+
+		runStopResumeHook(stopPayload());
+		runStopResumeHook(stopPayload());
+		appendFileSync(join(sessionDir(), "ledger.jsonl"), '{"kind":"goal_started"}\n');
+		const third = runStopResumeHook(stopPayload());
+
+		expect(JSON.parse(third).decision).toBe("block");
+		expect(existsSync(join(sessionDir(), "auto-resume-g1.stuck"))).toBe(false);
+	});
+});

--- a/packages/omo-codex/plugin/components/ulw-loop/test/stop-resume-hook.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/stop-resume-hook.test.ts
@@ -54,6 +54,15 @@ function writeGoals(goals: readonly Record<string, unknown>[], planOverrides: Re
 	writeFileSync(join(workDir, "transcript.jsonl"), "");
 }
 
+function writeBoulderPlan(remaining: boolean): string {
+	mkdirSync(join(workDir, ".omo", "plans"), { recursive: true });
+	writeFileSync(
+		join(workDir, ".omo", "plans", "p.md"),
+		remaining ? "## TODOs\n- [ ] pending task\n" : "## TODOs\n- [x] done task\n",
+	);
+	return ".omo/plans/p.md";
+}
+
 function pendingGoal(id = "g1", status = "pending"): Record<string, unknown> {
 	return {
 		id,
@@ -90,13 +99,42 @@ describe("runStopResumeHook", () => {
 		expect(runStopResumeHook({ hook_event_name: "Stop" })).toBe("");
 	});
 
-	it("#given an active boulder work for the session #when the hook runs #then defers to start-work-continuation", () => {
+	it("#given an active boulder work with remaining plan tasks #when the hook runs #then defers to start-work-continuation", () => {
 		writeGoals([pendingGoal()]);
-		mkdirSync(join(workDir, ".omo"), { recursive: true });
+		const plan = writeBoulderPlan(true);
 		writeFileSync(
 			join(workDir, ".omo", "boulder.json"),
-			JSON.stringify({ works: { w1: { session_ids: ["codex:s1"], status: "active" } } }),
+			JSON.stringify({ works: { w1: { session_ids: ["codex:s1"], status: "active", active_plan: plan } } }),
 		);
+
+		expect(runStopResumeHook(stopPayload())).toBe("");
+	});
+
+	it("#given an active boulder work whose plan is exhausted #when the hook runs #then resumes instead of deferring", () => {
+		writeGoals([pendingGoal()]);
+		const plan = writeBoulderPlan(false);
+		writeFileSync(
+			join(workDir, ".omo", "boulder.json"),
+			JSON.stringify({ works: { w1: { session_ids: ["codex:s1"], status: "active", active_plan: plan } } }),
+		);
+
+		expect(JSON.parse(runStopResumeHook(stopPayload())).decision).toBe("block");
+	});
+
+	it("#given a flat legacy boulder work with remaining plan tasks #when the hook runs #then still defers", () => {
+		writeGoals([pendingGoal()]);
+		const plan = writeBoulderPlan(true);
+		writeFileSync(
+			join(workDir, ".omo", "boulder.json"),
+			JSON.stringify({ session_ids: ["codex:s1"], status: "active", active_plan: plan }),
+		);
+
+		expect(runStopResumeHook(stopPayload())).toBe("");
+	});
+
+	it("#given a context-pressure marker in the transcript #when the hook runs #then no-ops", () => {
+		writeGoals([pendingGoal()]);
+		writeFileSync(join(workDir, "transcript.jsonl"), "note: context compacted mid-run\n");
 
 		expect(runStopResumeHook(stopPayload())).toBe("");
 	});
@@ -131,6 +169,14 @@ describe("runStopResumeHook", () => {
 		expect(counter.count).toBe(2);
 		expect(existsSync(join(sessionDir(), "auto-resume-g1.stuck"))).toBe(true);
 		expect(readFileSync(join(sessionDir(), "ledger.jsonl"), "utf8")).toBe("");
+	});
+
+	it("#given a session id needing normalization #when the hook blocks #then the directive carries the normalized flag", () => {
+		writeGoals([pendingGoal()]);
+
+		const output = runStopResumeHook(stopPayload({ session_id: "s1/" }));
+
+		expect(JSON.parse(output).reason).toContain("--session-id s1");
 	});
 
 	it("#given ledger movement between stops #when the hook fires again #then the cap resets", () => {

--- a/packages/omo-codex/plugin/hooks/pre-tool-use-guarding-ulw-loop-spawns.json
+++ b/packages/omo-codex/plugin/hooks/pre-tool-use-guarding-ulw-loop-spawns.json
@@ -1,0 +1,18 @@
+{
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "^(spawn_agent|collaborationspawn_agent|collaboration\\.spawn_agent)$",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"${PLUGIN_ROOT}/components/ulw-loop/dist/cli.js\" hook pre-tool-use-spawn",
+						"timeout": 5,
+						"statusMessage": "(OmO 4.16.3) Guarding Ulw-Loop Spawns",
+						"commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\node-dispatch.ps1\" \"${PLUGIN_ROOT}\\components\\ulw-loop\\dist\\cli.js\" hook pre-tool-use-spawn"
+					}
+				]
+			}
+		]
+	}
+}

--- a/packages/omo-codex/plugin/hooks/stop-checking-ulw-loop-resume.json
+++ b/packages/omo-codex/plugin/hooks/stop-checking-ulw-loop-resume.json
@@ -1,0 +1,17 @@
+{
+	"hooks": {
+		"Stop": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"${PLUGIN_ROOT}/components/ulw-loop/dist/cli.js\" hook stop",
+						"timeout": 10,
+						"statusMessage": "(OmO 4.16.3) Checking Ulw-Loop Resume",
+						"commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\node-dispatch.ps1\" \"${PLUGIN_ROOT}\\components\\ulw-loop\\dist\\cli.js\" hook stop"
+					}
+				]
+			}
+		]
+	}
+}

--- a/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
@@ -174,7 +174,12 @@ test("#given aggregate OMO plugin is enabled #when hooks are inspected #then she
 	assert.match(text, /Resetting Git Bash MCP Reminder/);
 	assert.match(text, /components\/ulw-loop\/dist\/cli\.js/);
 	assert.match(text, /hook pre-tool-use/);
-	assert.deepEqual(preToolUseGroups.map((group) => group.matcher), ["^Bash$", "^create_goal$"]);
+	assert.deepEqual(preToolUseGroups.map((group) => group.matcher), [
+		"^Bash$",
+		"^create_goal$",
+		"^(spawn_agent|collaborationspawn_agent|collaboration\\.spawn_agent)$",
+	]);
+	assert.match(text, /hook pre-tool-use-spawn/);
 });
 
 test("#given aggregate OMO plugin has a dedicated ultrawork trigger #when hooks are inspected #then ulw-loop does not duplicate ultrawork injection", async () => {

--- a/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
@@ -48,6 +48,22 @@ test("#given isolated components #when hooks are inspected #then commands stay i
 	assert.equal(await exists("scripts/migrate-codex-config.mjs"), true);
 });
 
+test("#given aggregate Stop hooks #when inspected #then start-work continuation and ulw-loop resume are separate groups", async () => {
+	// given
+	const manifests = await readAggregateHookManifests();
+
+	// when
+	const stopCommands = manifests
+		.filter(({ hooks }) => hooks.hooks.Stop)
+		.flatMap(({ hooks }) => hooks.hooks.Stop)
+		.flatMap((group) => group.hooks.map((handler) => handler.command));
+
+	// then
+	assert.equal(stopCommands.length, 2);
+	assert.ok(stopCommands.some((command) => command.includes("start-work-continuation/dist/cli.js")));
+	assert.ok(stopCommands.some((command) => command.includes("ulw-loop/dist/cli.js\" hook stop")));
+});
+
 test("#given aggregate SubagentStop hooks #when inspected #then start-work and LazyCodex executor verifier are separate groups", async () => {
 	// given
 	const manifests = await readAggregateHookManifests();

--- a/packages/omo-codex/plugin/test/aggregate-manifest.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-manifest.test.mjs
@@ -17,7 +17,7 @@ test("#given aggregate plugin manifest #when inspected #then it owns the omo nam
 	// then
 	assert.equal(manifest.name, "omo");
 	assert(Array.isArray(hookPaths));
-	assert.equal(hookPaths.length, 21);
+	assert.equal(hookPaths.length, 22);
 	assert(hookPaths.every((hookPath) => typeof hookPath === "string" && hookPath.startsWith("./hooks/")));
 	assert(!hookPaths.includes("./hooks/hooks.json"));
 	assert(!hookPaths.includes("./hooks/user-prompt-submit-selecting-lazycodex-workflow.json"));

--- a/packages/omo-codex/plugin/test/aggregate-manifest.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-manifest.test.mjs
@@ -17,7 +17,7 @@ test("#given aggregate plugin manifest #when inspected #then it owns the omo nam
 	// then
 	assert.equal(manifest.name, "omo");
 	assert(Array.isArray(hookPaths));
-	assert.equal(hookPaths.length, 22);
+	assert.equal(hookPaths.length, 23);
 	assert(hookPaths.every((hookPath) => typeof hookPath === "string" && hookPath.startsWith("./hooks/")));
 	assert(!hookPaths.includes("./hooks/hooks.json"));
 	assert(!hookPaths.includes("./hooks/user-prompt-submit-selecting-lazycodex-workflow.json"));


### PR DESCRIPTION
## Summary

Final PR of the ulw-loop verifier-fix package (tasks 8, 9 of `.omo/plans/ulw-verifier-fix-and-model-routing.md`). Two infra hooks close the remaining P7 gaps: a run whose turn dies with unfinished goals now auto-resumes through a Stop hook (previously it sat idle until the user typed something — observed 1h32m in session 019f4b1a), and spawn volume is now hard-capped per session with a preflight guard that refuses to spawn the final gate reviewer before the artifacts it audits exist (backstopping the 019f4b6b 10→869 fan-out class and enforcing PR-3's staged gate order at the hook layer).

## Changes

**Stop-hook auto-resume (task 8)** — new `components/ulw-loop/src/stop-resume-hook.ts` behind `hook stop`, registered as root manifest `hooks/stop-checking-ulw-loop-resume.json` (with Windows dispatcher). On turn end with a pending/in_progress goal it emits the standard Stop block directive pointing back into the loop (`omo ulw-loop status --session-id <sid> --json`, evidence, checkpoint). It defers to start-work-continuation when a continuable boulder work owns the session, no-ops on `stop_hook_active`/no state/terminal goals, and caps at two resumes without ledger movement, writing a separate `.stuck` marker (never a ledger append, which would self-reset the cap). Turn-death recovery only: mid-turn stalls emit no Stop event (documented).

**Spawn guards (task 9)** — new `components/ulw-loop/src/spawn-guard.ts` behind `hook pre-tool-use-spawn`, root manifest `hooks/pre-tool-use-guarding-ulw-loop-spawns.json`, matcher `^(spawn_agent|collaborationspawn_agent|collaboration\.spawn_agent)$` (third token observed in the live task-1 probe). Active only when ulw-loop session state exists. (a) Fan-out cap: per-session counter denies past `OMO_SPAWN_FANOUT_LIMIT` (default 60) naming `<count>/<limit>`; depth tracking descoped. (b) Gate-artifact guard: a `lazycodex-gate-reviewer` spawn (by `agent_type`, or by message regex on the agent_type-less v2 surface) is denied while the reviewer artifacts are missing — attempt-dir `<goalId>-code-review.md` + `<goalId>-manual-qa.md` on v2 plans, flat code-review report + any other evidence file on v1 — naming the exact missing path. Denial uses the PreToolUse `hookSpecificOutput.permissionDecision="deny"` shape, never `decision:block`. Non-gate spawns are never denied on the artifact rule.

**Surface registration** — `plugin.json` hooks array 21→23; aggregate pins updated (manifest count, new Stop-group assertion, PreToolUse matcher list); bootstrap Windows-dispatcher checks cover the new manifests automatically. Fixture correction: task-5 fixtures used `status: "active"` (not in the `UlwLoopStatus` union) — corrected to `in_progress`.

## QA & Evidence

- **What was tested:** Stop hook fires on a pending-goal turn end (full payload, mktemp sandbox, real CLI). **Observed:** `"decision":"block"` with the resume directive. **Artifact:** `.omo/evidence/task-8-auto-resume/stop-hook-fired.txt`. **Why sufficient:** the exact recovery target behavior, driven end-to-end.
- **What was tested:** two-strike cap against a static ledger, 3 invocations. **Observed:** block, block, silent; counter `count:2`; `.stuck` written; ledger untouched (0 lines throughout). **Artifact:** `.omo/evidence/task-8-auto-resume/two-strike.txt`. **Why sufficient:** proves the loop-breaker and that the cap cannot self-reset.
- **What was tested:** gate-reviewer spawn with no reviewer artifacts. **Observed:** deny naming `missing .omo/evidence/g1-code-review.md`. **Artifact:** `.omo/evidence/task-9-spawn-guards/gate-blocked.txt`. **Why sufficient:** P4 enforcement at the hook layer on the real payload shape.
- **What was tested:** fan-out cap at `OMO_SPAWN_FANOUT_LIMIT=3` with 4 spawns. **Observed:** 1-3 silent, 4th denied naming `4/3`. **Artifact:** `.omo/evidence/task-9-spawn-guards/fanout-cap.txt`. **Why sufficient:** cap, env override, and deny shape proven together.
- **Live hook wiring (pre-merge):** `bun run build && app-server-drive.sh --plugin` — hooks fired (sessionStart, stop, userPromptSubmit), `stop-checking-ulw-loop-resume` present ×2, 20 hook/started+completed notifications, real `~/.codex/config.toml` sha unchanged. **Artifact:** `.omo/evidence/task-9-spawn-guards/hook-wiring-pr4.txt`.
- **Suites:** component vitest 394/394 (+21 new TDD tests), plugin `.mjs` 350/350, tail gate `typecheck && bun test && test:codex` → `gate_exit=0` (`.omo/evidence/task-9-spawn-guards/pr4-gate.txt`; one earlier run failed only on load-induced perf/timeout flakes while builds ran concurrently — the quiet rerun is the artifact).

## Risks & Residuals

- The resume directive adds an automatic continuation surface; the ledger-keyed two-strike cap plus `.stuck` marker bounds it (proven by QA). Codex's own active-goal continuation behavior is upstream and out of scope.
- Boulder deferral is a local ~10-LOC approximation (no cross-component import allowed): it can over-defer when a finished boulder work is still marked `active` — fail direction is silence, not a duplicate injection.
- Spawn depth/lineage is descoped; the cap is total-volume per session.
- Windows dispatchers for both new manifests use the same node-dispatch.ps1 path as every existing hook and are covered by the bootstrap-hooks tests; live windows proof is CI's test:codex job.

## Related Issues

Part of the ulw-loop innocent-reject fix package (plan: `.omo/plans/ulw-verifier-fix-and-model-routing.md`; PR-1 #6029, PR-2 #6030, PR-3 #6031).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two infra hooks to keep `ulw-loop` runs moving: a Stop-hook that auto-resumes unfinished runs with a two-strike cap, and a PreToolUse spawn guard that caps fan-out and blocks the final gate reviewer until required artifacts exist. This prevents idle sessions and runaway spawns while enforcing the staged gate order.

- New Features
  - Stop-hook auto-resume: on turn end with a pending/in_progress goal, emits a block with a clear resume directive; defers to `start-work-continuation` only when an active boulder work still has remaining checklist items (flat legacy shape supported); bails on transcript context-pressure markers; uses a normalized `--session-id` in the directive; no-ops on `stop_hook_active`, missing state, or terminal goals; capped at two resumes without ledger movement (writes `.stuck`, never appends the ledger).
  - Spawn guards: active only when `ulw-loop` state exists; caps total spawn fan-out per session (default `OMO_SPAWN_FANOUT_LIMIT=60`, denials name `<count>/<limit>`); denies spawning `lazycodex-gate-reviewer` until artifacts exist (v2: `<goalId>-code-review.md` and `<goalId>-manual-qa.md` in the attempt dir; v1: flat `code-review` plus any other evidence file); uses `hookSpecificOutput.permissionDecision="deny"`; matches `spawn_agent`, `collaborationspawn_agent`, and `collaboration.spawn_agent`.
  - Registration: added root manifests and wired CLI subcommands `hook stop` and `hook pre-tool-use-spawn`; docs enumerate these surfaces; aggregate tests assert separate Stop groups and the new spawn-guard matcher.

<sup>Written for commit 384cb0d26af51ad636f5503b98063dfa0f2c4326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

