### PR TITLE
fix(senpi-task): release residency claim when a task is marked lost

### DIFF
--- a/packages/senpi-task/src/lifecycle/reconcile.test.ts
+++ b/packages/senpi-task/src/lifecycle/reconcile.test.ts
@@ -212,6 +212,7 @@ describe("reconcileOnSessionStart reattach", () => {
     // then
     expect(result.outcomes[0]?.kind).toBe("lost")
     expect(store.load("st_00000002")?.status).toBe("lost")
+    expect(store.load("st_00000002")?.residency_state).toBe("disposed")
     expect(respawnRunner.startedSpecs).toHaveLength(0)
   })
 
@@ -244,6 +245,34 @@ describe("reconcileOnSessionStart reattach", () => {
     // then
     expect(result.outcomes[0]?.kind).toBe("lost")
     expect(respawnRunner.startedSpecs).toHaveLength(0)
+  })
+  test(" w2reattach #given an in-process record marked lost #when reconciled #then its residency claim is released so the slot is reclaimable", async () => {
+    // given
+    const store = tempStore()
+    seedRecord(store, { task_id: "st_00000011", status: "running", residency_state: "resident", execution_mode: "in-process" })
+    const lifecycle = createTaskLifecycle({ store, registry: new FakeRegistry(), config: settings(), now, signaller: fakeSignaller(new Set(), []), orphanKillDelayMs: 0 })
+
+    // when
+    const result = await lifecycle.reconcileOnSessionStart()
+
+    // then
+    expect(result.outcomes[0]?.kind).toBe("lost")
+    expect(store.load("st_00000011")?.status).toBe("lost")
+    expect(store.load("st_00000011")?.residency_state).toBe("disposed")
+  })
+
+  test(" w2reattach #given a leaked {lost, resident} record from an earlier session #when reconciled #then it self-heals to disposed", async () => {
+    // given
+    const store = tempStore()
+    seedRecord(store, { task_id: "st_00000012", status: "lost", residency_state: "resident", execution_mode: "in-process" })
+    const lifecycle = createTaskLifecycle({ store, registry: new FakeRegistry(), config: settings(), now, signaller: fakeSignaller(new Set(), []), orphanKillDelayMs: 0 })
+
+    // when
+    const result = await lifecycle.reconcileOnSessionStart()
+
+    // then
+    expect(result.outcomes[0]?.kind).toBe("lost")
+    expect(store.load("st_00000012")?.residency_state).toBe("disposed")
   })
 
   test(" w2reattach #given reconcile reattach is disabled #when a durable session exists #then v1 lost behavior runs without respawn", async () => {

--- a/packages/senpi-task/src/lifecycle/reconcile.ts
+++ b/packages/senpi-task/src/lifecycle/reconcile.ts
@@ -29,13 +29,13 @@ async function reconcileRecord(context: LifecycleContext, record: TaskRecord): P
   }
 
   if (record.execution_mode !== "process") {
-    markLost(context, record, "in-process task from a previous process cannot be reattached")
+    await markLost(context, record, "in-process task from a previous process cannot be reattached")
     return { task_id: record.task_id, kind: "lost", reason: "previous-process in-process" }
   }
 
   const pid = record.pid
   if (pid === undefined) {
-    markLost(context, record, "rpc task had no recorded pid")
+    await markLost(context, record, "rpc task had no recorded pid")
     return { task_id: record.task_id, kind: "lost", reason: "no recorded pid" }
   }
 
@@ -47,17 +47,16 @@ async function reconcileRecord(context: LifecycleContext, record: TaskRecord): P
   const sessionPath = newestSessionPath(context, record.task_id)
   if (!alive) {
     if (sessionPath !== undefined) return reattachRecord(context, record, sessionPath)
-    markLost(context, record, `rpc pid=${pid} is dead; mapping exit facts only`)
+    await markLost(context, record, `rpc pid=${pid} is dead; mapping exit facts only`)
     return { task_id: record.task_id, kind: "lost", reason: `dead pid ${pid}` }
   }
 
   const heartbeat = heartbeatState(context, record)
-  markLost(
+  await markLost(
     context,
     record,
     `rpc orphan pid=${pid} session=${record.child_session_id ?? "unknown"} heartbeat=${heartbeat}; terminating before reattach`,
   )
-  await destroyResidentTask(context, record.task_id, "reconcile_lost")
   if (sessionPath === undefined) {
     return { task_id: record.task_id, kind: "lost_and_terminated", reason: `live orphan, heartbeat=${heartbeat}` }
   }
@@ -65,14 +64,14 @@ async function reconcileRecord(context: LifecycleContext, record: TaskRecord): P
   return reattachRecord(context, current, sessionPath)
 }
 
-function reconcileWithoutReattach(
+async function reconcileWithoutReattach(
   context: LifecycleContext,
   record: TaskRecord,
   pid: number,
   alive: boolean,
-): Promise<ReconcileOutcome> | ReconcileOutcome {
+): Promise<ReconcileOutcome> {
   if (!alive) {
-    markLost(context, record, `rpc pid=${pid} is dead; mapping exit facts only`)
+    await markLost(context, record, `rpc pid=${pid} is dead; mapping exit facts only`)
     return { task_id: record.task_id, kind: "lost", reason: `dead pid ${pid}` }
   }
   return loseAndTerminate(context, record, pid)
@@ -84,12 +83,11 @@ async function loseAndTerminate(
   pid: number,
 ): Promise<ReconcileOutcome> {
   const heartbeat = heartbeatState(context, record)
-  markLost(
+  await markLost(
     context,
     record,
     `rpc orphan pid=${pid} session=${record.child_session_id ?? "unknown"} heartbeat=${heartbeat}; reattach disabled, terminating orphan`,
   )
-  await destroyResidentTask(context, record.task_id, "reconcile_lost")
   return { task_id: record.task_id, kind: "lost_and_terminated", reason: `live orphan, heartbeat=${heartbeat}` }
 }
 
@@ -100,13 +98,13 @@ async function reattachRecord(
 ): Promise<ReconcileOutcome> {
   const ports = context.reattachPorts ?? getLifecycleReattachPorts(context.store)
   if (ports === undefined) {
-    markLost(context, record, "reattach ports unavailable")
+    await markLost(context, record, "reattach ports unavailable")
     return { task_id: record.task_id, kind: "lost", reason: "reattach ports unavailable" }
   }
 
   const respawned = await ports.respawn(record, sessionPath)
   if (!respawned.ok) {
-    markLost(context, record, `reattach failed: ${respawned.reason}`)
+    await markLost(context, record, `reattach failed: ${respawned.reason}`)
     return { task_id: record.task_id, kind: "lost", reason: respawned.reason }
   }
   const reattached = await ports.reattach(record, respawned.handle)
@@ -114,7 +112,7 @@ async function reattachRecord(
     if (reattached.kind === "already_attached") {
       return { task_id: record.task_id, kind: "resumed", reason: reattached.reason }
     }
-    markLost(context, context.store.load(record.task_id) ?? record, reattached.reason)
+    await markLost(context, context.store.load(record.task_id) ?? record, reattached.reason)
     return { task_id: record.task_id, kind: "lost", reason: reattached.reason }
   }
   context.store.appendEvent(record.task_id, {
@@ -125,7 +123,12 @@ async function reattachRecord(
 }
 
 async function reconcileTerminalRecord(context: LifecycleContext, record: TaskRecord): Promise<ReconcileOutcome> {
-  if (record.status === "lost") return { task_id: record.task_id, kind: "lost", reason: "already lost" }
+  if (record.status === "lost") {
+    // Self-heal leaked {lost, resident} records persisted before lost tasks released their claim: a
+    // lost child is unreachable, so it must never keep holding a residency slot across sessions.
+    if (record.residency_state === "resident") await destroyResidentTask(context, record.task_id, "reconcile_lost")
+    return { task_id: record.task_id, kind: "lost", reason: "already lost" }
+  }
   const pid = record.pid
   if (record.execution_mode !== "process" || record.residency_state !== "resident" || pid === undefined) {
     return { task_id: record.task_id, kind: "resumed" }
@@ -177,9 +180,13 @@ function heartbeatState(context: LifecycleContext, record: TaskRecord): "fresh" 
   return context.now() - Date.parse(record.updated_at) < HEARTBEAT_FRESH_MS ? "fresh" : "stale"
 }
 
-function markLost(context: LifecycleContext, record: TaskRecord, message: string): void {
+// Mark a record lost AND release its residency claim through the destruction port: a lost child is
+// unreachable, so it must never keep occupying a residency slot the LRU gate cannot reclaim
+// (the reconcile_lost cause also kills a still-alive orphan pid before the claim is dropped).
+async function markLost(context: LifecycleContext, record: TaskRecord, message: string): Promise<void> {
   const result = markRecordLostForReconciliation(record, { timestamp: nowIso(context), error_message: message })
   if (!result.applied) return
   context.store.replace(result.record)
   context.store.appendEvent(record.task_id, { type: "reconcile_lost", payload: { reason: message } })
+  await destroyResidentTask(context, record.task_id, "reconcile_lost")
 }

--- a/packages/senpi-task/src/lifecycle/residency.test.ts
+++ b/packages/senpi-task/src/lifecycle/residency.test.ts
@@ -107,4 +107,33 @@ describe("admitResident (residency cap + LRU eviction)", () => {
     // then
     expect(result.kind).toBe("admitted")
   })
+  test("#given lost residents pin every slot #when admitting #then the oldest lost resident is evicted (residency-leak regression)", async () => {
+    // given: the leak seen live - {lost, resident} records filling the cap while real work runs
+    const store = tempStore()
+    seedRecord(store, { task_id: "st_000000e0", status: "lost", residency_state: "resident", updated_at: iso(0) })
+    seedRecord(store, { task_id: "st_000000e1", status: "running", residency_state: "resident", updated_at: iso(10) })
+    const lifecycle = createTaskLifecycle({ store, registry: new FakeRegistry(), config: settings({ residency_max_children: 2 }) })
+
+    // when
+    const result = await lifecycle.admitResident("parent-1")
+
+    // then
+    expect(result).toEqual({ kind: "evicted", evicted_task_id: "st_000000e0" })
+    expect(store.load("st_000000e0")?.residency_state).toBe("evicted")
+    expect(store.load("st_000000e1")?.residency_state).toBe("resident")
+  })
+
+  test("#given a cancelled resident at the cap #when admitting #then it is evicted like any other terminal", async () => {
+    // given
+    const store = tempStore()
+    seedRecord(store, { task_id: "st_000000f0", status: "cancelled", residency_state: "resident", updated_at: iso(0) })
+    seedRecord(store, { task_id: "st_000000f1", status: "running", residency_state: "resident", updated_at: iso(10) })
+    const lifecycle = createTaskLifecycle({ store, registry: new FakeRegistry(), config: settings({ residency_max_children: 2 }) })
+
+    // when
+    const result = await lifecycle.admitResident("parent-1")
+
+    // then
+    expect(result).toEqual({ kind: "evicted", evicted_task_id: "st_000000f0" })
+  })
 })

--- a/packages/senpi-task/src/lifecycle/residency.ts
+++ b/packages/senpi-task/src/lifecycle/residency.ts
@@ -1,10 +1,8 @@
 import type { TaskRecord } from "../state"
-import type { LifecycleContext } from "./context"
+import { TERMINAL_STATUSES, type LifecycleContext } from "./context"
 import { destroyResidentTask } from "./destroy"
 import { AgentLimitReached } from "./errors"
 import type { AdmissionResult } from "./types"
-
-const EVICTABLE_STATUSES = new Set<TaskRecord["status"]>(["completed", "error", "interrupted"])
 
 /**
  * Residency cap gate (codex residency contract). A resident is a spawned-not-disposed child of the
@@ -39,9 +37,10 @@ function residentsFor(context: LifecycleContext, parentSessionId: string): reado
 }
 
 // Oldest-first scan (updated_at is touched on every steer/revive, so it tracks recency of use). The
-// first terminal resident with no pending send is the LRU victim.
+// first terminal resident with no pending send is the LRU victim. EVERY terminal status (including
+// lost and cancelled) is reclaimable: a lost child is unreachable and must never pin a slot.
 function lruEvictable(context: LifecycleContext, residents: readonly TaskRecord[]): TaskRecord | undefined {
   return [...residents]
-    .filter((record) => EVICTABLE_STATUSES.has(record.status) && !context.registry.hasPendingSends(record.task_id))
+    .filter((record) => TERMINAL_STATUSES.has(record.status) && !context.registry.hasPendingSends(record.task_id))
     .toSorted((left, right) => left.updated_at.localeCompare(right.updated_at))[0]
 }


### PR DESCRIPTION
## Problem

Seen live in a senpi session (`019f701d-03ab…`, project `~/local-workspaces/senpi`): F4 dispatch was rejected with `AgentLimitReached` ("Residency cap 8 reached … no terminal idle child is evictable") while **5 of the 8 residents were `{status: lost, residency_state: resident}`** records leaked from a previous process. `task_cancel` on them nooped ("is lost, not running"), so the slots were unreclaimable and the session was stuck until F1–F3 finished.

Root cause (3 compounding gaps in `packages/senpi-task`):

1. `reconcile.ts markLost()` rewrote `status -> lost` but **never released the residency claim** — the record stayed `resident` with no live handle.
2. `residency.ts EVICTABLE_STATUSES = {completed, error, interrupted}` excluded `lost` (and `cancelled`), so the LRU eviction gate could never reclaim those slots.
3. `reconcileTerminalRecord()` early-returned on already-`lost` records, so leaked records never self-healed on later session starts.

## Fix

- `markLost` now routes through `destroyResidentTask(…, "reconcile_lost")` after marking: every lost record releases its slot, and a still-alive orphan pid is still killed by the same port. The explicit destroy calls this absorbs (live-orphan path, `loseAndTerminate`) are removed — destruction remains single-writer through the port.
- The eviction gate now accepts every `TERMINAL_STATUSES` member (shared constant from `lifecycle/context.ts`) instead of a narrower private list — `lost`/`cancelled` residents are reclaimable like any other terminal.
- `reconcileTerminalRecord` self-heals pre-existing leaked `{lost, resident}` records at session start.

## QA

- Repro locked as regression tests: lost residents pinning the cap are now evicted (`residency.test.ts`), lost records end `{lost, disposed}` and leaked records self-heal (`reconcile.test.ts`).
- `bun test` in `packages/senpi-task`: **727 pass / 0 fail** (114 files, incl. chaos + single-writer audit).
- `bun run typecheck` (tsgo): clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a residency leak in `packages/senpi-task` where tasks marked lost kept their slot and pinned the cap. Lost tasks now release their slot and can be LRU‑evicted, preventing `AgentLimitReached` stalls.

- **Bug Fixes**
  - `markLost` now calls `destroyResidentTask("reconcile_lost")` to release residency; removed redundant destroy calls.
  - LRU eviction uses `TERMINAL_STATUSES`, so `lost` and `cancelled` residents are reclaimable.
  - Startup reconciliation self-heals leaked `{lost, resident}` records to `disposed` (regression tests added).

<sup>Written for commit ba50deea29352f40481331ff6d672f1c4ee3958e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

