### PR TITLE
perf(senpi-task): incremental lead-poller session scan and status-ui disposer

### DIFF
--- a/packages/omo-senpi/src/components/task/event-bridge.ts
+++ b/packages/omo-senpi/src/components/task/event-bridge.ts
@@ -70,6 +70,7 @@ export function wireEventBridge(
     engine.runtime.captureFrom(asLiveContext(eventCtx))
     transitions.onShutdown(engine.runtime.sessionId())
     engine.runtime.clearUi()
+    statusUi.dispose()
     state.leadPollers.shutdown()
     await engine.lifecycle.teardownOnSessionShutdown()
   })

--- a/packages/omo-senpi/src/components/task/index.test.ts
+++ b/packages/omo-senpi/src/components/task/index.test.ts
@@ -80,7 +80,7 @@ function fakeUi(): CapturedUi {
   }
 }
 
-const noopStatusUi = { scheduleSync: () => {}, syncNow: () => {} }
+const noopStatusUi = { scheduleSync: () => {}, syncNow: () => {}, dispose: () => {} }
 
 // Build the real engine and wire its event bridge over a fake ExtensionAPI so tests can drive the
 // registered handlers and observe the captured-ui bridge (todo 18: cleared on switch/shutdown).

--- a/packages/omo-senpi/src/components/task/status-ui.test.ts
+++ b/packages/omo-senpi/src/components/task/status-ui.test.ts
@@ -406,4 +406,34 @@ describe("createTaskStatusUi.scheduleSync", () => {
     // then exactly one sync ran
     expect(ui.statusCalls).toHaveLength(1)
   })
+
+  it("#given a pending debounce #when dispose is called #then the timer is cleared and syncNow never runs", () => {
+    // given a controllable timer with a pending scheduled sync
+    const active = new Map<number, () => void>()
+    let nextHandle = 1
+    let cleared = 0
+    const timers: StatusUiTimers = {
+      set: (callback) => {
+        const handle = nextHandle++
+        active.set(handle, callback)
+        return handle
+      },
+      clear: (handle) => {
+        if (typeof handle === "number" && active.delete(handle)) cleared += 1
+      },
+    }
+    const ui = fakeUi()
+    const manager = fakeManager([record({ task_id: "st_1", status: "running" })])
+    const statusUi = createTaskStatusUi({ manager, runtime: runtimeOf(ui, "session-a", "tui"), timers })
+    statusUi.scheduleSync()
+    expect(active.size).toBe(1)
+
+    // when the component is disposed before the debounce elapses
+    statusUi.dispose()
+
+    // then the pending timer is cleared and no render happens
+    expect(cleared).toBe(1)
+    expect(active.size).toBe(0)
+    expect(ui.statusCalls).toHaveLength(0)
+  })
 })

--- a/packages/omo-senpi/src/components/task/status-ui.ts
+++ b/packages/omo-senpi/src/components/task/status-ui.ts
@@ -52,6 +52,8 @@ export interface TaskStatusUi {
   scheduleSync(): void
   // Immediate render (used on session/model events and internally by the debounce timer).
   syncNow(): void
+  // Cancel any pending debounce timer so shutdown does not leave a render scheduled past teardown.
+  dispose(): void
 }
 
 function isTerminal(status: TaskStatus): boolean {
@@ -196,7 +198,14 @@ export function createTaskStatusUi(deps: TaskStatusUiDeps): TaskStatusUi {
     }, debounceMs)
   }
 
