### PR TITLE
fix(opencode): inherit plan fallback models

### DIFF
--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-models.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-models.test.ts
@@ -45,6 +45,87 @@ describe("runtime-fallback fallback-models", () => {
     expect(result).toEqual(["openai/gpt-5.5", "anthropic/claude-opus-4-7"])
   })
 
+  test("inherits prometheus fallback_models for a replaced plan agent by default", () => {
+    //#given
+    const pluginConfig = unsafeTestValue({
+      agents: {
+        plan: {},
+        prometheus: {
+          fallback_models: ["openai/gpt-5.5", "anthropic/claude-opus-4-7"],
+        },
+      },
+    })
+
+    //#when
+    const result = getFallbackModelsForSession("ses_runtime_fallback_plan", "plan", pluginConfig)
+
+    //#then
+    expect(result).toEqual(["openai/gpt-5.5", "anthropic/claude-opus-4-7"])
+  })
+
+  test("uses explicit plan fallback_models before prometheus inheritance", () => {
+    //#given
+    const pluginConfig = unsafeTestValue({
+      agents: {
+        plan: {
+          fallback_models: ["openai/gpt-5.4"],
+        },
+        prometheus: {
+          fallback_models: ["openai/gpt-5.5"],
+        },
+      },
+    })
+
+    //#when
+    const result = getFallbackModelsForSession("ses_runtime_fallback_plan", "plan", pluginConfig)
+
+    //#then
+    expect(result).toEqual(["openai/gpt-5.4"])
+  })
+
+  test("explicit empty plan fallback_models suppresses prometheus inheritance", () => {
+    //#given
+    const pluginConfig = unsafeTestValue({
+      agents: {
+        plan: {
+          fallback_models: [],
+        },
+        prometheus: {
+          fallback_models: ["openai/gpt-5.5"],
+        },
+      },
+    })
+
+    //#when
+    const result = getFallbackModelsForSession("ses_runtime_fallback_plan", "plan", pluginConfig)
+
+    //#then
+    expect(result).toEqual([])
+  })
+
+  test.each([
+    { planner_enabled: false },
+    { replace_plan: false },
+    { disabled: true },
+  ])("does not inherit prometheus fallback_models when plan replacement is disabled: %#", (sisyphusAgent) => {
+    //#given
+    const pluginConfig = unsafeTestValue({
+      sisyphus_agent: sisyphusAgent,
+      agents: {
+        plan: {},
+        prometheus: {
+          fallback_models: ["openai/gpt-5.5"],
+        },
+      },
+    })
+
+    //#when
+    const result = getFallbackModelsForSession("ses_runtime_fallback_plan", "plan", pluginConfig)
+
+    //#then
+    expect(result).toEqual([])
+  })
+
   test("does not fall back to another agent chain when agent cannot be resolved", () => {
     //#given
     const pluginConfig = unsafeTestValue({

--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-models.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-models.ts
@@ -68,9 +68,20 @@ function getRawFallbackModelsForSession(
     return undefined
   }
 
+  const shouldInheritPlanFallback =
+    pluginConfig.sisyphus_agent?.disabled !== true &&
+    pluginConfig.sisyphus_agent?.planner_enabled !== false &&
+    pluginConfig.sisyphus_agent?.replace_plan !== false
+  const tryGetPrometheusFallbackForPlan = (agentName: string) => {
+    if (agentName.toLowerCase() !== "plan" || !shouldInheritPlanFallback) return undefined
+    return tryGetFallbackFromAgent("prometheus")
+  }
+
   if (agent) {
     const result = tryGetFallbackFromAgent(agent)
     if (result) return result
+    const planFallback = tryGetPrometheusFallbackForPlan(agent)
+    if (planFallback) return planFallback
   }
 
   const sessionAgentMatch = sessionID.match(agentPattern)
@@ -78,6 +89,8 @@ function getRawFallbackModelsForSession(
     const detectedAgent = sessionAgentMatch[1].toLowerCase()
     const result = tryGetFallbackFromAgent(detectedAgent)
     if (result) return result
+    const planFallback = tryGetPrometheusFallbackForPlan(detectedAgent)
+    if (planFallback) return planFallback
   }
 
   log(`[${HOOK_NAME}] No category/agent fallback models resolved for session`, { sessionID, agent })

--- a/packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.test.ts
@@ -32,6 +32,7 @@ describe("buildPlanDemoteConfig", () => {
       reasoningEffort: "high",
       textVerbosity: "medium",
       providerOptions: { key: "value" },
+      fallback_models: [{ model: "openai/gpt-5.5", variant: "high" }, "opencode-go/glm-5.2"],
     }
 
     //#when
@@ -48,6 +49,10 @@ describe("buildPlanDemoteConfig", () => {
     expect(result.reasoningEffort).toBe("high")
     expect(result.textVerbosity).toBe("medium")
     expect(result.providerOptions).toEqual({ key: "value" })
+    expect(result.fallback_models).toEqual([
+      { model: "openai/gpt-5.5", variant: "high" },
+      "opencode-go/glm-5.2",
+    ])
     expect(result.prompt).toBeUndefined()
     expect(result.permission).toBeUndefined()
     expect(result.description).toBeUndefined()
@@ -62,12 +67,14 @@ describe("buildPlanDemoteConfig", () => {
       variant: "max",
       temperature: 0.1,
       reasoningEffort: "high",
+      fallback_models: ["openai/gpt-5.5"],
     }
     const planOverride = {
       model: "openai/gpt-5.4",
       variant: "high",
       temperature: 0.5,
       reasoningEffort: "low",
+      fallback_models: [{ model: "opencode-go/glm-5.2" }],
     }
 
     //#when
@@ -78,6 +85,7 @@ describe("buildPlanDemoteConfig", () => {
     expect(result.variant).toBe("high")
     expect(result.temperature).toBe(0.5)
     expect(result.reasoningEffort).toBe("low")
+    expect(result.fallback_models).toEqual([{ model: "opencode-go/glm-5.2" }])
   })
 
   test("falls back to prometheus when plan override has partial settings", () => {

--- a/packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.ts
+++ b/packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.ts
@@ -8,6 +8,7 @@ const MODEL_SETTINGS_KEYS = [
   "reasoningEffort",
   "textVerbosity",
   "providerOptions",
+  "fallback_models",
 ] as const
 
 export function buildPlanDemoteConfig(

--- a/packages/omo-opencode/src/plugin-handlers/prometheus-agent-config-builder.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/prometheus-agent-config-builder.test.ts
@@ -238,6 +238,52 @@ describe("buildPrometheusAgentConfig", () => {
       });
   });
 
+  describe("#given category fallback_models", () => {
+    test("materializes category fallback_models when Prometheus has no explicit fallback_models", async () => {
+      // given
+      const categoryFallbackModels = ["openai/gpt-5.4"];
+      resolveCategoryConfigSpy.mockReturnValue({
+        fallback_models: categoryFallbackModels,
+      } as CategoryConfig);
+
+      // when
+      const result = await buildPrometheusAgentConfig({
+        configAgentPlan: undefined,
+        pluginPrometheusOverride: { category: "test-category" },
+        userCategories: { "test-category": { fallback_models: categoryFallbackModels } },
+        currentModel: undefined,
+      });
+
+      // then
+      expect(result.fallback_models).toEqual(categoryFallbackModels);
+    });
+
+    test.each([
+      ["explicit fallback_models", ["openai/gpt-5.5"]],
+      ["explicit empty fallback_models", []],
+    ])("preserves %s over category fallback_models", async (_label, explicitFallbackModels) => {
+      // given
+      const categoryFallbackModels = ["openai/gpt-5.4"];
+      resolveCategoryConfigSpy.mockReturnValue({
+        fallback_models: categoryFallbackModels,
+      } as CategoryConfig);
+
+      // when
+      const result = await buildPrometheusAgentConfig({
+        configAgentPlan: undefined,
+        pluginPrometheusOverride: {
+          category: "test-category",
+          fallback_models: explicitFallbackModels,
+        },
+        userCategories: { "test-category": { fallback_models: categoryFallbackModels } },
+        currentModel: undefined,
+      });
+
+      // then
+      expect(result.fallback_models).toEqual(explicitFallbackModels);
+    });
+  });
+
   describe("#given no currentModel and no explicit config", () => {
     test("falls through to fallback chain", async () => {
       // given - no currentModel, no explicit config

--- a/packages/omo-opencode/src/plugin-handlers/prometheus-agent-config-builder.ts
+++ b/packages/omo-opencode/src/plugin-handlers/prometheus-agent-config-builder.ts
@@ -1,4 +1,5 @@
 import type { CategoryConfig } from "../config/schema";
+import type { FallbackModels } from "../config/schema/fallback-models";
 import { PROMETHEUS_PERMISSION, getPrometheusPrompt } from "../agents/prometheus";
 import { resolvePromptAppend } from "../agents/builtin-agents/resolve-file-uri";
 import { AGENT_MODEL_REQUIREMENTS } from "../shared/model-requirements";
@@ -20,6 +21,7 @@ type PrometheusOverride = Record<string, unknown> & {
   temperature?: number;
   top_p?: number;
   maxTokens?: number;
+  fallback_models?: FallbackModels;
   prompt?: string;
   prompt_append?: string;
 };
@@ -94,6 +96,8 @@ export async function buildPrometheusAgentConfig(params: {
   const topPToUse = params.pluginPrometheusOverride?.top_p ?? categoryConfig?.top_p;
   const maxTokensToUse =
     params.pluginPrometheusOverride?.maxTokens ?? categoryConfig?.maxTokens;
+  const fallbackModelsToUse =
+    params.pluginPrometheusOverride?.fallback_models ?? categoryConfig?.fallback_models;
 
   const base: Record<string, unknown> = {
     ...(resolvedModel ? { model: resolvedModel } : {}),
@@ -106,6 +110,7 @@ export async function buildPrometheusAgentConfig(params: {
     ...(temperatureToUse !== undefined ? { temperature: temperatureToUse } : {}),
     ...(topPToUse !== undefined ? { top_p: topPToUse } : {}),
     ...(maxTokensToUse !== undefined ? { maxTokens: maxTokensToUse } : {}),
+    ...(fallbackModelsToUse !== undefined ? { fallback_models: fallbackModelsToUse } : {}),
     ...(categoryConfig?.tools ? { tools: categoryConfig.tools } : {}),
     ...(thinkingToUse ? { thinking: thinkingToUse } : {}),
     ...(reasoningEffortToUse !== undefined


### PR DESCRIPTION
## Summary

- Preserve `fallback_models` when OhMyOpenAgent demotes/replaces the built-in OpenCode `plan` subagent with Prometheus model settings.
- Keep explicit `agents.plan.fallback_models` overrides higher priority than inherited Prometheus fallbacks.

## Changes

- Add `fallback_models` to the hidden plan model-setting inheritance allowlist.
- Extend `buildPlanDemoteConfig` regression coverage for inherited and explicit plan fallback chains.

## QA & Evidence

- **What was tested:** `bun test packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.test.ts`
  **Observed result:** `5 pass`, `0 fail`, `28 expect() calls`.
  **Artifact:** terminal output from local run.
  **Why sufficient:** Directly covers inherited Prometheus fallbacks and explicit plan override precedence.

- **What was tested:** `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.ts packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.test.ts`
  **Observed result:** `No violations in 2 file(s).`
  **Artifact:** terminal output from local run.
  **Why sufficient:** Checks strict TypeScript no-excuse rules for the changed files.

- **What was tested:** `bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json`
  **Observed result:** completed successfully.
  **Artifact:** terminal output from local run.
  **Why sufficient:** Typechecks the affected package.

- **What was tested:** `bun run typecheck`
  **Observed result:** completed successfully.
  **Artifact:** terminal output from local run.
  **Why sufficient:** Runs the repository typecheck gates.

## Risks & Residuals

- Risk: Hidden plan now receives fallback model config that previously stayed on Prometheus only. Mitigated by preserving the existing allowlist/precedence mechanism and adding focused tests for both inheritance and override cases.
- Residual: LSP diagnostics were unavailable in this harness because the TypeScript LSP server is not installed; repo typecheck gates passed instead.

## Automated Checks

```bash
bun test packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.test.ts
bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.ts packages/omo-opencode/src/plugin-handlers/plan-model-inheritance.test.ts
bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json
bun run typecheck
```

## Related Issues

<!-- No linked issue. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the `plan` subagent inherits `fallback_models` from Prometheus when replaced, including at runtime, while still honoring explicit `agents.plan.fallback_models` and Prometheus overrides.

- **Bug Fixes**
  - Added `fallback_models` to the plan model-setting inheritance allowlist in `plan-model-inheritance.ts` with tests.
  - Wired runtime fallback to use Prometheus `fallback_models` for `plan` when replacement is enabled, and to respect explicit plan values (including empty arrays) in `fallback-models.ts`.
  - In `prometheus-agent-config-builder.ts`, materialize category `fallback_models` when Prometheus has none, and preserve explicit `pluginPrometheusOverride.fallback_models` (including empty arrays).

<sup>Written for commit 469702b86c6c78a7c16df3b534bbad439084f755. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

