### PR TITLE
feat(omo-senpi): declare codegraph MCP server via senpi registerMcpServer

### DIFF
--- a/packages/omo-senpi/src/components/codegraph/index.test.ts
+++ b/packages/omo-senpi/src/components/codegraph/index.test.ts
@@ -1,0 +1,177 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+
+import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
+import type { OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types"
+import {
+	createCodegraphComponent,
+	type CodegraphCommandResolution,
+	type CodegraphComponentOptions,
+	type CodegraphNodeSupport,
+} from "./index"
+
+function fakeResolution(overrides: Partial<CodegraphCommandResolution> = {}): CodegraphCommandResolution {
+	return {
+		argsPrefix: [],
+		command: "/opt/homebrew/bin/codegraph",
+		exists: true,
+		source: "path",
+		...overrides,
+	}
+}
+
+function fakeNodeSupport(overrides: Partial<CodegraphNodeSupport> = {}): CodegraphNodeSupport {
+	return {
+		major: 22,
+		override: false,
+		supported: true,
+		...overrides,
+	}
+}
+
+function createTestComponent(options: CodegraphComponentOptions = {}): OmoSenpiComponent {
+	return createCodegraphComponent({
+		resolveCommand: () => fakeResolution(),
+		resolveNodeSupport: () => fakeNodeSupport(),
+		buildEnv: () => ({
+			CODEGRAPH_INSTALL_DIR: "/home/test/.omo/codegraph",
+			CODEGRAPH_NO_DAEMON: "1",
+			CODEGRAPH_NO_DOWNLOAD: "1",
+			CODEGRAPH_TELEMETRY: "0",
+			DO_NOT_TRACK: "1",
+		}),
+		...options,
+	})
+}
+
+function fakeContext() {
+	return {
+		logger: { info() {}, warn() {}, error() {} },
+		config: { getFlag: () => undefined },
+	}
+}
+
+describe("createCodegraphComponent", () => {
+	it("#given registerMcpServer available and supported binary #when registered #then declares codegraph stdio server", async () => {
+		const pi = new FakeExtensionAPI()
+		const component = createTestComponent()
+
+		await component.register(pi, fakeContext())
+
+		expect(pi.mcpServers).toEqual([
+			{
+				name: "codegraph",
+				config: {
+					type: "stdio",
+					command: "/opt/homebrew/bin/codegraph",
+					args: ["serve", "--mcp"],
+					enabled: true,
+					env: {
+						CODEGRAPH_INSTALL_DIR: "/home/test/.omo/codegraph",
+						CODEGRAPH_NO_DAEMON: "1",
+						CODEGRAPH_NO_DOWNLOAD: "1",
+						CODEGRAPH_TELEMETRY: "0",
+						DO_NOT_TRACK: "1",
+					},
+				},
+			},
+		])
+	})
+
+	it("#given bundled binary #when registered #then enables without node support check", async () => {
+		const pi = new FakeExtensionAPI()
+		const component = createTestComponent({
+			resolveCommand: () => fakeResolution({ source: "bundled", command: "/usr/local/bin/node", argsPrefix: ["/app/codegraph.js"] }),
+			resolveNodeSupport: () => fakeNodeSupport({ supported: false }),
+		})
+
+		await component.register(pi, fakeContext())
+
+		expect(pi.mcpServers[0]?.config.enabled).toBe(true)
+		expect(pi.mcpServers[0]?.config.command).toBe("/usr/local/bin/node")
+		expect(pi.mcpServers[0]?.config.args).toEqual(["/app/codegraph.js", "serve", "--mcp"])
+	})
+
+	it("#given binary missing #when registered #then registers disabled placeholder", async () => {
+		const pi = new FakeExtensionAPI()
+		const component = createTestComponent({
+			resolveCommand: () => fakeResolution({ exists: false, command: "codegraph" }),
+		})
+
+		await component.register(pi, fakeContext())
+
+		expect(pi.mcpServers).toHaveLength(1)
+		expect(pi.mcpServers[0]?.name).toBe("codegraph")
+		expect(pi.mcpServers[0]?.config.enabled).toBe(false)
+	})
+
+	it("#given PATH binary and unsupported node #when registered #then registers disabled placeholder", async () => {
+		const pi = new FakeExtensionAPI()
+		const component = createTestComponent({
+			resolveNodeSupport: () => fakeNodeSupport({ supported: false }),
+		})
+
+		await component.register(pi, fakeContext())
+
+		expect(pi.mcpServers).toHaveLength(1)
+		expect(pi.mcpServers[0]?.config.enabled).toBe(false)
+	})
+
+	it("#given old senpi without registerMcpServer #when registered #then skips gracefully", async () => {
+		const logs: string[] = []
+		const pi: Pick<SenpiExtensionAPI, "on" | "registerTool" | "registerCommand" | "registerFlag" | "getFlag" | "sendMessage" | "sendUserMessage"> = {
+			on() {},
+			registerTool() {},
+			registerCommand() {},
+			registerFlag() {},
+			getFlag() {
+				return undefined
+			},
+			sendMessage() {},
+			sendUserMessage() {},
+		}
+		const component = createTestComponent()
+
+		await component.register(pi as SenpiExtensionAPI, {
+			...fakeContext(),
+			logger: { info: (m: string) => logs.push(m), warn() {}, error() {} },
+		})
+
+		expect(logs.some((l) => l.includes("registerMcpServer"))).toBe(true)
+	})
+
+	it("#given senpi-task child marker #when registered #then skips registration", async () => {
+		const pi = new FakeExtensionAPI()
+		const env = { SENPI_CODING_AGENT_SESSION_DIR: "/tmp/agent" }
+		const component = createTestComponent({ env })
+
+		await component.register(pi, fakeContext())
+
+		expect(pi.mcpServers).toHaveLength(0)
+	})
+
+	it("#given win32 platform and .cmd binary #when registered #then wraps with cmd.exe", async () => {
+		const pi = new FakeExtensionAPI()
+		const component = createTestComponent({
+			resolveCommand: () => fakeResolution({ command: "C:\\Users\\test\\.omo\\codegraph\\bin\\codegraph.cmd" }),
+			platform: "win32",
+		})
+
+		await component.register(pi, fakeContext())
+
+		expect(pi.mcpServers[0]?.config.command).toBe("cmd.exe")
+		expect(pi.mcpServers[0]?.config.args).toEqual(["/d", "/s", "/c", "C:\\Users\\test\\.omo\\codegraph\\bin\\codegraph.cmd", "serve", "--mcp"])
+	})
+
+	it("#given argsPrefix #when registered #then prepends before serve --mcp", async () => {
+		const pi = new FakeExtensionAPI()
+		const component = createTestComponent({
+			resolveCommand: () => fakeResolution({ argsPrefix: ["--node-runtime", "node22"] }),
+		})
+
+		await component.register(pi, fakeContext())
+
+		expect(pi.mcpServers[0]?.config.args).toEqual(["--node-runtime", "node22", "serve", "--mcp"])
+	})
+})

--- a/packages/omo-senpi/src/components/codegraph/index.ts
+++ b/packages/omo-senpi/src/components/codegraph/index.ts
@@ -1,0 +1,73 @@
+import {
+	buildCodegraphEnv,
+	resolveCodegraphCommand,
+	resolveCodegraphNodeSupport,
+	type CodegraphCommandResolution,
+	type CodegraphNodeSupport,
+	type ResolveCodegraphCommandOptions,
+	type ResolveCodegraphNodeSupportOptions,
+} from "@oh-my-opencode/utils"
+
+import type { ComponentContext, OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types"
+
+export interface CodegraphComponentOptions {
+	readonly resolveCommand?: (options: ResolveCodegraphCommandOptions) => CodegraphCommandResolution
+	readonly resolveNodeSupport?: (options: ResolveCodegraphNodeSupportOptions) => CodegraphNodeSupport
+	readonly buildEnv?: () => Record<string, string>
+	readonly platform?: NodeJS.Platform
+	readonly env?: Record<string, string | undefined>
+}
+
+const CODEGRAPH_COMPONENT_NAME = "codegraph"
+const CHILD_SESSION_MARKER_ENV = "SENPI_CODING_AGENT_SESSION_DIR"
+
+export function createCodegraphComponent(options: CodegraphComponentOptions = {}): OmoSenpiComponent {
+	const resolveCommand = options.resolveCommand ?? resolveCodegraphCommand
+	const resolveNodeSupport = options.resolveNodeSupport ?? resolveCodegraphNodeSupport
+	const buildEnv = options.buildEnv ?? (() => buildCodegraphEnv())
+	const platform = options.platform ?? process.platform
+	const env = options.env ?? process.env
+
+	return {
+		name: CODEGRAPH_COMPONENT_NAME,
+		register(pi: SenpiExtensionAPI, ctx: ComponentContext): void {
+			if (typeof pi.registerMcpServer !== "function") {
+				ctx.logger.info("omo-senpi codegraph skipped: senpi ExtensionAPI does not expose registerMcpServer", {
+					component: CODEGRAPH_COMPONENT_NAME,
+				})
+				return
+			}
+
+			if (env[CHILD_SESSION_MARKER_ENV] !== undefined) {
+				ctx.logger.info("omo-senpi codegraph skipped: running inside a senpi-task RPC child", {
+					component: CODEGRAPH_COMPONENT_NAME,
+				})
+				return
+			}
+
+			const resolved = resolveCommand({ env })
+			const nodeSupport = resolveNodeSupport({ env })
+			const enabled =
+				resolved.exists &&
+				(resolved.source === "bundled" || resolved.source === "env" || nodeSupport.supported)
+
+			const command = resolved.command
+			const args: string[] = [...resolved.argsPrefix, "serve", "--mcp"]
+
+			const isWin32 = platform === "win32"
+			const isWindowsExecutable = /\.(cmd|bat)$/i.test(command)
+			const finalCommand = isWin32 && isWindowsExecutable ? "cmd.exe" : command
+			const finalArgs = isWin32 && isWindowsExecutable ? ["/d", "/s", "/c", command, ...args] : args
+
+			pi.registerMcpServer(CODEGRAPH_COMPONENT_NAME, {
+				type: "stdio",
+				command: finalCommand,
+				args: finalArgs,
+				env: buildEnv(),
+				enabled,
+			})
+		},
+	}
+}
+
+export type { CodegraphCommandResolution, CodegraphNodeSupport }

--- a/packages/omo-senpi/src/extension/compose.test.ts
+++ b/packages/omo-senpi/src/extension/compose.test.ts
@@ -126,6 +126,82 @@ describe("composeOmoSenpiExtension", () => {
     })
   })
 
