### PR TITLE
fix(lsp): bound MCP startup before model calls

### DIFF
--- a/packages/lsp-daemon/src/proxy.ts
+++ b/packages/lsp-daemon/src/proxy.ts
@@ -12,13 +12,17 @@ import { type DaemonPaths, daemonPaths } from "./paths.js";
 export interface ProxyOptions {
 	input?: Readable;
 	output?: Writable;
+	stderr?: Writable;
 	paths?: DaemonPaths;
 	context?: DaemonToolContext;
 	cwd?: string;
 	env?: Record<string, string | undefined>;
 	homeDir?: string;
 	ensure?: CallToolOptions["ensure"];
+	startupTimeoutMs?: number;
 }
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
 
 interface ToolCall {
 	id: JsonRpcId;
@@ -29,10 +33,34 @@ interface ToolCall {
 export async function runMcpStdioProxy(options: ProxyOptions = {}): Promise<void> {
 	const input = options.input ?? process.stdin;
 	const output = options.output ?? process.stdout;
+	const stderr = options.stderr ?? process.stderr;
+	const startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
 	const lifecycleController = new AbortController();
 	const abortFromInput = (): void => lifecycleController.abort();
+	let startupExpired = false;
+	let startupTimer: ReturnType<typeof setTimeout> | undefined;
+	const clearStartupWatchdog = (): void => {
+		if (startupTimer === undefined) return;
+		clearTimeout(startupTimer);
+		startupTimer = undefined;
+	};
 	input.once("end", abortFromInput);
 	input.once("close", abortFromInput);
+	if (startupTimeoutMs > 0) {
+		startupTimer = setTimeout(() => {
+			startupExpired = true;
+			input.destroy();
+			try {
+				stderr.write(`[lsp-daemon] no MCP request received within ${startupTimeoutMs}ms; exiting\n`);
+			} catch (error) {
+				if (stderr !== process.stderr) {
+					process.stderr.write(
+						`[lsp-daemon] startup diagnostic failed: ${error instanceof Error ? error.message : String(error)}\n`,
+					);
+				}
+			}
+		}, startupTimeoutMs);
+	}
 
 	try {
 		const paths = options.paths ?? daemonPaths();
@@ -55,19 +83,26 @@ export async function runMcpStdioProxy(options: ProxyOptions = {}): Promise<void
 			input,
 			output,
 			idleTimeoutMs: 0,
-			handler: (request, requestOptions) =>
-				runWithRequestContext(context, () => handleProxyRequest(request, requestOptions)),
+			handler: (request, requestOptions) => {
+				clearStartupWatchdog();
+				return runWithRequestContext(context, () => handleProxyRequest(request, requestOptions));
+			},
 			handlerOptions: callOptions,
 			onHandlerError: (error: unknown) => {
-				process.stderr.write(
-					`[lsp-daemon] proxy error: ${error instanceof Error ? error.message : String(error)}\n`,
-				);
+				stderr.write(`[lsp-daemon] proxy error: ${error instanceof Error ? error.message : String(error)}\n`);
 			},
 		});
+	} catch (error) {
+		if (!startupExpired || !isPrematureCloseError(error)) throw error;
 	} finally {
+		if (startupTimer !== undefined) clearTimeout(startupTimer);
 		input.removeListener("end", abortFromInput);
 		input.removeListener("close", abortFromInput);
 	}
+}
+
+function isPrematureCloseError(error: unknown): boolean {
+	return error instanceof Error && Reflect.get(error, "code") === "ERR_STREAM_PREMATURE_CLOSE";
 }
 
 async function handleProxyRequest(parsed: unknown, callOptions: CallToolOptions): Promise<JsonRpcResponse | undefined> {

--- a/packages/lsp-daemon/test/proxy-startup-watchdog.test.ts
+++ b/packages/lsp-daemon/test/proxy-startup-watchdog.test.ts
@@ -1,0 +1,169 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DaemonPaths } from "../src/paths.js";
+import { runMcpStdioProxy } from "../src/proxy.js";
+import { daemonTestPaths } from "./daemon-path-fixture.js";
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of tempDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("mcp stdio proxy startup watchdog", () => {
+	it("#given Codex spawns the proxy but sends no initialize bytes #when startup expires #then the proxy exits instead of blocking the turn forever", async () => {
+		const input = new PassThrough();
+		const stderrChunks: string[] = [];
+
+		await bounded(
+			runMcpStdioProxy({
+				input,
+				output: collectingOutput([]),
+				stderr: collectingOutput(stderrChunks),
+				paths: tempPaths(),
+				ensure: noSpawn,
+				startupTimeoutMs: 20,
+			}),
+			"proxy did not settle after its MCP startup deadline",
+		);
+
+		expect(input.destroyed).toBe(true);
+		expect(stderrChunks.join("")).toContain("no MCP request received within 20ms");
+	});
+
+	it("#given the parent sends only a partial MCP frame #when startup expires #then incomplete bytes do not disable the watchdog", async () => {
+		const input = new PassThrough();
+		const stderrChunks: string[] = [];
+		const proxy = runMcpStdioProxy({
+			input,
+			output: collectingOutput([]),
+			stderr: collectingOutput(stderrChunks),
+			paths: tempPaths(),
+			ensure: noSpawn,
+			startupTimeoutMs: 20,
+		});
+		input.write('{"jsonrpc":"2.0"');
+
+		await bounded(proxy, "partial MCP bytes disabled the startup watchdog");
+
+		expect(input.destroyed).toBe(true);
+		expect(stderrChunks.join("")).toContain("no MCP request received within 20ms");
+	});
+
+	it("#given the diagnostic stream throws #when startup expires #then diagnostic failure cannot prevent proxy shutdown", async () => {
+		vi.useFakeTimers();
+		const input = new PassThrough();
+		const proxy = runMcpStdioProxy({
+			input,
+			output: collectingOutput([]),
+			stderr: new Writable({
+				write(): void {
+					throw new Error("synthetic diagnostic failure");
+				},
+			}),
+			paths: tempPaths(),
+			ensure: noSpawn,
+			startupTimeoutMs: 20,
+		});
+
+		try {
+			await vi.advanceTimersByTimeAsync(20);
+			await bounded(proxy, "diagnostic failure prevented proxy shutdown");
+			expect(input.destroyed).toBe(true);
+		} finally {
+			input.destroy();
+			vi.useRealTimers();
+		}
+	});
+
+	it("#given the first MCP request arrives before startup expires #when the proxy becomes idle #then the startup watchdog stays disabled", async () => {
+		const input = new PassThrough();
+		const outputChunks: string[] = [];
+		const responseWritten = deferred();
+		const stderrChunks: string[] = [];
+		const proxy = runMcpStdioProxy({
+			input,
+			output: collectingOutput(outputChunks, responseWritten.resolve),
+			stderr: collectingOutput(stderrChunks),
+			paths: tempPaths(),
+			ensure: noSpawn,
+			startupTimeoutMs: 20,
+		});
+		input.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} })}\n`);
+		await bounded(responseWritten.promise, "proxy did not answer initialize before its startup deadline");
+
+		expect(await settlesWithin(proxy, 40)).toBe(false);
+		expect(input.destroyed).toBe(false);
+		expect(outputChunks.join("")).toContain('"id":1');
+		expect(stderrChunks).toEqual([]);
+
+		input.end();
+		await bounded(proxy, "initialized proxy did not settle after input ended");
+	});
+});
+
+function tempPaths(): DaemonPaths {
+	const directory = mkdtempSync(join(tmpdir(), "lsp-daemon-proxy-startup-"));
+	tempDirectories.push(directory);
+	const paths = daemonTestPaths(directory);
+	mkdirSync(paths.dir, { recursive: true });
+	writeFileSync(paths.auth, "proxy-startup-token\n", { mode: 0o600 });
+	return paths;
+}
+
+function collectingOutput(chunks: string[], afterWrite?: () => void): Writable {
+	return new Writable({
+		write(chunk, _encoding, callback): void {
+			chunks.push(chunk.toString());
+			afterWrite?.();
+			callback();
+		},
+	});
+}
+
+function deferred(): { readonly promise: Promise<void>; resolve(): void } {
+	let resolvePromise: (() => void) | undefined;
+	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: () => resolvePromise?.() };
+}
+
+async function bounded<T>(promise: Promise<T>, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error(message)), 1_000);
+				timer.unref();
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise.then(
+				() => true,
+				() => true,
+			),
+			new Promise<boolean>((resolve) => {
+				timer = setTimeout(() => resolve(false), timeoutMs);
+				timer.unref();
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+const noSpawn = (): Promise<void> => Promise.resolve();

--- a/packages/lsp-daemon/test/proxy.test.ts
+++ b/packages/lsp-daemon/test/proxy.test.ts
@@ -167,7 +167,7 @@ describe("mcp stdio proxy", () => {
 		expect((responses[0]?.["error"] as { code: number }).code).toBe(-32700);
 	});
 
-	it("#given an idle proxy #when the next request arrives after ten minutes #then it still responds", async () => {
+	it("#given an initialized idle proxy #when the next request arrives after ten minutes #then it still responds", async () => {
 		vi.useFakeTimers();
 		try {
 			const paths = tempPaths();
@@ -180,12 +180,14 @@ describe("mcp stdio proxy", () => {
 				ensure: noSpawn,
 			});
 
+			input.write(`${JSON.stringify({ jsonrpc: "2.0", id: 6, method: "initialize", params: {} })}\n`);
 			await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1);
-			input.end(`${JSON.stringify({ jsonrpc: "2.0", id: 6, method: "initialize", params: {} })}\n`);
+			input.end(`${JSON.stringify({ jsonrpc: "2.0", id: 7, method: "initialize", params: {} })}\n`);
 			await server;
 
 			const responses = parseResponses(out);
 			expect((responses[0]?.["result"] as { serverInfo?: unknown }).serverInfo).toBeDefined();
+			expect((responses[1]?.["result"] as { serverInfo?: unknown }).serverInfo).toBeDefined();
 		} finally {
 			vi.useRealTimers();
 		}

--- a/packages/omo-codex/plugin/.mcp.json
+++ b/packages/omo-codex/plugin/.mcp.json
@@ -20,7 +20,8 @@
 		"lsp": {
 			"command": "node",
 			"args": ["../../lsp-daemon/dist/cli.js", "mcp"],
-			"cwd": "."
+			"cwd": ".",
+			"startup_timeout_sec": 10
 		}
 	}
 }

--- a/packages/omo-codex/plugin/components/lsp/.mcp.json
+++ b/packages/omo-codex/plugin/components/lsp/.mcp.json
@@ -3,7 +3,8 @@
 		"lsp": {
 			"command": "node",
 			"args": ["../../../../lsp-daemon/dist/cli.js", "mcp"],
-			"cwd": "."
+			"cwd": ".",
+			"startup_timeout_sec": 10
 		}
 	}
 }

--- a/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
@@ -44,6 +44,7 @@ describe("plugin package metadata", () => {
 		expect(postCompactCommand).toBe(`node "${pluginRoot}/dist/cli.js" hook post-compact`);
 		expect(lspServer?.command).toBe("node");
 		expect(lspServer?.args).toEqual(["../../../../lsp-daemon/dist/cli.js", "mcp"]);
+		expect(lspServer?.startup_timeout_sec).toBe(10);
 		expect(cliSource).not.toContain("./lazy-lsp-mcp.js");
 		expect(cliSource).toContain("resolveLspDaemonCliPath");
 		expect(daemonCliPathSource).toContain("@code-yeongyu/lsp-daemon/cli");

--- a/packages/omo-codex/plugin/test/mcp-research-servers.test.mjs
+++ b/packages/omo-codex/plugin/test/mcp-research-servers.test.mjs
@@ -20,4 +20,5 @@ test("#given aggregate MCP config #when inspected #then registers research MCPs 
 	assert.equal(Object.hasOwn(mcp.mcpServers, "ast_grep"), false);
 	assert.deepEqual(mcp.mcpServers.codegraph.args, ["components/codegraph/dist/serve.js"]);
 	assert.equal(mcp.mcpServers.codegraph.required, false);
+	assert.equal(mcp.mcpServers.lsp.startup_timeout_sec, 10);
 });


### PR DESCRIPTION
## Summary

Codex could receive a turn from Senpi and then wait forever before the model call when the LSP MCP child was spawned but never received a complete initialization request. This PR bounds that pre-model state at both layers: the LSP proxy exits after 10 seconds without a complete first request, and both shipped Codex LSP manifests declare a 10-second MCP startup timeout.

Once the proxy parses its first request, the watchdog is permanently disabled, so initialized LSP sessions retain their existing long-idle behavior.

## Changes

- Add a first-complete-request watchdog to the LSP stdio proxy. No input and partial JSON frames expire after 10 seconds, input shutdown is guaranteed before best-effort diagnostics, and only watchdog-owned premature-close errors are suppressed.
- Add focused regression coverage for no-byte startup, partial frames, throwing diagnostic streams, and initialized sessions that remain idle beyond the startup window.
- Set `startup_timeout_sec: 10` in both the aggregate and component Codex LSP manifests, with contract assertions that prevent either distribution path from losing the bound.

## QA & Evidence

- **What was tested:** The complete `packages/lsp-daemon` test suite after the final reliability fixes.
  **Observed result:** 18 files and 128 tests passed.
  **Artifact:** `.omo/evidence/20260716-lsp-mcp-startup-timeout/lsp-daemon-full-test-final.txt`
  **Why sufficient:** Covers proxy lifecycle, transport behavior, daemon ownership, and the new startup edge cases together.

- **What was tested:** Built proxy processes with no bytes, a partial JSON frame, and a valid initialize request followed by more than 10 seconds of idle time.
  **Observed result:** No-byte and partial-frame processes exited cleanly with the diagnostic at about 10.05 seconds; the initialized process remained alive until EOF.
  **Artifacts:** `.omo/evidence/20260716-lsp-mcp-startup-timeout/real-lsp-startup-watchdog-final.txt`, `.omo/evidence/20260716-lsp-mcp-startup-timeout/manual-p0-initialize-idle-tmux.txt`
  **Why sufficient:** Directly proves the incident state is bounded without shortening valid initialized sessions.

- **What was tested:** Both shipped Codex manifests and their package contract suites.
  **Observed result:** Both manifests parsed with `lsp.startup_timeout_sec === 10`; aggregate and component contract tests passed.
  **Artifacts:** `.omo/evidence/20260716-lsp-mcp-startup-timeout/manual-p1-manifest-parse.txt`, `.omo/evidence/20260716-lsp-mcp-startup-timeout/manifest-tests-final.txt`
  **Why sufficient:** Prevents either Codex installation path from retaining an unbounded host-side startup wait.

- **What was tested:** A real isolated `codex app-server` turn using only this plugin and a local mock model.
  **Observed result:** The turn completed; `sessionStart`, `userPromptSubmit`, and `stop` hooks fired; the real `~/.codex/config.toml` hash was unchanged.
  **Artifact:** `.omo/evidence/20260716-lsp-mcp-startup-timeout/codex-app-server-plugin-final.txt`
  **Why sufficient:** Exercises the actual Codex harness path without production API or profile mutation.

- **What was tested:** A real isolated Senpi package/install/load run using the local mock provider.
  **Observed result:** PASS; the extension loaded, repeated LSP status calls reused the authenticated daemon owner, the real Senpi state hash was unchanged, and all QA-owned resources were removed.
  **Artifact:** `.omo/evidence/20260716-lsp-mcp-startup-timeout/senpi-lsp-e2e/result.json`
  **Why sufficient:** Covers the originating Senpi-to-Codex integration surface and daemon reuse behavior.

- **What was tested:** Codex compatibility gate.
  **Observed result:** One full run passed 483/483. Later reruns intermittently hit an unrelated existing CodeGraph environment test's hard 5-second timeout; that exact test passed alone in 2.7 seconds.
  **Artifacts:** `.omo/evidence/20260716-lsp-mcp-startup-timeout/test-codex-final.txt`, `.omo/evidence/20260716-lsp-mcp-startup-timeout/codegraph-flake-rerun.txt`
  **Why sufficient:** Establishes a complete green gate while documenting the independent timing flake for clean-environment CI confirmation.

## Risks & Residuals

- A parent that sends its first complete MCP request after 10 seconds will now see startup fail instead of waiting indefinitely. This is intentional and is independently enforced by Codex's matching manifest deadline.
- The watchdog is cleared only after parsing a complete first request, so slow partial writers remain bounded while normal initialized sessions preserve unlimited idle time.
- The unrelated CodeGraph 5-second timeout is not changed by this PR. It passed both in the recorded full gate and in isolation; CI is the final clean-environment confirmation.
- Sensitive incident databases, raw environment dumps, authentication data, and private logs were intentionally omitted. The evidence directory contains sanitized reviewer-readable receipts.

## Related Incident

Senpi session `019f68be-a986-724a-9fc0-72c48b106068`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound LSP MCP startup to 10 seconds to prevent Codex from hanging before model calls. Initialized sessions keep unlimited idle time.

- **Bug Fixes**
  - Added a startup watchdog to `lsp-daemon` MCP stdio proxy; exits after 10s if no complete first request; partial frames don’t disable it; cleared on first parsed request.
  - Set `startup_timeout_sec: 10` in both Codex LSP `.mcp.json` manifests to enforce the same bound.
  - Added focused tests for no bytes, partial frames, diagnostic stream failures, and long-idle sessions after initialize.

<sup>Written for commit 9a00d78878b2afde113eac5187fe4fcb13824a55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

