### PR TITLE
fix(codex-install): isolate npm 12 allow-scripts config

### DIFF
--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5903,7 +5903,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.17.0",
+    version: "4.17.1",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -7519,9 +7519,11 @@ function collectCommands(value, commands) {
 
 // packages/omo-codex/src/install/codex-cache-install.ts
 async function installCachedPlugin(input) {
+  const env = input.env ?? process.env;
+  const npmInstallEnv = sanitizeNpmInstallEnv(env);
   if (input.buildSource !== false) {
-    await maybeRunNpmInstall(input.sourcePath, input.runCommand);
-    await maybeRunNpmBuild(input.sourcePath, input.runCommand);
+    await maybeRunNpmInstall(input.sourcePath, input.runCommand, npmInstallEnv);
+    await maybeRunNpmBuild(input.sourcePath, input.runCommand, env);
   }
   const targetPath = join12(input.codexHome, "plugins", "cache", input.marketplaceName, input.name, input.version);
   const tempPath = createTempSiblingPath(targetPath);
@@ -7531,10 +7533,10 @@ async function installCachedPlugin(input) {
     await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath);
     await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath });
     await copyRootRuntimeDists({ pluginRoot: tempPath, sourcePath: input.sourcePath });
-    await maybeRunNpmInstall(tempPath, input.runCommand, ["ci", "--omit=dev"]);
+    await maybeRunNpmInstall(tempPath, input.runCommand, npmInstallEnv, ["ci", "--omit=dev"]);
     await removeCachedManagedNpmBinShims(tempPath);
     if (input.buildSource === false)
-      await maybeRunNpmSyncSkills(tempPath, input.runCommand);
+      await maybeRunNpmSyncSkills(tempPath, input.runCommand, env);
     await assertNoRemovedSparkshellPromptReferences(tempPath);
     await rewriteCachedMcpManifest(tempPath, input.sourcePath);
     await rewriteCachedManifestRoot(tempPath, tempPath, targetPath);
@@ -7546,12 +7548,12 @@ async function installCachedPlugin(input) {
   }
   return { name: input.name, version: input.version, path: targetPath };
 }
