### PR TITLE
fix(plans): repair ulw-plan checklist contract

### DIFF
--- a/packages/boulder-state/src/plan-checklist.test.ts
+++ b/packages/boulder-state/src/plan-checklist.test.ts
@@ -8,6 +8,23 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { getPlanChecklist, parsePlanChecklist } from "./plan-checklist"
 
 const cleanupRoots: string[] = []
+const SCAFFOLD_PLAN_MARKDOWN = [
+  "# Scaffold Parser Parity",
+  "",
+  "## Todos",
+  "- [ ] 1. Implement checklist parser parity",
+  "  - [ ] Nested acceptance detail",
+  "- [x] 2. Preserve completed implementation rows",
+  "- [ ] Missing numeric prefix must be ignored",
+  "",
+  "## Acceptance Criteria",
+  "- [ ] Outside tracked sections must be ignored",
+  "",
+  "## Final verification wave",
+  "- [ ] F1. Exercise the Codex Stop surface",
+  "- [X] F2. Preserve completed final verification rows",
+  "- [ ] 3. Wrong final-wave label must be ignored",
+].join("\n")
 
 afterEach(() => {
   for (const root of cleanupRoots.splice(0)) {
@@ -16,27 +33,20 @@ afterEach(() => {
 })
 
 describe("parsePlanChecklist", () => {
-  test("#given top-level checkboxes in counted sections #when parsed #then legacy continuation counts are preserved", () => {
+  test("#given scaffold headings and canonical numbered rows #when parsed #then structured totals and next label match", () => {
     // given
-    const markdown = [
-      "# Plan",
-      "- [ ] Preamble task",
-      "## TODOs",
-      "- [ ] First",
-      "- [x] Done",
-      "  - [ ] Nested",
-      "## Acceptance Criteria",
-      "- [ ] Ignored",
-      "## Final Verification Wave",
-      "- [X] Verified",
-      "- [ ] Final",
-    ].join("\n")
+    const markdown = SCAFFOLD_PLAN_MARKDOWN
 
     // when
     const checklist = parsePlanChecklist(markdown)
 
     // then
-    expect(checklist).toEqual({ completed: 2, remaining: 2, total: 4, nextTaskLabel: "First" })
+    expect(checklist).toEqual({
+      completed: 2,
+      remaining: 2,
+      total: 4,
+      nextTaskLabel: "1. Implement checklist parser parity",
+    })
   })
 
   test("#given no counted sections #when parsed #then all top-level checkboxes are counted", () => {
@@ -48,6 +58,22 @@ describe("parsePlanChecklist", () => {
 
     // then
     expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "First" })
+  })
+
+  test("#given completed implementation rows and pending final verifier #when parsed #then final verifier is next", () => {
+    // given
+    const markdown = [
+      "## Todos",
+      "- [x] 1. Implementation complete",
+      "## Final verification wave",
+      "- [ ] F1. Verify the result",
+    ].join("\n")
+
+    // when
+    const checklist = parsePlanChecklist(markdown)
+
+    // then
+    expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "F1. Verify the result" })
   })
 })
 
@@ -70,12 +96,15 @@ describe("getPlanChecklist", () => {
     const directory = mkdtempSync(join(tmpdir(), "boulder-plan-checklist-"))
     cleanupRoots.push(directory)
     const planPath = join(directory, "plan.md")
-    writeFileSync(planPath, "## TODOs\n- [x] First\n- [X] Second\n")
+    writeFileSync(
+      planPath,
+      "## Todos\n- [x] 1. First\n- [X] 2. Second\n## Final verification wave\n- [x] F1. Final\n",
+    )
 
     // when
     const checklist = getPlanChecklist(planPath)
 
     // then
-    expect(checklist).toEqual({ completed: 2, remaining: 0, total: 2, nextTaskLabel: null })
+    expect(checklist).toEqual({ completed: 3, remaining: 0, total: 3, nextTaskLabel: null })
   })
 })

--- a/packages/boulder-state/src/plan-checklist.test.ts
+++ b/packages/boulder-state/src/plan-checklist.test.ts
@@ -140,6 +140,17 @@ describe("parsePlanChecklist", () => {
     })
   })
 
+  test("#given a child heading inside TODOs #when parsed #then canonical rows remain in the parent section", () => {
+    // given
+    const markdown = ["## TODOs", "- [x] 1. First task", "### Notes", "- [ ] 2. Second task"].join("\n")
+
+    // when
+    const checklist = parsePlanChecklist(markdown)
+
+    // then
+    expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "2. Second task" })
+  })
+
   test("#given a four-backtick fence containing triple-backtick examples #when parsed #then shorter fences do not close it", () => {
     // given
     const markdown = [

--- a/packages/boulder-state/src/plan-checklist.test.ts
+++ b/packages/boulder-state/src/plan-checklist.test.ts
@@ -60,6 +60,17 @@ describe("parsePlanChecklist", () => {
     expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "First" })
   })
 
+  test("#given a heading-free legacy star checklist #when parsed #then fallback behavior is preserved", () => {
+    // given
+    const markdown = ["# Plan", "* [ ] First", "* [x] Done", "  * [ ] Nested"].join("\n")
+
+    // when
+    const checklist = parsePlanChecklist(markdown)
+
+    // then
+    expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "First" })
+  })
+
   test("#given completed implementation rows and pending final verifier #when parsed #then final verifier is next", () => {
     // given
     const markdown = [

--- a/packages/boulder-state/src/plan-checklist.test.ts
+++ b/packages/boulder-state/src/plan-checklist.test.ts
@@ -75,6 +75,59 @@ describe("parsePlanChecklist", () => {
     // then
     expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "F1. Verify the result" })
   })
+
+  test("#given noncanonical structured rows #when parsed #then only exact positive-number grammar is counted", () => {
+    // given
+    const markdown = [
+      "## Todos",
+      "- [ ] 0. Zero is invalid",
+      "- [ ] 01. Leading zero is invalid",
+      "* [ ] 2. Star marker is invalid",
+      "-[ ] 3. Missing spaces are invalid",
+      "- [ ] 4. Canonical implementation",
+      "## Final verification wave",
+      "- [ ] F0. Zero final verifier is invalid",
+      "- [ ] F01. Leading zero final verifier is invalid",
+      "- [x] F2. Canonical final verifier",
+    ].join("\n")
+
+    // when
+    const checklist = parsePlanChecklist(markdown)
+
+    // then
+    expect(checklist).toEqual({
+      completed: 1,
+      remaining: 1,
+      total: 2,
+      nextTaskLabel: "4. Canonical implementation",
+    })
+  })
+
+  test("#given fenced examples and a higher-level heading #when parsed #then section scope excludes them", () => {
+    // given
+    const markdown = [
+      "## Todos",
+      "- [ ] 1. Counted implementation",
+      "```md",
+      "- [ ] 2. Fenced example",
+      "```",
+      "# Appendix",
+      "- [ ] 3. Appendix checkbox",
+      "## Final verification wave",
+      "- [x] F1. Counted verifier",
+    ].join("\n")
+
+    // when
+    const checklist = parsePlanChecklist(markdown)
+
+    // then
+    expect(checklist).toEqual({
+      completed: 1,
+      remaining: 1,
+      total: 2,
+      nextTaskLabel: "1. Counted implementation",
+    })
+  })
 })
 
 describe("getPlanChecklist", () => {

--- a/packages/boulder-state/src/plan-checklist.test.ts
+++ b/packages/boulder-state/src/plan-checklist.test.ts
@@ -165,6 +165,50 @@ describe("parsePlanChecklist", () => {
       nextTaskLabel: "F1. Counted verifier",
     })
   })
+
+  test("#given structured headings with ATX closing markers #when parsed #then canonical tasks remain structured", () => {
+    // given
+    const markdown = [
+      "## TODOs ##",
+      "- [ ] 1. Implement",
+      "## Final Verification Wave ###",
+      "- [ ] F1. Verify",
+    ].join("\n")
+
+    // when
+    const checklist = parsePlanChecklist(markdown)
+
+    // then
+    expect(checklist).toEqual({
+      completed: 0,
+      remaining: 2,
+      total: 2,
+      nextTaskLabel: "1. Implement",
+    })
+  })
+
+  test("#given inline backtick code before a canonical task #when parsed #then it does not open a fence", () => {
+    // given
+    const markdown = ["## TODOs", "```example```", "- [ ] 1. Implement"].join("\n")
+
+    // when
+    const checklist = parsePlanChecklist(markdown)
+
+    // then
+    expect(checklist.total).toBe(1)
+    expect(checklist.nextTaskLabel).toBe("1. Implement")
+  })
+
+  test("#given a heading-free fenced checkbox example #when parsed #then legacy fallback ignores it", () => {
+    // given
+    const markdown = ["````md", "- [ ] 1. Example only", "````"].join("\n")
+
+    // when
+    const checklist = parsePlanChecklist(markdown)
+
+    // then
+    expect(checklist).toEqual({ completed: 0, remaining: 0, total: 0, nextTaskLabel: null })
+  })
 })
 
 describe("getPlanChecklist", () => {

--- a/packages/boulder-state/src/plan-checklist.test.ts
+++ b/packages/boulder-state/src/plan-checklist.test.ts
@@ -139,6 +139,32 @@ describe("parsePlanChecklist", () => {
       nextTaskLabel: "1. Counted implementation",
     })
   })
