### PR TITLE
fix(background-agent): reject continuation while task is running

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -162,7 +162,10 @@ class MockBackgroundManager {
     }
 
     if (existingTask.status === "running") {
-      return existingTask
+      throw new Error(
+        `Task ${existingTask.id} is currently running and cannot accept a continuation prompt. ` +
+        "Wait for it to complete before resuming it with task_id.",
+      )
     }
 
     this.resumeCalls.push({ sessionId: input.sessionId, prompt: input.prompt })
@@ -1795,7 +1798,7 @@ describe("BackgroundManager.resume", () => {
     expect(result.progress?.toolCalls).toBe(42)
   })
 
-  test("should ignore resume when task is already running", () => {
+  test("should reject resume when task is already running", () => {
     // given
     const runningTask = createMockTask({
       id: "task-a",
@@ -1806,15 +1809,18 @@ describe("BackgroundManager.resume", () => {
     manager.addTask(runningTask)
 
     // when
-    const result = manager.resume({
+    expect(() => manager.resume({
       sessionId: "session-a",
-      prompt: "resume should be ignored",
+      prompt: "resume should be rejected",
       parentSessionId: "new-parent",
       parentMessageId: "new-msg",
-    })
+    })).toThrow(
+      "Task task-a is currently running and cannot accept a continuation prompt",
+    )
 
     // then
-    expect(result.parentSessionId).toBe("session-parent")
+    expect(runningTask.parentSessionId).toBe("session-parent")
+    expect(runningTask.parentMessageId).toBe("mock-message-id")
     expect(manager.resumeCalls).toHaveLength(0)
   })
 })
@@ -2973,6 +2979,70 @@ describe("BackgroundManager.resume concurrency key", () => {
     const concurrencyManager = getConcurrencyManager(manager)
     expect(concurrencyManager.getCount("anthropic")).toBe(1)
     expect(task.concurrencyKey).toBe("anthropic")
+  })
+})
+
+describe("BackgroundManager.resume running-task guard", () => {
+  test("rejects a running task without changing parent context or dispatching a prompt", async () => {
+    //#given
+    const promptCalls: string[] = []
+    const client = {
+      session: {
+        prompt: async () => {
+          promptCalls.push("prompt")
+          return {}
+        },
+        promptAsync: async () => {
+          promptCalls.push("promptAsync")
+          return {}
+        },
+        abort: async () => ({}),
+      },
+    }
+    const manager = new BackgroundManager({ pluginContext: createPluginInput(client) })
+    const sessionId = "session-running-resume"
+    const task: BackgroundTask = {
+      id: "task-running-resume",
+      sessionId,
+      parentSessionId: "parent-session-original",
+      parentMessageId: "parent-message-original",
+      parentModel: { providerID: "openai", modelID: "gpt-5.4" },
+      parentAgent: "sisyphus",
+      parentTools: { task: false },
+      description: "running task",
+      prompt: "original prompt",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(),
+    }
+    getTaskMap(manager).set(task.id, task)
+
+    try {
+      //#when
+      await expectRejectsWithMessage(
+        manager.resume({
+          sessionId,
+          prompt: "continuation prompt",
+          parentSessionId: "parent-session-new",
+          parentMessageId: "parent-message-new",
+          parentModel: { providerID: "anthropic", modelID: "claude-opus" },
+          parentAgent: "atlas",
+          parentTools: { task: true },
+        }),
+        "Task task-running-resume is currently running and cannot accept a continuation prompt",
+      )
+
+      //#then
+      expect(task.status).toBe("running")
+      expect(task.parentSessionId).toBe("parent-session-original")
+      expect(task.parentMessageId).toBe("parent-message-original")
+      expect(task.parentModel).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+      expect(task.parentAgent).toBe("sisyphus")
+      expect(task.parentTools).toEqual({ task: false })
+      expect(promptCalls).toEqual([])
+    } finally {
+      manager.shutdown()
+    }
   })
 })
 

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -1309,11 +1309,10 @@ The fallback retry session is now created and can be inspected directly.
     }
 
     if (existingTask.status === "running") {
-      log("[background-agent] Resume skipped - task already running:", {
-        taskId: existingTask.id,
-        sessionID: existingTask.sessionId,
-      })
-      return existingTask
+      throw new Error(
+        `Task ${existingTask.id} is currently running and cannot accept a continuation prompt. ` +
+        "Wait for it to complete before resuming it with task_id.",
+      )
     }
 
     const resumeSnapshot = this.captureResumeTaskSnapshot(existingTask)

--- a/packages/omo-opencode/src/features/background-agent/spawner.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner.test.ts
@@ -4,7 +4,7 @@ import {
   getSessionPromptParams,
 } from "../../shared/session-prompt-params-state"
 import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
-import { buildFallbackBody, createTask, isAgentNotFoundError, startTask } from "./spawner"
+import { buildFallbackBody, createTask, isAgentNotFoundError, resumeTask, startTask } from "./spawner"
 import type { BackgroundTask } from "./types"
 
 type PromptRequest = {
@@ -38,6 +38,50 @@ async function waitForCondition(
     await new Promise((r) => setTimeout(r, intervalMs))
   }
 }
+
+describe("background-agent spawner resume guard", () => {
+  test("rejects a running task before acquiring concurrency or dispatching a prompt", async () => {
+    //#given
+    const acquire = mock(async () => {})
+    const promptAsync = mock(async () => ({}))
+    const sessionId = "session-running-resume"
+    const task: BackgroundTask = {
+      id: "task-running-resume",
+      sessionId,
+      parentSessionId: "parent-session-original",
+      parentMessageId: "parent-message-original",
+      description: "running task",
+      prompt: "original prompt",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(),
+      concurrencyGroup: "explore",
+    }
+    const input = {
+      sessionId,
+      prompt: "continuation prompt",
+      parentSessionId: "parent-session-new",
+      parentMessageId: "parent-message-new",
+    }
+
+    //#when
+    await expect(resumeTask(task, input, {
+      client: { session: { promptAsync } },
+      concurrencyManager: { acquire, release: () => {} },
+      directory: "/tmp/test",
+      onTaskError: () => {},
+    } as never)).rejects.toThrow(
+      "Task task-running-resume is currently running and cannot accept a continuation prompt",
+    )
+
+    //#then
+    expect(acquire).not.toHaveBeenCalled()
+    expect(promptAsync).not.toHaveBeenCalled()
+    expect(task.status).toBe("running")
+    expect(task.parentSessionId).toBe("parent-session-original")
+    expect(task.parentMessageId).toBe("parent-message-original")
+  })
+})
 
 describe("background-agent spawner agent-not-found fallback", () => {
   afterEach(() => {

--- a/packages/omo-opencode/src/features/background-agent/spawner.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner.ts
@@ -186,11 +186,10 @@ export async function resumeTask(
   const sessionID = task.sessionId
 
   if (task.status === "running") {
-    log("[background-agent] Resume skipped - task already running:", {
-      taskId: task.id,
-      sessionID,
-    })
-    return
+    throw new Error(
+      `Task ${task.id} is currently running and cannot accept a continuation prompt. ` +
+      "Wait for it to complete before resuming it with task_id.",
+    )
   }
 
   const concurrencyKey = task.concurrencyGroup ?? task.agent

--- a/packages/omo-opencode/src/tools/delegate-task/background-continuation.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-continuation.test.ts
@@ -1,6 +1,49 @@
 const { describe, test, expect, mock } = require("bun:test")
 
 describe("executeBackgroundContinuation - subagent metadata", () => {
+  test("reports an error instead of false success when the task is already running", async () => {
+    //#given - manager rejects a continuation that cannot be delivered
+    const mockManager = {
+      resume: async () => {
+        throw new Error(
+          "Task bg_running is currently running and cannot accept a continuation prompt. " +
+          "Wait for it to complete before resuming it with task_id.",
+        )
+      },
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-running",
+      metadata: mock(() => Promise.resolve()),
+    }
+
+    const args = {
+      task_id: "ses_running_123",
+      prompt: "apply updated instructions",
+      description: "update running task",
+      load_skills: [],
+      run_in_background: true,
+    }
+
+    //#when
+    const { executeBackgroundContinuation } = require("./background-continuation")
+    const result = await executeBackgroundContinuation(
+      args,
+      mockCtx,
+      { manager: mockManager },
+      {
+        sessionID: "parent-session",
+        messageID: "msg-parent",
+        agent: "sisyphus",
+      },
+    )
+
+    //#then - the tool cannot claim a continuation that was never delivered
+    expect(result).toContain("currently running and cannot accept a continuation prompt")
+    expect(result).not.toContain("Background task continued")
+  })
+
   test("includes subagent in task_metadata when task has agent", async () => {
     //#given - mock manager.resume returning task with agent info
     const mockManager = {


### PR DESCRIPTION
## Summary

- reject `task(task_id=...)` when the background task is still running
- prevent `background-continuation.ts` from returning `Background task continued` when no prompt was delivered
- cover the false-success path with a tool-boundary regression test

Fixes #5966.

## Why

`BackgroundManager.resume()` and the extracted `resumeTask()` helper returned successfully for a running task without sending `input.prompt`. The caller then reported success even though the prompt was silently dropped. Throwing at the state boundary routes the existing detailed error back to the model and makes a false delivery claim impossible.

## Verification

- `bun test packages/omo-opencode/src/tools/delegate-task/background-continuation.test.ts` — 4 pass, 0 fail
- `bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json` — pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject continuation prompts for running background tasks to prevent dropped prompts and false “success.” We now throw a clear error and avoid changing task state or dispatching prompts. Fixes #5966.

- **Bug Fixes**
  - Throw in `BackgroundManager.resume()` and `resumeTask()` when the task is running so the error reaches the model/tool and a continuation is never claimed.
  - Add tests across manager, spawner, and tool layers to ensure no prompt dispatch, no concurrency acquisition, and no changes to parent context when a task is running.

<sup>Written for commit 56c57a4f2545f07a249413600fe9d03963bdb740. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

