### PR TITLE
feat(omo-senpi): ship all shared + local skills by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "install:codex-dev": "bun run script/build-codex-install.ts && bun run script/install-codex-dev.ts",
     "build:codex-plugin": "npm --prefix packages/omo-codex/plugin ci && bun run --cwd packages/omo-codex/plugin build",
     "build:senpi-plugin": "bun run build:lsp-daemon && bun run build:senpi-plugin:stage",
-    "build:senpi-plugin:stage": "node packages/omo-senpi/plugin/scripts/stage-lsp-daemon-runtime.mjs && node packages/omo-senpi/plugin/scripts/build-extension.mjs && node packages/omo-senpi/plugin/scripts/sync-skills.mjs && node packages/omo-senpi/plugin/scripts/embed-directive.mjs --check && node packages/omo-senpi/plugin/scripts/build-install.mjs",
+    "build:senpi-plugin:stage": "bun run build:materialize-frontend && node packages/omo-senpi/plugin/scripts/stage-lsp-daemon-runtime.mjs && node packages/omo-senpi/plugin/scripts/build-extension.mjs && node packages/omo-senpi/plugin/scripts/sync-skills.mjs && node packages/omo-senpi/plugin/scripts/embed-directive.mjs --check && node packages/omo-senpi/plugin/scripts/build-install.mjs",
     "build:materialize-frontend": "node packages/omo-codex/plugin/scripts/materialize-shared-upstreams.mjs --strict",
     "build:shared-skills-assets": "bun run build:materialize-frontend && rm -rf dist/skills && cp -R packages/shared-skills/skills dist/skills",
     "build:lsp-tools-mcp": "npm --prefix packages/lsp-tools-mcp ci && npm --prefix packages/lsp-tools-mcp run build",

--- a/packages/omo-senpi/plugin/README.md
+++ b/packages/omo-senpi/plugin/README.md
@@ -2,6 +2,29 @@
 
 `@code-yeongyu/omo-senpi` is the Senpi edition of OMO packaged as one Pi package. It loads one generated extension entry from `extensions/omo.js` and generated skills from `skills/`.
 
+## Shipped skills
+
+The plugin ships 18 skills by default:
+
+- `ast-grep` — structural code search and rewrites
+- `coding-agent-sessions` — find, read, and reconstruct coding-agent session transcripts
+- `debugging` — hypothesis-driven runtime debugging across languages
+- `frontend` — UI/UX/visual design, styling, layout, and frontend implementation
+- `git-master` — advanced Git operations, history surgery, and workflow automation
+- `init-deep` — deep project initialization and scaffold setup
+- `lsp-setup` — Language Server configuration and troubleshooting
+- `programming` — type-strict, modern-stack programming guidance
+- `refactor` — safe refactoring and code quality improvement
+- `remove-ai-slops` — clean AI-generated code smells
+- `review-work` — multi-angle implementation and PR review
+- `start-work` — execute a Prometheus work plan with Boulder state
+- `ultimate-browsing` — escalation browsing for blocked or hard-to-reach pages
+- `ultrawork` — ultrawork mode directive
+- `ulw-loop` — goal-like ultrawork loop
+- `ulw-plan` — adversarial planning workflow
+- `ulw-research` — ultra-wide research orchestration
+- `visual-qa` — visual QA for web and terminal UIs
+
 ## Install
 
 Build the plugin artifacts before installing:

