### PR TITLE
fix(ultrawork-agents): worker TOML nicknames violate the codex role-loader charset

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-high.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-high.toml
@@ -1,6 +1,6 @@
 name = "lazycodex-worker-high"
 description = "LazyCodex high-difficulty implementation worker: new modules or abstractions, cross-module refactors, and concurrency, security, or migration work. Owns the smallest correct change and records evidence before claiming completion."
-nickname_candidates = ["Worker (high)"]
+nickname_candidates = ["High Worker"]
 model = "gpt-5.6-sol"
 model_reasoning_effort = "max"
 

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-low.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-low.toml
@@ -1,6 +1,6 @@
 name = "lazycodex-worker-low"
 description = "LazyCodex low-difficulty implementation worker: single-spot fixes, boilerplate, config/copy changes, and pattern-following edits confined to one file. Owns the smallest correct change and records evidence before claiming completion."
-nickname_candidates = ["Worker (low)"]
+nickname_candidates = ["Low Worker"]
 model = "gpt-5.6-luna"
 model_reasoning_effort = "high"
 

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-medium.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-medium.toml
@@ -1,6 +1,6 @@
 name = "lazycodex-worker-medium"
 description = "LazyCodex medium-difficulty implementation worker: standard features inside existing layers, touching a few files along established patterns. Owns the smallest correct change and records evidence before claiming completion."
-nickname_candidates = ["Worker (medium)"]
+nickname_candidates = ["Medium Worker"]
 model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 

--- a/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
@@ -166,6 +166,23 @@ test("#given bundled Codex agents #when components/ultrawork/agents directory is
 	}
 });
 
+test("#given bundled agent TOMLs #when nickname_candidates are inspected #then they use only the codex-accepted charset", async () => {
+	// given: codex_app_server ignores a role whose nickname has characters outside
+	// ASCII letters, digits, spaces, hyphens, underscores (observed live in task-15 QA)
+	const agentsDir = join(root, "components", "ultrawork", "agents");
+	const files = (await readdir(agentsDir)).filter((name) => name.endsWith(".toml"));
+
+	// when/then
+	for (const file of files) {
+		const text = await readFile(join(agentsDir, file), "utf8");
+		for (const match of text.matchAll(/nickname_candidates\s*=\s*\[([^\]]*)\]/g)) {
+			for (const nickname of match[1].matchAll(/"([^"]*)"/g)) {
+				assert.match(nickname[1], /^[A-Za-z0-9 _-]+$/, `${file}: nickname "${nickname[1]}"`);
+			}
+		}
+	}
+});
+
 test("#given planner agent prompt #when inspected #then generated artifacts stay under .omo", async () => {
 	const prompt = await readFile(join(root, "components", "ultrawork", "agents", "plan.toml"), "utf8");
 


### PR DESCRIPTION
## Summary

Task-15 final-integration QA for the ulw-loop verifier-fix package surfaced a live defect in the merged difficulty-tier routing (#6030): codex_app_server rejects any agent role whose `nickname_candidates` contain characters outside ASCII letters, digits, spaces, hyphens, and underscores. The three worker TOMLs used `"Worker (low|medium|high)"` — parentheses — so codex logged `Ignoring malformed agent role definition` for all three and the worker roles never registered at runtime. This PR renames them and pins the charset with a test.

## Changes

- `lazycodex-worker-{low,medium,high}.toml`: `nickname_candidates` → `"Low Worker"` / `"Medium Worker"` / `"High Worker"`.
- `aggregate-agents.test.mjs`: new test asserting every bundled agent TOML nickname matches `^[A-Za-z0-9 _-]+$`, so this class of silent role drop cannot recur.

## QA & Evidence

- **What was tested:** live `codex app-server` boot + one mock turn via the stock codex-qa driver (`app-server-drive.sh --plugin`, isolated CODEX_HOME, no real API), before and after the rename.
- **Observed:** before — 6 `Ignoring malformed agent role definition ... nickname_candidates may only contain ASCII letters, digits, spaces, hyphens, and underscores` ERROR lines for the three worker TOMLs (captured in the task-15 hook-wiring transcript). After — `malformed_role_errors=0`, turn completed, hooks fired, real `~/.codex/config.toml` sha unchanged. **Artifact:** `.omo/evidence/20260711-worker-nickname-fix/app-server-after-fix.txt`.
- **Why sufficient:** the failing constraint is codex's own role loader; zero loader errors on the same live surface proves the roles now register. The new aggregate test (runs in `test:codex` on all 3 CI OSes) locks the charset.

## Risks & Residuals

Rename-only change to display nicknames; role names, models, and prompts untouched. No residual risk identified.

## Related Issues

Follow-up to #6030 (difficulty-tier routing); found by the final-integration QA of the plan `.omo/plans/ulw-verifier-fix-and-model-routing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex role-loader rejections by renaming worker agent nicknames to the allowed charset so difficulty-tier workers reliably register. Adds a test to lock the nickname charset for all bundled agent TOMLs.

- **Bug Fixes**
  - Renamed `nickname_candidates` from "Worker (low|medium|high)" to "Low Worker" / "Medium Worker" / "High Worker".
  - Added test in `packages/omo-codex/plugin/test/aggregate-agents.test.mjs` to enforce `^[A-Za-z0-9 _-]+$` for all agent nicknames.

<sup>Written for commit 7124b08c2ff15b6e0381878aa2874aed7371d207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

