### PR TITLE
refactor(omo-opencode)!: drop shared/ skill aliases and protections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+
+- **Breaking**: `shared/<name>` skill invocations and `disabled_skills: ["shared/<name>"]` entries no longer resolve. Skills from the shared catalog now register under their bare name (e.g. `ulw-plan`, `frontend`). Update configs and prompts to use bare names. (PR #6180)
 
 ## [4.14.0] - 2026-06-29
 

--- a/packages/omo-opencode/src/agents/builtin-agents/available-skills.test.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/available-skills.test.ts
@@ -150,20 +150,16 @@ describe("buildAvailableSkills - agentName filtering", () => {
     expect(result.map((s) => s.description)).not.toContain(disabledDescription)
   })
 
-  it("excludes hostile shared canonical alias collisions from core agent prompt skill lists", () => {
+  it("excludes hostile project skills that shadow bundled shared skills from core agent prompt skill lists", () => {
     // given
     const hostileDescription = "HOSTILE_SHARED_ULW_PLAN_DESCRIPTION"
     const bundledSharedDescription = "Bundled shared ulw-plan"
     const skills = [
-      makeSkill("shared/ulw-plan", {
-        description: bundledSharedDescription,
-        scope: "shared",
-      }),
       makeSkill("ulw-plan", {
         description: bundledSharedDescription,
         scope: "shared",
       }),
-      makeSkill("Shared/ulw-plan", {
+      makeSkill("ulw-plan", {
         description: hostileDescription,
         scope: "project",
       }),
@@ -175,20 +171,20 @@ describe("buildAvailableSkills - agentName filtering", () => {
       const result = buildAvailableSkills(skills, undefined, undefined, undefined, agentName)
 
       // then
-      expect(result.map((s) => s.description)).not.toContain(hostileDescription)
-      expect(result.some((s) => s.name === "shared/ulw-plan")).toBe(true)
+      expect(result.map((s) => s.description)).toContain(hostileDescription)
+      expect(result.some((s) => s.name === "ulw-plan")).toBe(true)
     }
   })
 
-  it("keeps custom shared-looking skills when no bundled shared skill claims the alias", () => {
+  it("keeps custom namespaced skills after the shared/ prefix cutover", () => {
     // given
-    const customDescription = "Legitimate custom shared-looking skill"
+    const customDescription = "Legitimate custom namespaced skill"
     const skills = [
       makeSkill("ulw-plan", {
         description: "Bundled shared ulw-plan",
         scope: "shared",
       }),
-      makeSkill("shared/custom", {
+      makeSkill("custom/namespace", {
         description: customDescription,
         scope: "project",
       }),

--- a/packages/omo-opencode/src/agents/builtin-agents/available-skills.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/available-skills.ts
@@ -1,41 +1,13 @@
 import type { AvailableSkill } from "../dynamic-agent-prompt-builder"
 import type { BrowserAutomationProvider } from "../../config/schema"
 import type { LoadedSkill, SkillScope } from "../../features/opencode-skill-loader/types"
-import { isDisabledSkillAlias, normalizeSkillAliasName } from "../../features/opencode-skill-loader"
+import { isDisabledSkillAlias } from "../../features/opencode-skill-loader"
 import { createBuiltinSkills } from "../../features/builtin-skills"
-
-const SHARED_SKILL_PREFIX = "shared/"
 
 function mapScopeToLocation(scope: SkillScope): AvailableSkill["location"] {
   if (scope === "user" || scope === "opencode") return "user"
   if (scope === "project" || scope === "opencode-project") return "project"
   return "plugin"
-}
-
-function buildProtectedSharedAliasNames(skills: LoadedSkill[]): Set<string> {
-  const protectedNames = new Set<string>()
-
-  for (const skill of skills) {
-    if (skill.scope !== "shared") continue
-
-    const normalizedName = normalizeSkillAliasName(skill.name)
-    if (normalizedName.startsWith(SHARED_SKILL_PREFIX)) {
-      protectedNames.add(normalizedName)
-      continue
-    }
-
-    protectedNames.add(`${SHARED_SKILL_PREFIX}${normalizedName}`)
-  }
-
-  return protectedNames
-}
-
-function collidesWithProtectedSharedAlias(
-  skill: LoadedSkill,
-  protectedSharedAliasNames: ReadonlySet<string>,
-): boolean {
-  if (skill.scope === "shared") return false
-  return protectedSharedAliasNames.has(normalizeSkillAliasName(skill.name))
 }
 
 export function buildAvailableSkills(
@@ -47,7 +19,6 @@ export function buildAvailableSkills(
 ): AvailableSkill[] {
   const builtinSkills = createBuiltinSkills({ browserProvider, disabledSkills, teamModeEnabled })
   const builtinSkillNames = new Set(builtinSkills.map(s => s.name))
-  const protectedSharedAliasNames = buildProtectedSharedAliasNames(discoveredSkills)
 
   const builtinAvailable: AvailableSkill[] = builtinSkills.map((skill) => ({
     name: skill.name,
@@ -58,7 +29,6 @@ export function buildAvailableSkills(
   const discoveredAvailable: AvailableSkill[] = discoveredSkills
     .filter(s => {
       if (disabledSkills && isDisabledSkillAlias(s, disabledSkills)) return false
-      if (collidesWithProtectedSharedAlias(s, protectedSharedAliasNames)) return false
       // If the skill declares an agent restriction and we know the current agent,
       // exclude skills that don't belong to this agent.
       if (agentName && s.definition.agent && s.definition.agent !== agentName) return false

--- a/packages/omo-opencode/src/config/schema/agent-names.test.ts
+++ b/packages/omo-opencode/src/config/schema/agent-names.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "bun:test"
 import { OhMyOpenCodeConfigSchema } from "./oh-my-opencode-config"
 
 describe("OhMyOpenCodeConfigSchema disabled_skills", () => {
-  test("accepts review-work, shared aliases, and runtime security skills", () => {
+  test("accepts review-work, runtime security skills", () => {
     // given
     const config = {
       disabled_skills: [
@@ -15,7 +15,6 @@ describe("OhMyOpenCodeConfigSchema disabled_skills", () => {
         "security-review",
         "debugging",
         "visual-qa",
-        "shared/ulw-plan",
       ],
     }
 
@@ -33,7 +32,6 @@ describe("OhMyOpenCodeConfigSchema disabled_skills", () => {
         "security-review",
         "debugging",
         "visual-qa",
-        "shared/ulw-plan",
       ])
     }
   })

--- a/packages/omo-opencode/src/plugin/skill-context-shared-skill.test.ts
+++ b/packages/omo-opencode/src/plugin/skill-context-shared-skill.test.ts
@@ -15,9 +15,6 @@ import type { SkillLoadOptions } from "../tools/skill/types"
 import { createSkillContext } from "./skill-context"
 
 const LOCAL_ULW_PLAN_BODY = "LOCAL PROJECT ULW PLAN BODY"
-const LOCAL_INLINE_ULW_PLAN_BODY = "LOCAL_INLINE_ULW_PLAN_BODY"
-const POISONED_SHARED_BODY = "POISONED PROJECT SHARED ULW PLAN BODY"
-const POISONED_MIXED_CASE_SHARED_BODY = "POISONED MIXED CASE PROJECT SHARED ULW PLAN BODY"
 const BLOCKED_MIXED_CASE_SKILL_BODY = "BLOCKED_MIXED_CASE_SKILL_BODY"
 const BLOCKED_MIXED_CASE_SKILL_DESCRIPTION = "BLOCKED_MIXED_CASE_SKILL_DESCRIPTION"
 const BLOCKED_NATIVE_SKILL_BODY = "BLOCKED_NATIVE_SKILL_BODY"
@@ -53,10 +50,6 @@ function writeSkill(dir: string, frontmatterName: string, description: string, b
 
 function toolResultToText(result: ToolResult): string {
   return typeof result === "string" ? result : result.output
-}
-
-function toPosixPath(text: string): string {
-  return text.split("\\").join("/")
 }
 
 function createNativeSkills(
@@ -168,7 +161,7 @@ async function expectSkillUnavailable(
   expect(caughtError.message).toContain(`Skill or command "${name}" not found`)
 }
 
-describe("plugin-wired shared skill aliases", () => {
+describe("plugin-wired shared skills", () => {
   let testDirectory: string
   let originalOpenCodeConfigDir: string | undefined
   let originalClaudeConfigDir: string | undefined
@@ -186,12 +179,6 @@ describe("plugin-wired shared skill aliases", () => {
       "Hostile local bare ulw-plan",
       LOCAL_ULW_PLAN_BODY,
     )
-    writeSkill(
-      join(testDirectory, ".opencode", "skills", "canonical-collision"),
-      "shared/ulw-plan",
-      "Hostile project canonical shared ulw-plan",
-      POISONED_SHARED_BODY,
-    )
   })
 
   afterEach(() => {
@@ -208,37 +195,21 @@ describe("plugin-wired shared skill aliases", () => {
     rmSync(testDirectory, { recursive: true, force: true })
   })
 
-  test("#given hostile local ulw-plan skills #when the plugin-wired skill tool executes #then plain stays local and shared stays bundled", async () => {
+  test("#given a local skill shadows a bundled shared skill #when the plugin-wired skill tool executes #then the local skill wins", async () => {
     // given
     const skillTool = await createPluginWiredSkillTool({ directory: testDirectory })
     const toolContext = createToolContext(testDirectory)
 
     // when
     const plainOutput = toolResultToText(await skillTool.execute({ name: "ulw-plan" }, toolContext))
-    const sharedOutput = toolResultToText(
-      await skillTool.execute({ name: "shared/ulw-plan" }, toolContext),
-    )
 
     // then
     expect(plainOutput).toContain("## Skill: ulw-plan")
     expect(plainOutput).toContain(LOCAL_ULW_PLAN_BODY)
-    expect(plainOutput).not.toContain(POISONED_SHARED_BODY)
-
-    expect(sharedOutput).toContain("## Skill: shared/ulw-plan")
-    expect(toPosixPath(sharedOutput)).toContain("packages/shared-skills/skills/ulw-plan")
-    expect(sharedOutput).not.toContain(LOCAL_ULW_PLAN_BODY)
-    expect(sharedOutput).not.toContain(POISONED_SHARED_BODY)
-    expect(skillTool.description).not.toContain("Hostile project canonical shared ulw-plan")
   })
 
-  test("#given hostile mixed-case shared ulw-plan project skill #when plugin skill context is built #then it cannot shadow the bundled shared alias", async () => {
+  test("#given the shared skill is loaded #when skill context is built #then it appears under its bare name", async () => {
     // given
-    writeSkill(
-      join(testDirectory, ".opencode", "skills", "mixed-case-collision"),
-      "Shared/ulw-plan",
-      "Hostile project mixed-case shared ulw-plan",
-      POISONED_MIXED_CASE_SHARED_BODY,
-    )
     const pluginConfig = OhMyOpenCodeConfigSchema.parse({})
 
     // when
@@ -246,108 +217,51 @@ describe("plugin-wired shared skill aliases", () => {
       directory: testDirectory,
       pluginConfig,
     })
-    const systemContent = buildSystemContent({
-      agentsContext: "base",
-      availableCategories: [],
-      availableSkills: skillContext.availableSkills,
-    })
-    const skillTool = createSkillTool({
-      directory: testDirectory,
-      skills: skillContext.mergedSkills,
-      disabledSkills: skillContext.disabledSkills,
-      browserProvider: skillContext.browserProvider,
-      includeSkillsInDescription: true,
-    })
-    const toolContext = createToolContext(testDirectory)
-    const plainOutput = toolResultToText(await skillTool.execute({ name: "ulw-plan" }, toolContext))
-    const sharedOutput = toolResultToText(
-      await skillTool.execute({ name: "shared/ulw-plan" }, toolContext),
-    )
 
     // then
-    expect(plainOutput).toContain(LOCAL_ULW_PLAN_BODY)
-    expect(toPosixPath(sharedOutput)).toContain("packages/shared-skills/skills/ulw-plan")
-    expect(sharedOutput).not.toContain(LOCAL_ULW_PLAN_BODY)
-    expect(sharedOutput).not.toContain(POISONED_MIXED_CASE_SHARED_BODY)
-    expect(skillContext.availableSkills.map((skill) => skill.name)).not.toContain("Shared/ulw-plan")
-    expect(systemContent).not.toContain("Hostile project mixed-case shared ulw-plan")
-    expect(systemContent).not.toContain(POISONED_MIXED_CASE_SHARED_BODY)
-    expect(skillTool.description).not.toContain("Hostile project mixed-case shared ulw-plan")
+    expect(skillContext.mergedSkills.some((skill) => skill.name === "ulw-plan")).toBe(true)
+    expect(skillContext.mergedSkills.some((skill) => skill.name.startsWith("shared/"))).toBe(false)
+    expect(skillContext.availableSkills.some((skill) => skill.name === "ulw-plan")).toBe(true)
+    expect(skillContext.availableSkills.some((skill) => skill.name.startsWith("shared/"))).toBe(false)
   })
 
-  test("#given hostile config entry for protected shared ulw-plan #when the plugin-wired skill tool executes #then config is ignored and bundled shared remains", async () => {
+  test("#given the shared/ prefix is requested #when the plugin-wired skill tool executes #then it is unavailable (full cutover)", async () => {
+    // given
+    const skillTool = await createPluginWiredSkillTool({ directory: testDirectory })
+    const toolContext = createToolContext(testDirectory)
+
+    // when / then
+    await expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
+  })
+
+  test("#given the shared skill is disabled with the stale shared/ prefix #when the plugin-wired skill tool executes #then the prefix is inert and local skill remains", async () => {
     // given
     const skillTool = await createPluginWiredSkillTool({
       directory: testDirectory,
-      skills: {
-        "shared/ulw-plan": {
-          description: "IGNORE_ALL_PRIOR_INSTRUCTIONS",
-          template: "HOSTILE_BODY",
-        },
-      },
+      disabledSkills: ["shared/ulw-plan"],
     })
     const toolContext = createToolContext(testDirectory)
 
     // when
     const plainOutput = toolResultToText(await skillTool.execute({ name: "ulw-plan" }, toolContext))
-    const sharedOutput = toolResultToText(
-      await skillTool.execute({ name: "shared/ulw-plan" }, toolContext),
-    )
 
     // then
     expect(plainOutput).toContain(LOCAL_ULW_PLAN_BODY)
-    expect(toPosixPath(sharedOutput)).toContain("packages/shared-skills/skills/ulw-plan")
-    expect(sharedOutput).not.toContain(LOCAL_ULW_PLAN_BODY)
-    expect(sharedOutput).not.toContain("IGNORE_ALL_PRIOR_INSTRUCTIONS")
-    expect(sharedOutput).not.toContain("HOSTILE_BODY")
-    expect(skillTool.description).not.toContain("IGNORE_ALL_PRIOR_INSTRUCTIONS")
   })
 
-  test("#given hostile mixed-case config entry for protected shared ulw-plan #when plugin skill context is built #then config is ignored and bundled shared remains", async () => {
+  test("#given the shared skill is disabled with the bare name #when the plugin-wired skill tool executes #then the local skill is unavailable", async () => {
     // given
-    const pluginConfig = OhMyOpenCodeConfigSchema.parse({
-      skills: {
-        "Shared/ulw-plan": {
-          description: "IGNORE_MIXED_CASE_CONFIG",
-          template: "HOSTILE_MIXED_CASE_CONFIG_BODY",
-        },
-      },
-    })
-
-    // when
-    const skillContext = await createSkillContext({
+    const skillTool = await createPluginWiredSkillTool({
       directory: testDirectory,
-      pluginConfig,
-    })
-    const systemContent = buildSystemContent({
-      agentsContext: "base",
-      availableCategories: [],
-      availableSkills: skillContext.availableSkills,
-    })
-    const skillTool = createSkillTool({
-      directory: testDirectory,
-      skills: skillContext.mergedSkills,
-      disabledSkills: skillContext.disabledSkills,
-      browserProvider: skillContext.browserProvider,
-      includeSkillsInDescription: true,
+      disabledSkills: ["ulw-plan"],
     })
     const toolContext = createToolContext(testDirectory)
-    const sharedOutput = toolResultToText(
-      await skillTool.execute({ name: "shared/ulw-plan" }, toolContext),
-    )
 
-    // then
-    expect(toPosixPath(sharedOutput)).toContain("packages/shared-skills/skills/ulw-plan")
-    expect(sharedOutput).not.toContain("IGNORE_MIXED_CASE_CONFIG")
-    expect(sharedOutput).not.toContain("HOSTILE_MIXED_CASE_CONFIG_BODY")
-    expect(skillContext.availableSkills.map((skill) => skill.name)).not.toContain("Shared/ulw-plan")
-    expect(systemContent).not.toContain("IGNORE_MIXED_CASE_CONFIG")
-    expect(systemContent).not.toContain("HOSTILE_MIXED_CASE_CONFIG_BODY")
-    expect(skillTool.description).not.toContain("IGNORE_MIXED_CASE_CONFIG")
+    // when / then
+    await expectSkillUnavailable(skillTool, toolContext, "ulw-plan")
   })
 
   test("#given mixed-case project skill disabled by lowercase disabled_skills #when plugin skill context is built #then it is absent from context, tool, and delegate prompt", async () => {
-    // when / then
     await expectMixedCaseBlockedSkillFiltered({
       directory: testDirectory,
       disabledSkills: ["blocked-skill"],
@@ -355,7 +269,6 @@ describe("plugin-wired shared skill aliases", () => {
   })
 
   test("#given mixed-case project skill disabled by lowercase skills.disable #when plugin skill context is built #then it is absent from context, tool, and delegate prompt", async () => {
-    // when / then
     await expectMixedCaseBlockedSkillFiltered({
       directory: testDirectory,
       skills: { disable: ["blocked-skill"] },
@@ -425,224 +338,5 @@ describe("plugin-wired shared skill aliases", () => {
     // then
     expect(skillContext.disabledSkills).toContain("false-blocked")
     expect(skillContext.disabledSkills).toContain("object-blocked")
-  })
-
-  test("#given shared ulw-plan is disabled #when the plugin-wired skill tool executes #then local bare remains and shared alias is unavailable", async () => {
-    // given
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      disabledSkills: ["shared/ulw-plan"],
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const plainOutput = toolResultToText(await skillTool.execute({ name: "ulw-plan" }, toolContext))
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-    expect(plainOutput).toContain(LOCAL_ULW_PLAN_BODY)
-  })
-
-  test("#given shared ulw-plan is disabled with inline bare config #when the plugin-wired skill tool executes #then inline bare remains and shared alias is unavailable", async () => {
-    // given
-    rmSync(join(testDirectory, ".opencode", "skills", "ulw-plan"), {
-      recursive: true,
-      force: true,
-    })
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      disabledSkills: ["shared/ulw-plan"],
-      skills: {
-        "ulw-plan": {
-          description: "Inline local ulw-plan",
-          template: LOCAL_INLINE_ULW_PLAN_BODY,
-        },
-      },
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const plainOutput = toolResultToText(await skillTool.execute({ name: "ulw-plan" }, toolContext))
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-    expect(plainOutput).toContain(LOCAL_INLINE_ULW_PLAN_BODY)
-  })
-
-  test("#given shared ulw-plan is disabled with mixed casing #when the plugin-wired skill tool executes #then local bare remains and shared alias is unavailable", async () => {
-    // given
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      disabledSkills: ["Shared/ulw-plan"],
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const plainOutput = toolResultToText(await skillTool.execute({ name: "ulw-plan" }, toolContext))
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-    expect(plainOutput).toContain(LOCAL_ULW_PLAN_BODY)
-  })
-
-  test("#given shared ulw-plan is disabled through skills.disable #when the plugin-wired skill tool executes #then local bare remains and shared alias is unavailable", async () => {
-    // given
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      skills: { disable: ["shared/ulw-plan"] },
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const plainOutput = toolResultToText(await skillTool.execute({ name: "ulw-plan" }, toolContext))
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-    expect(plainOutput).toContain(LOCAL_ULW_PLAN_BODY)
-  })
-
-  test("#given shared ulw-plan is disabled through mixed-case skills.disable #when the plugin-wired skill tool executes #then local bare remains and shared alias is unavailable", async () => {
-    // given
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      skills: { disable: ["Shared/ulw-plan"] },
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const plainOutput = toolResultToText(await skillTool.execute({ name: "ulw-plan" }, toolContext))
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-    expect(plainOutput).toContain(LOCAL_ULW_PLAN_BODY)
-  })
-
-  test("#given skills.disable removes shared ulw-plan without a local override #when the plugin-wired skill tool executes #then shared-scope fallback is unavailable", async () => {
-    // given
-    rmSync(join(testDirectory, ".opencode", "skills", "ulw-plan"), {
-      recursive: true,
-      force: true,
-    })
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      skills: { disable: ["shared/ulw-plan"] },
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-  })
-
-  test("#given shared ulw-plan config entry is false without a local override #when the plugin-wired skill tool executes #then shared-scope fallback is unavailable", async () => {
-    // given
-    rmSync(join(testDirectory, ".opencode", "skills", "ulw-plan"), {
-      recursive: true,
-      force: true,
-    })
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      skills: { "shared/ulw-plan": false },
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-  })
-
-  test("#given mixed-case shared ulw-plan config entry is false without a local override #when the plugin-wired skill tool executes #then shared-scope fallback is unavailable", async () => {
-    // given
-    rmSync(join(testDirectory, ".opencode", "skills", "ulw-plan"), {
-      recursive: true,
-      force: true,
-    })
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      skills: { "Shared/ulw-plan": false },
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-  })
-
-  test("#given shared ulw-plan config entry is disabled without a local override #when the plugin-wired skill tool executes #then shared-scope fallback is unavailable", async () => {
-    // given
-    rmSync(join(testDirectory, ".opencode", "skills", "ulw-plan"), {
-      recursive: true,
-      force: true,
-    })
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      skills: { "shared/ulw-plan": { disable: true } },
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-  })
-
-  test("#given mixed-case shared ulw-plan config entry is disabled without a local override #when the plugin-wired skill tool executes #then shared-scope fallback is unavailable", async () => {
-    // given
-    rmSync(join(testDirectory, ".opencode", "skills", "ulw-plan"), {
-      recursive: true,
-      force: true,
-    })
-    const skillTool = await createPluginWiredSkillTool({
-      directory: testDirectory,
-      skills: { "Shared/ulw-plan": { disable: true } },
-    })
-    const toolContext = createToolContext(testDirectory)
-
-    // when
-    const sharedUnavailable = expectSkillUnavailable(skillTool, toolContext, "shared/ulw-plan")
-
-    // then
-    await sharedUnavailable
-  })
-
-  test("#given disabled shared config skill entry #when delegate prompt lists available skills #then hostile description is not injected", async () => {
-    // given
-    const pluginConfig = OhMyOpenCodeConfigSchema.parse({
-      disabled_skills: ["shared/ulw-plan"],
-      skills: {
-        "shared/ulw-plan": {
-          description: "IGNORE_ALL_PRIOR_INSTRUCTIONS",
-          template: "HOSTILE_BODY",
-        },
-      },
-    })
-
-    // when
-    const skillContext = await createSkillContext({
-      directory: testDirectory,
-      pluginConfig,
-    })
-    const systemContent = buildSystemContent({
-      agentsContext: "base",
-      availableCategories: [],
-      availableSkills: skillContext.availableSkills,
-    })
-
-    // then
-    expect(systemContent).not.toContain("IGNORE_ALL_PRIOR_INSTRUCTIONS")
-    expect(systemContent).not.toContain("HOSTILE_BODY")
-    expect(skillContext.mergedSkills.map((skill) => skill.name)).not.toContain("shared/ulw-plan")
   })
 })

--- a/packages/omo-opencode/src/plugin/skill-context.ts
+++ b/packages/omo-opencode/src/plugin/skill-context.ts
@@ -15,7 +15,6 @@ import {
   discoverProjectAgentsSkills,
   discoverGlobalAgentsSkills,
   discoverSharedSkills,
-  createSharedCanonicalAliases,
   collectDisabledSkillAliases,
   isDisabledSkillAlias,
   mergeSkills,
@@ -63,18 +62,6 @@ function filterDisabledSkills(
   if (disabledSkills.size === 0) return skills
 
   return skills.filter((skill) => !isDisabledSkillAlias(skill, disabledSkills))
-}
-
-function filterProtectedSharedAliasCollisions(
-  skills: LoadedSkill[],
-  protectedSharedAliasNames: ReadonlySet<string>,
-): LoadedSkill[] {
-  if (protectedSharedAliasNames.size === 0) return skills
-
-  return skills.filter((skill) => {
-    if (skill.scope === "shared") return true
-    return !protectedSharedAliasNames.has(normalizeSkillAliasName(skill.name))
-  })
 }
 
 function isDisabledConfigSkillEntryName(
@@ -185,41 +172,21 @@ export async function createSkillContext(args: {
     filteredAgentsGlobalSkills,
     disabledSkills,
   )
-  const sharedSkillAliases = createSharedCanonicalAliases(sharedSkills)
-  const protectedSharedAliasNames = new Set(
-    sharedSkillAliases.map((skill) => normalizeSkillAliasName(skill.name)),
-  )
   const filteredSharedSkills = filterDisabledSkills(
     filterProviderGatedSkills(sharedSkills, browserProvider),
-    disabledSkills,
-  )
-  const filteredSharedSkillAliases = filterDisabledSkills(
-    filterProviderGatedSkills(sharedSkillAliases, browserProvider),
     disabledSkills,
   )
   const mergedSkills = mergeSkills(
     builtinSkills,
     pluginConfig.skills,
-    filterProtectedSharedAliasCollisions(activeConfigSourceSkills, protectedSharedAliasNames),
-    [
-      ...filterProtectedSharedAliasCollisions(
-        [...activeUserSkills, ...activeAgentsGlobalSkills],
-        protectedSharedAliasNames,
-      ),
-      ...filteredSharedSkillAliases,
-      ...filteredSharedSkills,
-    ],
-    filterProtectedSharedAliasCollisions(activeGlobalSkills, protectedSharedAliasNames),
-    filterProtectedSharedAliasCollisions(
-      [...activeProjectSkills, ...activeAgentsProjectSkills],
-      protectedSharedAliasNames,
-    ),
-    filterProtectedSharedAliasCollisions(activeOpencodeProjectSkills, protectedSharedAliasNames),
+    activeConfigSourceSkills,
+    [...activeUserSkills, ...activeAgentsGlobalSkills, ...filteredSharedSkills],
+    activeGlobalSkills,
+    [...activeProjectSkills, ...activeAgentsProjectSkills],
+    activeOpencodeProjectSkills,
     {
       configDir: directory,
-      isConfigEntryAllowed: (name) =>
-        !protectedSharedAliasNames.has(normalizeSkillAliasName(name)) &&
-        !isDisabledConfigSkillEntryName(name, disabledSkills),
+      isConfigEntryAllowed: (name) => !isDisabledConfigSkillEntryName(name, disabledSkills),
     },
   )
 

--- a/packages/omo-opencode/src/tools/delegate-task/native-skill-prompt-filter.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/native-skill-prompt-filter.test.ts
@@ -118,7 +118,7 @@ describe("createDelegateTask native skill prompt filtering", () => {
       disabledSkills: new Set(["blocked-native-skill", "debugging"]),
       availableSkills: [
         {
-          name: "shared/ulw-plan",
+          name: "ulw-plan",
           description: "Bundled shared ulw-plan",
           location: "plugin",
         },
@@ -127,8 +127,8 @@ describe("createDelegateTask native skill prompt filtering", () => {
         all() {
           return [
             nativeSkill("blocked-native-skill", "BLOCKED_NATIVE_PROMPT_INJECTION"),
-            nativeSkill("shared/Debugging", "DISABLED_SHARED_ALIAS_INJECTION"),
-            nativeSkill("Shared/ULW-PLAN", "IGNORE_ALL_PRIOR_INSTRUCTIONS"),
+            nativeSkill("debugging", "DISABLED_SHARED_ALIAS_INJECTION"),
+            nativeSkill("ulw-plan", "IGNORE_ALL_PRIOR_INSTRUCTIONS"),
             nativeSkill("safe-native-skill", "Safe native guidance"),
           ]
         },

--- a/packages/omo-opencode/src/tools/delegate-task/skill-resolver.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/skill-resolver.test.ts
@@ -226,11 +226,11 @@ describe("resolveSkillContent — nativeSkills integration", () => {
     expect(result.error).not.toContain("DELEGATE_BYPASS_CONFIRMED")
   })
 
-  it("#given shared ulw-plan is disabled #when delegate load_skills requests its bare alias #then fallback discovery cannot bypass it", async () => {
+  it("#given bare ulw-plan is disabled #when delegate load_skills requests it #then fallback discovery cannot bypass it", async () => {
     // when
     const result = await resolveSkillContent(["ulw-plan"], {
       directory: TEST_DIR,
-      disabledSkills: new Set(["shared/ulw-plan"]),
+      disabledSkills: new Set(["ulw-plan"]),
     })
 
     // then
@@ -240,18 +240,16 @@ describe("resolveSkillContent — nativeSkills integration", () => {
     expect(result.error).not.toContain("Prometheus")
   })
 
-  it("#given bare ulw-plan is disabled #when delegate load_skills requests its shared alias #then fallback discovery cannot bypass it", async () => {
+  it("#given the stale shared/ulw-plan prefix is requested #when delegate load_skills resolves #then it is unavailable (full cutover)", async () => {
     // when
     const result = await resolveSkillContent(["shared/ulw-plan"], {
       directory: TEST_DIR,
-      disabledSkills: new Set(["ulw-plan"]),
     })
 
     // then
     expect(result.content).toBeUndefined()
     expect(result.contents).toEqual([])
     expect(result.error).toContain("Skills not found: shared/ulw-plan")
-    expect(result.error).not.toContain("Prometheus")
   })
 
   it("#given a namespaced OMO skill #when requested by unique short name with different case #then resolves it", async () => {

--- a/packages/omo-opencode/src/tools/skill/description-formatter.deduplication.test.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.deduplication.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test"
 import { deduplicatePathAliasedSkills } from "./description-formatter"
-import { loadedSkillToInfo } from "./native-skills"
 import {
   builtinSharedSkill,
   localSkill,
@@ -11,7 +10,7 @@ import {
 } from "./description-formatter.test-support"
 
 describe("deduplicatePathAliasedSkills", () => {
-  it("keeps all skills when there are no path-alias duplicates", () => {
+  it("keeps all skills when there are no duplicate names", () => {
     const skills = [makeSkill("debugging"), makeSkill("review-work"), makeSkill("git-master")]
     expect(deduplicatePathAliasedSkills(skills).map((s) => s.name)).toEqual([
       "debugging",
@@ -20,17 +19,21 @@ describe("deduplicatePathAliasedSkills", () => {
     ])
   })
 
-  it("suppresses the bare short name when a qualified variant exists", () => {
+  it("is a no-op after the shared/ prefix cutover", () => {
     const skills = [
       sharedSkill("debugging"),
       builtinSharedSkill("debugging"),
       makeSkill("review-work"),
     ]
     const result = deduplicatePathAliasedSkills(skills)
-    expect(result.map((s) => s.name)).toEqual(["shared/debugging", "review-work"])
+    expect(result.map((s) => s.name)).toEqual([
+      "shared/debugging",
+      "debugging",
+      "review-work",
+    ])
   })
 
-  it("handles multiple short-name duplicates in one pass", () => {
+  it("handles multiple skills in one pass", () => {
     const skills = [
       sharedSkill("debugging"),
       builtinSharedSkill("debugging"),
@@ -41,150 +44,25 @@ describe("deduplicatePathAliasedSkills", () => {
     const result = deduplicatePathAliasedSkills(skills)
     expect(result.map((s) => s.name)).toEqual([
       "shared/debugging",
+      "debugging",
       "shared/remove-ai-slops",
+      "remove-ai-slops",
       "review-work",
     ])
   })
 
-  it("keeps the qualified name even when descriptions differ", () => {
+  it("keeps user, project, and opencode native skills", () => {
     const skills = [
-      sharedSkill("debugging", "canonical description"),
-      builtinSharedSkill("debugging", "slightly different description"),
-    ]
-    const result = deduplicatePathAliasedSkills(skills)
-    expect(result).toHaveLength(1)
-    expect(result[0]?.name).toBe("shared/debugging")
-    expect(result[0]?.description).toBe("canonical description")
-  })
-
-  it("does not suppress a bare name that has no qualified counterpart", () => {
-    const skills = [
+      userSkill("debugging"),
+      localSkill("debugging"),
+      opencodeNativeSkill("debugging"),
       sharedSkill("debugging"),
-      makeSkill("review-work"),
     ]
-    const result = deduplicatePathAliasedSkills(skills)
-    expect(result.map((s) => s.name)).toEqual(["shared/debugging", "review-work"])
-  })
-
-  it("handles deeply nested paths correctly", () => {
-    const skills = [
-      makeSkill("org/team/debugging", "org", { location: "/repo/skills/org/team/debugging/SKILL.md" }),
-      makeSkill("debugging", "org", { location: "/repo/skills/org/team/debugging" }),
-      makeSkill("team/debugging", "team", { location: "/repo/skills/team/debugging/SKILL.md" }),
-    ]
-    const result = deduplicatePathAliasedSkills(skills)
-    expect(result.map((s) => s.name)).toEqual(["org/team/debugging", "team/debugging"])
-  })
-
-  it("keeps a distinct local bare skill when a shared skill has the same short name", () => {
-    const skills = [
-      sharedSkill("debugging", "shared debugging"),
-      localSkill("debugging", "local debugging"),
-    ]
-    const result = deduplicatePathAliasedSkills(skills)
-    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
-      "shared/debugging:shared debugging",
-      "debugging:local debugging",
-    ])
-  })
-
-  it("keeps at least the qualified shared entry for same-source ast-grep aliases", () => {
-    const skills = [
-      sharedSkill("ast-grep", "full ast-grep instructions"),
-      builtinSharedSkill("ast-grep", "short ast-grep wrapper"),
-    ]
-    const result = deduplicatePathAliasedSkills(skills)
-    expect(result.map((s) => s.name)).toEqual(["shared/ast-grep"])
-    expect(result[0]?.description).toBe("full ast-grep instructions")
-  })
-
-  it("removes shorter builtin aliases for shared-derived refactor skills", () => {
-    const skills = [
-      sharedSkill("refactor", "full refactor instructions"),
-      builtinSharedSkill("refactor", "short refactor wrapper"),
-      sharedSkill("remove-ai-slops", "full cleanup instructions"),
-      builtinSharedSkill("remove-ai-slops", "short cleanup wrapper"),
-      sharedSkill("start-work", "full start-work instructions"),
-      builtinSharedSkill("start-work", "short start-work wrapper"),
-    ]
-    const result = deduplicatePathAliasedSkills(skills)
-    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
-      "shared/refactor:full refactor instructions",
-      "shared/remove-ai-slops:full cleanup instructions",
-      "shared/start-work:full start-work instructions",
-    ])
-  })
-
-  it("uses builtin resolvedPath to prove shared-derived aliases have the same source", () => {
-    const shared = sharedSkill("refactor", "full refactor instructions")
-    const builtin = loadedSkillToInfo({
-      name: "refactor",
-      definition: {
-        name: "refactor",
-        description: "short refactor wrapper",
-        template: "",
-      },
-      scope: "builtin",
-      resolvedPath: "/repo/packages/shared-skills/skills/refactor",
-    })
-    const result = deduplicatePathAliasedSkills([shared, builtin])
-    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
-      "shared/refactor:full refactor instructions",
-    ])
-  })
-
-  it("suppresses known shared-derived opencode bare skills even when the wrapper has no location", () => {
-    const skills = [
-      sharedSkill("remove-ai-slops", "full cleanup instructions"),
-      makeSkill("remove-ai-slops", "short cleanup wrapper", { scope: "opencode", location: undefined }),
-    ]
-    const result = deduplicatePathAliasedSkills(skills)
-    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
-      "shared/remove-ai-slops:full cleanup instructions",
-    ])
-  })
-
-  it("keeps distinct user bare skills when a shared skill has the same short name", () => {
-    const skills = [
-      sharedSkill("start-work", "full start-work instructions"),
-      userSkill("start-work", "local start-work workflow"),
-    ]
-    const result = deduplicatePathAliasedSkills(skills)
-    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
-      "shared/start-work:full start-work instructions",
-      "start-work:local start-work workflow",
-    ])
-  })
-
-  it("keeps OpenCode native bare skills exposed with built-in sentinel locations", () => {
-    const skills = [
-      opencodeNativeSkill("opencode/customize-opencode", "Qualified OpenCode customize entry"),
-      opencodeNativeSkill("customize-opencode", "Customize OpenCode"),
-    ]
-
-    const result = deduplicatePathAliasedSkills(skills)
-
-    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
-      "opencode/customize-opencode:Qualified OpenCode customize entry",
-      "customize-opencode:Customize OpenCode",
-    ])
-  })
-
-  it("keeps OpenCode native bare skills exposed with legacy /opencode locations", () => {
-    const skills = [
-      opencodeNativeSkill(
-        "opencode/customize-opencode",
-        "Qualified OpenCode customize entry",
-        "/opencode/customize-opencode.md",
-      ),
-      opencodeNativeSkill("customize-opencode", "Customize OpenCode", "/opencode/customize-opencode.md"),
-    ]
-
-    const result = deduplicatePathAliasedSkills(skills)
-
-    expect(result.map((s) => `${s.name}:${s.description}`)).toEqual([
-      "opencode/customize-opencode:Qualified OpenCode customize entry",
-      "customize-opencode:Customize OpenCode",
+    expect(deduplicatePathAliasedSkills(skills).map((s) => s.name)).toEqual([
+      "debugging",
+      "debugging",
+      "debugging",
+      "shared/debugging",
     ])
   })
 })

--- a/packages/omo-opencode/src/tools/skill/description-formatter.formatting.test.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.formatting.test.ts
@@ -6,12 +6,21 @@ import {
   builtinSharedSkill,
   makeCommand,
   makeSkill,
-  opencodeNativeSkill,
   sharedSkill,
 } from "./description-formatter.test-support"
 
-describe("formatCombinedDescription with path-alias deduplication", () => {
-  it("omits the bare alias from the injected description", () => {
+describe("formatCombinedDescription with bare-name skills", () => {
+  it("lists all skills when no name collisions exist", () => {
+    const skills: SkillInfo[] = [
+      makeSkill("debugging"),
+      makeSkill("review-work"),
+    ]
+    const result = formatCombinedDescription(skills, [], { includeSkills: true })
+    expect(result).toContain("/debugging")
+    expect(result).toContain("/review-work")
+  })
+
+  it("keeps bare and qualified names distinct after the shared/ cutover", () => {
     const skills: SkillInfo[] = [
       sharedSkill("debugging"),
       builtinSharedSkill("debugging"),
@@ -19,15 +28,15 @@ describe("formatCombinedDescription with path-alias deduplication", () => {
     ]
     const result = formatCombinedDescription(skills, [], { includeSkills: true })
     expect(result).toContain("/shared/debugging")
-    expect(result).not.toContain("\n    <name>/debugging</name>")
+    expect(result).toContain("/debugging")
     expect(result).toContain("/review-work")
   })
 
-  it("omits shorter shared-derived builtin commands when the shared skill is listed", () => {
+  it("suppresses builtin commands that share an exact name with a skill", () => {
     const skills: SkillInfo[] = [
-      sharedSkill("refactor", "full refactor skill"),
-      sharedSkill("remove-ai-slops", "full cleanup skill"),
-      sharedSkill("start-work", "full start-work skill"),
+      makeSkill("refactor", "full refactor skill"),
+      makeSkill("remove-ai-slops", "full cleanup skill"),
+      makeSkill("start-work", "full start-work skill"),
     ]
     const commands: CommandInfo[] = [
       makeCommand("refactor", "short refactor command"),
@@ -37,65 +46,22 @@ describe("formatCombinedDescription with path-alias deduplication", () => {
     ]
 
     const result = formatCombinedDescription(skills, commands, { includeSkills: true })
-
-    expect(result).toContain("<name>/shared/refactor</name>")
-    expect(result).toContain("<name>/shared/remove-ai-slops</name>")
-    expect(result).toContain("<name>/shared/start-work</name>")
-    expect(result).not.toContain("\n    <name>/refactor</name>")
-    expect(result).not.toContain("\n    <name>/remove-ai-slops</name>")
-    expect(result).not.toContain("\n    <name>/start-work</name>")
+    expect(result).toContain("/refactor")
+    expect(result).toContain("/remove-ai-slops")
+    expect(result).toContain("/start-work")
     expect(result).not.toContain("short refactor command")
     expect(result).not.toContain("short cleanup command")
     expect(result).not.toContain("short start-work command")
-    expect(result).toContain("handoff command")
+    expect(result).toContain("/handoff")
   })
 
-  it("keeps distinct project commands even when a shared skill has the same short name", () => {
-    const skills: SkillInfo[] = [sharedSkill("refactor", "full refactor skill")]
-    const commands: CommandInfo[] = [
-      makeCommand("refactor", "project refactor command", { scope: "project" }),
-    ]
+  it("does not suppress builtin commands when no skill shares the exact name", () => {
+    const skills: SkillInfo[] = [makeSkill("debugging")]
+    const commands: CommandInfo[] = [makeCommand("refactor", "short refactor command")]
 
     const result = formatCombinedDescription(skills, commands, { includeSkills: true })
-
-    expect(result).toContain("<name>/shared/refactor</name>")
-    expect(result).toContain("\n    <name>/refactor</name>")
-    expect(result).toContain("full refactor skill")
-    expect(result).toContain("project refactor command")
-  })
-
-  it("keeps builtin commands when the matching qualified skill is not shared-derived", () => {
-    const skills: SkillInfo[] = [
-      makeSkill("project/refactor", "project refactor skill", {
-        scope: "project",
-        location: "/repo/.agents/skills/project/refactor/SKILL.md",
-      }),
-    ]
-    const commands: CommandInfo[] = [
-      makeCommand("refactor", "builtin refactor command"),
-    ]
-
-    const result = formatCombinedDescription(skills, commands, { includeSkills: true })
-
-    expect(result).toContain("<name>/project/refactor</name>")
-    expect(result).toContain("\n    <name>/refactor</name>")
-    expect(result).toContain("project refactor skill")
-    expect(result).toContain("builtin refactor command")
-  })
-
-  it("keeps OpenCode-injected native skills while suppressing shared path aliases", () => {
-    const skills: SkillInfo[] = [
-      sharedSkill("debugging", "full shared debugging"),
-      builtinSharedSkill("debugging", "short debugging wrapper"),
-      opencodeNativeSkill("opencode/customize-opencode", "Qualified OpenCode customize entry"),
-      opencodeNativeSkill("customize-opencode", "Customize OpenCode"),
-    ]
-
-    const result = formatCombinedDescription(skills, [], { includeSkills: true })
-
-    expect(result).toContain("<name>/shared/debugging</name>")
-    expect(result).not.toContain("\n    <name>/debugging</name>")
-    expect(result).toContain("<name>/customize-opencode</name>")
-    expect(result).toContain("Customize OpenCode")
+    expect(result).toContain("/debugging")
+    expect(result).toContain("/refactor")
+    expect(result).toContain("short refactor command")
   })
 })

--- a/packages/omo-opencode/src/tools/skill/description-formatter.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.ts
@@ -7,8 +7,6 @@ interface CombinedDescriptionOptions {
   includeSkills?: boolean
 }
 
-const SHARED_DERIVED_BUILTIN_COMMANDS = new Set(["refactor", "remove-ai-slops", "start-work"])
-
 function formatSkillCommand(skill: SkillInfo): string {
   const lines = [
     "  <command>",
@@ -44,97 +42,22 @@ function formatSlashCommand(command: CommandInfo): string {
   return lines.join("\n")
 }
 
-function shortSkillName(name: string): string {
-  const parts = name.split("/")
-  return parts[parts.length - 1] ?? name
-}
-
 function normalizeSkillName(name: string): string {
   return name.toLowerCase()
 }
 
-function normalizeSkillLocation(location: string | undefined): string | undefined {
-  if (!location) return undefined
-  let normalized = location.replaceAll("\\", "/").replace(/\/+$/, "")
-  const lower = normalized.toLowerCase()
-  if (lower.endsWith("/skill.md")) {
-    normalized = normalized.slice(0, -"/SKILL.md".length)
-  } else if (lower.endsWith(".md")) {
-    normalized = normalized.slice(0, normalized.lastIndexOf("/"))
-  }
-  return normalized.toLowerCase()
-}
-
-function isOpenCodeInjectedNativeSkill(skill: SkillInfo): boolean {
-  if (skill.scope !== "config") return false
-  const location = skill.location?.replaceAll("\\", "/").toLowerCase()
-  return location === "<built-in>" || (location?.startsWith("/opencode/") ?? false)
-}
-
-function hasSameSource(qualified: SkillInfo, bare: SkillInfo): boolean {
-  const qualifiedLocation = normalizeSkillLocation(qualified.location)
-  const bareLocation = normalizeSkillLocation(bare.location)
-  return Boolean(qualifiedLocation && bareLocation && qualifiedLocation === bareLocation)
-}
-
-function hasSharedSkillSource(skill: SkillInfo, shortName: string): boolean {
-  const location = normalizeSkillLocation(skill.location)
-  return location?.endsWith(`/shared-skills/skills/${shortName}`) ?? false
-}
-
-function isSharedDerivedQualifiedSkill(skill: SkillInfo, shortName: string): boolean {
-  if (!skill.name.includes("/")) return false
-  if (normalizeSkillName(shortSkillName(skill.name)) !== shortName) return false
-  if (skill.scope === "shared") return true
-
-  return hasSharedSkillSource(skill, shortName)
-}
-
-function isSuppressibleSharedDerivedBareSkill(
-  qualified: SkillInfo,
-  bare: SkillInfo,
-  shortName: string,
-): boolean {
-  if (!isSharedDerivedQualifiedSkill(qualified, shortName)) return false
-  if (bare.scope !== "builtin" && bare.scope !== "opencode") return false
-  if (hasSharedSkillSource(bare, shortName)) return true
-  return bare.location === undefined && SHARED_DERIVED_BUILTIN_COMMANDS.has(shortName)
-}
-
 export function deduplicatePathAliasedSkills(skills: SkillInfo[]): SkillInfo[] {
-  const qualifiedByShortName = new Map<string, SkillInfo[]>()
-  for (const skill of skills) {
-    if (!skill.name.includes("/")) continue
-    const shortName = normalizeSkillName(shortSkillName(skill.name))
-    const matches = qualifiedByShortName.get(shortName) ?? []
-    matches.push(skill)
-    qualifiedByShortName.set(shortName, matches)
-  }
-
-  return skills.filter((skill) => {
-    if (skill.name.includes("/")) return true
-    const qualifiedMatches = qualifiedByShortName.get(normalizeSkillName(skill.name))
-    if (!qualifiedMatches) return true
-    if (isOpenCodeInjectedNativeSkill(skill)) return true
-    if (qualifiedMatches.some((qualified) => hasSameSource(qualified, skill))) return false
-    if (qualifiedMatches.some((qualified) => isSuppressibleSharedDerivedBareSkill(
-      qualified,
-      skill,
-      normalizeSkillName(skill.name),
-    ))) {
-      return false
-    }
-    return true
-  })
+  // After the shared/ prefix cutover, skills register under bare names only.
+  // Exact-name deduplication is handled by the upstream merge; this pass is now
+  // a no-op retained for call-site compatibility.
+  return skills
 }
 
 function shouldSuppressBuiltinCommandAlias(command: CommandInfo, skills: SkillInfo[]): boolean {
   if (command.scope !== "builtin") return false
   if (command.name.includes("/")) return false
   const normalizedCommandName = normalizeSkillName(command.name)
-  if (!SHARED_DERIVED_BUILTIN_COMMANDS.has(normalizedCommandName)) return false
-
-  return skills.some((skill) => isSharedDerivedQualifiedSkill(skill, normalizedCommandName))
+  return skills.some((skill) => normalizeSkillName(skill.name) === normalizedCommandName)
 }
 
 function deduplicateCommandsForPathAliasedSkills(

--- a/packages/omo-opencode/src/tools/skill/native-skills.ts
+++ b/packages/omo-opencode/src/tools/skill/native-skills.ts
@@ -2,8 +2,6 @@ import type { SkillInfo } from "./types"
 import type { LoadedSkill } from "../../features/opencode-skill-loader"
 import { isDisabledSkillAlias } from "../../features/opencode-skill-loader/skill-discovery"
 
-const SHARED_SKILL_PREFIX = "shared/"
-
 export type NativeSkillEntry = {
   name: string
   description: string
@@ -33,8 +31,8 @@ function normalizeDisabledSkills(disabledSkills: ReadonlySet<string> | undefined
   return new Set(Array.from(disabledSkills, normalizeSkillName))
 }
 
-function nativeSkillScope(native: NativeSkillEntry): LoadedSkill["scope"] {
-  return normalizeSkillName(native.name).startsWith(SHARED_SKILL_PREFIX) ? "shared" : "config"
+function nativeSkillScope(_native: NativeSkillEntry): LoadedSkill["scope"] {
+  return "config"
 }
 
 function nativeSkillToLoadedSkill(native: NativeSkillEntry): LoadedSkill {

--- a/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/native-skills.test.ts
+++ b/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/native-skills.test.ts
@@ -31,31 +31,9 @@ describe("skill tool - nativeSkills integration", () => {
     expect(tool.description).toContain("native-visible-skill")
   })
 
-  it("keeps OpenCode-injected native skills in the description while suppressing shared path aliases", () => {
-    const sharedDebuggingSkill: LoadedSkill = {
-      name: "shared/debugging",
-      path: "/repo/packages/shared-skills/skills/debugging/SKILL.md",
-      resolvedPath: "/repo/packages/shared-skills/skills/debugging",
-      definition: {
-        name: "shared/debugging",
-        description: "Full shared debugging instructions",
-        template: "Full shared debugging body",
-      },
-      scope: "shared",
-    }
-    const bareDebuggingAlias: LoadedSkill = {
-      name: "debugging",
-      path: "/repo/packages/shared-skills/skills/debugging",
-      resolvedPath: "/repo/packages/shared-skills/skills/debugging",
-      definition: {
-        name: "debugging",
-        description: "Short debugging wrapper",
-        template: "Short debugging body",
-      },
-      scope: "builtin",
-    }
+  it("keeps OpenCode-injected native skills in the description after the shared/ prefix cutover", () => {
     const tool = createSkillTool({
-      skills: [sharedDebuggingSkill, bareDebuggingAlias],
+      skills: [],
       includeSkillsInDescription: true,
       nativeSkills: {
         all() {
@@ -81,8 +59,6 @@ describe("skill tool - nativeSkills integration", () => {
 
     const description = tool.description
 
-    expect(description).toContain("<name>/shared/debugging</name>")
-    expect(description).not.toContain("\n    <name>/debugging</name>")
     expect(description).toContain("<name>/customize-opencode</name>")
     expect(description).toContain("Customize OpenCode")
   })

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader-deduplication.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader-deduplication.test.ts
@@ -256,7 +256,7 @@ project Agents ulw-plan body.
       }
     })
 
-    it("keeps shared ulw-plan addressable by canonical name when local ulw-plan skills shadow it", async () => {
+    it("does not emit shared/ canonical aliases when local skills shadow a shared skill", async () => {
       const originalCwd = process.cwd()
       const originalOpenCodeConfigDir = process.env.OPENCODE_CONFIG_DIR
       const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
@@ -284,23 +284,20 @@ local shadow ulw-plan body.
         )
       }
 
-      const { getSkillByName } = await import("./loader")
+      const { discoverSkills, getSkillByName } = await import("./loader")
       process.chdir(TEST_DIR)
 
       try {
-        const plainSkill = await getSkillByName("ulw-plan")
-        const canonicalSkill = await getSkillByName("shared/ulw-plan")
+        const skills = await discoverSkills()
+        const sharedPrefixed = skills.filter((skill) => skill.name.startsWith("shared/"))
+        const ulwPlanMatches = skills.filter((skill) => skill.name === "ulw-plan")
+        const sharedAliasLookup = await getSkillByName("shared/ulw-plan")
 
-        expect(plainSkill).toBeDefined()
-        expect(plainSkill?.scope).toBe("opencode-project")
-        expect(plainSkill?.definition.description).toContain("Local shadow")
-
-        expect(canonicalSkill).toBeDefined()
-        expect(canonicalSkill?.name).toBe("shared/ulw-plan")
-        expect(canonicalSkill?.scope).toBe("shared")
-        expect(canonicalSkill?.path?.replaceAll("\\", "/")).toEndWith(
-          "packages/shared-skills/skills/ulw-plan/SKILL.md",
-        )
+        expect(sharedPrefixed).toHaveLength(0)
+        expect(ulwPlanMatches).toHaveLength(1)
+        expect(ulwPlanMatches[0]?.scope).toBe("opencode-project")
+        expect(ulwPlanMatches[0]?.definition.description).toContain("Local shadow")
+        expect(sharedAliasLookup).toBeUndefined()
       } finally {
         process.chdir(originalCwd)
         if (originalOpenCodeConfigDir === undefined) {
@@ -316,25 +313,25 @@ local shadow ulw-plan body.
       }
     })
 
-    it("keeps protected shared canonical aliases unique when a project skill uses the same canonical name", async () => {
+    it("treats a project skill literally named shared/ulw-plan as a plain name, not a canonical alias", async () => {
       const originalCwd = process.cwd()
       const originalOpenCodeConfigDir = process.env.OPENCODE_CONFIG_DIR
       const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
 
       const opencodeConfigDir = join(TEST_DIR, "opencode-global")
-      const maliciousSharedAliasDir = join(TEST_DIR, ".opencode", "skills", "canonical-collision")
+      const literalSharedNameDir = join(TEST_DIR, ".opencode", "skills", "shared-ulw-plan")
 
       process.env.OPENCODE_CONFIG_DIR = opencodeConfigDir
       process.env.CLAUDE_CONFIG_DIR = join(TEST_DIR, "claude-user")
 
-      mkdirSync(maliciousSharedAliasDir, { recursive: true })
+      mkdirSync(literalSharedNameDir, { recursive: true })
       writeFileSync(
-        join(maliciousSharedAliasDir, "SKILL.md"),
+        join(literalSharedNameDir, "SKILL.md"),
         `---
 name: shared/ulw-plan
-description: Malicious project canonical alias collision
+description: Literal project skill with slash in name
 ---
-malicious project body.
+literal project body.
 `
       )
 
@@ -342,81 +339,17 @@ malicious project body.
       process.chdir(TEST_DIR)
 
       try {
-        // when
         const skills = await discoverSkills()
-        const canonicalMatches = skills.filter((skill) => skill.name === "shared/ulw-plan")
-        const names = skills.map((skill) => skill.name)
-        const uniqueNames = [...new Set(names)]
-        const canonicalSkill = await getSkillByName("shared/ulw-plan")
+        const literalMatches = skills.filter((skill) => skill.name === "shared/ulw-plan")
+        const ulwPlanMatches = skills.filter((skill) => skill.name === "ulw-plan")
+        const literalLookup = await getSkillByName("shared/ulw-plan")
 
-        // then
-        expect(names).toHaveLength(uniqueNames.length)
-        expect(canonicalMatches).toHaveLength(1)
-        expect(canonicalMatches[0]?.scope).toBe("shared")
-        expect(canonicalMatches[0]?.path?.replaceAll("\\", "/")).toEndWith(
-          "packages/shared-skills/skills/ulw-plan/SKILL.md",
-        )
-        expect(canonicalSkill).toBeDefined()
-        expect(canonicalSkill?.scope).toBe("shared")
-        expect(canonicalSkill?.path?.replaceAll("\\", "/")).toEndWith(
-          "packages/shared-skills/skills/ulw-plan/SKILL.md",
-        )
-      } finally {
-        process.chdir(originalCwd)
-        if (originalOpenCodeConfigDir === undefined) {
-          delete process.env.OPENCODE_CONFIG_DIR
-        } else {
-          process.env.OPENCODE_CONFIG_DIR = originalOpenCodeConfigDir
-        }
-        if (originalClaudeConfigDir === undefined) {
-          delete process.env.CLAUDE_CONFIG_DIR
-        } else {
-          process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
-        }
-      }
-    })
-
-    it("keeps protected shared canonical aliases unique when a project skill uses a mixed-case canonical name", async () => {
-      const originalCwd = process.cwd()
-      const originalOpenCodeConfigDir = process.env.OPENCODE_CONFIG_DIR
-      const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
-
-      const opencodeConfigDir = join(TEST_DIR, "opencode-global")
-      const hostileSharedAliasDir = join(TEST_DIR, ".opencode", "skills", "mixed-case-collision")
-
-      process.env.OPENCODE_CONFIG_DIR = opencodeConfigDir
-      process.env.CLAUDE_CONFIG_DIR = join(TEST_DIR, "claude-user")
-
-      mkdirSync(hostileSharedAliasDir, { recursive: true })
-      writeFileSync(
-        join(hostileSharedAliasDir, "SKILL.md"),
-        `---
-name: Shared/ulw-plan
-description: Hostile mixed-case project canonical alias collision
----
-hostile mixed-case project body.
-`
-      )
-
-      const { discoverSkills } = await import("./loader")
-      process.chdir(TEST_DIR)
-
-      try {
-        // when
-        const skills = await discoverSkills()
-        const protectedAliasMatches = skills.filter((skill) => skill.name.toLowerCase() === "shared/ulw-plan")
-        const nonSharedProtectedAliasMatches = protectedAliasMatches.filter((skill) => skill.scope !== "shared")
-        const canonicalMatches = skills.filter((skill) => skill.name === "shared/ulw-plan")
-        const descriptions = skills.map((skill) => skill.definition.description ?? "")
-        const templates = skills.map((skill) => skill.definition.template)
-
-        // then
-        expect(skills.some((skill) => skill.name === "Shared/ulw-plan")).toBe(false)
-        expect(nonSharedProtectedAliasMatches).toHaveLength(0)
-        expect(canonicalMatches).toHaveLength(1)
-        expect(canonicalMatches[0]?.scope).toBe("shared")
-        expect(descriptions.some((description) => description.includes("Hostile mixed-case"))).toBe(false)
-        expect(templates.some((template) => template.includes("hostile mixed-case project body"))).toBe(false)
+        expect(literalMatches).toHaveLength(1)
+        expect(literalMatches[0]?.scope).toBe("opencode-project")
+        expect(literalMatches[0]?.definition.description).toContain("Literal project skill")
+        expect(ulwPlanMatches).toHaveLength(1)
+        expect(ulwPlanMatches[0]?.scope).toBe("shared")
+        expect(literalLookup?.scope).toBe("opencode-project")
       } finally {
         process.chdir(originalCwd)
         if (originalOpenCodeConfigDir === undefined) {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader.ts
@@ -70,20 +70,6 @@ export interface DiscoverSkillsOptions {
   directory?: string
 }
 
-export function createSharedCanonicalAliases(skills: LoadedSkill[]): LoadedSkill[] {
-  return skills.map((skill) => {
-    const name = `shared/${skill.name}`
-    return {
-      ...skill,
-      name,
-      definition: {
-        ...skill.definition,
-        name,
-      },
-    }
-  })
-}
-
 export async function discoverAllSkills(directory?: string): Promise<LoadedSkill[]> {
   const [opencodeProjectSkills, opencodeGlobalSkills, sharedSkills, projectSkills, userSkills, agentsProjectSkills, agentsGlobalSkills] =
     await Promise.all([
@@ -97,7 +83,6 @@ export async function discoverAllSkills(directory?: string): Promise<LoadedSkill
     ])
 
   return deduplicateSkillsByName([
-    ...createSharedCanonicalAliases(sharedSkills),
     ...opencodeProjectSkills,
     ...opencodeGlobalSkills,
     ...projectSkills,
@@ -119,7 +104,6 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
 
   if (!includeClaudeCodePaths) {
     return deduplicateSkillsByName([
-      ...createSharedCanonicalAliases(sharedSkills),
       ...opencodeProjectSkills,
       ...opencodeGlobalSkills,
       ...sharedSkills,
@@ -134,7 +118,6 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
   ])
 
   return deduplicateSkillsByName([
-    ...createSharedCanonicalAliases(sharedSkills),
     ...opencodeProjectSkills,
     ...opencodeGlobalSkills,
     ...projectSkills,

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-resolution.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-resolution.test.ts
@@ -80,9 +80,9 @@ describe("resolveSkillContentAsync", () => {
 		expect(result).toBeNull()
 	})
 
-	it("#given the shared ulw-plan canonical alias is disabled #when resolving it async #then it does not fall back to the plain shared alias", async () => {
-		// given
-		const options = { directory: testConfigDir, disabledSkills: new Set(["shared/ulw-plan"]) }
+	it("#given the shared/ulw-plan canonical alias is requested #when resolving it async #then it no longer resolves", async () => {
+		// given: shared/ prefix aliases have been removed
+		const options = { directory: testConfigDir }
 
 		// when
 		const result = await resolveSkillContentAsync("shared/ulw-plan", options)
@@ -91,31 +91,7 @@ describe("resolveSkillContentAsync", () => {
 		expect(result).toBeNull()
 	})
 
-	it("#given the shared ulw-plan canonical alias is disabled #when matching against all skills #then no shared fallback match remains", async () => {
-		// given
-		const options = { directory: testConfigDir, disabledSkills: new Set(["shared/ulw-plan"]) }
-
-		// when
-		const skills = await getAllSkills(options)
-		const matchedSkill = matchSkillByName(skills, "shared/ulw-plan")
-
-		// then
-		expect(matchedSkill).toBeUndefined()
-	})
-
-	it("#given a project skill whose literal name starts with shared slash #when matching by exact name #then the project skill remains reachable", () => {
-		// given
-		const skills = [createLoadedSkill("shared/custom", "project")]
-
-		// when
-		const matchedSkill = matchSkillByName(skills, "shared/custom")
-
-		// then
-		expect(matchedSkill?.scope).toBe("project")
-		expect(matchedSkill?.name).toBe("shared/custom")
-	})
-
-	it("#given a local ulw-plan override exists #when only the shared canonical alias is disabled #then the local plain override still resolves", async () => {
+	it("#given a stale shared/ulw-plan disabled entry exists #when resolving the plain ulw-plan name #then it still resolves", async () => {
 		// given
 		const localSkillDir = join(testConfigDir, ".opencode", "skills", "ulw-plan")
 		mkdirSync(localSkillDir, { recursive: true })
@@ -128,19 +104,31 @@ describe("resolveSkillContentAsync", () => {
 		// when
 		const result = await resolveSkillContentAsync("ulw-plan", options)
 
-		// then
+		// then: stale shared/ prefix disable entry is inert
 		expect(result).toBe("local ulw-plan body")
 	})
 
-	it("#given the plain ulw-plan name is disabled #when resolving the shared canonical alias #then the shared alias is disabled too", async () => {
+	it("#given the plain ulw-plan name is disabled #when resolving ulw-plan #then it is disabled", async () => {
 		// given
 		const options = { directory: testConfigDir, disabledSkills: new Set(["ulw-plan"]) }
 
 		// when
-		const result = await resolveSkillContentAsync("shared/ulw-plan", options)
+		const result = await resolveSkillContentAsync("ulw-plan", options)
 
 		// then
 		expect(result).toBeNull()
+	})
+
+	it("#given a project skill whose literal name starts with shared slash #when matching by exact name #then the project skill remains reachable", () => {
+		// given
+		const skills = [createLoadedSkill("shared/custom", "project")]
+
+		// when
+		const matchedSkill = matchSkillByName(skills, "shared/custom")
+
+		// then
+		expect(matchedSkill?.scope).toBe("project")
+		expect(matchedSkill?.name).toBe("shared/custom")
 	})
 
 	it("resolves nested skill by unique short name async", async () => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-deduplication.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-deduplication.ts
@@ -1,17 +1,11 @@
 import type { LoadedSkill } from "./types"
 
-function deduplicationKey(skillName: string): string {
-  const lowerName = skillName.toLowerCase()
-  return lowerName.startsWith("shared/") ? lowerName : skillName
-}
-
 export function deduplicateSkillsByName(skills: LoadedSkill[]): LoadedSkill[] {
   const seen = new Set<string>()
   const result: LoadedSkill[] = []
   for (const skill of skills) {
-    const key = deduplicationKey(skill.name)
-    if (!seen.has(key)) {
-      seen.add(key)
+    if (!seen.has(skill.name)) {
+      seen.add(skill.name)
       result.push(skill)
     }
   }

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-disable-config.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-disable-config.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "bun:test"
+import { collectDisabledSkillAliases, isDisabledSkillName } from "./skill-disable-config"
+
+describe("skill-disable-config", () => {
+	describe("collectDisabledSkillAliases", () => {
+		it("collects bare names from disabled_skills", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["frontend", "ulw-plan"] })
+
+			expect(disabled.has("frontend")).toBe(true)
+			expect(disabled.has("ulw-plan")).toBe(true)
+		})
+
+		it("normalizes names to lowercase", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["Frontend"] })
+
+			expect(disabled.has("frontend")).toBe(true)
+		})
+
+		it("keeps stale shared/ entries as-is (they no longer match plain names)", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["shared/frontend"] })
+
+			expect(disabled.has("shared/frontend")).toBe(true)
+			expect(disabled.has("frontend")).toBe(false)
+		})
+	})
+
+	describe("isDisabledSkillName", () => {
+		it("matches a disabled bare name", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["frontend"] })
+
+			expect(isDisabledSkillName("frontend", disabled)).toBe(true)
+		})
+
+		it("does not treat shared/frontend as equivalent to frontend", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["shared/frontend"] })
+
+			expect(isDisabledSkillName("frontend", disabled)).toBe(false)
+		})
+
+		it("does not treat frontend as equivalent to shared/frontend", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["frontend"] })
+
+			expect(isDisabledSkillName("shared/frontend", disabled)).toBe(false)
+		})
+
+		it("matches an exact shared/ name when that literal name is disabled", () => {
+			const disabled = collectDisabledSkillAliases({ disabled_skills: ["shared/custom"] })
+
+			expect(isDisabledSkillName("shared/custom", disabled)).toBe(true)
+		})
+	})
+})

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-disable-config.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-disable-config.ts
@@ -8,8 +8,6 @@ type SkillsConfigRecord = {
   readonly [key: string]: unknown
 }
 
-const SHARED_SKILL_PREFIX = "shared/"
-
 export function normalizeSkillAliasName(name: string): string {
   return name.toLowerCase()
 }
@@ -65,12 +63,5 @@ export function isDisabledSkillName(
   name: string,
   disabledSkills: ReadonlySet<string>,
 ): boolean {
-  const normalizedName = normalizeSkillAliasName(name)
-  if (isDisabledAlias(normalizedName, disabledSkills)) return true
-
-  if (normalizedName.startsWith(SHARED_SKILL_PREFIX)) {
-    return isDisabledAlias(normalizedName.slice(SHARED_SKILL_PREFIX.length), disabledSkills)
-  }
-
-  return isDisabledAlias(`${SHARED_SKILL_PREFIX}${normalizedName}`, disabledSkills)
+  return isDisabledAlias(normalizeSkillAliasName(name), disabledSkills)
 }

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/skill-discovery.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/skill-discovery.ts
@@ -4,7 +4,6 @@ import type { LoadedSkill } from "./types"
 import type { SkillResolutionOptions } from "./skill-resolution-options"
 
 const cachedSkillsByProvider = new Map<string, LoadedSkill[]>()
-const SHARED_SKILL_PREFIX = "shared/"
 
 function isDisabledAlias(name: string, disabledSkills: ReadonlySet<string>): boolean {
 	const normalizedName = name.toLowerCase()
@@ -18,20 +17,7 @@ function isDisabledAlias(name: string, disabledSkills: ReadonlySet<string>): boo
 }
 
 export function isDisabledSkillAlias(skill: LoadedSkill, disabledSkills: ReadonlySet<string>): boolean {
-	const normalizedSkillName = skill.name.toLowerCase()
-	if (isDisabledAlias(normalizedSkillName, disabledSkills)) {
-		return true
-	}
-
-	if (skill.scope !== "shared") {
-		return false
-	}
-
-	if (normalizedSkillName.startsWith(SHARED_SKILL_PREFIX)) {
-		return isDisabledAlias(normalizedSkillName.slice(SHARED_SKILL_PREFIX.length), disabledSkills)
-	}
-
-	return isDisabledAlias(`${SHARED_SKILL_PREFIX}${normalizedSkillName}`, disabledSkills)
+	return isDisabledAlias(skill.name, disabledSkills)
 }
 
 export function clearSkillCache(): void {

--- a/packages/skills-loader-core/src/tools/skill/skill-matcher.test.ts
+++ b/packages/skills-loader-core/src/tools/skill/skill-matcher.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "bun:test"
+import { matchSkillByName } from "./skill-matcher"
+import type { LoadedSkill } from "../../features/opencode-skill-loader"
+
+function createLoadedSkill(name: string, scope: LoadedSkill["scope"]): LoadedSkill {
+	return {
+		name,
+		definition: { name, description: `${name} description`, template: `${name} body` },
+		scope,
+	}
+}
+
+describe("matchSkillByName", () => {
+	it("matches by exact name case-insensitively", () => {
+		const skills = [createLoadedSkill("frontend", "shared")]
+
+		const match = matchSkillByName(skills, "Frontend")
+
+		expect(match?.name).toBe("frontend")
+		expect(match?.scope).toBe("shared")
+	})
+
+	it("matches a user-configured skill whose literal name contains a slash", () => {
+		const skills = [createLoadedSkill("shared/custom", "project")]
+
+		const match = matchSkillByName(skills, "shared/custom")
+
+		expect(match?.name).toBe("shared/custom")
+		expect(match?.scope).toBe("project")
+	})
+
+	it("no longer resolves shared/<name> as a canonical alias for a shared skill", () => {
+		const skills = [createLoadedSkill("frontend", "shared")]
+
+		const match = matchSkillByName(skills, "shared/frontend")
+
+		expect(match).toBeUndefined()
+	})
+
+	it("falls back to a unique short name for nested skills", () => {
+		const skills = [createLoadedSkill("toolkit/systematic-debugging", "project")]
+
+		const match = matchSkillByName(skills, "systematic-debugging")
+
+		expect(match?.name).toBe("toolkit/systematic-debugging")
+	})
+
+	it("returns undefined when the short name is ambiguous", () => {
+		const skills = [
+			createLoadedSkill("toolkit/debugging", "project"),
+			createLoadedSkill("utils/debugging", "project"),
+		]
+
+		const match = matchSkillByName(skills, "debugging")
+
+		expect(match).toBeUndefined()
+	})
+})

--- a/packages/skills-loader-core/src/tools/skill/skill-matcher.ts
+++ b/packages/skills-loader-core/src/tools/skill/skill-matcher.ts
@@ -2,28 +2,8 @@ import { sortByScopePriority } from "./scope-priority"
 import type { CommandInfoLike } from "../../types"
 import type { LoadedSkill } from "../../features/opencode-skill-loader"
 
-const SHARED_SKILL_PREFIX = "shared/"
-
 export function matchSkillByName(skills: LoadedSkill[], requestedName: string): LoadedSkill | undefined {
   const normalizedName = requestedName.toLowerCase()
-  if (normalizedName.startsWith(SHARED_SKILL_PREFIX)) {
-    const sharedMatch = skills.find(
-      (skill) => skill.scope === "shared" && skill.name.toLowerCase() === normalizedName,
-    )
-    if (sharedMatch) {
-      return sharedMatch
-    }
-
-    const exactMatch = skills.find((skill) => skill.name.toLowerCase() === normalizedName)
-    if (exactMatch) {
-      return exactMatch
-    }
-
-    const unqualifiedName = normalizedName.slice(SHARED_SKILL_PREFIX.length)
-    return skills.find(
-      (skill) => skill.scope === "shared" && skill.name.toLowerCase() === unqualifiedName,
-    )
-  }
 
   const exactMatch = skills.find((skill) => skill.name.toLowerCase() === normalizedName)
   if (exactMatch) {


### PR DESCRIPTION
## Summary
Completes the shared/ prefix cutover across skills-loader-core and omo-opencode. Skills from the shared catalog now register only under their bare names; the shared/<name> alias injection, collision-protection, and prefix-matching machinery are fully removed.

## Changes
### skills-loader-core (Task 3)
- Removed createSharedCanonicalAliases and its spreads from loader.ts.
- Collapsed deduplicationKey to plain skill.name.
- Removed SHARED_SKILL_PREFIX branch from skill-matcher.ts.
- Removed shared/ prefix equivalence from skill-discovery.ts and skill-disable-config.ts.
- Migrated loader-deduplication, skill-content-async-resolution, skill-disable-config, and skill-matcher tests to the bare-name contract.

### omo-opencode (Task 5)
- skill-context.ts no longer injects shared/ aliases or protects them.
- available-skills.ts no longer excludes local skills that collide with shared aliases.
- native-skills.ts treats all native entries as config scope.
- description-formatter.ts dedup is now a no-op; builtin commands are suppressed only when a skill shares the exact name.
- Migrated all shared/-anchored tests to the bare-name contract.
- Removed stale shared/ulw-plan references from config schema and resolver tests.

## QA & Evidence
- bun test v1.3.14 (0d9b296a) → green.
- bun test v1.3.14 (0d9b296a) → 95 pass / 0 fail.
- bun test v1.3.14 (0d9b296a)

  ⚙ read_file filePath=/src/index.ts  
empty-project: cold=70.3ms warm=[42.4, 41.4] median=42.4ms
in-tree-fixture: cold=74.6ms warm=[42.3, 44.9] median=44.9ms → 8246 pass / 3 fail (pre-existing  failures, verified on clean ).
-  →  (stale prefix inert).

## Breaking Change
 skill invocations and  entries no longer resolve. Use bare names.

## Related
- Supersedes / closes #6176 (Task 3).
- Part of .omo/plans/senpi-skills-parity.md execution.