### PR TITLE
fix(codex): stop shipping the dangling nested lsp .mcp.json into installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "packages/lsp-tools-mcp/dist",
     "packages/lsp-daemon/package.json",
     "packages/lsp-daemon/dist",
+    "packages/git-bash-mcp/package.json",
     "packages/git-bash-mcp/dist",
     "packages/shared-skills/package.json",
     "packages/shared-skills/index.mjs",

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -7612,7 +7612,12 @@ function shouldCopyPluginPath(path, root) {
   if (relative4 === "")
     return true;
   const parts = relative4.split(sep5);
-  return !parts.some((part) => part === ".git" || part === "node_modules");
+  if (parts.some((part) => part === ".git" || part === "node_modules"))
+    return false;
+  return !isNestedComponentMcpManifest(parts);
+}
+function isNestedComponentMcpManifest(parts) {
+  return parts.length > 1 && parts.at(-1) === ".mcp.json";
 }
 var removedSparkshellReferencePattern = /\b(?:sparkshell|spark[-_\s]+shell)\b/i;
 var removedSparkshellPromptSurfaceDirs = new Set([".codex-plugin", "agents", "bundled-rules", "hooks", "skills"]);

--- a/packages/omo-codex/src/install/codex-cache-install.test.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.test.ts
@@ -44,6 +44,39 @@ describe("codex-cache install", () => {
     15000,
   )
 
+  test(
+    "#given a component ships its own nested .mcp.json #when caching plugin #then only the plugin-root .mcp.json is cached",
+    async () => {
+      // given
+      const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-mcp-"))
+      const codexHome = join(root, "codex-home")
+      const sourceRoot = join(root, "plugin")
+      await mkdir(join(sourceRoot, "components", "lsp"), { recursive: true })
+      await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }))
+      await writeFile(join(sourceRoot, ".mcp.json"), JSON.stringify({ mcpServers: { grep_app: { url: "https://mcp.grep.app" } } }))
+      // A standalone-plugin dev manifest whose relative daemon path dangles once flattened into the cache.
+      await writeFile(
+        join(sourceRoot, "components", "lsp", ".mcp.json"),
+        JSON.stringify({ mcpServers: { lsp: { command: "node", args: ["../../../../lsp-daemon/dist/cli.js", "mcp"] } } }),
+      )
+
+      // when
+      const installed = await installCachedPlugin({
+        codexHome,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async () => undefined,
+      })
+
+      // then
+      expect(await readFile(join(installed.path, ".mcp.json"), "utf8")).toContain("grep_app")
+      await expect(stat(join(installed.path, "components", "lsp", ".mcp.json"))).rejects.toThrow()
+    },
+    15000,
+  )
+
   test("#given source plugin references missing hook command target #when caching plugin #then previous active cache is preserved", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-hook-target-"))

--- a/packages/omo-codex/src/install/codex-cache-install.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.ts
@@ -111,7 +111,16 @@ function shouldCopyPluginPath(path: string, root: string): boolean {
   const relative = path === root ? "" : path.slice(root.length + sep.length)
   if (relative === "") return true
   const parts = relative.split(sep)
-  return !parts.some((part) => part === ".git" || part === "node_modules")
+  if (parts.some((part) => part === ".git" || part === "node_modules")) return false
+  return !isNestedComponentMcpManifest(parts)
+}
+
+// Codex loads MCP servers only from the plugin-root .mcp.json (.codex-plugin/plugin.json declares
+// "mcpServers": "./.mcp.json"). A component's own nested .mcp.json is a standalone-plugin dev
+// manifest whose relative daemon path (e.g. ../../../../lsp-daemon/dist/cli.js) resolves in the repo
+// layout but dangles in the flattened cache layout, so it must never be copied into the cache.
+function isNestedComponentMcpManifest(parts: readonly string[]): boolean {
+  return parts.length > 1 && parts.at(-1) === ".mcp.json"
 }
 
 const removedSparkshellReferencePattern = /\b(?:sparkshell|spark[-_\s]+shell)\b/i

--- a/script/npm-payload-containment.test.ts
+++ b/script/npm-payload-containment.test.ts
@@ -30,6 +30,17 @@ describe("root npm payload containment", () => {
     expect(files).toContain("!packages/omo-codex/plugin/**/node_modules")
     expect(files).toContain("!packages/omo-codex/plugin/components/workflow-selector")
   })
+
+  test("#given root files allowlist #when vendored MCP shipping is checked #then each ships its package.json alongside dist", () => {
+    // given
+    const files = readRootFiles()
+
+    // when / then
+    for (const vendoredMcp of ["lsp-tools-mcp", "lsp-daemon", "git-bash-mcp"] as const) {
+      expect(files).toContain(`packages/${vendoredMcp}/dist`)
+      expect(files).toContain(`packages/${vendoredMcp}/package.json`)
+    }
+  })
 })
 
 describe("lazycodex-ai publish payload containment", () => {

--- a/script/sync-lazycodex-marketplace.test.ts
+++ b/script/sync-lazycodex-marketplace.test.ts
@@ -359,10 +359,9 @@ describe("sync-lazycodex-marketplace", () => {
     // then
     expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "bootstrap", "dist", "cli.js"))).isFile()).toBe(true)
     expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "bootstrap", "scripts", "bootstrap.ps1"))).isFile()).toBe(true)
