### PR TITLE
test(agents): cover Hephaestus GPT-5.6 registration

### DIFF
--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-6-registration.test.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-6-registration.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import type { CategoryConfig } from "../../config/schema";
+import { maybeCreateHephaestusConfig } from "../builtin-agents/hephaestus-agent";
+import type { AgentOverrides } from "../types";
+
+const GPT_5_6_PROMPT_MARKER = "based on GPT-5.6";
+const EXPLICIT_VARIANT = "xhigh";
+const SUPPORTED_MODEL_IDS = [
+	"openai/gpt-5.6-sol",
+	"openai/gpt-5.6-terra-fast",
+	"openai/gpt-5.6-luna-pro",
+	"vercel/openai/gpt-5.6-sol",
+	"cx/gpt-5.6-sol",
+] as const;
+
+describe("maybeCreateHephaestusConfig GPT-5.6 registration", () => {
+	for (const model of SUPPORTED_MODEL_IDS) {
+		test(`#given ${model} with an explicit variant #when Hephaestus registers #then the configured model and GPT-5.6 prompt are preserved`, () => {
+			// given
+			const agentOverrides: AgentOverrides = {
+				hephaestus: {
+					model,
+					variant: EXPLICIT_VARIANT,
+				},
+			};
+			const mergedCategories: Record<string, CategoryConfig> = {};
+
+			// when
+			const config = maybeCreateHephaestusConfig({
+				disabledAgents: [],
+				agentOverrides,
+				availableModels: new Set([model]),
+				systemDefaultModel: model,
+				isFirstRunNoCache: false,
+				availableAgents: [],
+				availableSkills: [],
+				availableCategories: [],
+				mergedCategories,
+				useTaskSystem: false,
+			});
+
+			// then
+			expect(config).toBeDefined();
+			expect(config?.model).toBe(model);
+			expect(config?.variant).toBe(EXPLICIT_VARIANT);
+			expect(config?.prompt).toContain(GPT_5_6_PROMPT_MARKER);
+		});
+	}
+
+	test("#given an unsupported Claude model #when Hephaestus registers #then no config is registered", () => {
+		// given
+		const model = "anthropic/claude-sonnet-4-6";
+		const agentOverrides: AgentOverrides = {
+			hephaestus: {
+				model,
+				variant: EXPLICIT_VARIANT,
+			},
+		};
+		const mergedCategories: Record<string, CategoryConfig> = {};
+
+		// when
+		const config = maybeCreateHephaestusConfig({
+			disabledAgents: [],
+			agentOverrides,
+			availableModels: new Set([model]),
+			systemDefaultModel: model,
+			isFirstRunNoCache: false,
+			availableAgents: [],
+			availableSkills: [],
+			availableCategories: [],
+			mergedCategories,
+			useTaskSystem: false,
+		});
+
+		// then
+		expect(config).toBeUndefined();
+	});
+});

--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-6-registration.test.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-6-registration.test.ts
@@ -1,8 +1,10 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, test } from "bun:test";
 import type { CategoryConfig } from "../../config/schema";
 import { maybeCreateHephaestusConfig } from "../builtin-agents/hephaestus-agent";
 import type { AgentOverrides } from "../types";
-import { getHephaestusPromptSource } from "./index";
+import { getHephaestusPrompt, getHephaestusPromptSource } from "./index";
 
 const EXPLICIT_VARIANT = "xhigh";
 const SYSTEM_DEFAULT_MODEL = "openai/gpt-5.5";
