### PR TITLE
fix(session-search): sort sessions by time.updated before scan limit

### DIFF
--- a/packages/omo-opencode/src/tools/session-manager/sdk-storage.ts
+++ b/packages/omo-opencode/src/tools/session-manager/sdk-storage.ts
@@ -59,7 +59,10 @@ export async function getSdkMainSessions(
 export async function getSdkAllSessions(client: PluginInput["client"]): Promise<string[]> {
   const response = await fetchSdkResponse(() => client.session.list())
   const sessions = normalizeSDKResponse(response, [] as SessionMetadata[])
-  return sessions.map((session) => session.id)
+  return sessions
+    .slice()
+    .sort((a, b) => b.time.updated - a.time.updated)
+    .map((session) => session.id)
 }
 
 export async function sdkSessionExists(client: PluginInput["client"], sessionID: string): Promise<boolean> {

--- a/packages/omo-opencode/src/tools/session-manager/storage.test.ts
+++ b/packages/omo-opencode/src/tools/session-manager/storage.test.ts
@@ -556,6 +556,30 @@ describe("session-manager storage - SDK path (beta mode)", () => {
     expect(sessionIDs).toEqual(["ses_1", "ses_2"])
   })
 
+  test("getAllSessions sorts SDK sessions by time.updated descending", async () => {
+    // given
+    const mockSessions = [
+      { id: "ses_old", directory: "/test", time: { created: 1000, updated: 1000 } },
+      { id: "ses_new", directory: "/test", time: { created: 2000, updated: 3000 } },
+      { id: "ses_mid", directory: "/test", time: { created: 1500, updated: 2000 } },
+    ]
+    mockClient.session.list.mockImplementation(() => Promise.resolve({ data: mockSessions }))
+
+    mock.module("../../shared/opencode-storage-detection", () => ({
+      isSqliteBackend: () => true,
+      resetSqliteBackendCache: () => {},
+    }))
+
+    const { setStorageClient, getAllSessions } = await import("./storage")
+    setStorageClient(unsafeTestValue<Parameters<typeof setStorageClient>[0]>(mockClient))
+
+    // when
+    const sessionIDs = await getAllSessions()
+
+    // then
+    expect(sessionIDs.slice(0, 3)).toEqual(["ses_new", "ses_mid", "ses_old"])
+  })
+
   test("readSessionMessages uses SDK when beta mode is enabled", async () => {
     // given
     const mockMessages = [


### PR DESCRIPTION
## Summary
- `session_search` only scans the first 50 session IDs from `getAllSessions()` / `getSdkAllSessions()`.
- SDK sessions were returned in arbitrary list order, so recent sessions could fall outside the scan window and return "No matches found".
- Sort SDK sessions by `time.updated` descending before mapping to IDs so the 50-session slice prefers newest sessions.

## Test plan
- [x] `bun test packages/omo-opencode/src/tools/session-manager/storage.test.ts`
- [x] Added regression test that unsorted SDK sessions are ordered by `time.updated` desc

Fixes #6211

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sort SDK sessions by time.updated descending before the 50-session scan in `session_search` so recent sessions are included and "No matches found" false negatives are reduced. Fixes #6211.

- **Bug Fixes**
  - `getSdkAllSessions` sorts normalized SDK sessions by `time.updated` desc before mapping to IDs.
  - Added a regression test to verify ordering.

<sup>Written for commit 6c7d54cf08b474744c13a64e28a3b2dbab036926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

