### PR TITLE
feat(shared-skills): add ulw-map, a deterministic wave execution map for ulw-plan work plans

### DIFF
--- a/packages/omo-codex/plugin/test/plan-map.test.mjs
+++ b/packages/omo-codex/plugin/test/plan-map.test.mjs
@@ -441,3 +441,20 @@ test("#given a slug instead of a path #when the plan lives in .omo/plans #then i
 		assert.equal(code, 0);
 	});
 });
+
+test("#given a fresh scaffold skeleton whose placeholder todo was never filled #when parsed #then the map warns about the template placeholder", async () => {
+	// given
+	const { parsePlanMap } = await import(scriptUrl);
+	const plan = `# fresh - Work Plan
+
+## Todos
+
+- [ ] 1. <title>
+  Parallelization: Wave <N> | Blocked by: <...> | Blocks: <...>
+`;
+	// when
+	const map = parsePlanMap(plan);
+	// then --- the map still renders, but says the plan may not contain real todos yet
+	assert.equal(map.taskCount, 1);
+	assert.ok(map.warnings.some((warning) => warning.includes("unfilled template placeholder")));
+});

--- a/packages/omo-codex/plugin/test/plan-map.test.mjs
+++ b/packages/omo-codex/plugin/test/plan-map.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -11,11 +11,39 @@ const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const scriptPath = join(root, "..", "..", "shared-skills", "skills", "ulw-map", "scripts", "plan-map.mjs");
 const scriptUrl = pathToFileURL(scriptPath).href;
 
-const GROUPED_PLAN = `# demo - Work Plan
+async function withTempDir(run) {
+	const dir = await mkdtemp(join(tmpdir(), "plan-map-"));
+	try {
+		return await run(dir);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+}
+
+const CANONICAL_PLAN = `# canonical - Work Plan
 
 ## TL;DR (For humans)
 
 What you'll get.
+
+## Todos
+
+- [x] 1. Build the parser
+  What to do / Must NOT do: parse only the mandated grammar
+  Parallelization: Wave 1 | Blocked by: - | Blocks: 3
+  Acceptance criteria (agent-executable): node --test passes
+- [ ] 2. Add fixtures
+  Parallelization: Wave 1 | Blocked by: - | Blocks: 3
+- [ ] 3. Emit mermaid
+  Parallelization: Wave 2 | Blocked by: 1, 2 | Blocks: -
+
+## Final verification wave
+
+- [ ] F1. Plan compliance audit
+- [ ] F2. Code quality review
+`;
+
+const HEADING_PLAN = `# demo - Work Plan
 
 ## Todos
 
@@ -43,55 +71,87 @@ const FLAT_PLAN = `# flat - Work Plan
 - [x] 3. Third step
 `;
 
