### PR TITLE
fix(background-agent): restore active-turn completion admission

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -110,7 +110,7 @@ async function flushPendingParentWakeForTest(manager: BackgroundManager, session
 }
 
 describe("BackgroundManager parent wake active turn events", () => {
-  test("#when background task completes during active parent turn #then parent wake stays queued without prompt injection", async () => {
+  test("#when background task completes during active parent turn #then parent sees a noReply wake immediately", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "busy" },
@@ -132,11 +132,12 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
   })
 
-  test("#when duplicate background completions overlap an active parent turn #then one coalesced wake stays queued", async () => {
+  test("#when duplicate background completions overlap an active parent turn #then one coalesced noReply wake is admitted", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "busy" },
@@ -170,9 +171,11 @@ describe("BackgroundManager parent wake active turn events", () => {
     ])
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
     const pendingWake = getPendingParentWakes(manager).get("parent-1")
     expect(pendingWake).toBeDefined()
+    expect(pendingWake?.shouldReply).toBe(true)
     expect(JSON.stringify(pendingWake?.notifications)).toContain("ALL BACKGROUND TASKS COMPLETE")
   })
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -50,10 +50,21 @@ export class ParentWakeFlushRunner {
     const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
     const forceDispatchAfterActiveDefer = sessionActive && this.shouldForceDispatchAfterActiveDefer(latestWake)
     if (sessionActive && !forceDispatchAfterActiveDefer) {
-      this.schedulePendingParentWakeFlush(sessionID)
-      log("[background-agent] Deferred parent wake because parent session is active:", {
+      if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
+        return
+      }
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry: false,
+        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+        retainPendingWake: latestWake.shouldReply,
+      })
+      log("[background-agent] Recorded admit-only parent wake during active parent turn:", {
         sessionID,
       })
+      if (latestWake.shouldReply) {
+        this.schedulePendingParentWakeFlush(sessionID)
+      }
       return
     }
 


### PR DESCRIPTION
## Summary

Restore immediate `noReply` admission for successful background completion wakes while the parent session is active.

PR #4478 established that successful completion reminders should join an active parent turn without starting an overlapping assistant reply. PR #5994 later added a 60-second active-defer ceiling, but its initial `sessionActive` guard returns before any admission path. Successful completions therefore remain invisible to the active turn until the parent becomes idle or the ceiling expires.

## Changes

- Admit the first successful active-turn wake with `forceNoReply: true`.
- Retain reply liveness for all-complete wakes and keep the existing retry timer.
- Continue deferring failures and already-admitted retained wakes through `deferReplyWakeWhileUnsafe`.
- Preserve the 60-second reply-producing fallback from #5994.
- Update active-turn event tests to assert immediate, coalesced `noReply` delivery.

## Why this is separate from #5994

#5994 bounds an otherwise indefinite defer, but it does not restore the immediate-delivery contract from #4478. This patch keeps that ceiling as the final reply-liveness fallback while making successful completion visible to the in-flight parent turn at its next context/tool boundary.

The broader symptoms in #5569 and #5790 are related, but neither tracks this exact early-return regression.

## Verification

- `bun test packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts` — 11 passed, 0 failed.
- `bun test packages/omo-opencode/src/features/background-agent` — 744 passed, 0 failed.
- LSP diagnostics — clean for both changed files.
- Isolated OpenCode serve probe with the equivalent patch observed the wake during the active parent turn (`WAKE_DISPATCHED_DURING_PARENT_TURN=true`), with one child session, one terminal parent stop, and no writes to the real session database.

### Baseline typecheck issue

`bun run typecheck` currently fails on unmodified `origin/dev` at:

```text
packages/omo-opencode/src/plugin/skill-context.ts(109,5): error TS2353:
'playwrightMcpArgs' does not exist in type 'ResolveActiveBuiltinSkillsOptions'.
```

The same diagnostic occurs with this PR diff stashed; neither changed file has diagnostics.

## Review focus

- Whether successful completion wakes should retain #4478's immediate active-turn visibility rather than wait for #5994's ceiling.
- Interaction between retained `noReply` admission, consumed-wake detection, and the existing 60-second reply fallback.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores immediate noReply admission for successful background completions during an active parent turn, making the completion visible without starting an overlapping assistant reply. Keeps the 60-second fallback to produce a reply if the wake still needs one.

- **Bug Fixes**
  - Admit the first successful active-turn wake with `forceNoReply: true`, and retain it if `shouldReply` for later flushing.
  - Continue deferring failed or already-admitted wakes via `deferReplyWakeWhileUnsafe`.
  - Preserve the 60-second reply-producing ceiling.
  - Update active-turn event tests to assert immediate, coalesced noReply delivery.

<sup>Written for commit 61945718e59bf6f213d6bd36e9b4a1f6a7f3ad10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

