### PR TITLE
fix: migrate remaining readers to plural getOpenCodeConfigDirs()

### DIFF
--- a/packages/claude-code-compat-core/src/features/claude-code-agent-loader/opencode-config-agents-reader.test.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-agent-loader/opencode-config-agents-reader.test.ts
@@ -7,13 +7,24 @@ import { readOpencodeConfigAgents } from "./opencode-config-agents-reader"
 
 describe("readOpencodeConfigAgents", () => {
   let mockGlobalConfigDir = ""
+  let mockXdgHomeDir = ""
+  let origXdgConfigHome: string | undefined
 
   beforeEach(() => {
     mockGlobalConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-mock-global-"))
+    mockXdgHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-mock-xdg-"))
+    origXdgConfigHome = process.env.XDG_CONFIG_HOME
     process.env.OPENCODE_CONFIG_DIR = mockGlobalConfigDir
+    process.env.XDG_CONFIG_HOME = mockXdgHomeDir
   })
 
   afterEach(() => {
+    if (origXdgConfigHome !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXdgConfigHome
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+    fs.rmSync(mockXdgHomeDir, { recursive: true, force: true })
     fs.rmSync(mockGlobalConfigDir, { recursive: true, force: true })
   })
 
@@ -357,5 +368,71 @@ describe("readOpencodeConfigAgents", () => {
     }
 
     fs.rmSync(tempDir, { recursive: true })
+  })
+
+  it("merges agents from custom OPENCODE_CONFIG_DIR and default XDG_CONFIG_HOME dirs", () => {
+    // given
+    const tempProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-test-project-"))
+    const customConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-custom-"))
+    const xdgHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-xdg-"))
+    const xdgConfigDir = path.join(xdgHomeDir, "opencode")
+    fs.mkdirSync(xdgConfigDir, { recursive: true })
+
+    fs.writeFileSync(
+      path.join(customConfigDir, "opencode.json"),
+      JSON.stringify({
+        agents: {
+          "custom-user-agent": {
+            description: "Custom user agent",
+            prompt: "Custom prompt",
+          },
+        },
+      })
+    )
+
+    fs.writeFileSync(
+      path.join(xdgConfigDir, "opencode.json"),
+      JSON.stringify({
+        agents: {
+          "default-user-agent": {
+            description: "Default user agent",
+            prompt: "Default prompt",
+          },
+        },
+      })
+    )
+
+    const origOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR
+    const origXdgConfigHome = process.env.XDG_CONFIG_HOME
+
+    try {
+      process.env.OPENCODE_CONFIG_DIR = customConfigDir
+      process.env.XDG_CONFIG_HOME = xdgHomeDir
+
+      // when
+      const result = readOpencodeConfigAgents(tempProjectDir)
+
+      // then
+      expect(result).toHaveProperty("custom-user-agent")
+      expect(result["custom-user-agent"].description).toBe("(opencode-config) Custom user agent")
+      expect(result["custom-user-agent"].prompt).toBe("Custom prompt")
+      expect(result).toHaveProperty("default-user-agent")
+      expect(result["default-user-agent"].description).toBe("(opencode-config) Default user agent")
+      expect(result["default-user-agent"].prompt).toBe("Default prompt")
+    } finally {
+      if (origOpencodeConfigDir !== undefined) {
+        process.env.OPENCODE_CONFIG_DIR = origOpencodeConfigDir
+      } else {
+        delete process.env.OPENCODE_CONFIG_DIR
+      }
+      if (origXdgConfigHome !== undefined) {
+        process.env.XDG_CONFIG_HOME = origXdgConfigHome
+      } else {
+        delete process.env.XDG_CONFIG_HOME
+      }
+      fs.rmSync(tempProjectDir, { recursive: true, force: true })
+      fs.rmSync(customConfigDir, { recursive: true, force: true })
+      fs.rmSync(xdgHomeDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/claude-code-compat-core/src/features/claude-code-agent-loader/opencode-config-agents-reader.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-agent-loader/opencode-config-agents-reader.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
 
-import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
+import { getOpenCodeConfigDirs } from "../../shared/opencode-config-dir"
 import { parseJsoncSafe } from "../../shared/jsonc-parser"
 import { parseToolsConfig } from "../../shared/parse-tools-config"
 import { resolveAgentDefinitionPaths } from "../../shared/resolve-agent-definition-paths"
@@ -16,15 +16,15 @@ interface OpencodeConfigWithAgents {
 }
 
 function getConfigPaths(directory: string): string[] {
-  const globalConfigDir = getOpenCodeConfigDir({ binary: "opencode" })
-  const paths = [
+  const globalConfigDirs = getOpenCodeConfigDirs({ binary: "opencode" })
+  return [
     path.join(directory, ".opencode", "opencode.json"),
     path.join(directory, ".opencode", "opencode.jsonc"),
-    path.join(globalConfigDir, "opencode.json"),
-    path.join(globalConfigDir, "opencode.jsonc"),
+    ...globalConfigDirs.flatMap((dir) => [
+      path.join(dir, "opencode.json"),
+      path.join(dir, "opencode.jsonc"),
+    ]),
   ]
-
-  return paths
 }
 
 function convertInlineAgent(agentData: unknown): ClaudeCodeAgentConfig | null {

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/config-loader.test.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/config-loader.test.ts
@@ -12,20 +12,22 @@ describe("loadPluginExtendedConfig", () => {
   let tempDirectory = ""
   let userConfigPath = ""
   let projectConfigPath = ""
-  let originalUserConfig: string | null = null
+  let originalXdgConfigHome: string | undefined = undefined
   let mockedNow = 0
 
   beforeEach(() => {
     //#given
     originalWorkingDirectory = process.cwd()
     tempDirectory = mkdtempSync(join(tmpdir(), "omo-cc-plugin-project-config-"))
+
+    // Isolate default user config dir inside temp so tests never touch the real system
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+    process.env.XDG_CONFIG_HOME = join(tempDirectory, ".config")
+
     userConfigPath = join(getOpenCodeConfigDir({ binary: "opencode" }), "opencode-cc-plugin.json")
     projectConfigPath = join(tempDirectory, ".opencode", "opencode-cc-plugin.json")
     mkdirSync(getOpenCodeConfigDir({ binary: "opencode" }), { recursive: true })
     mkdirSync(join(tempDirectory, ".opencode"), { recursive: true })
-    originalUserConfig = existsSync(userConfigPath)
-      ? readFileSync(userConfigPath, "utf8")
-      : null
     process.chdir(tempDirectory)
     mockedNow = 1_000
     Date.now = () => mockedNow
@@ -37,11 +39,14 @@ describe("loadPluginExtendedConfig", () => {
     Date.now = originalDateNow
     process.chdir(originalWorkingDirectory)
     rmSync(tempDirectory, { recursive: true, force: true })
-    if (originalUserConfig === null) {
-      rmSync(userConfigPath, { force: true })
+
+    // Restore env vars so subsequent tests are not affected
+    if (originalXdgConfigHome !== undefined) {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome
     } else {
-      writeFileSync(userConfigPath, originalUserConfig)
+      delete process.env.XDG_CONFIG_HOME
     }
+    delete process.env.OPENCODE_CONFIG_DIR
   })
 
   test("#given cached extended config #when files change within ttl #then cached config is reused", async () => {
@@ -150,6 +155,54 @@ describe("loadPluginExtendedConfig", () => {
     //#then
     expect(matchingResult).toBe(true)
     expect(nonMatchingResult).toBe(false)
+  })
+
+  test("#given custom and default user configs both exist #when no project config #then custom overrides default", async () => {
+    //#given
+    const customConfigDir = join(tempDirectory, "custom-opencode-config")
+    const customConfigPath = join(customConfigDir, "opencode-cc-plugin.json")
+    mkdirSync(customConfigDir, { recursive: true })
+    process.env.OPENCODE_CONFIG_DIR = customConfigDir
+
+    // default user config (inside tempDirectory/.config/opencode via XDG_CONFIG_HOME isolation)
+    writeConfigFile(customConfigPath, ["custom-stop"])
+    writeConfigFile(userConfigPath, ["default-stop"])
+
+    clearPluginExtendedConfigCache()
+
+    //#when
+    const result = await loadPluginExtendedConfig()
+
+    //#then custom wins over default
+    expect(result).toEqual({
+      disabledHooks: {
+        Stop: ["custom-stop"],
+      },
+    })
+  })
+
+  test("#given custom, default, and project configs all exist #when loading extended config #then project overrides all user configs", async () => {
+    //#given
+    const customConfigDir = join(tempDirectory, "custom-opencode-config")
+    const customConfigPath = join(customConfigDir, "opencode-cc-plugin.json")
+    mkdirSync(customConfigDir, { recursive: true })
+    process.env.OPENCODE_CONFIG_DIR = customConfigDir
+
+    writeConfigFile(customConfigPath, ["custom-stop"])
+    writeConfigFile(userConfigPath, ["default-stop"])
+    writeConfigFile(projectConfigPath, ["project-stop"])
+
+    clearPluginExtendedConfigCache()
+
+    //#when
+    const result = await loadPluginExtendedConfig()
+
+    //#then project wins over merged user configs
+    expect(result).toEqual({
+      disabledHooks: {
+        Stop: ["project-stop"],
+      },
+    })
   })
 })
 

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/config-loader.test.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/config-loader.test.ts
@@ -13,6 +13,7 @@ describe("loadPluginExtendedConfig", () => {
   let userConfigPath = ""
   let projectConfigPath = ""
   let originalXdgConfigHome: string | undefined = undefined
+  let originalOpencodeConfigDir: string | undefined = undefined
   let mockedNow = 0
 
   beforeEach(() => {
@@ -22,7 +23,9 @@ describe("loadPluginExtendedConfig", () => {
 
     // Isolate default user config dir inside temp so tests never touch the real system
     originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+    originalOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR
     process.env.XDG_CONFIG_HOME = join(tempDirectory, ".config")
+    delete process.env.OPENCODE_CONFIG_DIR
 
     userConfigPath = join(getOpenCodeConfigDir({ binary: "opencode" }), "opencode-cc-plugin.json")
     projectConfigPath = join(tempDirectory, ".opencode", "opencode-cc-plugin.json")
@@ -46,7 +49,11 @@ describe("loadPluginExtendedConfig", () => {
     } else {
       delete process.env.XDG_CONFIG_HOME
     }
-    delete process.env.OPENCODE_CONFIG_DIR
+    if (originalOpencodeConfigDir !== undefined) {
+      process.env.OPENCODE_CONFIG_DIR = originalOpencodeConfigDir
+    } else {
+      delete process.env.OPENCODE_CONFIG_DIR
+    }
   })
 
   test("#given cached extended config #when files change within ttl #then cached config is reused", async () => {

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/config-loader.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/config-loader.ts
@@ -2,7 +2,7 @@ import { existsSync } from "fs"
 import { join } from "path"
 import type { ClaudeHookEvent } from "./types"
 import { log } from "../../shared/logger"
-import { getOpenCodeConfigDir } from "../../shared"
+import { getOpenCodeConfigDirs } from "../../shared"
 import { bunFile } from "../../shared/bun-file-shim"
 
 const CONFIG_CACHE_TTL_MS = 30_000
@@ -33,8 +33,10 @@ interface PluginExtendedConfigCacheEntry {
 
 const configCache = new Map<string, PluginExtendedConfigCacheEntry>()
 
-function getUserConfigPath(): string {
-  return join(getOpenCodeConfigDir({ binary: "opencode" }), "opencode-cc-plugin.json")
+function getUserConfigPaths(): string[] {
+  return getOpenCodeConfigDirs({ binary: "opencode" }).map((dir) =>
+    join(dir, "opencode-cc-plugin.json"),
+  )
 }
 
 function getProjectConfigPath(): string {
@@ -42,7 +44,7 @@ function getProjectConfigPath(): string {
 }
 
 function getCacheKey(): string {
-  return `${process.cwd()}::${getUserConfigPath()}`
+  return `${process.cwd()}::${getUserConfigPaths().join("|")}`
 }
 
 function getCachedConfig(cacheKey: string): PluginExtendedConfig | undefined {
@@ -108,21 +110,32 @@ export async function loadPluginExtendedConfig(): Promise<PluginExtendedConfig> 
     return cachedConfig
   }
 
-  const userConfig = await loadConfigFromPath(getUserConfigPath())
-  const projectConfig = await loadConfigFromPath(getProjectConfigPath())
+  // User configs: iterate reversed so custom (last in array) overrides default (first)
+  const userPaths = [...getUserConfigPaths()].reverse()
+  let mergedDisabledHooks: DisabledHooksConfig = {}
 
-  const merged: PluginExtendedConfig = {
-    disabledHooks: mergeDisabledHooks(
-      userConfig?.disabledHooks,
-      projectConfig?.disabledHooks
-    ),
+  for (const userPath of userPaths) {
+    const userConfig = await loadConfigFromPath(userPath)
+    if (userConfig?.disabledHooks) {
+      mergedDisabledHooks = mergeDisabledHooks(mergedDisabledHooks, userConfig.disabledHooks)
+    }
   }
 
-  if (userConfig || projectConfig) {
+  // Project config overrides all user configs
+  const projectConfig = await loadConfigFromPath(getProjectConfigPath())
+  if (projectConfig?.disabledHooks) {
+    mergedDisabledHooks = mergeDisabledHooks(mergedDisabledHooks, projectConfig.disabledHooks)
+  }
+
+  const merged: PluginExtendedConfig = {
+    disabledHooks: mergedDisabledHooks,
+  }
+
+  if (Object.keys(mergedDisabledHooks).length > 0 || projectConfig) {
     log("Plugin extended config loaded", {
-      userConfigExists: userConfig !== null,
+      userConfigPaths: getUserConfigPaths(),
       projectConfigExists: projectConfig !== null,
-      mergedDisabledHooks: merged.disabledHooks,
+      mergedDisabledHooks,
     })
   }
 

--- a/packages/omo-opencode/src/shared/external-plugin-detector.test.ts
+++ b/packages/omo-opencode/src/shared/external-plugin-detector.test.ts
@@ -20,12 +20,15 @@ describe("external-plugin-detector", () => {
   let tempDir: string
   let tempHomeDir: string
   let originalOpencodeConfigDir: string | undefined
+  let originalXdgConfigHome: string | undefined
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omo-test-"))
     tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "omo-home-"))
     originalOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME
     delete process.env.OPENCODE_CONFIG_DIR
+    process.env.XDG_CONFIG_HOME = path.join(tempHomeDir, ".config")
   })
 
   afterEach(() => {
@@ -33,6 +36,11 @@ describe("external-plugin-detector", () => {
       delete process.env.OPENCODE_CONFIG_DIR
     } else {
       process.env.OPENCODE_CONFIG_DIR = originalOpencodeConfigDir
+    }
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome
     }
     mock.restore()
     fs.rmSync(tempDir, { recursive: true, force: true })
@@ -458,11 +466,6 @@ describe("external-plugin-detector", () => {
       fs.writeFileSync(path.join(projectConfigDir, "opencode.json"), JSON.stringify({}))
       fs.writeFileSync(path.join(userConfigDir, "opencode.json"), JSON.stringify({ plugin: ["opencode-skills"] }))
 
-      const nodeOs = await import("node:os")
-      mock.module("node:os", () => ({
-        ...nodeOs,
-        homedir: () => tempHomeDir,
-      }))
       const { detectExternalSkillPlugin: detectExternalSkillPluginFresh } = await importFreshExternalPluginDetectorModule()
 
       // when
@@ -509,11 +512,6 @@ describe("external-plugin-detector", () => {
       )
       process.env.OPENCODE_CONFIG_DIR = profileConfigDir
 
-      const nodeOs = await import("node:os")
-      mock.module("node:os", () => ({
-        ...nodeOs,
-        homedir: () => tempHomeDir,
-      }))
       const { detectDuplicateOmoPlugin: detectDuplicateOmoPluginFresh } = await importFreshExternalPluginDetectorModule()
 
       // when
@@ -536,11 +534,6 @@ describe("external-plugin-detector", () => {
         path.join(opencodeDir, "opencode.json"),
         JSON.stringify({ plugin: ["oh-my-opencode", "npm:oh-my-openagent@latest"] }),
       )
-      const nodeOs = await import("node:os")
-      mock.module("node:os", () => ({
-        ...nodeOs,
-        homedir: () => tempHomeDir,
-      }))
       const { detectDuplicateOmoPlugin: detectDuplicateOmoPluginFresh } = await importFreshExternalPluginDetectorModule()
 
       // when

--- a/packages/omo-opencode/src/shared/load-opencode-plugins.test.ts
+++ b/packages/omo-opencode/src/shared/load-opencode-plugins.test.ts
@@ -30,6 +30,7 @@ function writeProfileConfig(directory: string, pluginEntries: readonly string[])
 describe("loadOpencodePlugins", () => {
   const tempDirs: string[] = []
   let originalOpencodeConfigDir: string | undefined
+  let originalXdgConfigHome: string | undefined
 
   function createTempDir(prefix: string): string {
     const directory = mkdtempSync(join(os.tmpdir(), prefix))
@@ -39,8 +40,10 @@ describe("loadOpencodePlugins", () => {
 
   beforeEach(() => {
     originalOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME
 
     delete process.env.OPENCODE_CONFIG_DIR
+    process.env.XDG_CONFIG_HOME = createTempDir("omo-load-opencode-xdg-home-")
   })
 
   afterEach(() => {
@@ -48,6 +51,11 @@ describe("loadOpencodePlugins", () => {
       delete process.env.OPENCODE_CONFIG_DIR
     } else {
       process.env.OPENCODE_CONFIG_DIR = originalOpencodeConfigDir
+    }
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome
     }
     while (tempDirs.length > 0) {
       const directory = tempDirs.pop()
@@ -144,6 +152,35 @@ describe("loadOpencodePlugins", () => {
         expect(result).toContain(projectPlugin)
         expect(result).toContain(profilePlugin)
         expect(result.indexOf(projectPlugin)).toBeLessThan(result.indexOf(profilePlugin))
+      })
+    })
+  })
+
+  describe("#given XDG_CONFIG_HOME is set", () => {
+    describe("#when loading plugins for the project", () => {
+      it("#then discovers plugins from the XDG config directory (not just hardcoded ~/.config)", async () => {
+        // given
+        const projectDirectory = createTempDir("omo-load-opencode-project-")
+        const xdgHomeDirectory = createTempDir("omo-load-opencode-xdg-")
+        const xdgOpencodeDir = join(xdgHomeDirectory, "opencode")
+        mkdirSync(xdgOpencodeDir, { recursive: true })
+
+        process.env.XDG_CONFIG_HOME = xdgHomeDirectory
+        delete process.env.OPENCODE_CONFIG_DIR
+
+        const projectPlugin = `file://${join(projectDirectory, "src", "index.ts")}`
+        const xdgPlugin = `file://${join(xdgOpencodeDir, "xdg-plugin.ts")}`
+        writeOpencodeConfig(projectDirectory, [projectPlugin])
+        writeFileSync(join(xdgOpencodeDir, "opencode.json"), JSON.stringify({ plugin: [xdgPlugin] }))
+
+        const { loadOpencodePlugins } = await importFreshLoadOpencodePluginsModule()
+
+        // when
+        const result = loadOpencodePlugins(projectDirectory)
+
+        // then
+        expect(result).toContain(projectPlugin)
+        expect(result).toContain(xdgPlugin)
       })
     })
   })

--- a/packages/omo-opencode/src/shared/load-opencode-plugins.ts
+++ b/packages/omo-opencode/src/shared/load-opencode-plugins.ts
@@ -1,8 +1,8 @@
 import * as fs from "node:fs"
-import * as os from "node:os"
 import * as path from "node:path"
 
 import { parseJsoncSafe } from "./jsonc-parser"
+import { getOpenCodeConfigDirs } from "./opencode-config-dir"
 
 interface OpencodeConfig {
   plugin?: (string | [string, ...unknown[]])[]
@@ -10,35 +10,16 @@ interface OpencodeConfig {
 
 const opencodePluginsCache = new Map<string, string[]>()
 
-function getWindowsAppdataDir(): string | null {
-  return process.env.APPDATA || null
-}
-
 function getConfigPaths(directory: string): string[] {
-  const crossPlatformDir = path.join(os.homedir(), ".config")
-  const paths = [
+  const configDirs = getOpenCodeConfigDirs({ binary: "opencode" })
+  return [
     path.join(directory, ".opencode", "opencode.json"),
     path.join(directory, ".opencode", "opencode.jsonc"),
-    path.join(crossPlatformDir, "opencode", "opencode.json"),
-    path.join(crossPlatformDir, "opencode", "opencode.jsonc"),
+    ...configDirs.flatMap((dir) => [
+      path.join(dir, "opencode.json"),
+      path.join(dir, "opencode.jsonc"),
+    ]),
   ]
-
-  const customConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim()
-  if (customConfigDir) {
-    const resolvedCustomConfigDir = path.resolve(customConfigDir)
-    paths.push(path.join(resolvedCustomConfigDir, "opencode.json"))
-    paths.push(path.join(resolvedCustomConfigDir, "opencode.jsonc"))
-  }
-
-  if (process.platform === "win32") {
-    const appdataDir = getWindowsAppdataDir()
-    if (appdataDir) {
-      paths.push(path.join(appdataDir, "opencode", "opencode.json"))
-      paths.push(path.join(appdataDir, "opencode", "opencode.jsonc"))
-    }
-  }
-
-  return Array.from(new Set(paths))
 }
 
 export function loadOpencodePlugins(directory: string): string[] {

--- a/packages/omo-opencode/src/shared/opencode-config-dir.test.ts
+++ b/packages/omo-opencode/src/shared/opencode-config-dir.test.ts
@@ -150,6 +150,34 @@ describe("opencode-config-dir", () => {
         resolve("/xdg/config/opencode"),
       ])
     })
+
+    test("deduplicates when OPENCODE_CONFIG_DIR equals the default XDG path", () => {
+      // given OPENCODE_CONFIG_DIR points to the same path as the XDG default
+      const defaultDir = join(homedir(), ".config", "opencode")
+      process.env.OPENCODE_CONFIG_DIR = defaultDir
+      delete process.env.XDG_CONFIG_HOME
+      Object.defineProperty(process, "platform", { value: "linux" })
+
+      // when getOpenCodeConfigDirs is called
+      const result = getOpenCodeConfigDirs({ binary: "opencode", version: "1.0.200" })
+
+      // then the array contains a single deduplicated entry
+      expect(result).toEqual([resolve(defaultDir)])
+    })
+
+    test("returns single-element array for non-opencode binary", () => {
+      // given a Tauri desktop binary and OPENCODE_CONFIG_DIR is set
+      process.env.OPENCODE_CONFIG_DIR = "/custom/opencode/path"
+      Object.defineProperty(process, "platform", { value: "linux" })
+
+      // when getOpenCodeConfigDirs is called with binary="opencode-desktop"
+      const result = getOpenCodeConfigDirs({ binary: "opencode-desktop", version: "1.0.200" })
+
+      // then it returns a single-element array (no additive semantics for non-opencode binaries)
+      expect(result).toEqual([getOpenCodeConfigDir({ binary: "opencode-desktop", version: "1.0.200" })])
+      expect(result).toHaveLength(1)
+    })
+
   })
 
   describe("isDevBuild", () => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/opencode-config-skills-reader.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/opencode-config-skills-reader.test.ts
@@ -9,7 +9,7 @@ import { readOpencodeConfigSkills } from "./opencode-config-skills-reader"
 describe("readOpencodeConfigSkills", () => {
   let tmpDir: string
   let globalConfigDir: string
-  let getOpenCodeConfigDirSpy: ReturnType<typeof spyOn>
+  let getOpenCodeConfigDirsSpy: ReturnType<typeof spyOn>
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ohmo-host-skills-"))
@@ -17,13 +17,13 @@ describe("readOpencodeConfigSkills", () => {
     // empty tmp dir so the developer's real ~/.config/opencode does not
     // leak into these tests (or vice versa: CI passes while local fails).
     globalConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "ohmo-global-opencode-"))
-    getOpenCodeConfigDirSpy = spyOn(opencodeConfigDir, "getOpenCodeConfigDir").mockReturnValue(
+    getOpenCodeConfigDirsSpy = spyOn(opencodeConfigDir, "getOpenCodeConfigDirs").mockReturnValue([
       globalConfigDir,
-    )
+    ])
   })
 
   afterEach(() => {
-    getOpenCodeConfigDirSpy.mockRestore()
+    getOpenCodeConfigDirsSpy.mockRestore()
     fs.rmSync(tmpDir, { recursive: true, force: true })
     fs.rmSync(globalConfigDir, { recursive: true, force: true })
   })
@@ -104,6 +104,39 @@ describe("readOpencodeConfigSkills", () => {
       expect(result).toBeUndefined()
     } finally {
       readFileSyncSpy.mockRestore()
+    }
+  })
+
+  it("merges skills from multiple user config dirs", () => {
+    // given the plural function returns two config dirs, each with its own skills config
+    const customDir = fs.mkdtempSync(path.join(os.tmpdir(), "ohmo-custom-opencode-"))
+    const defaultDir = fs.mkdtempSync(path.join(os.tmpdir(), "ohmo-default-opencode-"))
+
+    fs.writeFileSync(
+      path.join(customDir, "opencode.json"),
+      JSON.stringify({
+        skills: { paths: ["/custom/skill"], urls: ["https://custom.example.com/s.md"] },
+      }),
+    )
+    fs.writeFileSync(
+      path.join(defaultDir, "opencode.json"),
+      JSON.stringify({
+        skills: { paths: ["/default/skill"], urls: ["https://default.example.com/s.md"] },
+      }),
+    )
+
+    getOpenCodeConfigDirsSpy.mockReturnValue([customDir, defaultDir])
+
+    try {
+      // when
+      const result = readOpencodeConfigSkills(tmpDir)
+
+      // then both dirs contribute skills, deduplicated by the existing !paths.includes check
+      expect(result?.paths).toEqual(["/custom/skill", "/default/skill"])
+      expect(result?.urls).toEqual(["https://custom.example.com/s.md", "https://default.example.com/s.md"])
+    } finally {
+      fs.rmSync(customDir, { recursive: true, force: true })
+      fs.rmSync(defaultDir, { recursive: true, force: true })
     }
   })
 })

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/opencode-config-skills-reader.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/opencode-config-skills-reader.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 
 import { parseJsoncSafe } from "@oh-my-opencode/utils"
-import { getOpenCodeConfigDir } from "../../shared"
+import { getOpenCodeConfigDirs } from "../../shared"
 
 interface OpencodeConfigWithSkills {
   skills?: { paths?: unknown; urls?: unknown }
@@ -14,12 +14,14 @@ export interface HostSkillConfigShape {
 }
 
 function getConfigPaths(directory: string): string[] {
-  const globalConfigDir = getOpenCodeConfigDir({ binary: "opencode" })
+  const globalConfigDirs = getOpenCodeConfigDirs({ binary: "opencode" })
   return [
     path.join(directory, ".opencode", "opencode.json"),
     path.join(directory, ".opencode", "opencode.jsonc"),
-    path.join(globalConfigDir, "opencode.json"),
-    path.join(globalConfigDir, "opencode.jsonc"),
+    ...globalConfigDirs.flatMap((dir) => [
+      path.join(dir, "opencode.json"),
+      path.join(dir, "opencode.jsonc"),
+    ]),
   ]
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #3875. The plural `getOpenCodeConfigDirs()` was introduced there and `loadPluginConfig()` was migrated, but 4 reader sites still call the singular `getOpenCodeConfigDir()`. In environments where `OPENCODE_CONFIG_DIR` is injected (e.g. Orca-managed terminals), these readers only see the injected dir and miss the user config at `~/.config/opencode/` — so agents, skills, hooks, and plugin lists silently fall back to defaults.

This PR migrates the 4 remaining multi-path readers to the plural function. It also fixes a separate bug in `loadOpencodePlugins()` where `XDG_CONFIG_HOME` was ignored (the old code hardcoded `os.homedir() + "/.config"`).

Related to #3846.

## Changes

- `opencode-config-dir.test.ts`: 2 contract tests for the plural function — dedup when `OPENCODE_CONFIG_DIR === XDG default`, and single-element return for non-opencode binaries.
- `opencode-config-agents-reader.ts` (claude-code-compat-core): `getOpenCodeConfigDir()` → `getOpenCodeConfigDirs().flatMap()`. Agents from both custom and default dirs are now merged.
- `opencode-config-skills-reader.ts` (skills-loader-core): same migration.
- `claude-code-hooks/config-loader.ts` (omo-opencode): `getUserConfigPath()` → `getUserConfigPaths()`. `loadPluginExtendedConfig()` now iterates all user config files (default first, custom last so custom wins) and merges `disabledHooks`. Project config still overrides all. This is a behavior change — previously only one user config file was read.
- `load-opencode-plugins.ts` (omo-opencode): replaced the self-contained `getConfigPaths()` (which hardcoded `~/.config`, manually read `OPENCODE_CONFIG_DIR` and `APPDATA`) with `getOpenCodeConfigDirs()`. Plugin discovery order changes from `[project, default, custom, APPDATA]` to `[project, custom, default]` — custom now wins over default on dedup, which matches the override semantics users expect.

Pattern B (6 diagnostic sites in doctor checks) and Pattern C (`claude-tasks/storage.ts`) are intentionally not in this PR. Pattern C uses single-dir semantics on purpose (`custom ?? default` is the correct primary location for a canonical storage path).

## Verification

```
bun run typecheck
bun test packages/omo-opencode/src/shared/opencode-config-dir.test.ts
bun test packages/omo-opencode/src/shared/load-opencode-plugins.test.ts
bun test packages/omo-opencode/src/hooks/claude-code-hooks/config-loader.test.ts
bun test packages/claude-code-compat-core/src/features/claude-code-agent-loader/
bun test packages/skills-loader-core/src/features/opencode-skill-loader/
```

All pass. The 4 failures in `opencode-skill-loader/` are pre-existing (`git-master async precedence`, `resolveMultipleSkillsAsync`) and unrelated to config-dir changes.

## Related Issues

- Follow-up to #3875
- Related to #3846

---

This is my first contribution here. If the approach or scope needs adjustment, happy to revise.