### PR TITLE
fix(stop-continuation): stop continuation from every /stop-continuation entry point

### DIFF
--- a/packages/omo-opencode/src/plugin-interface.ts
+++ b/packages/omo-opencode/src/plugin-interface.ts
@@ -57,6 +57,7 @@ export function createPluginInterface(args: {
     "chat.headers": createChatHeadersHandler({ ctx }),
 
     "command.execute.before": createCommandExecuteBeforeHandler({
+      directory: ctx.directory,
       hooks,
     }),
 

--- a/packages/omo-opencode/src/plugin/chat-message.ts
+++ b/packages/omo-opencode/src/plugin/chat-message.ts
@@ -1,6 +1,7 @@
 import type { OhMyOpenCodeConfig } from "../config"
 
 import { updateSessionAgent } from "../features/claude-code-session-state"
+import { detectSlashCommand, extractPromptText } from "../hooks/auto-slash-command/detector"
 import { isSyntheticOrInternalOnlyTextParts, log } from "../shared"
 import { applyUltraworkModelOverrideOnMessage } from "./ultrawork-model-override"
 import type { PluginContext } from "./types"
@@ -8,6 +9,7 @@ import { handleRalphLoopMessage } from "./chat-message/loop-commands"
 import { notifyWhenModelCacheIsMissing } from "./chat-message/model-cache-warning"
 import { recordSessionModel, getStoredMainSessionModel } from "./chat-message/session-model"
 import { runStartWorkHookIfApplicable } from "./chat-message/start-work-message"
+import { stopContinuation } from "./stop-continuation"
 import type {
   ChatMessageHandlerOutput,
   ChatMessageHooks,
@@ -94,6 +96,15 @@ export function createChatMessageHandler(args: {
 
     if (input.agent) {
       updateSessionAgent(input.sessionID, input.agent)
+    }
+
+    const slashCommand = detectSlashCommand(extractPromptText(output.parts))
+    if (slashCommand?.command === "stop-continuation") {
+      stopContinuation({
+        directory: ctx.directory,
+        hooks,
+        sessionID: input.sessionID,
+      })
     }
 
     const isFirstMessage = firstMessageVariantGate.shouldOverride(input.sessionID)

--- a/packages/omo-opencode/src/plugin/chat-message/types.ts
+++ b/packages/omo-opencode/src/plugin/chat-message/types.ts
@@ -57,6 +57,10 @@ type RalphLoopHook = {
   cancelLoop: (sessionID: string) => boolean | void
 }
 
+type TodoContinuationEnforcerHook = {
+  cancelAllCountdowns: () => void
+}
+
 export type ChatMessageHooks = {
   modelFallback?: ChatMessageHook | null
   stopContinuationGuard?: StopContinuationGuard | null
@@ -71,4 +75,5 @@ export type ChatMessageHooks = {
   hephaestusAgentsMdInjector?: ChatMessageHook | null
   startWork?: ChatMessageHook | null
   ralphLoop?: RalphLoopHook | null
+  todoContinuationEnforcer?: TodoContinuationEnforcerHook | null
 }

--- a/packages/omo-opencode/src/plugin/command-execute-before.test.ts
+++ b/packages/omo-opencode/src/plugin/command-execute-before.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from "bun:test"
+import { unsafeTestValue } from "../../../../test-support/unsafe-test-value"
 
 import { createCommandExecuteBeforeHandler } from "./command-execute-before"
 
@@ -8,7 +9,8 @@ describe("createCommandExecuteBeforeHandler", () => {
     const clear = mock(() => {})
     const isStopped = mock(() => true)
     const startLoop = mock(() => true)
-    const handler = createCommandExecuteBeforeHandler({
+    const handler = createCommandExecuteBeforeHandler(unsafeTestValue({
+      directory: process.cwd(),
       hooks: {
         ralphLoop: {
           startLoop,
@@ -19,7 +21,7 @@ describe("createCommandExecuteBeforeHandler", () => {
           clear,
         },
       },
-    })
+    }))
 
     // when
     await handler(
@@ -45,7 +47,8 @@ describe("createCommandExecuteBeforeHandler", () => {
     const clear = mock(() => {})
     const isStopped = mock(() => true)
     const startWorkHook = mock(async () => {})
-    const handler = createCommandExecuteBeforeHandler({
+    const handler = createCommandExecuteBeforeHandler(unsafeTestValue({
+      directory: process.cwd(),
       hooks: {
         startWork: {
           "command.execute.before": startWorkHook,
@@ -55,7 +58,7 @@ describe("createCommandExecuteBeforeHandler", () => {
           clear,
         },
       },
-    })
+    }))
 
     // when
     await handler(
@@ -81,7 +84,8 @@ describe("createCommandExecuteBeforeHandler", () => {
     const clear = mock(() => {})
     const isStopped = mock(() => false)
     const startLoop = mock(() => true)
-    const handler = createCommandExecuteBeforeHandler({
+    const handler = createCommandExecuteBeforeHandler(unsafeTestValue({
+      directory: process.cwd(),
       hooks: {
         ralphLoop: {
           startLoop,
@@ -92,7 +96,7 @@ describe("createCommandExecuteBeforeHandler", () => {
           clear,
         },
       },
-    })
+    }))
 
     // when
     await handler(
@@ -116,7 +120,8 @@ describe("createCommandExecuteBeforeHandler", () => {
     // given
     const startLoop = mock(() => true)
     const resumeLoop = mock(() => true)
-    const handler = createCommandExecuteBeforeHandler({
+    const handler = createCommandExecuteBeforeHandler(unsafeTestValue({
+      directory: process.cwd(),
       hooks: {
         ralphLoop: {
           startLoop,
@@ -124,7 +129,7 @@ describe("createCommandExecuteBeforeHandler", () => {
           cancelLoop: mock(() => true),
         },
       },
-    })
+    }))
 
     // when
     await handler(

--- a/packages/omo-opencode/src/plugin/command-execute-before.ts
+++ b/packages/omo-opencode/src/plugin/command-execute-before.ts
@@ -1,6 +1,7 @@
 import type { CreatedHooks } from "../create-hooks"
 import { isRalphLoopResumeArgument, parseRalphLoopArguments } from "../hooks/ralph-loop/command-arguments"
 import { log } from "../shared/logger"
+import { stopContinuation } from "./stop-continuation"
 
 type CommandExecuteBeforeInput = {
   command: string
@@ -23,18 +24,23 @@ function hasPartsOutput(value: unknown): value is CommandExecuteBeforeOutput {
 }
 
 export function createCommandExecuteBeforeHandler(args: {
+  directory: string
   hooks: CreatedHooks
 }): (
   input: CommandExecuteBeforeInput,
   output: CommandExecuteBeforeOutput,
 ) => Promise<void> {
-  const { hooks } = args
+  const { directory, hooks } = args
 
   return async (input, output): Promise<void> => {
     await hooks.autoSlashCommand?.["command.execute.before"]?.(input, output)
 
     const normalizedCommand = input.command.toLowerCase()
     const sessionID = input.sessionID
+    if (normalizedCommand === "stop-continuation" && sessionID) {
+      stopContinuation({ directory, hooks, sessionID })
+    }
+
     if (hooks.ralphLoop && sessionID) {
       if (normalizedCommand === "ralph-loop" || normalizedCommand === "ulw-loop") {
         const parsedArguments = parseRalphLoopArguments(input.arguments || "")

--- a/packages/omo-opencode/src/plugin/stop-continuation-entrypoints.test.ts
+++ b/packages/omo-opencode/src/plugin/stop-continuation-entrypoints.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
+import { mkdirSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { unsafeTestValue } from "../../../../test-support/unsafe-test-value"
+import type { OhMyOpenCodeConfig } from "../config"
+import {
+  createBoulderState,
+  readBoulderState,
+  writeBoulderState,
+} from "../features/boulder-state"
+import type { PluginContext } from "./types"
+import { createChatMessageHandler } from "./chat-message"
+import { createCommandExecuteBeforeHandler } from "./command-execute-before"
+import { createToolExecuteBeforeHandler } from "./tool-execute-before"
+
+type StopCalls = {
+  readonly stoppedSessions: string[]
+  readonly cancelledCountdowns: string[]
+  readonly cancelledLoops: string[]
+}
+
+function createStopHooks(): {
+  readonly calls: StopCalls
+  readonly hooks: Record<string, unknown>
+} {
+  const calls: StopCalls = {
+    stoppedSessions: [],
+    cancelledCountdowns: [],
+    cancelledLoops: [],
+  }
+
+  return {
+    calls,
+    hooks: {
+      stopContinuationGuard: {
+        "chat.message": async () => {},
+        stop: (sessionID: string) => calls.stoppedSessions.push(sessionID),
+        isStopped: () => false,
+        clear: () => {},
+      },
+      todoContinuationEnforcer: {
+        cancelAllCountdowns: () => calls.cancelledCountdowns.push("cancelled"),
+      },
+      ralphLoop: {
+        startLoop: () => true,
+        cancelLoop: (sessionID: string) => {
+          calls.cancelledLoops.push(sessionID)
+          return true
+        },
+      },
+    },
+  }
+}
+
+describe("stop continuation entrypoints", () => {
+  let testDirectory = ""
+
+  beforeEach(() => {
+    testDirectory = join(tmpdir(), `stop-continuation-entrypoints-${randomUUID()}`)
+    mkdirSync(testDirectory, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(testDirectory, { recursive: true, force: true })
+  })
+
+  function seedBoulderState(): void {
+    writeBoulderState(
+      testDirectory,
+      createBoulderState(join(testDirectory, "plan.md"), "ses-stop", "atlas"),
+    )
+  }
+
+  test("#given active continuations #when native /stop-continuation executes #then every mechanism stops", async () => {
+    // given
+    const { calls, hooks } = createStopHooks()
+    seedBoulderState()
+    const handler = createCommandExecuteBeforeHandler(unsafeTestValue({
+      hooks,
+      directory: testDirectory,
+    }))
+
+    // when
+    await handler(
+      { command: "stop-continuation", sessionID: "ses-stop", arguments: "" },
+      { parts: [] },
+    )
+
+    // then
+    expect(calls.stoppedSessions).toEqual(["ses-stop"])
+    expect(calls.cancelledCountdowns).toEqual(["cancelled"])
+    expect(calls.cancelledLoops).toEqual(["ses-stop"])
+    expect(readBoulderState(testDirectory)).toBeNull()
+  })
+
+  test("#given native expansion is unavailable #when raw /stop-continuation reaches chat.message #then every mechanism stops", async () => {
+    // given
+    const { calls, hooks } = createStopHooks()
+    seedBoulderState()
+    const handler = createChatMessageHandler({
+      ctx: unsafeTestValue<PluginContext>({
+        directory: testDirectory,
+        client: { tui: { showToast: async () => {} } },
+      }),
+      pluginConfig: unsafeTestValue<OhMyOpenCodeConfig>({}),
+      firstMessageVariantGate: {
+        shouldOverride: () => false,
+        markApplied: () => {},
+      },
+      hooks: unsafeTestValue(hooks),
+    })
+
+    // when
+    await handler(
+      { sessionID: "ses-stop", agent: "atlas" },
+      {
+        message: {},
+        parts: [
+          { type: "text", text: "internal context", synthetic: true },
+          { type: "text", text: "/stop-continuation" },
+        ],
+      },
+    )
+
+    // then
+    expect(calls.stoppedSessions).toEqual(["ses-stop"])
+    expect(calls.cancelledCountdowns).toEqual(["cancelled"])
+    expect(calls.cancelledLoops).toEqual(["ses-stop"])
+    expect(readBoulderState(testDirectory)).toBeNull()
+  })
+
+  test("#given ordinary text #when it mentions /stop-continuation inside a code block #then continuations stay active", async () => {
+    // given
+    const { calls, hooks } = createStopHooks()
+    seedBoulderState()
+    const handler = createChatMessageHandler({
+      ctx: unsafeTestValue<PluginContext>({
+        directory: testDirectory,
+        client: { tui: { showToast: async () => {} } },
+      }),
+      pluginConfig: unsafeTestValue<OhMyOpenCodeConfig>({}),
+      firstMessageVariantGate: {
+        shouldOverride: () => false,
+        markApplied: () => {},
+      },
+      hooks: unsafeTestValue(hooks),
+    })
+
+    // when
+    await handler(
+      { sessionID: "ses-stop", agent: "atlas" },
+      {
+        message: {},
+        parts: [{ type: "text", text: "Explain ```/stop-continuation``` without running it." }],
+      },
+    )
+
+    // then
+    expect(calls.stoppedSessions).toHaveLength(0)
+    expect(calls.cancelledCountdowns).toHaveLength(0)
+    expect(calls.cancelledLoops).toHaveLength(0)
+    expect(readBoulderState(testDirectory)).not.toBeNull()
+  })
+
+  test("#given the skill tool entrypoint #when stop-continuation runs #then existing behavior remains intact", async () => {
+    // given
+    const { calls, hooks } = createStopHooks()
+    seedBoulderState()
+    const handler = createToolExecuteBeforeHandler({
+      ctx: unsafeTestValue<PluginContext>({ directory: testDirectory, client: {} }),
+      hooks: unsafeTestValue(hooks),
+    })
+
+    // when
+    await handler(
+      { tool: "skill", sessionID: "ses-stop", callID: "call-stop" },
+      { args: { name: "stop-continuation" } },
+    )
+
+    // then
+    expect(calls.stoppedSessions).toEqual(["ses-stop"])
+    expect(calls.cancelledCountdowns).toEqual(["cancelled"])
+    expect(calls.cancelledLoops).toEqual(["ses-stop"])
+    expect(readBoulderState(testDirectory)).toBeNull()
+  })
+})

--- a/packages/omo-opencode/src/plugin/stop-continuation.ts
+++ b/packages/omo-opencode/src/plugin/stop-continuation.ts
@@ -1,0 +1,27 @@
+import { clearBoulderState } from "../features/boulder-state"
+import { log } from "../shared"
+
+type StopContinuationHooks = {
+  readonly stopContinuationGuard?: {
+    readonly stop?: (sessionID: string) => void
+  } | null
+  readonly todoContinuationEnforcer?: {
+    readonly cancelAllCountdowns: () => void
+  } | null
+  readonly ralphLoop?: {
+    readonly cancelLoop: (sessionID: string) => boolean | void
+  } | null
+}
+
+export function stopContinuation(args: {
+  readonly directory: string
+  readonly hooks: StopContinuationHooks
+  readonly sessionID: string
+}): void {
+  const { directory, hooks, sessionID } = args
+  hooks.stopContinuationGuard?.stop?.(sessionID)
+  hooks.todoContinuationEnforcer?.cancelAllCountdowns()
+  hooks.ralphLoop?.cancelLoop(sessionID)
+  clearBoulderState(directory)
+  log("[stop-continuation] All continuation mechanisms stopped", { sessionID })
+}

--- a/packages/omo-opencode/src/plugin/tool-execute-before.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-before.ts
@@ -2,13 +2,13 @@ import type { PluginContext } from "./types"
 import { randomUUID } from "node:crypto"
 
 import { getMainSessionID } from "../features/claude-code-session-state"
-import { clearBoulderState } from "../features/boulder-state"
 import { log, replaceToolArgs } from "../shared"
 import { stripInvisibleAgentCharacters } from "../shared/agent-display-names"
 import { resolveSessionAgent } from "./session-agent-resolver"
 import { isRalphLoopResumeArgument, parseRalphLoopArguments } from "../hooks/ralph-loop/command-arguments"
 import { ULTRAWORK_VERIFICATION_PROMISE } from "../hooks/ralph-loop/constants"
 import { readState, writeState } from "../hooks/ralph-loop/storage"
+import { stopContinuation } from "./stop-continuation"
 
 import type { CreatedHooks } from "../create-hooks"
 import type { BackgroundManager } from "../features/background-agent"
@@ -229,13 +229,7 @@ export function createToolExecuteBeforeHandler(args: {
       const sessionID = input.sessionID || getMainSessionID()
 
       if (command === "stop-continuation" && sessionID) {
-        hooks.stopContinuationGuard?.stop(sessionID)
-        hooks.todoContinuationEnforcer?.cancelAllCountdowns()
-        hooks.ralphLoop?.cancelLoop(sessionID)
-        clearBoulderState(ctx.directory)
-        log("[stop-continuation] All continuation mechanisms stopped", {
-          sessionID,
-        })
+        stopContinuation({ directory: ctx.directory, hooks, sessionID })
       }
 
       // Clear stop state when user explicitly resumes work via work-starting commands.


### PR DESCRIPTION
## What changed

`/stop-continuation` now stops **all** continuation mechanisms regardless of how it reaches the plugin. A new shared `stopContinuation()` module (`packages/omo-opencode/src/plugin/stop-continuation.ts`) cancels the stop-continuation guard, the todo-continuation-enforcer countdowns, the ralph loop, and clears boulder state, and is wired into all three entry points:

- `command.execute.before` (native command execution) — **new**
- `chat.message` (raw `/stop-continuation` text, via the existing auto-slash-command detector so code-block mentions do not trigger) — **new**
- `tool.execute.before` (pre-existing path, now delegating to the shared module)

## Why / root cause

Fixes #1919. The stop logic lived only in `tool-execute-before.ts`. When the command arrived through OpenCode's native command execution or as raw chat text, the todo-continuation-enforcer was never cancelled, so the session kept receiving `[SYSTEM DIRECTIVE: OH-MY-OPENCODE - TODO CONTINUATION]` after the user explicitly stopped it (reconfirmed on 4.16.3 / opencode 1.17.18 in the issue thread).

## QA / evidence (local `.omo/evidence/20260711-stop-continuation-entrypoints/`)

- **RED→GREEN**: with the production wiring stashed, the new regression suite fails 2/4 for the right reason (native + chat.message entry tests; the tool-path characterization test passes on old code, pinning it). With the fix: 4/4, run twice.
- **Real-harness native surface**: isolated XDG/HOME/OPENCODE_CONFIG_DIR sandbox, real opencode 1.17.18, worktree plugin via `file://`, local fake OpenAI server; `opencode run --command stop-continuation --format json` → exit 0, 1 text event, 0 error events, exactly 1 "All continuation mechanisms stopped" log, run-continuation marker `sources.stop.state == "stopped"`, seeded `boulder.json` deleted.
- **Real-harness raw chat surface**: `opencode run "/stop-continuation"` → same assertions plus exactly 1 `Detected: /stop-continuation`; single fire (entry points do not stack).
- **Isolation**: neither QA session ID exists in the host `opencode.db`; sandbox DB held exactly the 2 QA sessions; zero reads of the host opencode config in plugin logs; sandbox + fake server torn down with receipts.
- **Gates**: `bun test packages/omo-opencode/src/plugin/` 322 pass / 0 fail; `bun run typecheck` (tsgo full matrix) exit 0; LSP diagnostics clean on changed production files.

## Residual risk

- The QA sandbox disabled the unrelated `no-sisyphus-gpt` agent-routing hook: under a fake GPT-named model with Hephaestus unregistered, that hook stamps the unregistered key `"hephaestus"` on messages (`resolveRegisteredAgentName("hephaestus") ?? "hephaestus"`) and the turn fails after the stop side effect. That is a latent, pre-existing fallback defect unrelated to this fix — worth a follow-up issue.
- Stop operations are idempotent, so even if a future entry point double-fires, behavior stays correct (QA confirmed single-fire today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/stop-continuation` stop all continuation paths regardless of how it is invoked. This prevents sessions from continuing after a stop across native command, chat text, and tool paths.

- **Bug Fixes**
  - Added shared `stopContinuation()` in `packages/omo-opencode/src/plugin/stop-continuation.ts` to stop the guard, cancel todo-enforcer countdowns, cancel the `ralph` loop, and clear boulder state.
  - Wired into `command.execute.before` (new), `chat.message` via auto slash-command detection (ignores code blocks), and `tool.execute.before` (now delegates).
  - Added `stop-continuation-entrypoints.test.ts`; updated `plugin-interface` to pass `directory` and extended hooks to include `todoContinuationEnforcer`.

<sup>Written for commit c611246f0d82804c341d45823586ab3589c7ba55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

