### PR TITLE
fix(ultrawork): bind the declared WHEN TO STOP line to the full STOP GOAL

### DIFF
--- a/packages/prompts-core/prompts/ultrawork/gpt.md
+++ b/packages/prompts-core/prompts/ultrawork/gpt.md
@@ -123,7 +123,7 @@ Define 3+ scenarios covering: **happy path**, **edge** (boundary / empty / malfo
 - The real surface that proves it.
 - The test file + test id (written test-first; see TDD).
 
-Scenarios are the contract. Done = every scenario PASSES with RED→GREEN proof AND real-surface artifact captured. Then declare WHEN TO STOP for the whole run, in one line: "I'll stop right away when <the exact observable state that ends this run — every scenario passed with its evidence captured>". The Stop rules bind to this line — the moment it holds, you stop.
+Scenarios are the contract. Done = every scenario PASSES with RED→GREEN proof AND real-surface artifact captured. Then declare WHEN TO STOP for the whole run, in one line: "I'll stop right away when <the exact observable state that ends this run>" — its end state MUST be the full STOP GOAL from the Stop rules, never scenario completion alone. The Stop rules bind to this line — the moment it holds, you stop.
 
 ## TDD (MANDATORY on every production change)
 


### PR DESCRIPTION
## Summary
Follow-up to #6110. The delta review found that the run-level `WHEN TO STOP` template in the ULW GPT prompt pre-filled its placeholder with "every scenario passed with its evidence captured" — an end state that can hold BEFORE the STOP RULES' full STOP GOAL does (full suite green, clean `lsp_diagnostics`, teardown receipts, reviewer approval). That gave the prompt two incompatible endpoints and could stop a run before its mandatory completion checks.

## Changes
- `packages/prompts-core/prompts/ultrawork/gpt.md` (one line): the `WHEN TO STOP` placeholder is generic again, and the declared end state now MUST be the full STOP GOAL from the Stop rules, never scenario completion alone.

## QA & Evidence
- **What was tested:** rendered the shipped prompt via the runtime builder `getGptUltraworkMessage()` with a driver asserting the new binding sentence is present and the narrow pre-filled end state is gone.
  - **Observed result:** 3/3 PASS, exit 0.
  - **Why sufficient:** exercises the exact function the ultrawork keyword hook calls; proves the shipped text.
- **What was tested:** `bun test` on ultrawork-prompts + ultrawork-edge-trigger suites.
  - **Observed result:** 5 pass, 0 fail.

## Risks & Residuals
Prompt-prose-only, single sentence. No runtime code path changes. Risk: mitigated.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the run-level WHEN TO STOP line in the ULW GPT prompt to the full STOP GOAL from the Stop rules to prevent premature run stops. Removed the pre-filled "every scenario passed with its evidence captured" text and restored a generic placeholder that must reference the STOP GOAL, not scenario completion.

<sup>Written for commit 3d33d1d41a8ac304d13733a42614d1e44f0960b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

