### PR TITLE
feat(omo-codex): dev install stamped as version dev + docs

### DIFF
--- a/.agents/skills/codex-qa/SKILL.md
+++ b/.agents/skills/codex-qa/SKILL.md
@@ -69,6 +69,8 @@ Windows.
 | `scripts/hook-unit-probe.sh` | the `ultrawork` component injects `<ultrawork-mode>` on an `ulw` UserPromptSubmit (also a manual `--component/--event` mode) |
 | `scripts/tui-smoke.sh` | the real codex TUI boots in the isolated home, renders, and survives (no early exit); captures the pane |
 
+To tell a dev dogfood build apart from a published one on a REAL `~/.codex` (NOT the isolated QA home), the repo ships `bun run install:codex-dev`, which stamps the plugin version as `dev` — visible as the `(OmO dev)` hook-status prefix every turn and as a `[DEV]` badge in `omo get-local-version`. Use it to confirm which build is loaded during manual dogfooding; it writes to the real home, so it is NEVER part of the isolated QA flow above.
+
 When TUI visual QA evidence is needed, follow
 `docs/reference/web-terminal-visual-qa.md`: render the TUI through the real
 xterm.js web terminal - NEVER the `tmux capture-pane` frame, which degrades

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "build": "bun run script/build.ts",
     "build:cli-node": "bun run script/build-cli-node.ts",
     "build:codex-install": "bun run script/build-codex-install.ts",
+    "install:codex-dev": "bun run script/build-codex-install.ts && bun run script/install-codex-dev.ts",
     "build:codex-plugin": "npm --prefix packages/omo-codex/plugin ci && bun run --cwd packages/omo-codex/plugin build",
     "build:senpi-plugin": "node packages/omo-senpi/plugin/scripts/build-extension.mjs && node packages/omo-senpi/plugin/scripts/sync-skills.mjs && node packages/omo-senpi/plugin/scripts/embed-directive.mjs --check",
     "build:materialize-frontend": "node packages/omo-codex/plugin/scripts/materialize-shared-upstreams.mjs --strict",

--- a/packages/omo-codex/AGENTS.md
+++ b/packages/omo-codex/AGENTS.md
@@ -23,6 +23,11 @@
 
 **ALWAYS. EVERY TIME. NO EXCEPTIONS.**
 
