### PR TITLE
feat(lazycodex): retune worker-medium, qa-executor, plan model tiers

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-qa-executor.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-qa-executor.toml
@@ -1,8 +1,8 @@
 name = "lazycodex-qa-executor"
 description = "LazyCodex manual QA executor. Runs real scenarios and records artifact-backed surface evidence."
 nickname_candidates = ["QA Executor"]
-model = "gpt-5.6-terra"
-model_reasoning_effort = "medium"
+model = "gpt-5.6-luna"
+model_reasoning_effort = "high"
 
 developer_instructions = """
 Role: manual QA executor. You execute real scenarios and record evidence. Do not implement product changes unless the caller explicitly assigns a fix.

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-medium.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-medium.toml
@@ -1,8 +1,8 @@
 name = "lazycodex-worker-medium"
 description = "LazyCodex medium-difficulty implementation worker: standard features inside existing layers, touching a few files along established patterns. Owns the smallest correct change and records evidence before claiming completion."
 nickname_candidates = ["Medium Worker"]
-model = "gpt-5.6-sol"
-model_reasoning_effort = "high"
+model = "gpt-5.6-luna"
+model_reasoning_effort = "max"
 
 developer_instructions = """
 Role: implementation executor. You own the task end to end.

--- a/packages/omo-codex/plugin/components/ultrawork/agents/plan.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/plan.toml
@@ -2,7 +2,7 @@ name = "plan"
 description = "Strategic planning consultant. Produces a single executable work plan from a vague or large request. Planner only - never implements. Writes the plan to .omo/plans/<slug>.md."
 nickname_candidates = ["Planner"]
 model = "gpt-5.6-sol"
