### PR TITLE
fix(lsp-mcp): pass project cwd into local MCP config

### DIFF
--- a/packages/omo-opencode/src/mcp/index.ts
+++ b/packages/omo-opencode/src/mcp/index.ts
@@ -52,7 +52,10 @@ export function createBuiltinMcps(disabledMcps: string[] = [], config?: BuiltinM
   }
 
   if (!disabledMcps.includes("lsp")) {
-    mcps.lsp = createLspMcpConfig({ resolveExecutable: options.resolveExecutable })
+    mcps.lsp = createLspMcpConfig({
+      cwd: options.cwd,
+      resolveExecutable: options.resolveExecutable,
+    })
   }
 
   if (!disabledMcps.includes("codegraph") && config?.codegraph?.enabled !== false) {

--- a/packages/omo-opencode/src/mcp/lsp.test.ts
+++ b/packages/omo-opencode/src/mcp/lsp.test.ts
@@ -43,6 +43,7 @@ describe("createLspMcpConfig", () => {
     // then
     expect(config.enabled).toBe(true)
     expect(config.command).toEqual([nodePath, cliPath, "mcp"])
+    expect(config.cwd).toBe(unrelatedCwd)
   })
 
   it("uses the bun daemon source cli when the engine dist is already built", () => {

--- a/packages/omo-opencode/src/mcp/lsp.ts
+++ b/packages/omo-opencode/src/mcp/lsp.ts
@@ -54,6 +54,7 @@ export type LocalMcpConfig = {
   type: "local"
   command: string[]
   enabled: boolean
+  cwd?: string
   environment?: Record<string, string>
 }
 
@@ -142,6 +143,7 @@ export function createLspMcpConfig(options: LspMcpConfigOptions = {}): LocalMcpC
     type: "local",
     command: resolvedCommand.command,
     enabled: resolvedCommand.exists,
+    cwd,
     environment: {
       LSP_TOOLS_MCP_PROJECT_CONFIG: PROJECT_LSP_CONFIGS.map((configPath) => resolve(cwd, configPath)).join(delimiter),
       LSP_TOOLS_MCP_USER_CONFIG: resolve(configDir, "lsp.json"),


### PR DESCRIPTION
## Summary
- `createBuiltinMcps` did not forward `options.cwd` to `createLspMcpConfig`.
- The returned local MCP config also omitted `cwd`, so OpenCode Desktop spawned the LSP daemon under `$HOME` and `lsp_diagnostics` failed with "LSP file path must be inside request cwd".
- Pass `cwd: options.cwd` (same as codegraph) and include `cwd` on the returned local MCP config.

## Test plan
- [x] `bun test packages/omo-opencode/src/mcp/lsp.test.ts`
- [x] Assert `createLspMcpConfig({ cwd })` returns that `cwd` on the config object

Fixes #6221

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the project `cwd` into the local LSP MCP config so the LSP daemon runs in the project directory and `lsp_diagnostics` stops failing with “LSP file path must be inside request cwd”.

- **Bug Fixes**
  - Forward `cwd: options.cwd` from `createBuiltinMcps` to `createLspMcpConfig`.
  - Include `cwd` on the returned local MCP config (and its type).

<sup>Written for commit 1823d9b2906deb252dd7472f9f955c4dc122197a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

