### PR TITLE
fix(model-core): raise hephaestus sol default

### DIFF
--- a/packages/model-core/src/agent-model-requirements.ts
+++ b/packages/model-core/src/agent-model-requirements.ts
@@ -34,7 +34,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       {
         providers: ["openai", "vercel"],
         model: "gpt-5.6-sol",
-        variant: "medium",
+        variant: "high",
       },
       {
         providers: ["openai", "github-copilot", "opencode", "vercel"],

--- a/packages/model-core/src/model-requirements-agents.test.ts
+++ b/packages/model-core/src/model-requirements-agents.test.ts
@@ -268,7 +268,7 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(hephaestus.requiresAnyModel).toBe(true)
   })
 
-  test("hephaestus has gpt-5.6-sol medium as primary before gpt-5.5 medium", () => {
+  test("hephaestus has gpt-5.6-sol high as primary before gpt-5.5 medium", () => {
     // given
     const hephaestus = AGENT_MODEL_REQUIREMENTS["hephaestus"]
 
@@ -279,7 +279,7 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(primary).toEqual({
       providers: ["openai", "vercel"],
       model: "gpt-5.6-sol",
-      variant: "medium",
+      variant: "high",
     })
     expect(secondary).toEqual({
       providers: ["openai", "github-copilot", "opencode", "vercel"],

--- a/packages/omo-opencode/src/agents/utils.test.ts
+++ b/packages/omo-opencode/src/agents/utils.test.ts
@@ -1676,9 +1676,9 @@ describe("Deadlock prevention - fetchAvailableModels must not receive client", (
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - default "medium" variant is applied
+    // #then - default "high" variant is applied
     expect(agents.hephaestus).toBeDefined()
-    expect(agents.hephaestus.variant).toBe("medium")
+    expect(agents.hephaestus.variant).toBe("high")
     providerModelsSpy.mockRestore()
     connectedSpy.mockRestore()
     fetchSpy.mockRestore()

--- a/packages/omo-opencode/src/agents/utils.test.ts
+++ b/packages/omo-opencode/src/agents/utils.test.ts
@@ -1649,19 +1649,19 @@ describe("Deadlock prevention - fetchAvailableModels must not receive client", (
      cacheSpy.mockRestore?.()
    })
   test("Hephaestus variant override respects user config over hardcoded default", async () => {
-    // #given - user provides variant in config
+    // #given - user provides a non-default variant in config
     const providerModelsSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue(null)
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set())
     const overrides = {
-      hephaestus: { variant: "high" },
+      hephaestus: { variant: "medium" },
     }
 
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - user variant takes precedence over hardcoded "medium"
+    // #then - user variant takes precedence over hardcoded "high"
     expect(agents.hephaestus).toBeDefined()
-    expect(agents.hephaestus.variant).toBe("high")
+    expect(agents.hephaestus.variant).toBe("medium")
     providerModelsSpy.mockRestore()
     fetchSpy.mockRestore()
   })

--- a/packages/omo-opencode/src/cli/model-fallback.test.ts
+++ b/packages/omo-opencode/src/cli/model-fallback.test.ts
@@ -292,7 +292,7 @@ describe("generateModelConfig", () => {
 
       // #then
       expect(result.agents?.hephaestus?.model).toBe("openai/gpt-5.6-sol")
-      expect(result.agents?.hephaestus?.variant).toBe("medium")
+      expect(result.agents?.hephaestus?.variant).toBe("high")
     })
 
     test("Hephaestus falls back to Copilot GPT-5.5 when only Copilot is available", () => {


### PR DESCRIPTION
## Summary

Hephaestus now defaults to `openai/gpt-5.6-sol` at the `high` variant when OpenAI or the Vercel AI Gateway provides the primary fallback. The GPT-5.5 compatibility fallback remains `medium`, and explicit user variant overrides remain authoritative.

## Changes

- Updated the shared agent-model requirement that both runtime registration and installer config generation consume.
- Updated policy, runtime-resolution, and installer-resolution contracts for the new Sol/high default.

## QA & Evidence

- **RED -> GREEN policy proof:** The updated contracts failed against the previous medium policy, then passed after the one-line policy change. Artifact: `.omo/evidence/20260712-hephaestus-sol-high-default/red/targeted-contracts.log` and `.omo/evidence/20260712-hephaestus-sol-high-default/rebased-targeted-contracts.log`.
- **Real OpenCode surface:** Built the local plugin, loaded it through a `file://` entry under a fresh HOME/XDG sandbox, and queried `GET /agent`. The returned primary Hephaestus record has provider `openai`, model `gpt-5.6-sol`, and variant `high`. The host OpenCode DB session count was unchanged; the server listener and sandbox were removed. Artifact: `.omo/evidence/20260712-hephaestus-sol-high-default/surface/rebased/`.
- **Repository gates:** `bun run build`, `bun run typecheck`, and root `bun test` passed at the rebased commit. Root tests: 11,250 pass, 0 fail; the 2 tmux-live skips are pre-existing. Artifacts: `.omo/evidence/20260712-hephaestus-sol-high-default/rebased-{build,targeted-contracts,typecheck,root-bun-test}.log`.

## Risks & Residuals

The only behavior change is the primary Sol fallback's variant. The existing GPT-5.5 fallback remains medium and the explicit-override regression test stays green. No credentials, auth headers, or raw environment dumps are included in the evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise Hephaestus’s default to the high variant for `openai/gpt-5.6-sol` when OpenAI or the Vercel AI Gateway is the primary fallback. The GPT-5.5 compatibility fallback stays medium; user variant overrides still win, and tests were updated to cover this.

<sup>Written for commit 2c4c7f05b4a0c4bd7e5c43a83db59ea7126b7f8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

