### PR TITLE
fix(goal): only parse /goal commands in handleGoalMessage

### DIFF
--- a/packages/omo-opencode/src/hooks/session-notification.test.ts
+++ b/packages/omo-opencode/src/hooks/session-notification.test.ts
@@ -725,39 +725,53 @@ describe("session-notification", () => {
   })
 
   test("should cancel notification for activity after grace period", async () => {
-    // given - a regular session notification is scheduled
-    const sessionID = "main-grace-cancel"
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date("2026-01-01T00:00:00.000Z"))
 
-    const hook = createSessionNotification(createMockPluginInput(), {
-      idleConfirmationDelay: 200,
-      skipIfIncompleteTodos: false,
-      activityGracePeriodMs: 50,
-      enforceMainSessionFilter: false,
-    })
+    try {
+      // given - a regular session notification is scheduled
+      const sessionID = "main-grace-cancel"
 
-    // when - session goes idle
-    await hook({
-      event: {
-        type: "session.idle",
-        properties: { sessionID },
-      },
-    })
+      const hook = createSessionNotification(createMockPluginInput(), {
+        idleConfirmationDelay: 200,
+        skipIfIncompleteTodos: false,
+        activityGracePeriodMs: 50,
+        enforceMainSessionFilter: false,
+      })
 
-    // when - wait for grace period to pass
-    await new Promise((resolve) => setTimeout(resolve, 60))
+      // when - session goes idle
+      await hook({
+        event: {
+          type: "session.idle",
+          properties: { sessionID },
+        },
+      })
 
-    // when - activity happens after grace period
-    await hook({
-      event: {
-        type: "tool.execute.before",
-        properties: { sessionID },
-      },
-    })
+      // when - grace period elapses deterministically
+      jest.setSystemTime(new Date("2026-01-01T00:00:00.051Z"))
+      jest.advanceTimersByTime(51)
 
-    // Wait for original delay to pass
-    await new Promise((resolve) => setTimeout(resolve, 200))
+      // when - activity happens after grace period
+      await hook({
+        event: {
+          type: "tool.execute.before",
+          properties: { sessionID },
+        },
+      })
 
-    // then - notification should NOT be sent (activity cancelled it after grace period)
-    expect(notificationCalls).toHaveLength(0)
+      // when - original idle delay would have fired
+      jest.advanceTimersByTime(200)
+      jest.runOnlyPendingTimers()
+      await Promise.resolve()
+
+      // then - notification should NOT be sent (activity cancelled it after grace period)
+      expect(notificationCalls).toHaveLength(0)
+    } finally {
+      jest.clearAllTimers()
+      jest.useRealTimers()
+      globalThis.setTimeout = originalSetTimeout
+      globalThis.clearTimeout = originalClearTimeout
+      Date.now = originalDateNow
+    }
   })
 })

