### PR TITLE
fix(todo-continuation-enforcer): break directive-response loop

### DIFF
--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.test.ts
@@ -228,4 +228,63 @@ describe("handleSessionIdle", () => {
       store.cancelCountdown(sessionID)
     }
   })
+
+  it("skips todo continuation when the last user message is a system directive (loop breaker, #6109)", async () => {
+    // given
+    const sessionID = "ses_directive_loop_breaker"
+    const { store, trackCalls, state } = createStateStore()
+    const ctx = {
+      client: {
+        session: {
+          messages: async () => ({
+            data: [
+              {
+                info: { role: "user" },
+                parts: [{ type: "text", text: "do the original task", synthetic: false }],
+              },
+              {
+                info: { role: "assistant" },
+                parts: [{ type: "text", text: "doing the original task..." }],
+              },
+              {
+                info: { role: "user" },
+                parts: [
+                  {
+                    type: "text",
+                    text: "[SYSTEM DIRECTIVE: OH-MY-OPENCODE - TODO CONTINUATION]\n\ncontinue",
+                    synthetic: true,
+                  },
+                ],
+              },
+              {
+                info: { role: "assistant", finish: "stop" },
+                parts: [{ type: "text", text: "no longer responding" }],
+              },
+            ],
+          }),
+          todo: async () => ({
+            data: [
+              { id: "todo-1", content: "Finish init-deep", status: "pending", priority: "high" },
+            ],
+          }),
+        },
+      },
+      directory: "/tmp/test",
+    }
+
+    try {
+      // when
+      await handleSessionIdle({
+        ctx: ctx as never,
+        sessionID,
+        sessionStateStore: store,
+      })
+
+      // then — no continuation path reached
+      expect(trackCalls).toEqual([])
+      expect(state.countdownStartedAt).toBeUndefined()
+    } finally {
+      store.cancelCountdown(sessionID)
+    }
+  })
 })

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -5,6 +5,7 @@ import { normalizeSDKResponse } from "../../shared"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { log } from "../../shared/logger"
 import { latestAssistantTurnBlocksInternalPrompt } from "../../shared/prompt-async-gate/pending-tool-turn"
+import { isSystemDirective } from "../../shared/system-directive"
 
 import { isLastAssistantMessageAborted } from "./abort-detection"
 import { acknowledgeCompactionGuard, isCompactionGuardActive } from "./compaction-guard"
@@ -101,6 +102,10 @@ export async function handleSessionIdle(args: {
     }
     if (latestAssistantTurnBlocksInternalPrompt(prefetchedMessages)) {
       log(`[${HOOK_NAME}] Skipped: pending internal continuation response`, { sessionID })
+      return
+    }
+    if (lastUserMessageIsSystemDirective(prefetchedMessages)) {
+      log(`[${HOOK_NAME}] Skipped: last user message is a system directive (loop breaker)`, { sessionID })
       return
     }
   } catch (error) {
@@ -233,4 +238,21 @@ export async function handleSessionIdle(args: {
     sessionStateStore,
     isContinuationStopped,
   })
+}
+
+// Returns true when the most recent user message is itself an OMO system
+// directive. Used to break directive-response loops (#6109).
+export function lastUserMessageIsSystemDirective(
+  messages: ReadonlyArray<{ info?: { role?: string }; parts?: ReadonlyArray<{ type?: string; text?: string; synthetic?: boolean }> }> | undefined,
+): boolean {
+  if (!messages || messages.length === 0) return false
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m?.info?.role !== "user") continue
+    const parts = m.parts ?? []
+    return parts.some(
+      (p) => p.type === "text" && typeof p.text === "string" && isSystemDirective(p.text),
+    )
+  }
+  return false
 }


### PR DESCRIPTION
## Summary

Fix a directive-response loop in the `todo-continuation-enforcer` hook that re-injects TODO CONTINUATION (and other OMO system directives) into sessions where the assistant has already responded to a previous injection. Closes #6109.

## Root cause

`handleSessionIdle` in `packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.ts` had a guard for assistant-turn blocking (`latestAssistantTurnBlocksInternalPrompt`) but no guard for "the most recent user message is itself a system directive". When the assistant replied to a previous TODO CONTINUATION with a short acknowledgment (e.g. "no longer responding"), the assistant-turn predicate was satisfied, and the next `session.idle` event re-injected the same directive. With `COUNTDOWN_SECONDS=2` and the default cooldown, this produced 4+ consecutive injections within one minute on a real session.

## Reproduction

See the timeline in #6109: a single OpenCode session showed 10 directive injections in 2 hours, including 4 within 1 minute (05:33-05:39) and 2 more after the user complained at 07:35:57.

## Fix

Add a new guard in `handleSessionIdle` (alongside the existing assistant-turn guard):

```ts
if (lastUserMessageIsSystemDirective(prefetchedMessages)) {
  log(`[${HOOK_NAME}] Skipped: last user message is a system directive (loop breaker)`, { sessionID })
  return
}
```

`lastUserMessageIsSystemDirective` walks the messages in reverse, finds the most recent user message, and returns true if any of its text parts starts with `SYSTEM_DIRECTIVE_PREFIX`. It uses the existing `isSystemDirective` helper from `@omo-opencode/shared/system-directive`, so it correctly recognizes all directive types (TODO CONTINUATION, RALPH LOOP, BOULDER CONTINUATION, etc.).

## Test

Added a new test in `idle-event.test.ts` that simulates the exact loop-breaker scenario: real user message → real assistant response → injected TODO CONTINUATION (synthetic user) → short assistant acknowledgment. The test asserts that `trackContinuationProgress` is never called and the countdown never starts.

```
(pass) handleSessionIdle > skips todo continuation when the last user message is a system directive (loop breaker, #6109) [0.20ms]
```

All 6 tests in the file pass. `bun run typecheck` passes.

## Diff

```
.../todo-continuation-enforcer/idle-event.test.ts  | 59 ++++++++++++++++++++++
.../hooks/todo-continuation-enforcer/idle-event.ts | 22 ++++++++
2 files changed, 81 insertions(+)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the directive-response loop in the TODO continuation enforcer by skipping injections when the last user message is an OMO system directive. Prevents repeated TODO CONTINUATION spam and aligns with #6109.

- **Bug Fixes**
  - Added a guard in `handleSessionIdle` to skip continuation when the latest user message is a system directive, using `isSystemDirective` from `@omo-opencode/shared/system-directive`.
  - Introduced `lastUserMessageIsSystemDirective` to scan messages in reverse and detect directive user turns.
  - Added a test that mirrors the loop scenario and asserts no countdown or tracking is triggered.

<sup>Written for commit 410c133bd1606101b085c71b809850ae662f4d00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

