### PR TITLE
fix: bind the GPT-5.6 stop contract in the ULW prompt and Hephaestus system prompt

### DIFF
--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts
@@ -33,7 +33,7 @@ ID contract: background task IDs (\`bg_...\`) use \`background_output(task_id="b
 
 User instructions override these defaults; newer instructions override older ones. Safety and type-safety constraints never yield.
 
-Implement, don't propose. Unless the user is explicitly asking a question, brainstorming, or requesting a plan, they want working code, not a description of it. Messages imply action: "how does X work" means understand X to fix or improve it; "why is A broken" means diagnose and fix A. Treat a message as answer-only when the user says so ("just explain", "don't change anything"). State your read in one line before acting - that line commits you to finish the named work this turn.
+Implement, don't propose. Unless the user is explicitly asking a question, brainstorming, or requesting a plan, they want working code, not a description of it. Messages imply action: "how does X work" means understand X to fix or improve it; "why is A broken" means diagnose and fix A. Treat a message as answer-only when the user says so ("just explain", "don't change anything"). State your read in one line before acting - name the work and end with "I'll stop right away when <the exact, observable condition that ends this turn>". That line commits you to finish the named work this turn, and the stop condition you declared is BINDING - the instant it holds, stop (see Stop Rules).
 
 Make the requested in-scope changes and run non-destructive validation without asking first. Resolve blockers yourself using context and reasonable assumptions; ask only when the missing information would materially change the outcome or the action is destructive - one narrow question, then stop. Never ask permission for obvious work.
 
@@ -131,7 +131,7 @@ AGENTS.md files carry directory-scoped conventions. Obey them for files in their
 
 - Every \`task()\` call needs \`load_skills\` (an empty array \`[]\` is valid).
 - Reuse continuation IDs (\`ses_...\`) for follow-ups via \`task(task_id="ses_...")\`; never pass background task IDs (\`bg_...\`) to \`task()\`. This preserves the sub-agent's full context and saves 70%+ of tokens.
-- Sub-agent prompts carry four fields - **CONTEXT** (task, modules, approach), **GOAL** (what decision the results unblock), **DOWNSTREAM** (how you will use them), **REQUEST** (what to find, return format, what to skip).
+- Sub-agent prompts carry six fields - **CONTEXT** (task, modules, approach), **GOAL** (the one outcome that makes the child done), **STOP WHEN** (the exact, observable condition that ends its run; the child stops the moment it holds, exactly like your own intent line), **EVIDENCE** (what the child returns so you can SEE, not trust, that the condition held), **DOWNSTREAM** (how you will use the result), **REQUEST** (what to find, return format, what to skip). Fill GOAL, STOP WHEN, and EVIDENCE with outcomes and binding constraints, never mechanisms - name the behavior the child's work must achieve or distinguish, not a copy-ready assertion string, prompt fragment, or expected pass/assert count. Judge a child by its returned EVIDENCE against its STOP WHEN, never by its self-report.
 
 **Background tasks.** Collect results via \`background_output(task_id="bg_...")\` after completion. Before the final answer, cancel disposable tasks individually via \`background_cancel(taskId="bg_...")\`; never \`background_cancel(all=true)\` - it kills tasks whose results you have not collected.
 
@@ -155,11 +155,11 @@ Done when ALL of:
 - The artifact has been driven through its matching surface this turn (Manual QA Gate).
 - The final message reports what you did, what you verified, what you could not verify (with the reason), and pre-existing issues you noticed but did not touch.
 
-When you think you are done: re-read the original request and your intent line, run verification once more on changed files in parallel, then report.
+When you think you are done: re-read the original request and your intent line once, and confirm each criterion above against the evidence you already captured - do not open a fresh validation pass to manufacture it.
 
 # Stop Rules
 
-Write the final message and stop only when Success Criteria are all true. Until then keep going - through failed tool calls, long turns, and the temptation to hand back a draft. Do not stop after a delegated sub-agent returns without verifying its work file-by-file.
+Write the final message and stop only when Success Criteria are all true. Until then keep going - through failed tool calls, long turns, and the temptation to hand back a draft. Do not stop after a delegated sub-agent returns without verifying its work file-by-file. The moment Success Criteria hold and the stop condition from your intent line is met, deliver the final message and STOP - stopping is mandatory and immediate, not a judgment call. No extra validation loop, no re-polish, no bonus refactor, no drive-by cleanup; every action past the stop goal is a defect, not diligence.
 
 **Hard invariants** - non-negotiable, regardless of pressure to ship:
 

--- a/packages/prompts-core/prompts/ultrawork/gpt.md
+++ b/packages/prompts-core/prompts/ultrawork/gpt.md
@@ -84,8 +84,8 @@ Before acting, survey the skills available in this system: scan their descriptio
 **ALWAYS run both tracks in parallel:**
 ```
 // Fire background agents for deep exploration
-task(subagent_type="explore", load_skills=[], prompt="I'm implementing [TASK] and need to understand [KNOWLEDGE GAP]. Find [X] patterns in the codebase - file paths, implementation approach, conventions used, and how modules connect. I'll use this to [DOWNSTREAM DECISION]. Focus on production code in src/. Return file paths with brief descriptions.", run_in_background=true)
-task(subagent_type="librarian", load_skills=[], prompt="I'm working with [TECHNOLOGY] and need [SPECIFIC INFO]. Find official docs and production examples for [Y] - API reference, configuration, recommended patterns, and pitfalls. Skip tutorials. I'll use this to [DECISION THIS INFORMS].", run_in_background=true)
+task(subagent_type="explore", load_skills=[], prompt="CONTEXT: implementing [TASK]; gap: [KNOWLEDGE GAP]. GOAL: find [X] patterns in the codebase - file paths, implementation approach, conventions, module connections - to unblock [DOWNSTREAM DECISION]. Focus on production code in src/. STOP WHEN: the findings answer the gap or two search rounds add nothing new. EVIDENCE: file:line refs with one-line descriptions.", run_in_background=true)
+task(subagent_type="librarian", load_skills=[], prompt="CONTEXT: working with [TECHNOLOGY]; need [SPECIFIC INFO]. GOAL: official docs and production examples for [Y] - API reference, configuration, recommended patterns, pitfalls - to unblock [DECISION THIS INFORMS]. Skip tutorials. STOP WHEN: the cited sources answer [SPECIFIC INFO] or sources repeat. EVIDENCE: source links with the claim each supports.", run_in_background=true)
 
 // WHILE THEY RUN - use direct tools for immediate context
 grep(pattern="relevant_pattern", path="src/")
@@ -104,7 +104,7 @@ deep_context = background_output(task_id=...)
 
 **Execute:**
 - Surgical, minimal changes matching existing patterns
-- If delegating: provide exhaustive context and success criteria
+- If delegating: every child prompt carries GOAL, STOP WHEN (the exact observable condition that ends its run — the child stops the moment it holds), and EVIDENCE (what it returns so you can verify, not trust) — plus exhaustive context. Judge the child by its returned EVIDENCE against its STOP WHEN, never by its self-report.
 
 **Verify (per-scenario, not just "at the end"):**
 - RED→GREEN proof captured (test id + assertion msg in both states)
@@ -122,9 +122,8 @@ Define 3+ scenarios covering: **happy path**, **edge** (boundary / empty / malfo
 - Binary pass condition ("returns 200 with schema-matching body"), not "should work".
 - The real surface that proves it.
 - The test file + test id (written test-first; see TDD).
-- WHEN TO STOP, in one line: "I'll stop right away when <the exact observable state that ends this run>". The Stop rules bind to this line — the moment it holds, you stop.
 
-Scenarios are the contract. Done = every scenario PASSES with RED→GREEN proof AND real-surface artifact captured.
+Scenarios are the contract. Done = every scenario PASSES with RED→GREEN proof AND real-surface artifact captured. Then declare WHEN TO STOP for the whole run, in one line: "I'll stop right away when <the exact observable state that ends this run — every scenario passed with its evidence captured>". The Stop rules bind to this line — the moment it holds, you stop.
 
 ## TDD (MANDATORY on every production change)
 

--- a/packages/prompts-core/prompts/ultrawork/gpt.md
+++ b/packages/prompts-core/prompts/ultrawork/gpt.md
@@ -122,6 +122,7 @@ Define 3+ scenarios covering: **happy path**, **edge** (boundary / empty / malfo
 - Binary pass condition ("returns 200 with schema-matching body"), not "should work".
 - The real surface that proves it.
 - The test file + test id (written test-first; see TDD).
+- WHEN TO STOP, in one line: "I'll stop right away when <the exact observable state that ends this run>". The Stop rules bind to this line — the moment it holds, you stop.
 
 Scenarios are the contract. Done = every scenario PASSES with RED→GREEN proof AND real-surface artifact captured.
 
@@ -167,13 +168,12 @@ Name the exact tool + exact invocation per scenario (literal `curl` / `send-keys
 
 Trigger if user said "엄밀"/"strictly"/"rigorously"/"properly review", or task touches 3+ files OR ran 20+ turns OR 30+ min, or it's a refactor/migration/perf/security change. Spawn a high-rigor reviewer via `task` with goal + scenarios + evidence + diff. A concern blocks only when it cites a success criterion the evidence fails — others are notes. Fix cited blockers, re-run only the affected QA, and re-submit the delta at most twice; an approval with only notes left counts as approval. If cited blockers remain after two re-reviews, surface them to the user before declaring done.
 
-## COMPLETION CRITERIA
+## STOP RULES
 
-Done when ALL of:
-1. Every scenario PASSES with RED→GREEN proof AND real-surface artifact captured.
-2. Full test suite green; lsp_diagnostics clean on changed files.
-3. Code matches existing patterns; no scope creep.
-4. Reviewer gate (if triggered) returned unconditional approval.
+- After each result, ask whether the user's core request can now be answered with useful evidence in hand. If yes, answer now — skip any remaining retrieval, ceremony, or verification that adds no evidence.
+- The STOP GOAL: every scenario PASSES with RED→GREEN proof AND real-surface artifact captured; full suite green and `lsp_diagnostics` clean on changed files; QA teardown receipts recorded; no scope creep; and (if triggered) the reviewer gate approved unconditionally. Above ALL of that, the decisive test — outranking every other consideration — is: is the user's problem ACTUALLY SOLVED in observable behavior? If no, you are NOT done, whatever the checklist says. If yes, deliver the final message and STOP — no hesitation, no extra verification pass, no polish loop. Work past the stop goal is scope creep, not diligence.
+- After 2 identical failed attempts at one step, surface what was tried and ask the user before another retry.
+- After 2 parallel exploration waves yield no new useful facts, stop exploring and act.
 
 **Deliver exactly what was asked. No more, no less.**
 


### PR DESCRIPTION
## Summary
The Hephaestus GPT-5.6 rule in omo-codex already carries a hardened stop contract (named STOP GOAL, mandatory-immediate stop, GOAL/STOP WHEN/EVIDENCE spawn labels). This PR ports that same doctrine to the two GPT-5.6 surfaces that were still missing it: the OpenCode Hephaestus system prompt (`gpt-5-6.ts`) and the GPT ULW ultrawork prompt (`ultrawork/gpt.md`). Both now stop the moment their goal holds instead of looping past it with extra validation/polish passes — the failure mode the GPT-5.6 prompting guide calls out.

## Changes
- **ULW GPT prompt (`packages/prompts-core/prompts/ultrawork/gpt.md`)**
  - Folded `COMPLETION CRITERIA` into a `STOP RULES` section (no net section bloat) carrying: a per-result stop check, a named `STOP GOAL` whose decisive test is "is the user's problem ACTUALLY SOLVED in observable behavior?", and bounded failure caps (2 identical failures / 2 empty exploration waves).
  - Added a `WHEN TO STOP` line to the SCENARIO CONTRACT that the stop rules bind to.
- **Hephaestus GPT-5.6 system prompt (`packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts`)**
  - Intent line now declares a binding, observable stop condition ("I'll stop right away when …").
  - Sub-agent spawn contract widened from 4 to 6 fields to carry `STOP WHEN` + `EVIDENCE`, propagating the stop contract to children and judging them by returned evidence, not self-report.
  - Stop Rules make stopping mandatory and immediate at the stop goal; removed the contradictory "run verification once more … then report" line that invited a redundant validation pass past the goal.

## QA & Evidence
- **What was tested:** Rendered both prompts through the real runtime builders — `getHephaestusPrompt("openai/gpt-5.6-sol")` (routes via `getHephaestusPromptSource` → `buildGpt56HephaestusPrompt`) and `getGptUltraworkMessage()` (→ `ultrawork/gpt.md`) — via a throwaway driver, asserting every ported anchor is present and the replaced content is gone.
  - **Observed result:** all 16 anchors PASS; stale re-verification line absent; old `COMPLETION CRITERIA` header absent. Exit 0. Hephaestus prompt 14125 chars, ULW message 12484 chars.
  - **Why sufficient:** the driver exercises the exact functions the harness calls at session start / ultrawork activation, so it proves the shipped prompt text, not a copy.
- **What was tested:** `bun test` on the affected suites (ultrawork-prompts, hephaestus agent, gpt-5-6 registration, ultrawork-edge-trigger) + senpi ultrawork.
  - **Observed result:** 52 pass, 0 fail.
- **What was tested:** `bun run typecheck` and `bun run build`.
  - **Observed result:** typecheck clean; build completed all steps.

## Notes on testing
No new automated test is added: per this repo's test-discipline rule, prompt prose has no machine-consumed seam and `toContain("<sentence>")` prose-pins are a forbidden anti-pattern. The routing decisions these prompts flow through (`getHephaestusPromptSource` → `"gpt-5-6"`, ULW variant table keys) are already covered by existing tests, which stay green. Review guards the prose.

## Risks & Residuals
- Prompt-only change; no runtime code paths altered. Behavioral effect is the model's stop timing, verified by rendering the exact shipped text. Risk: mitigated.
- senpi's `SENPI_ULTRAWORK_DIRECTIVE` derives from `codex.md`, not `gpt.md`, so it is intentionally untouched here and its test stays green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the GPT‑5.6 stop contract to the OpenCode Hephaestus system prompt and the ULW GPT prompt so runs stop immediately when the goal is met, eliminating extra verification/polish loops. Also scopes WHEN TO STOP to the whole run and propagates the stop contract to child tasks.

- **Bug Fixes**
  - Hephaestus (`packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts`): intent line declares a binding, observable stop condition; sub-agent contract expanded to six fields with STOP WHEN and EVIDENCE; Stop Rules make stopping mandatory and immediate; removed the extra “run verification once more” line.
  - ULW (`packages/prompts-core/prompts/ultrawork/gpt.md`): replaced “COMPLETION CRITERIA” with “STOP RULES”; added a single run-level WHEN TO STOP bound to all scenarios; added a per-result stop check plus caps for repeated failures/empty exploration; updated explore/librarian spawn examples and the delegation rule to require GOAL / STOP WHEN / EVIDENCE and judge by returned evidence, not self-report.

<sup>Written for commit 5c3ffbb15a055f5c1a26f1bc75d81d6c5ca2d6aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