--- a/packages/omo-opencode/src/plugin/chat-message.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-message.test.ts
@@ -454,7 +454,7 @@ describe("createChatMessageHandler - goal command handling and stop continuation
     const handler = createChatMessageHandler(args)
     const output: ChatMessageHandlerOutput = {
       message: {},
-      parts: [{ type: "text", text: "Ship it" }],
+      parts: [{ type: "text", text: "/goal Ship it" }],
     }
 
     // when
@@ -476,7 +476,7 @@ describe("createChatMessageHandler - goal command handling and stop continuation
     const handler = createChatMessageHandler(args)
     const output: ChatMessageHandlerOutput = {
       message: {},
-      parts: [{ type: "text", text: "pause" }],
+      parts: [{ type: "text", text: "/goal pause" }],
     }
 
     // when
@@ -498,7 +498,7 @@ describe("createChatMessageHandler - goal command handling and stop continuation
     const handler = createChatMessageHandler(args)
     const output: ChatMessageHandlerOutput = {
       message: {},
-      parts: [{ type: "text", text: "resume" }],
+      parts: [{ type: "text", text: "/goal resume" }],
     }
 
     // when
@@ -520,7 +520,7 @@ describe("createChatMessageHandler - goal command handling and stop continuation
     const handler = createChatMessageHandler(args)
     const output: ChatMessageHandlerOutput = {
       message: {},
-      parts: [{ type: "text", text: "clear" }],
+      parts: [{ type: "text", text: "/goal clear" }],
     }
 
     // when
@@ -579,19 +579,19 @@ describe("createChatMessageHandler - goal command handling and stop continuation
     })
     await handler(createMockInput("sisyphus"), {
       message: {},
-      parts: [{ type: "text", text: "Ship it" }],
+      parts: [{ type: "text", text: "/goal Ship it" }],
     })
     await handler(createMockInput("sisyphus"), {
       message: {},
-      parts: [{ type: "text", text: "pause" }],
+      parts: [{ type: "text", text: "/goal pause" }],
     })
     await handler(createMockInput("sisyphus"), {
       message: {},
-      parts: [{ type: "text", text: "resume" }],
+      parts: [{ type: "text", text: "/goal resume" }],
     })
     await handler(createMockInput("sisyphus"), {
       message: {},
-      parts: [{ type: "text", text: "clear" }],
+      parts: [{ type: "text", text: "/goal clear" }],
     })
 
     // then
@@ -602,11 +602,8 @@ describe("createChatMessageHandler - goal command handling and stop continuation
       "test-session",
       "test-session",
     ])
+    // Ordinary start-work template text must not be treated as a goal objective.
     expect(goalMock.setGoalCalls).toEqual([
-      {
-        sessionID: "test-session",
-        objective: "<session-context>context</session-context>\nYou are starting an Atlas work session.",
-      },
       { sessionID: "test-session", objective: "Ship it" },
     ])
     expect(goalMock.pauseGoalCalls).toEqual(["test-session"])
@@ -661,7 +658,7 @@ describe("createChatMessageHandler - /goal raw slash fallback", () => {
     const input = createMockInput("sisyphus")
     const output: ChatMessageHandlerOutput = {
       message: {},
-      parts: [{ type: "text", text: "Ship the dashboard" }],
+      parts: [{ type: "text", text: "/goal Ship the dashboard" }],
     }
 
     // when
@@ -682,7 +679,7 @@ describe("createChatMessageHandler - /goal raw slash fallback", () => {
     const input = createMockInput("sisyphus")
     const output: ChatMessageHandlerOutput = {
       message: {},
-      parts: [{ type: "text", text: "pause" }],
+      parts: [{ type: "text", text: "/goal pause" }],
     }
 
     // when
@@ -702,7 +699,7 @@ describe("createChatMessageHandler - /goal raw slash fallback", () => {
     const input = createMockInput("sisyphus")
     const output: ChatMessageHandlerOutput = {
       message: {},
-      parts: [{ type: "text", text: "resume" }],
+      parts: [{ type: "text", text: "/goal resume" }],
     }
 
     // when
@@ -722,7 +719,7 @@ describe("createChatMessageHandler - /goal raw slash fallback", () => {
     const input = createMockInput("sisyphus")
     const output: ChatMessageHandlerOutput = {
       message: {},
-      parts: [{ type: "text", text: "clear" }],
+      parts: [{ type: "text", text: "/goal clear" }],
     }
 
     // when

--- a/packages/omo-opencode/src/plugin/chat-message/loop-commands.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-message/loop-commands.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, mock, test } from "bun:test"
+import { handleGoalMessage } from "./loop-commands"
+import type { ChatMessageHooks, ChatMessageHandlerOutput, ChatMessageInput } from "./types"
+
+function createParts(text: string): ChatMessageHandlerOutput["parts"] {
+  return [{ type: "text", text }]
+}
+
+describe("handleGoalMessage", () => {
+  test("#given ordinary user prompt #when handleGoalMessage runs #then does not set goal", () => {
+    // given
+    const setGoal = mock(() => {})
+    const hooks = {
+      goal: {
+        setGoal,
+        pauseGoal: mock(() => {}),
+        resumeGoal: mock(() => {}),
+        clearGoal: mock(() => {}),
+      },
+    } as unknown as ChatMessageHooks
+    const input = { sessionID: "ses_1" } as ChatMessageInput
+    const output = {
+      parts: createParts("please fix the flaky login test"),
+      message: {},
+    } as ChatMessageHandlerOutput
+
+    // when
+    handleGoalMessage({
+      hooks,
+      input,
+      output,
+      isFirstMessage: false,
+      pluginConfig: {},
+    })
+
+    // then
+    expect(setGoal).not.toHaveBeenCalled()
+  })
+
+  test("#given /goal command #when handleGoalMessage runs #then sets objective from args", () => {
+    // given
+    const setGoal = mock(() => {})
+    const hooks = {
+      goal: {
+        setGoal,
+        pauseGoal: mock(() => {}),
+        resumeGoal: mock(() => {}),
+        clearGoal: mock(() => {}),
+      },
+    } as unknown as ChatMessageHooks
+    const input = { sessionID: "ses_1" } as ChatMessageInput
+    const output = {
+      parts: createParts("/goal ship the release"),
+      message: {},
+    } as ChatMessageHandlerOutput
+
+    // when
+    handleGoalMessage({
+      hooks,
+      input,
+      output,
+      isFirstMessage: false,
+      pluginConfig: {},
+    })
+
+    // then
+    expect(setGoal).toHaveBeenCalledWith("ses_1", "ship the release")
+  })
+
+  test("#given first message with default_mode.goal #when handleGoalMessage runs #then auto-starts goal", () => {
+    // given
+    const setGoal = mock(() => {})
+    const hooks = {
+      goal: {
+        setGoal,
+        pauseGoal: mock(() => {}),
+        resumeGoal: mock(() => {}),
+        clearGoal: mock(() => {}),
+      },
+    } as unknown as ChatMessageHooks
+    const input = { sessionID: "ses_1" } as ChatMessageInput
+    const output = {
+      parts: createParts("build the dashboard"),
+      message: {},
+    } as ChatMessageHandlerOutput
+
+    // when
+    handleGoalMessage({
+      hooks,
+      input,
+      output,
+      isFirstMessage: true,
+      pluginConfig: { default_mode: { goal: true } },
+    })
+
+    // then
+    expect(setGoal).toHaveBeenCalledWith("ses_1", "build the dashboard")
+  })
+
+  test("#given long ordinary prompt #when handleGoalMessage runs #then does not set goal", () => {
+    // given
+    const setGoal = mock(() => {})
+    const hooks = {
+      goal: {
+        setGoal,
+        pauseGoal: mock(() => {}),
+        resumeGoal: mock(() => {}),
+        clearGoal: mock(() => {}),
+      },
+    } as unknown as ChatMessageHooks
+    const input = { sessionID: "ses_1" } as ChatMessageInput
+    const longPrompt = "x".repeat(2500)
+    const output = {
+      parts: createParts(longPrompt),
+      message: {},
+    } as ChatMessageHandlerOutput
+
+    // when
+    handleGoalMessage({
+      hooks,
+      input,
+      output,
+      isFirstMessage: false,
+      pluginConfig: {},
+    })
+
+    // then
+    expect(setGoal).not.toHaveBeenCalled()
+  })
+})

--- a/packages/omo-opencode/src/plugin/chat-message/loop-commands.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-message/loop-commands.test.ts
@@ -30,6 +30,7 @@ describe("handleGoalMessage", () => {
       input,
       output,
       isFirstMessage: false,
+      nativeGoalCommand: false,
       pluginConfig: {},
     })
 
@@ -60,6 +61,7 @@ describe("handleGoalMessage", () => {
       input,
       output,
       isFirstMessage: false,
+      nativeGoalCommand: false,
       pluginConfig: {},
     })
 
@@ -90,6 +92,7 @@ describe("handleGoalMessage", () => {
       input,
       output,
       isFirstMessage: true,
+      nativeGoalCommand: false,
       pluginConfig: { default_mode: { goal: true } },
     })
 
@@ -121,6 +124,7 @@ describe("handleGoalMessage", () => {
       input,
       output,
       isFirstMessage: false,
+      nativeGoalCommand: false,
       pluginConfig: {},
     })
 

--- a/packages/omo-opencode/src/plugin/chat-message/loop-commands.ts
+++ b/packages/omo-opencode/src/plugin/chat-message/loop-commands.ts
@@ -6,6 +6,15 @@ import { log } from "../../shared"
 import { extractPromptText } from "./prompt-text"
 import type { ChatMessageHooks, ChatMessageHandlerOutput, ChatMessageInput } from "./types"
 
+function parseRawGoalSlashCommand(promptText: string): string | null {
+  const trimmed = promptText.trim()
+  const match = trimmed.match(/^\/goal(?:\s+([\s\S]*))?$/i)
+  if (!match) {
+    return null
+  }
+  return match[1]?.trim() ?? ""
+}
+
 export function handleGoalMessage(args: {
   readonly hooks: ChatMessageHooks
   readonly input: ChatMessageInput
@@ -23,38 +32,38 @@ export function handleGoalMessage(args: {
   if (promptText.includes(AUTO_SLASH_COMMAND_TAG_OPEN)) {
     return
   }
-  const parsed = parseGoalCommand(promptText)
+  const goalArgs = parseRawGoalSlashCommand(promptText)
 
-  switch (parsed.kind) {
-    case "setObjective":
-      hooks.goal.setGoal(input.sessionID, parsed.objective)
-      log("[chat-message] Goal set", { sessionID: input.sessionID, objective: parsed.objective })
-      break
-    case "setStatus":
-      if (parsed.status === "paused") {
-        hooks.goal.pauseGoal(input.sessionID)
-        log("[chat-message] Goal paused", { sessionID: input.sessionID })
-      } else {
-        hooks.goal.resumeGoal(input.sessionID)
-        log("[chat-message] Goal resumed", { sessionID: input.sessionID })
-      }
-      break
-    case "clear":
-      hooks.goal.clearGoal(input.sessionID)
-      log("[chat-message] Goal cleared", { sessionID: input.sessionID })
-      break
-    case "show":
-      // No side effect; the goal is surfaced by TUI mirror and tools.
-      break
-    default:
-      break
+  if (goalArgs !== null) {
+    const parsed = parseGoalCommand(goalArgs)
+
+    switch (parsed.kind) {
+      case "setObjective":
+        hooks.goal.setGoal(input.sessionID, parsed.objective)
+        log("[chat-message] Goal set", { sessionID: input.sessionID, objective: parsed.objective })
+        break
+      case "setStatus":
+        if (parsed.status === "paused") {
+          hooks.goal.pauseGoal(input.sessionID)
+          log("[chat-message] Goal paused", { sessionID: input.sessionID })
+        } else {
+          hooks.goal.resumeGoal(input.sessionID)
+          log("[chat-message] Goal resumed", { sessionID: input.sessionID })
+        }
+        break
+      case "clear":
+        hooks.goal.clearGoal(input.sessionID)
+        log("[chat-message] Goal cleared", { sessionID: input.sessionID })
+        break
+      case "show":
+        break
+      default:
+        break
+    }
+    return
   }
 
-  if (
-    parsed.kind === "show"
-    && isFirstMessage
-    && pluginConfig.default_mode?.goal
-  ) {
+  if (isFirstMessage && pluginConfig.default_mode?.goal) {
     const objective = promptText.trim()
     if (objective.length > 0) {
       hooks.goal.setGoal(input.sessionID, objective)

--- a/packages/omo-senpi/plugin/scripts/stage-agent-toolkit.test.mjs
+++ b/packages/omo-senpi/plugin/scripts/stage-agent-toolkit.test.mjs
@@ -3,15 +3,18 @@ import { spawnSync } from "node:child_process"
 import { chmod, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
-import { afterEach, describe, test } from "node:test"
+import { describe, test } from "node:test"
 
 import { checkAgentToolkitFresh, stageAgentToolkit } from "./stage-agent-toolkit.mjs"
 
-const tempDirs = []
+async function cleanupDir(dir) {
+  // Windows can keep a handle on a just-written file; retry instead of
+  // letting afterEach hang until the 10s hook timeout.
+  await rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }).catch(() => {})
+}
 
 async function makeFixture() {
   const root = await mkdtemp(join(tmpdir(), "omo-senpi-agent-toolkit-stage-test-"))
-  tempDirs.push(root)
   const sourceEntry = join(root, "built", "cli.js")
   const directiveEntry = join(root, "built", "directive.md")
   const targetDir = join(root, "staged", "agent-toolkit")
@@ -19,102 +22,112 @@ async function makeFixture() {
   await writeFile(sourceEntry, "#!/usr/bin/env node\nconsole.log('ulw-loop help')\n", "utf8")
   await writeFile(directiveEntry, "# Ultrawork\n", "utf8")
   await chmod(sourceEntry, 0o755)
-  return { sourceEntry, directiveEntry, targetDir }
+  return { extraDirs: [], root, sourceEntry, directiveEntry, targetDir }
 }
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
-})
+async function withFixture(run) {
+  const fixture = await makeFixture()
+  try {
+    return await run(fixture)
+  } finally {
+    await Promise.all([fixture.root, ...fixture.extraDirs].map(cleanupDir))
+  }
+}
 
 describe("agent-toolkit runtime staging", () => {
   test("#given a standalone ulw-loop bundle #when staged #then dispatcher and executable shims are self-contained", async () => {
-    const fixture = await makeFixture()
+    await withFixture(async (fixture) => {
+      const result = await stageAgentToolkit({ ...fixture, buildBundle: false })
 
-    const result = await stageAgentToolkit({ ...fixture, buildBundle: false })
-
-    const posixShim = join(fixture.targetDir, "omo-agent-toolkit")
-    assert.equal(result.ok, true)
-    // Windows has no POSIX execute bit, so stat reports 0o666 there no matter what chmod requested.
-    if (process.platform !== "win32") {
-      assert.equal((await stat(posixShim)).mode & 0o777, 0o755)
-    }
-    assert.equal(await readFile(posixShim, "utf8"), "#!/bin/sh\nexec node \"$(dirname \"$0\")/cli.js\" \"$@\"\n")
-    assert.equal(await readFile(join(fixture.targetDir, "omo-agent-toolkit.cmd"), "utf8"), "@echo off\r\nnode \"%~dp0cli.js\" %*\r\n")
-    const probeCwd = await mkdtemp(join(tmpdir(), "omo-senpi-agent-toolkit-probe-test-"))
-    tempDirs.push(probeCwd)
-    const probe = spawnSync(process.execPath, [join(fixture.targetDir, "cli.js"), "ulw-loop", "--help"], {
-      cwd: probeCwd,
-      encoding: "utf8",
+      const posixShim = join(fixture.targetDir, "omo-agent-toolkit")
+      assert.equal(result.ok, true)
+      // Windows has no POSIX execute bit, so stat reports 0o666 there no matter what chmod requested.
+      if (process.platform !== "win32") {
+        assert.equal((await stat(posixShim)).mode & 0o777, 0o755)
+      }
+      assert.equal(await readFile(posixShim, "utf8"), "#!/bin/sh\nexec node \"$(dirname \"$0\")/cli.js\" \"$@\"\n")
+      assert.equal(await readFile(join(fixture.targetDir, "omo-agent-toolkit.cmd"), "utf8"), "@echo off\r\nnode \"%~dp0cli.js\" %*\r\n")
+      const probeCwd = await mkdtemp(join(tmpdir(), "omo-senpi-agent-toolkit-probe-test-"))
+      fixture.extraDirs.push(probeCwd)
+      const probe = spawnSync(process.execPath, [join(fixture.targetDir, "cli.js"), "ulw-loop", "--help"], {
+        cwd: probeCwd,
+        encoding: "utf8",
+      })
+      assert.equal(probe.status, 0, probe.stderr)
     })
-    assert.equal(probe.status, 0, probe.stderr)
   })
 
   test("#given a staged toolkit #when freshness is checked #then runtime artifacts and source bytes must match", async () => {
-    const fixture = await makeFixture()
-    await stageAgentToolkit({ ...fixture, buildBundle: false })
+    await withFixture(async (fixture) => {
+      await stageAgentToolkit({ ...fixture, buildBundle: false })
 
-    const result = await checkAgentToolkitFresh(fixture)
+      const result = await checkAgentToolkitFresh(fixture)
 
-    assert.equal(result.ok, true)
-    assert.equal(await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8"), await readFile(fixture.sourceEntry, "utf8"))
-    assert.equal(await readFile(join(fixture.targetDir, "directive.md"), "utf8"), await readFile(fixture.directiveEntry, "utf8"))
+      assert.equal(result.ok, true)
+      assert.equal(await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8"), await readFile(fixture.sourceEntry, "utf8"))
+      assert.equal(await readFile(join(fixture.targetDir, "directive.md"), "utf8"), await readFile(fixture.directiveEntry, "utf8"))
+    })
   })
 
   test("#given an identical staged toolkit #when staged again #then preserves the target directory identity", async () => {
-    const fixture = await makeFixture()
-    await stageAgentToolkit({ ...fixture, buildBundle: false })
-    const before = await stat(fixture.targetDir)
+    await withFixture(async (fixture) => {
+      await stageAgentToolkit({ ...fixture, buildBundle: false })
+      const before = await stat(fixture.targetDir)
 
-    await stageAgentToolkit({ ...fixture, buildBundle: false })
+      await stageAgentToolkit({ ...fixture, buildBundle: false })
 
-    assert.equal((await stat(fixture.targetDir)).ino, before.ino)
+      assert.equal((await stat(fixture.targetDir)).ino, before.ino)
+    })
   })
 
   test("#given a malformed staged toolkit #when staged again #then replaces the stale directory shape", async () => {
-    const fixture = await makeFixture()
-    await stageAgentToolkit({ ...fixture, buildBundle: false })
-    await rm(join(fixture.targetDir, "ulw-loop"), { recursive: true, force: true })
-    await writeFile(join(fixture.targetDir, "ulw-loop"), "stale", "utf8")
+    await withFixture(async (fixture) => {
+      await stageAgentToolkit({ ...fixture, buildBundle: false })
+      await rm(join(fixture.targetDir, "ulw-loop"), { recursive: true, force: true })
+      await writeFile(join(fixture.targetDir, "ulw-loop"), "stale", "utf8")
 
-    await stageAgentToolkit({ ...fixture, buildBundle: false })
+      await stageAgentToolkit({ ...fixture, buildBundle: false })
 
-    assert.equal(await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8"), await readFile(fixture.sourceEntry, "utf8"))
+      assert.equal(await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8"), await readFile(fixture.sourceEntry, "utf8"))
+    })
   })
 
   test("#given a partial Windows backup copy #when staging fails #then removes backup debris and preserves the target", async () => {
-    const fixture = await makeFixture()
-    await stageAgentToolkit({ ...fixture, buildBundle: false })
-    const original = await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8")
-    await writeFile(fixture.sourceEntry, "#!/usr/bin/env node\nconsole.log('changed')\n", "utf8")
+    await withFixture(async (fixture) => {
+      await stageAgentToolkit({ ...fixture, buildBundle: false })
+      const original = await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8")
+      await writeFile(fixture.sourceEntry, "#!/usr/bin/env node\nconsole.log('changed')\n", "utf8")
 
-    await assert.rejects(
-      stageAgentToolkit({
-        ...fixture,
-        buildBundle: false,
-        platform: "win32",
-        copyDirectory: async (_source, backupDir) => {
-          await mkdir(backupDir, { recursive: true })
-          await writeFile(join(backupDir, "partial"), "partial", "utf8")
-          throw new Error("copy failed")
-        },
-      }),
-      /copy failed/,
-    )
+      await assert.rejects(
+        stageAgentToolkit({
+          ...fixture,
+          buildBundle: false,
+          platform: "win32",
+          copyDirectory: async (_source, backupDir) => {
+            await mkdir(backupDir, { recursive: true })
+            await writeFile(join(backupDir, "partial"), "partial", "utf8")
+            throw new Error("copy failed")
+          },
+        }),
+        /copy failed/,
+      )
 
-    assert.equal(await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8"), original)
-    assert.equal(
-      (await readdir(dirname(fixture.targetDir))).some((entry) => entry.startsWith("agent-toolkit.backup-")),
-      false,
-    )
+      assert.equal(await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8"), original)
+      assert.equal(
+        (await readdir(dirname(fixture.targetDir))).some((entry) => entry.startsWith("agent-toolkit.backup-")),
+        false,
+      )
+    })
   })
 
   test("#given an unknown component #when dispatched #then it exits one and lists ulw-loop", async () => {
-    const fixture = await makeFixture()
-    await stageAgentToolkit({ ...fixture, buildBundle: false })
+    await withFixture(async (fixture) => {
+      await stageAgentToolkit({ ...fixture, buildBundle: false })
 
-    const result = spawnSync(process.execPath, [join(fixture.targetDir, "cli.js"), "no-such-component"], { encoding: "utf8" })
+      const result = spawnSync(process.execPath, [join(fixture.targetDir, "cli.js"), "no-such-component"], { encoding: "utf8" })
 
-    assert.equal(result.status, 1)
-    assert.match(result.stderr, /Available components: ulw-loop/)
+      assert.equal(result.status, 1)
+      assert.match(result.stderr, /Available components: ulw-loop/)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- `handleGoalMessage` called `parseGoalCommand` on every user prompt, so ordinary messages became `setObjective` and prompts over 2000 chars crashed with `InvalidObjectiveError`.
- Gate command parsing behind an actual `/goal` slash command in the message text.
- Keep `default_mode.goal` first-message auto-start behavior.
- Native `/goal` handling in `command.execute.before` is unchanged.

## Test plan
- [x] `bun test packages/omo-opencode/src/plugin/chat-message/loop-commands.test.ts`
- [x] Ordinary prompts do not call `setGoal`
- [x] `/goal <args>` still sets the objective
- [x] First message with `default_mode.goal` still auto-starts

Fixes #6214

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only parse the goal when the message starts with “/goal” in `handleGoalMessage`, fixing the prior behavior that treated every user prompt as a goal update and crashed on long text. Default `default_mode.goal` first-message auto-start is preserved, and native “/goal” handling in `command.execute.before` is unchanged (fixes #6214).

- Required: use “/goal …” to set/pause/resume/clear the goal; ordinary prompts no longer change the goal.
- Tests updated to send explicit “/goal …” and add focused coverage for `handleGoalMessage`; Windows CI stabilized by using fake timers in session-notification tests and isolating/retiring temp dirs with retries in agent-toolkit staging tests.

<sup>Written for commit 09d0b7203b2a2527a4cd8ce5e3ed605be6332a23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

