### PR TITLE
fix(category-skill-reminder): append reminder as new message to preserve prompt cache

### DIFF
--- a/packages/omo-opencode/src/hooks/category-skill-reminder/hook.ts
+++ b/packages/omo-opencode/src/hooks/category-skill-reminder/hook.ts
@@ -156,13 +156,17 @@ export function createCategorySkillReminderHook(
     const target = findLatestReminderTarget(output.messages, sessionStates)
     if (!target) return
 
-    target.message.parts.splice(target.textPartIndex, 0, {
-      id: `prt_category_skill_reminder_${target.messageID}`,
-      sessionID: target.sessionID,
-      messageID: target.messageID,
-      type: "text",
-      text: reminderMessage,
-      synthetic: true,
+    const reminderID = `msg_category_skill_reminder_${target.sessionID}`
+    output.messages.push({
+      info: { ...target.message.info, id: reminderID },
+      parts: [{
+        id: `prt_category_skill_reminder_${target.sessionID}`,
+        sessionID: target.sessionID,
+        messageID: reminderID,
+        type: "text",
+        text: reminderMessage,
+        synthetic: true,
+      }],
     })
     target.state.reminderPending = false
     target.state.reminderShown = true

--- a/packages/omo-opencode/src/hooks/category-skill-reminder/index.test.ts
+++ b/packages/omo-opencode/src/hooks/category-skill-reminder/index.test.ts
@@ -94,7 +94,7 @@ afterEach(() => {
 
 describe("category-skill-reminder hook", () => {
   test.each(["Sisyphus", "Atlas", "sisyphus-junior"])(
-    "#given target agent %s #when three delegatable tools finish #then one reminder is injected before the user text",
+    "#given target agent %s #when three delegatable tools finish #then one reminder is appended as a new user message",
     async (agent) => {
       const hook = createHook()
       const sessionID = `target-${agent}`
@@ -106,8 +106,13 @@ describe("category-skill-reminder hook", () => {
 
       expect(output.output).toBe("result")
       expect(findReminderParts(messages)).toHaveLength(1)
-      expect(messages[0]?.parts[0]).toMatchObject({ synthetic: true, type: "text" })
-      expect(messages[0]?.parts[1]).toMatchObject({ text: "continue working", type: "text" })
+      const originalMessage = messages[0]
+      expect(messages).toHaveLength(2)
+      expect(originalMessage.parts).toHaveLength(1)
+      expect(originalMessage.parts[0]).toMatchObject({ text: "continue working", type: "text" })
+      const appended = messages[1]
+      expect(appended.info.role).toBe("user")
+      expect(appended.parts[0]).toMatchObject({ synthetic: true, type: "text" })
     },
   )
 
@@ -132,11 +137,17 @@ describe("category-skill-reminder hook", () => {
     await useTools({ hook, sessionID: targetSessionID, tools: ["read", "grep", "glob"] })
     const targetMessage = createUserTurn(targetSessionID, "target request")
     const otherMessage = createUserTurn(otherSessionID, "other request")
+    const messages = [targetMessage, otherMessage]
 
-    await transformMessages(hook, [targetMessage, otherMessage])
+    await transformMessages(hook, messages)
 
-    expect(findReminderParts([targetMessage])).toHaveLength(1)
-    expect(findReminderParts([otherMessage])).toHaveLength(0)
+    expect(messages).toHaveLength(3)
+    const appended = messages[2]
+    expect(appended.info.sessionID).toBe(targetSessionID)
+    expect(appended.info.role).toBe("user")
+    expect(appended.parts[0]).toMatchObject({ synthetic: true, type: "text" })
+    expect(targetMessage.parts).toHaveLength(1)
+    expect(otherMessage.parts).toHaveLength(1)
   })
 
   test("#given no tracked agent #when the tool input identifies Sisyphus #then the reminder is injected", async () => {
@@ -227,7 +238,7 @@ describe("category-skill-reminder hook", () => {
     expect(findReminderParts(realMessages)).toHaveLength(1)
   })
 
-  test("#given multiple real and synthetic user texts #when a reminder is pending #then exactly one is inserted before the latest real text", async () => {
+  test("#given multiple real and synthetic user texts #when a reminder is pending #then exactly one reminder is appended as a new message leaving prior parts untouched", async () => {
     const hook = createHook()
     const sessionID = "latest-real-text"
     updateSessionAgent(sessionID, "Sisyphus")
@@ -256,24 +267,33 @@ describe("category-skill-reminder hook", () => {
       latestTurn,
       createUserTurn(sessionID, "synthetic tail", { id: "msg_tail", synthetic: true }),
     ]
+    const originalPartsSnapshot = messages.map((message) => message.parts.map((part) => part.id))
 
     await transformMessages(hook, messages)
     await transformMessages(hook, messages)
 
-    const reminderIndex = latestTurn.parts.findIndex(
-      (part) => part.type === "text" && part.text.includes(REMINDER_MARKER),
-    )
-    const latestTextIndex = latestTurn.parts.findIndex(
-      (part) => part.type === "text" && part.text === "latest real text",
-    )
     expect(findReminderParts(messages)).toHaveLength(1)
-    expect(reminderIndex).toBe(latestTextIndex - 1)
-    expect(latestTurn.parts[reminderIndex]).toMatchObject({
-      messageID: "msg_latest",
+    expect(messages).toHaveLength(4)
+    const appended = messages[3]
+    expect(appended.info.sessionID).toBe(sessionID)
+    expect(appended.info.role).toBe("user")
+    expect(appended.parts[0]).toMatchObject({
+      messageID: `msg_category_skill_reminder_${sessionID}`,
       sessionID,
       synthetic: true,
       type: "text",
     })
+    // prior messages' parts arrays are byte-identical (cache prefix preserved)
+    expect(messages[0]!.parts.map((part) => part.id)).toEqual(originalPartsSnapshot[0])
+    expect(messages[1]!.parts.map((part) => part.id)).toEqual(originalPartsSnapshot[1])
+    expect(messages[2]!.parts.map((part) => part.id)).toEqual(originalPartsSnapshot[2])
+    // latestTurn keeps exactly its original 3 parts, in order
+    expect(latestTurn.parts).toHaveLength(3)
+    expect(latestTurn.parts.map((part) => part.text)).toEqual([
+      "earlier text in latest turn",
+      "internal context",
+      "latest real text",
+    ])
   })
 
   test("#given a reminder is inserted #when transforms and tools repeat without assistant completion #then the same bytes appear only once", async () => {
@@ -295,6 +315,29 @@ describe("category-skill-reminder hook", () => {
     expect(findReminderParts(firstMessages)).toHaveLength(1)
     expect(JSON.stringify(findReminderParts(firstMessages)[0])).toBe(injectedBytes)
     expect(findReminderParts(secondMessages)).toHaveLength(0)
+  })
+
+  test("#given a reminder is appended #when the transform runs #then all prior messages and their parts are byte-identical before and after", async () => {
+    const hook = createHook()
+    const sessionID = "cache-prefix-session"
+    updateSessionAgent(sessionID, "Sisyphus")
+    await useTools({ hook, sessionID, tools: ["read", "grep", "bash"] })
+
+    const userMessage = createUserTurn(sessionID, "original user text", { id: "msg_user" })
+    const messages = [userMessage]
+    const priorSnapshot = JSON.stringify(messages.map((message) => ({
+      info: message.info,
+      parts: message.parts,
+    })))
+
+    await transformMessages(hook, messages)
+
+    // the reminder is appended as a new message
+    expect(messages).toHaveLength(2)
+    expect(findReminderParts(messages)).toHaveLength(1)
+    // the original user message and its parts array are unchanged -> cache prefix preserved
+    expect(messages[0]).toBe(userMessage)
+    expect(JSON.stringify([{ info: messages[0]!.info, parts: messages[0]!.parts }])).toBe(priorSnapshot)
   })
 
   test("#given a reminder is pending #when the session is deleted #then pending state and counts are cleared", async () => {


### PR DESCRIPTION
## Summary

The `category-skill-reminder` hook spliced a synthetic text part into an existing user message's `parts` array. This mutated the stored content of that message, which changed its cumulative prefix hash and invalidated the Anthropic prompt cache for that message and everything after it. On the next turn, when `reminderShown` was true and the reminder was not re-injected, the stored message content differed from what was cached upstream, causing a second cache miss and a lost cache breakpoint.

This change appends the reminder as a **new** user message at the end of `output.messages` instead. Prior messages and their `parts` arrays stay byte-identical, so the cache prefix remains valid on every subsequent turn.

## Changes

- **`packages/omo-opencode/src/hooks/category-skill-reminder/hook.ts`**: replaced the `target.message.parts.splice(...)` block in `messagesTransform` with an `output.messages.push(...)` that appends a new message. The new message clones `info` from the target user message via spread (only `id` is overridden) and carries a single synthetic text part. Net change: 3 lines.
- **`packages/omo-opencode/src/hooks/category-skill-reminder/index.test.ts`**: rewrote three tests that asserted part-level positioning inside an existing message to assert the reminder appears as a new entry in `output.messages` with `role: "user"`. Added one test that verifies prior messages are reference-stable and byte-identical before and after the transform runs (the cache-preservation invariant).

## How this preserves the cache

Anthropic prompt caching hashes the prefix cumulatively: changing any block at or before the breakpoint produces a different hash on the next request, and the messages cache is invalidated by content changes at the messages level. Splicing into an existing user message mutated that message's content, so its hash changed and the breakpoint at or after it missed. Appending a new message does not mutate any prior message, so every prior message's content hash is stable and the cache prefix stays valid.

Anthropic accepts consecutive user messages without error, so the appended reminder is read as additional user input. No `role: "system"` messages are introduced, so this works on Anthropic, OpenAI, and every Anthropic-compatible provider without model gating.

## QA & Evidence

- **What was tested:** `bun test packages/omo-opencode/src/hooks/category-skill-reminder/`
  **Observed result:** 21 pass, 0 fail, 83 expect() calls. Three rewritten tests assert the new append behavior; one new test directly verifies the cache-preservation invariant (prior messages reference-stable and byte-identical before/after transform).
  **Artifact:** reproducible from the branch.
  **Why sufficient:** the change is a pure data-structure mutation in one hook function; the unit suite covers the new behavior, the once-per-session gate, session-deletion cleanup, cross-session isolation, case-insensitive counting, and skill formatting.

- **What was tested:** `bun run typecheck` (full workspace, `tsgo --noEmit` + `typecheck:script` + `typecheck:packages`)
  **Observed result:** exit 0, no errors across all 29 package tsconfig projects.
  **Why sufficient:** confirms the cloned `info` spread is type-safe and no `as any` / `@ts-ignore` was introduced.

- **What was tested:** `bunx biome lint` on both changed files
  **Observed result:** exit 0, no warnings.

- **What was tested:** `bun test packages/omo-opencode/src/hooks/` (adjacent regression check)
  **Observed result:** 2048 pass, 46 fail. The 46 failures are pre-existing and unrelated: verified by stashing this change and re-running the same suite, which produces the identical 46 failures (2047 pass, 46 fail) on baseline `dev`. The failures are cross-test state pollution in `claude-code-hooks/handlers/session-event-handler-retry.test.ts` and related files; each failing test passes in isolation. This change adds one net passing test (2047 to 2048) and touches none of the failing tests.

- **Not covered:** the full `opencode-qa` skill harness (live OpenCode session driving with SSE hook probes) was not run in this environment. The change is a 3-line behavior swap inside one hook with passing unit tests; the maintainer is welcome to run the full `opencode-qa` harness before merge. `bun run build` was not run because the frontend submodule materialization step requires network access to private submodules not available in this checkout; this does not affect the hook source, which is plain TypeScript with no build-time codegen.

## Risks & Residuals

- **Weaker precedence signal:** the reminder now arrives as a trailing user turn rather than prepended text inside the existing user turn. This is a weaker precedence signal than a system message would be, which is appropriate for a nudge rather than a directive. Accepted.
- **`textPartIndex` in `findLatestReminderTarget` is now unused by `messagesTransform`:** the inner `parts` scan still serves as a meaningful guard (it ensures injection only happens when a real user message exists to clone `info` from, which the `pending-without-text` test depends on). Left unchanged to keep the diff minimal; can be simplified in a follow-up. Not blocking.
- **Cloned `info.time`:** the new message inherits the original message's `time.created` timestamp. Downstream consumers that sort or dedupe by `time.created` could behave oddly. Non-blocking; flag for follow-up if it matters for dashboard ordering.
- **Harness-level QA not run in this environment:** see QA section above. The unit-level evidence covers the hook contract; the maintainer can run `opencode-qa` for full harness proof before merge.

## Automated Checks

```bash
bun run typecheck
bun test packages/omo-opencode/src/hooks/category-skill-reminder/
bunx biome lint packages/omo-opencode/src/hooks/category-skill-reminder/hook.ts packages/omo-opencode/src/hooks/category-skill-reminder/index.test.ts
```

## Related Issues

<!-- Closes # -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Append the `category-skill-reminder` as a new user message instead of splicing it into an existing one to preserve the Anthropic prompt cache. Prior messages stay byte-identical, so cache breakpoints remain valid across turns.

- **Bug Fixes**
  - Swapped `parts.splice(...)` for `output.messages.push(...)` to append a new `user` message that clones `info` (with a new `id`) and carries the reminder text.
  - Ensures earlier messages and their `parts` are unchanged, keeping cumulative prefix hashes stable.
  - Updated tests to assert append behavior and added a test that verifies cache-preservation (prior messages remain reference- and byte-identical).

<sup>Written for commit 454713da0e567ba72645b5a0933feec546013037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

