### PR TITLE
fix(model-core): alias kimi-for-coding/k3 to the kimi-k3 capability snapshot

### DIFF
--- a/packages/model-core/src/model-capability-aliases.test.ts
+++ b/packages/model-core/src/model-capability-aliases.test.ts
@@ -67,6 +67,48 @@ describe("model-capability-aliases", () => {
     })
   })
 
+  test("normalizes Kimi for Coding k3 aliases to the snapshot ID", () => {
+    const result = resolveModelIDAlias("kimi-for-coding/k3")
+
+    expect(result).toEqual({
+      requestedModelID: "kimi-for-coding/k3",
+      canonicalModelID: "kimi-k3",
+      source: "exact-alias",
+      ruleID: "kimi-k3-alias",
+    })
+  })
+
+  test("normalizes a bare k3 model ID to the kimi-k3 snapshot ID", () => {
+    const result = resolveModelIDAlias("k3")
+
+    expect(result).toEqual({
+      requestedModelID: "k3",
+      canonicalModelID: "kimi-k3",
+      source: "exact-alias",
+      ruleID: "kimi-k3-alias",
+    })
+  })
+
+  test("does not alias unrelated IDs that only contain k3 as a prefix", () => {
+    const result = resolveModelIDAlias("some-provider/k3-highspeed")
+
+    expect(result).toEqual({
+      requestedModelID: "some-provider/k3-highspeed",
+      canonicalModelID: "k3-highspeed",
+      source: "canonical",
+    })
+  })
+
+  test("does not alias Kimi for Coding k3 variant IDs", () => {
+    const result = resolveModelIDAlias("kimi-for-coding/k3-thinking")
+
+    expect(result).toEqual({
+      requestedModelID: "kimi-for-coding/k3-thinking",
+      canonicalModelID: "k3-thinking",
+      source: "canonical",
+    })
+  })
+
   test("treats GitHub Copilot dotted Claude Opus 4.7 as canonical since models.dev now serves it natively", () => {
     const result = resolveModelIDAlias("github-copilot/claude-opus-4.7")
 

--- a/packages/model-core/src/model-capability-aliases.ts
+++ b/packages/model-core/src/model-capability-aliases.ts
@@ -40,6 +40,12 @@ const EXACT_ALIAS_RULES: ReadonlyArray<ExactAliasRule> = [
     canonicalModelID: "k2p5",
     rationale: "Kimi for Coding exposes k2pb while the bundled capabilities snapshot uses the canonical k2p5 ID.",
   },
+  {
+    aliasModelID: "k3",
+    ruleID: "kimi-k3-alias",
+    canonicalModelID: "kimi-k3",
+    rationale: "Kimi for Coding exposes k3 while the bundled capabilities snapshot uses the canonical kimi-k3 ID.",
+  },
 ]
 
 const EXACT_ALIAS_RULES_BY_MODEL: ReadonlyMap<string, ExactAliasRule> = new Map(


### PR DESCRIPTION
## Summary

fixes #6194. Commit 011fa228c added `isKimiK3Model()` and the `kimi-k3` supplemental capability entry, but no alias mapping the runtime model ID to it. `kimi-for-coding` serves the model as `k3`, so capability lookup stripped the provider prefix, found no rule for `k3`, and fell through to `unknown` — doctor reported every k3-configured agent as "capabilities: unknown".

This adds `k3 -> kimi-k3` to `EXACT_ALIAS_RULES`, matching the existing `k2pb -> k2p5` pattern for Kimi for Coding model IDs.

## Changes

- `model-capability-aliases.ts`: exact alias rule `k3 -> kimi-k3`. Exact match means only the literal `k3` resolves — `k3-thinking`, `k3-highspeed`, or any future composite ID is unaffected.
- `model-capability-aliases.test.ts`: 4 regression tests — provider-prefixed, bare, and two negative cases.

Out of scope: the `kimi` heuristic in `model-capability-heuristics.ts` (unnecessary once the alias provides snapshot-backed capabilities) and any change to `isKimiK3Model()`.

## Verification

```
bun test packages/model-core/src/model-capability-aliases.test.ts
bun test packages/model-core
bun run typecheck
OMO_SKIP_MATERIALIZE=1 bun run build
```

20/20 alias tests pass (baseline before the change was 16), full model-core suite 311/311, typecheck clean, build completes. `OMO_SKIP_MATERIALIZE=1` was needed locally only because `git submodule update --init` cannot fetch `packages/shared-skills/upstreams/open-design` from a fresh worktree here; unrelated to this change. QA evidence: `.omo/evidence/20260718-kimi-k3-alias/`.

## Related Issues

- fixes #6194

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Alias `k3` to the `kimi-k3` capability snapshot to fix capability lookup for Kimi for Coding, so `k3`-configured agents no longer show "capabilities: unknown". Matches the existing `k2pb` -> `k2p5` pattern and closes #6194.

- **Bug Fixes**
  - Added exact alias rule `k3 -> kimi-k3` (affects `kimi-for-coding/k3` and bare `k3`; variants like `k3-thinking` are unchanged).
  - Added regression tests for prefixed, bare, and negative cases.

<sup>Written for commit 52dcf79ccb56596884dcb9fa0c25a0daa1d3f1db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

