### PR TITLE
test(utils): stabilize port probe sequence

### DIFF
--- a/packages/utils/src/port-utils.test.ts
+++ b/packages/utils/src/port-utils.test.ts
@@ -1,3 +1,4 @@
+// allow: SIZE_OK - This intentionally oversized test keeps process-wide Server.prototype patches serialized in one file.
 import { createServer, Server } from "node:net"
 import type { AddressInfo } from "node:net"
 import { networkInterfaces } from "node:os"
@@ -19,9 +20,10 @@ type TimeoutProbeResult = {
   server: Server | undefined
 }
 
-type BlockedRangeProbeResult = {
+type AvailabilityProbeResult = {
   errorMessage: string | undefined
   probedPorts: number[]
+  selectedPort: number | undefined
 }
 
 function getRequiredPropertyDescriptor(target: object, propertyName: string): PropertyDescriptor {
@@ -198,25 +200,6 @@ async function startAlternateInterfaceBlockerWithDefaultHostFree(hostname: strin
   return undefined
 }
 
-async function startConsecutiveBlockers(
-  startPort: number,
-  portCount: number,
-  hostname: string = DEFAULT_HOSTNAME
-): Promise<Server[]> {
-  const servers: Server[] = []
-
-  try {
-    for (let offset = 0; offset < portCount; offset++) {
-      servers.push(await startTrackedServer(startPort + offset, hostname))
-    }
-
-    return servers
-  } catch (error) {
-    await Promise.all(servers.map((server) => closeTrackedServer(server)))
-    throw error
-  }
-}
-
 function isExpectedBindFailure(error: unknown): boolean {
   if (!(error instanceof Error)) {
     throw new Error("Expected port bind failure to throw an Error instance")
@@ -299,17 +282,21 @@ async function runTimedOutAvailabilityProbe(port: number): Promise<TimeoutProbeR
   }
 }
 
-async function runBlockedRangeAvailabilityProbe(startPort: number): Promise<BlockedRangeProbeResult> {
+async function runAvailabilityProbe(
+  startPort: number,
+  unavailableProbeCount: number
+): Promise<AvailabilityProbeResult> {
   const listenDescriptor = getRequiredPropertyDescriptor(Server.prototype, "listen")
   const closeDescriptor = getRequiredPropertyDescriptor(Server.prototype, "close")
   const probedPorts: number[] = []
   let errorMessage: string | undefined
+  let selectedPort: number | undefined
 
   Object.defineProperty(Server.prototype, "listen", {
     configurable: true,
-    value: function listenWithBlockedRange(this: Server, requestedPort: number): Server {
-      if (requestedPort >= startPort && requestedPort < startPort + MAX_PORT_ATTEMPTS) {
-        probedPorts.push(requestedPort)
+    value: function listenWithUnavailableProbes(this: Server, requestedPort: number): Server {
+      probedPorts.push(requestedPort)
+      if (requestedPort < startPort + unavailableProbeCount) {
         queueMicrotask(() => {
           this.emit("error", Object.assign(new Error(`mocked port ${requestedPort} unavailable`), { code: "EADDRINUSE" }))
         })
@@ -330,14 +317,14 @@ async function runBlockedRangeAvailabilityProbe(startPort: number): Promise<Bloc
 
   try {
     try {
-      await findAvailablePort(startPort)
+      selectedPort = await findAvailablePort(startPort)
     } catch (error) {
       if (!(error instanceof Error)) {
         throw error
       }
       errorMessage = error.message
     }
-    return { errorMessage, probedPorts }
+    return { errorMessage, probedPorts, selectedPort }
   } finally {
     Object.defineProperty(Server.prototype, "listen", listenDescriptor)
     Object.defineProperty(Server.prototype, "close", closeDescriptor)
@@ -444,19 +431,21 @@ describe("port-utils", () => {
     })
 
     test("#when the first three ports are blocked #then returns the next free port", async () => {
-      const startPort = await findContiguousAvailableStart(4)
-      await startConsecutiveBlockers(startPort, 3)
+      const startPort = 40_000
 
-      const result = await findAvailablePort(startPort)
+      const { errorMessage, probedPorts, selectedPort } = await runAvailabilityProbe(startPort, 3)
 
-      expect(result).toBe(startPort + 3)
+      expect(selectedPort).toBe(startPort + 3)
+      expect(errorMessage).toBeUndefined()
+      expect(probedPorts).toEqual(Array.from({ length: 4 }, (_, offset) => startPort + offset))
     })
 
     test("#when every attempted port is blocked #then throws", async () => {
       const startPort = 40_000
 
-      const { errorMessage, probedPorts } = await runBlockedRangeAvailabilityProbe(startPort)
+      const { errorMessage, probedPorts, selectedPort } = await runAvailabilityProbe(startPort, MAX_PORT_ATTEMPTS)
 
+      expect(selectedPort).toBeUndefined()
       expect(errorMessage).toBe(`No available port found in range ${startPort}-${startPort + MAX_PORT_ATTEMPTS - 1}`)
       expect(probedPorts).toEqual(Array.from({ length: MAX_PORT_ATTEMPTS }, (_, offset) => startPort + offset))
     })


### PR DESCRIPTION
## Summary

Deflakes the required Windows test job that blocked #6093. The failing test released a four-port preflight range, held only the first three ports, and then assumed the fourth port would remain globally free until `findAvailablePort()` reached it. On the failing runner another process claimed that port, so production correctly returned the fifth port while the test required the fourth.

This PR replaces that time-of-check assumption with the deterministic `Server.prototype.listen`/`close` fixture already used for the exhausted-range case. Production `port-utils.ts` is unchanged.

## Changes

- Generalize the existing deterministic availability fixture so a configured prefix emits `EADDRINUSE` and the next probe emits `listening`.
- Assert the exact four-port sequence for three unavailable probes followed by a successful fourth probe.
- Preserve the exact 20-probe exhaustion sequence and unchanged range error.
- Remove the real-port blocker helper that became unused.
- Document why the process-wide prototype-patching tests intentionally remain serialized in one file.

## QA & Evidence

- **Original Windows RED**
  - What was tested: GitHub Actions run `29271404085`, job `86889769407`.
  - Observed result: expected `52225`, received `52226`; 11,395 passed and this one test failed.
  - Artifact: `.omo/evidence/20260714-windows-port-utils-flake/original-ci-failure.txt`.
  - Why sufficient: proves the failure was the unreserved fourth-port assumption, not a product failure.

- **Deterministic partial availability**
  - What was tested: `bun test packages/utils/src/port-utils.test.ts -t "first three ports"`.
  - Observed result: 1 pass, 0 fail; selected `startPort + 3`, no error, exact four-port probe order.
  - Artifact: `.omo/evidence/20260714-windows-port-utils-flake/c001-deterministic-probe.txt`.
  - Why sufficient: the fixture owns every probe outcome required by the exact offset assertion.

- **Exhausted range boundary**
  - What was tested: `bun test packages/utils/src/port-utils.test.ts -t "every attempted port"`.
  - Observed result: 1 pass, 0 fail; all 20 ports probed in order and the range error stayed unchanged.
  - Artifact: `.omo/evidence/20260714-windows-port-utils-flake/c002-exhausted-range.txt`.
  - Why sufficient: preserves the adjacent error and attempt-limit contract.

- **Regression gates**
  - What was tested: the full test file 20 consecutive times, utils typecheck, Biome, no-excuse, LSP diagnostics, `git diff --check`, and production/lockfile/manifest diff checks.
  - Observed result: every run had 12 pass / 0 fail; static checks passed; LSP reported no diagnostics; no production or lockfile diff exists. On final head `64a069bcdf58e914072920f181e520228474d5f8`, GitHub Actions run `29480975674` passed every required check, including Windows test job `87564402781`.
  - Artifact: `.omo/evidence/20260714-windows-port-utils-flake/c003-regression-gates.txt`.
  - Why sufficient: demonstrates repeatability and confines the change to the flaky test fixture.

## Risks & Residuals

- The fixture patches `Server.prototype` process-wide, as the existing exhaustion test already did. Descriptors are restored in `finally`, and keeping these tests in one serialized file avoids cross-file concurrency.
- Existing real-network tests remain unchanged, so actual socket binding is still exercised separately from deterministic sequence coverage.
- Cubic review is skipped because the account review quota is exhausted until August 1, 2026; CI and the five-lane `review-work` gate remain authoritative for this PR.

## Related

- Unblocks #6093.
- Follows the deterministic Windows port-fixture approach established in #5819.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Windows port-probing tests by making the probe sequence deterministic and removing reliance on real socket blockers. Production code is unchanged; updates are limited to `packages/utils/src/port-utils.test.ts`.

- **Bug Fixes**
  - Replace real blockers with a `Server.prototype.listen`/`close` fixture that emits `EADDRINUSE` for the first N probes, then succeeds; capture `probedPorts` and `selectedPort`.
  - Add `runAvailabilityProbe(startPort, unavailableProbeCount)` and assert the exact sequence: three blocked ports, then a successful fourth; keep the 20‑attempt exhaustion and error.
  - Remove the real-port blocker helper and use a fixed `startPort` (40000) for repeatability; document why prototype‑patched tests stay serialized in one file.

<sup>Written for commit 64a069bcdf58e914072920f181e520228474d5f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

