### PR TITLE
perf(senpi-task): cache task records and reuse append fds

### DIFF
--- a/packages/senpi-task/src/store/record-store.test.ts
+++ b/packages/senpi-task/src/store/record-store.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { createTaskRecord } from "../state"
+import { createTaskRecordStore } from "./record-store"
+import { resolveStateDir } from "./state-dir"
+
+const cleanupRoots: string[] = []
+
+afterEach(() => {
+  for (const root of cleanupRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function tempProject(): string {
+  const directory = mkdtempSync(join(tmpdir(), "senpi-task-store-"))
+  cleanupRoots.push(directory)
+  return directory
+}
+
+function baseRecord(taskId: string) {
+  return {
+    ...createTaskRecord({
+      parent_session_id: "parent-session",
+      root_session_id: "root-session",
+      depth: 0,
+      execution_mode: "direct",
+      model: "gpt-5.2",
+    }),
+    task_id: taskId,
+  }
+}
+
+describe("createTaskRecordStore caching", () => {
+  test("#given unchanged records #when list() is called repeatedly #then results stay consistent", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    const ids = Array.from({ length: 5 }, (_, index) => `st_${String(index + 1).padStart(8, "0")}`)
+    for (const taskId of ids) store.save(baseRecord(taskId))
+
+    // when
+    const first = store.list().records.map((record) => record.task_id).sort()
+    const second = store.list().records.map((record) => record.task_id).sort()
+
+    // then
+    expect(second).toEqual(first)
+  })
+
+  test("#given an externally mutated record #when list() runs #then the change is reflected", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    const idA = "st_00000001"
+    const idB = "st_00000002"
+    store.save(baseRecord(idA))
+    store.save(baseRecord(idB))
+    store.list() // warm cache
+
+    const stateDir = resolveStateDir({ project_dir: project })
+    const pathA = join(stateDir, "tasks", `${idA}.json`)
+    const rawA = JSON.parse(readFileSync(pathA, "utf8")) as { name: string }
+    writeFileSync(pathA, JSON.stringify({ ...rawA, name: "mutated-A" }), "utf8")
+
+    // when
+    const result = store.list()
+
+    // then
+    expect(result.records.find((record) => record.task_id === idA)?.name).toBe("mutated-A")
+    expect(result.records.find((record) => record.task_id === idB)?.name).not.toBe("mutated-A")
+  })
+
+  test("#given a record removed by another process #when list() runs #then it disappears from results", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    store.save(baseRecord("st_00000003"))
+    store.list() // warm cache
+
+    const stateDir = resolveStateDir({ project_dir: project })
+    rmSync(join(stateDir, "tasks", "st_00000003.json"), { force: true })
+
+    // when
+    const result = store.list()
+
+    // then
+    expect(result.records).toHaveLength(0)
+  })
+
+  test("#given a record replaced through the store #when list() runs #then the cache reflects the new value", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    const record = baseRecord("st_00000004")
+    store.save(record)
+    store.list() // warm cache
+
+    // when
+    store.replace({ ...record, name: "replaced" })
+    const result = store.list()
+
+    // then
+    expect(result.records[0]?.name).toBe("replaced")
+  })
+})
+
+describe("createTaskRecordStore event append", () => {
+  test("#given a removed task #when appendEvent is called again #then the log file is recreated", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    store.save(baseRecord("st_00000005"))
+    store.appendEvent("st_00000005", { type: "before", payload: {} })
+    store.remove("st_00000005")
+
+    // when
+    store.appendEvent("st_00000005", { type: "after", payload: {} })
+
+    // then
+    const stateDir = resolveStateDir({ project_dir: project })
+    const logPath = join(stateDir, "logs", "st_00000005.jsonl")
+    const lines = readFileSync(logPath, "utf8").trim().split("\n")
+    expect(lines).toHaveLength(1)
+    expect(JSON.parse(lines[0] ?? "{}").type).toBe("after")
+  })
+
+  test("#given a record save #when the file is read back #then it is compact JSON without pretty-print indentation", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    const record = baseRecord("st_00000006")
+
+    // when
+    store.save(record)
+
+    // then
+    const stateDir = resolveStateDir({ project_dir: project })
+    const raw = readFileSync(join(stateDir, "tasks", "st_00000006.json"), "utf8")
+    expect(raw).not.toContain("\n  ")
+    expect(JSON.parse(raw).task_id).toBe("st_00000006")
+  })
+})

