### PR TITLE
fix(config): publish input-safe reconcile schema

### DIFF
--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -373,6 +373,9 @@
         "state_dir": {
           "type": "string"
         },
+        "reattach_on_reconcile": {
+          "type": "boolean"
+        },
         "wait": {
           "default": {
             "min_ms": 5000,

--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -403,11 +403,6 @@
               "maximum": 9007199254740991
             }
           },
-          "required": [
-            "min_ms",
-            "default_ms",
-            "max_ms"
-          ],
           "additionalProperties": false
         },
         "team": {
@@ -437,23 +432,9 @@
               "maximum": 9007199254740991
             }
           },
-          "required": [
-            "max_members",
-            "max_parallel_members",
-            "max_wall_clock_minutes"
-          ],
           "additionalProperties": false
         }
       },
-      "required": [
-        "default_execution_mode",
-        "default_concurrency",
-        "max_depth",
-        "residency_max_children",
-        "ttl_ms",
-        "wait",
-        "team"
-      ],
       "additionalProperties": false
     },
     "teams": {
@@ -550,8 +531,6 @@
                   },
                   "required": [
                     "name",
-                    "backendType",
-                    "isActive",
                     "kind",
                     "category",
                     "prompt"
@@ -607,8 +586,6 @@
                   },
                   "required": [
                     "name",
-                    "backendType",
-                    "isActive",
                     "kind",
                     "subagent_type"
                   ],
@@ -619,7 +596,6 @@
           }
         },
         "required": [
-          "version",
           "members"
         ],
         "additionalProperties": false

--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -598,7 +598,28 @@
         "required": [
           "members"
         ],
-        "additionalProperties": false
+        "additionalProperties": false,
+        "if": {
+          "properties": {
+            "members": {
+              "type": "array",
+              "minItems": 2
+            }
+          },
+          "required": [
+            "members"
+          ]
+        },
+        "then": {
+          "properties": {
+            "leadAgentId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "leadAgentId"
+          ]
+        }
       }
     }
   },

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
         "@typescript/native-preview": "7.0.0-dev.20260518.1",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/xterm": "^6.0.0",
+        "ajv": "8.20.0",
         "bun-types": "1.3.14",
         "node-pty": "^1.1.0",
         "puppeteer-core": "^25.3.0",

--- a/docs/reference/omo-json.md
+++ b/docs/reference/omo-json.md
@@ -138,6 +138,7 @@ Task engine settings; every field has a default, so the whole object is optional
 | `residency_max_children` | positive int | `8` |
 | `ttl_ms` | positive int | `86400000` (24h) |
 | `state_dir` | string | unset (defaults to `<project>/.omo/senpi-task`) |
+| `reattach_on_reconcile` | boolean | unset (reattach enabled unless explicitly `false`) |
 | `wait.min_ms` | positive int | `5000` |
 | `wait.default_ms` | positive int | `60000` |
 | `wait.max_ms` | positive int | `600000` |
@@ -145,7 +146,7 @@ Task engine settings; every field has a default, so the whole object is optional
 | `team.max_parallel_members` | int 1..8 | `4` |
 | `team.max_wall_clock_minutes` | positive int | `120` |
 
-`state_dir` defaults to `<project_dir>/.omo/senpi-task` when unset (`packages/senpi-task/src/store/state-dir.ts`). Completion delivery is not configurable: every child completion is batched with any other ready notifications and steered into the parent's running turn at the next tool-call boundary; see the completion routing table in [`packages/senpi-task/AGENTS.md`](../../packages/senpi-task/AGENTS.md).
+`state_dir` defaults to `<project_dir>/.omo/senpi-task` when unset (`packages/senpi-task/src/store/state-dir.ts`). `reattach_on_reconcile` defaults to enabled behavior: durable process tasks with a persisted session are respawned and rebound during reconciliation; set it to `false` only to retain the legacy lost-task behavior. Completion delivery is not configurable: every child completion is batched with any other ready notifications and steered into the parent's running turn at the next tool-call boundary; see the completion routing table in [`packages/senpi-task/AGENTS.md`](../../packages/senpi-task/AGENTS.md).
 
 ### `teams`
 
