### PR TITLE
test(senpi-task): stabilize member wait ordering

### DIFF
--- a/packages/senpi-task/src/team/member-extension/tools.test.ts
+++ b/packages/senpi-task/src/team/member-extension/tools.test.ts
@@ -102,13 +102,9 @@ describe("member extension tools", () => {
     // given
     const harness = createHarness()
     const value = message("88888888-8888-4888-8888-888888888888")
-    const deps = {
-      poller: harness.poller,
-      waitRegistry: harness.registry,
-      waitBounds: { min_ms: 5, default_ms: 100, max_ms: 200 },
-    }
-    const pending = runMemberTeamWait(deps, { from: "bob", timeout_ms: 100 }, undefined).then((result) => ({
-      result,
+    const registration = harness.registry.register({ from: "bob" })
+    const observed = registration.promise.then((resolved) => ({
+      resolved,
       processedAtResolve: existsSync(join(harness.inboxDir, "processed", `${value.messageId}.json`)),
     }))
     expect(harness.registry.size).toBe(1)
@@ -116,11 +112,11 @@ describe("member extension tools", () => {
     // when
     await seed(harness, value)
     await harness.poller.pollOnce()
-    const observed = await pending
+    const result = await observed
 
     // then
-    expect(observed.processedAtResolve).toBe(true)
-    expect(observed.result.details).toMatchObject({ kind: "message", message_id: value.messageId })
+    expect(result.resolved).toEqual(value)
+    expect(result.processedAtResolve).toBe(true)
     expect(harness.registry.size).toBe(0)
   })
 


### PR DESCRIPTION
## Summary

- make the parked member `team_wait` ordering test synchronize directly on its `WaitRegistry` registration
- keep the durability-before-resolution assertion while removing the Windows-sensitive 100 ms wall-clock race
- leave production delivery behavior unchanged

## Why

GitHub Actions run `29578929255` failed only on `windows-latest` in
`packages/senpi-task/src/team/member-extension/tools.test.ts`. The test's
`timeout_ms: 100` expired while the Windows filesystem path was still completing;
the case took 125 ms in CI. Source tracing and deterministic probes confirmed that
the member poller already awaits the processed-ledger commit before resolving the
registered waiter.

The ordering test now drives the poller once and awaits the exact registered claim,
matching the synchronization style used by adjacent lead-poller coverage. The
separate test above it continues to cover the public `runMemberTeamWait` tool path.

## Observed behavior

- focused test repeated 100 times: 400 pass, 0 fail
- post-rebase focused test repeated 20 times: 80 pass, 0 fail
- full `senpi-task` suite: 723 pass, 0 fail across 114 files
- `senpi-task` typecheck: pass
- Senpi compatibility gate: 217 pass, 0 fail across 46 files
- real isolated Senpi team E2E: PASS
  - later `team_wait` message received
  - processed ledger visible and wait event logged exactly once
  - crash/restart delivery exactly once
  - real credential directory unchanged
  - zero leaked processes

## QA evidence

Reviewer-readable artifacts are stored locally under:

`.omo/evidence/20260717-windows-team-wait-ci/`

The bundle includes the live verdict, exact command outputs, isolation proof, and
an explanation of why the coverage is sufficient. No credentials, tokens, auth
headers, or environment dumps were retained.

## Risk

Low. This changes one test only. It removes timer scheduling from the ordering
assertion and directly observes the same registry claim resolved by production code.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the member `team_wait` ordering test by awaiting the exact `WaitRegistry` registration instead of a 100 ms timeout, fixing Windows-only flakiness. Production behavior is unchanged.

- **Bug Fixes**
  - Replaced `runMemberTeamWait(..., { timeout_ms: 100 })` with direct `registry.register({ from: "bob" })` and awaited its promise.
  - Drove the poller once with `pollOnce()` and asserted the registered claim resolves to the seeded message.
  - Kept the durability-before-resolution check (processed ledger exists at resolve).

<sup>Written for commit 486ef2939a6fdb76d71414dcad0d42a91e13dc8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

