### PR TITLE
fix(lsp): cancel daemon calls when proxy parent closes

### DIFF
--- a/.agents/skills/codex-qa/scripts/lsp-e2e.sh
+++ b/.agents/skills/codex-qa/scripts/lsp-e2e.sh
@@ -36,6 +36,8 @@ DAEMON_DIST_BACKUP=""
 DAEMON_DIST_WAS_PRESENT=0
 DAEMON_DIST_PREPARED=0
 BUILD_LOCK_DIR=""
+CANCELLATION_SMOKE_RELATIVE="packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs"
+COMMIT_BARRIER_SMOKE_RELATIVE="packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs"
 
 log() { printf '[codex-lsp-e2e] %s\n' "$*" >&2; }
 fail() { log "FAIL: $*"; return 1; }
@@ -108,6 +110,21 @@ require_bins() {
     fi
   done
   [ "$missing" -eq 0 ]
+}
+
+verify_tracked_cancellation_probes() {
+  local dependency ignored_evidence_root=".omo""/evidence"
+  if grep -Fq "$ignored_evidence_root" "${BASH_SOURCE[0]}"; then
+    fail "LSP QA driver references ignored evidence state"
+    return 1
+  fi
+  for dependency in "$CANCELLATION_SMOKE_RELATIVE" "$COMMIT_BARRIER_SMOKE_RELATIVE"; do
+    [ -f "$REPO_ROOT/$dependency" ] || { fail "missing cancellation QA dependency: $dependency"; return 1; }
+    git -C "$REPO_ROOT" ls-files --error-unmatch -- "$dependency" >/dev/null 2>&1 || {
+      fail "cancellation QA dependency is not tracked: $dependency"
+      return 1
+    }
+  done
 }
 
 hash_path() {
@@ -970,24 +987,21 @@ NODE
 }
 
 run_cancellation_contract_probe() {
-  local cancellation_smoke="$REPO_ROOT/.omo/evidence/20260713-lsp-daemon-migration/task-7-cancellation/product-phase/manual/cancellation-smoke.mjs"
-  local commit_smoke="$REPO_ROOT/.omo/evidence/20260713-lsp-daemon-migration/task-7-cancellation/product-phase/manual/commit-barrier-smoke.mjs"
-  [ -f "$cancellation_smoke" ] || { fail "missing product cancellation smoke"; return 1; }
-  [ -f "$commit_smoke" ] || { fail "missing product commit-barrier smoke"; return 1; }
+  local cancellation_smoke="$REPO_ROOT/$CANCELLATION_SMOKE_RELATIVE"
+  local commit_smoke="$REPO_ROOT/$COMMIT_BARRIER_SMOKE_RELATIVE"
+  verify_tracked_cancellation_probes || return 1
 
-  run_bounded 90 "$EVIDENCE_DIR/cancellation-smoke-output.json" bun "$cancellation_smoke" || return 1
-  run_bounded 90 "$EVIDENCE_DIR/commit-barrier-smoke-output.json" bun "$commit_smoke" || return 1
+  run_bounded 90 "$EVIDENCE_DIR/cancellation-smoke-output.json" bun "$cancellation_smoke" "$REPO_ROOT" || return 1
+  run_bounded 90 "$EVIDENCE_DIR/commit-barrier-smoke-output.json" bun "$commit_smoke" "$REPO_ROOT" || return 1
 
   node --input-type=module - \
     "$EVIDENCE_DIR/cancellation-smoke-output.json" \
     "$EVIDENCE_DIR/commit-barrier-smoke-output.json" \
-    "$REPO_ROOT/.omo/evidence/20260713-lsp-daemon-migration/task-7-cancellation/product-phase/ProductPhaseClaim.json" \
     "$EVIDENCE_DIR/cancellation-contract.json" "$SCENARIO" "codex" <<'NODE'
 import { readFileSync, writeFileSync } from "node:fs";
-const [cancelPath, commitPath, claimPath, outputPath, scenario, harness] = process.argv.slice(2);
+const [cancelPath, commitPath, outputPath, scenario, harness] = process.argv.slice(2);
 const cancel = JSON.parse(readFileSync(cancelPath, "utf8"));
 const commit = JSON.parse(readFileSync(commitPath, "utf8"));
-const claim = JSON.parse(readFileSync(claimPath, "utf8"));
 const result = {
   result: "PASS",
   scenario,
@@ -1006,12 +1020,12 @@ const result = {
   },
   daemonTimeout: {
     bounded: true,
-    provenBy: "product focused daemon timeout and LSP timeout tests in ProductPhaseClaim.greenEvidence",
+    provenBy: "packages/lsp-daemon/test/daemon-client-retry.test.ts and packages/lsp-core/src/lsp/json-rpc-connection-cancellation.test.ts",
   },
   socketDisconnect: {
     abortsServerWork: true,
     activeDaemonControllersAfter: 0,
-    provenBy: "product focused request-routing socket-close test in ProductPhaseClaim.greenEvidence",
+    provenBy: "packages/lsp-daemon/test/request-routing.test.ts",
   },
   pendingAndLateResponse: {
     lspPendingRequestsAfter: cancel.directPendingAfterLateResponse,
@@ -1019,7 +1033,7 @@ const result = {
   },
   directoryDiagnostics: {
     stoppedSchedulingBetweenFiles: true,
-    provenBy: "packages/lsp-core/src/lsp/directory-diagnostics.test.ts and ProductPhaseClaim.greenEvidence",
+    provenBy: "packages/lsp-core/src/lsp/directory-diagnostics.test.ts",
   },
   delayedRenamePreCommitGate: {
     cancelTarget: commit.preGate.cancelTarget,
@@ -1041,7 +1055,7 @@ const result = {
   readOnlyPreWriteConnectionFailureRetry: {
     retryCount: 1,
     requestCount: 1,
-    provenBy: "packages/lsp-daemon/test/daemon-client-retry.test.ts and ProductPhaseClaim.greenEvidence",
+    provenBy: "packages/lsp-daemon/test/daemon-client-retry.test.ts",
   },
   sequentialProxyIds: {
     distinct: true,
@@ -1056,7 +1070,6 @@ const result = {
     cwdCanonical: true,
   },
   dirtyWorktreePreservation: {
-    productPhasePreExistingDirtyScope: claim.scope?.preExistingDirtyScope,
     driverMustPreserveDirtyWorktree: true,
   },
   noLeftovers: {
@@ -1065,9 +1078,8 @@ const result = {
   },
   promptInjectionApplicability: "not_applicable: deterministic fake-server protocol output is parsed as JSON evidence, not accepted as prose instructions",
   artifacts: {
-    cancellationSmoke: "cancellation-smoke-output.json",
-    commitBarrierSmoke: "commit-barrier-smoke-output.json",
-    productClaim: ".omo/evidence/20260713-lsp-daemon-migration/task-7-cancellation/product-phase/ProductPhaseClaim.json",
+    cancellationSmoke: "packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs",
+    commitBarrierSmoke: "packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs",
   },
 };
 const required = [
@@ -3166,6 +3178,7 @@ run_self_test() {
   require_bins bash node jq git || return 1
   local root before_omo after_omo before_codex after_codex before_status after_status failures=0 out rc start end
   local cancellation_result_fields=true client_package_result_fields=true installed_component_result_fields=true
+  local qa_dependencies_portable=true
   local fixture_run child sandbox_path attempts
   local missing_dist_build_order='{"result":"NOT_RUN"}'
   root="$(mktemp -d -t cqa-lsp-e2e.XXXXXX)" || return 1
@@ -3179,6 +3192,11 @@ run_self_test() {
   grep -q -- '--scenario requires a value' "$out" || failures=$((failures + 1))
   if bash "${BASH_SOURCE[0]}" --scenario ../bad --evidence-dir "$root/bad" >>"$out" 2>&1; then failures=$((failures + 1)); fi
   if bash "${BASH_SOURCE[0]}" --scenario ok --evidence-dir relative >>"$out" 2>&1; then failures=$((failures + 1)); fi
+
+  if ! verify_tracked_cancellation_probes >>"$out" 2>&1; then
+    qa_dependencies_portable=false
+    failures=$((failures + 1))
+  fi
 
   for fixture in fake-pass fake-skip; do
     local ev="$root/$fixture"
@@ -3402,8 +3420,9 @@ NODE
   [ "$before_codex" = "$after_codex" ] || failures=$((failures + 1))
   [ "$before_status" = "$after_status" ] || failures=$((failures + 1))
 
-  printf '{"result":"%s","selfTest":true,"malformedArgsRejected":true,"fakePassRejected":true,"skipRejected":true,"hungCommandBounded":true,"partialStagingCleanedTwice":true,"interruptCleanupRepeated":true,"missingDaemonDistBuildOrderIndependent":true,"cancellationResultFieldsMandatory":%s,"clientPackageResultFieldsMandatory":%s,"installedComponentResultFieldsMandatory":%s,"missingDistBuildOrder":%s,"dirtyWorktreePreserved":%s,"realHomesUnchanged":%s}\n' \
+  printf '{"result":"%s","selfTest":true,"malformedArgsRejected":true,"fakePassRejected":true,"skipRejected":true,"hungCommandBounded":true,"partialStagingCleanedTwice":true,"interruptCleanupRepeated":true,"missingDaemonDistBuildOrderIndependent":true,"qaDependenciesPortable":%s,"cancellationResultFieldsMandatory":%s,"clientPackageResultFieldsMandatory":%s,"installedComponentResultFieldsMandatory":%s,"missingDistBuildOrder":%s,"dirtyWorktreePreserved":%s,"realHomesUnchanged":%s}\n' \
     "$( [ "$failures" -eq 0 ] && echo PASS || echo FAIL )" \
+    "$qa_dependencies_portable" \
     "$cancellation_result_fields" \
     "$client_package_result_fields" \
     "$installed_component_result_fields" \

--- a/.agents/skills/codex-qa/scripts/lsp-e2e.sh
+++ b/.agents/skills/codex-qa/scripts/lsp-e2e.sh
@@ -1078,6 +1078,10 @@ const result = {
   },
   promptInjectionApplicability: "not_applicable: deterministic fake-server protocol output is parsed as JSON evidence, not accepted as prose instructions",
   artifacts: {
+    cancellationSmoke: "cancellation-smoke-output.json",
+    commitBarrierSmoke: "commit-barrier-smoke-output.json",
+  },
+  sources: {
     cancellationSmoke: "packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs",
     commitBarrierSmoke: "packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs",
   },

--- a/.agents/skills/opencode-qa/scripts/lsp-e2e.sh
+++ b/.agents/skills/opencode-qa/scripts/lsp-e2e.sh
@@ -41,6 +41,8 @@ SSE_ATTEMPT_SECONDS=2
 BUILD_LOCK_DIR=""
 SOURCE_PACKAGE_STAMP=""
 SOURCE_PACKAGE_STAMP_CREATED=0
+CANCELLATION_SMOKE_RELATIVE="packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs"
+COMMIT_BARRIER_SMOKE_RELATIVE="packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs"
 
 log() { printf '[opencode-lsp-e2e] %s\n' "$*" >&2; }
 fail() { log "FAIL: $*"; return 1; }
@@ -109,6 +111,21 @@ require_bins() {
     fi
   done
   [ "$missing" -eq 0 ]
+}
+
+verify_tracked_cancellation_probes() {
+  local dependency ignored_evidence_root=".omo""/evidence"
+  if grep -Fq "$ignored_evidence_root" "${BASH_SOURCE[0]}"; then
+    fail "LSP QA driver references ignored evidence state"
+    return 1
+  fi
+  for dependency in "$CANCELLATION_SMOKE_RELATIVE" "$COMMIT_BARRIER_SMOKE_RELATIVE"; do
+    [ -f "$REPO_ROOT/$dependency" ] || { fail "missing cancellation QA dependency: $dependency"; return 1; }
+    git -C "$REPO_ROOT" ls-files --error-unmatch -- "$dependency" >/dev/null 2>&1 || {
+      fail "cancellation QA dependency is not tracked: $dependency"
+      return 1
+    }
+  done
 }
 
 hash_path() {
@@ -920,24 +937,21 @@ NODE
 }
 
 run_cancellation_contract_probe() {
-  local cancellation_smoke="$REPO_ROOT/.omo/evidence/20260713-lsp-daemon-migration/task-7-cancellation/product-phase/manual/cancellation-smoke.mjs"
-  local commit_smoke="$REPO_ROOT/.omo/evidence/20260713-lsp-daemon-migration/task-7-cancellation/product-phase/manual/commit-barrier-smoke.mjs"
-  [ -f "$cancellation_smoke" ] || { fail "missing product cancellation smoke"; return 1; }
-  [ -f "$commit_smoke" ] || { fail "missing product commit-barrier smoke"; return 1; }
+  local cancellation_smoke="$REPO_ROOT/$CANCELLATION_SMOKE_RELATIVE"
+  local commit_smoke="$REPO_ROOT/$COMMIT_BARRIER_SMOKE_RELATIVE"
+  verify_tracked_cancellation_probes || return 1
 
-  run_bounded 90 "$EVIDENCE_DIR/cancellation-smoke-output.json" bun "$cancellation_smoke" || return 1
-  run_bounded 90 "$EVIDENCE_DIR/commit-barrier-smoke-output.json" bun "$commit_smoke" || return 1
+  run_bounded 90 "$EVIDENCE_DIR/cancellation-smoke-output.json" bun "$cancellation_smoke" "$REPO_ROOT" || return 1
+  run_bounded 90 "$EVIDENCE_DIR/commit-barrier-smoke-output.json" bun "$commit_smoke" "$REPO_ROOT" || return 1
 
   bun --input-type=module - \
     "$EVIDENCE_DIR/cancellation-smoke-output.json" \
     "$EVIDENCE_DIR/commit-barrier-smoke-output.json" \
-    "$REPO_ROOT/.omo/evidence/20260713-lsp-daemon-migration/task-7-cancellation/product-phase/ProductPhaseClaim.json" \
     "$EVIDENCE_DIR/cancellation-contract.json" "$SCENARIO" "opencode" <<'NODE'
 import { readFileSync, writeFileSync } from "node:fs";
-const [cancelPath, commitPath, claimPath, outputPath, scenario, harness] = process.argv.slice(2);
+const [cancelPath, commitPath, outputPath, scenario, harness] = process.argv.slice(2);
 const cancel = JSON.parse(readFileSync(cancelPath, "utf8"));
 const commit = JSON.parse(readFileSync(commitPath, "utf8"));
-const claim = JSON.parse(readFileSync(claimPath, "utf8"));
 const result = {
   result: "PASS",
   scenario,
@@ -956,12 +970,12 @@ const result = {
   },
   daemonTimeout: {
     bounded: true,
-    provenBy: "product focused daemon timeout and LSP timeout tests in ProductPhaseClaim.greenEvidence",
+    provenBy: "packages/lsp-daemon/test/daemon-client-retry.test.ts and packages/lsp-core/src/lsp/json-rpc-connection-cancellation.test.ts",
   },
   socketDisconnect: {
     abortsServerWork: true,
     activeDaemonControllersAfter: 0,
-    provenBy: "product focused request-routing socket-close test in ProductPhaseClaim.greenEvidence",
+    provenBy: "packages/lsp-daemon/test/request-routing.test.ts",
   },
   pendingAndLateResponse: {
     lspPendingRequestsAfter: cancel.directPendingAfterLateResponse,
@@ -969,7 +983,7 @@ const result = {
   },
   directoryDiagnostics: {
     stoppedSchedulingBetweenFiles: true,
-    provenBy: "packages/lsp-core/src/lsp/directory-diagnostics.test.ts and ProductPhaseClaim.greenEvidence",
+    provenBy: "packages/lsp-core/src/lsp/directory-diagnostics.test.ts",
   },
   delayedRenamePreCommitGate: {
     cancelTarget: commit.preGate.cancelTarget,
@@ -991,7 +1005,7 @@ const result = {
   readOnlyPreWriteConnectionFailureRetry: {
     retryCount: 1,
     requestCount: 1,
-    provenBy: "packages/lsp-daemon/test/daemon-client-retry.test.ts and ProductPhaseClaim.greenEvidence",
+    provenBy: "packages/lsp-daemon/test/daemon-client-retry.test.ts",
   },
   sequentialProxyIds: {
     distinct: true,
@@ -1006,7 +1020,6 @@ const result = {
     cwdCanonical: true,
   },
   dirtyWorktreePreservation: {
-    productPhasePreExistingDirtyScope: claim.scope?.preExistingDirtyScope,
     driverMustPreserveDirtyWorktree: true,
   },
   noLeftovers: {
@@ -1015,9 +1028,8 @@ const result = {
   },
   promptInjectionApplicability: "not_applicable: deterministic fake-server protocol output is parsed as JSON evidence, not accepted as prose instructions",
   artifacts: {
-    cancellationSmoke: "cancellation-smoke-output.json",
-    commitBarrierSmoke: "commit-barrier-smoke-output.json",
-    productClaim: ".omo/evidence/20260713-lsp-daemon-migration/task-7-cancellation/product-phase/ProductPhaseClaim.json",
+    cancellationSmoke: "packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs",
+    commitBarrierSmoke: "packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs",
   },
 };
 const required = [
@@ -2416,6 +2428,7 @@ run_self_test() {
   local fixture_run child sandbox_path attempts health_pid health_port accepted_count previous_opencode_pid
   local sse_pid sse_port previous_sse_ready previous_sse_attempt
   local terminal_pid terminal_port previous_scenario previous_evidence_dir terminal_killer
+  local qa_dependencies_portable=true
   root="$(mktemp -d -t oqa-lsp-e2e.XXXXXX)" || return 1
   SANDBOX_ROOT="$root"
   before_omo="$(hash_path "$REAL_OMO_ROOT")"
@@ -2428,6 +2441,11 @@ run_self_test() {
   grep -q -- '--scenario requires a value' "$out" || failures=$((failures + 1))
   if bash "${BASH_SOURCE[0]}" --scenario ../bad --evidence-dir "$root/bad" >>"$out" 2>&1; then failures=$((failures + 1)); fi
   if bash "${BASH_SOURCE[0]}" --scenario ok --evidence-dir relative >>"$out" 2>&1; then failures=$((failures + 1)); fi
+
+  if ! verify_tracked_cancellation_probes >>"$out" 2>&1; then
+    qa_dependencies_portable=false
+    failures=$((failures + 1))
+  fi
 
   for fixture in fake-pass fake-skip; do
     local ev="$root/$fixture"
@@ -2763,8 +2781,9 @@ NODE
   [ "$before_db" = "$after_db" ] || failures=$((failures + 1))
   [ "$before_status" = "$after_status" ] || failures=$((failures + 1))
 
-  printf '{"result":"%s","selfTest":true,"malformedArgsRejected":true,"fakePassRejected":true,"skipRejected":true,"hungCommandBounded":true,"healthTimeoutReadinessBounded":true,"sseStartupRetryDeterministic":true,"partialStagingCleanedTwice":true,"interruptCleanupRepeated":true,"cancellationResultFieldsMandatory":true,"clientPackageResultFieldsMandatory":true,"dirtyWorktreePreserved":%s,"realHomesUnchanged":%s}\n' \
+  printf '{"result":"%s","selfTest":true,"malformedArgsRejected":true,"fakePassRejected":true,"skipRejected":true,"hungCommandBounded":true,"healthTimeoutReadinessBounded":true,"sseStartupRetryDeterministic":true,"partialStagingCleanedTwice":true,"interruptCleanupRepeated":true,"qaDependenciesPortable":%s,"cancellationResultFieldsMandatory":true,"clientPackageResultFieldsMandatory":true,"dirtyWorktreePreserved":%s,"realHomesUnchanged":%s}\n' \
     "$( [ "$failures" -eq 0 ] && echo PASS || echo FAIL )" \
+    "$qa_dependencies_portable" \
     "$( [ "$before_status" = "$after_status" ] && echo true || echo false )" \
     "$( [ "$before_omo" = "$after_omo" ] && [ "$before_db" = "$after_db" ] && echo true || echo false )"
   cleanup_all || failures=$((failures + 1))

--- a/.agents/skills/opencode-qa/scripts/lsp-e2e.sh
+++ b/.agents/skills/opencode-qa/scripts/lsp-e2e.sh
@@ -1028,6 +1028,10 @@ const result = {
   },
   promptInjectionApplicability: "not_applicable: deterministic fake-server protocol output is parsed as JSON evidence, not accepted as prose instructions",
   artifacts: {
+    cancellationSmoke: "cancellation-smoke-output.json",
+    commitBarrierSmoke: "commit-barrier-smoke-output.json",
+  },
+  sources: {
     cancellationSmoke: "packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs",
     commitBarrierSmoke: "packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs",
   },

--- a/.agents/skills/opencode-qa/scripts/lsp-e2e.sh
+++ b/.agents/skills/opencode-qa/scripts/lsp-e2e.sh
@@ -1778,19 +1778,79 @@ NODE
 }
 
 run_mcp_status_call() {
-  local label="$1" output="$2"
+  local label="$1" output="$2" stderr_output="$EVIDENCE_DIR/${1}.stderr.log"
   shift 2
-  printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"lsp_status","arguments":{}}}\n' |
-    env \
-      HOME="$HOME" \
-      XDG_CONFIG_HOME="$XDG_CONFIG_HOME" \
-      OMO_LSP_DAEMON_DIR="$OMO_LSP_DAEMON_DIR" \
-      ${OMO_LSP_DAEMON_CLI+OMO_LSP_DAEMON_CLI="$OMO_LSP_DAEMON_CLI"} \
-      ${OMO_LSP_DAEMON_VERSION+OMO_LSP_DAEMON_VERSION="$OMO_LSP_DAEMON_VERSION"} \
-      LSP_TOOLS_MCP_PROJECT_CONFIG="$SANDBOX_ROOT/project/.opencode/lsp.json:$SANDBOX_ROOT/project/.omo/lsp.json:$SANDBOX_ROOT/project/.omo/lsp-client.json" \
-      LSP_TOOLS_MCP_USER_CONFIG="$XDG_CONFIG_HOME/opencode/lsp.json" \
-      LSP_TOOLS_MCP_INSTALL_DECISIONS="$XDG_CONFIG_HOME/opencode/lsp-install-decisions.json" \
-      "$@" >"$output" 2>"$EVIDENCE_DIR/${label}.stderr.log"
+  env \
+    HOME="$HOME" \
+    XDG_CONFIG_HOME="$XDG_CONFIG_HOME" \
+    OMO_LSP_DAEMON_DIR="$OMO_LSP_DAEMON_DIR" \
+    ${OMO_LSP_DAEMON_CLI+OMO_LSP_DAEMON_CLI="$OMO_LSP_DAEMON_CLI"} \
+    ${OMO_LSP_DAEMON_VERSION+OMO_LSP_DAEMON_VERSION="$OMO_LSP_DAEMON_VERSION"} \
+    LSP_TOOLS_MCP_PROJECT_CONFIG="$SANDBOX_ROOT/project/.opencode/lsp.json:$SANDBOX_ROOT/project/.omo/lsp.json:$SANDBOX_ROOT/project/.omo/lsp-client.json" \
+    LSP_TOOLS_MCP_USER_CONFIG="$XDG_CONFIG_HOME/opencode/lsp.json" \
+    LSP_TOOLS_MCP_INSTALL_DECISIONS="$XDG_CONFIG_HOME/opencode/lsp-install-decisions.json" \
+    node --input-type=module - "$output" "$stderr_output" "$@" <<'NODE'
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+const [output, stderrOutput, command, ...args] = process.argv.slice(2);
+if (!command) process.exit(125);
+
+const child = spawn(command, args, { env: process.env, stdio: ["pipe", "pipe", "pipe"] });
+let stdout = "";
+let stderr = "";
+let responseSeen = false;
+let forceTimer;
+
+child.stdout.setEncoding("utf8");
+child.stderr.setEncoding("utf8");
+child.stdout.on("data", (chunk) => {
+  stdout += chunk;
+  if (!responseSeen && stdout.includes("\n")) {
+    responseSeen = true;
+    child.stdin.end();
+  }
+});
+child.stderr.on("data", (chunk) => {
+  stderr += chunk;
+});
+child.stdin.on("error", (error) => {
+  stderr += `${error instanceof Error ? error.stack ?? error.message : String(error)}\n`;
+});
+
+const request = { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "lsp_status", arguments: {} } };
+child.stdin.write(`${JSON.stringify(request)}\n`);
+
+let timedOut = false;
+const timer = setTimeout(() => {
+  timedOut = true;
+  child.kill("SIGTERM");
+  forceTimer = setTimeout(() => child.kill("SIGKILL"), 3000);
+}, 30000);
+const outcome = await new Promise((resolve) => {
+  let settled = false;
+  const finish = (value) => {
+    if (settled) return;
+    settled = true;
+    resolve(value);
+  };
+  child.once("error", (error) => finish({ error }));
+  child.once("close", (code, signal) => finish({ code, signal }));
+});
+clearTimeout(timer);
+if (forceTimer) clearTimeout(forceTimer);
+writeFileSync(output, stdout);
+writeFileSync(stderrOutput, stderr);
+
+if (timedOut) process.exit(124);
+if ("error" in outcome) {
+  console.error(outcome.error);
+  process.exit(126);
+}
+if (!responseSeen) process.exit(1);
+if (typeof outcome.code === "number") process.exit(outcome.code);
+process.exit(outcome.signal ? 128 : 1);
+NODE
 }
 
 capture_current_daemon_owner() {

--- a/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
+++ b/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
@@ -148,7 +148,7 @@ describe("LspClient diagnostics freshness", () => {
 				capabilities: { diagnosticProvider: { interFileDependencies: false, workspaceDiagnostics: false } },
 				diagnosticResponses: [
 					{
-						delayMs: 20,
+						delayMs: 200,
 						report: { kind: "full", resultId: "v1", items: [diagnostic("pull-stale")] },
 					},
 					{
@@ -156,7 +156,7 @@ describe("LspClient diagnostics freshness", () => {
 					},
 				],
 			},
-			{ diagnosticsFreshnessTimeoutMs: 80, versionlessPublishQuiescenceMs: 5 },
+			{ diagnosticsFreshnessTimeoutMs: 800, versionlessPublishQuiescenceMs: 5 },
 		);
 		await context.client.openFile(context.source);
 
@@ -209,7 +209,7 @@ describe("LspClient diagnostics freshness", () => {
 				capabilities: { diagnosticProvider: { interFileDependencies: false, workspaceDiagnostics: false } },
 				diagnosticResponses: [{ action: "close" }],
 			},
-			{ diagnosticsFreshnessTimeoutMs: 50, versionlessPublishQuiescenceMs: 5 },
+			{ diagnosticsFreshnessTimeoutMs: 500, versionlessPublishQuiescenceMs: 5 },
 		);
 		await context.client.openFile(context.source);
 
@@ -229,7 +229,7 @@ describe("LspClient diagnostics freshness", () => {
 				],
 				diagnosticResponses: [{ error: { code: -32601, message: "Method not found" } }],
 			},
-			{ diagnosticsFreshnessTimeoutMs: 50, versionlessPublishQuiescenceMs: 5 },
+			{ diagnosticsFreshnessTimeoutMs: 500, versionlessPublishQuiescenceMs: 5 },
 		);
 
 		const result = await context.client.diagnostics(context.source);

--- a/packages/lsp-core/src/lsp/directory-diagnostics.test.ts
+++ b/packages/lsp-core/src/lsp/directory-diagnostics.test.ts
@@ -5,7 +5,8 @@ import { join } from "node:path";
 import { describe, expect, it } from "bun:test";
 
 import { aggregateDiagnosticsForDirectory } from "./directory-diagnostics.js";
-import type { LspClient } from "./client.js";
+import { LspClient } from "./client.js";
+import { LspManager } from "./manager.js";
 import type { Diagnostic, ResolvedServer } from "./types.js";
 
 describe("directory diagnostics", () => {
@@ -94,7 +95,123 @@ describe("directory diagnostics", () => {
 			rmSync(workspace, { recursive: true, force: true });
 		}
 	});
+
+	it("#given cold client acquisition is pending #when directory diagnostics are aborted #then acquisition settles and cleans up before startup releases", async () => {
+		const workspace = mkdtempSync(join(tmpdir(), "lsp-directory-diag-cold-cancel-"));
+		const controller = new AbortController();
+		const startupStarted = deferred();
+		const startupRelease = deferred();
+		const server: ResolvedServer = {
+			id: "typescript",
+			command: ["typescript-language-server"],
+			extensions: [".ts"],
+			priority: 1,
+		};
+		const client = new PendingStartLspClient({
+			root: workspace,
+			server,
+			startupStarted,
+			startupRelease,
+		});
+		const manager = new LspManager({
+			clientFactory: () => client,
+			reaperIntervalMs: 60_000,
+		});
+		const aggregation = aggregateDiagnosticsForDirectory(workspace, ".ts", "all", 1, {
+			manager,
+			listFiles: () => [join(workspace, "a.ts")],
+			workspaceRoot: workspace,
+			server,
+			signal: controller.signal,
+		});
+
+		try {
+			await startupStarted.promise;
+			controller.abort();
+
+			const settledBeforeStartupRelease = await settlesWithin(aggregation, 100);
+
+			expect(settledBeforeStartupRelease).toBe(true);
+			await expect(aggregation).rejects.toHaveProperty("name", "AbortError");
+			expect(manager.clientCount()).toBe(0);
+			expect(client.stopCallCount).toBe(1);
+		} finally {
+			startupRelease.resolve();
+			await aggregation.catch(() => undefined);
+			await manager.stopAll();
+			rmSync(workspace, { recursive: true, force: true });
+		}
+	});
 });
+
+class PendingStartLspClient extends LspClient {
+	stopCallCount = 0;
+	private readonly startupStarted: Deferred;
+	private readonly startupRelease: Deferred;
+
+	constructor(options: PendingStartLspClientOptions) {
+		super(options.root, options.server);
+		this.startupStarted = options.startupStarted;
+		this.startupRelease = options.startupRelease;
+	}
+
+	override async start(): Promise<void> {
+		this.startupStarted.resolve();
+		await this.startupRelease.promise;
+	}
+
+	override async initialize(): Promise<void> {}
+
+	override async stop(): Promise<void> {
+		this.stopCallCount += 1;
+	}
+
+	override isAlive(): boolean {
+		return true;
+	}
+
+	override async diagnostics(): Promise<{ readonly items: Diagnostic[] }> {
+		return { items: [] };
+	}
+}
+
+interface PendingStartLspClientOptions {
+	readonly root: string;
+	readonly server: ResolvedServer;
+	readonly startupStarted: Deferred;
+	readonly startupRelease: Deferred;
+}
+
+interface Deferred {
+	readonly promise: Promise<void>;
+	resolve(): void;
+}
+
+function deferred(): Deferred {
+	let resolvePromise: (() => void) | undefined;
+	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: () => resolvePromise?.() };
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise.then(
+				() => true,
+				() => true,
+			),
+			new Promise<boolean>((resolve) => {
+				timer = setTimeout(() => resolve(false), timeoutMs);
+				timer.unref();
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
 
 function diagnostic(message: string): Diagnostic {
 	return {

--- a/packages/lsp-core/src/lsp/directory-diagnostics.ts
+++ b/packages/lsp-core/src/lsp/directory-diagnostics.ts
@@ -124,7 +124,7 @@ export async function aggregateDiagnosticsForDirectory(
 	const maxConcurrency = Math.max(1, options.maxConcurrency ?? DIRECTORY_DIAGNOSTICS_MAX_CONCURRENCY);
 
 	options.signal?.throwIfAborted();
-	const client = await manager.getClient(root, server);
+	const client = await manager.getClient(root, server, options.signal);
 	try {
 		let nextIndex = 0;
 		const workers = Array.from({ length: Math.min(maxConcurrency, filesToProcess.length) }, async () => {

--- a/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
+++ b/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
@@ -12,6 +12,9 @@ if (!repositoryRoot) throw new Error("repository root argument is required");
 const root = realpathSync(repositoryRoot);
 
 const { callToolViaDaemon } = await import(pathToFileURL(join(root, "packages/lsp-daemon/src/daemon-client.ts")).href);
+const { daemonPaths: resolveDaemonPaths, OMO_LSP_DAEMON_DIR } = await import(
+	pathToFileURL(join(root, "packages/lsp-daemon/src/paths.ts")).href
+);
 const { handleDaemonMessage } = await import(pathToFileURL(join(root, "packages/lsp-daemon/src/request-routing.ts")).href);
 const { createLineDecoder, encodeJsonLine } = await import(
 	pathToFileURL(join(root, "packages/lsp-daemon/src/socket-jsonrpc.ts")).href
@@ -28,7 +31,10 @@ const sockets = new Set();
 let daemonServer;
 
 try {
-	const paths = daemonPaths(tempRoot);
+	const paths = resolveDaemonPaths(
+		{ [OMO_LSP_DAEMON_DIR]: join(tempRoot, "daemon") },
+		{ version: "manual", cliPath: join(root, "packages/lsp-daemon/src/cli.ts") },
+	);
 	mkdirSync(paths.dir, { recursive: true });
 	const token = "manual-smoke-token";
 	writeFileSync(paths.auth, `${token}\n`, { mode: 0o600 });
@@ -141,8 +147,14 @@ try {
 	assert(activeRequests.size === 0, "daemon active request map leaked");
 
 	const direct = await directJsonRpcCancellationCheck();
+	const daemonEndpointKind = paths.socket.startsWith("\\\\.\\pipe\\") ? "named-pipe" : "unix-socket";
+	assert(
+		daemonEndpointKind === (process.platform === "win32" ? "named-pipe" : "unix-socket"),
+		`production daemon endpoint kind did not match ${process.platform}`,
+	);
 	const summary = {
 		workspaceHash: sha256(readFileSync(source)),
+		daemonEndpointKind,
 		daemonProxyId: daemonRequest.id,
 		daemonCancelTarget: daemonCancel.params.id,
 		lspRequestId: lspRequest.id,
@@ -159,22 +171,6 @@ try {
 	if (daemonServer) await closeServer(daemonServer);
 	await disposeDefaultLspManager();
 	rmSync(tempRoot, { recursive: true, force: true });
-}
-
-function daemonPaths(base) {
-	const dir = join(base, "daemon");
-	return {
-		version: "manual",
-		cliPath: join(root, "packages/lsp-daemon/src/cli.ts"),
-		dir,
-		socket: join(dir, "daemon.sock"),
-		lock: join(dir, "daemon.lock"),
-		pid: join(dir, "daemon.pid"),
-		auth: join(dir, "daemon.auth"),
-		endpoint: join(dir, "daemon.endpoint"),
-		owner: join(dir, "daemon.owner"),
-		log: join(dir, "daemon.log"),
-	};
 }
 
 function fakeLspServerSource() {

--- a/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
+++ b/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
@@ -29,6 +29,7 @@ const daemonMessages = [];
 const activeRequests = new Map();
 const sockets = new Set();
 let daemonServer;
+let summary;
 
 try {
 	const paths = resolveDaemonPaths(
@@ -152,7 +153,7 @@ try {
 		daemonEndpointKind === (process.platform === "win32" ? "named-pipe" : "unix-socket"),
 		`production daemon endpoint kind did not match ${process.platform}`,
 	);
-	const summary = {
+	summary = {
 		workspaceHash: sha256(readFileSync(source)),
 		daemonEndpointKind,
 		daemonProxyId: daemonRequest.id,
@@ -165,13 +166,17 @@ try {
 		resultText: result.content[0]?.text ?? "",
 		auth: "redacted",
 	};
-	console.log(JSON.stringify(summary, null, 2));
 } finally {
-	for (const socket of sockets) socket.destroy();
-	if (daemonServer) await closeServer(daemonServer);
-	await disposeDefaultLspManager();
-	rmSync(tempRoot, { recursive: true, force: true });
+	await traceCleanupStage("daemon-sockets", () => {
+		for (const socket of sockets) socket.destroy();
+	});
+	if (daemonServer) await traceCleanupStage("daemon-server", () => closeServer(daemonServer));
+	await traceCleanupStage("lsp-manager", () => disposeDefaultLspManager());
+	await traceCleanupStage("temp-root", () => rmSync(tempRoot, { recursive: true, force: true }));
 }
+assert(summary, "cancellation summary missing after cleanup");
+process.stderr.write(`[cleanup:active-resources:${JSON.stringify(process.getActiveResourcesInfo())}]\n`);
+console.log(JSON.stringify(summary, null, 2));
 
 function fakeLspServerSource() {
 	return String.raw`
@@ -322,6 +327,12 @@ function listen(server, path) {
 
 function closeServer(server) {
 	return new Promise((resolve) => server.close(() => resolve()));
+}
+
+async function traceCleanupStage(stage, cleanup) {
+	process.stderr.write(`[cleanup:${stage}:start]\n`);
+	await cleanup();
+	process.stderr.write(`[cleanup:${stage}:complete]\n`);
 }
 
 function assert(condition, message) {

--- a/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
+++ b/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
@@ -1,0 +1,337 @@
+// allow: SIZE_OK - one deterministic socket-to-LSP cancellation scenario keeps request identity and cleanup evidence together.
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { pathToFileURL } from "node:url";
+
+const [repositoryRoot] = process.argv.slice(2);
+if (!repositoryRoot) throw new Error("repository root argument is required");
+const root = realpathSync(repositoryRoot);
+
+const { callToolViaDaemon } = await import(pathToFileURL(join(root, "packages/lsp-daemon/src/daemon-client.ts")).href);
+const { handleDaemonMessage } = await import(pathToFileURL(join(root, "packages/lsp-daemon/src/request-routing.ts")).href);
+const { createLineDecoder, encodeJsonLine } = await import(
+	pathToFileURL(join(root, "packages/lsp-daemon/src/socket-jsonrpc.ts")).href
+);
+const { JsonRpcConnection } = await import(
+	pathToFileURL(join(root, "packages/lsp-core/src/lsp/json-rpc-connection.ts")).href
+);
+const { disposeDefaultLspManager } = await import(pathToFileURL(join(root, "packages/lsp-core/src/lsp/manager.ts")).href);
+
+const tempRoot = mkdtempSync(join(tmpdir(), "lsp-cancel-smoke-"));
+const daemonMessages = [];
+const activeRequests = new Map();
+const sockets = new Set();
+let daemonServer;
+
+try {
+	const paths = daemonPaths(tempRoot);
+	mkdirSync(paths.dir, { recursive: true });
+	const token = "manual-smoke-token";
+	writeFileSync(paths.auth, `${token}\n`, { mode: 0o600 });
+
+	const workspace = join(tempRoot, "workspace");
+	mkdirSync(workspace);
+	const canonicalWorkspace = realpathSync(workspace);
+	writeFileSync(join(workspace, "package.json"), "{}\n");
+	const source = join(workspace, "source.ts");
+	writeFileSync(source, "const value: number = 1;\n");
+
+	const lspEvents = join(tempRoot, "lsp-events.jsonl");
+	const fakeServer = join(tempRoot, "fake-lsp-server.mjs");
+	writeFileSync(fakeServer, fakeLspServerSource(), "utf-8");
+	writeFileSync(lspEvents, "", "utf-8");
+	const userConfigPath = join(tempRoot, "user-lsp.json");
+	writeFileSync(
+		userConfigPath,
+		JSON.stringify({
+			lsp: {
+				manual: {
+					command: [process.env.NODE_BINARY ?? "node", fakeServer, lspEvents],
+					extensions: [".ts"],
+					priority: 100,
+				},
+			},
+		}),
+	);
+
+	daemonServer = createServer((socket) => {
+		sockets.add(socket);
+		const decoder = createLineDecoder((message) => {
+			daemonMessages.push(redactAuth(message));
+			void handleDaemonMessage(message, {
+				token,
+				owner: {
+					pid: process.pid,
+					nonce: "manual-smoke",
+					startedAt: new Date(0).toISOString(),
+					endpoint: { kind: "missing", path: "manual" },
+				},
+				activeRequests,
+			}).then((response) => {
+				daemonMessages.push({ direction: "response", response });
+				if (response && socket.writable) socket.write(encodeJsonLine(response));
+			});
+		});
+		socket.on("data", (chunk) => decoder.push(chunk));
+		socket.on("close", () => {
+			for (const controller of activeRequests.values()) controller.abort();
+			activeRequests.clear();
+			sockets.delete(socket);
+		});
+	});
+	await listen(daemonServer, paths.socket);
+
+	const controller = new AbortController();
+	const resultPromise = callToolViaDaemon(
+		"diagnostics",
+		{ filePath: source, severity: "error" },
+		{
+			paths,
+			ensure: async () => {},
+			requestTimeoutMs: 5_000,
+			signal: controller.signal,
+			context: {
+				cwd: canonicalWorkspace,
+				projectConfigPaths: [join(canonicalWorkspace, ".codex", "lsp-client.json")],
+				userConfigPath,
+				installDecisionsPath: join(tempRoot, "install-decisions.json"),
+				capabilities: { installDecisionTool: false },
+			},
+		},
+	);
+
+	const first = await Promise.race([
+		waitForEvent(lspEvents, (event) => event.type === "clientRequest" && event.method === "textDocument/diagnostic").then(
+			(event) => ({ kind: "lsp-request", event }),
+		),
+		resultPromise.then((result) => ({ kind: "daemon-result", result })),
+	]);
+	if (first.kind !== "lsp-request") {
+		throw new Error(
+			`Daemon call completed before fake LSP diagnostic request: ${JSON.stringify({
+				result: first.result,
+				daemonMessages,
+				lspEvents: readEvents(lspEvents),
+			})}`,
+		);
+	}
+	const lspRequest = first.event;
+	controller.abort(new Error("manual caller abort"));
+	const result = await resultPromise;
+	const lspCancel = await waitForEvent(
+		lspEvents,
+		(event) => event.type === "clientNotification" && event.method === "$/cancelRequest",
+	);
+	const lateResponse = await waitForEvent(
+		lspEvents,
+		(event) => event.type === "serverLateResponse" && event.id === lspRequest.id,
+	);
+	await waitUntil(() => activeRequests.size === 0, "daemon active request cleanup");
+
+	const daemonRequest = daemonMessages.find((message) => message.method === "tools/call");
+	const daemonCancel = daemonMessages.find((message) => message.method === "$/cancelRequest");
+	assert(daemonRequest?.id !== undefined, "daemon request id missing");
+	assert(daemonCancel?.params?.id === daemonRequest.id, "daemon cancel id did not match proxy request id");
+	assert(lspCancel.params?.id === lspRequest.id, "LSP cancel id did not match LSP request id");
+	assert(result.isError === true, "daemon call did not report cancellation as an error result");
+	assert(activeRequests.size === 0, "daemon active request map leaked");
+
+	const direct = await directJsonRpcCancellationCheck();
+	const summary = {
+		workspaceHash: sha256(readFileSync(source)),
+		daemonProxyId: daemonRequest.id,
+		daemonCancelTarget: daemonCancel.params.id,
+		lspRequestId: lspRequest.id,
+		lspCancelTarget: lspCancel.params.id,
+		lateResponseIgnoredProbe: lateResponse.id,
+		daemonActiveRequestsAfter: activeRequests.size,
+		directPendingAfterLateResponse: direct.pendingAfterLateResponse,
+		resultText: result.content[0]?.text ?? "",
+		auth: "redacted",
+	};
+	console.log(JSON.stringify(summary, null, 2));
+} finally {
+	for (const socket of sockets) socket.destroy();
+	if (daemonServer) await closeServer(daemonServer);
+	await disposeDefaultLspManager();
+	rmSync(tempRoot, { recursive: true, force: true });
+}
+
+function daemonPaths(base) {
+	const dir = join(base, "daemon");
+	return {
+		version: "manual",
+		cliPath: join(root, "packages/lsp-daemon/src/cli.ts"),
+		dir,
+		socket: join(dir, "daemon.sock"),
+		lock: join(dir, "daemon.lock"),
+		pid: join(dir, "daemon.pid"),
+		auth: join(dir, "daemon.auth"),
+		endpoint: join(dir, "daemon.endpoint"),
+		owner: join(dir, "daemon.owner"),
+		log: join(dir, "daemon.log"),
+	};
+}
+
+function fakeLspServerSource() {
+	return String.raw`
+import { appendFileSync } from "node:fs";
+
+const [, , eventsPath] = process.argv;
+let buffer = Buffer.alloc(0);
+let pendingDiagnosticId = null;
+
+function record(event) {
+	appendFileSync(eventsPath, JSON.stringify(event) + "\n", "utf-8");
+}
+
+function send(message) {
+	const body = Buffer.from(JSON.stringify(message), "utf-8");
+	process.stdout.write("Content-Length: " + body.length + "\r\n\r\n");
+	process.stdout.write(body);
+}
+
+function handle(message) {
+	if (Object.hasOwn(message, "id")) {
+		record({ type: "clientRequest", method: message.method, id: message.id });
+		if (message.method === "initialize") {
+			send({ jsonrpc: "2.0", id: message.id, result: { capabilities: { diagnosticProvider: {} } } });
+			return;
+		}
+		if (message.method === "textDocument/diagnostic") {
+			pendingDiagnosticId = message.id;
+			return;
+		}
+		send({ jsonrpc: "2.0", id: message.id, result: null });
+		return;
+	}
+	record({ type: "clientNotification", method: message.method, params: message.params ?? null });
+	if (message.method === "$/cancelRequest" && pendingDiagnosticId !== null) {
+		const id = pendingDiagnosticId;
+		setTimeout(() => {
+			record({ type: "serverLateResponse", id });
+			send({ jsonrpc: "2.0", id, result: { items: [] } });
+		}, 20);
+	}
+	if (message.method === "exit") process.exit(0);
+}
+
+process.stdin.on("data", (chunk) => {
+	buffer = Buffer.concat([buffer, chunk]);
+	for (;;) {
+		const headerEnd = buffer.indexOf("\r\n\r\n");
+		if (headerEnd === -1) return;
+		const header = buffer.subarray(0, headerEnd).toString("ascii");
+		const match = /content-length:\s*(\d+)/i.exec(header);
+		if (!match) process.exit(2);
+		const length = Number(match[1]);
+		const bodyStart = headerEnd + 4;
+		if (buffer.length < bodyStart + length) return;
+		const body = buffer.subarray(bodyStart, bodyStart + length).toString("utf-8");
+		buffer = buffer.subarray(bodyStart + length);
+		handle(JSON.parse(body));
+	}
+});
+`;
+}
+
+async function directJsonRpcCancellationCheck() {
+	const serverToClient = new PassThrough();
+	const clientToServer = new PassThrough();
+	const connection = new JsonRpcConnection(serverToClient, clientToServer);
+	const messages = [];
+	const decoder = createContentLengthDecoder((message) => messages.push(message));
+	clientToServer.on("data", (chunk) => decoder.push(chunk));
+	connection.listen();
+	const controller = new AbortController();
+	const request = connection.sendRequest("manual/slow", {}, { signal: controller.signal }).catch((error) => error);
+	await waitUntil(() => messages.some((message) => message.method === "manual/slow"), "direct JSON-RPC request");
+	const requestMessage = messages.find((message) => message.method === "manual/slow");
+	controller.abort(new Error("direct manual cancel"));
+	await request;
+	await waitUntil(() => messages.some((message) => message.method === "$/cancelRequest"), "direct JSON-RPC cancel");
+	serverToClient.write(encodeContentLength({ jsonrpc: "2.0", id: requestMessage.id, result: "late" }));
+	await new Promise((resolve) => setTimeout(resolve, 10));
+	const pendingAfterLateResponse = connection.pendingRequestCount();
+	connection.dispose();
+	return { pendingAfterLateResponse };
+}
+
+function createContentLengthDecoder(onMessage) {
+	let buffer = Buffer.alloc(0);
+	return {
+		push(chunk) {
+			buffer = Buffer.concat([buffer, Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)]);
+			for (;;) {
+				const headerEnd = buffer.indexOf("\r\n\r\n");
+				if (headerEnd === -1) return;
+				const match = /content-length:\s*(\d+)/i.exec(buffer.subarray(0, headerEnd).toString("ascii"));
+				if (!match) throw new Error("missing content-length");
+				const length = Number(match[1]);
+				const bodyStart = headerEnd + 4;
+				if (buffer.length < bodyStart + length) return;
+				const body = buffer.subarray(bodyStart, bodyStart + length).toString("utf-8");
+				buffer = buffer.subarray(bodyStart + length);
+				onMessage(JSON.parse(body));
+			}
+		},
+	};
+}
+
+function encodeContentLength(message) {
+	const body = JSON.stringify(message);
+	return `Content-Length: ${Buffer.byteLength(body, "utf-8")}\r\n\r\n${body}`;
+}
+
+function redactAuth(message) {
+	const cloned = structuredClone(message);
+	if (cloned?.params?._omo?.token) cloned.params._omo.token = "redacted";
+	return cloned;
+}
+
+function waitForEvent(path, predicate) {
+	return waitUntil(() => readEvents(path).find(predicate), `event in ${path}`);
+}
+
+async function waitUntil(fn, label) {
+	const deadline = Date.now() + 3_000;
+	for (;;) {
+		const value = fn();
+		if (value) return value;
+		if (Date.now() > deadline) throw new Error(`Timed out waiting for ${label}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+function readEvents(path) {
+	return readFileSync(path, "utf-8")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
+}
+
+function listen(server, path) {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(path, () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+}
+
+function closeServer(server) {
+	return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+function sha256(buffer) {
+	return createHash("sha256").update(buffer).digest("hex");
+}

--- a/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
+++ b/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
@@ -173,7 +173,12 @@ try {
 	rmSync(tempRoot, { recursive: true, force: true });
 }
 assert(summary, "cancellation summary missing after cleanup");
-await new Promise((resolve) => process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`, resolve));
+await new Promise((resolve, reject) => {
+	process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`, (error) => {
+		if (error) reject(error);
+		else resolve();
+	});
+});
 process.exit(0);
 
 function fakeLspServerSource() {

--- a/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
+++ b/packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs
@@ -167,16 +167,14 @@ try {
 		auth: "redacted",
 	};
 } finally {
-	await traceCleanupStage("daemon-sockets", () => {
-		for (const socket of sockets) socket.destroy();
-	});
-	if (daemonServer) await traceCleanupStage("daemon-server", () => closeServer(daemonServer));
-	await traceCleanupStage("lsp-manager", () => disposeDefaultLspManager());
-	await traceCleanupStage("temp-root", () => rmSync(tempRoot, { recursive: true, force: true }));
+	for (const socket of sockets) socket.destroy();
+	if (daemonServer) await closeServer(daemonServer);
+	await disposeDefaultLspManager();
+	rmSync(tempRoot, { recursive: true, force: true });
 }
 assert(summary, "cancellation summary missing after cleanup");
-process.stderr.write(`[cleanup:active-resources:${JSON.stringify(process.getActiveResourcesInfo())}]\n`);
-console.log(JSON.stringify(summary, null, 2));
+await new Promise((resolve) => process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`, resolve));
+process.exit(0);
 
 function fakeLspServerSource() {
 	return String.raw`
@@ -327,12 +325,6 @@ function listen(server, path) {
 
 function closeServer(server) {
 	return new Promise((resolve) => server.close(() => resolve()));
-}
-
-async function traceCleanupStage(stage, cleanup) {
-	process.stderr.write(`[cleanup:${stage}:start]\n`);
-	await cleanup();
-	process.stderr.write(`[cleanup:${stage}:complete]\n`);
 }
 
 function assert(condition, message) {

--- a/packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs
+++ b/packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+import { readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [repositoryRoot] = process.argv.slice(2);
+if (!repositoryRoot) throw new Error("repository root argument is required");
+const root = realpathSync(repositoryRoot);
+const { createWorkspaceEditTestHarness, readEvents, renameTextEdit, waitForEventCount } = await import(
+	pathToFileURL(join(root, "packages/lsp-core/src/lsp/workspace-apply-edit-test-support.ts")).href
+);
+
+const harness = createWorkspaceEditTestHarness();
+
+try {
+	const pre = await harness.makeClient({
+		renameSteps: [
+			{
+				applyDelayMs: 200,
+				applyEdit: renameTextEdit("before", "after", { version: 1 }),
+				renameResult: "same",
+			},
+		],
+	});
+	const preBefore = hashFile(pre.source);
+	const preController = new AbortController();
+	const preRename = pre.client.rename(pre.source, 1, 6, "after", preController.signal).catch((error) => error);
+	await waitForEventCount(
+		pre.events,
+		(event) => event.type === "clientRequest" && event.method === "textDocument/rename",
+		1,
+	);
+	preController.abort();
+	const preResult = await preRename;
+	const [preCancel] = await waitForEventCount(
+		pre.events,
+		(event) => event.type === "clientNotification" && event.method === "$/cancelRequest",
+		1,
+	);
+	const preAfter = hashFile(pre.source);
+	assert(preResult instanceof Error && /cancel/i.test(preResult.message), "pre-gate rename did not cancel");
+	assert(preBefore === preAfter, "pre-gate cancellation mutated the file");
+
+	const post = await harness.makeClient({
+		renameSteps: [
+			{
+				applyEdit: renameTextEdit("before", "after", { version: 1 }),
+				renameResult: "same",
+			},
+		],
+	});
+	let writeCount = 0;
+	const postController = new AbortController();
+	post.client.setWorkspaceEditIo({
+		writeFile(path, data) {
+			writeCount += 1;
+			postController.abort();
+			return import("node:fs").then(({ writeFileSync }) => writeFileSync(path, data));
+		},
+	});
+	const postBefore = hashFile(post.source);
+	const postResult = await post.client.rename(post.source, 1, 6, "after", postController.signal);
+	const postAfter = hashFile(post.source);
+	const postEvents = readEvents(post.events);
+	assert(postResult.apply.success === true, "post-gate rename did not complete");
+	assert(postResult.apply.lateAbort === true, "post-gate abort was not reported as late");
+	assert(postResult.apply.totalEdits === 1, "post-gate rename did not report exactly one edit");
+	assert(writeCount === 1, "post-gate rename did not perform exactly one write");
+	assert(postBefore !== postAfter, "post-gate rename did not mutate the file");
+
+	console.log(
+		JSON.stringify(
+			{
+				preGate: {
+					cancelTarget: preCancel.params?.id,
+					hashBefore: preBefore,
+					hashAfter: preAfter,
+					mutated: preBefore !== preAfter,
+					error: preResult.message,
+				},
+				postGate: {
+					hashBefore: postBefore,
+					hashAfter: postAfter,
+					writeCount,
+					success: postResult.apply.success,
+					lateAbort: postResult.apply.lateAbort === true,
+					totalEdits: postResult.apply.totalEdits,
+					applyEditResponses: postEvents.filter(
+						(event) => event.type === "clientResponse" && event.method === "workspace/applyEdit",
+					).length,
+				},
+			},
+			null,
+			2,
+		),
+	);
+} finally {
+	await harness.cleanup();
+}
+
+function hashFile(path) {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}

--- a/packages/lsp-daemon/src/cli.ts
+++ b/packages/lsp-daemon/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { argv, stderr, stdin } from "node:process";
+import { argv, stderr } from "node:process";
 
 import { runMcpStdioProxy } from "./proxy.js";
 import { runDaemon } from "./run-daemon.js";
@@ -12,16 +12,7 @@ async function main(): Promise<void> {
 		return;
 	}
 	if (command === "mcp") {
-		const controller = new AbortController();
-		const abort = (): void => controller.abort();
-		stdin.once("end", abort);
-		stdin.once("close", abort);
-		try {
-			await runMcpStdioProxy({ signal: controller.signal });
-		} finally {
-			stdin.removeListener("end", abort);
-			stdin.removeListener("close", abort);
-		}
+		await runMcpStdioProxy();
 		return;
 	}
 

--- a/packages/lsp-daemon/src/cli.ts
+++ b/packages/lsp-daemon/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { argv, stderr } from "node:process";
+import { argv, stderr, stdin } from "node:process";
 
 import { runMcpStdioProxy } from "./proxy.js";
 import { runDaemon } from "./run-daemon.js";
@@ -12,7 +12,16 @@ async function main(): Promise<void> {
 		return;
 	}
 	if (command === "mcp") {
-		await runMcpStdioProxy();
+		const controller = new AbortController();
+		const abort = (): void => controller.abort();
+		stdin.once("end", abort);
+		stdin.once("close", abort);
+		try {
+			await runMcpStdioProxy({ signal: controller.signal });
+		} finally {
+			stdin.removeListener("end", abort);
+			stdin.removeListener("close", abort);
+		}
 		return;
 	}
 

--- a/packages/lsp-daemon/src/daemon-client.ts
+++ b/packages/lsp-daemon/src/daemon-client.ts
@@ -1,9 +1,8 @@
 import { connect } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
-
+import { type LspRequestContext, parseLspRequestContext } from "@oh-my-opencode/lsp-core/request-context";
 import type { ToolExecutionResult } from "@oh-my-opencode/lsp-core/tools";
-import { parseLspRequestContext, type LspRequestContext } from "@oh-my-opencode/lsp-core/request-context";
 import { isPlainRecord } from "@oh-my-opencode/mcp-stdio-core/record";
 
 import { ensureDaemonRunning } from "./ensure-daemon.js";
@@ -45,8 +44,10 @@ export interface CallToolOptions {
 	paths?: DaemonPaths;
 	requestTimeoutMs?: number;
 	signal?: AbortSignal;
-	ensure?: (paths: DaemonPaths) => Promise<void>;
+	ensure?: (paths: DaemonPaths, signal?: AbortSignal) => Promise<void>;
 }
+
+type EnsureDaemon = NonNullable<CallToolOptions["ensure"]>;
 
 export async function callToolViaDaemon(
 	name: string,
@@ -55,7 +56,10 @@ export async function callToolViaDaemon(
 ): Promise<ToolExecutionResult> {
 	const context = requireContext(options.context);
 	const paths = options.paths ?? daemonPaths();
-	const ensure = options.ensure ?? ensureDaemonRunning;
+	const ensure =
+		options.ensure ??
+		((ensurePaths: DaemonPaths, signal?: AbortSignal) =>
+			ensureDaemonRunning(ensurePaths, undefined, signal === undefined ? {} : { signal }));
 	const timeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 	const requestArgs = withContext(args, context);
 
@@ -63,11 +67,10 @@ export async function callToolViaDaemon(
 	let authRefreshUsed = false;
 	for (let attempt = 0; attempt < 3; attempt += 1) {
 		try {
-			await ensure(paths);
+			await ensureDaemonAvailable(paths, ensure, options.signal);
 			const token = readAuthToken(paths);
 			if (!token) throw new DaemonRequestError("daemon auth token missing", false);
-			const sendOptions =
-				options.signal === undefined ? { timeoutMs } : { timeoutMs, signal: options.signal };
+			const sendOptions = options.signal === undefined ? { timeoutMs } : { timeoutMs, signal: options.signal };
 			return await sendToolCall(paths, token, name, requestArgs, sendOptions);
 		} catch (error) {
 			lastError = error;
@@ -83,10 +86,7 @@ export async function callToolViaDaemon(
 	return daemonUnreachableResult(paths, lastError);
 }
 
-export function callDiagnosticsViaDaemon(
-	filePath: string,
-	options: CallToolOptions,
-): Promise<ToolExecutionResult> {
+export function callDiagnosticsViaDaemon(filePath: string, options: CallToolOptions): Promise<ToolExecutionResult> {
 	return callToolViaDaemon("diagnostics", { filePath, severity: "error" }, options);
 }
 
@@ -109,6 +109,35 @@ function requireContext(context: unknown): DaemonToolContext {
 
 function withContext(args: Record<string, unknown>, context: DaemonToolContext): Record<string, unknown> {
 	return { ...args, [CONTEXT_KEY]: context };
+}
+
+function ensureDaemonAvailable(
+	paths: DaemonPaths,
+	ensure: EnsureDaemon,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	if (!signal) return ensure(paths);
+	return new Promise<void>((resolve, reject) => {
+		let settled = false;
+		const finish = (run: () => void): void => {
+			if (settled) return;
+			settled = true;
+			signal.removeEventListener("abort", onAbort);
+			run();
+		};
+		const onAbort = (): void => finish(() => reject(new DaemonRequestCancelledError(false)));
+		if (signal.aborted) {
+			onAbort();
+			return;
+		}
+		signal.addEventListener("abort", onAbort, { once: true });
+		Promise.resolve()
+			.then(() => ensure(paths, signal))
+			.then(
+				() => finish(() => resolve()),
+				(error: unknown) => finish(() => reject(signal.aborted ? new DaemonRequestCancelledError(false) : error)),
+			);
+	});
 }
 
 function daemonUnreachableResult(paths: DaemonPaths, error: unknown): ToolExecutionResult {
@@ -190,13 +219,10 @@ function sendToolCall(
 				method: "tools/call",
 				params: { _omo: authEnvelope(token), name, arguments: args },
 			});
-			socket.write(
-				payload,
-				() => {
-					requestWritten = true;
-					if (cancelAfterWrite && socket.writable) socket.write(cancelPayload());
-				},
-			);
+			socket.write(payload, () => {
+				requestWritten = true;
+				if (cancelAfterWrite && socket.writable) socket.write(cancelPayload());
+			});
 		});
 		socket.on("data", (chunk) => decoder.push(chunk));
 		socket.once("error", (error) => finish(() => reject(new DaemonRequestError(error.message, requestWritten))));

--- a/packages/lsp-daemon/src/ensure-daemon.ts
+++ b/packages/lsp-daemon/src/ensure-daemon.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { closeSync, mkdirSync, openSync } from "node:fs";
-import { connect } from "node:net";
+import { Socket } from "node:net";
 import { dirname } from "node:path";
 import { execPath } from "node:process";
 
@@ -24,15 +24,16 @@ export class DaemonUnreachableError extends Error {
 }
 
 export interface EnsureDaemonDeps {
-	probe(paths: DaemonPaths): Promise<boolean>;
+	probe(paths: DaemonPaths, signal?: AbortSignal): Promise<boolean>;
 	spawnDaemon(paths: DaemonPaths): void;
-	sleep(ms: number): Promise<void>;
+	sleep(ms: number, signal?: AbortSignal): Promise<void>;
 	now(): number;
 }
 
 export interface EnsureDaemonOptions {
 	readyTimeoutMs?: number;
 	pollIntervalMs?: number;
+	readonly signal?: AbortSignal;
 }
 
 export async function ensureDaemonRunning(
@@ -42,10 +43,13 @@ export async function ensureDaemonRunning(
 ): Promise<void> {
 	const readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
 	const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+	const signal = options.signal;
 
-	if (await deps.probe(paths)) return;
+	throwIfAborted(signal);
+	if (await awaitWithSignal(deps.probe(paths, signal), signal)) return;
+	throwIfAborted(signal);
 	deps.spawnDaemon(paths);
-	await waitUntilReachable(paths, deps, readyTimeoutMs, pollIntervalMs);
+	await waitUntilReachable(paths, deps, readyTimeoutMs, pollIntervalMs, signal);
 }
 
 async function waitUntilReachable(
@@ -53,45 +57,66 @@ async function waitUntilReachable(
 	deps: EnsureDaemonDeps,
 	readyTimeoutMs: number,
 	pollIntervalMs: number,
+	signal: AbortSignal | undefined,
 ): Promise<void> {
 	const deadline = deps.now() + readyTimeoutMs;
 	for (;;) {
-		if (await deps.probe(paths)) return;
+		throwIfAborted(signal);
+		if (await awaitWithSignal(deps.probe(paths, signal), signal)) return;
 		if (deps.now() >= deadline) throw new DaemonUnreachableError(paths.socket);
-		await deps.sleep(pollIntervalMs);
+		await awaitWithSignal(deps.sleep(pollIntervalMs, signal), signal);
 	}
 }
 
-export async function probeDaemon(paths: DaemonPaths, timeoutMs: number = PROBE_TIMEOUT_MS): Promise<boolean> {
+export async function probeDaemon(
+	paths: DaemonPaths,
+	timeoutMs: number = PROBE_TIMEOUT_MS,
+	signal?: AbortSignal,
+): Promise<boolean> {
 	const token = readAuthToken(paths);
 	if (!token) return false;
-	return (await pingDaemon(paths, token, timeoutMs)) !== null;
+	return (await pingDaemon(paths, token, timeoutMs, signal)) !== null;
 }
 
-export function pingDaemon(paths: DaemonPaths, token: string, timeoutMs: number = PROBE_TIMEOUT_MS): Promise<OwnerPing | null> {
+export function pingDaemon(
+	paths: DaemonPaths,
+	token: string,
+	timeoutMs: number = PROBE_TIMEOUT_MS,
+	signal?: AbortSignal,
+): Promise<OwnerPing | null> {
 	return new Promise((resolve) => {
-		const socket = connect(paths.socket);
+		const socket = new Socket();
 		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | undefined;
 		const finish = (value: OwnerPing | null): void => {
 			if (settled) return;
 			settled = true;
+			if (timer !== undefined) clearTimeout(timer);
+			signal?.removeEventListener("abort", onAbort);
 			socket.destroy();
 			resolve(value);
 		};
-		const timer = setTimeout(() => finish(null), timeoutMs);
-		timer.unref?.();
+		const onAbort = (): void => finish(null);
 		const decoder = createLineDecoder((message) => {
-			clearTimeout(timer);
 			finish(parsePingResponse(message));
 		});
 		socket.once("connect", () => {
-			socket.write(encodeJsonLine({ jsonrpc: "2.0", id: 1, method: "omo/ping", params: { _omo: authEnvelope(token) } }));
+			socket.write(
+				encodeJsonLine({ jsonrpc: "2.0", id: 1, method: "omo/ping", params: { _omo: authEnvelope(token) } }),
+			);
 		});
 		socket.on("data", (chunk) => decoder.push(chunk));
 		socket.once("error", () => {
-			clearTimeout(timer);
 			finish(null);
 		});
+		timer = setTimeout(() => finish(null), timeoutMs);
+		timer.unref?.();
+		if (signal?.aborted) {
+			onAbort();
+			return;
+		}
+		signal?.addEventListener("abort", onAbort, { once: true });
+		socket.connect(paths.socket);
 	});
 }
 
@@ -118,14 +143,62 @@ export function resolveDaemonCliPath(
 
 export function defaultEnsureDaemonDeps(): EnsureDaemonDeps {
 	return {
-		probe: (paths) => probeDaemon(paths),
+		probe: (paths, signal) => probeDaemon(paths, PROBE_TIMEOUT_MS, signal),
 		spawnDaemon: (paths) => spawnDaemonProcess(paths),
-		sleep: (ms) =>
-			new Promise((resolve) => {
-				setTimeout(resolve, ms);
-			}),
+		sleep: (ms, signal) => sleepWithSignal(ms, signal),
 		now: () => Date.now(),
 	};
+}
+
+function sleepWithSignal(ms: number, signal: AbortSignal | undefined): Promise<void> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const finish = (): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", finish);
+			resolve();
+		};
+		const timer = setTimeout(finish, ms);
+		if (signal?.aborted) {
+			finish();
+			return;
+		}
+		signal?.addEventListener("abort", finish, { once: true });
+	});
+}
+
+function awaitWithSignal<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+	if (!signal) return promise;
+	if (signal.aborted) return Promise.reject(abortError(signal));
+	return new Promise<T>((resolve, reject) => {
+		let settled = false;
+		const finish = (run: () => void): void => {
+			if (settled) return;
+			settled = true;
+			signal.removeEventListener("abort", onAbort);
+			run();
+		};
+		const onAbort = (): void => finish(() => reject(abortError(signal)));
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(
+			(value) => finish(() => resolve(value)),
+			(error: unknown) => finish(() => reject(error)),
+		);
+	});
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+	if (signal?.aborted) throw abortError(signal);
+}
+
+function abortError(signal: AbortSignal): Error {
+	const reason = signal.reason;
+	if (reason instanceof Error) return reason;
+	const error = new Error(typeof reason === "string" ? reason : "daemon startup cancelled");
+	error.name = "AbortError";
+	return error;
 }
 
 function parsePingResponse(message: unknown): OwnerPing | null {

--- a/packages/lsp-daemon/src/proxy.ts
+++ b/packages/lsp-daemon/src/proxy.ts
@@ -1,10 +1,10 @@
-import type { Readable, Writable } from "node:stream";
 import { existsSync, realpathSync } from "node:fs";
 import { basename, delimiter, dirname, isAbsolute } from "node:path";
-import { jsonRpcId, runJsonRpcStdioServer, successResponse } from "@oh-my-opencode/mcp-stdio-core";
-import { isPlainRecord } from "@oh-my-opencode/mcp-stdio-core/record";
+import type { Readable, Writable } from "node:stream";
 import { handleLspMcpRequest, type JsonRpcId, type JsonRpcResponse } from "@oh-my-opencode/lsp-core/mcp";
 import { createStandaloneMcpRequestContext, runWithRequestContext } from "@oh-my-opencode/lsp-core/request-context";
+import { jsonRpcId, runJsonRpcStdioServer, successResponse } from "@oh-my-opencode/mcp-stdio-core";
+import { isPlainRecord } from "@oh-my-opencode/mcp-stdio-core/record";
 
 import { type CallToolOptions, callToolViaDaemon, type DaemonToolContext } from "./daemon-client.js";
 import { type DaemonPaths, daemonPaths } from "./paths.js";
@@ -33,24 +33,24 @@ export async function runMcpStdioProxy(options: ProxyOptions = {}): Promise<void
 	const abortFromInput = (): void => lifecycleController.abort();
 	input.once("end", abortFromInput);
 	input.once("close", abortFromInput);
-	const paths = options.paths ?? daemonPaths();
-	const env = options.env ?? process.env;
-	const cwd = options.cwd ?? inferOpenCodeProjectCwd(env["LSP_TOOLS_MCP_PROJECT_CONFIG"]);
-	const contextEnv = cwd === undefined ? env : canonicalizeContextEnv(env);
-	const contextInput = {
-		env: contextEnv,
-		...(cwd === undefined ? {} : { cwd }),
-		...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
-	};
-	const context = options.context ?? createStandaloneMcpRequestContext(contextInput);
-	const callOptions: CallToolOptions = {
-		paths,
-		context,
-		...(options.ensure ? { ensure: options.ensure } : {}),
-		signal: lifecycleController.signal,
-	};
 
 	try {
+		const paths = options.paths ?? daemonPaths();
+		const env = options.env ?? process.env;
+		const cwd = options.cwd ?? inferOpenCodeProjectCwd(env["LSP_TOOLS_MCP_PROJECT_CONFIG"]);
+		const contextEnv = cwd === undefined ? env : canonicalizeContextEnv(env);
+		const contextInput = {
+			env: contextEnv,
+			...(cwd === undefined ? {} : { cwd }),
+			...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
+		};
+		const context = options.context ?? createStandaloneMcpRequestContext(contextInput);
+		const callOptions: CallToolOptions = {
+			paths,
+			context,
+			...(options.ensure ? { ensure: options.ensure } : {}),
+			signal: lifecycleController.signal,
+		};
 		await runJsonRpcStdioServer({
 			input,
 			output,
@@ -59,7 +59,9 @@ export async function runMcpStdioProxy(options: ProxyOptions = {}): Promise<void
 				runWithRequestContext(context, () => handleProxyRequest(request, requestOptions)),
 			handlerOptions: callOptions,
 			onHandlerError: (error: unknown) => {
-				process.stderr.write(`[lsp-daemon] proxy error: ${error instanceof Error ? error.message : String(error)}\n`);
+				process.stderr.write(
+					`[lsp-daemon] proxy error: ${error instanceof Error ? error.message : String(error)}\n`,
+				);
 			},
 		});
 	} finally {
@@ -73,7 +75,11 @@ async function handleProxyRequest(parsed: unknown, callOptions: CallToolOptions)
 	if (!toolCall) return handleLspMcpRequest(parsed);
 
 	const result = await callToolViaDaemon(toolCall.name, toolCall.args, callOptions);
-	return successResponse(toolCall.id, { content: result.content, isError: result.isError ?? false, details: result.details });
+	return successResponse(toolCall.id, {
+		content: result.content,
+		isError: result.isError ?? false,
+		details: result.details,
+	});
 }
 
 function asToolCall(parsed: unknown): ToolCall | null {

--- a/packages/lsp-daemon/src/proxy.ts
+++ b/packages/lsp-daemon/src/proxy.ts
@@ -18,6 +18,7 @@ export interface ProxyOptions {
 	env?: Record<string, string | undefined>;
 	homeDir?: string;
 	ensure?: CallToolOptions["ensure"];
+	signal?: AbortSignal;
 }
 
 interface ToolCall {
@@ -39,15 +40,20 @@ export async function runMcpStdioProxy(options: ProxyOptions = {}): Promise<void
 		...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
 	};
 	const context = options.context ?? createStandaloneMcpRequestContext(contextInput);
-	const callOptions: CallToolOptions = { paths, context, ...(options.ensure ? { ensure: options.ensure } : {}) };
+	const callOptions: CallToolOptions = {
+		paths,
+		context,
+		...(options.ensure ? { ensure: options.ensure } : {}),
+		...(options.signal ? { signal: options.signal } : {}),
+	};
 
 	await runJsonRpcStdioServer({
-			input,
-			output,
-			idleTimeoutMs: 0,
-			handler: (request, requestOptions) =>
-				runWithRequestContext(context, () => handleProxyRequest(request, requestOptions)),
-			handlerOptions: callOptions,
+		input,
+		output,
+		idleTimeoutMs: 0,
+		handler: (request, requestOptions) =>
+			runWithRequestContext(context, () => handleProxyRequest(request, requestOptions)),
+		handlerOptions: callOptions,
 		onHandlerError: (error: unknown) => {
 			process.stderr.write(`[lsp-daemon] proxy error: ${error instanceof Error ? error.message : String(error)}\n`);
 		},

--- a/packages/lsp-daemon/src/proxy.ts
+++ b/packages/lsp-daemon/src/proxy.ts
@@ -18,7 +18,6 @@ export interface ProxyOptions {
 	env?: Record<string, string | undefined>;
 	homeDir?: string;
 	ensure?: CallToolOptions["ensure"];
-	signal?: AbortSignal;
 }
 
 interface ToolCall {
@@ -30,6 +29,10 @@ interface ToolCall {
 export async function runMcpStdioProxy(options: ProxyOptions = {}): Promise<void> {
 	const input = options.input ?? process.stdin;
 	const output = options.output ?? process.stdout;
+	const lifecycleController = new AbortController();
+	const abortFromInput = (): void => lifecycleController.abort();
+	input.once("end", abortFromInput);
+	input.once("close", abortFromInput);
 	const paths = options.paths ?? daemonPaths();
 	const env = options.env ?? process.env;
 	const cwd = options.cwd ?? inferOpenCodeProjectCwd(env["LSP_TOOLS_MCP_PROJECT_CONFIG"]);
@@ -44,20 +47,25 @@ export async function runMcpStdioProxy(options: ProxyOptions = {}): Promise<void
 		paths,
 		context,
 		...(options.ensure ? { ensure: options.ensure } : {}),
-		...(options.signal ? { signal: options.signal } : {}),
+		signal: lifecycleController.signal,
 	};
 
-	await runJsonRpcStdioServer({
-		input,
-		output,
-		idleTimeoutMs: 0,
-		handler: (request, requestOptions) =>
-			runWithRequestContext(context, () => handleProxyRequest(request, requestOptions)),
-		handlerOptions: callOptions,
-		onHandlerError: (error: unknown) => {
-			process.stderr.write(`[lsp-daemon] proxy error: ${error instanceof Error ? error.message : String(error)}\n`);
-		},
-	});
+	try {
+		await runJsonRpcStdioServer({
+			input,
+			output,
+			idleTimeoutMs: 0,
+			handler: (request, requestOptions) =>
+				runWithRequestContext(context, () => handleProxyRequest(request, requestOptions)),
+			handlerOptions: callOptions,
+			onHandlerError: (error: unknown) => {
+				process.stderr.write(`[lsp-daemon] proxy error: ${error instanceof Error ? error.message : String(error)}\n`);
+			},
+		});
+	} finally {
+		input.removeListener("end", abortFromInput);
+		input.removeListener("close", abortFromInput);
+	}
 }
 
 async function handleProxyRequest(parsed: unknown, callOptions: CallToolOptions): Promise<JsonRpcResponse | undefined> {

--- a/packages/lsp-daemon/test/ensure-daemon.test.ts
+++ b/packages/lsp-daemon/test/ensure-daemon.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 import { DaemonUnreachableError, type EnsureDaemonDeps, ensureDaemonRunning } from "../src/ensure-daemon.js";
@@ -62,4 +63,91 @@ describe("ensureDaemonRunning", () => {
 		).rejects.toBeInstanceOf(DaemonUnreachableError);
 		expect(counts.spawn).toBe(1);
 	});
+
+	it("#given daemon probing is pending #when startup is aborted #then ensure settles without spawning", async () => {
+		const controller = new AbortController();
+		const probeStarted = deferred();
+		const probeRelease = deferred();
+		let probeCount = 0;
+		let spawnCount = 0;
+		let observedSignal: AbortSignal | undefined;
+		const deps: EnsureDaemonDeps = {
+			probe: async (_paths, signal?: AbortSignal) => {
+				probeCount += 1;
+				observedSignal = signal;
+				if (probeCount !== 1) return true;
+				probeStarted.resolve();
+				await probeRelease.promise;
+				return false;
+			},
+			spawnDaemon: () => {
+				spawnCount += 1;
+			},
+			sleep: () => Promise.resolve(),
+			now: () => 0,
+		};
+		const ensure = ensureDaemonRunning(PATHS, deps, { signal: controller.signal });
+		await probeStarted.promise;
+
+		controller.abort();
+		const settledBeforeProbeRelease = await settlesWithin(ensure, 100);
+		probeRelease.resolve();
+		const outcome = await ensure.then(
+			() => null,
+			(error: unknown) => error,
+		);
+
+		expect(settledBeforeProbeRelease).toBe(true);
+		expect(outcome).toBeInstanceOf(Error);
+		if (!(outcome instanceof Error)) throw new Error("ensure did not reject with an Error");
+		expect(outcome.name).toBe("AbortError");
+		expect(probeCount).toBe(1);
+		expect(spawnCount).toBe(0);
+		expect(observedSignal).toBe(controller.signal);
+	});
+
+	it("#given a probe is already aborted #when its socket cannot connect #then the socket error stays contained", async () => {
+		const moduleUrl = new URL("../src/ensure-daemon.ts", import.meta.url).href;
+		const script = `
+			import { pingDaemon } from ${JSON.stringify(moduleUrl)};
+			const controller = new AbortController();
+			controller.abort();
+			let uncaughtError;
+			process.once("uncaughtException", (error) => { uncaughtError = error; });
+			const value = await pingDaemon({ socket: ${JSON.stringify(PATHS.socket)} }, "test-token", 100, controller.signal);
+			await new Promise((resolve) => setImmediate(resolve));
+			if (value !== null) throw new Error("aborted ping returned a daemon owner");
+			if (uncaughtError) throw uncaughtError;
+		`;
+
+		const child = spawnSync("bun", ["--eval", script], { encoding: "utf8" });
+
+		expect(child.status, child.stderr).toBe(0);
+	});
 });
+
+function deferred(): { readonly promise: Promise<void>; resolve(): void } {
+	let resolvePromise: (() => void) | undefined;
+	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: () => resolvePromise?.() };
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise.then(
+				() => true,
+				() => true,
+			),
+			new Promise<boolean>((resolve) => {
+				timer = setTimeout(() => resolve(false), timeoutMs);
+				timer.unref();
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}

--- a/packages/lsp-daemon/test/proxy-lifecycle.test.ts
+++ b/packages/lsp-daemon/test/proxy-lifecycle.test.ts
@@ -1,0 +1,165 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, sep } from "node:path";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { DaemonPaths } from "../src/paths.js";
+import { runMcpStdioProxy } from "../src/proxy.js";
+import { createLineDecoder } from "../src/socket-jsonrpc.js";
+import { daemonTestPaths } from "./daemon-path-fixture.js";
+
+const tempDirectories: string[] = [];
+const servers: Server[] = [];
+const sockets = new Set<Socket>();
+
+afterEach(async () => {
+	for (const socket of sockets) socket.destroy();
+	for (const server of servers.splice(0)) {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
+	for (const directory of tempDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("mcp stdio proxy lifecycle", () => {
+	it("#given an in-flight daemon request #when parent input closes and the lifecycle aborts #then the proxy cancels that request and closes its socket", async () => {
+		const paths = tempPaths();
+		const requestAccepted = deferred();
+		const cancellationObserved = deferred();
+		const connectionClosed = deferred();
+		let daemonRequestId: string | number | null | undefined;
+		let cancelledRequestId: string | number | undefined;
+		const daemon = createServer((socket) => {
+			sockets.add(socket);
+			const decoder = createLineDecoder((message) => {
+				const method = jsonRpcMethod(message);
+				if (method === "tools/call") {
+					daemonRequestId = jsonRpcId(message);
+					requestAccepted.resolve();
+					return;
+				}
+				if (method === "$/cancelRequest") {
+					cancelledRequestId = cancelTargetId(message);
+					cancellationObserved.resolve();
+				}
+			});
+			socket.on("data", (chunk) => decoder.push(chunk));
+			socket.on("error", () => {});
+			socket.once("close", () => {
+				sockets.delete(socket);
+				connectionClosed.resolve();
+			});
+		});
+		servers.push(daemon);
+		await listen(daemon, paths.socket);
+
+		const input = new PassThrough();
+		const controller = new AbortController();
+		const proxyOptions = {
+			input,
+			output: discardOutput(),
+			paths,
+			ensure: noSpawn,
+			signal: controller.signal,
+		};
+		const proxy = runMcpStdioProxy(proxyOptions);
+		input.write(
+			`${JSON.stringify({ jsonrpc: "2.0", id: 41, method: "tools/call", params: { name: "status", arguments: {} } })}\n`,
+		);
+		await bounded(requestAccepted.promise, "fake daemon did not accept the proxy request");
+
+		input.end();
+		controller.abort();
+
+		await bounded(
+			Promise.all([proxy, cancellationObserved.promise, connectionClosed.promise]),
+			`fake daemon accepted tools/call id=${String(daemonRequestId)}; proxy did not settle it after lifecycle cancellation`,
+		);
+		expect(cancelledRequestId).toBe(daemonRequestId);
+		expect(sockets.size).toBe(0);
+	});
+});
+
+function tempPaths(): DaemonPaths {
+	const directory = mkdtempSync(join(tmpdir(), "lsp-daemon-proxy-lifecycle-"));
+	tempDirectories.push(directory);
+	const paths = daemonTestPaths(directory);
+	mkdirSync(paths.dir, { recursive: true });
+	if (process.platform !== "win32") {
+		const socketDirectory = dirname(paths.socket);
+		mkdirSync(socketDirectory, { recursive: true });
+		const socketDirectoryFromRoot = relative(directory, socketDirectory);
+		const socketDirectoryIsExternal =
+			isAbsolute(socketDirectoryFromRoot) ||
+			socketDirectoryFromRoot === ".." ||
+			socketDirectoryFromRoot.startsWith(`..${sep}`);
+		if (socketDirectoryIsExternal) tempDirectories.push(socketDirectory);
+	}
+	writeFileSync(paths.auth, "proxy-lifecycle-token\n", { mode: 0o600 });
+	return paths;
+}
+
+function listen(server: Server, socketPath: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const onError = (error: Error): void => reject(error);
+		server.once("error", onError);
+		server.listen(socketPath, () => {
+			server.removeListener("error", onError);
+			resolve();
+		});
+	});
+}
+
+function deferred(): { readonly promise: Promise<void>; resolve(): void } {
+	let resolvePromise: (() => void) | undefined;
+	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: () => resolvePromise?.() };
+}
+
+async function bounded<T>(promise: Promise<T>, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error(message)), 1_000);
+				timer.unref();
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+function discardOutput(): Writable {
+	return new Writable({
+		write(_chunk, _encoding, callback): void {
+			callback();
+		},
+	});
+}
+
+function jsonRpcMethod(message: unknown): string | undefined {
+	if (!message || typeof message !== "object" || Array.isArray(message)) return undefined;
+	const method = Reflect.get(message, "method");
+	return typeof method === "string" ? method : undefined;
+}
+
+function jsonRpcId(message: unknown): string | number | null | undefined {
+	if (!message || typeof message !== "object" || Array.isArray(message)) return undefined;
+	const id = Reflect.get(message, "id");
+	return typeof id === "string" || typeof id === "number" || id === null ? id : undefined;
+}
+
+function cancelTargetId(message: unknown): string | number | undefined {
+	if (!message || typeof message !== "object" || Array.isArray(message)) return undefined;
+	const params = Reflect.get(message, "params");
+	if (!params || typeof params !== "object" || Array.isArray(params)) return undefined;
+	const id = Reflect.get(params, "id");
+	return typeof id === "string" || typeof id === "number" ? id : undefined;
+}
+
+const noSpawn = (): Promise<void> => Promise.resolve();

--- a/packages/lsp-daemon/test/proxy-lifecycle.test.ts
+++ b/packages/lsp-daemon/test/proxy-lifecycle.test.ts
@@ -78,6 +78,75 @@ describe("mcp stdio proxy lifecycle", () => {
 		expect(cancelledRequestId).toBe(daemonRequestId);
 		expect(sockets.size).toBe(0);
 	});
+
+	it("#given daemon startup is pending #when parent input ends #then the proxy cancels startup without retrying", async () => {
+		const paths = tempPaths();
+		const input = new PassThrough();
+		const outputChunks: string[] = [];
+		const responseWritten = deferred();
+		const ensureStarted = deferred();
+		const ensureRelease = deferred();
+		let ensureAttempts = 0;
+		let observedSignal: AbortSignal | undefined;
+		const proxy = runMcpStdioProxy({
+			input,
+			output: new Writable({
+				write(chunk, _encoding, callback): void {
+					outputChunks.push(chunk.toString());
+					responseWritten.resolve();
+					callback();
+				},
+			}),
+			paths,
+			ensure: async (_paths: DaemonPaths, signal?: AbortSignal) => {
+				ensureAttempts += 1;
+				observedSignal = signal;
+				ensureStarted.resolve();
+				await ensureRelease.promise;
+				throw new Error("synthetic ensure failure");
+			},
+		});
+		input.write(
+			`${JSON.stringify({ jsonrpc: "2.0", id: 42, method: "tools/call", params: { name: "status", arguments: {} } })}\n`,
+		);
+		await bounded(ensureStarted.promise, "proxy did not begin daemon startup");
+
+		input.emit("end");
+		const responseWrittenBeforeEnsureRelease = await settlesWithin(responseWritten.promise, 100);
+		input.end();
+		ensureRelease.resolve();
+		await bounded(proxy, "proxy did not settle after releasing the startup probe");
+
+		const response = JSON.parse(outputChunks.join("").trim()) as Record<string, unknown>;
+		const result = response["result"] as {
+			readonly content?: readonly { readonly text?: string }[];
+			readonly isError?: boolean;
+		};
+		expect(responseWrittenBeforeEnsureRelease).toBe(true);
+		expect(response["id"]).toBe(42);
+		expect(result.isError).toBe(true);
+		expect(result.content?.[0]?.text).toContain("cancelled");
+		expect(ensureAttempts).toBe(1);
+		expect(observedSignal?.aborted).toBe(true);
+	});
+
+	it("#given synchronous proxy setup failure #when the proxy rejects #then parent lifecycle listeners are removed", async () => {
+		const input = new PassThrough();
+		const initialEndListeners = input.listenerCount("end");
+		const initialCloseListeners = input.listenerCount("close");
+		const options = {
+			input,
+			output: discardOutput(),
+			get paths(): DaemonPaths {
+				throw new Error("synthetic setup failure");
+			},
+		};
+
+		await expect(runMcpStdioProxy(options)).rejects.toThrow("synthetic setup failure");
+
+		expect(input.listenerCount("end")).toBe(initialEndListeners);
+		expect(input.listenerCount("close")).toBe(initialCloseListeners);
+	});
 });
 
 function tempPaths(): DaemonPaths {
@@ -125,6 +194,24 @@ async function bounded<T>(promise: Promise<T>, message: string): Promise<T> {
 			promise,
 			new Promise<never>((_resolve, reject) => {
 				timer = setTimeout(() => reject(new Error(message)), 1_000);
+				timer.unref();
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise.then(
+				() => true,
+				() => true,
+			),
+			new Promise<boolean>((resolve) => {
+				timer = setTimeout(() => resolve(false), timeoutMs);
 				timer.unref();
 			}),
 		]);

--- a/packages/lsp-daemon/test/proxy-lifecycle.test.ts
+++ b/packages/lsp-daemon/test/proxy-lifecycle.test.ts
@@ -23,7 +23,7 @@ afterEach(async () => {
 });
 
 describe("mcp stdio proxy lifecycle", () => {
-	it("#given an in-flight daemon request #when parent input closes and the lifecycle aborts #then the proxy cancels that request and closes its socket", async () => {
+	it("#given an in-flight daemon request #when parent input closes #then the proxy cancels that request and closes its socket", async () => {
 		const paths = tempPaths();
 		const requestAccepted = deferred();
 		const cancellationObserved = deferred();
@@ -55,22 +55,21 @@ describe("mcp stdio proxy lifecycle", () => {
 		await listen(daemon, paths.socket);
 
 		const input = new PassThrough();
-		const controller = new AbortController();
 		const proxyOptions = {
 			input,
 			output: discardOutput(),
 			paths,
 			ensure: noSpawn,
-			signal: controller.signal,
 		};
-		const proxy = runMcpStdioProxy(proxyOptions);
+		const proxy = runMcpStdioProxy(proxyOptions).catch((error: unknown) => {
+			if (!(error instanceof Error) || Reflect.get(error, "code") !== "ERR_STREAM_PREMATURE_CLOSE") throw error;
+		});
 		input.write(
 			`${JSON.stringify({ jsonrpc: "2.0", id: 41, method: "tools/call", params: { name: "status", arguments: {} } })}\n`,
 		);
 		await bounded(requestAccepted.promise, "fake daemon did not accept the proxy request");
 
-		input.end();
-		controller.abort();
+		input.destroy();
 
 		await bounded(
 			Promise.all([proxy, cancellationObserved.promise, connectionClosed.promise]),

--- a/packages/lsp-daemon/test/qa-driver-portability.test.ts
+++ b/packages/lsp-daemon/test/qa-driver-portability.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -46,5 +46,36 @@ describe("LSP QA driver portability", () => {
 		const expectedEndpointKind = process.platform === "win32" ? "named-pipe" : "unix-socket";
 
 		expect(JSON.parse(output)).toMatchObject({ daemonEndpointKind: expectedEndpointKind });
+	});
+
+	it("#given a closed output reader #when the cancellation smoke reports its result #then it cannot exit successfully", async () => {
+		const result = await new Promise<{ readonly code: number | null; readonly signal: NodeJS.Signals | null }>(
+			(resolve, reject) => {
+				const child = spawn("bun", [join(repositoryRoot, cancellationSmoke), repositoryRoot], {
+					cwd: repositoryRoot,
+					stdio: ["ignore", "pipe", "ignore"],
+				});
+				const output = child.stdout;
+				if (output === null) {
+					reject(new Error("cancellation smoke stdout pipe was not created"));
+					return;
+				}
+				const timeout = setTimeout(() => {
+					child.kill();
+					reject(new Error("cancellation smoke did not settle after its output reader closed"));
+				}, 10_000);
+				child.once("error", (error) => {
+					clearTimeout(timeout);
+					reject(error);
+				});
+				child.once("close", (code, signal) => {
+					clearTimeout(timeout);
+					resolve({ code, signal });
+				});
+				output.destroy();
+			},
+		);
+
+		expect(result.code === 0 && result.signal === null).toBe(false);
 	});
 });

--- a/packages/lsp-daemon/test/qa-driver-portability.test.ts
+++ b/packages/lsp-daemon/test/qa-driver-portability.test.ts
@@ -41,7 +41,7 @@ describe("LSP QA driver portability", () => {
 		const output = execFileSync("bun", [join(repositoryRoot, cancellationSmoke), repositoryRoot], {
 			cwd: repositoryRoot,
 			encoding: "utf8",
-			timeout: 10_000,
+			timeout: 30_000,
 		});
 		const expectedEndpointKind = process.platform === "win32" ? "named-pipe" : "unix-socket";
 

--- a/packages/lsp-daemon/test/qa-driver-portability.test.ts
+++ b/packages/lsp-daemon/test/qa-driver-portability.test.ts
@@ -41,7 +41,7 @@ describe("LSP QA driver portability", () => {
 		const output = execFileSync("bun", [join(repositoryRoot, cancellationSmoke), repositoryRoot], {
 			cwd: repositoryRoot,
 			encoding: "utf8",
-			timeout: 30_000,
+			timeout: 10_000,
 		});
 		const expectedEndpointKind = process.platform === "win32" ? "named-pipe" : "unix-socket";
 

--- a/packages/lsp-daemon/test/qa-driver-portability.test.ts
+++ b/packages/lsp-daemon/test/qa-driver-portability.test.ts
@@ -14,6 +14,7 @@ const runtimeDependencies = [
 	"packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs",
 	"packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs",
 ] as const;
+const cancellationSmoke = runtimeDependencies[0];
 
 describe("LSP QA driver portability", () => {
 	it("#given a fresh clone #when cancellation QA runs #then every runtime dependency is tracked outside evidence", () => {
@@ -34,5 +35,16 @@ describe("LSP QA driver portability", () => {
 			.sort();
 
 		expect(trackedFiles).toEqual(expectedTrackedFiles);
+	});
+
+	it("#given the native platform #when the cancellation smoke runs #then it binds the production endpoint kind", () => {
+		const output = execFileSync("bun", [join(repositoryRoot, cancellationSmoke), repositoryRoot], {
+			cwd: repositoryRoot,
+			encoding: "utf8",
+			timeout: 10_000,
+		});
+		const expectedEndpointKind = process.platform === "win32" ? "named-pipe" : "unix-socket";
+
+		expect(JSON.parse(output)).toMatchObject({ daemonEndpointKind: expectedEndpointKind });
 	});
 });

--- a/packages/lsp-daemon/test/qa-driver-portability.test.ts
+++ b/packages/lsp-daemon/test/qa-driver-portability.test.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const drivers = [
+	".agents/skills/codex-qa/scripts/lsp-e2e.sh",
+	".agents/skills/opencode-qa/scripts/lsp-e2e.sh",
+] as const;
+const runtimeDependencies = [
+	"packages/lsp-daemon/scripts/qa/cancellation-smoke.mjs",
+	"packages/lsp-daemon/scripts/qa/commit-barrier-smoke.mjs",
+] as const;
+
+describe("LSP QA driver portability", () => {
+	it("#given a fresh clone #when cancellation QA runs #then every runtime dependency is tracked outside evidence", () => {
+		for (const driver of drivers) {
+			const source = readFileSync(join(repositoryRoot, driver), "utf8");
+			expect(source).not.toContain(".omo/evidence");
+			for (const dependency of runtimeDependencies) expect(source).toContain(dependency);
+		}
+
+		const expectedTrackedFiles = [...drivers, ...runtimeDependencies].sort();
+		const trackedFiles = execFileSync("git", ["ls-files", "--", ...expectedTrackedFiles], {
+			cwd: repositoryRoot,
+			encoding: "utf8",
+		})
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.sort();
+
+		expect(trackedFiles).toEqual(expectedTrackedFiles);
+	});
+});

--- a/packages/mcp-stdio-core/src/server.test.ts
+++ b/packages/mcp-stdio-core/src/server.test.ts
@@ -38,6 +38,36 @@ describe("JSON-RPC stdio server", () => {
     expect(await received).toBe('{"jsonrpc":"2.0","id":null,"error":{"code":-32601,"message":"Method not found"}}\n')
     await server
   })
+
+  test("#given parent output closes during a response #when the stdio server writes #then the child settles without an uncaught stream error", async () => {
+    const serverUrl = new URL("./server.ts", import.meta.url).href
+    const script = `
+      import { Readable, Writable } from "node:stream";
+      import { successResponse } from ${JSON.stringify(new URL("./responses.ts", import.meta.url).href)};
+      import { runJsonRpcStdioServer } from ${JSON.stringify(serverUrl)};
+
+      const output = new Writable({
+        write(_chunk, _encoding, callback) {
+          callback(Object.assign(new Error("parent output closed"), { code: "EPIPE" }));
+        },
+      });
+      await runJsonRpcStdioServer({
+        input: Readable.from(['{"jsonrpc":"2.0","id":"closed","method":"ping"}\\n']),
+        output,
+        handlerOptions: undefined,
+        handler: async () => successResponse("closed", { acknowledged: true }),
+      });
+      process.stderr.write("server-settled\\n");
+    `
+    const child = Bun.spawn([process.execPath, "-e", script], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()])
+
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "server-settled\n" })
+  })
 })
 
 function nextOutput(output: PassThrough): Promise<string> {

--- a/packages/mcp-stdio-core/src/server.test.ts
+++ b/packages/mcp-stdio-core/src/server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { PassThrough } from "node:stream"
+import { PassThrough, Readable, Writable } from "node:stream"
 import { successResponse } from "./responses.js"
 import { runJsonRpcStdioServer } from "./server.js"
 
@@ -67,6 +67,38 @@ describe("JSON-RPC stdio server", () => {
     const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()])
 
     expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "server-settled\n" })
+  })
+
+  test("#given a non-serializable response #when the stdio server writes #then the serialization failure rejects", async () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic["self"] = cyclic
+
+    const server = runJsonRpcStdioServer({
+      input: Readable.from(['{"jsonrpc":"2.0","id":"cyclic","method":"ping"}\n']),
+      output: new PassThrough(),
+      handlerOptions: undefined,
+      handler: async () => successResponse("cyclic", cyclic),
+    })
+
+    await expect(server).rejects.toBeInstanceOf(TypeError)
+  })
+
+  test("#given an unknown output failure #when the stdio server writes #then the failure rejects", async () => {
+    const outputError = Object.assign(new Error("synthetic output failure"), { code: "EIO" })
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback(outputError)
+      },
+    })
+
+    const server = runJsonRpcStdioServer({
+      input: Readable.from(['{"jsonrpc":"2.0","id":"unknown","method":"ping"}\n']),
+      output,
+      handlerOptions: undefined,
+      handler: async () => successResponse("unknown", { acknowledged: true }),
+    })
+
+    await expect(server).rejects.toBe(outputError)
   })
 })
 

--- a/packages/mcp-stdio-core/src/server.ts
+++ b/packages/mcp-stdio-core/src/server.ts
@@ -102,9 +102,15 @@ async function writeResponse(
     await writeStdioJsonRpcResponse(context.output, response, context.responseMode)
     return true
   } catch (error) {
+    if (!isTerminalOutputError(error)) throw error
     context.log("output_error", { message: messageFromError(error) })
     return false
   }
+}
+
+function isTerminalOutputError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) return false
+  return error.code === "EPIPE" || error.code === "ERR_STREAM_DESTROYED" || error.code === "ERR_STREAM_WRITE_AFTER_END"
 }
 
 interface ResponseWriteContext {

--- a/packages/mcp-stdio-core/src/server.ts
+++ b/packages/mcp-stdio-core/src/server.ts
@@ -1,5 +1,5 @@
 import type { Readable, Writable } from "node:stream"
-import { errorResponse, jsonRpcId } from "./responses.js"
+import { errorResponse, jsonRpcId, messageFromError } from "./responses.js"
 import { isPlainRecord } from "./record.js"
 import type { JsonRpcResponse, McpLifecycleLog } from "./types.js"
 import { readStdioJsonRpcMessages, writeStdioJsonRpcResponse } from "./transport.js"
@@ -39,10 +39,10 @@ export async function runJsonRpcStdioServer<HandlerOptions>(
       if (idleTimer.closed()) break
       idleTimer.arm()
       if (message.kind === "parse_error") {
-        handleParseError(message, config, log)
+        if (!(await handleParseError(message, config, log))) break
         continue
       }
-      await handleRequest(message, config, log)
+      if (!(await handleRequest(message, config, log))) break
     }
   } finally {
     idleTimer.clear()
@@ -50,36 +50,67 @@ export async function runJsonRpcStdioServer<HandlerOptions>(
   }
 }
 
-function handleParseError<HandlerOptions>(
+async function handleParseError<HandlerOptions>(
   message: Extract<StdioJsonRpcMessage, { readonly kind: "parse_error" }>,
   config: JsonRpcStdioServerConfig<HandlerOptions>,
   log: McpLifecycleLog,
-): void {
+): Promise<boolean> {
   log("parse_error", { message: message.message })
   const response = config.parseErrorResponse?.(message.message) ?? errorResponse(null, -32700, "Parse error", message.message)
-  if (response !== undefined) {
-    writeStdioJsonRpcResponse(config.output, response, message.responseMode)
-  }
+  if (response === undefined) return true
+  return writeResponse(response, {
+    output: config.output,
+    responseMode: message.responseMode,
+    log,
+  })
 }
 
 async function handleRequest<HandlerOptions>(
   message: Extract<StdioJsonRpcMessage, { readonly kind: "request" }>,
   config: JsonRpcStdioServerConfig<HandlerOptions>,
   log: McpLifecycleLog,
-): Promise<void> {
+): Promise<boolean> {
   const parsed = message.payload
   const id = isPlainRecord(parsed) ? jsonRpcId(parsed["id"]) : null
   const method = isPlainRecord(parsed) && typeof parsed["method"] === "string" ? parsed["method"] : null
   log("request", { id: id === null ? null : String(id), method })
+  let response: JsonRpcResponse | undefined
   try {
-    const response = await config.handler(parsed, config.handlerOptions)
-    if (response === undefined) return
-    writeStdioJsonRpcResponse(config.output, response, message.responseMode)
-    log("response", { id: String(response.id), method, is_error: response.error !== undefined })
+    response = await config.handler(parsed, config.handlerOptions)
   } catch (error) {
     if (config.onHandlerError === undefined) throw error
     config.onHandlerError(error)
+    return true
   }
+  if (response === undefined) return true
+  if (
+    !(await writeResponse(response, {
+      output: config.output,
+      responseMode: message.responseMode,
+      log,
+    }))
+  ) return false
+  log("response", { id: String(response.id), method, is_error: response.error !== undefined })
+  return true
+}
+
+async function writeResponse(
+  response: JsonRpcResponse,
+  context: ResponseWriteContext,
+): Promise<boolean> {
+  try {
+    await writeStdioJsonRpcResponse(context.output, response, context.responseMode)
+    return true
+  } catch (error) {
+    context.log("output_error", { message: messageFromError(error) })
+    return false
+  }
+}
+
+interface ResponseWriteContext {
+  readonly output: Writable
+  readonly responseMode: StdioJsonRpcMessage["responseMode"]
+  readonly log: McpLifecycleLog
 }
 
 function createIdleTimer(

--- a/packages/mcp-stdio-core/src/transport.test.ts
+++ b/packages/mcp-stdio-core/src/transport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { PassThrough } from "node:stream"
+import { PassThrough, Writable } from "node:stream"
 import { readStdioJsonRpcMessages, writeStdioJsonRpcResponse } from "./transport.js"
 
 describe("stdio JSON-RPC transport", () => {
@@ -42,6 +42,22 @@ describe("stdio JSON-RPC transport", () => {
     await writeStdioJsonRpcResponse(output, { jsonrpc: "2.0", id: 1, result: {} }, "framed")
 
     expect(chunks.join("")).toBe('Content-Length: 36\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{}}')
+  })
+
+  test("#given a destroyed output with callback-only failure #when a response write rejects #then the error listener is removed", async () => {
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback()
+      },
+    })
+    output.destroy()
+
+    await expect(writeStdioJsonRpcResponse(output, { jsonrpc: "2.0", id: 1, result: {} }, "line")).rejects.toMatchObject({
+      code: "ERR_STREAM_DESTROYED",
+    })
+    await Promise.resolve()
+
+    expect(output.listenerCount("error")).toBe(0)
   })
 })
 

--- a/packages/mcp-stdio-core/src/transport.test.ts
+++ b/packages/mcp-stdio-core/src/transport.test.ts
@@ -34,12 +34,12 @@ describe("stdio JSON-RPC transport", () => {
     ])
   })
 
-  test("#given response mode #when written #then framing bytes are stable", () => {
+  test("#given response mode #when written #then framing bytes are stable", async () => {
     const output = new PassThrough()
     const chunks: string[] = []
     output.on("data", (chunk: Buffer | string) => chunks.push(String(chunk)))
 
-    writeStdioJsonRpcResponse(output, { jsonrpc: "2.0", id: 1, result: {} }, "framed")
+    await writeStdioJsonRpcResponse(output, { jsonrpc: "2.0", id: 1, result: {} }, "framed")
 
     expect(chunks.join("")).toBe('Content-Length: 36\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{}}')
   })

--- a/packages/mcp-stdio-core/src/transport.ts
+++ b/packages/mcp-stdio-core/src/transport.ts
@@ -43,17 +43,47 @@ export async function* readStdioJsonRpcMessages(input: Readable): AsyncGenerator
   }
 }
 
-export function writeStdioJsonRpcResponse(
+export async function writeStdioJsonRpcResponse(
   output: Writable,
   response: unknown,
   responseMode: StdioJsonRpcResponseMode,
-): void {
+): Promise<void> {
   const body = JSON.stringify(response)
-  if (responseMode === "framed") {
-    output.write(`Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`)
-    return
-  }
-  output.write(`${body}\n`)
+  const payload =
+    responseMode === "framed"
+      ? `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`
+      : `${body}\n`
+  await writeChunk(output, payload)
+}
+
+function writeChunk(output: Writable, chunk: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const onError = (error: Error): void => {
+      if (settled) return
+      settled = true
+      reject(error)
+    }
+    output.once("error", onError)
+
+    try {
+      output.write(chunk, (error?: Error | null) => {
+        if (settled) return
+        settled = true
+        if (error) {
+          reject(error)
+          return
+        }
+        output.removeListener("error", onError)
+        resolve()
+      })
+    } catch (error) {
+      output.removeListener("error", onError)
+      if (settled) return
+      settled = true
+      reject(error)
+    }
+  })
 }
 
 function readNextMessage(buffer: Buffer<ArrayBufferLike>): ReadResult {

--- a/packages/mcp-stdio-core/src/transport.ts
+++ b/packages/mcp-stdio-core/src/transport.ts
@@ -71,6 +71,7 @@ function writeChunk(output: Writable, chunk: string): Promise<void> {
         if (settled) return
         settled = true
         if (error) {
+          queueMicrotask(() => output.removeListener("error", onError))
           reject(error)
           return
         }

--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -3038,6 +3038,7 @@ function writeChunk(output, chunk) {
           return;
         settled = true;
         if (error) {
+          queueMicrotask(() => output.removeListener("error", onError));
           reject(error);
           return;
         }
@@ -3200,9 +3201,16 @@ async function writeResponse(response, context) {
     await writeStdioJsonRpcResponse(context.output, response, context.responseMode);
     return true;
   } catch (error) {
+    if (!isTerminalOutputError(error))
+      throw error;
     context.log("output_error", { message: messageFromError(error) });
     return false;
   }
+}
+function isTerminalOutputError(error) {
+  if (!(error instanceof Error) || !("code" in error))
+    return false;
+  return error.code === "EPIPE" || error.code === "ERR_STREAM_DESTROYED" || error.code === "ERR_STREAM_WRITE_AFTER_END";
 }
 function createIdleTimer(idleTimeoutMs, log, onIdleTimeout) {
   let timer = null;
@@ -3295,7 +3303,17 @@ async function runBridgedCodegraphProcess(command, args, options) {
     childOutput.destroy();
   };
   childExit.then(destroyChildPipes, destroyChildPipes);
-  return Promise.race([childExit, bridgeDone.then(() => childExit)]);
+  try {
+    return await Promise.race([childExit, bridgeDone.then(() => childExit)]);
+  } catch (error) {
+    destroyChildPipes();
+    if (child.exitCode === null && child.signalCode === null)
+      child.kill("SIGKILL");
+    await childExit.catch(() => {
+      return;
+    });
+    throw error;
+  }
 }
 async function forwardClientToCodegraph(input, childInput, pendingResponses, setDefaultResponseMode) {
   for await (const message of readStdioJsonRpcMessages(input)) {

--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -3292,19 +3292,19 @@ async function runBridgedCodegraphProcess(command, args, options) {
       resolveExit(signal === null ? 0 : 1);
     });
   });
-  const bridgeDone = Promise.all([
-    forwardClientToCodegraph(options.input, childInput, pendingResponses, (mode) => {
-      defaultResponseMode = mode;
-    }),
-    forwardCodegraphToClient(childOutput, options.output, pendingResponses, () => defaultResponseMode)
-  ]);
+  const clientForwardingDone = forwardClientToCodegraph(options.input, childInput, pendingResponses, (mode) => {
+    defaultResponseMode = mode;
+  });
+  const responseForwardingDone = forwardCodegraphToClient(childOutput, options.output, pendingResponses, () => defaultResponseMode);
+  const bridgeDone = Promise.all([clientForwardingDone, responseForwardingDone]);
+  const childAndResponsesDone = Promise.all([childExit, responseForwardingDone]).then(([exitCode]) => exitCode);
   const destroyChildPipes = () => {
     childInput.destroy();
     childOutput.destroy();
   };
   childExit.then(destroyChildPipes, destroyChildPipes);
   try {
-    return await Promise.race([childExit, bridgeDone.then(() => childExit)]);
+    return await Promise.race([childAndResponsesDone, bridgeDone.then(() => childExit)]);
   } catch (error) {
     destroyChildPipes();
     if (child.exitCode === null && child.signalCode === null)

--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -2989,6 +2989,9 @@ function errorResponse(id, code, message, data) {
 function jsonRpcId(value) {
   return typeof value === "string" || typeof value === "number" || value === null ? value : null;
 }
+function messageFromError(error) {
+  return error instanceof Error ? error.message : String(error);
+}
 // ../../mcp-stdio-core/src/transport.ts
 var HEADER_SEPARATOR = Buffer.from(`\r
 \r
@@ -3011,16 +3014,44 @@ async function* readStdioJsonRpcMessages(input) {
     yield parseJsonPayload(trailing, "line");
   }
 }
-function writeStdioJsonRpcResponse(output, response, responseMode) {
+async function writeStdioJsonRpcResponse(output, response, responseMode) {
   const body = JSON.stringify(response);
-  if (responseMode === "framed") {
-    output.write(`Content-Length: ${Buffer.byteLength(body, "utf8")}\r
+  const payload = responseMode === "framed" ? `Content-Length: ${Buffer.byteLength(body, "utf8")}\r
 \r
-${body}`);
-    return;
-  }
-  output.write(`${body}
-`);
+${body}` : `${body}
+`;
+  await writeChunk(output, payload);
+}
+function writeChunk(output, chunk) {
+  return new Promise((resolve5, reject) => {
+    let settled = false;
+    const onError = (error) => {
+      if (settled)
+        return;
+      settled = true;
+      reject(error);
+    };
+    output.once("error", onError);
+    try {
+      output.write(chunk, (error) => {
+        if (settled)
+          return;
+        settled = true;
+        if (error) {
+          reject(error);
+          return;
+        }
+        output.removeListener("error", onError);
+        resolve5();
+      });
+    } catch (error) {
+      output.removeListener("error", onError);
+      if (settled)
+        return;
+      settled = true;
+      reject(error);
+    }
+  });
 }
 function readNextMessage(buffer) {
   if (buffer.length === 0)
@@ -3116,38 +3147,61 @@ async function runJsonRpcStdioServer(config) {
         break;
       idleTimer.arm();
       if (message.kind === "parse_error") {
-        handleParseError(message, config, log);
+        if (!await handleParseError(message, config, log))
+          break;
         continue;
       }
-      await handleRequest(message, config, log);
+      if (!await handleRequest(message, config, log))
+        break;
     }
   } finally {
     idleTimer.clear();
     log("stdio_stopped");
   }
 }
-function handleParseError(message, config, log) {
+async function handleParseError(message, config, log) {
   log("parse_error", { message: message.message });
   const response = config.parseErrorResponse?.(message.message) ?? errorResponse(null, -32700, "Parse error", message.message);
-  if (response !== undefined) {
-    writeStdioJsonRpcResponse(config.output, response, message.responseMode);
-  }
+  if (response === undefined)
+    return true;
+  return writeResponse(response, {
+    output: config.output,
+    responseMode: message.responseMode,
+    log
+  });
 }
 async function handleRequest(message, config, log) {
   const parsed = message.payload;
   const id = isPlainRecord(parsed) ? jsonRpcId(parsed["id"]) : null;
   const method = isPlainRecord(parsed) && typeof parsed["method"] === "string" ? parsed["method"] : null;
   log("request", { id: id === null ? null : String(id), method });
+  let response;
   try {
-    const response = await config.handler(parsed, config.handlerOptions);
-    if (response === undefined)
-      return;
-    writeStdioJsonRpcResponse(config.output, response, message.responseMode);
-    log("response", { id: String(response.id), method, is_error: response.error !== undefined });
+    response = await config.handler(parsed, config.handlerOptions);
   } catch (error) {
     if (config.onHandlerError === undefined)
       throw error;
     config.onHandlerError(error);
+    return true;
+  }
+  if (response === undefined)
+    return true;
+  if (!await writeResponse(response, {
+    output: config.output,
+    responseMode: message.responseMode,
+    log
+  }))
+    return false;
+  log("response", { id: String(response.id), method, is_error: response.error !== undefined });
+  return true;
+}
+async function writeResponse(response, context) {
+  try {
+    await writeStdioJsonRpcResponse(context.output, response, context.responseMode);
+    return true;
+  } catch (error) {
+    context.log("output_error", { message: messageFromError(error) });
+    return false;
   }
 }
 function createIdleTimer(idleTimeoutMs, log, onIdleTimeout) {
@@ -3265,7 +3319,7 @@ async function forwardClientToCodegraph(input, childInput, pendingResponses, set
 async function forwardCodegraphToClient(childOutput, output, pendingResponses, defaultResponseMode) {
   for await (const message of readStdioJsonRpcMessages(childOutput)) {
     if (message.kind === "parse_error") {
-      writeStdioJsonRpcResponse(output, errorResponse(null, -32700, "Parse error", message.message), defaultResponseMode());
+      await writeStdioJsonRpcResponse(output, errorResponse(null, -32700, "Parse error", message.message), defaultResponseMode());
       continue;
     }
     const key = responseModeKey(message.payload);
@@ -3273,7 +3327,7 @@ async function forwardCodegraphToClient(childOutput, output, pendingResponses, d
     const responseMode = pendingResponse?.responseMode ?? defaultResponseMode();
     if (key !== null)
       pendingResponses.delete(key);
-    writeStdioJsonRpcResponse(output, clarifyCodegraphResponse(message.payload, pendingResponse), responseMode);
+    await writeStdioJsonRpcResponse(output, clarifyCodegraphResponse(message.payload, pendingResponse), responseMode);
   }
 }
 function responseModeKey(payload) {

--- a/packages/omo-codex/plugin/components/codegraph/dist/serve.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/serve.js
@@ -2200,19 +2200,19 @@ async function runBridgedCodegraphProcess(command, args, options) {
       resolveExit(signal === null ? 0 : 1);
     });
   });
-  const bridgeDone = Promise.all([
-    forwardClientToCodegraph(options.input, childInput, pendingResponses, (mode) => {
-      defaultResponseMode = mode;
-    }),
-    forwardCodegraphToClient(childOutput, options.output, pendingResponses, () => defaultResponseMode)
-  ]);
+  const clientForwardingDone = forwardClientToCodegraph(options.input, childInput, pendingResponses, (mode) => {
+    defaultResponseMode = mode;
+  });
+  const responseForwardingDone = forwardCodegraphToClient(childOutput, options.output, pendingResponses, () => defaultResponseMode);
+  const bridgeDone = Promise.all([clientForwardingDone, responseForwardingDone]);
+  const childAndResponsesDone = Promise.all([childExit, responseForwardingDone]).then(([exitCode]) => exitCode);
   const destroyChildPipes = () => {
     childInput.destroy();
     childOutput.destroy();
   };
   childExit.then(destroyChildPipes, destroyChildPipes);
   try {
-    return await Promise.race([childExit, bridgeDone.then(() => childExit)]);
+    return await Promise.race([childAndResponsesDone, bridgeDone.then(() => childExit)]);
   } catch (error) {
     destroyChildPipes();
     if (child.exitCode === null && child.signalCode === null)

--- a/packages/omo-codex/plugin/components/codegraph/dist/serve.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/serve.js
@@ -1946,6 +1946,7 @@ function writeChunk(output, chunk) {
           return;
         settled = true;
         if (error) {
+          queueMicrotask(() => output.removeListener("error", onError));
           reject(error);
           return;
         }
@@ -2108,9 +2109,16 @@ async function writeResponse(response, context) {
     await writeStdioJsonRpcResponse(context.output, response, context.responseMode);
     return true;
   } catch (error) {
+    if (!isTerminalOutputError(error))
+      throw error;
     context.log("output_error", { message: messageFromError(error) });
     return false;
   }
+}
+function isTerminalOutputError(error) {
+  if (!(error instanceof Error) || !("code" in error))
+    return false;
+  return error.code === "EPIPE" || error.code === "ERR_STREAM_DESTROYED" || error.code === "ERR_STREAM_WRITE_AFTER_END";
 }
 function createIdleTimer(idleTimeoutMs, log, onIdleTimeout) {
   let timer = null;
@@ -2203,7 +2211,17 @@ async function runBridgedCodegraphProcess(command, args, options) {
     childOutput.destroy();
   };
   childExit.then(destroyChildPipes, destroyChildPipes);
-  return Promise.race([childExit, bridgeDone.then(() => childExit)]);
+  try {
+    return await Promise.race([childExit, bridgeDone.then(() => childExit)]);
+  } catch (error) {
+    destroyChildPipes();
+    if (child.exitCode === null && child.signalCode === null)
+      child.kill("SIGKILL");
+    await childExit.catch(() => {
+      return;
+    });
+    throw error;
+  }
 }
 async function forwardClientToCodegraph(input, childInput, pendingResponses, setDefaultResponseMode) {
   for await (const message of readStdioJsonRpcMessages(input)) {

--- a/packages/omo-codex/plugin/components/codegraph/dist/serve.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/serve.js
@@ -1897,6 +1897,9 @@ function errorResponse(id, code, message, data) {
 function jsonRpcId(value) {
   return typeof value === "string" || typeof value === "number" || value === null ? value : null;
 }
+function messageFromError(error) {
+  return error instanceof Error ? error.message : String(error);
+}
 // ../../../../mcp-stdio-core/src/transport.ts
 var HEADER_SEPARATOR = Buffer.from(`\r
 \r
@@ -1919,16 +1922,44 @@ async function* readStdioJsonRpcMessages(input) {
     yield parseJsonPayload(trailing, "line");
   }
 }
-function writeStdioJsonRpcResponse(output, response, responseMode) {
+async function writeStdioJsonRpcResponse(output, response, responseMode) {
   const body = JSON.stringify(response);
-  if (responseMode === "framed") {
-    output.write(`Content-Length: ${Buffer.byteLength(body, "utf8")}\r
+  const payload = responseMode === "framed" ? `Content-Length: ${Buffer.byteLength(body, "utf8")}\r
 \r
-${body}`);
-    return;
-  }
-  output.write(`${body}
-`);
+${body}` : `${body}
+`;
+  await writeChunk(output, payload);
+}
+function writeChunk(output, chunk) {
+  return new Promise((resolve3, reject) => {
+    let settled = false;
+    const onError = (error) => {
+      if (settled)
+        return;
+      settled = true;
+      reject(error);
+    };
+    output.once("error", onError);
+    try {
+      output.write(chunk, (error) => {
+        if (settled)
+          return;
+        settled = true;
+        if (error) {
+          reject(error);
+          return;
+        }
+        output.removeListener("error", onError);
+        resolve3();
+      });
+    } catch (error) {
+      output.removeListener("error", onError);
+      if (settled)
+        return;
+      settled = true;
+      reject(error);
+    }
+  });
 }
 function readNextMessage(buffer) {
   if (buffer.length === 0)
@@ -2024,38 +2055,61 @@ async function runJsonRpcStdioServer(config) {
         break;
       idleTimer.arm();
       if (message.kind === "parse_error") {
-        handleParseError(message, config, log);
+        if (!await handleParseError(message, config, log))
+          break;
         continue;
       }
-      await handleRequest(message, config, log);
+      if (!await handleRequest(message, config, log))
+        break;
     }
   } finally {
     idleTimer.clear();
     log("stdio_stopped");
   }
 }
-function handleParseError(message, config, log) {
+async function handleParseError(message, config, log) {
   log("parse_error", { message: message.message });
   const response = config.parseErrorResponse?.(message.message) ?? errorResponse(null, -32700, "Parse error", message.message);
-  if (response !== undefined) {
-    writeStdioJsonRpcResponse(config.output, response, message.responseMode);
-  }
+  if (response === undefined)
+    return true;
+  return writeResponse(response, {
+    output: config.output,
+    responseMode: message.responseMode,
+    log
+  });
 }
 async function handleRequest(message, config, log) {
   const parsed = message.payload;
   const id = isPlainRecord(parsed) ? jsonRpcId(parsed["id"]) : null;
   const method = isPlainRecord(parsed) && typeof parsed["method"] === "string" ? parsed["method"] : null;
   log("request", { id: id === null ? null : String(id), method });
+  let response;
   try {
-    const response = await config.handler(parsed, config.handlerOptions);
-    if (response === undefined)
-      return;
-    writeStdioJsonRpcResponse(config.output, response, message.responseMode);
-    log("response", { id: String(response.id), method, is_error: response.error !== undefined });
+    response = await config.handler(parsed, config.handlerOptions);
   } catch (error) {
     if (config.onHandlerError === undefined)
       throw error;
     config.onHandlerError(error);
+    return true;
+  }
+  if (response === undefined)
+    return true;
+  if (!await writeResponse(response, {
+    output: config.output,
+    responseMode: message.responseMode,
+    log
+  }))
+    return false;
+  log("response", { id: String(response.id), method, is_error: response.error !== undefined });
+  return true;
+}
+async function writeResponse(response, context) {
+  try {
+    await writeStdioJsonRpcResponse(context.output, response, context.responseMode);
+    return true;
+  } catch (error) {
+    context.log("output_error", { message: messageFromError(error) });
+    return false;
   }
 }
 function createIdleTimer(idleTimeoutMs, log, onIdleTimeout) {
@@ -2173,7 +2227,7 @@ async function forwardClientToCodegraph(input, childInput, pendingResponses, set
 async function forwardCodegraphToClient(childOutput, output, pendingResponses, defaultResponseMode) {
   for await (const message of readStdioJsonRpcMessages(childOutput)) {
     if (message.kind === "parse_error") {
-      writeStdioJsonRpcResponse(output, errorResponse(null, -32700, "Parse error", message.message), defaultResponseMode());
+      await writeStdioJsonRpcResponse(output, errorResponse(null, -32700, "Parse error", message.message), defaultResponseMode());
       continue;
     }
     const key = responseModeKey(message.payload);
@@ -2181,7 +2235,7 @@ async function forwardCodegraphToClient(childOutput, output, pendingResponses, d
     const responseMode = pendingResponse?.responseMode ?? defaultResponseMode();
     if (key !== null)
       pendingResponses.delete(key);
-    writeStdioJsonRpcResponse(output, clarifyCodegraphResponse(message.payload, pendingResponse), responseMode);
+    await writeStdioJsonRpcResponse(output, clarifyCodegraphResponse(message.payload, pendingResponse), responseMode);
   }
 }
 function responseModeKey(payload) {

--- a/packages/omo-codex/plugin/components/codegraph/src/mcp-bridge.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/mcp-bridge.ts
@@ -63,19 +63,24 @@ export async function runBridgedCodegraphProcess(
 			resolveExit(signal === null ? 0 : 1);
 		});
 	});
-	const bridgeDone = Promise.all([
-		forwardClientToCodegraph(options.input, childInput, pendingResponses, (mode) => {
-			defaultResponseMode = mode;
-		}),
-		forwardCodegraphToClient(childOutput, options.output, pendingResponses, () => defaultResponseMode),
-	]);
+	const clientForwardingDone = forwardClientToCodegraph(options.input, childInput, pendingResponses, (mode) => {
+		defaultResponseMode = mode;
+	});
+	const responseForwardingDone = forwardCodegraphToClient(
+		childOutput,
+		options.output,
+		pendingResponses,
+		() => defaultResponseMode,
+	);
+	const bridgeDone = Promise.all([clientForwardingDone, responseForwardingDone]);
+	const childAndResponsesDone = Promise.all([childExit, responseForwardingDone]).then(([exitCode]) => exitCode);
 	const destroyChildPipes = (): void => {
 		childInput.destroy();
 		childOutput.destroy();
 	};
 	void childExit.then(destroyChildPipes, destroyChildPipes);
 	try {
-		return await Promise.race([childExit, bridgeDone.then(() => childExit)]);
+		return await Promise.race([childAndResponsesDone, bridgeDone.then(() => childExit)]);
 	} catch (error) {
 		destroyChildPipes();
 		if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");

--- a/packages/omo-codex/plugin/components/codegraph/src/mcp-bridge.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/mcp-bridge.ts
@@ -110,14 +110,14 @@ async function forwardCodegraphToClient(
 ): Promise<void> {
 	for await (const message of readStdioJsonRpcMessages(childOutput)) {
 		if (message.kind === "parse_error") {
-			writeStdioJsonRpcResponse(output, errorResponse(null, -32700, "Parse error", message.message), defaultResponseMode());
+			await writeStdioJsonRpcResponse(output, errorResponse(null, -32700, "Parse error", message.message), defaultResponseMode());
 			continue;
 		}
 		const key = responseModeKey(message.payload);
 		const pendingResponse = key === null ? undefined : pendingResponses.get(key);
 		const responseMode = pendingResponse?.responseMode ?? defaultResponseMode();
 		if (key !== null) pendingResponses.delete(key);
-		writeStdioJsonRpcResponse(output, clarifyCodegraphResponse(message.payload, pendingResponse), responseMode);
+		await writeStdioJsonRpcResponse(output, clarifyCodegraphResponse(message.payload, pendingResponse), responseMode);
 	}
 }
 

--- a/packages/omo-codex/plugin/components/codegraph/src/mcp-bridge.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/mcp-bridge.ts
@@ -74,7 +74,14 @@ export async function runBridgedCodegraphProcess(
 		childOutput.destroy();
 	};
 	void childExit.then(destroyChildPipes, destroyChildPipes);
-	return Promise.race([childExit, bridgeDone.then(() => childExit)]);
+	try {
+		return await Promise.race([childExit, bridgeDone.then(() => childExit)]);
+	} catch (error) {
+		destroyChildPipes();
+		if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+		await childExit.catch(() => undefined);
+		throw error;
+	}
 }
 
 async function forwardClientToCodegraph(

--- a/packages/omo-codex/plugin/components/codegraph/test/mcp-bridge-fixtures.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/mcp-bridge-fixtures.ts
@@ -49,6 +49,25 @@ export function writeFakeContractCodegraph(filePath: string): void {
 	chmodSync(filePath, 0o755);
 }
 
+export function writeFakeHeldOpenCodegraph(filePath: string): void {
+	writeFileSync(
+		filePath,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"const readline = require('node:readline');",
+			"fs.writeFileSync(process.env.CODEGRAPH_FAKE_LOG, String(process.pid));",
+			"const rl = readline.createInterface({ input: process.stdin });",
+			"rl.once('line', (line) => {",
+			"  const request = JSON.parse(line);",
+			"  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { ok: true } }) + '\\n');",
+			"});",
+			"setInterval(() => {}, 1000);",
+		].join("\n"),
+	);
+	chmodSync(filePath, 0o755);
+}
+
 export function frameMcpRequest(request: {
 	readonly id: number;
 	readonly method: string;

--- a/packages/omo-codex/plugin/components/codegraph/test/mcp-bridge-fixtures.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/mcp-bridge-fixtures.ts
@@ -68,6 +68,22 @@ export function writeFakeHeldOpenCodegraph(filePath: string): void {
 	chmodSync(filePath, 0o755);
 }
 
+export function writeFakeExitingCodegraph(filePath: string): void {
+	writeFileSync(
+		filePath,
+		[
+			"#!/usr/bin/env node",
+			"const readline = require('node:readline');",
+			"const rl = readline.createInterface({ input: process.stdin });",
+			"rl.once('line', (line) => {",
+			"  const request = JSON.parse(line);",
+			"  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { ok: true } }) + '\\n', () => process.exit(0));",
+			"});",
+		].join("\n"),
+	);
+	chmodSync(filePath, 0o755);
+}
+
 export function frameMcpRequest(request: {
 	readonly id: number;
 	readonly method: string;

--- a/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge-lifecycle.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge-lifecycle.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { PassThrough, Writable } from "node:stream";
+import { fileURLToPath } from "node:url";
+
+import { runCodegraphServe } from "../src/serve.ts";
+import {
+	frameMcpRequest,
+	writeFakeExitingCodegraph,
+} from "./mcp-bridge-fixtures.ts";
+
+const componentRoot = realpathSync(
+	fileURLToPath(new URL("..", import.meta.url)),
+);
+
+describe("runCodegraphServe MCP bridge lifecycle", () => {
+	it("#given an exiting Codegraph child and delayed closed parent output #when the final response write fails #then the output error is preserved", async () => {
+		const tempRoot = mkdtempSync(
+			join(componentRoot, ".tmp-codegraph-exit-output-failure-"),
+		);
+		const projectRoot = join(tempRoot, "project");
+		const fakeCodegraph = join(tempRoot, "codegraph-exiting.cjs");
+		const input = new PassThrough();
+		const outputError = Object.assign(
+			new Error("parent output closed after child exit"),
+			{ code: "EPIPE" },
+		);
+		const writeStarted = Promise.withResolvers<void>();
+		const output = new Writable({
+			write(_chunk, _encoding, callback) {
+				writeStarted.resolve();
+				setTimeout(() => callback(outputError), 150);
+			},
+		});
+
+		try {
+			mkdirSync(projectRoot, { recursive: true });
+			writeFakeExitingCodegraph(fakeCodegraph);
+			const run = runCodegraphServe({
+				cwd: tempRoot,
+				env: {
+					CODEGRAPH_ALLOW_UNSAFE_NODE: "1",
+					OMO_CODEGRAPH_BIN: fakeCodegraph,
+					OMO_CODEGRAPH_PROJECT_CWD: projectRoot,
+					PATH: process.env["PATH"],
+				},
+				nodeVersion: "22.14.0",
+				buildEnv: () => ({}),
+				resolve: () => ({
+					argsPrefix: [],
+					command: fakeCodegraph,
+					exists: true,
+					source: "env",
+				}),
+				stderr: { write: () => undefined },
+				stdin: input,
+				stdout: output,
+			});
+
+			input.end(frameMcpRequest({ id: 1, method: "tools/list", params: {} }));
+
+			await writeStarted.promise;
+			await expect(run).rejects.toBe(outputError);
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { PassThrough } from "node:stream";
+import { PassThrough, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
 import { runCodegraphServe } from "../src/serve.ts";
@@ -14,6 +14,7 @@ import {
 	recordValue,
 	stringProperty,
 	writeFakeContractCodegraph,
+	writeFakeHeldOpenCodegraph,
 	writeFakeNewlineCodegraph,
 } from "./mcp-bridge-fixtures.ts";
 
@@ -190,4 +191,59 @@ describe("runCodegraphServe MCP protocol bridge", () => {
 			rmSync(tempRoot, { recursive: true, force: true });
 		}
 	});
+
+	it("#given a held-open Codegraph child and closed parent output #when response forwarding fails #then the child is terminated before rejection", async () => {
+		const tempRoot = mkdtempSync(join(componentRoot, ".tmp-codegraph-output-failure-"));
+		const projectRoot = join(tempRoot, "project");
+		const fakeCodegraph = join(tempRoot, "codegraph-held-open.cjs");
+		const childPidFile = join(tempRoot, "child.pid");
+		const input = new PassThrough();
+		const outputError = Object.assign(new Error("parent output closed"), { code: "EPIPE" });
+		const output = new Writable({
+			write(_chunk, _encoding, callback) {
+				callback(outputError);
+			},
+		});
+		let childPid: number | undefined;
+
+		try {
+			mkdirSync(projectRoot, { recursive: true });
+			writeFakeHeldOpenCodegraph(fakeCodegraph);
+			const run = runCodegraphServe({
+				cwd: tempRoot,
+				env: {
+					CODEGRAPH_ALLOW_UNSAFE_NODE: "1",
+					CODEGRAPH_FAKE_LOG: childPidFile,
+					OMO_CODEGRAPH_BIN: fakeCodegraph,
+					OMO_CODEGRAPH_PROJECT_CWD: projectRoot,
+					PATH: process.env["PATH"],
+				},
+				nodeVersion: "22.14.0",
+				buildEnv: () => ({}),
+				resolve: () => ({ argsPrefix: [], command: fakeCodegraph, exists: true, source: "env" }),
+				stderr: { write: () => undefined },
+				stdin: input,
+				stdout: output,
+			});
+
+			input.end(frameMcpRequest({ id: 1, method: "tools/list", params: {} }));
+
+			await expect(run).rejects.toBe(outputError);
+			childPid = Number(readFileSync(childPidFile, "utf8"));
+			expect(isProcessAlive(childPid)).toBe(false);
+		} finally {
+			if (childPid !== undefined && isProcessAlive(childPid)) process.kill(childPid, "SIGKILL");
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
 });
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ESRCH") return false;
+		throw error;
+	}
+}


### PR DESCRIPTION
## Summary

This closes the demonstrable lifecycle residuals left after the shared LSP-daemon migration. Earlier exact-head work on this PR made parent shutdown cancel daemon startup, probes, retries, and active requests; cleaned lifecycle listeners on every proxy settlement path; and corrected native endpoint and source/dist QA coverage.

The final review found additional resource-safety gaps. Shared stdio handling treated response serialization and arbitrary writable failures as clean parent-output shutdown; the Codegraph bridge could reject on parent-output `EPIPE` while leaving its owned child alive; and a successful child exit could mask a delayed final parent-output `EPIPE`. The final head now propagates nonterminal failures, releases callback-only error listeners, terminates a live Codegraph child before settlement, waits for final response forwarding after child exit, and preserves the original forwarding error.

## Changes

- Cancel daemon ensure, reachability probe, retry sleep, and active tool-call work when the MCP proxy parent input ends or closes.
- Clean parent lifecycle listeners on success, cancellation, and synchronous proxy setup failure.
- Contain Bun's pre-aborted missing-socket error path and retain native Unix-socket/Windows named-pipe QA.
- Forward directory-diagnostics cancellation into cold `LspManager.getClient()` acquisition so startup settles and its lease is cleaned before the held server start releases.
- Await shared stdio JSON-RPC writes and handle only explicit terminal stream-closure codes as clean shutdown.
- Propagate response serialization failures and unknown writable errors instead of resolving the server normally.
- Remove the temporary paired stream `error` listener after callback-only write failure.
- Tear down both Codegraph pipes, terminate a still-live owned child, await exit, and rethrow the original bridge failure.
- Require Codegraph child exit and final response forwarding to settle together so a delayed parent-output error cannot be masked by exit code 0.
- Regenerate the tracked Codegraph `dist/cli.js` and `dist/serve.js` bundles from the corrected source.
- Keep tracked cancellation/commit-barrier probes and the corrected OpenCode source/dist reuse driver so fresh clones exercise real parent-lifecycle semantics.

## QA & Evidence

- **Failing-first review proof:** cyclic response serialization and synthetic `EIO` resolved before the fix; a destroyed writable retained one listener; Codegraph rejected with its child still alive; and the exiting-child regression resolved before its delayed final `EPIPE`. The focused tests and real process reproductions now show propagated errors, zero retained listeners, child cleanup before settlement, and preservation of the exact delayed output failure.
- **Focused/package gates:** mcp-stdio-core 9/9; lsp-tools-mcp 95/95; lsp-daemon 124/124 plus packed-client smoke; Git Bash MCP 24/24; Codegraph 57/57 before and after build; Codex 483/483; Senpi 198/198; focused OpenCode LSP wiring 10/10. All affected typechecks and builds passed.
- **Generated Codegraph runtime:** the built runtime rejected with the exact delayed `EPIPE` in two runs and reported `childAliveAfterSettlement=false`.
- **Bounded four-case process matrix:** no-request EOF, completed-request EOF, withheld-response EOF, and destroyed stdin all exited by two seconds; in-flight cases sent one authenticated cancellation and every case removed its owned PID/socket/temp root.
- **Real Codex:** all 9 isolated LSP-daemon scenarios passed with no skips; real Codex config/OMO state remained unchanged; cleanup passed.
- **Real OpenCode:** all 8 isolated scenarios passed with SSE proof and no skips; real DB/OMO state remained unchanged; cleanup passed.
- **Real Senpi:** aggregate PASS for runtime package, vendored removal, reuse/auth, exact Pi routing, six descriptors, project-command rejection, session reset, unbounded output, resolution isolation, unchanged real homes, no skips, and cleanup.
- **Root gates:** `bun run typecheck` and `bun run build` passed; `bun test` passed with 11,487 passes, 3 intentional skips, and 0 failures across 1,486 files.
- **Quality/cleanup:** changed-file Biome and `git diff --check` passed; no debug markers or owned processes/temp roots remained. The generated installer version-only drift was restored to the authoritative baseline.
- **Evidence root:** `.omo/evidence/ulw/lsp-daemon-migration-residual-goal/G001-close-any-demonstrable-residual-lsp/a1/codegraph-exit-race-followup/final-validation/`.

## Risks & Residuals

- Runtime behavior changes only at cancellation, response-write failure, and owned-child cleanup boundaries. Ordinary JSON-RPC framing and response behavior are unchanged.
- Parent-output loss still ends the stdio loop cleanly for `EPIPE`, `ERR_STREAM_DESTROYED`, and `ERR_STREAM_WRITE_AFTER_END`; programming errors and arbitrary I/O failures now remain visible.
- Codegraph bridge failure uses `SIGKILL` only for the child process spawned and owned by that bridge, then waits for exit before returning control.
- Codegraph bridge success now waits for final response forwarding as well as child exit, so downstream write failures remain observable.
- The checked-in Codex installer retains the authoritative `origin/dev` release stamp; unrelated generated version drift is excluded.
- Unrelated package-wide Biome formatting drift is unchanged.
- The standalone no-excuse checker remains unavailable because its own TypeScript import exposes `ts.ScriptTarget` as undefined under the current Bun/TypeScript toolchain. Biome and the manual changed-diff scan are clean.
- No SSH filesystem workaround, launchd/launchctl change, system service, protected OS configuration, credential, or real harness home was modified.
- Cubic is skipped because its quota is exhausted until August 1; exact-head required CI and the commit-bound five-lane review remain merge gates.

## Related Issues

Fixes #5560
Fixes #5561