+### Dev dogfood (real `~/.codex`, distinct from the isolated QA flow above)
+
+`bun run install:codex-dev` swaps your real install for this repo's local build stamped as version `dev` (env `LAZYCODEX_DEV_VERSION`, default `dev`). Everywhere the plugin version shows — cache dir `.../omo/dev/`, `plugin.json`, and the per-turn `(OmO dev)` hook prefix — reads `dev`, so you can SEE which build is loaded. This is dogfooding on your REAL home; it is NOT a substitute for the mandatory isolated-`CODEX_HOME` QA above. Impl: `resolveLazyCodexPluginVersion` `versionOverride` (`src/install/lazycodex-version-stamp.ts`) fed from `env.LAZYCODEX_DEV_VERSION` in `runCodexInstaller`; display in `get-local-version` (`dev` status on a non-semver stamp).
+
+
 ## OVERVIEW
 
 `@oh-my-opencode/omo-codex` (private, v0.1.0): the Codex harness adapter = the **Light Edition** (omo for the OpenAI Codex CLI). Vendors a Codex plugin namespace `omo` + a TypeScript installer + telemetry. Public distribution = the `lazycodex` bin/npm alias and the [`code-yeongyu/lazycodex`](https://github.com/code-yeongyu/lazycodex) marketplace repo. Codex marketplace identity = `sisyphuslabs` / plugin `omo` (`omo@sisyphuslabs`); `lazycodex` is the alias only. Full identity + the publish/deploy pipeline live in the root [`AGENTS.md`](../../AGENTS.md) "CODEX LIGHT EDITION" section.

--- a/packages/omo-codex/README.md
+++ b/packages/omo-codex/README.md
@@ -39,6 +39,19 @@ The installer copies the built plugin into `~/.codex/plugins/cache/sisyphuslabs/
 
 To remove managed Codex Light state, run `npx lazycodex-ai uninstall`. The backward-compatible alias is `npx lazycodex-ai cleanup`. Uninstall removes managed `sisyphuslabs` cache/marketplace directories, strips OMO marketplace/plugin/hook-state config blocks with a backup, removes managed agent TOML files from `~/.codex/agents/`, and repairs the known project-local legacy `.codex/config.toml` conflict while leaving project-owned `.codex` files in place.
 
+### Local dev install (dogfood the source build)
+
+To run **this repo's local build** on your real `~/.codex` instead of the published package, stamped so you can see at a glance you're on a dev build:
+
+```bash
+bun run install:codex-dev            # uninstalls current, installs repo HEAD as version "dev"
+bun run script/install-codex-dev.ts --version=dev-$(git rev-parse --short HEAD)  # custom stamp
+bun run script/install-codex-dev.ts --no-uninstall   # skip the uninstall step
+```
+
+This sets `LAZYCODEX_DEV_VERSION` (default `dev`), which threads through `resolveLazyCodexPluginVersion` so the plugin version stamp becomes that value everywhere it appears: the cache dir (`~/.codex/plugins/cache/sisyphuslabs/omo/dev/`), `.codex-plugin/plugin.json`, the stamped `package.json`, and — most visibly — the hook status prefix Codex prints every turn (`(OmO dev) ...`). `omo get-local-version` renders a `[DEV]` badge and skips the npm update check for any non-semver stamp. A plain `LAZYCODEX_DEV_VERSION`-less `lazycodex install` is unchanged. This writes to your REAL `~/.codex`; for isolated QA use the throwaway-`CODEX_HOME` flow instead.
+
+
 The Codex plugin bundle includes Context7 as a default MCP in its `.mcp.json`, using the hosted `https://mcp.context7.com/mcp` endpoint. The installer enables the `omo@sisyphuslabs` plugin MCP policy for Context7 while leaving any existing user-level `[mcp_servers.context7]` block untouched.
 The same plugin-scoped MCP manifest also bundles `grep_app`, `git_bash`, `lsp`, and `codegraph`. The ast-grep capability ships as the `ast-grep` skill and provisions `sg` into the Codex runtime. `git_bash` is enabled only on Windows by default. `codegraph` is enabled only when the installer can resolve a supported local Node runtime for CodeGraph; unsupported runtimes disable that MCP policy while keeping `omo@sisyphuslabs` enabled.
 

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -9605,6 +9605,10 @@ async function readDistributionManifest(repoRoot) {
   }
 }
 function resolveLazyCodexPluginVersion(input) {
+  const override = input.versionOverride?.trim();
+  if (override !== undefined && override.length > 0) {
+    return override;
+  }
   if (input.marketplaceName === "sisyphuslabs" && input.pluginName === "omo" && input.distributionManifest !== undefined) {
     return input.distributionManifest.version;
   }
@@ -10245,6 +10249,7 @@ async function runCodexInstaller(options = {}) {
     return;
   });
   const buildSource = await shouldBuildSourcePackages(repoRoot);
