### PR TITLE
fix(codex): preserve explicit V2 thread caps

### DIFF
--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-v2-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/multi-agent-v2-guard.mjs
@@ -26,7 +26,17 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 
+import {
+	findTomlSection as findSection,
+	hasTomlSetting,
+	removeTomlSectionSetting,
+	removeRootTomlSetting,
+	replaceOrInsertTomlSectionSetting,
+	replaceOrInsertRootTomlSetting,
+} from "./toml-section-editor.mjs";
+
 const MANAGED_COMMENT_MARKER = "openai/codex#26753";
+const MULTI_AGENT_V2_THREAD_LIMIT_KEY = "features.multi_agent_v2.max_concurrent_threads_per_session";
 const MANAGED_DISABLE_COMMENT = [
 	"# Managed by LazyCodex: multi_agent_v2 is re-disabled on every Codex session start",
 	`# because enabling it fails every turn with HTTP 400 (${MANAGED_COMMENT_MARKER}).`,
@@ -177,7 +187,11 @@ function isGpt56Family(model) {
 
 function clearMultiAgentV2DisableForReservedSchema(config) {
 	// `config` arrives shorthand-normalized from forceDisableMultiAgentV2.
-	const result = removeManagedDisableComments(config);
+	let result = removeManagedDisableComments(config);
+	result = removeRootTomlSetting(result, "features.multi_agent_v2.enabled", "false");
+	result = removeRootTomlSetting(result, "features.multi_agent_v2.hide_spawn_agent_metadata", "false");
+	result = removeDottedMultiAgentV2Setting(result, "enabled", "false");
+	result = removeDottedMultiAgentV2Setting(result, "hide_spawn_agent_metadata", "false");
 
 	const section = findSection(result, "[features.multi_agent_v2]");
 	if (!section) return result;
@@ -203,6 +217,9 @@ function forceDisableLegacyEncryptedV2(config) {
 	const section = findSection(config, "[features.multi_agent_v2]");
 
 	if (!section) {
+		if (hasTomlSetting(config, MULTI_AGENT_V2_THREAD_LIMIT_KEY)) {
+			return setDottedMultiAgentV2Disable(config);
+		}
 		return ensureManagedComment(appendDisabledSection(config));
 	}
 
@@ -220,6 +237,20 @@ function forceDisableLegacyEncryptedV2(config) {
 	const insertAt = headerEnd === -1 ? section.text.length : headerEnd + 1;
 	const patched = `${section.text.slice(0, insertAt)}${headerEnd === -1 ? "\n" : ""}enabled = false\n${section.text.slice(insertAt)}`;
 	return ensureManagedComment(config.slice(0, section.start) + patched + config.slice(section.end));
+}
+
+function setDottedMultiAgentV2Disable(config) {
+	const featuresSection = findSection(config, "[features]");
+	if (!featuresSection) {
+		return replaceOrInsertRootTomlSetting(config, "features.multi_agent_v2.enabled", "false");
+	}
+	return replaceOrInsertTomlSectionSetting(config, featuresSection, "multi_agent_v2.enabled", "false");
+}
+
+function removeDottedMultiAgentV2Setting(config, key, expectedValue) {
+	const featuresSection = findSection(config, "[features]");
+	if (!featuresSection) return config;
+	return removeTomlSectionSetting(config, featuresSection, `multi_agent_v2.${key}`, expectedValue);
 }
 
 function ensureManagedComment(config) {
@@ -268,31 +299,4 @@ function appendDisabledSection(config) {
 	const trimmed = config.trimEnd();
 	const prefix = trimmed.length === 0 ? "" : `${trimmed}\n\n`;
 	return `${prefix}[features.multi_agent_v2]\nenabled = false\n`;
-}
-
-// Strips a trailing # comment from a TOML line fragment (best-effort; quoted keys containing # are out of scope).
-function stripTrailingComment(line) {
-	const idx = line.indexOf("#");
-	return idx === -1 ? line : line.slice(0, idx).trim();
-}
-
-function findSection(config, headerLine) {
-	const lines = config.match(/[^\n]*\n?|$/g) ?? [];
-	let offset = 0;
-	let start = -1;
-	for (const line of lines) {
-		if (line.length === 0) break;
-		const trimmed = line.trim();
-		if (start === -1) {
-			if (stripTrailingComment(trimmed) === headerLine) start = offset;
-		} else {
-			const bare = stripTrailingComment(trimmed);
-			if (bare.startsWith("[") && bare.endsWith("]")) {
-				return { start, end: offset, text: config.slice(start, offset) };
-			}
-		}
-		offset += line.length;
-	}
-	if (start === -1) return null;
-	return { start, end: config.length, text: config.slice(start) };
 }

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/subagent-limit-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/subagent-limit-guard.mjs
@@ -3,6 +3,7 @@ import { prefersMultiAgentV2, readRootModel, resolveMultiAgentVersionFromConfig 
 const CODEX_AGENTS_HEADER = "[agents]";
 const CODEX_MULTI_AGENT_V2_HEADER = "[features.multi_agent_v2]";
 const CODEX_SUBAGENT_THREAD_LIMIT = "1000";
+const CODEX_MULTI_AGENT_V2_DEFAULT_THREAD_LIMIT = "16";
 
 /**
  * Ensure subagent concurrency limits without writing settings that conflict
@@ -83,10 +84,16 @@ function ensureMultiAgentV2ThreadLimit(config) {
 	if (!section) {
 		return appendBlock(
 			config,
-			`${CODEX_MULTI_AGENT_V2_HEADER}\nmax_concurrent_threads_per_session = ${CODEX_SUBAGENT_THREAD_LIMIT}\n`,
+			`${CODEX_MULTI_AGENT_V2_HEADER}\nmax_concurrent_threads_per_session = ${CODEX_MULTI_AGENT_V2_DEFAULT_THREAD_LIMIT}\n`,
 		);
 	}
-	return replaceOrInsertSetting(config, section, "max_concurrent_threads_per_session", CODEX_SUBAGENT_THREAD_LIMIT);
+	if (/^\s*max_concurrent_threads_per_session\s*=/m.test(section.text)) return config;
+	return replaceOrInsertSetting(
+		config,
+		section,
+		"max_concurrent_threads_per_session",
+		CODEX_MULTI_AGENT_V2_DEFAULT_THREAD_LIMIT,
+	);
 }
 
 function replaceOrInsertSetting(config, section, key, value) {

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/subagent-limit-guard.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/subagent-limit-guard.mjs
@@ -1,7 +1,13 @@
 import { prefersMultiAgentV2, readRootModel, resolveMultiAgentVersionFromConfig } from "./multi-agent-v2-guard.mjs";
+import {
+	findTomlSection as findSection,
+	hasTomlSetting,
+	replaceOrInsertTomlSectionSetting,
+} from "./toml-section-editor.mjs";
 
 const CODEX_AGENTS_HEADER = "[agents]";
 const CODEX_MULTI_AGENT_V2_HEADER = "[features.multi_agent_v2]";
+const CODEX_MULTI_AGENT_V2_THREAD_LIMIT_KEY = "features.multi_agent_v2.max_concurrent_threads_per_session";
 const CODEX_SUBAGENT_THREAD_LIMIT = "1000";
 const CODEX_MULTI_AGENT_V2_DEFAULT_THREAD_LIMIT = "16";
 
@@ -54,13 +60,13 @@ function raiseExistingAgentsMaxThreads(config) {
 	const section = findSection(config, CODEX_AGENTS_HEADER);
 	if (!section) return config;
 	if (!/^\s*max_threads\s*=/m.test(section.text)) return config;
-	return replaceOrInsertSetting(config, section, "max_threads", CODEX_SUBAGENT_THREAD_LIMIT);
+	return replaceOrInsertTomlSectionSetting(config, section, "max_threads", CODEX_SUBAGENT_THREAD_LIMIT);
 }
 
 function ensureAgentsMaxThreads(config) {
 	const section = findSection(config, CODEX_AGENTS_HEADER);
 	if (!section) return appendBlock(config, `${CODEX_AGENTS_HEADER}\nmax_threads = ${CODEX_SUBAGENT_THREAD_LIMIT}\n`);
-	return replaceOrInsertSetting(config, section, "max_threads", CODEX_SUBAGENT_THREAD_LIMIT);
+	return replaceOrInsertTomlSectionSetting(config, section, "max_threads", CODEX_SUBAGENT_THREAD_LIMIT);
 }
 
 function removeAgentsMaxThreads(config) {
@@ -80,6 +86,7 @@ function removeAgentsMaxThreads(config) {
 }
 
 function ensureMultiAgentV2ThreadLimit(config) {
+	if (hasTomlSetting(config, CODEX_MULTI_AGENT_V2_THREAD_LIMIT_KEY)) return config;
 	const section = findSection(config, CODEX_MULTI_AGENT_V2_HEADER);
 	if (!section) {
 		return appendBlock(
@@ -87,28 +94,12 @@ function ensureMultiAgentV2ThreadLimit(config) {
 			`${CODEX_MULTI_AGENT_V2_HEADER}\nmax_concurrent_threads_per_session = ${CODEX_MULTI_AGENT_V2_DEFAULT_THREAD_LIMIT}\n`,
 		);
 	}
-	if (/^\s*max_concurrent_threads_per_session\s*=/m.test(section.text)) return config;
-	return replaceOrInsertSetting(
+	return replaceOrInsertTomlSectionSetting(
 		config,
 		section,
 		"max_concurrent_threads_per_session",
 		CODEX_MULTI_AGENT_V2_DEFAULT_THREAD_LIMIT,
 	);
-}
-
-function replaceOrInsertSetting(config, section, key, value) {
-	const pattern = new RegExp(`^(\\s*)${escapeRegExp(key)}\\s*=\\s*[^\\n#]*(#[^\\n]*)?$`, "m");
-	if (pattern.test(section.text)) {
-		const patched = section.text.replace(pattern, (_match, indent, comment) =>
-			comment ? `${indent}${key} = ${value} ${comment}` : `${indent}${key} = ${value}`,
-		);
-		return config.slice(0, section.start) + patched + config.slice(section.end);
-	}
-
-	const headerEnd = section.text.indexOf("\n");
-	const insertAt = headerEnd === -1 ? section.text.length : headerEnd + 1;
-	const patched = `${section.text.slice(0, insertAt)}${headerEnd === -1 ? "\n" : ""}${key} = ${value}\n${section.text.slice(insertAt)}`;
-	return config.slice(0, section.start) + patched + config.slice(section.end);
 }
 
 function appendBlock(config, block) {
@@ -119,30 +110,4 @@ function appendBlock(config, block) {
 
 function escapeRegExp(value) {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function stripTrailingComment(line) {
-	const idx = line.indexOf("#");
-	return idx === -1 ? line : line.slice(0, idx).trim();
-}
-
-function findSection(config, headerLine) {
-	const lines = config.match(/[^\n]*\n?|$/g) ?? [];
-	let offset = 0;
-	let start = -1;
-	for (const line of lines) {
-		if (line.length === 0) break;
-		const trimmed = line.trim();
-		if (start === -1) {
-			if (stripTrailingComment(trimmed) === headerLine) start = offset;
-		} else {
-			const bare = stripTrailingComment(trimmed);
-			if (bare.startsWith("[") && bare.endsWith("]")) {
-				return { start, end: offset, text: config.slice(start, offset) };
-			}
-		}
-		offset += line.length;
-	}
-	if (start === -1) return null;
-	return { start, end: config.length, text: config.slice(start) };
 }

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/toml-section-editor.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/toml-section-editor.mjs
@@ -1,0 +1,455 @@
+export function findTomlSection(config, headerLine) {
+	const targetHeaderPath = parseTomlTableHeader(headerLine);
+	const lines = config.match(/[^\n]*\n?|$/g) ?? [];
+	let offset = 0;
+	let start = -1;
+	let multilineQuote = null;
+	for (const line of lines) {
+		if (line.length === 0) break;
+		const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+		multilineQuote = multilineScan.nextQuote;
+		if (multilineScan.wasInside) {
+			offset += line.length;
+			continue;
+		}
+		if (start === -1) {
+			if (tomlTableHeaderMatches(line, targetHeaderPath)) start = offset;
+		} else if (isTomlTableHeaderLine(line)) {
+			return { start, end: offset, text: config.slice(start, offset) };
+		}
+		offset += line.length;
+	}
+	if (start === -1) return null;
+	return { start, end: config.length, text: config.slice(start) };
+}
+
+export function hasTomlSetting(config, keyPath) {
+	const targetPath = parseTomlDottedKey(keyPath);
+	if (!targetPath) return false;
+
+	let tablePath = [];
+	let multilineQuote = null;
+	for (const line of config.split("\n")) {
+		const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+		multilineQuote = multilineScan.nextQuote;
+		if (multilineScan.wasInside) continue;
+		const normalizedLine = stripUnquotedInlineComment(line).trim();
+		if (normalizedLine.length === 0) continue;
+
+		const headerPath = parseTomlTableHeader(normalizedLine);
+		if (headerPath) {
+			tablePath = headerPath;
+			continue;
+		}
+		if (isTomlTableHeaderLine(normalizedLine)) {
+			tablePath = null;
+			continue;
+		}
+		if (!tablePath) continue;
+
+		const assignmentIndex = findUnquotedAssignment(normalizedLine);
+		if (assignmentIndex < 0) continue;
+		const settingPath = parseTomlDottedKey(normalizedLine.slice(0, assignmentIndex).trim());
+		if (!settingPath) continue;
+		const fullPath = [...tablePath, ...settingPath];
+		if (fullPath.length !== targetPath.length) continue;
+		if (fullPath.every((part, index) => part === targetPath[index])) return true;
+	}
+	return false;
+}
+
+export function replaceOrInsertRootTomlSetting(config, keyPath, value) {
+	const targetPath = parseTomlDottedKey(keyPath);
+	if (!targetPath) return config;
+	const match = findRootTomlSetting(config, targetPath);
+	if (match) {
+		const commentIndex = findUnquotedComment(match.lineBody, match.assignmentIndex + 1);
+		const comment = commentIndex === -1 ? "" : ` ${match.lineBody.slice(commentIndex).trimStart()}`;
+		const replacement = `${match.lineBody.slice(0, match.assignmentIndex + 1)} ${value}${comment}${match.newline}`;
+		return config.slice(0, match.offset) + replacement + config.slice(match.offset + match.line.length);
+	}
+	const firstTable = findFirstTomlTableStart(config);
+	const root = config.slice(0, firstTable).trimEnd();
+	const suffix = config.slice(firstTable);
+	const replacement = `${root}${root.length > 0 ? "\n" : ""}${keyPath} = ${value}\n`;
+	if (suffix.length === 0) return replacement;
+	return `${replacement.trimEnd()}\n\n${suffix.trimStart()}`;
+}
+
+export function replaceOrInsertTomlSectionSetting(config, section, keyPath, value) {
+	const targetPath = parseTomlDottedKey(keyPath);
+	if (!targetPath) return config;
+	const lines = section.text.match(/[^\n]*\n?|$/g) ?? [];
+	let offset = 0;
+	let multilineQuote = null;
+	for (const line of lines) {
+		if (line.length === 0) break;
+		const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+		multilineQuote = multilineScan.nextQuote;
+		if (multilineScan.wasInside) {
+			offset += line.length;
+			continue;
+		}
+		const assignmentIndex = findUnquotedAssignment(line);
+		if (assignmentIndex >= 0) {
+			const settingPath = parseTomlDottedKey(line.slice(0, assignmentIndex).trim());
+			if (settingPath && tomlPathMatches(settingPath, targetPath)) {
+				const replacement = replaceTomlAssignmentValue(line, assignmentIndex, value);
+				const patched = section.text.slice(0, offset) + replacement + section.text.slice(offset + line.length);
+				return config.slice(0, section.start) + patched + config.slice(section.end);
+			}
+		}
+		offset += line.length;
+	}
+	const headerEnd = section.text.indexOf("\n");
+	const insertAt = headerEnd === -1 ? section.text.length : headerEnd + 1;
+	const patched = `${section.text.slice(0, insertAt)}${headerEnd === -1 ? "\n" : ""}${keyPath} = ${value}\n${section.text.slice(insertAt)}`;
+	return config.slice(0, section.start) + patched + config.slice(section.end);
+}
+
+export function removeTomlSectionSetting(config, section, keyPath, expectedValue) {
+	const targetPath = parseTomlDottedKey(keyPath);
+	if (!targetPath) return config;
+	const lines = section.text.match(/[^\n]*\n?|$/g) ?? [];
+	let offset = 0;
+	let multilineQuote = null;
+	for (const line of lines) {
+		if (line.length === 0) break;
+		const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+		multilineQuote = multilineScan.nextQuote;
+		if (multilineScan.wasInside) {
+			offset += line.length;
+			continue;
+		}
+		const assignmentIndex = findUnquotedAssignment(line);
+		if (assignmentIndex >= 0) {
+			const settingPath = parseTomlDottedKey(line.slice(0, assignmentIndex).trim());
+			if (settingPath && tomlPathMatches(settingPath, targetPath)) {
+				const lineBody = line.endsWith("\n") ? line.slice(0, -1) : line;
+				const commentIndex = findUnquotedComment(lineBody, assignmentIndex + 1);
+				const valueEnd = commentIndex === -1 ? lineBody.length : commentIndex;
+				if (lineBody.slice(assignmentIndex + 1, valueEnd).trim() !== expectedValue) return config;
+				const patched = section.text.slice(0, offset) + section.text.slice(offset + line.length);
+				return config.slice(0, section.start) + patched + config.slice(section.end);
+			}
+		}
+		offset += line.length;
+	}
+	return config;
+}
+
+export function removeRootTomlSetting(config, keyPath, expectedValue) {
+	const targetPath = parseTomlDottedKey(keyPath);
+	if (!targetPath) return config;
+	const match = findRootTomlSetting(config, targetPath);
+	if (!match) return config;
+	const commentIndex = findUnquotedComment(match.lineBody, match.assignmentIndex + 1);
+	const valueEnd = commentIndex === -1 ? match.lineBody.length : commentIndex;
+	if (match.lineBody.slice(match.assignmentIndex + 1, valueEnd).trim() !== expectedValue) return config;
+	return config.slice(0, match.offset) + config.slice(match.offset + match.line.length);
+}
+
+function tomlTableHeaderMatches(line, targetHeaderPath) {
+	if (!targetHeaderPath) return false;
+	const candidateHeaderPath = parseTomlTableHeader(line);
+	if (!candidateHeaderPath || candidateHeaderPath.length !== targetHeaderPath.length) return false;
+	return candidateHeaderPath.every((part, index) => part === targetHeaderPath[index]);
+}
+
+function isTomlTableHeaderLine(line) {
+	const normalizedLine = stripUnquotedInlineComment(line).trim();
+	return normalizedLine.startsWith("[") && normalizedLine.endsWith("]");
+}
+
+function scanTomlMultilineLine(line, currentQuote) {
+	if (currentQuote) {
+		return {
+			wasInside: true,
+			nextQuote: findTomlMultilineDelimiter(line, currentQuote, 0) === -1 ? currentQuote : null,
+		};
+	}
+
+	let quote = null;
+	let index = 0;
+	while (index < line.length) {
+		const char = line[index];
+		if (quote === '"') {
+			if (char === "\\") {
+				index += 2;
+				continue;
+			}
+			if (char === '"') quote = null;
+			index += 1;
+			continue;
+		}
+		if (quote === "'") {
+			if (char === "'") quote = null;
+			index += 1;
+			continue;
+		}
+		if (char === "#") break;
+		const delimiter = line.startsWith('"""', index) ? '"""' : line.startsWith("'''", index) ? "'''" : null;
+		if (delimiter) {
+			const closingIndex = findTomlMultilineDelimiter(line, delimiter, index + delimiter.length);
+			return { wasInside: false, nextQuote: closingIndex === -1 ? delimiter : null };
+		}
+		if (char === '"' || char === "'") quote = char;
+		index += 1;
+	}
+	return { wasInside: false, nextQuote: null };
+}
+
+function findTomlMultilineDelimiter(line, delimiter, startIndex) {
+	let index = line.indexOf(delimiter, startIndex);
+	while (index !== -1) {
+		if (delimiter === "'''" || countPrecedingBackslashes(line, index) % 2 === 0) return index;
+		index = line.indexOf(delimiter, index + 1);
+	}
+	return -1;
+}
+
+function countPrecedingBackslashes(line, index) {
+	let count = 0;
+	let cursor = index - 1;
+	while (cursor >= 0 && line[cursor] === "\\") {
+		count += 1;
+		cursor -= 1;
+	}
+	return count;
+}
+
+function findRootTomlSetting(config, targetPath) {
+	const lines = config.match(/[^\n]*\n?|$/g) ?? [];
+	let offset = 0;
+	let multilineQuote = null;
+	for (const line of lines) {
+		if (line.length === 0) break;
+		const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+		multilineQuote = multilineScan.nextQuote;
+		if (multilineScan.wasInside) {
+			offset += line.length;
+			continue;
+		}
+		if (isTomlTableHeaderLine(line)) break;
+		const assignmentIndex = findUnquotedAssignment(line);
+		if (assignmentIndex >= 0) {
+			const settingPath = parseTomlDottedKey(line.slice(0, assignmentIndex).trim());
+			if (settingPath && tomlPathMatches(settingPath, targetPath)) {
+				const newline = line.endsWith("\n") ? "\n" : "";
+				return { line, lineBody: newline ? line.slice(0, -1) : line, newline, offset, assignmentIndex };
+			}
+		}
+		offset += line.length;
+	}
+	return null;
+}
+
+function findFirstTomlTableStart(config) {
+	const lines = config.match(/[^\n]*\n?|$/g) ?? [];
+	let offset = 0;
+	let multilineQuote = null;
+	for (const line of lines) {
+		if (line.length === 0) break;
+		const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+		multilineQuote = multilineScan.nextQuote;
+		if (!multilineScan.wasInside && isTomlTableHeaderLine(line)) return offset;
+		offset += line.length;
+	}
+	return config.length;
+}
+
+function findUnquotedComment(line, startIndex) {
+	let quote = null;
+	let index = startIndex;
+	while (index < line.length) {
+		const char = line[index];
+		if (quote === '"') {
+			if (char === "\\") {
+				index += 2;
+				continue;
+			}
+			if (char === '"') quote = null;
+			index += 1;
+			continue;
+		}
+		if (quote === "'") {
+			if (char === "'") quote = null;
+			index += 1;
+			continue;
+		}
+		if (char === '"' || char === "'") quote = char;
+		else if (char === "#") return index;
+		index += 1;
+	}
+	return -1;
+}
+
+function tomlPathMatches(candidate, target) {
+	return candidate.length === target.length && candidate.every((part, index) => part === target[index]);
+}
+
+function replaceTomlAssignmentValue(line, assignmentIndex, value) {
+	const newline = line.endsWith("\n") ? "\n" : "";
+	const lineBody = newline ? line.slice(0, -1) : line;
+	const commentIndex = findUnquotedComment(lineBody, assignmentIndex + 1);
+	const comment = commentIndex === -1 ? "" : ` ${lineBody.slice(commentIndex).trimStart()}`;
+	return `${lineBody.slice(0, assignmentIndex + 1)} ${value}${comment}${newline}`;
+}
+
+function parseTomlTableHeader(line) {
+	const normalizedLine = stripUnquotedInlineComment(line).trim();
+	if (!normalizedLine.startsWith("[") || !normalizedLine.endsWith("]") || normalizedLine.startsWith("[[")) {
+		return null;
+	}
+	return parseTomlDottedKey(normalizedLine.slice(1, -1).trim());
+}
+
+function stripUnquotedInlineComment(line) {
+	let quote = null;
+	let index = 0;
+	while (index < line.length) {
+		const char = line[index];
+		if (quote === '"') {
+			if (char === "\\") {
+				index += 2;
+				continue;
+			}
+			if (char === '"') quote = null;
+			index += 1;
+			continue;
+		}
+		if (quote === "'") {
+			if (char === "'") quote = null;
+			index += 1;
+			continue;
+		}
+		if (char === '"' || char === "'") {
+			quote = char;
+			index += 1;
+			continue;
+		}
+		if (char === "#") return line.slice(0, index);
+		index += 1;
+	}
+	return line;
+}
+
+function findUnquotedAssignment(line) {
+	let quote = null;
+	let index = 0;
+	while (index < line.length) {
+		const char = line[index];
+		if (quote === '"') {
+			if (char === "\\") {
+				index += 2;
+				continue;
+			}
+			if (char === '"') quote = null;
+			index += 1;
+			continue;
+		}
+		if (quote === "'") {
+			if (char === "'") quote = null;
+			index += 1;
+			continue;
+		}
+		if (char === '"' || char === "'") {
+			quote = char;
+			index += 1;
+			continue;
+		}
+		if (char === "=") return index;
+		index += 1;
+	}
+	return -1;
+}
+
+function parseTomlDottedKey(input) {
+	const parts = [];
+	let index = 0;
+	while (index < input.length) {
+		index = skipWhitespace(input, index);
+		const parsedKey = parseTomlKeyPart(input, index);
+		if (!parsedKey) return null;
+		parts.push(parsedKey.value);
+		index = skipWhitespace(input, parsedKey.nextIndex);
+		if (index === input.length) return parts;
+		if (input[index] !== ".") return null;
+		index += 1;
+	}
+	return parts.length > 0 ? parts : null;
+}
+
+function parseTomlKeyPart(input, startIndex) {
+	const quote = input[startIndex];
+	if (quote === "'") return parseLiteralTomlString(input, startIndex);
+	if (quote === '"') return parseBasicTomlString(input, startIndex);
+	return parseBareTomlKey(input, startIndex);
+}
+
+function parseLiteralTomlString(input, startIndex) {
+	let index = startIndex + 1;
+	let value = "";
+	while (index < input.length) {
+		const char = input[index];
+		if (char === "'") return { value, nextIndex: index + 1 };
+		value += char;
+		index += 1;
+	}
+	return null;
+}
+
+function parseBasicTomlString(input, startIndex) {
+	let index = startIndex + 1;
+	let value = "";
+	while (index < input.length) {
+		const char = input[index];
+		if (char === '"') return { value, nextIndex: index + 1 };
+		if (char !== "\\") {
+			value += char;
+			index += 1;
+			continue;
+		}
+		const escaped = parseBasicTomlEscape(input, index);
+		if (!escaped) return null;
+		value += escaped.value;
+		index = escaped.nextIndex;
+	}
+	return null;
+}
+
+function parseBasicTomlEscape(input, backslashIndex) {
+	const escape = input[backslashIndex + 1];
+	if (escape === undefined) return null;
+	if (escape === "b") return { value: "\b", nextIndex: backslashIndex + 2 };
+	if (escape === "t") return { value: "\t", nextIndex: backslashIndex + 2 };
+	if (escape === "n") return { value: "\n", nextIndex: backslashIndex + 2 };
+	if (escape === "f") return { value: "\f", nextIndex: backslashIndex + 2 };
+	if (escape === "r") return { value: "\r", nextIndex: backslashIndex + 2 };
+	if (escape === '"') return { value: '"', nextIndex: backslashIndex + 2 };
+	if (escape === "\\") return { value: "\\", nextIndex: backslashIndex + 2 };
+	if (escape === "u") return parseUnicodeEscape(input, backslashIndex + 2, 4);
+	if (escape === "U") return parseUnicodeEscape(input, backslashIndex + 2, 8);
+	return null;
+}
+
+function parseUnicodeEscape(input, digitsStart, digitCount) {
+	const digits = input.slice(digitsStart, digitsStart + digitCount);
+	if (digits.length !== digitCount || !/^[0-9A-Fa-f]+$/.test(digits)) return null;
+	const codePoint = Number.parseInt(digits, 16);
+	if (codePoint > 0x10ffff) return null;
+	return { value: String.fromCodePoint(codePoint), nextIndex: digitsStart + digitCount };
+}
+
+function parseBareTomlKey(input, startIndex) {
+	let index = startIndex;
+	while (index < input.length && /[A-Za-z0-9_-]/.test(input[index])) index += 1;
+	if (index === startIndex) return null;
+	return { value: input.slice(startIndex, index), nextIndex: index };
+}
+
+function skipWhitespace(input, startIndex) {
+	let index = startIndex;
+	while (index < input.length && /\s/.test(input[index])) index += 1;
+	return index;
+}

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -243,7 +243,7 @@ test("#given user-customized Codex model config #when migrating #then user value
 	assert.doesNotMatch(content, /^\s*multi_agent_mode\s*=/m);
 	assert.match(content, /\[agents\][\s\S]*?max_threads = 1000/);
 	assert.match(content, /\[features\.multi_agent_v2\][\s\S]*?enabled = false/);
-	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_concurrent_threads_per_session = 16/);
 });
 
 test("#given managed config state is malformed #when migrating #then migration ignores stale state safely", async () => {
@@ -405,7 +405,7 @@ test("#given config already matches current catalog #when catalog version advanc
 	const content = await readFile(configPath, "utf8");
 	assert.doesNotMatch(content, /^\s*multi_agent_mode\s*=/m);
 	assert.match(content, /\[agents\][\s\S]*?max_threads = 1000/);
-	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_concurrent_threads_per_session = 16/);
 });
 
 test("#given stale Context7 placeholder MCP config #when migrating #then removes it and keeps plugin policy", async () => {
@@ -642,7 +642,7 @@ test("#given global config without multi_agent_v2 section #when full migration r
 	assert.deepEqual(result.modeChanged, []);
 	const content = await readFile(configPath, "utf8");
 	assert.match(content, /\[features\.multi_agent_v2\][\s\S]*?enabled = false/);
-	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_concurrent_threads_per_session = 16/);
 	assert.match(content, /\[agents\][\s\S]*?max_threads = 1000/);
 	assert.doesNotMatch(content, /^\s*multi_agent_mode\s*=/m);
 });
@@ -749,7 +749,7 @@ test("#given global config with forced multi_agent_v2 #when full migration runs 
 	const content = await readFile(configPath, "utf8");
 	assert.match(content, /enabled = false/);
 	assert.doesNotMatch(content, /enabled = true/);
-	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_concurrent_threads_per_session = 10000/);
 	assert.match(content, /\[agents\][\s\S]*?max_threads = 1000/);
 });
 
@@ -1030,7 +1030,7 @@ test("#given legacy shorthand and no session model on hook path #when full migra
 	const parsed = parseTomlWithPython(content);
 	assert.doesNotMatch(content, /^\s*multi_agent_v2\s*=\s*(?:true|false)/m);
 	assert.equal(parsed.features.plugins, true);
-	assert.equal(parsed.features.multi_agent_v2.max_concurrent_threads_per_session, 1000);
+	assert.equal(parsed.features.multi_agent_v2.max_concurrent_threads_per_session, 16);
 	assert.equal("enabled" in parsed.features.multi_agent_v2, false);
 });
 
@@ -1151,7 +1151,7 @@ test("#given user-modified config without root model #when full non-hook migrati
 	assert.doesNotMatch(content, /^\s*enabled\s*=\s*false/m);
 	assert.doesNotMatch(content, /openai\/codex#26753/);
 	assert.doesNotMatch(content, /^\s*max_threads\s*=/m);
-	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_concurrent_threads_per_session = 16/);
 });
 
 async function canCreateSymlink(type) {

--- a/packages/omo-codex/plugin/test/multi-agent-v2-regression.test.mjs
+++ b/packages/omo-codex/plugin/test/multi-agent-v2-regression.test.mjs
@@ -22,7 +22,7 @@ test("#given relative model_catalog_json declares gpt-5.6 model as v1 #when migr
 			"",
 			"[features.multi_agent_v2]",
 			"enabled = false",
-			"max_concurrent_threads_per_session = 1000",
+			"max_concurrent_threads_per_session = 6",
 			"",
 		].join("\n"),
 	);
@@ -54,7 +54,7 @@ test("#given no SessionStart model and root gpt-5.6 model without catalog #when 
 			"",
 			"[features.multi_agent_v2]",
 			"enabled = false",
-			"max_concurrent_threads_per_session = 1000",
+			"max_concurrent_threads_per_session = 6",
 			"",
 		].join("\n"),
 	);
@@ -67,5 +67,5 @@ test("#given no SessionStart model and root gpt-5.6 model without catalog #when 
 	const content = await readFile(configPath, "utf8");
 	assert.doesNotMatch(content, /^\s*enabled\s*=\s*false/m);
 	assert.doesNotMatch(content, /^\s*max_threads\s*=/m);
-	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_concurrent_threads_per_session = 6/);
 });

--- a/packages/omo-codex/plugin/test/subagent-limit-migration.test.mjs
+++ b/packages/omo-codex/plugin/test/subagent-limit-migration.test.mjs
@@ -1,10 +1,30 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import { migrateConfigFile } from "../scripts/migrate-codex-config.mjs";
+
+function parseTomlWithPython(config) {
+	const python = resolvePython();
+	const result = spawnSync(
+		python,
+		["-c", "import json, sys, tomllib; print(json.dumps(tomllib.loads(sys.stdin.read())))"],
+		{ encoding: "utf8", input: config },
+	);
+	assert.equal(result.status, 0, result.stderr);
+	return JSON.parse(result.stdout);
+}
+
+function resolvePython() {
+	for (const command of ["python3", "python"]) {
+		const result = spawnSync(command, ["-c", "import tomllib"], { encoding: "utf8" });
+		if (result.status === 0) return command;
+	}
+	assert.fail("Python with tomllib is required for TOML parse assertions");
+}
 
 test("#given SessionStart migration sees an inline-commented V2 cap #when migrating twice #then preserves the line and ordering byte-for-byte", async () => {
 	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-migration-"));
@@ -50,6 +70,213 @@ test("#given SessionStart migration sees an inline-commented V2 cap #when migrat
 	assert.match(secondPass, /\[agents\.explorer\]\nconfig_file = "\.\/agents\/explorer\.toml"/);
 	assert.match(secondPass, /\[features\.multi_agent_v2\][\s\S]*?enabled = false/);
 	assert.doesNotMatch(secondPass, /^max_threads\s*=\s*6$/m);
+});
+
+for (const header of [
+	'["features"."multi_agent_v2"]',
+	"[ features . multi_agent_v2 ]",
+	'["features"."multi_agent_v\\u0032"]',
+]) {
+	test(`#given SessionStart migration sees equivalent V2 header ${header} #when migrating twice #then preserves one valid table and the explicit cap`, async () => {
+		const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-equivalent-header-"));
+		const configPath = join(root, "config.toml");
+		await writeFile(
+			configPath,
+			[
+				'model = "gpt-5.4"',
+				"",
+				header,
+				"usage_hint_enabled = false",
+				"max_concurrent_threads_per_session = 7 # user cap",
+				"show_tool_use = false",
+				"",
+			].join("\n"),
+		);
+
+		await migrateConfigFile(configPath);
+		const firstPass = await readFile(configPath, "utf8");
+		const parsed = parseTomlWithPython(firstPass);
+		const secondResult = await migrateConfigFile(configPath);
+		const secondPass = await readFile(configPath, "utf8");
+
+		assert.equal(parsed.features.multi_agent_v2.max_concurrent_threads_per_session, 7);
+		assert.equal(secondResult.changed, false);
+		assert.equal(secondPass, firstPass);
+		assert.equal((secondPass.match(/max_concurrent_threads_per_session\s*=/g) ?? []).length, 1);
+		assert.match(
+			secondPass,
+			/usage_hint_enabled = false\nmax_concurrent_threads_per_session = 7 # user cap\nshow_tool_use = false/,
+		);
+		assert.match(secondPass, new RegExp(header.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	});
+}
+
+for (const fixture of [
+	{
+		name: "quoted cap key",
+		lines: [
+			"[features.multi_agent_v2]",
+			'"max_concurrent_threads_per_session" = 7 # user cap',
+		],
+		preservedLine: '"max_concurrent_threads_per_session" = 7 # user cap',
+	},
+	{
+		name: "escaped quoted cap key",
+		lines: [
+			"[features.multi_agent_v2]",
+			'"max_concurrent_threads_per_sessio\\u006e" = 7 # user cap',
+		],
+		preservedLine: '"max_concurrent_threads_per_sessio\\u006e" = 7 # user cap',
+	},
+	{
+		name: "dotted cap key",
+		lines: [
+			"[features]",
+			"multi_agent_v2.max_concurrent_threads_per_session = 7 # user cap",
+		],
+		preservedLine: "multi_agent_v2.max_concurrent_threads_per_session = 7 # user cap",
+	},
+	{
+		name: "root-qualified dotted cap key",
+		lines: ["features.multi_agent_v2.max_concurrent_threads_per_session = 7 # user cap"],
+		preservedLine: "features.multi_agent_v2.max_concurrent_threads_per_session = 7 # user cap",
+	},
+]) {
+	test(`#given SessionStart migration sees a ${fixture.name} #when migrating twice #then preserves the semantic cap without duplication`, async () => {
+		const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-semantic-key-"));
+		const configPath = join(root, "config.toml");
+		await writeFile(configPath, ['model = "gpt-5.4"', "", ...fixture.lines, ""].join("\n"));
+
+		await migrateConfigFile(configPath);
+		const firstPass = await readFile(configPath, "utf8");
+		const parsed = parseTomlWithPython(firstPass);
+		const secondResult = await migrateConfigFile(configPath);
+		const secondPass = await readFile(configPath, "utf8");
+
+		assert.equal(parsed.features.multi_agent_v2.max_concurrent_threads_per_session, 7);
+		assert.equal(secondResult.changed, false);
+		assert.equal(secondPass, firstPass);
+		assert.match(secondPass, new RegExp(fixture.preservedLine.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+		assert.doesNotMatch(secondPass, /^max_concurrent_threads_per_session = 16$/m);
+		if (fixture.name === "root-qualified dotted cap key") {
+			assert.equal(parsed.features.multi_agent_v2.enabled, false);
+		}
+	});
+}
+
+test("#given multiline string contains V2 cap lookalikes #when SessionStart migrates #then writes the absent semantic default", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-multiline-lookalike-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.4"',
+			'notes = """',
+			"[features.multi_agent_v2]",
+			"max_concurrent_threads_per_session = 7",
+			'"""',
+			"",
+		].join("\n"),
+	);
+
+	await migrateConfigFile(configPath);
+	const content = await readFile(configPath, "utf8");
+	const parsed = parseTomlWithPython(content);
+
+	assert.match(parsed.notes, /max_concurrent_threads_per_session = 7/);
+	assert.equal(parsed.features.multi_agent_v2.max_concurrent_threads_per_session, 16);
+});
+
+test("#given V2 section multiline value contains a cap lookalike #when SessionStart migrates #then writes the absent default", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-section-multiline-lookalike-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.4"',
+			"[features.multi_agent_v2]",
+			'notes = """',
+			"max_concurrent_threads_per_session = 7",
+			'"""',
+			"",
+		].join("\n"),
+	);
+
+	await migrateConfigFile(configPath);
+	const parsed = parseTomlWithPython(await readFile(configPath, "utf8"));
+
+	assert.equal(parsed.features.multi_agent_v2.max_concurrent_threads_per_session, 16);
+});
+
+test("#given V2 root-dotted disable and cap #when gpt-5.6 SessionStart migrates #then removes disable and V1 agents cap", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-root-dotted-v2-cleanup-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.6-terra"',
+			"features.multi_agent_v2.max_concurrent_threads_per_session = 7",
+			"features.multi_agent_v2.enabled = false",
+			"",
+			"[agents]",
+			"max_threads = 1000",
+			"",
+		].join("\n"),
+	);
+
+	await migrateConfigFile(configPath, { sessionModel: "gpt-5.6-terra" });
+	const content = await readFile(configPath, "utf8");
+	const parsed = parseTomlWithPython(content);
+
+	assert.equal(parsed.features.multi_agent_v2.max_concurrent_threads_per_session, 7);
+	assert.equal(parsed.features.multi_agent_v2.enabled, undefined);
+	assert.equal(parsed.agents, undefined);
+});
+
+test("#given quoted dotted V1 keys under features #when SessionStart migrates #then replaces enabled without a duplicate", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-quoted-dotted-v1-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.4"',
+			"",
+			"[features]",
+			'"multi_agent_v2".enabled = true',
+			'"multi_agent_v2".max_concurrent_threads_per_session = 7',
+			"",
+		].join("\n"),
+	);
+
+	await migrateConfigFile(configPath);
+	const content = await readFile(configPath, "utf8");
+	const parsed = parseTomlWithPython(content);
+
+	assert.equal(parsed.features.multi_agent_v2.enabled, false);
+	assert.equal(parsed.features.multi_agent_v2.max_concurrent_threads_per_session, 7);
+	assert.equal((content.match(/enabled\s*=/g) ?? []).length, 1);
+});
+
+test("#given multiline string closes after an escaped quote #when SessionStart migrates #then preserves the following explicit cap", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-overlapping-closer-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.4"',
+			'notes = """abc\\\""""',
+			"[features.multi_agent_v2]",
+			"max_concurrent_threads_per_session = 7",
+			"",
+		].join("\n"),
+	);
+
+	await migrateConfigFile(configPath);
+	const content = await readFile(configPath, "utf8");
+	const parsed = parseTomlWithPython(content);
+
+	assert.equal(parsed.features.multi_agent_v2.max_concurrent_threads_per_session, 7);
+	assert.equal((content.match(/^\[features\.multi_agent_v2\]$/gm) ?? []).length, 1);
 });
 
 test("#given gpt-5.6 session model with no models_cache and an explicit V2 cap #when migrating #then removes agents.max_threads but preserves the cap", async () => {

--- a/packages/omo-codex/plugin/test/subagent-limit-migration.test.mjs
+++ b/packages/omo-codex/plugin/test/subagent-limit-migration.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { migrateConfigFile } from "../scripts/migrate-codex-config.mjs";
 
-test("#given SessionStart config migration sees an explicit V2 cap #when migrating #then preserves it while raising the legacy cap", async () => {
+test("#given SessionStart migration sees an inline-commented V2 cap #when migrating twice #then preserves the line and ordering byte-for-byte", async () => {
 	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-migration-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
@@ -26,21 +26,30 @@ test("#given SessionStart config migration sees an explicit V2 cap #when migrati
 			"",
 			"[features.multi_agent_v2]",
 			"enabled = false",
-			"max_concurrent_threads_per_session = 6",
+			"usage_hint_enabled = false",
+			"max_concurrent_threads_per_session = 7 # user cap",
+			"show_tool_use = false",
 			"",
 		].join("\n"),
 	);
 
-	const result = await migrateConfigFile(configPath);
+	const firstResult = await migrateConfigFile(configPath);
+	const firstPass = await readFile(configPath, "utf8");
+	const secondResult = await migrateConfigFile(configPath);
 
-	const content = await readFile(configPath, "utf8");
-	assert.equal(result.changed, true);
-	assert.match(content, /\[agents\][\s\S]*?max_threads = 1000/);
-	assert.match(content, /max_depth = 4/);
-	assert.match(content, /\[agents\.explorer\]\nconfig_file = "\.\/agents\/explorer\.toml"/);
-	assert.match(content, /\[features\.multi_agent_v2\][\s\S]*?enabled = false/);
-	assert.match(content, /max_concurrent_threads_per_session = 6/);
-	assert.doesNotMatch(content, /^max_threads\s*=\s*6$/m);
+	const secondPass = await readFile(configPath, "utf8");
+	assert.equal(firstResult.changed, true);
+	assert.equal(secondResult.changed, false);
+	assert.equal(secondPass, firstPass);
+	assert.match(
+		secondPass,
+		/usage_hint_enabled = false\nmax_concurrent_threads_per_session = 7 # user cap\nshow_tool_use = false/,
+	);
+	assert.match(secondPass, /\[agents\][\s\S]*?max_threads = 1000/);
+	assert.match(secondPass, /max_depth = 4/);
+	assert.match(secondPass, /\[agents\.explorer\]\nconfig_file = "\.\/agents\/explorer\.toml"/);
+	assert.match(secondPass, /\[features\.multi_agent_v2\][\s\S]*?enabled = false/);
+	assert.doesNotMatch(secondPass, /^max_threads\s*=\s*6$/m);
 });
 
 test("#given gpt-5.6 session model with no models_cache and an explicit V2 cap #when migrating #then removes agents.max_threads but preserves the cap", async () => {

--- a/packages/omo-codex/plugin/test/subagent-limit-migration.test.mjs
+++ b/packages/omo-codex/plugin/test/subagent-limit-migration.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { migrateConfigFile } from "../scripts/migrate-codex-config.mjs";
 
-test("#given SessionStart config migration sees a low subagent cap #when migrating #then raises it to 1000", async () => {
+test("#given SessionStart config migration sees an explicit V2 cap #when migrating #then preserves it while raising the legacy cap", async () => {
 	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-migration-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
@@ -39,11 +39,11 @@ test("#given SessionStart config migration sees a low subagent cap #when migrati
 	assert.match(content, /max_depth = 4/);
 	assert.match(content, /\[agents\.explorer\]\nconfig_file = "\.\/agents\/explorer\.toml"/);
 	assert.match(content, /\[features\.multi_agent_v2\][\s\S]*?enabled = false/);
-	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_concurrent_threads_per_session = 6/);
 	assert.doesNotMatch(content, /^max_threads\s*=\s*6$/m);
 });
 
-test("#given gpt-5.6 session model with no models_cache #when migrating #then does not write agents.max_threads", async () => {
+test("#given gpt-5.6 session model with no models_cache and an explicit V2 cap #when migrating #then removes agents.max_threads but preserves the cap", async () => {
 	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-gpt56-nocache-"));
 	const configPath = join(root, "config.toml");
 	await writeFile(
@@ -58,7 +58,7 @@ test("#given gpt-5.6 session model with no models_cache #when migrating #then do
 			"",
 			"[features.multi_agent_v2]",
 			"enabled = false",
-			"max_concurrent_threads_per_session = 1000",
+			"max_concurrent_threads_per_session = 6",
 			"",
 		].join("\n"),
 	);
@@ -73,7 +73,28 @@ test("#given gpt-5.6 session model with no models_cache #when migrating #then do
 	assert.doesNotMatch(content, /^\s*max_threads\s*=/m);
 	assert.doesNotMatch(content, /^\s*enabled\s*=\s*false/m);
 	assert.match(content, /max_depth = 4/);
-	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_concurrent_threads_per_session = 6/);
+});
+
+test("#given SessionStart config migration has no V2 cap #when migrating #then writes the conservative managed default", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-subagent-limit-missing-cap-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.4"',
+			"",
+			"[features.multi_agent_v2]",
+			"enabled = false",
+			"",
+		].join("\n"),
+	);
+
+	await migrateConfigFile(configPath);
+
+	const content = await readFile(configPath, "utf8");
+	assert.match(content, /max_concurrent_threads_per_session = 16/);
+	assert.doesNotMatch(content, /max_concurrent_threads_per_session = 1000/);
 });
 
 test("#given config without any model #when migrating #then does not introduce agents.max_threads", async () => {
@@ -89,7 +110,7 @@ test("#given config without any model #when migrating #then does not introduce a
 	const content = await readFile(configPath, "utf8");
 	assert.doesNotMatch(content, /^\s*max_threads\s*=/m);
 	assert.match(content, /max_depth = 4/);
-	assert.match(content, /max_concurrent_threads_per_session = 1000/);
+	assert.match(content, /max_concurrent_threads_per_session = 16/);
 });
 
 test("#given config without any model but an existing low cap #when migrating #then still raises the existing cap", async () => {

--- a/packages/omo-codex/scripts/install-config.test.mjs
+++ b/packages/omo-codex/scripts/install-config.test.mjs
@@ -29,9 +29,9 @@ test("#given empty Codex config #when script installer updates config #then sets
 	assert.doesNotMatch(config, /^\s*multi_agent_mode\s*=/m);
 	assert.doesNotMatch(config, /^\s*max_threads\s*=/m);
 	assert.match(config, /\[features\.multi_agent_v2\]/);
-const v2Section = multiAgentV2Section(config);
+	const v2Section = multiAgentV2Section(config);
 	assert.doesNotMatch(v2Section, /^enabled\s*=/m);
-	assert.match(v2Section, /max_concurrent_threads_per_session = 1000/);
+	assert.match(v2Section, /max_concurrent_threads_per_session = 16/);
 });
 
 test("#given queue multi-agent mode #when script installer updates config #then removes unsupported root key", async () => {
@@ -313,8 +313,8 @@ test("#given existing MultiAgentV2 table #when script installer updates config #
 	assert.match(config, /\[features\.multi_agent_v2\]/);
 	assert.doesNotMatch(sectionText(config, "[features.multi_agent_v2]"), /enabled = true/);
 	assert.match(config, /usage_hint_enabled = false/);
-	assert.match(config, /max_concurrent_threads_per_session = 1000/);
-	assert.doesNotMatch(config, /max_concurrent_threads_per_session = 4/);
+	assert.match(config, /max_concurrent_threads_per_session = 4/);
+	assert.doesNotMatch(config, /max_concurrent_threads_per_session = 1000/);
 });
 
 test("#given empty Codex config #when script installer updates config #then sets the generated MultiAgentV2 thread limit", async () => {
@@ -337,7 +337,7 @@ test("#given empty Codex config #when script installer updates config #then sets
 	const config = await readFile(configPath, "utf8");
 	const v2Section = config.slice(config.indexOf("[features.multi_agent_v2]"));
 	assert.doesNotMatch(config, /^\s*max_threads\s*=/m);
-	assert.match(v2Section, /max_concurrent_threads_per_session = 1000/);
+	assert.match(v2Section, /max_concurrent_threads_per_session = 16/);
 	assert.doesNotMatch(v2Section, /hide_spawn_agent_metadata/);
 });
 
@@ -401,10 +401,10 @@ test("#given legacy boolean MultiAgentV2 flag and table #when script installer u
 	const config = await readFile(configPath, "utf8");
 	assert.doesNotMatch(config, /^multi_agent_v2\s*=/m);
 	assert.match(config, /\[features\.multi_agent_v2\]/);
-const v2Section = multiAgentV2Section(config);
+	const v2Section = multiAgentV2Section(config);
 	assert.doesNotMatch(v2Section, /^enabled\s*=/m);
 	assert.match(v2Section, /usage_hint_enabled = false/);
-	assert.match(v2Section, /max_concurrent_threads_per_session = 1000/);
+	assert.match(v2Section, /max_concurrent_threads_per_session = 16/);
 });
 
 test("#given legacy boolean MultiAgentV2 flag false #when script installer updates config #then normalizes to a disabled table config", async () => {
@@ -440,7 +440,7 @@ test("#given legacy boolean MultiAgentV2 flag false #when script installer updat
 	assert.match(config, /\[features\.multi_agent_v2\]/);
 	const disabledV2Section = multiAgentV2Section(config);
 	assert.match(disabledV2Section, /^enabled = false$/m);
-	assert.match(disabledV2Section, /^max_concurrent_threads_per_session = 1000$/m);
+	assert.match(disabledV2Section, /^max_concurrent_threads_per_session = 16$/m);
 });
 
 test("#given legacy agents max_threads #when script installer updates config #then raises the root subagent thread cap", async () => {
@@ -474,9 +474,9 @@ test("#given legacy agents max_threads #when script installer updates config #th
 	// then
 	const config = await readFile(configPath, "utf8");
 	assert.match(config, /\[features\.multi_agent_v2\]/);
-const v2Section = multiAgentV2Section(config);
+	const v2Section = multiAgentV2Section(config);
 	assert.doesNotMatch(v2Section, /^enabled\s*=/m);
-	assert.match(v2Section, /max_concurrent_threads_per_session = 1000/);
+	assert.match(v2Section, /max_concurrent_threads_per_session = 16/);
 	assert.match(config, /\[agents\]/);
 	assert.match(config, /max_threads = 1000/);
 	assert.doesNotMatch(config, /max_threads = 16/);

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5903,7 +5903,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.18.0",
+    version: "4.18.1",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -8687,12 +8687,12 @@ import { dirname as dirname7, isAbsolute as isAbsolute6, join as join18 } from "
 var CODEX_AGENTS_HEADER = "agents";
 var CODEX_MULTI_AGENT_V2_HEADER = "features.multi_agent_v2";
 var CODEX_SUBAGENT_THREAD_LIMIT = 1000;
+var CODEX_MULTI_AGENT_V2_THREAD_LIMIT = 16;
 function ensureCodexMultiAgentV2Config(config, options = {}) {
   const featureFlag = removeFeatureFlagSetting(config, "multi_agent_v2");
   const v2Preferred = options.multiAgentVersion === "v2";
   const modelKnown = options.multiAgentVersion != null || readRootModel(featureFlag.config) !== null;
   const agentsConfig = v2Preferred ? removeAgentsMaxThreads(featureFlag.config) : modelKnown ? ensureAgentsMaxThreads(featureFlag.config) : raiseExistingAgentsMaxThreads(featureFlag.config);
-  const maxThreadsValue = CODEX_SUBAGENT_THREAD_LIMIT.toString();
   const preserveDisable = featureFlag.value === false && !v2Preferred;
   const featureConfig = preserveDisable ? setMultiAgentV2Disable(agentsConfig) : v2Preferred ? removeMultiAgentV2Disable(agentsConfig) : agentsConfig;
   const section = findTomlSection(featureConfig, CODEX_MULTI_AGENT_V2_HEADER);
@@ -8700,10 +8700,12 @@ function ensureCodexMultiAgentV2Config(config, options = {}) {
     const enabledSetting = preserveDisable ? `enabled = false
 ` : "";
     return appendBlock(featureConfig, `[${CODEX_MULTI_AGENT_V2_HEADER}]
-${enabledSetting}max_concurrent_threads_per_session = ${maxThreadsValue}
+${enabledSetting}max_concurrent_threads_per_session = ${CODEX_MULTI_AGENT_V2_THREAD_LIMIT}
 `);
   }
-  return replaceOrInsertSetting(featureConfig, section, "max_concurrent_threads_per_session", maxThreadsValue);
+  if (/^\s*max_concurrent_threads_per_session\s*=/m.test(section.text))
+    return featureConfig;
+  return replaceOrInsertSetting(featureConfig, section, "max_concurrent_threads_per_session", CODEX_MULTI_AGENT_V2_THREAD_LIMIT.toString());
 }
 function resolveCodexMultiAgentVersion(config, configPath) {
   const model = readRootModel(config);

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5903,7 +5903,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.18.1",
+    version: "4.18.2",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -7837,9 +7837,16 @@ function findTomlSection(config, header) {
   const lines = config.match(/[^\n]*\n?|$/g) ?? [];
   let offset = 0;
   let start = -1;
+  let multilineQuote = null;
   for (const line of lines) {
     if (line.length === 0)
       break;
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+    multilineQuote = multilineScan.nextQuote;
+    if (multilineScan.wasInside) {
+      offset += line.length;
+      continue;
+    }
     const trimmed = line.trim();
     if (start === -1) {
       if (tomlTableHeaderMatches(trimmed, headerLine, targetHeaderPath))
@@ -7854,8 +7861,37 @@ function findTomlSection(config, header) {
   return { start, end: config.length, text: config.slice(start) };
 }
 function replaceOrInsertSetting(config, section, key, value) {
-  const linePattern = new RegExp(`^[ \\t]*${escapeRegExp(key)}[ \\t]*=.*$`, "m");
-  const replacement = linePattern.test(section.text) ? section.text.replace(linePattern, `${key} = ${value}`) : insertSetting(section.text, key, value);
+  const targetPath = parseTomlDottedKey(key);
+  if (!targetPath)
+    return config;
+  const lines = section.text.match(/[^\n]*\n?|$/g) ?? [];
+  let offset = 0;
+  let multilineQuote = null;
+  for (const line of lines) {
+    if (line.length === 0)
+      break;
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+    multilineQuote = multilineScan.nextQuote;
+    if (multilineScan.wasInside) {
+      offset += line.length;
+      continue;
+    }
+    const assignmentIndex = findUnquotedAssignment(line);
+    if (assignmentIndex < 0) {
+      offset += line.length;
+      continue;
+    }
+    const settingPath = parseTomlDottedKey(line.slice(0, assignmentIndex).trim());
+    if (!settingPath || !tomlPathMatches(settingPath, targetPath)) {
+      offset += line.length;
+      continue;
+    }
+    const replacement2 = replaceTomlAssignmentValue(line, assignmentIndex, value);
+    const assignmentEnd = multilineScan.nextQuote ? findTomlMultilineValueEnd(section.text, offset + line.length, multilineScan.nextQuote) : offset + line.length;
+    const sectionReplacement = section.text.slice(0, offset) + replacement2 + section.text.slice(assignmentEnd);
+    return config.slice(0, section.start) + sectionReplacement + config.slice(section.end);
+  }
+  const replacement = insertSetting(section.text, key, value);
   return config.slice(0, section.start) + replacement + config.slice(section.end);
 }
 function removeSetting(config, section, key) {
@@ -7877,6 +7913,50 @@ function replaceOrInsertRootSetting(config, key, value) {
 
 ${suffix.trimStart()}`;
 }
+function replaceOrInsertRootDottedSetting(config, keyPath, value) {
+  const targetPath = parseTomlDottedKey(keyPath);
+  if (!targetPath)
+    return config;
+  const lines = config.match(/[^\n]*\n?|$/g) ?? [];
+  let offset = 0;
+  let multilineQuote = null;
+  for (const line of lines) {
+    if (line.length === 0)
+      break;
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+    multilineQuote = multilineScan.nextQuote;
+    if (multilineScan.wasInside) {
+      offset += line.length;
+      continue;
+    }
+    if (isTomlTableHeaderLine(line))
+      break;
+    const assignmentIndex = findUnquotedAssignment(line);
+    if (assignmentIndex < 0) {
+      offset += line.length;
+      continue;
+    }
+    const settingPath = parseTomlDottedKey(line.slice(0, assignmentIndex).trim());
+    if (!settingPath || !tomlPathMatches(settingPath, targetPath)) {
+      offset += line.length;
+      continue;
+    }
+    const replacement2 = replaceTomlAssignmentValue(line, assignmentIndex, value);
+    const assignmentEnd = multilineScan.nextQuote ? findTomlMultilineValueEnd(config, offset + line.length, multilineScan.nextQuote) : offset + line.length;
+    return config.slice(0, offset) + replacement2 + config.slice(assignmentEnd);
+  }
+  const sectionStart = findFirstTableStart(config);
+  const root = config.slice(0, sectionStart).trimEnd();
+  const suffix = config.slice(sectionStart);
+  const replacement = `${root}${root.length > 0 ? `
+` : ""}${keyPath} = ${value}
+`;
+  if (suffix.length === 0)
+    return replacement;
+  return `${replacement.trimEnd()}
+
+${suffix.trimStart()}`;
+}
 function appendBlock(config, block) {
   const prefix = config.trimEnd();
   return `${prefix}${prefix.length > 0 ? `
@@ -7887,9 +7967,16 @@ function appendBlock(config, block) {
 function findFirstTableStart(config) {
   const lines = config.match(/[^\n]*\n?|$/g) ?? [];
   let offset = 0;
+  let multilineQuote = null;
   for (const line of lines) {
     if (line.length === 0)
       break;
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+    multilineQuote = multilineScan.nextQuote;
+    if (multilineScan.wasInside) {
+      offset += line.length;
+      continue;
+    }
     if (isTomlTableHeaderLine(line))
       return offset;
     offset += line.length;
@@ -7926,6 +8013,131 @@ function parseTomlTableHeader(line) {
 function isTomlTableHeaderLine(line) {
   const normalizedLine = stripUnquotedInlineComment(line).trim();
   return normalizedLine.startsWith("[") && normalizedLine.endsWith("]");
+}
+function scanTomlMultilineLine(line, currentQuote) {
+  if (currentQuote) {
+    return {
+      wasInside: true,
+      nextQuote: findTomlMultilineDelimiter(line, currentQuote, 0) === -1 ? currentQuote : null
+    };
+  }
+  let quote = null;
+  let index = 0;
+  while (index < line.length) {
+    const char = line[index];
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"')
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'")
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (char === "#")
+      break;
+    const delimiter2 = line.startsWith('"""', index) ? '"""' : line.startsWith("'''", index) ? "'''" : null;
+    if (delimiter2) {
+      const closingIndex = findTomlMultilineDelimiter(line, delimiter2, index + delimiter2.length);
+      return { wasInside: false, nextQuote: closingIndex === -1 ? delimiter2 : null };
+    }
+    if (char === '"' || char === "'")
+      quote = char;
+    index += 1;
+  }
+  return { wasInside: false, nextQuote: null };
+}
+function findTomlMultilineDelimiter(line, delimiter2, startIndex) {
+  let index = line.indexOf(delimiter2, startIndex);
+  while (index !== -1) {
+    if (delimiter2 === "'''" || countPrecedingBackslashes(line, index) % 2 === 0)
+      return index;
+    index = line.indexOf(delimiter2, index + 1);
+  }
+  return -1;
+}
+function countPrecedingBackslashes(line, index) {
+  let count = 0;
+  let cursor = index - 1;
+  while (cursor >= 0 && line[cursor] === "\\") {
+    count += 1;
+    cursor -= 1;
+  }
+  return count;
+}
+function findUnquotedAssignment(line) {
+  return findUnquotedCharacter(line, "=", 0);
+}
+function findUnquotedComment(line, startIndex) {
+  return findUnquotedCharacter(line, "#", startIndex);
+}
+function findUnquotedCharacter(line, target, startIndex) {
+  let quote = null;
+  let index = startIndex;
+  while (index < line.length) {
+    const char = line[index];
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"')
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'")
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      index += 1;
+      continue;
+    }
+    if (char === target)
+      return index;
+    if (char === "#")
+      return -1;
+    index += 1;
+  }
+  return -1;
+}
+function tomlPathMatches(candidate, target) {
+  return candidate.length === target.length && candidate.every((part, index) => part === target[index]);
+}
+function replaceTomlAssignmentValue(line, assignmentIndex, value) {
+  const newline = line.endsWith(`
+`) ? `
+` : "";
+  const lineBody = newline ? line.slice(0, -1) : line;
+  const commentIndex = findUnquotedComment(lineBody, assignmentIndex + 1);
+  const comment = commentIndex === -1 ? "" : ` ${lineBody.slice(commentIndex).trimStart()}`;
+  return `${lineBody.slice(0, assignmentIndex + 1)} ${value}${comment}${newline}`;
+}
+function findTomlMultilineValueEnd(text, startOffset, quote) {
+  const lines = text.slice(startOffset).match(/[^\n]*\n?|$/g) ?? [];
+  let offset = startOffset;
+  let currentQuote = quote;
+  for (const line of lines) {
+    if (line.length === 0)
+      break;
+    const scan = scanTomlMultilineLine(line, currentQuote);
+    currentQuote = scan.nextQuote;
+    offset += line.length;
+    if (currentQuote === null)
+      return offset;
+  }
+  return text.length;
 }
 function stripUnquotedInlineComment(line) {
   let quote = null;
@@ -8257,13 +8469,137 @@ function delay(milliseconds) {
   return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
 }
 
+// packages/omo-codex/src/install/toml-setting-reader.ts
+function hasTomlSetting(config, keyPath) {
+  const targetPath = parseTomlDottedKey(keyPath);
+  if (!targetPath)
+    return false;
+  return hasTomlAssignment(config, (tablePath, settingPath) => {
+    const fullPath = [...tablePath, ...settingPath];
+    return fullPath.length === targetPath.length && fullPath.every((part, index) => part === targetPath[index]);
+  });
+}
+function hasTomlRootDottedKeyPrefix(config, rootKey) {
+  return hasTomlAssignment(config, (tablePath, settingPath) => tablePath.length === 0 && settingPath.length > 1 && settingPath[0] === rootKey);
+}
+function hasTomlAssignment(config, predicate) {
+  let tablePath = [];
+  let multilineQuote = null;
+  for (const line of config.split(`
+`)) {
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote);
+    multilineQuote = multilineScan.nextQuote;
+    if (multilineScan.wasInside)
+      continue;
+    const normalizedLine = stripUnquotedInlineComment2(line).trim();
+    if (normalizedLine.length === 0)
+      continue;
+    const headerPath = parseTomlTableHeader2(normalizedLine);
+    if (headerPath) {
+      tablePath = headerPath;
+      continue;
+    }
+    if (isTomlTableHeaderLine2(normalizedLine)) {
+      tablePath = null;
+      continue;
+    }
+    if (!tablePath)
+      continue;
+    const assignmentIndex = findUnquotedAssignment2(normalizedLine);
+    if (assignmentIndex < 0)
+      continue;
+    const settingPath = parseTomlDottedKey(normalizedLine.slice(0, assignmentIndex).trim());
+    if (!settingPath)
+      continue;
+    if (predicate(tablePath, settingPath))
+      return true;
+  }
+  return false;
+}
+function parseTomlTableHeader2(line) {
+  if (!line.startsWith("[") || !line.endsWith("]") || line.startsWith("[["))
+    return null;
+  return parseTomlDottedKey(line.slice(1, -1).trim());
+}
+function isTomlTableHeaderLine2(line) {
+  return line.startsWith("[") && line.endsWith("]");
+}
+function stripUnquotedInlineComment2(line) {
+  let quote = null;
+  let index = 0;
+  while (index < line.length) {
+    const char = line[index];
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"')
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'")
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      index += 1;
+      continue;
+    }
+    if (char === "#")
+      return line.slice(0, index);
+    index += 1;
+  }
+  return line;
+}
+function findUnquotedAssignment2(line) {
+  let quote = null;
+  let index = 0;
+  while (index < line.length) {
+    const char = line[index];
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"')
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'")
+        quote = null;
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      index += 1;
+      continue;
+    }
+    if (char === "=")
+      return index;
+    index += 1;
+  }
+  return -1;
+}
+
 // packages/omo-codex/src/install/codex-config-features.ts
 function ensureFeatureEnabled(config, featureName) {
   const section = findTomlSection(config, "features");
-  if (!section)
+  if (!section) {
+    if (hasTomlRootDottedKeyPrefix(config, "features")) {
+      return replaceOrInsertRootDottedSetting(config, `features.${featureName}`, "true");
+    }
     return appendBlock(config, `[features]
 ${featureName} = true
 `);
+  }
   return replaceOrInsertSetting(config, section, featureName, "true");
 }
 
@@ -8331,7 +8667,7 @@ function ensureAutonomousPermissions(config) {
   next = replaceOrInsertRootSetting(next, "sandbox_mode", JSON.stringify("danger-full-access"));
   next = replaceOrInsertRootSetting(next, "network_access", JSON.stringify("enabled"));
   for (const featureName of AUTONOMOUS_FEATURES) {
-    next = ensureFeatureEnabled2(next, featureName);
+    next = ensureFeatureEnabled(next, featureName);
   }
   next = removeWindowsSandboxSetting(next);
   next = ensureNoticeEnabled(next, "hide_full_access_warning");
@@ -8347,14 +8683,6 @@ function ensureNoticeEnabled(config, key) {
   const section = findTomlSection(config, "notice");
   if (section === null)
     return appendNoticeBlock(config, key);
-  return replaceOrInsertSetting(config, section, key, "true");
-}
-function ensureFeatureEnabled2(config, key) {
-  const section = findTomlSection(config, "features");
-  if (section === null)
-    return appendBlock(config, `[features]
-${key} = true
-`);
   return replaceOrInsertSetting(config, section, key, "true");
 }
 function appendNoticeBlock(config, key) {
@@ -8428,7 +8756,7 @@ function readStringArraySetting(sectionText, key) {
     const assignmentIndex = line.indexOf("=");
     if (assignmentIndex === -1)
       return null;
-    return parseTomlStringArray(stripUnquotedInlineComment2(line.slice(assignmentIndex + 1)).trim());
+    return parseTomlStringArray(stripUnquotedInlineComment3(line.slice(assignmentIndex + 1)).trim());
   }
   return null;
 }
@@ -8472,7 +8800,7 @@ function parseTomlString(input, startIndex) {
   }
   return null;
 }
-function stripUnquotedInlineComment2(line) {
+function stripUnquotedInlineComment3(line) {
   let quote = null;
   let index = 0;
   while (index < line.length) {
@@ -8686,6 +9014,7 @@ import { readFileSync } from "node:fs";
 import { dirname as dirname7, isAbsolute as isAbsolute6, join as join18 } from "node:path";
 var CODEX_AGENTS_HEADER = "agents";
 var CODEX_MULTI_AGENT_V2_HEADER = "features.multi_agent_v2";
+var CODEX_MULTI_AGENT_V2_THREAD_LIMIT_KEY = `${CODEX_MULTI_AGENT_V2_HEADER}.max_concurrent_threads_per_session`;
 var CODEX_SUBAGENT_THREAD_LIMIT = 1000;
 var CODEX_MULTI_AGENT_V2_THREAD_LIMIT = 16;
 function ensureCodexMultiAgentV2Config(config, options = {}) {
@@ -8695,6 +9024,8 @@ function ensureCodexMultiAgentV2Config(config, options = {}) {
   const agentsConfig = v2Preferred ? removeAgentsMaxThreads(featureFlag.config) : modelKnown ? ensureAgentsMaxThreads(featureFlag.config) : raiseExistingAgentsMaxThreads(featureFlag.config);
   const preserveDisable = featureFlag.value === false && !v2Preferred;
   const featureConfig = preserveDisable ? setMultiAgentV2Disable(agentsConfig) : v2Preferred ? removeMultiAgentV2Disable(agentsConfig) : agentsConfig;
+  if (hasTomlSetting(featureConfig, CODEX_MULTI_AGENT_V2_THREAD_LIMIT_KEY))
+    return featureConfig;
   const section = findTomlSection(featureConfig, CODEX_MULTI_AGENT_V2_HEADER);
   if (!section) {
     const enabledSetting = preserveDisable ? `enabled = false
@@ -8703,8 +9034,6 @@ function ensureCodexMultiAgentV2Config(config, options = {}) {
 ${enabledSetting}max_concurrent_threads_per_session = ${CODEX_MULTI_AGENT_V2_THREAD_LIMIT}
 `);
   }
-  if (/^\s*max_concurrent_threads_per_session\s*=/m.test(section.text))
-    return featureConfig;
   return replaceOrInsertSetting(featureConfig, section, "max_concurrent_threads_per_session", CODEX_MULTI_AGENT_V2_THREAD_LIMIT.toString());
 }
 function resolveCodexMultiAgentVersion(config, configPath) {

--- a/packages/omo-codex/scripts/install-generated-bundle.test.mjs
+++ b/packages/omo-codex/scripts/install-generated-bundle.test.mjs
@@ -78,7 +78,7 @@ test("#given no root model #when generated bundle updates config #then it does n
 	assert.match(config, /max_concurrent_threads_per_session = 16/);
 });
 
-test("#given an explicit V2 thread cap #when generated bundle updates config #then preserves the configured cap", async () => {
+test("#given an inline-commented V2 thread cap #when generated bundle updates config twice #then preserves the line and ordering byte-for-byte", async () => {
 	// given
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-generated-explicit-v2-cap-"));
 	const configPath = join(root, "config.toml");
@@ -86,26 +86,33 @@ test("#given an explicit V2 thread cap #when generated bundle updates config #th
 		configPath,
 		[
 			"[features.multi_agent_v2]",
-			"max_concurrent_threads_per_session = 6",
 			"usage_hint_enabled = false",
+			"max_concurrent_threads_per_session = 7 # user cap",
+			"show_tool_use = false",
 			"",
 		].join("\n"),
 	);
 
 	// when
-	await updateCodexConfig({
+	const updateInput = {
 		configPath,
 		repoRoot: "/repo/packages/omo-codex",
 		marketplaceName: "debug",
 		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
 		pluginNames: ["omo"],
-	});
+	};
+	await updateCodexConfig(updateInput);
+	const firstPass = await readFile(configPath, "utf8");
+	const firstV2Section = sectionText(firstPass, "[features.multi_agent_v2]");
+	await updateCodexConfig(updateInput);
 
 	// then
-	const config = await readFile(configPath, "utf8");
-	const v2Section = sectionText(config, "[features.multi_agent_v2]");
-	assert.match(v2Section, /^max_concurrent_threads_per_session = 6$/m);
-	assert.doesNotMatch(v2Section, /^max_concurrent_threads_per_session = 1000$/m);
+	const secondPass = await readFile(configPath, "utf8");
+	assert.equal(sectionText(secondPass, "[features.multi_agent_v2]"), firstV2Section);
+	assert.match(
+		sectionText(secondPass, "[features.multi_agent_v2]"),
+		/usage_hint_enabled = false\nmax_concurrent_threads_per_session = 7 # user cap\nshow_tool_use = false/,
+	);
 });
 
 test("#given explicit v1 model_catalog_json and stale models_cache v2 #when generated bundle updates config #then explicit catalog preserves disable and cap", async () => {

--- a/packages/omo-codex/scripts/install-generated-bundle.test.mjs
+++ b/packages/omo-codex/scripts/install-generated-bundle.test.mjs
@@ -75,7 +75,37 @@ test("#given no root model #when generated bundle updates config #then it does n
 	// then
 	const config = await readFile(configPath, "utf8");
 	assert.doesNotMatch(config, /^\s*max_threads\s*=/m);
-	assert.match(config, /max_concurrent_threads_per_session = 1000/);
+	assert.match(config, /max_concurrent_threads_per_session = 16/);
+});
+
+test("#given an explicit V2 thread cap #when generated bundle updates config #then preserves the configured cap", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-generated-explicit-v2-cap-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			"[features.multi_agent_v2]",
+			"max_concurrent_threads_per_session = 6",
+			"usage_hint_enabled = false",
+			"",
+		].join("\n"),
+	);
+
+	// when
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "debug",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+		pluginNames: ["omo"],
+	});
+
+	// then
+	const config = await readFile(configPath, "utf8");
+	const v2Section = sectionText(config, "[features.multi_agent_v2]");
+	assert.match(v2Section, /^max_concurrent_threads_per_session = 6$/m);
+	assert.doesNotMatch(v2Section, /^max_concurrent_threads_per_session = 1000$/m);
 });
 
 test("#given explicit v1 model_catalog_json and stale models_cache v2 #when generated bundle updates config #then explicit catalog preserves disable and cap", async () => {
@@ -153,7 +183,7 @@ test("#given explicit v2 model_catalog_json and stale models_cache v1 #when gene
 	const v2Section = sectionText(config, "[features.multi_agent_v2]");
 	assert.doesNotMatch(v2Section, /^enabled\s*=/m);
 	assert.doesNotMatch(config, /^\s*max_threads\s*=/m);
-	assert.match(v2Section, /max_concurrent_threads_per_session = 1000/);
+	assert.match(v2Section, /max_concurrent_threads_per_session = 16/);
 });
 
 function sectionText(config, header) {

--- a/packages/omo-codex/src/install/codex-config-features.ts
+++ b/packages/omo-codex/src/install/codex-config-features.ts
@@ -1,7 +1,13 @@
-import { appendBlock, findTomlSection, replaceOrInsertSetting } from "./toml-section-editor"
+import { appendBlock, findTomlSection, replaceOrInsertRootDottedSetting, replaceOrInsertSetting } from "./toml-section-editor"
+import { hasTomlRootDottedKeyPrefix } from "./toml-setting-reader"
 
 export function ensureFeatureEnabled(config: string, featureName: string): string {
   const section = findTomlSection(config, "features")
-  if (!section) return appendBlock(config, `[features]\n${featureName} = true\n`)
+  if (!section) {
+    if (hasTomlRootDottedKeyPrefix(config, "features")) {
+      return replaceOrInsertRootDottedSetting(config, `features.${featureName}`, "true")
+    }
+    return appendBlock(config, `[features]\n${featureName} = true\n`)
+  }
   return replaceOrInsertSetting(config, section, featureName, "true")
 }

--- a/packages/omo-codex/src/install/codex-config-permissions.ts
+++ b/packages/omo-codex/src/install/codex-config-permissions.ts
@@ -1,4 +1,5 @@
 import { appendBlock, findTomlSection, removeSetting, replaceOrInsertRootSetting, replaceOrInsertSetting } from "./toml-section-editor"
+import { ensureFeatureEnabled } from "./codex-config-features"
 
 const AUTONOMOUS_FEATURES = ["multi_agent", "unified_exec", "goals"] as const
 
@@ -23,12 +24,6 @@ function removeWindowsSandboxSetting(config: string): string {
 function ensureNoticeEnabled(config: string, key: string): string {
   const section = findTomlSection(config, "notice")
   if (section === null) return appendNoticeBlock(config, key)
-  return replaceOrInsertSetting(config, section, key, "true")
-}
-
-function ensureFeatureEnabled(config: string, key: string): string {
-  const section = findTomlSection(config, "features")
-  if (section === null) return appendBlock(config, `[features]\n${key} = true\n`)
   return replaceOrInsertSetting(config, section, key, "true")
 }
 

--- a/packages/omo-codex/src/install/codex-config-toml.test.ts
+++ b/packages/omo-codex/src/install/codex-config-toml.test.ts
@@ -80,7 +80,7 @@ describe("codex-config-toml", () => {
     const v2Section = content.slice(content.indexOf("[features.multi_agent_v2]"))
       .split(/^\[/m).slice(0, 1).join("")
     expect(v2Section).not.toContain("enabled")
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
     // The stamped gpt-5.6 default is a V2-preferred model: Codex rejects
     // agents.max_threads while MultiAgentV2 is active, so a fresh install
     // must not introduce it.
@@ -205,8 +205,8 @@ describe("codex-config-toml", () => {
     expect(content).toContain("[features.multi_agent_v2]")
     expect(content).toContain("enabled = false")
     expect(content).toContain("usage_hint_enabled = false")
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
-    expect(content).not.toContain("max_concurrent_threads_per_session = 4")
+    expect(content).toContain("max_concurrent_threads_per_session = 4")
+    expect(content).not.toContain("max_concurrent_threads_per_session = 1000")
   })
 
   test("#given empty Codex config #when updating config #then leaves Context7 to the plugin MCP manifest", async () => {
@@ -384,7 +384,7 @@ describe("codex-config-toml", () => {
       .split(/^\[/m).slice(0, 1).join("")
     expect(v2LegacySection).not.toContain("enabled")
     expect(content).toContain("usage_hint_enabled = false")
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
   })
 
   test("#given legacy boolean MultiAgentV2 flag false #when updating config #then normalizes to a disabled table config", async () => {
@@ -418,7 +418,7 @@ describe("codex-config-toml", () => {
     const content = await readFile(configPath, "utf8")
     expect(content).not.toMatch(/^multi_agent_v2\s*=/m)
     expect(content).toContain("[features.multi_agent_v2]")
-    expect(content).toMatch(/\[features\.multi_agent_v2\]\nenabled = false\nmax_concurrent_threads_per_session = 1000/)
+    expect(content).toMatch(/\[features\.multi_agent_v2\]\nenabled = false\nmax_concurrent_threads_per_session = 16/)
   })
 
   test("#given legacy agents max_threads #when updating config #then raises the root subagent thread cap", async () => {
@@ -455,7 +455,7 @@ describe("codex-config-toml", () => {
     const v2ThreadsSection = content.slice(content.indexOf("[features.multi_agent_v2]"))
       .split(/^\[/m).slice(0, 1).join("")
     expect(v2ThreadsSection).not.toContain("enabled")
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
     expect(content).toContain("[agents]")
     expect(content).toContain("max_threads = 1000")
     expect(content).not.toContain("max_threads = 16")
@@ -501,7 +501,7 @@ describe("codex-config-toml", () => {
     expect(content).not.toMatch(/^\s*multi_agent_v2\s*=/m)
     expect(content).not.toMatch(/^\s*enabled\s*=\s*false/m)
     expect(content).toContain("max_depth = 4")
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
   })
 
   test("#given gpt-5.6 family model without models_cache #when updating config #then treats it as V2-preferred", async () => {
@@ -522,7 +522,7 @@ describe("codex-config-toml", () => {
     // then
     const content = await readFile(configPath, "utf8")
     expect(content).not.toMatch(/^\s*max_threads\s*=/m)
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
   })
 
   test("#given gpt-5.6-luna resolving v1 in models_cache #when updating config #then keeps the v1 thread cap", async () => {
@@ -547,7 +547,7 @@ describe("codex-config-toml", () => {
     // then
     const content = await readFile(configPath, "utf8")
     expect(content).toContain("max_threads = 1000")
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
   })
 
   test("#given user-modified config without root model #when updating config #then does not introduce agents.max_threads", async () => {
@@ -571,7 +571,7 @@ describe("codex-config-toml", () => {
     // then
     const content = await readFile(configPath, "utf8")
     expect(content).not.toMatch(/^\s*max_threads\s*=/m)
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
   })
 
   test("#given managed agent role sections #when updating config #then preserves role config while raising only root agents max_threads", async () => {
@@ -873,5 +873,5 @@ describe("codex-config-toml", () => {
     // then
     const content = await readFile(configPath, "utf8")
     expect(content).toContain("max_threads = 1000")
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
   })

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
@@ -40,8 +40,37 @@ describe("codex MultiAgentV2 config", () => {
     expect(content).not.toMatch(/^\s*multi_agent_v2\s*=/m)
     expect(parsed.features.multi_agent_v2).toEqual({
       usage_hint_enabled: false,
-      max_concurrent_threads_per_session: 1000,
+      max_concurrent_threads_per_session: 16,
     })
+  })
+
+  test("#given an explicit V2 thread cap #when updating config #then preserves the configured cap", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-mav2-explicit-cap-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      [
+        "[features.multi_agent_v2]",
+        "usage_hint_enabled = false",
+        "max_concurrent_threads_per_session = 6",
+        "",
+      ].join("\n"),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    const parsed = parseToml(content)
+    expect(parsed.features.multi_agent_v2.max_concurrent_threads_per_session).toBe(6)
   })
 
   test("#given disabled boolean shorthand #when updating config #then explicit disable is preserved in table form", async () => {
@@ -77,7 +106,7 @@ describe("codex MultiAgentV2 config", () => {
     expect(content).not.toMatch(/^\s*multi_agent_v2\s*=/m)
     expect(parsed.features.multi_agent_v2).toEqual({
       enabled: false,
-      max_concurrent_threads_per_session: 1000,
+      max_concurrent_threads_per_session: 16,
     })
   })
 })

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
@@ -44,7 +44,7 @@ describe("codex MultiAgentV2 config", () => {
     })
   })
 
-  test("#given an explicit V2 thread cap #when updating config #then preserves the configured cap", async () => {
+  test("#given an inline-commented V2 thread cap #when updating config twice #then preserves the line and ordering byte-for-byte", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-mav2-explicit-cap-"))
     const configPath = join(root, "config.toml")
@@ -53,24 +53,33 @@ describe("codex MultiAgentV2 config", () => {
       [
         "[features.multi_agent_v2]",
         "usage_hint_enabled = false",
-        "max_concurrent_threads_per_session = 6",
+        "max_concurrent_threads_per_session = 7 # user cap",
+        "show_tool_use = false",
         "",
       ].join("\n"),
     )
 
     // when
-    await updateCodexConfig({
+    const updateInput = {
       configPath,
       repoRoot: "/repo/packages/omo-codex",
       marketplaceName: "debug",
       marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
       pluginNames: ["omo"],
-    })
+    } as const
+    await updateCodexConfig(updateInput)
+    const firstPass = await readFile(configPath, "utf8")
+    const firstV2Section = sectionText(firstPass, "[features.multi_agent_v2]")
+    await updateCodexConfig(updateInput)
 
     // then
-    const content = await readFile(configPath, "utf8")
-    const parsed = parseToml(content)
-    expect(parsed.features.multi_agent_v2.max_concurrent_threads_per_session).toBe(6)
+    const secondPass = await readFile(configPath, "utf8")
+    const parsed = parseToml(secondPass)
+    expect(secondPass).toContain(
+      "usage_hint_enabled = false\nmax_concurrent_threads_per_session = 7 # user cap\nshow_tool_use = false",
+    )
+    expect(parsed.features.multi_agent_v2.max_concurrent_threads_per_session).toBe(7)
+    expect(sectionText(secondPass, "[features.multi_agent_v2]")).toBe(firstV2Section)
   })
 
   test("#given disabled boolean shorthand #when updating config #then explicit disable is preserved in table form", async () => {
@@ -134,4 +143,11 @@ function isParsedCodexConfig(value: unknown): value is ParsedCodexConfig {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function sectionText(config: string, header: string): string {
+  const start = config.indexOf(header)
+  if (start < 0) return ""
+  const next = config.indexOf("\n[", start + header.length)
+  return next < 0 ? config.slice(start) : config.slice(start, next)
 }

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.test.ts
@@ -82,6 +82,215 @@ describe("codex MultiAgentV2 config", () => {
     expect(sectionText(secondPass, "[features.multi_agent_v2]")).toBe(firstV2Section)
   })
 
+  for (const fixture of [
+    {
+      name: "escaped quoted V2 header",
+      lines: ['["features"."multi_agent_v\\u0032"]', "max_concurrent_threads_per_session = 7 # user cap"],
+      preservedLine: '["features"."multi_agent_v\\u0032"]',
+    },
+    {
+      name: "quoted cap key",
+      lines: ["[features.multi_agent_v2]", '"max_concurrent_threads_per_session" = 7 # user cap'],
+      preservedLine: '"max_concurrent_threads_per_session" = 7 # user cap',
+    },
+    {
+      name: "escaped quoted cap key",
+      lines: ["[features.multi_agent_v2]", '"max_concurrent_threads_per_sessio\\u006e" = 7 # user cap'],
+      preservedLine: '"max_concurrent_threads_per_sessio\\u006e" = 7 # user cap',
+    },
+    {
+      name: "dotted cap key",
+      lines: ["[features]", "multi_agent_v2.max_concurrent_threads_per_session = 7 # user cap"],
+      preservedLine: "multi_agent_v2.max_concurrent_threads_per_session = 7 # user cap",
+    },
+    {
+      name: "root-qualified dotted cap key",
+      lines: ["features.multi_agent_v2.max_concurrent_threads_per_session = 7 # user cap"],
+      preservedLine: "features.multi_agent_v2.max_concurrent_threads_per_session = 7 # user cap",
+    },
+  ] as const) {
+    test(`#given installer config has a ${fixture.name} #when updating twice #then preserves the semantic cap without duplication`, async () => {
+      // given
+      const root = await mkdtemp(join(tmpdir(), "omo-codex-mav2-semantic-key-"))
+      const configPath = join(root, "config.toml")
+      await writeFile(configPath, ['model = "gpt-5.4"', "", ...fixture.lines, ""].join("\n"))
+      const updateInput = {
+        configPath,
+        repoRoot: "/repo/packages/omo-codex",
+        marketplaceName: "debug",
+        marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+        pluginNames: ["omo"],
+      } as const
+
+      // when
+      await updateCodexConfig(updateInput)
+      const firstPass = await readFile(configPath, "utf8")
+      const parsed = parseToml(firstPass)
+      await updateCodexConfig(updateInput)
+
+      // then
+      const secondPass = await readFile(configPath, "utf8")
+      const secondParsed = parseToml(secondPass)
+      expect(parsed.features.multi_agent_v2.max_concurrent_threads_per_session).toBe(7)
+      expect(secondParsed.features.multi_agent_v2.max_concurrent_threads_per_session).toBe(7)
+      expect(secondPass.indexOf(fixture.preservedLine)).toBe(firstPass.indexOf(fixture.preservedLine))
+      expect(secondPass.split(fixture.preservedLine)).toHaveLength(2)
+      expect(secondPass).toContain(fixture.preservedLine)
+      expect(secondPass).not.toMatch(/^max_concurrent_threads_per_session = 16$/m)
+      if (fixture.name === "root-qualified dotted cap key") expect(secondPass).not.toContain("[features]")
+    })
+  }
+
+  test("#given multiline string contains V2 cap lookalikes #when updating config #then writes the absent semantic default", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-mav2-multiline-lookalike-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      [
+        'notes = """',
+        "[features.multi_agent_v2]",
+        "max_concurrent_threads_per_session = 7",
+        '"""',
+        "",
+      ].join("\n"),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    const parsed = parseToml(content)
+    expect(content).toContain("max_concurrent_threads_per_session = 7")
+    expect(parsed.features.multi_agent_v2.max_concurrent_threads_per_session).toBe(16)
+  })
+
+  test("#given V2 section multiline value contains a cap lookalike #when updating config #then writes the absent default", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-mav2-section-multiline-lookalike-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      [
+        "[features.multi_agent_v2]",
+        'notes = """',
+        "max_concurrent_threads_per_session = 7",
+        '"""',
+        "",
+      ].join("\n"),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const parsed = parseToml(await readFile(configPath, "utf8"))
+    expect(parsed.features.multi_agent_v2.max_concurrent_threads_per_session).toBe(16)
+  })
+
+  test("#given root-dotted features and string lookalikes #when updating config #then replaces the semantic flag only", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-mav2-root-feature-integrity-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      [
+        'notes = """',
+        "features.plugins = false",
+        '"""',
+        '"features".plugins = false # user flag',
+        "features.multi_agent_v2.max_concurrent_threads_per_session = 7",
+        "",
+      ].join("\n"),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content).toContain('notes = """\nfeatures.plugins = false\n"""')
+    expect(content).toContain('"features".plugins = true # user flag')
+    expect(content).not.toContain("[features]")
+  })
+
+  test("#given root-dotted plugin flag has a multiline value #when updating config #then replaces the whole semantic assignment", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-mav2-root-feature-multiline-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      [
+        '"features".plugins = """',
+        "false",
+        '"""',
+        "features.multi_agent_v2.max_concurrent_threads_per_session = 7",
+        "",
+      ].join("\n"),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content).toContain('"features".plugins = true')
+    expect(content).not.toContain('\nfalse\n"""')
+    expect(parseToml(content).features.multi_agent_v2.max_concurrent_threads_per_session).toBe(7)
+  })
+
+  test("#given multiline string closes after an escaped quote #when updating config #then preserves the following explicit cap", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-mav2-overlapping-closer-"))
+    const configPath = join(root, "config.toml")
+    await writeFile(
+      configPath,
+      ['notes = """abc\\\""""', "[features.multi_agent_v2]", "max_concurrent_threads_per_session = 7", ""].join(
+        "\n",
+      ),
+    )
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    const parsed = parseToml(content)
+    expect(parsed.features.multi_agent_v2.max_concurrent_threads_per_session).toBe(7)
+    expect(content.match(/^\[features\.multi_agent_v2\]$/gm)).toHaveLength(1)
+  })
+
   test("#given disabled boolean shorthand #when updating config #then explicit disable is preserved in table form", async () => {
     // given
     // A pinned v1 model keeps the explicit disable materializing in table form;

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
@@ -6,6 +6,7 @@ import { appendBlock, escapeRegExp, findTomlSection, removeSetting, replaceOrIns
 const CODEX_AGENTS_HEADER = "agents"
 const CODEX_MULTI_AGENT_V2_HEADER = "features.multi_agent_v2"
 const CODEX_SUBAGENT_THREAD_LIMIT = 1000
+const CODEX_MULTI_AGENT_V2_THREAD_LIMIT = 16
 
 export type CodexMultiAgentVersion = "v1" | "v2" | null
 
@@ -45,7 +46,6 @@ export function ensureCodexMultiAgentV2Config(
     : modelKnown
       ? ensureAgentsMaxThreads(featureFlag.config)
       : raiseExistingAgentsMaxThreads(featureFlag.config)
-  const maxThreadsValue = CODEX_SUBAGENT_THREAD_LIMIT.toString()
   const preserveDisable = featureFlag.value === false && !v2Preferred
   const featureConfig = preserveDisable
     ? setMultiAgentV2Disable(agentsConfig)
@@ -57,10 +57,16 @@ export function ensureCodexMultiAgentV2Config(
     const enabledSetting = preserveDisable ? "enabled = false\n" : ""
     return appendBlock(
       featureConfig,
-      `[${CODEX_MULTI_AGENT_V2_HEADER}]\n${enabledSetting}max_concurrent_threads_per_session = ${maxThreadsValue}\n`,
+      `[${CODEX_MULTI_AGENT_V2_HEADER}]\n${enabledSetting}max_concurrent_threads_per_session = ${CODEX_MULTI_AGENT_V2_THREAD_LIMIT}\n`,
     )
   }
-  return replaceOrInsertSetting(featureConfig, section, "max_concurrent_threads_per_session", maxThreadsValue)
+  if (/^\s*max_concurrent_threads_per_session\s*=/m.test(section.text)) return featureConfig
+  return replaceOrInsertSetting(
+    featureConfig,
+    section,
+    "max_concurrent_threads_per_session",
+    CODEX_MULTI_AGENT_V2_THREAD_LIMIT.toString(),
+  )
 }
 
 /**

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-config.ts
@@ -1,10 +1,18 @@
 import { readFileSync } from "node:fs"
 import { dirname, isAbsolute, join } from "node:path"
 
-import { appendBlock, escapeRegExp, findTomlSection, removeSetting, replaceOrInsertSetting } from "./toml-section-editor"
+import {
+  appendBlock,
+  escapeRegExp,
+  findTomlSection,
+  removeSetting,
+  replaceOrInsertSetting,
+} from "./toml-section-editor"
+import { hasTomlSetting } from "./toml-setting-reader"
 
 const CODEX_AGENTS_HEADER = "agents"
 const CODEX_MULTI_AGENT_V2_HEADER = "features.multi_agent_v2"
+const CODEX_MULTI_AGENT_V2_THREAD_LIMIT_KEY = `${CODEX_MULTI_AGENT_V2_HEADER}.max_concurrent_threads_per_session`
 const CODEX_SUBAGENT_THREAD_LIMIT = 1000
 const CODEX_MULTI_AGENT_V2_THREAD_LIMIT = 16
 
@@ -52,6 +60,7 @@ export function ensureCodexMultiAgentV2Config(
     : v2Preferred
       ? removeMultiAgentV2Disable(agentsConfig)
       : agentsConfig
+  if (hasTomlSetting(featureConfig, CODEX_MULTI_AGENT_V2_THREAD_LIMIT_KEY)) return featureConfig
   const section = findTomlSection(featureConfig, CODEX_MULTI_AGENT_V2_HEADER)
   if (!section) {
     const enabledSetting = preserveDisable ? "enabled = false\n" : ""
@@ -60,7 +69,6 @@ export function ensureCodexMultiAgentV2Config(
       `[${CODEX_MULTI_AGENT_V2_HEADER}]\n${enabledSetting}max_concurrent_threads_per_session = ${CODEX_MULTI_AGENT_V2_THREAD_LIMIT}\n`,
     )
   }
-  if (/^\s*max_concurrent_threads_per_session\s*=/m.test(section.text)) return featureConfig
   return replaceOrInsertSetting(
     featureConfig,
     section,

--- a/packages/omo-codex/src/install/codex-multi-agent-v2-regression.test.ts
+++ b/packages/omo-codex/src/install/codex-multi-agent-v2-regression.test.ts
@@ -41,7 +41,8 @@ describe("codex MultiAgentV2 release blockers", () => {
     // then
     const content = await readFile(configPath, "utf8")
     expect(sectionText(content, "[features.multi_agent_v2]")).not.toMatch(/^\s*enabled\s*=\s*false/m)
-    expect(sectionText(content, "[features.multi_agent_v2]")).toContain("max_concurrent_threads_per_session = 1000")
+    expect(sectionText(content, "[features.multi_agent_v2]")).toContain("max_concurrent_threads_per_session = 6")
+    expect(sectionText(content, "[features.multi_agent_v2]")).not.toContain("max_concurrent_threads_per_session = 1000")
     expect(content).not.toMatch(/^\s*max_threads\s*=/m)
     expect(content).toContain("max_depth = 4")
   })
@@ -68,7 +69,7 @@ describe("codex MultiAgentV2 release blockers", () => {
     // then
     const content = await readFile(configPath, "utf8")
     expect(content).toContain("max_threads = 1000")
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
   })
 
   test("#given root gpt-5.6 model without catalog #when updating config #then removes stale V2 disable", async () => {
@@ -102,6 +103,7 @@ describe("codex MultiAgentV2 release blockers", () => {
     // then
     const content = await readFile(configPath, "utf8")
     expect(sectionText(content, "[features.multi_agent_v2]")).not.toMatch(/^\s*enabled\s*=\s*false/m)
+    expect(sectionText(content, "[features.multi_agent_v2]")).toContain("max_concurrent_threads_per_session = 6")
     expect(content).not.toMatch(/^\s*max_threads\s*=/m)
   })
 })

--- a/packages/omo-codex/src/install/codex-subagent-limit-config.test.ts
+++ b/packages/omo-codex/src/install/codex-subagent-limit-config.test.ts
@@ -28,7 +28,7 @@ describe("codex subagent limit config", () => {
     const content = await readFile(configPath, "utf8")
     expect(content).not.toMatch(/^\s*max_threads\s*=/m)
     expect(content).toContain("[features.multi_agent_v2]")
-    expect(content).toContain("max_concurrent_threads_per_session = 1000")
+    expect(content).toContain("max_concurrent_threads_per_session = 16")
   })
 
   test("#given existing low agents max_threads #when updating config #then raises only the root cap", async () => {

--- a/packages/omo-codex/src/install/toml-section-editor.ts
+++ b/packages/omo-codex/src/install/toml-section-editor.ts
@@ -4,14 +4,28 @@ export interface TomlSection {
   readonly text: string
 }
 
+export type TomlMultilineQuote = '"""' | "'''"
+
+export interface TomlMultilineLineScan {
+  readonly wasInside: boolean
+  readonly nextQuote: TomlMultilineQuote | null
+}
+
 export function findTomlSection(config: string, header: string): TomlSection | null {
   const headerLine = `[${header}]`
   const targetHeaderPath = parseTomlDottedKey(header)
   const lines = config.match(/[^\n]*\n?|$/g) ?? []
   let offset = 0
   let start = -1
+  let multilineQuote: TomlMultilineQuote | null = null
   for (const line of lines) {
     if (line.length === 0) break
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote)
+    multilineQuote = multilineScan.nextQuote
+    if (multilineScan.wasInside) {
+      offset += line.length
+      continue
+    }
     const trimmed = line.trim()
     if (start === -1) {
       if (tomlTableHeaderMatches(trimmed, headerLine, targetHeaderPath)) start = offset
@@ -25,10 +39,39 @@ export function findTomlSection(config: string, header: string): TomlSection | n
 }
 
 export function replaceOrInsertSetting(config: string, section: TomlSection, key: string, value: string): string {
-  const linePattern = new RegExp(`^[ \\t]*${escapeRegExp(key)}[ \\t]*=.*$`, "m")
-  const replacement = linePattern.test(section.text)
-    ? section.text.replace(linePattern, `${key} = ${value}`)
-    : insertSetting(section.text, key, value)
+  const targetPath = parseTomlDottedKey(key)
+  if (!targetPath) return config
+
+  const lines = section.text.match(/[^\n]*\n?|$/g) ?? []
+  let offset = 0
+  let multilineQuote: TomlMultilineQuote | null = null
+  for (const line of lines) {
+    if (line.length === 0) break
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote)
+    multilineQuote = multilineScan.nextQuote
+    if (multilineScan.wasInside) {
+      offset += line.length
+      continue
+    }
+    const assignmentIndex = findUnquotedAssignment(line)
+    if (assignmentIndex < 0) {
+      offset += line.length
+      continue
+    }
+    const settingPath = parseTomlDottedKey(line.slice(0, assignmentIndex).trim())
+    if (!settingPath || !tomlPathMatches(settingPath, targetPath)) {
+      offset += line.length
+      continue
+    }
+    const replacement = replaceTomlAssignmentValue(line, assignmentIndex, value)
+    const assignmentEnd = multilineScan.nextQuote
+      ? findTomlMultilineValueEnd(section.text, offset + line.length, multilineScan.nextQuote)
+      : offset + line.length
+    const sectionReplacement = section.text.slice(0, offset) + replacement + section.text.slice(assignmentEnd)
+    return config.slice(0, section.start) + sectionReplacement + config.slice(section.end)
+  }
+
+  const replacement = insertSetting(section.text, key, value)
   return config.slice(0, section.start) + replacement + config.slice(section.end)
 }
 
@@ -50,6 +93,48 @@ export function replaceOrInsertRootSetting(config: string, key: string, value: s
   return `${replacement.trimEnd()}\n\n${suffix.trimStart()}`
 }
 
+export function replaceOrInsertRootDottedSetting(config: string, keyPath: string, value: string): string {
+  const targetPath = parseTomlDottedKey(keyPath)
+  if (!targetPath) return config
+
+  const lines = config.match(/[^\n]*\n?|$/g) ?? []
+  let offset = 0
+  let multilineQuote: TomlMultilineQuote | null = null
+  for (const line of lines) {
+    if (line.length === 0) break
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote)
+    multilineQuote = multilineScan.nextQuote
+    if (multilineScan.wasInside) {
+      offset += line.length
+      continue
+    }
+    if (isTomlTableHeaderLine(line)) break
+
+    const assignmentIndex = findUnquotedAssignment(line)
+    if (assignmentIndex < 0) {
+      offset += line.length
+      continue
+    }
+    const settingPath = parseTomlDottedKey(line.slice(0, assignmentIndex).trim())
+    if (!settingPath || !tomlPathMatches(settingPath, targetPath)) {
+      offset += line.length
+      continue
+    }
+    const replacement = replaceTomlAssignmentValue(line, assignmentIndex, value)
+    const assignmentEnd = multilineScan.nextQuote
+      ? findTomlMultilineValueEnd(config, offset + line.length, multilineScan.nextQuote)
+      : offset + line.length
+    return config.slice(0, offset) + replacement + config.slice(assignmentEnd)
+  }
+
+  const sectionStart = findFirstTableStart(config)
+  const root = config.slice(0, sectionStart).trimEnd()
+  const suffix = config.slice(sectionStart)
+  const replacement = `${root}${root.length > 0 ? "\n" : ""}${keyPath} = ${value}\n`
+  if (suffix.length === 0) return replacement
+  return `${replacement.trimEnd()}\n\n${suffix.trimStart()}`
+}
+
 export function appendBlock(config: string, block: string): string {
   const prefix = config.trimEnd()
   return `${prefix}${prefix.length > 0 ? "\n\n" : ""}${block.trimEnd()}\n`
@@ -58,8 +143,15 @@ export function appendBlock(config: string, block: string): string {
 function findFirstTableStart(config: string): number {
   const lines = config.match(/[^\n]*\n?|$/g) ?? []
   let offset = 0
+  let multilineQuote: TomlMultilineQuote | null = null
   for (const line of lines) {
     if (line.length === 0) break
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote)
+    multilineQuote = multilineScan.nextQuote
+    if (multilineScan.wasInside) {
+      offset += line.length
+      continue
+    }
     if (isTomlTableHeaderLine(line)) return offset
     offset += line.length
   }
@@ -94,6 +186,131 @@ function parseTomlTableHeader(line: string): readonly string[] | null {
 export function isTomlTableHeaderLine(line: string): boolean {
   const normalizedLine = stripUnquotedInlineComment(line).trim()
   return normalizedLine.startsWith("[") && normalizedLine.endsWith("]")
+}
+
+export function scanTomlMultilineLine(
+  line: string,
+  currentQuote: TomlMultilineQuote | null,
+): TomlMultilineLineScan {
+  if (currentQuote) {
+    return {
+      wasInside: true,
+      nextQuote: findTomlMultilineDelimiter(line, currentQuote, 0) === -1 ? currentQuote : null,
+    }
+  }
+
+  let quote: "'" | '"' | null = null
+  let index = 0
+  while (index < line.length) {
+    const char = line[index]
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2
+        continue
+      }
+      if (char === '"') quote = null
+      index += 1
+      continue
+    }
+    if (quote === "'") {
+      if (char === "'") quote = null
+      index += 1
+      continue
+    }
+    if (char === "#") break
+    const delimiter = line.startsWith('"""', index) ? '"""' : line.startsWith("'''", index) ? "'''" : null
+    if (delimiter) {
+      const closingIndex = findTomlMultilineDelimiter(line, delimiter, index + delimiter.length)
+      return { wasInside: false, nextQuote: closingIndex === -1 ? delimiter : null }
+    }
+    if (char === '"' || char === "'") quote = char
+    index += 1
+  }
+  return { wasInside: false, nextQuote: null }
+}
+
+function findTomlMultilineDelimiter(line: string, delimiter: TomlMultilineQuote, startIndex: number): number {
+  let index = line.indexOf(delimiter, startIndex)
+  while (index !== -1) {
+    if (delimiter === "'''" || countPrecedingBackslashes(line, index) % 2 === 0) return index
+    index = line.indexOf(delimiter, index + 1)
+  }
+  return -1
+}
+
+function countPrecedingBackslashes(line: string, index: number): number {
+  let count = 0
+  let cursor = index - 1
+  while (cursor >= 0 && line[cursor] === "\\") {
+    count += 1
+    cursor -= 1
+  }
+  return count
+}
+
+function findUnquotedAssignment(line: string): number {
+  return findUnquotedCharacter(line, "=", 0)
+}
+
+function findUnquotedComment(line: string, startIndex: number): number {
+  return findUnquotedCharacter(line, "#", startIndex)
+}
+
+function findUnquotedCharacter(line: string, target: "=" | "#", startIndex: number): number {
+  let quote: "'" | '"' | null = null
+  let index = startIndex
+  while (index < line.length) {
+    const char = line[index]
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2
+        continue
+      }
+      if (char === '"') quote = null
+      index += 1
+      continue
+    }
+    if (quote === "'") {
+      if (char === "'") quote = null
+      index += 1
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      index += 1
+      continue
+    }
+    if (char === target) return index
+    if (char === "#") return -1
+    index += 1
+  }
+  return -1
+}
+
+function tomlPathMatches(candidate: readonly string[], target: readonly string[]): boolean {
+  return candidate.length === target.length && candidate.every((part, index) => part === target[index])
+}
+
+function replaceTomlAssignmentValue(line: string, assignmentIndex: number, value: string): string {
+  const newline = line.endsWith("\n") ? "\n" : ""
+  const lineBody = newline ? line.slice(0, -1) : line
+  const commentIndex = findUnquotedComment(lineBody, assignmentIndex + 1)
+  const comment = commentIndex === -1 ? "" : ` ${lineBody.slice(commentIndex).trimStart()}`
+  return `${lineBody.slice(0, assignmentIndex + 1)} ${value}${comment}${newline}`
+}
+
+function findTomlMultilineValueEnd(text: string, startOffset: number, quote: TomlMultilineQuote): number {
+  const lines = text.slice(startOffset).match(/[^\n]*\n?|$/g) ?? []
+  let offset = startOffset
+  let currentQuote: TomlMultilineQuote | null = quote
+  for (const line of lines) {
+    if (line.length === 0) break
+    const scan = scanTomlMultilineLine(line, currentQuote)
+    currentQuote = scan.nextQuote
+    offset += line.length
+    if (currentQuote === null) return offset
+  }
+  return text.length
 }
 
 function stripUnquotedInlineComment(line: string): string {

--- a/packages/omo-codex/src/install/toml-setting-reader.ts
+++ b/packages/omo-codex/src/install/toml-setting-reader.ts
@@ -1,0 +1,120 @@
+import { parseTomlDottedKey, scanTomlMultilineLine, type TomlMultilineQuote } from "./toml-section-editor"
+
+export function hasTomlSetting(config: string, keyPath: string): boolean {
+  const targetPath = parseTomlDottedKey(keyPath)
+  if (!targetPath) return false
+
+  return hasTomlAssignment(config, (tablePath, settingPath) => {
+    const fullPath = [...tablePath, ...settingPath]
+    return fullPath.length === targetPath.length && fullPath.every((part, index) => part === targetPath[index])
+  })
+}
+
+export function hasTomlRootDottedKeyPrefix(config: string, rootKey: string): boolean {
+  return hasTomlAssignment(
+    config,
+    (tablePath, settingPath) => tablePath.length === 0 && settingPath.length > 1 && settingPath[0] === rootKey,
+  )
+}
+
+function hasTomlAssignment(
+  config: string,
+  predicate: (tablePath: readonly string[], settingPath: readonly string[]) => boolean,
+): boolean {
+  let tablePath: readonly string[] | null = []
+  let multilineQuote: TomlMultilineQuote | null = null
+  for (const line of config.split("\n")) {
+    const multilineScan = scanTomlMultilineLine(line, multilineQuote)
+    multilineQuote = multilineScan.nextQuote
+    if (multilineScan.wasInside) continue
+    const normalizedLine = stripUnquotedInlineComment(line).trim()
+    if (normalizedLine.length === 0) continue
+
+    const headerPath = parseTomlTableHeader(normalizedLine)
+    if (headerPath) {
+      tablePath = headerPath
+      continue
+    }
+    if (isTomlTableHeaderLine(normalizedLine)) {
+      tablePath = null
+      continue
+    }
+    if (!tablePath) continue
+
+    const assignmentIndex = findUnquotedAssignment(normalizedLine)
+    if (assignmentIndex < 0) continue
+    const settingPath = parseTomlDottedKey(normalizedLine.slice(0, assignmentIndex).trim())
+    if (!settingPath) continue
+    if (predicate(tablePath, settingPath)) return true
+  }
+  return false
+}
+
+function parseTomlTableHeader(line: string): readonly string[] | null {
+  if (!line.startsWith("[") || !line.endsWith("]") || line.startsWith("[[")) return null
+  return parseTomlDottedKey(line.slice(1, -1).trim())
+}
+
+function isTomlTableHeaderLine(line: string): boolean {
+  return line.startsWith("[") && line.endsWith("]")
+}
+
+function stripUnquotedInlineComment(line: string): string {
+  let quote: "'" | '"' | null = null
+  let index = 0
+  while (index < line.length) {
+    const char = line[index]
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2
+        continue
+      }
+      if (char === '"') quote = null
+      index += 1
+      continue
+    }
+    if (quote === "'") {
+      if (char === "'") quote = null
+      index += 1
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      index += 1
+      continue
+    }
+    if (char === "#") return line.slice(0, index)
+    index += 1
+  }
+  return line
+}
+
+function findUnquotedAssignment(line: string): number {
+  let quote: "'" | '"' | null = null
+  let index = 0
+  while (index < line.length) {
+    const char = line[index]
+    if (quote === '"') {
+      if (char === "\\") {
+        index += 2
+        continue
+      }
+      if (char === '"') quote = null
+      index += 1
+      continue
+    }
+    if (quote === "'") {
+      if (char === "'") quote = null
+      index += 1
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      index += 1
+      continue
+    }
+    if (char === "=") return index
+    index += 1
+  }
+  return -1
+}


### PR DESCRIPTION
## Summary

- preserve every explicit semantic `features.multi_agent_v2.max_concurrent_threads_per_session` value across installer and SessionStart migration
- write a conservative managed default of `16` only when the complete semantic path is absent
- retain the separate model-aware V1 `agents.max_threads = 1000` policy and regenerate the published installer bundle

## Why

The installer and SessionStart migration independently replaced or duplicated explicit V2 caps. That overwrote user policy on install/startup and could amplify the process and file-descriptor pressure reported in #6101.

This fix treats an explicit semantic V2 cap as user-owned, including quoted/dotted TOML spellings, inline comments, and relative ordering. The managed default applies only to a genuinely absent setting.

## Observed behavior

- `max_concurrent_threads_per_session = 7 # user cap` survives installer and SessionStart passes exactly in place
- canonical, quoted, spaced, Unicode-escaped, dotted-under-`[features]`, and root-qualified dotted forms remain valid without duplicate keys or tables
- multiline string lookalikes and escaped/overlapping multiline closers do not spoof the setting
- root-dotted feature and V1/V2 cleanup settings are updated semantically without rewriting string contents
- an absent V2 cap becomes `16`
- V1 retains `agents.max_threads = 1000` and a compatible V2 disable; V2 models remove only incompatible legacy settings
- repeated passes are byte-identical and source/generated installer output is byte-identical

## Verification

- focused installer/config tests: 44 passed
- focused SessionStart migration tests: 73 passed
- isolated `bun run test:codex`: passed, including 497 Node/plugin/generated tests
- TypeScript typecheck and Biome: passed
- fresh generated installer parity: 419,675 bytes, byte-identical
- `codex-qa` common self-check: passed
- isolated local installer verification: passed with omo 4.18.2, 9 component bins, and agent TOMLs
- real mock-backed `codex app-server` turn: passed with completed `sessionStart`, `userPromptSubmit`, and `stop` hooks
- real `~/.codex/config.toml` remained unchanged at SHA-1 `b912e65baa09463cf1d11d49ccad88c4b4136520` and mtime `1784188952` throughout the final codex-qa gate

Evidence is recorded under `.omo/evidence/20260716-issue-6101-thread-cap/` in the task worktree. The exact reviewed head is `c32bca008bf2e7fad3b7e6225de08f502fb566ce`.

## Residual risk

The TOML editor is intentionally broader than the original line regexes so equivalent valid TOML spellings are preserved. Focused adversarial fixtures, the full Codex gate, generated parity, and isolated live-harness proof cover that increased parser surface.

Closes #6101
