### PR TITLE
test(team-mode): deflake C-10.4/C-10.5 concurrency cases on Windows CI

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/integration.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/integration.test.ts
@@ -313,8 +313,8 @@ describe("team-mode integration", () => {
       { kind: "subagent_type", name: "worker-b", subagent_type: "atlas", backendType: "in-process", isActive: true },
     ]), "ses_lead", createContext(baseDir, manager, new Set(["ses_lead"])), createConfig(baseDir, { max_parallel_members: launchLimit }), manager)
     try {
-      const firstBatch = await launchProbe.waitForFirstBatch("timed out waiting for the first two member launches")
-      await launchProbe.releaseAndWaitForCompletion(run, "timed out waiting for all member launches")
+      const firstBatch = await launchProbe.waitForFirstBatch()
+      await launchProbe.releaseAndWaitForCompletion(run)
       const completed = launchProbe.snapshot()
 
       // then

--- a/packages/omo-opencode/src/features/team-mode/integration.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/integration.test.ts
@@ -293,7 +293,7 @@ describe("team-mode integration", () => {
         thinking: { type: "enabled", budgetTokens: 1024 },
       },
     })
-  })
+  }, 30000)
 
   test("C-10.4 keeps member spawn concurrency within max_parallel_members", async () => {
     // given
@@ -327,5 +327,5 @@ describe("team-mode integration", () => {
       launchProbe.release()
       run.catch(() => undefined)
     }
-  })
+  }, 30000)
 })

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
@@ -356,8 +356,8 @@ describe("createTeamRun", () => {
     // when
     const run = createTeamRun(createSpec(8), "lead-session", createContext(baseDir, manager), createConfig(baseDir, launchLimit), manager)
     try {
-      const firstBatch = await launchProbe.waitForFirstBatch("timed out waiting for the first four member launches")
-      await launchProbe.releaseAndWaitForCompletion(run, "timed out waiting for all member launches")
+      const firstBatch = await launchProbe.waitForFirstBatch()
+      await launchProbe.releaseAndWaitForCompletion(run)
       const completed = launchProbe.snapshot()
 
       // then

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
@@ -370,7 +370,7 @@ describe("createTeamRun", () => {
       launchProbe.release()
       run.catch(() => undefined)
     }
-  })
+  }, 30000)
 
   test("reuses the caller session for the lead when the lead matches the caller agent", async () => {
     // given

--- a/packages/omo-opencode/src/features/team-mode/test-support/async-test-helpers.ts
+++ b/packages/omo-opencode/src/features/team-mode/test-support/async-test-helpers.ts
@@ -1,7 +1,5 @@
 import type { BackgroundTask, LaunchInput } from "../../background-agent/types"
 
-const DEFAULT_LAUNCH_PROBE_TIMEOUT_MS = 5_000
-
 type Deferred<T> = {
   readonly promise: Promise<T>
   readonly resolve: (value: T | PromiseLike<T>) => void
@@ -16,9 +14,9 @@ export type LaunchConcurrencySnapshot = {
 export type LaunchConcurrencyProbe = {
   readonly launch: (input: LaunchInput) => Promise<BackgroundTask>
   readonly release: () => void
-  readonly releaseAndWaitForCompletion: <T>(promise: Promise<T>, message: string, timeoutMs?: number) => Promise<T>
+  readonly releaseAndWaitForCompletion: <T>(promise: Promise<T>) => Promise<T>
   readonly snapshot: () => LaunchConcurrencySnapshot
-  readonly waitForFirstBatch: (message: string, timeoutMs?: number) => Promise<LaunchConcurrencySnapshot>
+  readonly waitForFirstBatch: () => Promise<LaunchConcurrencySnapshot>
 }
 
 export type LaunchConcurrencyProbeOptions = {
@@ -36,20 +34,10 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve: resolveDeferred }
 }
 
-async function withCircuitBreaker<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | undefined
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_, reject) => {
-        timeout = setTimeout(() => reject(new Error(message)), timeoutMs)
-      }),
-    ])
-  } finally {
-    if (timeout) clearTimeout(timeout)
-  }
-}
-
+// The waits below resolve on the real launch callbacks (firstBatchStarted / releaseLaunches),
+// so they are awaited directly with no wall-clock timer guarding them. A fixed intra-helper
+// deadline used to race those events and lost to slow Windows CI scheduling, which flaked the
+// concurrency tests; a genuine launch deadlock is now caught by the per-test timeout instead.
 export function createLaunchConcurrencyProbe(options: LaunchConcurrencyProbeOptions): LaunchConcurrencyProbe {
   const firstBatchStarted = createDeferred<void>()
   const releaseLaunches = createDeferred<void>()
@@ -83,13 +71,13 @@ export function createLaunchConcurrencyProbe(options: LaunchConcurrencyProbeOpti
       } satisfies BackgroundTask
     },
     release,