-test("#given a grouped plan #when parsed #then waves, statuses, and finals come from the mandated grammar", async () => {
+test("#given a canonical plan with Parallelization metadata #when parsed #then waves come from the metadata, not headings or order", async () => {
 	// given
 	const { parsePlanMap } = await import(scriptUrl);
 	// when
-	const map = parsePlanMap(GROUPED_PLAN);
+	const map = parsePlanMap(CANONICAL_PLAN);
 	// then
-	assert.equal(map.title, "demo - Work Plan");
+	assert.equal(map.grouping, "wave-metadata");
 	assert.deepEqual(
-		map.groups.map((group) => group.label),
-		["Wave 1 - parser", "Wave 2 - emitter"],
-	);
-	assert.deepEqual(
-		map.groups[0].tasks.map((task) => [task.id, task.done]),
+		map.groups.map((group) => [group.label, group.tasks.map((task) => task.id)]),
 		[
-			["T1", true],
-			["T2", false],
+			["Wave 1", ["T1", "T2"]],
+			["Wave 2", ["T3"]],
 		],
 	);
+	assert.equal(map.groups[0].tasks[0].done, true);
 	assert.deepEqual(
 		map.finals.map((final) => final.id),
 		["F1", "F2"],
 	);
 });
 
-test("#given a grouped plan #when mermaid is emitted #then subgraphs chain in order and finals fan out to a join", async () => {
+test("#given a task without a Parallelization line among tasks that have one #when parsed #then it inherits the previous wave with a diagnostic", async () => {
+	// given
+	const { parsePlanMap } = await import(scriptUrl);
+	const plan = `# partial - Work Plan
+
+## Todos
+
+- [ ] 1. Has metadata
+  Parallelization: Wave 1 | Blocked by: - | Blocks: -
+- [ ] 2. No metadata line here
+- [ ] 3. Later wave
+  Parallelization: Wave 2 | Blocked by: - | Blocks: -
+`;
+	// when
+	const map = parsePlanMap(plan);
+	// then
+	assert.equal(map.grouping, "wave-metadata");
+	assert.deepEqual(
+		map.groups.map((group) => [group.label, group.tasks.map((task) => task.number)]),
+		[
+			["Wave 1", [1, 2]],
+			["Wave 2", [3]],
+		],
+	);
+	assert.ok(map.warnings.some((warning) => warning.includes("task 2 has no `Parallelization: Wave <N>` line")));
+});
+
+test("#given a heading-grouped plan without metadata #when parsed #then headings group the waves (ladder rung 2)", async () => {
 	// given
 	const { parsePlanMap, buildMermaid } = await import(scriptUrl);
 	// when
-	const mermaid = buildMermaid(parsePlanMap(GROUPED_PLAN));
+	const map = parsePlanMap(HEADING_PLAN);
+	const mermaid = buildMermaid(map);
 	// then
+	assert.equal(map.grouping, "headings");
 	assert.ok(mermaid.includes('subgraph W1["Wave 1 - parser"]'));
 	assert.ok(mermaid.includes("W1 --> W2"));
 	assert.ok(mermaid.includes("W2 --> F1"));
-	assert.ok(mermaid.includes("W2 --> F2"));
 	assert.ok(mermaid.includes("F1 --> FIN"));
 	assert.ok(mermaid.includes('T1["✓ 1. Build the parser"]'));
 	assert.ok(mermaid.includes("class T1 done"));
 });
 
-test("#given a flat plan without wave headings #when mermaid is emitted #then tasks chain in document order without subgraphs", async () => {
+test("#given a flat plan without metadata or headings #when rendered #then tasks chain in document order (ladder rung 3)", async () => {
 	// given
-	const { parsePlanMap, buildMermaid } = await import(scriptUrl);
+	const { parsePlanMap, buildMermaid, buildMapMarkdown } = await import(scriptUrl);
 	// when
-	const mermaid = buildMermaid(parsePlanMap(FLAT_PLAN));
+	const map = parsePlanMap(FLAT_PLAN);
+	const mermaid = buildMermaid(map);
 	// then
+	assert.equal(map.grouping, "document-order");
 	assert.ok(!mermaid.includes("subgraph"));
 	assert.ok(mermaid.includes("T1 --> T2"));
 	assert.ok(mermaid.includes("T2 --> T3"));
 	assert.ok(mermaid.includes("class T3 done"));
+	assert.ok(
+		buildMapMarkdown(map, mermaid, { slug: "flat", hash: "x", sourceRelPath: "p.md" }).includes(
+			"shown in plan document order",
+		),
+	);
 });
 
 test("#given headings and task rows inside code fences #when parsed #then fenced content is ignored", async () => {
@@ -117,6 +177,26 @@ test("#given headings and task rows inside code fences #when parsed #then fenced
 	assert.deepEqual(map.groups[0].tasks[0].id, "T1");
 });
 
+test("#given a fence line with an info string inside an open fence #when parsed #then it does NOT close the fence (CommonMark closing rule)", async () => {
+	// given
+	const { parsePlanMap } = await import(scriptUrl);
+	const plan = `# pseudo - Work Plan
+
+## Todos
+
+- [ ] 1. Real task
+
+\`\`\`markdown
+\`\`\`js
+- [ ] 88. Still fenced - a closing fence has no info string
+\`\`\`
+`;
+	// when
+	const map = parsePlanMap(plan);
+	// then
+	assert.equal(map.taskCount, 1);
+});
+
 test("#given a document without a Todos section #when parsed #then it fails closed with a fixable diagnostic", async () => {
 	// given
 	const { parsePlanMap, PlanMapError } = await import(scriptUrl);
@@ -135,7 +215,7 @@ test("#given checkbox rows that do not match the mandated grammar #when parsed #
 ## Todos
 
 - [ ] unnumbered todo
-- [ ] another loose row
+- [ ] 0. zero is not a positive task number
 `;
 	// when / then
 	assert.throws(
@@ -143,6 +223,24 @@ test("#given checkbox rows that do not match the mandated grammar #when parsed #
 		(error) =>
 			error instanceof PlanMapError && error.kind === "no-tasks" && error.message.includes("2 checkbox row(s)"),
 	);
+});
+
+test("#given whitespace-only titles and unsafe task numbers #when parsed #then those rows are ignored with a diagnostic", async () => {
+	// given
+	const { parsePlanMap } = await import(scriptUrl);
+	const plan = `# edge - Work Plan
+
+## Todos
+
+- [ ] 1. Real task
+- [ ] 2.${"   "}
+- [ ] 99999999999999999999. unsafe number
+`;
+	// when
+	const map = parsePlanMap(plan);
+	// then
+	assert.equal(map.taskCount, 1);
+	assert.ok(map.warnings.some((warning) => warning.includes("2 checkbox row(s)")));
 });
 
 test("#given duplicate task numbers #when parsed #then node ids stay unique and a warning is recorded", async () => {
@@ -182,17 +280,17 @@ test("#given bracket and quote injection in titles #when mermaid is emitted #the
 	assert.ok(!mermaid.includes("Break \"the]"));
 });
 
-test("#given CRLF and LF variants of the same plan #when rendered #then output bytes are identical (determinism)", async () => {
+test("#given CRLF and LF variants of the same plan #when rendered #then output is identical (parse-level determinism)", async () => {
 	// given
 	const { parsePlanMap, buildMermaid, buildMapMarkdown, planHash } = await import(scriptUrl);
-	const crlf = GROUPED_PLAN.replaceAll("\n", "\r\n");
-	const meta = { slug: "demo", hash: "x", sourceRelPath: "p.md" };
+	const crlf = CANONICAL_PLAN.replaceAll("\n", "\r\n");
+	const meta = { slug: "canonical", hash: "x", sourceRelPath: "p.md" };
 	// when
-	const fromLf = buildMapMarkdown(parsePlanMap(GROUPED_PLAN), buildMermaid(parsePlanMap(GROUPED_PLAN)), meta);
+	const fromLf = buildMapMarkdown(parsePlanMap(CANONICAL_PLAN), buildMermaid(parsePlanMap(CANONICAL_PLAN)), meta);
 	const fromCrlf = buildMapMarkdown(parsePlanMap(crlf), buildMermaid(parsePlanMap(crlf)), meta);
-	// then --- parse-level determinism; hashes differ because the input bytes differ, which the map records honestly
+	// then --- hashes differ because the input bytes differ, which the map records honestly
 	assert.equal(fromLf, fromCrlf);
-	assert.notEqual(planHash(GROUPED_PLAN), planHash(crlf));
+	assert.notEqual(planHash(CANONICAL_PLAN), planHash(crlf));
 });
 
 test("#given nested (indented) checkboxes under a task #when parsed #then only column-zero rows count", async () => {
@@ -221,18 +319,18 @@ test("#given a plan without a final verification section #when rendered #then th
 	assert.ok(!mermaid.includes("FIN"));
 });
 
-test("#given the HTML viewer #when built #then the mermaid source is escaped content and the only remote URL is the pinned renderer", async () => {
+test("#given the HTML viewer #when built #then the mermaid source is escaped content and the only remote URL is the exact-version renderer", async () => {
 	// given
-	const { parsePlanMap, buildMermaid, buildMapHtml } = await import(scriptUrl);
-	const map = parsePlanMap(GROUPED_PLAN);
+	const { parsePlanMap, buildMermaid, buildMapHtml, MERMAID_CDN_URL } = await import(scriptUrl);
+	const map = parsePlanMap(HEADING_PLAN);
 	// when
 	const html = buildMapHtml(map, buildMermaid(map), { slug: "demo", hash: "abc", sourceRelPath: "p.md" });
 	// then
 	assert.ok(html.includes('<pre class="mermaid">'));
-	assert.ok(html.includes("cdn.jsdelivr.net/npm/mermaid@11"));
+	assert.ok(MERMAID_CDN_URL.startsWith("https://cdn.jsdelivr.net/npm/mermaid@11."));
 	const remoteUrls = html.match(/https?:\/\/[^"' )]+/g) ?? [];
 	assert.deepEqual(
-		remoteUrls.filter((url) => !url.startsWith("https://cdn.jsdelivr.net/npm/mermaid@11")),
+		remoteUrls.filter((url) => url !== MERMAID_CDN_URL),
 		[],
 	);
 	assert.ok(!html.includes('T1["'));
@@ -242,57 +340,104 @@ test("#given the HTML viewer #when built #then the mermaid source is escaped con
 test("#given the CLI in --check mode #when run against a temp plan #then it reports without writing anything", async () => {
 	// given
 	const { runCli, EXIT_OK } = await import(scriptUrl);
-	const dir = await mkdtemp(join(tmpdir(), "plan-map-"));
-	const planPath = join(dir, "demo.md");
-	await writeFile(planPath, GROUPED_PLAN, "utf8");
-	// when
-	const code = await runCli(["node", "plan-map.mjs", planPath, "--check"], dir);
-	// then
-	assert.equal(code, EXIT_OK);
-	assert.deepEqual(await readdir(dir), ["demo.md"]);
+	await withTempDir(async (dir) => {
+		const planPath = join(dir, "demo.md");
+		await writeFile(planPath, CANONICAL_PLAN, "utf8");
+		// when
+		const code = await runCli(["node", "plan-map.mjs", planPath, "--check"], dir);
+		// then
+		assert.equal(code, EXIT_OK);
+		assert.deepEqual(await readdir(dir), ["demo.md"]);
+	});
 });
 
-test("#given the CLI in default mode #when run twice #then it writes under .omo/maps and re-runs are byte-identical", async () => {
+test("#given the CLI in default mode #when run twice #then it writes under .omo/maps, re-runs are byte-identical, and the source is untouched", async () => {
 	// given
 	const { runCli } = await import(scriptUrl);
-	const dir = await mkdtemp(join(tmpdir(), "plan-map-"));
-	const planPath = join(dir, "demo.md");
-	await writeFile(planPath, GROUPED_PLAN, "utf8");
-	// when
-	await runCli(["node", "plan-map.mjs", planPath, "--html"], dir);
-	const mdPath = join(dir, ".omo", "maps", "demo.md");
-	const first = await readFile(mdPath, "utf8");
-	await runCli(["node", "plan-map.mjs", planPath, "--html"], dir);
-	const second = await readFile(mdPath, "utf8");
-	// then
-	assert.equal(first, second);
-	assert.ok(first.endsWith("\n"));
-	assert.ok((await readFile(join(dir, ".omo", "maps", "demo.html"), "utf8")).includes("Plan map"));
-	// and --- the source plan was never modified
-	assert.equal(await readFile(planPath, "utf8"), GROUPED_PLAN);
+	await withTempDir(async (dir) => {
+		const planPath = join(dir, "demo.md");
+		await writeFile(planPath, CANONICAL_PLAN, "utf8");
+		// when
+		await runCli(["node", "plan-map.mjs", planPath, "--html"], dir);
+		const mdPath = join(dir, ".omo", "maps", "demo.md");
+		const first = await readFile(mdPath, "utf8");
+		await runCli(["node", "plan-map.mjs", planPath, "--html"], dir);
+		const second = await readFile(mdPath, "utf8");
+		// then
+		assert.equal(first, second);
+		assert.ok(first.endsWith("\n"));
+		assert.ok((await readFile(join(dir, ".omo", "maps", "demo.html"), "utf8")).includes("Plan map"));
+		assert.equal(await readFile(planPath, "utf8"), CANONICAL_PLAN);
+	});
+});
+
+test("#given --out-dir pointing at the plan's own directory #when run #then overwriting the source plan is refused", async () => {
+	// given
+	const { runCli, PlanMapError } = await import(scriptUrl);
+	await withTempDir(async (dir) => {
+		const planPath = join(dir, "demo.md");
+		await writeFile(planPath, CANONICAL_PLAN, "utf8");
+		// when / then
+		await assert.rejects(
+			() => runCli(["node", "plan-map.mjs", planPath, "--out-dir", "."], dir),
+			(error) => error instanceof PlanMapError && error.kind === "source-overwrite",
+		);
+		// and --- the plan survived
+		assert.equal(await readFile(planPath, "utf8"), CANONICAL_PLAN);
+	});
 });
 
 test("#given an --out-dir that escapes the working directory #when run #then it refuses", async () => {
 	// given
 	const { runCli, PlanMapError } = await import(scriptUrl);
-	const dir = await mkdtemp(join(tmpdir(), "plan-map-"));
-	await writeFile(join(dir, "demo.md"), GROUPED_PLAN, "utf8");
+	await withTempDir(async (dir) => {
+		await writeFile(join(dir, "demo.md"), CANONICAL_PLAN, "utf8");
+		// when / then
+		await assert.rejects(
+			() => runCli(["node", "plan-map.mjs", join(dir, "demo.md"), "--out-dir", ".."], dir),
+			(error) => error instanceof PlanMapError && error.kind === "path-escape",
+		);
+	});
+});
+
+test("#given an --out-dir routed through a symlink to outside #when run #then the symlinked component is refused", async () => {
+	// given
+	const { runCli, PlanMapError } = await import(scriptUrl);
+	await withTempDir(async (outside) => {
+		await withTempDir(async (dir) => {
+			await writeFile(join(dir, "demo.md"), CANONICAL_PLAN, "utf8");
+			await symlink(outside, join(dir, "leak"), "dir");
+			// when / then
+			await assert.rejects(
+				() => runCli(["node", "plan-map.mjs", join(dir, "demo.md"), "--out-dir", "leak"], dir),
+				(error) => error instanceof PlanMapError && error.kind === "path-escape",
+			);
+			// and --- nothing landed outside the workspace
+			assert.deepEqual(await readdir(outside), []);
+		});
+	});
+});
+
+test("#given --out-dir immediately followed by another flag #when parsed #then it is a usage error, not a directory named --check", async () => {
+	// given
+	const { parseArgs, PlanMapError } = await import(scriptUrl);
 	// when / then
-	await assert.rejects(
-		() => runCli(["node", "plan-map.mjs", join(dir, "demo.md"), "--out-dir", ".."], dir),
-		(error) => error instanceof PlanMapError && error.kind === "path-escape",
+	assert.throws(
+		() => parseArgs(["node", "plan-map.mjs", "demo.md", "--out-dir", "--check"]),
+		(error) => error instanceof PlanMapError && error.kind === "usage",
 	);
 });
 
 test("#given a slug instead of a path #when the plan lives in .omo/plans #then it resolves by slug", async () => {
 	// given
 	const { runCli } = await import(scriptUrl);
-	const dir = await mkdtemp(join(tmpdir(), "plan-map-"));
-	const plansDir = join(dir, ".omo", "plans");
-	await import("node:fs/promises").then(({ mkdir }) => mkdir(plansDir, { recursive: true }));
-	await writeFile(join(plansDir, "demo.md"), GROUPED_PLAN, "utf8");
-	// when
-	const code = await runCli(["node", "plan-map.mjs", "demo", "--check"], dir);
-	// then
-	assert.equal(code, 0);
+	await withTempDir(async (dir) => {
+		const plansDir = join(dir, ".omo", "plans");
+		await mkdir(plansDir, { recursive: true });
+		await writeFile(join(plansDir, "demo.md"), CANONICAL_PLAN, "utf8");
+		// when
+		const code = await runCli(["node", "plan-map.mjs", "demo", "--check"], dir);
+		// then
+		assert.equal(code, 0);
+	});
 });

--- a/packages/omo-codex/plugin/test/plan-map.test.mjs
+++ b/packages/omo-codex/plugin/test/plan-map.test.mjs
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+// ulw-map is a shared skill (single source; sync-skills copies it into the plugin at build time),
+// so the contract tests import the shared source directly.
+const scriptPath = join(root, "..", "..", "shared-skills", "skills", "ulw-map", "scripts", "plan-map.mjs");
+const scriptUrl = pathToFileURL(scriptPath).href;
+
+const GROUPED_PLAN = `# demo - Work Plan
+
+## TL;DR (For humans)
+
+What you'll get.
+
+## Todos
+
+### Wave 1 - parser
+
+- [x] 1. Build the parser
+- [ ] 2. Add fixtures
+
+### Wave 2 - emitter
+
+- [ ] 3. Emit mermaid
+
+## Final verification wave
+
+- [ ] F1. Plan compliance audit
+- [ ] F2. Code quality review
+`;
+
+const FLAT_PLAN = `# flat - Work Plan
+
+## Todos
+
+- [ ] 1. First step
+- [ ] 2. Second step
+- [x] 3. Third step
+`;
+
+test("#given a grouped plan #when parsed #then waves, statuses, and finals come from the mandated grammar", async () => {
+	// given
+	const { parsePlanMap } = await import(scriptUrl);
+	// when
+	const map = parsePlanMap(GROUPED_PLAN);
+	// then
+	assert.equal(map.title, "demo - Work Plan");
+	assert.deepEqual(
+		map.groups.map((group) => group.label),
+		["Wave 1 - parser", "Wave 2 - emitter"],
+	);
+	assert.deepEqual(
+		map.groups[0].tasks.map((task) => [task.id, task.done]),
+		[
+			["T1", true],
+			["T2", false],
+		],
+	);
+	assert.deepEqual(
+		map.finals.map((final) => final.id),
+		["F1", "F2"],
+	);
+});
+
+test("#given a grouped plan #when mermaid is emitted #then subgraphs chain in order and finals fan out to a join", async () => {
+	// given
+	const { parsePlanMap, buildMermaid } = await import(scriptUrl);
+	// when
+	const mermaid = buildMermaid(parsePlanMap(GROUPED_PLAN));
+	// then
+	assert.ok(mermaid.includes('subgraph W1["Wave 1 - parser"]'));
+	assert.ok(mermaid.includes("W1 --> W2"));
+	assert.ok(mermaid.includes("W2 --> F1"));
+	assert.ok(mermaid.includes("W2 --> F2"));
+	assert.ok(mermaid.includes("F1 --> FIN"));
+	assert.ok(mermaid.includes('T1["✓ 1. Build the parser"]'));
+	assert.ok(mermaid.includes("class T1 done"));
+});
+
+test("#given a flat plan without wave headings #when mermaid is emitted #then tasks chain in document order without subgraphs", async () => {
+	// given
+	const { parsePlanMap, buildMermaid } = await import(scriptUrl);
+	// when
+	const mermaid = buildMermaid(parsePlanMap(FLAT_PLAN));
+	// then
+	assert.ok(!mermaid.includes("subgraph"));
+	assert.ok(mermaid.includes("T1 --> T2"));
+	assert.ok(mermaid.includes("T2 --> T3"));
+	assert.ok(mermaid.includes("class T3 done"));
+});
+
+test("#given headings and task rows inside code fences #when parsed #then fenced content is ignored", async () => {
+	// given
+	const { parsePlanMap } = await import(scriptUrl);
+	const plan = `# fenced - Work Plan
+
+## Todos
+
+- [ ] 1. Real task
+
+\`\`\`markdown
+## Todos
+
+- [ ] 99. Fake task inside a fence
+### Fake wave
+\`\`\`
+`;
+	// when
+	const map = parsePlanMap(plan);
+	// then
+	assert.equal(map.taskCount, 1);
+	assert.deepEqual(map.groups[0].tasks[0].id, "T1");
+});
+
+test("#given a document without a Todos section #when parsed #then it fails closed with a fixable diagnostic", async () => {
+	// given
+	const { parsePlanMap, PlanMapError } = await import(scriptUrl);
+	// when / then
+	assert.throws(
+		() => parsePlanMap("# not a plan\n\njust prose\n"),
+		(error) => error instanceof PlanMapError && error.kind === "no-todos-section",
+	);
+});
+
+test("#given checkbox rows that do not match the mandated grammar #when parsed #then it fails closed and counts the ignored rows", async () => {
+	// given
+	const { parsePlanMap, PlanMapError } = await import(scriptUrl);
+	const plan = `# loose - Work Plan
+
+## Todos
+
+- [ ] unnumbered todo
+- [ ] another loose row
+`;
+	// when / then
+	assert.throws(
+		() => parsePlanMap(plan),
+		(error) =>
+			error instanceof PlanMapError && error.kind === "no-tasks" && error.message.includes("2 checkbox row(s)"),
+	);
+});
+
+test("#given duplicate task numbers #when parsed #then node ids stay unique and a warning is recorded", async () => {
+	// given
+	const { parsePlanMap, buildMermaid } = await import(scriptUrl);
+	const plan = `# dup - Work Plan
+
+## Todos
+
+- [ ] 1. First
+- [ ] 1. Duplicate number
+`;
+	// when
+	const map = parsePlanMap(plan);
+	// then
+	assert.deepEqual(
+		map.groups[0].tasks.map((task) => task.id),
+		["T1", "T1_2"],
+	);
+	assert.ok(map.warnings.some((warning) => warning.includes("duplicate task number 1")));
+	assert.ok(buildMermaid(map).includes("T1_2"));
+});
+
+test("#given bracket and quote injection in titles #when mermaid is emitted #then labels are sanitized and ids stay program-generated", async () => {
+	// given
+	const { parsePlanMap, buildMermaid } = await import(scriptUrl);
+	const plan = `# inject - Work Plan
+
+## Todos
+
+- [ ] 1. Break "the] renderer\` with [brackets
+`;
+	// when
+	const mermaid = buildMermaid(parsePlanMap(plan));
+	// then
+	assert.ok(mermaid.includes(`T1["1. Break 'the) renderer' with (brackets"]`));
+	assert.ok(!mermaid.includes("Break \"the]"));
+});
+
+test("#given CRLF and LF variants of the same plan #when rendered #then output bytes are identical (determinism)", async () => {
+	// given
+	const { parsePlanMap, buildMermaid, buildMapMarkdown, planHash } = await import(scriptUrl);
+	const crlf = GROUPED_PLAN.replaceAll("\n", "\r\n");
+	const meta = { slug: "demo", hash: "x", sourceRelPath: "p.md" };
+	// when
+	const fromLf = buildMapMarkdown(parsePlanMap(GROUPED_PLAN), buildMermaid(parsePlanMap(GROUPED_PLAN)), meta);
+	const fromCrlf = buildMapMarkdown(parsePlanMap(crlf), buildMermaid(parsePlanMap(crlf)), meta);
+	// then --- parse-level determinism; hashes differ because the input bytes differ, which the map records honestly
+	assert.equal(fromLf, fromCrlf);
+	assert.notEqual(planHash(GROUPED_PLAN), planHash(crlf));
+});
+
+test("#given nested (indented) checkboxes under a task #when parsed #then only column-zero rows count", async () => {
+	// given
+	const { parsePlanMap } = await import(scriptUrl);
+	const plan = `# nested - Work Plan
+
+## Todos
+
+- [ ] 1. Real task
+  - [ ] acceptance criterion, not a task
+  - [ ] 2. also not a task (indented)
+`;
+	// when
+	const map = parsePlanMap(plan);
+	// then
+	assert.equal(map.taskCount, 1);
+});
+
+test("#given a plan without a final verification section #when rendered #then the map has no FIN join", async () => {
+	// given
+	const { parsePlanMap, buildMermaid } = await import(scriptUrl);
+	// when
+	const mermaid = buildMermaid(parsePlanMap(FLAT_PLAN));
+	// then
+	assert.ok(!mermaid.includes("FIN"));
+});
+
+test("#given the HTML viewer #when built #then the mermaid source is escaped content and the only remote URL is the pinned renderer", async () => {
+	// given
+	const { parsePlanMap, buildMermaid, buildMapHtml } = await import(scriptUrl);
+	const map = parsePlanMap(GROUPED_PLAN);
+	// when
+	const html = buildMapHtml(map, buildMermaid(map), { slug: "demo", hash: "abc", sourceRelPath: "p.md" });
+	// then
+	assert.ok(html.includes('<pre class="mermaid">'));
+	assert.ok(html.includes("cdn.jsdelivr.net/npm/mermaid@11"));
+	const remoteUrls = html.match(/https?:\/\/[^"' )]+/g) ?? [];
+	assert.deepEqual(
+		remoteUrls.filter((url) => !url.startsWith("https://cdn.jsdelivr.net/npm/mermaid@11")),
+		[],
+	);
+	assert.ok(!html.includes('T1["'));
+	assert.ok(html.includes("T1[&quot;"));
+});
+
+test("#given the CLI in --check mode #when run against a temp plan #then it reports without writing anything", async () => {
+	// given
+	const { runCli, EXIT_OK } = await import(scriptUrl);
+	const dir = await mkdtemp(join(tmpdir(), "plan-map-"));
+	const planPath = join(dir, "demo.md");
+	await writeFile(planPath, GROUPED_PLAN, "utf8");
+	// when
+	const code = await runCli(["node", "plan-map.mjs", planPath, "--check"], dir);
+	// then
+	assert.equal(code, EXIT_OK);
+	assert.deepEqual(await readdir(dir), ["demo.md"]);
+});
+
+test("#given the CLI in default mode #when run twice #then it writes under .omo/maps and re-runs are byte-identical", async () => {
+	// given
+	const { runCli } = await import(scriptUrl);
+	const dir = await mkdtemp(join(tmpdir(), "plan-map-"));
+	const planPath = join(dir, "demo.md");
+	await writeFile(planPath, GROUPED_PLAN, "utf8");
+	// when
+	await runCli(["node", "plan-map.mjs", planPath, "--html"], dir);
+	const mdPath = join(dir, ".omo", "maps", "demo.md");
+	const first = await readFile(mdPath, "utf8");
+	await runCli(["node", "plan-map.mjs", planPath, "--html"], dir);
+	const second = await readFile(mdPath, "utf8");
+	// then
+	assert.equal(first, second);
+	assert.ok(first.endsWith("\n"));
+	assert.ok((await readFile(join(dir, ".omo", "maps", "demo.html"), "utf8")).includes("Plan map"));
+	// and --- the source plan was never modified
+	assert.equal(await readFile(planPath, "utf8"), GROUPED_PLAN);
+});
+
+test("#given an --out-dir that escapes the working directory #when run #then it refuses", async () => {
+	// given
+	const { runCli, PlanMapError } = await import(scriptUrl);
+	const dir = await mkdtemp(join(tmpdir(), "plan-map-"));
+	await writeFile(join(dir, "demo.md"), GROUPED_PLAN, "utf8");
+	// when / then
+	await assert.rejects(
+		() => runCli(["node", "plan-map.mjs", join(dir, "demo.md"), "--out-dir", ".."], dir),
+		(error) => error instanceof PlanMapError && error.kind === "path-escape",
+	);
+});
+
+test("#given a slug instead of a path #when the plan lives in .omo/plans #then it resolves by slug", async () => {
+	// given
+	const { runCli } = await import(scriptUrl);
+	const dir = await mkdtemp(join(tmpdir(), "plan-map-"));
+	const plansDir = join(dir, ".omo", "plans");
+	await import("node:fs/promises").then(({ mkdir }) => mkdir(plansDir, { recursive: true }));
+	await writeFile(join(plansDir, "demo.md"), GROUPED_PLAN, "utf8");
+	// when
+	const code = await runCli(["node", "plan-map.mjs", "demo", "--check"], dir);
+	// then
+	assert.equal(code, 0);
+});

--- a/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
@@ -27,6 +27,7 @@ export const expectedSkills = [
 	"ultimate-browsing",
 	"ultrawork",
 	"ulw-loop",
+	"ulw-map",
 	"ulw-plan",
 	"ulw-research",
 	"visual-qa",

--- a/packages/shared-skills/AGENTS.md
+++ b/packages/shared-skills/AGENTS.md
@@ -6,11 +6,11 @@
 
 Hand-authored, cross-harness skill bundle shared between the OpenCode and Codex editions. Mostly authored skill data, with skill-owned scripts/assets when required and no transform inside the package. `index.mjs` exports `sharedSkillsRootPath()` returning the absolute path to `skills/`. Package: `@oh-my-opencode/shared-skills` (`files`: `index.mjs`, `index.d.ts`, `skills`).
 
-## SKILLS (20 under `skills/<name>/`)
+## SKILLS (21 under `skills/<name>/`)
 
-`programming`, `debugging`, `frontend`, `visual-qa`, `ast-grep`, `coding-agent-sessions`, `git-master`, `refactor`, `review-work`, `start-work`, `ulw-plan`, `ulw-research`, `ultraresearch`, `init-deep`, `remove-ai-slops`, `lsp-setup`, `ultimate-browsing` (shared) + `lcx-report-bug`, `lcx-contribute-bug-fix`, `lcx-doctor` (Codex-only, `lcx-` prefix).
+`programming`, `debugging`, `frontend`, `visual-qa`, `ast-grep`, `coding-agent-sessions`, `git-master`, `refactor`, `review-work`, `start-work`, `ulw-plan`, `ulw-map`, `ulw-research`, `ultraresearch`, `init-deep`, `remove-ai-slops`, `lsp-setup`, `ultimate-browsing` (shared) + `lcx-report-bug`, `lcx-contribute-bug-fix`, `lcx-doctor` (Codex-only, `lcx-` prefix).
 
-Per-skill layout: `SKILL.md` (YAML frontmatter `name:` + single-line `description:` with triggers) + optional `references/` (the real content; SKILL.md is a router/index) + optional `scripts/` + optional `agents/openai.yaml` (6 skills carry the Codex agent role declaration).
+Per-skill layout: `SKILL.md` (YAML frontmatter `name:` + single-line `description:` with triggers) + optional `references/` (the real content; SKILL.md is a router/index) + optional `scripts/` + optional `agents/openai.yaml` (7 skills carry the Codex agent role declaration).
 
 ## PIPELINE
 

--- a/packages/shared-skills/skills/ulw-map/SKILL.md
+++ b/packages/shared-skills/skills/ulw-map/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ulw-map
+description: "Turn a ulw-plan work plan into a READ-ONLY visual wave execution map (deterministic Mermaid, optional browser viewer). Use when the user wants to SEE a plan instead of reading it: before approving a plan at the ulw-plan gate, when a non-expert asks what will happen or in what order, or to check progress at a glance (checked todos render as done). Triggers: ulw-map, plan map, show me the plan, visualize the plan, draw the plan, what's the execution order, 계획 보여줘, 플랜 그림으로. NOT for creating or editing plans (use ulw-plan) and NOT for executing them (use start-work)."
+metadata:
+  short-description: Visual wave execution map for ulw-plan work plans
+---
+
+# ulw-map
+
+You render an existing `.omo/plans/<slug>.md` work plan as a **wave execution map** so a human - expert or not - can see at a glance what will run, in what order, and what runs in parallel. You are a VIEWER: you never create, edit, or execute plans, and you never modify the plan file.
+
+Everything is derived **deterministically** from the plan text by a script - no LLM anywhere in the parse/emit path, so the diagram cannot hallucinate structure the plan does not contain. Identical plan bytes + identical source path and options → identical map bytes.
+
+## RUN THE SCRIPT - do not hand-draw the diagram
+
+```
+node "<skill-root>/scripts/plan-map.mjs" <plan-file-or-slug> [--html] [--open] [--check] [--stdout] [--out-dir <dir>]
+```
+
+(Replace `<skill-root>` with this skill's own directory; `bun` is an accepted substitute for `node`.) Never write the Mermaid by hand - a hand-drawn diagram can drift from the plan, which defeats the point.
+
+- Default: writes `.omo/maps/<slug>.md` (Mermaid + a "how to read this" legend + diagnostics).
+- `--html`: also writes `.omo/maps/<slug>.html`, a self-written viewer page. The Mermaid **source** is the page content; the renderer loads from a pinned CDN URL at view time (nothing vendored). Offline, the page still shows the source.
+- `--open`: opens the HTML viewer in the default browser (implies `--html`). Use it when the user asks to *see* the map; do not open a browser unprompted - plans can contain paths and commands the user may not want on screen.
+- `--stdout`: prints the map Markdown instead of writing files (useful to show the Mermaid inline).
+- `--check`: parses and reports diagnostics without writing anything.
+
+## What the map claims (honesty contract)
+
+- It parses only the mandated plan grammar: column-zero `- [ ] N. <title>` rows in `## Todos` and `- [ ] F<n>. <title>` rows in `## Final verification wave`.
+- Wave grouping ladder, most-canonical first: (1) the per-todo `Parallelization: Wave <N>` metadata line the ulw-plan template mandates; (2) column-zero `###` headings inside `## Todos`; (3) neither → a document-order chain, labeled as such. Tasks inside one group are lanes that may run concurrently; groups are barriers. The map states which ladder rung produced the grouping.
+- **Arrows mean plan document order, never inferred per-task dependencies.** Do not present the map as a dependency graph.
+- The final verification wave renders as a parallel fan-out joining at "All approve → complete" - that is the upstream contract, not an inference.
+- `✓` marks checkboxes already checked off, so re-running after execution shows progress.
+
+## Fail-soft contract
+
+The script never guesses. Exit 0 = map generated (diagnostics, if any, are embedded in the output and printed as `warning:` lines - relay them to the user). Exit 1 = unsupported plan structure (missing `## Todos`, or no rows matching the grammar) with a human-fixable message. Exit 2 = usage or IO errors. On exit 1, tell the user what the script looked for; offer `$ulw-plan` if they don't have a real work plan yet.
+
+## Typical moments to offer the map
+
+1. **At the approval gate** - after `$ulw-plan` presents a plan and before the user approves it, offer: "want to see this as a map?" Then run with `--open` if they say yes.
+2. **Mid-execution** - "how far along are we?" Re-run the script; checked boxes render as done.
+3. **Explaining a plan to someone else** - `--html` produces a single file that can be viewed anywhere.
+
+## Boundaries
+
+- Never edit the plan file or write outside `.omo/` (or the explicit `--out-dir`, which must stay inside the working directory).
+- Never substitute an image-generation model for the script - the map must stay deterministic.
+- Creating or changing plans is `$ulw-plan`; executing them is `$start-work`; this skill only shows them.

--- a/packages/shared-skills/skills/ulw-map/agents/openai.yaml
+++ b/packages/shared-skills/skills/ulw-map/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "ulw-map (omo)"
+  short_description: "See a ulw-plan as a visual wave execution map"
+  search_terms:
+    - "ulw-map"
+    - "plan map"
+    - "visualize plan"
+  default_prompt: "Use $ulw-map to render my current work plan as a visual wave execution map and open it in the browser."

--- a/packages/shared-skills/skills/ulw-map/scripts/plan-map.mjs
+++ b/packages/shared-skills/skills/ulw-map/scripts/plan-map.mjs
@@ -1,0 +1,625 @@
+// plan-map.mjs - derive a READ-ONLY wave execution map (Mermaid) from a ulw-plan work plan.
+//
+// Zero external dependencies (node:fs/path/process/url/crypto/child_process builtins only) so it
+// runs byte-identically under `node` and `bun` on macOS, Linux, and Windows - same portability
+// contract as ulw-plan's scaffold-plan.mjs.
+//
+// Usage:  node "<skill-root>/scripts/plan-map.mjs" <plan-file-or-slug> [--html] [--open] [--check] [--stdout] [--out-dir <dir>]
+//
+// WHAT IT CLAIMS (and nothing more):
+// - It parses ONLY the mandated plan grammar (full-workflow.md / scaffold-plan.mjs): column-zero
+//   `- [ ] N. <title>` rows in `## Todos` and `- [ ] F<n>. <title>` rows in
+//   `## Final verification wave`.
+// - Wave grouping ladder, most-canonical first:
+//     1. the per-todo `Parallelization: Wave <N>` metadata line the ulw-plan template mandates;
+//     2. column-zero `###`(+) headings inside the Todos region (one group per heading);
+//     3. neither present -> tasks render as a document-order chain, labeled as such.
+//   Tasks inside one group are lanes that may run concurrently; groups are barriers.
+// - Edges mean wave barriers / plan DOCUMENT ORDER, never inferred per-task dependencies.
+//   No LLM anywhere in the parse/emit path; identical plan bytes + identical source path and
+//   options -> identical output bytes.
+//
+// FAIL-SOFT CONTRACT (exit codes):
+//   0 - map generated (warnings, if any, are printed and embedded in the map)
+//   1 - unsupported plan structure (missing `## Todos`, or zero rows matching the grammar);
+//       a human-fixable diagnostic explains exactly what was looked for
+//   2 - usage / IO errors (unknown flag, unreadable input, write-path escape, opener failure)
+//
+// WRITE BOUNDARY: the plan file is NEVER modified (writing over the source plan is refused even
+// via --out-dir). Default output goes under `.omo/maps/`; any output path must resolve inside the
+// working directory through real paths (symlinked components are refused, mirroring
+// scaffold-plan.mjs's write guards).
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const EXIT_OK = 0;
+export const EXIT_UNSUPPORTED = 1;
+export const EXIT_USAGE = 2;
+
+const TODOS_SECTION = "todos";
+const FINAL_SECTION = "final verification wave";
+const TASK_ROW = /^- \[( |x|X)\] (\d+)\.\s+(.*)$/;
+const FINAL_ROW = /^- \[( |x|X)\] F(\d+)\.\s+(.*)$/;
+const CHECKBOX_LIKE = /^- \[( |x|X)\]\s/;
+const PARALLELIZATION_WAVE = /^Parallelization:.*\bWave\s+(\d+)\b/;
+const MAX_LABEL_LENGTH = 60;
+const READABILITY_WARNING_NODES = 30;
+// Exact version pin (verified against the npm registry when this skill was authored); the viewer
+// page states this URL and tests assert it is the page's only remote reference.
+export const MERMAID_CDN_URL = "https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.esm.min.mjs";
+
+export class PlanMapError extends Error {
+	constructor(kind, message) {
+		super(message);
+		this.name = "PlanMapError";
+		this.kind = kind;
+	}
+}
+
+function normalizeHeadingText(text) {
+	return text.trim().replace(/:$/, "").toLowerCase();
+}
+
+// Track fenced code blocks so documentation examples can never be mistaken for
+// real sections or task rows. A fence opens with 3+ backticks or tildes at
+// column zero (info string allowed) and closes only on a bare column-zero fence
+// of the same character, at least the same length, with nothing but trailing
+// whitespace after it (CommonMark closing-fence rule).
+function createFenceTracker() {
+	let fenceChar = null;
+	let fenceLength = 0;
+	return (line) => {
+		const match = /^(`{3,}|~{3,})(.*)$/.exec(line);
+		if (match) {
+			const char = match[1][0];
+			const length = match[1].length;
+			const rest = match[2];
+			if (fenceChar === null) {
+				fenceChar = char;
+				fenceLength = length;
+				return true;
+			}
+			if (char === fenceChar && length >= fenceLength && rest.trim() === "") {
+				fenceChar = null;
+				fenceLength = 0;
+				return true;
+			}
+			return true;
+		}
+		return fenceChar !== null;
+	};
+}
+
+function isMandatedTaskNumber(number) {
+	return Number.isSafeInteger(number) && number >= 1;
+}
+
+// Parse the mandated plan grammar into { title, groups, finals, warnings, taskCount, grouping }.
+// Throws PlanMapError("no-todos-section" | "no-tasks") for unsupported structure.
+export function parsePlanMap(content) {
+	const lines = content.replaceAll("\r\n", "\n").split("\n");
+	const insideFence = createFenceTracker();
+	const warnings = [];
+	let title = null;
+	let section = null;
+	let sawTodosSection = false;
+	const headingGroups = [{ label: null, tasks: [] }];
+	const tasks = [];
+	const finals = [];
+	const seenTaskNumbers = new Map();
+	const seenFinalNumbers = new Set();
+	let ignoredCheckboxRows = 0;
+	let currentTask = null;
+
+	for (const line of lines) {
+		if (insideFence(line)) continue;
+
+		const heading = /^(#{1,6})\s+(.*)$/.exec(line);
+		if (heading) {
+			currentTask = null;
+			const level = heading[1].length;
+			const text = heading[2].trim();
+			if (level === 1 && title === null) {
+				title = text;
+				continue;
+			}
+			if (level <= 2) {
+				const normalized = normalizeHeadingText(text);
+				if (normalized === TODOS_SECTION) {
+					section = "todos";
+					sawTodosSection = true;
+				} else if (normalized === FINAL_SECTION) {
+					section = "final";
+				} else {
+					section = null;
+				}
+				continue;
+			}
+			if (section === "todos") {
+				headingGroups.push({ label: text, tasks: [] });
+			}
+			continue;
+		}
+
+		if (section === "todos") {
+			const row = TASK_ROW.exec(line);
+			if (row) {
+				currentTask = null;
+				const number = Number.parseInt(row[2], 10);
+				const taskTitle = row[3].trim();
+				if (!isMandatedTaskNumber(number) || taskTitle === "") {
+					ignoredCheckboxRows += 1;
+					continue;
+				}
+				const count = (seenTaskNumbers.get(number) ?? 0) + 1;
+				seenTaskNumbers.set(number, count);
+				if (count > 1) {
+					warnings.push(`duplicate task number ${number} - node ids stay unique (T${number}_${count})`);
+				}
+				currentTask = {
+					id: count === 1 ? `T${number}` : `T${number}_${count}`,
+					number,
+					title: taskTitle,
+					done: row[1] !== " ",
+					wave: null,
+				};
+				tasks.push(currentTask);
+				headingGroups.at(-1).tasks.push(currentTask);
+				continue;
+			}
+			if (line.startsWith("- ") || /^\S/.test(line)) currentTask = null;
+			if (currentTask && /^\s+\S/.test(line)) {
+				const waveMatch = PARALLELIZATION_WAVE.exec(line.trim());
+				if (waveMatch) {
+					const wave = Number.parseInt(waveMatch[1], 10);
+					if (isMandatedTaskNumber(wave)) currentTask.wave = wave;
+				}
+				continue;
+			}
+			if (CHECKBOX_LIKE.test(line)) {
+				ignoredCheckboxRows += 1;
+				continue;
+			}
+			continue;
+		}
+
+		if (section === "final") {
+			const finalRow = FINAL_ROW.exec(line);
+			if (finalRow) {
+				const number = Number.parseInt(finalRow[2], 10);
+				const finalTitle = finalRow[3].trim();
+				if (!isMandatedTaskNumber(number) || finalTitle === "") {
+					warnings.push(`final-verifier row outside the mandated grammar ignored: ${line.trim()}`);
+					continue;
+				}
+				if (seenFinalNumbers.has(number)) {
+					warnings.push(`duplicate final-verifier number F${number} - later row ignored`);
+					continue;
+				}
+				seenFinalNumbers.add(number);
+				finals.push({ id: `F${number}`, number, title: finalTitle, done: finalRow[1] !== " " });
+				continue;
+			}
+			if (TASK_ROW.test(line)) {
+				warnings.push(`implementation row found inside ## Final verification wave - ignored: ${line.trim()}`);
+			}
+		}
+	}
+
+	if (!sawTodosSection) {
+		throw new PlanMapError(
+			"no-todos-section",
+			"unsupported plan structure: no `## Todos` section found outside code fences. " +
+				"ulw-map reads the plan shape ulw-plan's scaffold emits; point it at a `.omo/plans/<slug>.md` work plan.",
+		);
+	}
+	if (tasks.length === 0) {
+		const hint =
+			ignoredCheckboxRows > 0
+				? `${ignoredCheckboxRows} checkbox row(s) found, but none match the mandated column-zero \`- [ ] N. <title>\` grammar (positive decimal N, non-empty title).`
+				: "no checkbox rows found in the `## Todos` section.";
+		throw new PlanMapError("no-tasks", `unsupported plan structure: ${hint}`);
+	}
+	if (ignoredCheckboxRows > 0) {
+		warnings.push(
+			`${ignoredCheckboxRows} checkbox row(s) in ## Todos ignored - they do not match the \`- [ ] N. <title>\` grammar`,
+		);
+	}
+
+	// Wave grouping ladder: Parallelization metadata > headings > document order.
+	let groups;
+	let grouping;
+	const withWave = tasks.filter((task) => task.wave !== null);
+	if (withWave.length > 0) {
+		grouping = "wave-metadata";
+		let lastWave = null;
+		for (const task of tasks) {
+			if (task.wave === null) {
+				task.wave = lastWave ?? withWave[0].wave;
+				warnings.push(
+					`task ${task.number} has no \`Parallelization: Wave <N>\` line - inherited Wave ${task.wave} from document order`,
+				);
+			}
+			lastWave = task.wave;
+		}
+		const byWave = new Map();
+		for (const task of tasks) {
+			if (!byWave.has(task.wave)) byWave.set(task.wave, []);
+			byWave.get(task.wave).push(task);
+		}
+		groups = [...byWave.keys()].sort((a, b) => a - b).map((wave) => ({ label: `Wave ${wave}`, tasks: byWave.get(wave) }));
+	} else {
+		const implicitGroup = headingGroups[0];
+		groups = headingGroups.filter((group) => {
+			if (group.tasks.length > 0) return true;
+			if (group.label !== null) warnings.push(`group heading with no task rows dropped: "${group.label}"`);
+			return false;
+		});
+		const hasExplicitGroups = groups.some((group) => group.label !== null);
+		if (hasExplicitGroups && implicitGroup.tasks.length > 0) {
+			implicitGroup.label = "(ungrouped)";
+			warnings.push('tasks found before the first group heading - grouped as "(ungrouped)"');
+		}
+		grouping = hasExplicitGroups ? "headings" : "document-order";
+	}
+
+	if (tasks.length + finals.length > READABILITY_WARNING_NODES) {
+		warnings.push(
+			`${tasks.length + finals.length} nodes - large maps render but read poorly; consider reviewing wave by wave`,
+		);
+	}
+
+	return { title, groups, finals, warnings, taskCount: tasks.length, grouping };
+}
+
+// Mermaid label sanitization: node ids are program-generated (injection-safe by
+// construction); labels are quoted, stripped of fence/bracket/quote characters,
+// and truncated for readability.
+export function sanitizeLabel(text) {
+	let label = text
+		.replaceAll('"', "'")
+		.replaceAll("`", "'")
+		.replaceAll("[", "(")
+		.replaceAll("]", ")")
+		.replaceAll("{", "(")
+		.replaceAll("}", ")")
+		.replaceAll(/\s+/g, " ")
+		.trim();
+	if (label.length > MAX_LABEL_LENGTH) label = `${label.slice(0, MAX_LABEL_LENGTH - 1)}…`;
+	return label;
+}
+
+export function buildMermaid(map) {
+	const out = [];
+	out.push("flowchart TD");
+	const flat = map.grouping === "document-order";
+
+	if (flat) {
+		const tasks = map.groups[0].tasks;
+		for (const task of tasks) {
+			out.push(`    ${task.id}["${task.done ? "✓ " : ""}${task.number}. ${sanitizeLabel(task.title)}"]`);
+		}
+		for (let i = 0; i + 1 < tasks.length; i += 1) {
+			out.push(`    ${tasks[i].id} --> ${tasks[i + 1].id}`);
+		}
+	} else {
+		map.groups.forEach((group, index) => {
+			const waveId = `W${index + 1}`;
+			out.push(`    subgraph ${waveId}["${sanitizeLabel(group.label ?? "Todos")}"]`);
+			for (const task of group.tasks) {
+				out.push(`        ${task.id}["${task.done ? "✓ " : ""}${task.number}. ${sanitizeLabel(task.title)}"]`);
+			}
+			out.push("    end");
+		});
+		for (let i = 0; i + 1 < map.groups.length; i += 1) {
+			out.push(`    W${i + 1} --> W${i + 2}`);
+		}
+	}
+
+	if (map.finals.length > 0) {
+		const sourceId = flat ? map.groups[0].tasks.at(-1).id : `W${map.groups.length}`;
+		for (const final of map.finals) {
+			out.push(`    ${final.id}["${final.done ? "✓ " : ""}F${final.number}. ${sanitizeLabel(final.title)}"]`);
+		}
+		for (const final of map.finals) {
+			out.push(`    ${sourceId} --> ${final.id}`);
+		}
+		out.push('    FIN(["All approve → complete"])');
+		for (const final of map.finals) {
+			out.push(`    ${final.id} --> FIN`);
+		}
+	}
+
+	const doneIds = [...map.groups.flatMap((group) => group.tasks), ...map.finals]
+		.filter((node) => node.done)
+		.map((node) => node.id);
+	out.push("    classDef done fill:#14532d,stroke:#22c55e,color:#ffffff");
+	if (doneIds.length > 0) out.push(`    class ${doneIds.join(",")} done`);
+
+	return `${out.join("\n")}\n`;
+}
+
+export function planHash(content) {
+	return createHash("sha256").update(content, "utf8").digest("hex").slice(0, 12);
+}
+
+const GROUPING_NOTES = {
+	"wave-metadata": "Wave groups come from the plan's own `Parallelization: Wave <N>` metadata lines.",
+	headings: "Wave groups come from headings inside `## Todos` (no `Parallelization: Wave <N>` metadata found).",
+	"document-order": "No wave metadata or headings found - tasks are shown in plan document order.",
+};
+
+export function buildMapMarkdown(map, mermaid, meta) {
+	const doneCount = map.groups.reduce((sum, group) => sum + group.tasks.filter((task) => task.done).length, 0);
+	const lines = [];
+	lines.push(`# Plan map: ${map.title ?? meta.slug}`);
+	lines.push("");
+	lines.push(
+		`> Derived READ-ONLY from \`${meta.sourceRelPath}\` (sha256 \`${meta.hash}\`) - no LLM in the loop; regenerate with \`$ulw-map\` after the plan changes.`,
+	);
+	lines.push("");
+	lines.push(
+		`${map.taskCount} task(s), ${doneCount} done · ${map.groups.length} wave group(s) · ${map.finals.length} final verifier(s)`,
+	);
+	lines.push("");
+	lines.push("```mermaid");
+	lines.push(mermaid.trimEnd());
+	lines.push("```");
+	lines.push("");
+	lines.push("## How to read this map");
+	lines.push("");
+	lines.push(`- ${GROUPING_NOTES[map.grouping]}`);
+	lines.push("- Arrows show **wave barriers in plan document order**, not inferred per-task dependencies.");
+	lines.push("- Tasks inside one wave group are lanes that may run concurrently; groups run in order.");
+	lines.push("- The final verification wave runs in parallel and **all** verifiers must approve.");
+	lines.push("- `✓` marks checkboxes already checked off in the plan.");
+	if (map.warnings.length > 0) {
+		lines.push("");
+		lines.push("## Diagnostics");
+		lines.push("");
+		for (const warning of map.warnings) lines.push(`- ${warning}`);
+	}
+	lines.push("");
+	return lines.join("\n");
+}
+
+function escapeHtml(text) {
+	return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
+}
+
+// Self-written viewer page: the Mermaid SOURCE is the content (always visible as
+// text if rendering is unavailable); the renderer loads from an exact-version CDN
+// URL at view time - nothing is vendored into the repository.
+export function buildMapHtml(map, mermaid, meta) {
+	const title = escapeHtml(map.title ?? meta.slug);
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Plan map: ${title}</title>
+<style>
+  body { font-family: -apple-system, "Segoe UI", sans-serif; margin: 2rem auto; max-width: 960px; padding: 0 1rem; background: #0b1020; color: #e5e7eb; }
+  h1 { font-size: 1.3rem; }
+  .meta { color: #9ca3af; font-size: 0.85rem; }
+  .legend { color: #9ca3af; font-size: 0.85rem; border-top: 1px solid #1f2937; margin-top: 1.5rem; padding-top: 0.75rem; }
+  pre.mermaid { background: #111827; border-radius: 8px; padding: 1rem; overflow-x: auto; }
+  #fallback-note { display: none; color: #fbbf24; font-size: 0.85rem; }
+</style>
+</head>
+<body>
+<h1>Plan map: ${title}</h1>
+<p class="meta">Derived read-only from <code>${escapeHtml(meta.sourceRelPath)}</code> (sha256 <code>${escapeHtml(meta.hash)}</code>) - no LLM in the loop.</p>
+<p id="fallback-note">Diagram renderer unavailable (offline?) - the Mermaid source below IS the map.</p>
+<pre class="mermaid">${escapeHtml(mermaid.trimEnd())}</pre>
+<p class="legend">Arrows = wave barriers in plan document order, not inferred dependencies. Lanes inside a wave may run concurrently. Final verification runs in parallel; all must approve. ✓ = already checked off.</p>
+<script type="module">
+  try {
+    const { default: mermaidLib } = await import("${MERMAID_CDN_URL}");
+    mermaidLib.initialize({ startOnLoad: true, theme: "dark", securityLevel: "strict" });
+  } catch {
+    document.getElementById("fallback-note").style.display = "block";
+  }
+</script>
+</body>
+</html>
+`;
+}
+
+function assertContainedPath(parent, child, message) {
+	const rel = relative(parent, child);
+	if (rel.startsWith("..") || isAbsolute(rel)) {
+		throw new PlanMapError("path-escape", message);
+	}
+}
+
+// Mirrors scaffold-plan.mjs's write guards: create directories one component at a
+// time refusing symlinks, then re-check containment through real paths.
+async function mkdirWithoutSymlinks(dir, stopAt) {
+	if (dir === stopAt) return;
+	const parent = dirname(dir);
+	if (parent === dir || relative(stopAt, dir).startsWith("..") || isAbsolute(relative(stopAt, dir))) {
+		throw new PlanMapError("path-escape", `refused: output path escapes the working directory: ${dir}`);
+	}
+	await mkdirWithoutSymlinks(parent, stopAt);
+	const stat = await lstat(dir).catch((err) => {
+		if (err && err.code === "ENOENT") return null;
+		throw err;
+	});
+	if (stat) {
+		if (stat.isSymbolicLink()) {
+			throw new PlanMapError("path-escape", `refused: output path component is a symlink: ${dir}`);
+		}
+		if (!stat.isDirectory()) {
+			throw new PlanMapError("path-escape", `refused: output path component is not a directory: ${dir}`);
+		}
+		return;
+	}
+	await mkdir(dir);
+}
+
+async function prepareOutputRoot(cwd, outRoot) {
+	const workspaceRoot = resolve(cwd);
+	assertContainedPath(workspaceRoot, outRoot, `refused: --out-dir escapes the working directory: ${outRoot}`);
+	await mkdirWithoutSymlinks(outRoot, workspaceRoot);
+	const workspaceReal = await realpath(workspaceRoot);
+	const outReal = await realpath(outRoot);
+	assertContainedPath(
+		workspaceReal,
+		outReal,
+		`refused: --out-dir escapes the working directory through symlinks: ${outRoot}`,
+	);
+}
+
+async function assertSafeWriteTarget(target, planReal) {
+	const stat = await lstat(target).catch((err) => {
+		if (err && err.code === "ENOENT") return null;
+		throw err;
+	});
+	if (stat?.isSymbolicLink()) {
+		throw new PlanMapError("path-escape", `refused: output target is a symlink: ${target}`);
+	}
+	if (stat) {
+		const targetReal = await realpath(target);
+		if (targetReal === planReal) {
+			throw new PlanMapError(
+				"source-overwrite",
+				`refused: output path resolves to the source plan itself (${target}) - ulw-map never modifies the plan`,
+			);
+		}
+	}
+}
+
+export function parseArgs(argv) {
+	const rest = argv.slice(2);
+	let input;
+	let html = false;
+	let open = false;
+	let check = false;
+	let stdout = false;
+	let outDir;
+	for (let i = 0; i < rest.length; i += 1) {
+		const arg = rest[i];
+		if (arg === "--html") html = true;
+		else if (arg === "--open") {
+			open = true;
+			html = true;
+		} else if (arg === "--check") check = true;
+		else if (arg === "--stdout") stdout = true;
+		else if (arg === "--out-dir") {
+			outDir = rest[i + 1];
+			if (outDir === undefined || outDir.startsWith("--")) {
+				throw new PlanMapError("usage", "--out-dir requires a directory argument");
+			}
+			i += 1;
+		} else if (arg.startsWith("--")) throw new PlanMapError("usage", `unknown flag: ${arg}`);
+		else if (input === undefined) input = arg;
+		else throw new PlanMapError("usage", `unexpected argument: ${arg}`);
+	}
+	if (!input) {
+		throw new PlanMapError(
+			"usage",
+			"usage: plan-map.mjs <plan-file-or-slug> [--html] [--open] [--check] [--stdout] [--out-dir <dir>]",
+		);
+	}
+	return { input, html, open, check, stdout, outDir };
+}
+
+function resolvePlanPath(cwd, input) {
+	const direct = resolve(cwd, input);
+	if (existsSync(direct)) return direct;
+	const bySlug = join(cwd, ".omo", "plans", `${input}.md`);
+	if (existsSync(bySlug)) return bySlug;
+	throw new PlanMapError("usage", `plan not found - tried: ${direct} and ${bySlug}`);
+}
+
+// Resolves once the opener process actually spawned; rejects if the platform
+// opener is unavailable so "opened nothing" can never report success.
+function openInBrowser(filePath) {
+	const [command, args] =
+		process.platform === "darwin"
+			? ["open", [filePath]]
+			: process.platform === "win32"
+				? ["explorer.exe", [filePath]]
+				: ["xdg-open", [filePath]];
+	return new Promise((resolvePromise, rejectPromise) => {
+		const child = spawn(command, args, { stdio: "ignore", detached: true });
+		child.once("error", (error) => {
+			rejectPromise(new PlanMapError("open-failed", `files were written, but opening the browser failed: ${error.message}`));
+		});
+		child.once("spawn", () => {
+			child.unref();
+			resolvePromise();
+		});
+	});
+}
+
+export async function runCli(argv, cwd) {
+	const options = parseArgs(argv);
+	const planPath = resolvePlanPath(cwd, options.input);
+	const content = await readFile(planPath, "utf8");
+	const map = parsePlanMap(content);
+	const slug = basename(planPath).replace(/\.md$/i, "");
+	const hash = planHash(content);
+	const sourceRelPath = relative(cwd, planPath) || planPath;
+	const mermaid = buildMermaid(map);
+	const meta = { slug, hash, sourceRelPath: sourceRelPath.replaceAll("\\", "/") };
+	const markdown = buildMapMarkdown(map, mermaid, meta);
+
+	for (const warning of map.warnings) console.warn(`warning: ${warning}`);
+
+	if (options.stdout) {
+		process.stdout.write(markdown);
+		return EXIT_OK;
+	}
+
+	const outRoot = options.outDir ? resolve(cwd, options.outDir) : join(cwd, ".omo", "maps");
+	const mdPath = join(outRoot, `${slug}.md`);
+	const htmlPath = join(outRoot, `${slug}.html`);
+
+	if (options.check) {
+		console.log(
+			`plan-map --check: ${slug} - ${map.taskCount} task(s), ${map.groups.length} group(s), ${map.finals.length} final(s); would write ${mdPath}${options.html ? ` and ${htmlPath}` : ""}`,
+		);
+		return EXIT_OK;
+	}
+
+	await prepareOutputRoot(cwd, outRoot);
+	const planReal = await realpath(planPath);
+	await assertSafeWriteTarget(mdPath, planReal);
+	await writeFile(mdPath, markdown, "utf8");
+	const written = [mdPath];
+	if (options.html) {
+		await assertSafeWriteTarget(htmlPath, planReal);
+		await writeFile(htmlPath, buildMapHtml(map, mermaid, meta), "utf8");
+		written.push(htmlPath);
+	}
+	console.log(
+		`plan-map: ${slug} - ${map.taskCount} task(s), ${map.groups.length} group(s), ${map.finals.length} final(s) → ${written.join(", ")}`,
+	);
+	if (options.open) await openInBrowser(htmlPath);
+	return EXIT_OK;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	// process.exitCode (not process.exit) so stdout fully drains before termination.
+	runCli(process.argv, process.cwd()).then(
+		(code) => {
+			process.exitCode = code;
+		},
+		(error) => {
+			if (error instanceof PlanMapError) {
+				console.error(`plan-map: ${error.message}`);
+				process.exitCode = error.kind === "no-todos-section" || error.kind === "no-tasks" ? EXIT_UNSUPPORTED : EXIT_USAGE;
+				return;
+			}
+			console.error(`plan-map: unexpected error: ${error?.message ?? error}`);
+			process.exitCode = EXIT_USAGE;
+		},
+	);
+}

--- a/packages/shared-skills/skills/ulw-map/scripts/plan-map.mjs
+++ b/packages/shared-skills/skills/ulw-map/scripts/plan-map.mjs
@@ -161,6 +161,11 @@ export function parsePlanMap(content) {
 				if (count > 1) {
 					warnings.push(`duplicate task number ${number} - node ids stay unique (T${number}_${count})`);
 				}
+				if (/^<.*>$/.test(taskTitle)) {
+					warnings.push(
+						`task ${number} title looks like an unfilled template placeholder (${taskTitle}) - the plan may not contain real todos yet`,
+					);
+				}
 				currentTask = {
 					id: count === 1 ? `T${number}` : `T${number}_${count}`,
 					number,


### PR DESCRIPTION
## What

`$ulw-map`: a new shared skill that renders a `ulw-plan` work plan as a **read-only, deterministic wave execution map** (Mermaid), with an optional single-file HTML viewer.

`ulw-plan` already ends at an explicit approval gate, and its plans lead with `## TL;DR (For humans)`. But the plan body itself is a long Markdown document: wave ordering, concurrent lanes, and the final verification fan-out are invisible at a glance, especially for the non-expert users who are asked to approve. `ulw-map` turns the plan they are approving into a picture, without letting any model draw it: the diagram is derived mechanically from the plan text, so it cannot contain structure the plan does not.

- **Parses only the mandated grammar** ([full-workflow.md](packages/shared-skills/skills/ulw-plan/references/full-workflow.md), [scaffold-plan.mjs](packages/shared-skills/skills/ulw-plan/scripts/scaffold-plan.mjs) template): column-zero `- [ ] N. <title>` rows in `## Todos`, `- [ ] F<n>. <title>` rows in `## Final verification wave`. Fence-aware with the CommonMark closing-fence rule (documentation examples never parse as real sections), CRLF-tolerant, byte-identical output under `node` and `bun`.
- **Wave grouping ladder, most-canonical first**: (1) the per-todo `Parallelization: Wave <N>` metadata line the ulw-plan template mandates; (2) column-zero `###` headings inside `## Todos`; (3) neither → a document-order chain. The emitted map states which rung produced the grouping, and tasks missing a metadata line inherit the previous wave with a named diagnostic.
- **Honest semantics, narrowly claimed**: arrows mean **wave barriers in plan document order, never inferred per-task dependencies**, and the emitted legend says so. Tasks inside a wave are lanes that may run concurrently. The final verification wave renders as the parallel all-must-approve fan-out that the upstream contract already defines.
- **Fail-soft, with diagnostics instead of guesses**: exit 0 = map generated (warnings embedded in the artifact), exit 1 = unsupported structure with a human-fixable message (missing `## Todos`, or checkbox rows outside the grammar, counted and named; task `0`, unsafe numbers, and blank titles are rejected), exit 2 = usage/IO. Duplicate numbers, fenced fakes, indented pseudo-tasks, and label injection are all handled and tested.
- **Read-only by construction**: the plan file is never modified; an output path that resolves to the source plan is refused (`--out-dir .` cannot clobber it), output confinement re-checks through real paths and refuses symlinked components (mirroring `scaffold-plan.mjs`'s write guards), and re-runs are byte-identical. Checked-off todos render as done, so re-running after execution shows progress.
- **Zero new dependencies**: node builtins only, same portability contract as `scaffold-plan.mjs` (the CLI sets `process.exitCode` so large `--stdout` output always drains; the Windows opener is `explorer.exe` with a literal path, no `cmd` reparse surface). The HTML viewer is source-first; the Mermaid text is the page content; the renderer loads from an exact-version CDN URL (`mermaid@11.16.0`, asserted in tests as the page's only remote reference) and the page degrades to the readable source offline. Nothing is vendored. `--open` (browser) is opt-in only.

## Why

Text is a good format for writing plans; it is a poor format for *approving* them. The approval gate is the one moment a human, often a non-developer, must actually understand the plan, and `## TL;DR (For humans)` already acknowledges that the raw plan body is not that interface. This is the same idea one step further: the structure the plan already encodes (`Parallelization: Wave <N>`, the final verification contract), shown instead of described. Deriving it deterministically (rather than asking a model to draw a diagram) makes plan/diagram drift structurally impossible.

## Demo (dogfooding: this contribution's own plan in the canonical template shape, block below generated by the script)

```mermaid
flowchart TD
    subgraph W1["Wave 1"]
        T1["✓ 1. Fence-aware parser for the mandated todo grammar"]
        T2["✓ 2. Wave grouping ladder (metadata > headings > document order)"]
        T3["✓ 3. Mermaid emitter with sanitized labels and done-state classes"]
    end
    subgraph W2["Wave 2"]
        T4["✓ 4. Map Markdown artifact with legend and diagnostics"]
        T5["✓ 5. HTML viewer (source-first, exact-pin CDN renderer, offline …"]
    end
    subgraph W3["Wave 3"]
        T6["6. CLI: slug resolution, symlink-safe .omo/maps confinement, -…"]
        T7["7. Contract tests: fences, duplicates, injection, CRLF determi…"]
    end
    W1 --> W2
    W2 --> W3
    F1["F1. Plan compliance audit"]
    F2["F2. Code quality review"]
    F3["F3. Real manual QA"]
    F4["F4. Scope fidelity"]
    W3 --> F1
    W3 --> F2
    W3 --> F3
    W3 --> F4
    FIN(["All approve → complete"])
    F1 --> FIN
    F2 --> FIN
    F3 --> FIN
    F4 --> FIN
    classDef done fill:#14532d,stroke:#22c55e,color:#ffffff
    class T1,T2,T3,T4,T5 done
```

Fail-soft, exercised live: a document without `## Todos` exits 1 with `unsupported plan structure: no \`## Todos\` section found outside code fences...`; checkbox rows outside the grammar exit 1 with the ignored-row count; an unknown flag or `--out-dir` escape exits 2.

## Scope (deliberately narrow)

- `ulw-plan` templates, prompts, and contracts are untouched; this is a viewer, not a protocol change.
- No per-task dependency inference: the map claims wave barriers and the upstream-defined parallel semantics, nothing more. (Rendering the plan's *declared* `Blocked by:` edges is a possible follow-up, kept out on purpose.)
- No vendored renderer, no image generation. A future dependency-free `--format svg` and an artifact/structure map are possible follow-ups, also kept out.
- Registration footprint: `expectedSkills` in the sync contract test + the shared-skills `AGENTS.md` skill list (count updates included). `sync-skills.mjs` picks the skill up without changes.

## Testing

- `node --test test/plan-map.test.mjs`: **23 pass**: wave-metadata grouping (canonical template fixture), metadata-inheritance diagnostic, heading and document-order ladder rungs, fenced fakes + CommonMark pseudo-closer, missing-section and wrong-grammar diagnostics (including task `0`, unsafe numbers, blank titles), duplicate numbers, label injection, CRLF/LF determinism, nested-checkbox exclusion, HTML escaping + exact-pin single remote URL, `--check` writes nothing, default-mode idempotency (double run byte-identical, source untouched), source-overwrite refusal, unfilled-template-placeholder diagnostic, lexical + symlink `--out-dir` escape refusal, `--out-dir --check` usage error, slug resolution. Temp trees are cleaned in `finally`.
- `node --test test/*.test.mjs` (omo-codex plugin): **376 pass, 0 fail** including the sync-skills drift contract with the new skill registered.
- `bun test` at the repo root: **11,642 pass, 0 fail** (full monorepo, pre-review baseline; affected suites re-run green after review fixes).
- Live CLI: canonical-template plan → 3 wave groups from `Parallelization` metadata; triple run `diff` empty; `node` and `bun` `--stdout` byte-identical (same sha1).
- Post-build review: an independent Codex CLI review of the staged diff returned FIX-THEN-SUBMIT with 13 findings (2 blockers: canonical `Parallelization: Wave <N>` metadata was not parsed; `--out-dir .` could overwrite the source plan). All 13 are fixed above and covered by the new tests.

Naming note: `ulw-map` is provisional; happy to rename (e.g. `ulw-plan-map`) if you prefer the input to be explicit in the name.
