### PR TITLE
feat: default the browser skill to the openchrome-aside tiered stack (aside + openchrome, Playwright MCP fallback)

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -6739,13 +6739,14 @@
       "type": "object",
       "properties": {
         "provider": {
-          "default": "playwright",
+          "default": "openchrome-aside",
           "type": "string",
           "enum": [
             "playwright",
             "agent-browser",
             "dev-browser",
-            "playwright-cli"
+            "playwright-cli",
+            "openchrome-aside"
           ]
         }
       },

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -557,15 +557,20 @@ Available commands: `init-deep`, `ralph-loop`, `ulw-loop`, `cancel-ralph`, `refa
 
 ### Browser Automation
 
-| Provider               | Interface | Installation                                        |
-| ---------------------- | --------- | --------------------------------------------------- |
-| `playwright` (default) | MCP tools | Auto-installed via npx                              |
-| `agent-browser`        | Bash CLI  | `bun add -g agent-browser && agent-browser install` |
+The `browser_automation_engine.provider` field selects the browser skill implementation. The default `openchrome-aside` is a tiered stack: aside LLM ask mode first, openchrome for deterministic real Chrome, and Playwright MCP as a zero-setup fallback when aside and openchrome are not installed. Every provider is exposed through the `playwright` skill trigger.
+
+| Provider                     | Interface                              | Installation                                                    |
+| ---------------------------- | -------------------------------------- | --------------------------------------------------------------- |
+| `openchrome-aside` (default) | aside/oc CLI + Playwright MCP fallback | aside CLI + `npm install -g openchrome-mcp`; fallback needs none |
+| `playwright`                 | MCP tools                              | Auto-installed via npx                                          |
+| `agent-browser`              | Bash CLI                               | `bun add -g agent-browser && agent-browser install`             |
+| `playwright-cli`             | Bash CLI                               | `playwright-cli install`                                        |
+| `dev-browser`                | Persistent Chromium                    | Chromium via npx                                                |
 
 Switch provider:
 
 ```json
-{ "browser_automation_engine": { "provider": "agent-browser" } }
+{ "browser_automation_engine": { "provider": "playwright" } }
 ```
 
 ### Tmux Integration

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -438,7 +438,7 @@ Skill sets provide specialized workflows with embedded MCP servers and detailed 
 | Skill set              | Trigger                                                 | Description                                                                                                                                                                                                                                                                                                                                   |
 | ---------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **git-master**         | commit, rebase, squash, "who wrote", "when was X added" | Git expert. Detects commit styles, splits atomic commits, formulates rebase strategies. Three specializations: Commit Architect (atomic commits, dependency ordering), Rebase Surgeon (history rewriting, conflict resolution), and History Archaeologist (finding when/where specific changes were introduced).                              |
-| **playwright**         | Browser tasks, testing, screenshots                     | Browser automation via Playwright MCP. MUST USE for browser verification, browsing, web scraping, testing, and screenshots.                                                                                                                                                                                                                   |
+| **playwright**         | Browser tasks, testing, screenshots                     | Browser automation via a tiered stack (aside LLM ask mode by default, openchrome real Chrome, Playwright MCP fallback), selected by `browser_automation_engine.provider`. MUST USE for browser verification, browsing, web scraping, testing, and screenshots.                                                                                                                                                                                                                   |
 | **agent-browser**      | Browser tasks on agent-browser                          | Browser automation via the `agent-browser` CLI. Covers navigation, snapshots, screenshots, network inspection, and scripted interactions.                                                                                                                                                                                                     |
 | **dev-browser**        | Stateful browser scripting                              | Browser automation with persistent page state for iterative workflows and authenticated sessions.                                                                                                                                                                                                                                             |
 | **frontend**           | UI/UX tasks, styling                                    | Designer-turned-developer persona. Crafts strong UI/UX even without design mockups. Emphasizes bold aesthetic direction, distinctive typography, cohesive color palettes.                                                                                                                                                                     |
@@ -482,9 +482,33 @@ Skill sets provide specialized workflows with embedded MCP servers and detailed 
 
 ### Browser Automation Options
 
-Oh-My-OpenAgent provides two browser automation providers, configurable via `browser_automation_engine.provider`.
+Oh-My-OpenAgent selects the browser automation engine via `browser_automation_engine.provider`. The default (`openchrome-aside`) is a tiered stack: it leads with the aside AI browser's LLM ask mode, uses openchrome for deterministic real-Chrome precision, and falls back to Playwright MCP when neither is installed. Every provider is exposed through the same `playwright` skill trigger. Other providers (`playwright-cli`, `dev-browser`) are listed in the [configuration reference](configuration.md#browser-automation).
 
-#### Option 1: Playwright MCP (Default)
+#### Option 1: openchrome + aside (Default)
+
+Tiered stack; no configuration needed because it is the default.
+
+```json
+{
+  "browser_automation_engine": {
+    "provider": "openchrome-aside"
+  }
+}
+```
+
+- **Tier 1 (primary): aside LLM ask mode.** `aside "<task>"` drives a real, logged-in browser from a natural-language task. Install: `curl -fsSL https://releases.aside.com/install.sh | bash`.
+- **Tier 2 (precision): openchrome.** Deterministic real Chrome over CDP through the `oc` CLI (or its MCP). Install: `npm install -g openchrome-mcp`.
+- **Tier 3 (fallback): Playwright MCP.** Always available via npx, so browser automation still works with zero setup when aside and openchrome are absent.
+
+#### Option 2: Playwright MCP
+
+```json
+{
+  "browser_automation_engine": {
+    "provider": "playwright"
+  }
+}
+```
 
 ```yaml
 mcp:
@@ -493,13 +517,7 @@ mcp:
     args: ["@playwright/mcp@latest"]
 ```
 
