### PR TITLE
fix(delegate-task): cap sync result size to prevent context saturation

### DIFF
--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -373,6 +373,9 @@
         "state_dir": {
           "type": "string"
         },
+        "reattach_on_reconcile": {
+          "type": "boolean"
+        },
         "wait": {
           "default": {
             "min_ms": 5000,

--- a/packages/omo-opencode/src/tools/delegate-task/sync-result-fetcher.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-result-fetcher.test.ts
@@ -450,4 +450,59 @@ describe("fetchSyncResult", () => {
       expect(result.textContent).not.toBe("internal draft sketch")
     }
   })
+
+  test("truncates oversized sync result to the maxTokens budget", async () => {
+    //#given - a subagent deliverable far larger than the budget
+    const { fetchSyncResult } = require("./sync-result-fetcher")
+
+    const oversized = `${"x".repeat(100_000)}`
+    const mockClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+            {
+              info: { id: "msg_002", role: "assistant", time: { created: 2000 } },
+              parts: [{ type: "text", text: oversized }],
+            },
+          ],
+        }),
+      },
+    }
+
+    //#when - budget of 10 tokens (40 chars at 4 chars/token)
+    const result = await fetchSyncResult(mockClient, "ses_test", undefined, { maxTokens: 10 })
+
+    //#then - the returned content is capped and flagged as truncated
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.textContent.length).toBeLessThan(oversized.length)
+      expect(result.textContent).toContain("[TRUNCATED]")
+    }
+  })
+
+  test("leaves small sync results untouched", async () => {
+    //#given - a normal-sized deliverable well under the default budget
+    const { fetchSyncResult } = require("./sync-result-fetcher")
+
+    const mockClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+            {
+              info: { id: "msg_002", role: "assistant", time: { created: 2000 } },
+              parts: [{ type: "text", text: "Short deliverable." }],
+            },
+          ],
+        }),
+      },
+    }
+
+    //#when
+    const result = await fetchSyncResult(mockClient, "ses_test")
+
+    //#then - no truncation marker, content preserved verbatim
+    expect(result).toEqual({ ok: true, textContent: "Short deliverable." })
+  })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/sync-result-fetcher.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-result-fetcher.ts
@@ -1,9 +1,22 @@
 import type { OpencodeClient } from "./types"
 import type { SessionMessage } from "./executor-types"
 import { normalizeSDKResponse } from "../../shared"
+import { truncateToTokenBudget } from "./token-limiter"
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+// Caps the text returned to the parent so an oversized subagent deliverable
+// cannot saturate the parent context. The post-tool truncator hook skips the
+// task tool, so the cap must be applied here on the fetch path. Sized to match
+// OpenCode's tool_output.max_bytes default (~51200 bytes ≈ 12800 tokens); the
+// full transcript stays available via background_output.
+const DEFAULT_MAX_SYNC_RESULT_TOKENS = 12_800
+
+function capSyncResult(content: string, maxTokens: number): string {
+  if (maxTokens <= 0) return content
+  return truncateToTokenBudget(content, maxTokens)
 }
 
 function messageText(msg: SessionMessage): string {
@@ -58,8 +71,13 @@ export async function fetchSyncResult(
   client: OpencodeClient,
   sessionID: string,
   anchorMessageCount?: number,
-  options?: { strictAbortRecovery?: boolean; deliverableTag?: string }
+  options?: {
+    strictAbortRecovery?: boolean
+    deliverableTag?: string
+    maxTokens?: number
+  }
 ): Promise<{ ok: true; textContent: string } | { ok: false; error: string }> {
+  const maxTokens = options?.maxTokens ?? DEFAULT_MAX_SYNC_RESULT_TOKENS
   const messagesResult = await client.session.messages({
     path: { id: sessionID },
   })
@@ -122,11 +140,11 @@ export async function fetchSyncResult(
     if (options.deliverableTag) {
       const tagged = extractTaggedDeliverable(assistantMessages, options.deliverableTag)
       if (tagged) {
-        return { ok: true, textContent: tagged }
+        return { ok: true, textContent: capSyncResult(tagged, maxTokens) }
       }
     }
 
-    return { ok: true, textContent: lastContent }
+    return { ok: true, textContent: capSyncResult(lastContent, maxTokens) }
   }
 
   // Prefer an explicit deliverable envelope (e.g. `<plan>...</plan>`) when the
@@ -137,7 +155,7 @@ export async function fetchSyncResult(
   if (options?.deliverableTag) {
     const tagged = extractTaggedDeliverable(assistantMessages, options.deliverableTag)
     if (tagged) {
-      return { ok: true, textContent: tagged }
+      return { ok: true, textContent: capSyncResult(tagged, maxTokens) }
     }
   }
 
@@ -160,5 +178,5 @@ export async function fetchSyncResult(
     }
   }
 
-  return { ok: true, textContent }
+  return { ok: true, textContent: capSyncResult(textContent, maxTokens) }
 }


### PR DESCRIPTION
## What

`fetchSyncResult` returned the subagent's full final assistant message with no size limit. The post-tool `tool-output-truncator` hook skips the `task` tool (it isn't in `TRUNCATABLE_TOOLS`), so oversized sync `delegate_task` results were injected verbatim into the parent context.