+
+  test("#given a four-backtick fence containing triple-backtick examples #when parsed #then shorter fences do not close it", () => {
+    // given
+    const markdown = [
+      "## Todos",
+      "- [x] 1. Counted implementation",
+      "````md",
+      "```ts",
+      "- [ ] 2. Fenced example",
+      "```",
+      "````",
+      "## Final verification wave",
+      "- [ ] F1. Counted verifier",
+    ].join("\n")
+
+    // when
+    const checklist = parsePlanChecklist(markdown)
+
+    // then
+    expect(checklist).toEqual({
+      completed: 1,
+      remaining: 1,
+      total: 2,
+      nextTaskLabel: "F1. Counted verifier",
+    })
+  })
 })
 
 describe("getPlanChecklist", () => {

--- a/packages/boulder-state/src/plan-checklist.ts
+++ b/packages/boulder-state/src/plan-checklist.ts
@@ -2,10 +2,22 @@ import { existsSync, readFileSync } from "node:fs"
 
 import type { PlanChecklist } from "./types"
 
-const CHECKBOX_PATTERN = /^- \[[ xX]\] /
-const UNCHECKED_PATTERN = /^- \[ \] /
-const TODO_HEADING = "TODOs"
-const FINAL_VERIFICATION_HEADING = "Final Verification Wave"
+const SIMPLE_CHECKBOX_PATTERN = /^- \[[ xX]\] /
+const SIMPLE_UNCHECKED_PATTERN = /^- \[ \] /
+const TODO_HEADING_PATTERN = /^##\s+TODOs\b/i
+const FINAL_VERIFICATION_HEADING_PATTERN = /^##\s+Final Verification Wave\b/i
+const SECOND_LEVEL_HEADING_PATTERN = /^##\s+/
+const UNCHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[\s*\]\s*(.+)$/
+const CHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[[xX]\]\s*(.+)$/
+const TODO_TASK_PATTERN = /^\d+\.\s+/
+const FINAL_WAVE_TASK_PATTERN = /^F\d+\.\s+/i
+
+type ChecklistSection = "todo" | "final-wave" | "other"
+
+type ParsedCheckbox = {
+  readonly checked: boolean
+  readonly label: string
+}
 
 export function getPlanChecklist(planPath: string): PlanChecklist {
   if (!existsSync(planPath)) {
@@ -24,29 +36,38 @@ export function getPlanChecklist(planPath: string): PlanChecklist {
 
 export function parsePlanChecklist(markdown: string): PlanChecklist {
   const lines = markdown.split(/\r?\n/)
-  const hasCountedSections = lines.some(hasCountedSectionHeading)
+  if (!lines.some(hasStructuredSectionHeading)) {
+    return parseSimpleChecklist(lines)
+  }
+
   let remaining = 0
   let total = 0
   let nextTaskLabel: string | null = null
-  let isCountedSection = !hasCountedSections
+  let section: ChecklistSection = "other"
 
   for (const line of lines) {
-    const heading = parseLevelTwoHeading(line)
-    if (heading !== null) {
-      isCountedSection = isCountedHeading(heading)
+    const headingSection = parseStructuredSectionHeading(line)
+    if (headingSection !== null) {
+      section = headingSection
+      continue
     }
-    if (!isCountedSection || !CHECKBOX_PATTERN.test(line)) {
+    if (section === "other") {
+      continue
+    }
+
+    const checkbox = parseStructuredTopLevelCheckbox(line, section)
+    if (checkbox === null) {
       continue
     }
 
     total += 1
-    if (!UNCHECKED_PATTERN.test(line)) {
+    if (checkbox.checked) {
       continue
     }
 
     remaining += 1
     if (nextTaskLabel === null) {
-      nextTaskLabel = line.slice("- [ ] ".length)
+      nextTaskLabel = checkbox.label
     }
   }
 
@@ -58,20 +79,71 @@ export function parsePlanChecklist(markdown: string): PlanChecklist {
   }
 }
 
-function hasCountedSectionHeading(line: string): boolean {
-  const heading = parseLevelTwoHeading(line)
-  return heading !== null && isCountedHeading(heading)
+function parseSimpleChecklist(lines: readonly string[]): PlanChecklist {
+  let remaining = 0
+  let total = 0
+  let nextTaskLabel: string | null = null
+
+  for (const line of lines) {
+    if (!SIMPLE_CHECKBOX_PATTERN.test(line)) {
+      continue
+    }
+
+    total += 1
+    if (!SIMPLE_UNCHECKED_PATTERN.test(line)) {
+      continue
+    }
+
+    remaining += 1
+    if (nextTaskLabel === null) {
+      nextTaskLabel = line.slice("- [ ] ".length)
+    }
+  }
+
+  return { completed: total - remaining, remaining, total, nextTaskLabel }
 }
 
-function parseLevelTwoHeading(line: string): string | null {
-  if (!line.startsWith("## ")) {
+function hasStructuredSectionHeading(line: string): boolean {
+  const section = parseStructuredSectionHeading(line)
+  return section === "todo" || section === "final-wave"
+}
+
+function parseStructuredSectionHeading(line: string): ChecklistSection | null {
+  if (!SECOND_LEVEL_HEADING_PATTERN.test(line)) {
     return null
   }
-  return line.slice("## ".length).trim()
+
+  if (TODO_HEADING_PATTERN.test(line)) {
+    return "todo"
+  }
+  if (FINAL_VERIFICATION_HEADING_PATTERN.test(line)) {
+    return "final-wave"
+  }
+  return "other"
 }
 
-function isCountedHeading(heading: string): boolean {
-  return heading === TODO_HEADING || heading === FINAL_VERIFICATION_HEADING
+function parseStructuredTopLevelCheckbox(
+  line: string,
+  section: "todo" | "final-wave",
+): ParsedCheckbox | null {
+  const checkedMatch = line.match(CHECKED_CHECKBOX_PATTERN)
+  const match = checkedMatch ?? line.match(UNCHECKED_CHECKBOX_PATTERN)
+  if (match === null) {
+    return null
+  }
+
+  const indentation = match[1]
+  const taskBody = match[2]?.trim()
+  if (indentation !== "" || taskBody === undefined) {
+    return null
+  }
+
+  const labelPattern = section === "todo" ? TODO_TASK_PATTERN : FINAL_WAVE_TASK_PATTERN
+  if (!labelPattern.test(taskBody)) {
+    return null
+  }
+
+  return { checked: checkedMatch !== null, label: taskBody }
 }
 
 function emptyChecklist(): PlanChecklist {

--- a/packages/boulder-state/src/plan-checklist.ts
+++ b/packages/boulder-state/src/plan-checklist.ts
@@ -2,8 +2,7 @@ import { existsSync, readFileSync } from "node:fs"
 
 import type { PlanChecklist } from "./types"
 
-const SIMPLE_CHECKBOX_PATTERN = /^- \[[ xX]\] /
-const SIMPLE_UNCHECKED_PATTERN = /^- \[ \] /
+const SIMPLE_CHECKBOX_PATTERN = /^[-*][ \t]*\[[ \t]*([xX]?)[ \t]*\][ \t]+(.+)$/
 const TODO_HEADING_PATTERN = /^##[ \t]+TODOs[ \t]*$/i
 const FINAL_VERIFICATION_HEADING_PATTERN = /^##[ \t]+Final Verification Wave[ \t]*$/i
 const MARKDOWN_HEADING_PATTERN = /^#{1,6}(?:[ \t]+|$)/
@@ -93,22 +92,33 @@ function parseSimpleChecklist(lines: readonly string[]): PlanChecklist {
   let nextTaskLabel: string | null = null
 
   for (const line of lines) {
-    if (!SIMPLE_CHECKBOX_PATTERN.test(line)) {
+    const checkbox = parseSimpleTopLevelCheckbox(line)
+    if (checkbox === null) {
       continue
     }
 
     total += 1
-    if (!SIMPLE_UNCHECKED_PATTERN.test(line)) {
+    if (checkbox.checked) {
       continue
     }
 
     remaining += 1
     if (nextTaskLabel === null) {
-      nextTaskLabel = line.slice("- [ ] ".length)
+      nextTaskLabel = checkbox.label
     }
   }
 
   return { completed: total - remaining, remaining, total, nextTaskLabel }
+}
+
+function parseSimpleTopLevelCheckbox(line: string): ParsedCheckbox | null {
+  const match = line.match(SIMPLE_CHECKBOX_PATTERN)
+  const marker = match?.[1]
+  const label = match?.[2]
+  if (marker === undefined || label === undefined) {
+    return null
+  }
+  return { checked: marker.toLowerCase() === "x", label }
 }
 
 function hasStructuredSection(lines: readonly string[]): boolean {

--- a/packages/boulder-state/src/plan-checklist.ts
+++ b/packages/boulder-state/src/plan-checklist.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 
-import type { PlanChecklist } from "./types"
+import type { PlanChecklist, TopLevelTaskRef } from "./types"
 
 const SIMPLE_CHECKBOX_PATTERN = /^[-*][ \t]*\[[ \t]*([xX]?)[ \t]*\][ \t]+(.+)$/
 const TODO_HEADING_PATTERN = /^##[ \t]+TODOs[ \t]*$/i
@@ -15,6 +15,20 @@ type ChecklistSection = "todo" | "final-wave" | "other"
 type ParsedCheckbox = {
   readonly checked: boolean
   readonly label: string
+}
+
+type ParsedStructuredCheckbox = ParsedCheckbox & {
+  readonly task: TopLevelTaskRef
+}
+
+type MarkdownFence = {
+  readonly marker: "`" | "~"
+  readonly length: number
+}
+
+type ParsedStructuredPlan = {
+  readonly checklist: PlanChecklist
+  readonly nextTask: TopLevelTaskRef | null
 }
 
 export function getPlanChecklist(planPath: string): PlanChecklist {
@@ -38,19 +52,37 @@ export function parsePlanChecklist(markdown: string): PlanChecklist {
     return parseSimpleChecklist(lines)
   }
 
+  return parseStructuredPlan(lines).checklist
+}
+
+export function parseCurrentTopLevelTask(markdown: string): TopLevelTaskRef | null {
+  const lines = markdown.split(/\r?\n/)
+  if (!hasStructuredSection(lines)) {
+    return null
+  }
+
+  return parseStructuredPlan(lines).nextTask
+}
+
+function parseStructuredPlan(lines: readonly string[]): ParsedStructuredPlan {
   let remaining = 0
   let total = 0
   let nextTaskLabel: string | null = null
+  let nextTask: TopLevelTaskRef | null = null
   let section: ChecklistSection = "other"
-  let fence: "`" | "~" | null = null
+  let fence: MarkdownFence | null = null
 
   for (const line of lines) {
-    const fenceMarker = parseFenceMarker(line)
-    if (fenceMarker !== null) {
-      fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence
+    if (fence !== null) {
+      if (isClosingFence(line, fence)) {
+        fence = null
+      }
       continue
     }
-    if (fence !== null) {
+
+    const openingFence = parseOpeningFence(line)
+    if (openingFence !== null) {
+      fence = openingFence
       continue
     }
 
@@ -75,14 +107,18 @@ export function parsePlanChecklist(markdown: string): PlanChecklist {
     remaining += 1
     if (nextTaskLabel === null) {
       nextTaskLabel = checkbox.label
+      nextTask = checkbox.task
     }
   }
 
   return {
-    completed: total - remaining,
-    remaining,
-    total,
-    nextTaskLabel,
+    checklist: {
+      completed: total - remaining,
+      remaining,
+      total,
+      nextTaskLabel,
+    },
+    nextTask,
   }
 }
 
@@ -122,14 +158,21 @@ function parseSimpleTopLevelCheckbox(line: string): ParsedCheckbox | null {
 }
 
 function hasStructuredSection(lines: readonly string[]): boolean {
-  let fence: "`" | "~" | null = null
+  let fence: MarkdownFence | null = null
   for (const line of lines) {
-    const fenceMarker = parseFenceMarker(line)
-    if (fenceMarker !== null) {
-      fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence
+    if (fence !== null) {
+      if (isClosingFence(line, fence)) {
+        fence = null
+      }
       continue
     }
-    if (fence === null && parseStructuredSectionHeading(line) !== "other") {
+
+    const openingFence = parseOpeningFence(line)
+    if (openingFence !== null) {
+      fence = openingFence
+      continue
+    }
+    if (parseStructuredSectionHeading(line) !== "other") {
       return true
     }
   }
@@ -149,7 +192,7 @@ function parseStructuredSectionHeading(line: string): ChecklistSection {
 function parseStructuredTopLevelCheckbox(
   line: string,
   section: "todo" | "final-wave",
-): ParsedCheckbox | null {
+): ParsedStructuredCheckbox | null {
   const pattern = section === "todo" ? TODO_CHECKBOX_PATTERN : FINAL_WAVE_CHECKBOX_PATTERN
   const match = line.match(pattern)
   const marker = match?.[1]
@@ -157,12 +200,41 @@ function parseStructuredTopLevelCheckbox(
   if (marker === undefined || label === undefined) {
     return null
   }
-  return { checked: marker.toLowerCase() === "x", label }
+  const task = buildTaskRef(section, label)
+  if (task === null) {
+    return null
+  }
+  return { checked: marker.toLowerCase() === "x", label, task }
 }
 
-function parseFenceMarker(line: string): "`" | "~" | null {
-  const marker = line.match(FENCE_PATTERN)?.[1]?.[0]
-  return marker === "`" || marker === "~" ? marker : null
+function buildTaskRef(section: "todo" | "final-wave", label: string): TopLevelTaskRef | null {
+  const pattern = section === "todo" ? /^([1-9]\d*)\. (.+)$/ : /^(F[1-9]\d*)\. (.+)$/i
+  const match = label.match(pattern)
+  const rawLabel = match?.[1]
+  const title = match?.[2]
+  if (rawLabel === undefined || title === undefined) {
+    return null
+  }
+  return {
+    key: `${section}:${rawLabel.toLowerCase()}`,
+    section,
+    label: rawLabel,
+    title,
+  }
+}
+
+function parseOpeningFence(line: string): MarkdownFence | null {
+  const run = line.match(FENCE_PATTERN)?.[1]
+  const marker = run?.charAt(0)
+  if (run === undefined || (marker !== "`" && marker !== "~")) {
+    return null
+  }
+  return { marker, length: run.length }
+}
+
+function isClosingFence(line: string, fence: MarkdownFence): boolean {
+  const run = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/)?.[1]
+  return run?.charAt(0) === fence.marker && run.length >= fence.length
 }
 
 function emptyChecklist(): PlanChecklist {

--- a/packages/boulder-state/src/plan-checklist.ts
+++ b/packages/boulder-state/src/plan-checklist.ts
@@ -3,10 +3,11 @@ import { existsSync, readFileSync } from "node:fs"
 import type { PlanChecklist, TopLevelTaskRef } from "./types"
 
 const SIMPLE_CHECKBOX_PATTERN = /^[-*][ \t]*\[[ \t]*([xX]?)[ \t]*\][ \t]+(.+)$/
-const TODO_HEADING_PATTERN = /^##[ \t]+TODOs[ \t]*$/i
-const FINAL_VERIFICATION_HEADING_PATTERN = /^##[ \t]+Final Verification Wave[ \t]*$/i
+const TODO_HEADING_PATTERN = /^##[ \t]+TODOs(?:[ \t]+#+)?[ \t]*$/i
+const FINAL_VERIFICATION_HEADING_PATTERN =
+  /^##[ \t]+Final Verification Wave(?:[ \t]+#+)?[ \t]*$/i
 const MARKDOWN_HEADING_PATTERN = /^#{1,6}(?:[ \t]+|$)/
-const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/
+const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})(.*)$/
 const TODO_CHECKBOX_PATTERN = /^- \[([ xX])\] ([1-9]\d*\. .+)$/
 const FINAL_WAVE_CHECKBOX_PATTERN = /^- \[([ xX])\] (F[1-9]\d*\. .+)$/i
 
@@ -126,8 +127,22 @@ function parseSimpleChecklist(lines: readonly string[]): PlanChecklist {
   let remaining = 0
   let total = 0
   let nextTaskLabel: string | null = null
+  let fence: MarkdownFence | null = null
 
   for (const line of lines) {
+    if (fence !== null) {
+      if (isClosingFence(line, fence)) {
+        fence = null
+      }
+      continue
+    }
+
+    const openingFence = parseOpeningFence(line)
+    if (openingFence !== null) {
+      fence = openingFence
+      continue
+    }
+
     const checkbox = parseSimpleTopLevelCheckbox(line)
     if (checkbox === null) {
       continue
@@ -224,9 +239,16 @@ function buildTaskRef(section: "todo" | "final-wave", label: string): TopLevelTa
 }
 
 function parseOpeningFence(line: string): MarkdownFence | null {
-  const run = line.match(FENCE_PATTERN)?.[1]
+  const match = line.match(FENCE_PATTERN)
+  const run = match?.[1]
+  const info = match?.[2]
   const marker = run?.charAt(0)
-  if (run === undefined || (marker !== "`" && marker !== "~")) {
+  if (
+    run === undefined ||
+    info === undefined ||
+    (marker !== "`" && marker !== "~") ||
+    (marker === "`" && info.includes("`"))
+  ) {
     return null
   }
   return { marker, length: run.length }

--- a/packages/boulder-state/src/plan-checklist.ts
+++ b/packages/boulder-state/src/plan-checklist.ts
@@ -6,7 +6,7 @@ const SIMPLE_CHECKBOX_PATTERN = /^[-*][ \t]*\[[ \t]*([xX]?)[ \t]*\][ \t]+(.+)$/
 const TODO_HEADING_PATTERN = /^##[ \t]+TODOs(?:[ \t]+#+)?[ \t]*$/i
 const FINAL_VERIFICATION_HEADING_PATTERN =
   /^##[ \t]+Final Verification Wave(?:[ \t]+#+)?[ \t]*$/i
-const MARKDOWN_HEADING_PATTERN = /^#{1,6}(?:[ \t]+|$)/
+const SECTION_BOUNDARY_HEADING_PATTERN = /^#{1,2}(?:[ \t]+|$)/
 const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})(.*)$/
 const TODO_CHECKBOX_PATTERN = /^- \[([ xX])\] ([1-9]\d*\. .+)$/
 const FINAL_WAVE_CHECKBOX_PATTERN = /^- \[([ xX])\] (F[1-9]\d*\. .+)$/i
@@ -87,7 +87,7 @@ function parseStructuredPlan(lines: readonly string[]): ParsedStructuredPlan {
       continue
     }
 
-    if (MARKDOWN_HEADING_PATTERN.test(line)) {
+    if (SECTION_BOUNDARY_HEADING_PATTERN.test(line)) {
       section = parseStructuredSectionHeading(line)
       continue
     }

--- a/packages/boulder-state/src/plan-checklist.ts
+++ b/packages/boulder-state/src/plan-checklist.ts
@@ -4,13 +4,12 @@ import type { PlanChecklist } from "./types"
 
 const SIMPLE_CHECKBOX_PATTERN = /^- \[[ xX]\] /
 const SIMPLE_UNCHECKED_PATTERN = /^- \[ \] /
-const TODO_HEADING_PATTERN = /^##\s+TODOs\b/i
-const FINAL_VERIFICATION_HEADING_PATTERN = /^##\s+Final Verification Wave\b/i
-const SECOND_LEVEL_HEADING_PATTERN = /^##\s+/
-const UNCHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[\s*\]\s*(.+)$/
-const CHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[[xX]\]\s*(.+)$/
-const TODO_TASK_PATTERN = /^\d+\.\s+/
-const FINAL_WAVE_TASK_PATTERN = /^F\d+\.\s+/i
+const TODO_HEADING_PATTERN = /^##[ \t]+TODOs[ \t]*$/i
+const FINAL_VERIFICATION_HEADING_PATTERN = /^##[ \t]+Final Verification Wave[ \t]*$/i
+const MARKDOWN_HEADING_PATTERN = /^#{1,6}(?:[ \t]+|$)/
+const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/
+const TODO_CHECKBOX_PATTERN = /^- \[([ xX])\] ([1-9]\d*\. .+)$/
+const FINAL_WAVE_CHECKBOX_PATTERN = /^- \[([ xX])\] (F[1-9]\d*\. .+)$/i
 
 type ChecklistSection = "todo" | "final-wave" | "other"
 
@@ -36,7 +35,7 @@ export function getPlanChecklist(planPath: string): PlanChecklist {
 
 export function parsePlanChecklist(markdown: string): PlanChecklist {
   const lines = markdown.split(/\r?\n/)
-  if (!lines.some(hasStructuredSectionHeading)) {
+  if (!hasStructuredSection(lines)) {
     return parseSimpleChecklist(lines)
   }
 
@@ -44,11 +43,20 @@ export function parsePlanChecklist(markdown: string): PlanChecklist {
   let total = 0
   let nextTaskLabel: string | null = null
   let section: ChecklistSection = "other"
+  let fence: "`" | "~" | null = null
 
   for (const line of lines) {
-    const headingSection = parseStructuredSectionHeading(line)
-    if (headingSection !== null) {
-      section = headingSection
+    const fenceMarker = parseFenceMarker(line)
+    if (fenceMarker !== null) {
+      fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence
+      continue
+    }
+    if (fence !== null) {
+      continue
+    }
+
+    if (MARKDOWN_HEADING_PATTERN.test(line)) {
+      section = parseStructuredSectionHeading(line)
       continue
     }
     if (section === "other") {
@@ -103,16 +111,22 @@ function parseSimpleChecklist(lines: readonly string[]): PlanChecklist {
   return { completed: total - remaining, remaining, total, nextTaskLabel }
 }
 
-function hasStructuredSectionHeading(line: string): boolean {
-  const section = parseStructuredSectionHeading(line)
-  return section === "todo" || section === "final-wave"
+function hasStructuredSection(lines: readonly string[]): boolean {
+  let fence: "`" | "~" | null = null
+  for (const line of lines) {
+    const fenceMarker = parseFenceMarker(line)
+    if (fenceMarker !== null) {
+      fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence
+      continue
+    }
+    if (fence === null && parseStructuredSectionHeading(line) !== "other") {
+      return true
+    }
+  }
+  return false
 }
 
-function parseStructuredSectionHeading(line: string): ChecklistSection | null {
-  if (!SECOND_LEVEL_HEADING_PATTERN.test(line)) {
-    return null
-  }
-
+function parseStructuredSectionHeading(line: string): ChecklistSection {
   if (TODO_HEADING_PATTERN.test(line)) {
     return "todo"
   }
@@ -126,24 +140,19 @@ function parseStructuredTopLevelCheckbox(
   line: string,
   section: "todo" | "final-wave",
 ): ParsedCheckbox | null {
-  const checkedMatch = line.match(CHECKED_CHECKBOX_PATTERN)
-  const match = checkedMatch ?? line.match(UNCHECKED_CHECKBOX_PATTERN)
-  if (match === null) {
+  const pattern = section === "todo" ? TODO_CHECKBOX_PATTERN : FINAL_WAVE_CHECKBOX_PATTERN
+  const match = line.match(pattern)
+  const marker = match?.[1]
+  const label = match?.[2]
+  if (marker === undefined || label === undefined) {
     return null
   }
+  return { checked: marker.toLowerCase() === "x", label }
+}
 
-  const indentation = match[1]
-  const taskBody = match[2]?.trim()
-  if (indentation !== "" || taskBody === undefined) {
-    return null
-  }
-
-  const labelPattern = section === "todo" ? TODO_TASK_PATTERN : FINAL_WAVE_TASK_PATTERN
-  if (!labelPattern.test(taskBody)) {
-    return null
-  }
-
-  return { checked: checkedMatch !== null, label: taskBody }
+function parseFenceMarker(line: string): "`" | "~" | null {
+  const marker = line.match(FENCE_PATTERN)?.[1]?.[0]
+  return marker === "`" || marker === "~" ? marker : null
 }
 
 function emptyChecklist(): PlanChecklist {

--- a/packages/boulder-state/src/storage/plan-progress.ts
+++ b/packages/boulder-state/src/storage/plan-progress.ts
@@ -2,19 +2,11 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
 import { basename, join } from "node:path"
 
 import { PROMETHEUS_PLANS_DIR } from "../constants"
+import { parsePlanChecklist } from "../plan-checklist"
 import type { PlanProgress } from "../types"
 
-const TODO_HEADING_PATTERN = /^##\s+TODOs\b/i
-const FINAL_VERIFICATION_HEADING_PATTERN = /^##\s+Final Verification Wave\b/i
-const SECOND_LEVEL_HEADING_PATTERN = /^##\s+/
-const UNCHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[\s*\]\s*(.+)$/
-const CHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[[xX]\]\s*(.+)$/
-const TODO_TASK_PATTERN = /^\d+\.\s+/
-const FINAL_WAVE_TASK_PATTERN = /^F\d+\.\s+/i
 const LEGACY_PROMETHEUS_PLANS_DIR = ".sisyphus/plans"
 const PROMETHEUS_PLAN_DIRS = [PROMETHEUS_PLANS_DIR, LEGACY_PROMETHEUS_PLANS_DIR] as const
-
-type ProgressSection = "todo" | "final-wave" | "other"
 
 export function findPrometheusPlans(directory: string): string[] {
   try {
@@ -45,65 +37,13 @@ export function getPlanProgress(planPath: string): PlanProgress {
 
   try {
     const content = readFileSync(planPath, "utf-8")
-    const lines = content.split(/\r?\n/)
-    const hasStructuredSections = lines.some(
-      (line) => TODO_HEADING_PATTERN.test(line) || FINAL_VERIFICATION_HEADING_PATTERN.test(line),
-    )
-    if (hasStructuredSections) {
-      return getStructuredPlanProgress(lines)
+    const checklist = parsePlanChecklist(content)
+    return {
+      total: checklist.total,
+      completed: checklist.completed,
+      isComplete: checklist.total > 0 && checklist.remaining === 0,
     }
-
-    return getSimplePlanProgress(content)
   } catch {
     return { total: 0, completed: 0, isComplete: false }
   }
-}
-
-function getStructuredPlanProgress(lines: string[]): PlanProgress {
-  let section: ProgressSection = "other"
-  let total = 0
-  let completed = 0
-
-  for (const line of lines) {
-    if (SECOND_LEVEL_HEADING_PATTERN.test(line)) {
-      section = TODO_HEADING_PATTERN.test(line)
-        ? "todo"
-        : FINAL_VERIFICATION_HEADING_PATTERN.test(line)
-          ? "final-wave"
-          : "other"
-      continue
-    }
-
-    if (section !== "todo" && section !== "final-wave") {
-      continue
-    }
-
-    const checkedMatch = line.match(CHECKED_CHECKBOX_PATTERN)
-    const uncheckedMatch = checkedMatch ? null : line.match(UNCHECKED_CHECKBOX_PATTERN)
-    const match = checkedMatch ?? uncheckedMatch
-    if (!match || match[1].length > 0) {
-      continue
-    }
-
-    const taskBody = match[2].trim()
-    const labelPattern = section === "todo" ? TODO_TASK_PATTERN : FINAL_WAVE_TASK_PATTERN
-    if (!labelPattern.test(taskBody)) {
-      continue
-    }
-
-    total += 1
-    if (checkedMatch) {
-      completed += 1
-    }
-  }
-
-  return { total, completed, isComplete: total > 0 && completed === total }
-}
-
-function getSimplePlanProgress(content: string): PlanProgress {
-  const uncheckedMatches = content.match(/^[-*]\s*\[\s*\]/gm) ?? []
-  const checkedMatches = content.match(/^[-*]\s*\[[xX]\]/gm) ?? []
-  const total = uncheckedMatches.length + checkedMatches.length
-  const completed = checkedMatches.length
-  return { total, completed, isComplete: total > 0 && completed === total }
 }

--- a/packages/boulder-state/src/top-level-task.ts
+++ b/packages/boulder-state/src/top-level-task.ts
@@ -1,32 +1,7 @@
 import { existsSync, readFileSync } from "node:fs"
 
+import { parseCurrentTopLevelTask } from "./plan-checklist"
 import type { TopLevelTaskRef } from "./types"
-
-const TODO_HEADING_PATTERN = /^##\s+TODOs\b/i
-const FINAL_VERIFICATION_HEADING_PATTERN = /^##\s+Final Verification Wave\b/i
-const SECOND_LEVEL_HEADING_PATTERN = /^##\s+/
-const UNCHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[\s*\]\s*(.+)$/
-const TODO_TASK_PATTERN = /^(\d+)\.\s+(.+)$/
-const FINAL_WAVE_TASK_PATTERN = /^(F\d+)\.\s+(.+)$/i
-
-type PlanSection = "todo" | "final-wave" | "other"
-
-function buildTaskRef(section: "todo" | "final-wave", taskLabel: string): TopLevelTaskRef | null {
-  const pattern = section === "todo" ? TODO_TASK_PATTERN : FINAL_WAVE_TASK_PATTERN
-  const match = taskLabel.match(pattern)
-  if (!match) {
-    return null
-  }
-
-  const rawLabel = match[1]
-  const title = match[2].trim()
-  return {
-    key: `${section}:${rawLabel.toLowerCase()}`,
-    section,
-    label: rawLabel,
-    title,
-  }
-}
 
 export function readCurrentTopLevelTask(planPath: string): TopLevelTaskRef | null {
   if (!existsSync(planPath)) {
@@ -35,34 +10,7 @@ export function readCurrentTopLevelTask(planPath: string): TopLevelTaskRef | nul
 
   try {
     const content = readFileSync(planPath, "utf-8")
-    const lines = content.split(/\r?\n/)
-    let section: PlanSection = "other"
-
-    for (const line of lines) {
-      if (SECOND_LEVEL_HEADING_PATTERN.test(line)) {
-        section = TODO_HEADING_PATTERN.test(line)
-          ? "todo"
-          : FINAL_VERIFICATION_HEADING_PATTERN.test(line)
-            ? "final-wave"
-            : "other"
-      }
-
-      const uncheckedTaskMatch = line.match(UNCHECKED_CHECKBOX_PATTERN)
-      if (!uncheckedTaskMatch || uncheckedTaskMatch[1].length > 0) {
-        continue
-      }
-
-      if (section !== "todo" && section !== "final-wave") {
-        continue
-      }
-
-      const taskRef = buildTaskRef(section, uncheckedTaskMatch[2].trim())
-      if (taskRef) {
-        return taskRef
-      }
-    }
-
-    return null
+    return parseCurrentTopLevelTask(content)
   } catch {
     return null
   }

--- a/packages/omo-codex/plugin/components/start-work-continuation/src/boulder-reader.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/src/boulder-reader.ts
@@ -35,10 +35,21 @@ export type ContinuationState = {
 	readonly checklist: PlanChecklist;
 };
 
-const TODO_HEADING = "TODOs";
-const FINAL_VERIFICATION_HEADING = "Final Verification Wave";
-const CHECKBOX_PREFIX_LENGTH = "- [ ] ".length;
+const TODO_HEADING_PATTERN = /^##\s+TODOs\b/i;
+const FINAL_VERIFICATION_HEADING_PATTERN = /^##\s+Final Verification Wave\b/i;
+const SECOND_LEVEL_HEADING_PATTERN = /^##\s+/;
+const UNCHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[\s*\]\s*(.+)$/;
+const CHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[[xX]\]\s*(.+)$/;
+const TODO_TASK_PATTERN = /^\d+\.\s+/;
+const FINAL_WAVE_TASK_PATTERN = /^F\d+\.\s+/i;
 const SESSION_ID_PREFIX_PATTERN = /^(codex|opencode):/;
+
+type ChecklistSection = "todo" | "final-wave" | "other";
+
+type ParsedCheckbox = {
+	readonly checked: boolean;
+	readonly label: string;
+};
 
 export function readContinuationState(cwd: string, sessionId: string): ContinuationState | null {
 	const boulderPath = getBoulderFilePath(cwd);
@@ -75,21 +86,42 @@ export function getPlanChecklist(planPath: string): PlanChecklist {
 
 function parsePlanChecklist(markdown: string): PlanChecklist {
 	const lines = markdown.split(/\r?\n/);
-	const hasCountedSections = lines.some((line) => isCountedHeading(parseLevelTwoHeading(line)));
+	if (!lines.some(hasStructuredSectionHeading)) return parseSimpleChecklist(lines);
+
 	let completed = 0;
 	let remaining = 0;
 	let nextTaskLabel: string | null = null;
-	let isCountedSection = !hasCountedSections;
+	let section: ChecklistSection = "other";
 
 	for (const line of lines) {
-		const heading = parseLevelTwoHeading(line);
-		if (heading !== null) {
-			isCountedSection = isCountedHeading(heading);
+		const headingSection = parseStructuredSectionHeading(line);
+		if (headingSection !== null) {
+			section = headingSection;
 			continue;
 		}
-		if (!isCountedSection) continue;
+		if (section === "other") continue;
 
-		const checkbox = parseTopLevelCheckbox(line);
+		const checkbox = parseStructuredTopLevelCheckbox(line, section);
+		if (checkbox === null) continue;
+
+		if (checkbox.checked) {
+			completed += 1;
+		} else {
+			remaining += 1;
+			nextTaskLabel = nextTaskLabel ?? checkbox.label;
+		}
+	}
+
+	return { completed, remaining, total: completed + remaining, nextTaskLabel };
+}
+
+function parseSimpleChecklist(lines: readonly string[]): PlanChecklist {
+	let completed = 0;
+	let remaining = 0;
+	let nextTaskLabel: string | null = null;
+
+	for (const line of lines) {
+		const checkbox = parseSimpleTopLevelCheckbox(line);
 		if (checkbox === null) continue;
 
 		if (checkbox.checked) {
@@ -193,21 +225,39 @@ function resolveTrackedPath(baseDirectory: string, trackedPath: string): string 
 	return isAbsolute(trackedPath) ? resolve(trackedPath) : resolve(baseDirectory, trackedPath);
 }
 
-function parseTopLevelCheckbox(line: string): { readonly checked: boolean; readonly label: string } | null {
-	if (line.startsWith("- [ ] ")) return { checked: false, label: line.slice(CHECKBOX_PREFIX_LENGTH) };
+function parseSimpleTopLevelCheckbox(line: string): ParsedCheckbox | null {
+	if (line.startsWith("- [ ] ")) return { checked: false, label: line.slice("- [ ] ".length) };
 	if (line.startsWith("- [x] ") || line.startsWith("- [X] ")) {
-		return { checked: true, label: line.slice(CHECKBOX_PREFIX_LENGTH) };
+		return { checked: true, label: line.slice("- [ ] ".length) };
 	}
 	return null;
 }
 
-function parseLevelTwoHeading(line: string): string | null {
-	if (!line.startsWith("## ")) return null;
-	return line.slice("## ".length).trim();
+function hasStructuredSectionHeading(line: string): boolean {
+	const section = parseStructuredSectionHeading(line);
+	return section === "todo" || section === "final-wave";
 }
 
-function isCountedHeading(heading: string | null): boolean {
-	return heading === TODO_HEADING || heading === FINAL_VERIFICATION_HEADING;
+function parseStructuredSectionHeading(line: string): ChecklistSection | null {
+	if (!SECOND_LEVEL_HEADING_PATTERN.test(line)) return null;
+	if (TODO_HEADING_PATTERN.test(line)) return "todo";
+	if (FINAL_VERIFICATION_HEADING_PATTERN.test(line)) return "final-wave";
+	return "other";
+}
+
+function parseStructuredTopLevelCheckbox(line: string, section: "todo" | "final-wave"): ParsedCheckbox | null {
+	const checkedMatch = line.match(CHECKED_CHECKBOX_PATTERN);
+	const match = checkedMatch ?? line.match(UNCHECKED_CHECKBOX_PATTERN);
+	if (match === null) return null;
+
+	const indentation = match[1];
+	const taskBody = match[2]?.trim();
+	if (indentation !== "" || taskBody === undefined) return null;
+
+	const labelPattern = section === "todo" ? TODO_TASK_PATTERN : FINAL_WAVE_TASK_PATTERN;
+	if (!labelPattern.test(taskBody)) return null;
+
+	return { checked: checkedMatch !== null, label: taskBody };
 }
 
 function parseBoulderWorkStatus(value: unknown): BoulderWorkStatus | undefined {

--- a/packages/omo-codex/plugin/components/start-work-continuation/src/boulder-reader.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/src/boulder-reader.ts
@@ -1,12 +1,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
+import { getPlanChecklist, type PlanChecklist } from "./plan-checklist.js";
 
-export type PlanChecklist = {
-	readonly completed: number;
-	readonly remaining: number;
-	readonly total: number;
-	readonly nextTaskLabel: string | null;
-};
+export type { PlanChecklist } from "./plan-checklist.js";
+export { getPlanChecklist } from "./plan-checklist.js";
 
 type BoulderWorkStatus = "active" | "paused" | "completed" | "abandoned";
 
@@ -35,21 +32,7 @@ export type ContinuationState = {
 	readonly checklist: PlanChecklist;
 };
 
-const TODO_HEADING_PATTERN = /^##\s+TODOs\b/i;
-const FINAL_VERIFICATION_HEADING_PATTERN = /^##\s+Final Verification Wave\b/i;
-const SECOND_LEVEL_HEADING_PATTERN = /^##\s+/;
-const UNCHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[\s*\]\s*(.+)$/;
-const CHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[[xX]\]\s*(.+)$/;
-const TODO_TASK_PATTERN = /^\d+\.\s+/;
-const FINAL_WAVE_TASK_PATTERN = /^F\d+\.\s+/i;
 const SESSION_ID_PREFIX_PATTERN = /^(codex|opencode):/;
-
-type ChecklistSection = "todo" | "final-wave" | "other";
-
-type ParsedCheckbox = {
-	readonly checked: boolean;
-	readonly label: string;
-};
 
 export function readContinuationState(cwd: string, sessionId: string): ContinuationState | null {
 	const boulderPath = getBoulderFilePath(cwd);
@@ -71,68 +54,6 @@ export function readContinuationState(cwd: string, sessionId: string): Continuat
 		worktreePath: work.worktreePath ?? null,
 		checklist,
 	};
-}
-
-export function getPlanChecklist(planPath: string): PlanChecklist {
-	if (!existsSync(planPath)) return emptyChecklist();
-
-	try {
-		return parsePlanChecklist(readFileSync(planPath, "utf8"));
-	} catch (error) {
-		if (error instanceof Error) return emptyChecklist();
-		throw error;
-	}
-}
-
-function parsePlanChecklist(markdown: string): PlanChecklist {
-	const lines = markdown.split(/\r?\n/);
-	if (!lines.some(hasStructuredSectionHeading)) return parseSimpleChecklist(lines);
-
-	let completed = 0;
-	let remaining = 0;
-	let nextTaskLabel: string | null = null;
-	let section: ChecklistSection = "other";
-
-	for (const line of lines) {
-		const headingSection = parseStructuredSectionHeading(line);
-		if (headingSection !== null) {
-			section = headingSection;
-			continue;
-		}
-		if (section === "other") continue;
-
-		const checkbox = parseStructuredTopLevelCheckbox(line, section);
-		if (checkbox === null) continue;
-
-		if (checkbox.checked) {
-			completed += 1;
-		} else {
-			remaining += 1;
-			nextTaskLabel = nextTaskLabel ?? checkbox.label;
-		}
-	}
-
-	return { completed, remaining, total: completed + remaining, nextTaskLabel };
-}
-
-function parseSimpleChecklist(lines: readonly string[]): PlanChecklist {
-	let completed = 0;
-	let remaining = 0;
-	let nextTaskLabel: string | null = null;
-
-	for (const line of lines) {
-		const checkbox = parseSimpleTopLevelCheckbox(line);
-		if (checkbox === null) continue;
-
-		if (checkbox.checked) {
-			completed += 1;
-		} else {
-			remaining += 1;
-			nextTaskLabel = nextTaskLabel ?? checkbox.label;
-		}
-	}
-
-	return { completed, remaining, total: completed + remaining, nextTaskLabel };
 }
 
 function readBoulderState(path: string): BoulderState | null {
@@ -225,41 +146,6 @@ function resolveTrackedPath(baseDirectory: string, trackedPath: string): string 
 	return isAbsolute(trackedPath) ? resolve(trackedPath) : resolve(baseDirectory, trackedPath);
 }
 
-function parseSimpleTopLevelCheckbox(line: string): ParsedCheckbox | null {
-	if (line.startsWith("- [ ] ")) return { checked: false, label: line.slice("- [ ] ".length) };
-	if (line.startsWith("- [x] ") || line.startsWith("- [X] ")) {
-		return { checked: true, label: line.slice("- [ ] ".length) };
-	}
-	return null;
-}
-
-function hasStructuredSectionHeading(line: string): boolean {
-	const section = parseStructuredSectionHeading(line);
-	return section === "todo" || section === "final-wave";
-}
-
-function parseStructuredSectionHeading(line: string): ChecklistSection | null {
-	if (!SECOND_LEVEL_HEADING_PATTERN.test(line)) return null;
-	if (TODO_HEADING_PATTERN.test(line)) return "todo";
-	if (FINAL_VERIFICATION_HEADING_PATTERN.test(line)) return "final-wave";
-	return "other";
-}
-
-function parseStructuredTopLevelCheckbox(line: string, section: "todo" | "final-wave"): ParsedCheckbox | null {
-	const checkedMatch = line.match(CHECKED_CHECKBOX_PATTERN);
-	const match = checkedMatch ?? line.match(UNCHECKED_CHECKBOX_PATTERN);
-	if (match === null) return null;
-
-	const indentation = match[1];
-	const taskBody = match[2]?.trim();
-	if (indentation !== "" || taskBody === undefined) return null;
-
-	const labelPattern = section === "todo" ? TODO_TASK_PATTERN : FINAL_WAVE_TASK_PATTERN;
-	if (!labelPattern.test(taskBody)) return null;
-
-	return { checked: checkedMatch !== null, label: taskBody };
-}
-
 function parseBoulderWorkStatus(value: unknown): BoulderWorkStatus | undefined {
 	if (value === "active" || value === "paused" || value === "completed" || value === "abandoned") return value;
 	return undefined;
@@ -291,10 +177,6 @@ function isContinuableStatus(status: BoulderWorkStatus | undefined): boolean {
 
 function getBoulderFilePath(cwd: string): string {
 	return join(cwd, ".omo", "boulder.json");
-}
-
-function emptyChecklist(): PlanChecklist {
-	return { completed: 0, remaining: 0, total: 0, nextTaskLabel: null };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
@@ -1,0 +1,132 @@
+import { existsSync, readFileSync } from "node:fs";
+
+export type PlanChecklist = {
+	readonly completed: number;
+	readonly remaining: number;
+	readonly total: number;
+	readonly nextTaskLabel: string | null;
+};
+
+const TODO_HEADING_PATTERN = /^##[ \t]+TODOs[ \t]*$/i;
+const FINAL_VERIFICATION_HEADING_PATTERN = /^##[ \t]+Final Verification Wave[ \t]*$/i;
+const MARKDOWN_HEADING_PATTERN = /^#{1,6}(?:[ \t]+|$)/;
+const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/;
+const TODO_CHECKBOX_PATTERN = /^- \[([ xX])\] ([1-9]\d*\. .+)$/;
+const FINAL_WAVE_CHECKBOX_PATTERN = /^- \[([ xX])\] (F[1-9]\d*\. .+)$/i;
+
+type ChecklistSection = "todo" | "final-wave" | "other";
+
+type ParsedCheckbox = {
+	readonly checked: boolean;
+	readonly label: string;
+};
+
+export function getPlanChecklist(planPath: string): PlanChecklist {
+	if (!existsSync(planPath)) return emptyChecklist();
+
+	try {
+		return parsePlanChecklist(readFileSync(planPath, "utf8"));
+	} catch (error) {
+		if (error instanceof Error) return emptyChecklist();
+		throw error;
+	}
+}
+
+export function parsePlanChecklist(markdown: string): PlanChecklist {
+	const lines = markdown.split(/\r?\n/);
+	if (!hasStructuredSection(lines)) return parseSimpleChecklist(lines);
+
+	let completed = 0;
+	let remaining = 0;
+	let nextTaskLabel: string | null = null;
+	let section: ChecklistSection = "other";
+	let fence: "`" | "~" | null = null;
+
+	for (const line of lines) {
+		const fenceMarker = parseFenceMarker(line);
+		if (fenceMarker !== null) {
+			fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence;
+			continue;
+		}
+		if (fence !== null) continue;
+
+		if (MARKDOWN_HEADING_PATTERN.test(line)) {
+			section = parseStructuredSectionHeading(line);
+			continue;
+		}
+		if (section === "other") continue;
+
+		const checkbox = parseStructuredCheckbox(line, section);
+		if (checkbox === null) continue;
+		if (checkbox.checked) completed += 1;
+		else {
+			remaining += 1;
+			nextTaskLabel = nextTaskLabel ?? checkbox.label;
+		}
+	}
+
+	return { completed, remaining, total: completed + remaining, nextTaskLabel };
+}
+
+function hasStructuredSection(lines: readonly string[]): boolean {
+	let fence: "`" | "~" | null = null;
+	for (const line of lines) {
+		const fenceMarker = parseFenceMarker(line);
+		if (fenceMarker !== null) {
+			fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence;
+			continue;
+		}
+		if (fence === null && parseStructuredSectionHeading(line) !== "other") return true;
+	}
+	return false;
+}
+
+function parseSimpleChecklist(lines: readonly string[]): PlanChecklist {
+	let completed = 0;
+	let remaining = 0;
+	let nextTaskLabel: string | null = null;
+
+	for (const line of lines) {
+		const checkbox = parseSimpleTopLevelCheckbox(line);
+		if (checkbox === null) continue;
+		if (checkbox.checked) completed += 1;
+		else {
+			remaining += 1;
+			nextTaskLabel = nextTaskLabel ?? checkbox.label;
+		}
+	}
+
+	return { completed, remaining, total: completed + remaining, nextTaskLabel };
+}
+
+function parseStructuredSectionHeading(line: string): ChecklistSection {
+	if (TODO_HEADING_PATTERN.test(line)) return "todo";
+	if (FINAL_VERIFICATION_HEADING_PATTERN.test(line)) return "final-wave";
+	return "other";
+}
+
+function parseStructuredCheckbox(line: string, section: "todo" | "final-wave"): ParsedCheckbox | null {
+	const pattern = section === "todo" ? TODO_CHECKBOX_PATTERN : FINAL_WAVE_CHECKBOX_PATTERN;
+	const match = line.match(pattern);
+	const marker = match?.[1];
+	const label = match?.[2];
+	if (marker === undefined || label === undefined) return null;
+	return { checked: marker.toLowerCase() === "x", label };
+}
+
+function parseSimpleTopLevelCheckbox(line: string): ParsedCheckbox | null {
+	if (line.startsWith("- [ ] ")) return { checked: false, label: line.slice("- [ ] ".length) };
+	if (line.startsWith("- [x] ") || line.startsWith("- [X] ")) {
+		return { checked: true, label: line.slice("- [ ] ".length) };
+	}
+	return null;
+}
+
+function parseFenceMarker(line: string): "`" | "~" | null {
+	const marker = line.match(FENCE_PATTERN)?.[1]?.[0];
+	return marker === "`" || marker === "~" ? marker : null;
+}
+
+function emptyChecklist(): PlanChecklist {
+	return { completed: 0, remaining: 0, total: 0, nextTaskLabel: null };
+}

--- a/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
@@ -11,6 +11,7 @@ const TODO_HEADING_PATTERN = /^##[ \t]+TODOs[ \t]*$/i;
 const FINAL_VERIFICATION_HEADING_PATTERN = /^##[ \t]+Final Verification Wave[ \t]*$/i;
 const MARKDOWN_HEADING_PATTERN = /^#{1,6}(?:[ \t]+|$)/;
 const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/;
+const SIMPLE_CHECKBOX_PATTERN = /^[-*][ \t]*\[[ \t]*([xX]?)[ \t]*\][ \t]+(.+)$/;
 const TODO_CHECKBOX_PATTERN = /^- \[([ xX])\] ([1-9]\d*\. .+)$/;
 const FINAL_WAVE_CHECKBOX_PATTERN = /^- \[([ xX])\] (F[1-9]\d*\. .+)$/i;
 
@@ -115,11 +116,11 @@ function parseStructuredCheckbox(line: string, section: "todo" | "final-wave"): 
 }
 
 function parseSimpleTopLevelCheckbox(line: string): ParsedCheckbox | null {
-	if (line.startsWith("- [ ] ")) return { checked: false, label: line.slice("- [ ] ".length) };
-	if (line.startsWith("- [x] ") || line.startsWith("- [X] ")) {
-		return { checked: true, label: line.slice("- [ ] ".length) };
-	}
-	return null;
+	const match = line.match(SIMPLE_CHECKBOX_PATTERN);
+	const marker = match?.[1];
+	const label = match?.[2];
+	if (marker === undefined || label === undefined) return null;
+	return { checked: marker.toLowerCase() === "x", label };
 }
 
 function parseFenceMarker(line: string): "`" | "~" | null {

--- a/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
@@ -9,7 +9,7 @@ export type PlanChecklist = {
 
 const TODO_HEADING_PATTERN = /^##[ \t]+TODOs(?:[ \t]+#+)?[ \t]*$/i;
 const FINAL_VERIFICATION_HEADING_PATTERN = /^##[ \t]+Final Verification Wave(?:[ \t]+#+)?[ \t]*$/i;
-const MARKDOWN_HEADING_PATTERN = /^#{1,6}(?:[ \t]+|$)/;
+const SECTION_BOUNDARY_HEADING_PATTERN = /^#{1,2}(?:[ \t]+|$)/;
 const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})(.*)$/;
 const SIMPLE_CHECKBOX_PATTERN = /^[-*][ \t]*\[[ \t]*([xX]?)[ \t]*\][ \t]+(.+)$/;
 const TODO_CHECKBOX_PATTERN = /^- \[([ xX])\] ([1-9]\d*\. .+)$/;
@@ -59,7 +59,7 @@ export function parsePlanChecklist(markdown: string): PlanChecklist {
 			continue;
 		}
 
-		if (MARKDOWN_HEADING_PATTERN.test(line)) {
+		if (SECTION_BOUNDARY_HEADING_PATTERN.test(line)) {
 			section = parseStructuredSectionHeading(line);
 			continue;
 		}

--- a/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
@@ -22,6 +22,11 @@ type ParsedCheckbox = {
 	readonly label: string;
 };
 
+type MarkdownFence = {
+	readonly marker: "`" | "~";
+	readonly length: number;
+};
+
 export function getPlanChecklist(planPath: string): PlanChecklist {
 	if (!existsSync(planPath)) return emptyChecklist();
 
@@ -41,15 +46,18 @@ export function parsePlanChecklist(markdown: string): PlanChecklist {
 	let remaining = 0;
 	let nextTaskLabel: string | null = null;
 	let section: ChecklistSection = "other";
-	let fence: "`" | "~" | null = null;
+	let fence: MarkdownFence | null = null;
 
 	for (const line of lines) {
-		const fenceMarker = parseFenceMarker(line);
-		if (fenceMarker !== null) {
-			fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence;
+		if (fence !== null) {
+			if (isClosingFence(line, fence)) fence = null;
 			continue;
 		}
-		if (fence !== null) continue;
+		const openingFence = parseOpeningFence(line);
+		if (openingFence !== null) {
+			fence = openingFence;
+			continue;
+		}
 
 		if (MARKDOWN_HEADING_PATTERN.test(line)) {
 			section = parseStructuredSectionHeading(line);
@@ -70,14 +78,18 @@ export function parsePlanChecklist(markdown: string): PlanChecklist {
 }
 
 function hasStructuredSection(lines: readonly string[]): boolean {
-	let fence: "`" | "~" | null = null;
+	let fence: MarkdownFence | null = null;
 	for (const line of lines) {
-		const fenceMarker = parseFenceMarker(line);
-		if (fenceMarker !== null) {
-			fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence;
+		if (fence !== null) {
+			if (isClosingFence(line, fence)) fence = null;
 			continue;
 		}
-		if (fence === null && parseStructuredSectionHeading(line) !== "other") return true;
+		const openingFence = parseOpeningFence(line);
+		if (openingFence !== null) {
+			fence = openingFence;
+			continue;
+		}
+		if (parseStructuredSectionHeading(line) !== "other") return true;
 	}
 	return false;
 }
@@ -123,9 +135,16 @@ function parseSimpleTopLevelCheckbox(line: string): ParsedCheckbox | null {
 	return { checked: marker.toLowerCase() === "x", label };
 }
 
-function parseFenceMarker(line: string): "`" | "~" | null {
-	const marker = line.match(FENCE_PATTERN)?.[1]?.[0];
-	return marker === "`" || marker === "~" ? marker : null;
+function parseOpeningFence(line: string): MarkdownFence | null {
+	const run = line.match(FENCE_PATTERN)?.[1];
+	const marker = run?.charAt(0);
+	if (run === undefined || (marker !== "`" && marker !== "~")) return null;
+	return { marker, length: run.length };
+}
+
+function isClosingFence(line: string, fence: MarkdownFence): boolean {
+	const run = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/)?.[1];
+	return run?.charAt(0) === fence.marker && run.length >= fence.length;
 }
 
 function emptyChecklist(): PlanChecklist {

--- a/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/src/plan-checklist.ts
@@ -7,10 +7,10 @@ export type PlanChecklist = {
 	readonly nextTaskLabel: string | null;
 };
 
-const TODO_HEADING_PATTERN = /^##[ \t]+TODOs[ \t]*$/i;
-const FINAL_VERIFICATION_HEADING_PATTERN = /^##[ \t]+Final Verification Wave[ \t]*$/i;
+const TODO_HEADING_PATTERN = /^##[ \t]+TODOs(?:[ \t]+#+)?[ \t]*$/i;
+const FINAL_VERIFICATION_HEADING_PATTERN = /^##[ \t]+Final Verification Wave(?:[ \t]+#+)?[ \t]*$/i;
 const MARKDOWN_HEADING_PATTERN = /^#{1,6}(?:[ \t]+|$)/;
-const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/;
+const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})(.*)$/;
 const SIMPLE_CHECKBOX_PATTERN = /^[-*][ \t]*\[[ \t]*([xX]?)[ \t]*\][ \t]+(.+)$/;
 const TODO_CHECKBOX_PATTERN = /^- \[([ xX])\] ([1-9]\d*\. .+)$/;
 const FINAL_WAVE_CHECKBOX_PATTERN = /^- \[([ xX])\] (F[1-9]\d*\. .+)$/i;
@@ -98,8 +98,19 @@ function parseSimpleChecklist(lines: readonly string[]): PlanChecklist {
 	let completed = 0;
 	let remaining = 0;
 	let nextTaskLabel: string | null = null;
+	let fence: MarkdownFence | null = null;
 
 	for (const line of lines) {
+		if (fence !== null) {
+			if (isClosingFence(line, fence)) fence = null;
+			continue;
+		}
+		const openingFence = parseOpeningFence(line);
+		if (openingFence !== null) {
+			fence = openingFence;
+			continue;
+		}
+
 		const checkbox = parseSimpleTopLevelCheckbox(line);
 		if (checkbox === null) continue;
 		if (checkbox.checked) completed += 1;
@@ -136,9 +147,17 @@ function parseSimpleTopLevelCheckbox(line: string): ParsedCheckbox | null {
 }
 
 function parseOpeningFence(line: string): MarkdownFence | null {
-	const run = line.match(FENCE_PATTERN)?.[1];
+	const match = line.match(FENCE_PATTERN);
+	const run = match?.[1];
+	const info = match?.[2];
 	const marker = run?.charAt(0);
-	if (run === undefined || (marker !== "`" && marker !== "~")) return null;
+	if (
+		run === undefined ||
+		info === undefined ||
+		(marker !== "`" && marker !== "~") ||
+		(marker === "`" && info.includes("`"))
+	)
+		return null;
 	return { marker, length: run.length };
 }
 

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
@@ -1,40 +1,44 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { getPlanChecklist, readContinuationState } from "../src/boulder-reader.js";
 
 const cleanupRoots: string[] = [];
+const SCAFFOLD_PLAN_MARKDOWN = readFileSync(new URL("./fixtures/plan-scaffold.md", import.meta.url), "utf8");
 
 afterEach(() => {
 	for (const root of cleanupRoots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
 describe("start-work plan checklist consumption", () => {
-	it("#given top-level completed and incomplete checkboxes #when parsed #then counts remaining and total", () => {
+	it("#given scaffold headings and canonical numbered rows #when parsed #then structured totals and next label match", () => {
 		// given
-		const planPath = createPlan(
-			["# Plan", "", "## TODOs", "- [ ] First", "- [x] Done", "- [X] Also done", "- [ ] Second"].join("\n"),
-		);
+		const planPath = createPlan(SCAFFOLD_PLAN_MARKDOWN);
 
 		// when
 		const checklist = getPlanChecklist(planPath);
 
 		// then
-		expect(checklist).toEqual({ completed: 2, remaining: 2, total: 4, nextTaskLabel: "First" });
+		expect(checklist).toEqual({
+			completed: 2,
+			remaining: 2,
+			total: 4,
+			nextTaskLabel: "1. Implement checklist parser parity",
+		});
 	});
 
 	it("#given nested checkboxes #when parsed #then ignores non-column-zero items", () => {
 		// given
 		const planPath = createPlan(
-			["## TODOs", "- [ ] Top-level", "  - [ ] Nested", "\t- [ ] Tab nested", "- [x] Complete"].join("\n"),
+			["## TODOs", "- [ ] 1. Top-level", "  - [ ] Nested", "\t- [ ] Tab nested", "- [x] 2. Complete"].join("\n"),
 		);
 
 		// when
 		const checklist = getPlanChecklist(planPath);
 
 		// then
-		expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "Top-level" });
+		expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "1. Top-level" });
 	});
 
 	it("#given checkboxes outside counted sections #when parsed #then ignores unrelated top-level tasks", () => {
@@ -44,12 +48,12 @@ describe("start-work plan checklist consumption", () => {
 				"# Plan",
 				"- [ ] Preamble task",
 				"## TODOs",
-				"- [ ] Build hook",
+				"- [ ] 1. Build hook",
 				"## Acceptance Criteria",
 				"- [ ] Acceptance item",
 				"## Final Verification Wave",
-				"- [x] Run tests",
-				"- [ ] Run smoke",
+				"- [x] F1. Run tests",
+				"- [ ] F2. Run smoke",
 			].join("\n"),
 		);
 
@@ -57,18 +61,31 @@ describe("start-work plan checklist consumption", () => {
 		const checklist = getPlanChecklist(planPath);
 
 		// then
-		expect(checklist).toEqual({ completed: 1, remaining: 2, total: 3, nextTaskLabel: "Build hook" });
+		expect(checklist).toEqual({ completed: 1, remaining: 2, total: 3, nextTaskLabel: "1. Build hook" });
 	});
 
 	it("#given all top-level tasks complete #when parsed #then next task is null", () => {
 		// given
-		const planPath = createPlan(["## TODOs", "- [x] First", "- [X] Second"].join("\n"));
+		const planPath = createPlan(
+			["## Todos", "- [x] 1. First", "- [X] 2. Second", "## Final verification wave", "- [x] F1. Final"].join("\n"),
+		);
 
 		// when
 		const checklist = getPlanChecklist(planPath);
 
 		// then
-		expect(checklist).toEqual({ completed: 2, remaining: 0, total: 2, nextTaskLabel: null });
+		expect(checklist).toEqual({ completed: 3, remaining: 0, total: 3, nextTaskLabel: null });
+	});
+
+	it("#given no structured headings #when parsed #then legacy top-level checkbox fallback remains", () => {
+		// given
+		const planPath = createPlan(["# Plan", "- [ ] First", "- [x] Done", "  - [ ] Nested"].join("\n"));
+
+		// when
+		const checklist = getPlanChecklist(planPath);
+
+		// then
+		expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "First" });
 	});
 });
 
@@ -77,7 +94,7 @@ describe("start-work boulder state reader", () => {
 		// given
 		const workspace = createWorkspace({
 			boulderJson: createBoulderJson({ status: "active", sessionIds: ["codex:sess_abc"] }),
-			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n- [x] Done\n- [ ] Second\n",
+			planMarkdown: SCAFFOLD_PLAN_MARKDOWN,
 		});
 
 		// when
@@ -90,7 +107,12 @@ describe("start-work boulder state reader", () => {
 			boulderPath: join(workspace, ".omo", "boulder.json"),
 			ledgerPath: join(workspace, ".omo", "start-work", "ledger.jsonl"),
 			worktreePath: null,
-			checklist: { completed: 1, remaining: 2, total: 3, nextTaskLabel: "First" },
+			checklist: {
+				completed: 2,
+				remaining: 2,
+				total: 4,
+				nextTaskLabel: "1. Implement checklist parser parity",
+			},
 		});
 	});
 
@@ -98,7 +120,7 @@ describe("start-work boulder state reader", () => {
 		// given
 		const workspace = createWorkspace({
 			boulderJson: createBoulderJson({ status: "completed", sessionIds: ["codex:sess_abc"] }),
-			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n",
+			planMarkdown: "# Plan\n\n## TODOs\n- [ ] 1. First\n",
 		});
 
 		// when
@@ -112,7 +134,7 @@ describe("start-work boulder state reader", () => {
 		// given
 		const workspace = createWorkspace({
 			boulderJson: createBoulderJson({ status: "paused", sessionIds: ["codex:sess_abc"] }),
-			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n",
+			planMarkdown: "# Plan\n\n## TODOs\n- [ ] 1. First\n",
 		});
 
 		// when
@@ -120,14 +142,14 @@ describe("start-work boulder state reader", () => {
 
 		// then
 		expect(state?.planName).toBe("launch-plan");
-		expect(state?.checklist).toEqual({ completed: 0, remaining: 1, total: 1, nextTaskLabel: "First" });
+		expect(state?.checklist).toEqual({ completed: 0, remaining: 1, total: 1, nextTaskLabel: "1. First" });
 	});
 
 	it("#given active codex work with no remaining checklist items #when state is read #then final gate continuation remains present", () => {
 		// given
 		const workspace = createWorkspace({
 			boulderJson: createBoulderJson({ status: "active", sessionIds: ["codex:sess_abc"] }),
-			planMarkdown: "# Plan\n\n## TODOs\n- [x] First\n",
+			planMarkdown: "# Plan\n\n## TODOs\n- [x] 1. First\n",
 		});
 
 		// when
@@ -155,7 +177,7 @@ describe("start-work boulder state reader", () => {
 		// given
 		const workspace = createWorkspace({
 			boulderJson: "{",
-			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n",
+			planMarkdown: "# Plan\n\n## TODOs\n- [ ] 1. First\n",
 		});
 
 		// when
@@ -169,7 +191,7 @@ describe("start-work boulder state reader", () => {
 		// given
 		const workspace = createWorkspace({
 			boulderJson: createBoulderJson({ status: "active", sessionIds: ["sess_abc"] }),
-			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n",
+			planMarkdown: "# Plan\n\n## TODOs\n- [ ] 1. First\n",
 		});
 
 		// when
@@ -201,7 +223,7 @@ describe("start-work boulder state reader", () => {
 				started_at: "2026-06-12T00:00:00.000Z",
 				session_ids: ["codex:sess_abc"],
 			}),
-			planMarkdown: "# Plan\n\n## TODOs\n- [ ] First\n",
+			planMarkdown: "# Plan\n\n## TODOs\n- [ ] 1. First\n",
 		});
 
 		// when

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
@@ -88,6 +88,17 @@ describe("start-work plan checklist consumption", () => {
 		expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "First" });
 	});
 
+	it("#given a heading-free legacy star checklist #when parsed #then fallback behavior is preserved", () => {
+		// given
+		const planPath = createPlan(["# Plan", "* [ ] First", "* [x] Done", "  * [ ] Nested"].join("\n"));
+
+		// when
+		const checklist = getPlanChecklist(planPath);
+
+		// then
+		expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "First" });
+	});
+
 	it("#given noncanonical structured rows #when parsed #then only exact positive-number grammar is counted", () => {
 		// given
 		const planPath = createPlan(

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
@@ -156,6 +156,17 @@ describe("start-work plan checklist consumption", () => {
 		});
 	});
 
+	it("#given a child heading inside TODOs #when parsed #then canonical rows remain in the parent section", () => {
+		// given
+		const planPath = createPlan(["## TODOs", "- [x] 1. First task", "### Notes", "- [ ] 2. Second task"].join("\n"));
+
+		// when
+		const checklist = getPlanChecklist(planPath);
+
+		// then
+		expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "2. Second task" });
+	});
+
 	it("#given a four-backtick fence containing triple-backtick examples #when parsed #then shorter fences do not close it", () => {
 		// given
 		const planPath = createPlan(

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
@@ -183,6 +183,52 @@ describe("start-work plan checklist consumption", () => {
 			nextTaskLabel: "F1. Counted verifier",
 		});
 	});
+
+	it("#given structured headings with ATX closing markers #when parsed #then canonical tasks remain structured", () => {
+		// given
+		const planPath = createPlan(
+			["## TODOs ##", "- [ ] 1. Implement", "## Final Verification Wave ###", "- [ ] F1. Verify"].join("\n"),
+		);
+
+		// when
+		const checklist = getPlanChecklist(planPath);
+
+		// then
+		expect(checklist).toEqual({
+			completed: 0,
+			remaining: 2,
+			total: 2,
+			nextTaskLabel: "1. Implement",
+		});
+	});
+
+	it("#given inline backtick code before a canonical task #when parsed #then it does not open a fence", () => {
+		// given
+		const planPath = createPlan(["## TODOs", "```example```", "- [ ] 1. Implement"].join("\n"));
+
+		// when
+		const checklist = getPlanChecklist(planPath);
+
+		// then
+		expect(checklist.total).toBe(1);
+		expect(checklist.nextTaskLabel).toBe("1. Implement");
+	});
+
+	it("#given a heading-free fenced checkbox example #when parsed #then legacy fallback ignores it", () => {
+		// given
+		const planPath = createPlan(["````md", "- [ ] 1. Example only", "````"].join("\n"));
+
+		// when
+		const checklist = getPlanChecklist(planPath);
+
+		// then
+		expect(checklist).toEqual({
+			completed: 0,
+			remaining: 0,
+			total: 0,
+			nextTaskLabel: null,
+		});
+	});
 });
 
 describe("start-work boulder state reader", () => {

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
@@ -155,6 +155,34 @@ describe("start-work plan checklist consumption", () => {
 			nextTaskLabel: "1. Counted implementation",
 		});
 	});
+
+	it("#given a four-backtick fence containing triple-backtick examples #when parsed #then shorter fences do not close it", () => {
+		// given
+		const planPath = createPlan(
+			[
+				"## Todos",
+				"- [x] 1. Counted implementation",
+				"````md",
+				"```ts",
+				"- [ ] 2. Fenced example",
+				"```",
+				"````",
+				"## Final verification wave",
+				"- [ ] F1. Counted verifier",
+			].join("\n"),
+		);
+
+		// when
+		const checklist = getPlanChecklist(planPath);
+
+		// then
+		expect(checklist).toEqual({
+			completed: 1,
+			remaining: 1,
+			total: 2,
+			nextTaskLabel: "F1. Counted verifier",
+		});
+	});
 });
 
 describe("start-work boulder state reader", () => {

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/boulder-reader.test.ts
@@ -87,6 +87,63 @@ describe("start-work plan checklist consumption", () => {
 		// then
 		expect(checklist).toEqual({ completed: 1, remaining: 1, total: 2, nextTaskLabel: "First" });
 	});
+
+	it("#given noncanonical structured rows #when parsed #then only exact positive-number grammar is counted", () => {
+		// given
+		const planPath = createPlan(
+			[
+				"## Todos",
+				"- [ ] 0. Zero is invalid",
+				"- [ ] 01. Leading zero is invalid",
+				"* [ ] 2. Star marker is invalid",
+				"-[ ] 3. Missing spaces are invalid",
+				"- [ ] 4. Canonical implementation",
+				"## Final verification wave",
+				"- [ ] F0. Zero final verifier is invalid",
+				"- [ ] F01. Leading zero final verifier is invalid",
+				"- [x] F2. Canonical final verifier",
+			].join("\n"),
+		);
+
+		// when
+		const checklist = getPlanChecklist(planPath);
+
+		// then
+		expect(checklist).toEqual({
+			completed: 1,
+			remaining: 1,
+			total: 2,
+			nextTaskLabel: "4. Canonical implementation",
+		});
+	});
+
+	it("#given fenced examples and a higher-level heading #when parsed #then section scope excludes them", () => {
+		// given
+		const planPath = createPlan(
+			[
+				"## Todos",
+				"- [ ] 1. Counted implementation",
+				"```md",
+				"- [ ] 2. Fenced example",
+				"```",
+				"# Appendix",
+				"- [ ] 3. Appendix checkbox",
+				"## Final verification wave",
+				"- [x] F1. Counted verifier",
+			].join("\n"),
+		);
+
+		// when
+		const checklist = getPlanChecklist(planPath);
+
+		// then
+		expect(checklist).toEqual({
+			completed: 1,
+			remaining: 1,
+			total: 2,
+			nextTaskLabel: "1. Counted implementation",
+		});
+	});
 });
 
 describe("start-work boulder state reader", () => {

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/cli.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/cli.test.ts
@@ -6,6 +6,7 @@ import { execPath } from "node:process";
 import { afterEach, describe, expect, it } from "vitest";
 
 const cleanupRoots: string[] = [];
+const SCAFFOLD_PLAN_MARKDOWN = readFileSync(new URL("./fixtures/plan-scaffold.md", import.meta.url), "utf8");
 
 afterEach(() => {
 	for (const root of cleanupRoots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -25,8 +26,8 @@ describe("start-work continuation CLI", () => {
 		expect(result.status).toBe(0);
 		const output = parseStopHookOutput(result.stdout);
 		expect(output.decision).toBe("block");
-		expect(output.reason).toContain("Remaining top-level checkboxes: `2` of `3`");
-		expect(output.reason).toContain("Next incomplete task: `Task one`");
+		expect(output.reason).toContain("Remaining top-level checkboxes: `2` of `4`");
+		expect(output.reason).toContain("Next incomplete task: `1. Implement checklist parser parity`");
 		expect(output.reason).toContain("Your session id in boulder.json: `codex:s1`");
 	});
 
@@ -106,7 +107,7 @@ function createWorkspace(sessionIds: readonly string[]): string {
 	const root = mkdtempSync(join(tmpdir(), "codex-continuation-cli-"));
 	cleanupRoots.push(root);
 	mkdirSync(join(root, ".omo", "plans"), { recursive: true });
-	writeFileSync(join(root, ".omo", "plans", "plan.md"), "## TODOs\n\n- [ ] Task one\n- [x] Done\n- [ ] Task two\n");
+	writeFileSync(join(root, ".omo", "plans", "plan.md"), SCAFFOLD_PLAN_MARKDOWN);
 	const work = {
 		work_id: "w1",
 		active_plan: ".omo/plans/plan.md",

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/codex-hook.test.ts
@@ -74,7 +74,7 @@ describe("start-work Stop hook", () => {
 		// given
 		const workspace = createWorkspace({
 			boulderJson: createBoulderJson({ sessionIds: ["codex:sess_abc"], status: "active" }),
-			planMarkdown: ["# Plan", "", "## TODOs", "- [x] Done"].join("\n"),
+			planMarkdown: ["# Plan", "", "## TODOs", "- [x] 1. Done"].join("\n"),
 		});
 		const fs = createMemoryFs();
 

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/codex-hook.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -8,6 +8,7 @@ import type { ReadonlyFileSystem, StopInput } from "../src/types.js";
 
 const DEFAULT_WORKSPACE = "/repo";
 const cleanupRoots: string[] = [];
+const SCAFFOLD_PLAN_MARKDOWN = readFileSync(new URL("./fixtures/plan-scaffold.md", import.meta.url), "utf8");
 
 afterEach(() => {
 	for (const root of cleanupRoots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -49,7 +50,7 @@ describe("start-work Stop hook", () => {
 				status: "active",
 				worktreePath: "/tmp/worktree",
 			}),
-			planMarkdown: ["# Plan", "", "## TODOs", "- [ ] First", "- [x] Done", "- [ ] Second"].join("\n"),
+			planMarkdown: SCAFFOLD_PLAN_MARKDOWN,
 		});
 		const fs = createMemoryFs();
 
@@ -62,8 +63,8 @@ describe("start-work Stop hook", () => {
 		expect(parsed.reason).toContain("- Plan: `launch-plan`");
 		expect(parsed.reason).toContain(`- Plan file: \`${join(workspace, ".omo", "plans", "plan.md")}\``);
 		expect(parsed.reason).toContain(`- Boulder state: \`${join(workspace, ".omo", "boulder.json")}\``);
-		expect(parsed.reason).toContain("- Remaining top-level checkboxes: `2` of `3`");
-		expect(parsed.reason).toContain("- Next incomplete task: `First`");
+		expect(parsed.reason).toContain("- Remaining top-level checkboxes: `2` of `4`");
+		expect(parsed.reason).toContain("- Next incomplete task: `1. Implement checklist parser parity`");
 		expect(parsed.reason).toContain("- Worktree: `/tmp/worktree`");
 		expect(parsed.reason).toContain(`- Ledger: \`${join(workspace, ".omo", "start-work", "ledger.jsonl")}\``);
 		expect(parsed.reason).toContain("- Your session id in boulder.json: `codex:sess_abc`");

--- a/packages/omo-codex/plugin/components/start-work-continuation/test/fixtures/plan-scaffold.md
+++ b/packages/omo-codex/plugin/components/start-work-continuation/test/fixtures/plan-scaffold.md
@@ -1,0 +1,15 @@
+# Scaffold Parser Parity
+
+## Todos
+- [ ] 1. Implement checklist parser parity
+  - [ ] Nested acceptance detail
+- [x] 2. Preserve completed implementation rows
+- [ ] Missing numeric prefix must be ignored
+
+## Acceptance Criteria
+- [ ] Outside tracked sections must be ignored
+
+## Final verification wave
+- [ ] F1. Exercise the Codex Stop surface
+- [X] F2. Preserve completed final verification rows
+- [ ] 3. Wrong final-wave label must be ignored

--- a/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/SKILL.md
+++ b/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/SKILL.md
@@ -43,6 +43,10 @@ node "<skill-root>/scripts/scaffold-plan.mjs" <slug> [--clear|--unclear]
 
 Run it ONCE at plan generation. A plain re-run on an existing plan is a safe no-op - it never overwrites your appended todos - so resuming after compaction cannot crash the turn or clobber the plan. Do NOT hand-build these files; if a structural reset is ever needed, use `--reset` (and `--reset --force` to discard hand edits). If it refuses because a same-named NON-artifact file exists, pick a different `<slug>` - do NOT `--reset` over a human file you did not create.
 
+## Plan artifact producer contract
+
+When producing the plan, encode every executable item as a column-zero Markdown task row: implementation rows MUST match `- [ ] N. <title>` (where `N` is a positive decimal integer), and final-verifier rows MUST match `- [ ] F<number>. <title>`. Prose headings, numbered paragraphs, and ordinary bullets are not task substitutes and MUST NOT be counted as implementation or final-verifier tasks. Before handoff, run a structural self-check over the plan: verify that every implementation row and final-verifier row is column-zero, matches its required grammar, and appears in the intended `## Todos` or `## Final verification wave` section; verify that no prose heading or bullet is being used as a task; and repair the plan before handoff if any check fails.
+
 ## Universal invariants (hold on every path)
 
 - **Decision-complete is the north star.** The executor has NO interview context - spell out exact paths, "every X in Y", and an explicit Must-NOT-Have. Leave the implementer ZERO judgment calls.

--- a/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/references/full-workflow.md
+++ b/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/references/full-workflow.md
@@ -76,6 +76,10 @@ No Metis, no plan file, no execution until the user approves. The UNCLEAR path a
 ```
 > Target 5-8 todos per wave; fewer than 3 (except the final) means under-splitting. Implementation + Test = ONE todo. Each todo carries: exhaustive References (the executor has no interview context), agent-executable Acceptance criteria, happy + failure QA scenarios each with an evidence path, and a Commit line.
 
+## Plan artifact producer contract
+
+When producing the plan, encode every executable item as a column-zero Markdown task row: implementation rows MUST match `- [ ] N. <title>` (where `N` is a positive decimal integer), and final-verifier rows MUST match `- [ ] F<number>. <title>`. Prose headings, numbered paragraphs, and ordinary bullets are not task substitutes and MUST NOT be counted as implementation or final-verifier tasks. Before handoff, run a structural self-check over the plan: verify that every implementation row and final-verifier row is column-zero, matches its required grammar, and appears in the intended `## Todos` or `## Final verification wave` section; verify that no prose heading or bullet is being used as a task; and repair the plan before handoff if any check fails.
+
 ### Final verification wave (after ALL todos)
 Runs in parallel; ALL must APPROVE; surface results and wait for the user's explicit okay before declaring complete: F1 plan compliance audit, F2 code quality review, F3 real manual QA, F4 scope fidelity.
 

--- a/packages/omo-codex/plugin/skills/ulw-plan/SKILL.md
+++ b/packages/omo-codex/plugin/skills/ulw-plan/SKILL.md
@@ -43,6 +43,10 @@ node "<skill-root>/scripts/scaffold-plan.mjs" <slug> [--clear|--unclear]
 
 Run it ONCE at plan generation. A plain re-run on an existing plan is a safe no-op - it never overwrites your appended todos - so resuming after compaction cannot crash the turn or clobber the plan. Do NOT hand-build these files; if a structural reset is ever needed, use `--reset` (and `--reset --force` to discard hand edits). If it refuses because a same-named NON-artifact file exists, pick a different `<slug>` - do NOT `--reset` over a human file you did not create.
 
+## Plan artifact producer contract
+
+When producing the plan, encode every executable item as a column-zero Markdown task row: implementation rows MUST match `- [ ] N. <title>` (where `N` is a positive decimal integer), and final-verifier rows MUST match `- [ ] F<number>. <title>`. Prose headings, numbered paragraphs, and ordinary bullets are not task substitutes and MUST NOT be counted as implementation or final-verifier tasks. Before handoff, run a structural self-check over the plan: verify that every implementation row and final-verifier row is column-zero, matches its required grammar, and appears in the intended `## Todos` or `## Final verification wave` section; verify that no prose heading or bullet is being used as a task; and repair the plan before handoff if any check fails.
+
 ## Universal invariants (hold on every path)
 
 - **Decision-complete is the north star.** The executor has NO interview context - spell out exact paths, "every X in Y", and an explicit Must-NOT-Have. Leave the implementer ZERO judgment calls.

--- a/packages/omo-opencode/src/features/boulder-state/storage.test.ts
+++ b/packages/omo-opencode/src/features/boulder-state/storage.test.ts
@@ -809,6 +809,45 @@ describe("boulder-state", () => {
       expect(progress.isComplete).toBe(false)
     })
 
+    test("#given a subsection inside TODOs #when progress is read #then subsection rows match continuation scope", () => {
+      // given
+      const planPath = join(TEST_DIR, "todo-subsection-plan.md")
+      writeFileSync(planPath, `# Plan
+
+## TODOs
+- [x] 1. Canonical task
+
+### Notes
+- [ ] 2. Example outside task scope
+`)
+
+      // when
+      const progress = getPlanProgress(planPath)
+
+      // then
+      expect(progress).toEqual({ total: 1, completed: 1, isComplete: true })
+    })
+
+    test("#given fenced task examples #when progress is read #then fenced rows match continuation scope", () => {
+      // given
+      const planPath = join(TEST_DIR, "fenced-task-example-plan.md")
+      writeFileSync(planPath, `# Plan
+
+## TODOs
+- [x] 1. Canonical task
+
+\`\`\`md
+- [ ] 2. Fenced example
+\`\`\`
+`)
+
+      // when
+      const progress = getPlanProgress(planPath)
+
+      // then
+      expect(progress).toEqual({ total: 1, completed: 1, isComplete: true })
+    })
+
     test("should ignore indented checkboxes under top-level tasks", () => {
       // given - plan with indented unchecked nested checkboxes
       const planPath = join(TEST_DIR, "nested-indented-plan.md")
@@ -915,8 +954,8 @@ describe("boulder-state", () => {
       expect(progress.isComplete).toBe(false)
     })
 
-    test("should support asterisk bullet top-level tasks", () => {
-      // given - plan with asterisk bullet tasks
+    test("should reject noncanonical asterisk bullets in structured task sections", () => {
+      // given - structured rows that do not use the canonical dash marker
       const planPath = join(TEST_DIR, "asterisk-bullet-plan.md")
       writeFileSync(planPath, `# Plan
 
@@ -929,8 +968,8 @@ describe("boulder-state", () => {
       const progress = getPlanProgress(planPath)
 
       // then
-      expect(progress.total).toBe(2)
-      expect(progress.completed).toBe(1)
+      expect(progress.total).toBe(0)
+      expect(progress.completed).toBe(0)
       expect(progress.isComplete).toBe(false)
     })
 

--- a/packages/omo-opencode/src/features/boulder-state/storage.test.ts
+++ b/packages/omo-opencode/src/features/boulder-state/storage.test.ts
@@ -809,7 +809,7 @@ describe("boulder-state", () => {
       expect(progress.isComplete).toBe(false)
     })
 
-    test("#given a subsection inside TODOs #when progress is read #then subsection rows match continuation scope", () => {
+    test("#given a child heading inside TODOs #when progress is read #then parent-section rows remain counted", () => {
       // given
       const planPath = join(TEST_DIR, "todo-subsection-plan.md")
       writeFileSync(planPath, `# Plan
@@ -818,14 +818,14 @@ describe("boulder-state", () => {
 - [x] 1. Canonical task
 
 ### Notes
-- [ ] 2. Example outside task scope
+- [ ] 2. Canonical task after child heading
 `)
 
       // when
       const progress = getPlanProgress(planPath)
 
       // then
-      expect(progress).toEqual({ total: 1, completed: 1, isComplete: true })
+      expect(progress).toEqual({ total: 2, completed: 1, isComplete: false })
     })
 
     test("#given fenced task examples #when progress is read #then fenced rows match continuation scope", () => {

--- a/packages/omo-opencode/src/features/boulder-state/top-level-task.test.ts
+++ b/packages/omo-opencode/src/features/boulder-state/top-level-task.test.ts
@@ -229,6 +229,27 @@ describe("readCurrentTopLevelTask", () => {
     })
   })
 
+  test("supports structured headings with ATX closing markers", () => {
+    // given
+    const planPath = writePlanFile(
+      `top-level-task-closing-marker-${Date.now()}.md`,
+      `## TODOs ##
+- [ ] 1. Implement
+`,
+    )
+
+    // when
+    const result = readCurrentTopLevelTask(planPath)
+
+    // then
+    expect(result).toEqual({
+      key: "todo:1",
+      section: "todo",
+      label: "1",
+      title: "Implement",
+    })
+  })
+
   test("returns final-wave task when plan has only Final Verification Wave section", () => {
     // given
     const planPath = writePlanFile(

--- a/packages/omo-opencode/src/features/boulder-state/top-level-task.test.ts
+++ b/packages/omo-opencode/src/features/boulder-state/top-level-task.test.ts
@@ -195,7 +195,7 @@ describe("readCurrentTopLevelTask", () => {
     expect(result?.title).toBe("Canonical task")
   })
 
-  test("ignores subsection rows and fenced examples when selecting the current task", () => {
+  test("keeps parent-section rows after child headings and ignores fenced examples", () => {
     // given
     const planPath = writePlanFile(
       `top-level-task-scope-${Date.now()}.md`,
@@ -205,7 +205,7 @@ describe("readCurrentTopLevelTask", () => {
 - [x] 1. Done task
 
 ### Acceptance Criteria
-- [ ] 2. Subsection example
+- [ ] 2. Canonical task after child heading
 
 ## TODOs
 \`\`\`\`md
@@ -222,10 +222,10 @@ describe("readCurrentTopLevelTask", () => {
 
     // then
     expect(result).toEqual({
-      key: "todo:4",
+      key: "todo:2",
       section: "todo",
-      label: "4",
-      title: "Canonical task",
+      label: "2",
+      title: "Canonical task after child heading",
     })
   })
 

--- a/packages/omo-opencode/src/features/boulder-state/top-level-task.test.ts
+++ b/packages/omo-opencode/src/features/boulder-state/top-level-task.test.ts
@@ -175,7 +175,7 @@ describe("readCurrentTopLevelTask", () => {
     })
   })
 
-  test("supports unchecked tasks with asterisk bullets", () => {
+  test("rejects structured asterisk rows and selects the next canonical task", () => {
     // given
     const planPath = writePlanFile(
       `top-level-task-asterisk-${Date.now()}.md`,
@@ -183,6 +183,7 @@ describe("readCurrentTopLevelTask", () => {
 
 ## TODOs
 * [ ] 1. Task using asterisk bullet
+- [ ] 2. Canonical task
 `,
     )
 
@@ -190,8 +191,42 @@ describe("readCurrentTopLevelTask", () => {
     const result = readCurrentTopLevelTask(planPath)
 
     // then
-    expect(result?.key).toBe("todo:1")
-    expect(result?.title).toBe("Task using asterisk bullet")
+    expect(result?.key).toBe("todo:2")
+    expect(result?.title).toBe("Canonical task")
+  })
+
+  test("ignores subsection rows and fenced examples when selecting the current task", () => {
+    // given
+    const planPath = writePlanFile(
+      `top-level-task-scope-${Date.now()}.md`,
+      `# Plan
+
+## TODOs
+- [x] 1. Done task
+
+### Acceptance Criteria
+- [ ] 2. Subsection example
+
+## TODOs
+\`\`\`\`md
+\`\`\`ts
+- [ ] 3. Fenced example
+\`\`\`
+\`\`\`\`
+- [ ] 4. Canonical task
+`,
+    )
+
+    // when
+    const result = readCurrentTopLevelTask(planPath)
+
+    // then
+    expect(result).toEqual({
+      key: "todo:4",
+      section: "todo",
+      label: "4",
+      title: "Canonical task",
+    })
   })
 
   test("returns final-wave task when plan has only Final Verification Wave section", () => {

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
@@ -212,4 +212,46 @@ Describe the final checks here.
       fixture.cleanup()
     }
   })
+
+  test("warns for prose-only sections under headings with ATX closing markers", async () => {
+    // given
+    const fixture = createFixture(`# Plan
+
+## TODOs ##
+Describe implementation tasks here.
+
+## Final Verification Wave ###
+Describe final checks here.
+`)
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toContain("<plan-format-warning>")
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test("preserves a canonical task after inline backtick code", async () => {
+    // given
+    const fixture = createFixture(`# Plan
+
+## Todos
+\`\`\`example\`\`\`
+- [ ] 1. Implement
+`)
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).not.toContain("<plan-format-warning>")
+    } finally {
+      fixture.cleanup()
+    }
+  })
 })

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
@@ -103,6 +103,28 @@ Describe the final checks here.
     }
   })
 
+  test("warns when a later valid Todos section masks an earlier prose-only Todos section", async () => {
+    // given
+    const fixture = createFixture(`# Plan
+
+## TODOs
+Describe the first implementation section here.
+
+## TODOs
+- [ ] 1. Implement the change
+`)
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toContain("<plan-format-warning>")
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
   test("preserves a valid structured plan", async () => {
     // given
     const fixture = createFixture(`# Plan
@@ -250,6 +272,29 @@ Describe final checks here.
 
       // then
       expect(fixture.output.output).not.toContain("<plan-format-warning>")
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test("preserves canonical tasks after a child heading inside Todos", async () => {
+    // given
+    const fixture = createFixture(`# Plan
+
+## TODOs
+- [x] 1. First task
+
+### Notes
+- [ ] 2. Second task
+`)
+    const originalOutput = fixture.output.output
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toBe(originalOutput)
     } finally {
       fixture.cleanup()
     }

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
@@ -81,6 +81,28 @@ describe("plan-format-validator", () => {
     }
   })
 
+  test("warns when a valid Todos section masks a prose-only final wave", async () => {
+    // given
+    const fixture = createFixture(`# Plan
+
+## Todos
+- [ ] 1. Implement the change
+
+## Final Verification Wave
+Describe the final checks here.
+`)
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toContain("<plan-format-warning>")
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
   test("preserves a valid structured plan", async () => {
     // given
     const fixture = createFixture(`# Plan
@@ -115,7 +137,6 @@ describe("plan-format-validator", () => {
 
       // then
       expect(fixture.output.output).toContain("<plan-format-warning>")
-      expect(fixture.output.output).toContain("parsed **0**")
     } finally {
       fixture.cleanup()
     }

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+import type { PluginInput } from "@opencode-ai/plugin"
+
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { createPlanFormatValidatorHook } from "./hook"
+
+type PlanFormatValidatorHook = ReturnType<typeof createPlanFormatValidatorHook>
+type ToolExecuteAfter = NonNullable<PlanFormatValidatorHook["tool.execute.after"]>
+type HookInput = Parameters<ToolExecuteAfter>[0]
+type HookOutput = Parameters<ToolExecuteAfter>[1]
+
+type FixtureOptions = {
+  readonly filePath?: string
+  readonly initialOutput?: string
+  readonly tool?: string
+}
+
+function createFixture(content: string, options: FixtureOptions = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "plan-format-validator-"))
+  const filePath = options.filePath ?? ".omo/plans/plan.md"
+  const resolvedPath = join(directory, filePath)
+  mkdirSync(dirname(resolvedPath), { recursive: true })
+  writeFileSync(resolvedPath, content, "utf-8")
+
+  const hook = createPlanFormatValidatorHook(unsafeTestValue<PluginInput>({ directory }))
+  const input: HookInput = {
+    tool: options.tool ?? "Write",
+    sessionID: "ses_plan-format-validator",
+    callID: "call_plan-format-validator",
+    args: { filePath },
+  }
+  const output: HookOutput = {
+    title: "plan.md",
+    output: options.initialOutput ?? "write complete",
+    metadata: {},
+  }
+
+  return {
+    output,
+    async run(): Promise<void> {
+      await hook["tool.execute.after"](input, output)
+    },
+    cleanup(): void {
+      rmSync(directory, { recursive: true, force: true })
+    },
+  }
+}
+
+describe("plan-format-validator", () => {
+  test("appends a warning when a recognized Todos section contains only prose", async () => {
+    // given
+    const fixture = createFixture(`# Plan\n\n## Todos\nDescribe the implementation work here.`)
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toContain("<plan-format-warning>")
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test("appends a warning when a recognized Final Verification Wave contains only prose", async () => {
+    // given
+    const fixture = createFixture(`# Plan\n\n## Final Verification Wave\nDescribe the final checks here.`)
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toContain("<plan-format-warning>")
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test("preserves a valid structured plan", async () => {
+    // given
+    const fixture = createFixture(`# Plan
+
+## Todos
+- [ ] 1. Implement the change
+- [x] 2. Review the change
+
+## Final Verification Wave
+- [ ] F1. Run the focused tests
+`)
+    const originalOutput = fixture.output.output
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toBe(originalOutput)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test("warns when a structured plan has malformed checkboxes", async () => {
+    // given
+    const fixture = createFixture(`# Plan\n\n## Todos\n- [ ] missing a numeric task label`)
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toContain("<plan-format-warning>")
+      expect(fixture.output.output).toContain("parsed **0**")
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test("does not append a duplicate warning", async () => {
+    // given
+    const initialOutput = "write complete\n<plan-format-warning>already emitted</plan-format-warning>"
+    const fixture = createFixture(`# Plan\n\n## Todos\n- [ ] missing a numeric task label`, { initialOutput })
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toBe(initialOutput)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test("bypasses non-plan files", async () => {
+    // given
+    const fixture = createFixture(`# Notes\n- [ ] 1. This is not a plan`, { filePath: "notes.md" })
+    const originalOutput = fixture.output.output
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toBe(originalOutput)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test("preserves legacy plans with no recognized structured headings", async () => {
+    // given
+    const fixture = createFixture(`# Legacy Plan\n- [ ] 1. Legacy task`)
+    const originalOutput = fixture.output.output
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toBe(originalOutput)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+})

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.test.ts
@@ -189,4 +189,27 @@ Describe the final checks here.
       fixture.cleanup()
     }
   })
+
+  test("warns when a four-backtick fence contains the only apparent task row", async () => {
+    // given
+    const fixture = createFixture(`# Plan
+
+## Todos
+\`\`\`\`md
+\`\`\`ts
+- [ ] 1. Fenced example
+\`\`\`
+\`\`\`\`
+`)
+
+    try {
+      // when
+      await fixture.run()
+
+      // then
+      expect(fixture.output.output).toContain("<plan-format-warning>")
+    } finally {
+      fixture.cleanup()
+    }
+  })
 })

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
@@ -8,7 +8,7 @@ import { log } from "../../shared/logger"
 
 const WRITE_TOOLS = new Set(["Write", "Edit", "write", "edit"])
 
-const HEADING_ANY_LEVEL = /^#{1,6}(?:[ \t]+|$)/
+const SECTION_BOUNDARY_HEADING = /^#{1,2}(?:[ \t]+|$)/
 const HEADING_TODOS = /^##[ \t]+TODOs(?:[ \t]+#+)?[ \t]*$/i
 const HEADING_FINAL_WAVE = /^##[ \t]+Final Verification Wave(?:[ \t]+#+)?[ \t]*$/i
 const TOPLEVEL_CHECKBOX = /^[-*]\s*\[[ xX]?\]/
@@ -19,9 +19,13 @@ const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})(.*)$/
 type SectionName = "todo" | "final-wave"
 
 type SectionStats = {
-  readonly recognized: boolean
   readonly rawCount: number
   readonly validCount: number
+}
+
+type ActiveSection = {
+  readonly name: SectionName
+  readonly stats: { rawCount: number; validCount: number }
 }
 
 type PlanFormatStats = {
@@ -38,11 +42,8 @@ type MarkdownFence = {
 
 function analyzeStructuredSections(content: string): PlanFormatStats {
   const lines = content.split(/\r?\n/)
-  const stats: Record<SectionName, { recognized: boolean; rawCount: number; validCount: number }> = {
-    todo: { recognized: false, rawCount: 0, validCount: 0 },
-    "final-wave": { recognized: false, rawCount: 0, validCount: 0 },
-  }
-  let section: SectionName | null = null
+  const sections: SectionStats[] = []
+  let section: ActiveSection | null = null
   let fence: MarkdownFence | null = null
 
   for (const line of lines) {
@@ -56,24 +57,29 @@ function analyzeStructuredSections(content: string): PlanFormatStats {
       continue
     }
 
-    if (HEADING_ANY_LEVEL.test(line)) {
-      section = HEADING_TODOS.test(line) ? "todo" : HEADING_FINAL_WAVE.test(line) ? "final-wave" : null
-      if (section !== null) stats[section].recognized = true
+    if (SECTION_BOUNDARY_HEADING.test(line)) {
+      const name = HEADING_TODOS.test(line) ? "todo" : HEADING_FINAL_WAVE.test(line) ? "final-wave" : null
+      if (name === null) {
+        section = null
+      } else {
+        const stats = { rawCount: 0, validCount: 0 }
+        sections.push(stats)
+        section = { name, stats }
+      }
       continue
     }
     if (section === null || !TOPLEVEL_CHECKBOX.test(line)) continue
 
-    stats[section].rawCount += 1
-    const validPattern = section === "todo" ? TODO_TASK : FINAL_WAVE_TASK
-    if (validPattern.test(line)) stats[section].validCount += 1
+    section.stats.rawCount += 1
+    const validPattern = section.name === "todo" ? TODO_TASK : FINAL_WAVE_TASK
+    if (validPattern.test(line)) section.stats.validCount += 1
   }
 
-  const sections: readonly SectionStats[] = [stats.todo, stats["final-wave"]]
   return {
     rawCount: sections.reduce((total, item) => total + item.rawCount, 0),
-    hasEmptySection: sections.some((item) => item.recognized && item.validCount === 0),
+    hasEmptySection: sections.some((item) => item.validCount === 0),
     hasMalformedRows: sections.some((item) => item.rawCount !== item.validCount),
-    recognized: sections.some((item) => item.recognized),
+    recognized: sections.length > 0,
   }
 }
 

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
@@ -9,12 +9,12 @@ import { log } from "../../shared/logger"
 const WRITE_TOOLS = new Set(["Write", "Edit", "write", "edit"])
 
 const HEADING_ANY_LEVEL = /^#{1,6}(?:[ \t]+|$)/
-const HEADING_TODOS = /^##[ \t]+TODOs[ \t]*$/i
-const HEADING_FINAL_WAVE = /^##[ \t]+Final Verification Wave[ \t]*$/i
+const HEADING_TODOS = /^##[ \t]+TODOs(?:[ \t]+#+)?[ \t]*$/i
+const HEADING_FINAL_WAVE = /^##[ \t]+Final Verification Wave(?:[ \t]+#+)?[ \t]*$/i
 const TOPLEVEL_CHECKBOX = /^[-*]\s*\[[ xX]?\]/
 const TODO_TASK = /^- \[[ xX]\] [1-9]\d*\. .+$/
 const FINAL_WAVE_TASK = /^- \[[ xX]\] F[1-9]\d*\. .+$/i
-const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/
+const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})(.*)$/
 
 type SectionName = "todo" | "final-wave"
 
@@ -26,7 +26,6 @@ type SectionStats = {
 
 type PlanFormatStats = {
   readonly rawCount: number
-  readonly validCount: number
   readonly hasEmptySection: boolean
   readonly hasMalformedRows: boolean
   readonly recognized: boolean
@@ -72,7 +71,6 @@ function analyzeStructuredSections(content: string): PlanFormatStats {
   const sections: readonly SectionStats[] = [stats.todo, stats["final-wave"]]
   return {
     rawCount: sections.reduce((total, item) => total + item.rawCount, 0),
-    validCount: sections.reduce((total, item) => total + item.validCount, 0),
     hasEmptySection: sections.some((item) => item.recognized && item.validCount === 0),
     hasMalformedRows: sections.some((item) => item.rawCount !== item.validCount),
     recognized: sections.some((item) => item.recognized),
@@ -80,9 +78,18 @@ function analyzeStructuredSections(content: string): PlanFormatStats {
 }
 
 function parseOpeningFence(line: string): MarkdownFence | null {
-  const run = line.match(FENCE_PATTERN)?.[1]
+  const match = line.match(FENCE_PATTERN)
+  const run = match?.[1]
+  const info = match?.[2]
   const marker = run?.charAt(0)
-  if (run === undefined || (marker !== "`" && marker !== "~")) return null
+  if (
+    run === undefined ||
+    info === undefined ||
+    (marker !== "`" && marker !== "~") ||
+    (marker === "`" && info.includes("`"))
+  ) {
+    return null
+  }
   return { marker, length: run.length }
 }
 

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
@@ -32,6 +32,11 @@ type PlanFormatStats = {
   readonly recognized: boolean
 }
 
+type MarkdownFence = {
+  readonly marker: "`" | "~"
+  readonly length: number
+}
+
 function analyzeStructuredSections(content: string): PlanFormatStats {
   const lines = content.split(/\r?\n/)
   const stats: Record<SectionName, { recognized: boolean; rawCount: number; validCount: number }> = {
@@ -39,15 +44,18 @@ function analyzeStructuredSections(content: string): PlanFormatStats {
     "final-wave": { recognized: false, rawCount: 0, validCount: 0 },
   }
   let section: SectionName | null = null
-  let fence: "`" | "~" | null = null
+  let fence: MarkdownFence | null = null
 
   for (const line of lines) {
-    const fenceMarker = parseFenceMarker(line)
-    if (fenceMarker !== null) {
-      fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence
+    if (fence !== null) {
+      if (isClosingFence(line, fence)) fence = null
       continue
     }
-    if (fence !== null) continue
+    const openingFence = parseOpeningFence(line)
+    if (openingFence !== null) {
+      fence = openingFence
+      continue
+    }
 
     if (HEADING_ANY_LEVEL.test(line)) {
       section = HEADING_TODOS.test(line) ? "todo" : HEADING_FINAL_WAVE.test(line) ? "final-wave" : null
@@ -71,9 +79,16 @@ function analyzeStructuredSections(content: string): PlanFormatStats {
   }
 }
 
-function parseFenceMarker(line: string): "`" | "~" | null {
-  const marker = line.match(FENCE_PATTERN)?.[1]?.[0]
-  return marker === "`" || marker === "~" ? marker : null
+function parseOpeningFence(line: string): MarkdownFence | null {
+  const run = line.match(FENCE_PATTERN)?.[1]
+  const marker = run?.charAt(0)
+  if (run === undefined || (marker !== "`" && marker !== "~")) return null
+  return { marker, length: run.length }
+}
+
+function isClosingFence(line: string, fence: MarkdownFence): boolean {
+  const run = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/)?.[1]
+  return run?.charAt(0) === fence.marker && run.length >= fence.length
 }
 
 function buildWarning(rawCount: number, parsedCount: number, hasEmptySection: boolean): string {

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
@@ -8,53 +8,88 @@ import { log } from "../../shared/logger"
 
 const WRITE_TOOLS = new Set(["Write", "Edit", "write", "edit"])
 
-const HEADING_SECOND_LEVEL = /^##\s+/
-const HEADING_TODOS = /^##\s+TODOs\b/i
-const HEADING_FINAL_WAVE = /^##\s+Final Verification Wave\b/i
+const HEADING_ANY_LEVEL = /^#{1,6}(?:[ \t]+|$)/
+const HEADING_TODOS = /^##[ \t]+TODOs[ \t]*$/i
+const HEADING_FINAL_WAVE = /^##[ \t]+Final Verification Wave[ \t]*$/i
 const TOPLEVEL_CHECKBOX = /^[-*]\s*\[[ xX]?\]/
+const TODO_TASK = /^- \[[ xX]\] [1-9]\d*\. .+$/
+const FINAL_WAVE_TASK = /^- \[[ xX]\] F[1-9]\d*\. .+$/i
+const FENCE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/
 
-function countRawTopLevelCheckboxes(content: string): number {
+type SectionName = "todo" | "final-wave"
+
+type SectionStats = {
+  readonly recognized: boolean
+  readonly rawCount: number
+  readonly validCount: number
+}
+
+type PlanFormatStats = {
+  readonly rawCount: number
+  readonly validCount: number
+  readonly hasEmptySection: boolean
+  readonly hasMalformedRows: boolean
+  readonly recognized: boolean
+}
+
+function analyzeStructuredSections(content: string): PlanFormatStats {
   const lines = content.split(/\r?\n/)
-  let section: "todo" | "final-wave" | "other" = "other"
-  let count = 0
+  const stats: Record<SectionName, { recognized: boolean; rawCount: number; validCount: number }> = {
+    todo: { recognized: false, rawCount: 0, validCount: 0 },
+    "final-wave": { recognized: false, rawCount: 0, validCount: 0 },
+  }
+  let section: SectionName | null = null
+  let fence: "`" | "~" | null = null
 
   for (const line of lines) {
-    if (HEADING_SECOND_LEVEL.test(line)) {
-      section = HEADING_TODOS.test(line)
-        ? "todo"
-        : HEADING_FINAL_WAVE.test(line)
-          ? "final-wave"
-          : "other"
+    const fenceMarker = parseFenceMarker(line)
+    if (fenceMarker !== null) {
+      fence = fence === null ? fenceMarker : fence === fenceMarker ? null : fence
       continue
     }
+    if (fence !== null) continue
 
-    if (section === "other") continue
-    if (!TOPLEVEL_CHECKBOX.test(line)) continue
+    if (HEADING_ANY_LEVEL.test(line)) {
+      section = HEADING_TODOS.test(line) ? "todo" : HEADING_FINAL_WAVE.test(line) ? "final-wave" : null
+      if (section !== null) stats[section].recognized = true
+      continue
+    }
+    if (section === null || !TOPLEVEL_CHECKBOX.test(line)) continue
 
-    count++
+    stats[section].rawCount += 1
+    const validPattern = section === "todo" ? TODO_TASK : FINAL_WAVE_TASK
+    if (validPattern.test(line)) stats[section].validCount += 1
   }
 
-  return count
+  const sections: readonly SectionStats[] = [stats.todo, stats["final-wave"]]
+  return {
+    rawCount: sections.reduce((total, item) => total + item.rawCount, 0),
+    validCount: sections.reduce((total, item) => total + item.validCount, 0),
+    hasEmptySection: sections.some((item) => item.recognized && item.validCount === 0),
+    hasMalformedRows: sections.some((item) => item.rawCount !== item.validCount),
+    recognized: sections.some((item) => item.recognized),
+  }
 }
 
-function hasRecognizedStructuredHeading(content: string): boolean {
-  return content.split(/\r?\n/).some((line) => HEADING_TODOS.test(line) || HEADING_FINAL_WAVE.test(line))
+function parseFenceMarker(line: string): "`" | "~" | null {
+  const marker = line.match(FENCE_PATTERN)?.[1]?.[0]
+  return marker === "`" || marker === "~" ? marker : null
 }
 
-function buildWarning(rawCount: number, parsedCount: number): string {
+function buildWarning(rawCount: number, parsedCount: number, hasEmptySection: boolean): string {
   const skipped = rawCount - parsedCount
 
-  if (parsedCount === 0) {
+  if (hasEmptySection) {
     const summary =
-      rawCount === 0
-        ? "Plan has a recognized task section but no valid task rows."
-        : `Plan has **${rawCount} task checkbox(es)** but \`getPlanProgress()\` parsed **0**.`
+      parsedCount === 0
+        ? "Plan has recognized task sections but no valid task rows."
+        : "One or more recognized task sections contain no valid task rows."
 
     return [
       "",
       "<plan-format-warning>",
       summary,
-      "This means `/start-work` will show **\"Progress: 0/0\"** for this plan.",
+      "Those sections will contribute no tasks to `/start-work` progress.",
       "",
       "**Fix**: Every task checkbox under `## TODOs` MUST start with a bare number",
       "followed by dot + space: `1.`, `2.`, `3.` — NOT `T1.`, `Phase 1:`, `Task-1.` etc.",
@@ -118,22 +153,22 @@ export function createPlanFormatValidatorHook(_ctx: PluginInput) {
       if (!existsSync(resolvedPath)) return
 
       const content = readFileSync(resolvedPath, "utf-8")
-      const rawCount = countRawTopLevelCheckboxes(content)
-      if (rawCount === 0 && !hasRecognizedStructuredHeading(content)) return
+      const formatStats = analyzeStructuredSections(content)
+      if (!formatStats.recognized) return
 
       const progress = getPlanProgress(resolvedPath)
       const parsedCount = progress.total
 
-      if (rawCount === parsedCount && parsedCount > 0) return
+      if (!formatStats.hasEmptySection && !formatStats.hasMalformedRows) return
 
-      log(`[plan-format-validator] Plan ${filePath}: ${parsedCount}/${rawCount} tasks parsed`, {
+      log(`[plan-format-validator] Plan ${filePath}: ${parsedCount}/${formatStats.rawCount} tasks parsed`, {
         sessionID: input.sessionID,
         filePath,
-        rawCount,
+        rawCount: formatStats.rawCount,
         parsedCount,
       })
 
-      output.output = `${output.output}${buildWarning(rawCount, parsedCount)}`
+      output.output = `${output.output}${buildWarning(formatStats.rawCount, parsedCount, formatStats.hasEmptySection)}`
     },
   }
 }

--- a/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
+++ b/packages/omo-opencode/src/hooks/plan-format-validator/hook.ts
@@ -8,8 +8,6 @@ import { log } from "../../shared/logger"
 
 const WRITE_TOOLS = new Set(["Write", "Edit", "write", "edit"])
 
-const CHECKBOX_PATTERN = /^[-*]\s*\[[ xX]\]/m
-
 const HEADING_SECOND_LEVEL = /^##\s+/
 const HEADING_TODOS = /^##\s+TODOs\b/i
 const HEADING_FINAL_WAVE = /^##\s+Final Verification Wave\b/i
@@ -39,14 +37,23 @@ function countRawTopLevelCheckboxes(content: string): number {
   return count
 }
 
+function hasRecognizedStructuredHeading(content: string): boolean {
+  return content.split(/\r?\n/).some((line) => HEADING_TODOS.test(line) || HEADING_FINAL_WAVE.test(line))
+}
+
 function buildWarning(rawCount: number, parsedCount: number): string {
   const skipped = rawCount - parsedCount
 
   if (parsedCount === 0) {
+    const summary =
+      rawCount === 0
+        ? "Plan has a recognized task section but no valid task rows."
+        : `Plan has **${rawCount} task checkbox(es)** but \`getPlanProgress()\` parsed **0**.`
+
     return [
       "",
       "<plan-format-warning>",
-      `Plan has **${rawCount} task checkbox(es)** but \`getPlanProgress()\` parsed **0**.`,
+      summary,
       "This means `/start-work` will show **\"Progress: 0/0\"** for this plan.",
       "",
       "**Fix**: Every task checkbox under `## TODOs` MUST start with a bare number",
@@ -111,15 +118,13 @@ export function createPlanFormatValidatorHook(_ctx: PluginInput) {
       if (!existsSync(resolvedPath)) return
 
       const content = readFileSync(resolvedPath, "utf-8")
-      if (!CHECKBOX_PATTERN.test(content)) return
-
       const rawCount = countRawTopLevelCheckboxes(content)
-      if (rawCount === 0) return
+      if (rawCount === 0 && !hasRecognizedStructuredHeading(content)) return
 
       const progress = getPlanProgress(resolvedPath)
       const parsedCount = progress.total
 
-      if (rawCount === parsedCount) return
+      if (rawCount === parsedCount && parsedCount > 0) return
 
       log(`[plan-format-validator] Plan ${filePath}: ${parsedCount}/${rawCount} tasks parsed`, {
         sessionID: input.sessionID,

--- a/packages/shared-skills/skills/ulw-plan/SKILL.md
+++ b/packages/shared-skills/skills/ulw-plan/SKILL.md
@@ -43,6 +43,10 @@ node "<skill-root>/scripts/scaffold-plan.mjs" <slug> [--clear|--unclear]
 
 Run it ONCE at plan generation. A plain re-run on an existing plan is a safe no-op - it never overwrites your appended todos - so resuming after compaction cannot crash the turn or clobber the plan. Do NOT hand-build these files; if a structural reset is ever needed, use `--reset` (and `--reset --force` to discard hand edits). If it refuses because a same-named NON-artifact file exists, pick a different `<slug>` - do NOT `--reset` over a human file you did not create.
 
+## Plan artifact producer contract
+
+When producing the plan, encode every executable item as a column-zero Markdown task row: implementation rows MUST match `- [ ] N. <title>` (where `N` is a positive decimal integer), and final-verifier rows MUST match `- [ ] F<number>. <title>`. Prose headings, numbered paragraphs, and ordinary bullets are not task substitutes and MUST NOT be counted as implementation or final-verifier tasks. Before handoff, run a structural self-check over the plan: verify that every implementation row and final-verifier row is column-zero, matches its required grammar, and appears in the intended `## Todos` or `## Final verification wave` section; verify that no prose heading or bullet is being used as a task; and repair the plan before handoff if any check fails.
+
 ## Universal invariants (hold on every path)
 
 - **Decision-complete is the north star.** The executor has NO interview context - spell out exact paths, "every X in Y", and an explicit Must-NOT-Have. Leave the implementer ZERO judgment calls.

--- a/packages/shared-skills/skills/ulw-plan/references/full-workflow.md
+++ b/packages/shared-skills/skills/ulw-plan/references/full-workflow.md
@@ -76,6 +76,10 @@ No Metis, no plan file, no execution until the user approves. The UNCLEAR path a
 ```
 > Target 5-8 todos per wave; fewer than 3 (except the final) means under-splitting. Implementation + Test = ONE todo. Each todo carries: exhaustive References (the executor has no interview context), agent-executable Acceptance criteria, happy + failure QA scenarios each with an evidence path, and a Commit line.
 
+## Plan artifact producer contract
+
+When producing the plan, encode every executable item as a column-zero Markdown task row: implementation rows MUST match `- [ ] N. <title>` (where `N` is a positive decimal integer), and final-verifier rows MUST match `- [ ] F<number>. <title>`. Prose headings, numbered paragraphs, and ordinary bullets are not task substitutes and MUST NOT be counted as implementation or final-verifier tasks. Before handoff, run a structural self-check over the plan: verify that every implementation row and final-verifier row is column-zero, matches its required grammar, and appears in the intended `## Todos` or `## Final verification wave` section; verify that no prose heading or bullet is being used as a task; and repair the plan before handoff if any check fails.
+
 ### Final verification wave (after ALL todos)
 Runs in parallel; ALL must APPROVE; surface results and wait for the user's explicit okay before declaring complete: F1 plan compliance audit, F2 code quality review, F3 real manual QA, F4 scope fidelity.
 


### PR DESCRIPTION
## Summary

Fixes the `ulw-plan` producer/validator/parser contract mismatch that could turn prose or scaffold-shaped plans into silent `0/0` progress. The producer now documents one canonical column-zero numbered grammar, Core/OpenCode and Codex consume it consistently, and every recognized section occurrence with no valid rows produces an OpenCode warning.

## Changes

- Define implementation rows as `- [ ] N. <title>` and final verification rows as `- [ ] F<N>. <title>` in the maintained shared and Codex `ulw-plan` sources.
- Parse scaffold headings and canonical rows consistently in Core/OpenCode and Codex while excluding nested/indented rows, fenced examples, malformed rows, and unrelated peer/parent sections.
- Keep `###` child headings inside their parent `## TODOs` or `## Final Verification Wave` section.
- Validate repeated recognized sections independently, so a later valid `## TODOs` cannot hide an earlier prose-only section.
- Preserve heading-free dash/star legacy fallback and PR #6147's canonical zero-remaining final gate.

## QA & Evidence

- **Focused contracts:** 99 Core/OpenCode tests and 37 Codex continuation tests passed at exact head `3b860221903c0e55f652adb57bb04e5c4215dd8a` on base `13e560820d97d2ed312454cea087b471a623ac37`.
  - `.omo/evidence/20260716-issue-6094-contract/focused-opencode-core-exact-head.txt`
  - `.omo/evidence/20260716-issue-6094-contract/codex-continuation-exact-head.txt`
- **Scaffold parity:** the real scaffold plus canonical rows produced total `5` and the same next task in Core and the built Codex Stop hook; Codex returned `decision=block`.
  - `.omo/evidence/20260716-issue-6094-contract/scaffold-consumer-parity.txt`
- **Full gates:** workspace typecheck passed; serial `bun run test:codex` passed with 381 Bun tests, one Windows-only skip, and 497 Node/plugin tests.
  - `.omo/evidence/20260716-issue-6094-contract/root-typecheck-exact-head.txt`
  - `.omo/evidence/20260716-issue-6094-contract/test-codex-exact-head.txt`
- **Real isolated OpenCode:** a real `Write` completed through the production validator, which appended `<plan-format-warning>` for prose-only `## TODOs`; SSE captured the completion; real DB stayed `5751 -> 5751`; real config hashes were unchanged.
  - `.omo/evidence/20260716-issue-6094-contract/opencode-validator-live-final.jsonl`
  - `.omo/evidence/20260716-issue-6094-contract/opencode-validator-sse-final.txt`
  - `.omo/evidence/20260716-issue-6094-contract/opencode-validator-isolation-final.txt`
- **Real isolated Codex:** the app-server completed a mock-model turn with first-party `sessionStart`, `userPromptSubmit`, and `stop` hook notifications, including `stop-checking-start-work-continuation`; real `~/.codex/config.toml` was unchanged.
  - `.omo/evidence/20260716-issue-6094-contract/codex-app-server-exact-head.json`
- **Exact-head provenance:** timestamped base/head, clean worktree, `origin/dev...HEAD = 0 13`, executed commands, and matching receipt hashes.
  - `.omo/evidence/20260716-issue-6094-contract/exact-head-gate-manifest.txt`

Full evidence index: `.omo/evidence/20260716-issue-6094-contract/QA.md`.

## Review

Four independent exact-head review lanes passed: acceptance/correctness, QA/evidence, goal/criteria, and context/security/scope. No branch-introduced blockers or scope creep remained.

## Risks & Residuals

- Structured plans deliberately ignore malformed or unnumbered rows; the validator warning makes that visible before handoff.
- Heading-free legacy plans retain their previous simple top-level checkbox behavior.
- Arbitrary noncanonical heading suffixes are outside the canonical producer contract; ATX closing markers such as `## TODOs ##` remain supported.

## Related Issues

Fixes #6094.

This supersedes the narrower coverage-only approaches in #4522 and #5638 for the cross-consumer contract gap.
