### PR TITLE
test(team-tasklist): stabilize Windows CI coverage

### DIFF
--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -373,6 +373,9 @@
         "state_dir": {
           "type": "string"
         },
+        "reattach_on_reconcile": {
+          "type": "boolean"
+        },
         "wait": {
           "default": {
             "min_ms": 5000,

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5903,7 +5903,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.17.1",
+    version: "4.18.0",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",

--- a/packages/omo-opencode/src/features/team-mode/team-tasklist/claim.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-tasklist/claim.test.ts
@@ -1,109 +1,20 @@
-/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
 
-import { expect, test } from "bun:test"
-import { writeFile } from "node:fs/promises"
-import path from "node:path"
+import {
+  AlreadyClaimedError,
+  BlockedByError,
+  claimTask,
+} from "./claim"
+import {
+  AlreadyClaimedError as coreAlreadyClaimedError,
+  BlockedByError as coreBlockedByError,
+  claimTask as coreClaimTask,
+} from "@oh-my-opencode/team-core/team-tasklist/claim"
 
-import { getTasksDir, resolveBaseDir } from "../team-registry"
-import { claimTask, AlreadyClaimedError, BlockedByError } from "./claim"
-import { createTask } from "./store"
-import { createTaskInput, createTasklistFixture } from "./test-support"
-import { updateTaskStatus } from "./update"
-
-test("claimTask allows exactly one concurrent claimant", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const task = await createTask(fixture.teamRunId, createTaskInput(), fixture.config)
-
-    // when
-    const claimResults = await Promise.allSettled([
-      claimTask(fixture.teamRunId, task.id, "member-a", fixture.config),
-      claimTask(fixture.teamRunId, task.id, "member-b", fixture.config),
-    ])
-
-    const successfulClaims = claimResults.filter((result) => result.status === "fulfilled")
-    const failedClaims = claimResults.filter((result) => result.status === "rejected")
-
-    // then
-    expect(successfulClaims).toHaveLength(1)
-    expect(failedClaims).toHaveLength(1)
-    expect(failedClaims[0]?.status).toBe("rejected")
-    if (failedClaims[0]?.status === "rejected") {
-      expect(failedClaims[0].reason).toBeInstanceOf(AlreadyClaimedError)
-    }
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("claimTask rejects blocked tasks until blockers complete", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const blockerTask = await createTask(fixture.teamRunId, createTaskInput({ subject: "blocker" }), fixture.config)
-    const blockedTask = await createTask(
-      fixture.teamRunId,
-      createTaskInput({ subject: "blocked", blockedBy: [blockerTask.id] }),
-      fixture.config,
-    )
-
-    // when
-    const blockedClaim = claimTask(fixture.teamRunId, blockedTask.id, "member-a", fixture.config)
-
-    // then
-    await expect(blockedClaim).rejects.toBeInstanceOf(BlockedByError)
-
-    // given
-    await claimTask(fixture.teamRunId, blockerTask.id, "member-b", fixture.config)
-    await updateTaskStatus(fixture.teamRunId, blockerTask.id, "in_progress", "member-b", fixture.config)
-    await updateTaskStatus(fixture.teamRunId, blockerTask.id, "completed", "member-b", fixture.config)
-
-    // when
-    const claimedTask = await claimTask(fixture.teamRunId, blockedTask.id, "member-a", fixture.config)
-
-    // then
-    expect(claimedTask.status).toBe("claimed")
-    expect(claimedTask.owner).toBe("member-a")
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("claimTask reaps a stale claim lock before claiming", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const task = await createTask(fixture.teamRunId, createTaskInput(), fixture.config)
-    const tasksDirectory = getTasksDir(resolveBaseDir(fixture.config), fixture.teamRunId)
-    const staleLockPath = path.join(tasksDirectory, "claims", `${task.id}.lock`)
-    await writeFile(staleLockPath, `member-z\n999999\n${Date.now() - 600_000}\n`)
-
-    // when
-    const claimedTask = await claimTask(fixture.teamRunId, task.id, "member-a", fixture.config)
-
-    // then
-    expect(claimedTask.status).toBe("claimed")
-    expect(claimedTask.owner).toBe("member-a")
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("#given traversal task id #when claiming a task #then it rejects before creating an escaped claim lock", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    // when
-    const claimedTask = claimTask(fixture.teamRunId, "../escape", "member-a", fixture.config)
-
-    // then
-    await expect(claimedTask).rejects.toThrow("team path escapes base directory")
-  } finally {
-    await fixture.cleanup()
-  }
+describe("claimTask adapter shim", () => {
+  test("#given omo-opencode shim #when imported #then it re-exports team-core implementation", () => {
+    expect(claimTask).toBe(coreClaimTask)
+    expect(AlreadyClaimedError).toBe(coreAlreadyClaimedError)
+    expect(BlockedByError).toBe(coreBlockedByError)
+  })
 })

--- a/packages/omo-opencode/src/features/team-mode/team-tasklist/dependencies.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-tasklist/dependencies.test.ts
@@ -1,47 +1,10 @@
-/// <reference types="bun-types" />
-
 import { describe, expect, test } from "bun:test"
 
-import type { Task } from "../types"
 import { canClaim } from "./dependencies"
+import { canClaim as coreCanClaim } from "@oh-my-opencode/team-core/team-tasklist/dependencies"
 
-function buildTask(id: string, status: Task["status"], blockedBy: string[] = []): Task {
-  const now = Date.now()
-  return {
-    version: 1,
-    id,
-    subject: `subject-${id}`,
-    description: `description-${id}`,
-    status,
-    blocks: [],
-    blockedBy,
-    createdAt: now,
-    updatedAt: now,
-  }
-}
-
-describe("canClaim", () => {
-  test("returns false when a blocker is not completed", () => {
-    // given
-    const blockerTask = buildTask("2", "in_progress")
-    const dependentTask = buildTask("1", "pending", ["2"])
-
-    // when
-    const claimable = canClaim(dependentTask, [dependentTask, blockerTask])
-
-    // then
-    expect(claimable).toBe(false)
-  })
-
-  test("ignores missing blockers and completed blockers", () => {
-    // given
-    const completedBlockerTask = buildTask("2", "completed")
-    const dependentTask = buildTask("1", "pending", ["2", "999"])
-
-    // when
-    const claimable = canClaim(dependentTask, [dependentTask, completedBlockerTask])
-
-    // then
-    expect(claimable).toBe(true)
+describe("canClaim adapter shim", () => {
+  test("#given omo-opencode shim #when imported #then it re-exports team-core implementation", () => {
+    expect(canClaim).toBe(coreCanClaim)
   })
 })

--- a/packages/omo-opencode/src/features/team-mode/team-tasklist/get.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-tasklist/get.test.ts
@@ -1,54 +1,10 @@
-/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
 
-import { expect, test } from "bun:test"
-
-import { createTask } from "./store"
-import { createTaskInput, createTasklistFixture } from "./test-support"
 import { getTask } from "./get"
+import { getTask as coreGetTask } from "@oh-my-opencode/team-core/team-tasklist/get"
 
-test("getTask returns a persisted task", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const createdTask = await createTask(fixture.teamRunId, createTaskInput({ subject: "persisted task" }), fixture.config)
-
-    // when
-    const loadedTask = await getTask(fixture.teamRunId, createdTask.id, fixture.config)
-
-    // then
-    expect(loadedTask).toEqual(createdTask)
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("getTask throws when the task file is missing", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    // when
-    const loadedTask = getTask(fixture.teamRunId, "999", fixture.config)
-
-    // then
-    await expect(loadedTask).rejects.toBeInstanceOf(Error)
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("#given traversal task id #when loading a task #then it rejects before reading outside the task directory", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    // when
-    const loadedTask = getTask(fixture.teamRunId, "../escape", fixture.config)
-
-    // then
-    await expect(loadedTask).rejects.toThrow("team path escapes base directory")
-  } finally {
-    await fixture.cleanup()
-  }
+describe("getTask adapter shim", () => {
+  test("#given omo-opencode shim #when imported #then it re-exports team-core implementation", () => {
+    expect(getTask).toBe(coreGetTask)
+  })
 })

--- a/packages/omo-opencode/src/features/team-mode/team-tasklist/list.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-tasklist/list.test.ts
@@ -1,63 +1,10 @@
-/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
 
-import { expect, test } from "bun:test"
-import { writeFile } from "node:fs/promises"
-import path from "node:path"
-
-import { getTasksDir, resolveBaseDir } from "../team-registry"
-import { createTask } from "./store"
-import { createTaskInput, createTasklistFixture } from "./test-support"
-import { updateTaskStatus } from "./update"
 import { listTasks } from "./list"
+import { listTasks as coreListTasks } from "@oh-my-opencode/team-core/team-tasklist/list"
 
-test("listTasks returns tasks sorted ascending and honors filters", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const firstTask = await createTask(
-      fixture.teamRunId,
-      createTaskInput({ subject: "one", status: "claimed", owner: "member-a", claimedAt: Date.now() }),
-      fixture.config,
-    )
-    await createTask(fixture.teamRunId, createTaskInput({ subject: "two" }), fixture.config)
-    const thirdTask = await createTask(
-      fixture.teamRunId,
-      createTaskInput({ subject: "three", status: "claimed", owner: "member-a", claimedAt: Date.now() }),
-      fixture.config,
-    )
-    await updateTaskStatus(fixture.teamRunId, thirdTask.id, "in_progress", "member-a", fixture.config)
-
-    // when
-    const allTasks = await listTasks(fixture.teamRunId, fixture.config)
-    const claimedTasks = await listTasks(fixture.teamRunId, fixture.config, { status: "claimed", owner: "member-a" })
-
-    // then
-    expect(allTasks.map((task) => task.id)).toEqual([firstTask.id, "2", thirdTask.id])
-    expect(claimedTasks).toHaveLength(1)
-    expect(claimedTasks[0]?.id).toBe(firstTask.id)
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("listTasks skips malformed task files", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const validTask = await createTask(fixture.teamRunId, createTaskInput(), fixture.config)
-    const tasksDirectory = getTasksDir(resolveBaseDir(fixture.config), fixture.teamRunId)
-    await writeFile(path.join(tasksDirectory, "bad.json"), "{not-json")
-    await writeFile(path.join(tasksDirectory, ".highwatermark"), "1")
-
-    // when
-    const listedTasks = await listTasks(fixture.teamRunId, fixture.config)
-
-    // then
-    expect(listedTasks).toHaveLength(1)
-    expect(listedTasks[0]?.id).toBe(validTask.id)
-  } finally {
-    await fixture.cleanup()
-  }
+describe("listTasks adapter shim", () => {
+  test("#given omo-opencode shim #when imported #then it re-exports team-core implementation", () => {
+    expect(listTasks).toBe(coreListTasks)
+  })
 })

--- a/packages/omo-opencode/src/features/team-mode/team-tasklist/store.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-tasklist/store.test.ts
@@ -1,49 +1,10 @@
-/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
 
-import { expect, test } from "bun:test"
-import { readFile, stat } from "node:fs/promises"
-import path from "node:path"
-
-import { getTasksDir, resolveBaseDir } from "../team-registry"
 import { createTask } from "./store"
-import { createTaskInput, createTasklistFixture } from "./test-support"
+import { createTask as coreCreateTask } from "@oh-my-opencode/team-core/team-tasklist/store"
 
-test("createTask assigns distinct ids during concurrent creation", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    // when
-    const [firstTask, secondTask] = await Promise.all([
-      createTask(fixture.teamRunId, createTaskInput({ subject: "first task" }), fixture.config),
-      createTask(fixture.teamRunId, createTaskInput({ subject: "second task" }), fixture.config),
-    ])
-
-    const tasksDirectory = getTasksDir(resolveBaseDir(fixture.config), fixture.teamRunId)
-    const watermarkContent = await readFile(path.join(tasksDirectory, ".highwatermark"), "utf8")
-    const sortedIds = [firstTask.id, secondTask.id].sort((leftId, rightId) => Number(leftId) - Number(rightId))
-
-    // then
-    expect(sortedIds).toEqual(["1", "2"])
-    expect(watermarkContent.trim()).toBe("2")
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("#given traversal team run id #when creating a task #then no task directory escapes the team base", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-  const escapedDirectory = path.resolve(fixture.rootDirectory, "..", "escape")
-
-  try {
-    // when
-    const createdTask = createTask("../../escape", createTaskInput(), fixture.config)
-
-    // then
-    await expect(createdTask).rejects.toThrow("team path escapes base directory")
-    await expect(stat(escapedDirectory)).rejects.toBeInstanceOf(Error)
-  } finally {
-    await fixture.cleanup()
-  }
+describe("createTask adapter shim", () => {
+  test("#given omo-opencode shim #when imported #then it re-exports team-core implementation", () => {
+    expect(createTask).toBe(coreCreateTask)
+  })
 })

--- a/packages/omo-opencode/src/features/team-mode/team-tasklist/update.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-tasklist/update.test.ts
@@ -1,120 +1,16 @@
-/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
 
-import { expect, test } from "bun:test"
-
-import { claimTask } from "./claim"
-import { getTask } from "./get"
-import { createTask } from "./store"
-import { createTaskInput, createTasklistFixture } from "./test-support"
 import { CrossOwnerUpdateError, InvalidTaskTransitionError, updateTaskStatus } from "./update"
+import {
+  CrossOwnerUpdateError as CoreCrossOwnerUpdateError,
+  InvalidTaskTransitionError as CoreInvalidTaskTransitionError,
+  updateTaskStatus as coreUpdateTaskStatus,
+} from "@oh-my-opencode/team-core/team-tasklist/update"
 
-test("updateTaskStatus supports the one-way claim to complete flow", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const task = await createTask(fixture.teamRunId, createTaskInput(), fixture.config)
-    await claimTask(fixture.teamRunId, task.id, "member-a", fixture.config)
-
-    // when
-    await updateTaskStatus(fixture.teamRunId, task.id, "in_progress", "member-a", fixture.config)
-    const completedTask = await updateTaskStatus(fixture.teamRunId, task.id, "completed", "member-a", fixture.config)
-    const loadedTask = await getTask(fixture.teamRunId, task.id, fixture.config)
-
-    // then
-    expect(completedTask.status).toBe("completed")
-    expect(loadedTask.status).toBe("completed")
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("updateTaskStatus auto-claims when a member starts a pending task directly", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const task = await createTask(fixture.teamRunId, createTaskInput(), fixture.config)
-
-    // when
-    const inProgressTask = await updateTaskStatus(fixture.teamRunId, task.id, "in_progress", "member-a", fixture.config)
-    const loadedTask = await getTask(fixture.teamRunId, task.id, fixture.config)
-
-    // then
-    expect(inProgressTask.status).toBe("in_progress")
-    expect(inProgressTask.owner).toBe("member-a")
-    expect(typeof inProgressTask.claimedAt).toBe("number")
-    expect(loadedTask.status).toBe("in_progress")
-    expect(loadedTask.owner).toBe("member-a")
-    expect(typeof loadedTask.claimedAt).toBe("number")
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("updateTaskStatus rejects reverse transitions", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const task = await createTask(
-      fixture.teamRunId,
-      createTaskInput({ status: "completed", owner: "member-a", claimedAt: Date.now() }),
-      fixture.config,
-    )
-
-    // when
-    const reversedTransition = updateTaskStatus(fixture.teamRunId, task.id, "claimed", "member-a", fixture.config)
-
-    // then
-    await expect(reversedTransition).rejects.toBeInstanceOf(InvalidTaskTransitionError)
-    await expect(reversedTransition).rejects.toHaveProperty(
-      "message",
-      "no reverse transitions from completed to claimed",
-    )
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("updateTaskStatus rejects non-owner updates except deletion", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    const task = await createTask(
-      fixture.teamRunId,
-      createTaskInput({ status: "claimed", owner: "member-a", claimedAt: Date.now() }),
-      fixture.config,
-    )
-
-    // when
-    const crossOwnerUpdate = updateTaskStatus(fixture.teamRunId, task.id, "in_progress", "member-b", fixture.config)
-
-    // then
-    await expect(crossOwnerUpdate).rejects.toBeInstanceOf(CrossOwnerUpdateError)
-
-    // when
-    const deletedTask = await updateTaskStatus(fixture.teamRunId, task.id, "deleted", "lead-member", fixture.config)
-
-    // then
-    expect(deletedTask.status).toBe("deleted")
-  } finally {
-    await fixture.cleanup()
-  }
-})
-
-test("#given traversal task id #when updating a task #then it rejects before writing outside the task directory", async () => {
-  // given
-  const fixture = await createTasklistFixture()
-
-  try {
-    // when
-    const updatedTask = updateTaskStatus(fixture.teamRunId, "../escape", "completed", "member-a", fixture.config)
-
-    // then
-    await expect(updatedTask).rejects.toThrow("team path escapes base directory")
-  } finally {
-    await fixture.cleanup()
-  }
+describe("updateTaskStatus adapter shim", () => {
+  test("#given omo-opencode shim #when imported #then it re-exports team-core implementation", () => {
+    expect(updateTaskStatus).toBe(coreUpdateTaskStatus)
+    expect(CrossOwnerUpdateError).toBe(CoreCrossOwnerUpdateError)
+    expect(InvalidTaskTransitionError).toBe(CoreInvalidTaskTransitionError)
+  })
 })

--- a/packages/team-core/src/team-tasklist/claim.test.ts
+++ b/packages/team-core/src/team-tasklist/claim.test.ts
@@ -70,7 +70,7 @@ test("claimTask rejects blocked tasks until blockers complete", async () => {
   } finally {
     await fixture.cleanup()
   }
-})
+}, 30_000)
 
 test("claimTask reaps a stale claim lock before claiming", async () => {
   // given

--- a/packages/team-core/src/team-tasklist/list.test.ts
+++ b/packages/team-core/src/team-tasklist/list.test.ts
@@ -39,7 +39,7 @@ test("listTasks returns tasks sorted ascending and honors filters", async () => 
   } finally {
     await fixture.cleanup()
   }
-})
+}, 30_000)
 
 test("listTasks skips malformed task files", async () => {
   // given
@@ -60,4 +60,4 @@ test("listTasks skips malformed task files", async () => {
   } finally {
     await fixture.cleanup()
   }
-})
+}, 30_000)

--- a/packages/team-core/src/team-tasklist/store.test.ts
+++ b/packages/team-core/src/team-tasklist/store.test.ts
@@ -29,7 +29,7 @@ test("createTask assigns distinct ids during concurrent creation", async () => {
   } finally {
     await fixture.cleanup()
   }
-})
+}, 30_000)
 
 test("#given traversal team run id #when creating a task #then no task directory escapes the team base", async () => {
   // given

--- a/packages/team-core/src/team-tasklist/update.test.ts
+++ b/packages/team-core/src/team-tasklist/update.test.ts
@@ -27,7 +27,7 @@ test("updateTaskStatus supports the one-way claim to complete flow", async () =>
   } finally {
     await fixture.cleanup()
   }
-})
+}, 30_000)
 
 test("updateTaskStatus auto-claims when a member starts a pending task directly", async () => {
   // given
@@ -50,7 +50,7 @@ test("updateTaskStatus auto-claims when a member starts a pending task directly"
   } finally {
     await fixture.cleanup()
   }
-})
+}, 30_000)
 
 test("updateTaskStatus rejects reverse transitions", async () => {
   // given


### PR DESCRIPTION
## Summary

PR #6106 exposed six intermittent Windows timeouts in duplicated team-tasklist filesystem tests. The same release SHA failed those tests at 5015-5016 ms, then passed unchanged on rerun, which confirms load-sensitive flakiness rather than a deterministic product regression.

This PR keeps behavior coverage at the owning `team-core` boundary, gives the six Windows-heavy scenarios scoped 30-second timeouts, and changes the `omo-opencode` facade tests to verify exact re-export identity instead of rerunning the same filesystem behavior a second time.

## Changes

- Preserve all tasklist behavior assertions in `packages/team-core` while applying numeric `30_000` timeouts only to the six filesystem-heavy scenarios that exceeded Bun's default under Windows full-suite load.
- Replace six byte-identical `packages/omo-opencode` behavior suites with direct identity assertions against their `@oh-my-openagent/team-core` implementations.
- Leave production locking, persistence, and tasklist behavior unchanged.
- Regenerate the two v4.18.0 artifacts omitted by the merged release commit: the current OMO schema and Codex installer bundle. This is a separate atomic commit and makes the full suite pass from a clean checkout instead of relying on build-time drift.

## QA & Evidence

- **Focused tasklist suites:** 24/24 tests passed across the six core suites and six adapter suites. The adapters assert exact export identity and contain no filesystem fixtures.
- **Stress:** core behavior passed 1,800/1,800 randomized executions; adapter identity checks passed 600/600 executions in about 0.23 seconds.
- **Regression:** post-rebase typecheck, build, shared-core extraction guard, focused checks, stress checks, and the full suite passed. Full-suite result: 11,373 pass, 2 skip, 0 fail. Generated build outputs were restored and the worktree was clean.
- **Clean-tree correction:** the final gate found that the release branch's committed schema and installer were stale. Before regeneration, their two freshness tests were 2 pass / 2 fail; after official generation they were 4 pass / 0 fail. A fresh ordered C003 run then passed typecheck, build with no tracked drift, the shared-core guard, and the full 11,373 pass / 2 skip / 0 fail suite without restoring any file.
- **Live OpenCode smoke:** an isolated HOME/XDG server loaded the branch source plugin; `/global/health` was healthy and `/agent` exposed both `Sisyphus - ultraworker` and `Atlas - Plan Executor`. The host session database was unchanged and all server, port, and sandbox resources were removed.

Evidence is retained locally under `.omo/evidence/ulw/windows-team-tasklist-flake-6106/G001-fix-the-flaky-windows-ci-failures-ex/a1/` and the ULW ledger records the exact commands and cleanup receipts.

## Risks & Residuals

- The 30-second bounds do not weaken assertions or mask failures; they only allow legitimate Windows filesystem latency in the behavior-owning package and match existing scoped timeout precedent in the repository.
- The decisive remaining gate is this PR's standalone `test (windows-latest)` job. It must complete without any 5-second tasklist timeout before merge.

## Related

- Follow-up to #6106
