### PR TITLE
fix(codex-rules): scope review-work gate to PR handoffs only

### DIFF
--- a/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.5.md
+++ b/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.5.md
@@ -74,7 +74,7 @@ Diagnostics catch type errors, not logic bugs; tests cover only what their autho
 
 # Global Review and Debugging Gate
 
-Before declaring significant work or a PR handoff complete, run `review-work` plus a `debugging` runtime audit; record three debugging hypotheses with runtime evidence each. Timeout, missing deliverable, ack-only, `BLOCKED:`, or inconclusive lanes fail the gate. Redact secrets, tokens, and PII from ledgers, PR bodies, and handoffs.
+Run `review-work` plus a `debugging` runtime audit only before a PR handoff or when the user asks for a review; lane pass/fail semantics live in those skills. For everything else, the gate above is the whole gate: once you have personally observed the artifact working, report your evidence. Redact secrets, tokens, and PII from ledgers, PR bodies, and handoffs.
 
 # Failure Recovery
 

--- a/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md
+++ b/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md
@@ -50,7 +50,7 @@ Diagnostics catch type errors, not logic bugs; tests cover only what their autho
 
 "This should work" from reading source does not pass. A defect found in usage is yours to fix this turn.
 
-Before declaring significant work or a PR handoff complete, run `review-work` plus a `debugging` runtime audit; record three debugging hypotheses with runtime evidence each. Timeout, missing deliverable, ack-only, `BLOCKED:`, or inconclusive lanes fail the gate. Redact secrets, tokens, and PII from ledgers, PR bodies, and handoffs.
+Run `review-work` plus a `debugging` runtime audit only before a PR handoff or when the user asks for a review; lane pass/fail semantics live in those skills. For everything else, the gate above is the whole gate: once you have personally observed the artifact working, report your evidence. Redact secrets, tokens, and PII from ledgers, PR bodies, and handoffs.
 
 # Failure Recovery
 

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5903,7 +5903,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.16.3",
+    version: "4.17.0",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",

--- a/packages/shared-skills/skills/review-work/SKILL.md
+++ b/packages/shared-skills/skills/review-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-work
-description: "Post-implementation review orchestrator. Launches 5 parallel background sub-agents: Oracle (goal/constraint verification), Oracle (code quality), Oracle (security), unspecified-high (hands-on QA execution), unspecified-high (context mining from GitHub/git/Slack/Notion). All must pass for review to pass. MUST USE after completing any significant implementation work. Triggers: 'review work', 'review my work', 'review changes', 'QA my work', 'verify implementation', 'check my work', 'validate changes', 'post-implementation review'."
+description: "Post-implementation review orchestrator. Launches 5 parallel background sub-agents: Oracle (goal/constraint verification), Oracle (code quality), Oracle (security), unspecified-high (hands-on QA execution), unspecified-high (context mining from GitHub/git/Slack/Notion). All must pass for review to pass. Use before a PR handoff or when the user asks to review completed work. Triggers: 'review work', 'review my work', 'review changes', 'QA my work', 'verify implementation', 'check my work', 'validate changes', 'post-implementation review'."
 ---
 ## Codex Harness Tool Compatibility
 

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/review-work.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/review-work.ts
@@ -4,6 +4,6 @@ import type { BuiltinSkill } from "../types"
 export const reviewWorkSkill: BuiltinSkill = {
 	name: "review-work",
 	description:
-		"Post-implementation review orchestrator. Launches 5 parallel background sub-agents: Oracle (goal/constraint verification), Oracle (code quality), Oracle (security), unspecified-high (hands-on QA execution), unspecified-high (context mining from GitHub/git/Slack/Notion). All must pass for review to pass. MUST USE after completing any significant implementation work. Triggers: 'review work', 'review my work', 'review changes', 'QA my work', 'verify implementation', 'check my work', 'validate changes', 'post-implementation review'.",
+		"Post-implementation review orchestrator. Launches 5 parallel background sub-agents: Oracle (goal/constraint verification), Oracle (code quality), Oracle (security), unspecified-high (hands-on QA execution), unspecified-high (context mining from GitHub/git/Slack/Notion). All must pass for review to pass. Use before a PR handoff or when the user asks to review completed work. Triggers: 'review work', 'review my work', 'review changes', 'QA my work', 'verify implementation', 'check my work', 'validate changes', 'post-implementation review'.",
 	template: loadSharedSkillTemplate("review-work"),
 }


### PR DESCRIPTION
## Summary

Scopes the Hephaestus review-work gate from a fuzzy "significant work" trigger to concrete observable conditions (PR handoff or explicit user request). Prevents GPT-5.6 from spawning 5 reviewer subagents — and retrying failed lanes on alternative models — for simple conversational fixes where direct observation already proves the work is done.

## Changes

- **Bundled rules (gpt-5.5.md, gpt-5.6.md):** Replaced the Manual QA Gate's review-work mandate sentence. The new phrasing ties the review/debugging audit to PR handoffs and explicit requests only; removes duplicate lane-failure semantics (already defined in the review-work skill); makes the personal-observation gate the sole completion gate for non-PR work.
- **review-work skill description:** Replaced "MUST USE after completing any significant implementation work" with "Use before a PR handoff or when the user asks to review completed work" — eliminates the independent reinforcement path that also triggers over-compliance.

## QA & Evidence

- **What was tested:** Full typecheck (`bun run typecheck`) and test suite (`bun test`) in the worktree.
- **Observed result:** Typecheck clean. 11,248 tests pass; 2 pre-existing failures (`shared builtin skill extraction`) unrelated to this change.
- **Why sufficient:** These are prompt-only markdown edits to bundled rules and a skill description. No code paths, hooks, or runtime behavior changed — the behavioral change is in model prompting, which was diagnosed from a real failing session transcript (019f556b-1081-7980-9861-bc60444fa3f2) where the model spawned 5 review subagents + retried 2 on gpt-5.4 for a simple process-kill fix.

## Risks & Residuals

- **Risk: PR handoffs lose the review gate.** Mitigated — the new phrasing preserves review-work for PR handoffs explicitly.
- **Risk: Users who want the full review for non-PR work lose it silently.** Mitigated — "or when the user asks for a review" preserves the opt-in path.
- **Risk: The review-work skill body still defines 5-lane semantics.** Accepted — that's correct; the skill body is the right place for those semantics, not the bundled rules file.

## Related Issues

Diagnosed from Codex session `019f556b-1081-7980-9861-bc60444fa3f2` (2026-07-12) where a "please fix this SQLite startup error" request escalated into a 5-lane review fan-out with 503 retries on an alternative model.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the Hephaestus review gate to PR handoffs or explicit user requests to stop auto-running the heavy 5-lane review on small fixes. Keeps the personal-observation gate as the default for non-PR work.

- **Bug Fixes**
  - Hephaestus bundled rules (`gpt-5.5`, `gpt-5.6`): run `review-work` + `debugging` only before PR handoffs or on explicit request; removed duplicate lane-failure wording.
  - `review-work` skill: updated description in `SKILL.md` and loader to match the new trigger.

- **Dependencies**
  - Bumped `@oh-my-opencode/omo-codex` to 4.17.0 in the local installer.

<sup>Written for commit d5fa06820e35c02720f26521e4d8507f2c918ba8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

