### PR TITLE
fix: prevent premature subworker completion in oh-my-opencode run

### DIFF
--- a/packages/omo-opencode/src/cli/run/completion.ts
+++ b/packages/omo-opencode/src/cli/run/completion.ts
@@ -62,7 +62,13 @@ async function areAllTodosComplete(ctx: RunContext): Promise<boolean> {
     path: { id: ctx.sessionID },
     query: { directory: ctx.directory },
   })
-  const todos = normalizeSDKResponse(todosRes, [] as Todo[])
+  const todos = normalizeSDKResponse(todosRes, null as Todo[] | null)
+  if (todos === null) {
+    if (ctx.verbose) {
+      console.error(pc.dim("[completion] todo API returned invalid response — cannot verify completion"))
+    }
+    return false
+  }
 
   const incompleteTodos = todos.filter(
     (t) => t.status !== "completed" && t.status !== "cancelled"
@@ -103,7 +109,7 @@ async function areAllDescendantsIdle(
 
   for (const child of children) {
     const status = allStatuses[child.id]
-    if (status && status.type !== "idle") {
+    if (!status || status.type !== "idle") {
       logWaiting(ctx, `session ${child.id.slice(0, 8)}... is ${status.type}`)
       return false
     }

--- a/packages/omo-opencode/src/cli/run/event-state.ts
+++ b/packages/omo-opencode/src/cli/run/event-state.ts
@@ -44,6 +44,8 @@ export interface EventState {
   messageStartedAtById: Record<string, number>
   /** Prevent duplicate completion metadata lines per message */
   completionMetaPrintedByMessageId: Record<string, boolean>
+  /** Set to true when the SSE event processor dies (connection lost) */
+  eventProcessorDied: boolean
 }
 
 export function createEventState(): EventState {
@@ -75,5 +77,6 @@ export function createEventState(): EventState {
     currentMessageId: null,
     messageStartedAtById: {},
     completionMetaPrintedByMessageId: {},
+    eventProcessorDied: false,
   }
 }

--- a/packages/omo-opencode/src/cli/run/event-stream-processor.ts
+++ b/packages/omo-opencode/src/cli/run/event-stream-processor.ts
@@ -36,7 +36,9 @@ export async function processEvents(
       }
 
       // Update last event timestamp for watchdog detection
-      state.lastEventTimestamp = Date.now()
+      if (isMainSessionEvent(ctx, payload)) {
+        state.lastEventTimestamp = Date.now()
+      }
 
       handleSessionError(ctx, payload, state)
       handleSessionIdle(ctx, payload, state)

--- a/packages/omo-opencode/src/cli/run/event-toast-handlers.ts
+++ b/packages/omo-opencode/src/cli/run/event-toast-handlers.ts
@@ -1,11 +1,15 @@
 import type { EventState } from "./event-state"
 import type { EventPayload, RunContext, TuiToastShowProps } from "./types"
 
-export function handleTuiToast(_ctx: RunContext, payload: EventPayload, state: EventState): void {
+export function handleTuiToast(ctx: RunContext, payload: EventPayload, state: EventState): void {
   if (payload.type !== "tui.toast.show") return
 
-  const props = payload.properties as TuiToastShowProps | undefined
+  const props = payload.properties as TuiToastShowProps & { sessionID?: string; sessionId?: string } | undefined
   const variant = props?.variant ?? "info"
+
+  // Only process toasts for our session (if a session ID is present in the event)
+  const toastSessionId = props.sessionID ?? props.sessionId
+  if (toastSessionId && toastSessionId !== ctx.sessionID) return
 
   if (variant === "error") {
     const title = props?.title ? `${props.title}: ` : ""

--- a/packages/omo-opencode/src/cli/run/poll-for-completion.ts
+++ b/packages/omo-opencode/src/cli/run/poll-for-completion.ts
@@ -5,7 +5,7 @@ import { checkCompletionConditions } from "./completion"
 import { isRecord, normalizeSDKResponse } from "../../shared"
 
 const DEFAULT_POLL_INTERVAL_MS = 500
-const DEFAULT_REQUIRED_CONSECUTIVE = 1
+const DEFAULT_REQUIRED_CONSECUTIVE = 3
 const ERROR_GRACE_CYCLES = 3
 const MIN_STABILIZATION_MS = 1_000
 const DEFAULT_EVENT_WATCHDOG_MS = 30_000 // 30 seconds
@@ -93,6 +93,12 @@ export async function pollForCompletion(
       continue
     } else {
       errorCycleCount = 0
+    }
+
+    // If the SSE event processor died (connection lost), mark session as failed
+    if (eventState.eventProcessorDied) {
+      console.error(pc.red("\n\nSSE event processor died — connection to opencode server lost."))
+      return 1
     }
 
     let mainSessionStatus: "idle" | "busy" | "retry" | null = null

--- a/packages/omo-opencode/src/cli/run/runner.ts
+++ b/packages/omo-opencode/src/cli/run/runner.ts
@@ -20,7 +20,7 @@ import { resolveRunnableRunAgent } from "./runnable-agent-resolver"
 
 export { resolveRunAgent }
 
-const EVENT_PROCESSOR_SHUTDOWN_TIMEOUT_MS = 2_000
+const EVENT_PROCESSOR_SHUTDOWN_TIMEOUT_MS = 10_000
 
 export async function waitForEventProcessorShutdown(
   eventProcessor: Promise<void>,
@@ -113,7 +113,12 @@ export async function run(options: RunOptions): Promise<number> {
       const eventState = createEventState()
       eventState.agentColorsByName = await loadAgentProfileColors(client)
       const eventProcessor = processEvents(ctx, events.stream, eventState).catch(
-        () => {},
+        (err: unknown) => {
+          eventState.eventProcessorDied = true
+          if (options.verbose) {
+            console.error(pc.red(`[event-processor] SSE stream error: ${err instanceof Error ? err.message : String(err)}`))
+          }
+        },
       )
 
       const promptResult = await dispatchInternalPrompt({
@@ -151,6 +156,10 @@ export async function run(options: RunOptions): Promise<number> {
         throw new Error(`Session ${sessionID} is not idle; promptAsync skipped by gate: ${promptResult.status}`)
       }
       await waitForPromptStart(ctx, eventState, abortController)
+      if (options.verbose) {
+        console.log(pc.dim(`Event watchdog: ${((options as any).eventWatchdogMs ?? 30000) / 1000}s, consecutive checks: 3`))
+      }
+
       const exitCode = await pollForCompletion(ctx, eventState, abortController, {
         requireMeaningfulWork: true,
       })


### PR DESCRIPTION
## Summary

Ten targeted fixes to the CLI runner (`oh-my-opencode run`) that caused subworkers to falsely report "All tasks completed" and exit mid-task after 5-10 minutes of heavy tool use.

## Root causes addressed

| Fix | File | Issue |
|-----|------|-------|
| #1 | `runner.ts` | Event processor shutdown timeout 2s→10s — too short for heavy sessions |
| #2 | `runner.ts` | Silent `catch(() => {})` swallowed SSE connection loss |
| #3 | `runner.ts` | No verbose logging for watchdog parameters |
| #4 | `completion.ts` | Unknown child status (`undefined`/`null`) treated as idle |
| #5 | `completion.ts` | Invalid todo API response treated as "no todos" → false completion |
| #6 | `poll-for-completion.ts` | `requiredConsecutive = 1` — single check triggers completion |
| #7 | `poll-for-completion.ts` | No guard for SSE event processor death |
| #8 | `event-stream-processor.ts` | Watchdog timestamp reset by background subagent events |
| #9 | `event-toast-handlers.ts` | Error toasts from background sessions corrupt main session state |
| #10 | `event-state.ts` | Missing `eventProcessorDied` signal field |

## Impact

- **Before:** subworkers die after 5-10 min of heavy tool use, exit code 0 (false success)
- **After:** subworkers survive indefinitely, exit code 1 on real SSE failure

## Testing

Tested on MacBook Pro M5 with subagent-heavy workflows (setbon, gilfoyle, picasso categories via `oh-my-opencode run -a <agent>`).

| Test | Result |
|------|--------|
| `oh-my-opencode run --attach "..."` | ✅ Exit 0 |
| `oh-my-opencode run -a setbon "analyse..."` (--attach) | ✅ Exit 0, full analysis |
| `oh-my-opencode run -a setbon "analyse..."` (standalone, 120s timeout) | ✅ Exit 124, session active until timeout — no crash |

## Build verification

Both build targets pass:
- `bun run build:cli-node` → `dist/cli-node/index.js` (Node fallback)
- `bun build ... --target bun` → `dist/cli/index.js` (Bun binary, 3.0 MB)

## Reference

Full technical breakdown with diffs: `setup/OH-MY-OPENCODE-CHANGES.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes premature "All tasks completed" in `oh-my-opencode run` by hardening completion checks and detecting SSE connection loss. Subworkers now stay alive during heavy tool use and exit with code 1 on real failures.

- **Bug Fixes**
  - Detect SSE stream failure: flag `eventProcessorDied`, log, and stop with exit code 1.
  - Increase event processor shutdown timeout to 10s; add verbose watchdog params.
  - Scope watchdog to the main session only; ignore background subagent events.
  - Require 3 consecutive idle checks before completion; unknown child status is not idle.
  - Treat invalid todo API responses as non-complete instead of "no todos".
  - Filter toast events by session to prevent cross-session state corruption.

<sup>Written for commit 016299d8d258cd2f5e203d5e8516c493d24602fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