-model_reasoning_effort = "xhigh"
+model_reasoning_effort = "max"
 
 developer_instructions = """
 Role: strategic planning consultant. You produce a single, bulletproof, executable work plan from a vague or large request.

--- a/packages/omo-codex/plugin/components/ultrawork/directive.md
+++ b/packages/omo-codex/plugin/components/ultrawork/directive.md
@@ -270,7 +270,7 @@ omit `agent_type`, describe the role and difficulty tier inside
 `message`, and expect the session model for children. Difficulty tiers
 when `agent_type` IS exposed: low -> `lazycodex-worker-low`
 (gpt-5.6-luna/high), medium -> `lazycodex-worker-medium`
-(gpt-5.6-sol/high), high -> `lazycodex-worker-high` (gpt-5.6-sol/max);
+(gpt-5.6-luna/max), high -> `lazycodex-worker-high` (gpt-5.6-sol/max);
 explorer/librarian carry their own TOMLs (gpt-5.6-luna/low). Difficulty
 (model power) is orthogonal to LIGHT/HEAVY rigor (process size).
 

--- a/packages/omo-codex/plugin/components/ultrawork/skills/ultrawork/SKILL.md
+++ b/packages/omo-codex/plugin/components/ultrawork/skills/ultrawork/SKILL.md
@@ -277,7 +277,7 @@ omit `agent_type`, describe the role and difficulty tier inside
 `message`, and expect the session model for children. Difficulty tiers
 when `agent_type` IS exposed: low -> `lazycodex-worker-low`
 (gpt-5.6-luna/high), medium -> `lazycodex-worker-medium`
-(gpt-5.6-sol/high), high -> `lazycodex-worker-high` (gpt-5.6-sol/max);
+(gpt-5.6-luna/max), high -> `lazycodex-worker-high` (gpt-5.6-sol/max);
 explorer/librarian carry their own TOMLs (gpt-5.6-luna/low). Difficulty
 (model power) is orthogonal to LIGHT/HEAVY rigor (process size).
 

--- a/packages/omo-codex/plugin/components/ulw-loop/directive.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/directive.md
@@ -270,7 +270,7 @@ omit `agent_type`, describe the role and difficulty tier inside
 `message`, and expect the session model for children. Difficulty tiers
 when `agent_type` IS exposed: low -> `lazycodex-worker-low`
 (gpt-5.6-luna/high), medium -> `lazycodex-worker-medium`
-(gpt-5.6-sol/high), high -> `lazycodex-worker-high` (gpt-5.6-sol/max);
+(gpt-5.6-luna/max), high -> `lazycodex-worker-high` (gpt-5.6-sol/max);
 explorer/librarian carry their own TOMLs (gpt-5.6-luna/low). Difficulty
 (model power) is orthogonal to LIGHT/HEAVY rigor (process size).
 

--- a/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
@@ -52,7 +52,7 @@ const lazycodexAgentInvariants = new Map([
 		"plan.toml",
 		{
 			model: "gpt-5.6-sol",
-			effort: "xhigh",
+			effort: "max",
 			includes: [/strategic planning consultant/i, /\.omo\/plans\/<slug>\.md/, /never implements/i],
 		},
 	],
@@ -75,8 +75,8 @@ const lazycodexAgentInvariants = new Map([
 	[
 		"lazycodex-worker-medium.toml",
 		{
-			model: "gpt-5.6-sol",
-			effort: "high",
+			model: "gpt-5.6-luna",
+			effort: "max",
 			includes: [/EVIDENCE_RECORDED: <path>/, /medium-difficulty/i, /smallest correct change/i],
 		},
 	],
@@ -107,8 +107,8 @@ const lazycodexAgentInvariants = new Map([
 	[
 		"lazycodex-qa-executor.toml",
 		{
-			model: "gpt-5.6-terra",
-			effort: "medium",
+			model: "gpt-5.6-luna",
+			effort: "high",
 			includes: [/not_applicable/, /surfaceEvidence/, /adversarialCases/, /<attemptDir>\/<goalId>-manual-qa\.md/],
 		},
 	],

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -9039,6 +9039,33 @@ var MANAGED_REASONING_DEFAULT_UPGRADES = new Map([
         current: { model: "gpt-5.6-sol", effort: "ultra" }
       }
     ]
+  ],
+  [
+    "plan",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "xhigh" },
+        current: { model: "gpt-5.6-sol", effort: "max" }
+      }
+    ]
+  ],
+  [
+    "lazycodex-worker-medium",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "high" },
+        current: { model: "gpt-5.6-luna", effort: "max" }
+      }
+    ]
+  ],
+  [
+    "lazycodex-qa-executor",
+    [
+      {
+        previous: { model: "gpt-5.6-terra", effort: "medium" },
+        current: { model: "gpt-5.6-luna", effort: "high" }
+      }
+    ]
   ]
 ]);
 function resolveManagedAgentReasoning(input) {

--- a/packages/omo-codex/src/install/managed-agent-reasoning-defaults.test.ts
+++ b/packages/omo-codex/src/install/managed-agent-reasoning-defaults.test.ts
@@ -42,13 +42,49 @@ describe("resolveManagedAgentReasoning", () => {
 	test("#given an unlisted agent #when resolving #then the preserved effort is untouched", () => {
 		// when
 		const effort = resolveManagedAgentReasoning({
-			agentName: "plan",
+			agentName: "lazycodex-executor",
 			bundledModel: "gpt-5.6-sol",
-			bundledEffort: "xhigh",
+			bundledEffort: "high",
 			preserved: { model: "gpt-5.6-sol", effort: "medium" },
 		})
 		// then
 		expect(effort).toBe("medium")
+	})
+
+	test("#given a preserved plan sol/xhigh default #when resolving against sol/max #then the new bundled effort wins", () => {
+		// when
+		const effort = resolveManagedAgentReasoning({
+			agentName: "plan",
+			bundledModel: "gpt-5.6-sol",
+			bundledEffort: "max",
+			preserved: { model: "gpt-5.6-sol", effort: "xhigh" },
+		})
+		// then
+		expect(effort).toBe("max")
+	})
+
+	test("#given a preserved worker-medium sol/high default #when resolving against luna/max #then the new bundled effort wins", () => {
+		// when
+		const effort = resolveManagedAgentReasoning({
+			agentName: "lazycodex-worker-medium",
+			bundledModel: "gpt-5.6-luna",
+			bundledEffort: "max",
+			preserved: { model: "gpt-5.6-sol", effort: "high" },
+		})
+		// then
+		expect(effort).toBe("max")
+	})
+
+	test("#given a preserved qa-executor terra/medium default #when resolving against luna/high #then the new bundled effort wins", () => {
+		// when
+		const effort = resolveManagedAgentReasoning({
+			agentName: "lazycodex-qa-executor",
+			bundledModel: "gpt-5.6-luna",
+			bundledEffort: "high",
+			preserved: { model: "gpt-5.6-terra", effort: "medium" },
+		})
+		// then
+		expect(effort).toBe("high")
 	})
 
 	test("#given a second resolve over already-migrated values #when resolving #then the result is stable", () => {

--- a/packages/omo-codex/src/install/managed-agent-reasoning-defaults.ts
+++ b/packages/omo-codex/src/install/managed-agent-reasoning-defaults.ts
@@ -44,6 +44,33 @@ const MANAGED_REASONING_DEFAULT_UPGRADES = new Map<string, readonly ManagedReaso
       },
     ],
   ],
+  [
+    "plan",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "xhigh" },
+        current: { model: "gpt-5.6-sol", effort: "max" },
+      },
+    ],
+  ],
+  [
+    "lazycodex-worker-medium",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "high" },
+        current: { model: "gpt-5.6-luna", effort: "max" },
+      },
+    ],
+  ],
+  [
+    "lazycodex-qa-executor",
+    [
+      {
+        previous: { model: "gpt-5.6-terra", effort: "medium" },
+        current: { model: "gpt-5.6-luna", effort: "high" },
+      },
+    ],
+  ],
 ])
 
 export function resolveManagedAgentReasoning(input: {

--- a/packages/prompts-core/prompts/ultrawork/codex.md
+++ b/packages/prompts-core/prompts/ultrawork/codex.md
@@ -270,7 +270,7 @@ omit `agent_type`, describe the role and difficulty tier inside
 `message`, and expect the session model for children. Difficulty tiers
 when `agent_type` IS exposed: low -> `lazycodex-worker-low`
 (gpt-5.6-luna/high), medium -> `lazycodex-worker-medium`
-(gpt-5.6-sol/high), high -> `lazycodex-worker-high` (gpt-5.6-sol/max);
+(gpt-5.6-luna/max), high -> `lazycodex-worker-high` (gpt-5.6-sol/max);
 explorer/librarian carry their own TOMLs (gpt-5.6-luna/low). Difficulty
 (model power) is orthogonal to LIGHT/HEAVY rigor (process size).
 


### PR DESCRIPTION
## What
Retunes three bundled Codex (lazycodex) agent roles:

| Agent | Before | After |
|-------|--------|-------|
| `lazycodex-worker-medium` | gpt-5.6-sol / high | **gpt-5.6-luna / max** |
| `lazycodex-qa-executor` | gpt-5.6-terra / medium | **gpt-5.6-luna / high** |
| `plan` | gpt-5.6-sol / xhigh | **gpt-5.6-sol / max** |

## Why
Move the medium implementation tier and the QA executor onto the cheaper
`gpt-5.6-luna` model at maximum/high reasoning effort, and push the
lazycodex planner to full `max` effort. Difficulty (model power) stays
orthogonal to LIGHT/HEAVY rigor.

## Kept in lockstep
- `managed-agent-reasoning-defaults` migration map: one upgrade step per
  role so an existing install carrying the old effort is bumped on
  reinstall, while a user-customized effort is preserved.
- `aggregate-agents` pin test + reasoning-defaults unit tests.
- ultrawork / ulw-loop directive + synced `SKILL.md` difficulty-tier lines,
  sourced from `prompts-core/ultrawork/codex.md` and regenerated via
  `sync-directive.mjs` + `sync-skills.mjs` (directives stay byte-identical).
- Regenerated `install-dist/install-local.mjs` bundle (embeds the map).

## QA (isolated, evidence-bound)
- `bun run test:codex` — **504 pass / 0 fail** (node --test) + all bun install suites green.
- `codex-qa` `install-verify.sh --keep` — installed the local build into a
  throwaway `CODEX_HOME`; all three retuned TOMLs landed with the new pins
  (worker-medium luna/max, qa-executor luna/high, plan sol/max);
  worker-low/high untouched.
- Isolation proof: real `~/.codex/config.toml` shasum
  `09a4ee7e…` identical before/after.

Evidence: `.omo/evidence/20260711-lazycodex-model-retune/` (gitignored, local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retuned three `lazycodex` agents to rebalance cost and reasoning quality: `worker-medium` and `qa-executor` now use `gpt-5.6-luna` at higher effort, and `plan` is bumped to `max`. Includes managed upgrade steps so reinstalls auto-migrate while preserving user overrides.

- **Refactors**
  - `lazycodex-worker-medium`: `gpt-5.6-sol/high` → `gpt-5.6-luna/max`
  - `lazycodex-qa-executor`: `gpt-5.6-terra/medium` → `gpt-5.6-luna/high`
  - `plan`: `gpt-5.6-sol/xhigh` → `gpt-5.6-sol/max`
  - Synced directives, skills docs, tests, and `install-dist`; added `managed-agent-reasoning-defaults` entries.

<sup>Written for commit 45ac7be80bbe17f4cc126377fe1035d8ddd314ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

