### PR TITLE
feat(opencode): align codegraph exclusion with codex

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -6562,6 +6562,18 @@
           "default": true,
           "type": "boolean"
         },
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excluded_roots": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "install_dir": {
           "type": "string"
         },

--- a/packages/omo-opencode/src/config/schema/codegraph.test.ts
+++ b/packages/omo-opencode/src/config/schema/codegraph.test.ts
@@ -52,6 +52,8 @@ describe("OhMyOpenCodeConfigSchema codegraph", () => {
         codegraph: {
           auto_provision: false,
           enabled: true,
+          exclude: ["pixie/", "bcc/"],
+          excluded_roots: ["~/scratch/codegraph"],
           install_dir: "~/.omo/codegraph",
           telemetry: false,
           watch_debounce_ms: 250,

--- a/packages/omo-opencode/src/config/schema/codegraph.ts
+++ b/packages/omo-opencode/src/config/schema/codegraph.ts
@@ -4,6 +4,8 @@ export const CodegraphConfigSchema = z.object({
   auto_init: z.boolean().default(true),
   auto_provision: z.boolean().default(true),
   enabled: z.boolean().default(true),
+  exclude: z.array(z.string()).optional(),
+  excluded_roots: z.array(z.string()).optional(),
   install_dir: z.string().optional(),
   telemetry: z.boolean().optional(),
   watch_debounce_ms: z.number().nonnegative().optional(),

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/auto-init.test.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/auto-init.test.ts
@@ -1,9 +1,8 @@
 /// <reference types="bun-types" />
 
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, rmSync } from "node:fs"
 import { join } from "node:path"
-import { tmpdir } from "node:os"
 
 import {
   clearCodegraphBootstrapProjectsForTesting,
@@ -11,6 +10,12 @@ import {
   type CodegraphBootstrapDeps,
   type CodegraphBootstrapEventInput,
 } from "./index"
+
+function createAllowedWorkspace(name: string): string {
+  const workspace = join(process.cwd(), `.tmp-omo-codegraph-auto-init-${name}-${crypto.randomUUID()}`)
+  mkdirSync(workspace, { recursive: true })
+  return workspace
+}
 
 function createDeps(
   events: string[],
@@ -74,7 +79,7 @@ describe("codegraph-bootstrap auto_init", () => {
   // #then it should skip bootstrap without creating .codegraph
   test("#given auto_init is false and .codegraph does not exist #when bootstrap runs #then it skips without creating .codegraph", async () => {
     // given
-    workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-skip-"))
+    workspace = createAllowedWorkspace("skip")
     expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
     const events: string[] = []
     const scheduledTasks: Promise<void>[] = []
@@ -99,7 +104,7 @@ describe("codegraph-bootstrap auto_init", () => {
   // #then it should continue with sync (prepareWorkspace is called)
   test("#given auto_init is false and .codegraph already exists #when bootstrap runs #then it continues with sync", async () => {
     // given
-    workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-existing-"))
+    workspace = createAllowedWorkspace("existing")
     mkdirSync(join(workspace, ".codegraph"), { recursive: true })
     expect(existsSync(join(workspace, ".codegraph"))).toBe(true)
     const events: string[] = []
@@ -123,7 +128,7 @@ describe("codegraph-bootstrap auto_init", () => {
   // #then it should proceed with bootstrap (current behavior preserved)
   test("#given auto_init is true and .codegraph does not exist #when bootstrap runs #then it proceeds with bootstrap", async () => {
     // given
-    workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-true-"))
+    workspace = createAllowedWorkspace("true")
     expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
     const events: string[] = []
     const scheduledTasks: Promise<void>[] = []
@@ -146,7 +151,7 @@ describe("codegraph-bootstrap auto_init", () => {
   // #then ensureProvisioned should NOT be called (minimal side effects)
   test("#given auto_init false with default auto_provision and no .codegraph #when bootstrap runs #then ensureProvisioned is not called", async () => {
     // given
-    workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-auto-init-no-provision-"))
+    workspace = createAllowedWorkspace("no-provision")
     expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
     const events: string[] = []
     const scheduledTasks: Promise<void>[] = []

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/codegraph-bootstrap.test.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/codegraph-bootstrap.test.ts
@@ -1,8 +1,7 @@
 /// <reference types="bun-types" />
 
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdtempSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs"
 import { join, resolve } from "node:path"
 
 import { prepareCodegraphWorkspace } from "@oh-my-opencode/utils"
@@ -12,6 +11,12 @@ import {
   createCodegraphBootstrapHook,
   type CodegraphBootstrapDeps,
 } from "./index"
+
+function createAllowedWorkspace(name: string): string {
+  const workspace = join(process.cwd(), `.tmp-omo-codegraph-${name}-${crypto.randomUUID()}`)
+  mkdirSync(workspace, { recursive: true })
+  return workspace
+}
 
 function createDeps(events: string[], overrides: Partial<CodegraphBootstrapDeps> = {}): CodegraphBootstrapDeps {
   return {
@@ -178,8 +183,8 @@ describe("createCodegraphBootstrapHook", () => {
 
   test("#given a PATH CodeGraph binary but the host Node is unsupported #when background work runs #then it leaves the project untouched", async () => {
     // given
-    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-node-"))
-    const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-node-home-"))
+    const workspace = createAllowedWorkspace("unsupported-node")
+    const homeDir = createAllowedWorkspace("unsupported-node-home")
     const events: string[] = []
     const hook = createCodegraphBootstrapHook(
       { directory: workspace },
@@ -217,8 +222,8 @@ describe("createCodegraphBootstrapHook", () => {
 
   test("#given CodeGraph is missing and auto provision is enabled on unsupported Node #when background work runs #then it does not provision or mutate the project", async () => {
     // given
-    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-provision-"))
-    const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-provision-home-"))
+    const workspace = createAllowedWorkspace("unsupported-provision")
+    const homeDir = createAllowedWorkspace("unsupported-provision-home")
     const events: string[] = []
     const hook = createCodegraphBootstrapHook(
       { directory: workspace },
@@ -259,8 +264,8 @@ describe("createCodegraphBootstrapHook", () => {
 
   test("#given CodeGraph is unavailable and auto provisioning is disabled #when background work runs #then it leaves the project untouched", async () => {
     // given
-    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unavailable-"))
-    const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unavailable-home-"))
+    const workspace = createAllowedWorkspace("unavailable")
+    const homeDir = createAllowedWorkspace("unavailable-home")
     const events: string[] = []
     const hook = createCodegraphBootstrapHook(
       { directory: workspace },
@@ -292,6 +297,65 @@ describe("createCodegraphBootstrapHook", () => {
     } finally {
       rmSync(workspace, { recursive: true, force: true })
       rmSync(homeDir, { recursive: true, force: true })
+    }
+  })
+
+  test("#given project root is excluded by policy #when background work runs #then it skips before mutating the project", async () => {
+    // given
+    const excludedRoot = createAllowedWorkspace("excluded-root")
+    const projectRoot = join(excludedRoot, "repo")
+    mkdirSync(projectRoot, { recursive: true })
+    const events: string[] = []
+    const hook = createCodegraphBootstrapHook(
+      { directory: projectRoot },
+      { enabled: true, excluded_roots: [excludedRoot] },
+      createDeps(events, {
+        schedule: (task) => {
+          void task()
+        },
+      }),
+    )
+
+    try {
+      // when
+      hook.event({ event: { type: "session.created", properties: { worktree: projectRoot } } })
+      await waitForBackground()
+
+      // then
+      expect(events).toContain("log:[codegraph-bootstrap] Project excluded by CodeGraph policy; skipping bootstrap")
+      expect(events.some((event) => event.startsWith("prepare:"))).toBe(false)
+      expect(events.some((event) => event.startsWith("run:"))).toBe(false)
+    } finally {
+      rmSync(excludedRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("#given exclude patterns are configured #when background work runs #then codegraph.json is written before init", async () => {
+    // given
+    const workspace = createAllowedWorkspace("exclude-patterns")
+    const events: string[] = []
+    const hook = createCodegraphBootstrapHook(
+      { directory: workspace },
+      { enabled: true, exclude: ["pixie/", "bcc/"] },
+      createDeps(events, {
+        schedule: (task) => {
+          void task()
+        },
+      }),
+    )
+
+    try {
+      // when
+      hook.event({ event: { type: "session.created", properties: { worktree: workspace } } })
+      await waitForBackground()
+
+      // then
+      expect(JSON.parse(readFileSync(join(workspace, "codegraph.json"), "utf8"))).toEqual({
+        exclude: ["pixie/", "bcc/"],
+      })
+      expect(events).toContain("run:/bin/codegraph:init")
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
     }
   })
 

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
@@ -5,10 +5,12 @@ import { join } from "node:path"
 import {
   buildCodegraphEnv,
   ensureCodegraphGitignored,
+  ensureCodegraphProjectConfig,
   ensureCodegraphProvisioned,
   prepareCodegraphWorkspace,
   resolveCodegraphCommand,
   resolveCodegraphNodeSupport,
+  shouldExcludeCodegraphProject,
   type BuildCodegraphEnvOptions,
   type CodegraphCommandResolution,
   type CodegraphNodeSupport,
@@ -132,12 +134,27 @@ async function resolveOrProvisionCommand(
   return { argsPrefix: [], command: provisioned.binPath, exists: true, source: "provisioned" }
 }
 
+function isProjectExcludedByPolicy(projectRoot: string, config: Partial<CodegraphConfig>): boolean {
+  const exclusion = shouldExcludeCodegraphProject(projectRoot, {
+    excludedRoots: config.excluded_roots,
+    homeDir: homedir(),
+  })
+  return exclusion.excluded
+}
+
 async function runBootstrap(
   projectRoot: string,
   config: Partial<CodegraphConfig>,
   deps: CodegraphBootstrapDeps,
 ): Promise<void> {
   try {
+    if (isProjectExcludedByPolicy(projectRoot, config)) {
+      deps.log("[codegraph-bootstrap] Project excluded by CodeGraph policy; skipping bootstrap", { projectRoot })
+      return
+    }
+
+    ensureCodegraphProjectConfig(projectRoot, { exclude: config.exclude })
+
     const autoInit = config.auto_init !== false
     const codegraphPath = join(projectRoot, ".codegraph")
     if (!autoInit && !existsSync(codegraphPath)) {

--- a/packages/omo-opencode/src/mcp/codegraph.test.ts
+++ b/packages/omo-opencode/src/mcp/codegraph.test.ts
@@ -155,6 +155,26 @@ describe("createCodegraphMcpConfig", () => {
     expect(config.environment?.[DO_NOT_TRACK_ENV]).toBe("1")
   })
 
+  it("keeps the registration disabled when the project is excluded by policy", () => {
+    // given
+    const codegraphPath = "/opt/omo/codegraph/bin/codegraph"
+    const homeDir = "/tmp/omo-codegraph-excluded-home"
+    const excludedRoot = `${homeDir}/research-cache`
+    const projectRoot = `${excludedRoot}/repo`
+
+    // when
+    const config = createCodegraphMcpConfig({
+      cwd: projectRoot,
+      config: { enabled: true, excluded_roots: ["~/research-cache"] },
+      fileExists: () => false,
+      homeDir,
+      resolveExecutable: createResolver({ codegraph: codegraphPath }),
+    })
+
+    // then
+    expect(config.enabled).toBe(false)
+  })
+
   it("uses configured install_dir for provisioned lookup and MCP environment", () => {
     // given
     const installDir = "/custom/codegraph"

--- a/packages/omo-opencode/src/mcp/codegraph.ts
+++ b/packages/omo-opencode/src/mcp/codegraph.ts
@@ -1,6 +1,11 @@
 import { existsSync } from "node:fs"
 import { join } from "node:path"
-import { buildCodegraphEnv, resolveCodegraphCommand, resolveCodegraphNodeSupport } from "@oh-my-opencode/utils"
+import {
+  buildCodegraphEnv,
+  resolveCodegraphCommand,
+  resolveCodegraphNodeSupport,
+  shouldExcludeCodegraphProject,
+} from "@oh-my-opencode/utils"
 import type { ResolveCodegraphCommandOptions } from "@oh-my-opencode/utils"
 import type { CodegraphConfig } from "../config/schema/codegraph"
 import type { LocalMcpConfig } from "./lsp"
@@ -59,8 +64,17 @@ export function createCodegraphMcpConfig(options: CodegraphMcpConfigOptions = {}
     nodeVersion: options.nodeVersionForExecutable,
     which,
   })
+  const projectExcluded =
+    options.cwd === undefined
+      ? false
+      : shouldExcludeCodegraphProject(options.cwd, {
+          excludedRoots: options.config?.excluded_roots,
+          homeDir: options.homeDir,
+        }).excluded
   const enabled =
-    resolvedCommand.exists && (resolvedCommand.source === "bundled" || resolvedCommand.source === "env" || nodeSupport.supported)
+    !projectExcluded &&
+    resolvedCommand.exists &&
+    (resolvedCommand.source === "bundled" || resolvedCommand.source === "env" || nodeSupport.supported)
 
   return {
     type: "local",

--- a/packages/utils/src/codegraph-project-config.test.ts
+++ b/packages/utils/src/codegraph-project-config.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { ensureCodegraphProjectConfig } from "./codegraph/project-config"
+
+describe("ensureCodegraphProjectConfig", () => {
+  it("writes exclude patterns into codegraph.json when configured", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-project-config-"))
+
+    try {
+      const changed = ensureCodegraphProjectConfig(workspace, {
+        exclude: ["pixie/", "bcc/", "opencode/"],
+      })
+
+      expect(changed).toBe(true)
+      expect(JSON.parse(readFileSync(join(workspace, "codegraph.json"), "utf8"))).toEqual({
+        exclude: ["pixie/", "bcc/", "opencode/"],
+      })
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it("merges configured exclude patterns with existing project config", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-project-config-merge-"))
+    const configPath = join(workspace, "codegraph.json")
+
+    try {
+      writeFileSync(configPath, `${JSON.stringify({ exclude: ["signoz/"], watch: true }, null, 2)}\n`, "utf8")
+
+      const changed = ensureCodegraphProjectConfig(workspace, {
+        exclude: ["pixie/", "signoz/"],
+      })
+
+      expect(changed).toBe(true)
+      expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
+        exclude: ["signoz/", "pixie/"],
+        watch: true,
+      })
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it("returns false when no exclude patterns are configured", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-project-config-empty-"))
+
+    try {
+      const changed = ensureCodegraphProjectConfig(workspace, { exclude: [] })
+
+      expect(changed).toBe(false)
+      expect(existsSync(join(workspace, "codegraph.json"))).toBe(false)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it("returns false when the merged config is unchanged", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-project-config-stable-"))
+    const configPath = join(workspace, "codegraph.json")
+
+    try {
+      writeFileSync(configPath, `${JSON.stringify({ exclude: ["pixie/"] }, null, 2)}\n`, "utf8")
+
+      const changed = ensureCodegraphProjectConfig(workspace, { exclude: ["pixie/"] })
+
+      expect(changed).toBe(false)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/utils/src/codegraph/index.ts
+++ b/packages/utils/src/codegraph/index.ts
@@ -1,6 +1,7 @@
 export * from "./env"
 export * from "./guidance"
 export * from "./node-support"
+export * from "./project-config"
 export * from "./provision"
 export * from "./process-sweep"
 export * from "./resolve"

--- a/packages/utils/src/codegraph/project-config.ts
+++ b/packages/utils/src/codegraph/project-config.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+export interface EnsureCodegraphProjectConfigOptions {
+  readonly exclude?: readonly string[]
+}
+
+function mergeUniqueStringArrays(...arrays: readonly (readonly string[])[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const array of arrays) {
+    for (const entry of array) {
+      const trimmed = entry.trim()
+      if (trimmed.length === 0 || seen.has(trimmed)) continue
+      seen.add(trimmed)
+      result.push(trimmed)
+    }
+  }
+
+  return result
+}
+
+function readExistingProjectConfig(configPath: string): Record<string, unknown> {
+  if (!existsSync(configPath)) return {}
+
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(configPath, "utf8"))
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) ? { ...parsed } : {}
+  } catch {
+    return {}
+  }
+}
+
+function readExistingExclude(existing: Record<string, unknown>): string[] {
+  if (!Array.isArray(existing.exclude)) return []
+  return existing.exclude.filter((entry): entry is string => typeof entry === "string")
+}
+
+export function ensureCodegraphProjectConfig(
+  projectRoot: string,
+  options: EnsureCodegraphProjectConfigOptions = {},
+): boolean {
+  const configuredExclude = options.exclude?.map((entry) => entry.trim()).filter((entry) => entry.length > 0) ?? []
+  if (configuredExclude.length === 0) return false
+
+  const configPath = join(projectRoot, "codegraph.json")
+  const existing = readExistingProjectConfig(configPath)
+  const mergedExclude = mergeUniqueStringArrays(readExistingExclude(existing), configuredExclude)
+  const next = { ...existing, exclude: mergedExclude }
+  const content = `${JSON.stringify(next, null, 2)}\n`
+
+  if (existsSync(configPath) && readFileSync(configPath, "utf8") === content) {
+    return false
+  }
+
+  writeFileSync(configPath, content, "utf8")
+  return true
+}


### PR DESCRIPTION
## Summary

Codex already applies CodeGraph project exclusion policy via `codegraph.excluded_roots` in bootstrap and MCP serve. OpenCode had no equivalent wiring, so workspaces under configured roots could still bootstrap and register the CodeGraph MCP.

This PR aligns the OpenCode path with Codex:

- **`excluded_roots`**: reuse `shouldExcludeCodegraphProject()` in OpenCode bootstrap and MCP registration to skip excluded workspaces.
- **`exclude`**: merge configured project-level exclude patterns into `codegraph.json` before `init`/`sync`, because the CodeGraph CLI reads that file for in-project indexing rules.
- **Hand-written `codegraph.json`**: still supported as-is; OMO only merges `exclude` when `codegraph.exclude` is configured and preserves other existing fields.

## Test plan

- [x] `bun test` for `ensureCodegraphProjectConfig`
- [x] `bun test` for OpenCode codegraph schema, bootstrap hook, and MCP config
- [x] `bun run build:schema`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns OpenCode with Codex so CodeGraph respects project exclusion. Skips bootstrap/MCP registration for workspaces under `excluded_roots`, and writes configured `exclude` patterns to `codegraph.json` before init.

- **Bug Fixes**
  - Honor `excluded_roots` via `shouldExcludeCodegraphProject()` in bootstrap and MCP.
  - Merge `codegraph.exclude` into `codegraph.json` while preserving existing fields.
  - Update schema to include `exclude` and `excluded_roots`.
  - Add `ensureCodegraphProjectConfig()` in `@oh-my-opencode/utils` with tests.
  - Adjust bootstrap tests to run outside tmp roots now excluded by default.

<sup>Written for commit c361c1b53a09ddc758a64599f6b4fabd69bc5ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