@@ -17,7 +19,7 @@ const SUPPORTED_MODEL_IDS = [
 
 describe("maybeCreateHephaestusConfig GPT-5.6 registration", () => {
 	for (const model of SUPPORTED_MODEL_IDS) {
-		test(`#given ${model} overrides a different system default #when Hephaestus registers #then the override and GPT-5.6 prompt source are preserved`, () => {
+		test(`#given ${model} overrides a different system default #when Hephaestus registers #then the override, variant, and GPT-5.6 prompt are preserved`, () => {
 			// given
 			const agentOverrides: AgentOverrides = {
 				hephaestus: {
@@ -46,6 +48,7 @@ describe("maybeCreateHephaestusConfig GPT-5.6 registration", () => {
 			expect(config?.model).toBe(model);
 			expect(config?.variant).toBe(EXPLICIT_VARIANT);
 			expect(getHephaestusPromptSource(config?.model)).toBe("gpt-5-6");
+			expect(config?.prompt).toBe(getHephaestusPrompt(model));
 		});
 	}
 

--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-6-registration.test.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-6-registration.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 import type { CategoryConfig } from "../../config/schema";
 import { maybeCreateHephaestusConfig } from "../builtin-agents/hephaestus-agent";
 import type { AgentOverrides } from "../types";
+import { getHephaestusPromptSource } from "./index";
 
-const GPT_5_6_PROMPT_MARKER = "based on GPT-5.6";
 const EXPLICIT_VARIANT = "xhigh";
+const SYSTEM_DEFAULT_MODEL = "openai/gpt-5.5";
 const SUPPORTED_MODEL_IDS = [
+	"openai/gpt-5.6",
 	"openai/gpt-5.6-sol",
 	"openai/gpt-5.6-terra-fast",
 	"openai/gpt-5.6-luna-pro",
@@ -15,7 +17,7 @@ const SUPPORTED_MODEL_IDS = [
 
 describe("maybeCreateHephaestusConfig GPT-5.6 registration", () => {
 	for (const model of SUPPORTED_MODEL_IDS) {
-		test(`#given ${model} with an explicit variant #when Hephaestus registers #then the configured model and GPT-5.6 prompt are preserved`, () => {
+		test(`#given ${model} overrides a different system default #when Hephaestus registers #then the override and GPT-5.6 prompt source are preserved`, () => {
 			// given
 			const agentOverrides: AgentOverrides = {
 				hephaestus: {
@@ -29,8 +31,8 @@ describe("maybeCreateHephaestusConfig GPT-5.6 registration", () => {
 			const config = maybeCreateHephaestusConfig({
 				disabledAgents: [],
 				agentOverrides,
-				availableModels: new Set([model]),
-				systemDefaultModel: model,
+				availableModels: new Set([model, SYSTEM_DEFAULT_MODEL]),
+				systemDefaultModel: SYSTEM_DEFAULT_MODEL,
 				isFirstRunNoCache: false,
 				availableAgents: [],
 				availableSkills: [],
@@ -43,7 +45,7 @@ describe("maybeCreateHephaestusConfig GPT-5.6 registration", () => {
 			expect(config).toBeDefined();
 			expect(config?.model).toBe(model);
 			expect(config?.variant).toBe(EXPLICIT_VARIANT);
-			expect(config?.prompt).toContain(GPT_5_6_PROMPT_MARKER);
+			expect(getHephaestusPromptSource(config?.model)).toBe("gpt-5-6");
 		});
 	}
 


### PR DESCRIPTION
## Summary

Hephaestus GPT-5.6 registration was already fixed on `dev`, but the issue stayed open without focused coverage at the registration boundary. This PR adds a mutation-resistant regression contract so official, suffixed, nested-provider, and gateway GPT-5.6 IDs cannot be silently dropped or registered with a prompt built for the wrong model family.

## Changes

- Add registration-level coverage for `openai/gpt-5.6`, `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra-fast`, `openai/gpt-5.6-luna-pro`, `vercel/openai/gpt-5.6-sol`, and `cx/gpt-5.6-sol`.
- Verify each configured GPT-5.6 model overrides a distinct supported system default, preserves the exact model ID and explicit `xhigh` variant, and resolves the stable `gpt-5-6` prompt-source token.
- Verify the registered `config.prompt` exactly matches the public GPT-5.6 prompt builder output for the configured model.
- Pin the unsupported boundary with `anthropic/claude-sonnet-4-6`, which must remain unregistered.

## QA & Evidence

- **Focused regression test:** `bun test packages/omo-opencode/src/agents/hephaestus/gpt-5-6-registration.test.ts` passed with 7 tests and 31 assertions. The adjacent Hephaestus suite passed with 38 tests and 121 assertions. Artifacts: `.omo/evidence/20260714-hephaestus-gpt56-registration/final-focused-bun-test-v2.txt` and `final-adjacent-bun-test-v2.txt`.
- **Mutation-red proof:** temporarily forcing prompt construction from the GPT-5.5 system default produced 6 supported-case failures at the new prompt equality assertion. Reverting the temporary mutation restored all 7 focused tests. No production mutation remains. Artifact: `.omo/evidence/20260714-hephaestus-gpt56-registration/review-remediation-2.md`.
- **Type and style gates:** changed-file Biome, package and full repository typecheck, the canonical TypeScript no-excuse checker, and full build passed. Artifacts are under `.omo/evidence/20260714-hephaestus-gpt56-registration/`.
- **Real OpenCode surface:** a final isolated HOME/XDG replay loaded the locally built plugin and ran `opencode debug agent "Hephaestus - Deep Agent"`. The result preserved provider `openai`, model `gpt-5.6-sol`, variant `xhigh`, included GPT-5.6 prompt content, and excluded GPT-5.5 prompt content. The host OpenCode session count remained `21868` before and after. Artifacts: `.omo/evidence/20260714-hephaestus-gpt56-registration/surface-final/`.
- **Isolation cleanup:** `/tmp/oqa-hephaestus-gpt56-20260714-2` was removed after evidence capture.

## Review Remediation

- The first review iteration caught identical override/default values, a missing unsuffixed family ID, and copied prompt prose. Commit `3262f8502` fixed those issues.
- The second review iteration caught a false-confidence prompt assertion that classified only the final model string. Commit `bbba1a15d` now observes the actual registered prompt and includes a mutation-red proof that the assertion detects wrong-model prompt construction.

## Risks & Residuals

This is a test-only change, so runtime risk is limited to test maintenance. The standalone LSP server attached to the external worktree reports missing `bun:test` declarations despite the neighboring `bun-types` reference; package and root `tsgo` compilers pass, so this is recorded as workspace-context noise. Build-generated unrelated schema churn was removed from the diff.

## Related Issues

Closes #6009
