### PR TITLE
fix(runtime-fallback): preserve native context compaction

### DIFF
--- a/packages/model-core/src/runtime-fallback-error-classifier.test.ts
+++ b/packages/model-core/src/runtime-fallback-error-classifier.test.ts
@@ -158,6 +158,26 @@ describe("runtime fallback error classifier", () => {
     expect(type).toBeUndefined()
   })
 
+  test("leaves OpenCode context overflow to native compaction", () => {
+    //#given
+    const error = {
+      name: "ContextOverflowError",
+      data: {
+        message: "Your input exceeds the context window of this model. Please adjust your input and try again.",
+        responseBody:
+          '{"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again.","type":"invalid_request_error","code":"context_too_large"}}',
+      },
+    }
+
+    //#when
+    const type = classifyRuntimeFallbackError(error)
+    const retryable = isRuntimeFallbackRetryableError(error, [400, ...DEFAULT_RETRY_CODES])
+
+    //#then
+    expect(type).toBe("context_overflow")
+    expect(retryable).toBe(false)
+  })
+
   test("extracts provider auto-retry signals from status summary or details", () => {
     //#given
     const retryInfo = {

--- a/packages/model-core/src/runtime-fallback-error-classifier.ts
+++ b/packages/model-core/src/runtime-fallback-error-classifier.ts
@@ -21,6 +21,7 @@ export type RuntimeFallbackErrorType =
   | "invalid_api_key"
   | "model_not_found"
   | "quota_exceeded"
+  | "context_overflow"
   | "abort"
 
 export const RUNTIME_FALLBACK_RETRYABLE_ERROR_PATTERNS = [
@@ -77,6 +78,10 @@ export function classifyRuntimeFallbackError(error: unknown): RuntimeFallbackErr
 
   if (errorName?.includes("messageabortederror") || errorName?.includes("aborterror")) {
     return "abort"
+  }
+
+  if (errorName === "contextoverflowerror") {
+    return "context_overflow"
   }
 
   if (
@@ -139,7 +144,8 @@ export function isRuntimeFallbackRetryableError(
   const message = getRuntimeFallbackErrorMessage(error)
   const errorType = classifyRuntimeFallbackError(error)
 
-  if (errorType === "abort") return false
+  // OpenCode starts native compaction for this error; fallback would abort that compaction on its timeout.
+  if (errorType === "abort" || errorType === "context_overflow") return false
 
   if (
     errorType === "missing_api_key" ||

--- a/packages/omo-opencode/src/hooks/runtime-fallback/context-overflow-compaction.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/context-overflow-compaction.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import type { OhMyOpenCodeConfig, RuntimeFallbackConfig } from "../../config"
+import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+import { releaseAllPromptAsyncReservationsForTesting } from "../shared/prompt-async-gate"
+import { createRuntimeFallbackHook } from "./hook"
+import {
+  installRuntimeFallbackTestClock,
+  restoreRuntimeFallbackTestClock,
+} from "./test-timeout-clock.test-support"
+import type { RuntimeFallbackPluginInput } from "./types"
+
+const SESSION_ID = "test-session-context-overflow-compaction"
+
+describe("runtime-fallback context overflow handling", () => {
+  afterEach(() => {
+    restoreRuntimeFallbackTestClock()
+    SessionCategoryRegistry.clear()
+    releaseAllPromptAsyncReservationsForTesting()
+  })
+
+  test("leaves native compaction active after the fallback timeout window", async () => {
+    //#given
+    const clock = installRuntimeFallbackTestClock()
+    const promptCalls: unknown[] = []
+    const abortCalls: unknown[] = []
+    const config = {
+      enabled: true,
+      retry_on_errors: [400, 429, 500, 502, 503, 504],
+      max_fallback_attempts: 3,
+      cooldown_seconds: 30,
+      timeout_seconds: 30,
+      notify_on_fallback: false,
+      restore_primary_after_cooldown: false,
+    } satisfies RuntimeFallbackConfig
+    const pluginConfig = {
+      categories: {
+        test: {
+          fallback_models: ["winson/codex/gpt-5.6-luna"],
+        },
+      },
+    } satisfies OhMyOpenCodeConfig
+    const hook = createRuntimeFallbackHook(
+      unsafeTestValue<RuntimeFallbackPluginInput>({
+        client: {
+          session: {
+            messages: async () => ({ data: [] }),
+            promptAsync: async (input: unknown) => {
+              promptCalls.push(input)
+              return {}
+            },
+            abort: async (input: unknown) => {
+              abortCalls.push(input)
+              return {}
+            },
+          },
+          tui: { showToast: async () => ({}) },
+        },
+        directory: "/test/dir",
+      }),
+      { config, pluginConfig },
+    )
+    SessionCategoryRegistry.register(SESSION_ID, "test")
+    await hook.event({
+      event: {
+        type: "session.created",
+        properties: { info: { id: SESSION_ID, model: "winson/codex/gpt-5.6-sol" } },
+      },
+    })
+
+    //#when
+    await hook.event({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: SESSION_ID,
+          error: {
+            name: "ContextOverflowError",
+            data: {
+              message:
+                "Your input exceeds the context window of this model. Please adjust your input and try again.",
+              responseBody:
+                '{"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again.","type":"invalid_request_error","code":"context_too_large"}}',
+            },
+          },
+        },
+      },
+    })
+    await clock.advanceBy(31_000)
+
+    //#then
+    expect(promptCalls).toHaveLength(0)
+    expect(abortCalls).toHaveLength(0)
+    hook.dispose?.()
+  })
+})


### PR DESCRIPTION
## Summary

- Preserve OpenCode's native context compaction when the host emits `ContextOverflowError`.
- Prevent runtime fallback from treating the underlying configured HTTP 400 as retryable and aborting a compaction that remains active beyond the fallback timeout.

## Changes

- Add an exact normalized `ContextOverflowError` classification to the shared runtime fallback error classifier.
- Mark that classification as non-retryable before status-code and message heuristics run, while leaving ordinary 400, 429, and 5xx behavior unchanged.
- Add classifier and hook-level regressions that cover a configured retryable 400 and verify there is no fallback prompt or abort after the 30-second timeout window.

## QA & Evidence

- **What was tested:** `bun test packages/model-core/src/runtime-fallback-error-classifier.test.ts packages/omo-opencode/src/hooks/runtime-fallback/context-overflow-compaction.test.ts --bail`
  **Observed result:** 7 passed, 0 failed, 24 assertions.
  **Artifact:** Local terminal output; the red/green logs are retained under the ignored `.omo/evidence/20260714-context-overflow-native-compaction/` directory.
  **Why sufficient:** Covers exact classification and the no-prompt/no-abort behavior after advancing beyond the fallback timeout.

- **What was tested:** `bun test packages/omo-opencode/src/hooks/runtime-fallback`
  **Observed result:** 242 passed, 0 failed, 435 assertions.
  **Artifact:** Local terminal output under the ignored evidence directory.
  **Why sufficient:** Exercises the surrounding runtime fallback behavior, including ordinary retry and abort paths.

- **What was tested:** `bun run typecheck`
  **Observed result:** Passed for the root, scripts, and package projects.
  **Artifact:** Local terminal output.
  **Why sufficient:** Confirms the new error-type member is handled by all typed consumers.

- **What was tested:** `bun run build`
  **Observed result:** Completed successfully, including the OpenCode plugin bundle and declarations.
  **Artifact:** Local terminal output; the tested `dist/index.js` SHA-256 was `c8886bf4a04b636b4313180adeef2700d66d10a21f618bd9943dddb23d8bffad`.
  **Why sufficient:** Confirms the production plugin artifact contains the classifier change used by manual QA.

- **What was tested:** Real OpenCode 1.17.19 server/API/SSE flow in isolated HOME and XDG directories, using a localhost fake OpenAI Responses provider. The provider emitted one structured context overflow, held native compaction open for 31.5 seconds, then allowed core auto-continuation.
  **Observed result:** `prompt_async` returned 204; one `ContextOverflowError` and one `session.compacted` event were observed; provider requests were exactly context-overflow:1, compaction-start:1, compaction-finish:1, continuation:1, fallback:0, unexpected:0; one finished summary and one `QA_FINAL_OK` part were persisted; `MessageAbortedError` count was 0. The live DB remained at 1557 sessions, the sandbox session count in the live DB was 0, and both QA processes stopped.
  **Artifact:** Sanitized local evidence under ignored `.omo/evidence/20260714-context-overflow-native-compaction/qa-summary.txt` and `isolation-receipt.txt`.
  **Why sufficient:** Proves that native compaction remains active beyond `runtime_fallback.timeout_seconds=30`, completes, and auto-continues without fallback or abort while preserving host isolation.

## Risks & Residuals

- **Regression risk:** Mitigated by exact error-name matching, focused classifier assertions, the 242-test runtime fallback suite, and real lifecycle QA. Generic configured HTTP 400, 429, and 5xx errors continue through the existing retry logic.
- **Root test suite:** `bun test` completed with 11,374 passed, 2 skipped, and 4 unrelated failures. One is an existing generated `omo.schema.json` freshness mismatch for `reattach_on_reconcile`; three permission tests expect chmod denial that UID 0 bypasses. None of those files or modules are changed by this PR.
- **Codex compatibility gate:** Not run because this change does not touch the Codex-side adapter or components.
- **QA evidence:** Detailed evidence remains local and ignored by design; no `.omo/` or `.sisyphus/` content is included in the commit.

## Automated Checks

```bash
bun test packages/model-core/src/runtime-fallback-error-classifier.test.ts packages/omo-opencode/src/hooks/runtime-fallback/context-overflow-compaction.test.ts --bail
bun test packages/omo-opencode/src/hooks/runtime-fallback
bun run typecheck
bun run build
bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/model-core/src/runtime-fallback-error-classifier.ts packages/model-core/src/runtime-fallback-error-classifier.test.ts packages/omo-opencode/src/hooks/runtime-fallback/context-overflow-compaction.test.ts
```

## Related Issues

- None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps OpenCode’s native context compaction running on `ContextOverflowError`. Runtime fallback no longer retries in this case or aborts compaction after the 30s timeout.

- **Bug Fixes**
  - Added exact `context_overflow` classification for `ContextOverflowError` in `packages/model-core`, marked non-retryable before status/message heuristics.
  - Preserved existing behavior for generic 400/429/5xx errors.
  - Added tests in `packages/model-core` and `packages/omo-opencode` to verify no fallback prompt or abort after the timeout.

<sup>Written for commit 104da03c4b9e094c10f773f25d961e6bdb714349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

