### PR TITLE
test(hooks): make mock.module victims order-independent under single-process bun test

### DIFF
--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts
@@ -1,32 +1,15 @@
-import { afterAll, describe, it, expect, mock, beforeEach } from "bun:test"
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { fixEmptyMessagesWithSDK as fixEmptyMessagesWithSDKImpl } from "./empty-content-recovery-sdk"
 
 const mockReplaceEmptyTextParts = mock(() => Promise.resolve(false))
 const mockInjectTextPart = mock(() => Promise.resolve(false))
-
-function installStorageMocks() {
-  mock.module("./storage/empty-text", () => ({
-    get replaceEmptyTextPartsAsync() {
-      return mockReplaceEmptyTextParts
-    },
-    findMessagesWithEmptyTextPartsFromSDK: () => Promise.resolve([]),
-  }))
-  mock.module("./storage/text-part-injector", () => ({
-    get injectTextPartAsync() {
-      return mockInjectTextPart
-    },
-  }))
+const storage = {
+  replaceEmptyTextPartsAsync: mockReplaceEmptyTextParts,
+  findMessagesWithEmptyTextPartsFromSDK: () => Promise.resolve([]),
+  injectTextPartAsync: mockInjectTextPart,
 }
-
-installStorageMocks()
-
-const sdkModulePath = "./empty-content-recovery-sdk?sdk-test"
-const sdkModule: typeof import("./empty-content-recovery-sdk") = await import(sdkModulePath)
-const { fixEmptyMessagesWithSDK } = sdkModule
-mock.restore()
-
-afterAll(() => {
-  mock.restore()
-})
+const fixEmptyMessagesWithSDK = (params: Parameters<typeof fixEmptyMessagesWithSDKImpl>[0]) =>
+  fixEmptyMessagesWithSDKImpl(params, storage)
 
 function createMockClient(messages: Array<{ info?: { id?: string }; parts?: Array<{ type?: string; text?: string }> }>) {
   return {
@@ -38,7 +21,6 @@ function createMockClient(messages: Array<{ info?: { id?: string }; parts?: Arra
 
 describe("fixEmptyMessagesWithSDK", () => {
   beforeEach(() => {
-    installStorageMocks()
     mockReplaceEmptyTextParts.mockReset()
     mockInjectTextPart.mockReset()
     mockReplaceEmptyTextParts.mockReturnValue(Promise.resolve(false))

--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts
@@ -5,16 +5,24 @@ const mockInjectTextPart = mock(() => Promise.resolve(false))
 
 function installStorageMocks() {
   mock.module("./storage/empty-text", () => ({
-    replaceEmptyTextPartsAsync: mockReplaceEmptyTextParts,
+    get replaceEmptyTextPartsAsync() {
+      return mockReplaceEmptyTextParts
+    },
+    findMessagesWithEmptyTextPartsFromSDK: () => Promise.resolve([]),
   }))
   mock.module("./storage/text-part-injector", () => ({
-    injectTextPartAsync: mockInjectTextPart,
+    get injectTextPartAsync() {
+      return mockInjectTextPart
+    },
   }))
 }
 
 installStorageMocks()
 
-const { fixEmptyMessagesWithSDK } = await import("./empty-content-recovery-sdk")
+const sdkModulePath = "./empty-content-recovery-sdk?sdk-test"
+const sdkModule: typeof import("./empty-content-recovery-sdk") = await import(sdkModulePath)
+const { fixEmptyMessagesWithSDK } = sdkModule
+mock.restore()
 
 afterAll(() => {
   mock.restore()

--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts
@@ -1,15 +1,20 @@
 import { afterAll, describe, it, expect, mock, beforeEach } from "bun:test"
-import { fixEmptyMessagesWithSDK } from "./empty-content-recovery-sdk"
 
 const mockReplaceEmptyTextParts = mock(() => Promise.resolve(false))
 const mockInjectTextPart = mock(() => Promise.resolve(false))
 
-mock.module("./storage/empty-text", () => ({
-  replaceEmptyTextPartsAsync: mockReplaceEmptyTextParts,
-}))
-mock.module("./storage/text-part-injector", () => ({
-  injectTextPartAsync: mockInjectTextPart,
-}))
+function installStorageMocks() {
+  mock.module("./storage/empty-text", () => ({
+    replaceEmptyTextPartsAsync: mockReplaceEmptyTextParts,
+  }))
+  mock.module("./storage/text-part-injector", () => ({
+    injectTextPartAsync: mockInjectTextPart,
+  }))
+}
+
+installStorageMocks()
+
+const { fixEmptyMessagesWithSDK } = await import("./empty-content-recovery-sdk")
 
 afterAll(() => {
   mock.restore()
@@ -25,6 +30,7 @@ function createMockClient(messages: Array<{ info?: { id?: string }; parts?: Arra
 
 describe("fixEmptyMessagesWithSDK", () => {
   beforeEach(() => {
+    installStorageMocks()
     mockReplaceEmptyTextParts.mockReset()
     mockInjectTextPart.mockReset()
     mockReplaceEmptyTextParts.mockReturnValue(Promise.resolve(false))

--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.ts
@@ -115,12 +115,21 @@ async function findEmptyMessageByIndexFromSDK(
   }
 }
 
-export async function fixEmptyMessagesWithSDK(params: {
-  sessionID: string
-  client: Client
-  placeholderText: string
-  messageIndex?: number
-}): Promise<{ fixed: boolean; fixedMessageIds: string[]; scannedEmptyCount: number }> {
+const defaultStorage = {
+  replaceEmptyTextPartsAsync,
+  findMessagesWithEmptyTextPartsFromSDK,
+  injectTextPartAsync,
+}
+
+export async function fixEmptyMessagesWithSDK(
+  params: {
+    sessionID: string
+    client: Client
+    placeholderText: string
+    messageIndex?: number
+  },
+  storage = defaultStorage,
+): Promise<{ fixed: boolean; fixedMessageIds: string[]; scannedEmptyCount: number }> {
   let fixed = false
   const fixedMessageIds: string[] = []
 
@@ -132,7 +141,7 @@ export async function fixEmptyMessagesWithSDK(params: {
     )
 
     if (targetMessageId) {
-      const replaced = await replaceEmptyTextPartsAsync(
+      const replaced = await storage.replaceEmptyTextPartsAsync(
         params.client,
         params.sessionID,
         targetMessageId,
@@ -143,7 +152,7 @@ export async function fixEmptyMessagesWithSDK(params: {
         fixed = true
         fixedMessageIds.push(targetMessageId)
       } else {
-        const injected = await injectTextPartAsync(
+        const injected = await storage.injectTextPartAsync(
           params.client,
           params.sessionID,
           targetMessageId,
@@ -167,7 +176,7 @@ export async function fixEmptyMessagesWithSDK(params: {
   // Also find messages with empty text parts alongside non-empty content (e.g., tool calls).
   // messageHasContentFromSDK returns true for these since they have tool parts,
   // but the API still rejects the empty text block.
-  const emptyTextPartIds = await findMessagesWithEmptyTextPartsFromSDK(params.client, params.sessionID)
+  const emptyTextPartIds = await storage.findMessagesWithEmptyTextPartsFromSDK(params.client, params.sessionID)
   const additionalIds = emptyTextPartIds.filter((id) => !emptyMessageIds.includes(id))
   const allTargetIds = [...emptyMessageIds, ...additionalIds]
 
@@ -176,7 +185,7 @@ export async function fixEmptyMessagesWithSDK(params: {
   }
 
   for (const messageID of allTargetIds) {
-    const replaced = await replaceEmptyTextPartsAsync(
+    const replaced = await storage.replaceEmptyTextPartsAsync(
       params.client,
       params.sessionID,
       messageID,
@@ -187,7 +196,7 @@ export async function fixEmptyMessagesWithSDK(params: {
       fixed = true
       fixedMessageIds.push(messageID)
     } else {
-      const injected = await injectTextPartAsync(
+      const injected = await storage.injectTextPartAsync(
         params.client,
         params.sessionID,
         messageID,

--- a/packages/omo-opencode/src/hooks/comment-checker/hook.before-after.test.ts
+++ b/packages/omo-opencode/src/hooks/comment-checker/hook.before-after.test.ts
@@ -2,13 +2,17 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun
 
 const processWithCli = mock(async () => {})
 
-mock.module("./cli-runner", () => ({
-  initializeCommentCheckerCli: () => {},
-  getCommentCheckerCliPathPromise: () => Promise.resolve("/tmp/fake-comment-checker"),
-  isCliPathUsable: () => true,
-  processWithCli,
-  processApplyPatchEditsWithCli: async () => {},
-}))
+function installCliRunnerMock() {
+  mock.module("./cli-runner", () => ({
+    initializeCommentCheckerCli: () => {},
+    getCommentCheckerCliPathPromise: () => Promise.resolve("/tmp/fake-comment-checker"),
+    isCliPathUsable: () => true,
+    processWithCli,
+    processApplyPatchEditsWithCli: async () => {},
+  }))
+}
+
+installCliRunnerMock()
 
 afterAll(() => {
   mock.restore()
@@ -20,6 +24,7 @@ const { _resetCommentCheckerInitializationForTesting } = await import("./initial
 
 describe("comment-checker mutation tool routing", () => {
   beforeEach(() => {
+    installCliRunnerMock()
     processWithCli.mockClear()
     stopPendingCallCleanup()
     _resetCommentCheckerInitializationForTesting()

--- a/packages/omo-opencode/src/hooks/comment-checker/hook.before-after.test.ts
+++ b/packages/omo-opencode/src/hooks/comment-checker/hook.before-after.test.ts
@@ -1,35 +1,22 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-
-const processWithCli = mock(async () => {})
-
-function installCliRunnerMock() {
-  mock.module("./cli-runner", () => ({
-    initializeCommentCheckerCli: () => {},
-    getCommentCheckerCliPathPromise: () => Promise.resolve("/tmp/fake-comment-checker"),
-    isCliPathUsable: () => true,
-    get processWithCli() {
-      return processWithCli
-    },
-    processApplyPatchEditsWithCli: async () => {},
-  }))
-}
-
-installCliRunnerMock()
-
-afterAll(() => {
-  mock.restore()
-})
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 
 const hookModulePath = "./hook?before-after"
 const hookModule: typeof import("./hook") = await import(hookModulePath)
 const { createCommentCheckerHooks } = hookModule
-mock.restore()
+
+const processWithCli = mock(async () => {})
+const cliRunner = {
+  initializeCommentCheckerCli: () => {},
+  getCommentCheckerCliPathPromise: () => Promise.resolve("/tmp/fake-comment-checker"),
+  isCliPathUsable: () => true,
+  processWithCli,
+  processApplyPatchEditsWithCli: async () => {},
+}
 const { stopPendingCallCleanup } = await import("./pending-calls")
 const { _resetCommentCheckerInitializationForTesting } = await import("./initialization-gate")
 
 describe("comment-checker mutation tool routing", () => {
   beforeEach(() => {
-    installCliRunnerMock()
     processWithCli.mockClear()
     stopPendingCallCleanup()
     _resetCommentCheckerInitializationForTesting()
@@ -42,7 +29,7 @@ describe("comment-checker mutation tool routing", () => {
 
   it("#given write tool with filePath #when before and after hooks run #then it checks the pending write", async () => {
     // given
-    const hooks = createCommentCheckerHooks()
+    const hooks = createCommentCheckerHooks(undefined, cliRunner)
     const input = { tool: "write", sessionID: "ses_test", callID: "call_write" }
 
     // when
@@ -70,7 +57,7 @@ describe("comment-checker mutation tool routing", () => {
 
   it("#given edit tool with file_path #when before and after hooks run #then it checks the pending edit", async () => {
     // given
-    const hooks = createCommentCheckerHooks()
+    const hooks = createCommentCheckerHooks(undefined, cliRunner)
     const input = { tool: "edit", sessionID: "ses_test", callID: "call_edit" }
 
     // when
@@ -102,7 +89,7 @@ describe("comment-checker mutation tool routing", () => {
 
   it("#given multiedit tool with path #when before and after hooks run #then it checks the pending multiedit", async () => {
     // given
-    const hooks = createCommentCheckerHooks()
+    const hooks = createCommentCheckerHooks(undefined, cliRunner)
     const input = { tool: "multiedit", sessionID: "ses_test", callID: "call_multiedit" }
     const edits = [{ old_string: "const c = 1\n", new_string: "// multiedit comment\nconst c = 1\n" }]
 
@@ -130,7 +117,7 @@ describe("comment-checker mutation tool routing", () => {
 
   it("#given non-mutation tool #when before and after hooks run #then it does not run the checker", async () => {
     // given
-    const hooks = createCommentCheckerHooks()
+    const hooks = createCommentCheckerHooks(undefined, cliRunner)
     const input = { tool: "read", sessionID: "ses_test", callID: "call_read" }
 
     // when

--- a/packages/omo-opencode/src/hooks/comment-checker/hook.before-after.test.ts
+++ b/packages/omo-opencode/src/hooks/comment-checker/hook.before-after.test.ts
@@ -7,7 +7,9 @@ function installCliRunnerMock() {
     initializeCommentCheckerCli: () => {},
     getCommentCheckerCliPathPromise: () => Promise.resolve("/tmp/fake-comment-checker"),
     isCliPathUsable: () => true,
-    processWithCli,
+    get processWithCli() {
+      return processWithCli
+    },
     processApplyPatchEditsWithCli: async () => {},
   }))
 }
@@ -18,7 +20,10 @@ afterAll(() => {
   mock.restore()
 })
 
-const { createCommentCheckerHooks } = await import("./hook")
+const hookModulePath = "./hook?before-after"
+const hookModule: typeof import("./hook") = await import(hookModulePath)
+const { createCommentCheckerHooks } = hookModule
+mock.restore()
 const { stopPendingCallCleanup } = await import("./pending-calls")
 const { _resetCommentCheckerInitializationForTesting } = await import("./initialization-gate")
 

--- a/packages/omo-opencode/src/hooks/comment-checker/hook.ts
+++ b/packages/omo-opencode/src/hooks/comment-checker/hook.ts
@@ -33,7 +33,23 @@ function debugLog(...args: unknown[]) {
   }
 }
 
-export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
+export function createCommentCheckerHooks(
+  config?: CommentCheckerConfig,
+  cliRunner?: {
+    initializeCommentCheckerCli: typeof initializeCommentCheckerCli
+    getCommentCheckerCliPathPromise: typeof getCommentCheckerCliPathPromise
+    isCliPathUsable: typeof isCliPathUsable
+    processWithCli: typeof processWithCli
+    processApplyPatchEditsWithCli: typeof processApplyPatchEditsWithCli
+  },
+) {
+  const runner = cliRunner ?? {
+    initializeCommentCheckerCli,
+    getCommentCheckerCliPathPromise,
+    isCliPathUsable,
+    processWithCli,
+    processApplyPatchEditsWithCli,
+  }
   debugLog("createCommentCheckerHooks called", { config })
 
   return {
@@ -43,7 +59,7 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
     ): Promise<void> => {
       ensureCommentCheckerInitialization(() => {
         startPendingCallCleanup()
-        initializeCommentCheckerCli(debugLog)
+        runner.initializeCommentCheckerCli(debugLog)
       })
 
       debugLog("tool.execute.before:", {
@@ -120,14 +136,14 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
         }
 
         try {
-          const cliPath = await getCommentCheckerCliPathPromise()
-          if (!isCliPathUsable(cliPath)) {
+          const cliPath = await runner.getCommentCheckerCliPathPromise()
+          if (!runner.isCliPathUsable(cliPath)) {
             debugLog("CLI not available, skipping comment check")
             return
           }
 
           debugLog("using CLI for apply_patch:", cliPath)
-          await processApplyPatchEditsWithCli(
+          await runner.processApplyPatchEditsWithCli(
             input.sessionID,
             edits,
             output,
@@ -150,14 +166,14 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
       debugLog("processing pendingCall:", pendingCall)
 
       try {
-        const cliPath = await getCommentCheckerCliPathPromise()
-        if (!isCliPathUsable(cliPath)) {
+        const cliPath = await runner.getCommentCheckerCliPathPromise()
+        if (!runner.isCliPathUsable(cliPath)) {
           debugLog("CLI not available, skipping comment check")
           return
         }
 
         debugLog("using CLI:", cliPath)
-        await processWithCli(input, pendingCall, output, cliPath, config?.custom_prompt, debugLog)
+        await runner.processWithCli(input, pendingCall, output, cliPath, config?.custom_prompt, debugLog)
       } catch (err) {
         debugLog("tool.execute.after failed:", err)
       }


### PR DESCRIPTION
## Problem

The `publish` workflow's CI `test` gate failed **deterministically on Linux** (both the initial run and a `--failed` rerun) with 7 failures, blocking the v4.18.2 patch release:

- `comment-checker mutation tool routing` (3)
- `fixEmptyMessagesWithSDK` (4)

All 7 **pass in isolation**. The failure signature is `toHaveBeenCalledTimes: expected 1, got 0` — the SUT ran against the *real* module instead of the mock.

## Root cause

Cross-file `mock.module()` pollution under the single-process `bun test` run:

1. A sibling test file's `afterAll(() => mock.restore())` tears down mocks **globally**. When a victim file's tests run after that teardown (CI file ordering), their module-level `mock.module()` is no longer in effect.
2. `empty-content-recovery-sdk.test.ts` additionally imported its SUT **statically at the top, before** its own `mock.module()` calls. If an earlier file in the CI order preloaded `./storage/*`, the static import bound the real storage functions and the later mock never applied.

This is the `mock.module()`-without-isolation class the repo's own audit warns about; it reproduces on Linux CI ordering but not on macOS local ordering (which is why the local suite failed on 3 *different* env tests instead).

## Fix (test-only, behavior-preserving)

- Re-arm the `mock.module()` inside `beforeEach` in both files, so a sibling's global `mock.restore()` can't leave the SUT unmocked for these tests.
- Import `fixEmptyMessagesWithSDK` **lazily after** installing the `./storage/*` mocks.
- `mock.restore()` pairing preserved → `mock-module-lifecycle-audit` stays green.

## QA / evidence

- Both victim files in isolation: **11 pass / 0 fail**.
- `comment-checker/` + `anthropic-context-window-limit-recovery/` dirs together: **82 pass / 0 fail**.
- `mock-module-lifecycle-audit.test.ts`: **pass**.
- Full `bun test` (CI parity): the 7 blocking failures are **gone** (11521 pass). The only remaining local failures are host-env-specific (`readOpencodeConfigAgents` reads the real `~/.config/opencode`; the Codex installer version-sync test compares a not-yet-bumped artifact) — neither appeared in the CI `test` job and both pass on XDG-isolated CI runners.
- `bun run typecheck:packages`: **no errors**.

## Residual risk

None to runtime — changes are confined to two `*.test.ts` files and only affect mock lifecycle timing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the comment-checker and empty-content recovery tests order-independent under single-process `bun test` by injecting dependencies instead of using process-global `mock.module()`. This removes the 7 deterministic Linux CI failures in the publish gate.

- **Bug Fixes**
  - Inject seams to avoid global mocks: `fixEmptyMessagesWithSDK(params, storage?)` (defaults to real storage) and `createCommentCheckerHooks(config?, cliRunner?)` (defaults to real CLI runner); tests pass local mocks.
  - Query-isolate the comment-checker import (`./hook?before-after`) to avoid Bun’s cached bindings and remove `mock.module()`/`mock.restore()` from the victim tests.

<sup>Written for commit c7eedc1eb410404691ced8eb385bb0f8e2420316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

