### PR TITLE
feat(omo-codex): default lazycodex install model to gpt-5.6-sol/372k/high

### DIFF
--- a/packages/omo-codex/plugin/model-catalog.json
+++ b/packages/omo-codex/plugin/model-catalog.json
@@ -1,28 +1,37 @@
 {
-	"version": "2026-06-04.gpt-5.5-400k-reviewer-high",
+	"version": "2026-07-11.gpt-5.6-sol-372k-high",
 	"current": {
-		"model": "gpt-5.5",
-		"model_context_window": 400000,
+		"model": "gpt-5.6-sol",
+		"model_context_window": 372000,
 		"model_reasoning_effort": "high",
 		"plan_mode_reasoning_effort": "xhigh"
 	},
 	"roles": {
 		"default": {
-			"model": "gpt-5.5",
-			"model_context_window": 400000,
+			"model": "gpt-5.6-sol",
+			"model_context_window": 372000,
 			"model_reasoning_effort": "high",
 			"plan_mode_reasoning_effort": "xhigh"
 		},
 		"verifier": {
-			"model": "gpt-5.5",
+			"model": "gpt-5.6-sol",
 			"model_reasoning_effort": "high"
 		},
 		"worker": {
-			"model": "gpt-5.5",
+			"model": "gpt-5.6-sol",
 			"model_reasoning_effort": "high"
 		}
 	},
 	"managedProfiles": [
+		{
+			"version": "legacy.gpt-5.5-400k-reviewer-high",
+			"match": {
+				"model": "gpt-5.5",
+				"model_context_window": 400000,
+				"model_reasoning_effort": "high",
+				"plan_mode_reasoning_effort": "xhigh"
+			}
+		},
 		{
 			"version": "legacy.gpt-5.5-1m",
 			"match": {

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/catalog.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/catalog.mjs
@@ -3,24 +3,33 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const FALLBACK_CATALOG = {
-	version: "fallback.gpt-5.5-400k-reviewer-high",
+	version: "fallback.gpt-5.6-sol-372k-high",
 	current: {
-		model: "gpt-5.5",
-		model_context_window: 400_000,
+		model: "gpt-5.6-sol",
+		model_context_window: 372_000,
 		model_reasoning_effort: "high",
 		plan_mode_reasoning_effort: "xhigh",
 	},
 	roles: {
 		default: {
-			model: "gpt-5.5",
-			model_context_window: 400_000,
+			model: "gpt-5.6-sol",
+			model_context_window: 372_000,
 			model_reasoning_effort: "high",
 			plan_mode_reasoning_effort: "xhigh",
 		},
-		verifier: { model: "gpt-5.5", model_reasoning_effort: "high" },
-		worker: { model: "gpt-5.5", model_reasoning_effort: "high" },
+		verifier: { model: "gpt-5.6-sol", model_reasoning_effort: "high" },
+		worker: { model: "gpt-5.6-sol", model_reasoning_effort: "high" },
 	},
 	managedProfiles: [
+		{
+			version: "legacy.gpt-5.5-400k-reviewer-high",
+			match: {
+				model: "gpt-5.5",
+				model_context_window: 400_000,
+				model_reasoning_effort: "high",
+				plan_mode_reasoning_effort: "xhigh",
+			},
+		},
 		{
 			version: "legacy.gpt-5.5-1m",
 			match: {

--- a/packages/omo-codex/plugin/test/aggregate-model-catalog.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-model-catalog.test.mjs
@@ -8,17 +8,17 @@ import { root } from "./aggregate-plugin-fixture.mjs";
 test("#given bundled model catalog #when inspected #then default verifier and worker roles are pinned", async () => {
 	const catalog = JSON.parse(await readFile(join(root, "model-catalog.json"), "utf8"));
 
-	assert.equal(catalog.current.model, "gpt-5.5");
-	assert.equal(catalog.current.model_context_window, 400000);
+	assert.equal(catalog.current.model, "gpt-5.6-sol");
+	assert.equal(catalog.current.model_context_window, 372000);
 	assert.equal(catalog.current.model_reasoning_effort, "high");
 	assert.equal(catalog.current.plan_mode_reasoning_effort, "xhigh");
 	assert.deepEqual(catalog.roles.default, catalog.current);
 	assert.deepEqual(catalog.roles.verifier, {
-		model: "gpt-5.5",
+		model: "gpt-5.6-sol",
 		model_reasoning_effort: "high",
 	});
 	assert.deepEqual(catalog.roles.worker, {
-		model: "gpt-5.5",
+		model: "gpt-5.6-sol",
 		model_reasoning_effort: "high",
 	});
 });

--- a/packages/omo-codex/plugin/test/auto-update.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update.test.mjs
@@ -225,7 +225,7 @@ test("#given test command override #when running check #then records state and l
 			toVersion: "1.0.1",
 		},
 	]);
-	assert.match(await readFile(join(env.CODEX_HOME, "config.toml"), "utf8"), /model = "gpt-5\.5"/);
+	assert.match(await readFile(join(env.CODEX_HOME, "config.toml"), "utf8"), /model = "gpt-5\.6-sol"/);
 });
 
 test("#given failed waited update #when retry window passes #then next update is not blocked by success throttle", async () => {
@@ -279,7 +279,7 @@ test("#given active lock #when running check #then skips concurrent update", asy
 
 	assert.equal(result.started, false);
 	assert.equal(result.reason, "locked");
-	assert.match(await readFile(join(root, "codex-home", "config.toml"), "utf8"), /model_context_window = 400000/);
+	assert.match(await readFile(join(root, "codex-home", "config.toml"), "utf8"), /model_context_window = 372000/);
 });
 
 test("#given stale lock #when running check #then removes lock and runs update", async () => {
@@ -645,8 +645,8 @@ test("#given throttled updater and stale Codex config #when running check #then 
 	const content = await readFile(join(codexHome, "config.toml"), "utf8");
 	assert.equal(result.started, false);
 	assert.equal(result.reason, "throttled");
-	assert.match(content, /model = "gpt-5\.5"/);
-	assert.match(content, /model_context_window = 400000/);
+	assert.match(content, /model = "gpt-5\.6-sol"/);
+	assert.match(content, /model_context_window = 372000/);
 	assert.match(content, /model_reasoning_effort = "high"/);
 	assert.match(content, /plan_mode_reasoning_effort = "xhigh"/);
 	assert.doesNotMatch(content, /gpt-5\.2/);

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -54,8 +54,8 @@ test("#given stale root reasoning config #when ensuring config #then replaces st
 	assert.equal(result.match(/^model_context_window\s*=/gm)?.length, 1);
 	assert.equal(result.match(/^model_reasoning_effort\s*=/gm)?.length, 1);
 	assert.equal(result.match(/^plan_mode_reasoning_effort\s*=/gm)?.length, 1);
-	assert.match(result, /model = "gpt-5\.5"/);
-	assert.match(result, /model_context_window = 400000/);
+	assert.match(result, /model = "gpt-5\.6-sol"/);
+	assert.match(result, /model_context_window = 372000/);
 	assert.match(result, /model_reasoning_effort = "high"/);
 	assert.match(result, /plan_mode_reasoning_effort = "xhigh"/);
 	assert.doesNotMatch(result, /gpt-5\.2/);
@@ -79,8 +79,8 @@ test("#given section settings reuse managed root keys #when ensuring config #the
 		].join("\n"),
 	);
 
-	assert.match(result, /^model = "gpt-5\.5"$/m);
-	assert.match(result, /^model_context_window = 400000$/m);
+	assert.match(result, /^model = "gpt-5\.6-sol"$/m);
+	assert.match(result, /^model_context_window = 372000$/m);
 	assert.match(result, /\[model_providers\.openai\]\nmodel = "provider-scoped-value"\nmodel_context_window = 123456/);
 	assert.match(result, /\[profiles\.review\]\nmodel_reasoning_effort = "medium"\nplan_mode_reasoning_effort = "medium"/);
 });
@@ -161,8 +161,8 @@ test("#given global and project-local stale Codex configs #when migrating #then 
 	});
 
 	assert.deepEqual(result.changed.sort(), [join(codexHome, "config.toml"), projectConfig].sort());
-	assert.match(await readFile(join(codexHome, "config.toml"), "utf8"), /model = "gpt-5\.5"/);
-	assert.match(await readFile(projectConfig, "utf8"), /model_context_window = 400000/);
+	assert.match(await readFile(join(codexHome, "config.toml"), "utf8"), /model = "gpt-5\.6-sol"/);
+	assert.match(await readFile(projectConfig, "utf8"), /model_context_window = 372000/);
 });
 
 test("#given model catalog is unavailable and stale 272k config #when migrating #then fallback catalog still upgrades it", async () => {
@@ -183,8 +183,8 @@ test("#given model catalog is unavailable and stale 272k config #when migrating 
 
 	const content = await readFile(join(codexHome, "config.toml"), "utf8");
 	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
-	assert.match(content, /model = "gpt-5\.5"/);
-	assert.match(content, /model_context_window = 400000/);
+	assert.match(content, /model = "gpt-5\.6-sol"/);
+	assert.match(content, /model_context_window = 372000/);
 });
 
 test("#given model catalog is malformed and stale config #when migrating #then fallback catalog still upgrades it", async () => {
@@ -206,8 +206,8 @@ test("#given model catalog is malformed and stale config #when migrating #then f
 
 	const content = await readFile(join(codexHome, "config.toml"), "utf8");
 	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
-	assert.match(content, /model = "gpt-5\.5"/);
-	assert.match(content, /model_context_window = 400000/);
+	assert.match(content, /model = "gpt-5\.6-sol"/);
+	assert.match(content, /model_context_window = 372000/);
 });
 
 test("#given user-customized Codex model config #when migrating #then user values are preserved without root multi-agent mode", async () => {
@@ -262,7 +262,7 @@ test("#given managed config state is malformed #when migrating #then migration i
 	const content = await readFile(join(codexHome, "config.toml"), "utf8");
 	const state = JSON.parse(await readFile(statePath, "utf8"));
 	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
-	assert.match(content, /model_context_window = 400000/);
+	assert.match(content, /model_context_window = 372000/);
 	assert.equal(state.files[join(codexHome, "config.toml")].managed, true);
 });
 
@@ -670,15 +670,15 @@ test("#given global config starts with inline-comment features table #when full 
 	const content = await readFile(configPath, "utf8");
 	const parsed = parseTomlWithPython(content);
 	assert.equal("multi_agent_mode" in parsed, false);
-	assert.equal(parsed.model, "gpt-5.5");
-	assert.equal(parsed.model_context_window, 400000);
+	assert.equal(parsed.model, "gpt-5.6-sol");
+	assert.equal(parsed.model_context_window, 372000);
 	assert.equal(parsed.model_reasoning_effort, "high");
 	assert.equal(parsed.plan_mode_reasoning_effort, "xhigh");
 	assert.equal(parsed.features.plugins, true);
 	assert.equal("multi_agent_mode" in parsed.features, false);
 	assert.equal("model" in parsed.features, false);
 	assert.equal("model_context_window" in parsed.features, false);
-	assert.match(content, /^model = "gpt-5\.5"\nmodel_context_window = 400000/m);
+	assert.match(content, /^model = "gpt-5\.6-sol"\nmodel_context_window = 372000/m);
 	assert.doesNotMatch(content, /^\s*multi_agent_mode\s*=/m);
 	assert.match(content, /\[features\] # keep comment\nplugins = true/);
 });

--- a/packages/omo-codex/scripts/install-config-reasoning.test.mjs
+++ b/packages/omo-codex/scripts/install-config-reasoning.test.mjs
@@ -22,8 +22,8 @@ test("#given empty Codex config #when script installer updates config #then sets
 
 	// then
 	const content = await readFile(configPath, "utf8");
-	assert.match(content, /model = "gpt-5\.5"/);
-	assert.match(content, /model_context_window = 400000/);
+	assert.match(content, /model = "gpt-5\.6-sol"/);
+	assert.match(content, /model_context_window = 372000/);
 	assert.match(content, /model_reasoning_effort = "high"/);
 	assert.match(content, /plan_mode_reasoning_effort = "xhigh"/);
 });
@@ -61,8 +61,8 @@ test("#given existing model and reasoning config #when script installer updates 
 	assert.equal(content.match(/^model_context_window\s*=/gm)?.length, 1);
 	assert.equal(content.match(/^model_reasoning_effort\s*=/gm)?.length, 1);
 	assert.equal(content.match(/^plan_mode_reasoning_effort\s*=/gm)?.length, 1);
-	assert.match(content, /model = "gpt-5\.5"/);
-	assert.match(content, /model_context_window = 400000/);
+	assert.match(content, /model = "gpt-5\.6-sol"/);
+	assert.match(content, /model_context_window = 372000/);
 	assert.match(content, /model_reasoning_effort = "high"/);
 	assert.match(content, /plan_mode_reasoning_effort = "xhigh"/);
 	assert.doesNotMatch(content, /model = "gpt-5\.2"/);
@@ -148,6 +148,6 @@ test("#given fallback model catalog #when catalog file is unavailable #then no m
 	const catalog = await readCodexModelCatalog(root);
 
 	// then
-	assert.equal(catalog.current.model, "gpt-5.5");
+	assert.equal(catalog.current.model, "gpt-5.6-sol");
 	assert.equal(catalog.managedProfiles.some((profile) => profile.model === "gpt-5.4"), false);
 });

--- a/packages/omo-codex/scripts/install-config.test.mjs
+++ b/packages/omo-codex/scripts/install-config.test.mjs
@@ -23,10 +23,11 @@ test("#given empty Codex config #when script installer updates config #then sets
 	});
 
 	// then
+	// The stamped default model is v2-preferred, so the installer must not
+	// introduce agents.max_threads (Codex rejects it under MultiAgentV2).
 	const config = await readFile(configPath, "utf8");
 	assert.doesNotMatch(config, /^\s*multi_agent_mode\s*=/m);
-	assert.match(config, /\[agents\]/);
-	assert.match(config, /max_threads = 1000/);
+	assert.doesNotMatch(config, /^\s*max_threads\s*=/m);
 	assert.match(config, /\[features\.multi_agent_v2\]/);
 const v2Section = multiAgentV2Section(config);
 	assert.doesNotMatch(v2Section, /^enabled\s*=/m);
@@ -281,11 +282,15 @@ test("#given sisyphuslabs config without explicit source #when script installer 
 
 test("#given existing MultiAgentV2 table #when script installer updates config #then preserves unrelated tuning while setting subagent thread limits", async () => {
 	// given
+	// A pinned v1 model keeps this on the preserve-user-disable path; the
+	// stamped v2-preferred default would clear the disable instead.
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-existing-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
 		configPath,
 		[
+			'model = "gpt-5.5"',
+			"",
 			"[features.multi_agent_v2]",
 			"enabled = false",
 			"usage_hint_enabled = false",
@@ -327,9 +332,11 @@ test("#given empty Codex config #when script installer updates config #then sets
 	});
 
 	// then
+	// The stamped default model is v2-preferred, so agents.max_threads is not
+	// introduced (Codex rejects it under MultiAgentV2).
 	const config = await readFile(configPath, "utf8");
 	const v2Section = config.slice(config.indexOf("[features.multi_agent_v2]"));
-	assert.match(config, /\[agents\][\s\S]*?max_threads = 1000/);
+	assert.doesNotMatch(config, /^\s*max_threads\s*=/m);
 	assert.match(v2Section, /max_concurrent_threads_per_session = 1000/);
 	assert.doesNotMatch(v2Section, /hide_spawn_agent_metadata/);
 });
@@ -402,11 +409,15 @@ const v2Section = multiAgentV2Section(config);
 
 test("#given legacy boolean MultiAgentV2 flag false #when script installer updates config #then normalizes to a disabled table config", async () => {
 	// given
+	// A pinned v1 model keeps the legacy boolean materializing as a disabled
+	// table; the stamped v2-preferred default would drop the disable instead.
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-legacy-false-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
 		configPath,
 		[
+			'model = "gpt-5.5"',
+			"",
 			"[features]",
 			"multi_agent_v2 = false",
 			"plugins = false",
@@ -434,11 +445,15 @@ test("#given legacy boolean MultiAgentV2 flag false #when script installer updat
 
 test("#given legacy agents max_threads #when script installer updates config #then raises the root subagent thread cap", async () => {
 	// given
+	// A pinned v1 model keeps the legacy low-cap raise path exercised; the
+	// stamped v2-preferred default would remove agents.max_threads instead.
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-legacy-threads-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
 		configPath,
 		[
+			'model = "gpt-5.5"',
+			"",
 			"[agents]",
 			"max_threads = 16",
 			"max_depth = 4",
@@ -471,11 +486,15 @@ const v2Section = multiAgentV2Section(config);
 
 test("#given managed agent role sections #when script installer updates config #then preserves role config while raising only root agents max_threads", async () => {
 	// given
+	// A pinned v1 model keeps the legacy low-cap raise path exercised; the
+	// stamped v2-preferred default would remove agents.max_threads instead.
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-multi-agent-role-section-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
 		configPath,
 		[
+			'model = "gpt-5.5"',
+			"",
 			"[agents]",
 			"max_threads = 16",
 			"",

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -8559,12 +8559,18 @@ import { readFile as readFile10 } from "node:fs/promises";
 import { join as join17 } from "node:path";
 var FALLBACK_CODEX_MODEL_CATALOG = {
   current: {
-    model: "gpt-5.5",
-    modelContextWindow: 400000,
+    model: "gpt-5.6-sol",
+    modelContextWindow: 372000,
     modelReasoningEffort: "high",
     planModeReasoningEffort: "xhigh"
   },
   managedProfiles: [
+    {
+      model: "gpt-5.5",
+      modelContextWindow: 400000,
+      modelReasoningEffort: "high",
+      planModeReasoningEffort: "xhigh"
+    },
     {
       model: "gpt-5.5",
       modelContextWindow: 1e6,

--- a/packages/omo-codex/src/install/codex-config-reasoning.test.ts
+++ b/packages/omo-codex/src/install/codex-config-reasoning.test.ts
@@ -25,8 +25,8 @@ describe("codex-config-reasoning", () => {
 
     // then
     const content = await readFile(configPath, "utf8")
-    expect(content).toContain('model = "gpt-5.5"')
-    expect(content).toContain("model_context_window = 400000")
+    expect(content).toContain('model = "gpt-5.6-sol"')
+    expect(content).toContain("model_context_window = 372000")
     expect(content).toContain('model_reasoning_effort = "high"')
     expect(content).toContain('plan_mode_reasoning_effort = "xhigh"')
   })
@@ -64,8 +64,8 @@ describe("codex-config-reasoning", () => {
     expect(content.match(/^model_context_window\s*=/gm)).toHaveLength(1)
     expect(content.match(/^model_reasoning_effort\s*=/gm)).toHaveLength(1)
     expect(content.match(/^plan_mode_reasoning_effort\s*=/gm)).toHaveLength(1)
-    expect(content).toContain('model = "gpt-5.5"')
-    expect(content).toContain("model_context_window = 400000")
+    expect(content).toContain('model = "gpt-5.6-sol"')
+    expect(content).toContain("model_context_window = 372000")
     expect(content).toContain('model_reasoning_effort = "high"')
     expect(content).toContain('plan_mode_reasoning_effort = "xhigh"')
     expect(content).not.toContain("model_context_window = 272000")
@@ -152,7 +152,7 @@ describe("codex-config-reasoning", () => {
     const catalog = await readCodexModelCatalog(root)
 
     // then
-    expect(catalog.current.model).toBe("gpt-5.5")
+    expect(catalog.current.model).toBe("gpt-5.6-sol")
     expect(catalog.managedProfiles.map(profile => profile.model)).not.toContain("gpt-5.4")
   })
 })

--- a/packages/omo-codex/src/install/codex-config-toml.test.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.test.ts
@@ -81,6 +81,10 @@ describe("codex-config-toml", () => {
       .split(/^\[/m).slice(0, 1).join("")
     expect(v2Section).not.toContain("enabled")
     expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    // The stamped gpt-5.6 default is a V2-preferred model: Codex rejects
+    // agents.max_threads while MultiAgentV2 is active, so a fresh install
+    // must not introduce it.
+    expect(content).not.toMatch(/^\s*max_threads\s*=/m)
   })
 
   test("#given stale queue multi-agent mode #when updating config #then removes unsupported root key", async () => {
@@ -169,11 +173,16 @@ describe("codex-config-toml", () => {
 
   test("#given existing MultiAgentV2 table #when updating config #then preserves user enabled flag and unrelated tuning while setting thread limit", async () => {
     // given
+    // A pinned v1 model keeps this exercising the preserve-user-disable path;
+    // an absent model would be stamped with the v2-preferred default, which
+    // intentionally clears the disable.
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-existing-"))
     const configPath = join(root, "config.toml")
     await writeFile(
       configPath,
       [
+        'model = "gpt-5.5"',
+        "",
         "[features.multi_agent_v2]",
         "enabled = false",
         "usage_hint_enabled = false",
@@ -380,11 +389,15 @@ describe("codex-config-toml", () => {
 
   test("#given legacy boolean MultiAgentV2 flag false #when updating config #then normalizes to a disabled table config", async () => {
     // given
+    // A pinned v1 model keeps the legacy boolean materializing as a disabled
+    // table; the stamped v2-preferred default would drop the disable instead.
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-legacy-false-"))
     const configPath = join(root, "config.toml")
     await writeFile(
       configPath,
       [
+        'model = "gpt-5.5"',
+        "",
         "[features]",
         "multi_agent_v2 = false",
         "plugins = false",
@@ -410,11 +423,15 @@ describe("codex-config-toml", () => {
 
   test("#given legacy agents max_threads #when updating config #then raises the root subagent thread cap", async () => {
     // given
+    // A pinned v1 model keeps the legacy low-cap raise path exercised; the
+    // stamped v2-preferred default would remove agents.max_threads instead.
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-legacy-threads-"))
     const configPath = join(root, "config.toml")
     await writeFile(
       configPath,
       [
+        'model = "gpt-5.5"',
+        "",
         "[agents]",
         "max_threads = 16",
         "max_depth = 4",
@@ -559,11 +576,15 @@ describe("codex-config-toml", () => {
 
   test("#given managed agent role sections #when updating config #then preserves role config while raising only root agents max_threads", async () => {
     // given
+    // A pinned v1 model keeps the legacy low-cap raise path exercised; the
+    // stamped v2-preferred default would remove agents.max_threads instead.
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-multi-agent-role-section-"))
     const configPath = join(root, "config.toml")
     await writeFile(
       configPath,
       [
+        'model = "gpt-5.5"',
+        "",
         "[agents]",
         "max_threads = 16",
         "",

--- a/packages/omo-codex/src/install/codex-model-catalog.ts
+++ b/packages/omo-codex/src/install/codex-model-catalog.ts
@@ -18,12 +18,18 @@ export type CodexModelCatalog = {
 
 const FALLBACK_CODEX_MODEL_CATALOG: CodexModelCatalog = {
   current: {
-    model: "gpt-5.5",
-    modelContextWindow: 400_000,
+    model: "gpt-5.6-sol",
+    modelContextWindow: 372_000,
     modelReasoningEffort: "high",
     planModeReasoningEffort: "xhigh",
   },
   managedProfiles: [
+    {
+      model: "gpt-5.5",
+      modelContextWindow: 400_000,
+      modelReasoningEffort: "high",
+      planModeReasoningEffort: "xhigh",
+    },
     {
       model: "gpt-5.5",
       modelContextWindow: 1_000_000,

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
@@ -46,11 +46,15 @@ describe("codex MultiAgentV2 config", () => {
 
   test("#given disabled boolean shorthand #when updating config #then explicit disable is preserved in table form", async () => {
     // given
+    // A pinned v1 model keeps the explicit disable materializing in table form;
+    // the stamped v2-preferred default would drop the disable instead.
     const root = await mkdtemp(join(tmpdir(), "omo-codex-mav2-disabled-shorthand-"))
     const configPath = join(root, "config.toml")
     await writeFile(
       configPath,
       [
+        'model = "gpt-5.5"',
+        "",
         "[features]",
         "multi_agent_v2 = false # user disabled the beta path",
         "plugins = false",

--- a/packages/omo-codex/src/install/codex-subagent-limit-config.test.ts
+++ b/packages/omo-codex/src/install/codex-subagent-limit-config.test.ts
@@ -8,7 +8,7 @@ import { join } from "node:path"
 import { updateCodexConfig } from "./codex-config-toml"
 
 describe("codex subagent limit config", () => {
-  test("#given empty Codex config #when updating config #then installs v1 and v2 subagent limits at 1000", async () => {
+  test("#given empty Codex config #when updating config #then installs the v2 thread limit without agents.max_threads", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-subagent-limit-empty-"))
     const configPath = join(root, "config.toml")
@@ -23,20 +23,25 @@ describe("codex subagent limit config", () => {
     })
 
     // then
+    // The stamped default model is v2-preferred, so Codex would reject a
+    // fresh agents.max_threads while MultiAgentV2 is active.
     const content = await readFile(configPath, "utf8")
-    expect(content).toContain("[agents]")
-    expect(content).toContain("max_threads = 1000")
+    expect(content).not.toMatch(/^\s*max_threads\s*=/m)
     expect(content).toContain("[features.multi_agent_v2]")
     expect(content).toContain("max_concurrent_threads_per_session = 1000")
   })
 
   test("#given existing low agents max_threads #when updating config #then raises only the root cap", async () => {
     // given
+    // A pinned v1 model keeps the raise path exercised; the stamped
+    // v2-preferred default would remove agents.max_threads instead.
     const root = await mkdtemp(join(tmpdir(), "omo-codex-subagent-limit-existing-"))
     const configPath = join(root, "config.toml")
     await writeFile(
       configPath,
       [
+        'model = "gpt-5.5"',
+        "",
         "[agents]",
         "max_threads = 6",
         "max_depth = 4",

--- a/packages/omo-codex/src/install/install-codex-project-local-cleanup.test.ts
+++ b/packages/omo-codex/src/install/install-codex-project-local-cleanup.test.ts
@@ -98,9 +98,13 @@ describe("install-codex project-local cleanup", () => {
     const repoRoot = await createPackagedCodexRepoRoot()
     await mkdir(projectDirectory, { recursive: true })
     await mkdir(codexHome, { recursive: true })
+    // A pinned v1 model keeps the legacy cap raise observable; the stamped
+    // v2-preferred default would remove agents.max_threads instead.
     await writeFile(
       globalConfigPath,
       [
+        'model = "gpt-5.5"',
+        "",
         "[features.multi_agent_v2]",
         "enabled = true",
         "",


### PR DESCRIPTION
## Summary

lazycodex (`packages/omo-codex`, the Codex Light edition) stamps a default model
and reasoning profile into `~/.codex/config.toml` at install time and on every
SessionStart migration. That default was `gpt-5.5` / `400000` ctx / `high`
(plan mode `xhigh`). This PR moves it to **`gpt-5.6-sol` / `372000` ctx /
`high`** (plan mode stays `xhigh`), so fresh installs and managed upgrades land
on the current frontier coding model. `372000` matches gpt-5.6-sol's real
context window from Codex's `models_cache`.

Existing MANAGED installs auto-migrate: the prior gpt-5.5 profiles are retained
as `managedProfiles`, so a config the installer previously wrote is recognized
and upgraded to gpt-5.6-sol. Configs a user hand-edited are still left untouched.

## Changes

- **Default source of truth** — `plugin/model-catalog.json` `current` +
  `roles.{default,verifier,worker}` now gpt-5.6-sol/372k/high (plan xhigh).
- **Both fallbacks kept in lockstep** — `src/install/codex-model-catalog.ts`
  (TS, used by the marketplace/bootstrap path) and
  `plugin/scripts/migrate-codex-config/catalog.mjs` (runtime SessionStart path).
- **Regenerated bundle** — `scripts/install-dist/install-local.mjs` rebuilt via
  `bun run build:codex-install` so the shipped installer carries the new fallback.
- **Legacy migration** — added `legacy.gpt-5.5-400k-reviewer-high` alongside the
  existing 1m/272k managed profiles so the outgoing default migrates up.
- **Tests** — every pinned install/migration test updated to the new default.
  Because gpt-5.6-sol is a V2-preferred model (Codex rejects `agents.max_threads`
  under MultiAgentV2), a fresh install no longer stamps `agents.max_threads`;
  tests that specifically cover the v1 legacy-cap-raise / preserve-disable paths
  now pin an explicit gpt-5.5 model in their fixture so those branches stay
  exercised.

## QA & Evidence

Ran the `codex-qa` skill against an isolated `CODEX_HOME` (mock model, no API
call); the real `~/.codex/config.toml` shasum was unchanged before/after every
run (`8896a47d…`). Evidence under `.omo/evidence/20260711-codex-default-model-gpt56sol/`.

- **Fresh install landing** — `install-verify.sh` with `REPO_ROOT` = this
  worktree drove the real installer + regenerated bundle into an isolated home.
  Landed `config.toml` root block was exactly `model = "gpt-5.6-sol"`,
  `model_context_window = 372000`, `model_reasoning_effort = "high"`,
  `plan_mode_reasoning_effort = "xhigh"`, `[features.multi_agent_v2]
  max_concurrent_threads_per_session = 1000`, and NO `agents.max_threads`
  (correct for a V2-preferred model). All install-verify assertions PASS.
  Artifact: `install-verify.txt`, `landed-config.toml`.
- **Legacy managed migration** — a pre-existing `gpt-5.5/400000/high/xhigh`
  managed config run through the real `migrate-codex-config.mjs` upgraded to
  `gpt-5.6-sol/372000/high/xhigh`. Artifacts: `migration-before.toml`,
  `migration-after.toml`.
- **User-override protection** — a non-managed `my-private-model/123456/medium/
  medium` config was preserved byte-for-byte. Artifact: `user-modified-preserved.toml`.
- **Unit gates** — bun `src/install` 221 pass / 0 fail; node `plugin/test`
  351 pass / 0 fail; `scripts` config tests + bootstrap drift-guard green;
  `packages/omo-codex` typecheck clean.

## Risks & Residuals

- Managed migration is intended and proven (scenario 2); user configs stay
  untouched (scenario 3). Mitigated.
- The v2-preferred `agents.max_threads` removal on fresh install is the correct
  Codex behavior and is asserted directly in the landed config + unit suites.
- Full hermetic `bun run test:codex` gate runs in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the lazycodex default model in `packages/omo-codex` to `gpt-5.6-sol` with a `372000` context window and `high` reasoning (plan mode stays `xhigh`). Managed installs auto-migrate; fresh installs no longer write `agents.max_threads` because `gpt-5.6-sol` is MultiAgentV2‑preferred.

- **New Features**
  - Updated `plugin/model-catalog.json` (`current` and `roles.{default,verifier,worker}`) to `gpt-5.6-sol`/372000/`high`.
  - Kept fallbacks in sync (`src/install/codex-model-catalog.ts`, `plugin/scripts/migrate-codex-config/catalog.mjs`) and regenerated `scripts/install-dist/install-local.mjs`.
  - Added a managed legacy profile for `gpt-5.5`/400000/`high` so managed configs upgrade; user-edited configs stay unchanged.
  - Adjusted tests and assertions: no `agents.max_threads` on fresh install; v1 legacy paths remain covered by pinning `gpt-5.5` in fixtures.

<sup>Written for commit 8d610cf64ab91c222f3fe7a3efc0fd5cf0714c31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

