### PR TITLE
fix(hephaestus): GPT-5.6 waiting discipline + bounded re-validation in both editions

### DIFF
--- a/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md
+++ b/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md
@@ -25,7 +25,9 @@ Never speculate about code you have not read: verify with tools and re-read on e
 
 Explore -> Plan (`update_plan`, per Task Tracking) -> Implement -> Verify -> Manually QA.
 
-Implement surgically, matching codebase style (naming, indentation, imports, error handling) even when you would write it differently. omo-codex auto-runs LSP diagnostics after every edit and injects the result: any reported error is blocking until resolved. Verify with targeted tests and builds for changed behavior; if validation cannot run, say why and name the next best check.
+Implement surgically, matching codebase style (naming, indentation, imports, error handling) even when you would write it differently. omo-codex auto-runs LSP diagnostics after every edit and injects the result: any reported error is blocking until resolved. Verify with targeted tests and builds for changed behavior; if validation cannot run, say why and name the next best check. Re-run a validation command only when its inputs changed since its last green run; one full pass right before the final message replaces repeated identical reruns.
+
+Waiting is not free: a status poll replays the whole accumulated context through the model. Run a long command (install, build, suite, container, CI watch) to completion in ONE `exec` call with a timeout sized to the expected wait - or send output to a log file read once on a completion signal - never re-poll the same surface with empty reads or sub-minute waits. If two consecutive checks show no state change, double the wait or switch to a completion signal.
 
 # Subagents
 

--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts
@@ -61,6 +61,8 @@ Once you delegate exploration to background agents, do not search the same thing
 
 Independent tool calls run in the same response; serial is the exception and requires a real dependency. Each independent shell command is its own tool call - do not chain unrelated steps with \`;\` or \`&&\`. After every file edit, run \`lsp_diagnostics\` on every changed file in parallel.
 
+Waiting is not free: a status poll replays the whole accumulated context through the model. Run a long command (install, build, suite, CI watch) to completion in one call with a timeout sized to the expected wait - or send output to a log file read once on a completion signal - never re-poll the same surface with empty reads or sub-minute waits. If two consecutive checks show no state change, double the wait or switch to a completion signal.
+
 # Operating Loop
 
 **Explore -> Plan -> Implement -> Verify -> Manually QA.**
@@ -68,7 +70,7 @@ Independent tool calls run in the same response; serial is the exception and req
 - **Explore** per Discovery & Retrieval.
 - **Plan** with \`update_plan\` for non-trivial work: files to modify, specific changes, dependencies. Skip planning for the easiest 25%; never make single-step plans.
 - **Implement** surgically, matching codebase style - naming, indentation, imports, error handling - even when you would write it differently in a greenfield.
-- **Verify** with the most relevant validation available, in parallel where possible: \`lsp_diagnostics\` on changed files, targeted tests for changed behavior, build for affected packages. If validation cannot run, say why and name the next best check.
+- **Verify** with the most relevant validation available, in parallel where possible: \`lsp_diagnostics\` on changed files, targeted tests for changed behavior, build for affected packages. If validation cannot run, say why and name the next best check. Re-run a validation command only when its inputs changed since its last green run; one full pass at the end replaces repeated identical reruns.
 - **Manually QA** through the artifact's surface, then write the final message.
 
 # Manual QA Gate


### PR DESCRIPTION
## What changed

The same GPT-5.6 prompting-guide fixes that just landed in the ultrawork codex directive (#6146), applied to the Hephaestus GPT-5.6 prompts in **both editions**:

1. **Waiting discipline** - a status poll replays the whole accumulated context through the model. Long commands (installs, builds, suites, CI watch) run to completion in ONE sized call, or log to a file read once on a completion signal; empty re-polls / sub-minute waits are forbidden; two no-change checks double the wait.
2. **Bounded re-validation** - a validation command re-runs only when its inputs changed since its last green run; one full pass at the end replaces repeated identical reruns.

Surfaces:
- `packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts` - waiting rule appended to `# Parallelize`, revalidation rule appended to the `Verify` bullet.
- `packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md` - both rules appended to `# Operating Loop` (`exec`-phrased for the Codex harness).

Not touched: STOP WHEN spawn propagation and SHA-bound review lanes - both already present from #6099/#6100 and the review-work approval PR. The gpt-5.5/5.4/base variants are intentionally unchanged (5.6 stop-condition doctrine).

## Why

Codex session `019f68c3` analysis (see #6146): ~74 of 112 minutes went to model inference across 328 rounds at a ~134k-token median context, driven by poll-per-round waiting (91 empty stdin reads) and repeated identical validation gates. The ultrawork directive got the fix in #6146; Hephaestus's GPT-5.6 prompts had the same two gaps.

## QA & Evidence (`.omo/evidence/20260716-hephaestus-gpt56-waiting/`, on-disk per repo policy)

- **OpenCode (real harness):** isolated XDG sandbox, real `opencode serve` v1.18.2 loading the worktree-built plugin, hephaestus pinned to `openai/gpt-5.6-sol` (config-connected provider, dummy key, offline - no model call). `GET /agent` exposes the Hephaestus prompt containing both new rules and the GPT-5.6 identity: 3/3 PASS (`opencode-agent-probe.log`). Isolation proof: real `opencode.db` session count 21875 unchanged before/after.
- **Codex (documented smoke surface, #6100 precedent):** `node dist/cli.js hook session-start` with a `model: gpt-5.6-sol` fixture and bundled-rules-only env - injected output contains both rules with the `ONE exec call` phrasing, and the gpt-5.5 variant did not leak (`codex-session-start-hook.json`).
- **Automated:** `bun test packages/omo-opencode/src/agents/hephaestus/` 38 pass (incl. GPT-5.6 registration suite); rules component vitest 163 pass (incl. gpt-5.5/5.6 variant routing and never-truncate budget suites with the enlarged rule). LSP diagnostics clean on `gpt-5-6.ts`.

## Residual risk

Prose-only prompt change; model behavior under the new wording is empirical. The wording is copied nearly verbatim from the GPT-5.6 guide's context-accumulation doctrine and mirrors #6146, keeping both editions' registers consistent.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds waiting discipline and bounded re-validation to the Hephaestus GPT-5.6 prompts in both the OpenCode agent and Codex rule. This prevents empty polls and repeated validations, reducing run time and model cost.

- **Bug Fixes**
  - Long commands run to completion in one `exec` (or log-and-read once); no sub-minute re-polls or empty reads; double the wait after two no-change checks.
  - Validation reruns only if inputs changed since the last green run; do one full pass before the final message.
  - Applied in `packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts` and `packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md`.

<sup>Written for commit 293065bd272c08628b5b663d4cbb323714c75c8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

