### PR TITLE
fix(glob): keep the no-rg fallback on find

### DIFF
--- a/packages/omo-opencode/src/tools/glob/cli.test.ts
+++ b/packages/omo-opencode/src/tools/glob/cli.test.ts
@@ -225,4 +225,29 @@ describe("runRgFiles", () => {
     })
     expect(spawnMock).toHaveBeenCalled()
   })
+
+  if (process.platform !== "win32") {
+    it(
+      "#given GNU grep is the discovery fallback #when glob runs #then it executes find instead of passing find flags to grep",
+      async () => {
+        const commands: string[][] = []
+        const spawnMock = mock((command: string[], _options?: SpawnOptions): SpawnedProcess => {
+          commands.push(command)
+          return createSpawnedProcess(0)
+        })
+
+        const result = await runRgFiles(
+          { pattern: "*.ts", paths: ["."], timeout: 1000 },
+          { path: "/usr/bin/grep", backend: "grep" },
+          spawnMock
+        )
+
+        expect(result.error).toBeUndefined()
+        expect(commands).toHaveLength(1)
+        expect(commands[0]?.[0]).toBe("find")
+        expect(commands[0]).toContain("-maxdepth")
+        expect(commands[0]?.[0]).not.toBe("/usr/bin/grep")
+      }
+    )
+  }
 })

--- a/packages/omo-opencode/src/tools/glob/cli.ts
+++ b/packages/omo-opencode/src/tools/glob/cli.ts
@@ -139,7 +139,7 @@ async function runRgFilesInternal(
     const args = buildFindArgs(options)
     const paths = options.paths?.length ? options.paths : ["."]
     cwd = paths[0] || "."
-    command = [cli.path, ...args]
+    command = ["find", ...args]
   }
 
   try {


### PR DESCRIPTION
## Summary

Fix the Unix glob fallback used when ripgrep is unavailable. The fallback already builds GNU `find` arguments, but it accidentally executed the discovered `grep` binary with those arguments, producing errors such as `grep: invalid max count` instead of returning files.

This branch is now based directly on `dev` and contains only the single glob fix commit.

## Changes

- Execute `find` directly for the non-Windows no-ripgrep fallback.
- Add a regression test proving the grep discovery sentinel is not invoked with `find`-specific flags such as `-maxdepth`.

## QA & Evidence

- **Focused regression:** `bun test packages/omo-opencode/src/tools/glob/cli.test.ts`
  - Observed after unstacking: **22 passed, 0 failed**.
- **Type safety:** `bun run typecheck`
  - Observed after unstacking: passed.
- **Build:** `bun run build`
  - Observed after unstacking: passed. The build regenerated the already-known stale Codex installer version artifact from `dev`; that unrelated generated diff was intentionally not included.
- **Full repository gate:** `env -u OMO_DISABLE_POSTHOG -u OMO_SEND_ANONYMOUS_TELEMETRY bun test --only-failures`
  - Observed after unstacking: **11,491 passed, 3 skipped, 2 failed**.
  - Both failures are outside this PR's two-file diff and reproduce the current `dev` baseline gaps previously isolated in #6137: the stale generated Codex installer version and the Bun transcript-module mock interaction.
- **Real OpenCode QA:** isolated `opencode run --format json` with the local plugin and a fake provider, with ripgrep unavailable.
  - Observed: the glob tool returned the target file; `find` ran with `-maxdepth`; grep did not receive find flags; the localized grep error was absent.
  - Local sanitized artifacts: `.omo/evidence/20260716-glob-find-fallback/`.

## Scope and risk

- Final PR scope: one commit, two glob files.
- The Windows PowerShell fallback is unchanged.
- This remains a draft while the unrelated `dev` baseline failures prevent a fully green repository gate.