+  it("#given a component using optional registerMcpServer on an old API #when composed #then skips that component and registers later components", async () => {
+    // given
+    const pi: Omit<FakeExtensionAPI, "registerMcpServer"> & { registerMcpServer?: undefined } = {
+      handlers: [],
+      tools: [],
+      commands: [],
+      flags: [],
+      messages: [],
+      userMessages: [],
+      messageRenderers: [],
+      mcpServers: [],
+      on(event, handler) {
+        this.handlers.push({ event, handler })
+      },
+      registerTool(tool) {
+        this.tools.push(tool)
+      },
+      registerCommand(name, options) {
+        this.commands.push({ name, options })
+      },
+      registerFlag(name, options) {
+        this.flags.push({ name, options })
+      },
+      getFlag() {
+        return undefined
+      },
+      sendMessage(message, options) {
+        this.messages.push({ message, options })
+      },
+      sendUserMessage(content, options) {
+        this.userMessages.push({ content, options })
+      },
+      registerMessageRenderer() {},
+      setFlag() {},
+      async dispatch(event, payload, ctx) {
+        const results: unknown[] = []
+        for (const registration of this.handlers) {
+          if (registration.event !== event) continue
+          results.push(await registration.handler(payload, ctx))
+        }
+        return results
+      },
+    }
+    const logger = createRecordingLogger()
+    const components: OmoSenpiComponent[] = [
+      {
+        name: "codegraph-like",
+        register(api, ctx) {
+          if (typeof api.registerMcpServer !== "function") {
+            ctx.logger.info("skipped: missing registerMcpServer")
+            return
+          }
+          api.registerMcpServer("x", {})
+        },
+      },
+      {
+        name: "after",
+        register(api) {
+          api.registerCommand("after", { description: "After command", handler: () => undefined })
+        },
+      },
+    ]
+
+    // when
+    await composeOmoSenpiExtension(components, { logger })(pi as unknown as FakeExtensionAPI)
+
+    // then
+    expect(pi.commands.map((command) => command.name)).toEqual(["after"])
+    expect(pi.mcpServers).toHaveLength(0)
+    expect(logger.entries).toContainEqual({
+      level: "info",
+      message: "skipped: missing registerMcpServer",
+      details: undefined,
+    })
+  })
+
   it("#given a fake missing sendUserMessage #when composed #then logs one version mismatch and registers nothing", async () => {
     // given
     const logger = createRecordingLogger()

--- a/packages/omo-senpi/src/extension/index.test.ts
+++ b/packages/omo-senpi/src/extension/index.test.ts
@@ -16,6 +16,7 @@ describe("omo-senpi extension entry", () => {
         "omo-senpi-comment-checker-disabled",
         "omo-senpi-telemetry-disabled",
         "omo-senpi-lsp-disabled",
+        "omo-senpi-codegraph-disabled",
       ]),
     )
     expect(pi.handlers.map((handler) => handler.event)).toEqual(

--- a/packages/omo-senpi/src/extension/index.ts
+++ b/packages/omo-senpi/src/extension/index.ts
@@ -2,6 +2,7 @@ import { composeOmoSenpiExtension } from "./compose"
 import type { OmoSenpiComponent } from "./types"
 import { createCommentCheckerComponent } from "../components/comment-checker"
 import { createLspComponent } from "../components/lsp"
+import { createCodegraphComponent } from "../components/codegraph"
 import { createSenpiTelemetryComponent } from "../components/telemetry"
 import { createTaskComponent } from "../components/task"
 import { createStartWorkContinuationComponent } from "../components/start-work-continuation"
@@ -15,6 +16,7 @@ const components: OmoSenpiComponent[] = [
   createCommentCheckerComponent(),
   createSenpiTelemetryComponent(),
   createLspComponent(),
+  createCodegraphComponent(),
   createTaskComponent(),
 ]
 

--- a/packages/omo-senpi/src/extension/types.ts
+++ b/packages/omo-senpi/src/extension/types.ts
@@ -18,6 +18,7 @@ export interface SenpiExtensionAPI {
   sendMessage(message: Record<string, unknown>, options?: Record<string, unknown>): void
   sendUserMessage(content: string | readonly Record<string, unknown>[], options?: { deliverAs?: "steer" | "followUp" }): void
   registerMessageRenderer?(customType: string, renderer: unknown): void
+  registerMcpServer?(name: string, config: Record<string, unknown>): void
 }
 
 export interface ComponentLogger {

--- a/packages/omo-senpi/test-support/fake-extension-api.ts
+++ b/packages/omo-senpi/test-support/fake-extension-api.ts
@@ -39,6 +39,7 @@ export class FakeExtensionAPI implements SenpiExtensionAPI {
   readonly messages: FakeSendMessageCall[] = []
   readonly userMessages: FakeSendUserMessageCall[] = []
   readonly messageRenderers: FakeMessageRendererRegistration[] = []
+  readonly mcpServers: Array<{ name: string; config: Record<string, unknown> }> = []
 
   private readonly flagValues = new Map<string, boolean | string | undefined>()
 
@@ -79,6 +80,10 @@ export class FakeExtensionAPI implements SenpiExtensionAPI {
 
   sendUserMessage(content: string | readonly Record<string, unknown>[], options?: { deliverAs?: "steer" | "followUp" }): void {
     this.userMessages.push({ content, options })
+  }
+
+  registerMcpServer(name: string, config: Record<string, unknown>): void {
+    this.mcpServers.push({ name, config })
   }
 
   async dispatch(event: string, payload: unknown, ctx?: unknown): Promise<unknown[]> {


### PR DESCRIPTION
## Summary
Wires the omo-senpi extension to declare the codegraph MCP server through the new senpi `registerMcpServer` API, gated by capability and availability.

## Changes
- New omo-senpi extension component that resolves the codegraph command and environment
- Capability-gated: skips registration when codegraph is unavailable
- `enabled:false` fallback when binary/runtime support is missing
- win32 `.cmd` wrapper handling and child-process marker skip via `SENPI_CODING_AGENT_SESSION_DIR`
- Wired into `compose.ts` and exported from `index.ts`
- Tests for component resolution, enabled-gating, and compose integration

## Verification
- `bun test packages/omo-senpi/src/extension` passes
- `bun run typecheck` passes
- Cross-repo e2e driver scenarios A/B/C pass (11/11)

## Dependencies
- Requires senpi PR code-yeongyu/senpi#231 (registerMcpServer API). Merged state is not required because omo-senpi uses runtime capability gating.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the `codegraph` MCP server from the `omo-senpi` extension via senpi’s `registerMcpServer`, with capability and runtime gating. This enables `codegraph` as a stdio server when supported and safely no-ops otherwise.

- **New Features**
  - Adds a `codegraph` component that resolves the binary and env, then registers a `stdio` MCP server.
  - Runtime gating: enables only when the binary exists and Node is supported (bundled/env sources bypass the Node check); otherwise registers with `enabled:false`. Skips in senpi-task children via `SENPI_CODING_AGENT_SESSION_DIR`.
  - Windows support: wraps `.cmd` binaries with `cmd.exe`; supports `argsPrefix` from resolution.
  - Integrated into extension compose and exports; tests cover resolution, gating, and integration.

- **Dependencies**
  - Uses senpi `registerMcpServer`. Compatible with older senpi versions by detecting the missing API and skipping registration.

<sup>Written for commit d43d641d14350f1a1143911215300db5f65517e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

