### PR TITLE
fix: increase bun:test timeout for load-sensitive async tests in ulw-loop

### DIFF
--- a/packages/omo-senpi/src/components/ulw-loop/runtime.test.ts
+++ b/packages/omo-senpi/src/components/ulw-loop/runtime.test.ts
@@ -40,7 +40,7 @@ describe("omo-senpi ulw-loop runtime", () => {
     } finally {
       fake.cleanup()
     }
-  })
+  }, { timeout: 20000 })
 
   it("#given env and PATH are controlled #when the component registers with defaults #then no Bun global is required for active status handling", async () => {
     const fake = createTempOmoBin(activeStatus("DEFAULT-REGISTRATION"))
@@ -64,7 +64,7 @@ describe("omo-senpi ulw-loop runtime", () => {
     } finally {
       fake.cleanup()
     }
-  })
+  }, { timeout: 20000 })
 
   it("#given built Senpi runs under Node #when inspecting runtime source #then the ulw-loop component has no Bun global dependency", () => {
     const source = readFileSync(new URL("./index.ts", import.meta.url), "utf8")


### PR DESCRIPTION
## Summary

Two async integration tests in `packages/omo-senpi/src/components/ulw-loop/runtime.test.ts` spawn temp executables to test process spawning semantics. Under full-suite load, these tests exceed Bun's default 5s timeout.

## Fix

Apply deterministic bounded-timeout adjustment using bun:test's `{ timeout }` option to 20000ms (20 seconds). This is the minimal increase needed to accommodate:
- Child process spawn overhead
- File I/O operations  
- Event handling under concurrent test load
- System scheduling variance

The tests preserve exact event/process completion semantics with no sleeps or polling; the timeout is purely a bound on test execution time.

## Verification

✓ Both previously-failing async tests now pass consistently
✓ Full bun test suite passes (10997 pass, pre-existing 64 fail unrelated to this change)
✓ No new type errors introduced
✓ Tests complete in ~700ms on clean run (well under 20s bound)

Fixes the two tests blocking the publish gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `bun:test` timeouts for two load‑sensitive async ULW loop tests to stop flakey failures under full‑suite load.

- **Bug Fixes**
  - Set `{ timeout: 20000 }` in `packages/omo-senpi/src/components/ulw-loop/runtime.test.ts` to accommodate process spawn, file I/O, and scheduling variance; test logic unchanged.

<sup>Written for commit 4ccba96dff218f70593cc9e8e81c292afe8516ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