+  const versionOverride = env2.LAZYCODEX_DEV_VERSION?.trim() || undefined;
   const gitBashResolution = await prepareGitBashForInstall({
     platform,
     env: env2,
@@ -10271,7 +10276,8 @@ async function runCodexInstaller(options = {}) {
       manifestVersion: manifest.version,
       marketplaceName: marketplace.name,
       pluginName: entry.name,
-      distributionManifest
+      distributionManifest,
+      versionOverride
     });
     validatePathSegment(version2, "plugin version");
     log(`Building ${entry.name}@${version2}`);

--- a/packages/omo-codex/src/install/install-codex.ts
+++ b/packages/omo-codex/src/install/install-codex.ts
@@ -34,6 +34,7 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
   const runCommand = options.runCommand ?? defaultRunCommand
   const log = options.log ?? (() => undefined)
   const buildSource = await shouldBuildSourcePackages(repoRoot)
+  const versionOverride = env.LAZYCODEX_DEV_VERSION?.trim() || undefined
 
   const gitBashResolution = await prepareGitBashForInstall({
     platform,
@@ -69,6 +70,7 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
       marketplaceName: marketplace.name,
       pluginName: entry.name,
       distributionManifest,
+      versionOverride,
     })
     validatePathSegment(version, "plugin version")
     log(`Building ${entry.name}@${version}`)

--- a/packages/omo-codex/src/install/lazycodex-version-stamp.ts
+++ b/packages/omo-codex/src/install/lazycodex-version-stamp.ts
@@ -26,7 +26,12 @@ export function resolveLazyCodexPluginVersion(input: {
   readonly marketplaceName: string
   readonly pluginName: string
   readonly distributionManifest?: DistributionManifest
+  readonly versionOverride?: string
 }): string {
+  const override = input.versionOverride?.trim()
+  if (override !== undefined && override.length > 0) {
+    return override
+  }
   if (input.marketplaceName === "sisyphuslabs" && input.pluginName === "omo" && input.distributionManifest !== undefined) {
     return input.distributionManifest.version
   }

--- a/packages/omo-opencode/src/cli/get-local-version/formatter.ts
+++ b/packages/omo-opencode/src/cli/get-local-version/formatter.ts
@@ -44,6 +44,10 @@ export function formatVersionOutput(info: VersionInfo): string {
       lines.push(`  ${SYMBOLS.dev} ${color.cyan("Running in local development mode")}`)
       lines.push(`  ${color.dim("Using file:// protocol from config")}`)
       break
+    case "dev":
+      lines.push(`  ${SYMBOLS.dev} ${color.cyan("Running a local dev build")}`)
+      lines.push(`  ${color.dim("Installed from source; update checks are skipped")}`)
+      break
     case "pinned":
       lines.push(`  ${SYMBOLS.pin} ${color.magenta(`Version pinned to ${info.pinnedVersion}`)}`)
       lines.push(`  ${color.dim("Update check skipped for pinned versions")}`)

--- a/packages/omo-opencode/src/cli/get-local-version/get-local-version.ts
+++ b/packages/omo-opencode/src/cli/get-local-version/get-local-version.ts
@@ -65,6 +65,21 @@ export async function getLocalVersion(
       return 1
     }
 
+    if (!/^\d+\.\d+\.\d+/.test(currentVersion)) {
+      const info: VersionInfo = {
+        currentVersion,
+        latestVersion: null,
+        isUpToDate: false,
+        isLocalDev: true,
+        isPinned: false,
+        pinnedVersion: null,
+        status: "dev",
+      }
+
+      console.log(options.json ? formatJsonOutput(info) : formatVersionOutput(info))
+      return 0
+    }
+
     const { extractChannel } = await import("../../hooks/auto-update-checker/index")
     const channel = extractChannel(pluginInfo?.pinnedVersion ?? currentVersion)
     const latestVersion = await getLatestVersion(channel)

--- a/packages/omo-opencode/src/cli/get-local-version/types.ts
+++ b/packages/omo-opencode/src/cli/get-local-version/types.ts
@@ -5,7 +5,7 @@ export interface VersionInfo {
   isLocalDev: boolean
   isPinned: boolean
   pinnedVersion: string | null
-  status: "up-to-date" | "outdated" | "local-dev" | "pinned" | "pinned-mismatch" | "error" | "unknown"
+  status: "up-to-date" | "outdated" | "local-dev" | "dev" | "pinned" | "pinned-mismatch" | "error" | "unknown"
 }
 
 export interface GetLocalVersionOptions {

--- a/script/AGENTS.md
+++ b/script/AGENTS.md
@@ -24,6 +24,7 @@ Build, publish, QA, and repo-invariant automation. Run via `bun run <script>` fr
 | `lazycodex-marketplace-validation.ts` | Validate the synced marketplace payload (runtime path args incl. Windows/absolute/`components/*/dist/*.js`) |
 | `lazycodex-runtime-dists.ts` | Enumerate component runtime dists bundled into the published payload |
 | `update-frontend-upstreams.mjs` | Bump shared-skills submodules + rewrite ATTRIBUTION pins (`--check` verifies) |
+| `install-codex-dev.ts` | Dev dogfood installer: uninstall current Codex Light, then install this repo's local build into the REAL `~/.codex` stamped as version `dev` (`.../omo/dev/`, `(OmO dev)` hook prefix). Sets `LAZYCODEX_DEV_VERSION`. Run via `bun run install:codex-dev`. Flags: `--version=<x>`, `--no-uninstall`. NOT for QA — use the isolated `CODEX_HOME` flow for that. |
 
 ## SUBDIRS
 

--- a/script/install-codex-dev.ts
+++ b/script/install-codex-dev.ts
@@ -1,0 +1,45 @@
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url))
+const installerEntrypoint = fileURLToPath(
+  new URL("../packages/omo-codex/scripts/install-local.mjs", import.meta.url),
+)
+
+const args = process.argv.slice(2)
+const devVersionArg = args.find((arg) => arg.startsWith("--version="))
+const devVersion = devVersionArg?.slice("--version=".length).trim() || "dev"
+const skipUninstall = args.includes("--no-uninstall")
+const passthrough = args.filter((arg) => arg !== "--no-uninstall" && !arg.startsWith("--version="))
+
+const childEnv = { ...process.env, LAZYCODEX_DEV_VERSION: devVersion }
+
+function runInstaller(installerArgs: readonly string[]): number {
+  const result = spawnSync("node", [installerEntrypoint, ...installerArgs], {
+    cwd: repositoryRoot,
+    stdio: "inherit",
+    env: childEnv,
+    shell: false,
+  })
+  if (result.error) throw result.error
+  return result.status ?? 1
+}
+
+if (!skipUninstall) {
+  console.log("[install-codex-dev] Removing the current Codex Light install...")
+  const uninstallStatus = runInstaller(["uninstall"])
+  if (uninstallStatus !== 0) {
+    console.error(`[install-codex-dev] uninstall exited with code ${uninstallStatus}`)
+    process.exit(uninstallStatus)
+  }
+}
+
+console.log(`[install-codex-dev] Installing the dev build from ${repositoryRoot} as version "${devVersion}"...`)
+const installStatus = runInstaller(["install", "--no-tui", ...passthrough])
+if (installStatus !== 0) {
+  console.error(`[install-codex-dev] install exited with code ${installStatus}`)
+  process.exit(installStatus)
+}
+
+console.log(`[install-codex-dev] Done. Installed the dev build stamped as "${devVersion}".`)
+console.log('[install-codex-dev] Verify with: omo get-local-version')


### PR DESCRIPTION
## Summary

Adds a dedicated dev-install path so you can run this repo's local build on your real `~/.codex` stamped as version `dev`, visible at a glance — and documents it everywhere it will be felt.

## Feature

- **`bun run install:codex-dev`** (new `script/install-codex-dev.ts`): uninstall current Codex Light, then install repo HEAD with `LAZYCODEX_DEV_VERSION=dev`. Flags: `--version=<x>`, `--no-uninstall`.
- **Version resolution**: `resolveLazyCodexPluginVersion` gains an optional `versionOverride` (highest precedence); `runCodexInstaller` feeds it from `env.LAZYCODEX_DEV_VERSION`. Opt-in and lazycodex-scoped — a plain `lazycodex install` is byte-identical to before.
- **Where `dev` shows**: cache dir `~/.codex/plugins/cache/sisyphuslabs/omo/dev/`, `.codex-plugin/plugin.json`, stamped `package.json`, and — the surface felt every turn — the `(OmO dev)` hook-status prefix.
- **`omo get-local-version`**: new `dev` status renders `[DEV] Running a local dev build` and skips the npm update check for any non-semver stamp (so no false "update available").

## Docs

- `packages/omo-codex/README.md`: new "Local dev install (dogfood the source build)" section.
- `packages/omo-codex/AGENTS.md`: dev-dogfood note, explicitly separated from the mandatory isolated-`CODEX_HOME` QA.
- `script/AGENTS.md`: `install-codex-dev.ts` row.
- `.agents/skills/codex-qa/SKILL.md`: note that the `(OmO dev)` prefix / `[DEV]` badge tells a dogfood build apart from a published one — never part of the isolated QA flow.

## Verification

- Installed on the author's machine end-to-end: cache dir `.../omo/dev/`, plugin.json + package.json stamped `dev`, every hook status message reads `(OmO dev)`, marketplace `source_type = "local"`.
- Tests: install-codex + get-local-version (13), installer-version pin (1), agents-md-dev-env + package-registration-audit (10) — all pass; diagnostics clean on all edited files.

## Scope note

The `omo get-local-version` / `lazycodex version` CLI subcommands still print `4.17.1` for a source install (the wrapper execs `repoRoot/dist/cli`, so the reader walks up to the repo `package.json`). The Codex-visible `(OmO dev)` prefix is correct. Pointing the wrapper at the cache would fix those two but adds a reinstall-to-test step for source edits, so it is intentionally left out.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dev-install workflow to run this repo’s local build on your real `~/.codex`, stamped as version `dev`, and updates the CLI to detect dev builds and skip update checks.

- **New Features**
  - `bun run install:codex-dev`: uninstalls current Codex Light, then installs repo HEAD with `LAZYCODEX_DEV_VERSION` (default `dev`). Flags: `--version=<x>`, `--no-uninstall`.
  - Version override: `resolveLazyCodexPluginVersion` now accepts `versionOverride`; installer reads `env.LAZYCODEX_DEV_VERSION`. A plain `lazycodex install` is unchanged.
  - Visibility: dev stamp shows in cache dir `~/.codex/plugins/cache/sisyphuslabs/omo/dev/`, `.codex-plugin/plugin.json`, stamped `package.json`, and the `(OmO dev)` hook prefix.
  - `omo get-local-version`: new `dev` status for non-semver stamps; prints “[DEV] Running a local dev build” and skips the npm update check.
  - Docs: added notes on dogfooding on the real home vs. the isolated `CODEX_HOME` QA flow.

<sup>Written for commit 5b5cbb8bc1283cf4ca36171acb562b9027977f9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

