### PR TITLE
feat(hephaestus): mandatory GOAL/STOP WHEN/EVIDENCE contract for GPT-5.6 subagent spawns

### DIFF
--- a/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md
+++ b/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md
@@ -29,12 +29,14 @@ Implement surgically, matching codebase style (naming, indentation, imports, err
 
 # Subagents
 
-Read-only Codex subagent roles live in `CODEX_HOME/agents/`. Spawn: `multi_agent_v1.spawn_agent({"message":"TASK: act as a <role>. ...","fork_context":false})`. If your tool list instead has a flat `spawn_agent` with a required `task_name` (`multi_agent_v2`): `spawn_agent({"task_name":"<lowercase_digits_underscores>","message":"TASK: act as a <role>. ...","fork_turns":"none"})` - finished agents end on their own; `wait_agent` takes only `timeout_ms`.
+Read-only Codex subagent roles live in `CODEX_HOME/agents/`. Spawn: `multi_agent_v1.spawn_agent({"message":"TASK: act as a <role>. GOAL: ... STOP WHEN: ... EVIDENCE: ...","fork_context":false})`. If your tool list instead has a flat `spawn_agent` with a required `task_name` (`multi_agent_v2`): `spawn_agent({"task_name":"<lowercase_digits_underscores>","message":"TASK: act as a <role>. GOAL: ... STOP WHEN: ... EVIDENCE: ...","fork_turns":"none"})` - finished agents end on their own; `wait_agent` takes only `timeout_ms`.
 
 - `explorer` - codebase search
 - `librarian` - external docs, OSS code, API contracts
 - `plan` - planning when design is still open after discovery; never for a known checklist or for work being delegated onward
 - `lazycodex-gate-reviewer` - final verification of a finished change
+
+Every spawn message MUST fill all three labels - **GOAL** (the one outcome that makes the child done), **STOP WHEN** (the exact, observable condition that ends its run; the child stops the moment it holds, exactly like your own intent line), **EVIDENCE** (what the child returns so you can SEE, not trust, that the condition held). A spawn missing any label is a defect: the child wanders past its goal, overworks, or reports "done" you cannot verify. Judge a child by its returned EVIDENCE against its STOP WHEN, never by its self-report.
 
 Spawn in parallel for independent investigations; do non-overlapping prep while they run, integrate on return. Never duplicate a running search or poll without a completion signal; post brief status updates while children run (active subagent count, latest `WORKING:` phase).
 


### PR DESCRIPTION
## Summary
The Hephaestus GPT-5.6 Codex bundled rule now forces every subagent spawn to carry an explicit goal, an observable stop condition, and returnable evidence. Previously the parent's own turn had a binding Stop Goal, but spawned children got free-form `TASK: ...` messages — they could wander past their goal, overwork, or report an unverifiable "done". After this PR the spawn message templates and a defining paragraph make GOAL / STOP WHEN / EVIDENCE mandatory in every spawn, mirroring the parent's own intent-line + Stop Goal discipline, and instruct the parent to judge children by returned evidence against the declared stop condition rather than self-reports.

Scope note: applies to the omo-codex edition only (per request). The OpenCode `gpt-5-6.ts` prompt is intentionally untouched.

Written per the GPT-5.6 prompting doctrine (prompt-engineering `references/gpt-5.6.md`): the change edits the existing spawn-contract lines at their source instead of appending new sections, keeps stopping conditions outcome-shaped, and reserves MUST for a true invariant.

## Changes
- `packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md`: both `spawn_agent` message templates in `# Subagents` (multi_agent_v1 and v2) now inline `GOAL: ... STOP WHEN: ... EVIDENCE: ...`, and a new paragraph after the role list defines the three labels, marks a missing label as a defect, and requires judging children by EVIDENCE against STOP WHEN, never self-reports. This rule is in `NEVER_TRUNCATED_RULE_PATHS`, so the added text cannot be cut by the rules-engine budget.

## QA & Evidence
- **What was tested:** ran the real Codex `runSessionStartHook()` with `model: "gpt-5.6-codex"` against a fixture project (bundled-rules-only env).
  - **Observed result:** injected output contains the spawn templates with `GOAL: ... STOP WHEN: ... EVIDENCE: ...`, the three-label paragraph, identity `based on GPT-5.6`, and no truncation notice.
  - **Artifact:** `.omo/evidence/20260714-heph56-spawn-contract-codex.txt`
  - **Why sufficient:** this is the exact surface (SessionStart hook injection) through which Codex sessions receive the rule, including model-variant routing and the never-truncate guarantee.
- **Automated:** omo-codex rules `bun run test` — 163 pass, including the gpt-5.5/gpt-5.6 variant-routing suite proving the 5.5 rule is untouched and the 5.6 rule injects in full.

## Risks & Residuals
- Prompt-behavior change is inherently empirical; the wording follows the GPT-5.6 guide (outcome-first, explicit stopping conditions) and the existing Stop Goal register of the file. Mitigated by keeping the edit local to the `# Subagents` section — no other section touched.
- gpt-5.5 variant intentionally unchanged: this contract is written against 5.6 stop-condition doctrine.

## Related Issues
None.
