### PR TITLE
fix(release): remove stale framing block from generated release notes

### DIFF
--- a/script/generate-changelog.ts
+++ b/script/generate-changelog.ts
@@ -41,72 +41,6 @@ async function generateChangelog(previousTag: string): Promise<string[]> {
   return notes
 }
 
-async function getChangedFiles(previousTag: string): Promise<string[]> {
-  try {
-    const diff = await $`git diff --name-only ${previousTag}..HEAD`.text()
-    return diff
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean)
-  } catch {
-    return []
-  }
-}
-
-function touchesAnyPath(files: string[], candidates: string[]): boolean {
-  return files.some((file) => candidates.some((candidate) => file === candidate || file.startsWith(`${candidate}/`)))
-}
-
-function buildReleaseFraming(files: string[]): string[] {
-  const bullets: string[] = []
-
-  if (
-    touchesAnyPath(files, [
-      "packages/omo-opencode/src/index.ts",
-      "packages/omo-opencode/src/plugin-config.ts",
-      "bin/platform.js",
-      "postinstall.mjs",
-      "docs",
-    ])
-  ) {
-    bullets.push("Rename transition updates across package detection, plugin/config compatibility, and install surfaces.")
-  }
-
-  if (touchesAnyPath(files, ["packages/omo-opencode/src/tools/delegate-task", "packages/omo-opencode/src/plugin/tool-registry.ts"])) {
-    bullets.push("Task and tool behavior updates, including delegate-task contract and runtime registration behavior.")
-  }
-
-  if (
-    touchesAnyPath(files, [
-      "packages/omo-opencode/src/plugin/tool-registry.ts",
-      "packages/omo-opencode/src/plugin-handlers/agent-config-handler.ts",
-      "packages/omo-opencode/src/plugin-handlers/tool-config-handler.ts",
-      "packages/omo-opencode/src/hooks/tasks-todowrite-disabler",
-    ])
-  ) {
-    bullets.push("Task-system default behavior alignment so omitted configuration behaves consistently across runtime paths.")
-  }
-
-  if (touchesAnyPath(files, [".github/workflows", "docs/guide/installation.md", "postinstall.mjs"])) {
-    bullets.push("Install and publish workflow hardening, including safer release sequencing and package/install fixes.")
-  }
-
-  if (bullets.length === 0) {
-    return []
-  }
-
-  return [
-    "## Minor Compatibility and Stability Release",
-    "",
-    "This release carries compatibility-facing behavior changes and operational hardening. Read the summary below before upgrading or publishing.",
-    "",
-    ...bullets.map((bullet) => `- ${bullet}`),
-    "",
-    "## Commit Summary",
-    "",
-  ]
-}
-
 async function getContributors(previousTag: string): Promise<string[]> {
   const notes: string[] = []
 
@@ -151,11 +85,9 @@ async function main() {
     process.exit(0)
   }
 
-  const changedFiles = await getChangedFiles(previousTag)
   const changelog = await generateChangelog(previousTag)
   const contributors = await getContributors(previousTag)
-  const framing = buildReleaseFraming(changedFiles)
-  const notes = [...framing, ...changelog, ...contributors]
+  const notes = [...changelog, ...contributors]
 
   if (notes.length === 0) {
     console.log("No notable changes")


### PR DESCRIPTION
## What

Removes the hardcoded **"## Minor Compatibility and Stability Release"** preamble that `script/generate-changelog.ts` was prepending to nearly every release's notes.

## Why

`buildReleaseFraming()` prepended that framing block whenever the release diff touched `docs/`, `.github/workflows/`, `postinstall.mjs`, or `tool-registry.ts`. Those paths are hit in almost every release, so the text — frozen to the v4.x rename-transition state when it was introduced in `d2c576c51` — appeared on every release regardless of what actually shipped, with no relationship to the real contents. It read as a stale, misleading artifact on releases that had nothing to do with compatibility/rename work.

## Change

- Delete `buildReleaseFraming()` and its two helpers `getChangedFiles()` and `touchesAnyPath()` (no other consumers).
- Drop the call site in `main()`; notes now compose from `changelog` + `contributors` only.
- Net: `script/generate-changelog.ts` — 1 insertion, 69 deletions.

After this, release notes contain only the commit summary and the community contributors section.

## Verification

- `bun test script/generate-changelog.test.ts` → **14/14 pass** (the existing `isExcludedReleaseNoteSubject` suite is unaffected).
- LSP diagnostics on the changed file → clean.
- `grep` for `buildReleaseFraming | getChangedFiles | touchesAnyPath | "Minor Compatibility and Stability"` across the worktree → no matches (no dangling references).
- Diff is a pure deletion: `git diff --stat` → `1 file changed, 1 insertion(+), 69 deletions(-)`.

## Notes / residual risk

- No new test added: the deleted function had no test coverage and leaves no behavioral seam to pin. A `not.toContain("Minor Compatibility")` assertion would be a banned phrase-absence guard per `.omo/rules/test-discipline.md`. This is a deletion-only change.
- Scope is limited to the release-note generator; no plugin runtime, hook, tool, or installer surface is touched, so no `opencode-qa` / `codex-qa` gate applies.
- This is a release-pipeline text change, so the real-surface proof is the next GitHub release body (will be observable post-merge on the next `publish.yml` or dev-push draft).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stale "Minor Compatibility and Stability Release" preamble from `script/generate-changelog.ts` so release notes reflect actual changes. Notes now include only the commit summary and community contributors.

- **Bug Fixes**
  - Deleted `buildReleaseFraming()` and helpers (`getChangedFiles()`, `touchesAnyPath()`), and removed the call in `main()`.
  - Generator now outputs only changelog entries plus contributors; no more hardcoded framing text.

<sup>Written for commit 04717bff72d372845864638a9e8dbe1436799058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

