### PR TITLE
fix(omo-opencode): fold per-agent providerOptions into options so it reaches the request

### DIFF
--- a/packages/omo-opencode/src/plugin-handlers/agent-config-assembly-provider-options.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/agent-config-assembly-provider-options.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "bun:test"
+
+import type { OhMyOpenCodeConfig } from "../config"
+import { assembleAgentConfig } from "./agent-config-assembly"
+
+type AssembleParams = Parameters<typeof assembleAgentConfig>[0]
+
+function makePluginConfig(partial: Partial<OhMyOpenCodeConfig>): OhMyOpenCodeConfig {
+  return {
+    git_master: { commit_footer: true, include_co_authored_by: true, git_env_prefix: "GIT_MASTER=1" },
+    ...partial,
+  } as OhMyOpenCodeConfig
+}
+
+function emptySources(): AssembleParams["sources"] {
+  return {
+    userAgents: {},
+    projectAgents: {},
+    opencodeGlobalAgents: {},
+    opencodeProjectAgents: {},
+    pluginAgents: {},
+    agentDefinitionAgents: {},
+    opencodeConfigAgents: {},
+    configAgent: undefined,
+    customAgentSummaries: [],
+  }
+}
+
+function makeParams(agents: Record<string, Record<string, unknown>>): AssembleParams {
+  return {
+    config: {},
+    pluginConfig: makePluginConfig({ sisyphus_agent: { planner_enabled: false } }),
+    builtinAgents: agents as AssembleParams["builtinAgents"],
+    sources: emptySources(),
+    currentModel: undefined,
+    useTaskSystem: false,
+    disabledAgentNames: new Set<string>(),
+  }
+}
+
+function resolved(params: AssembleParams): Record<string, Record<string, unknown>> {
+  return params.config.agent as Record<string, Record<string, unknown>>
+}
+
+describe("assembleAgentConfig provider options folding (#5479)", () => {
+  test("#given an agent with top-level providerOptions #when assembled #then it is folded into options and the key is dropped", async () => {
+    //#given
+    const params = makeParams({
+      sisyphus: {
+        name: "sisyphus",
+        model: "openai/gpt-5.5",
+        mode: "primary",
+        prompt: "s",
+        providerOptions: { thinking_token_budget: 1024, chat_template_kwargs: { enable_thinking: false } },
+      },
+      oracle: { name: "oracle", model: "openai/gpt-5.5", mode: "subagent", prompt: "o" },
+    })
+
+    //#when
+    await assembleAgentConfig(params)
+
+    //#then
+    const agents = resolved(params)
+    expect(agents.sisyphus.options).toEqual({
+      thinking_token_budget: 1024,
+      chat_template_kwargs: { enable_thinking: false },
+    })
+    expect("providerOptions" in agents.sisyphus).toBe(false)
+  })
+
+  test("#given an agent with existing options and providerOptions #when assembled #then they are deep-merged", async () => {
+    //#given
+    const params = makeParams({
+      sisyphus: {
+        name: "sisyphus",
+        model: "openai/gpt-5.5",
+        mode: "primary",
+        prompt: "s",
+        options: { existing: 1, chat_template_kwargs: { keep: true } },
+        providerOptions: { added: 2, chat_template_kwargs: { enable_thinking: false } },
+      },
+    })
+
+    //#when
+    await assembleAgentConfig(params)
+
+    //#then
+    const agents = resolved(params)
+    expect(agents.sisyphus.options).toEqual({
+      existing: 1,
+      added: 2,
+      chat_template_kwargs: { keep: true, enable_thinking: false },
+    })
+    expect("providerOptions" in agents.sisyphus).toBe(false)
+  })
+
+  test("#given an agent without providerOptions #when assembled #then options is left untouched", async () => {
+    //#given
+    const params = makeParams({
+      sisyphus: { name: "sisyphus", model: "openai/gpt-5.5", mode: "primary", prompt: "s" },
+      oracle: { name: "oracle", model: "openai/gpt-5.5", mode: "subagent", prompt: "o" },
+    })
+
+    //#when
+    await assembleAgentConfig(params)
+
+    //#then
+    const agents = resolved(params)
+    expect(agents.oracle.options).toBeUndefined()
+    expect("providerOptions" in agents.oracle).toBe(false)
+  })
+})

--- a/packages/omo-opencode/src/plugin-handlers/agent-config-assembly.ts
+++ b/packages/omo-opencode/src/plugin-handlers/agent-config-assembly.ts
@@ -14,6 +14,7 @@ import {
 import type { AgentSourceMap, AgentSources } from "./agent-config-types";
 import { buildPlanDemoteConfig } from "./plan-model-inheritance";
 import { buildPrometheusAgentConfig } from "./prometheus-agent-config-builder";
+import { deepMerge } from "../shared";
 
 type BuiltinAgentMap = Record<string, AgentConfig | undefined>;
 
@@ -230,6 +231,32 @@ function assembleSisyphusDisabledConfig(params: AssembleAgentConfigParams): void
   };
 }
 
