### PR TITLE
feat(start-work): auto-scaffold notepad files on plan commit

### DIFF
--- a/packages/omo-opencode/src/hooks/sisyphus-junior-notepad/constants.ts
+++ b/packages/omo-opencode/src/hooks/sisyphus-junior-notepad/constants.ts
@@ -10,7 +10,7 @@ NOTEPAD PATH: .omo/notepads/{plan-name}/
 - problems.md: Record unresolved issues, technical debt
 
 You SHOULD append findings to notepad files after completing work.
-IMPORTANT: Always APPEND to notepad files - never overwrite or use Edit tool.
+Notepad files are auto-scaffolded by /start-work. APPEND only - use the \`edit\` tool (match-and-insert after the last line) or \`bash\` \`>>\`. Never use the \`write\` tool (blocked by notepad-write-guard) and never overwrite.
 
 ## Plan Location (subagent: READ ONLY)
 PLAN PATH: .omo/plans/{plan-name}.md

--- a/packages/omo-opencode/src/hooks/start-work/context-info-builder.test.ts
+++ b/packages/omo-opencode/src/hooks/start-work/context-info-builder.test.ts
@@ -412,4 +412,109 @@ describe("buildStartWorkContextInfo", () => {
     }
     expect(workIds).toContain(workC.work_id)
   })
+
+  describe("notepad scaffolding side-effect", () => {
+    test("#given single incomplete plan and no active work #when buildStartWorkContextInfo auto-selects it #then scaffolds .omo/notepads/<plan-basename>/{learnings,decisions,issues,problems}.md", () => {
+      // given
+      writePlan("auto-scaffold-plan", "## TODOs\n- [ ] 1. Auto task")
+
+      // when
+      buildStartWorkContextInfo({
+        ctx: createPluginInput(),
+        explicitPlanName: null,
+        existingState: null,
+        sessionId: "session-current",
+        timestamp: "2026-05-11T00:00:00.000Z",
+        activeAgent: "atlas",
+        worktreePath: undefined,
+        worktreeBlock: "",
+      })
+
+      // then
+      const notepadDir = join(testDirectory, ".omo", "notepads", "auto-scaffold-plan")
+      expect(existsSync(join(notepadDir, "learnings.md"))).toBe(true)
+      expect(existsSync(join(notepadDir, "decisions.md"))).toBe(true)
+      expect(existsSync(join(notepadDir, "issues.md"))).toBe(true)
+      expect(existsSync(join(notepadDir, "problems.md"))).toBe(true)
+    })
+
+    test("#given explicit plan name matching a plan file #when built with explicitPlanName #then scaffolds notepad for that plan", () => {
+      // given
+      writePlan("explicit-scaffold-plan", "## TODOs\n- [ ] 1. Explicit task")
+
+      // when
+      buildStartWorkContextInfo({
+        ctx: createPluginInput(),
+        explicitPlanName: "explicit-scaffold-plan",
+        existingState: null,
+        sessionId: "session-current",
+        timestamp: "2026-05-11T00:00:00.000Z",
+        activeAgent: "atlas",
+        worktreePath: undefined,
+        worktreeBlock: "",
+      })
+
+      // then
+      const notepadDir = join(testDirectory, ".omo", "notepads", "explicit-scaffold-plan")
+      expect(existsSync(join(notepadDir, "learnings.md"))).toBe(true)
+      expect(existsSync(join(notepadDir, "decisions.md"))).toBe(true)
+      expect(existsSync(join(notepadDir, "issues.md"))).toBe(true)
+      expect(existsSync(join(notepadDir, "problems.md"))).toBe(true)
+    })
+
+    test("#given existing active boulder state for a plan #when resume path taken #then scaffolds notepad (idempotent - files appear)", () => {
+      // given
+      const planPath = writePlan("resume-scaffold-plan", "## TODOs\n- [ ] 1. Resume task")
+      const initialState = createBoulderState(planPath, "session-a", "atlas", "/tmp/worktree-resume")
+      writeBoulderState(testDirectory, initialState)
+
+      // when
+      buildStartWorkContextInfo({
+        ctx: createPluginInput(),
+        explicitPlanName: null,
+        existingState: readExistingState(),
+        sessionId: "session-current",
+        timestamp: "2026-05-11T00:00:00.000Z",
+        activeAgent: "atlas",
+        worktreePath: undefined,
+        worktreeBlock: "",
+      })
+
+      // then
+      const notepadDir = join(testDirectory, ".omo", "notepads", "resume-scaffold-plan")
+      expect(existsSync(join(notepadDir, "learnings.md"))).toBe(true)
+      expect(existsSync(join(notepadDir, "decisions.md"))).toBe(true)
+      expect(existsSync(join(notepadDir, "issues.md"))).toBe(true)
+      expect(existsSync(join(notepadDir, "problems.md"))).toBe(true)
+    })
+
+    test("#given multiple active works #when built (ask-user branch) #then does NOT create any notepad files", () => {
+      // given
+      const planAPath = writePlan("multi-scaffold-plan-a", "## TODOs\n- [ ] 1. Multi A")
+      const planBPath = writePlan("multi-scaffold-plan-b", "## TODOs\n- [ ] 1. Multi B")
+      const initialState = createBoulderState(planAPath, "session-a", "atlas", "/tmp/worktree-multi-a")
+      writeBoulderState(testDirectory, initialState)
+      addBoulderWork(testDirectory, {
+        planPath: planBPath,
+        sessionId: "session-b",
+        agent: "atlas",
+        worktreePath: "/tmp/worktree-multi-b",
+      })
+
+      // when
+      buildStartWorkContextInfo({
+        ctx: createPluginInput(),
+        explicitPlanName: null,
+        existingState: readExistingState(),
+        sessionId: "session-current",
+        timestamp: "2026-05-11T00:00:00.000Z",
+        activeAgent: "atlas",
+        worktreePath: undefined,
+        worktreeBlock: "",
+      })
+
+      // then
+      expect(existsSync(join(testDirectory, ".omo", "notepads"))).toBe(false)
+    })
+  })
 })

--- a/packages/omo-opencode/src/hooks/start-work/context-info-formatters.ts
+++ b/packages/omo-opencode/src/hooks/start-work/context-info-formatters.ts
@@ -7,6 +7,7 @@ import {
 } from "../../features/boulder-state"
 import type { BoulderState, BoulderWorkResumeOption } from "../../features/boulder-state"
 import { createWorktreeActiveBlock } from "./worktree-block"
+import { ensureNotepadScaffold } from "./notepad-scaffold"
 
 export function buildAutoSelectedPlanContextInfoOnly(params: {
   readonly planPath: string
@@ -119,6 +120,8 @@ Looking for new plans...`
   } else if (!sessionAlreadyTracked) {
     appendSessionId(directory, sessionId)
   }