--- a/packages/senpi-task/src/store/record-store.ts
+++ b/packages/senpi-task/src/store/record-store.ts
@@ -1,4 +1,16 @@
-import { mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  type Stats,
+  writeFileSync,
+  writeSync,
+} from "node:fs"
 import { join } from "node:path"
 
 import { parseTaskId, transitionTaskRecord } from "../state"
@@ -16,6 +28,14 @@ import type {
 
 type WriteRecordMode = "create" | "replace"
 
+type CacheEntry = {
+  readonly record: TaskRecord
+  readonly mtimeMs: number
+  readonly size: number
+}
+
+const APPEND_FD_CAP = 16
+
 export class TaskRecordCollisionError extends Error {
   readonly taskId: TaskId
   readonly path: string
@@ -30,62 +50,121 @@ export class TaskRecordCollisionError extends Error {
 
 export function createTaskRecordStore(config: StateDirConfig): TaskRecordStore {
   const stateDir = resolveStateDir(config)
+  const cache = new Map<string, CacheEntry>()
+  const appendFds = new Map<string, number>()
+
+  function cacheSet(path: string): void {
+    const record = readRecord(path)
+    if (record === null) return
+    const stat = statSync(path)
+    cache.set(path, { record, mtimeMs: stat.mtimeMs, size: stat.size })
+  }
+
   return {
     stateDir,
     save(record) {
       writeRecord(stateDir, record, "create")
+      cacheSet(taskPath(stateDir, parseTaskId(record.task_id)))
     },
     replace(record) {
+      const taskId = parseTaskId(record.task_id)
       writeRecord(stateDir, record, "replace")
+      cacheSet(taskPath(stateDir, taskId))
     },
     load(taskId) {
-      const path = taskPath(stateDir, parseTaskId(taskId))
-      return readRecord(path)
+      return readCached(taskPath(stateDir, parseTaskId(taskId)), cache)
     },
     list() {
-      return listRecords(stateDir)
+      return listRecords(stateDir, cache)
     },
     appendEvent(taskId, event) {
-      return appendTaskEvent(stateDir, parseTaskId(taskId), event)
+      return appendTaskEvent(stateDir, parseTaskId(taskId), event, appendFds)
     },
     transition(taskId, transition) {
       const parsedTaskId = parseTaskId(taskId)
-      const record = readRecord(taskPath(stateDir, parsedTaskId))
+      const path = taskPath(stateDir, parsedTaskId)
+      const record = readCached(path, cache)
       if (record === null) throw new Error(`Task record not found: ${taskId}`)
       const result = transitionTaskRecord(record, transition)
-      appendTaskEvent(stateDir, parsedTaskId, { type: result.audit.type, payload: result.audit })
-      if (result.applied) writeRecord(stateDir, result.record, "replace")
+      appendTaskEvent(stateDir, parsedTaskId, { type: result.audit.type, payload: result.audit }, appendFds)
+      if (result.applied) {
+        writeRecord(stateDir, result.record, "replace")
+        cacheSet(path)
+      }
       return result
     },
     remove(taskId) {
-      removeRecord(stateDir, parseTaskId(taskId))
+      const parsedTaskId = parseTaskId(taskId)
+      removeRecord(stateDir, parsedTaskId, cache, appendFds)
     },
   }
 }
 
-function removeRecord(stateDir: string, taskId: TaskId): void {
-  rmSync(taskPath(stateDir, taskId), { force: true })
-  rmSync(join(stateDir, "logs", `${taskId}.jsonl`), { force: true })
+function removeRecord(
+  stateDir: string,
+  taskId: TaskId,
+  cache: Map<string, CacheEntry>,
+  appendFds: Map<string, number>,
+): void {
+  const recordPath = taskPath(stateDir, taskId)
+  const logPath = join(stateDir, "logs", `${taskId}.jsonl`)
+  rmSync(recordPath, { force: true })
+  rmSync(logPath, { force: true })
+  cache.delete(recordPath)
+  const fd = appendFds.get(logPath)
+  if (fd !== undefined) {
+    appendFds.delete(logPath)
+    closeSync(fd)
+  }
 }
 
-function listRecords(stateDir: string): ListTaskRecordsResult {
+function listRecords(stateDir: string, cache: Map<string, CacheEntry>): ListTaskRecordsResult {
   const tasksDir = join(stateDir, "tasks")
   mkdirSync(tasksDir, { recursive: true })
   const records: TaskRecord[] = []
   const diagnostics: TaskRecordDiagnostic[] = []
+  const seen = new Set<string>()
 
   for (const file of readdirSync(tasksDir).filter((entry) => entry.endsWith(".json")).toSorted()) {
     const path = join(tasksDir, file)
+    seen.add(path)
     try {
-      const parsed: unknown = JSON.parse(readFileSync(path, "utf8"))
-      records.push(parseTaskRecord(parsed, path))
+      const record = readCached(path, cache)
+      if (record !== null) records.push(record)
     } catch (error) {
       if (!(error instanceof Error)) throw error
       diagnostics.push({ type: "parse_error", path, message: error.message })
     }
   }
 
+  // Prune cached records that no longer exist on disk (e.g. TTL cleanup in another process).
+  for (const key of cache.keys()) {
+    if (!seen.has(key) && key.startsWith(tasksDir)) cache.delete(key)
+  }
+
   return { records, diagnostics }
+}
+
+function readCached(path: string, cache: Map<string, CacheEntry>): TaskRecord | null {
+  let stat: Stats
+  try {
+    stat = statSync(path)
+  } catch (error) {
+    if (isEnoent(error)) {
+      cache.delete(path)
+      return null
+    }
+    throw error
+  }
+
+  const hit = cache.get(path)
+  if (hit !== undefined && hit.mtimeMs === stat.mtimeMs && hit.size === stat.size) {
+    return hit.record
+  }
+
+  const record = readRecord(path)
+  if (record !== null) cache.set(path, { record, mtimeMs: stat.mtimeMs, size: stat.size })
+  return record
 }
 
 function readRecord(path: string): TaskRecord | null {
@@ -103,7 +182,7 @@ function writeRecord(stateDir: string, record: TaskRecord, mode: WriteRecordMode
   mkdirSync(tasksDir, { recursive: true })
   const taskId = parseTaskId(record.task_id)
   const path = taskPath(stateDir, taskId)
-  const payload = JSON.stringify(record, null, 2)
+  const payload = JSON.stringify(record)
   if (mode === "create") {
     try {
       writeFileSync(path, payload, { encoding: "utf8", flag: "wx" })
@@ -121,15 +200,45 @@ function writeRecord(stateDir: string, record: TaskRecord, mode: WriteRecordMode
   renameSync(tmpPath, path)
 }
 
-function appendTaskEvent(stateDir: string, taskId: TaskId, event: PersistedTaskEvent): string {
+function appendTaskEvent(
+  stateDir: string,
+  taskId: TaskId,
+  event: PersistedTaskEvent,
+  appendFds: Map<string, number>,
+): string {
   const logsDir = join(stateDir, "logs")
   mkdirSync(logsDir, { recursive: true })
   const path = join(logsDir, `${taskId}.jsonl`)
-  const line = JSON.stringify({ type: event.type, payload: redactEventPayload(event.payload) })
-  writeFileSync(path, `${line}\n`, { encoding: "utf8", flag: "a" })
+  const line = `${JSON.stringify({ type: event.type, payload: redactEventPayload(event.payload) })}
+`
+  const fd = appendFdFor(path, appendFds)
+  writeSync(fd, line)
   return path
+}
+
+function appendFdFor(path: string, appendFds: Map<string, number>): number {
+  const existing = appendFds.get(path)
+  if (existing !== undefined) {
+    // Move to the end to keep LRU order.
+    appendFds.delete(path)
+    appendFds.set(path, existing)
+    return existing
+  }
+
+  const fd = openSync(path, "a")
+  appendFds.set(path, fd)
+  if (appendFds.size > APPEND_FD_CAP) {
+    const [oldPath, oldFd] = appendFds.entries().next().value as [string, number]
+    appendFds.delete(oldPath)
+    closeSync(oldFd)
+  }
+  return fd
 }
 
 function taskPath(stateDir: string, taskId: TaskId): string {
   return join(stateDir, "tasks", `${taskId}.json`)
+}
+
+function isEnoent(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT"
 }


### PR DESCRIPTION
## Summary

Second PR in the senpi-task memory/performance series (follows #6170). Fixes the two store-level hot paths in `packages/senpi-task/src/store/record-store.ts`.

### F4 — `list()`/`load()` re-parsed everything on every call
`list()` did a full `readFileSync` + `JSON.parse` of **every** task JSON file on **every** call. `list()` fires constantly — resident admission, steering name resolution, session reconciliation, status-UI sync — so cost grew linearly with the backlog and was paid over and over.

**Fix:** stat-validated in-memory cache (`Map<path, {record, mtimeMs, size}>`). Unchanged files (same mtime+size) are served from memory; writes go through the cache; vanished files are pruned on `list()`. The cached value is the **parsed** record (read back after write) so a cache hit is byte-for-byte identical to a fresh disk read. External mutations/removals still reflect via stat invalidation.

### F5 — `appendEvent()` open+write+close per event + pretty-printed records
Every event did `writeFileSync(path, ..., { flag: "a" })` = open+write+close, three syscalls per event for chatty children. Records were also written pretty-printed.

**Fix:** bounded LRU (`APPEND_FD_CAP = 16`) of open append fds — one `open()` per task lifetime, closed + evicted on `remove()` so a later append recreates the file. Records now serialize compact.

## QA evidence

Scripts + report under `.omo/evidence/20260717-pr2-senpi-task-store-perf/` (gitignored).

**F4 (2000 records, ~4 KB each):**
```
Second list()  (warm cache, stat-only):  5.66 ms
OLD behavior   (full read+parse):       33.11 ms
Warm list() vs OLD full re-parse:  5.8x faster  (~28 ms saved/call)
```

**F5 (5000 events):**
```
OLD open+write+close per event:  171.93 ms
NEW single fd + writeSync:        10.32 ms
Speed-up:                         16.7x
Log integrity: 5000 lines, correct order
```

## Tests

New `packages/senpi-task/src/store/record-store.test.ts`:
- repeated `list()` stays consistent
- externally mutated record reflected (stat invalidation)
- externally removed record pruned
- `replace()` write-through reflected
- removed task → `appendEvent()` recreates log (fd closed on remove)
- saved record is compact JSON

```
bun test packages/senpi-task packages/omo-senpi  → 912 pass, 0 fail
bun run typecheck:packages  → exit 0
bun run build  → exit 0
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Boosts `senpi-task` store performance by caching parsed task records and reusing append file descriptors to cut repeated JSON parses and syscalls. Warm `list()` is ~5.8x faster; event appends are ~16.7x faster.

- **Refactors**
  - Add stat-validated in-memory cache for `list()`/`load()`; writes update cache; external edits/removals invalidate via mtime/size; prunes missing files.
  - Add LRU (cap 16) of append FDs for `appendEvent()`; close on `remove()`; write compact JSON; logs auto-recreate on append.

<sup>Written for commit a5371ee97667efa2bbbec5022032361fca38d9bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