--- a/packages/omo-senpi/plugin/scripts/install.mjs
+++ b/packages/omo-senpi/plugin/scripts/install.mjs
@@ -17,8 +17,24 @@ import { promisify } from "node:util";
 var execFileAsync = promisify(execFile);
 var REQUIRED_PLUGIN_ARTIFACTS = [
   join("extensions", "omo.js"),
+  join("skills", "ast-grep", "SKILL.md"),
+  join("skills", "coding-agent-sessions", "SKILL.md"),
+  join("skills", "debugging", "SKILL.md"),
+  join("skills", "frontend", "SKILL.md"),
+  join("skills", "git-master", "SKILL.md"),
+  join("skills", "init-deep", "SKILL.md"),
+  join("skills", "lsp-setup", "SKILL.md"),
+  join("skills", "programming", "SKILL.md"),
+  join("skills", "refactor", "SKILL.md"),
+  join("skills", "remove-ai-slops", "SKILL.md"),
+  join("skills", "review-work", "SKILL.md"),
+  join("skills", "start-work", "SKILL.md"),
+  join("skills", "ultimate-browsing", "SKILL.md"),
   join("skills", "ultrawork", "SKILL.md"),
   join("skills", "ulw-loop", "SKILL.md"),
+  join("skills", "ulw-plan", "SKILL.md"),
+  join("skills", "ulw-research", "SKILL.md"),
+  join("skills", "visual-qa", "SKILL.md"),
   join("runtime", "lsp-daemon", "dist", "cli.js"),
   join("runtime", "lsp-daemon", "dist", "index.js"),
   join("runtime", "lsp-daemon", "dist", "index.d.ts"),
@@ -91,6 +107,7 @@ async function ensurePluginArtifacts(context) {
     throw new Error(`Packed omo-senpi plugin is missing required runtime artifacts at ${context.pluginPath}`);
   }
   await context.runCommand("node", [join(context.pluginPath, "scripts", "build-extension.mjs")], { cwd: context.repoRoot });
+  await context.runCommand("node", [join("packages", "omo-codex", "plugin", "scripts", "materialize-shared-upstreams.mjs")], { cwd: context.repoRoot });
   await context.runCommand("node", [join(context.pluginPath, "scripts", "sync-skills.mjs")], { cwd: context.repoRoot });
   await context.runCommand("node", [join(context.pluginPath, "scripts", "build-install.mjs")], { cwd: context.repoRoot });
   await context.runCommand("node", [join(context.pluginPath, "scripts", "stage-lsp-daemon-runtime.mjs")], { cwd: context.repoRoot });

--- a/packages/omo-senpi/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-senpi/plugin/scripts/sync-skills.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const repoRoot = dirname(dirname(pluginRoot))
 const skillsRoot = join(pluginRoot, "skills")
+const sharedSkillsRoot = join(repoRoot, "shared-skills", "skills")
 
 const skillSources = [
   {
@@ -17,6 +18,7 @@ const skillSources = [
     source: join(repoRoot, "omo-codex", "plugin", "components", "ulw-loop", "skills", "ulw-loop"),
   },
 ]
+const componentSkillNames = new Set(skillSources.map(({ name }) => name))
 
 const textExtensions = new Set([".md", ".yaml", ".yml", ".json", ".txt"])
 const sectionHeadingsToStrip = new Set([
@@ -24,8 +26,41 @@ const sectionHeadingsToStrip = new Set([
   "Codex Tool Mapping",
   "Codex subagent reliability",
   "Subagent-dependent transition barrier",
+  "Senpi Harness Tool Compatibility",
 ])
 const forbiddenGuidancePattern = /\b(?:multi_agent|spawn_agent)\b/i
+
+const sourceTestFilePattern = /\.test\.ts$/
+const ignoredSkillSourceDirNames = new Set([
+  ".mypy_cache",
+  ".omo",
+  ".pytest_cache",
+  ".ruff_cache",
+  "__pycache__",
+])
+const ignoredSkillSourceFileNames = new Set([".gitignore", ".npmignore", "pyrightconfig.json", "openai.yaml"])
+
+const opencodeOnlyOrchestrationPattern = /\b(?:call_omo_agent|background_output|team_[a-z_]+|task)\s*\(/
+
+export const senpiHarnessToolCompatibility = `## Senpi Harness Tool Compatibility
+
+This skill may include examples copied from the OpenCode harness. In Senpi, do not call OpenCode-only tools such as \`call_omo_agent(...)\`, \`task(...)\`, \`background_output(...)\`, or \`team_*(...)\` literally. Translate those examples to Senpi native tools:
+
+| OpenCode example | Senpi tool to use |
+| --- | --- |
+| \`call_omo_agent(subagent_type="explore", ...)\` | \`task\` tool with category/agent matching \`.omo/omo.json\` (e.g. \`agent: "scout"\`) |
+| \`call_omo_agent(subagent_type="librarian", ...)\` | \`task\` tool with category/agent matching \`.omo/omo.json\` (e.g. \`agent: "librarian"\`) |
+| \`task(...)\` | \`task\` tool |
+| \`background_output(task_id="...")\` | \`task_output\` tool with the task id |
+| \`team_*(...)\` | Lead team tools (\`team_create\`, \`task_create\`, \`team_wait\`, ...); members poll with \`task_send\` / \`team_wait\` |
+
+If a code block below conflicts with this section, this section wins.
+
+`
+
+const senpiCompatibilityEndMarkers = [
+  "If a code block below conflicts with this section, this section wins.\n\n",
+]
 
 function isTextFile(path) {
   return textExtensions.has(extname(path))
@@ -91,8 +126,84 @@ function normalizeBlankLines(content) {
   return content.replace(/\n{3,}/g, "\n\n")
 }
 
-function adaptSkillText(content) {
+function applyTier1Adaptation(content) {
   return normalizeBlankLines(stripForbiddenGuidanceLines(stripNamedSections(rewriteEditionNaming(content))))
+}
+
+function applyStartWorkOverlay(content) {
+  return content.replace(/codex:<session_id>/g, "senpi:<session_id>").replace(/\bcodex:/g, "senpi:")
+}
+
+function findSenpiCompatibilitySectionEnd(content, searchStart) {
+  const structuralEndPattern = /\n(?:---|export\s+const\s+|#{1,6}\s)/g
+  structuralEndPattern.lastIndex = searchStart
+  const structuralEnd = structuralEndPattern.exec(content)
+  if (structuralEnd) return structuralEnd.index + 1
+
+  const knownEndMarker = senpiCompatibilityEndMarkers.find((marker) => content.indexOf(marker, searchStart) !== -1)
+  if (knownEndMarker === undefined) return content.length
+
+  return content.indexOf(knownEndMarker, searchStart) + knownEndMarker.length
+}
+
+function removeSenpiCompatibilityGuidance(content) {
+  const heading = "## Senpi Harness Tool Compatibility"
+  let withoutGuidance = content
+
+  while (true) {
+    const start = withoutGuidance.indexOf(heading)
+    if (start === -1) return withoutGuidance
+
+    const end = findSenpiCompatibilitySectionEnd(withoutGuidance, start + heading.length)
+    withoutGuidance = `${withoutGuidance.slice(0, start)}${withoutGuidance.slice(end)}`
+  }
+}
+
+function hasKnownGeneratedSenpiCompatibilityGuidance(content, compatibilityIndex) {
+  return senpiCompatibilityEndMarkers.some((marker) => content.indexOf(marker, compatibilityIndex) !== -1)
+}
+
+export function insertSenpiCompatibilityGuidance(content) {
+  if (!opencodeOnlyOrchestrationPattern.test(content)) return content
+  const firstExampleIndex = content.search(opencodeOnlyOrchestrationPattern)
+  const compatibilityIndex = content.indexOf("## Senpi Harness Tool Compatibility")
+  if (
+    compatibilityIndex !== -1 &&
+    compatibilityIndex < firstExampleIndex &&
+    !hasKnownGeneratedSenpiCompatibilityGuidance(content, compatibilityIndex)
+  ) {
+    return content
+  }
+
+  const contentWithoutGuidance = removeSenpiCompatibilityGuidance(content)
+
+  const frontmatterMatch = contentWithoutGuidance.match(/^---\n[\s\S]*?\n---\n+/)
+  if (!frontmatterMatch) {
+    return `${senpiHarnessToolCompatibility}${contentWithoutGuidance}`
+  }
+
+  return `${frontmatterMatch[0]}${senpiHarnessToolCompatibility}${contentWithoutGuidance.slice(frontmatterMatch[0].length)}`
+}
+
+function applySharedTierAdaptation(skillName, content) {
+  let adapted = content
+  if (skillName === "start-work") {
+    adapted = applyStartWorkOverlay(adapted)
+  }
+  adapted = stripNamedSections(adapted)
+  adapted = insertSenpiCompatibilityGuidance(adapted)
+  return normalizeBlankLines(adapted)
+}
+
+function shouldCopySkillSource(source) {
+  const normalized = source.replaceAll("\\", "/")
+  const segments = normalized.split("/")
+  const name = segments.at(-1) ?? ""
+  if (segments.some((segment) => ignoredSkillSourceDirNames.has(segment))) return false
+  if (ignoredSkillSourceFileNames.has(name)) return false
+  if (sourceTestFilePattern.test(name) || name.endsWith(".pyc")) return false
+  const scriptsIndex = segments.lastIndexOf("scripts")
+  return scriptsIndex === -1 || segments[scriptsIndex + 1] !== "tests"
 }
 
 async function listFiles(root) {
@@ -102,7 +213,7 @@ async function listFiles(root) {
   for (const entry of entries) {
     const entryPath = join(root, entry.name)
     if (entry.isDirectory()) {
-      files.push(...await listFiles(entryPath))
+      files.push(...(await listFiles(entryPath)))
     } else if (entry.isFile()) {
       files.push(entryPath)
     }
@@ -111,13 +222,13 @@ async function listFiles(root) {
   return files
 }
 
-async function adaptSkillTree(skillRoot) {
+async function adaptSkillTree(skillRoot, adapter) {
   const files = await listFiles(skillRoot)
   for (const file of files) {
     if (!isTextFile(file)) continue
 
     const before = await readFile(file, "utf8")
-    const after = adaptSkillText(before)
+    const after = adapter(before)
     if (after !== before) {
       await writeFile(file, after, "utf8")
     }
@@ -138,11 +249,25 @@ export async function syncSkills() {
   for (const { name, source } of skillSources) {
     await assertSourceExists(source)
     const destination = join(skillsRoot, name)
-    await cp(source, destination, { recursive: true })
-    await adaptSkillTree(destination)
+    await cp(source, destination, { filter: shouldCopySkillSource, recursive: true })
+    await adaptSkillTree(destination, applyTier1Adaptation)
   }
 
-  console.log(`synced ${skillSources.length} omo-senpi skills to ${skillsRoot}`)
+  const sharedSkillEntries = await readdir(sharedSkillsRoot, { withFileTypes: true })
+  const sharedSkillNames = sharedSkillEntries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+
+  for (const skillName of sharedSkillNames) {
+    if (componentSkillNames.has(skillName)) continue
+    const source = join(sharedSkillsRoot, skillName)
+    const destination = join(skillsRoot, skillName)
+    await cp(source, destination, { filter: shouldCopySkillSource, recursive: true })
+    await adaptSkillTree(destination, (content) => applySharedTierAdaptation(skillName, content))
+  }
+
+  console.log(`synced omo-senpi skills to ${skillsRoot}`)
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/packages/omo-senpi/src/install/cli-local.test.ts
+++ b/packages/omo-senpi/src/install/cli-local.test.ts
@@ -20,8 +20,29 @@ async function makePackagedPlugin(): Promise<string> {
   tempDirs.push(pluginPath)
   await writeFixtureFile(join(pluginPath, "package.json"), JSON.stringify({ name: "@code-yeongyu/omo-senpi" }))
   await writeFixtureFile(join(pluginPath, "extensions", "omo.js"), "export default {}\n")
-  await writeFixtureFile(join(pluginPath, "skills", "ultrawork", "SKILL.md"), "# Ultrawork\n")
-  await writeFixtureFile(join(pluginPath, "skills", "ulw-loop", "SKILL.md"), "# ULW Loop\n")
+  const requiredSkillNames = [
+    "ast-grep",
+    "coding-agent-sessions",
+    "debugging",
+    "frontend",
+    "git-master",
+    "init-deep",
+    "lsp-setup",
+    "programming",
+    "refactor",
+    "remove-ai-slops",
+    "review-work",
+    "start-work",
+    "ultimate-browsing",
+    "ultrawork",
+    "ulw-loop",
+    "ulw-plan",
+    "ulw-research",
+    "visual-qa",
+  ]
+  for (const skillName of requiredSkillNames) {
+    await writeFixtureFile(join(pluginPath, "skills", skillName, "SKILL.md"), `# ${skillName}\n`)
+  }
   await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "cli.js"), "console.log('cli')\n")
   await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "index.js"), "export {}\n")
   await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "index.d.ts"), "export {}\n")

--- a/packages/omo-senpi/src/install/install-senpi.test.ts
+++ b/packages/omo-senpi/src/install/install-senpi.test.ts
@@ -28,8 +28,29 @@ async function makePluginFixture(options: { readonly runtime?: boolean } = { run
   tempDirs.push(pluginPath)
   await writeFixtureFile(join(pluginPath, "package.json"), JSON.stringify({ name: "@code-yeongyu/omo-senpi" }))
   await writeFixtureFile(join(pluginPath, "extensions", "omo.js"), "export default {}\n")
-  await writeFixtureFile(join(pluginPath, "skills", "ultrawork", "SKILL.md"), "# Ultrawork\n")
-  await writeFixtureFile(join(pluginPath, "skills", "ulw-loop", "SKILL.md"), "# ULW Loop\n")
+  const requiredSkillNames = [
+    "ast-grep",
+    "coding-agent-sessions",
+    "debugging",
+    "frontend",
+    "git-master",
+    "init-deep",
+    "lsp-setup",
+    "programming",
+    "refactor",
+    "remove-ai-slops",
+    "review-work",
+    "start-work",
+    "ultimate-browsing",
+    "ultrawork",
+    "ulw-loop",
+    "ulw-plan",
+    "ulw-research",
+    "visual-qa",
+  ]
+  for (const skillName of requiredSkillNames) {
+    await writeFixtureFile(join(pluginPath, "skills", skillName, "SKILL.md"), `# ${skillName}\n`)
+  }
   await writeFixtureFile(join(pluginPath, "scripts", "install.mjs"), "#!/usr/bin/env node\n")
   if (options.runtime !== false) {
     await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "cli.js"), "console.log('cli')\n")

--- a/packages/omo-senpi/src/install/install-senpi.ts
+++ b/packages/omo-senpi/src/install/install-senpi.ts
@@ -33,8 +33,24 @@ type SettingsRecord = Record<string, unknown>
 
 const REQUIRED_PLUGIN_ARTIFACTS = [
   join("extensions", "omo.js"),
+  join("skills", "ast-grep", "SKILL.md"),
+  join("skills", "coding-agent-sessions", "SKILL.md"),
+  join("skills", "debugging", "SKILL.md"),
+  join("skills", "frontend", "SKILL.md"),
+  join("skills", "git-master", "SKILL.md"),
+  join("skills", "init-deep", "SKILL.md"),
+  join("skills", "lsp-setup", "SKILL.md"),
+  join("skills", "programming", "SKILL.md"),
+  join("skills", "refactor", "SKILL.md"),
+  join("skills", "remove-ai-slops", "SKILL.md"),
+  join("skills", "review-work", "SKILL.md"),
+  join("skills", "start-work", "SKILL.md"),
+  join("skills", "ultimate-browsing", "SKILL.md"),
   join("skills", "ultrawork", "SKILL.md"),
   join("skills", "ulw-loop", "SKILL.md"),
+  join("skills", "ulw-plan", "SKILL.md"),
+  join("skills", "ulw-research", "SKILL.md"),
+  join("skills", "visual-qa", "SKILL.md"),
   join("runtime", "lsp-daemon", "dist", "cli.js"),
   join("runtime", "lsp-daemon", "dist", "index.js"),
   join("runtime", "lsp-daemon", "dist", "index.d.ts"),
@@ -120,6 +136,7 @@ async function ensurePluginArtifacts(context: ReturnType<typeof resolveInstallCo
   }
 
   await context.runCommand("node", [join(context.pluginPath, "scripts", "build-extension.mjs")], { cwd: context.repoRoot })
+  await context.runCommand("node", [join("packages", "omo-codex", "plugin", "scripts", "materialize-shared-upstreams.mjs")], { cwd: context.repoRoot })
   await context.runCommand("node", [join(context.pluginPath, "scripts", "sync-skills.mjs")], { cwd: context.repoRoot })
   await context.runCommand("node", [join(context.pluginPath, "scripts", "build-install.mjs")], { cwd: context.repoRoot })
   await context.runCommand("node", [join(context.pluginPath, "scripts", "stage-lsp-daemon-runtime.mjs")], { cwd: context.repoRoot })

--- a/packages/omo-senpi/src/skills-sync.test.ts
+++ b/packages/omo-senpi/src/skills-sync.test.ts
@@ -4,8 +4,37 @@ import { join, relative } from "node:path"
 
 const repoRoot = join(import.meta.dir, "..", "..", "..")
 const skillsRoot = join(repoRoot, "packages", "omo-senpi", "plugin", "skills")
-const expectedSkillNames = ["ultrawork", "ulw-loop"] as const
+
+const expectedSkillNames = [
+  "ast-grep",
+  "coding-agent-sessions",
+  "debugging",
+  "frontend",
+  "git-master",
+  "init-deep",
+  "lsp-setup",
+  "programming",
+  "refactor",
+  "remove-ai-slops",
+  "review-work",
+  "start-work",
+  "ultimate-browsing",
+  "ultrawork",
+  "ulw-loop",
+  "ulw-plan",
+  "ulw-research",
+  "visual-qa",
+] as const
+
+const CODEX_DERIVED_SKILL_NAMES: Record<string, true> = {
+  ultrawork: true,
+  "ulw-loop": true,
+}
+const sharedSkillNames = expectedSkillNames.filter((name) => !(name in CODEX_DERIVED_SKILL_NAMES))
+const namePattern = /^[a-z0-9-]{1,64}$/
 const forbiddenTokenPattern = /\b(?:codex|multi_agent|spawn_agent)\b/i
+const opencodeOrchestrationPattern = /\b(?:call_omo_agent|background_output|team_[a-z_]+|task)\s*\(/
+const compatibilitySectionHeading = "## Senpi Harness Tool Compatibility"
 
 function listDirectoryNames(path: string): string[] {
   if (!existsSync(path)) {
@@ -47,44 +76,97 @@ function expectFrontmatterField(frontmatter: string, field: string, path: string
   expect(pattern.test(frontmatter), `${relative(repoRoot, path)} frontmatter must include ${field}`).toBe(true)
 }
 
+function extractFrontmatterField(frontmatter: string, field: string): string | undefined {
+  const match = frontmatter.match(new RegExp(`^${field}:\\s*(.*?)$`, "m"))
+  return match?.[1]?.trim()
+}
+
 describe("OMO Senpi scoped skill sync", () => {
-  test("#given synced skill output #when inspected #then only ultrawork and ulw-loop roots exist", () => {
-    expect(listDirectoryNames(skillsRoot)).toEqual([...expectedSkillNames].sort())
+  test("#given synced skill output #when inspected #then exactly 18 roots exist with valid names", () => {
+    const actualNames = listDirectoryNames(skillsRoot)
+    expect(actualNames).toEqual([...expectedSkillNames].sort())
 
     for (const skillName of expectedSkillNames) {
       const skillFile = join(skillsRoot, skillName, "SKILL.md")
       expect(existsSync(skillFile), `${relative(repoRoot, skillFile)} must exist`).toBe(true)
       expect(statSync(skillFile).isFile(), `${relative(repoRoot, skillFile)} must be a file`).toBe(true)
+      expect(namePattern.test(skillName), `${skillName} must match ${namePattern.source}`).toBe(true)
     }
-
-    expect(existsSync(join(skillsRoot, "ulw-plan"))).toBe(false)
   })
 
-  test("#given synced skill roots #when frontmatter is parsed #then every root skill has name and description", () => {
+  test("#given synced skill roots #when frontmatter is parsed #then every root skill has name, description, and valid values", () => {
     for (const skillName of expectedSkillNames) {
       const skillFile = join(skillsRoot, skillName, "SKILL.md")
-      const frontmatter = readFrontmatter(readFileSync(skillFile, "utf8"), skillFile)
+      const content = readFileSync(skillFile, "utf8")
+      const frontmatter = readFrontmatter(content, skillFile)
 
       expectFrontmatterField(frontmatter, "name", skillFile)
       expectFrontmatterField(frontmatter, "description", skillFile)
+
+      const name = extractFrontmatterField(frontmatter, "name")
+      expect(name, `${relative(repoRoot, skillFile)} frontmatter name must equal ${skillName}`).toBe(skillName)
+
+      const descriptionLine = frontmatter.match(/^description:\\s*(.*)$/m)?.[0] ?? ""
+      expect(
+        descriptionLine.length,
+        `${relative(repoRoot, skillFile)} description line must be <= 1024 chars`,
+      ).toBeLessThanOrEqual(1024)
     }
   })
 
-  test("#given synced skill files #when scanned #then no Codex or multi-agent harness guidance survives", () => {
-    const files = listFiles(skillsRoot)
-    expect(files.map((file) => toPortablePath(relative(skillsRoot, file))).sort()).toContain(
-      "ulw-loop/references/full-workflow.md",
-    )
+  test("#given codex-derived skill roots #when scanned #then no Codex or multi-agent harness guidance survives", () => {
+    const leaks: string[] = []
 
-    const leaks = files.flatMap((file) => {
-      const content = readFileSync(file, "utf8")
-      return forbiddenTokenPattern.test(content) ? [relative(repoRoot, file)] : []
-    })
+    for (const skillName of Object.keys(CODEX_DERIVED_SKILL_NAMES)) {
+      const skillRoot = join(skillsRoot, skillName)
+      if (!existsSync(skillRoot)) continue
+
+      for (const file of listFiles(skillRoot)) {
+        const content = readFileSync(file, "utf8")
+        if (forbiddenTokenPattern.test(content)) {
+          leaks.push(relative(repoRoot, file))
+        }
+      }
+    }
 
     expect(leaks).toEqual([])
   })
-})
 
-function toPortablePath(path: string): string {
-  return path.replaceAll("\\", "/")
-}
+  test("#given shared skill roots with opencode orchestration #when inspected #then a Senpi compatibility section precedes the first example", () => {
+    const missing: string[] = []
+
+    for (const skillName of sharedSkillNames) {
+      const skillFile = join(skillsRoot, skillName, "SKILL.md")
+      if (!existsSync(skillFile)) continue
+
+      const content = readFileSync(skillFile, "utf8")
+      const firstExampleMatch = opencodeOrchestrationPattern.exec(content)
+      if (firstExampleMatch === null) continue
+
+      const sectionIndex = content.indexOf(compatibilitySectionHeading)
+      if (sectionIndex === -1 || sectionIndex > firstExampleMatch.index) {
+        missing.push(relative(repoRoot, skillFile))
+      }
+    }
+
+    expect(missing).toEqual([])
+  })
+
+  test("#given start-work skill #when inspected #then session ids reference senpi, not codex", () => {
+    const skillFile = join(skillsRoot, "start-work", "SKILL.md")
+    const content = readFileSync(skillFile, "utf8")
+
+    expect(content.includes("senpi:<session_id>"), "start-work must reference senpi:<session_id>").toBe(true)
+    expect(content.includes("codex:<session_id>"), "start-work must not reference codex:<session_id>").toBe(false)
+  })
+
+  test("#given synced skill tree #when inspected #then no codex-only display metadata is packaged", () => {
+    const openaiFiles = listFiles(skillsRoot).filter((file) => file.endsWith("agents/openai.yaml"))
+    expect(openaiFiles.map((file) => relative(repoRoot, file))).toEqual([])
+  })
+
+  test("#given frontend skill #when inspected #then materialized design references exist", () => {
+    const refsDir = join(skillsRoot, "frontend", "references", "design")
+    expect(existsSync(refsDir), "frontend/references/design must exist after materialization").toBe(true)
+  })
+})

--- a/script/senpi-test-script.test.ts
+++ b/script/senpi-test-script.test.ts
@@ -53,6 +53,7 @@ describe("Senpi compatibility test script", () => {
       "bun run build:senpi-plugin:stage",
     ].join(" && ")
     const hasStageScript = manifest.scripts?.["build:senpi-plugin:stage"] === [
+      "bun run build:materialize-frontend",
       "node packages/omo-senpi/plugin/scripts/stage-lsp-daemon-runtime.mjs",
       "node packages/omo-senpi/plugin/scripts/build-extension.mjs",
       "node packages/omo-senpi/plugin/scripts/sync-skills.mjs",
@@ -86,12 +87,32 @@ describe("Senpi compatibility test script", () => {
     try {
       const pluginRoot = join(tempRoot, "packages", "omo-senpi", "plugin")
       await mkdir(join(pluginRoot, "extensions"), { recursive: true })
-      await mkdir(join(pluginRoot, "skills", "ultrawork"), { recursive: true })
-      await mkdir(join(pluginRoot, "skills", "ulw-loop"), { recursive: true })
+      const requiredSkillNames = [
+        "ast-grep",
+        "coding-agent-sessions",
+        "debugging",
+        "frontend",
+        "git-master",
+        "init-deep",
+        "lsp-setup",
+        "programming",
+        "refactor",
+        "remove-ai-slops",
+        "review-work",
+        "start-work",
+        "ultimate-browsing",
+        "ultrawork",
+        "ulw-loop",
+        "ulw-plan",
+        "ulw-research",
+        "visual-qa",
+      ]
+      for (const skillName of requiredSkillNames) {
+        await mkdir(join(pluginRoot, "skills", skillName), { recursive: true })
+        await writeFile(join(pluginRoot, "skills", skillName, "SKILL.md"), `# ${skillName}\n`)
+      }
       await writeFile(join(pluginRoot, "package.json"), JSON.stringify({ name: "@code-yeongyu/omo-senpi" }))
       await writeFile(join(pluginRoot, "extensions", "omo.js"), "export default {}\n")
-      await writeFile(join(pluginRoot, "skills", "ultrawork", "SKILL.md"), "# Ultrawork\n")
-      await writeFile(join(pluginRoot, "skills", "ulw-loop", "SKILL.md"), "# ULW Loop\n")
       await mkdir(join(pluginRoot, "scripts"), { recursive: true })
       await writeFile(join(pluginRoot, "scripts", "install.mjs"), "#!/usr/bin/env node\n")
       await mkdir(join(pluginRoot, "runtime", "lsp-daemon", "dist"), { recursive: true })


### PR DESCRIPTION
Ship all 18 skills (16 shared + ultrawork + ulw-loop) in the omo-senpi plugin by default.

## Changes
- Rewrite `packages/omo-senpi/plugin/scripts/sync-skills.mjs` with a two-tier pipeline:
  - Tier 1 (codex-derived): `ultrawork`, `ulw-loop` copied from `omo-codex/plugin/components/*/skills/*` with the existing full adaptation.
  - Tier 2 (shared): enumerate `shared-skills/skills/`, skip tier-1 collisions, copy with codex-style source filter plus `agents/openai.yaml` exclusion.
  - Shared-tier curated adaptation: Senpi Harness Tool Compatibility section for opencode-orchestration examples; start-work overlay rewrites `codex:<session_id>` → `senpi:<session_id>`.
- Rewrite `packages/omo-senpi/src/skills-sync.test.ts` to the 18-skill contract with name/description validation and orchestration-section checks.
- Extend `REQUIRED_PLUGIN_ARTIFACTS` in `install-senpi.ts` to all 18 `skills/<name>/SKILL.md` paths and run frontend materialization before sync in the installer.
- Prepend `build:materialize-frontend` to root `build:senpi-plugin:stage`.
- Document the 18 shipped skills in `packages/omo-senpi/plugin/README.md`.
- Update install test fixtures to provide all 18 skills.

## QA
- `bun run test:senpi` → 203 pass, 0 fail.
- `node packages/omo-senpi/plugin/scripts/sync-skills.mjs && ls packages/omo-senpi/plugin/skills | wc -l` → 18.
- Senpi loader accepts all 18 skills with 0 warnings.
- Artifact gate rejects a packed plugin missing a required skill.
- Evidence captured under `.omo/evidence/task-6-*`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship all 18 skills (16 shared + `ultrawork` + `ulw-loop`) by default in `@code-yeongyu/omo-senpi`. Adds a two-tier sync, enforces required artifacts, and materializes frontend assets in build/install.

- **New Features**
  - Two-tier `sync-skills.mjs`: Tier 1 copies `ultrawork`/`ulw-loop` from `omo-codex` (adapts text, strips Codex/multi-agent guidance). Tier 2 syncs all `shared-skills`, filters sources (`scripts/tests`, caches, `.pyc`, `agents/openai.yaml`), inserts a “Senpi Harness Tool Compatibility” section before opencode-only examples (dedupes if present), and for `start-work` rewrites `codex:<session_id>` → `senpi:<session_id>`.
  - Installer hardening: `install.mjs` and `install-senpi.ts` require all 18 `skills/*/SKILL.md`, run `materialize-shared-upstreams.mjs` before sync, then rebuild/install artifacts.
  - Build flow: `build:senpi-plugin:stage` now starts with `build:materialize-frontend`.
  - Docs/Tests: README lists the 18 skills; tests assert exact 18 roots with valid names, frontmatter name matches dir and description length, no Codex tokens in tier‑1, compatibility section precedes opencode examples, no `agents/openai.yaml`, `start-work` uses `senpi:<session_id>`, and frontend design references are materialized.

<sup>Written for commit 6301e52a406efb8a796f7e5234c43e02ae1b3683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