@@ -219,6 +220,5 @@ This is deliberate: `omo.json` landed **senpi-first**. Adopting it in the OpenCo
 
 ## Follow-ups
 
-- No generated `assets/omo.schema.json` artifact or published `$schema` URL exists yet; the `$schema` key is accepted but points at nothing shipped in this repo.
 - `member.backendType: "tmux"` and non-project (user-global) team storage are schema-level only and are not exercised by the current Senpi runtime; use `in-process` members in project `.omo/` teams.
 - OpenCode-edition adoption of `omo.json` and a `oh-my-openagent.json` migration path are not implemented.

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260518.1",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/xterm": "^6.0.0",
+    "ajv": "8.20.0",
     "bun-types": "1.3.14",
     "node-pty": "^1.1.0",
     "puppeteer-core": "^25.3.0",

--- a/packages/omo-config-core/AGENTS.md
+++ b/packages/omo-config-core/AGENTS.md
@@ -64,7 +64,10 @@ bun test packages/omo-config-core
 
 Co-located `*.test.ts` cover the schema (`src/schema/config-schema.test.ts`), the loader precedence and diagnostics (`src/loader/loader.test.ts`), the deep-merge and pollution guard (`src/loader/merge.test.ts`), and the writer plus its symlink/atomicity security path (`src/writer/writer.test.ts`, `src/writer/writer-security.test.ts`). Parent: [`packages/AGENTS.md`](../AGENTS.md).
 
+## GENERATED SCHEMA
+
+- `assets/omo.schema.json` is generated from `OmoConfigSchema` by `bun run build:omo-schema`; `tests/omo-schema-freshness.test.ts` enforces byte freshness and the documented raw dev-branch URL at `https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/omo.schema.json`.
+
 ## FOLLOW-UPS
 
-- A generated `assets/omo.schema.json` artifact and a documented `$schema` URL are a separate task (the schema already accepts and ignores a `$schema` string key at `src/schema/config.ts:8`). Until it lands, do not reference a checked-in JSON schema file.
 - The category schema must stay in field parity with `packages/omo-opencode/src/config/schema/categories.ts`; a drift guard belongs with the OpenCode-migration phase, not here.

