### PR TITLE
docs: replace Ralph Loop with the Goal feature across user docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Even with only the following subscriptions, `ultrawork` works well (this project
 |   🔎   | **AST-Grep**                                             | Ultimate | Pattern-aware code search and rewriting across 25 languages.                                                                                                                                                     |
 |   🧠   | **Background Agents**                                    | Ultimate | Fire 5+ specialists in parallel. Context stays lean. Results when ready.                                                                                                                                         |
 |   📚   | **Built-in MCPs** (web/docs/code search)                 | Ultimate | Exa (web search), Context7 (official docs), Grep.app (GitHub search). Always on.                                                                                                                                 |
-|   🔁   | **Ralph Loop / `/ulw-loop`**                             | Ultimate | Self-referential loop. Doesn't stop until 100% done.                                                                                                                                                             |
+|   🔁   | **Goal / `/goal`**                                       | Ultimate | Persistent per-session objective. Re-injects a continuation prompt on every idle until a completion audit says it's done.                                                                                        |
 |   ✅   | **Todo Enforcer**                                        | Ultimate | Agent goes idle? System yanks it back. Your task gets done, period.                                                                                                                                              |
 |   💬   | **Comment Checker**                                      | Both     | No AI slop in comments. Code reads like a senior wrote it.                                                                                                                                                       |
 |   📐   | **Rules Injection** (`AGENTS.md` / `.omo/rules/**`)      | Both     | Project rules and AGENTS.md auto-loaded into the agent's context at every prompt.                                                                                                                                |
@@ -433,7 +433,7 @@ See full [Features Documentation](docs/reference/features.md).
 - **Claude Code Compatibility**: Full hook system, commands, skills, agents, MCPs
 - **Built-in MCPs**: websearch (Exa), context7 (docs), grep_app (GitHub search) — injected at runtime by the plugin; not visible in `opencode mcp list` (see [MCP docs](docs/reference/features.md#native-vs-plugin-injected-mcps))
 - **Session Tools**: List, read, search, and analyze session history
-- **Productivity Features**: Ralph Loop, Todo Enforcer, Comment Checker, Think Mode, and more
+- **Productivity Features**: Goal, Todo Enforcer, Comment Checker, Think Mode, and more
 - **Doctor Command**: Built-in diagnostics (`bunx oh-my-opencode doctor`) verify plugin registration, config, models, and environment
 - **Model Fallbacks**: `fallback_models` can mix plain model strings with per-fallback object settings in the same array
 - **File Prompts**: Load prompts from files with `file://` support in agent configurations

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -659,15 +659,13 @@ All built-in slash commands are **Ultimate-only** — Codex CLI does not have a 
 
 | Command | Editions | Purpose |
 |---------|:--------:|---------|
-| `/init-deep` | Ultimate | Auto-generate hierarchical `AGENTS.md` files throughout the project |
 | `/start-work` | Ultimate | Spawn Prometheus to interview the user and build a plan, then execute |
-| `/ralph-loop` | Ultimate | Self-referential dev loop until 100% done |
-| `/ulw-loop` | Ultimate | Ultrawork-mode variant of the loop |
-| `/cancel-ralph` | Ultimate | Stop an active Ralph loop |
-| `/stop-continuation` | Ultimate | Stop ralph loop + todo continuation + boulder |
+| `/goal` | Ultimate | Set, show, pause, resume, or clear a persistent thread goal that auto-continues on idle until done |
+| `/stop-continuation` | Ultimate | Stop todo continuation, clear the active Goal, and clear boulder state |
 | `/refactor` | Ultimate | LSP + AST-grep + TDD-verified intelligent refactor |
 | `/handoff` | Ultimate | Generate detailed context summary to continue in a new session |
 | `/remove-ai-slops` | Ultimate | Strip AI-generated code smells from recent changes |
+| `/init-deep` | Ultimate | Generate hierarchical AGENTS.md knowledge base (skill-backed slash command) |
 | `/hyperplan` | Ultimate | Direct invocation of hyperplan skill |
 
 #### Agents (11) — Ultimate only
@@ -834,10 +832,10 @@ Every agent, hook, skill, MCP, command, and tool is configurable via `disabled_*
 ```jsonc
 {
   "disabled_agents": ["multimodal-looker"],
-  "disabled_hooks": ["ralph-loop", "ultrawork"],
+  "disabled_hooks": ["goal", "keyword-detector"],
   "disabled_skills": ["playwright-cli"],
   "disabled_mcps": ["grep_app"],
-  "disabled_commands": ["/handoff"],
+  "disabled_commands": ["hyperplan"],
   "disabled_tools": ["interactive_bash"]
 }
 ```

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -258,7 +258,7 @@ Oh My OpenAgent turns that into a coordinated team:
 
 **Skills with embedded MCPs.** Each skill brings its own MCP servers, scoped to the task. Context window stays clean instead of bloating with every tool.
 
-**Discipline enforcement.** Todo enforcer yanks idle agents back to work. Comment checker strips AI slop. Ralph Loop keeps going until 100% done. The system doesn't let the agent slack off.
+**Discipline enforcement.** Todo enforcer yanks idle agents back to work. Comment checker strips AI slop. Goal holds a persistent per-session objective and re-injects a continuation prompt on every idle until a completion audit confirms the work is done. The system doesn't let the agent slack off.
 
 **The fundamental advantage.** Models have different temperaments. Claude thinks deeply. GPT reasons architecturally. Gemini visualizes. Haiku moves fast. Single-model tools force you to pick one personality for all tasks. Oh My OpenAgent leverages them all, routing by task type. This isn't a temporary hack — it's the only architecture that makes sense as models specialize further. The gap between multi-model orchestration and single-model limitation widens every month. We're betting on that future.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -535,9 +535,9 @@ Disable built-in hooks via `disabled_hooks`:
 { "disabled_hooks": ["comment-checker"] }
 ```
 
-Available hooks: `todo-continuation-enforcer`, `session-notification`, `comment-checker`, `tool-output-truncator`, `question-label-truncator`, `directory-agents-injector`, `directory-readme-injector`, `empty-task-response-detector`, `think-mode`, `model-fallback`, `anthropic-context-window-limit-recovery`, `preemptive-compaction`, `rules-injector`, `background-notification`, `auto-update-checker`, `startup-toast`, `keyword-detector`, `agent-usage-reminder`, `non-interactive-env`, `interactive-bash-session`, `thinking-block-validator`, `tool-pair-validator`, `ralph-loop`, `category-skill-reminder`, `compaction-context-injector`, `compaction-todo-preserver`, `claude-code-hooks`, `auto-slash-command`, `edit-error-recovery`, `json-error-recovery`, `delegate-task-retry`, `prometheus-md-only`, `sisyphus-junior-notepad`, `team-tool-gating`, `no-sisyphus-gpt`, `no-hephaestus-non-gpt`, `start-work`, `atlas`, `unstable-agent-babysitter`, `task-resume-info`, `stop-continuation-guard`, `tasks-todowrite-disabler`, `runtime-fallback`, `write-existing-file-guard`, `bash-file-read-guard`, `hashline-read-enhancer`, `read-image-resizer`, `todo-description-override`, `webfetch-redirect-guard`, `fsync-skip-warning`, `legacy-plugin-toast`
+Available hooks: `todo-continuation-enforcer`, `session-notification`, `comment-checker`, `tool-output-truncator`, `question-label-truncator`, `directory-agents-injector`, `directory-readme-injector`, `empty-task-response-detector`, `think-mode`, `model-fallback`, `anthropic-context-window-limit-recovery`, `preemptive-compaction`, `rules-injector`, `background-notification`, `auto-update-checker`, `codegraph-bootstrap`, `ast-grep-sg-provision`, `startup-toast`, `keyword-detector`, `agent-usage-reminder`, `non-interactive-env`, `interactive-bash-session`, `tool-pair-validator`, `monitor-status-injector`, `goal`, `category-skill-reminder`, `compaction-context-injector`, `compaction-todo-preserver`, `claude-code-hooks`, `auto-slash-command`, `edit-error-recovery`, `json-error-recovery`, `delegate-task-retry`, `prometheus-md-only`, `sisyphus-junior-notepad`, `team-tool-gating`, `no-sisyphus-gpt`, `no-hephaestus-non-gpt`, `hephaestus-agents-md-injector`, `start-work`, `atlas`, `unstable-agent-babysitter`, `task-resume-info`, `stop-continuation-guard`, `tasks-todowrite-disabler`, `runtime-fallback`, `write-existing-file-guard`, `notepad-write-guard`, `bash-file-read-guard`, `hashline-read-enhancer`, `read-image-resizer`, `todo-description-override`, `webfetch-redirect-guard`, `fsync-skip-warning`, `plan-format-validator`, `legacy-plugin-toast`
 
-Guard hooks such as `team-tool-gating`, `write-existing-file-guard`, `bash-file-read-guard`, `webfetch-redirect-guard`, `prometheus-md-only`, `rules-injector`, `tool-pair-validator`, and `thinking-block-validator` protect safety, permissions, or provider protocol correctness. Disable them only for audited local debugging in a trusted environment.
+Guard hooks such as `team-tool-gating`, `write-existing-file-guard`, `bash-file-read-guard`, `webfetch-redirect-guard`, `prometheus-md-only`, `rules-injector`, and `tool-pair-validator` protect safety, permissions, or provider protocol correctness. Disable them only for audited local debugging in a trusted environment.
 
 **Notes:**
 
@@ -550,10 +550,10 @@ Guard hooks such as `team-tool-gating`, `write-existing-file-guard`, `bash-file-
 Disable built-in commands via `disabled_commands`:
 
 ```json
-{ "disabled_commands": ["init-deep", "start-work"] }
+{ "disabled_commands": ["refactor", "start-work"] }
 ```
 
-Available commands: `init-deep`, `ralph-loop`, `ulw-loop`, `cancel-ralph`, `refactor`, `start-work`, `stop-continuation`, `handoff`
+Available commands: `goal`, `refactor`, `start-work`, `stop-continuation`, `remove-ai-slops`, `hyperplan`
 
 ### Browser Automation
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -321,12 +321,10 @@ Commands are slash-triggered workflows that execute predefined templates.
 | Command              | Description                                                                                |
 | -------------------- | ------------------------------------------------------------------------------------------ |
 | `/init-deep`         | Initialize hierarchical AGENTS.md knowledge base                                           |
-| `/ralph-loop`        | Start self-referential development loop until completion                                   |
-| `/ulw-loop`          | Start ultrawork loop - continues with ultrawork mode                                       |
-| `/cancel-ralph`      | Cancel active Ralph Loop                                                                   |
+| `/goal`              | Set, show, pause, resume, or clear the active thread goal                                  |
 | `/refactor`          | Intelligent refactoring with LSP, AST-grep, architecture analysis, and TDD verification    |
 | `/start-work`        | Start Atlas work session from Prometheus plan                                              |
-| `/stop-continuation` | Stop all continuation mechanisms (ralph loop, todo continuation, boulder) for this session |
+| `/stop-continuation` | Stop all continuation mechanisms (todo continuation, Goal, boulder) for this session       |
 | `/handoff`           | Create a detailed context summary for continuing work in a new session                     |
 
 ### /init-deep
@@ -350,33 +348,55 @@ project/
 │       └── AGENTS.md                # Component-specific context
 ```
 
-### /ralph-loop
+### /goal
 
-**Purpose**: Self-referential development loop that runs until task completion
-
-**Named after**: Anthropic's Ralph Wiggum plugin
+**Purpose**: Set a persistent thread objective the agent pursues across turns until paused, cleared, or completed.
 
 **Usage**:
 
 ```
-/ralph-loop "Build a REST API with authentication"
-/ralph-loop "Refactor the payment module" --max-iterations=50
+/goal "Build a REST API with authentication"
+/goal                    # show the current goal
+/goal pause              # stop idle continuations
+/goal resume             # resume a paused goal
+/goal clear              # clear the current goal
 ```
 
 **Behavior**:
 
-- Agent works continuously toward the goal
-- Detects `<promise>DONE</promise>` to know when complete
-- Auto-continues if agent stops without completion
-- Ends when: completion detected, max iterations reached (default 100), or `/cancel-ralph`
+- The goal persists for the session and is shown in the TUI.
+- While a goal is active, every `session.idle` re-injects a continuation prompt that tracks `tokensUsed` and `timeUsedSeconds`.
+- The agent calls `update_goal({ status: "complete" })` only after a completion audit confirms the objective is achieved.
+- `pause` stops idle continuations without clearing the goal; `clear` removes it. `session.deleted` also clears the goal.
+- Goal state is stored in `.omo/goal/<sessionID>.json`.
 
-**Configure**: `{ "ralph_loop": { "enabled": true, "default_max_iterations": 100 } }`
+**Tools** (registered only when `goal.enabled` is true):
+
+- `create_goal` - create or replace the active goal objective.
+- `update_goal` - pause, resume, mark complete, or change the objective.
+- `get_goal` - read the current objective, status, and usage accounting.
+
+**Configure**:
+
+```jsonc
+{
+  "goal": {
+    "enabled": true,
+    "auto_start": false,
+    "default_max_iterations": 100
+  }
+}
+```
+
+- `enabled` (default `false`) gates the Goal subsystem and its tools.
+- `auto_start` (default `false`) allows a goal to be auto-created from the first main-session message when `default_mode.goal` is true.
+- `default_max_iterations` (1-1000, default `100`) is the continuation iteration cap, preserved for Ralph Loop behavioral parity.
+
+**Migration**: the legacy top-level `ralph_loop` config auto-migrates to `goal` at load time and logs a deprecation warning; explicit `goal` config wins over migrated values. `default_mode.ralph_loop` was renamed to `default_mode.goal`.
 
 ### /ulw-loop
 
-**Purpose**: Same as ralph-loop but with ultrawork mode active
-
-Everything runs at maximum intensity - parallel agents, background tasks, aggressive exploration.
+The `/ulw-loop` slash command has been removed; continuous goal pursuit is now handled by `/goal`. The `omo ulw-loop` CLI subcommand remains as a passthrough to the Codex LazyCodex ulw-loop CLI.
 
 ### /refactor
 
@@ -412,7 +432,7 @@ Uses atlas agent to execute planned tasks systematically.
 
 **Purpose**: Stop all continuation mechanisms for this session
 
-Stops ralph loop, todo continuation, and boulder state. Use when you want the agent to stop its current multi-step workflow.
+Stops todo continuation, clears the active Goal, and clears boulder state. Use when you want the agent to stop its current multi-step workflow.
 
 ### /handoff
 
@@ -843,7 +863,7 @@ Current composition counts:
 | --------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **keyword-detector**        | Message + Transform | IntentGate detector. Activates `ultrawork`/`ulw`, `search`, `analyze`, and `team` modes from message keywords. |
 | **think-mode**              | Params              | Auto-detects extended thinking needs. Catches "think deeply", "ultrathink" and adjusts model settings.                                                      |
-| **ralph-loop**              | Event + Message     | Manages self-referential loop continuation.                                                                                                                 |
+| **goal**                    | Event               | Re-injects a goal continuation prompt on session.idle while a goal is active; clears the goal on session.deleted.                                           |
 | **start-work**              | Message             | Handles /start-work command execution.                                                                                                                      |
 | **auto-slash-command**      | Message             | Automatically executes slash commands from prompts.                                                                                                         |
 | **stop-continuation-guard** | Event + Message     | Guards the stop-continuation mechanism.                                                                                                                     |

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -164,7 +164,7 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 
 - **Affects**: Sessions with an active Ralph Loop and background child subagents.
 - **Symptom**: `/tmp/oh-my-opencode.log` repeats `promptAsync reservation release skipped for different source` while child subagents emit message events.
-- **Workaround**: If you are not using Ralph Loop in that workspace, add `"disabled_hooks": ["ralph-loop"]` to `oh-my-openagent.jsonc`. If a loop is already active, run `/cancel-ralph` before disabling the hook.
+- **Workaround**: Ralph Loop was replaced by the Goal subsystem (PR #6184), and the `ralph-loop` hook is no longer wired at HEAD, so the original flooding only affects releases before that migration. On those older releases, the historical controls were `"disabled_hooks": ["ralph-loop"]` in `oh-my-openagent.jsonc` and `/cancel-ralph`. On current releases, Goal is opt-in (`goal.enabled` defaults to `false`); if you see the same log pattern while a Goal continuation is active, disable the hook with `"disabled_hooks": ["goal"]` and run `/goal clear` (or `/stop-continuation`) to stop the active continuation before disabling it.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/5105.
 
 ## #5025 — OpenCode Desktop loads the plugin but only shows native modes


### PR DESCRIPTION
## What changed

Docs-only follow-up to the goal-replaces-ralph migration (#6184) and the AGENTS.md refresh (#6187): the user-facing docs still documented the removed Ralph Loop. 6 files updated: `docs/reference/features.md`, `docs/reference/configuration.md`, `docs/reference/known-issues.md`, `docs/guide/installation.md`, `docs/guide/overview.md`, `README.md`.

## Why

`/ralph-loop`, `/cancel-ralph`, and `/ulw-loop` no longer exist as builtin commands, `ralph-loop` is no longer a valid `disabled_hooks` value, and the documented `disabled_commands` example failed schema validation. Users following the docs would hit dead commands and invalid config.

## Highlights

- features.md: `/ralph-loop` section rewritten as `/goal` (usage, pause/resume/clear, idle continuation with tokensUsed/timeUsedSeconds, completion-audit rule, `create_goal`/`update_goal`/`get_goal` tools, `goal` config block, `ralph_loop -> goal` migration note); hooks table row `ralph-loop` -> `goal` (Event only, verified in `hooks/goal/index.ts`); `/ulw-loop` section now documents the removal and the surviving `omo ulw-loop` CLI passthrough.
- configuration.md: hook and command lists regenerated exactly from `HookNameSchema` (56 entries) and `BuiltinCommandNameSchema` (6 entries); removed stale `thinking-block-validator`; fixed the `disabled_commands` example that would fail Zod validation.
- known-issues.md: historical records kept; the #5105 workaround now distinguishes pre-migration releases (`disabled_hooks: ["ralph-loop"]`, `/cancel-ralph`) from current releases (`disabled_hooks: ["goal"]`, `/goal clear`).
- installation.md: command table matched to current enum plus live skill-backed `/init-deep`; `disabled_hooks` example uses valid names; `/stop-continuation` description matches the current template (todo continuation + Goal + boulder).
- README.md + overview.md: feature rows and prose describe Goal; the user testimonial mentioning ralph loop is kept verbatim.

## How it was produced

5 parallel `unspecified-low` subagents (one per doc scope) grounded in the current schema enums and `hooks/goal/` source; main session reconciled one cross-doc inconsistency (`/init-deep` kept as a skill-backed slash command, pinned by `init-deep-skill.test.ts`).

## QA / evidence

- Docs-only: `git diff --name-only` is exactly 6 `.md` files.
- `bun test packages/omo-opencode/src/shared/markdown-link-audit.test.ts`: 16 pass / 0 fail.
- Style audit on added lines: zero em/en dashes, machine-local paths, filler words.
- Remaining `ralph` mentions are all intentional: verbatim testimonial, migration/parity notes, historical issue records.

## Residual risk

`/handoff` is a live registered builtin command but is absent from `BuiltinCommandNameSchema`, so it cannot be disabled via `disabled_commands` (pre-existing schema gap, flagged by the installation.md pass; docs work around it accurately). Separate source fix candidate, not addressed here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all user docs references to Ralph Loop with the new Goal feature to match the migration, and corrected command/hook lists and config examples so users don’t hit removed commands or invalid settings.

- **Migration**
  - Use `/goal` to set/show/pause/resume/clear a session goal; it auto-continues on idle until a completion audit passes.
  - Removed `/ralph-loop`, `/cancel-ralph`, and `/ulw-loop` from docs; the `omo ulw-loop` CLI passthrough note remains.
  - Update configs: `disabled_hooks: ["goal"]`; `disabled_commands` examples now use valid names (e.g., `"hyperplan"`).
  - Hook/command lists regenerated from current schemas; known-issues now distinguish pre-migration controls from Goal equivalents.

<sup>Written for commit 1b6c477403b2401464d63b08f76ffc67a2a93a54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