-  return { scheduleSync, syncNow }
+  function dispose(): void {
+    if (pending !== undefined) {
+      timers.clear(pending)
+      pending = undefined
+    }
+  }
+
+  return { scheduleSync, syncNow, dispose }
 }
 
 function scopedRecords(manager: StatusUiManager, sessionId: string | undefined): readonly TaskRecord[] {

--- a/packages/senpi-task/src/team/messaging/lead-poller.ts
+++ b/packages/senpi-task/src/team/messaging/lead-poller.ts
@@ -9,6 +9,7 @@ import { MessageSchema, type Message } from "@oh-my-opencode/team-core/types"
 import type { PersistedTaskEvent } from "../../store"
 import { TEAM_LEAD_SENTINEL } from "../normalize"
 import { buildPeerMessageEnvelope } from "./message"
+import { createSessionMarkerIndex, type SessionMarkerIndex } from "./session-marker-index"
 import type { WaitClaim, WaitRegistry } from "./wait-registry"
 
 const DEAD_PID_LEASE_STALE_MS = 0
@@ -33,7 +34,11 @@ export type LeadPollerDeps = {
 type PendingPhase = "awaiting_flush" | "awaiting_persistence" | "recovery"
 
 type PendingDelivery = { readonly message: Message; readonly reservation: DeliveryReservation; phase: PendingPhase }
-type LeadPollState = { readonly pending: Map<string, PendingDelivery>; readonly isStopped: () => boolean }
+type LeadPollState = {
+  readonly pending: Map<string, PendingDelivery>
+  readonly isStopped: () => boolean
+  readonly markerIndex: SessionMarkerIndex
+}
 
 class InvalidReservedLeadMessageError extends Error {
   readonly path: string
@@ -47,7 +52,7 @@ class InvalidReservedLeadMessageError extends Error {
 export function createLeadPoller(deps: LeadPollerDeps): LeadPoller {
   const pending = new Map<string, PendingDelivery>()
   let stopped = false
-  const state: LeadPollState = { pending, isStopped: () => stopped }
+  const state: LeadPollState = { pending, isStopped: () => stopped, markerIndex: createSessionMarkerIndex() }
   const withLease = <T>(fn: () => Promise<T>): Promise<T> => withInboxConsumerLease(
     deps.teamRunId, TEAM_LEAD_SENTINEL, deps.config, fn, { staleAfterMs: DEAD_PID_LEASE_STALE_MS },
   )
@@ -85,7 +90,7 @@ async function settlePending(deps: LeadPollerDeps, state: LeadPollState): Promis
     }
     const sessionFile = deps.leadSessionFile?.()
     if (sessionFile === undefined) continue
-    const persisted = await sessionFileContainsMessage(sessionFile, delivery.message.messageId)
+    const persisted = await state.markerIndex.contains(sessionFile, delivery.message.messageId)
     if (!persisted && !releaseWhenMissing) continue
     if (!persisted) {
       await releaseDeliveryReservation(delivery.reservation)
@@ -114,7 +119,7 @@ async function processMessage(deps: LeadPollerDeps, message: Message, state: Lea
   }
 
   const sessionFile = deps.leadSessionFile?.()
-  if (sessionFile !== undefined && await sessionFileContainsMessage(sessionFile, message.messageId)) {
+  if (await state.markerIndex.contains(sessionFile, message.messageId)) {
     await commitDeliveryReservation(reservation)
     appendDeliveredEvent(deps, message)
     return
@@ -196,7 +201,7 @@ async function recoverReservations(deps: LeadPollerDeps, state: LeadPollState): 
     const sessionFile = deps.leadSessionFile?.()
     if (sessionFile === undefined) {
       state.pending.set(message.messageId, { message, reservation, phase: "recovery" })
-    } else if (await sessionFileContainsMessage(sessionFile, message.messageId)) {
+    } else if (await state.markerIndex.contains(sessionFile, message.messageId)) {
       await commitDeliveryReservation(reservation)
       appendDeliveredEvent(deps, message)
     } else {
@@ -216,36 +221,6 @@ async function readReservedMessage(path: string): Promise<Message> {
   const parsed = MessageSchema.safeParse(value)
   if (!parsed.success) throw new InvalidReservedLeadMessageError(path)
   return parsed.data
-}
-
-async function sessionFileContainsMessage(path: string, messageId: string): Promise<boolean> {
-  let text: string
-  try {
-    text = await readFile(path, "utf8")
-  } catch (error) {
-    if (isMissingPath(error)) return false
-    throw error
-  }
-  return text.split("\n").some((line) => containsEnvelopeMarker(parseJsonLine(line), messageId))
-}
-
-function parseJsonLine(line: string): unknown {
-  if (line.trim().length === 0) return undefined
-  try {
-    return JSON.parse(line)
-  } catch (error) {
-    if (error instanceof SyntaxError) return undefined
-    throw error
-  }
-}
-
-function containsEnvelopeMarker(value: unknown, messageId: string): boolean {
-  if (typeof value === "string") {
-    return value.includes("<peer_message ") && value.includes(`messageId="${messageId}"`)
-  }
-  if (Array.isArray(value)) return value.some((entry) => containsEnvelopeMarker(entry, messageId))
-  if (!isRecord(value)) return false
-  return Object.values(value).some((entry) => containsEnvelopeMarker(entry, messageId))
 }
 
 function appendDeliveredEvent(deps: LeadPollerDeps, message: Message): void {
@@ -268,10 +243,6 @@ function appendWaitedEvent(deps: LeadPollerDeps, message: Message): void {
 
 function inboxDir(deps: LeadPollerDeps): string {
   return getInboxDir(resolveBaseDir(deps.config), deps.teamRunId, TEAM_LEAD_SENTINEL)
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function isMissingPath(error: unknown): boolean {

--- a/packages/senpi-task/src/team/messaging/session-marker-index.test.ts
+++ b/packages/senpi-task/src/team/messaging/session-marker-index.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import type { Message } from "@oh-my-opencode/team-core/types"
+
+import { buildPeerMessageEnvelope } from "./message"
+import { createSessionMarkerIndex } from "./session-marker-index"
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function tempSessionFile(): string {
+  const root = mkdtempSync(join(tmpdir(), "senpi-marker-index-"))
+  roots.push(root)
+  return join(root, "session.jsonl")
+}
+
+function envelopeLine(messageId: string): string {
+  const value: Message = { version: 1, messageId, from: "alpha", to: "lead", kind: "message", body: "ready", timestamp: 1 }
+  const entry = { type: "message", message: { role: "user", content: buildPeerMessageEnvelope(value) } }
+  return `${JSON.stringify(entry)}\n`
+}
+
+// Counting reader: records how many bytes each slice read consumes so tests can prove the index
+// reads incrementally (only appended bytes) instead of re-reading the whole session file.
+function countingReader(counter: { bytes: number }) {
+  return async (path: string, start: number, end: number): Promise<string> => {
+    counter.bytes += end - start
+    const text = await readFile(path, "utf8")
+    return text.slice(start, end)
+  }
+}
+
+describe("createSessionMarkerIndex", () => {
+  test("#given a session file with an envelope #when contains is queried #then it finds the messageId", async () => {
+    // given
+    const file = tempSessionFile()
+    writeFileSync(file, envelopeLine("id-1"), "utf8")
+    const index = createSessionMarkerIndex()
+
+    // when / then
+    expect(await index.contains(file, "id-1")).toBe(true)
+    expect(await index.contains(file, "id-missing")).toBe(false)
+  })
+
+  test("#given repeated queries on an unchanged file #when contains runs again #then no bytes are re-read", async () => {
+    // given
+    const file = tempSessionFile()
+    writeFileSync(file, envelopeLine("id-1"), "utf8")
+    const counter = { bytes: 0 }
+    const index = createSessionMarkerIndex(countingReader(counter))
+
+    // when
+    await index.contains(file, "id-1")
+    const afterFirst = counter.bytes
+    await index.contains(file, "id-1")
+    await index.contains(file, "id-1")
+
+    // then the file was read once; subsequent idle queries read nothing
+    expect(afterFirst).toBeGreaterThan(0)
+    expect(counter.bytes).toBe(afterFirst)
+  })
+
+  test("#given an appended envelope #when contains runs #then only the appended bytes are read", async () => {
+    // given
+    const file = tempSessionFile()
+    writeFileSync(file, envelopeLine("id-1"), "utf8")
+    const counter = { bytes: 0 }
+    const index = createSessionMarkerIndex(countingReader(counter))
+    await index.contains(file, "id-1")
+    const afterFirst = counter.bytes
+
+    // when a second envelope is appended
+    const second = envelopeLine("id-2")
+    appendFileSync(file, second, "utf8")
+    const found = await index.contains(file, "id-2")
+
+    // then only the appended slice was read (not the whole file again)
+    expect(found).toBe(true)
+    expect(counter.bytes - afterFirst).toBe(Buffer.byteLength(second, "utf8"))
+    expect(await index.contains(file, "id-1")).toBe(true)
+  })
+
+  test("#given a missing session file #when contains runs #then it returns false", async () => {
+    // given
+    const index = createSessionMarkerIndex()
+
+    // when / then
+    expect(await index.contains(join(tmpdir(), "does-not-exist-senpi.jsonl"), "id-1")).toBe(false)
+    expect(await index.contains(undefined, "id-1")).toBe(false)
+  })
+
+  test("#given a truncated/rotated file #when contains runs #then the index resets and rescans", async () => {
+    // given an append-only file with two envelopes
+    const file = tempSessionFile()
+    writeFileSync(file, envelopeLine("id-old-1") + envelopeLine("id-old-2"), "utf8")
+    const index = createSessionMarkerIndex()
+    expect(await index.contains(file, "id-old-2")).toBe(true)
+
+    // when the file is truncated to a smaller size (rotation/reset)
+    writeFileSync(file, envelopeLine("id-new"), "utf8")
+
+    // then the shrink is detected, the index resets, and the new content is visible
+    expect(await index.contains(file, "id-new")).toBe(true)
+  })
+})

--- a/packages/senpi-task/src/team/messaging/session-marker-index.ts
+++ b/packages/senpi-task/src/team/messaging/session-marker-index.ts
@@ -1,0 +1,87 @@
+import { open, stat } from "node:fs/promises"
+
+// Reads the byte range [start, end) of a session JSONL file. Injectable so tests can count bytes.
+export type SessionSliceReader = (path: string, start: number, end: number) => Promise<string>
+
+// Incremental index over a lead's append-only session JSONL. The lead poller must check, many times
+// per tick, whether a peer-message envelope for a given messageId has been persisted. The naive check
+// re-read + re-split the ENTIRE file on every call (O(pending x fileSize) per tick). This index keeps
+// a per-path byte offset and the set of messageIds already seen, so each check reads only the bytes
+// appended since the last check (and reads NOTHING when the file has not grown).
+export type SessionMarkerIndex = {
+  contains(path: string | undefined, messageId: string): Promise<boolean>
+}
+
+type PathState = { offset: number; residual: string; readonly seen: Set<string> }
+
+// messageId="..." inside a persisted peer_message envelope. The envelope lives inside JSON-encoded
+// strings, so the quote before the id may be a raw " or an escaped \". Match both.
+const MESSAGE_ID_MARKER = /<peer_message [^>]*?messageId=\\?"([^"\\]+)\\?"/g
+
+export function createSessionMarkerIndex(readSlice: SessionSliceReader = defaultReadSlice): SessionMarkerIndex {
+  const states = new Map<string, PathState>()
+
+  async function refresh(path: string): Promise<Set<string> | null> {
+    let size: number
+    try {
+      size = (await stat(path)).size
+    } catch (error) {
+      if (isMissingPath(error)) return null
+      throw error
+    }
+
+    let state = states.get(path)
+    if (state === undefined || size < state.offset) {
+      // First sight, or the file shrank (rotation/truncation): start clean and rescan from zero.
+      state = { offset: 0, residual: "", seen: new Set<string>() }
+      states.set(path, state)
+    }
+    if (size === state.offset) return state.seen
+
+    const chunk = await readSlice(path, state.offset, size)
+    state.offset = size
+    const text = state.residual + chunk
+    const lastNewline = text.lastIndexOf("\n")
+    const complete = lastNewline < 0 ? "" : text.slice(0, lastNewline + 1)
+    state.residual = lastNewline < 0 ? text : text.slice(lastNewline + 1)
+    for (const id of extractMessageIds(complete)) state.seen.add(id)
+    return state.seen
+  }
+
+  return {
+    async contains(path, messageId) {
+      if (path === undefined) return false
+      const seen = await refresh(path)
+      return seen !== null && seen.has(messageId)
+    },
+  }
+}
+
+function extractMessageIds(text: string): string[] {
+  const ids: string[] = []
+  MESSAGE_ID_MARKER.lastIndex = 0
+  let match = MESSAGE_ID_MARKER.exec(text)
+  while (match !== null) {
+    const id = match[1]
+    if (id !== undefined) ids.push(id)
+    match = MESSAGE_ID_MARKER.exec(text)
+  }
+  return ids
+}
+
+async function defaultReadSlice(path: string, start: number, end: number): Promise<string> {
+  const length = end - start
+  if (length <= 0) return ""
+  const handle = await open(path, "r")
+  try {
+    const buffer = Buffer.allocUnsafe(length)
+    const { bytesRead } = await handle.read(buffer, 0, length, start)
+    return buffer.toString("utf8", 0, bytesRead)
+  } finally {
+    await handle.close()
+  }
+}
+
+function isMissingPath(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT"
+}


### PR DESCRIPTION
## Summary

Fourth PR in the senpi-task memory/performance series (follows #6170, #6171, #6172).

### F9 - lead poller re-read the whole session JSONL per check
`sessionFileContainsMessage` did `readFile` + `split("\n")` over the **entire** lead session transcript on every check, called in `settlePending` (per pending), `processMessage` (per message), and `recoverReservations` (per reservation). One `pollOnce` was O(pending x fileSize), every second.

**Fix:** new `team/messaging/session-marker-index.ts` - a byte-offset index over the append-only session JSONL. Each `contains(path, id)` stats the file and reads only bytes appended since the last check (nothing when unchanged), extracting `messageId`s in one regex pass. Shrink/rotation resets it. The poller owns one index for its lifetime; all three call sites use it.

### F11 - status-UI debounce timer had no disposer
The 250 ms debounce kept the event loop alive on `session_shutdown` and could fire `syncNow` after teardown.

**Fix:** `createTaskStatusUi` now returns `dispose()`; `event-bridge` calls it in the `session_shutdown` handler alongside the lead-poller shutdown.

## QA evidence

Scripts + report under `.omo/evidence/20260717-pr4-senpi-task-poller-misc/` (gitignored).

```
Session file: 5000 lines, 1864 KB
OLD full re-read x200: 78.8 ms, 364.1 MB read
NEW byte-offset x200:   8.3 ms, 1864 KB read once
Speed-up: 9.5x; bytes read reduced 200x
After append, contains('appended-1') = true (incremental)
Idle re-check = true (no new bytes read)
```

## Tests

- `team/messaging/session-marker-index.test.ts` (new): finds envelopes, idle reads nothing, reads only appended bytes, missing-path false, truncation reset.
- `team/messaging/lead-poller.test.ts` (unchanged, green): crash/recovery/JSONL-dedup proves behavior preserved.
- `components/task/status-ui.test.ts` (extended): dispose clears the debounce timer.

```
bun test packages/senpi-task packages/omo-senpi  -> 912 pass, 0 fail
bun run typecheck:packages  -> exit 0
bun run build  -> exit 0
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized the lead poller to scan session JSONL incrementally and added a disposer to the task status UI to stop the debounce timer on shutdown. This cuts I/O, speeds up polling, and prevents stray renders after teardown.

- **Refactors**
  - Added `createSessionMarkerIndex` to read only appended bytes and cache seen `messageId`s; used in `settlePending`, `processMessage`, and `recoverReservations`.
  - Polling no longer scales with file size; measured ~9.5x faster with ~200x less I/O on a 1.8 MB session.

- **Bug Fixes**
  - `createTaskStatusUi` now exposes `dispose()` to clear the 250 ms debounce timer.
  - `event-bridge` calls `statusUi.dispose()` on `session_shutdown` to avoid post-teardown `syncNow` calls.

<sup>Written for commit 25a58dc6a7ed2909f06a277fafe0e52aef91ce9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

