### PR TITLE
feat(skills): reject prose prompt assertions

### DIFF
--- a/packages/shared-skills/skills/programming/references/typescript/README.md
+++ b/packages/shared-skills/skills/programming/references/typescript/README.md
@@ -170,6 +170,7 @@ Violations caught by `../../scripts/typescript/check-no-excuse-rules.ts`. Run af
 | `no-explicit-any-return` | `(): any` or `(): Promise<any>` return types | `// no-excuse-ok: any` |
 | `empty-catch` | `catch { }` or `catch (e) { }` with empty body | `// no-excuse-ok: catch` |
 | `catch-without-narrowing` | `catch (e)` used without `instanceof` or re-throw | `// no-excuse-ok: catch` |
+| `no-prose-assertion` | Natural-language `toContain`, `not.toContain`, string `toMatch`, long-string `toBe`, or `toMatchSnapshot` in `*.test.*`, `*.spec.*`, and `__tests__` files | `// no-excuse-ok: no-prose-assertion` |
 
 Biome enforces additional rules (noExplicitAny, noNonNullAssertion, noDefaultExport, useImportType). The script catches what Biome cannot.
 

--- a/packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.test.ts
+++ b/packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.test.ts
@@ -1,0 +1,88 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const CHECKER_PATH = join(import.meta.dir, "check-no-excuse-rules.ts")
+
+type CheckerResult = {
+  readonly exitCode: number
+  readonly output: string
+}
+
+function runChecker(source: string, relativePath = "prompt.test.ts"): CheckerResult {
+  const directory = mkdtempSync(join(tmpdir(), "no-prose-assertion-"))
+  const testFile = join(directory, relativePath)
+  mkdirSync(dirname(testFile), { recursive: true })
+  writeFileSync(testFile, source)
+
+  try {
+    const result = Bun.spawnSync({
+      cmd: ["bun", "run", CHECKER_PATH, testFile],
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    return {
+      exitCode: result.exitCode,
+      output: `${result.stdout.toString()}${result.stderr.toString()}`,
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+describe("check-no-excuse-rules no-prose-assertion", () => {
+  test("#given prose assertion matchers #when checked #then reports every prose assertion", () => {
+    const source = [
+      'expect(prompt).toContain("based on GPT-5.6")',
+      'expect(prompt).toContain("You build context by examining")',
+      'expect(prompt).not.toContain("Never chain together bash commands")',
+      'expect(prompt).toMatch("Never chain together bash commands")',
+      'expect(prompt).toBe("Never chain together bash commands in a prompt")',
+      "expect(prompt).toMatchSnapshot()",
+    ].join("\n")
+
+    const result = runChecker(source)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.output.match(/\[no-prose-assertion\]/g)).toHaveLength(6)
+  })
+
+  test("#given a __tests__ file #when checked #then reports a prose assertion", () => {
+    const result = runChecker(
+      'expect(prompt).toContain("You build context by examining")',
+      "fixtures/__tests__/prompt.ts",
+    )
+
+    expect(result.exitCode).toBe(1)
+    expect(result.output).toContain("[no-prose-assertion]")
+  })
+
+  test("#given machine tokens #when checked #then accepts them", () => {
+    const source = [
+      'expect(prompt).toContain("<agent-identity>")',
+      'expect(prompt).toContain("gpt-5-6")',
+      'expect(prompt).toContain("packages/shared-skills/skills/programming/SKILL.md")',
+      'expect(prompt).toContain("{\\"model\\":\\"gpt-5-6\\"}")',
+      'expect(prompt).toContain("promptToken")',
+      'expect(prompt).toMatch("<agent-identity>")',
+      'expect(prompt).toBe("gpt-5-6")',
+    ].join("\n")
+
+    const result = runChecker(source)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain("No violations")
+  })
+
+  test("#given an explicit rule opt-out #when checked #then accepts the assertion", () => {
+    const source = [
+      'expect(prompt).toContain("You build context by examining") // no-excuse-ok: no-prose-assertion',
+      "expect(prompt).toMatchSnapshot() // no-excuse-ok: no-prose-assertion",
+    ].join("\n")
+
+    const result = runChecker(source)
+
+    expect(result.exitCode).toBe(0)
+  })
+})

--- a/packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts
+++ b/packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts
@@ -15,6 +15,7 @@
  *   no-explicit-any-return  - `(): any` return types (opt out: `// no-excuse-ok: any`)
  *   empty-catch             - `catch { }` or `catch (e) { }` with empty body
  *   catch-without-narrowing - catch block that uses error without instanceof narrowing
+ *   no-prose-assertion      - natural-language assertions in test files
  *
  * Usage:
  *   bun run scripts/check-no-excuse-rules.ts <file-or-dir>...
@@ -43,6 +44,7 @@ type RuleId =
   | "no-explicit-any-return"
   | "empty-catch"
   | "catch-without-narrowing"
+  | "no-prose-assertion"
 
 type Violation = {
   readonly ruleId: RuleId
@@ -60,6 +62,10 @@ const IGNORED_DIRECTORIES = new Set([
 
 const OPT_OUT_RE = /\/\/\s*no-excuse-ok:\s*any/
 const CATCH_OK_RE = /\/\/\s*no-excuse-ok:\s*catch/
+const PROSE_ASSERTION_OK_RE = /\/\/\s*no-excuse-ok:\s*no-prose-assertion/
+const PROSE_STRING_ASSERTION_MATCHERS = new Set(["toContain", "toMatch", "toBe"])
+const MACHINE_STRING_RE = /[<>{}\[\]\\/:=]|(?:^|\s)--/
+const PROSE_WORD_RE = /[A-Za-z][A-Za-z0-9'-]*/g
 
 function isIncludedFile(filePath: string): boolean {
   return INCLUDED_EXTENSIONS.has(path.extname(filePath).toLowerCase())
@@ -67,6 +73,15 @@ function isIncludedFile(filePath: string): boolean {
 
 function isDeclarationFile(filePath: string): boolean {
   return filePath.endsWith(".d.ts") || filePath.endsWith(".d.mts") || filePath.endsWith(".d.cts")
+}
+
+function isTestFile(filePath: string): boolean {
+  return /\.(test|spec)\.[^.]+$/i.test(path.basename(filePath)) || /(^|[\\/])__tests__([\\/]|$)/.test(filePath)
+}
+
+function isNaturalLanguageProse(value: string): boolean {
+  if (MACHINE_STRING_RE.test(value)) return false
+  return (value.match(PROSE_WORD_RE)?.length ?? 0) >= 3
 }
 
 function discoverFiles(inputs: string[]): string[] {
@@ -192,6 +207,31 @@ function analyzeFile(filePath: string): Violation[] {
           const p = pos(node)
           violations.push({ ruleId: "no-explicit-any-return", filePath, ...p, message: "`(): any` return — use a specific type" })
         }
+      }
+    }
+
+    // ── prose assertions in test files ──
+    if (isTestFile(filePath) && ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const matcher = node.expression.name.text
+      const argument = node.arguments[0]
+      const isOptedOut = PROSE_ASSERTION_OK_RE.test(getLineText(sourceFile, sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line))
+      const stringArgument = argument !== undefined && ts.isStringLiteral(argument) ? argument : null
+      const isProseArgument = stringArgument !== null && isNaturalLanguageProse(stringArgument.text)
+      const shouldFlag = matcher === "toMatchSnapshot"
+        || (PROSE_STRING_ASSERTION_MATCHERS.has(matcher) && isProseArgument && (
+          matcher === "toContain"
+          || matcher === "toMatch"
+          || (matcher === "toBe" && stringArgument !== null && stringArgument.text.length >= 24)
+        ))
+
+      if (shouldFlag && !isOptedOut) {
+        const p = pos(node)
+        violations.push({
+          ruleId: "no-prose-assertion",
+          filePath,
+          ...p,
+          message: `\`${matcher}\` prose assertion — assert parsed behavior, structure, or rule data instead`,
+        })
       }
     }
 


### PR DESCRIPTION
## Summary
Adds a deterministic `no-prose-assertion` rule to the TypeScript no-excuse checker for test files. It prevents prompt and skill tests from pinning prose, addressing the first review cycle lost on PR #6099 when a delegated worker asserted `based on GPT-5.6` directly.

## Changes
- Detects natural-language strings in `toContain` and `not.toContain`, string `toMatch`, long-string `toBe`, and `toMatchSnapshot` in `*.test.*`, `*.spec.*`, and `__tests__` files.
- Preserves machine-token assertions such as sentinels, model IDs, file paths, JSON fragments, flags, and identifiers.
- Supports the documented escape hatch: `// no-excuse-ok: no-prose-assertion`.
- Documents the new rule and adds real-process checker tests.

## QA & Evidence
Evidence is intentionally local and ignored under `.omo/evidence/20260714-prose-assertion-lint/`; it is not committed.

- **What was tested:** checker rejection of the three motivating prose assertions.
  **Local artifact:** `.omo/evidence/20260714-prose-assertion-lint/checker-flags-prose.txt`
  **Observed output:**
  ```text
  3 violation(s) in 1 file(s).
  exit=1
  ```
- **What was tested:** checker acceptance of machine tokens.
  **Local artifact:** `.omo/evidence/20260714-prose-assertion-lint/checker-accepts-machine-tokens.txt`
  **Observed output:**
  ```text
  No violations in 1 file(s).
  exit=0
  ```
- **What was tested:** focused Bun unit suite.
  **Local artifact:** `.omo/evidence/20260714-prose-assertion-lint/focused-bun-test.txt`
  **Observed output:**
  ```text
  4 pass
  0 fail
  Ran 4 tests across 1 file.
  exit=0
  ```

The checker is not invoked by CI. It is documented as a changed-path audit agents run after TypeScript edits, so this PR scopes the rule to test files and does not require a corpus cleanup.

## Risks & Residuals
The prose heuristic is intentionally conservative: it requires at least three word-like tokens and excludes strings containing common machine syntax. One-off exceptions remain explicit and reviewable via the rule-specific escape hatch.

`toMatchSnapshot` is intentionally blanket-flagged, so it also catches legitimate structural snapshots such as CLI-help or JSON-shape snapshots. Future changes should retain those structural assertions with `// no-excuse-ok: no-prose-assertion` rather than delete them.