### PR TITLE
fix(hephaestus): align delegation table contract

### DIFF
--- a/packages/omo-opencode/src/agents/hephaestus/delegation-table-contract.test.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/delegation-table-contract.test.ts
@@ -1,0 +1,221 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test";
+import type {
+	AvailableAgent,
+	AvailableCategory,
+	AvailableSkill,
+} from "../dynamic-agent-prompt-builder";
+import { buildGpt55SisyphusPrompt } from "../sisyphus/gpt-5-5";
+import { buildGpt55HephaestusPrompt } from "./gpt-5-5";
+import { buildGpt56HephaestusPrompt } from "./gpt-5-6";
+
+const AVAILABLE_AGENTS: AvailableAgent[] = [
+	{
+		name: "explore",
+		description: "Contextual grep for codebases.",
+		metadata: {
+			category: "exploration",
+			cost: "FREE",
+			triggers: [
+				{
+					domain: "Codebase discovery",
+					trigger: "Find local implementation patterns",
+				},
+			],
+		},
+	},
+	{
+		name: "librarian",
+		description: "External documentation and open-source research.",
+		metadata: {
+			category: "exploration",
+			cost: "CHEAP",
+			triggers: [
+				{
+					domain: "External references",
+					trigger: "Find official docs and OSS examples",
+				},
+			],
+		},
+	},
+	{
+		name: "oracle",
+		description: "Read-only architecture and debugging consultant.",
+		metadata: {
+			category: "advisor",
+			cost: "EXPENSIVE",
+			triggers: [
+				{
+					domain: "Architecture review",
+					trigger: "Resolve cross-system tradeoffs",
+				},
+			],
+			useWhen: ["Complex architecture design"],
+			avoidWhen: ["Simple file operations"],
+		},
+	},
+	{
+		name: "metis",
+		description: "Pre-planning scope consultant.",
+		metadata: {
+			category: "advisor",
+			cost: "EXPENSIVE",
+			triggers: [
+				{
+					domain: "Scope analysis",
+					trigger: "Clarify ambiguous requirements before planning",
+				},
+			],
+		},
+	},
+	{
+		name: "momus",
+		description: "Plan quality reviewer.",
+		metadata: {
+			category: "advisor",
+			cost: "EXPENSIVE",
+			triggers: [
+				{
+					domain: "Plan audit",
+					trigger: "Review plans for missing steps",
+				},
+			],
+		},
+	},
+	{
+		name: "critic",
+		description: "A future non-direct review agent.",
+		metadata: {
+			category: "advisor",
+			cost: "CHEAP",
+			triggers: [
+				{
+					domain: "Implementation critique",
+					trigger: "Review an implementation before delivery",
+				},
+			],
+		},
+	},
+];
+
+const AVAILABLE_SKILLS: AvailableSkill[] = [
+	{
+		name: "focused-testing",
+		description: "Focused test patterns",
+		location: "plugin",
+	},
+];
+
+const AVAILABLE_CATEGORIES: AvailableCategory[] = [
+	{
+		name: "deep",
+		description: "Autonomous implementation and verification",
+	},
+	{
+		name: "quick",
+		description: "Single-file changes",
+	},
+];
+
+const PROMPT_BUILDERS = [
+	{
+		name: "GPT-5.5",
+		build: buildGpt55HephaestusPrompt,
+	},
+	{
+		name: "GPT-5.6",
+		build: buildGpt56HephaestusPrompt,
+	},
+] as const;
+
+function extractDelegationAgentNames(prompt: string): Set<string> {
+	const tableRows = prompt.match(
+		/### Delegation Table:\n\n(?<rows>(?:- .+\n?)*)/,
+	)?.groups?.rows;
+	return new Set(
+		[...(tableRows ?? "").matchAll(/→ `(?<agent>[^`]+)`/g)].flatMap(
+			(match) => (match.groups?.agent ? [match.groups.agent] : []),
+		),
+	);
+}
+
+for (const { name, build } of PROMPT_BUILDERS) {
+	describe(`${name} Hephaestus generated prompt`, () => {
+		test("renders exactly the direct-agent allowlist", () => {
+			// given: direct agents, planning agents, and an arbitrary future agent are available
+			const prompt = build(
+				AVAILABLE_AGENTS,
+				[],
+				AVAILABLE_SKILLS,
+				AVAILABLE_CATEGORIES,
+				false,
+			);
+
+			// then: the rendered table contains the complete direct-agent set and nothing else
+			expect(extractDelegationAgentNames(prompt)).toEqual(
+				new Set(["explore", "librarian", "oracle"]),
+			);
+		});
+
+		test("preserves category and Oracle guidance outside the table", () => {
+			// given: the generated prompt includes category and Oracle inputs
+			const todoPrompt = build(
+				AVAILABLE_AGENTS,
+				[],
+				AVAILABLE_SKILLS,
+				AVAILABLE_CATEGORIES,
+				false,
+			);
+
+			// then: filtering the table does not remove separate delegation surfaces
+			expect(todoPrompt).toContain("### Category + Skills Delegation System");
+			expect(todoPrompt).toContain("`deep`");
+			expect(todoPrompt).toContain("<Oracle_Usage>");
+		});
+
+		test("preserves the selected tracking tool", () => {
+			// given: the same generated prompt with each supported tracking mode
+			const todoPrompt = build(
+				AVAILABLE_AGENTS,
+				[],
+				AVAILABLE_SKILLS,
+				AVAILABLE_CATEGORIES,
+				false,
+			);
+			const taskPrompt = build(
+				AVAILABLE_AGENTS,
+				[],
+				AVAILABLE_SKILLS,
+				AVAILABLE_CATEGORIES,
+				true,
+			);
+
+			// then: each mode continues to advertise only its own tracking surface
+			expect(todoPrompt).toContain("todowrite");
+			expect(todoPrompt).not.toContain("task_create");
+			expect(taskPrompt).toContain("task_create");
+			expect(taskPrompt).toContain("task_update");
+			expect(taskPrompt).not.toContain("todowrite");
+		});
+	});
+}
+
+describe("planner delegation contracts", () => {
+	test("keeps Metis and Momus routes in Sisyphus", () => {
+		// given: the same agent catalog used to build Hephaestus prompts
+		const prompt = buildGpt55SisyphusPrompt(
+			"openai/gpt-5.5",
+			AVAILABLE_AGENTS,
+			[],
+			AVAILABLE_SKILLS,
+			AVAILABLE_CATEGORIES,
+			false,
+		);
+
+		// then: the orchestrator still advertises its planning specialists
+		expect(extractDelegationAgentNames(prompt)).toEqual(
+			new Set(["explore", "librarian", "oracle", "metis", "momus", "critic"]),
+		);
+	});
+});

--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-5.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-5.ts
@@ -244,7 +244,11 @@ export function buildGpt55HephaestusPrompt(
     availableCategories,
     availableSkills,
   )
-  const delegationTable = buildDelegationTable(availableAgents)
+  const delegationTable = buildDelegationTable(
+    availableAgents.filter((agent) =>
+      ["explore", "librarian", "oracle"].includes(agent.name),
+    ),
+  )
   const oracleSection = buildOracleSection(availableAgents)
   const frontendGuidance = buildFrontendGuidanceSection(availableCategories)
 

--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-6.ts
@@ -187,7 +187,11 @@ export function buildGpt56HephaestusPrompt(
     availableCategories,
     availableSkills,
   )
-  const delegationTable = buildDelegationTable(availableAgents)
+  const delegationTable = buildDelegationTable(
+    availableAgents.filter((agent) =>
+      ["explore", "librarian", "oracle"].includes(agent.name),
+    ),
+  )
   const oracleSection = buildOracleSection(availableAgents)
   const frontendGuidance = buildFrontendGuidanceSection(availableCategories)
 


### PR DESCRIPTION
## Summary

Align GPT-5.5 and GPT-5.6 Hephaestus delegation tables with the direct-agent contract already documented in their prompts. Hephaestus now advertises only Explore, Librarian, and Oracle as direct `task()` agents instead of also exposing planner-only Metis and Momus routes.

## Changes

- Filter the generated delegation table inside the two Hephaestus prompt builders only.
- Preserve category delegation, the full Oracle section, and both `todowrite` and task-system tracking guidance.
- Add parsed delegation-table coverage for both model variants, including a synthetic future agent, plus guards that Sisyphus keeps its full planner-agent table while the existing Prometheus `ulw-plan` suite remains green.

## QA & Evidence

- **Failing-first contract test:** before the production edit, the new test recorded `2 pass, 2 fail`; both failures were the leaked Metis/Momus rows in GPT-5.5 and GPT-5.6 Hephaestus.
- **Latest-rebase scoped tests:** `68 pass`, `0 fail`, `196 assertions` after rebasing onto `origin/dev` at `b7a2e33ac25bf103a11c06b5c7e30073a19ee935`.
- **Full agent regressions:** `bun test packages/omo-opencode/src/agents` recorded `357 pass`, `0 fail`, `996 assertions`.
- **Typecheck:** `bun run --cwd packages/omo-opencode typecheck` passed.
- **Real isolated OpenCode QA:** OpenCode 1.17.13 loaded this worktree plugin through an absolute `file://` entry and generated both GPT-5.5/medium and GPT-5.6-sol/high Hephaestus configurations via `opencode debug agent 'Hephaestus - Deep Agent'`. Parsed delegation-table identities were exactly `explore`, `librarian`, and `oracle` in both prompts; Oracle guidance and `todowrite` remained present.
- **Isolation:** the real OpenCode session count was `5751` before and after; the isolated HOME/XDG runtime was removed.

Evidence is recorded locally under `.omo/evidence/20260716-issue-6087-hephaestus-delegation/` per repository policy. No secrets, auth state, or external model calls were used.

## Risks & Residuals

The filter is deliberately local to Hephaestus. Global `availableAgents` behavior and planner prompts are unchanged and covered by regression assertions.

Closes #6087

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Hephaestus delegation table for GPT-5.5 and GPT-5.6 with the direct-agent contract by listing only Explore, Librarian, and Oracle and hiding planner-only Metis and Momus. Closes #6087.

- **Bug Fixes**
  - Filtered Hephaestus delegation tables to include only Explore, Librarian, and Oracle.
  - Preserved category delegation, Oracle guidance, and tracking mode (`todowrite` vs `task_create/task_update`).
  - Added contract tests for both models and a guard that Sisyphus still advertises Metis/Momus.

<sup>Written for commit 82bf7be14fdd6e76ccf3ef1fbffa139cc9138553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



