### PR TITLE
feat(tui): add live Team sidebar status

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "picocolors": "^1.1.1",
         "picomatch": "^4.0.4",
         "posthog-node": "^5.34.3",
+        "solid-js": "1.9.12",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.4",
     "posthog-node": "^5.34.3",
+    "solid-js": "1.9.12",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/omo-opencode/src/create-managers.ts
+++ b/packages/omo-opencode/src/create-managers.ts
@@ -196,6 +196,7 @@ export function createManagers(args: {
       client: ctx.client,
       projectDir: ctx.directory,
       backgroundManager,
+      teamModeConfig: pluginConfig.team_mode,
     })
     tuiStateMirror.start()
   }

--- a/packages/omo-opencode/src/features/tui-sidebar/compute-view.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/compute-view.test.ts
@@ -8,6 +8,7 @@ import type {
   LoopState,
   RosterState,
   SidebarView,
+  TeamsState,
 } from "./state-types"
 
 const validConfig: ConfigState = { kind: "valid" }
@@ -22,6 +23,7 @@ const roster: RosterState = {
 const idleAgents: AgentsState = { kind: "none" }
 const idleJobs: JobBoardState = { kind: "none" }
 const idleLoop: LoopState = { kind: "none" }
+const idleTeams: TeamsState = { kind: "none" }
 const activeAgents: AgentsState = {
   kind: "list",
   agents: [{ name: "sisyphus", status: "busy" }],
@@ -50,6 +52,7 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: idleJobs,
       loop: idleLoop,
+      teams: idleTeams,
     }
 
     // when
@@ -68,6 +71,7 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: idleJobs,
       loop: idleLoop,
+      teams: idleTeams,
     }
 
     // when
@@ -85,6 +89,7 @@ describe("tui sidebar computeView", () => {
       agents: activeAgents,
       jobs: idleJobs,
       loop: idleLoop,
+      teams: idleTeams,
     }
 
     // when
@@ -96,6 +101,7 @@ describe("tui sidebar computeView", () => {
       loop: idleLoop,
       agents: activeAgents,
       jobs: idleJobs,
+      teams: idleTeams,
       configBanner: { kind: "none" },
     })
   })
@@ -108,6 +114,7 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: activeJobs,
       loop: idleLoop,
+      teams: idleTeams,
     }
 
     // when
@@ -119,6 +126,7 @@ describe("tui sidebar computeView", () => {
       loop: idleLoop,
       agents: idleAgents,
       jobs: activeJobs,
+      teams: idleTeams,
       configBanner: { kind: "invalid" },
     })
   })
@@ -131,6 +139,7 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: idleJobs,
       loop: liveLoop,
+      teams: idleTeams,
     }
 
     // when
@@ -142,8 +151,39 @@ describe("tui sidebar computeView", () => {
       loop: liveLoop,
       agents: idleAgents,
       jobs: idleJobs,
+      teams: idleTeams,
       configBanner: { kind: "none" },
     })