-**Usage**:
-
-```
-/playwright Navigate to example.com and take a screenshot
-```
-
-#### Option 2: Agent Browser CLI (Vercel)
+#### Option 3: Agent Browser CLI (Vercel)
 
 ```json
 {
@@ -515,13 +533,7 @@ mcp:
 bun add -g agent-browser
 ```
 
-**Usage**:
-
-```
-Use agent-browser to navigate to example.com and extract the main heading
-```
-
-**Capabilities (Both Providers)**:
+**Capabilities (All Providers)**:
 
 - Navigate and interact with web pages
 - Take screenshots and PDFs

--- a/packages/omo-opencode/src/config/schema.test.ts
+++ b/packages/omo-opencode/src/config/schema.test.ts
@@ -750,10 +750,22 @@ describe("BrowserAutomationProviderSchema", () => {
     expect(result.success).toBe(true)
     expect(result.data).toBe("playwright-cli")
   })
+
+  test("accepts 'openchrome-aside' as valid provider", () => {
+    // given
+    const input = "openchrome-aside"
+
+    // when
+    const result = BrowserAutomationProviderSchema.safeParse(input)
+
+    // then
+    expect(result.success).toBe(true)
+    expect(result.data).toBe("openchrome-aside")
+  })
 })
 
 describe("BrowserAutomationConfigSchema", () => {
-  test("defaults provider to 'playwright' when not specified", () => {
+  test("defaults provider to 'openchrome-aside' when not specified", () => {
     // given
     const input = {}
 
@@ -761,7 +773,7 @@ describe("BrowserAutomationConfigSchema", () => {
     const result = BrowserAutomationConfigSchema.parse(input)
 
     // then
-    expect(result.provider).toBe("playwright")
+    expect(result.provider).toBe("openchrome-aside")
   })
 
   test("accepts agent-browser provider", () => {

--- a/packages/omo-opencode/src/config/schema/browser-automation.ts
+++ b/packages/omo-opencode/src/config/schema/browser-automation.ts
@@ -5,17 +5,20 @@ export const BrowserAutomationProviderSchema = z.enum([
   "agent-browser",
   "dev-browser",
   "playwright-cli",
+  "openchrome-aside",
 ])
 
 export const BrowserAutomationConfigSchema = z.object({
   /**
    * Browser automation provider to use for the "playwright" skill.
-   * - "playwright": Uses Playwright MCP server (@playwright/mcp) - default
+   * - "openchrome-aside": Tiered stack - aside LLM ask mode (primary) + openchrome real-Chrome
+   *   precision, with graceful fallback to Playwright MCP when aside/openchrome are not installed - default
+   * - "playwright": Uses Playwright MCP server (@playwright/mcp)
    * - "agent-browser": Uses Vercel's agent-browser CLI (requires: bun add -g agent-browser)
    * - "dev-browser": Uses dev-browser skill with persistent browser state
    * - "playwright-cli": Uses Playwright CLI (@playwright/cli) - token-efficient CLI alternative
    */
-  provider: BrowserAutomationProviderSchema.default("playwright"),
+  provider: BrowserAutomationProviderSchema.default("openchrome-aside"),
 })
 
 export type BrowserAutomationProvider = z.infer<

--- a/packages/omo-opencode/src/features/builtin-skills/skills.test.ts
+++ b/packages/omo-opencode/src/features/builtin-skills/skills.test.ts
@@ -5,7 +5,7 @@ import { createBuiltinSkills } from "./skills"
 import { agentBrowserSkill, playwrightSkill } from "./skills/playwright"
 
 describe("createBuiltinSkills", () => {
-	test("returns playwright skill by default", () => {
+	test("returns the tiered openchrome-aside browser skill (named playwright) by default", () => {
 		// given - no options (default)
 
 		// when
@@ -16,6 +16,8 @@ describe("createBuiltinSkills", () => {
 		expect(browserSkill).toBeDefined()
 		expect(browserSkill?.description).toContain("browser")
 		expect(browserSkill?.mcpConfig?.playwright).toBeDefined()
+		expect(browserSkill?.template).toContain("### 1. aside")
+		expect(browserSkill?.template).toContain("### 2. openchrome")
 	})
 
 	test("exports browser skill contracts with stable tool surfaces", () => {
@@ -333,5 +335,27 @@ describe("createBuiltinSkills", () => {
 		expect(playwrightSkill?.allowedTools).toContain("Bash(playwright-cli:*)")
 		expect(playwrightSkill?.mcpConfig).toBeUndefined()
 		expect(agentBrowserSkill).toBeUndefined()
+	})
+
+	test("returns tiered openchrome-aside skill when browserProvider is 'openchrome-aside'", () => {
+		// given
+		const options = { browserProvider: "openchrome-aside" as const }
+
+		// when
+		const skills = createBuiltinSkills(options)
+
+		// then
+		const browserSkill = skills.find((s) => s.name === "playwright")
+		const agentBrowserSkill = skills.find((s) => s.name === "agent-browser")
+		const devBrowserSkill = skills.find((s) => s.name === "dev-browser")
+		expect(browserSkill).toBeDefined()
+		expect(browserSkill?.description).toContain("browser")
+		expect(browserSkill?.template).toContain("### 1. aside")
+		expect(browserSkill?.template).toContain("### 2. openchrome")
+		expect(browserSkill?.mcpConfig?.playwright).toBeDefined()
+		expect(browserSkill?.allowedTools).toBeUndefined()
+		expect(agentBrowserSkill).toBeUndefined()
+		expect(devBrowserSkill).toBeUndefined()
+		expect(skills).toHaveLength(10)
 	})
 })

--- a/packages/omo-opencode/src/features/opencode-skill-loader/git-master-async-precedence.test.ts
+++ b/packages/omo-opencode/src/features/opencode-skill-loader/git-master-async-precedence.test.ts
@@ -64,7 +64,7 @@ describe("git-master async precedence", () => {
 		expect(result.notFound).toEqual([])
 		expect(result.resolved.get("git-master")).toContain("custom git master content")
 		expect(result.resolved.get("git-master")).not.toContain("Git Master Agent")
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("preserves requested batch order when git-master uses the fast path", async () => {

--- a/packages/omo-opencode/src/features/opencode-skill-loader/skill-content.test.ts
+++ b/packages/omo-opencode/src/features/opencode-skill-loader/skill-content.test.ts
@@ -65,7 +65,7 @@ describe("resolveSkillContent", () => {
 		// then: returns template string
 		expect(result).not.toBeNull()
 		expect(typeof result).toBe("string")
-		expect(result).toContain("Playwright Browser Automation")
+		expect(result).toContain("Browser Automation")
 	})
 
 	it("should return null for non-existent skill", () => {
@@ -101,7 +101,7 @@ describe("resolveMultipleSkills", () => {
 		expect(result.resolved.size).toBe(2)
 		expect(result.notFound).toEqual([])
 		expect(result.resolved.get("frontend")).toContain("router, not a rulebook")
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("should handle partial success - some skills not found", () => {
@@ -115,7 +115,7 @@ describe("resolveMultipleSkills", () => {
 		expect(result.resolved.size).toBe(2)
 		expect(result.notFound).toEqual(["nonexistent", "another-missing"])
 		expect(result.resolved.get("frontend")).toContain("router, not a rulebook")
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("should handle empty array", () => {
@@ -258,7 +258,7 @@ describe("resolveMultipleSkillsAsync", () => {
 		// then: all builtin skills resolved
 		expect(result.resolved.size).toBe(2)
 		expect(result.notFound).toEqual([])
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 		expect(result.resolved.get("git-master")).toContain("Git Master Agent")
 	})
 
@@ -272,7 +272,7 @@ describe("resolveMultipleSkillsAsync", () => {
 		// then: existing skills resolved, non-existing in notFound
 		expect(result.resolved.size).toBe(1)
 		expect(result.notFound).toEqual(["nonexistent-skill-12345"])
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("should treat disabled skills as not found async", async () => {
@@ -449,7 +449,7 @@ describe("resolveMultipleSkillsAsync", () => {
 		expect(result.resolved.size).toBe(2)
 		expect(result.notFound).toEqual([])
 		expect(result.resolved.get("systematic-debugging")).toContain("short name resolved")
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("does not resolve ambiguous short name in batch", async () => {

--- a/packages/omo-opencode/src/plugin-handlers/agent-config-handler-agents-skills.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/agent-config-handler-agents-skills.test.ts
@@ -123,6 +123,20 @@ describe("applyAgentConfig .agents skills", () => {
     expect(discoveredSkills.map(skill => skill.name)).toContain("global-agent-skill")
   })
 
+  test("passes the openchrome-aside browser provider to builtin agents by default", async () => {
+    // when
+    await applyAgentConfig({
+      config: { model: "anthropic/claude-opus-4-7", agent: {} },
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp/project" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then - browserProvider (9th arg) defaults to the tiered provider, not vanilla playwright
+    const browserProvider = createBuiltinAgentsSpy.mock.calls[0]?.[8] as string
+    expect(browserProvider).toBe("openchrome-aside")
+  })
+
   test("discovers skills from host config.skills.paths set by other plugins", async () => {
     // given - second call to discoverConfigSourceSkills returns host config skills
     discoverConfigSourceSkillsSpy

--- a/packages/omo-opencode/src/plugin-handlers/agent-config-handler.ts
+++ b/packages/omo-opencode/src/plugin-handlers/agent-config-handler.ts
@@ -17,7 +17,7 @@ export async function applyAgentConfig(
   const allDiscoveredSkills = await discoverAgentSkills(params);
   const sources = loadAgentSources(params);
   const browserProvider =
-    params.pluginConfig.browser_automation_engine?.provider ?? "playwright";
+    params.pluginConfig.browser_automation_engine?.provider ?? "openchrome-aside";
   const currentModel = params.config.model as string | undefined;
   const disabledSkills = collectDisabledSkillAliases(params.pluginConfig);
   const useTaskSystem = isTaskSystemEnabled(params.pluginConfig);

--- a/packages/omo-opencode/src/plugin-handlers/command-config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/command-config-handler.test.ts
@@ -256,6 +256,24 @@ describe("applyCommandConfig", () => {
     expect(commandConfig["init-deep"]?.template).toContain("<skill-instruction>");
   });
 
+  test("registers the tiered openchrome-aside browser skill (named playwright) by default", async () => {
+    // given - default config, no browser_automation_engine set
+    const config: Record<string, unknown> = { command: {} };
+
+    // when
+    await applyCommandConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    });
+
+    // then - the default /playwright command carries the tiered aside->openchrome stack
+    const commandConfig = config.command as Record<string, { template?: string }>;
+    expect(commandConfig["playwright"]?.template).toContain("### 1. aside");
+    expect(commandConfig["playwright"]?.template).toContain("### 2. openchrome");
+  });
+
   test("#given disabled_commands contains remove-ai-slops #when applying command config #then the skill-backed command does not resurrect", async () => {
     // given
     const pluginConfig: OhMyOpenCodeConfig = {

--- a/packages/omo-opencode/src/plugin-handlers/command-config-handler.ts
+++ b/packages/omo-opencode/src/plugin-handlers/command-config-handler.ts
@@ -48,7 +48,7 @@ export async function applyCommandConfig(params: {
   });
   const builtinSkillCommands = builtinSkillsToCommandDefinitionRecord(
     resolveActiveBuiltinSkills({
-      browserProvider: params.pluginConfig.browser_automation_engine?.provider ?? "playwright",
+      browserProvider: params.pluginConfig.browser_automation_engine?.provider ?? "openchrome-aside",
       disabledSkills,
       teamModeEnabled: params.pluginConfig.team_mode?.enabled ?? false,
       systemMcpNames: getSystemMcpServerNames(),

--- a/packages/omo-opencode/src/plugin/skill-context.test.ts
+++ b/packages/omo-opencode/src/plugin/skill-context.test.ts
@@ -446,4 +446,88 @@ describe("createSkillContext", () => {
       getSystemMcpServerNamesSpy.mockRestore()
     }
   })
+
+  it("defaults the browser provider to openchrome-aside when browser_automation_engine is unset", async () => {
+    // given
+    const discoverConfigSourceSkillsSpy = spyOn(skillLoader, "discoverConfigSourceSkills").mockResolvedValue([])
+    const discoverUserClaudeSkillsSpy = spyOn(skillLoader, "discoverUserClaudeSkills").mockResolvedValue([])
+    const discoverProjectClaudeSkillsSpy = spyOn(skillLoader, "discoverProjectClaudeSkills").mockResolvedValue([])
+    const discoverOpencodeGlobalSkillsSpy = spyOn(skillLoader, "discoverOpencodeGlobalSkills").mockResolvedValue([])
+    const discoverOpencodeProjectSkillsSpy = spyOn(skillLoader, "discoverOpencodeProjectSkills").mockResolvedValue([])
+    const discoverProjectAgentsSkillsSpy = spyOn(skillLoader, "discoverProjectAgentsSkills").mockResolvedValue([])
+    const discoverGlobalAgentsSkillsSpy = spyOn(skillLoader, "discoverGlobalAgentsSkills").mockResolvedValue([])
+    const getSystemMcpServerNamesSpy = spyOn(mcpLoader, "getSystemMcpServerNames").mockReturnValue(new Set<string>())
+
+    const pluginConfig = OhMyOpenCodeConfigSchema.parse({})
+
+    try {
+      // when
+      const result = await createSkillContext({
+        directory: testDirectory,
+        pluginConfig,
+      })
+
+      // then
+      expect(result.browserProvider).toBe("openchrome-aside")
+      expect(result.mergedSkills.some((skill) => skill.name === "playwright")).toBe(true)
+    } finally {
+      discoverConfigSourceSkillsSpy.mockRestore()
+      discoverUserClaudeSkillsSpy.mockRestore()
+      discoverProjectClaudeSkillsSpy.mockRestore()
+      discoverOpencodeGlobalSkillsSpy.mockRestore()
+      discoverOpencodeProjectSkillsSpy.mockRestore()
+      discoverProjectAgentsSkillsSpy.mockRestore()
+      discoverGlobalAgentsSkillsSpy.mockRestore()
+      getSystemMcpServerNamesSpy.mockRestore()
+    }
+  })
+
+  it("keeps a discovered playwright skill when browser provider is openchrome-aside", async () => {
+    // given - a user-authored playwright SKILL.md on disk must survive under the new default
+    const discoveredPlaywrightDir = join(testDirectory, ".claude", "skills", "playwright")
+    mkdirSync(discoveredPlaywrightDir, { recursive: true })
+    writeFileSync(
+      join(discoveredPlaywrightDir, "SKILL.md"),
+      [
+        "---",
+        "name: playwright",
+        "description: Discovered user playwright skill",
+        "---",
+        "Discovered user playwright body.",
+        "",
+      ].join("\n"),
+    )
+
+    const discoverConfigSourceSkillsSpy = spyOn(skillLoader, "discoverConfigSourceSkills").mockResolvedValue([])
+    const discoverUserClaudeSkillsSpy = spyOn(skillLoader, "discoverUserClaudeSkills").mockResolvedValue([])
+    const discoverOpencodeGlobalSkillsSpy = spyOn(skillLoader, "discoverOpencodeGlobalSkills").mockResolvedValue([])
+    const discoverProjectAgentsSkillsSpy = spyOn(skillLoader, "discoverProjectAgentsSkills").mockResolvedValue([])
+    const discoverGlobalAgentsSkillsSpy = spyOn(skillLoader, "discoverGlobalAgentsSkills").mockResolvedValue([])
+    const getSystemMcpServerNamesSpy = spyOn(mcpLoader, "getSystemMcpServerNames").mockReturnValue(new Set<string>())
+
+    const pluginConfig = OhMyOpenCodeConfigSchema.parse({
+      browser_automation_engine: { provider: "openchrome-aside" },
+    })
+
+    try {
+      // when
+      const result = await createSkillContext({
+        directory: testDirectory,
+        pluginConfig,
+      })
+
+      // then - the user's discovered playwright skill survives gating AND overrides the builtin
+      expect(result.browserProvider).toBe("openchrome-aside")
+      const playwright = result.mergedSkills.find((skill) => skill.name === "playwright")
+      expect(playwright).toBeDefined()
+      expect(playwright?.definition.description).toContain("Discovered user playwright skill")
+    } finally {
+      discoverConfigSourceSkillsSpy.mockRestore()
+      discoverUserClaudeSkillsSpy.mockRestore()
+      discoverOpencodeGlobalSkillsSpy.mockRestore()
+      discoverProjectAgentsSkillsSpy.mockRestore()
+      discoverGlobalAgentsSkillsSpy.mockRestore()
+      getSystemMcpServerNamesSpy.mockRestore()
+    }
+  })
 })

--- a/packages/omo-opencode/src/plugin/skill-context.ts
+++ b/packages/omo-opencode/src/plugin/skill-context.ts
@@ -43,16 +43,23 @@ function mapScopeToLocation(scope: SkillScope): AvailableSkill["location"] {
   return "plugin"
 }
 
+function activeBrowserSkillName(browserProvider: BrowserAutomationProvider): string {
+  if (browserProvider === "agent-browser") return "agent-browser"
+  if (browserProvider === "dev-browser") return "dev-browser"
+  return "playwright"
+}
+
 function filterProviderGatedSkills(
   skills: LoadedSkill[],
   browserProvider: BrowserAutomationProvider,
 ): LoadedSkill[] {
+  const activeName = activeBrowserSkillName(browserProvider)
   return skills.filter((skill) => {
     if (!PROVIDER_GATED_SKILL_NAMES.has(skill.name)) {
       return true
     }
 
-    return skill.name === browserProvider
+    return skill.name === activeName
   })
 }
 
@@ -97,7 +104,7 @@ export async function createSkillContext(args: {
   const { directory, pluginConfig, hostSkills } = args
 
   const browserProvider: BrowserAutomationProvider =
-    pluginConfig.browser_automation_engine?.provider ?? "playwright"
+    pluginConfig.browser_automation_engine?.provider ?? "openchrome-aside"
 
   const disabledSkills = collectDisabledSkillAliases(pluginConfig)
 

--- a/packages/skills-loader-core/src/features/builtin-skills/skills.test.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills.test.ts
@@ -5,7 +5,7 @@ import { createBuiltinSkills } from "./skills"
 import { agentBrowserSkill, playwrightSkill } from "./skills/playwright"
 
 describe("createBuiltinSkills", () => {
-	test("returns playwright skill by default", () => {
+	test("returns the tiered openchrome-aside browser skill (named playwright) by default", () => {
 		// given - no options (default)
 
 		// when
@@ -16,6 +16,8 @@ describe("createBuiltinSkills", () => {
 		expect(browserSkill).toBeDefined()
 		expect(browserSkill?.description).toContain("browser")
 		expect(browserSkill?.mcpConfig?.playwright).toBeDefined()
+		expect(browserSkill?.template).toContain("### 1. aside")
+		expect(browserSkill?.template).toContain("### 2. openchrome")
 	})
 
 	test("exports browser skill contracts with stable tool surfaces", () => {
@@ -333,5 +335,27 @@ describe("createBuiltinSkills", () => {
 		expect(playwrightSkill?.allowedTools).toContain("Bash(playwright-cli:*)")
 		expect(playwrightSkill?.mcpConfig).toBeUndefined()
 		expect(agentBrowserSkill).toBeUndefined()
+	})
+
+	test("returns tiered openchrome-aside skill when browserProvider is 'openchrome-aside'", () => {
+		// given
+		const options = { browserProvider: "openchrome-aside" as const }
+
+		// when
+		const skills = createBuiltinSkills(options)
+
+		// then
+		const browserSkill = skills.find((s) => s.name === "playwright")
+		const agentBrowserSkill = skills.find((s) => s.name === "agent-browser")
+		const devBrowserSkill = skills.find((s) => s.name === "dev-browser")
+		expect(browserSkill).toBeDefined()
+		expect(browserSkill?.description).toContain("browser")
+		expect(browserSkill?.template).toContain("### 1. aside")
+		expect(browserSkill?.template).toContain("### 2. openchrome")
+		expect(browserSkill?.mcpConfig?.playwright).toBeDefined()
+		expect(browserSkill?.allowedTools).toBeUndefined()
+		expect(agentBrowserSkill).toBeUndefined()
+		expect(devBrowserSkill).toBeUndefined()
+		expect(skills).toHaveLength(10)
 	})
 })

--- a/packages/skills-loader-core/src/features/builtin-skills/skills.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills.ts
@@ -5,6 +5,7 @@ import {
   playwrightSkill,
   agentBrowserSkill,
   playwrightCliSkill,
+  openchromeAsideSkill,
   frontendSkill,
   gitMasterSkill,
   devBrowserSkill,
@@ -25,7 +26,7 @@ export interface CreateBuiltinSkillsOptions {
 }
 
 export function createBuiltinSkills(options: CreateBuiltinSkillsOptions = {}): BuiltinSkill[] {
-  const { browserProvider = "playwright", disabledSkills, teamModeEnabled = false } = options
+  const { browserProvider = "openchrome-aside", disabledSkills, teamModeEnabled = false } = options
 
   let browserSkill: BuiltinSkill
 	if (browserProvider === "agent-browser") {
@@ -34,6 +35,8 @@ export function createBuiltinSkills(options: CreateBuiltinSkillsOptions = {}): B
 		browserSkill = devBrowserSkill
 	} else if (browserProvider === "playwright-cli") {
 		browserSkill = playwrightCliSkill
+	} else if (browserProvider === "openchrome-aside") {
+		browserSkill = openchromeAsideSkill
 	} else {
 		browserSkill = playwrightSkill
 	}

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/index.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/index.ts
@@ -1,5 +1,6 @@
 export { playwrightSkill, agentBrowserSkill } from "./playwright"
 export { playwrightCliSkill } from "./playwright-cli"
+export { openchromeAsideSkill } from "./openchrome-aside-skill"
 export { frontendSkill } from "./frontend"
 export { gitMasterSkill } from "./git-master"
 export { devBrowserSkill } from "./dev-browser"

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/openchrome-aside-skill.test.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/openchrome-aside-skill.test.ts
@@ -1,0 +1,65 @@
+/// <reference path="../../../../../../bun-test.d.ts" />
+
+import { describe, expect, test } from "bun:test"
+import { openchromeAsideSkill } from "./openchrome-aside-skill"
+
+function orderedIndexes(source: string, markers: readonly string[]): readonly number[] {
+  return markers.map((marker) => source.indexOf(marker))
+}
+
+describe("openchromeAsideSkill", () => {
+  test("#given the tiered browser skill #when inspected #then it keeps the canonical playwright name and browser trigger", () => {
+    // #then
+    expect(openchromeAsideSkill.name).toBe("playwright")
+    expect(openchromeAsideSkill.description).toContain("MUST USE")
+    expect(openchromeAsideSkill.description.toLowerCase()).toContain("browser")
+  })
+
+  test("#given graceful-fallback requirement #when inspecting tooling #then allowedTools is omitted and only Playwright MCP is declared", () => {
+    // #then - allowedTools omitted so the agent keeps Bash + Read + skill_mcp
+    expect(openchromeAsideSkill.allowedTools).toBeUndefined()
+    // only Playwright MCP is declared (always available via npx); aside/openchrome are Bash-driven
+    expect(openchromeAsideSkill.mcpConfig?.playwright).toEqual({
+      command: "npx",
+      args: ["@playwright/mcp@latest"],
+    })
+    expect(openchromeAsideSkill.mcpConfig?.aside).toBeUndefined()
+    expect(openchromeAsideSkill.mcpConfig?.openchrome).toBeUndefined()
+  })
+
+  test("#given the ask-first routing #when reading the template #then aside precedes openchrome precedes Playwright MCP fallback", () => {
+    // #given
+    const template = openchromeAsideSkill.template
+    const markers = [
+      "# Browser Automation",
+      "### 1. aside",
+      "### 2. openchrome",
+      "### 3. Playwright MCP",
+      "## Install",
+    ] as const
+
+    // #when
+    const markerIndexes = orderedIndexes(template, markers)
+
+    // #then - every tier present, strictly ordered aside -> openchrome -> playwright -> install
+    expect(markerIndexes.every((index) => index >= 0)).toBe(true)
+    expect(markerIndexes).toEqual([...markerIndexes].sort((left, right) => left - right))
+  })
+
+  test("#given detection + install guidance #when reading the template #then command detection, ask mode, CLI, fallback, and install hints are present", () => {
+    // #given
+    const template = openchromeAsideSkill.template
+
+    // #then
+    expect(template).toContain("command -v aside")
+    expect(template).toContain("command -v openchrome")
+    expect(template).toContain("command -v oc")
+    expect(template).toContain('aside "')
+    expect(template).toContain("oc navigate")
+    expect(template).toContain("skill_mcp")
+    expect(template).toContain("cdp_url")
+    expect(template).toContain("9222")
+    expect(template).toContain("curl -fsSL https://releases.aside.com/install.sh | bash")
+    expect(template).toContain("npm install -g openchrome-mcp")
+  })
+})

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/openchrome-aside-skill.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/openchrome-aside-skill.ts
@@ -1,0 +1,103 @@
+import type { BuiltinSkill } from "../types"
+
+const openchromeAsideTemplate = `# Browser Automation
+
+Drive browsers for e2e testing, verification, scraping, screenshots, and any web interaction.
+
+This skill routes through a tiered stack. Detect what is installed, then use the highest available tier. Every tier degrades gracefully: when aside and openchrome are absent, Playwright MCP still works with zero setup.
+
+## Pick a tier
+
+Detect availability once at the start of a browser task:
+
+\`\`\`bash
+command -v aside        # tier 1: LLM ask mode (natural-language browser agent)
+command -v openchrome || command -v oc   # tier 2: deterministic real Chrome over CDP (CLI binary is oc)
+\`\`\`
+
+Use the first available tier, in order: aside -> openchrome -> Playwright MCP.
+
+### 1. aside (primary - LLM ask mode)
+
+aside is an AI browser. Its ask mode takes a natural-language task and drives a real, logged-in browser end to end. Prefer it for high-level e2e flows such as "sign up, then confirm the dashboard loads".
+
+\`\`\`bash
+# Run a browser task in natural language (the LLM ask mode)
+aside "Open http://localhost:3000, complete signup with a test account, and confirm the dashboard renders"
+
+# Continue an existing run by session id
+aside --session <session-id> "Continue and capture a screenshot of the settings page"
+
+# Choose the account and model explicitly
+aside exec --account u1 -m openai-codex/gpt-5.5 "Summarize the current page"
+\`\`\`
+
+For deterministic, Playwright-like steps (open a tab, read the DOM, screenshot) use the REPL:
+
+\`\`\`bash
+aside repl "const p = await openTab('http://localhost:3000'); await p.screenshot('/tmp/home.png')"
+\`\`\`
+
+If aside is not on PATH, install it (see Install) or drop to tier 2.
+
+### 2. openchrome (precision - deterministic real Chrome)
+
+openchrome controls your real, already-logged-in Chrome over CDP. Use it for deterministic clicks, form fills, assertions, and screenshots. The CLI binary is oc.
+
+\`\`\`bash
+oc navigate http://localhost:3000
+oc run read_page --arg mode=dom --json                        # structured page state
+oc run page_screenshot --arg path=/tmp/shot.png
+oc run validate_page --arg url=http://localhost:3000 --json   # console errors + health summary
+oc click <ref>
+\`\`\`
+
+openchrome also exposes an MCP server. This skill drives openchrome through the oc CLI above; to use its MCP instead, register it globally with npx openchrome-mcp setup --client opencode, then call skill_mcp:
+
+\`\`\`
+skill_mcp(mcp_name="openchrome", tool_name="navigate", arguments='{"url":"http://localhost:3000"}')
+\`\`\`
+
+If openchrome or oc is not on PATH, install it (see Install) or drop to tier 3.
+
+### 3. Playwright MCP (universal fallback - zero setup)
+
+Always available through npx; use it when neither aside nor openchrome is installed.
+
+\`\`\`
+skill_mcp(mcp_name="playwright", tool_name="browser_navigate", arguments='{"url":"http://localhost:3000"}')
+skill_mcp(mcp_name="playwright", tool_name="browser_snapshot")
+skill_mcp(mcp_name="playwright", tool_name="browser_take_screenshot", arguments='{"filename":"/tmp/shot.png"}')
+\`\`\`
+
+To attach Playwright MCP to an already-running Chrome (for example openchrome's, on port 9222), pass a CDP endpoint via cdp_url:
+
+\`\`\`
+skill_mcp(mcp_name="playwright", tool_name="browser_navigate", arguments='{"url":"http://localhost:3000"}', cdp_url="http://127.0.0.1:9222")
+\`\`\`
+
+## Install
+
+Only the higher tiers need setup; Playwright MCP needs nothing.
+
+\`\`\`bash
+# aside (tier 1): install the CLI, then sign in from the Aside app
+curl -fsSL https://releases.aside.com/install.sh | bash
+
+# openchrome (tier 2)
+npm install -g openchrome-mcp
+\`\`\`
+`
+
+export const openchromeAsideSkill: BuiltinSkill = {
+  name: "playwright",
+  description:
+    "MUST USE for any browser-related tasks. Browser automation via aside (LLM ask mode) plus openchrome real Chrome, with Playwright MCP fallback - verification, browsing, information gathering, web scraping, testing, screenshots, and all browser interactions.",
+  template: openchromeAsideTemplate,
+  mcpConfig: {
+    playwright: {
+      command: "npx",
+      args: ["@playwright/mcp@latest"],
+    },
+  },
+}

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/git-master-async-precedence.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/git-master-async-precedence.test.ts
@@ -64,7 +64,7 @@ describe("git-master async precedence", () => {
 		expect(result.notFound).toEqual([])
 		expect(result.resolved.get("git-master")).toContain("custom git master content")
 		expect(result.resolved.get("git-master")).not.toContain("Git Master Agent")
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("preserves requested batch order when git-master uses the fast path", async () => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-multiple.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-multiple.test.ts
@@ -56,7 +56,7 @@ describe("resolveMultipleSkillsAsync", () => {
 		// then: all builtin skills resolved
 		expect(result.resolved.size).toBe(2)
 		expect(result.notFound).toEqual([])
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 		expect(result.resolved.get("git-master")).toContain("Git Master Agent")
 	})
 
@@ -70,7 +70,7 @@ describe("resolveMultipleSkillsAsync", () => {
 		// then: existing skills resolved, non-existing in notFound
 		expect(result.resolved.size).toBe(1)
 		expect(result.notFound).toEqual(["nonexistent-skill-12345"])
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("should treat disabled skills as not found async", async () => {
@@ -247,7 +247,7 @@ describe("resolveMultipleSkillsAsync", () => {
 		expect(result.resolved.size).toBe(2)
 		expect(result.notFound).toEqual([])
 		expect(result.resolved.get("systematic-debugging")).toContain("short name resolved")
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("does not resolve ambiguous short name in batch", async () => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content.test.ts
@@ -65,7 +65,7 @@ describe("resolveSkillContent", () => {
 		// then: returns template string
 		expect(result).not.toBeNull()
 		expect(typeof result).toBe("string")
-		expect(result).toContain("Playwright Browser Automation")
+		expect(result).toContain("Browser Automation")
 	})
 
 	it("should return null for non-existent skill", () => {
@@ -101,7 +101,7 @@ describe("resolveMultipleSkills", () => {
 		expect(result.resolved.size).toBe(2)
 		expect(result.notFound).toEqual([])
 		expect(result.resolved.get("frontend")).toContain("router, not a rulebook")
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("should handle partial success - some skills not found", () => {
@@ -115,7 +115,7 @@ describe("resolveMultipleSkills", () => {
 		expect(result.resolved.size).toBe(2)
 		expect(result.notFound).toEqual(["nonexistent", "another-missing"])
 		expect(result.resolved.get("frontend")).toContain("router, not a rulebook")
-		expect(result.resolved.get("playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("playwright")).toContain("Browser Automation")
 	})
 
 	it("should handle empty array", () => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-discovery.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-discovery.ts
@@ -39,7 +39,7 @@ export function clearSkillCache(): void {
 }
 
 export async function getAllSkills(options?: SkillResolutionOptions): Promise<LoadedSkill[]> {
-	const browserProvider = options?.browserProvider ?? "playwright"
+	const browserProvider = options?.browserProvider ?? "openchrome-aside"
 	const teamModeEnabled = options?.teamModeEnabled ?? false
 	const directory = options?.directory ?? ""
 	const cacheKey = `${directory}:${browserProvider}:${teamModeEnabled ? "team-on" : "team-off"}`
@@ -81,13 +81,20 @@ export async function getAllSkills(options?: SkillResolutionOptions): Promise<Lo
 	// Provider-gated skill names that should be filtered based on browserProvider
 	const providerGatedSkillNames = new Set(["agent-browser", "playwright"])
 
+	const activeBrowserSkillName =
+		browserProvider === "agent-browser"
+			? "agent-browser"
+			: browserProvider === "dev-browser"
+				? "dev-browser"
+				: "playwright"
+
 	// Filter discovered skills to exclude provider-gated names that don't match the selected provider
 	const filteredDiscoveredSkills = discoveredSkills.filter((skill) => {
 		if (!providerGatedSkillNames.has(skill.name)) {
 			return true
 		}
-		// For provider-gated skills, only include if it matches the selected provider
-		return skill.name === browserProvider
+		// For provider-gated skills, only include if it matches the active browser skill name
+		return skill.name === activeBrowserSkillName
 	})
 
 	const discoveredNames = new Set(filteredDiscoveredSkills.map((skill) => skill.name))

--- a/packages/skills-loader-core/src/types.ts
+++ b/packages/skills-loader-core/src/types.ts
@@ -5,7 +5,7 @@ export type { CommandDefinition }
 
 export type SkillMcpConfig = Record<string, ClaudeCodeMcpServer>
 
-export type BrowserAutomationProvider = "playwright" | "agent-browser" | "dev-browser" | "playwright-cli"
+export type BrowserAutomationProvider = "playwright" | "agent-browser" | "dev-browser" | "playwright-cli" | "openchrome-aside"
 
 export interface GitMasterConfig {
   readonly commit_footer?: boolean | string


### PR DESCRIPTION
## What

Adds a new `openchrome-aside` value for `browser_automation_engine.provider` and makes it the **default**. It backs the built-in browser skill (canonical name `playwright`, so existing triggers keep working) with a tiered stack:

1. **aside** — LLM ask mode (`aside "<task>"`) as the primary path
2. **openchrome** — deterministic real Chrome via the `oc` CLI
3. **Playwright MCP** — always-available `npx` fallback

## Why

Requested: make our e2e/browser tooling default to openchrome + aside, leveraging aside's connected LLM ask mode. The tiered design keeps zero-setup behaviour — users without aside/openchrome fall back to Playwright MCP automatically, so nothing breaks.

## Zero-breakage gating fix (the important bit)

Flipping the default surfaced a latent bug: `filterProviderGatedSkills` compared `skill.name === browserProvider`, so once the default was no longer literally `playwright`, a user's own `playwright` SKILL.md would be **silently dropped**. Fixed in both gating copies (`skill-context.ts` and `skill-discovery.ts`) with a provider to rendered-skill-name map, guarded by a regression test that fails on the old gating and passes on the fix.

Six default sources now consistently resolve `openchrome-aside`: the Zod `.default`, `skill-context.ts`, the `createBuiltinSkills` internal default, `skill-discovery.ts`, and the `agent-config-handler` + `command-config-handler` config-pipeline handlers.

## Commits

1. `feat(skills):` core — provider, tiered skill, selection branch, gating fix, defaults
2. `feat(config):` handler default consistency (agent + command config)
3. `docs(reference):` docs + regenerated schema

## QA / evidence

- TDD RED to GREEN on every behaviour change (enum, skill, selection, six default flips, both gating fixes, both handlers).
- `bun run build` **succeeds** on this branch; blast-radius suite **505 pass / 0 fail**; shim-inventory audit passes; LSP clean on changed files.
- Real-surface QA, two layers, both in isolated XDG sandboxes:
  1. Drove the unmocked `createSkillContext` / `createBuiltinSkills` / schema — the default resolves to the tiered `playwright` skill with the aside / openchrome / Playwright MCP tiers, and a user's own `playwright` SKILL.md survives.
  2. Booted **real opencode 1.18.1** with the freshly-built plugin — the plugin loaded and `browser_automation_engine.provider: "openchrome-aside"` was accepted into the merged config with no validation error; plugin init completed.
  - Isolation proof: real `opencode.db` session count unchanged across both.
- Independent reviewer pass: **NO BLOCKERS**.

## Notes

- `mcpConfig` declares only Playwright MCP (always available via npx). aside and openchrome are driven via their CLIs (`aside`, `oc`), which the skill detects with `command -v` before use.
- Evidence recorded locally under `.omo/evidence/20260715-openchrome-aside/` (gitignored).

Holding merge per request.