## Why

Observed incident (2026-07-16): an Atlas orchestrator session (glm-5.2) dispatched two sync `delegate_task` calls whose results measured **529KB and 535KB**. The payloads saturated the parent context — glm-5.2 produced an empty response (0 output tokens, `finish_reason "stop"`) and the session halted. Re-collection via `background_output` then immediately pruned the results (788KB across 6 items).

`fetchSyncResult` (`packages/omo-opencode/src/tools/delegate-task/sync-result-fetcher.ts`) returns raw `textContent` at four sites with no size limiter. The `tool_output.max_bytes` setting only governs plugin tool outputs via OpenCode's registry and never reaches the task tool's own result.

## Change

Apply the existing token-limiter (`truncateToTokenBudget` from `./token-limiter`) on the fetch path so every successful result is capped before returning to the parent:

- New `DEFAULT_MAX_SYNC_RESULT_TOKENS = 12_800` (≈ 51200 chars), sized to match OpenCode's `tool_output.max_bytes` default. Caps the reported 500KB+ dumps (~10x reduction) while leaving legitimate plan/deliverable outputs (well under 51KB) untouched.
- New `maxTokens?` option makes the cap overridable and testable; `capSyncResult()` is a no-op when `maxTokens <= 0`.
- Applied at all four `ok: true` return sites (strict-abort tagged, strict-abort recency, deliverable-tag, and final recency).
- The full transcript stays retrievable via `background_output` with `full_session=true`, so no information is lost.

## Observed behavior

`bun test packages/omo-opencode/src/tools/delegate-task/sync-result-fetcher.test.ts` → 17 pass (15 existing + 2 new). New cases assert that an oversized deliverable is capped and flagged `[TRUNCATED]`, and that a small deliverable is returned verbatim. `token-limiter.test.ts` → 10 pass (unchanged).

`tsgo --noEmit` on `packages/omo-opencode`: no new errors in the touched files (7 pre-existing errors all in `src/plugin/skill-context.ts`, unrelated).

## Residual risk

- Default budget (12.8k tokens / ~51KB) is generous for normal deliverables; agents emitting a legitimate deliverable larger than ~51KB will see it truncated with a `[TRUNCATED]` marker and must re-fetch via `background_output`. This matches the existing behavior of every other tool output.
- Budget is token-estimated (4 chars/token, same heuristic as the rest of `token-limiter.ts`), so the exact byte ceiling is approximate.

Fixes #6164

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap sync `delegate_task` results (~51KB) to prevent parent context saturation and stalled sessions, fixing #6164. Truncation is applied in `fetchSyncResult`; full transcripts remain in `background_output`.

- **Bug Fixes**
  - Apply `truncateToTokenBudget` to sync results with a 12,800-token default (~51KB), aligned with `tool_output.max_bytes`.
  - Add `maxTokens` override; no-op when <= 0.
  - Cap is enforced on all success paths (strict-abort, recency, deliverable-tag). New tests cover truncation and pass-through.

- **New Features**
  - Add `reattach_on_reconcile` boolean to `assets/omo.schema.json`.

<sup>Written for commit a0747ef0b76edab10970d1e14f0cc482272e3bd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

