### PR TITLE
fix(senpi-task): bound manager release guard and tear down subscriptions

### DIFF
--- a/packages/senpi-task/src/manager/__fixtures__/manager-fakes.ts
+++ b/packages/senpi-task/src/manager/__fixtures__/manager-fakes.ts
@@ -31,6 +31,8 @@ export type FakeHandle = {
   settle: (outcome: RunnerOutcome) => void
   readonly steerCalls: string[]
   readonly followUpCalls: string[]
+  subscribeCount(): number
+  unsubscribeCount(): number
 }
 
 export function makeHandle(taskId: string, pid?: number): FakeHandle {
@@ -42,6 +44,8 @@ export function makeHandle(taskId: string, pid?: number): FakeHandle {
   })
   const steerCalls: string[] = []
   const followUpCalls: string[] = []
+  let subscribeCalls = 0
+  let unsubscribeCalls = 0
   const handle: ManagedChildHandle = {
     task_id: taskId,
     sessionId: `sess-${taskId}`,
@@ -53,7 +57,12 @@ export function makeHandle(taskId: string, pid?: number): FakeHandle {
       followUpCalls.push(text)
     },
     abort: async () => {},
-    subscribe: () => () => {},
+    subscribe: () => {
+      subscribeCalls += 1
+      return () => {
+        unsubscribeCalls += 1
+      }
+    },
     waitForOutcome: () => outcome,
     lastAssistantText: () => undefined,
     dispose: async () => {},
@@ -65,7 +74,14 @@ export function makeHandle(taskId: string, pid?: number): FakeHandle {
     })
     resolveCurrent(value)
   }
-  return { handle, settle, steerCalls, followUpCalls }
+  return {
+    handle,
+    settle,
+    steerCalls,
+    followUpCalls,
+    subscribeCount: () => subscribeCalls,
+    unsubscribeCount: () => unsubscribeCalls,
+  }
 }
 
 export class FakeRunner implements ManagedRunner {

--- a/packages/senpi-task/src/manager/manager-hygiene.test.ts
+++ b/packages/senpi-task/src/manager/manager-hygiene.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { FakeRunner, baseSpec, cleanupProjects, flush, makeManager, settings } from "./__fixtures__/manager-fakes"
+
+afterEach(cleanupProjects)
+
+// F6: the release guard (#released) was a Set keyed by `${taskId}:${epoch}` whose only prune was a
+// linear scan in forget(). A resident task revived N times left N epoch keys behind for the whole
+// session. The guard is now a Map keyed by taskId (latest released epoch), so growth is bounded by
+// the number of distinct live tasks and forget() prunes in O(1).
+describe("TaskManager release guard growth", () => {
+  test("#given a task revived multiple times #when each run completes #then the release guard keeps one entry per task, not per epoch", async () => {
+    // given
+    const inProcess = new FakeRunner()
+    const { manager } = makeManager({ inProcess, config: settings({ default_concurrency: 5, max_depth: 1 }) })
+    const started = await manager.start(baseSpec({ name: "a" }))
+    if (started.kind !== "started") throw new Error("expected started")
+    const taskId = started.task_id
+
+    // when the task completes, is revived, and completes again — twice
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      inProcess.handles.get(taskId)?.settle({ status: "completed", finalResponse: `pass-${cycle}` })
+      await flush()
+      if (cycle < 2) {
+        const revived = await manager.continueTask(taskId, "again")
+        if (revived.kind !== "continued") throw new Error("expected continued")
+      }
+    }
+
+    // then the guard has a single entry for the task (not one per run_epoch)
+    expect(manager.releasedKeyCount()).toBe(1)
+  })
+
+  test("#given a completed task #when it is forgotten #then the release guard entry is pruned", async () => {
+    // given
+    const inProcess = new FakeRunner()
+    const { manager } = makeManager({ inProcess, config: settings({ default_concurrency: 5, max_depth: 1 }) })
+    const started = await manager.start(baseSpec({ name: "a" }))
+    if (started.kind !== "started") throw new Error("expected started")
+    inProcess.handles.get(started.task_id)?.settle({ status: "completed", finalResponse: "done" })
+    await flush()
+    expect(manager.releasedKeyCount()).toBe(1)
+
+    // when
+    manager.forget(started.task_id)
+
+    // then
+    expect(manager.releasedKeyCount()).toBe(0)
+  })
+})
+
+// F7: #launch subscribed the child's transcript log and DISCARDED the unsubscribe, so the listener
+// closure outlived the handle. The manager now owns the unsubscribe and calls it on forget().
+describe("TaskManager transcript subscription ownership", () => {
+  test("#given a running task with a transcript subscription #when it is forgotten #then the subscription is torn down", async () => {
+    // given
+    const inProcess = new FakeRunner()
+    const { manager } = makeManager({ inProcess, config: settings({ default_concurrency: 5, max_depth: 1 }) })
+    const started = await manager.start(baseSpec({ name: "a" }))
+    if (started.kind !== "started") throw new Error("expected started")
+    const fake = inProcess.handles.get(started.task_id)
+    if (fake === undefined) throw new Error("expected live handle")
+    expect(fake.subscribeCount()).toBe(1)
+    expect(fake.unsubscribeCount()).toBe(0)
+
+    // when
+    manager.forget(started.task_id)
+
+    // then
+    expect(fake.unsubscribeCount()).toBe(1)
+  })
+})