-async function maybeRunNpmInstall(cwd, runCommand, args = ["install"]) {
+async function maybeRunNpmInstall(cwd, runCommand, env, args = ["install"]) {
   if (!await fileExistsStrict(join12(cwd, "package.json")))
     return;
-  await runCommand("npm", args, { cwd });
+  await runCommand("npm", args, { cwd, env });
 }
-async function maybeRunNpmBuild(cwd, runCommand) {
+async function maybeRunNpmBuild(cwd, runCommand, env) {
   if (!await fileExistsStrict(join12(cwd, "package.json")))
     return;
   const packageJson = JSON.parse(await readFile8(join12(cwd, "package.json"), "utf8"));
@@ -7560,9 +7562,9 @@ async function maybeRunNpmBuild(cwd, runCommand) {
   const scripts = packageJson.scripts;
   if (!isPlainRecord(scripts) || typeof scripts.build !== "string")
     return;
-  await runCommand("npm", ["run", "build"], { cwd });
+  await runCommand("npm", ["run", "build"], { cwd, env });
 }
-async function maybeRunNpmSyncSkills(cwd, runCommand) {
+async function maybeRunNpmSyncSkills(cwd, runCommand, env) {
   if (!await fileExistsStrict(join12(cwd, "package.json")))
     return;
   const packageJson = JSON.parse(await readFile8(join12(cwd, "package.json"), "utf8"));
@@ -7571,7 +7573,10 @@ async function maybeRunNpmSyncSkills(cwd, runCommand) {
   const scripts = packageJson.scripts;
   if (!isPlainRecord(scripts) || typeof scripts["sync:skills"] !== "string")
     return;
-  await runCommand("npm", ["run", "sync:skills"], { cwd });
+  await runCommand("npm", ["run", "sync:skills"], { cwd, env });
+}
+function sanitizeNpmInstallEnv(env) {
+  return Object.fromEntries(Object.entries(env).filter(([key]) => key.toLowerCase() !== "npm_config_allow_scripts"));
 }
 function createTempSiblingPath(targetPath) {
   return join12(dirname5(targetPath), `.tmp-${basename3(targetPath)}-${process.pid}-${Date.now()}`);
@@ -8094,6 +8099,14 @@ function parsePluginHeaderKey(header) {
 function parseAgentHeaderName(header) {
   const path = parseTomlDottedKey(header);
   return path?.[0] === "agents" ? path[1] ?? null : null;
+}
+function parseJsonString(value) {
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 function parseHookStateHeaderKey(header) {
   const path = parseTomlDottedKey(header);
@@ -9250,16 +9263,6 @@ function isSectionHeader3(line) {
 function agentNameFromToml(fileName) {
   return fileName.endsWith(".toml") ? fileName.slice(0, -".toml".length) : fileName;
 }
-function parseJsonString(value) {
-  try {
-    const parsed = JSON.parse(value);
-    return typeof parsed === "string" ? parsed : null;
-  } catch (error) {
-    if (error instanceof Error)
-      return null;
-    return null;
-  }
-}
 async function exists2(path) {
   try {
     await lstat7(path);
@@ -10275,6 +10278,7 @@ async function runCodexInstaller(options = {}) {
     const plugin = await installCachedPlugin({
       buildSource,
       codexHome,
+      env: env2,
       marketplaceName: marketplace.name,
       name: entry.name,
       runCommand,

--- a/packages/omo-codex/src/install/codex-cache-install.test.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.test.ts
@@ -45,6 +45,55 @@ describe("codex-cache install", () => {
   )
 
   test(
+    "#given outer npx env has allow-scripts case variants #when caching plugin #then npm install commands preserve only unrelated env",
+    async () => {
+      // given
+      const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-npm-env-"))
+      const codexHome = join(root, "codex-home")
+      const sourceRoot = join(root, "plugin")
+      const env: NodeJS.ProcessEnv = {
+        npm_config_allow_scripts: "@code-yeongyu/comment-checker",
+        NPM_CONFIG_ALLOW_SCRIPTS: "@code-yeongyu/codex-ulw-loop",
+        NpM_CoNfIg_AlLoW_ScRiPtS: "@code-yeongyu/codex-rules",
+        npm_config_registry: "https://registry.example.test",
+        "npm_config_//registry.example.test/:_authToken": "test-token",
+        npm_config_https_proxy: "http://proxy.example.test:8080",
+        PATH: "/test/bin",
+        HOME: "/test/home",
+      }
+      const preservedEnv: NodeJS.ProcessEnv = {
+        npm_config_registry: "https://registry.example.test",
+        "npm_config_//registry.example.test/:_authToken": "test-token",
+        npm_config_https_proxy: "http://proxy.example.test:8080",
+        PATH: "/test/bin",
+        HOME: "/test/home",
+      }
+      const npmInstallEnvs: Array<NodeJS.ProcessEnv | undefined> = []
+      await mkdir(sourceRoot, { recursive: true })
+      await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }))
+
+      // when
+      await installCachedPlugin({
+        codexHome,
+        env,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async (command, args, options) => {
+          if (command !== "npm") return
+          expect(args).toEqual(npmInstallEnvs.length === 0 ? ["install"] : ["ci", "--omit=dev"])
+          npmInstallEnvs.push(options.env)
+        },
+      })
+
+      // then
+      expect(npmInstallEnvs).toEqual([preservedEnv, preservedEnv])
+    },
+    15000,
+  )
+
+  test(
     "#given a component ships its own nested .mcp.json #when caching plugin #then only the plugin-root .mcp.json is cached",
     async () => {
       // given

--- a/packages/omo-codex/src/install/codex-cache-install.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.ts
@@ -13,6 +13,7 @@ type RenameDirectory = (fromPath: string, toPath: string) => Promise<void>
 export async function installCachedPlugin(input: {
   readonly buildSource?: boolean
   readonly codexHome: string
+  readonly env?: NodeJS.ProcessEnv
   readonly marketplaceName: string
   readonly name: string
   readonly renameDirectory?: RenameDirectory
@@ -20,9 +21,11 @@ export async function installCachedPlugin(input: {
   readonly version: string
   readonly runCommand: RunCommand
 }): Promise<InstalledPlugin> {
+  const env = input.env ?? process.env
+  const npmInstallEnv = sanitizeNpmInstallEnv(env)
   if (input.buildSource !== false) {
-    await maybeRunNpmInstall(input.sourcePath, input.runCommand)
-    await maybeRunNpmBuild(input.sourcePath, input.runCommand)
+    await maybeRunNpmInstall(input.sourcePath, input.runCommand, npmInstallEnv)
+    await maybeRunNpmBuild(input.sourcePath, input.runCommand, env)
   }
 
   const targetPath = join(input.codexHome, "plugins", "cache", input.marketplaceName, input.name, input.version)
@@ -33,9 +36,9 @@ export async function installCachedPlugin(input: {
     await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath)
     await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath })
     await copyRootRuntimeDists({ pluginRoot: tempPath, sourcePath: input.sourcePath })
-    await maybeRunNpmInstall(tempPath, input.runCommand, ["ci", "--omit=dev"])
+    await maybeRunNpmInstall(tempPath, input.runCommand, npmInstallEnv, ["ci", "--omit=dev"])
     await removeCachedManagedNpmBinShims(tempPath)
-    if (input.buildSource === false) await maybeRunNpmSyncSkills(tempPath, input.runCommand)
+    if (input.buildSource === false) await maybeRunNpmSyncSkills(tempPath, input.runCommand, env)
     await assertNoRemovedSparkshellPromptReferences(tempPath)
     await rewriteCachedMcpManifest(tempPath, input.sourcePath)
     await rewriteCachedManifestRoot(tempPath, tempPath, targetPath)
@@ -48,27 +51,36 @@ export async function installCachedPlugin(input: {
   return { name: input.name, version: input.version, path: targetPath }
 }
 
-async function maybeRunNpmInstall(cwd: string, runCommand: RunCommand, args: readonly string[] = ["install"]): Promise<void> {
+async function maybeRunNpmInstall(
+  cwd: string,
+  runCommand: RunCommand,
+  env: NodeJS.ProcessEnv,
+  args: readonly string[] = ["install"],
+): Promise<void> {
   if (!(await fileExistsStrict(join(cwd, "package.json")))) return
-  await runCommand("npm", args, { cwd })
+  await runCommand("npm", args, { cwd, env })
 }
 
-async function maybeRunNpmBuild(cwd: string, runCommand: RunCommand): Promise<void> {
+async function maybeRunNpmBuild(cwd: string, runCommand: RunCommand, env: NodeJS.ProcessEnv): Promise<void> {
   if (!(await fileExistsStrict(join(cwd, "package.json")))) return
   const packageJson: unknown = JSON.parse(await readFile(join(cwd, "package.json"), "utf8"))
   if (!isPlainRecord(packageJson)) return
   const scripts = packageJson.scripts
   if (!isPlainRecord(scripts) || typeof scripts.build !== "string") return
-  await runCommand("npm", ["run", "build"], { cwd })
+  await runCommand("npm", ["run", "build"], { cwd, env })
 }
 
-async function maybeRunNpmSyncSkills(cwd: string, runCommand: RunCommand): Promise<void> {
+async function maybeRunNpmSyncSkills(cwd: string, runCommand: RunCommand, env: NodeJS.ProcessEnv): Promise<void> {
   if (!(await fileExistsStrict(join(cwd, "package.json")))) return
   const packageJson: unknown = JSON.parse(await readFile(join(cwd, "package.json"), "utf8"))
   if (!isPlainRecord(packageJson)) return
   const scripts = packageJson.scripts
   if (!isPlainRecord(scripts) || typeof scripts["sync:skills"] !== "string") return
-  await runCommand("npm", ["run", "sync:skills"], { cwd })
+  await runCommand("npm", ["run", "sync:skills"], { cwd, env })
+}
+
+function sanitizeNpmInstallEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return Object.fromEntries(Object.entries(env).filter(([key]) => key.toLowerCase() !== "npm_config_allow_scripts"))
 }
 
 function createTempSiblingPath(targetPath: string): string {

--- a/packages/omo-codex/src/install/install-codex.ts
+++ b/packages/omo-codex/src/install/install-codex.ts
@@ -76,6 +76,7 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
     const plugin = await installCachedPlugin({
       buildSource,
       codexHome,
+      env,
       marketplaceName: marketplace.name,
       name: entry.name,
       runCommand,


### PR DESCRIPTION
## Summary

Fixes the `EALLOWSCRIPTS` failure seen when the omo-codex installer is launched through npm 12 with an inherited `npm_config_allow_scripts` value. npm 12 treats that outer user policy as invalid for project-scoped install commands, so the installer now removes only that setting from its internal `npm install` and `npm ci` environments.

All unrelated environment and npm configuration, including registry, auth, proxy, PATH, and HOME values, remains intact. Build and skill-sync commands continue to receive the original environment.

## Changes

- pass the installer environment into the plugin cache installation path
- create an install-only environment with case-insensitive `npm_config_allow_scripts` variants removed
- use the sanitized environment for source `npm install` and cached `npm ci --omit=dev`
- add a regression test covering lowercase, uppercase, and mixed-case variants while asserting unrelated npm config is preserved
- regenerate the committed omo-codex installer bundle and verify byte-for-byte rebuild parity

## Verification

- `bun test packages/omo-codex/src/install/codex-cache-install.test.ts` — 6 passed
- `node --test packages/omo-codex/scripts/install-generated-bundle.test.mjs` — 6 passed
- `bun run --cwd packages/omo-codex typecheck` — passed
- `bun run test:codex` — 359 Bun tests and 481 Node tests passed
- `bun run build:codex-install` followed by a second rebuild — zero generated diff
- isolated real install with exact npm `12.0.1`, inherited `npm_config_allow_scripts`, and a tracing wrapper — exit 0; both internal install commands observed `allow=<unset>`
- isolated `CODEX_HOME` contained the omo `4.17.1` cache, enabled plugin config, 13 bins, and 12 agent TOMLs
- real `~/.codex/config.toml` SHA-256 remained unchanged
- final code, QA, and gate reviewers all approved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `EALLOWSCRIPTS` failures in the `@oh-my-opencode/omo-codex` installer on npm 12 by stripping only `npm_config_allow_scripts` (case-insensitive) from internal `npm install`/`npm ci` while preserving the rest of the environment. Build and skill-sync still run with the full env.

- **Bug Fixes**
  - Sanitize env for internal installs by removing `npm_config_allow_scripts` variants; keep registry/auth/proxy, `PATH`, and `HOME`.
  - Pass sanitized env to `npm install` and `npm ci --omit=dev`; pass original env to `npm run build` and `npm run sync:skills`.
  - Add tests verifying case-variant removal and preservation of unrelated config.
  - Regenerate installer bundle and bump bundled version to `4.17.1`.

<sup>Written for commit 389a0d168bb1a7a6f003f6dcff10eba76e6dfac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