+/**
+ * OpenCode's agent schema has no top-level `providerOptions`; per-request
+ * provider options come from the flat `options` record on the agent, which
+ * OpenCode wraps under the SDK provider key at request time. OMO config,
+ * category expansion, and plan/model inheritance write `providerOptions` as a
+ * top-level agent key, so without this fold it is silently dropped and never
+ * reaches the request body (#5479). Fold each agent's `providerOptions` into
+ * its `options` record and drop the unrecognized key.
+ */
+function foldAgentProviderOptions(agents: Record<string, unknown>): void {
+  for (const value of Object.values(agents)) {
+    if (typeof value !== "object" || value === null) continue;
+    const agent = value as Record<string, unknown>;
+    const providerOptions = agent.providerOptions;
+    if (providerOptions === undefined) continue;
+    if (typeof providerOptions === "object" && providerOptions !== null) {
+      const existing =
+        typeof agent.options === "object" && agent.options !== null
+          ? (agent.options as Record<string, unknown>)
+          : {};
+      agent.options = deepMerge(existing, providerOptions as Record<string, unknown>);
+    }
+    delete agent.providerOptions;
+  }
+}
+
 export async function assembleAgentConfig(params: AssembleAgentConfigParams): Promise<AssemblyResult> {
   const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
   const isSisyphusEnabled = params.pluginConfig.sisyphus_agent?.disabled !== true;
@@ -238,6 +265,10 @@ export async function assembleAgentConfig(params: AssembleAgentConfigParams): Pr
     await assembleSisyphusEnabledConfig(params);
   } else {
     assembleSisyphusDisabledConfig(params);
+  }
+
+  if (params.config.agent && typeof params.config.agent === "object") {
+    foldAgentProviderOptions(params.config.agent as Record<string, unknown>);
   }
 
   return { configuredDefaultAgent };


### PR DESCRIPTION
## Summary

Closes #5479. A per-agent `providerOptions` block was accepted by the schema but never reached the request body, so the configured options had no effect (silent, no error). This folds it into the agent's `options` record during assembly, where OpenCode actually reads it.

## Root cause

OpenCode's agent schema (`packages/opencode/src/agent/agent.ts`) has no top-level `providerOptions`. Per-request provider options come from the flat `options` record on the agent: `session/llm/request.ts` merges `agent.options`, and `provider/transform.ts` `providerOptions()` wraps that record under the SDK provider key (e.g. `openaiCompatible`, which `@ai-sdk/openai-compatible` spreads into the body). OMO config, category expansion, and plan/model inheritance write `providerOptions` as a top-level agent key (via `mergeAgentConfig` deep-merge and `MODEL_SETTINGS_KEYS`), which OpenCode does not read, so it is dropped.

## Fix

`agent-config-assembly.ts` now folds each resolved agent's `providerOptions` into its `options` record (deep-merge) and removes the top-level key, in a single pass over the final agent map. OpenCode's own request-time wrapping under the SDK provider key is unchanged.

## Changes

- `plugin-handlers/agent-config-assembly.ts`: add `foldAgentProviderOptions`, applied at the end of `assembleAgentConfig`.
- `plugin-handlers/agent-config-assembly-provider-options.test.ts`: new tests.

## QA and evidence

Real `opencode serve` in an isolated XDG sandbox with this build's plugin loaded and `agents.sisyphus.providerOptions` set, reading `GET /agent`:

```
Sisyphus - ultraworker
  options = {"thinking_token_budget":1024,"chat_template_kwargs":{"enable_thinking":false}}
  has providerOptions key = false
```

The configured options land in the resolved agent's `options` record; the unrecognized top-level `providerOptions` key is gone. `Sisyphus-Junior` (no options configured) keeps `options = {}`. DB isolation confirmed: real session count `9368` before and after.

Tests: 3 new integration tests (fold, deep-merge into existing `options`, no-op when absent). Full plugin-handlers suite (227) stays green. `tsgo --noEmit` clean.

## Residual risk

The fold is a shallow pass over the final agent map that only moves a key OpenCode already ignores; it does not change model resolution or any other agent field. Deep-merge preserves nested keys when an agent already has an `options` record (rare in OMO).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-agent provider options being ignored by folding each agent’s `providerOptions` into `options` so they reach OpenCode requests. Addresses #5479 and makes configured provider options take effect.

- **Bug Fixes**
  - Fold `providerOptions` into `options` during `assembleAgentConfig` (deep-merge) and remove the top-level key.
  - Leave request-time provider wrapping unchanged; no impact on model resolution or other fields.
  - Added tests to cover folding, deep-merge with existing `options`, and no-op when absent.

<sup>Written for commit 89ab0e6b7b7fd1c9134893845722951bdc6e9124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

