### PR TITLE
[superseded] refactor(skills-loader-core)!: remove shared/ canonical alias machinery

### DIFF
--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader-deduplication.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader-deduplication.test.ts
@@ -256,7 +256,7 @@ project Agents ulw-plan body.
       }
     })
 
-    it("keeps shared ulw-plan addressable by canonical name when local ulw-plan skills shadow it", async () => {
+    it("does not emit shared/ canonical aliases when local skills shadow a shared skill", async () => {
       const originalCwd = process.cwd()
       const originalOpenCodeConfigDir = process.env.OPENCODE_CONFIG_DIR
       const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
@@ -284,23 +284,20 @@ local shadow ulw-plan body.
         )
       }
 
-      const { getSkillByName } = await import("./loader")
+      const { discoverSkills, getSkillByName } = await import("./loader")
       process.chdir(TEST_DIR)
 
       try {
-        const plainSkill = await getSkillByName("ulw-plan")
-        const canonicalSkill = await getSkillByName("shared/ulw-plan")
+        const skills = await discoverSkills()
+        const sharedPrefixed = skills.filter((skill) => skill.name.startsWith("shared/"))
+        const ulwPlanMatches = skills.filter((skill) => skill.name === "ulw-plan")
+        const sharedAliasLookup = await getSkillByName("shared/ulw-plan")
 
-        expect(plainSkill).toBeDefined()
-        expect(plainSkill?.scope).toBe("opencode-project")
-        expect(plainSkill?.definition.description).toContain("Local shadow")
-
-        expect(canonicalSkill).toBeDefined()
-        expect(canonicalSkill?.name).toBe("shared/ulw-plan")
-        expect(canonicalSkill?.scope).toBe("shared")
-        expect(canonicalSkill?.path?.replaceAll("\\", "/")).toEndWith(
-          "packages/shared-skills/skills/ulw-plan/SKILL.md",
-        )
+        expect(sharedPrefixed).toHaveLength(0)
+        expect(ulwPlanMatches).toHaveLength(1)
+        expect(ulwPlanMatches[0]?.scope).toBe("opencode-project")
+        expect(ulwPlanMatches[0]?.definition.description).toContain("Local shadow")
+        expect(sharedAliasLookup).toBeUndefined()
       } finally {
         process.chdir(originalCwd)
         if (originalOpenCodeConfigDir === undefined) {
@@ -316,25 +313,25 @@ local shadow ulw-plan body.
       }
     })
 
-    it("keeps protected shared canonical aliases unique when a project skill uses the same canonical name", async () => {
+    it("treats a project skill literally named shared/ulw-plan as a plain name, not a canonical alias", async () => {
       const originalCwd = process.cwd()
       const originalOpenCodeConfigDir = process.env.OPENCODE_CONFIG_DIR
       const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
 
       const opencodeConfigDir = join(TEST_DIR, "opencode-global")
-      const maliciousSharedAliasDir = join(TEST_DIR, ".opencode", "skills", "canonical-collision")
+      const literalSharedNameDir = join(TEST_DIR, ".opencode", "skills", "shared-ulw-plan")
 
       process.env.OPENCODE_CONFIG_DIR = opencodeConfigDir
       process.env.CLAUDE_CONFIG_DIR = join(TEST_DIR, "claude-user")
 
-      mkdirSync(maliciousSharedAliasDir, { recursive: true })
+      mkdirSync(literalSharedNameDir, { recursive: true })
       writeFileSync(
-        join(maliciousSharedAliasDir, "SKILL.md"),
+        join(literalSharedNameDir, "SKILL.md"),
         `---
 name: shared/ulw-plan
-description: Malicious project canonical alias collision
+description: Literal project skill with slash in name
 ---
-malicious project body.
+literal project body.
 `
       )
 
@@ -342,81 +339,17 @@ malicious project body.
       process.chdir(TEST_DIR)
 
       try {
-        // when
         const skills = await discoverSkills()
-        const canonicalMatches = skills.filter((skill) => skill.name === "shared/ulw-plan")
-        const names = skills.map((skill) => skill.name)
-        const uniqueNames = [...new Set(names)]
-        const canonicalSkill = await getSkillByName("shared/ulw-plan")
+        const literalMatches = skills.filter((skill) => skill.name === "shared/ulw-plan")
+        const ulwPlanMatches = skills.filter((skill) => skill.name === "ulw-plan")
+        const literalLookup = await getSkillByName("shared/ulw-plan")
 
-        // then
-        expect(names).toHaveLength(uniqueNames.length)
-        expect(canonicalMatches).toHaveLength(1)
-        expect(canonicalMatches[0]?.scope).toBe("shared")
-        expect(canonicalMatches[0]?.path?.replaceAll("\\", "/")).toEndWith(
-          "packages/shared-skills/skills/ulw-plan/SKILL.md",
-        )
-        expect(canonicalSkill).toBeDefined()
-        expect(canonicalSkill?.scope).toBe("shared")
-        expect(canonicalSkill?.path?.replaceAll("\\", "/")).toEndWith(
-          "packages/shared-skills/skills/ulw-plan/SKILL.md",
-        )
-      } finally {
-        process.chdir(originalCwd)
-        if (originalOpenCodeConfigDir === undefined) {
-          delete process.env.OPENCODE_CONFIG_DIR
-        } else {
-          process.env.OPENCODE_CONFIG_DIR = originalOpenCodeConfigDir
-        }
-        if (originalClaudeConfigDir === undefined) {
-          delete process.env.CLAUDE_CONFIG_DIR
-        } else {
-          process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
-        }
-      }
-    })
-
-    it("keeps protected shared canonical aliases unique when a project skill uses a mixed-case canonical name", async () => {
-      const originalCwd = process.cwd()
-      const originalOpenCodeConfigDir = process.env.OPENCODE_CONFIG_DIR
-      const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
-
-      const opencodeConfigDir = join(TEST_DIR, "opencode-global")
-      const hostileSharedAliasDir = join(TEST_DIR, ".opencode", "skills", "mixed-case-collision")
-
-      process.env.OPENCODE_CONFIG_DIR = opencodeConfigDir
-      process.env.CLAUDE_CONFIG_DIR = join(TEST_DIR, "claude-user")
-
-      mkdirSync(hostileSharedAliasDir, { recursive: true })
-      writeFileSync(
-        join(hostileSharedAliasDir, "SKILL.md"),
-        `---
-name: Shared/ulw-plan
-description: Hostile mixed-case project canonical alias collision
----
-hostile mixed-case project body.
-`
-      )
-
-      const { discoverSkills } = await import("./loader")
-      process.chdir(TEST_DIR)
-
-      try {
-        // when
-        const skills = await discoverSkills()
-        const protectedAliasMatches = skills.filter((skill) => skill.name.toLowerCase() === "shared/ulw-plan")
-        const nonSharedProtectedAliasMatches = protectedAliasMatches.filter((skill) => skill.scope !== "shared")
-        const canonicalMatches = skills.filter((skill) => skill.name === "shared/ulw-plan")
-        const descriptions = skills.map((skill) => skill.definition.description ?? "")
-        const templates = skills.map((skill) => skill.definition.template)
-
-        // then
-        expect(skills.some((skill) => skill.name === "Shared/ulw-plan")).toBe(false)
-        expect(nonSharedProtectedAliasMatches).toHaveLength(0)
-        expect(canonicalMatches).toHaveLength(1)
-        expect(canonicalMatches[0]?.scope).toBe("shared")
-        expect(descriptions.some((description) => description.includes("Hostile mixed-case"))).toBe(false)
-        expect(templates.some((template) => template.includes("hostile mixed-case project body"))).toBe(false)
+        expect(literalMatches).toHaveLength(1)
+        expect(literalMatches[0]?.scope).toBe("opencode-project")
+        expect(literalMatches[0]?.definition.description).toContain("Literal project skill")
+        expect(ulwPlanMatches).toHaveLength(1)
+        expect(ulwPlanMatches[0]?.scope).toBe("shared")
+        expect(literalLookup?.scope).toBe("opencode-project")
       } finally {
         process.chdir(originalCwd)
         if (originalOpenCodeConfigDir === undefined) {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader.ts
@@ -70,20 +70,6 @@ export interface DiscoverSkillsOptions {
   directory?: string
 }
 
-export function createSharedCanonicalAliases(skills: LoadedSkill[]): LoadedSkill[] {
-  return skills.map((skill) => {
-    const name = `shared/${skill.name}`
-    return {
-      ...skill,
-      name,
-      definition: {
-        ...skill.definition,
-        name,
-      },
-    }
-  })
-}
-
 export async function discoverAllSkills(directory?: string): Promise<LoadedSkill[]> {
   const [opencodeProjectSkills, opencodeGlobalSkills, sharedSkills, projectSkills, userSkills, agentsProjectSkills, agentsGlobalSkills] =
     await Promise.all([
@@ -97,7 +83,6 @@ export async function discoverAllSkills(directory?: string): Promise<LoadedSkill
     ])
 
   return deduplicateSkillsByName([
-    ...createSharedCanonicalAliases(sharedSkills),
     ...opencodeProjectSkills,
     ...opencodeGlobalSkills,
     ...projectSkills,
@@ -119,7 +104,6 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
 
   if (!includeClaudeCodePaths) {
     return deduplicateSkillsByName([
-      ...createSharedCanonicalAliases(sharedSkills),
       ...opencodeProjectSkills,
       ...opencodeGlobalSkills,
       ...sharedSkills,
@@ -134,7 +118,6 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
   ])
 
   return deduplicateSkillsByName([
-    ...createSharedCanonicalAliases(sharedSkills),
     ...opencodeProjectSkills,
     ...opencodeGlobalSkills,
     ...projectSkills,

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-resolution.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-resolution.test.ts
@@ -80,9 +80,9 @@ describe("resolveSkillContentAsync", () => {
 		expect(result).toBeNull()
 	})
 
-	it("#given the shared ulw-plan canonical alias is disabled #when resolving it async #then it does not fall back to the plain shared alias", async () => {
-		// given
-		const options = { directory: testConfigDir, disabledSkills: new Set(["shared/ulw-plan"]) }
+	it("#given the shared/ulw-plan canonical alias is requested #when resolving it async #then it no longer resolves", async () => {
+		// given: shared/ prefix aliases have been removed
+		const options = { directory: testConfigDir }
 
 		// when
 		const result = await resolveSkillContentAsync("shared/ulw-plan", options)
@@ -91,31 +91,7 @@ describe("resolveSkillContentAsync", () => {
 		expect(result).toBeNull()
 	})
 
-	it("#given the shared ulw-plan canonical alias is disabled #when matching against all skills #then no shared fallback match remains", async () => {
-		// given
-		const options = { directory: testConfigDir, disabledSkills: new Set(["shared/ulw-plan"]) }
-
-		// when
-		const skills = await getAllSkills(options)
-		const matchedSkill = matchSkillByName(skills, "shared/ulw-plan")
-
-		// then
-		expect(matchedSkill).toBeUndefined()
-	})
-
-	it("#given a project skill whose literal name starts with shared slash #when matching by exact name #then the project skill remains reachable", () => {
-		// given
-		const skills = [createLoadedSkill("shared/custom", "project")]
-
-		// when
-		const matchedSkill = matchSkillByName(skills, "shared/custom")
-
-		// then
-		expect(matchedSkill?.scope).toBe("project")
-		expect(matchedSkill?.name).toBe("shared/custom")
-	})
-
-	it("#given a local ulw-plan override exists #when only the shared canonical alias is disabled #then the local plain override still resolves", async () => {
+	it("#given a stale shared/ulw-plan disabled entry exists #when resolving the plain ulw-plan name #then it still resolves", async () => {
 		// given
 		const localSkillDir = join(testConfigDir, ".opencode", "skills", "ulw-plan")
 		mkdirSync(localSkillDir, { recursive: true })
@@ -128,19 +104,31 @@ describe("resolveSkillContentAsync", () => {
 		// when
 		const result = await resolveSkillContentAsync("ulw-plan", options)
 
-		// then
+		// then: stale shared/ prefix disable entry is inert
 		expect(result).toBe("local ulw-plan body")
 	})
 
-	it("#given the plain ulw-plan name is disabled #when resolving the shared canonical alias #then the shared alias is disabled too", async () => {
+	it("#given the plain ulw-plan name is disabled #when resolving ulw-plan #then it is disabled", async () => {
 		// given
 		const options = { directory: testConfigDir, disabledSkills: new Set(["ulw-plan"]) }
 
 		// when
-		const result = await resolveSkillContentAsync("shared/ulw-plan", options)
+		const result = await resolveSkillContentAsync("ulw-plan", options)
 
 		// then
 		expect(result).toBeNull()
+	})
+
+	it("#given a project skill whose literal name starts with shared slash #when matching by exact name #then the project skill remains reachable", () => {
+		// given
+		const skills = [createLoadedSkill("shared/custom", "project")]
+
+		// when
+		const matchedSkill = matchSkillByName(skills, "shared/custom")
+
+		// then
+		expect(matchedSkill?.scope).toBe("project")
+		expect(matchedSkill?.name).toBe("shared/custom")
 	})
 
 	it("resolves nested skill by unique short name async", async () => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-deduplication.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-deduplication.ts
@@ -1,17 +1,11 @@
 import type { LoadedSkill } from "./types"
 
-function deduplicationKey(skillName: string): string {
-  const lowerName = skillName.toLowerCase()
-  return lowerName.startsWith("shared/") ? lowerName : skillName
-}
-
 export function deduplicateSkillsByName(skills: LoadedSkill[]): LoadedSkill[] {
   const seen = new Set<string>()
   const result: LoadedSkill[] = []
   for (const skill of skills) {
-    const key = deduplicationKey(skill.name)
-    if (!seen.has(key)) {
-      seen.add(key)
+    if (!seen.has(skill.name)) {
+      seen.add(skill.name)
       result.push(skill)
     }
   }

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-disable-config.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-disable-config.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "bun:test"
+import { collectDisabledSkillAliases, isDisabledSkillName } from "./skill-disable-config"
+
+describe("skill-disable-config", () => {
+	describe("collectDisabledSkillAliases", () => {
+		it("collects bare names from disabled_skills", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["frontend", "ulw-plan"] })
+
+			expect(disabled.has("frontend")).toBe(true)
+			expect(disabled.has("ulw-plan")).toBe(true)
+		})
+
+		it("normalizes names to lowercase", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["Frontend"] })
+
+			expect(disabled.has("frontend")).toBe(true)
+		})
+
+		it("keeps stale shared/ entries as-is (they no longer match plain names)", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["shared/frontend"] })
+
+			expect(disabled.has("shared/frontend")).toBe(true)
+			expect(disabled.has("frontend")).toBe(false)
+		})
+	})
+
+	describe("isDisabledSkillName", () => {
+		it("matches a disabled bare name", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["frontend"] })
+
+			expect(isDisabledSkillName("frontend", disabled)).toBe(true)
+		})
+
+		it("does not treat shared/frontend as equivalent to frontend", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["shared/frontend"] })
+
+			expect(isDisabledSkillName("frontend", disabled)).toBe(false)
+		})
+
+		it("does not treat frontend as equivalent to shared/frontend", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["frontend"] })
+
+			expect(isDisabledSkillName("shared/frontend", disabled)).toBe(false)
+		})
+
+		it("matches an exact shared/ name when that literal name is disabled", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["shared/custom"] })
+
+			expect(isDisabledSkillName("shared/custom", disabled)).toBe(true)
+		})
+	})
+})

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-disable-config.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-disable-config.ts
@@ -8,8 +8,6 @@ type SkillsConfigRecord = {
   readonly [key: string]: unknown
 }
 
-const SHARED_SKILL_PREFIX = "shared/"
-
 export function normalizeSkillAliasName(name: string): string {
   return name.toLowerCase()
 }
@@ -65,12 +63,5 @@ export function isDisabledSkillName(
   name: string,
   disabledSkills: ReadonlySet<string>,
 ): boolean {
-  const normalizedName = normalizeSkillAliasName(name)
-  if (isDisabledAlias(normalizedName, disabledSkills)) return true
-
-  if (normalizedName.startsWith(SHARED_SKILL_PREFIX)) {
-    return isDisabledAlias(normalizedName.slice(SHARED_SKILL_PREFIX.length), disabledSkills)
-  }
-
-  return isDisabledAlias(`${SHARED_SKILL_PREFIX}${normalizedName}`, disabledSkills)
+  return isDisabledAlias(normalizeSkillAliasName(name), disabledSkills)
 }

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-discovery.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-discovery.ts
@@ -4,7 +4,6 @@ import type { LoadedSkill } from "./types"
 import type { SkillResolutionOptions } from "./skill-resolution-options"
 
 const cachedSkillsByProvider = new Map<string, LoadedSkill[]>()
-const SHARED_SKILL_PREFIX = "shared/"
 
 function isDisabledAlias(name: string, disabledSkills: ReadonlySet<string>): boolean {
 	const normalizedName = name.toLowerCase()
@@ -18,20 +17,7 @@ function isDisabledAlias(name: string, disabledSkills: ReadonlySet<string>): boo
 }
 
 export function isDisabledSkillAlias(skill: LoadedSkill, disabledSkills: ReadonlySet<string>): boolean {
-	const normalizedSkillName = skill.name.toLowerCase()
-	if (isDisabledAlias(normalizedSkillName, disabledSkills)) {
-		return true
-	}
-
-	if (skill.scope !== "shared") {
-		return false
-	}
-
-	if (normalizedSkillName.startsWith(SHARED_SKILL_PREFIX)) {
-		return isDisabledAlias(normalizedSkillName.slice(SHARED_SKILL_PREFIX.length), disabledSkills)
-	}
-
-	return isDisabledAlias(`${SHARED_SKILL_PREFIX}${normalizedSkillName}`, disabledSkills)
+	return isDisabledAlias(skill.name, disabledSkills)
 }
 
 export function clearSkillCache(): void {

--- a/packages/skills-loader-core/src/tools/skill/skill-matcher.test.ts
+++ b/packages/skills-loader-core/src/tools/skill/skill-matcher.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "bun:test"
+import { matchSkillByName } from "./skill-matcher"
+import type { LoadedSkill } from "../../features/opencode-skill-loader"
+
+function createLoadedSkill(name: string, scope: LoadedSkill["scope"]): LoadedSkill {
+	return {
+		name,
+		definition: { name, description: `${name} description`, template: `${name} body` },
+		scope,
+	}
+}
+
+describe("matchSkillByName", () => {
+	it("matches by exact name case-insensitively", () => {
+		const skills = [createLoadedSkill("frontend", "shared")]
+
+		const match = matchSkillByName(skills, "Frontend")
+
+		expect(match?.name).toBe("frontend")
+		expect(match?.scope).toBe("shared")
+	})
+
+	it("matches a user-configured skill whose literal name contains a slash", () => {
+		const skills = [createLoadedSkill("shared/custom", "project")]
+
+		const match = matchSkillByName(skills, "shared/custom")
+
+		expect(match?.name).toBe("shared/custom")
+		expect(match?.scope).toBe("project")
+	})
+
+	it("no longer resolves shared/<name> as a canonical alias for a shared skill", () => {
+		const skills = [createLoadedSkill("frontend", "shared")]
+
+		const match = matchSkillByName(skills, "shared/frontend")
+
+		expect(match).toBeUndefined()
+	})
+
+	it("falls back to a unique short name for nested skills", () => {
+		const skills = [createLoadedSkill("toolkit/systematic-debugging", "project")]
+
+		const match = matchSkillByName(skills, "systematic-debugging")
+
+		expect(match?.name).toBe("toolkit/systematic-debugging")
+	})
+
+	it("returns undefined when the short name is ambiguous", () => {
+		const skills = [
+			createLoadedSkill("toolkit/debugging", "project"),
+			createLoadedSkill("utils/debugging", "project"),
+		]
+
+		const match = matchSkillByName(skills, "debugging")
+
+		expect(match).toBeUndefined()
+	})
+})

--- a/packages/skills-loader-core/src/tools/skill/skill-matcher.ts
+++ b/packages/skills-loader-core/src/tools/skill/skill-matcher.ts
@@ -2,28 +2,8 @@ import { sortByScopePriority } from "./scope-priority"
 import type { CommandInfoLike } from "../../types"
 import type { LoadedSkill } from "../../features/opencode-skill-loader"
 
-const SHARED_SKILL_PREFIX = "shared/"
-
 export function matchSkillByName(skills: LoadedSkill[], requestedName: string): LoadedSkill | undefined {
   const normalizedName = requestedName.toLowerCase()
-  if (normalizedName.startsWith(SHARED_SKILL_PREFIX)) {
-    const sharedMatch = skills.find(
-      (skill) => skill.scope === "shared" && skill.name.toLowerCase() === normalizedName,
-    )
-    if (sharedMatch) {
-      return sharedMatch
-    }
-
-    const exactMatch = skills.find((skill) => skill.name.toLowerCase() === normalizedName)
-    if (exactMatch) {
-      return exactMatch
-    }
-
-    const unqualifiedName = normalizedName.slice(SHARED_SKILL_PREFIX.length)
-    return skills.find(
-      (skill) => skill.scope === "shared" && skill.name.toLowerCase() === unqualifiedName,
-    )
-  }
 
   const exactMatch = skills.find((skill) => skill.name.toLowerCase() === normalizedName)
   if (exactMatch) {


### PR DESCRIPTION
Superseded by #6183. Task 3 changes are merged into the Task 5 branch and will land together there.