### PR TITLE
feat(lazycodex): drop gate-reviewer reasoning effort to high

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-gate-reviewer.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-gate-reviewer.toml
@@ -2,7 +2,7 @@ name = "lazycodex-gate-reviewer"
 description = "Read-only LazyCodex gate reviewer. Re-audits executor, code review, and QA artifacts before final approval."
 nickname_candidates = ["Gate Reviewer"]
 model = "gpt-5.6-sol"
-model_reasoning_effort = "xhigh"
+model_reasoning_effort = "high"
 
 developer_instructions = """
 Role: final gate reviewer. Read-only.

--- a/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
@@ -116,7 +116,7 @@ const lazycodexAgentInvariants = new Map([
 		"lazycodex-gate-reviewer.toml",
 		{
 			model: "gpt-5.6-sol",
-			effort: "xhigh",
+			effort: "high",
 			includes: [/APPROVE\/REJECT/, /blockers/, /<attemptDir>\/<goalId>-gate-review\.md/, /currentAttemptDir/],
 		},
 	],

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -9066,6 +9066,15 @@ var MANAGED_REASONING_DEFAULT_UPGRADES = new Map([
         current: { model: "gpt-5.6-luna", effort: "high" }
       }
     ]
+  ],
+  [
+    "lazycodex-gate-reviewer",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "xhigh" },
+        current: { model: "gpt-5.6-sol", effort: "high" }
+      }
+    ]
   ]
 ]);
 function resolveManagedAgentReasoning(input) {

--- a/packages/omo-codex/src/install/managed-agent-reasoning-defaults.test.ts
+++ b/packages/omo-codex/src/install/managed-agent-reasoning-defaults.test.ts
@@ -87,6 +87,18 @@ describe("resolveManagedAgentReasoning", () => {
 		expect(effort).toBe("high")
 	})
 
+	test("#given a preserved gate-reviewer sol/xhigh default #when resolving against sol/high #then the new bundled effort wins", () => {
+		// when
+		const effort = resolveManagedAgentReasoning({
+			agentName: "lazycodex-gate-reviewer",
+			bundledModel: "gpt-5.6-sol",
+			bundledEffort: "high",
+			preserved: { model: "gpt-5.6-sol", effort: "xhigh" },
+		})
+		// then
+		expect(effort).toBe("high")
+	})
+
 	test("#given a second resolve over already-migrated values #when resolving #then the result is stable", () => {
 		// when — after migration the installed file reads luna/low; resolving again must not flip anything
 		const effort = resolveManagedAgentReasoning({

--- a/packages/omo-codex/src/install/managed-agent-reasoning-defaults.ts
+++ b/packages/omo-codex/src/install/managed-agent-reasoning-defaults.ts
@@ -71,6 +71,15 @@ const MANAGED_REASONING_DEFAULT_UPGRADES = new Map<string, readonly ManagedReaso
       },
     ],
   ],
+  [
+    "lazycodex-gate-reviewer",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "xhigh" },
+        current: { model: "gpt-5.6-sol", effort: "high" },
+      },
+    ],
+  ],
 ])
 
 export function resolveManagedAgentReasoning(input: {


### PR DESCRIPTION
## What
`lazycodex-gate-reviewer`: **gpt-5.6-sol / xhigh -> gpt-5.6-sol / high** (model unchanged).

## Kept in lockstep
- `managed-agent-reasoning-defaults` migration map: `{sol,xhigh}->{sol,high}` step
  so an existing install carrying the old xhigh is bumped to high on reinstall;
  user-customized effort still preserved.
- `aggregate-agents` pin + reasoning-defaults unit test.
- Regenerated `install-dist/install-local.mjs` bundle.
- No doc/SKILL references the gate-reviewer effort value, so none needed updating.

## QA (isolated, evidence-bound)
- `bun run test:codex` — **506 pass / 0 fail** + all bun install suites green.
- `codex-qa` `install-verify.sh --keep` — landed `lazycodex-gate-reviewer.toml` at
  `gpt-5.6-sol` / `high` in an isolated `CODEX_HOME`; real `~/.codex/config.toml`
  shasum `8ba8eb7c…` unchanged.

Evidence: `.omo/evidence/20260712-lazycodex-gate-reviewer-high/` (gitignored, local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowers `lazycodex-gate-reviewer` reasoning effort from xhigh to high while keeping the `gpt-5.6-sol` model unchanged.

- **Migration**
  - Existing installs move from `gpt-5.6-sol`/`xhigh` to `gpt-5.6-sol`/`high` on reinstall.
  - User-customized effort values remain unchanged.

<sup>Written for commit b70edfc76c2049c7e6bb5a6f91eeab95b0713006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

