### PR TITLE
feat(boulder-state): add senpi session platform

### DIFF
--- a/packages/boulder-state/index.d.ts
+++ b/packages/boulder-state/index.d.ts
@@ -158,7 +158,7 @@ export declare function getWorkByPlanName(
 ): BoulderWorkState | null
 export declare function getWorkForSession(directory: string, sessionId: string): BoulderWorkState | null
 export declare function getWorkResumeOptions(directory: string): BoulderWorkResumeOption[]
-export declare function normalizeSessionId(sessionId: string, platform?: "codex" | "opencode"): string
+export declare function normalizeSessionId(sessionId: string, platform?: "codex" | "opencode" | "senpi"): string
 export declare function readBoulderState(directory: string): BoulderState | null
 export declare function resolveBoulderPlanPath(
   directory: string,

--- a/packages/boulder-state/src/read-state.test.ts
+++ b/packages/boulder-state/src/read-state.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from "bun:test"
 
 import type { BoulderState, BoulderWorkState } from "./types"
 import { getWorkForSession, readBoulderState } from "./storage/read-state"
+import { normalizeSessionId } from "./storage/shared"
 
 function createTempDirectory(): string {
   return mkdtempSync(join(tmpdir(), "boulder-read-state-"))
@@ -108,6 +109,20 @@ describe("readBoulderState", () => {
 
     // then
     expect(state).toBeNull()
+  })
+})
+
+describe("normalizeSessionId", () => {
+  test("#given bare id and senpi platform #when normalizing #then senpi prefix is applied", () => {
+    expect(normalizeSessionId("abc", "senpi")).toBe("senpi:abc")
+  })
+
+  test("#given already senpi-prefixed id #when normalizing #then id is unchanged", () => {
+    expect(normalizeSessionId("senpi:abc")).toBe("senpi:abc")
+  })
+
+  test("#given senpi-prefixed id with different platform #when normalizing #then prefix wins", () => {
+    expect(normalizeSessionId("senpi:abc", "codex")).toBe("senpi:abc")
   })
 })
 

--- a/packages/boulder-state/src/storage/shared.ts
+++ b/packages/boulder-state/src/storage/shared.ts
@@ -2,9 +2,12 @@ import type { BoulderState, BoulderWorkState, BoulderWorkStatus } from "../types
 
 export const RESERVED_KEYS = new Set(["__proto__", "prototype", "constructor"])
 
-type SessionPlatform = "codex" | "opencode"
+// Bare session ids default to "opencode" for legacy compatibility.
+// Senpi callers MUST pass pre-prefixed "senpi:<id>" to read APIs such as
+// getWorkForSession, because the default platform remains "opencode".
+type SessionPlatform = "codex" | "opencode" | "senpi"
 
-const SESSION_ID_PREFIX_PATTERN = /^(codex|opencode):/
+const SESSION_ID_PREFIX_PATTERN = /^(codex|opencode|senpi):/
 
 export function normalizeSessionId(sessionId: string, platform: SessionPlatform = "opencode"): string {
   if (SESSION_ID_PREFIX_PATTERN.test(sessionId)) {


### PR DESCRIPTION
## Summary
Adds `senpi` as a supported session platform in `boulder-state`, enabling senpi work to be tracked with `senpi:<session_id>` ids.

## Changes
- Widen `SessionPlatform` union and `SESSION_ID_PREFIX_PATTERN` to include `senpi`.
- Mirror the widened union in hand-maintained `index.d.ts`.
- Add unit tests for `normalizeSessionId` covering senpi prefix application, idempotency, and prefix-wins behavior.
- Document that bare ids still default to `opencode` for legacy compat and senpi callers must pass pre-prefixed ids to read APIs.

## QA Evidence
- `bun test packages/boulder-state` → 31 pass, 0 fail.
- Senpi id round-trip: `.omo/evidence/task-2-senpi-roundtrip.txt` → `{"found":true,"ids":["senpi:qa-1"]}`
- Default platform regression: `.omo/evidence/task-2-default-platform.txt` → `opencode:bare-id senpi:bare-id`

## Verification
- [x] Local typecheck passed (`tsgo --noEmit -p packages/boulder-state/tsconfig.json`).
- [x] Evidence captured to `.omo/evidence/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `senpi` as a supported session platform in `boulder-state`. Enables tracking and lookup using `senpi:<session_id>`.

- **New Features**
  - Include `senpi` in `SessionPlatform` and `SESSION_ID_PREFIX_PATTERN`.
  - Update `index.d.ts` to expose the new platform.
  - Add tests for `normalizeSessionId` (senpi prefix, idempotency, prefix precedence).

- **Migration**
  - Pass pre-prefixed `senpi:<id>` to read APIs like `getWorkForSession` (bare ids still default to `opencode`).

<sup>Written for commit 466677b4361e21bc9fb865800315f28af1f9714c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