--- a/packages/senpi-task/src/manager/manager.ts
+++ b/packages/senpi-task/src/manager/manager.ts
@@ -39,6 +39,7 @@ import type {
 type LiveTask = {
   readonly handle: ManagedChildHandle
   readonly model: string
+  readonly unsubscribe: () => void
 }
 
 type LaunchContext = {
@@ -66,6 +67,7 @@ type ReattachingTaskManager = TaskManager & {
   respawn(record: TaskRecord, resumeSessionPath: string): Promise<RespawnResult>
   reattach(record: TaskRecord, handle: ManagedChildHandle): Promise<ReattachResult>
   waiterKeyCount(): number
+  releasedKeyCount(): number
 }
 
 const NOOP_DESTRUCTION: DestructionPort = { destroyResidentTask: () => Promise.resolve() }
@@ -98,9 +100,11 @@ class TaskManagerImpl implements TaskManager {
   readonly #rpcRespawnRunner: RpcRespawnRunner
   readonly #names = new NameRegistry()
   readonly #live = new Map<string, LiveTask>()
-  // Release guard keyed by `${taskId}:${runEpoch}` so a revived task (new epoch) can re-acquire a
-  // slot and still have its LATER release counted instead of swallowed by an already-released id.
-  readonly #released = new Set<string>()
+  // Release guard: latest released run_epoch per task_id. A revived task (higher epoch) can still
+  // release its LATER occupancy, while a stale re-release of an already-released epoch is a no-op.
+  // Keyed by task_id (not `${taskId}:${epoch}`) so growth is bounded by live tasks and forget()
+  // prunes in O(1).
+  readonly #released = new Map<string, number>()
   readonly #waiters = new Map<string, TaskWaiter[]>()
   readonly #background = new Set<string>()
   readonly #steering: SteeringEngine
@@ -268,9 +272,11 @@ class TaskManagerImpl implements TaskManager {
   }
 
   forget(taskId: string): void {
+    this.#live.get(taskId)?.unsubscribe()
     this.#live.delete(taskId)
     this.#background.delete(taskId)
-    for (const key of this.#released) if (key.startsWith(`${taskId}:`)) this.#released.delete(key)
+    this.#released.delete(taskId)
+    this.#steering.dropPending(taskId)
   }
 
   getResidentHandle(taskId: string): ManagedChildHandle | undefined { return this.#live.get(taskId)?.handle }
@@ -321,11 +327,11 @@ class TaskManagerImpl implements TaskManager {
       await discardManagedHandle(handle)
       return { ok: false, kind: "already_attached", reason: "task already has a live handle" }
     }
-    this.#live.set(record.task_id, { handle, model: record.model })
     let unsubscribe: (() => void) | undefined
     let acquiredEpoch: number | undefined
     try {
       unsubscribe = subscribeTranscriptLog(handle, this.#options.store, record.task_id)
+      this.#live.set(record.task_id, { handle, model: record.model, unsubscribe })
       if (isTerminalRecord(record) && record.status !== "lost") {
         this.#options.store.replace({
           ...record,
@@ -397,6 +403,9 @@ class TaskManagerImpl implements TaskManager {
   // Test-only observability for proving waitFor never retains empty waiter-map keys.
   waiterKeyCount(): number { return this.#waiters.size }
 
+  // Test-only observability for proving the release guard never grows unboundedly across revives.
+  releasedKeyCount(): number { return this.#released.size }
+
   async #disposeFailedRespawn(handle: RpcChildHandle): Promise<boolean> {
     try {
       await discardRpcHandle(handle)
@@ -412,6 +421,7 @@ class TaskManagerImpl implements TaskManager {
     const startResult = this.#options.store.transition(record.task_id, { type: "start", timestamp: nowIso(this.#now) })
     if (!startResult.applied) {
       this.#releaseSlot(record.task_id, model, record.notification.run_epoch)
+      this.#steering.dropPending(record.task_id)
       this.#settleWaiters(record.task_id)
       return { ok: false, error: "task was cancelled before launch" }
     }
@@ -424,22 +434,23 @@ class TaskManagerImpl implements TaskManager {
       this.#releaseSlot(record.task_id, model, record.notification.run_epoch)
       this.#options.store.transition(record.task_id, { type: "fail", timestamp: nowIso(this.#now), error_message: message })
       this.#options.store.appendEvent(record.task_id, { type: "task_start_failed", payload: { error_message: message } })
+      this.#steering.dropPending(record.task_id)
       this.#settleWaiters(record.task_id)
       return { ok: false, error: message }
     }
 
     const current = this.#tryLoad(record.task_id)
     if (current?.status === "cancelled") {
-      this.#live.set(record.task_id, { handle, model })
+      this.#live.set(record.task_id, { handle, model, unsubscribe: () => undefined })
       await (this.#options.destruction ?? NOOP_DESTRUCTION).destroyResidentTask(record.task_id, "cancel")
       this.#releaseSlot(record.task_id, model, record.notification.run_epoch)
       this.#settleWaiters(record.task_id)
       return { ok: false, error: "task was cancelled during launch" }
     }
 
-    this.#live.set(record.task_id, { handle, model })
+    const unsubscribe = subscribeTranscriptLog(handle, this.#options.store, record.task_id)
+    this.#live.set(record.task_id, { handle, model, unsubscribe })
     this.#recordSpawnFacts(record.task_id, handle)
-    subscribeTranscriptLog(handle, this.#options.store, record.task_id)
     this.#trackOutcome(record.task_id, handle, model, record.notification.run_epoch)
     void this.#steering.notifyStarted(record.task_id)
     return { ok: true }
@@ -501,9 +512,11 @@ class TaskManagerImpl implements TaskManager {
   }
 
   #releaseSlot(taskId: string, model: string, epoch: number): void {
-    const key = `${taskId}:${epoch}`
-    if (this.#released.has(key)) return
-    this.#released.add(key)
+    // Release once per (task, epoch). A stale re-release of an already-released epoch is a no-op;
+    // a revived task's higher epoch supersedes the prior one so its later release still counts.
+    const released = this.#released.get(taskId)
+    if (released !== undefined && released >= epoch) return
+    this.#released.set(taskId, epoch)
     this.#concurrency.release(model)
   }
 

--- a/packages/senpi-task/src/steering/engine.test.ts
+++ b/packages/senpi-task/src/steering/engine.test.ts
@@ -293,4 +293,22 @@ describe("steering pending cancellation", () => {
     expect(interrupted.kind).toBe("noop")
     expect(harness.store.load(record.task_id)?.status).toBe("pending")
   })
+
+  test("#given a pending child with queued sends w2pend #when dropPending then notified started #then buffered messages are discarded", async () => {
+    // given a queued task with two buffered messages
+    const harness = makeHarness()
+    const record = harness.seedRecord()
+    await harness.engine.sendToTask({ idOrName: record.task_id, message: "first" })
+    await harness.engine.sendToTask({ idOrName: record.task_id, message: "second" })
+
+    // when the manager forgets the task before it ever launches, then a stale start fires
+    harness.engine.dropPending(record.task_id)
+    const fake = makeFakeHandle(record.task_id, "in-process")
+    harness.setLive(record.task_id, fake.handle)
+    await harness.engine.notifyStarted(record.task_id)
+
+    // then nothing is delivered (the buffer was released, not retained for the session)
+    expect(fake.followUpCalls).toEqual([])
+    expect(fake.steerCalls).toEqual([])
+  })
 })

--- a/packages/senpi-task/src/steering/engine.ts
+++ b/packages/senpi-task/src/steering/engine.ts
@@ -95,6 +95,10 @@ export function createSteeringEngine(port: SteeringPort): SteeringEngine {
     return { kind: "queued", task_id: taskId, queue_position: queue.length }
   }
 
+  function dropPending(taskId: string): void {
+    pending.delete(taskId)
+  }
+
   async function notifyStarted(taskId: string): Promise<void> {
     const queue = pending.get(taskId)
     if (queue === undefined || queue.length === 0) return
@@ -184,7 +188,7 @@ export function createSteeringEngine(port: SteeringPort): SteeringEngine {
     return { kind: "cancelled", task_id: record.task_id, previous_status: "running" }
   }
 
-  return { sendToTask, interruptTask, cancelTask, notifyStarted }
+  return { sendToTask, interruptTask, cancelTask, notifyStarted, dropPending }
 }
 
 function scopeDenied(record: TaskRecord, input: SendInput): SendOutcome | undefined {

--- a/packages/senpi-task/src/steering/types.ts
+++ b/packages/senpi-task/src/steering/types.ts
@@ -61,6 +61,9 @@ export type SteeringEngine = {
   cancelTask(idOrName: string, reason?: string): Promise<CancelOutcome>
   // Called by the manager right after a queued child launches: drains ordered pending messages.
   notifyStarted(taskId: string): Promise<void>
+  // Called by the manager when a task is forgotten (destroyed/evicted/failed to launch) so buffered
+  // messages for a child that will never start are not retained for the session.
+  dropPending(taskId: string): void
 }
 
 export type { TaskRecord }


### PR DESCRIPTION
## Summary

Third PR in the senpi-task memory series (follows #6170, #6171). Fixes three per-session growth leaks in the manager and steering engine.

### F6 — release guard grew per epoch, pruned by linear scan
`#released` was a `Set<string>` keyed by `${taskId}:${runEpoch}`, pruned only by a linear scan in `forget()`. A resident task revived N times left N keys for the whole session.

**Fix:** `Map<task_id, latestReleasedEpoch>`. Release is skipped only when the stored epoch `>= epoch`, so a revived task's higher epoch still releases; growth is bounded by live tasks and `forget()` prunes in O(1).

### F7 — transcript subscription leaked
`#launch` called `subscribeTranscriptLog(...)` and discarded the returned unsubscribe. The listener closure outlived the handle.

**Fix:** `LiveTask` now owns `unsubscribe`; `#launch`/`reattach` store it and `forget()` calls it. The cancelled-during-launch path uses a no-op (never subscribed).

### F8 — steering pending buffer stranded on failed launch
`pending` was drained only on start/cancel. A task that failed to launch (start not applied, or runner threw) stranded its queued messages.

**Fix:** added `SteeringEngine.dropPending(taskId)`, called by `forget()` and both launch-failure paths.

## QA evidence

Scripts + report under `.omo/evidence/20260717-pr3-senpi-task-manager-hygiene/` (gitignored).

```
F6: after 50 revive/complete cycles, releasedKeyCount = 1 (old Set would be 50)
F6: after forget(), releasedKeyCount = 0
F7: 20/20 subscribed on launch, 20/20 unsubscribed on forget (no listener leak)
F8: 30 pending tasks dropped; messages delivered after dropPending = 0 (expected 0)
```

## Tests

- `manager/manager-hygiene.test.ts` (new): bounded release guard, forget prunes guard + tears down subscription.
- `steering/engine.test.ts` (extended): `dropPending` discards the buffer.
- `manager/__fixtures__/manager-fakes.ts`: `makeHandle` tracks subscribe/unsubscribe counts.

```
bun test packages/senpi-task packages/omo-senpi  → 910 pass, 0 fail
bun run typecheck:packages  → exit 0
bun run build  → exit 0
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the task manager release guard, tears down transcript subscriptions on forget, and drops stranded steering buffers on failed launches to prevent session leaks in `senpi-task`.

- **Bug Fixes**
  - Release guard: replaced Set of `${taskId}:${epoch}` with `Map<task_id, latestEpoch>`; `forget()` now prunes in O(1) and growth is bounded.
  - Transcript subscriptions: `LiveTask` stores the unsubscribe; `forget()` calls it. Cancelled-during-launch uses a no-op.
  - Steering buffers: added `SteeringEngine.dropPending(taskId)` and call it on `forget()` and both launch-failure paths to avoid retaining pending messages.

<sup>Written for commit 814ca5b7f04f26f3f8957c96cc050568f30a3045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

