### PR TITLE
feat(omo-senpi): boulder start-work continuation component

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -218,6 +218,7 @@
       "version": "4.18.2",
       "dependencies": {
         "@code-yeongyu/lsp-daemon": "file:../lsp-daemon",
+        "@oh-my-opencode/boulder-state": "workspace:*",
         "@oh-my-opencode/comment-checker-core": "workspace:*",
         "@oh-my-opencode/delegate-core": "workspace:*",
         "@oh-my-opencode/lsp-core": "workspace:*",

--- a/packages/omo-senpi/AGENTS.md
+++ b/packages/omo-senpi/AGENTS.md
@@ -10,7 +10,7 @@ This package is adapter-only. It may depend on harness-neutral core packages plu
 |------|---------|
 | `package.json` | Private workspace package `@oh-my-opencode/omo-senpi`; exports the adapter, extension, and local installer entrypoints. |
 | `src/extension/` | Senpi ExtensionAPI composition layer. It validates the required API surface, registers global and per-component disable flags, and wires components defensively. |
-| `src/components/` | Six live components: `ultrawork`, `ulw-loop`, `comment-checker`, `telemetry`, `lsp`, and `task`. |
+| `src/components/` | Seven live components: `ultrawork`, `start-work-continuation`, `ulw-loop`, `comment-checker`, `telemetry`, `lsp`, and `task`. |
 | `src/install/` | Local Senpi installer and uninstaller helpers. They add or remove the absolute plugin path in `SENPI_CODING_AGENT_DIR` or `~/.senpi/agent` settings. |
 | `scripts/qa/` | Live Senpi QA drivers, continuation probe, and mock provider used by task 13 validation. |
 | `plugin/` | The single Pi package `@code-yeongyu/omo-senpi`. It contains generated `extensions/omo.js`, generated skills, package metadata, and plugin-local build scripts. |
@@ -20,7 +20,8 @@ The v1 install surface is local-path only. Install the built Pi package from `pa
 ## Components
 
 - `ultrawork`: injects the Senpi ultrawork directive on matching input, backed by `src/components/ultrawork/generated-directive.ts`.
-- `ulw-loop`: detects active `omo ulw-loop` state and injects continuation guidance when the cwd has an incomplete run.
+- `start-work-continuation`: reads `.omo/boulder.json` on `agent_end` (the Senpi analog of Codex's Stop hook) and injects a continuation directive when the current session owns an active or paused Prometheus work plan. It uses `senpi:<session_id>` state produced by the `start-work` skill, suppresses repeats by a `work_id:updated_at:completed/total` signature, and caps consecutive continuations at 8 (reset on user input). It registers before `ulw-loop` so active boulder work takes precedence over ulw-loop continuation.
+- `ulw-loop`: detects active `omo ulw-loop` state and injects continuation guidance when the cwd has an incomplete run. It explicitly defers to `start-work-continuation` when boulder state is continuable for the same session.
 - `comment-checker`: runs the shared comment-checker flow after write-like tool results when a resolver finds the binary.
 - `telemetry`: sends the anonymous once-per-UTC-day `omo_senpi_daily_active` event, with product-specific opt-outs.
 - `lsp`: registers direct LSP tools and optional post-edit diagnostics through the packaged shared LSP daemon runtime. The Senpi adapter owns only descriptors, schemas, renderers, path extraction, and project-config migration warnings.

--- a/packages/omo-senpi/package.json
+++ b/packages/omo-senpi/package.json
@@ -33,6 +33,7 @@
     "@oh-my-opencode/omo-config-core": "workspace:*",
     "@oh-my-opencode/delegate-core": "workspace:*",
     "@oh-my-opencode/team-core": "workspace:*",
+    "@oh-my-opencode/boulder-state": "workspace:*",
     "@code-yeongyu/lsp-daemon": "file:../lsp-daemon"
   },
   "peerDependencies": {

--- a/packages/omo-senpi/src/components/start-work-continuation/boulder-eligibility.ts
+++ b/packages/omo-senpi/src/components/start-work-continuation/boulder-eligibility.ts
@@ -1,0 +1,36 @@
+import {
+  getPlanChecklist,
+  getWorkForSession,
+  resolveBoulderPlanPathForWork,
+  type BoulderWorkState,
+  type PlanChecklist,
+} from "@oh-my-opencode/boulder-state"
+
+export interface ContinuableWork {
+  readonly work: BoulderWorkState
+  readonly planPath: string
+  readonly checklist: PlanChecklist
+}
+
+export function findContinuableBoulderWork(
+  cwd: string,
+  sessionId: string,
+): ContinuableWork | null {
+  const work = getWorkForSession(cwd, `senpi:${sessionId}`)
+  if (!work) {
+    return null
+  }
+
+  if (work.status !== "active" && work.status !== "paused") {
+    return null
+  }
+
+  const planPath = resolveBoulderPlanPathForWork(cwd, work)
+  const checklist = getPlanChecklist(planPath)
+  if (checklist.total <= 0) {
+    return null
+  }
+
+  return { work, planPath, checklist }
+}
+

--- a/packages/omo-senpi/src/components/start-work-continuation/index.test.ts
+++ b/packages/omo-senpi/src/components/start-work-continuation/index.test.ts
@@ -1,0 +1,464 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "bun:test"
+
+import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
+import { IdleInjectionCoordinator } from "../../extension/idle-injection-coordinator"
+import type { ComponentContext } from "../../extension/types"
+import { createStartWorkContinuationComponent } from "./index"
+
+const cleanupRoots: string[] = []
+
+function cleanupAll(): void {
+  for (const root of cleanupRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function createTempWorkspace(): string {
+  const root = mkdtempSync(join(tmpdir(), "senpi-start-work-"))
+  cleanupRoots.push(root)
+  mkdirSync(join(root, ".omo", "plans"), { recursive: true })
+  mkdirSync(join(root, ".omo", "start-work"), { recursive: true })
+  return root
+}
+
+function writePlan(root: string, name: string, content: string): void {
+  writeFileSync(join(root, ".omo", "plans", `${name}.md`), content)
+}
+
+function writeBoulderJson(root: string, content: unknown): void {
+  writeFileSync(join(root, ".omo", "boulder.json"), JSON.stringify(content))
+}
+
+function createLogger(): ComponentContext["logger"] & { entries: unknown[] } {
+  const entries: unknown[] = []
+  return {
+    info: (_message: string, details?: unknown) => entries.push({ level: "info", details }),
+    warn: (_message: string, details?: unknown) => entries.push({ level: "warn", details }),
+    error: (_message: string, details?: unknown) => entries.push({ level: "error", details }),
+    entries,
+  }
+}
+
+function eventCtx(root: string, sessionId: string): unknown {
+  return {
+    cwd: root,
+    sessionManager: { getSessionId: () => sessionId },
+  }
+}
+
+function makeCoordinator(): {
+  coordinator: IdleInjectionCoordinator
+  delivered: string[]
+} {
+  const delivered: string[] = []
+  const coordinator = new IdleInjectionCoordinator((content) => delivered.push(content))
+  return { coordinator, delivered }
+}
+
+describe("omo-senpi start-work-continuation", () => {
+  it("#given no boulder state #when agent_end fires #then stays quiet", async () => {
+    const root = createTempWorkspace()
+    const pi = new FakeExtensionAPI()
+    const logger = createLogger()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger,
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+
+    expect(delivered).toEqual([])
+    expect(pi.userMessages).toEqual([])
+  })
+
+  it("#given malformed boulder JSON #when agent_end fires #then no injection and no throw", async () => {
+    const root = createTempWorkspace()
+    writeFileSync(join(root, ".omo", "boulder.json"), "not-json")
+    const pi = new FakeExtensionAPI()
+    const logger = createLogger()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger,
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    await expect(
+      pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1")),
+    ).resolves.toBeDefined()
+    expect(delivered).toEqual([])
+    expect(pi.userMessages).toEqual([])
+  })
+
+  it("#given completed work #when agent_end fires #then no injection", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [ ] 1. One\n")
+    writeBoulderJson(root, {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["senpi:qa-s1"],
+          status: "completed",
+          started_at: "2026-07-17T00:00:00Z",
+        },
+      },
+    })
+    const pi = new FakeExtensionAPI()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+
+    expect(delivered).toEqual([])
+  })
+
+  it("#given work owned by another harness #when agent_end fires #then no injection", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [ ] 1. One\n")
+    writeBoulderJson(root, {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["codex:qa-s1"],
+          status: "active",
+          started_at: "2026-07-17T00:00:00Z",
+        },
+      },
+    })
+    const pi = new FakeExtensionAPI()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+
+    expect(delivered).toEqual([])
+  })
+
+  it("#given active work with remaining tasks #when agent_end fires #then injects continuation directive", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [ ] 1. Task one\n- [ ] 2. Task two\n")
+    writeBoulderJson(root, {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["senpi:qa-s1"],
+          status: "active",
+          started_at: "2026-07-17T00:00:00Z",
+          updated_at: "2026-07-17T01:00:00Z",
+        },
+      },
+    })
+    const pi = new FakeExtensionAPI()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+
+    expect(delivered).toHaveLength(1)
+    const content = delivered[0] ?? ""
+    expect(content).toContain("Plan file:")
+    expect(content).toContain("t.md")
+    expect(content).toContain("[Status: 0/2")
+    expect(content).toContain("next: 1.")
+    expect(content).toContain("senpi:qa-s1")
+  })
+
+  it("#given zero remaining tasks but total > 0 #when agent_end fires #then still injects final-gate directive", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [x] 1. Task one\n- [x] 2. Task two\n")
+    writeBoulderJson(root, {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["senpi:qa-s1"],
+          status: "active",
+          started_at: "2026-07-17T00:00:00Z",
+          updated_at: "2026-07-17T01:00:00Z",
+        },
+      },
+    })
+    const pi = new FakeExtensionAPI()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+
+    expect(delivered).toHaveLength(1)
+    const content = delivered[0] ?? ""
+    expect(content).toContain("[Status: 2/2")
+    expect(content).toContain("Final gate")
+    expect(content).toMatch(/final gate|Final Verification/i)
+  })
+
+  it("#given paused work #when agent_end fires #then injects continuation directive", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [ ] 1. Task one\n")
+    writeBoulderJson(root, {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["senpi:qa-s1"],
+          status: "paused",
+          started_at: "2026-07-17T00:00:00Z",
+          updated_at: "2026-07-17T01:00:00Z",
+        },
+      },
+    })
+    const pi = new FakeExtensionAPI()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0]).toContain("[Status: 0/1")
+  })
+
+  it("#given identical boulder signature twice #when agent_end repeats #then second is suppressed", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [ ] 1. Task one\n")
+    writeBoulderJson(root, {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["senpi:qa-s1"],
+          status: "active",
+          started_at: "2026-07-17T00:00:00Z",
+          updated_at: "2026-07-17T01:00:00Z",
+        },
+      },
+    })
+    const pi = new FakeExtensionAPI()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+    await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+
+    expect(delivered).toHaveLength(1)
+  })
+
+  it("#given 9 consecutive agent_end events with changing signature #when cap is 8 #then only 8 injections are delivered", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [ ] 1. Task one\n")
+    const baseState = {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["senpi:qa-s1"],
+          status: "active",
+          started_at: "2026-07-17T00:00:00Z",
+          updated_at: "2026-07-17T01:00:00Z",
+        },
+      },
+    }
+    writeBoulderJson(root, baseState)
+    const pi = new FakeExtensionAPI()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    for (let i = 0; i < 9; i++) {
+      // Vary the signature each iteration so stale-signature suppression does not mask the cap.
+      const varied = structuredClone(baseState)
+      varied.works.w1.updated_at = `2026-07-17T01:00:0${i}Z`
+      writeBoulderJson(root, varied)
+      await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+    }
+
+    expect(delivered).toHaveLength(8)
+  })
+
+  it("#given cap reached #when user input arrives #then resets and continuation resumes", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [ ] 1. Task one\n")
+    const baseState = {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["senpi:qa-s1"],
+          status: "active",
+          started_at: "2026-07-17T00:00:00Z",
+          updated_at: "2026-07-17T01:00:00Z",
+        },
+      },
+    }
+    writeBoulderJson(root, baseState)
+    const pi = new FakeExtensionAPI()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    for (let i = 0; i < 8; i++) {
+      const varied = structuredClone(baseState)
+      varied.works.w1.updated_at = `2026-07-17T01:00:0${i}Z`
+      writeBoulderJson(root, varied)
+      await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+    }
+    expect(delivered).toHaveLength(8)
+
+    await pi.dispatch("input", { type: "input", text: "hello", source: "user" }, eventCtx(root, "qa-s1"))
+    const varied = structuredClone(baseState)
+    varied.works.w1.updated_at = "2026-07-17T01:00:10Z"
+    writeBoulderJson(root, varied)
+    await pi.dispatch("agent_end", { type: "agent_end" }, eventCtx(root, "qa-s1"))
+
+    expect(delivered).toHaveLength(9)
+  })
+
+  it("#given eligible boulder work #when user input arrives #then appends start-work steering reminder", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [ ] 1. Task one\n")
+    writeBoulderJson(root, {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["senpi:qa-s1"],
+          status: "active",
+          started_at: "2026-07-17T00:00:00Z",
+          updated_at: "2026-07-17T01:00:00Z",
+        },
+      },
+    })
+    const pi = new FakeExtensionAPI()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+    })
+
+    const results = await pi.dispatch(
+      "input",
+      { type: "input", text: "hello", source: "user" },
+      eventCtx(root, "qa-s1"),
+    )
+
+    expect(results).toHaveLength(1)
+    const result = results[0]
+    expect(result).toMatchObject({ action: "transform" })
+    if (result && typeof result === "object" && "text" in result) {
+      expect(result.text).toContain("<omo-senpi-start-work>")
+      expect(result.text).toContain("hello")
+    }
+  })
+
+  it("#given extension-sourced input #when eligible boulder work exists #then no transform", async () => {
+    const root = createTempWorkspace()
+    writePlan(root, "t", "## TODOs\n- [ ] 1. Task one\n")
+    writeBoulderJson(root, {
+      schema_version: 2,
+      active_work_id: "w1",
+      works: {
+        w1: {
+          work_id: "w1",
+          active_plan: ".omo/plans/t.md",
+          plan_name: "t",
+          session_ids: ["senpi:qa-s1"],
+          status: "active",
+          started_at: "2026-07-17T00:00:00Z",
+          updated_at: "2026-07-17T01:00:00Z",
+        },
+      },
+    })
+    const pi = new FakeExtensionAPI()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+    })
+
+    const results = await pi.dispatch(
+      "input",
+      { type: "input", text: "hello", source: "extension" },
+      eventCtx(root, "qa-s1"),
+    )
+
+    expect(results).toEqual([{ action: "continue" }])
+  })
+
+  it("#given missing session manager #when agent_end fires #then skips silently", async () => {
+    const root = createTempWorkspace()
+    const pi = new FakeExtensionAPI()
+    const { coordinator, delivered } = makeCoordinator()
+    await createStartWorkContinuationComponent().register(pi, {
+      logger: createLogger(),
+      config: { getFlag: () => false },
+      idleCoordinator: coordinator,
+    })
+
+    await pi.dispatch("agent_end", { type: "agent_end" }, { cwd: root })
+
+    expect(delivered).toEqual([])
+  })
+})
+
+process.on("beforeExit", cleanupAll)

--- a/packages/omo-senpi/src/components/start-work-continuation/index.ts
+++ b/packages/omo-senpi/src/components/start-work-continuation/index.ts
@@ -1,0 +1,213 @@
+import { join } from "node:path"
+
+import type { ComponentContext, OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types"
+import { findContinuableBoulderWork } from "./boulder-eligibility"
+
+export interface StartWorkContinuationComponentOptions {
+  // none yet; retained for future DI seams
+}
+
+const CONTINUATION_LIMIT = 8
+
+const START_WORK_STEERING_REMINDER = [
+  "<omo-senpi-start-work>",
+  "An active Prometheus start-work plan is present in this working directory.",
+  "Before continuing, read `.omo/boulder.json` and the active plan file to determine what remains; use the ledger and plan as the source of truth.",
+  "Continue the current work with evidence-bound execution; do not start unrelated work until every top-level checkbox is `- [x]`.",
+  "</omo-senpi-start-work>",
+].join("\n")
+
+interface InputEventLike {
+  text: string
+  source?: unknown
+  images?: unknown
+}
+
+interface SessionManagerLike {
+  getSessionId(): string | undefined
+}
+
+interface AgentEndEventCtx {
+  cwd?: unknown
+  sessionManager?: SessionManagerLike
+}
+
+export function createStartWorkContinuationComponent(
+  _options: StartWorkContinuationComponentOptions = {},
+): OmoSenpiComponent {
+  return {
+    name: "start-work-continuation",
+    register(pi: SenpiExtensionAPI, ctx: ComponentContext): void {
+      const state = {
+        consecutiveContinuations: 0,
+        lastSignature: undefined as string | undefined,
+      }
+
+      pi.on("input", async (payload, eventCtx) => {
+        if (!isInputEvent(payload)) return { action: "continue" }
+        if (!isUserSourcedInput(payload)) return { action: "continue" }
+
+        state.consecutiveContinuations = 0
+        state.lastSignature = undefined
+
+        const sessionId = extractSessionId(eventCtx)
+        const cwd = extractCwd(eventCtx)
+        if (!sessionId || !cwd) return { action: "continue" }
+
+        const continuable = findContinuableBoulderWork(cwd, sessionId)
+        if (!continuable) return { action: "continue" }
+
+        return {
+          action: "transform",
+          text: `${payload.text}\n\n${START_WORK_STEERING_REMINDER}`,
+          ...(Array.isArray(payload.images) ? { images: payload.images } : {}),
+        }
+      })
+
+      pi.on("agent_end", async (_payload, eventCtx) => {
+        if (state.consecutiveContinuations >= CONTINUATION_LIMIT) {
+          ctx.logger.info("omo-senpi start-work-continuation skipped", {
+            reason: "continuation-cap-reached",
+            count: state.consecutiveContinuations,
+          })
+          return
+        }
+
+        const sessionId = extractSessionId(eventCtx)
+        const cwd = extractCwd(eventCtx)
+        if (!sessionId || !cwd) {
+          ctx.logger.info("omo-senpi start-work-continuation skipped", { reason: "missing-context" })
+          return
+        }
+
+        const continuable = findContinuableBoulderWork(cwd, sessionId)
+        if (!continuable) {
+          state.lastSignature = undefined
+          ctx.logger.info("omo-senpi start-work-continuation skipped", { reason: "not-continuable" })
+          return
+        }
+
+        const { work, planPath, checklist } = continuable
+        const signature = `${work.work_id}:${work.updated_at ?? work.started_at}:${checklist.completed}/${checklist.total}`
+        if (state.lastSignature === signature) {
+          ctx.logger.info("omo-senpi start-work-continuation skipped", { reason: "stale-signature" })
+          return
+        }
+
+        state.lastSignature = signature
+        state.consecutiveContinuations += 1
+
+        const content = renderDirective({
+          planName: work.plan_name,
+          planPath,
+          boulderPath: join(cwd, ".omo", "boulder.json"),
+          ledgerPath: join(cwd, ".omo", "start-work", "ledger.jsonl"),
+          checklist,
+          worktreePath: work.worktree_path ?? null,
+          sessionId: `senpi:${sessionId}`,
+        })
+
+        deliverContinuation(pi, ctx, content)
+      })
+    },
+  }
+}
+
+const START_WORK_CONTINUATION_INJECTION_KEY = "omo-senpi-start-work-continuation"
+
+function deliverContinuation(pi: SenpiExtensionAPI, ctx: ComponentContext, content: string): void {
+  if (ctx.idleCoordinator !== undefined) {
+    ctx.idleCoordinator.enqueue({
+      key: START_WORK_CONTINUATION_INJECTION_KEY,
+      source: "boulder-continuation",
+      content,
+    })
+    ctx.idleCoordinator.scheduleFlush()
+    return
+  }
+  pi.sendUserMessage(content, { deliverAs: "followUp" })
+}
+
+interface DirectiveState {
+  planName: string
+  planPath: string
+  boulderPath: string
+  ledgerPath: string
+  checklist: { completed: number; remaining: number; total: number; nextTaskLabel: string | null }
+  worktreePath: string | null
+  sessionId: string
+}
+
+function renderDirective(state: DirectiveState): string {
+  const worktreeBlock =
+    state.worktreePath === null
+      ? ""
+      : `\n- Worktree: \`${state.worktreePath}\` (all edits, tests, and commands run inside this directory)`
+  const nextLabel = state.checklist.nextTaskLabel ?? "none (final gate pending)"
+  const finalGateHint =
+    state.checklist.remaining === 0
+      ? "\nAll top-level checkboxes are complete. Run the Final Verification Wave and mark the boulder work completed."
+      : ""
+
+  return [
+    "<omo-senpi-start-work-continuation>",
+    "You are mid-flight on a Prometheus work plan; this turn is an automatic continuation. Do NOT ask whether to continue — the contract is auto-continue until every top-level checkbox is `- [x]`.",
+    "",
+    "# State",
+    "",
+    `- Plan: \`${state.planName}\``,
+    `- Plan file: \`${state.planPath}\``,
+    `- Boulder state: \`${state.boulderPath}\``,
+    `- Remaining top-level checkboxes: ${state.checklist.remaining} of ${state.checklist.total}`,
+    `- [Status: ${state.checklist.completed}/${state.checklist.total}, next: ${nextLabel}]`,
+    `- Ledger: \`${state.ledgerPath}\``,
+    `- Your session id in boulder.json: ${state.sessionId}`,
+    `${worktreeBlock}`,
+    "",
+    "# What to do this turn",
+    "",
+    "1. Read the plan file AND the ledger first — they are the only sources of truth for what remains and what evidence exists; do not trust your memory of prior turns.",
+    `2. When the remaining count is \`0\`, skip checkbox execution and perform the Final gate now. Otherwise, pick the FIRST unchecked top-level checkbox in \`## TODOs\` or \`## Final Verification Wave\`.${finalGateHint}`,
+    "3. Apply the checkbox's tier and verify with real-surface evidence. Decompose and dispatch sub-tasks in parallel via Senpi's `task` tool when safe.",
+    "4. After verification, apply the checkbox, append a durable evidence record to the ledger, and continue.",
+    "</omo-senpi-start-work-continuation>",
+  ].join("\n")
+}
+
+function extractCwd(eventCtx: unknown): string | undefined {
+  if (isRecord(eventCtx) && typeof eventCtx["cwd"] === "string") {
+    return eventCtx["cwd"]
+  }
+  return undefined
+}
+
+function extractSessionId(eventCtx: unknown): string | undefined {
+  const sessionManager = extractSessionManager(eventCtx)
+  if (sessionManager === undefined) return undefined
+  const id = sessionManager.getSessionId()
+  return typeof id === "string" ? id : undefined
+}
+
+function extractSessionManager(eventCtx: unknown): SessionManagerLike | undefined {
+  if (!isRecord(eventCtx)) return undefined
+  const value = eventCtx["sessionManager"]
+  if (!isRecord(value)) return undefined
+  if (typeof value["getSessionId"] !== "function") return undefined
+  return value as unknown as SessionManagerLike
+}
+
+function isInputEvent(value: unknown): value is InputEventLike {
+  return isRecord(value) && typeof value["text"] === "string"
+}
+
+function isUserSourcedInput(value: InputEventLike): boolean {
+  return value.source !== "extension"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export const __testInternals = {
+  renderDirective,
+}

--- a/packages/omo-senpi/src/components/ulw-loop/coordinator-routing.test.ts
+++ b/packages/omo-senpi/src/components/ulw-loop/coordinator-routing.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { describe, expect, it } from "bun:test"
 
 import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
@@ -46,5 +49,54 @@ describe("omo-senpi ulw-loop continuation routing through the idle coordinator",
     // then exactly one injection carries both, completion first
     expect(delivered).toHaveLength(1)
     expect(delivered[0]).toBe("task st_done completed\n\nContinue the active omo ulw-loop run.\nRun `omo ulw-loop status --json` in this session cwd, inspect the active incomplete goals, and keep working until the run is complete or safely checkpointed.")
+  })
+
+  it("#given active boulder start-work continuation #when ulw-loop agent_end fires #then it enqueues nothing", async () => {
+    // given a workspace with active senpi boulder work
+    const root = mkdtempSync(join(tmpdir(), "senpi-ulw-precedence-"))
+    try {
+      mkdirSync(join(root, ".omo", "plans"), { recursive: true })
+      writeFileSync(join(root, ".omo", "plans", "t.md"), "## TODOs\n- [ ] 1. Task one\n")
+      writeFileSync(
+        join(root, ".omo", "boulder.json"),
+        JSON.stringify({
+          schema_version: 2,
+          active_work_id: "w1",
+          works: {
+            w1: {
+              work_id: "w1",
+              active_plan: ".omo/plans/t.md",
+              plan_name: "t",
+              session_ids: ["senpi:qa-s1"],
+              status: "active",
+              started_at: "2026-07-17T00:00:00Z",
+              updated_at: "2026-07-17T01:00:00Z",
+            },
+          },
+        }),
+      )
+
+      const pi = new FakeExtensionAPI()
+      const logger = createLogger()
+      const delivered: string[] = []
+      const idleCoordinator = new IdleInjectionCoordinator((content) => delivered.push(content))
+      await createUlwLoopComponent({
+        resolveOmoBin: () => "/tmp/omo",
+        runCommand: async () => ({ code: 0, stdout: activeStatus() }),
+      }).register(pi, { logger, config: { getFlag: () => false }, idleCoordinator })
+
+      // when
+      await pi.dispatch(
+        "agent_end",
+        { type: "agent_end" },
+        { cwd: root, sessionManager: { getSessionId: () => "qa-s1" } },
+      )
+
+      // then ulw-loop defers to boulder continuation
+      expect(delivered).toEqual([])
+      expect(pi.userMessages).toEqual([])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/omo-senpi/src/components/ulw-loop/index.ts
+++ b/packages/omo-senpi/src/components/ulw-loop/index.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process"
 import { accessSync, constants, existsSync } from "node:fs"
 import { delimiter, join } from "node:path"
 
+import { findContinuableBoulderWork } from "../start-work-continuation/boulder-eligibility"
 import type { ComponentContext, OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types"
 
 const STATUS_ARGS = ["ulw-loop", "status", "--json"] as const
@@ -78,7 +79,14 @@ export function createUlwLoopComponent(options: UlwLoopComponentOptions = {}): O
           return
         }
 
-        const status = await readActiveStatus(omoBin, runCommand, cwdFromContext(eventCtx), ctx)
+        const cwd = cwdFromContext(eventCtx)
+        const sessionId = extractSessionId(eventCtx)
+        if (sessionId && findContinuableBoulderWork(cwd, sessionId) !== null) {
+          ctx.logger.info("omo-senpi ulw-loop continuation skipped", { reason: "boulder-continuation-active" })
+          return
+        }
+
+        const status = await readActiveStatus(omoBin, runCommand, cwd, ctx)
         if (!status.active) {
           state.previousStatusRaw = undefined
           ctx.logger.info("omo-senpi ulw-loop continuation skipped", { reason: "inactive" })
@@ -212,6 +220,15 @@ function isInputEvent(value: unknown): value is InputEventLike {
 
 function isUserSourcedInput(value: InputEventLike): boolean {
   return value.source !== "extension"
+}
+
+function extractSessionId(eventCtx: unknown): string | undefined {
+  if (!isRecord(eventCtx)) return undefined
+  const value = eventCtx["sessionManager"]
+  if (!isRecord(value) || typeof value["getSessionId"] !== "function") return undefined
+  const manager = value as unknown as { getSessionId(): unknown }
+  const id = manager.getSessionId()
+  return typeof id === "string" ? id : undefined
 }
 
 function cwdFromContext(value: unknown): string {

--- a/packages/omo-senpi/src/extension/idle-injection-coordinator.ts
+++ b/packages/omo-senpi/src/extension/idle-injection-coordinator.ts
@@ -1,4 +1,4 @@
-export type IdleInjectionSource = "task-completion" | "team-message" | "ulw-continuation"
+export type IdleInjectionSource = "task-completion" | "team-message" | "boulder-continuation" | "ulw-continuation"
 
 export interface IdleInjection {
   // Dedupe/order key. Task completions key on their task id; the ulw continuation keys on its source
@@ -25,7 +25,8 @@ export interface IdleInjectionCoordinatorOptions {
 const SOURCE_RANK: Readonly<Record<IdleInjectionSource, number>> = {
   "task-completion": 0,
   "team-message": 1,
-  "ulw-continuation": 2,
+  "boulder-continuation": 2,
+  "ulw-continuation": 3,
 }
 
 /**

--- a/packages/omo-senpi/src/extension/index.ts
+++ b/packages/omo-senpi/src/extension/index.ts
@@ -4,11 +4,13 @@ import { createCommentCheckerComponent } from "../components/comment-checker"
 import { createLspComponent } from "../components/lsp"
 import { createSenpiTelemetryComponent } from "../components/telemetry"
 import { createTaskComponent } from "../components/task"
+import { createStartWorkContinuationComponent } from "../components/start-work-continuation"
 import { createUltraworkComponent } from "../components/ultrawork"
 import { createUlwLoopComponent } from "../components/ulw-loop"
 
 const components: OmoSenpiComponent[] = [
   createUltraworkComponent(),
+  createStartWorkContinuationComponent(),
   createUlwLoopComponent(),
   createCommentCheckerComponent(),
   createSenpiTelemetryComponent(),


### PR DESCRIPTION
## What

Ports the boulder-state based start-work continuation hook to the Senpi harness as a new `start-work-continuation` component.

## Changes

- Added `@oh-my-opencode/boulder-state` workspace dependency to `packages/omo-senpi`.
- Implemented `src/components/start-work-continuation/index.ts`:
  - `input` handler resets suppression state and appends a `<omo-senpi-start-work>` steering reminder when eligible boulder work exists.
  - `agent_end` handler (Senpi Stop analog) reads `.omo/boulder.json`, finds work owned by `senpi:<session_id>` with `active` or `paused` status, and injects a continuation directive.
  - Suppresses repeats via signature `work_id:updated_at:completed/total`.
  - Caps consecutive continuations at 8 (reset on user input).
  - Delivers through `IdleInjectionCoordinator` with source `"boulder-continuation"`, falling back to `sendUserMessage(..., { deliverAs: "followUp" })`.
- Added shared `boulder-eligibility.ts` helper used by both the new component and `ulw-loop`.
- Added `"boulder-continuation"` to `IdleInjectionSource` at rank 2; renumbered `"ulw-continuation"` to rank 3.
- Gated `ulw-loop` continuation: skips when boulder work is continuable for the same session.
- Registered `start-work-continuation` before `ulw-loop` in `src/extension/index.ts`.
- Updated `packages/omo-senpi/AGENTS.md` to document the new component, eligibility/suppression, and precedence.

## QA

- `bun run test:senpi` → 213 pass, 0 fail.
- Evidence captured under `.omo/evidence/task-7-*`:
  - `task-7-continuation-injects.txt`
  - `task-7-isolation-error.txt`
  - `task-7-precedence.txt`

## Depends on

- Task 2 (`boulder-state` senpi platform) — already in `dev`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new start-work continuation component for Senpi that auto-continues active or paused Prometheus work from `.omo/boulder.json`, taking precedence over `ulw-loop`. Part of skills parity Task 7.

- **New Features**
  - `start-work-continuation`: on `agent_end`, continues `senpi:<session_id>` boulder work (`active` or `paused`) with signature-based repeat suppression and an 8-turn cap; on user input, appends a `<omo-senpi-start-work>` steering reminder.
  - Delivery and precedence: uses IdleInjectionCoordinator with source `"boulder-continuation"` (ranked before `"ulw-continuation"`); `ulw-loop` defers when boulder work is continuable; component registers before `ulw-loop`.
  - Shared helper: `boulder-eligibility.ts` used by both this component and `ulw-loop`.

- **Dependencies**
  - Adds `@oh-my-opencode/boulder-state`.

<sup>Written for commit f63763cbd7465d654c1d80491bdb8e0748e97762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