-    const nestedMcpManifest = JSON.parse(
-      await readFile(join(lazycodexRoot, "plugins", "omo", "components", "lsp", ".mcp.json"), "utf8"),
-    )
-    expect(nestedMcpManifest.mcpServers.lsp.args[0]).toBe("../../../../lsp-daemon/dist/cli.js")
+    // Codex reads MCP servers only from the plugin-root .mcp.json; a component's nested dev manifest
+    // (whose relative daemon path dangles in the flattened bundle) must not ship in plugins/omo.
+    await expectPathMissing(join(lazycodexRoot, "plugins", "omo", "components", "lsp", ".mcp.json"))
   })
 
   test("#given missing bootstrap commandWindows target #when syncing marketplace #then rejects naming the bootstrap.ps1 path", async () => {
@@ -406,7 +405,7 @@ describe("sync-lazycodex-marketplace", () => {
     expect(message).toContain("zero bytes")
   })
 
-  test("#given nested component .mcp.json referencing an absent in-bundle runtime #when syncing marketplace #then rejects the broken bundle", async () => {
+  test("#given a component ships a nested .mcp.json #when syncing marketplace #then it is dropped from the bundle and the sync succeeds", async () => {
     // given
     const sourceRoot = await mkdtemp(join(tmpdir(), "omo-sync-nested-mcp-source-"))
     const lazycodexRoot = await mkdtemp(join(tmpdir(), "omo-sync-nested-mcp-lazycodex-"))
@@ -418,16 +417,10 @@ describe("sync-lazycodex-marketplace", () => {
     })
 
     // when
-    let message = ""
-    try {
-      await syncLazycodexMarketplace({ sourceRoot, lazycodexRoot })
-    } catch (error) {
-      message = error instanceof Error ? error.message : String(error)
-    }
+    await syncLazycodexMarketplace({ sourceRoot, lazycodexRoot })
 
     // then
-    expect(message).toContain("missing MCP runtime path for lsp")
-    expect(message).toContain("packages/lsp-tools-mcp/dist/cli.js")
+    await expectPathMissing(join(lazycodexRoot, "plugins", "omo", "components", "lsp", ".mcp.json"))
   })
 
   test("#given multiple missing referenced targets #when syncing marketplace #then reports the full list", async () => {

--- a/script/sync-lazycodex-marketplace.ts
+++ b/script/sync-lazycodex-marketplace.ts
@@ -222,7 +222,13 @@ const PLUGIN_COPY_DENYLIST = new Set([".git", "node_modules", ".ulw", ".claude"]
 function shouldCopyPluginPath(path: string, root: string): boolean {
   const relative = path === root ? "" : path.slice(root.length + sep.length)
   if (relative.length === 0) return true
-  return !relative.split(sep).some((part) => PLUGIN_COPY_DENYLIST.has(part))
+  const parts = relative.split(sep)
+  if (parts.some((part) => PLUGIN_COPY_DENYLIST.has(part))) return false
+  // Codex loads MCP servers only from the plugin-root .mcp.json (.codex-plugin/plugin.json declares
+  // "mcpServers": "./.mcp.json"). A component's own nested .mcp.json is a standalone-plugin dev
+  // manifest whose relative daemon path dangles once the plugin is flattened into the bundle, so it
+  // must never ship in plugins/omo.
+  return !(parts.length > 1 && parts.at(-1) === ".mcp.json")
 }
 
 


### PR DESCRIPTION
## Summary
The Codex (lazycodex) plugin ships a nested `components/lsp/.mcp.json` whose arg `../../../../lsp-daemon/dist/cli.js` resolves in the repo/npm layout but **dangles once the plugin is flattened into an install cache** (`~/.codex/plugins/cache/sisyphuslabs/omo/<ver>/components/lsp/.mcp.json` -> a non-existent `sisyphuslabs/lsp-daemon/dist/cli.js`). Codex loads MCP servers only from the plugin-root `.mcp.json` (`.codex-plugin/plugin.json` declares `"mcpServers": "./.mcp.json"`), so the nested manifest is never read and nothing breaks at runtime — but it is exactly what an install-cache inspection flags as a "missing package". This PR stops shipping that vestigial dev manifest into either install path, and closes a vendored-MCP `files` asymmetry.

## Root cause
`components/lsp/.mcp.json` is a leftover from when the lsp component was the standalone `@code-yeongyu/codex-lsp` plugin. In the flattened install layout its relative daemon path escapes the plugin root. The bunx installer already rewrites the *root* `.mcp.json` to absolute cache paths and bundles `components/lsp-daemon`/`components/git-bash-mcp`, but nested component manifests were copied verbatim.

## Changes
- **Install cache (`packages/omo-codex/src/install/codex-cache-install.ts`)** — `shouldCopyPluginPath` now excludes any nested component `.mcp.json`; only the plugin-root manifest reaches `~/.codex`. Regenerated the install-dist bundle.
- **Codex-native marketplace (`script/sync-lazycodex-marketplace.ts`)** — same rule for the `plugins/omo` bundle. The two sync tests move from the old "ship + tolerate the out-of-bundle path" invariant to the cleaner "nested component manifest never ships".
- **`files` parity (`package.json`)** — add `packages/git-bash-mcp/package.json` so every vendored MCP ships `package.json` alongside `dist` (matching `lsp-tools-mcp` / `lsp-daemon`).

## QA & Evidence
Isolated, real-`~/.codex`-untouched runs (evidence under `.omo/evidence/`, sanitized):
- **What was tested:** install the plugin into an isolated cache with this code (`installCachedPlugin` against the real worktree plugin), then inspect the cache and boot lsp.
- **Observed result (before → after):**
  - before (published 4.16.3): cache **contained** `components/lsp/.mcp.json` with the dangling `../../../../lsp-daemon` arg.
  - after: `components/lsp/.mcp.json` **absent**; root `.mcp.json` present; `codegraph`/`git_bash`/`lsp` runtime paths all resolve (**MISSING COUNT: 0**); bundled `lsp-daemon` boots with a valid JSON-RPC `initialize`, **no MODULE_NOT_FOUND**.
  - real `~/.codex/config.toml` shasum unchanged across the install.
- **Automated:** `codex-cache-install.test.ts`, `sync-lazycodex-marketplace.test.ts`, `npm-payload-containment.test.ts` (new/updated); `codex-cache-bundled-mcps.pin.test.ts` + `lazycodex-marketplace-validation.pin.test.ts` unchanged and green. 262 pass / 0 fail across the install + marketplace suites; tsgo typecheck green for `omo-codex` + `script`.
- **Why sufficient:** the fix removes a file, and the after-cache proof shows it gone while lsp stays fully functional (paths resolve + daemon boots), so the change is behavior-preserving for the surface Codex actually reads.

## Risks & Residuals
- Functionally harmless before and after (Codex never read the nested manifest); this is hardening that removes a confusing dangling artifact and prevents the "missing package" false alarm. Mitigated by the before/after cache proof.
- The marketplace validation's now-unreachable nested-manifest tolerance branch is left in place as harmless defensive code.
- Windows path handling not reproduced locally; covered by the existing `cli-suffix` tests and CI `codex-compatibility` (ubuntu/macos/windows).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the nested `components/lsp/.mcp.json` from Codex installs and marketplace bundles. Only the plugin-root `.mcp.json` ships, eliminating a dangling path that triggered “missing package” checks while keeping MCP loading unchanged.

- **Bug Fixes**
  - Cache installer: `shouldCopyPluginPath` now drops any nested component `.mcp.json` so only the root manifest is cached; install-dist regenerated.
  - Marketplace sync: applies the same rule; nested manifests are excluded from `plugins/omo`; tests updated to reflect the new invariant.
  - Packaging parity: added `packages/git-bash-mcp/package.json` to the root `files` list so every vendored MCP ships `package.json` alongside `dist`.

<sup>Written for commit 367d3b0078862fc9d475369f448c0deccba17f92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