--- a/script/build-omo-schema-document.ts
+++ b/script/build-omo-schema-document.ts
@@ -7,6 +7,7 @@ export const OMO_SCHEMA_ID =
 export function createOmoJsonSchema(): Record<string, unknown> {
   const jsonSchema = z.toJSONSchema(OmoConfigSchema, {
     target: "draft-7",
+    io: "input",
     unrepresentable: "any",
   }) as Record<string, unknown>
 

--- a/script/build-omo-schema-document.ts
+++ b/script/build-omo-schema-document.ts
@@ -4,12 +4,35 @@ import { OmoConfigSchema } from "../packages/omo-config-core/src/schema"
 export const OMO_SCHEMA_ID =
   "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/omo.schema.json"
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function addTeamLeadAgentRequirement(schema: Record<string, unknown>): void {
+  const properties = isRecord(schema.properties) ? schema.properties : undefined
+  const teams = isRecord(properties?.teams) ? properties.teams : undefined
+  const teamSpec = isRecord(teams?.additionalProperties) ? teams.additionalProperties : undefined
+  if (teamSpec === undefined) {
+    throw new Error("generated omo schema is missing the teams specification")
+  }
+
+  teamSpec.if = {
+    properties: { members: { type: "array", minItems: 2 } },
+    required: ["members"],
+  }
+  Reflect.set(teamSpec, "then", {
+    properties: { leadAgentId: { type: "string" } },
+    required: ["leadAgentId"],
+  })
+}
+
 export function createOmoJsonSchema(): Record<string, unknown> {
   const jsonSchema = z.toJSONSchema(OmoConfigSchema, {
     target: "draft-7",
     io: "input",
     unrepresentable: "any",
   }) as Record<string, unknown>
+  addTeamLeadAgentRequirement(jsonSchema)
 
   return {
     $schema: "http://json-schema.org/draft-07/schema#",

--- a/tests/omo-schema-freshness.test.ts
+++ b/tests/omo-schema-freshness.test.ts
@@ -26,6 +26,20 @@ function createCommittedSchemaValidator(): ReturnType<Ajv["compile"]> {
   return new Ajv({ strict: true }).compile(schema)
 }
 
+function createTwoMemberTeamConfig(leadAgentId?: string): unknown {
+  return {
+    teams: {
+      builders: {
+        ...(leadAgentId === undefined ? {} : { leadAgentId }),
+        members: [
+          { name: "lead", kind: "category", category: "quick", prompt: "Lead" },
+          { name: "member", kind: "subagent_type", subagent_type: "sisyphus" },
+        ],
+      },
+    },
+  }
+}
+
 describe("omo schema freshness", () => {
   test("#given the current Zod schema #when regenerated #then it matches the committed artifact", () => {
     // given
@@ -98,6 +112,47 @@ describe("omo schema freshness", () => {
     // then
     expect(valid).toBe(false)
     expect(validate.errors?.some((error) => error.keyword === "additionalProperties")).toBe(true)
+  })
+
+  test("#given a multi-member team without a lead #when validated #then runtime and shipped schemas reject it", () => {
+    // given
+    const validate = createCommittedSchemaValidator()
+    const config = createTwoMemberTeamConfig()
+
+    // when
+    const runtimeResult = OmoConfigSchema.safeParse(config)
+    const artifactResult = validate(config)
+
+    // then
+    expect(runtimeResult.success).toBe(false)
+    if (runtimeResult.success) throw new Error("Expected runtime team validation to fail")
+    expect(runtimeResult.error.issues.some((issue) => issue.path.join(".") === "teams.builders.leadAgentId")).toBe(
+      true,
+    )
+    expect(artifactResult).toBe(false)
+    expect(
+      validate.errors?.some(
+        (error) =>
+          error.keyword === "required" &&
+          error.instancePath === "/teams/builders" &&
+          error.params.missingProperty === "leadAgentId",
+      ),
+    ).toBe(true)
+  })
+
+  test("#given a multi-member team with a lead #when validated #then runtime and shipped schemas accept it", () => {
+    // given
+    const validate = createCommittedSchemaValidator()
+    const config = createTwoMemberTeamConfig("lead")
+
+    // when
+    const runtimeResult = OmoConfigSchema.safeParse(config)
+    const artifactResult = validate(config)
+
+    // then
+    expect(runtimeResult.success).toBe(true)
+    if (!artifactResult) throw new Error(JSON.stringify(validate.errors))
+    expect(artifactResult).toBe(true)
   })
 
   test("#given the docs example #when read #then it points at the documented dev-branch schema URL", () => {

--- a/tests/omo-schema-freshness.test.ts
+++ b/tests/omo-schema-freshness.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { describe, expect, test } from "bun:test"
+import Ajv from "ajv"
 import { OmoConfigSchema } from "../packages/omo-config-core/src/schema"
 import { createOmoJsonSchema } from "../script/build-omo-schema-document"
 
@@ -15,6 +16,14 @@ function extractSchemaExample(markdown: string): unknown {
     if (body.includes("\"$schema\"")) return JSON.parse(body)
   }
   throw new Error("no $schema-bearing json example found in omo-json.md")
+}
+
+function createCommittedSchemaValidator(): ReturnType<Ajv["compile"]> {
+  const schema: unknown = JSON.parse(readFileSync(SCHEMA_PATH, "utf-8"))
+  if (typeof schema !== "object" || schema === null) {
+    throw new Error("assets/omo.schema.json must contain a JSON object")
+  }
+  return new Ajv({ strict: true }).compile(schema)
 }
 
 describe("omo schema freshness", () => {
@@ -39,6 +48,56 @@ describe("omo schema freshness", () => {
     // then
     expect(result.success).toBe(true)
     if (!result.success) throw new Error(result.error.message)
+  })
+
+  test("#given a minimal task opt-out #when validated by the shipped schema #then defaulted siblings remain optional", () => {
+    // given
+    const validate = createCommittedSchemaValidator()
+    const config = { task: { reattach_on_reconcile: false } }
+
+    // when
+    const valid = validate(config)
+
+    // then
+    if (!valid) throw new Error(JSON.stringify(validate.errors))
+    expect(valid).toBe(true)
+  })
+
+  test("#given the documented partial omo.json #when validated by the shipped schema #then it validates", () => {
+    // given
+    const validate = createCommittedSchemaValidator()
+    const example = extractSchemaExample(readFileSync(DOC_PATH, "utf-8"))
+
+    // when
+    const valid = validate(example)
+
+    // then
+    if (!valid) throw new Error(JSON.stringify(validate.errors))
+    expect(valid).toBe(true)
+  })
+
+  test("#given an unknown task key #when validated by the shipped schema #then strictness is retained", () => {
+    // given
+    const validate = createCommittedSchemaValidator()
+    const config = {
+      task: {
+        default_execution_mode: "in-process",
+        default_concurrency: 5,
+        max_depth: 1,
+        residency_max_children: 8,
+        ttl_ms: 86400000,
+        wait: { min_ms: 5000, default_ms: 60000, max_ms: 600000 },
+        team: { max_members: 8, max_parallel_members: 4, max_wall_clock_minutes: 120 },
+        unexpected: true,
+      },
+    }
+
+    // when
+    const valid = validate(config)
+
+    // then
+    expect(valid).toBe(false)
+    expect(validate.errors?.some((error) => error.keyword === "additionalProperties")).toBe(true)
   })
 
   test("#given the docs example #when read #then it points at the documented dev-branch schema URL", () => {


### PR DESCRIPTION
## Summary

This PR publishes the existing `task.reattach_on_reconcile` setting in the generated `omo.json` schema and reference, then closes two exact-head review findings in the generated Draft-07 contract.

The final artifact now models runtime input semantics for defaulted task fields and the runtime-only multi-member team lead rule. Partial task configs and explicit `false` validate, unknown keys remain rejected, and teams with more than one member require a string `leadAgentId` exactly as `OmoTeamSpecSchema` does.

Exact reviewed head: `5466623d3752775dff050a93d67784a08db5715f`.

## Changes

- Publish `task.reattach_on_reconcile` in the generated artifact and reference docs.
- Generate Draft-07 with `io: "input"`, keeping Zod-defaulted properties optional to callers while retaining strict objects and genuinely required fields.
- Compile the exact committed artifact with Ajv 8 in regression tests.
- Cover minimal explicit-false input, the documented partial config, and unknown task-key rejection.
- Encode the `OmoTeamSpecSchema.superRefine()` rule with Draft-07 `if`/`then`: when `members` has at least two entries, `leadAgentId` is required and typed as a string.
- Preserve current runtime policy: a present string lead is accepted even when it does not match a member name.
- Document the generated artifact, freshness gate, and raw dev URL in the owning config package instruction.

## QA & Evidence

### RED/PIN: multi-member lead parity

- **What was tested:** strict Ajv validation of the exact committed artifact beside `OmoConfigSchema.safeParse()` for two valid team members.
- **Observed result before the final correction:** runtime rejected the no-lead input while the artifact accepted it; focused result was `7` pass / `1` fail. The same input with `leadAgentId: "lead"` was accepted by both, pinning valid behavior.
- **Artifact:** `.omo/evidence/20260713-c15-schema-artifact/p0-c15-red-lead-agent-conditional.txt` (`563ec29f...`).
- **Why sufficient:** it reproduces the sole code-quality blocker through the machine-consumed shipped schema, not a shape-only assertion.

### GREEN: focused artifact/runtime contract

- **What was tested:** the exact current `tests/omo-schema-freshness.test.ts`.
- **Observed result:** `8/8` passed, including byte freshness, partial-input acceptance, unknown-key rejection, no-lead rejection in both validators, and with-lead acceptance in both validators.
- **Artifact:** `.omo/evidence/20260713-c15-schema-artifact/p0-c15-green-lead-agent-conditional-v5.txt` (`9d0deda9...`).
- **Why sufficient:** the same assertion that failed before the generator change now passes against committed bytes.

### Six-case team matrix

- **What was tested:** single/no lead, two/no lead, two/with lead, two/unmatched string lead, wrong lead type, and unknown team key.
- **Observed result:** runtime Zod and committed Ajv agreed in all six cases.
- **Artifact:** `.omo/evidence/20260713-c15-schema-artifact/p0-c15-team-runtime-artifact-matrix-green.txt` (`655ec22d...`).
- **Why sufficient:** it covers the conditional boundary, current permissive lead-value policy, type safety, and strict objects.

### Original input-schema correction

- **Failing-first result:** minimal `{ task: { reattach_on_reconcile: false } }` and the documented partial config were rejected by the output-mode artifact because defaulted siblings were required.
- **GREEN result:** config/generator matrix `35/35`; runtime/artifact input matrix PASS; Senpi reconcile/config matrix `14/14`.
- **Artifacts:** `p0-c15-red-ajv-partial-inputs.txt`, `p0-c15-config-generator-green-v3.txt`, `p0-c15-runtime-artifact-matrix-green.txt`, and `p0-c15-senpi-reconcile-green-v3.txt`.

### Repository gates

- Biome: clean on both changed TypeScript files.
- No-excuse audit: zero violations.
- Pure LOC: generator `38`, regression test `118`.
- `bun run typecheck`: passed repository-wide on the exact current tree.
- `bun run build`: passed; unrelated installer ordering drift was captured and restored.
- Rebuilt `bun test`: `11,361` pass, `2` pre-existing live-tmux skips, `0` fail across `1,459` files.
- Deterministic generation: repeated and committed schema SHA-256 `ada764a80801b56cbc00195485b9e1c69791dbbad3ca3cd0436436c931d3058a`.
- Terminal audit: exact seven-file PR scope, exact three-file final correction, valid JSON, clean diff, zero secret/skip/suppression additions, and zero owned process/tmux/temp residue.

Reviewer-readable summary: `.omo/evidence/20260713-c15-schema-artifact/summary-v3.md`.

Verified SHA manifest: `.omo/evidence/20260713-c15-schema-artifact/p0-c15-sha256-v5.txt`, `142/142` artifacts verified; index SHA-256 `d01c86f342aa2137548c873c6d0e1e28e4f74f4a8b0338e3d6de67731befc0a9`.

## Risks & Residuals

- **Runtime/artifact drift:** mitigated by strict Ajv validation of exact committed bytes and direct Zod/Ajv parity scenarios.
- **Generated-schema limitation:** Zod `superRefine()` is not represented automatically, so the generator has a focused structured post-process. The freshness/parity regression fails closed if that seam moves or the rule disappears.
- **Lead identity policy:** intentionally unchanged; the artifact and runtime both accept any present string lead.
- **Harness QA:** no OpenCode/Codex hook, tool, installer behavior, or runtime plugin path changed in P0. Release-wide live OpenCode and Codex QA remains mandatory before `4.17.1` publication.
- **Root suite timing:** the root suite preceded the last test-only error-path assertion refinement. Production code and schema bytes were unchanged afterward; focused tests, Biome, no-excuse, LOC, repository typecheck, deterministic generation, and the final audit were rerun on the exact current tree.

## Review State

At `d75722d42`, Goal, QA, Security, and History/Context passed. Code Quality failed only because the committed artifact accepted a two-member team without `leadAgentId`. Commit `5466623d3` is the failing-first correction for that exact blocker. All five exact-head lanes now pass unconditionally. GitHub checks have zero pending or failing results. Cubic is SKIPPED (quota exhausted), not approved: its neutral check says the monthly review line limit is reached, with reviews resuming August 1, 2026; it posted zero reviews, issue comments, inline comments, or annotations.

## Commit Structure

- `3cedf00c6` fix(config): publish reconcile reattach schema
- `58a0cd010` test(config): add Ajv schema validator
- `c2d6f31ad` fix(config): generate input-safe omo schema
- `d75722d42` docs(config): document omo schema ownership
- `5466623d3` fix(config): preserve team lead schema parity

## Release Context

This is the P0 prerequisite for the guarded OMO `4.17.1` correction train. It targets `release/4.17.1-corrections` and must merge before P1 commit `9602722c7` is refreshed and reverified.