-    async releaseAndWaitForCompletion<T>(promise: Promise<T>, message: string, timeoutMs = DEFAULT_LAUNCH_PROBE_TIMEOUT_MS): Promise<T> {
+    async releaseAndWaitForCompletion<T>(promise: Promise<T>): Promise<T> {
       release()
-      return await withCircuitBreaker(promise, timeoutMs, message)
+      return await promise
     },
     snapshot,
-    async waitForFirstBatch(message: string, timeoutMs = DEFAULT_LAUNCH_PROBE_TIMEOUT_MS): Promise<LaunchConcurrencySnapshot> {
-      await withCircuitBreaker(firstBatchStarted.promise, timeoutMs, message)
+    async waitForFirstBatch(): Promise<LaunchConcurrencySnapshot> {
+      await firstBatchStarted.promise
       return snapshot()
     },
   }


### PR DESCRIPTION
## Summary

Two team-mode integration tests flake only on `test (windows-latest)` (green on macOS/Linux and locally), failing at `[5031ms]` / `[5172ms]` — durations that match the two 5-second ceilings these tests sit under. This PR removes a redundant wall-clock race inside the shared launch-concurrency test probe and gives the affected cases the same explicit 30s per-test timeout their non-flaky siblings already use. Behavior asserted by the tests is unchanged; the change is test-only.

## Changes

**Launch-concurrency probe (`test-support/async-test-helpers.ts`)**
- The probe already resolves `firstBatchStarted` / `releaseLaunches` on the real launch callbacks, but `waitForFirstBatch` / `releaseAndWaitForCompletion` wrapped those promises in a `withCircuitBreaker` that raced a fixed 5000ms wall-clock `setTimeout`. On slow Windows CI scheduling the timer won the race before the real launch/completion event arrived.
- Removed `withCircuitBreaker` and `DEFAULT_LAUNCH_PROBE_TIMEOUT_MS`; the two waits now `await` the real promises directly (purely event-driven). A genuine launch deadlock is now caught by the per-test timeout instead of an intra-helper deadline. The two consumers (`integration.test.ts` C-10.4, `create.test.ts`) drop the now-unused message argument.

**Explicit per-test timeouts (`integration.test.ts`, `team-runtime/create.test.ts`)**
- `C-10.5` and the two probe-driven concurrency cases inherited Bun's 5000ms default per-test timeout, unlike the filesystem-heavy siblings `C-10.1/2/3` which already declare `30000`. These cases do real `createTeamRun` / mailbox / state I/O that can exceed 5000ms on slow Windows CI.
- Pinned the same `30000` budget the sibling integration cases use, so the per-test timeout only fires on a genuine hang, not on slow-but-progressing CI. This is also the deadlock guard for the now event-driven probe.

## QA & Evidence

This change touches only test files plus a test-support helper that is imported exclusively by `*.test.ts` (verified: no non-test importer of `async-test-helpers`, and it is not in the `src/index.ts` build graph). It reaches no OpenCode runtime surface, so per repo policy the loop-run determinism proof is the appropriate QA rather than the `opencode-qa` skill. Evidence written to `.omo/evidence/20260712-teammode-deflake/` (gitignored; on disk in the worktree).

- **What was tested:** the two flaky integration cases and the third probe consumer, run in tight loops, clean and under induced CPU scheduling pressure.
  - **Observed:** `integration.test.ts` x50 clean → PASS=50/50 (`clean-integration-50x.txt`); x50 under 36 CPU hogs on an 18-core host → PASS=50/50 (`loaded-integration-50x.txt`); `create.test.ts` x30 under load → PASS=30/30 (`loaded-create-30x.txt`).
  - **Why sufficient:** confirms the change is deterministic and regression-free across 130 loop iterations including under load.
- **What was tested:** full team-mode suite and the CI typecheck path.
  - **Observed:** `bun test packages/omo-opencode/src/features/team-mode/` → 298 pass / 1 skip / 0 fail; `bun run typecheck` → exit 0.

## Risks & Residuals

- **Reproducing Windows starvation locally:** the 18-core host gives the foreground process scheduling priority, so loaded runs stayed well under the new 30s budget and cannot reproduce a shared Windows runner's extreme starvation. Mitigation is by root cause, not just by loop count: the two 5s ceilings that produced the `[5031ms]` / `[5172ms]` failures are removed (event-driven waits) or raised to the proven-safe 30s sibling budget. Windows CI on this PR is the live confirmation.
- **Lost debug message:** the removed circuit breaker emitted a per-wait timeout string; a genuine deadlock now surfaces as a Bun per-test timeout naming the test instead. Accepted — the wall-clock race was the flake source and the test name still localizes a hang.
- Pre-existing (not introduced here): `integration.test.ts:218` has a mock-client cast type error that exists verbatim on `dev`; CI's `tsgo` skips `*.test.ts`, so it does not gate. Left untouched to keep this PR scoped to the flake.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes Windows CI for team-mode concurrency tests (C-10.4/C-10.5) by making the launch probe waits event-driven and setting 30s per-test timeouts to match siblings.

- **Bug Fixes**
  - Removed the 5s wall-clock circuit breaker in `test-support/async-test-helpers.ts`; `waitForFirstBatch` and `releaseAndWaitForCompletion` now await real launch events.
  - Set 30000ms per-test timeouts for the affected cases in `integration.test.ts` and `team-runtime/create.test.ts` to avoid false timeouts on slow CI.
  - Test-only changes; no runtime behavior changed.

<sup>Written for commit 7baf2bdb1810f2878656cab861aaeb6d95c81a44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