+
+  ensureNotepadScaffold({ directory, planName: existingState.plan_name })
 
   const worktreeDisplay = effectiveWorktree
     ? worktreeBlock || createWorktreeActiveBlock(effectiveWorktree)

--- a/packages/omo-opencode/src/hooks/start-work/notepad-scaffold.test.ts
+++ b/packages/omo-opencode/src/hooks/start-work/notepad-scaffold.test.ts
@@ -1,0 +1,159 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { randomUUID } from "node:crypto"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { ensureNotepadScaffold } from "./notepad-scaffold"
+
+describe("ensureNotepadScaffold", () => {
+  let testDirectory = ""
+
+  beforeEach(() => {
+    testDirectory = join(tmpdir(), `notepad-scaffold-${randomUUID()}`)
+    mkdirSync(testDirectory, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (existsSync(testDirectory)) {
+      rmSync(testDirectory, { recursive: true, force: true })
+    }
+  })
+
+  test("#given fresh temp dir #when ensureNotepadScaffold called #then creates all 4 notepad files with headers", () => {
+    // given
+    const directory = testDirectory
+
+    // when
+    const result = ensureNotepadScaffold({
+      directory,
+      planName: "alpha",
+      timestamp: "2026-01-01T00:00:00Z",
+    })
+
+    // then
+    const notepadDir = join(directory, ".omo", "notepads", "alpha")
+
+    expect(existsSync(join(notepadDir, "learnings.md"))).toBe(true)
+    expect(existsSync(join(notepadDir, "decisions.md"))).toBe(true)
+    expect(existsSync(join(notepadDir, "issues.md"))).toBe(true)
+    expect(existsSync(join(notepadDir, "problems.md"))).toBe(true)
+
+    const learnings = readFileSync(join(notepadDir, "learnings.md"), "utf8")
+    const decisions = readFileSync(join(notepadDir, "decisions.md"), "utf8")
+    const issues = readFileSync(join(notepadDir, "issues.md"), "utf8")
+    const problems = readFileSync(join(notepadDir, "problems.md"), "utf8")
+
+    expect(learnings).toContain("# Learnings \u2014 alpha")
+    expect(decisions).toContain("# Decisions \u2014 alpha")
+    expect(issues).toContain("# Issues \u2014 alpha")
+    expect(problems).toContain("# Problems \u2014 alpha")
+
+    expect(learnings).toContain("Auto-scaffolded by /start-work")
+    expect(decisions).toContain("Auto-scaffolded by /start-work")
+    expect(issues).toContain("Auto-scaffolded by /start-work")
+    expect(problems).toContain("Auto-scaffolded by /start-work")
+
+    expect(result.created).toContain("learnings.md")
+    expect(result.created).toContain("decisions.md")
+    expect(result.created).toContain("issues.md")
+    expect(result.created).toContain("problems.md")
+  })
+
+  test("#given already-scaffolded dir #when called again #then all 4 files unchanged (idempotent)", () => {
+    // given
+    const directory = testDirectory
+
+    // when
+    ensureNotepadScaffold({
+      directory,
+      planName: "alpha",
+      timestamp: "2026-01-01T00:00:00Z",
+    })
+
+    const notepadDir = join(directory, ".omo", "notepads", "alpha")
+    const learningsBefore = readFileSync(join(notepadDir, "learnings.md"), "utf8")
+    const decisionsBefore = readFileSync(join(notepadDir, "decisions.md"), "utf8")
+    const issuesBefore = readFileSync(join(notepadDir, "issues.md"), "utf8")
+    const problemsBefore = readFileSync(join(notepadDir, "problems.md"), "utf8")
+
+    const result = ensureNotepadScaffold({
+      directory,
+      planName: "alpha",
+      timestamp: "2026-01-01T00:00:00Z",
+    })
+
+    // then
+    const learningsAfter = readFileSync(join(notepadDir, "learnings.md"), "utf8")
+    const decisionsAfter = readFileSync(join(notepadDir, "decisions.md"), "utf8")
+    const issuesAfter = readFileSync(join(notepadDir, "issues.md"), "utf8")
+    const problemsAfter = readFileSync(join(notepadDir, "problems.md"), "utf8")
+
+    expect(learningsAfter).toBe(learningsBefore)
+    expect(decisionsAfter).toBe(decisionsBefore)
+    expect(issuesAfter).toBe(issuesBefore)
+    expect(problemsAfter).toBe(problemsBefore)
+
+    expect(result.created).toEqual([])
+    expect(result.skipped).toContain("learnings.md")
+    expect(result.skipped).toContain("decisions.md")
+    expect(result.skipped).toContain("issues.md")
+    expect(result.skipped).toContain("problems.md")
+  })
+
+  test("#given dir with learnings.md and decisions.md pre-existing #when called #then creates only issues.md and problems.md; leaves pre-existing untouched", () => {
+    // given
+    const directory = testDirectory
+    const notepadDir = join(directory, ".omo", "notepads", "alpha")
+    mkdirSync(notepadDir, { recursive: true })
+    writeFileSync(join(notepadDir, "learnings.md"), "ORIGINAL LEARNINGS")
+    writeFileSync(join(notepadDir, "decisions.md"), "ORIGINAL DECISIONS")
+
+    // when
+    const result = ensureNotepadScaffold({
+      directory,
+      planName: "alpha",
+      timestamp: "2026-01-01T00:00:00Z",
+    })
+
+    // then
+    const learnings = readFileSync(join(notepadDir, "learnings.md"), "utf8")
+    const decisions = readFileSync(join(notepadDir, "decisions.md"), "utf8")
+
+    expect(learnings).toBe("ORIGINAL LEARNINGS")
+    expect(decisions).toBe("ORIGINAL DECISIONS")
+
+    expect(existsSync(join(notepadDir, "issues.md"))).toBe(true)
+    expect(existsSync(join(notepadDir, "problems.md"))).toBe(true)
+
+    const issues = readFileSync(join(notepadDir, "issues.md"), "utf8")
+    const problems = readFileSync(join(notepadDir, "problems.md"), "utf8")
+
+    expect(issues).toContain("# Issues \u2014 alpha")
+    expect(problems).toContain("# Problems \u2014 alpha")
+
+    expect(result.created).toEqual(["issues.md", "problems.md"])
+    expect(result.skipped).toEqual(["learnings.md", "decisions.md"])
+  })
+
+  test("#given nested missing parent dirs #when called #then creates full .omo/notepads/alpha path", () => {
+    // given
+    const directory = testDirectory
+    // do NOT pre-create .omo/
+
+    // when
+    ensureNotepadScaffold({
+      directory,
+      planName: "alpha",
+      timestamp: "2026-01-01T00:00:00Z",
+    })
+
+    // then
+    expect(existsSync(join(directory, ".omo", "notepads", "alpha"))).toBe(true)
+    expect(existsSync(join(directory, ".omo", "notepads", "alpha", "learnings.md"))).toBe(true)
+    expect(existsSync(join(directory, ".omo", "notepads", "alpha", "decisions.md"))).toBe(true)
+    expect(existsSync(join(directory, ".omo", "notepads", "alpha", "issues.md"))).toBe(true)
+    expect(existsSync(join(directory, ".omo", "notepads", "alpha", "problems.md"))).toBe(true)
+  })
+})

--- a/packages/omo-opencode/src/hooks/start-work/notepad-scaffold.ts
+++ b/packages/omo-opencode/src/hooks/start-work/notepad-scaffold.ts
@@ -1,0 +1,73 @@
+/// <reference types="bun-types" />
+
+import { mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { log } from "../../shared/logger"
+import { HOOK_NAME } from "./start-work-hook"
+
+export const NOTEPAD_FILES = [
+  "learnings.md",
+  "decisions.md",
+  "issues.md",
+  "problems.md",
+] as const
+
+export type NotepadFileName = (typeof NOTEPAD_FILES)[number]
+
+const NOTEPAD_PURPOSES: Readonly<Record<NotepadFileName, string>> = {
+  "learnings.md": "Conventions, patterns, and successful approaches discovered during work on this plan.",
+  "decisions.md": "Architectural choices and rationales discovered during work on this plan.",
+  "issues.md": "Problems and gotchas encountered during work on this plan.",
+  "problems.md": "Unresolved blockers and technical debt discovered during work on this plan.",
+}
+
+const NOTEPAD_LABELS: Readonly<Record<NotepadFileName, string>> = {
+  "learnings.md": "Learnings",
+  "decisions.md": "Decisions",
+  "issues.md": "Issues",
+  "problems.md": "Problems",
+}
+
+const NOTEPAD_FOOTER =
+  "_Auto-scaffolded by /start-work. Append new entries below - never overwrite._"
+
+function buildHeader(
+  fileName: NotepadFileName,
+  planName: string,
+  timestamp: string,
+): string {
+  void timestamp
+  const label = NOTEPAD_LABELS[fileName]
+  const purpose = NOTEPAD_PURPOSES[fileName]
+  return `# ${label} \u2014 ${planName}\n\n${purpose}\n\n${NOTEPAD_FOOTER}\n\n---\n`
+}
+
+export function ensureNotepadScaffold(params: {
+  readonly directory: string
+  readonly planName: string
+  readonly timestamp?: string
+}): { created: string[]; skipped: string[] } {
+  const { directory, planName, timestamp = new Date().toISOString() } = params
+  const notepadDir = join(directory, ".omo", "notepads", planName)
+  mkdirSync(notepadDir, { recursive: true })
+
+  const created: string[] = []
+  const skipped: string[] = []
+
+  for (const fileName of NOTEPAD_FILES) {
+    const header = buildHeader(fileName, planName, timestamp)
+    try {
+      writeFileSync(join(notepadDir, fileName), header, { flag: "wx" })
+      created.push(fileName)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+        skipped.push(fileName)
+      } else {
+        throw err
+      }
+    }
+  }
+
+  log(`[${HOOK_NAME}] Notepad scaffold`, { planName, created, skipped })
+  return { created, skipped }
+}

--- a/packages/omo-opencode/src/hooks/start-work/work-initializer.ts
+++ b/packages/omo-opencode/src/hooks/start-work/work-initializer.ts
@@ -1,9 +1,11 @@
 import {
   addBoulderWork,
   createBoulderState,
+  getPlanName,
   writeBoulderState,
 } from "../../features/boulder-state"
 import { buildAutoSelectedPlanContextInfoOnly } from "./context-info-formatters"
+import { ensureNotepadScaffold } from "./notepad-scaffold"
 
 export function createNewWorkOrInitialize(params: {
   readonly directory: string
@@ -24,6 +26,8 @@ export function createNewWorkOrInitialize(params: {
     const initializedState = createBoulderState(planPath, sessionId, activeAgent, worktreePath)
     writeBoulderState(directory, initializedState)
   }
+
+  ensureNotepadScaffold({ directory, planName: getPlanName(planPath) })
 }
 
 export function buildAutoSelectedPlanContextWithStateInit(params: {
@@ -41,6 +45,8 @@ export function buildAutoSelectedPlanContextWithStateInit(params: {
 
   const newState = createBoulderState(planPath, sessionId, activeAgent, worktreePath)
   writeBoulderState(directory, newState)
+
+  ensureNotepadScaffold({ directory, planName: getPlanName(planPath), timestamp })
 
   return buildAutoSelectedPlanContextInfoOnly({
     planPath,

--- a/packages/prompts-core/prompts/atlas/default.md
+++ b/packages/prompts-core/prompts/atlas/default.md
@@ -228,20 +228,15 @@ TASK ANALYSIS:
 - Sequential (with named dependency): [list with reason]
 ```
 
-## Step 2: Initialize Notepad
+## Step 2: Notepad (auto-scaffolded)
 
-```bash
-mkdir -p .omo/notepads/{plan-name}
-```
+`/start-work` creates `.omo/notepads/{plan-name}/` with these files automatically:
+- `learnings.md` - Conventions, patterns
+- `decisions.md` - Architectural choices
+- `issues.md` - Problems, gotchas
+- `problems.md` - Unresolved blockers
 
-Structure:
-```
-.omo/notepads/{plan-name}/
-  learnings.md    # Conventions, patterns
-  decisions.md    # Architectural choices
-  issues.md       # Problems, gotchas
-  problems.md     # Unresolved blockers
-```
+If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 
@@ -391,7 +386,7 @@ FILES MODIFIED: [list]
 3. Include as "Inherited Wisdom" in prompt
 
 **After EVERY completion**:
-- Instruct subagent to append findings (never overwrite, never use Edit tool)
+- Instruct subagent to append findings (append only; use `edit` or bash `>>`, never `write` which is blocked, and never overwrite)
 
 **Format**:
 ```markdown

--- a/packages/prompts-core/prompts/atlas/gemini.md
+++ b/packages/prompts-core/prompts/atlas/gemini.md
@@ -261,13 +261,15 @@ TASK ANALYSIS:
 - Sequential: [list]
 ```
 
-## Step 2: Initialize Notepad
+## Step 2: Notepad (auto-scaffolded)
 
-```bash
-mkdir -p .omo/notepads/{plan-name}
-```
+`/start-work` creates `.omo/notepads/{plan-name}/` with these files automatically:
+- `learnings.md` - Conventions, patterns
+- `decisions.md` - Architectural choices
+- `issues.md` - Problems, gotchas
+- `problems.md` - Unresolved blockers
 
-Structure: learnings.md, decisions.md, issues.md, problems.md
+If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 
@@ -405,7 +407,7 @@ FILES MODIFIED: [list]
 3. Include as "Inherited Wisdom" in prompt
 
 **After EVERY completion**:
-- Instruct subagent to append findings (never overwrite, never use Edit tool)
+- Instruct subagent to append findings (append only; use `edit` or bash `>>`, never `write` which is blocked, and never overwrite)
 
 **Format**:
 ```markdown

--- a/packages/prompts-core/prompts/atlas/glm.md
+++ b/packages/prompts-core/prompts/atlas/glm.md
@@ -212,9 +212,15 @@ TASK ANALYSIS:
 - Sequential: [checkbox labels with named dependency]
 ```
 
-## Step 2: Initialize Notepad
+## Step 2: Notepad (auto-scaffolded)
 
-Ensure `.omo/notepads/{plan-name}/` exists with `learnings.md`, `decisions.md`, `issues.md`, and `problems.md`.
+`/start-work` creates `.omo/notepads/{plan-name}/` with these files automatically:
+- `learnings.md` - Conventions, patterns
+- `decisions.md` - Architectural choices
+- `issues.md` - Problems, gotchas
+- `problems.md` - Unresolved blockers
+
+If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Implementation Tasks
 
@@ -299,7 +305,7 @@ FILES MODIFIED: [list]
 
 The notepad is cumulative memory for stateless subagents.
 Before delegation: read relevant notepad files, extract conventions and gotchas, and include them as Inherited Wisdom.
-After completion: require the subagent to append findings, never overwrite files, and record reusable patterns, problems, decisions, and commands.
+After completion: require the subagent to append findings, append only (use `edit` or bash `>>`; never `write` which is blocked, and never overwrite files), and record reusable patterns, problems, decisions, and commands.
 
 Append format:
 

--- a/packages/prompts-core/prompts/atlas/gpt.md
+++ b/packages/prompts-core/prompts/atlas/gpt.md
@@ -237,13 +237,15 @@ TASK ANALYSIS:
 - Sequential (with named dependency): [list with reason]
 ```
 
-## Step 2: Initialize Notepad
+## Step 2: Notepad (auto-scaffolded)
 
-```bash
-mkdir -p .omo/notepads/{plan-name}
-```
+`/start-work` creates `.omo/notepads/{plan-name}/` with these files automatically:
+- `learnings.md` - Conventions, patterns
+- `decisions.md` - Architectural choices
+- `issues.md` - Problems, gotchas
+- `problems.md` - Unresolved blockers
 
-Files: learnings.md, decisions.md, issues.md, problems.md.
+If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 
@@ -353,7 +355,7 @@ FILES MODIFIED: [list]
 3. Include as "Inherited Wisdom" in prompt
 
 **After EVERY completion**:
-- Instruct subagent to append findings (never overwrite, never use Edit tool)
+- Instruct subagent to append findings (append only; use `edit` or bash `>>`, never `write` which is blocked, and never overwrite)
 
 **Format**:
 ```markdown

--- a/packages/prompts-core/prompts/atlas/kimi-k2-7.md
+++ b/packages/prompts-core/prompts/atlas/kimi-k2-7.md
@@ -163,13 +163,15 @@ TASK ANALYSIS:
 - Sequential (with named dependency): [list with reason]
 ```
 
-## Step 2: Initialize Notepad
+## Step 2: Notepad (auto-scaffolded)
 
-```bash
-mkdir -p .omo/notepads/{plan-name}
-```
+`/start-work` creates `.omo/notepads/{plan-name}/` with these files automatically:
+- `learnings.md` - Conventions, patterns
+- `decisions.md` - Architectural choices
+- `issues.md` - Problems, gotchas
+- `problems.md` - Unresolved blockers
 
-Files: learnings.md, decisions.md, issues.md, problems.md.
+If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 
@@ -256,7 +258,7 @@ FILES MODIFIED: [list]
 <notepad_protocol>
 ## Notepad System
 
-Subagents are stateless; the notepad is your cumulative intelligence. Before every delegation, read the notepad files, extract the relevant wisdom, and include it as "Inherited Wisdom" in the prompt. After every completion, instruct the subagent to append its findings (never overwrite, never use the Edit tool).
+Subagents are stateless; the notepad is your cumulative intelligence. Before every delegation, read the notepad files, extract the relevant wisdom, and include it as "Inherited Wisdom" in the prompt. After every completion, instruct the subagent to append its findings (append only; use `edit` or bash `>>`, never `write` which is blocked, and never overwrite).
 
 Format:
 ```markdown

--- a/packages/prompts-core/prompts/atlas/kimi-k3.md
+++ b/packages/prompts-core/prompts/atlas/kimi-k3.md
@@ -163,13 +163,15 @@ TASK ANALYSIS:
 - Sequential (with named dependency): [list with reason]
 ```
 
-## Step 2: Initialize Notepad
+## Step 2: Notepad (auto-scaffolded)
 
-```bash
-mkdir -p .omo/notepads/{plan-name}
-```
+`/start-work` creates `.omo/notepads/{plan-name}/` with these files automatically:
+- `learnings.md` - Conventions, patterns
+- `decisions.md` - Architectural choices
+- `issues.md` - Problems, gotchas
+- `problems.md` - Unresolved blockers
 
-Files: learnings.md, decisions.md, issues.md, problems.md.
+If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 
@@ -256,7 +258,7 @@ FILES MODIFIED: [list]
 <notepad_protocol>
 ## Notepad System
 
-Subagents are stateless; the notepad is your cumulative intelligence. Before every delegation, read the notepad files, extract the relevant wisdom, and include it as "Inherited Wisdom" in the prompt. After every completion, instruct the subagent to append its findings (never overwrite, never use the Edit tool).
+Subagents are stateless; the notepad is your cumulative intelligence. Before every delegation, read the notepad files, extract the relevant wisdom, and include it as "Inherited Wisdom" in the prompt. After every completion, instruct the subagent to append its findings (append only; use `edit` or bash `>>`, never `write` which is blocked, and never overwrite).
 
 Format:
 ```markdown

--- a/packages/prompts-core/prompts/atlas/kimi.md
+++ b/packages/prompts-core/prompts/atlas/kimi.md
@@ -251,13 +251,15 @@ TASK ANALYSIS:
 - Sequential (with named dependency): [list with reason]
 ```
 
-## Step 2: Initialize Notepad
+## Step 2: Notepad (auto-scaffolded)
 
-```bash
-mkdir -p .omo/notepads/{plan-name}
-```
+`/start-work` creates `.omo/notepads/{plan-name}/` with these files automatically:
+- `learnings.md` - Conventions, patterns
+- `decisions.md` - Architectural choices
+- `issues.md` - Problems, gotchas
+- `problems.md` - Unresolved blockers
 
-Files: learnings.md, decisions.md, issues.md, problems.md.
+If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 
@@ -364,7 +366,7 @@ FILES MODIFIED: [list]
 3. Include as "Inherited Wisdom" in prompt
 
 **After EVERY completion**:
-- Instruct subagent to append findings (never overwrite, never use Edit tool)
+- Instruct subagent to append findings (append only; use `edit` or bash `>>`, never `write` which is blocked, and never overwrite)
 
 **Format**:
 ```markdown

--- a/packages/prompts-core/prompts/atlas/opus-4-7.md
+++ b/packages/prompts-core/prompts/atlas/opus-4-7.md
@@ -244,13 +244,15 @@ TASK ANALYSIS:
 - Sequential (with named dependency): [list with reason]
 ```
 
-## Step 2: Initialize Notepad
+## Step 2: Notepad (auto-scaffolded)
 
-```bash
-mkdir -p .omo/notepads/{plan-name}
-```
+`/start-work` creates `.omo/notepads/{plan-name}/` with these files automatically:
+- `learnings.md` - Conventions, patterns
+- `decisions.md` - Architectural choices
+- `issues.md` - Problems, gotchas
+- `problems.md` - Unresolved blockers
 
-Files: learnings.md, decisions.md, issues.md, problems.md.
+If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 
@@ -380,7 +382,7 @@ FILES MODIFIED: [list]
 3. Include as "Inherited Wisdom" in prompt
 
 **After EVERY completion**:
-- Instruct subagent to append findings (never overwrite, never use Edit tool)
+- Instruct subagent to append findings (append only; use `edit` or bash `>>`, never `write` which is blocked, and never overwrite)
 
 **Format**:
 ```markdown


### PR DESCRIPTION
## What

`/start-work` now auto-scaffolds the 4 notepad files (with a pre-seeded header) at the moment a plan is committed. This unblocks a chicken-and-egg deadlock: `notepad-write-guard` blocks the `write` tool on `.omo/notepads/**` unconditionally (append-only protection), and `edit` cannot seed an empty file, so the agent could never create the first notepad entry.

The hook writes via `node:fs` directly at the 3 boulder-state write sites, so the tool guard is bypassed and **stays unchanged**.

## Why

The deadlock was hit in production (ulw with atlas): the agent tried `Write` (blocked by guard), fell back to `bash touch` + `Edit` with empty oldString (rejected). There was no supported path to create the first notepad line. The guard's *intent* (protect accumulated learnings from overwrite) is sound; only the bootstrap case was unsupported. The directive (`sisyphus-junior-notepad`) also told workers to append but forbade both `write` and `edit` - contradictory.

The fix matches the guard's real intent: scaffold once at plan-commit (no history to destroy), then the agent only ever appends (which the guard allows and the directive wants).

## Changes

**Core behavior** (`27beb30dd`)
- New `ensureNotepadScaffold({directory, planName, timestamp?})` in `packages/omo-opencode/src/hooks/start-work/notepad-scaffold.ts`: `mkdir -p .omo/notepads/<plan>` + per-file `writeFileSync({flag:"wx"})` (EEXIST -> skipped, so idempotent and partial-safe). Pre-seeds each file with a header (title with em-dash separator + one-line purpose + "Auto-scaffolded by /start-work. Append new entries below - never overwrite." footer).
- Wired into the 3 boulder-state write sites:
  - `createNewWorkOrInitialize` (work-initializer.ts) - explicit + new work
  - `buildAutoSelectedPlanContextWithStateInit` (work-initializer.ts) - auto-selected single plan
  - `buildExistingSessionContext` (context-info-formatters.ts) - resume, AFTER its `isComplete` early-return so completed plans don't trigger it
- `planName` via the existing `getPlanName(planPath)` / `existingState.plan_name`. Does NOT scaffold on the multiple-works (ask-user) or no-plan branches.

**Directive + prompt docs** (`1345dfe99`)
- `sisyphus-junior-notepad/constants.ts`: replaced "never use Edit tool" with steer to `edit`/bash `>>` (write is blocked, overwrite forbidden).
- 8 atlas prompt variants (`default`, `gpt`, `gemini`, `glm`, `kimi`, `kimi-k2-7`, `kimi-k3`, `opus-4-7`): replaced the manual "Step 2: Initialize Notepad" (`mkdir` + structure tree) with an auto-scaffolded note, and fixed the Notepad System/Protocol append directive line.

## Observed behavior

- Unit tests (`notepad-scaffold.test.ts`, 4 cases): create / idempotent (re-run byte-identical) / partial (2 of 4 pre-existing preserved, 2 created) / nested mkdir - all GREEN.
- Integration tests (`context-info-builder.test.ts`, 4 cases): auto-select / explicit / resume all scaffold the 4 files; multiple-works does NOT scaffold - all GREEN.
- Full start-work suite: 85 pass / 0 fail.
- Plugin bundles: `dist/index.js` 5.48MB / 1922 modules, exit 0.
- `notepad-write-guard/` is untouched (verified: `git diff` shows no entries there).

## QA / Evidence

The scaffold logic is proven at three levels; the live `opencode run` end-to-end is a documented partial (environment blocker, not a code defect):

| Layer | Status |
|---|---|
| Unit tests (real fs, temp dir) | GREEN |
| Integration tests (real `buildStartWorkContextInfo` -> write sites -> scaffold) | GREEN |
| Plugin-level hook proof (drove real hook module, 4 files + idempotency via shasum + host DB isolation 6147->6147) | GREEN |
| Live `opencode run "/start-work"` end-to-end | NOT reproduced - the bare worktree plugin couldn't fully materialize (`dist/skills/frontend/SKILL.md` ENOENT, so commands didn't register; `--command start-work` hit UnknownError). Blocked by incomplete plugin asset materialization in the worktree, not by this change. |

Evidence dir: `.omo/evidence/20260717-notepad-scaffold/` (what-was-tested, what-was-observed, why-it-is-enough, what-was-omitted, raw run logs, source-hook-proof.json).

## Residual risk

- The scaffold writes to `<directory>/.omo/notepads/<plan>/` where `directory` is the same root `boulder.json` uses. For worktree sessions where the agent's cwd is the worktree, the relative `.omo/notepads/` read resolves to the worktree cwd, while the scaffold wrote to the main `directory`. This matches the existing `boulder.json` location behavior (same class of pre-existing path resolution), so it is consistent, not a regression. Flagged as a possible follow-up if worktree notepad isolation is later desired.
- The integration tests exercise the exact production code path the live hook calls (`buildStartWorkContextInfo`); the hook wiring itself is unchanged shipped code, so the scaffold is a proven side effect of an already-firing hook.

## Notes

- Pre-existing (not introduced): `build:cli` fails on `@oh-my-opencode/omo-senpi/install` resolution - confirmed on base via stash. Blocks the full `bun run build` independent of this change; the plugin entry (`dist/index.js`) builds cleanly in isolation.
- 14 files changed, +412/-53. 2 atomic commits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
/start-work now auto-scaffolds `.omo/notepads/{plan}/` with four files on plan commit, fixing the append-only deadlock with `notepad-write-guard`. Prompts and directives now tell agents to append with `edit` or bash `>>` and never use `write`.

- **New Features**
  - Added `ensureNotepadScaffold({directory, planName, timestamp?})`: creates `learnings.md`, `decisions.md`, `issues.md`, `problems.md` with a small header. Uses `mkdir -p` and `writeFileSync` with `flag: "wx"` for idempotency; existing files are preserved.
  - Wired into plan commit points: explicit new work, auto-selected single plan, and resume path (skipped for multi-work and no-plan branches). The `notepad-write-guard` stays unchanged; scaffolding writes via `node:fs` to bypass tool guards safely.
  - Updated `sisyphus-junior-notepad` and all `atlas` prompt variants: removed manual notepad init; instruct to append only with `edit` or bash `>>`; never use `write`.

- **Migration**
  - No action needed. Files are created automatically on plan commit and reruns are safe. Existing notepads are left untouched.

<sup>Written for commit 1345dfe99e0e251d34772943af977a35009199c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