+  })
+
+  it("#given only relevant team members #when computing and keying the view #then teams activate the view and change its key", () => {
+    // given
+    const firstSections = {
+      config: validConfig,
+      roster,
+      agents: idleAgents,
+      jobs: idleJobs,
+      loop: idleLoop,
+      teams: {
+        kind: "list" as const,
+        teams: [{ name: "sidebar-team", members: [{ name: "idle-member", status: "idle" as const, work: "Reviewing sidebar", sessionId: "ses-member" }] }],
+      },
+    }
+    const secondSections = {
+      ...firstSections,
+      teams: {
+        kind: "list" as const,
+        teams: [{ name: "sidebar-team", members: [{ name: "idle-member", status: "idle" as const, work: "Testing sidebar", sessionId: "ses-member" }] }],
+      },
+    }
+
+    // when
+    const firstView = computeView(firstSections)
+    const secondView = computeView(secondSections)
+
+    // then
+    expect(firstView).toMatchObject({ kind: "active", teams: firstSections.teams })
+    expect(viewKey(secondView)).not.toBe(viewKey(firstView))
   })
 
   it("#given equivalent views built with different literal key order #when computing keys #then viewKey is stable", () => {
@@ -153,6 +193,7 @@ describe("tui sidebar computeView", () => {
       loop: liveLoop,
       agents: activeAgents,
       jobs: activeJobs,
+      teams: idleTeams,
       configBanner: { kind: "invalid" },
     }
     const second: SidebarView = {
@@ -162,6 +203,7 @@ describe("tui sidebar computeView", () => {
         kind: "list",
       },
       agents: { agents: [{ status: "busy", name: "sisyphus" }], kind: "list" },
+      teams: idleTeams,
       loop: {
         activeGoal: "Ship sidebar",
         blocked: 1,

--- a/packages/omo-opencode/src/features/tui-sidebar/compute-view.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/compute-view.ts
@@ -7,6 +7,7 @@ import type {
   LoopState,
   RosterState,
   SidebarView,
+  TeamsState,
 } from "./state-types"
 
 export type ComputeViewSections = {
@@ -15,6 +16,7 @@ export type ComputeViewSections = {
   readonly agents: AgentsState
   readonly jobs: JobBoardState
   readonly loop: LoopState
+  readonly teams: TeamsState
 }
 
 export function computeView(sections: ComputeViewSections): SidebarView {
@@ -24,6 +26,7 @@ export function computeView(sections: ComputeViewSections): SidebarView {
       loop: sections.loop,
       agents: sections.agents,
       jobs: sections.jobs,
+      teams: sections.teams,
       configBanner: sections.config.kind === "invalid" ? { kind: "invalid" } : { kind: "none" },
     }
   }
@@ -43,6 +46,7 @@ export function viewKey(view: SidebarView): string {
         loopKeyParts(view.loop),
         agentsKeyParts(view.agents),
         jobsKeyParts(view.jobs),
+        teamsKeyParts(view.teams),
         ["configBanner", view.configBanner.kind],
       ])
     case "broken":
@@ -55,7 +59,10 @@ export function viewKey(view: SidebarView): string {
 }
 
 function isActive(sections: ComputeViewSections): boolean {
-  return sections.agents.kind === "list" || sections.jobs.kind === "list" || sections.loop.kind === "live"
+  return sections.agents.kind === "list"
+    || sections.jobs.kind === "list"
+    || sections.loop.kind === "live"
+    || sections.teams.kind === "list"
 }
 
 function stableKey(parts: readonly unknown[]): string {
@@ -96,6 +103,24 @@ function jobsKeyParts(jobs: JobBoardState): readonly unknown[] {
       ]
     default:
       return assertNever(jobs)
+  }
+}
+
+function teamsKeyParts(teams: TeamsState): readonly unknown[] {
+  switch (teams.kind) {
+    case "none":
+      return ["teams", "none"]
+    case "list":
+      return [
+        "teams",
+        "list",
+        teams.teams.map((team) => [
+          team.name,
+          team.members.map((member) => [member.name, member.status, member.work, member.sessionId]),
+        ]),
+      ]
+    default:
+      return assertNever(teams)
   }
 }
 

--- a/packages/omo-opencode/src/features/tui-sidebar/derivers.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/derivers.test.ts
@@ -6,10 +6,11 @@ import {
   deriveJobBoard,
   deriveLoop,
   deriveRoster,
+  deriveTeams,
 } from "./derivers"
 import { MAX_AGENTS, MAX_JOBS, MIRROR_SCHEMA_VERSION } from "./constants"
 import type { TuiRuntimeSnapshot } from "./snapshot-schema"
-import type { AgentRow, JobRow, LoopLive, RosterRow } from "./state-types"
+import type { AgentRow, JobRow, LoopLive, RosterRow, TeamRow } from "./state-types"
 
 const liveLoop: LoopLive = {
   kind: "live",
@@ -26,6 +27,7 @@ function snapshot(input: {
   readonly activeAgents?: readonly AgentRow[]
   readonly jobBoard?: readonly JobRow[]
   readonly loop?: LoopLive | null
+  readonly teams?: readonly TeamRow[]
 }): TuiRuntimeSnapshot {
   return {
     version: MIRROR_SCHEMA_VERSION,
@@ -34,6 +36,7 @@ function snapshot(input: {
     activeAgents: [...(input.activeAgents ?? [])],
     jobBoard: [...(input.jobBoard ?? [])],
     loop: input.loop ?? null,
+    teams: [...(input.teams ?? [])],
   }
 }
 
@@ -199,6 +202,25 @@ describe("tui sidebar section derivers", () => {
     // then
     expect(nullState).toEqual({ kind: "none" })
     expect(emptyState).toEqual({ kind: "none" })
+  })
+
+  it("#given a snapshot with idle team members #when deriving teams #then it keeps every member for rendering", () => {
+    // given
+    const teams: readonly TeamRow[] = [
+      {
+        name: "sidebar-team",
+        members: [
+          { name: "running", status: "running", work: "Implementing sidebar", sessionId: "ses-running" },
+          { name: "idle", status: "idle", work: null, sessionId: null },
+        ],
+      },
+    ]
+
+    // when
+    const state = deriveTeams(snapshot({ teams }))
+
+    // then
+    expect(state).toEqual({ kind: "list", teams })
   })
 
   it("#given a live loop with pass fail pending and blocked counts #when deriving loop #then it passes the live state through", () => {

--- a/packages/omo-opencode/src/features/tui-sidebar/derivers.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/derivers.ts
@@ -8,6 +8,7 @@ import type {
   LoopState,
   RosterRow,
   RosterState,
+  TeamsState,
 } from "./state-types"
 import type { BackgroundTaskStatus } from "../background-agent/types"
 
@@ -66,6 +67,14 @@ export function deriveJobBoard(snap: TuiRuntimeSnapshot | null): JobBoardState {
 
 export function deriveLoop(snap: TuiRuntimeSnapshot | null): LoopState {
   return snap?.loop ?? { kind: "none" }
+}
+
+export function deriveTeams(snap: TuiRuntimeSnapshot | null): TeamsState {
+  if (!snap || snap.teams.length === 0) {
+    return { kind: "none" }
+  }
+
+  return { kind: "list", teams: snap.teams }
 }
 
 function compareRosterRows(left: RosterRow, right: RosterRow): number {

--- a/packages/omo-opencode/src/features/tui-sidebar/mirror-io.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/mirror-io.test.ts
@@ -32,6 +32,7 @@ function snapshotFor(projectDir: string, updatedAt: number): TuiRuntimeSnapshot 
       },
     ],
     loop: null,
+    teams: [],
   }
 }
 

--- a/packages/omo-opencode/src/features/tui-sidebar/mirror-manager.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/mirror-manager.ts
@@ -10,6 +10,7 @@ import type {
   TuiMirrorClient,
 } from "./snapshot-builder"
 import type { TuiRuntimeSnapshot } from "./snapshot-schema"
+import type { TeamModeConfig } from "@oh-my-opencode/team-core/config"
 
 export type TuiStateMirrorInput = {
   readonly client: TuiMirrorClient
@@ -17,6 +18,7 @@ export type TuiStateMirrorInput = {
   readonly backgroundManager: TuiBackgroundSnapshotProvider
   readonly getStatuses?: () => Promise<SessionStatusMap>
   readonly sessionAgentResolver?: SessionAgentResolver
+  readonly teamModeConfig?: TeamModeConfig
   readonly reportFlushError?: (error: Error) => void
 }
 

--- a/packages/omo-opencode/src/features/tui-sidebar/render-view.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/render-view.test.ts
@@ -21,6 +21,10 @@ const activeSections: ComputeViewSections = {
   roster: { kind: "empty" },
   agents: { kind: "list", agents: [{ name: "fixer", status: "busy" }] },
   jobs: { kind: "list", jobs: [{ title: "explore repo", status: "running", toolCalls: 3, lastTool: "grep" }] },
+  teams: {
+    kind: "list",
+    teams: [{ name: "sidebar-team", members: [{ name: "idle-member", status: "idle", work: "Reviewing sidebar", sessionId: null }] }],
+  },
   loop: {
     kind: "live",
     goalsDone: 0,
@@ -34,7 +38,7 @@ const activeSections: ComputeViewSections = {
 }
 
 describe("tui sidebar renderView", () => {
-  it("#given active view #when building nodes #then it renders ULW agents jobs and invalid banner in order", () => {
+  it("#given active view #when building nodes #then it renders ULW agents jobs Team and invalid banner in order", () => {
     // given
     const view = computeView(activeSections)
 
@@ -46,11 +50,13 @@ describe("tui sidebar renderView", () => {
     expect(description).toContain("config invalid")
     expect(description.indexOf("ULW")).toBeLessThan(description.indexOf("Agents"))
     expect(description.indexOf("Agents")).toBeLessThan(description.indexOf("Jobs"))
+    expect(description.indexOf("Jobs")).toBeLessThan(description.indexOf("Team (1)"))
     expect(description).toContain("0/1")
     expect(description).toContain("pass 1")
     expect(description).toContain("fail 1")
     expect(description).toContain("fixer")
     expect(description).toContain("explore repo")
+    expect(description).toContain("sidebar-team/idle-mem...")
     expect(nodes[0]?.kind).toBe("box")
   })
 
@@ -76,6 +82,7 @@ describe("tui sidebar renderView", () => {
       roster: { kind: "empty" },
       agents: { kind: "none" },
       jobs: { kind: "none" },
+      teams: { kind: "none" },
       loop: { kind: "none" },
     })
 

--- a/packages/omo-opencode/src/features/tui-sidebar/render-view.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/render-view.ts
@@ -2,6 +2,8 @@ import { LABEL_MAX } from "./constants"
 import { box, text } from "./element-helpers"
 import type { ViewNode } from "./element-helpers"
 import { assertNever } from "./state-types"
+import { teamLines, teamNodes } from "./team-section"
+import type { TeamSectionInteraction } from "./team-section"
 import type {
   AgentsState,
   ConfigBanner,
@@ -22,7 +24,7 @@ type ThemeLike = {
   readonly borderSubtle?: unknown
 }
 
-export function buildViewNodes(view: SidebarView, theme: ThemeLike): ViewNode[] {
+export function buildViewNodes(view: SidebarView, theme: ThemeLike, teamInteraction?: TeamSectionInteraction): ViewNode[] {
   switch (view.kind) {
     case "active":
       return [
@@ -31,6 +33,7 @@ export function buildViewNodes(view: SidebarView, theme: ThemeLike): ViewNode[] 
           ...loopNodes(view.loop, theme),
           ...agentNodes(view.agents, theme),
           ...jobNodes(view.jobs, theme),
+          ...teamNodes(view.teams, theme, teamInteraction),
         ]),
       ]
     case "broken":
@@ -54,6 +57,7 @@ function linesForView(view: SidebarView): string[] {
         ...loopLines(view.loop),
         ...agentLines(view.agents),
         ...jobLines(view.jobs),
+        ...teamLines(view.teams),
       ]
     case "broken":
       return ["config invalid - run doctor", ...view.messages]

--- a/packages/omo-opencode/src/features/tui-sidebar/snapshot-builder-team.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/snapshot-builder-team.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test"
+
+import { TeamModeConfigSchema } from "@oh-my-opencode/team-core/config"
+import { RuntimeStateSchema } from "@oh-my-opencode/team-core/types"
+
+import { buildTuiRuntimeSnapshot } from "./snapshot-builder"
+import type { TeamRuntimeProvider } from "./team-projection"
+import type { TuiBackgroundSnapshotProvider, TuiMirrorClient } from "./snapshot-builder"
+
+const TEAM_RUN_ID = "11111111-1111-4111-8111-111111111111"
+const enabledTeamMode = TeamModeConfigSchema.parse({ enabled: true })
+const disabledTeamMode = TeamModeConfigSchema.parse({ enabled: false })
+const idleBackgroundManager: TuiBackgroundSnapshotProvider = {
+  getTasksSnapshot: () => [],
+}
+
+function runtimeProvider(sessionID: string, calls?: string[]): TeamRuntimeProvider {
+  return {
+    listActiveTeams: async () => {
+      calls?.push("listActiveTeams")
+      return [{ teamRunId: TEAM_RUN_ID, teamName: "sidebar-team", status: "active", memberCount: 1, scope: "project" }]
+    },
+    loadRuntimeState: async () => {
+      calls?.push("loadRuntimeState")
+      return RuntimeStateSchema.parse({
+        version: 1,
+        teamRunId: TEAM_RUN_ID,
+        teamName: "sidebar-team",
+        specSource: "project",
+        createdAt: 1,
+        status: "active",
+        leadSessionId: sessionID,
+        members: [{
+          name: "lead",
+          sessionId: sessionID,
+          agentType: "leader",
+          status: "running",
+          pendingInjectedMessageIds: [],
+        }],
+        shutdownRequests: [],
+        bounds: {
+          maxMembers: 8,
+          maxParallelMembers: 4,
+          maxMessagesPerRun: 10_000,
+          maxWallClockMinutes: 120,
+          maxMemberTurns: 500,
+        },
+      })
+    },
+    listTasks: async () => {
+      calls?.push("listTasks")
+      return []
+    },
+  }
+}
+
+function clientWithList(list: NonNullable<TuiMirrorClient["session"]["list"]>): TuiMirrorClient {
+  return {
+    session: {
+      status: async () => ({ data: {} }),
+      messages: async () => ({ data: [] }),
+      list,
+    },
+  }
+}
+
+describe("buildTuiRuntimeSnapshot Team projection", () => {
+  it("#given an SDK session list method that requires its owner #when building Team state #then the call preserves its this binding", async () => {
+    // given
+    const projectDir = "/tmp/omo-sidebar-binding"
+    const sessionID = "ses-binding"
+    let ownerMatched = false
+    const session = {
+      status: async () => ({ data: {} }),
+      messages: async () => ({ data: [] }),
+      async list(): Promise<unknown> {
+        ownerMatched = this === session
+        return { data: [{ id: sessionID, directory: projectDir }] }
+      },
+    }
+
+    // when
+    const snapshot = await buildTuiRuntimeSnapshot({
+      projectDir,
+      client: { session },
+      backgroundManager: idleBackgroundManager,
+      teamModeConfig: enabledTeamMode,
+      teamRuntimeProvider: runtimeProvider(sessionID),
+    })
+
+    // then
+    expect(ownerMatched).toBe(true)
+    expect(snapshot.teams).toHaveLength(1)
+  })
+
+  it("#given Team mode is disabled #when building a snapshot #then session and runtime providers are not scanned", async () => {
+    // given
+    const calls: string[] = []
+    const client = clientWithList(async () => {
+      calls.push("listSessions")
+      return { data: [] }
+    })
+
+    // when
+    const snapshot = await buildTuiRuntimeSnapshot({
+      projectDir: "/tmp/omo-sidebar-disabled",
+      client,
+      backgroundManager: idleBackgroundManager,
+      teamModeConfig: disabledTeamMode,
+      teamRuntimeProvider: runtimeProvider("ses-disabled", calls),
+    })
+
+    // then
+    expect(snapshot.teams).toEqual([])
+    expect(calls).toEqual([])
+  })
+
+  it("#given the relevant Team session follows more than one hundred newer sessions #when building Team state #then the complete project-scoped list includes it", async () => {
+    // given
+    const projectDir = "/tmp/omo-sidebar-many-sessions"
+    const relevantSessionID = "ses-relevant"
+    const sessions = [
+      ...Array.from({ length: 100 }, (_, index) => ({ id: `ses-newer-${index}`, directory: projectDir })),
+      { id: relevantSessionID, directory: projectDir },
+    ]
+    let receivedQuery: { readonly directory?: string; readonly limit?: number } | undefined
+    const client = clientWithList(async (options) => {
+      receivedQuery = options?.query
+      const limit = options?.query?.limit
+      return { data: limit === 500 ? sessions : sessions.slice(0, limit ?? 100) }
+    })
+
+    // when
+    const snapshot = await buildTuiRuntimeSnapshot({
+      projectDir,
+      client,
+      backgroundManager: idleBackgroundManager,
+      teamModeConfig: enabledTeamMode,
+      teamRuntimeProvider: runtimeProvider(relevantSessionID),
+    })
+
+    // then
+    expect(receivedQuery).toEqual({ limit: 500 })
+    expect(snapshot.teams[0]?.members[0]?.sessionId).toBe(relevantSessionID)
+  })
+})

--- a/packages/omo-opencode/src/features/tui-sidebar/snapshot-builder.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/snapshot-builder.ts
@@ -1,16 +1,28 @@
 import { getLastAgentFromSession } from "../../hooks/atlas/session-last-agent"
 import { normalizeSDKResponse } from "../../shared/normalize-sdk-response"
+import { z } from "zod"
 import { MIRROR_SCHEMA_VERSION } from "./constants"
 import { readActiveLoop } from "./loop-reader"
 import { canonicalProjectDir } from "./mirror-path"
+import { buildTeamsProjection, createTeamRuntimeProvider } from "./team-projection"
 import type { TuiRuntimeSnapshot } from "./snapshot-schema"
+import type { TeamRuntimeProvider } from "./team-projection"
 import type { AgentStatus, JobRow } from "./state-types"
 import type { BackgroundTaskSnapshot } from "../background-agent/types"
+import type { TeamModeConfig } from "@oh-my-opencode/team-core/config"
+
+const MAX_PROJECT_SESSIONS = 500
 
 export type TuiMirrorClient = {
   readonly session: {
     readonly status: () => Promise<unknown>
     readonly messages: (input: { readonly path: { readonly id: string } }) => Promise<unknown>
+    readonly list?: (input?: {
+      readonly query?: {
+        readonly directory?: string
+        readonly limit?: number
+      }
+    }) => Promise<unknown>
   }
 }
 
@@ -32,9 +44,18 @@ export type BuildTuiRuntimeSnapshotInput = {
   readonly backgroundManager: TuiBackgroundSnapshotProvider
   readonly getStatuses?: () => Promise<SessionStatusMap>
   readonly sessionAgentResolver?: SessionAgentResolver
+  readonly teamModeConfig?: TeamModeConfig
+  readonly teamRuntimeProvider?: TeamRuntimeProvider
 }
 
 type ActiveAgentStatus = Extract<AgentStatus, "busy" | "retry" | "running">
+
+const TeamProjectSessionSchema = z.object({
+  id: z.string().min(1),
+  directory: z.string().min(1),
+})
+
+const TeamProjectSessionsSchema = z.array(TeamProjectSessionSchema)
 
 export async function buildTuiRuntimeSnapshot(
   input: BuildTuiRuntimeSnapshotInput,
@@ -49,7 +70,33 @@ export async function buildTuiRuntimeSnapshot(
     activeAgents: await activeAgentsFromStatuses(statuses, input.client, input.sessionAgentResolver ?? getLastAgentFromSession),
     jobBoard: input.backgroundManager.getTasksSnapshot().map(toJobRow),
     loop: loop.kind === "live" ? redactLoopText(loop) : null,
+    teams: await teamsFromRuntime(input),
   }
+}
+
+async function teamsFromRuntime(input: BuildTuiRuntimeSnapshotInput): Promise<TuiRuntimeSnapshot["teams"]> {
+  if (input.teamModeConfig?.enabled !== true || input.client.session.list === undefined) {
+    return []
+  }
+
+  const runtimeProvider = input.teamRuntimeProvider ?? createTeamRuntimeProvider(input.teamModeConfig)
+
+  const sessions = TeamProjectSessionsSchema.safeParse(
+    normalizeSDKResponse<unknown>(await input.client.session.list({
+      query: {
+        limit: MAX_PROJECT_SESSIONS,
+      },
+    }), []),
+  )
+  if (!sessions.success) {
+    return []
+  }
+
+  return buildTeamsProjection({
+    projectDir: input.projectDir,
+    sessions: sessions.data,
+    runtimeProvider,
+  })
 }
 
 async function readStatuses(input: BuildTuiRuntimeSnapshotInput): Promise<SessionStatusMap> {

--- a/packages/omo-opencode/src/features/tui-sidebar/snapshot-schema.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/snapshot-schema.test.ts
@@ -33,6 +33,7 @@ describe("TuiRuntimeSnapshotSchema", () => {
         blocked: 1,
         activeGoal: "Render sidebar",
       },
+      teams: [],
     }
 
     // when
@@ -60,6 +61,24 @@ describe("TuiRuntimeSnapshotSchema", () => {
 
     // then
     expect(parsed).toBeNull()
+  })
+
+  it("#given a v1 mirror without teams #when parsed #then it supplies the additive empty teams projection", () => {
+    // given
+    const legacySnapshot = {
+      version: MIRROR_SCHEMA_VERSION,
+      projectDir: "/tmp/project",
+      updatedAt: 1,
+      activeAgents: [],
+      jobBoard: [],
+      loop: null,
+    }
+
+    // when
+    const parsed = parseSnapshot(legacySnapshot)
+
+    // then
+    expect(parsed).toMatchObject({ teams: [] })
   })
 
   it("#given a snapshot without projectDir #when parsed #then it returns null", () => {

--- a/packages/omo-opencode/src/features/tui-sidebar/snapshot-schema.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/snapshot-schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
 import { MIRROR_SCHEMA_VERSION } from "./constants"
-import type { AgentStatus, LoopLive } from "./state-types"
+import type { AgentStatus, LoopLive, TeamMemberStatus, TeamRow } from "./state-types"
 import type { BackgroundTaskStatus } from "../background-agent/types"
 
 const AGENT_STATUS_VALUES = [
@@ -33,6 +33,27 @@ const JobRowSchema = z.object({
   lastTool: z.string().nullable(),
 })
 
+const TEAM_MEMBER_STATUS_VALUES = [
+  "pending",
+  "running",
+  "idle",
+  "errored",
+  "completed",
+  "shutdown_approved",
+] as const satisfies readonly TeamMemberStatus[]
+
+const TeamMemberRowSchema = z.object({
+  name: z.string(),
+  status: z.enum(TEAM_MEMBER_STATUS_VALUES),
+  work: z.string().nullable(),
+  sessionId: z.string().min(1).nullable(),
+})
+
+const TeamRowSchema = z.object({
+  name: z.string(),
+  members: z.array(TeamMemberRowSchema),
+})
+
 const LoopLiveSchema = z.object({
   kind: z.literal("live"),
   goalsDone: z.number().int().nonnegative(),
@@ -51,9 +72,12 @@ export const TuiRuntimeSnapshotSchema = z.object({
   activeAgents: z.array(AgentRowSchema),
   jobBoard: z.array(JobRowSchema),
   loop: LoopLiveSchema.nullable(),
+  teams: z.array(TeamRowSchema).default([]),
 })
 
-export type TuiRuntimeSnapshot = z.infer<typeof TuiRuntimeSnapshotSchema>
+export type TuiRuntimeSnapshot = Omit<z.infer<typeof TuiRuntimeSnapshotSchema>, "teams"> & {
+  readonly teams: readonly TeamRow[]
+}
 
 export function parseSnapshot(raw: unknown): TuiRuntimeSnapshot | null {
   const parsed = TuiRuntimeSnapshotSchema.safeParse(raw)

--- a/packages/omo-opencode/src/features/tui-sidebar/state-types.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/state-types.ts
@@ -1,4 +1,5 @@
 import type { BackgroundTaskStatus } from "../background-agent/types"
+import type { RuntimeState } from "@oh-my-opencode/team-core/types"
 
 export type AgentStatus = "busy" | "idle" | "error" | "running" | "retry"
 
@@ -12,6 +13,20 @@ export type JobRow = {
   readonly status: BackgroundTaskStatus
   readonly toolCalls: number | null
   readonly lastTool: string | null
+}
+
+export type TeamMemberStatus = RuntimeState["members"][number]["status"]
+
+export type TeamMemberRow = {
+  readonly name: string
+  readonly status: TeamMemberStatus
+  readonly work: string | null
+  readonly sessionId: string | null
+}
+
+export type TeamRow = {
+  readonly name: string
+  readonly members: readonly TeamMemberRow[]
 }
 
 export type RosterRow = {
@@ -34,6 +49,10 @@ export type AgentsState =
 export type JobBoardState =
   | { readonly kind: "none" }
   | { readonly kind: "list"; readonly jobs: readonly JobRow[] }
+
+export type TeamsState =
+  | { readonly kind: "none" }
+  | { readonly kind: "list"; readonly teams: readonly TeamRow[] }
 
 export type LoopLive = {
   readonly kind: "live"
@@ -58,6 +77,7 @@ export type SidebarView =
       readonly loop: LoopState
       readonly agents: AgentsState
       readonly jobs: JobBoardState
+      readonly teams: TeamsState
       readonly configBanner: ConfigBanner
     }
   | { readonly kind: "broken"; readonly messages: readonly string[] }

--- a/packages/omo-opencode/src/features/tui-sidebar/team-projection.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/team-projection.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test"
+
+import { TaskSchema, RuntimeStateSchema } from "@oh-my-opencode/team-core/types"
+
+import { buildTeamsProjection, selectCurrentWork } from "./team-projection"
+import type { RuntimeState, Task } from "@oh-my-opencode/team-core/types"
+
+const CURRENT_PROJECT = "/tmp/omo-team-current"
+const OTHER_PROJECT = "/tmp/omo-team-other"
+const CURRENT_RUN_ID = "11111111-1111-4111-8111-111111111111"
+const OTHER_RUN_ID = "22222222-2222-4222-8222-222222222222"
+
+function runtime(input: {
+  readonly teamRunId: string
+  readonly teamName: string
+  readonly leadSessionId: string
+  readonly members: RuntimeState["members"]
+}): RuntimeState {
+  return RuntimeStateSchema.parse({
+    version: 1,
+    teamRunId: input.teamRunId,
+    teamName: input.teamName,
+    specSource: "project",
+    createdAt: 1,
+    status: "active",
+    leadSessionId: input.leadSessionId,
+    members: input.members,
+    shutdownRequests: [],
+    bounds: {
+      maxMembers: 8,
+      maxParallelMembers: 4,
+      maxMessagesPerRun: 10_000,
+      maxWallClockMinutes: 120,
+      maxMemberTurns: 500,
+    },
+  })
+}
+
+function task(input: {
+  readonly id: string
+  readonly subject: string
+  readonly activeForm?: string
+  readonly status: Task["status"]
+  readonly owner?: string
+  readonly updatedAt: number
+}): Task {
+  return TaskSchema.parse({
+    version: 1,
+    id: input.id,
+    subject: input.subject,
+    description: "private task description",
+    activeForm: input.activeForm,
+    status: input.status,
+    owner: input.owner,
+    blocks: [],
+    blockedBy: [],
+    createdAt: 1,
+    updatedAt: input.updatedAt,
+  })
+}
+
+describe("team sidebar projection", () => {
+  it("#given global runtime teams #when projecting for a project #then it keeps only teams with a project session and preserves idle members", async () => {
+    // given
+    const currentRuntime = runtime({
+      teamRunId: CURRENT_RUN_ID,
+      teamName: "current-team",
+      leadSessionId: "ses-current-lead",
+      members: [
+        {
+          name: "lead",
+          sessionId: "ses-current-lead",
+          agentType: "leader",
+          status: "running",
+          pendingInjectedMessageIds: [],
+        },
+        {
+          name: "idle-member",
+          sessionId: "ses-other-member",
+          agentType: "general-purpose",
+          status: "idle",
+          pendingInjectedMessageIds: [],
+        },
+      ],
+    })
+    const otherRuntime = runtime({
+      teamRunId: OTHER_RUN_ID,
+      teamName: "other-team",
+      leadSessionId: "ses-other-lead",
+      members: [
+        {
+          name: "other-lead",
+          sessionId: "ses-other-lead",
+          agentType: "leader",
+          status: "running",
+          pendingInjectedMessageIds: [],
+        },
+      ],
+    })
+    const tasksByRunId = new Map<string, readonly Task[]>([
+      [CURRENT_RUN_ID, [task({ id: "task-current", subject: "Current subject", activeForm: "Reviewing current work", status: "in_progress", owner: "lead", updatedAt: 2 })]],
+      [OTHER_RUN_ID, [task({ id: "task-other", subject: "Other subject", status: "in_progress", owner: "other-lead", updatedAt: 2 })]],
+    ])
+
+    // when
+    const teams = await buildTeamsProjection({
+      projectDir: CURRENT_PROJECT,
+      sessions: [
+        { id: "ses-current-lead", directory: CURRENT_PROJECT },
+        { id: "ses-other-member", directory: OTHER_PROJECT },
+        { id: "ses-other-lead", directory: OTHER_PROJECT },
+      ],
+      runtimeProvider: {
+        listActiveTeams: async () => [
+          { teamRunId: CURRENT_RUN_ID, teamName: "current-team", status: "active", memberCount: 2, scope: "project" },
+          { teamRunId: OTHER_RUN_ID, teamName: "other-team", status: "active", memberCount: 1, scope: "project" },
+        ],
+        loadRuntimeState: async (teamRunId) => teamRunId === CURRENT_RUN_ID ? currentRuntime : otherRuntime,
+        listTasks: async (teamRunId) => tasksByRunId.get(teamRunId) ?? [],
+      },
+    })
+
+    // then
+    expect(teams).toEqual([
+      {
+        name: "current-team",
+        members: [
+          { name: "lead", status: "running", work: "Reviewing current work", sessionId: "ses-current-lead" },
+          { name: "idle-member", status: "idle", work: null, sessionId: "ses-other-member" },
+        ],
+      },
+    ])
+    expect(JSON.stringify(teams)).not.toContain("private task description")
+  })
+
+  it("#given assigned tasks with competing statuses and timestamps #when selecting member work #then it uses status priority then newest update then task id", () => {
+    // given
+    const tasks = [
+      task({ id: "task-pending", subject: "Pending work", status: "pending", owner: "member", updatedAt: 99 }),
+      task({ id: "task-claimed", subject: "Claimed work", status: "claimed", owner: "member", updatedAt: 99 }),
+      task({ id: "task-b", subject: "In progress B", activeForm: "Working B", status: "in_progress", owner: "member", updatedAt: 100 }),
+      task({ id: "task-a", subject: "In progress A", activeForm: "Working A", status: "in_progress", owner: "member", updatedAt: 100 }),
+      task({ id: "task-other", subject: "Other owner", status: "in_progress", owner: "other", updatedAt: 101 }),
+    ]
+
+    // when
+    const work = selectCurrentWork("member", tasks)
+
+    // then
+    expect(work).toBe("Working A")
+  })
+})

--- a/packages/omo-opencode/src/features/tui-sidebar/team-projection.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/team-projection.ts
@@ -1,0 +1,133 @@
+import { canonicalProjectDir } from "./mirror-path"
+import { assertNever } from "./state-types"
+import { listActiveTeams, loadRuntimeState } from "@oh-my-opencode/team-core/team-state-store/store"
+import { listTasks } from "@oh-my-opencode/team-core/team-tasklist/list"
+import type { TeamModeConfig } from "@oh-my-opencode/team-core/config"
+import type { TeamMemberRow, TeamRow } from "./state-types"
+import type { ActiveTeamSummary, RuntimeState, RuntimeStateMember, Task } from "@oh-my-opencode/team-core/types"
+
+export type TeamProjectSession = {
+  readonly id: string
+  readonly directory: string
+}
+
+export type TeamRuntimeProvider = {
+  readonly listActiveTeams: () => Promise<readonly ActiveTeamSummary[]>
+  readonly loadRuntimeState: (teamRunId: string) => Promise<RuntimeState>
+  readonly listTasks: (teamRunId: string) => Promise<readonly Task[]>
+}
+
+export type BuildTeamsProjectionInput = {
+  readonly projectDir: string
+  readonly sessions: readonly TeamProjectSession[]
+  readonly runtimeProvider: TeamRuntimeProvider
+}
+
+export function createTeamRuntimeProvider(config: TeamModeConfig): TeamRuntimeProvider {
+  return {
+    listActiveTeams: () => listActiveTeams(config),
+    loadRuntimeState: (teamRunId) => loadRuntimeState(teamRunId, config),
+    listTasks: (teamRunId) => listTasks(teamRunId, config),
+  }
+}
+
+export async function buildTeamsProjection(input: BuildTeamsProjectionInput): Promise<readonly TeamRow[]> {
+  const sessionsById = new Map(input.sessions.map((session) => [session.id, session]))
+  const projectSessionIds = new Set(
+    input.sessions
+      .filter((session) => canonicalProjectDir(session.directory) === canonicalProjectDir(input.projectDir))
+      .map((session) => session.id),
+  )
+  const activeTeams = await input.runtimeProvider.listActiveTeams()
+  const runtimes = await Promise.all(activeTeams.map((team) => input.runtimeProvider.loadRuntimeState(team.teamRunId)))
+  const teams: Array<TeamRow | null> = await Promise.all(
+    runtimes.map(async (runtime) => {
+      if (!isRelevantToProject(runtime, projectSessionIds)) {
+        return null
+      }
+
+      const tasks = await input.runtimeProvider.listTasks(runtime.teamRunId)
+      return {
+        name: runtime.teamName,
+        members: runtime.members.map((member) => toTeamMemberRow(member, tasks, sessionsById)),
+      }
+    }),
+  )
+
+  return teams
+    .filter((team): team is TeamRow => team !== null)
+    .toSorted((left, right) => left.name.localeCompare(right.name))
+}
+
+export function selectCurrentWork(memberName: string, tasks: readonly Task[]): string | null {
+  const task = tasks
+    .filter((candidate) => candidate.owner === memberName && isCurrentTask(candidate))
+    .toSorted(compareCurrentTasks)[0]
+
+  return task?.activeForm ?? task?.subject ?? null
+}
+
+function isRelevantToProject(runtime: RuntimeState, projectSessionIds: ReadonlySet<string>): boolean {
+  if (runtime.leadSessionId !== undefined && projectSessionIds.has(runtime.leadSessionId)) {
+    return true
+  }
+
+  return runtime.members.some((member) => member.sessionId !== undefined && projectSessionIds.has(member.sessionId))
+}
+
+function toTeamMemberRow(
+  member: RuntimeStateMember,
+  tasks: readonly Task[],
+  sessionsById: ReadonlyMap<string, TeamProjectSession>,
+): TeamMemberRow {
+  return {
+    name: member.name,
+    status: member.status,
+    work: selectCurrentWork(member.name, tasks),
+    sessionId: member.sessionId !== undefined && sessionsById.has(member.sessionId) ? member.sessionId : null,
+  }
+}
+
+function isCurrentTask(task: Task): boolean {
+  switch (task.status) {
+    case "in_progress":
+    case "claimed":
+    case "pending":
+      return true
+    case "completed":
+    case "deleted":
+      return false
+    default:
+      return assertNever(task.status)
+  }
+}
+
+function compareCurrentTasks(left: Task, right: Task): number {
+  const statusOrder = currentTaskStatusOrder(left.status) - currentTaskStatusOrder(right.status)
+  if (statusOrder !== 0) {
+    return statusOrder
+  }
+
+  const updatedAtOrder = right.updatedAt - left.updatedAt
+  if (updatedAtOrder !== 0) {
+    return updatedAtOrder
+  }
+
+  return left.id.localeCompare(right.id)
+}
+
+function currentTaskStatusOrder(status: Task["status"]): number {
+  switch (status) {
+    case "in_progress":
+      return 0
+    case "claimed":
+      return 1
+    case "pending":
+      return 2
+    case "completed":
+    case "deleted":
+      return Number.POSITIVE_INFINITY
+    default:
+      return assertNever(status)
+  }
+}

--- a/packages/omo-opencode/src/features/tui-sidebar/team-section.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/team-section.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test"
+
+import { LABEL_MAX } from "./constants"
+import { teamLines, teamNodes } from "./team-section"
+import type { ViewNode } from "./element-helpers"
+import type { TeamsState } from "./state-types"
+
+const theme = {
+  accent: "accent",
+  borderSubtle: "border",
+  error: "error",
+  info: "info",
+  success: "success",
+  text: "text",
+  textMuted: "muted",
+  warning: "warning",
+}
+
+function isMouseHandler(value: unknown): value is (event: { stopPropagation: () => void }) => void {
+  return typeof value === "function"
+}
+
+function memberRows(nodes: readonly ViewNode[]): readonly ViewNode[] {
+  return nodes[0]?.children?.slice(1) ?? []
+}
+
+describe("team sidebar section", () => {
+  it("#given expanded teams with valid and missing member sessions #when rendering #then it shows the count and navigates only valid rows without bubbling", () => {
+    // given
+    const teams: TeamsState = {
+      kind: "list",
+      teams: [
+        {
+          name: "sidebar-team",
+          members: [
+            { name: "running", status: "running", work: "Implementing sidebar", sessionId: "ses-running" },
+            { name: "idle", status: "idle", work: null, sessionId: null },
+          ],
+        },
+      ],
+    }
+    const navigatedSessionIds: string[] = []
+    let toggleCount = 0
+
+    // when
+    const nodes = teamNodes(teams, theme, {
+      collapsed: false,
+      onToggle: () => {
+        toggleCount += 1
+      },
+      onNavigateSession: (sessionId) => {
+        navigatedSessionIds.push(sessionId)
+      },
+    })
+    const [header, navigableRow, idleRow] = nodes[0]?.children ?? []
+    const navigateHandler = navigableRow?.props.onMouseDown
+    const toggleHandler = header?.props.onMouseDown
+    let propagationStopped = false
+
+    // then
+    expect(nodes).toHaveLength(1)
+    expect(header?.text).toBeUndefined()
+    expect(JSON.stringify(nodes)).toContain("Team (2)")
+    expect(memberRows(nodes)).toHaveLength(2)
+    expect(idleRow?.props.onMouseDown).toBeUndefined()
+    if (!isMouseHandler(toggleHandler)) {
+      throw new Error("team header was not interactive")
+    }
+    if (!isMouseHandler(navigateHandler)) {
+      throw new Error("member row was not interactive")
+    }
+    toggleHandler({ stopPropagation: () => undefined })
+    navigateHandler({
+      stopPropagation: () => {
+        propagationStopped = true
+      },
+    })
+    expect(toggleCount).toBe(1)
+    expect(propagationStopped).toBe(true)
+    expect(navigatedSessionIds).toEqual(["ses-running"])
+  })
+
+  it("#given collapsed teams #when rendering #then it keeps only the foldable Team header", () => {
+    // given
+    const teams: TeamsState = {
+      kind: "list",
+      teams: [{ name: "sidebar-team", members: [{ name: "idle", status: "idle", work: null, sessionId: null }] }],
+    }
+
+    // when
+    const nodes = teamNodes(teams, theme, {
+      collapsed: true,
+      onToggle: () => undefined,
+      onNavigateSession: () => undefined,
+    })
+
+    // then
+    expect(memberRows(nodes)).toHaveLength(0)
+    expect(JSON.stringify(nodes)).toContain("Team (1)")
+  })
+
+  it("#given long Team member fields #when rendering a member row #then the full row stays within the sidebar label bound", () => {
+    // given
+    const teams: TeamsState = {
+      kind: "list",
+      teams: [{
+        name: "team-name-that-is-far-too-long",
+        members: [{
+          name: "member-name-that-is-far-too-long",
+          status: "running",
+          work: "current work that is also far too long",
+          sessionId: null,
+        }],
+      }],
+    }
+
+    // when
+    const memberLine = teamLines(teams)[1]
+
+    // then
+    expect(memberLine?.length).toBeLessThanOrEqual(LABEL_MAX)
+    expect(memberLine).toEndWith("...")
+  })
+})

--- a/packages/omo-opencode/src/features/tui-sidebar/team-section.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/team-section.ts
@@ -1,0 +1,118 @@
+import type { MouseEvent } from "@opentui/core"
+
+import { LABEL_MAX } from "./constants"
+import { box, text } from "./element-helpers"
+import type { ViewNode } from "./element-helpers"
+import { assertNever } from "./state-types"
+import type { TeamMemberRow, TeamsState } from "./state-types"
+
+type ThemeLike = {
+  readonly error?: unknown
+  readonly text?: unknown
+  readonly textMuted?: unknown
+  readonly warning?: unknown
+  readonly success?: unknown
+  readonly info?: unknown
+  readonly accent?: unknown
+  readonly borderSubtle?: unknown
+}
+
+export type TeamSectionInteraction = {
+  readonly collapsed: boolean
+  readonly onToggle: () => void
+  readonly onNavigateSession: (sessionId: string) => void
+}
+
+export function teamNodes(
+  teams: TeamsState,
+  theme: ThemeLike,
+  interaction?: TeamSectionInteraction,
+): ViewNode[] {
+  switch (teams.kind) {
+    case "none":
+      return []
+    case "list":
+      return [
+        box({ borderStyle: "single", borderColor: theme.borderSubtle, flexDirection: "column", padding: 1 }, [
+          teamHeader(teams, theme, interaction),
+          ...(interaction?.collapsed ? [] : teams.teams.flatMap((team) => team.members.map((member) => teamMemberNode(team.name, member, theme, interaction)))),
+        ]),
+      ]
+    default:
+      return assertNever(teams)
+  }
+}
+
+export function teamLines(teams: TeamsState): string[] {
+  switch (teams.kind) {
+    case "none":
+      return []
+    case "list":
+      return [
+        `Team (${memberCount(teams)})`,
+        ...teams.teams.flatMap((team) => team.members.map((member) => teamMemberLine(team.name, member))),
+      ]
+    default:
+      return assertNever(teams)
+  }
+}
+
+function teamHeader(teams: Extract<TeamsState, { readonly kind: "list" }>, theme: ThemeLike, interaction?: TeamSectionInteraction): ViewNode {
+  return box(
+    interaction === undefined ? {} : { onMouseDown: interaction.onToggle },
+    [text({ fg: theme.info }, `Team (${memberCount(teams)}) ${interaction?.collapsed ? ">" : "v"}`)],
+  )
+}
+
+function teamMemberNode(
+  teamName: string,
+  member: TeamMemberRow,
+  theme: ThemeLike,
+  interaction?: TeamSectionInteraction,
+): ViewNode {
+  const content = teamMemberLine(teamName, member)
+  const sessionId = member.sessionId
+  if (sessionId === null || interaction === undefined) {
+    return text({ fg: memberStatusColor(member, theme) }, content)
+  }
+
+  return box(
+    {
+      onMouseDown: (event: MouseEvent): void => {
+        event.stopPropagation()
+        interaction.onNavigateSession(sessionId)
+      },
+    },
+    [text({ fg: memberStatusColor(member, theme) }, content)],
+  )
+}
+
+function memberCount(teams: Extract<TeamsState, { readonly kind: "list" }>): number {
+  return teams.teams.reduce((count, team) => count + team.members.length, 0)
+}
+
+function teamMemberLine(teamName: string, member: TeamMemberRow): string {
+  const currentWork = member.work === null ? "" : ` ${member.work}`
+  return truncate(`${teamName}/${member.name} ${member.status}${currentWork}`)
+}
+
+function memberStatusColor(member: TeamMemberRow, theme: ThemeLike): unknown {
+  switch (member.status) {
+    case "running":
+      return theme.success
+    case "errored":
+      return theme.error
+    case "pending":
+      return theme.warning
+    case "idle":
+    case "completed":
+    case "shutdown_approved":
+      return theme.textMuted
+    default:
+      return assertNever(member.status)
+  }
+}
+
+function truncate(value: string): string {
+  return value.length <= LABEL_MAX ? value : `${value.slice(0, LABEL_MAX - 3)}...`
+}

--- a/packages/omo-opencode/src/shared/write-file-atomically.test.ts
+++ b/packages/omo-opencode/src/shared/write-file-atomically.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, statSync } from "fs"
-import { join } from "path"
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, statSync, readdirSync } from "fs"
+import { basename, join } from "path"
 import { tmpdir } from "os"
 import { writeFileAtomically } from "./write-file-atomically"
 
 const testDir = join(tmpdir(), "write-file-atomically-test-" + Date.now())
+
+function temporaryFilesFor(filePath: string): readonly string[] {
+  const prefix = `${basename(filePath)}.`
+  return readdirSync(testDir).filter((name) => name.startsWith(prefix) && name.endsWith(".tmp"))
+}
 
 beforeEach(() => {
   mkdirSync(testDir, { recursive: true })
@@ -41,7 +46,22 @@ describe("writeFileAtomically", () => {
     // then
     expect(existsSync(filePath)).toBe(true)
     expect(readFileSync(filePath, "utf-8")).toBe(newContent)
-    expect(existsSync(`${filePath}.tmp`)).toBe(false)
+    expect(temporaryFilesFor(filePath)).toEqual([])
+  })
+
+  it("#given a reentrant write to the same target #when the outer write renames #then both writes complete without sharing a temporary path", () => {
+    // given
+    const filePath = join(testDir, "reentrant-write.txt")
+
+    // when
+    writeFileAtomically(filePath, "outer", {
+      beforeRenameSync: () => {
+        writeFileAtomically(filePath, "inner")
+      },
+    })
+
+    // then
+    expect(readFileSync(filePath, "utf-8")).toBe("outer")
   })
 
   it("#given private mode #when writeFileAtomically called #then temp and final files use that mode", () => {
@@ -108,5 +128,32 @@ describe("writeFileAtomically", () => {
         },
       }),
     ).toThrow("EIO")
+    expect(temporaryFilesFor(filePath)).toEqual([])
+  })
+
+  it("#given the before-rename hook fails #when writeFileAtomically is called #then it removes its unique temporary file", () => {
+    // given
+    const filePath = join(testDir, "before-rename-error.txt")
+
+    // when/then
+    expect(() => writeFileAtomically(filePath, "content", {
+      beforeRenameSync: () => {
+        throw new Error("before rename failed")
+      },
+    })).toThrow("before rename failed")
+    expect(temporaryFilesFor(filePath)).toEqual([])
+  })
+
+  it("#given rename fails #when writeFileAtomically is called #then it removes its unique temporary file", () => {
+    // given
+    const filePath = join(testDir, "rename-error.txt")
+
+    // when/then
+    expect(() => writeFileAtomically(filePath, "content", {
+      renameSync: () => {
+        throw new Error("rename failed")
+      },
+    })).toThrow("rename failed")
+    expect(temporaryFilesFor(filePath)).toEqual([])
   })
 })

--- a/packages/omo-opencode/src/shared/write-file-atomically.ts
+++ b/packages/omo-opencode/src/shared/write-file-atomically.ts
@@ -4,9 +4,11 @@ import {
   type fsyncSync as FsyncSync,
   openSync,
   renameSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs"
+import { randomUUID } from "node:crypto"
 
 import { tolerantFsyncSync } from "./tolerant-fsync"
 
@@ -17,38 +19,44 @@ export function writeFileAtomically(
     fsyncSync?: typeof FsyncSync
     mode?: number
     beforeRenameSync?: (tempPath: string) => void
+    renameSync?: typeof renameSync
   } = {},
 ): void {
-  const tempPath = `${filePath}.tmp`
+  const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`
   const mode = deps.mode
-  writeFileSync(tempPath, content, { encoding: "utf-8", mode })
-  if (mode !== undefined) {
-    chmodSync(tempPath, mode)
-  }
-  const tempFileDescriptor = openSync(tempPath, "r+")
   try {
-    tolerantFsyncSync(tempFileDescriptor, `writeFileAtomically:${filePath}`, deps.fsyncSync)
-  } finally {
-    closeSync(tempFileDescriptor)
-  }
-
-  try {
-    deps.beforeRenameSync?.(tempPath)
-    renameSync(tempPath, filePath)
-  } catch (error) {
-    const isWindows = process.platform === "win32"
-    const isPermissionError =
-      error instanceof Error &&
-      (error.message.includes("EPERM") || error.message.includes("EACCES"))
-
-    if (isWindows && isPermissionError) {
-      unlinkSync(filePath)
-      renameSync(tempPath, filePath)
-    } else {
-      throw error
+    writeFileSync(tempPath, content, { encoding: "utf-8", mode })
+    if (mode !== undefined) {
+      chmodSync(tempPath, mode)
     }
-  }
-  if (mode !== undefined) {
-    chmodSync(filePath, mode)
+    const tempFileDescriptor = openSync(tempPath, "r+")
+    try {
+      tolerantFsyncSync(tempFileDescriptor, `writeFileAtomically:${filePath}`, deps.fsyncSync)
+    } finally {
+      closeSync(tempFileDescriptor)
+    }
+
+    const renameFileSync = deps.renameSync ?? renameSync
+    try {
+      deps.beforeRenameSync?.(tempPath)
+      renameFileSync(tempPath, filePath)
+    } catch (error) {
+      const isWindows = process.platform === "win32"
+      const isPermissionError =
+        error instanceof Error &&
+        (error.message.includes("EPERM") || error.message.includes("EACCES"))
+
+      if (isWindows && isPermissionError) {
+        unlinkSync(filePath)
+        renameFileSync(tempPath, filePath)
+      } else {
+        throw error
+      }
+    }
+    if (mode !== undefined) {
+      chmodSync(filePath, mode)
+    }
+  } finally {
+    rmSync(tempPath, { force: true })
   }
 }

--- a/packages/omo-opencode/src/tui.test.ts
+++ b/packages/omo-opencode/src/tui.test.ts
@@ -5,9 +5,9 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import type { TuiPluginApi, TuiPluginMeta, TuiSlotPlugin } from "@opencode-ai/plugin/tui"
+import type { TuiSlotPlugin } from "@opencode-ai/plugin/tui"
 
-import tuiModule, { handleTuiPollError } from "./tui"
+import tuiModule, { handleTuiPollError, materializeReactive, navigateToTeamSession } from "./tui"
 
 type SolidNode = {
   readonly tag: string
@@ -89,7 +89,7 @@ describe("TUI sidebar polling", () => {
     } satisfies SidebarApiForTest
 
     // when
-    await tuiModule.tui(api as unknown as TuiPluginApi, undefined, {} as TuiPluginMeta)
+    await Reflect.apply(tuiModule.tui, undefined, [api, undefined, {}])
 
     // then
     expect(calls).toEqual(["register", "render"])
@@ -122,5 +122,51 @@ describe("TUI sidebar polling", () => {
     const thrownValue = "bad poll state"
 
     expect(() => handleTuiPollError(thrownValue)).toThrow(thrownValue)
+  })
+
+  it("#given a Team member session id #when navigating #then it opens the OpenCode session route", () => {
+    // given
+    const navigations: Array<{ readonly name: string; readonly params: Record<string, unknown> | undefined }> = []
+
+    // when
+    navigateToTeamSession(
+      {
+        navigate: (name, params): void => {
+          navigations.push({ name, params })
+        },
+      },
+      "ses-member",
+    )
+
+    // then
+    expect(navigations).toEqual([{ name: "session", params: { sessionID: "ses-member" } }])
+  })
+})
+
+describe("reactive sidebar materialization", () => {
+  it("#given a changing node accessor #when the sidebar root is created #then node construction remains reactive", () => {
+    // given
+    let readCount = 0
+    const solid = {
+      createElement: (tag: string): SolidNode => ({ tag, props: {}, children: [] }),
+      insert: (parent: SolidNode, child: unknown): void => {
+        parent.children.push(child)
+      },
+      setProp: (node: SolidNode, name: string, value: unknown): void => {
+        node.props[name] = value
+      },
+    }
+
+    // when
+    const root = materializeReactive(() => {
+      readCount += 1
+      return []
+    }, solid)
+
+    // then
+    expect(readCount).toBe(0)
+    expect(root.children[0]).toBeFunction()
+    Reflect.apply(root.children[0] as () => SolidNode, undefined, [])
+    expect(readCount).toBe(1)
   })
 })

--- a/packages/omo-opencode/src/tui.ts
+++ b/packages/omo-opencode/src/tui.ts
@@ -1,8 +1,8 @@
-import type { TuiPluginModule } from "@opencode-ai/plugin/tui"
+import type { TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
 
 import { computeView, viewKey } from "./features/tui-sidebar/compute-view"
 import { POLL_INTERVAL_MS } from "./features/tui-sidebar/constants"
-import { deriveAgents, deriveConfig, deriveJobBoard, deriveLoop, deriveRoster } from "./features/tui-sidebar/derivers"
+import { deriveAgents, deriveConfig, deriveJobBoard, deriveLoop, deriveRoster, deriveTeams } from "./features/tui-sidebar/derivers"
 import type { ViewNode } from "./features/tui-sidebar/element-helpers"
 import { readMirror } from "./features/tui-sidebar/mirror-io"
 import { buildViewNodes } from "./features/tui-sidebar/render-view"
@@ -12,7 +12,7 @@ import { log } from "./shared/logger"
 
 type SolidRuntime<Node> = {
   readonly createElement: (tag: string) => Node
-  readonly insert: (parent: Node, child: Node | string) => unknown
+  readonly insert: (parent: Node, child: Node | string | (() => Node)) => unknown
   readonly setProp: (node: Node, name: string, value: unknown) => unknown
 }
 
@@ -49,6 +49,13 @@ function materialize<Node>(nodes: readonly ViewNode[], solid: SolidRuntime<Node>
   for (const node of nodes) {
     solid.insert(root, materializeNode(node, solid))
   }
+  return root
+}
+
+export function materializeReactive<Node>(nodes: () => readonly ViewNode[], solid: SolidRuntime<Node>): Node {
+  const root = solid.createElement("box")
+  solid.setProp(root, "flexDirection", "column")
+  solid.insert(root, () => materialize(nodes(), solid))
   return root
 }
 
@@ -100,7 +107,15 @@ async function readView(directory: string): Promise<SidebarView> {
     agents: deriveAgents(mirror),
     jobs: deriveJobBoard(mirror),
     loop: deriveLoop(mirror),
+    teams: deriveTeams(mirror),
   })
+}
+
+export function navigateToTeamSession(
+  route: Pick<TuiPluginApi["route"], "navigate">,
+  sessionID: string,
+): void {
+  route.navigate("session", { sessionID })
 }
 
 export function handleTuiPollError(
@@ -127,8 +142,10 @@ const module: TuiPluginModule = {
       return
     }
 
-    let currentView = await readView(directory)
-    let currentKey = viewKey(currentView)
+    const { createSignal } = await import("solid-js")
+    const [currentView, setCurrentView] = createSignal(await readView(directory))
+    const [teamCollapsed, setTeamCollapsed] = createSignal(false)
+    let currentKey = viewKey(currentView())
     let disposed = false
     let inFlight = false
     let timer: ReturnType<typeof setTimeout> | null = null
@@ -140,7 +157,13 @@ const module: TuiPluginModule = {
       requestRender: () => {
         api.renderer.requestRender()
       },
-      renderSidebar: () => materialize(buildViewNodes(currentView, api.theme.current), solid),
+      renderSidebar: () => materializeReactive(() => buildViewNodes(currentView(), api.theme.current, {
+        collapsed: teamCollapsed(),
+        onToggle: () => {
+          setTeamCollapsed((collapsed) => !collapsed)
+        },
+        onNavigateSession: (sessionID) => navigateToTeamSession(api.route, sessionID),
+      }), solid),
     })
 
     const schedule = (): void => {
@@ -157,12 +180,15 @@ const module: TuiPluginModule = {
         const nextView = await readView(directory)
         const nextKey = viewKey(nextView)
         if (nextKey !== currentKey) {
-          currentView = nextView
+          setCurrentView(nextView)
           currentKey = nextKey
-          api.renderer.requestRender()
         }
       } catch (error) {
-        handleTuiPollError(error)
+        if (error instanceof Error) {
+          handleTuiPollError(error)
+        } else {
+          throw error
+        }
       } finally {
         inFlight = false
         if (!disposed) schedule()

--- a/script/build.ts
+++ b/script/build.ts
@@ -49,7 +49,7 @@ type BuildNode = {
 	deps: string[];
 };
 
-const OPENTUI_EXTERNALS = ["@opentui/core", "@opentui/keymap", "@opentui/solid"];
+const OPENTUI_EXTERNALS = ["@opentui/core", "@opentui/keymap", "@opentui/solid", "solid-js"];
 
 const nodes: BuildNode[] = [
 	{ id: "git-bash-mcp", command: "bun", args: ["run", "build:git-bash-mcp"], deps: [] },


### PR DESCRIPTION
## Summary

Add a privacy-safe Team section to the OpenCode TUI sidebar. The sidebar now projects active Team members and current work from the local mirror, supports collapse/reopen, and navigates member rows to their sessions.

## Changes
- Extend the additive mirror schema with Team state and project live runtime records into bounded sidebar rows.
- Wire Team snapshots through manager, derivation, view, and rendering layers.
- Make plugin sidebar content Solid-reactive so polling and mouse-driven folding update the live tree.
- Clean failed atomic-write temporary files and preserve SDK session-list binding/unlimited scans.

## QA & Evidence
- Focused sidebar suite: 90 pass, 0 fail.
- Typecheck: `bun run typecheck` passed.
- Build: `bun run build` passed.
- TypeScript no-excuse audit: 35 files, no violations.
- Live isolated OpenCode QA: `.omo/evidence/20260718-team-tui-sidebar/` proved local mirror generation, active work rendering, private-description omission, mouse collapse/reopen, member-session navigation, and unchanged host DB count.

## Risks & Residuals
- Full local `bun test` reached 11,682 pass / 3 skip / 3 unrelated failures because a shared `/tmp/.git` directory made existing project-root tests detect `/tmp`; affected feature tests pass in the focused suite.
- The LSP diagnostics tool was cwd-restricted from the sibling worktree; repository `tsgo` typecheck passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live Team section to the TUI sidebar that shows active members and their current work, with collapse/expand and session navigation. The sidebar is now reactive and privacy-safe by projecting team runtime into the local mirror.

- **New Features**
  - Show active teams/members with status and current work; collapsible header; click a member to open their session.
  - Project team runtime from `@oh-my-opencode/team-core` into the mirror; filter to current project; omit private task descriptions.
  - Add `teams` to the snapshot and view; update `viewKey` when team data changes.
  - Use `solid-js` signals to keep the sidebar live during polling and mouse toggles; gate by `team_mode.enabled`; scan up to 500 sessions to include relevant ones.

- **Bug Fixes**
  - Atomic writes now use unique temp files and always clean them up on success or failure, preventing orphaned `.tmp` files and handling reentrant writes.

<sup>Written for commit 0628f14e6536d7f0cb456d64ae9319e018dde494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

