### PR TITLE
feat(omo-codex): size-drive the ulw worker-tier selection

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-high.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-high.toml
@@ -1,5 +1,5 @@
 name = "lazycodex-worker-high"
-description = "LazyCodex high-difficulty implementation worker: new modules or abstractions, cross-module refactors, and concurrency, security, or migration work. Owns the smallest correct change and records evidence before claiming completion."
+description = "LazyCodex high-difficulty implementation worker, sized for LARGE changes: a new module or abstraction, a cross-module refactor, concurrency/security/migration work, or any real, complex, big problem that has ONE clear goal. Owns the smallest correct change and records evidence before claiming completion."
 nickname_candidates = ["High Worker"]
 model = "gpt-5.6-sol"
 model_reasoning_effort = "max"

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-low.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-low.toml
@@ -1,5 +1,5 @@
 name = "lazycodex-worker-low"
-description = "LazyCodex low-difficulty implementation worker: single-spot fixes, boilerplate, config/copy changes, and pattern-following edits confined to one file. Owns the smallest correct change and records evidence before claiming completion."
+description = "LazyCodex low-difficulty implementation worker, sized for SMALL changes: single-spot fixes, boilerplate, config/copy changes, and pattern-following edits confined to one file. Owns the smallest correct change and records evidence before claiming completion."
 nickname_candidates = ["Low Worker"]
 model = "gpt-5.6-luna"
 model_reasoning_effort = "high"

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-medium.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-medium.toml
@@ -1,5 +1,5 @@
 name = "lazycodex-worker-medium"
-description = "LazyCodex medium-difficulty implementation worker: standard features inside existing layers, touching a few files along established patterns. Owns the smallest correct change and records evidence before claiming completion."
+description = "LazyCodex medium-difficulty implementation worker, sized for MID-SIZED changes: a standard feature inside existing layers, touching a few files along established patterns. Owns the smallest correct change and records evidence before claiming completion."
 nickname_candidates = ["Medium Worker"]
 model = "gpt-5.6-luna"
 model_reasoning_effort = "max"

--- a/packages/omo-codex/plugin/components/ulw-loop/skills/ulw-loop/references/full-workflow.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/skills/ulw-loop/references/full-workflow.md
@@ -42,7 +42,7 @@ Size each worker to the task. Put the intended role, rigor level, and specialty 
 | Deep debugging / race / perf / subtle cross-module reasoning | `TASK: act as a deep debugging worker. ...` |
 | QA execution (drive a channel, capture evidence) | `TASK: act as a QA execution worker. ...` |
 | Read-only codebase search | `TASK: act as an explorer. ...` |
-| Implementation — pick difficulty: LOW (one-file fix, boilerplate) / MEDIUM (standard feature, known patterns) / HIGH (new module, cross-module, concurrency/security/migration) | `TASK: act as a <low|medium|high>-difficulty implementation worker. ...` + `agent_type: "lazycodex-worker-<low|medium|high>"` when exposed |
+| Implementation — pick the tier by change SIZE: LOW small (one-file fix, boilerplate) / MEDIUM mid-sized (standard feature, a few files) / HIGH large (new module, cross-module, concurrency/security/migration, or a big complex problem with one clear goal) | `TASK: act as a <low|medium|high>-difficulty implementation worker. ...` + `agent_type: "lazycodex-worker-<low|medium|high>"` when exposed |
 | External library / docs research | `TASK: act as a librarian. ...` |
 | Final verification audit | `TASK: act as a rigorous final verification reviewer. ...` |
 


### PR DESCRIPTION
## Summary

Pick the ulw implementation worker tier by the **SIZE of the change**, and say so where the model actually reads it. Follows up the `lazycodex-executor` removal (#6049): now that execution routes only through `lazycodex-worker-{low,medium,high}`, the selection axis is made explicit.

## Changes

- **Worker agent descriptions** graded by size:
  - `worker-low` → **SMALL** (single-spot fixes, boilerplate, one-file edits)
  - `worker-medium` → **MID-SIZED** (a standard feature, a few files)
  - `worker-high` → **LARGE** (new module / cross-module / concurrency-security-migration, **or any real, complex, big problem with ONE clear goal**)
- **ulw-loop Delegation table** names the axis outright: "pick the tier by change SIZE" with small / mid-sized / large brackets.

`plan` (sol/max) and `metis` (sol/high) are already at the intended values on dev and are untouched.

## QA & Evidence

Evidence dir (gitignored, in the worktree): `.omo/evidence/20260712-ulw-size-tier-guidance/`

- Pinned phrases preserved (`<tier>-difficulty`, `smallest correct change`, `EVIDENCE_RECORDED`) and ulw-loop word budgets held (full-workflow 3930/3930, SKILL 668/680).
- `ulw-loop` vitest **398/0** (skill-contract budget green); plugin `node --test` roster (`aggregate-agents`) + context-hygiene green.
- Isolated codex install landing (`install-verify.sh --keep`): the installed worker TOMLs carry the SMALL/MID-SIZED/LARGE grading and the delegation table carries the size axis; real `~/.codex/config.toml` shasum unchanged before/after; isolated home removed.

## Notes

- Guidance lives where tier selection actually happens (the executor's Delegation table + the worker agent descriptions); ulw-plan is planner-only and does not spawn implementation workers, so it is not touched.
- The earlier-flagged directive drift is already resolved on current dev (`directive-source.test.ts` passes), so no directive sync is included here.

## Local-only test note

`component-bundled-cli.test.mjs` fails locally only (Bun 1.3.14 vs the CI-pinned 1.3.12 bundling); this change touches no CLI source (`git diff origin/dev` is TOML + markdown only), and CI builds with 1.3.12 where it passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route ULW implementation workers by change size (small, mid-sized, large) and make this explicit in agent descriptions and the `ulw-loop` delegation table. Clarifies when to use `lazycodex-worker-low`, `lazycodex-worker-medium`, or `lazycodex-worker-high`.

- **New Features**
  - Graded `lazycodex-worker-{low,medium,high}` by SMALL / MID-SIZED / LARGE; `-high` now also covers a big, complex problem with one clear goal.
  - Delegation table in `ulw-loop` now says “pick the tier by change SIZE” with clear examples.

<sup>Written for commit 9741e995a250575cafd5b5004e86e34eb07a2fc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

