### PR TITLE
fix(senpi-task): cleanup critical memory/cleanup leaks (TTL, stderr, notifier retries)

### DIFF
--- a/packages/omo-senpi/src/components/task/event-bridge.ts
+++ b/packages/omo-senpi/src/components/task/event-bridge.ts
@@ -32,6 +32,10 @@ export function wireEventBridge(
     engine.runtime.captureFrom(asLiveContext(eventCtx))
     transitions.onSessionStart(engine.runtime.sessionId())
     await engine.lifecycle.reconcileOnSessionStart()
+    const cleanup = engine.lifecycle.cleanupExpiredRecords()
+    if (cleanup.deleted.length > 0) {
+      ctx.logger.info("senpi-task ttl cleanup", { deleted: cleanup.deleted.length, retained: cleanup.retained.length })
+    }
     await reconcileTeamMailboxBestEffort(ctx, state)
     const sessionId = engine.runtime.sessionId()
     if (sessionId !== undefined) {

--- a/packages/omo-senpi/src/components/task/index.test.ts
+++ b/packages/omo-senpi/src/components/task/index.test.ts
@@ -201,7 +201,7 @@ describe("omo-senpi task component wiring", () => {
     expect(leadCalls.ticks).toBe(2)
   })
 
-  it("#given a session start #when reconciliation runs #then reattach, mailbox reclaim, notification retry, and lead polling stay ordered", async () => {
+  it("#given a session start #when reconciliation runs #then reattach, cleanup, mailbox reclaim, notification retry, and lead polling stay ordered", async () => {
     // given
     const cwd = tempProject()
     const pi = new FakeExtensionAPI()
@@ -215,6 +215,10 @@ describe("omo-senpi task component wiring", () => {
         reconcileOnSessionStart: async () => {
           order.push("reattach")
           return { outcomes: [] }
+        },
+        cleanupExpiredRecords: () => {
+          order.push("cleanup")
+          return { deleted: [], retained: [] }
         },
       },
       notifier: {
@@ -246,7 +250,7 @@ describe("omo-senpi task component wiring", () => {
     })
 
     // then
-    expect(order).toEqual(["reattach", "reclaim", "notify", "poll"])
+    expect(order).toEqual(["reattach", "cleanup", "reclaim", "notify", "poll"])
   })
 
   it("#given a captured ui #when session_before_switch fires #then the ui bridge is cleared", async () => {

--- a/packages/senpi-task/src/completion/notifier-retry.test.ts
+++ b/packages/senpi-task/src/completion/notifier-retry.test.ts
@@ -151,7 +151,7 @@ describe("createCompletionNotifier scheduled retries", () => {
     expect(parent.calls).toHaveLength(1)
   })
 
-  test("#given persistent enqueue failures w2notif #when eight timers exhaust #then no ninth timer is scheduled", () => {
+  test("#given persistent enqueue failures w2notif #when eight timers exhaust #then the cycle caps and the count is cleaned so a later reconcile restarts fresh", () => {
     // given
     const record = baseRecord()
     const { store, records } = fakeStore([record])
@@ -162,11 +162,18 @@ describe("createCompletionNotifier scheduled retries", () => {
 
     // when
     for (let index = 0; index < 8; index += 1) scheduler.run(index)
-    completion.reconcileFailedNotifications({ sessionId: "session-a", parentState: { kind: "idle" } })
 
-    // then
+    // then no ninth timer is scheduled within the same cycle
     expect(scheduler.calls).toHaveLength(8)
     expect(records.get(record.task_id)?.notification.notification_failed_epoch).toBe(0)
+
+    // when a later reconcile retries the same failed epoch
+    completion.reconcileFailedNotifications({ sessionId: "session-a", parentState: { kind: "idle" } })
+
+    // then the cleaned retry count restarts a fresh backoff cycle instead of leaking exhaustion
+    expect(scheduler.calls).toHaveLength(9)
+    expect(scheduler.calls[8]?.delayMs).toBeGreaterThanOrEqual(500)
+    expect(scheduler.calls[8]?.delayMs).toBeLessThan(700)
   })
 
   test("#given failed records from mixed sessions w2notif #when reconciled twice #then only eligible work delivers once", () => {

--- a/packages/senpi-task/src/completion/notifier.ts
+++ b/packages/senpi-task/src/completion/notifier.ts
@@ -52,7 +52,12 @@ export function createCompletionNotifier(deps: CompletionNotifierDeps): Completi
     const key = retryKey(entry)
     if (scheduledRetries.has(key)) return
     const retryNumber = (scheduledRetryCounts.get(key) ?? 0) + 1
-    if (retryNumber > MAX_SCHEDULED_RETRIES) return
+    if (retryNumber > MAX_SCHEDULED_RETRIES) {
+      // Exhausted the backoff ladder: drop the retry state so it does not leak for the lifetime of
+      // the process. A later reconcile or notifyTerminal for the same epoch will restart fresh.
+      finishRetryChain(entry)
+      return
+    }
     scheduledRetryCounts.set(key, retryNumber)
     const cancel = schedule(() => {
       scheduledRetries.delete(key)

--- a/packages/senpi-task/src/lifecycle/ttl.test.ts
+++ b/packages/senpi-task/src/lifecycle/ttl.test.ts
@@ -7,6 +7,7 @@ import { createTaskLifecycle } from "./create"
 import type { ProcessSignaller } from "./port"
 import {
   cleanupProjects,
+  fakeHandle,
   FakeRegistry,
   seedRecord,
   settings,
@@ -99,5 +100,29 @@ describe("cleanupExpiredRecords (TTL)", () => {
 
     // then
     expect(result.deleted).toContain("st_00000005")
+  })
+
+  test("#given an expired terminal record owned by a live resident handle #when cleaning #then it is retained until the handle is forgotten", () => {
+    // given
+    const store = tempStore()
+    seedRecord(store, { task_id: "st_00000006", status: "completed", updated_at: iso(TTL + 1) })
+    const registry = new FakeRegistry()
+    registry.add(fakeHandle("st_00000006", "in-process", []))
+    const lifecycle = createTaskLifecycle({ store, registry, config: settings({ ttl_ms: TTL }), now })
+
+    // when
+    const retained = lifecycle.cleanupExpiredRecords()
+
+    // then the live resident protects the record; deleting it would orphan an in-memory handle
+    expect(retained.retained).toContain("st_00000006")
+    expect(existsSync(recordPath(store, "st_00000006"))).toBe(true)
+
+    // when the resident is forgotten and cleanup runs again
+    registry.forget("st_00000006")
+    const afterForget = lifecycle.cleanupExpiredRecords()
+
+    // then the expired terminal record can be safely removed
+    expect(afterForget.deleted).toContain("st_00000006")
+    expect(existsSync(recordPath(store, "st_00000006"))).toBe(false)
   })
 })

--- a/packages/senpi-task/src/lifecycle/ttl.ts
+++ b/packages/senpi-task/src/lifecycle/ttl.ts
@@ -3,10 +3,10 @@ import { TERMINAL_STATUSES, type LifecycleContext } from "./context"
 import type { CleanupResult } from "./types"
 
 /**
- * On component start, delete terminal records + logs older than task.ttl_ms. Non-terminal records
- * are always kept. A `lost` rpc record is NEVER deleted without pid-dead proof (its breadcrumbs may
- * still be needed). Because this runs at start, fresh in-run records are far younger than the TTL,
- * so evidence-referenced logs of the current run are never touched.
+ * Delete terminal records + logs older than task.ttl_ms. Non-terminal records are always kept. A
+ * `lost` process record is NEVER deleted without pid-dead proof (its breadcrumbs may still be
+ * needed). Records with a live resident handle in this process are also retained: deleting them
+ * would orphan an in-memory handle and allow late transcript appends to recreate the deleted log.
  */
 export function cleanupExpiredRecords(context: LifecycleContext): CleanupResult {
   const deleted: string[] = []
@@ -25,6 +25,7 @@ export function cleanupExpiredRecords(context: LifecycleContext): CleanupResult 
 }
 
 function isExpungeable(context: LifecycleContext, record: TaskRecord, cutoff: number): boolean {
+  if (context.registry.get(record.task_id) !== undefined) return false
   if (!TERMINAL_STATUSES.has(record.status)) return false
   if (Date.parse(record.updated_at) > cutoff) return false
   if (record.status === "lost" && record.execution_mode === "process") {

--- a/packages/senpi-task/src/runners/rpc/protocol-client.test.ts
+++ b/packages/senpi-task/src/runners/rpc/protocol-client.test.ts
@@ -54,6 +54,19 @@ function spawnSessionCommandChild(): ChildProcess {
   })
 }
 
+function spawnStderrFloodChild(): ChildProcess {
+  const source = String.raw`
+    const chunk = "x".repeat(1000);
+    for (let i = 0; i < 50; i++) process.stderr.write(chunk);
+    process.stdin.resume();
+  `
+  return spawn("node", ["--input-type=module", "-e", source], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: ["pipe", "pipe", "pipe"],
+  })
+}
+
 async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (!predicate()) {
@@ -213,5 +226,21 @@ describe("RpcProtocolClient", () => {
 
     // when / then
     expect(client.send({ type: "get_state" })).rejects.toThrow()
+  })
+
+  test("#given a verbose child stderr #when chunks accumulate #then the internal buffer is capped and tail reflects recent bytes", async () => {
+    // given
+    const child = track(spawnStderrFloodChild())
+    const client = new RpcProtocolClient({ child })
+    const STDERR_BUFFER_CAP = 16_384
+    const STDERR_TAIL_CAP = 4_096
+
+    // when
+    await waitFor(() => client.stderrTail.length >= STDERR_TAIL_CAP)
+
+    // then the raw buffer never exceeds the cap, preventing memory growth for chatty children
+    expect(client.stderrBufferLength).toBeLessThanOrEqual(STDERR_BUFFER_CAP)
+    expect(client.stderrTail.length).toBeLessThanOrEqual(STDERR_TAIL_CAP)
+    expect(client.stderrTail.startsWith("x")).toBe(true)
   })
 })

--- a/packages/senpi-task/src/runners/rpc/protocol-client.ts
+++ b/packages/senpi-task/src/runners/rpc/protocol-client.ts
@@ -7,6 +7,8 @@ import { RpcCommandError } from "./errors"
 import { tailStderr } from "./exit-mapping"
 import { buildAutoUiResponse } from "./ui-auto-answer"
 
+const STDERR_BUFFER_CAP = 16_384
+
 export type MalformedLineHandler = (line: string, error: unknown) => void
 
 export type RpcProtocolClientOptions = {
@@ -57,6 +59,11 @@ export class RpcProtocolClient {
 
   get stderrTail(): string {
     return tailStderr(this.stderrBuffer)
+  }
+
+  /** Length of the raw stderr buffer, exposed for tests/diagnostics. */
+  get stderrBufferLength(): number {
+    return this.stderrBuffer.length
   }
 
   send(command: RpcCommand): Promise<RpcResponse> {
@@ -113,7 +120,7 @@ export class RpcProtocolClient {
     this.child.stdout?.on("data", (chunk: string) => this.ingest(chunk))
     this.child.stderr?.setEncoding("utf8")
     this.child.stderr?.on("data", (chunk: string) => {
-      this.stderrBuffer += chunk
+      this.stderrBuffer = (this.stderrBuffer + chunk).slice(-STDERR_BUFFER_CAP)
     })
     this.child.once("error", (error) => this.finalize(error))
     this.child.once("exit", () => this.finalize())


### PR DESCRIPTION
## Summary
This PR fixes three independent critical cleanup issues in `packages/senpi-task` and the `omo-senpi` task event bridge:

1. **TTL cleanup was implemented but never invoked** — terminal task records accumulated forever, making every `store.list()` scan slower over time.
2. **RPC child `stderrBuffer` grew unbounded** — only the 4 KB tail was ever read, but the full buffer was retained for the child's lifetime.
3. **Completion-notifier retry counts leaked on exhaustion** — a permanently failing `(task_id, epoch)` left an entry in `scheduledRetryCounts` until process exit.

## Changes

### TTL cleanup wired into `session_start`
- `packages/omo-senpi/src/components/task/event-bridge.ts`: calls `engine.lifecycle.cleanupExpiredRecords()` immediately after `reconcileOnSessionStart()`.
- `packages/senpi-task/src/lifecycle/ttl.ts`: added a live-handle guard so records with a resident handle in this process are retained. Deleting them would orphan an in-memory handle and allow late transcript appends to recreate the deleted log file.
- Tests updated to assert the new ordering (`reattach → cleanup → reclaim → notify → poll`) and the live-handle guard.

### RPC stderr buffer cap
- `packages/senpi-task/src/runners/rpc/protocol-client.ts`: trims `stderrBuffer` to 16 KB on every `data` event. Exposes `stderrBufferLength` for tests/diagnostics.
- Added a test that floods stderr with 50 KB and asserts the raw buffer stays ≤ 16 KB while the tail stays ≤ 4 KB.

### Notifier retry-state cleanup
- `packages/senpi-task/src/completion/notifier.ts`: on exceeding `MAX_SCHEDULED_RETRIES`, calls `finishRetryChain(entry)` to remove both `scheduledRetries` and `scheduledRetryCounts` entries.
- A later `reconcileFailedNotifications` for the same failed epoch now restarts the backoff ladder fresh instead of staying muted by the leaked count.

## QA & Evidence
All commands run from the worktree `~/local-workspaces/oh-my-openagent-wt/fix-senpi-task-cleanup-critical`.

| Fix | What was tested | Observed result | Artifact |
|---|---|---|---|
| F1 TTL | Seeded 10 completed records past TTL, called `cleanupExpiredRecords()` | `Before cleanup: 10 records, 10 logs` → `After cleanup: 0 records`, `Deleted: 10` | `.omo/evidence/20260717-pr1-senpi-task-cleanup-critical/qa-cleanup.ts` |
| F2 stderr cap | Spawned a child writing 50 KB to stderr, observed `RpcProtocolClient` | `stderrBufferLength: 16384`, `stderrTail.length: 4096`, both capped true | `.omo/evidence/20260717-pr1-senpi-task-cleanup-critical/qa-stderr-cap.ts` |
| F3 notifier retries | Ran 8 failing retries to exhaustion, then reconciled | `Timers after 8 retries: 8` → `Timers after reconcile: 9` with fresh base delay (601 ms) | `.omo/evidence/20260717-pr1-senpi-task-cleanup-critical/qa-retry-cleanup.ts` |
| Suite | `bun test packages/senpi-task packages/omo-senpi/src/components/task` | 778 pass, 0 fail | CI will re-run |
| Typecheck | `bun run typecheck:packages` | exit 0 | — |
| Build | `bun run build` | exit 0 | — |

Full report: `.omo/evidence/20260717-pr1-senpi-task-cleanup-critical/QA_REPORT.md`

## Risks & Residuals
- **TTL ordering**: cleanup runs after reconciliation so completed process-mode records with live orphan PIDs are terminated before the record is deleted. The live-handle guard provides defense-in-depth for mid-session TTL runs.
- **Notifier semantics change**: exhausted retries now restart on reconcile. This is intentional — the previous "permanent mute" was a side effect of the leak, not a designed backpressure policy. Each cycle is still capped at 8 retries.
- **stderr cap**: 16 KB gives 4× the 4 KB tail read window, preserving multi-line error context while bounding memory.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three cleanup leaks in `packages/senpi-task` and the `omo-senpi` event bridge to stop unbounded growth and stuck retry state. TTL cleanup now runs on session start, RPC stderr is bounded, and notifier retries no longer leak.

- **Bug Fixes**
  - TTL: run `cleanupExpiredRecords()` after session-start reconcile; retain records with live resident handles; maintains order: reattach → cleanup → reclaim → notify → poll.
  - RPC stderr: cap internal `stderrBuffer` at 16 KB while keeping a 4 KB `stderrTail`; expose `stderrBufferLength` for diagnostics.
  - Notifier retries: on exhausting `MAX_SCHEDULED_RETRIES`, drop retry state to prevent leaks; later reconciles restart the backoff cycle instead of remaining muted.

<sup>Written for commit 72d87ab55271ce0689c60aeb046f55f6e5ee5ecd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

