### PR TITLE
fix(opencode): stop continuation rearming

### DIFF
--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -189,6 +189,14 @@ ${todoList}`
     return
   }
 
+  if (injectionState?.continuationBlockReason) {
+    log(`[${HOOK_NAME}] Skipped injection: continuation paused at turn boundary`, {
+      sessionID,
+      reason: injectionState.continuationBlockReason,
+    })
+    return
+  }
+
   if (injectionState) {
     injectionState.inFlight = true
   }
@@ -234,6 +242,9 @@ ${todoList}`
           injectionState.inFlight = false
           injectionState.lastInjectedAt = Date.now()
           injectionState.awaitingPostInjectionProgressCheck = true
+          injectionState.continuationResponseObserved = false
+          injectionState.continuationBlockReason = undefined
+          injectionState.pendingUserMessageID = undefined
           injectionState.consecutiveFailures = 0
         }
         return
@@ -253,6 +264,9 @@ ${todoList}`
       injectionState.inFlight = false
       injectionState.lastInjectedAt = Date.now()
       injectionState.awaitingPostInjectionProgressCheck = true
+      injectionState.continuationResponseObserved = false
+      injectionState.continuationBlockReason = undefined
+      injectionState.pendingUserMessageID = undefined
       injectionState.consecutiveFailures = 0
     }
   } catch (error) {

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.ts
@@ -85,6 +85,9 @@ export function createTodoContinuationHandler(args: {
         state.lastIncompleteCount = undefined
         state.lastInjectedAt = undefined
         state.awaitingPostInjectionProgressCheck = false
+        state.continuationResponseObserved = false
+        state.continuationBlockReason = undefined
+        state.pendingUserMessageID = undefined
         state.stagnationCount = 0
         state.consecutiveFailures = 0
         shouldCancelCountdown = true

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -219,6 +219,14 @@ export async function handleSessionIdle(args: {
     incompleteCount,
     todos,
   )
+  if (state.continuationBlockReason) {
+    log(`[${HOOK_NAME}] Skipped: continuation paused at turn boundary`, {
+      sessionID,
+      reason: state.continuationBlockReason,
+      hasProgressed: progressUpdate.hasProgressed,
+    })
+    return
+  }
   if (shouldStopForStagnation({ sessionID, incompleteCount, progressUpdate })) {
     return
   }

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
@@ -98,4 +98,120 @@ describe("handleNonIdleEvent", () => {
     expect(state.wasCancelled).toBe(true)
     expect(state.tokenLimitDetected).toBe(true)
   })
+
+  test("given a real user message after accepted continuation, records an interruption boundary", () => {
+    // given
+    const sessionID = "ses_real_user_interruption"
+    const state = sessionStateStore.getState(sessionID)
+    state.awaitingPostInjectionProgressCheck = true
+    state.countdownStartedAt = Date.now()
+
+    // when
+    handleNonIdleEvent({
+      eventType: "message.updated",
+      properties: {
+        sessionID,
+        info: { role: "user" },
+        parts: [{ type: "text", text: "Stop and inspect the context.", synthetic: false }],
+      },
+      sessionStateStore,
+    })
+
+    // then
+    expect(state.continuationBlockReason).toBe("user-interruption")
+    expect(state.countdownStartedAt).toBeUndefined()
+  })
+
+  test("given a synthetic message after accepted continuation, does not record a user interruption", () => {
+    // given
+    const sessionID = "ses_synthetic_not_interruption"
+    const state = sessionStateStore.getState(sessionID)
+    state.awaitingPostInjectionProgressCheck = true
+
+    // when
+    handleNonIdleEvent({
+      eventType: "message.updated",
+      properties: {
+        sessionID,
+        info: { role: "user" },
+        parts: [{ type: "text", text: "internal wake", synthetic: true }],
+      },
+      sessionStateStore,
+    })
+
+    // then
+    expect(state.continuationBlockReason).toBeUndefined()
+  })
+
+  test("given OpenCode splits an internal user message across events, waits for synthetic part provenance", () => {
+    // given
+    const sessionID = "ses_split_internal_message"
+    const messageID = "msg_split_internal"
+    const state = sessionStateStore.getState(sessionID)
+    state.awaitingPostInjectionProgressCheck = true
+
+    // when
+    handleNonIdleEvent({
+      eventType: "message.updated",
+      properties: { sessionID, info: { id: messageID, role: "user" } },
+      sessionStateStore,
+    })
+
+    // then
+    expect(state.continuationBlockReason).toBeUndefined()
+
+    // when
+    handleNonIdleEvent({
+      eventType: "message.part.updated",
+      properties: {
+        sessionID,
+        part: {
+          messageID,
+          type: "text",
+          text: `internal wake\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+          synthetic: true,
+        },
+      },
+      sessionStateStore,
+    })
+
+    // then
+    expect(state.continuationBlockReason).toBeUndefined()
+  })
+
+  test("given OpenCode splits a genuine user message across events, records interruption from its part", () => {
+    // given
+    const sessionID = "ses_split_genuine_message"
+    const messageID = "msg_split_genuine"
+    const state = sessionStateStore.getState(sessionID)
+    state.awaitingPostInjectionProgressCheck = true
+
+    // when
+    handleNonIdleEvent({
+      eventType: "message.updated",
+      properties: { sessionID, info: { id: messageID, role: "user" } },
+      sessionStateStore,
+    })
+
+    // then
+    expect(state.continuationBlockReason).toBeUndefined()
+
+    // when
+    handleNonIdleEvent({
+      eventType: "message.part.updated",
+      properties: {
+        sessionID,
+        part: {
+          messageID,
+          type: "text",
+          text: "Stop and inspect the context.",
+          synthetic: false,
+        },
+      },
+      sessionStateStore,
+    })
+
+    // then
+    expect(state.continuationBlockReason).toBe("user-interruption")
+  })
 })

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.ts
@@ -6,6 +6,7 @@ import { isSystemDirective } from "../../shared/system-directive"
 
 import { COUNTDOWN_GRACE_PERIOD_MS, HOOK_NAME } from "./constants"
 import type { SessionStateStore } from "./session-state"
+import type { SessionState } from "./types"
 
 function isEventPart(value: unknown): value is InternalInitiatorTextPartLike {
   if (typeof value !== "object" || value === null) {
@@ -43,6 +44,53 @@ function hasInternalSystemDirective(parts: InternalInitiatorTextPartLike[] | und
   )
 }
 
+function hasAcceptedContinuationLifecycle(state: SessionState): boolean {
+  return state.awaitingPostInjectionProgressCheck === true
+    || state.continuationResponseObserved === true
+    || state.continuationBlockReason === "directive-response"
+}
+
+function markContinuationResponseObserved(state: SessionState | undefined): void {
+  if (state?.awaitingPostInjectionProgressCheck === true) {
+    state.continuationResponseObserved = true
+  }
+}
+
+function pauseForGenuineUserInterruption(args: {
+  state: SessionState
+  sessionID: string
+  sessionStateStore: SessionStateStore
+}): void {
+  const { state, sessionID, sessionStateStore } = args
+  state.continuationBlockReason = "user-interruption"
+  state.continuationResponseObserved = false
+  state.pendingUserMessageID = undefined
+  state.abortDetectedAt = undefined
+  state.wasCancelled = false
+  state.tokenLimitDetected = false
+  sessionStateStore.cancelCountdown(sessionID)
+  log(`[${HOOK_NAME}] Paused continuation after genuine user interruption`, { sessionID })
+}
+
+function resolveUpdatedPart(
+  properties: Record<string, unknown> | undefined,
+): (InternalInitiatorTextPartLike & { messageID?: string }) | undefined {
+  const part = properties?.part
+  if (!isEventPart(part)) {
+    return undefined
+  }
+
+  const messageID = (part as Record<string, unknown>).messageID
+  if (messageID !== undefined && typeof messageID !== "string") {
+    return undefined
+  }
+
+  return {
+    ...part,
+    ...(messageID ? { messageID } : {}),
+  }
+}
+
 export function handleNonIdleEvent(args: {
   eventType: string
   properties: Record<string, unknown> | undefined
@@ -68,6 +116,19 @@ export function handleNonIdleEvent(args: {
         return
       }
       const state = sessionStateStore.getExistingState(sessionID)
+      const messageID = typeof info?.id === "string" ? info.id : undefined
+      if (parts === undefined && state && hasAcceptedContinuationLifecycle(state) && messageID) {
+        state.pendingUserMessageID = messageID
+        log(`[${HOOK_NAME}] Deferred user interruption classification until message part`, {
+          sessionID,
+          messageID,
+        })
+        return
+      }
+      if (state && hasAcceptedContinuationLifecycle(state)) {
+        pauseForGenuineUserInterruption({ state, sessionID, sessionStateStore })
+        return
+      }
       if (state?.countdownStartedAt) {
         const elapsed = Date.now() - state.countdownStartedAt
         if (elapsed < COUNTDOWN_GRACE_PERIOD_MS) {
@@ -87,6 +148,7 @@ export function handleNonIdleEvent(args: {
     if (role === "assistant") {
       const state = sessionStateStore.getExistingState(sessionID)
       if (state) {
+        markContinuationResponseObserved(state)
         state.abortDetectedAt = undefined
         state.wasCancelled = false
       }
@@ -103,6 +165,27 @@ export function handleNonIdleEvent(args: {
     if (targetSessionID) {
       const state = sessionStateStore.getExistingState(targetSessionID)
       if (state) {
+        const part = resolveUpdatedPart(properties)
+        if (part?.messageID && part.messageID === state.pendingUserMessageID) {
+          state.pendingUserMessageID = undefined
+          if (isSyntheticOrInternalOnlyTextParts([part])) {
+            log(`[${HOOK_NAME}] Ignoring synthetic/internal split user message`, {
+              sessionID: targetSessionID,
+              messageID: part.messageID,
+            })
+          } else if (hasAcceptedContinuationLifecycle(state)) {
+            pauseForGenuineUserInterruption({
+              state,
+              sessionID: targetSessionID,
+              sessionStateStore,
+            })
+          }
+          return
+        }
+        const info = properties?.info as Record<string, unknown> | undefined
+        if (info?.role === "assistant") {
+          markContinuationResponseObserved(state)
+        }
         state.abortDetectedAt = undefined
       }
       sessionStateStore.cancelCountdown(targetSessionID)
@@ -115,6 +198,10 @@ export function handleNonIdleEvent(args: {
     if (sessionID) {
       const state = sessionStateStore.getExistingState(sessionID)
       if (state) {
+        const info = properties?.info as Record<string, unknown> | undefined
+        if (info?.role === "assistant") {
+          markContinuationResponseObserved(state)
+        }
         state.abortDetectedAt = undefined
         state.wasCancelled = false
       }
@@ -128,6 +215,7 @@ export function handleNonIdleEvent(args: {
     if (sessionID) {
       const state = sessionStateStore.getExistingState(sessionID)
       if (state) {
+        markContinuationResponseObserved(state)
         state.abortDetectedAt = undefined
         state.wasCancelled = false
       }

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/session-state.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/session-state.test.ts
@@ -194,4 +194,65 @@ describe("createSessionStateStore", () => {
     expect(progressUpdate.progressSource).toBe("none")
     expect(progressUpdate.stagnationCount).toBe(1)
   })
+
+  test("given an observed continuation response without progress, blocks directive re-arming", () => {
+    // given
+    const sessionID = "ses-directive-response-block"
+    const state = sessionStateStore.getState(sessionID)
+    const todos = [
+      { id: "1", content: "Task 1", status: "pending", priority: "high" },
+    ]
+    sessionStateStore.trackContinuationProgress(sessionID, 1, todos)
+    state.awaitingPostInjectionProgressCheck = true
+    state.continuationResponseObserved = true
+
+    // when
+    sessionStateStore.trackContinuationProgress(sessionID, 1, todos)
+
+    // then
+    expect(state.continuationBlockReason).toBe("directive-response")
+    expect(state.continuationResponseObserved).toBe(false)
+  })
+
+  test("given a user interruption, preserves it over directive-response provenance", () => {
+    // given
+    const sessionID = "ses-user-interruption-priority"
+    const state = sessionStateStore.getState(sessionID)
+    const todos = [
+      { id: "1", content: "Task 1", status: "pending", priority: "high" },
+    ]
+    sessionStateStore.trackContinuationProgress(sessionID, 1, todos)
+    state.awaitingPostInjectionProgressCheck = true
+    state.continuationResponseObserved = true
+    state.continuationBlockReason = "user-interruption"
+
+    // when
+    sessionStateStore.trackContinuationProgress(sessionID, 1, todos)
+
+    // then
+    expect(state.continuationBlockReason).toBe("user-interruption")
+  })
+
+  test("given todo progress after an interruption, clears the continuation block", () => {
+    // given
+    const sessionID = "ses-progress-clears-interruption"
+    const state = sessionStateStore.getState(sessionID)
+    const initialTodos = [
+      { id: "1", content: "Task 1", status: "pending", priority: "high" },
+      { id: "2", content: "Task 2", status: "pending", priority: "medium" },
+    ]
+    sessionStateStore.trackContinuationProgress(sessionID, 2, initialTodos)
+    state.awaitingPostInjectionProgressCheck = true
+    state.continuationBlockReason = "user-interruption"
+
+    // when
+    const progressUpdate = sessionStateStore.trackContinuationProgress(sessionID, 1, [
+      { id: "1", content: "Task 1", status: "completed", priority: "high" },
+      { id: "2", content: "Task 2", status: "pending", priority: "medium" },
+    ])
+
+    // then
+    expect(progressUpdate.hasProgressed).toBe(true)
+    expect(state.continuationBlockReason).toBeUndefined()
+  })
 })

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/session-state.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/session-state.ts
@@ -160,6 +160,9 @@ export function createSessionStateStore(): SessionStateStore {
     if (hasProgressed) {
       state.stagnationCount = 0
       state.awaitingPostInjectionProgressCheck = false
+      state.continuationResponseObserved = false
+      state.continuationBlockReason = undefined
+      state.pendingUserMessageID = undefined
       return {
         previousIncompleteCount,
         previousStagnationCount,
@@ -180,6 +183,14 @@ export function createSessionStateStore(): SessionStateStore {
     }
 
     state.awaitingPostInjectionProgressCheck = false
+    if (
+      state.continuationResponseObserved === true
+      && state.continuationBlockReason !== "user-interruption"
+    ) {
+      state.continuationBlockReason = "directive-response"
+    }
+    state.continuationResponseObserved = false
+    state.pendingUserMessageID = undefined
     state.stagnationCount += 1
     return {
       previousIncompleteCount,
@@ -201,6 +212,9 @@ export function createSessionStateStore(): SessionStateStore {
     state.lastIncompleteCount = undefined
     state.stagnationCount = 0
     state.awaitingPostInjectionProgressCheck = false
+    state.continuationResponseObserved = false
+    state.continuationBlockReason = undefined
+    state.pendingUserMessageID = undefined
     state.allTodosCompletedAt = undefined
     trackedSession.lastCompletedCount = undefined
     trackedSession.lastTodoSnapshot = undefined

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -157,8 +157,10 @@ describe("todo-continuation-enforcer", () => {
     info: {
       id: string
       role: "user" | "assistant"
+      finish?: string
       error?: { name: string; data?: { message: string } }
     }
+    parts?: Array<{ type: string; text?: string; synthetic?: boolean }>
   }
 
   interface PromptRequestOptions {
@@ -1022,6 +1024,100 @@ describe("todo-continuation-enforcer", () => {
     // then
     expect(promptCalls).toHaveLength(MAX_STAGNATION_COUNT)
   }, { timeout: 60000 })
+
+  test("given a continuation response without todo progress, does not re-arm the directive", async () => {
+    // given
+    const sessionID = "main-directive-response-loop-breaker"
+    setMainSession(sessionID)
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), {})
+
+    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+    await fakeTimers.advanceBy(2500, true)
+    expect(promptCalls).toHaveLength(1)
+
+    // when
+    await hook.handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { sessionID, role: "assistant" } },
+      },
+    })
+    await fakeTimers.advanceBy(CONTINUATION_COOLDOWN_MS, true)
+    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+    await fakeTimers.advanceBy(2500, true)
+
+    // then
+    expect(promptCalls).toHaveLength(1)
+  }, { timeout: 30000 })
+
+  test("given a real user interruption after continuation, does not re-arm after the user turn", async () => {
+    // given
+    const sessionID = "main-user-interruption-loop-breaker"
+    setMainSession(sessionID)
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), {})
+
+    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+    await fakeTimers.advanceBy(2500, true)
+    expect(promptCalls).toHaveLength(1)
+
+    // when
+    await hook.handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: { sessionID, role: "user" },
+          parts: [{ type: "text", text: "Stop. Inspect the broken context first.", synthetic: false }],
+        },
+      },
+    })
+    await hook.handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { sessionID, role: "assistant" } },
+      },
+    })
+    await fakeTimers.advanceBy(CONTINUATION_COOLDOWN_MS, true)
+    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+    await fakeTimers.advanceBy(2500, true)
+
+    // then
+    expect(promptCalls).toHaveLength(1)
+  }, { timeout: 30000 })
+
+  test("given todo progress after a continuation response, permits the next continuation", async () => {
+    // given
+    const sessionID = "main-directive-response-progress"
+    setMainSession(sessionID)
+    let todos = [
+      { id: "1", content: "Task 1", status: "pending", priority: "high" },
+      { id: "2", content: "Task 2", status: "pending", priority: "medium" },
+    ]
+    const mockInput = createMockPluginInput()
+    mockInput.client.session.todo = async () => ({ data: todos })
+    const hook = createTodoContinuationEnforcer(mockInput, {})
+
+    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+    await fakeTimers.advanceBy(2500, true)
+    expect(promptCalls).toHaveLength(1)
+
+    // when
+    await hook.handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { sessionID, role: "assistant" } },
+      },
+    })
+    todos = [
+      { id: "1", content: "Task 1", status: "completed", priority: "high" },
+      { id: "2", content: "Task 2", status: "pending", priority: "medium" },
+    ]
+    await fakeTimers.advanceBy(CONTINUATION_COOLDOWN_MS, true)
+    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+    await fakeTimers.advanceBy(2500, true)
+
+    // then
+    expect(promptCalls).toHaveLength(2)
+  }, { timeout: 30000 })
 
   test("should skip idle handling while injection is in flight", async () => {
     //#given

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/types.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/types.ts
@@ -33,6 +33,9 @@ export interface SessionState {
   lastIncompleteCount?: number
   lastInjectedAt?: number
   awaitingPostInjectionProgressCheck?: boolean
+  continuationResponseObserved?: boolean
+  continuationBlockReason?: "directive-response" | "user-interruption"
+  pendingUserMessageID?: string
   inFlight?: boolean
   stagnationCount: number
   consecutiveFailures: number


### PR DESCRIPTION
## Summary

Stop `todo-continuation-enforcer` from re-arming its own directive after the directive receives an assistant response without todo progress. Also pause continuation when a genuine user turn interrupts the accepted continuation lifecycle, while preserving the existing progress and safety guards.

OpenCode reports synthetic user prompts in two shapes: some events carry parts inline, while current live sessions emit `message.updated` before a separate `message.part.updated` containing `synthetic:true`. This PR defers interruption classification until that matching part arrives so the hook's own directive is not mistaken for a real user interruption.

## Changes

- Track accepted continuation response provenance and durable block reasons per session.
- Promote a later genuine user turn to the higher-priority `user-interruption` block.
- Clear the block only when todo status genuinely progresses or the existing reset/cleanup paths run.
- Recheck the block immediately before dispatch to cover countdown races.
- Add regressions for directive-response recursion, genuine user interruption, progress resumption, and OpenCode's split message event ordering.

## QA & Evidence

- **What was tested:** Full `todo-continuation-enforcer` suite after rebasing onto current `dev`.
  - **Observed result:** 134 passed, 0 failed, 230 assertions.
  - **Artifact:** `.omo/evidence/20260716-issue-6109-continuation-rearm/post-rebase-full-hook-suite.log`
  - **Why sufficient:** Covers the new boundaries plus stagnation, in-flight, cooldown, pending-turn, abort, token-limit, compaction, background-task, and unanswered-question guards.
- **What was tested:** `cd packages/omo-opencode && bun run typecheck`.
  - **Observed result:** `tsgo --noEmit -p tsconfig.json` passed.
  - **Artifact:** `.omo/evidence/20260716-issue-6109-continuation-rearm/post-rebase-typecheck.log`
  - **Why sufficient:** Confirms the new session-state and event-shape contracts are type-correct.
- **What was tested:** Real OpenCode 1.17.13 server, local plugin source, real SSE lifecycle, real `todowrite`, and deterministic local OpenAI-compatible model under isolated `HOME`/`XDG_*` state.
  - **Observed result:** One directive before and after both boundaries, one pending todo, `directive-response` then `user-interruption` logs, live DB session count 5751 -> 5751.
  - **Artifacts:** `.omo/evidence/20260716-issue-6109-continuation-rearm/real-opencode-verdict.txt`, `hook-session.log`, `fake-model-branches.log`, `sse-events.log`
  - **Why sufficient:** Proves actual OpenCode event ordering and observable loop termination rather than only mocked hook calls.

## Risks & Residuals

- Future OpenCode event schema changes remain a compatibility risk. Both inline-parts and current split-parts shapes now have regression coverage.
- The optional programming skill `check-no-excuse-rules.ts` helper crashes under Bun while accessing `ts.ScriptTarget.Latest`; this tooling failure is captured in `no-excuse-check.log`. Typecheck, full tests, line-count review, diff checks, and real harness QA passed.
- PR #6118 was inspected read-only only. Its live head `410c133bd1606101b085c71b809850ae662f4d00` does not cover genuine user interruption and can indefinitely suppress continuation after legitimate directive-driven progress. This PR does not modify, comment on, push to, review, or merge #6118.

## Related Issues

Fixes #6109


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `todo-continuation-enforcer` from re-arming after an assistant reply with no TODO progress and pauses continuation when a real user message interrupts. Also handles OpenCode split message events to avoid misclassifying synthetic internal prompts as user turns. Fixes #6109.

- **Bug Fixes**
  - Track continuation lifecycle and block reason per session; prevent injection while blocked.
  - After accepted continuation, mark assistant replies; if no progress, set block to `directive-response`.
  - Promote real user turns to `user-interruption`, cancel countdowns, and only clear on actual TODO progress or existing reset paths.
  - Defer interruption classification until `message.part.updated` when needed; ignore synthetic/internal split messages.
  - Reset new fields (`continuationResponseObserved`, `continuationBlockReason`, `pendingUserMessageID`) on progress and cleanup; recheck block before dispatch to avoid races.
  - Added tests for directive-response recursion, genuine interruption, progress resumption, and split-event ordering.

<sup>Written for commit 425c37107142194c68d03e3462a3e3d45e4c115d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

