### PR TITLE
fix(senpi-task): collision-proof cross-process task-id allocation

### DIFF
--- a/packages/omo-senpi/scripts/qa/task-id-race-mock-provider.mjs
+++ b/packages/omo-senpi/scripts/qa/task-id-race-mock-provider.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// QA-local provider for task-id-race-qa.mjs. Unlike the shared provider, its script is
+// process-private so two parent harnesses can use one project cwd without sharing input.
+import { existsSync, mkdirSync, readFileSync, watch, writeFileSync } from "node:fs"
+import { dirname, isAbsolute } from "node:path"
+
+const model = {
+  id: "mock-1",
+  name: "Mock 1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 16_000,
+  maxTokens: 4096,
+}
+
+let callCount = 0
+let gateUsed = false
+
+export default function registerTaskIdRaceMockProvider(pi) {
+  pi.registerProvider("omo-mock", {
+    name: "omo task-id race mock provider",
+    baseUrl: "file://task-id-race-mock-provider",
+    apiKey: "mock",
+    api: "openai-completions",
+    models: [model],
+    streamSimple(_model, _context, options) {
+      return streamMockResponse(options)
+    },
+  })
+}
+
+export function loadMockScript() {
+  const scriptPath = process.env.SENPI_QA_MOCK_SCRIPT
+  if (typeof scriptPath !== "string" || !isAbsolute(scriptPath)) {
+    throw new Error("SENPI_QA_MOCK_SCRIPT must be an absolute path")
+  }
+  const parsed = JSON.parse(readFileSync(scriptPath, "utf8"))
+  if (!isMockScript(parsed)) throw new Error(`${scriptPath} must contain valid mock steps`)
+  return parsed
+}
+
+function streamMockResponse(options) {
+  const stream = createStream()
+  const script = loadMockScript()
+  const step = script.steps[Math.min(callCount, script.steps.length - 1)]
+  callCount += 1
+  const message = stepToAssistantMessage(step, callCount)
+
+  queueMicrotask(async () => {
+    try {
+      if (!gateUsed) {
+        gateUsed = true
+        await waitForGoFile()
+      }
+      if (options?.signal?.aborted) {
+        const aborted = { ...message, stopReason: "aborted" }
+        stream.push({ type: "error", reason: "aborted", error: aborted })
+        stream.end(aborted)
+        return
+      }
+      stream.push({ type: "start", partial: { ...message, content: [] } })
+      if (step.type === "text") {
+        const partial = { ...message, content: [{ type: "text", text: "" }] }
+        stream.push({ type: "text_start", contentIndex: 0, partial })
+        stream.push({ type: "text_delta", contentIndex: 0, delta: step.text, partial: message })
+        stream.push({ type: "text_end", contentIndex: 0, content: step.text, partial: message })
+      } else {
+        const toolCall = message.content[0]
+        stream.push({ type: "toolcall_start", contentIndex: 0, partial: { ...message, content: [] } })
+        stream.push({ type: "toolcall_delta", contentIndex: 0, delta: JSON.stringify(step.arguments), partial: message })
+        stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial: message })
+      }
+      stream.push({ type: "done", reason: message.stopReason, message })
+      stream.end(message)
+    } catch (error) {
+      stream.fail(error instanceof Error ? error : new Error(String(error)))
+    }
+  })
+  return stream
+}
+
+// Subscribe before READY is visible, then immediately inspect existence so a GO creation
+// between the subscription and this check cannot be missed. There is intentionally no polling.
+export function waitForGoFile() {
+  const readyFile = requiredPath("SENPI_QA_READY_FILE")
+  const goFile = requiredPath("SENPI_QA_GO_FILE")
+  const timeoutMs = positiveTimeout(process.env.SENPI_QA_GATE_TIMEOUT_MS, 120_000)
+  mkdirSync(dirname(readyFile), { recursive: true })
+  mkdirSync(dirname(goFile), { recursive: true })
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let watcher
+    const finish = (error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      watcher?.close()
+      if (error === undefined) resolve()
+      else reject(error)
+    }
+    const timer = setTimeout(() => finish(new Error(`task-id race gate timed out after ${timeoutMs}ms waiting for ${goFile}`)), timeoutMs)
+    try {
+      watcher = watch(dirname(goFile), (_eventType, filename) => {
+        if (filename === null || filename.toString() === goFile.split("/").at(-1)) {
+          if (existsSync(goFile)) finish()
+        }
+      })
+      writeFileSync(readyFile, "ready\n", { flag: "wx" })
+      if (existsSync(goFile)) finish()
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)))
+    }
+  })
+}
+
+function requiredPath(name) {
+  const value = process.env[name]
+  if (typeof value !== "string" || !isAbsolute(value)) throw new Error(`${name} must be an absolute path`)
+  return value
+}
+
+function positiveTimeout(value, fallback) {
+  const parsed = Number(value ?? fallback)
+  if (!Number.isFinite(parsed) || parsed <= 0) throw new Error("SENPI_QA_GATE_TIMEOUT_MS must be a positive number")
+  return parsed
+}
+
+function isMockScript(value) {
+  return typeof value === "object" && value !== null && Array.isArray(value.steps) && value.steps.every(isMockStep)
+}
+
+function isMockStep(value) {
+  if (typeof value !== "object" || value === null) return false
+  if (value.type === "text") return typeof value.text === "string"
+  return value.type === "tool_call" && typeof value.name === "string" && typeof value.arguments === "object" && value.arguments !== null
+}
+
+function stepToAssistantMessage(step, callNumber) {
+  const content = step.type === "text"
+    ? [{ type: "text", text: step.text }]
+    : [{ type: "toolCall", id: step.id ?? `omo-race-tool-${callNumber}`, name: step.name, arguments: step.arguments }]
+  return {
+    role: "assistant",
+    content,
+    api: "openai-completions",
+    provider: "omo-mock",
+    model: "mock-1",
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: 0 },
+    stopReason: step.type === "tool_call" ? "toolUse" : "stop",
+    timestamp: Date.now(),
+  }
+}
+
+function createStream() {
+  const queue = []
+  const waiters = []
+  let done = false
+  let settleResult = () => {}
+  let rejectResult = () => {}
+  const result = new Promise((resolve, reject) => { settleResult = resolve; rejectResult = reject })
+  result.catch(() => {})
+  const drain = () => {
+    while (waiters.length > 0) waiters.shift()({ value: undefined, done: true })
+  }
+  return {
+    push(event) {
+      if (done) return
+      const waiter = waiters.shift()
+      if (waiter) waiter({ value: event, done: false })
+      else queue.push(event)
+    },
+    end(message) {
+      if (done) return
+      done = true
+      settleResult(message)
+      drain()
+    },
+    fail(error) {
+      if (done) return
+      done = true
+      rejectResult(error)
+      drain()
+    },
+    result: () => result,
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          if (queue.length > 0) return Promise.resolve({ value: queue.shift(), done: false })
+          if (done) return Promise.resolve({ value: undefined, done: true })
+          return new Promise((resolve) => waiters.push(resolve))
+        },
+      }
+    },
+  }
+}

--- a/packages/omo-senpi/scripts/qa/task-id-race-qa.mjs
+++ b/packages/omo-senpi/scripts/qa/task-id-race-qa.mjs
@@ -55,7 +55,11 @@ async function main() {
 function regeneratePlugin() {
   const paths = [pluginEntry, join(pluginRoot, "extensions", "omo-member.js")]
   const originals = paths.map((path) => ({ path, content: existsSync(path) ? readFileSync(path) : undefined }))
-  const result = spawnSync(process.execPath, [join(pluginRoot, "scripts", "build-extension.mjs")], { cwd: resolve(packageRoot, "..", ".."), encoding: "utf8" })
+  const result = spawnSync(process.execPath, [join(pluginRoot, "scripts", "build-extension.mjs")], {
+    cwd: resolve(packageRoot, "..", ".."),
+    encoding: "utf8",
+    timeout: 120_000,
+  })
   if (result.status !== 0 && !existsSync(pluginEntry)) throw new Error(`plugin build failed:\n${result.stdout}${result.stderr}`)
   return originals
 }
@@ -86,7 +90,7 @@ async function runAttempt(input) {
     await Promise.all(parents.map((parent) => waitForFile(parent.readyFile, input.timeoutMs)))
     buckets.before = Math.floor(Date.now() / 65_536)
     for (const parent of parents) writeFileSync(parent.goFile, "go\n", { flag: "wx" })
-    const completions = await Promise.all(runs.map((run) => run.completion))
+    const completions = await Promise.all(runs.map((run) => waitForCompletion(run, input.timeoutMs, attemptDir, "post-go")))
     buckets.after = Math.floor(Date.now() / 65_536)
     after = lsTasks(projectDir)
     taskIds = taskIdsFromListing(after)
@@ -112,7 +116,7 @@ async function runAttempt(input) {
     writeFileSync(join(attemptDir, "tasks-before.ls.txt"), before)
     writeFileSync(join(attemptDir, "tasks-after.ls.txt"), after || lsTasks(projectDir))
   } finally {
-    cleanup = await cleanupRuns(runs, root)
+    cleanup = await cleanupRuns(runs, root, input.timeoutMs, attemptDir)
     writeJson(join(attemptDir, "cleanup-receipt.json"), cleanup)
     writeJson(join(input.evidenceDir, "cleanup-receipt.txt"), cleanup)
   }
@@ -187,7 +191,33 @@ function startSenpi(senpiBin, parent, projectDir, timeoutMs) {
     child.on("close", (status, signal) => resolve({ status, signal, stdout, stderr }))
     child.on("error", (error) => resolve({ status: null, signal: null, stdout, stderr: `${stderr}\n${error.message}` }))
   })
-  return { pid: child.pid, completion }
+  return { name: parent.name, pid: child.pid, completion }
+}
+
+function waitForCompletion(run, timeoutMs, artifactDir, phase) {
+  let timer
+  return Promise.race([
+    run.completion,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        killProcessGroup(run.pid)
+        const timeout = { phase, name: run.name, pid: run.pid, timeout_ms: timeoutMs }
+        writeJson(join(artifactDir, `${run.name}.${phase}.timeout.json`), timeout)
+        reject(new Error(`timed out after ${timeoutMs}ms waiting for ${run.name} during ${phase}`))
+      }, timeoutMs)
+    }),
+  ]).finally(() => clearTimeout(timer))
+}
+
+function killProcessGroup(pid) {
+  if (!Number.isInteger(pid)) return false
+  try {
+    process.kill(-pid, "SIGKILL")
+    return true
+  } catch (error) {
+    if (isMissingProcess(error)) return false
+    throw error
+  }
 }
 
 function waitForFile(path, timeoutMs) {
@@ -212,13 +242,13 @@ function waitForFile(path, timeoutMs) {
   })
 }
 
-async function cleanupRuns(runs, root) {
+async function cleanupRuns(runs, root, timeoutMs, artifactDir) {
   const pids = runs.map((run) => run.pid).filter((pid) => Number.isInteger(pid))
   const terminated = []
   for (const pid of pids) {
-    try { process.kill(-pid, "SIGKILL"); terminated.push(pid) } catch (error) { if (!isMissingProcess(error)) throw error }
+    if (killProcessGroup(pid)) terminated.push(pid)
   }
-  await Promise.all(runs.map((run) => run.completion))
+  await Promise.all(runs.map((run) => waitForCompletion(run, timeoutMs, artifactDir, "teardown")))
   const verified_dead = pids.filter((pid) => !isAlive(pid))
   if (verified_dead.length !== pids.length) throw new Error(`cleanup could not terminate process groups: ${pids.filter((pid) => isAlive(pid)).join(", ")}`)
   rmSync(root, { recursive: true, force: true })
@@ -236,7 +266,7 @@ function isMissingProcess(error) {
 function lsTasks(projectDir) {
   const tasksDir = join(projectDir, ".omo", "senpi-task", "tasks")
   if (!existsSync(tasksDir)) return "<absent>\n"
-  const result = spawnSync("ls", ["-la", tasksDir], { encoding: "utf8" })
+  const result = spawnSync("ls", ["-la", tasksDir], { encoding: "utf8", timeout: 30_000 })
   return `${result.stdout}${result.stderr}`
 }
 
@@ -271,12 +301,12 @@ function resolveSenpi(bin) {
 }
 
 function versionOf(bin) {
-  const result = spawnSync(bin, ["--version"], { encoding: "utf8" })
+  const result = spawnSync(bin, ["--version"], { encoding: "utf8", timeout: 30_000 })
   return `${result.stdout}${result.stderr}`.trim() || "unknown"
 }
 
 function git(...args) {
-  const result = spawnSync("git", args, { cwd: resolve(packageRoot, "..", ".."), encoding: "utf8" })
+  const result = spawnSync("git", args, { cwd: resolve(packageRoot, "..", ".."), encoding: "utf8", timeout: 30_000 })
   return result.status === 0 ? result.stdout.trim() : "unknown"
 }
 

--- a/packages/omo-senpi/scripts/qa/task-id-race-qa.mjs
+++ b/packages/omo-senpi/scripts/qa/task-id-race-qa.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process"
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, watch, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { basename, delimiter, dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const COLLISION_TEXT = "Task record already exists"
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, "..", "..")
+const pluginRoot = join(packageRoot, "plugin")
+const pluginEntry = join(pluginRoot, "extensions", "omo.js")
+const mockProviderEntry = join(scriptDir, "task-id-race-mock-provider.mjs")
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  mkdirSync(options.evidenceDir, { recursive: true })
+  const generated = regeneratePlugin()
+  try {
+    const senpiBin = resolveSenpi(process.env.SENPI_BIN?.trim() || "senpi")
+    const metadata = {
+      worktree_sha: git("rev-parse", "HEAD"),
+      worktree_root: resolve(packageRoot, "..", ".."),
+      resolved_plugin_entry: realpathSync(pluginEntry),
+      senpi_binary: senpiBin,
+      senpi_version: senpiBin === null ? "unavailable" : versionOf(senpiBin),
+    }
+    writeJson(join(options.evidenceDir, "environment.json"), metadata)
+    if (senpiBin === null) throw new Error("senpi binary unavailable")
+    if (!existsSync(pluginEntry)) throw new Error(`plugin entry missing: ${pluginEntry}`)
+
+    let last
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      last = await runAttempt({ ...options, senpiBin, attempt, metadata })
+      if (last.bucketStable) break
+    }
+    const reasons = last.reasons
+    const pass = last.bucketStable && reasons.length === 0
+    writeJson(join(options.evidenceDir, "verdict.json"), {
+      result: pass ? "PASS" : "FAIL",
+      attempts: last.attempt,
+      bucketStable: last.bucketStable,
+      buckets: last.buckets,
+      taskIds: last.taskIds,
+      reasons,
+      ...metadata,
+    })
+    console.log(JSON.stringify({ result: pass ? "PASS" : "FAIL", reasons, taskIds: last.taskIds, buckets: last.buckets }))
+    if (!pass) process.exitCode = 1
+  } finally {
+    restorePlugin(generated)
+  }
+}
+
+function regeneratePlugin() {
+  const paths = [pluginEntry, join(pluginRoot, "extensions", "omo-member.js")]
+  const originals = paths.map((path) => ({ path, content: existsSync(path) ? readFileSync(path) : undefined }))
+  const result = spawnSync(process.execPath, [join(pluginRoot, "scripts", "build-extension.mjs")], { cwd: resolve(packageRoot, "..", ".."), encoding: "utf8" })
+  if (result.status !== 0 && !existsSync(pluginEntry)) throw new Error(`plugin build failed:\n${result.stdout}${result.stderr}`)
+  return originals
+}
+
+function restorePlugin(originals) {
+  for (const original of originals) {
+    if (original.content !== undefined) writeFileSync(original.path, original.content)
+  }
+}
+
+async function runAttempt(input) {
+  const attemptDir = join(input.evidenceDir, `attempt-${input.attempt}`)
+  mkdirSync(attemptDir, { recursive: true })
+  const root = mkdtempSync(join(tmpdir(), "omo-senpi-task-id-race-"))
+  const projectDir = join(root, "project")
+  seedProject(projectDir)
+  const parents = ["parent-a", "parent-b"].map((name) => createParent(root, name, projectDir, input.timeoutMs))
+  const runs = []
+  let cleanup = { pids: [], terminated: [], verified_dead: [], sandbox_removed: false }
+  let before = ""
+  let after = ""
+  let buckets = { before: null, after: null }
+  let taskIds = []
+  const reasons = []
+  try {
+    before = lsTasks(projectDir)
+    for (const parent of parents) runs.push(startSenpi(input.senpiBin, parent, projectDir, input.timeoutMs))
+    await Promise.all(parents.map((parent) => waitForFile(parent.readyFile, input.timeoutMs)))
+    buckets.before = Math.floor(Date.now() / 65_536)
+    for (const parent of parents) writeFileSync(parent.goFile, "go\n", { flag: "wx" })
+    const completions = await Promise.all(runs.map((run) => run.completion))
+    buckets.after = Math.floor(Date.now() / 65_536)
+    after = lsTasks(projectDir)
+    taskIds = taskIdsFromListing(after)
+    for (let index = 0; index < completions.length; index += 1) {
+      writeFileSync(join(attemptDir, `${parents[index].name}.stdout.jsonl`), completions[index].stdout)
+      writeFileSync(join(attemptDir, `${parents[index].name}.stderr.log`), completions[index].stderr)
+      writeJson(join(attemptDir, `${parents[index].name}.exit.json`), { status: completions[index].status, signal: completions[index].signal })
+      copySessionTranscript(parents[index].sessionDir, join(attemptDir, `${parents[index].name}.sessions`))
+      if (completions[index].status !== 0) reasons.push(`${parents[index].name} senpi exited ${completions[index].status ?? completions[index].signal ?? "unknown"}`)
+    }
+    const transcript = completions.map((completion) => `${completion.stdout}\n${completion.stderr}`).join("\n")
+    if (transcript.includes(COLLISION_TEXT)) reasons.push(`transcript contains ${JSON.stringify(COLLISION_TEXT)}`)
+    if (taskIds.length !== 2) reasons.push(`expected exactly 2 task records, observed ${taskIds.length}`)
+    if (new Set(taskIds).size !== taskIds.length) reasons.push("task ids are not unique")
+    if (buckets.before !== buckets.after) reasons.push(`bucket changed from ${buckets.before} to ${buckets.after}`)
+    writeFileSync(join(attemptDir, "tasks-before.ls.txt"), before)
+    writeFileSync(join(attemptDir, "tasks-after.ls.txt"), after)
+    writeJson(join(attemptDir, "run.json"), { buckets, taskIds, reasons, ...input.metadata })
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error)
+    reasons.push(message)
+    writeFileSync(join(attemptDir, "driver-error.log"), `${message}\n`)
+    writeFileSync(join(attemptDir, "tasks-before.ls.txt"), before)
+    writeFileSync(join(attemptDir, "tasks-after.ls.txt"), after || lsTasks(projectDir))
+  } finally {
+    cleanup = await cleanupRuns(runs, root)
+    writeJson(join(attemptDir, "cleanup-receipt.json"), cleanup)
+    writeJson(join(input.evidenceDir, "cleanup-receipt.txt"), cleanup)
+  }
+  return { attempt: input.attempt, bucketStable: buckets.before !== null && buckets.before === buckets.after, buckets, taskIds, reasons }
+}
+
+function createParent(root, name, projectDir, timeoutMs) {
+  const parentRoot = join(root, name)
+  const home = join(parentRoot, "home")
+  const agentDir = join(parentRoot, "agent")
+  const sessionDir = join(parentRoot, "sessions")
+  const gates = join(parentRoot, "gates")
+  mkdirSync(home, { recursive: true })
+  mkdirSync(agentDir, { recursive: true })
+  mkdirSync(sessionDir, { recursive: true })
+  mkdirSync(gates, { recursive: true })
+  const canonicalProject = realpathSync(projectDir)
+  writeJson(join(agentDir, "settings.json"), { defaultProjectTrust: "ask", packages: [pluginRoot] })
+  writeJson(join(agentDir, "trust.json"), { [canonicalProject]: true })
+  const script = {
+    steps: [
+      { type: "tool_call", name: "task", arguments: { category: "mockcat", prompt: `race task from ${name}`, run_in_background: true, name: `${name}-race` } },
+      { type: "text", text: `${name} parent complete` },
+    ],
+  }
+  const scriptPath = join(parentRoot, "mock-script.json")
+  writeJson(scriptPath, script)
+  return {
+    name,
+    home,
+    agentDir,
+    sessionDir,
+    scriptPath,
+    readyFile: join(gates, "ready"),
+    goFile: join(gates, "go"),
+    timeoutMs,
+  }
+}
+
+function seedProject(projectDir) {
+  mkdirSync(join(projectDir, ".omo"), { recursive: true })
+  writeJson(join(projectDir, ".omo", "omo.json"), {
+    categories: { mockcat: { description: "local QA-only mock category", model: "omo-mock/mock-1" } },
+  })
+}
+
+function startSenpi(senpiBin, parent, projectDir, timeoutMs) {
+  const child = spawn(senpiBin, [
+    "-e", mockProviderEntry, "-p", "--mode", "json", "--provider", "omo-mock", "--model", "mock-1",
+    "--session-dir", parent.sessionDir, `launch the ${parent.name} background race task`,
+  ], {
+    cwd: projectDir,
+    env: {
+      ...process.env,
+      HOME: parent.home,
+      SENPI_CODING_AGENT_DIR: parent.agentDir,
+      SENPI_CODING_AGENT_SESSION_DIR: parent.sessionDir,
+      SENPI_QA_MOCK_SCRIPT: parent.scriptPath,
+      SENPI_QA_READY_FILE: parent.readyFile,
+      SENPI_QA_GO_FILE: parent.goFile,
+      SENPI_QA_GATE_TIMEOUT_MS: String(timeoutMs),
+      OMO_SENPI_QA: "1",
+    },
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => { stdout += chunk })
+  child.stderr.on("data", (chunk) => { stderr += chunk })
+  const completion = new Promise((resolve) => {
+    child.on("close", (status, signal) => resolve({ status, signal, stdout, stderr }))
+    child.on("error", (error) => resolve({ status: null, signal: null, stdout, stderr: `${stderr}\n${error.message}` }))
+  })
+  return { pid: child.pid, completion }
+}
+
+function waitForFile(path, timeoutMs) {
+  if (existsSync(path)) return Promise.resolve()
+  return new Promise((resolvePromise, reject) => {
+    let settled = false
+    const finish = (error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      watcher.close()
+      if (error === undefined) resolvePromise()
+      else reject(error)
+    }
+    const watcher = watch(dirname(path), (_event, filename) => {
+      if (filename === null || filename.toString() === basename(path)) {
+        if (existsSync(path)) finish()
+      }
+    })
+    const timer = setTimeout(() => finish(new Error(`timed out after ${timeoutMs}ms waiting for ${path}`)), timeoutMs)
+    if (existsSync(path)) finish()
+  })
+}
+
+async function cleanupRuns(runs, root) {
+  const pids = runs.map((run) => run.pid).filter((pid) => Number.isInteger(pid))
+  const terminated = []
+  for (const pid of pids) {
+    try { process.kill(-pid, "SIGKILL"); terminated.push(pid) } catch (error) { if (!isMissingProcess(error)) throw error }
+  }
+  await Promise.all(runs.map((run) => run.completion))
+  const verified_dead = pids.filter((pid) => !isAlive(pid))
+  if (verified_dead.length !== pids.length) throw new Error(`cleanup could not terminate process groups: ${pids.filter((pid) => isAlive(pid)).join(", ")}`)
+  rmSync(root, { recursive: true, force: true })
+  return { pids, terminated, verified_dead, sandbox_removed: !existsSync(root) }
+}
+
+function isAlive(pid) {
+  try { process.kill(pid, 0); return true } catch (error) { if (isMissingProcess(error)) return false; throw error }
+}
+
+function isMissingProcess(error) {
+  return error instanceof Error && "code" in error && error.code === "ESRCH"
+}
+
+function lsTasks(projectDir) {
+  const tasksDir = join(projectDir, ".omo", "senpi-task", "tasks")
+  if (!existsSync(tasksDir)) return "<absent>\n"
+  const result = spawnSync("ls", ["-la", tasksDir], { encoding: "utf8" })
+  return `${result.stdout}${result.stderr}`
+}
+
+function taskIdsFromListing(listing) {
+  return listing.split(/\r?\n/).map((line) => line.trim().split(/\s+/).at(-1) ?? "").filter((entry) => /^st_[0-9a-f]{8}\.json$/.test(entry)).map((entry) => entry.slice(0, -5))
+}
+
+function copySessionTranscript(from, to) {
+  if (existsSync(from)) cpSync(from, to, { recursive: true })
+}
+
+function parseArgs(args) {
+  let evidenceDir
+  let timeoutMs = 120_000
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--evidence-dir") evidenceDir = args[++index]
+    else if (args[index] === "--timeout-ms") timeoutMs = Number(args[++index])
+    else throw new Error(`unknown argument: ${args[index]}`)
+  }
+  if (typeof evidenceDir !== "string" || evidenceDir.length === 0) throw new Error("usage: node task-id-race-qa.mjs --evidence-dir <dir> [--timeout-ms 120000]")
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error("--timeout-ms must be a positive number")
+  return { evidenceDir: resolve(evidenceDir), timeoutMs }
+}
+
+function resolveSenpi(bin) {
+  if (bin.includes("/")) return existsSync(bin) ? resolve(bin) : null
+  for (const entry of (process.env.PATH ?? "").split(delimiter)) {
+    const candidate = resolve(entry || ".", bin)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+function versionOf(bin) {
+  const result = spawnSync(bin, ["--version"], { encoding: "utf8" })
+  return `${result.stdout}${result.stderr}`.trim() || "unknown"
+}
+
+function git(...args) {
+  const result = spawnSync("git", args, { cwd: resolve(packageRoot, "..", ".."), encoding: "utf8" })
+  return result.status === 0 ? result.stdout.trim() : "unknown"
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error))
+  process.exitCode = 1
+})

--- a/packages/senpi-task/src/lifecycle/ttl.test.ts
+++ b/packages/senpi-task/src/lifecycle/ttl.test.ts
@@ -75,6 +75,25 @@ describe("cleanupExpiredRecords (TTL)", () => {
     expect(result.retained).toContain("st_00000003")
   })
 
+  test("#given a freshly claimed pending record #when the cutoff is far in the future #then it is retained", () => {
+    // given
+    const store = tempStore()
+    seedRecord(store, { task_id: "st_00000007", status: "pending", updated_at: iso(0) })
+    const lifecycle = createTaskLifecycle({
+      store,
+      registry: new FakeRegistry(),
+      config: settings({ ttl_ms: TTL }),
+      now: () => now() + TTL * 100,
+    })
+
+    // when
+    const result = lifecycle.cleanupExpiredRecords()
+
+    // then
+    expect(result.retained).toContain("st_00000007")
+    expect(existsSync(recordPath(store, "st_00000007"))).toBe(true)
+  })
+
   test("#given an old lost RPC record with a LIVE pid #when cleaning #then it is retained (no pid-dead proof)", () => {
     // given
     const store = tempStore()

--- a/packages/senpi-task/src/manager/__fixtures__/collision-store.ts
+++ b/packages/senpi-task/src/manager/__fixtures__/collision-store.ts
@@ -1,0 +1,20 @@
+import type { TaskRecordStore } from "../../store"
+
+export function collisionStore(inner: TaskRecordStore): { readonly store: TaskRecordStore; readonly firstCandidate: () => string | undefined } {
+  let firstSave = true
+  let firstCandidate: string | undefined
+  return {
+    store: {
+      ...inner,
+      save(record) {
+        if (firstSave) {
+          firstSave = false
+          firstCandidate = record.task_id
+          inner.save({ ...record, name: "foreign-winner" })
+        }
+        inner.save(record)
+      },
+    },
+    firstCandidate: () => firstCandidate,
+  }
+}

--- a/packages/senpi-task/src/manager/__fixtures__/seed-floor-child.ts
+++ b/packages/senpi-task/src/manager/__fixtures__/seed-floor-child.ts
@@ -1,0 +1,97 @@
+import { strict as assert } from "node:assert"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import type { TaskRecord } from "../../state"
+import { createTaskRecordStore } from "../../store"
+import { createTaskManager } from "../manager"
+import { FakeRunner, baseSpec, categoryPlanner, settings } from "./manager-fakes"
+
+const mode = process.argv[2]
+
+function record(taskId: string): TaskRecord {
+  return {
+    task_id: taskId,
+    status: "pending",
+    residency_state: "resident",
+    parent_session_id: "parent-session",
+    root_session_id: "root-session",
+    depth: 1,
+    execution_mode: "in-process",
+    model: "test/model",
+    name: taskId,
+    created_at: "2026-07-20T00:00:00.000Z",
+    updated_at: "2026-07-20T00:00:00.000Z",
+    notification: { run_epoch: 0, notified_epoch: -1 },
+  }
+}
+
+function makeManager(project: string) {
+  const store = createTaskRecordStore({ project_dir: project })
+  const inProcess = new FakeRunner()
+  const process = new FakeRunner()
+  const manager = createTaskManager({
+    store,
+    runners: { "in-process": inProcess, process },
+    planner: categoryPlanner(),
+    config: settings({ default_concurrency: 5, max_depth: 1 }),
+    cwd: project,
+  })
+  return { manager, store }
+}
+
+async function run(): Promise<void> {
+  const project = mkdtempSync(join(tmpdir(), "senpi-task-seed-floor-"))
+  try {
+    switch (mode) {
+      case "seed": {
+        const store = createTaskRecordStore({ project_dir: project })
+        store.save(record("st_7fffff00"))
+        const { manager } = makeManager(project)
+        const result = await manager.start(baseSpec())
+        assert.equal(result.kind, "started")
+        assert.equal(result.task_id, "st_7fffff01")
+        break
+      }
+      case "warm-cache": {
+        const store = createTaskRecordStore({ project_dir: project })
+        store.list()
+        mkdirSync(join(store.stateDir, "tasks"), { recursive: true })
+        writeFileSync(join(store.stateDir, "tasks", "st_7fffff10.json"), JSON.stringify(record("st_7fffff10")), "utf8")
+        const inProcess = new FakeRunner()
+        const process = new FakeRunner()
+        const manager = createTaskManager({
+          store,
+          runners: { "in-process": inProcess, process },
+          planner: categoryPlanner(),
+          config: settings({ default_concurrency: 5, max_depth: 1 }),
+          cwd: project,
+        })
+        const result = await manager.start(baseSpec())
+        assert.equal(result.kind, "started")
+        assert.equal(result.task_id, "st_7fffff11")
+        break
+      }
+      case "diagnostics": {
+        const store = createTaskRecordStore({ project_dir: project })
+        store.save(record("st_00000020"))
+        mkdirSync(join(store.stateDir, "tasks"), { recursive: true })
+        writeFileSync(join(store.stateDir, "tasks", "broken.json"), "{not-json", "utf8")
+        const { manager } = makeManager(project)
+        const result = await manager.start(baseSpec())
+        assert.equal(result.kind, "started")
+        break
+      }
+      default:
+        throw new Error(`Unknown mode: ${mode ?? "undefined"}`)
+    }
+  } finally {
+    rmSync(project, { recursive: true, force: true })
+  }
+}
+
+run().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exit(1)
+})

--- a/packages/senpi-task/src/manager/manager-claim.test.ts
+++ b/packages/senpi-task/src/manager/manager-claim.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { FakeRunner, baseSpec, cleanupProjects, flush, makeManager } from "./__fixtures__/manager-fakes"
+
+afterEach(cleanupProjects)
+
+describe("TaskManager claim characterization", () => {
+  test("#given no requested name #when started #then the fallback name is the task id", async () => {
+    // given
+    const { manager } = makeManager()
+
+    // when
+    const result = await manager.start(baseSpec())
+
+    // then
+    if (result.kind !== "started") throw new Error("expected started")
+    expect(result.name).toMatch(/^st_[0-9a-f]{8}$/)
+    expect(result.name).toBe(result.task_id)
+  })
+
+  test("#given a duplicate requested name in one parent #when started #then it receives a suffix and warning", async () => {
+    // given
+    const { manager } = makeManager()
+    await manager.start(baseSpec({ name: "reviewer" }))
+
+    // when
+    const result = await manager.start(baseSpec({ name: "reviewer" }))
+
+    // then
+    if (result.kind !== "started") throw new Error("expected started")
+    expect(result.name).toBe("reviewer-2")
+    expect(result.name_warning).toBeDefined()
+  })
+
+  test("#given a background spec #when started #then the manager tracks its task as background", async () => {
+    // given
+    const { manager } = makeManager()
+
+    // when
+    const result = await manager.start(baseSpec({ run_in_background: true }))
+
+    // then
+    if (result.kind !== "started") throw new Error("expected started")
+    expect(manager.wasBackground(result.task_id)).toBe(true)
+  })
+
+  test("#given a runner that fails after persistence #when started and its name is requested again #then the record is terminal and the name remains reserved", async () => {
+    // given
+    const inProcess = new FakeRunner()
+    inProcess.throwOnStart = true
+    const { manager, store } = makeManager({ inProcess })
+
+    // when
+    const failed = await manager.start(baseSpec({ name: "durable-name" }))
+    await flush()
+    inProcess.throwOnStart = false
+    const retried = await manager.start(baseSpec({ name: "durable-name" }))
+
+    // then
+    expect(failed.kind).toBe("start_failed")
+    if (failed.kind !== "start_failed") throw new Error("expected start_failed")
+    expect(store.load(failed.task_id)?.status).toBe("error")
+    if (retried.kind !== "started") throw new Error("expected started")
+    expect(retried.name).toBe("durable-name-2")
+    expect(retried.name_warning).toBeDefined()
+  })
+
+  test("#given process execution mode #when started #then its record persists a spawn spec", async () => {
+    // given
+    const { manager, store } = makeManager()
+
+    // when
+    const result = await manager.start(baseSpec({ execution_mode: "process" }))
+
+    // then
+    if (result.kind !== "started") throw new Error("expected started")
+    expect(store.load(result.task_id)?.spawn_spec).toBeDefined()
+  })
+
+  test.each(["", "   "])("#given a blank requested name %p #when started #then it falls back to the task id", async (name) => {
+    // given
+    const { manager } = makeManager()
+
+    // when
+    const result = await manager.start(baseSpec({ name }))
+
+    // then
+    if (result.kind !== "started") throw new Error("expected started")
+    expect(result.name).toMatch(/^st_[0-9a-f]{8}$/)
+    expect(result.name).toBe(result.task_id)
+  })
+})

--- a/packages/senpi-task/src/manager/manager-claim.test.ts
+++ b/packages/senpi-task/src/manager/manager-claim.test.ts
@@ -1,6 +1,21 @@
+import { resolve } from "node:path"
+
 import { afterEach, describe, expect, test } from "bun:test"
 
 import { FakeRunner, baseSpec, cleanupProjects, flush, makeManager } from "./__fixtures__/manager-fakes"
+
+const seedFloorChildFixturePath = resolve(import.meta.dir, "__fixtures__", "seed-floor-child.ts")
+
+async function expectSeedFloorChildModeToSucceed(mode: string): Promise<void> {
+  const child = Bun.spawn([process.execPath, seedFloorChildFixturePath, mode], { stdout: "pipe", stderr: "pipe" })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+
+  expect(exitCode, `stdout:\n${stdout}\nstderr:\n${stderr}`).toBe(0)
+}
 
 afterEach(cleanupProjects)
 
@@ -89,4 +104,11 @@ describe("TaskManager claim characterization", () => {
     expect(result.name).toMatch(/^st_[0-9a-f]{8}$/)
     expect(result.name).toBe(result.task_id)
   })
+
+  test.each(["seed", "warm-cache", "diagnostics"])(
+    "#given an isolated manager process #when %s seeds from disk #then it succeeds",
+    async (mode) => {
+      await expectSeedFloorChildModeToSucceed(mode)
+    },
+  )
 })

--- a/packages/senpi-task/src/manager/manager-claim.test.ts
+++ b/packages/senpi-task/src/manager/manager-claim.test.ts
@@ -7,27 +7,9 @@ import { bumpTaskId } from "../state"
 import type { TaskRecord, TaskTransition, TaskTransitionResult } from "../state"
 import { TaskRecordCollisionError, createTaskRecordStore } from "../store"
 import type { PersistedTaskEvent, TaskRecordStore } from "../store"
+import { collisionStore } from "./__fixtures__/collision-store"
 import { FakeRunner, baseSpec, categoryPlanner, cleanupProjects, flush, makeManager, settings, tempProject } from "./__fixtures__/manager-fakes"
 import { createTaskManager } from "./manager"
-
-function collisionStore(inner: TaskRecordStore): { readonly store: TaskRecordStore; readonly firstCandidate: () => string | undefined } {
-  let firstSave = true
-  let firstCandidate: string | undefined
-  return {
-    store: {
-      ...inner,
-      save(record) {
-        if (firstSave) {
-          firstSave = false
-          firstCandidate = record.task_id
-          inner.save({ ...record, name: "foreign-winner" })
-        }
-        inner.save(record)
-      },
-    },
-    firstCandidate: () => firstCandidate,
-  }
-}
 
 function firstAllocationFailsStore(inner: TaskRecordStore): TaskRecordStore {
   let armed = true

--- a/packages/senpi-task/src/manager/manager-claim.test.ts
+++ b/packages/senpi-task/src/manager/manager-claim.test.ts
@@ -2,7 +2,85 @@ import { resolve } from "node:path"
 
 import { afterEach, describe, expect, test } from "bun:test"
 
-import { FakeRunner, baseSpec, cleanupProjects, flush, makeManager } from "./__fixtures__/manager-fakes"
+import { normalizeSenpiTeamSpec, spawnTeamMembers } from "../team"
+import { bumpTaskId } from "../state"
+import type { TaskRecord, TaskTransition, TaskTransitionResult } from "../state"
+import { TaskRecordCollisionError, createTaskRecordStore } from "../store"
+import type { PersistedTaskEvent, TaskRecordStore } from "../store"
+import { FakeRunner, baseSpec, categoryPlanner, cleanupProjects, flush, makeManager, settings, tempProject } from "./__fixtures__/manager-fakes"
+import { createTaskManager } from "./manager"
+
+function collisionStore(inner: TaskRecordStore): { readonly store: TaskRecordStore; readonly firstCandidate: () => string | undefined } {
+  let firstSave = true
+  let firstCandidate: string | undefined
+  return {
+    store: {
+      ...inner,
+      save(record) {
+        if (firstSave) {
+          firstSave = false
+          firstCandidate = record.task_id
+          inner.save({ ...record, name: "foreign-winner" })
+        }
+        inner.save(record)
+      },
+    },
+    firstCandidate: () => firstCandidate,
+  }
+}
+
+function firstAllocationFailsStore(inner: TaskRecordStore): TaskRecordStore {
+  let armed = true
+  return {
+    ...inner,
+    save(record) {
+      if (armed) {
+        armed = false
+        throw new TaskRecordCollisionError({ taskId: "st_ffffffff", path: "injected" })
+      }
+      inner.save(record)
+    },
+  }
+}
+
+function replaceFailsOnceStore(
+  inner: TaskRecordStore,
+  transitions: TaskTransition[],
+): { readonly store: TaskRecordStore; readonly applied: () => readonly boolean[] } {
+  let failReplace = true
+  const applied: boolean[] = []
+  return {
+    store: {
+      ...inner,
+      replace(record) {
+        if (failReplace) {
+          failReplace = false
+          throw new Error("injected bookkeeping failure")
+        }
+        inner.replace(record)
+      },
+      transition(taskId, transition): TaskTransitionResult {
+        transitions.push(transition)
+        const result = inner.transition(taskId, transition)
+        applied.push(result.applied)
+        return result
+      },
+    },
+    applied: () => applied,
+  }
+}
+
+function managerWithStore(store: TaskRecordStore, inProcess = new FakeRunner(), process = new FakeRunner()) {
+  const project = tempProject()
+  const manager = createTaskManager({
+    store,
+    runners: { "in-process": inProcess, process },
+    planner: categoryPlanner(),
+    config: settings({ default_concurrency: 5, max_depth: 1 }),
+    cwd: project,
+  })
+  return { manager, inProcess, process }
+}
 
 const seedFloorChildFixturePath = resolve(import.meta.dir, "__fixtures__", "seed-floor-child.ts")
 
@@ -111,4 +189,128 @@ describe("TaskManager claim characterization", () => {
       await expectSeedFloorChildModeToSucceed(mode)
     },
   )
+
+  test("#given a foreign winner for the first candidate #when started #then it claims the next id", async () => {
+    // given
+    const project = tempProject()
+    const inner = createTaskRecordStore({ project_dir: project })
+    const collision = collisionStore(inner)
+    const { manager } = managerWithStore(collision.store)
+
+    // when
+    const result = await manager.start(baseSpec())
+
+    // then
+    if (result.kind !== "started") throw new Error("expected started")
+    expect(result.task_id).toBe(bumpTaskId(collision.firstCandidate() as `st_${string}`))
+    expect(result.name).toBe(result.task_id)
+    expect(inner.load(collision.firstCandidate() as string)?.name).toBe("foreign-winner")
+    expect(inner.load(result.task_id)?.name).toBe(result.task_id)
+  })
+
+  test("#given a requested name and a foreign winner #when started #then only the loser keeps the requested name", async () => {
+    // given
+    const project = tempProject()
+    const inner = createTaskRecordStore({ project_dir: project })
+    const collision = collisionStore(inner)
+    const { manager } = managerWithStore(collision.store)
+
+    // when
+    const result = await manager.start(baseSpec({ name: "todo11" }))
+
+    // then
+    if (result.kind !== "started") throw new Error("expected started")
+    const records = inner.list().records.filter((record) => record.parent_session_id === "parent-1")
+    expect(inner.load(collision.firstCandidate() as string)?.name).toBe("foreign-winner")
+    expect(result.name).toBe("todo11")
+    expect(records.filter((record) => record.name === "todo11")).toHaveLength(1)
+    expect(new Set(records.map((record) => record.name)).size).toBe(records.length)
+  })
+
+  test("#given a real manager under collision #when team members spawn #then no member start is rejected", async () => {
+    // given
+    const project = tempProject()
+    const inner = createTaskRecordStore({ project_dir: project })
+    const collision = collisionStore(inner)
+    const { manager } = managerWithStore(collision.store)
+    const spec = normalizeSenpiTeamSpec(
+      { members: [{ name: "alpha", kind: "category", category: "quick", prompt: "work" }] },
+      "collision-team",
+    )
+
+    // when
+    const result = await spawnTeamMembers({
+      spec,
+      teamRunId: "collision-run",
+      manager,
+      leadSessionId: "parent-1",
+      spawnDepth: 1,
+      maxParallel: 1,
+      deadlineAt: 1_000,
+      now: () => 0,
+    })
+
+    // then
+    if (result.failure !== undefined) expect(result.failure.message).not.toContain("member_start_rejected")
+    expect(result.failure).toBeUndefined()
+    expect(result.spawned.size).toBe(1)
+  })
+
+  test("#given an allocation failure #when the requested name is retried #then its reservation was released", async () => {
+    // given
+    const project = tempProject()
+    const inner = createTaskRecordStore({ project_dir: project })
+    const { manager } = managerWithStore(firstAllocationFailsStore(inner))
+
+    // when
+    const failed = await manager.start(baseSpec({ name: "todo11" }))
+    const retried = await manager.start(baseSpec({ name: "todo11" }))
+
+    // then
+    expect(failed.kind).toBe("start_failed")
+    if (failed.kind !== "start_failed") throw new Error("expected start_failed")
+    expect(failed.task_id).toBe("")
+    expect(failed.error_message).toContain("allocation failed")
+    expect(failed.error_message).not.toContain("already exists")
+    if (retried.kind !== "started") throw new Error("expected started")
+    expect(retried.name).toBe("todo11")
+  })
+
+  test("#given bookkeeping fails after a claim #when process mode starts #then it records a terminal failure", async () => {
+    // given
+    const project = tempProject()
+    const inner = createTaskRecordStore({ project_dir: project })
+    const transitions: TaskTransition[] = []
+    const bookkeeping = replaceFailsOnceStore(inner, transitions)
+    const { manager } = managerWithStore(bookkeeping.store)
+
+    // when
+    const result = await manager.start(baseSpec({ execution_mode: "process", run_in_background: true }))
+
+    // then
+    expect(result.kind).toBe("start_failed")
+    if (result.kind !== "start_failed") throw new Error("expected start_failed")
+    expect(result.task_id).toMatch(/^st_[0-9a-f]{8}$/)
+    expect(inner.load(result.task_id)?.status).toBe("error")
+    expect(inner.load(result.task_id)?.error_message).toBe("spawn bookkeeping failed")
+    expect(transitions.map((transition) => transition.type)).toEqual(["start", "fail"])
+    expect(bookkeeping.applied()).toEqual([true, true])
+    expect(manager.wasBackground(result.task_id)).toBe(false)
+  })
+
+  test("#given a whitespace requested name #when a collision is claimed #then the fallback follows the final id", async () => {
+    // given
+    const project = tempProject()
+    const inner = createTaskRecordStore({ project_dir: project })
+    const collision = collisionStore(inner)
+    const { manager } = managerWithStore(collision.store)
+
+    // when
+    const result = await manager.start(baseSpec({ name: "  " }))
+
+    // then
+    if (result.kind !== "started") throw new Error("expected started")
+    expect(result.name).toBe(result.task_id)
+    expect(result.name).not.toBe("task-1")
+  })
 })

--- a/packages/senpi-task/src/manager/manager-claim.test.ts
+++ b/packages/senpi-task/src/manager/manager-claim.test.ts
@@ -52,7 +52,12 @@ function replaceFailsOnceStore(
   }
 }
 
-function managerWithStore(store: TaskRecordStore, inProcess = new FakeRunner(), process = new FakeRunner()) {
+function managerWithStore(
+  store: TaskRecordStore,
+  inProcess = new FakeRunner(),
+  process = new FakeRunner(),
+  now?: () => number,
+) {
   const project = tempProject()
   const manager = createTaskManager({
     store,
@@ -60,6 +65,7 @@ function managerWithStore(store: TaskRecordStore, inProcess = new FakeRunner(), 
     planner: categoryPlanner(),
     config: settings({ default_concurrency: 5, max_depth: 1 }),
     cwd: project,
+    ...(now === undefined ? {} : { now }),
   })
   return { manager, inProcess, process }
 }
@@ -105,6 +111,37 @@ describe("TaskManager claim characterization", () => {
     if (result.kind !== "started") throw new Error("expected started")
     expect(result.name).toBe("reviewer-2")
     expect(result.name_warning).toBeDefined()
+  })
+
+  test("#given an id-shaped requested name #when an unnamed task claims its fallback #then every saved sibling name is unique", async () => {
+    // given
+    const project = tempProject()
+    const inner = createTaskRecordStore({ project_dir: project })
+    const invariantStore: TaskRecordStore = {
+      ...inner,
+      save(record) {
+        for (const sibling of inner.list().records) {
+          if (sibling.parent_session_id === record.parent_session_id && sibling.name === record.name) {
+            throw new Error(`duplicate task name persisted: ${record.name}`)
+          }
+        }
+        inner.save(record)
+      },
+    }
+    const clock = () => (Math.floor(Date.now() / 65_536) + 1_000_000) * 65_536
+    const firstTaskId = `st_${Math.floor(clock() / 65_536).toString(16).padStart(8, "0")}`
+    const { manager } = managerWithStore(invariantStore, new FakeRunner(), new FakeRunner(), clock)
+
+    // when
+    const first = await manager.start(baseSpec({ name: bumpTaskId(firstTaskId as `st_${string}`) }))
+    const second = await manager.start(baseSpec())
+
+    // then
+    if (first.kind !== "started" || second.kind !== "started") throw new Error("expected both tasks to start")
+    expect(first.task_id).toBe(firstTaskId)
+    expect(first.name).toBe(bumpTaskId(firstTaskId as `st_${string}`))
+    expect(second.task_id).toBe(bumpTaskId(first.name as `st_${string}`))
+    expect(second.name).toBe(second.task_id)
   })
 
   test("#given a background spec #when started #then the manager tracks its task as background", async () => {

--- a/packages/senpi-task/src/manager/manager.ts
+++ b/packages/senpi-task/src/manager/manager.ts
@@ -76,11 +76,6 @@ const NOOP_DESTRUCTION: DestructionPort = { destroyResidentTask: () => Promise.r
 const GENERIC_START_FAILURE_MESSAGE = "Task runner failed to start."
 const RESPAWN_CLEANUP_FAILURE_REASON = "rpc respawn cleanup failed"
 
-function normalizeSpecName(value: string | undefined): string | undefined {
-  const trimmed = value?.trim()
-  return trimmed === undefined || trimmed.length === 0 ? undefined : trimmed
-}
-
 function publicStartFailureMessage(error: unknown): string {
   try {
     if (!RunnerError.is(error)) return GENERIC_START_FAILURE_MESSAGE
@@ -161,6 +156,11 @@ class TaskManagerImpl implements TaskManager {
   }
 
   async start(spec: ManagerStartSpec): Promise<StartResult> {
+    const normalizeSpecName = (value: string | undefined): string | undefined => {
+      const trimmed = value?.trim()
+      return trimmed === undefined || trimmed.length === 0 ? undefined : trimmed
+    }
+
     const resolution = this.#options.planner(spec)
     if (resolution.kind === "error") return { kind: "plan_unresolved", error: resolution.error }
     const plan = resolution.plan

--- a/packages/senpi-task/src/manager/manager.ts
+++ b/packages/senpi-task/src/manager/manager.ts
@@ -198,7 +198,12 @@ class TaskManagerImpl implements TaskManager {
     try {
       const draft = createTaskRecord(buildRecordInput({ spec, plan, name: "", executionMode }), this.#now())
       const claimDraft: TaskRecord = { ...draft, name: requestedRegistration?.name ?? draft.task_id }
-      claimed = claimTaskRecord(this.#options.store, claimDraft, { nameFollowsId: requestedRegistration === undefined })
+      claimed = claimTaskRecord(this.#options.store, claimDraft, {
+        nameFollowsId: requestedRegistration === undefined,
+        ...(requestedRegistration === undefined
+          ? { nameAvailable: (name) => this.#names.isAvailable(spec.parent_session_id, name) }
+          : {}),
+      })
     } catch (error) {
       if (!(error instanceof TaskRecordCollisionError) && !(error instanceof TaskIdSpaceExhaustedError)) throw error
       if (requestedRegistration !== undefined) this.#names.release(spec.parent_session_id, requestedRegistration.name)

--- a/packages/senpi-task/src/manager/manager.ts
+++ b/packages/senpi-task/src/manager/manager.ts
@@ -5,7 +5,7 @@ import { registerLifecycleReattachPorts, type ReattachResult, type RespawnResult
 import { RunnerError } from "../runners/in-process/runner-error"
 import { RpcProcessRunner } from "../runners/rpc-process"
 import type { RpcChildHandle, RpcRunnerSpec } from "../runners/types"
-import { createTaskRecord, parseTaskId } from "../state"
+import { createTaskRecord, parseTaskId, syncTaskIdFloor } from "../state"
 import type { TaskRecord } from "../state"
 import { createSteeringEngine } from "../steering"
 import type { CancelOutcome, DestructionPort, InterruptOutcome, SendInput, SendOutcome, SteeringEngine, SteeringPort } from "../steering"
@@ -111,6 +111,19 @@ class TaskManagerImpl implements TaskManager {
 
   constructor(options: TaskManagerImplOptions) {
     this.#options = options
+    try {
+      const listed = options.store.list()
+      if (listed.diagnostics.length > 0) {
+        log("senpi-task manager task record diagnostics while seeding id floor", { count: listed.diagnostics.length })
+      }
+      const maxId = listed.records.reduce<string | undefined>(
+        (maximum, record) => (maximum === undefined || record.task_id > maximum ? record.task_id : maximum),
+        undefined,
+      )
+      if (maxId !== undefined) syncTaskIdFloor(parseTaskId(maxId))
+    } catch (error) {
+      log("senpi-task manager failed to seed task id floor", { error: String(error) })
+    }
     this.#now = options.now ?? Date.now
     this.#rpcRespawnRunner = options.rpcRespawnRunner ?? new RpcProcessRunner()
     this.#concurrency = new TaskConcurrency({

--- a/packages/senpi-task/src/manager/manager.ts
+++ b/packages/senpi-task/src/manager/manager.ts
@@ -6,6 +6,7 @@ import { RunnerError } from "../runners/in-process/runner-error"
 import { RpcProcessRunner } from "../runners/rpc-process"
 import type { RpcChildHandle, RpcRunnerSpec } from "../runners/types"
 import { createTaskRecord, parseTaskId, syncTaskIdFloor } from "../state"
+import { TaskIdSpaceExhaustedError } from "../state/id"
 import type { TaskRecord } from "../state"
 import { createSteeringEngine } from "../steering"
 import type { CancelOutcome, DestructionPort, InterruptOutcome, SendInput, SendOutcome, SteeringEngine, SteeringPort } from "../steering"
@@ -22,6 +23,7 @@ import {
   nowIso,
   recordSpawnedPid,
 } from "./manager-helpers"
+import { claimTaskRecord, TaskRecordCollisionError } from "../store"
 import { NameRegistry } from "./names"
 import { subscribeTranscriptLog } from "./transcript-log"
 import type {
@@ -73,6 +75,11 @@ type ReattachingTaskManager = TaskManager & {
 const NOOP_DESTRUCTION: DestructionPort = { destroyResidentTask: () => Promise.resolve() }
 const GENERIC_START_FAILURE_MESSAGE = "Task runner failed to start."
 const RESPAWN_CLEANUP_FAILURE_REASON = "rpc respawn cleanup failed"
+
+function normalizeSpecName(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed === undefined || trimmed.length === 0 ? undefined : trimmed
+}
 
 function publicStartFailureMessage(error: unknown): string {
   try {
@@ -182,63 +189,114 @@ class TaskManagerImpl implements TaskManager {
       configMode: this.#options.config.default_execution_mode,
     })
 
-    const draft = createTaskRecord(buildRecordInput({ spec, plan, name: spec.name ?? "", executionMode }))
-    const registration = this.#names.register(spec.parent_session_id, spec.name, draft.task_id)
-    const record: TaskRecord = { ...draft, name: registration.name }
-    if (spec.run_in_background === true) this.#background.add(record.task_id)
-    this.#options.store.save(record)
+    const requestedName = normalizeSpecName(spec.name)
+    const requestedRegistration = requestedName === undefined
+      ? undefined
+      : this.#names.register(spec.parent_session_id, requestedName)
 
-    const managedSpec = buildManagedSpec({
-      record,
-      spec,
-      plan,
-      cwd: this.#options.cwd,
-      stateDir: this.#options.store.stateDir,
-    })
-    const persistedRecord: TaskRecord = executionMode === "process"
-      ? {
-          ...record,
-          spawn_spec: {
-            cwd: managedSpec.cwd,
-            ...(managedSpec.extensions === undefined ? {} : { extensions: managedSpec.extensions }),
-            ...(managedSpec.memberEnv === undefined ? {} : { member_env: managedSpec.memberEnv }),
-          },
-        }
-      : record
-    if (persistedRecord !== record) this.#options.store.replace(persistedRecord)
+    let claimed: TaskRecord
+    try {
+      const draft = createTaskRecord(buildRecordInput({ spec, plan, name: "", executionMode }), this.#now())
+      const claimDraft: TaskRecord = { ...draft, name: requestedRegistration?.name ?? draft.task_id }
+      claimed = claimTaskRecord(this.#options.store, claimDraft, { nameFollowsId: requestedRegistration === undefined })
+    } catch (error) {
+      if (!(error instanceof TaskRecordCollisionError) && !(error instanceof TaskIdSpaceExhaustedError)) throw error
+      if (requestedRegistration !== undefined) this.#names.release(spec.parent_session_id, requestedRegistration.name)
+      return {
+        kind: "start_failed",
+        task_id: "",
+        name: requestedName ?? "",
+        ...(spec.category ?? plan.category !== undefined ? { category: spec.category ?? plan.category } : {}),
+        ...(spec.subagent_type ?? plan.agentType !== undefined ? { subagent_type: spec.subagent_type ?? plan.agentType } : {}),
+        execution_mode: executionMode,
+        model: plan.model,
+        ...(plan.resolved_model !== undefined ? { resolved_model: plan.resolved_model } : {}),
+        run_in_background: spec.run_in_background === true,
+        error_message: "task id allocation failed under contention; retry the spawn",
+      }
+    }
+
+    const registration = requestedRegistration ?? this.#names.register(spec.parent_session_id, undefined, claimed.task_id)
+    let finalRecord: TaskRecord
+    let managedSpec: ManagedStartSpec
+    try {
+      const renamedRecord: TaskRecord = registration.name === claimed.name ? claimed : { ...claimed, name: registration.name }
+      managedSpec = buildManagedSpec({
+        record: renamedRecord,
+        spec,
+        plan,
+        cwd: this.#options.cwd,
+        stateDir: this.#options.store.stateDir,
+      })
+      finalRecord = executionMode === "process"
+        ? {
+            ...renamedRecord,
+            spawn_spec: {
+              cwd: managedSpec.cwd,
+              ...(managedSpec.extensions === undefined ? {} : { extensions: managedSpec.extensions }),
+              ...(managedSpec.memberEnv === undefined ? {} : { member_env: managedSpec.memberEnv }),
+            },
+          }
+        : renamedRecord
+      if (finalRecord !== claimed) this.#options.store.replace(finalRecord)
+      if (spec.run_in_background === true) this.#background.add(finalRecord.task_id)
+    } catch (error) {
+      if (registration.name !== claimed.name) this.#names.release(spec.parent_session_id, registration.name)
+      this.#background.delete(claimed.task_id)
+      const timestamp = nowIso(this.#now)
+      const started = this.#options.store.transition(claimed.task_id, { type: "start", timestamp })
+      const failed = this.#options.store.transition(claimed.task_id, {
+        type: "fail",
+        timestamp,
+        error_message: "spawn bookkeeping failed",
+      })
+      if (!started.applied || !failed.applied) throw new Error("spawn bookkeeping failure transitions were not applied")
+      return {
+        kind: "start_failed",
+        task_id: claimed.task_id,
+        name: registration.name,
+        ...(claimed.category !== undefined ? { category: claimed.category } : {}),
+        ...(claimed.agent_type !== undefined ? { subagent_type: claimed.agent_type } : {}),
+        execution_mode: executionMode,
+        model: claimed.model,
+        ...(claimed.resolved_model !== undefined ? { resolved_model: claimed.resolved_model } : {}),
+        run_in_background: spec.run_in_background === true,
+        error_message: "spawn bookkeeping failed",
+      }
+    }
     const runner = this.#options.runners[executionMode]
-    const context: LaunchContext = { record: persistedRecord, managedSpec, runner, model: plan.model }
+    const context: LaunchContext = { record: finalRecord, managedSpec, runner, model: plan.model }
     const startParts = {
       ...(plan.resolved_model !== undefined ? { resolved_model: plan.resolved_model } : {}),
       ...(registration.warning !== undefined ? { name_warning: registration.warning } : {}),
     }
 
     if (this.#concurrency.hasFreeSlot(plan.model)) {
-      this.#concurrency.acquire(plan.model, record.task_id)
+      this.#concurrency.acquire(plan.model, finalRecord.task_id)
       const launched = await this.#launch(context)
       if (!launched.ok) {
         return {
           kind: "start_failed",
-          task_id: record.task_id,
+          task_id: finalRecord.task_id,
           name: registration.name,
-          ...(record.category !== undefined ? { category: record.category } : {}),
-          ...(record.agent_type !== undefined ? { subagent_type: record.agent_type } : {}),
+          ...(finalRecord.category !== undefined ? { category: finalRecord.category } : {}),
+          ...(finalRecord.agent_type !== undefined ? { subagent_type: finalRecord.agent_type } : {}),
           execution_mode: executionMode,
-          model: record.model,
-          ...(record.resolved_model !== undefined ? { resolved_model: record.resolved_model } : {}),
+          model: finalRecord.model,
+          ...(finalRecord.resolved_model !== undefined ? { resolved_model: finalRecord.resolved_model } : {}),
           run_in_background: spec.run_in_background === true,
           error_message: launched.error,
         }
       }
-      return { kind: "started", task_id: record.task_id, status: "running", name: registration.name, ...startParts }
+      return { kind: "started", task_id: finalRecord.task_id, status: "running", name: registration.name, ...startParts }
     }
 
-    const position = this.#concurrency.enqueue(plan.model, record.task_id, () => {
+    const position = this.#concurrency.enqueue(plan.model, finalRecord.task_id, () => {
       void this.#launch(context)
     })
     return {
       kind: "started",
-      task_id: record.task_id,
+      task_id: finalRecord.task_id,
       status: "pending",
       name: registration.name,
       queue_position: position,

--- a/packages/senpi-task/src/manager/names.test.ts
+++ b/packages/senpi-task/src/manager/names.test.ts
@@ -65,4 +65,46 @@ describe("NameRegistry", () => {
     // then
     expect(first.name).not.toBe(second.name)
   })
+
+  test("#given a registered name #when released and re-registered #then the bare name is available", () => {
+    // given
+    const registry = new NameRegistry()
+    registry.register("parent-a", "reviewer")
+
+    // when
+    registry.release("parent-a", "reviewer")
+    const result = registry.register("parent-a", "reviewer")
+
+    // then
+    expect(result.name).toBe("reviewer")
+    expect(result.warning).toBeUndefined()
+  })
+
+  test("#given an unknown name #when released #then registration is unchanged", () => {
+    // given
+    const registry = new NameRegistry()
+
+    // when
+    registry.release("parent-a", "reviewer")
+    const result = registry.register("parent-a", "reviewer")
+
+    // then
+    expect(result.name).toBe("reviewer")
+    expect(result.warning).toBeUndefined()
+  })
+
+  test("#given names in separate parents #when one is released #then the other remains reserved", () => {
+    // given
+    const registry = new NameRegistry()
+    registry.register("parent-a", "reviewer")
+    registry.register("parent-b", "reviewer")
+
+    // when
+    registry.release("parent-a", "reviewer")
+    const result = registry.register("parent-b", "reviewer")
+
+    // then
+    expect(result.name).toBe("reviewer-2")
+    expect(result.warning).toContain("reviewer")
+  })
 })

--- a/packages/senpi-task/src/manager/names.ts
+++ b/packages/senpi-task/src/manager/names.ts
@@ -25,6 +25,10 @@ export class NameRegistry {
     return { name: resolved, warning: `Task name "${desired}" already exists in this session; using "${resolved}".` }
   }
 
+  isAvailable(parentSessionId: string, name: string): boolean {
+    return !this.#byParent.get(parentSessionId)?.has(name)
+  }
+
   release(parentSessionId: string, name: string): void {
     this.#byParent.get(parentSessionId)?.delete(name)
   }

--- a/packages/senpi-task/src/manager/names.ts
+++ b/packages/senpi-task/src/manager/names.ts
@@ -24,6 +24,10 @@ export class NameRegistry {
     taken.add(resolved)
     return { name: resolved, warning: `Task name "${desired}" already exists in this session; using "${resolved}".` }
   }
+
+  release(parentSessionId: string, name: string): void {
+    this.#byParent.get(parentSessionId)?.delete(name)
+  }
 }
 
 function normalize(value: string | undefined): string | undefined {

--- a/packages/senpi-task/src/state/__fixtures__/id-child.ts
+++ b/packages/senpi-task/src/state/__fixtures__/id-child.ts
@@ -1,0 +1,47 @@
+import { strict as assert } from "node:assert"
+
+import { createTaskRecord } from "../record"
+import { bumpTaskId, createTaskId, syncTaskIdFloor, TaskIdSpaceExhaustedError } from "../id"
+
+const mode = process.argv[2]
+
+try {
+  switch (mode) {
+    case "bump-exhaust":
+      assert.throws(() => bumpTaskId("st_ffffffff"), TaskIdSpaceExhaustedError)
+      break
+    case "create-exhaust":
+      syncTaskIdFloor("st_ffffffff")
+      assert.throws(() => createTaskId(), TaskIdSpaceExhaustedError)
+      break
+    case "floor-raise":
+      syncTaskIdFloor("st_00000100")
+      assert.equal(createTaskId(0x10 * 0x10000), "st_00000101")
+      break
+    case "floor-never-lower":
+      syncTaskIdFloor("st_00000200")
+      syncTaskIdFloor("st_00000100")
+      assert.equal(createTaskId(0x10 * 0x10000), "st_00000201")
+      break
+    case "nowms":
+      assert.equal(
+        createTaskRecord(
+          {
+            parent_session_id: "parent-session",
+            root_session_id: "root-session",
+            depth: 0,
+            execution_mode: "in-process",
+            model: "test/model",
+          },
+          0x123 * 0x10000,
+        ).task_id,
+        "st_00000123",
+      )
+      break
+    default:
+      throw new Error(`Unknown mode: ${mode ?? "undefined"}`)
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exit(1)
+}

--- a/packages/senpi-task/src/state/id.test.ts
+++ b/packages/senpi-task/src/state/id.test.ts
@@ -1,6 +1,51 @@
+import { resolve } from "node:path"
 import { describe, expect, test } from "bun:test"
 
-import { createTaskId, createTaskIdFactory } from "./id"
+import { bumpTaskId, createTaskId, createTaskIdFactory } from "./id"
+
+const idChildFixturePath = resolve(import.meta.dir, "__fixtures__", "id-child.ts")
+
+async function expectChildModeToSucceed(mode: string): Promise<void> {
+  const child = Bun.spawn([process.execPath, idChildFixturePath, mode], { stdout: "pipe", stderr: "pipe" })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+
+  expect(exitCode, `stdout:\n${stdout}\nstderr:\n${stderr}`).toBe(0)
+}
+
+describe("task id primitives", () => {
+  test("#given a task id ending in ffff #when bumped #then it carries into the next hexadecimal group", () => {
+    // given
+    const taskId = "st_0000ffff"
+
+    // when
+    const bumped = bumpTaskId(taskId)
+
+    // then
+    expect(bumped).toBe("st_00010000")
+  })
+
+  test("#given a task id #when bumped #then the hexadecimal value increments", () => {
+    // given
+    const taskId = "st_00000010"
+
+    // when
+    const bumped = bumpTaskId(taskId)
+
+    // then
+    expect(bumped).toBe("st_00000011")
+  })
+
+  test.each(["bump-exhaust", "create-exhaust", "floor-raise", "floor-never-lower", "nowms"])(
+    "#given an isolated module process #when %s executes #then it succeeds",
+    async (mode) => {
+      await expectChildModeToSucceed(mode)
+    },
+  )
+})
 
 describe("createTaskId", () => {
   test("#given a deterministic clock #when ids are created #then ids are canonical and sortable", () => {

--- a/packages/senpi-task/src/state/id.ts
+++ b/packages/senpi-task/src/state/id.ts
@@ -22,6 +22,17 @@ export function createTaskIdFactory(clock: () => number = Date.now): () => TaskI
   }
 }
 
+export function bumpTaskId(id: TaskId): TaskId {
+  const value = Number.parseInt(id.slice(3), 16)
+  if (value >= MAX_TASK_ID_VALUE) throw new TaskIdSpaceExhaustedError()
+  return formatTaskId(value + 1)
+}
+
+export function syncTaskIdFloor(id: TaskId): void {
+  const value = Number.parseInt(id.slice(3), 16)
+  lastTaskIdValue = Math.max(lastTaskIdValue ?? -1, value)
+}
+
 export function parseTaskId(value: string): TaskId {
   if (!isTaskId(value)) throw new Error("Invalid task id; expected st_[0-9a-f]{8}")
   return value

--- a/packages/senpi-task/src/state/index.ts
+++ b/packages/senpi-task/src/state/index.ts
@@ -13,7 +13,7 @@ export type {
   TaskTransitionResult,
 } from "./types"
 export { createTaskRecord } from "./record"
-export { createTaskId, parseTaskId } from "./id"
+export { bumpTaskId, createTaskId, parseTaskId, syncTaskIdFloor } from "./id"
 export type { TaskId } from "./id"
 export { messageability } from "./messageability"
 export { markRecordLostForReconciliation, transitionTaskRecord } from "./transitions"

--- a/packages/senpi-task/src/state/record.ts
+++ b/packages/senpi-task/src/state/record.ts
@@ -1,7 +1,7 @@
 import { createTaskId } from "./id"
 import type { TaskRecord, TaskRecordInput } from "./types"
 
-export function createTaskRecord(input: TaskRecordInput): TaskRecord {
+export function createTaskRecord(input: TaskRecordInput, nowMs?: number): TaskRecord {
   const timestamp = new Date().toISOString()
   const {
     agent_type,
@@ -17,7 +17,7 @@ export function createTaskRecord(input: TaskRecordInput): TaskRecord {
     tool_deny,
   } = input
   return {
-    task_id: createTaskId(),
+    task_id: nowMs === undefined ? createTaskId() : createTaskId(nowMs),
     status: "pending",
     residency_state: "resident",
     parent_session_id,

--- a/packages/senpi-task/src/store/__fixtures__/claim-floor-child.ts
+++ b/packages/senpi-task/src/store/__fixtures__/claim-floor-child.ts
@@ -1,0 +1,40 @@
+import { strict as assert } from "node:assert"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { createTaskId, type TaskRecord } from "../../state"
+import { claimTaskRecord } from "../claim"
+import { createTaskRecordStore } from "../record-store"
+
+function baseRecord(taskId: string): TaskRecord {
+  return {
+    task_id: taskId,
+    name: taskId,
+    status: "pending",
+    residency_state: "resident",
+    parent_session_id: "parent-session",
+    root_session_id: "root-session",
+    depth: 0,
+    execution_mode: "in-process",
+    model: "test/model",
+    created_at: "2026-07-20T00:00:00.000Z",
+    updated_at: "2026-07-20T00:00:00.000Z",
+    notification: { run_epoch: 0, notified_epoch: -1 },
+  }
+}
+
+const project = mkdtempSync(join(tmpdir(), "senpi-task-claim-floor-"))
+
+try {
+  const store = createTaskRecordStore({ project_dir: project })
+  store.save(baseRecord("st_00000030"))
+  const claimed = claimTaskRecord(store, baseRecord("st_00000030"), { nameFollowsId: true })
+  assert.equal(claimed.task_id, "st_00000031")
+  assert.equal(createTaskId(0x10 * 0x10000), "st_00000032")
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+} finally {
+  rmSync(project, { recursive: true, force: true })
+}

--- a/packages/senpi-task/src/store/__fixtures__/claim-race-child.ts
+++ b/packages/senpi-task/src/store/__fixtures__/claim-race-child.ts
@@ -1,0 +1,70 @@
+import { createInterface } from "node:readline"
+
+import { createTaskId, type TaskRecord } from "../../state"
+import { claimTaskRecord } from "../claim"
+import { createTaskRecordStore } from "../record-store"
+
+const [projectDir, nowMsRaw, countRaw, tag] = process.argv.slice(2)
+
+if (projectDir === undefined || nowMsRaw === undefined || countRaw === undefined || tag === undefined) {
+  process.stderr.write("Expected argv: [projectDir, nowMs, count, tag]\n")
+  process.exit(1)
+}
+
+const nowMs = Number(nowMsRaw)
+const count = Number(countRaw)
+
+if (!Number.isFinite(nowMs) || !Number.isSafeInteger(count) || count < 0) {
+  process.stderr.write("nowMs must be finite and count must be a non-negative integer\n")
+  process.exit(1)
+}
+
+function waitForGo(): Promise<void> {
+  const input = createInterface({ input: process.stdin })
+  return new Promise((resolve) => {
+    input.on("line", (line) => {
+      if (line === "GO") {
+        input.close()
+        resolve()
+      }
+    })
+  })
+}
+
+function draftRecord(taskId: string): TaskRecord {
+  const timestamp = new Date(nowMs).toISOString()
+  return {
+    task_id: taskId,
+    status: "pending",
+    residency_state: "resident",
+    parent_session_id: `race-${tag}`,
+    root_session_id: `race-${tag}`,
+    depth: 1,
+    execution_mode: "in-process",
+    model: "test/model",
+    created_at: timestamp,
+    updated_at: timestamp,
+    notification: { run_epoch: 0, notified_epoch: -1 },
+    name: taskId,
+  }
+}
+
+try {
+  const store = createTaskRecordStore({ project_dir: projectDir })
+  process.stdout.write("READY\n")
+  await waitForGo()
+
+  const ids: string[] = []
+  let retries = 0
+  for (let index = 0; index < count; index++) {
+    const draft = draftRecord(createTaskId(nowMs))
+    const claimed = claimTaskRecord(store, draft, { nameFollowsId: true })
+    ids.push(claimed.task_id)
+    if (claimed.task_id !== draft.task_id) retries++
+  }
+
+  process.stdout.write(`${JSON.stringify({ ids, retries })}\n`)
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`)
+  process.exitCode = 1
+}

--- a/packages/senpi-task/src/store/claim-race.test.ts
+++ b/packages/senpi-task/src/store/claim-race.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, readdirSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+const cleanupRoots: string[] = []
+const claimRaceChildFixturePath = resolve(import.meta.dir, "__fixtures__", "claim-race-child.ts")
+const frozenNowMs = 0x10 * 0x10000
+
+afterEach(() => {
+  for (const root of cleanupRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function tempProject(): string {
+  const directory = mkdtempSync(join(tmpdir(), "senpi-task-claim-race-"))
+  cleanupRoots.push(directory)
+  return directory
+}
+
+type ChildResult = {
+  readonly output: string
+  readonly ready: Promise<void>
+}
+
+function readChildStdout(stdout: ReadableStream<Uint8Array>): ChildResult {
+  let output = ""
+  let buffered = ""
+  let resolveReady: () => void = () => {}
+  let rejectReady: (error: Error) => void = () => {}
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve
+    rejectReady = reject
+  })
+
+  void (async () => {
+    const reader = stdout.getReader()
+    const decoder = new TextDecoder()
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        const chunk = decoder.decode(value, { stream: true })
+        output += chunk
+        buffered += chunk
+        let newlineIndex = buffered.indexOf("\n")
+        while (newlineIndex >= 0) {
+          const line = buffered.slice(0, newlineIndex)
+          buffered = buffered.slice(newlineIndex + 1)
+          if (line === "READY") resolveReady()
+          newlineIndex = buffered.indexOf("\n")
+        }
+      }
+      const trailing = decoder.decode()
+      output += trailing
+      buffered += trailing
+      if (buffered === "READY") resolveReady()
+    } catch (error) {
+      rejectReady(error instanceof Error ? error : new Error(String(error)))
+    }
+  })()
+
+  return { get output() { return output }, ready }
+}
+
+function parseChildResult(output: string): { readonly ids: readonly string[]; readonly retries: number } {
+  const resultLine = output.split("\n").find((line) => line.startsWith("{"))
+  if (resultLine === undefined) throw new Error(`Child did not emit a JSON result:\n${output}`)
+  return JSON.parse(resultLine) as { readonly ids: readonly string[]; readonly retries: number }
+}
+
+describe("claimTaskRecord cross-process race", () => {
+  test("#given two processes in one frozen id bucket #when they claim task records concurrently #then every record is unique and collisions retry", async () => {
+    // given
+    const project = tempProject()
+    const children = ["a", "b"].map((tag) => Bun.spawn([
+      process.execPath,
+      claimRaceChildFixturePath,
+      project,
+      String(frozenNowMs),
+      "50",
+      tag,
+    ], { stdin: "pipe", stdout: "pipe", stderr: "pipe" }))
+    const stdout = children.map((child) => readChildStdout(child.stdout))
+    const stderr = children.map((child) => new Response(child.stderr).text())
+
+    // when
+    await Promise.all(stdout.map((child) => child.ready))
+    for (const child of children) child.stdin.write("GO\n")
+    const [exitCodes, stderrOutput] = await Promise.all([
+      Promise.all(children.map((child) => child.exited)),
+      Promise.all(stderr),
+    ])
+    // then
+    for (const [index, exitCode] of exitCodes.entries()) {
+      expect(exitCode, `stdout:\n${stdout[index]?.output}\nstderr:\n${stderrOutput[index]}`).toBe(0)
+    }
+    const results = stdout.map((child) => parseChildResult(child.output))
+    const ids = results.flatMap((result) => result.ids)
+    expect(ids).toHaveLength(100)
+    expect(new Set(ids).size).toBe(100)
+    expect(readdirSync(join(project, ".omo", "senpi-task", "tasks"))).toHaveLength(100)
+    expect(results.reduce((total, result) => total + result.retries, 0)).toBeGreaterThanOrEqual(1)
+    for (const output of stderrOutput) expect(output).not.toContain("already exists")
+  })
+})

--- a/packages/senpi-task/src/store/claim.test.ts
+++ b/packages/senpi-task/src/store/claim.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+import type { TaskRecord } from "../state"
+import { claimTaskRecord } from "./claim"
+import { TaskRecordCollisionError, createTaskRecordStore } from "./record-store"
+import { resolveStateDir } from "./state-dir"
+
+const cleanupRoots: string[] = []
+const claimFloorChildFixturePath = resolve(import.meta.dir, "__fixtures__", "claim-floor-child.ts")
+
+afterEach(() => {
+  for (const root of cleanupRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function tempProject(): string {
+  const directory = mkdtempSync(join(tmpdir(), "senpi-task-claim-"))
+  cleanupRoots.push(directory)
+  return directory
+}
+
+function baseRecord(taskId: string, name = taskId): TaskRecord {
+  return {
+    task_id: taskId,
+    name,
+    status: "pending",
+    residency_state: "resident",
+    parent_session_id: "parent-session",
+    root_session_id: "root-session",
+    depth: 0,
+    execution_mode: "in-process",
+    model: "test/model",
+    created_at: "2026-07-20T00:00:00.000Z",
+    updated_at: "2026-07-20T00:00:00.000Z",
+    notification: { run_epoch: 0, notified_epoch: -1 },
+  }
+}
+
+describe("claimTaskRecord", () => {
+  test("#given consecutive persisted records #when a colliding draft is claimed #then it saves the next available record", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    store.save(baseRecord("st_00000010"))
+    store.save(baseRecord("st_00000011"))
+
+    // when
+    const claimed = claimTaskRecord(store, baseRecord("st_00000010"))
+
+    // then
+    expect(claimed.task_id).toBe("st_00000012")
+    expect(existsSync(join(resolveStateDir({ project_dir: project }), "tasks", "st_00000012.json"))).toBe(true)
+  })
+
+  test("#given more collisions than the attempt limit #when a draft is claimed #then the final collision propagates", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    store.save(baseRecord("st_00000010"))
+    store.save(baseRecord("st_00000011"))
+    store.save(baseRecord("st_00000012"))
+
+    // when
+    const claim = () => claimTaskRecord(store, baseRecord("st_00000010"), { maxAttempts: 2 })
+
+    // then
+    expect(claim).toThrow(TaskRecordCollisionError)
+  })
+
+  test("#given a name derived from its id #when the draft is bumped with nameFollowsId #then its name follows the claimed id", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    store.save(baseRecord("st_00000010"))
+
+    // when
+    const claimed = claimTaskRecord(store, baseRecord("st_00000010"), { nameFollowsId: true })
+
+    // then
+    expect(claimed.name).toBe(claimed.task_id)
+  })
+
+  test("#given a task-id-shaped requested name #when the draft is bumped without nameFollowsId #then its name is preserved verbatim", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    store.save(baseRecord("st_00000010"))
+
+    // when
+    const claimed = claimTaskRecord(store, baseRecord("st_00000010", "st_00000010"))
+
+    // then
+    expect(claimed.task_id).toBe("st_00000011")
+    expect(claimed.name).toBe("st_00000010")
+  })
+
+  test("#given a store that raises a non-collision error #when a draft is claimed #then the error propagates unwrapped", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+    const expected = new TypeError("store unavailable")
+    const failingStore = { ...store, save: () => { throw expected } }
+
+    // when
+    const claim = () => claimTaskRecord(failingStore, baseRecord("st_00000010"))
+
+    // then
+    expect(claim).toThrow(expected)
+  })
+
+  test("#given a claimed record in an isolated process #when a new id is created #then the id floor follows the claim", async () => {
+    // given
+    const child = Bun.spawn([process.execPath, claimFloorChildFixturePath], { stdout: "pipe", stderr: "pipe" })
+
+    // when
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ])
+
+    // then
+    expect(exitCode, `stdout:\n${stdout}\nstderr:\n${stderr}`).toBe(0)
+  })
+})

--- a/packages/senpi-task/src/store/claim.test.ts
+++ b/packages/senpi-task/src/store/claim.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 
 import type { TaskRecord } from "../state"
+import { TaskIdSpaceExhaustedError } from "../state/id"
 import { claimTaskRecord } from "./claim"
 import { TaskRecordCollisionError, createTaskRecordStore } from "./record-store"
 import { resolveStateDir } from "./state-dir"
@@ -80,6 +81,38 @@ describe("claimTaskRecord", () => {
 
     // then
     expect(claimed.name).toBe(claimed.task_id)
+  })
+
+  test("#given an unavailable id-derived name #when a draft is claimed #then it skips to the next available id and name", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+
+    // when
+    const claimed = claimTaskRecord(store, baseRecord("st_00000010"), {
+      nameFollowsId: true,
+      nameAvailable: (name) => name !== "st_00000010",
+    })
+
+    // then
+    expect(claimed.task_id).toBe("st_00000011")
+    expect(claimed.name).toBe("st_00000011")
+  })
+
+  test("#given unavailable id-derived names exhaust the attempt budget #when a draft is claimed #then it throws task-id space exhaustion", () => {
+    // given
+    const project = tempProject()
+    const store = createTaskRecordStore({ project_dir: project })
+
+    // when
+    const claim = () => claimTaskRecord(store, baseRecord("st_00000010"), {
+      maxAttempts: 2,
+      nameFollowsId: true,
+      nameAvailable: () => false,
+    })
+
+    // then
+    expect(claim).toThrow(TaskIdSpaceExhaustedError)
   })
 
   test("#given a task-id-shaped requested name #when the draft is bumped without nameFollowsId #then its name is preserved verbatim", () => {

--- a/packages/senpi-task/src/store/claim.ts
+++ b/packages/senpi-task/src/store/claim.ts
@@ -1,22 +1,37 @@
 import { bumpTaskId, parseTaskId, syncTaskIdFloor } from "../state"
+import { TaskIdSpaceExhaustedError } from "../state/id"
 import type { TaskRecord } from "../state"
 import { TaskRecordCollisionError } from "./record-store"
 import type { TaskRecordStore } from "./types"
 
 const DEFAULT_MAX_CLAIM_ATTEMPTS = 4096
 
-export type ClaimOptions = { readonly maxAttempts?: number; readonly nameFollowsId?: boolean }
+export type ClaimOptions = {
+  readonly maxAttempts?: number
+  readonly nameFollowsId?: boolean
+  readonly nameAvailable?: (name: string) => boolean
+}
 
 export function claimTaskRecord(store: TaskRecordStore, draft: TaskRecord, options?: ClaimOptions): TaskRecord {
   const maxAttempts = options?.maxAttempts ?? DEFAULT_MAX_CLAIM_ATTEMPTS
+  let attempts = 0
   let candidate = draft
-  for (let attempt = 1; ; attempt++) {
+  for (;;) {
+    const nameAvailable = options?.nameAvailable
+    while (options?.nameFollowsId === true && nameAvailable !== undefined && !nameAvailable(candidate.name ?? candidate.task_id)) {
+      if (attempts >= maxAttempts) throw new TaskIdSpaceExhaustedError()
+      attempts += 1
+      const nextId = bumpTaskId(parseTaskId(candidate.task_id))
+      candidate = { ...candidate, task_id: nextId, name: nextId }
+    }
     try {
+      if (attempts >= maxAttempts) throw new TaskIdSpaceExhaustedError()
+      attempts += 1
       store.save(candidate)
       syncTaskIdFloor(parseTaskId(candidate.task_id))
       return candidate
     } catch (error) {
-      if (!(error instanceof TaskRecordCollisionError) || attempt >= maxAttempts) throw error
+      if (!(error instanceof TaskRecordCollisionError) || attempts >= maxAttempts) throw error
       const nextId = bumpTaskId(error.taskId)
       candidate = { ...candidate, task_id: nextId, ...(options?.nameFollowsId === true ? { name: nextId } : {}) }
     }

--- a/packages/senpi-task/src/store/claim.ts
+++ b/packages/senpi-task/src/store/claim.ts
@@ -1,0 +1,24 @@
+import { bumpTaskId, parseTaskId, syncTaskIdFloor } from "../state"
+import type { TaskRecord } from "../state"
+import { TaskRecordCollisionError } from "./record-store"
+import type { TaskRecordStore } from "./types"
+
+const DEFAULT_MAX_CLAIM_ATTEMPTS = 4096
+
+export type ClaimOptions = { readonly maxAttempts?: number; readonly nameFollowsId?: boolean }
+
+export function claimTaskRecord(store: TaskRecordStore, draft: TaskRecord, options?: ClaimOptions): TaskRecord {
+  const maxAttempts = options?.maxAttempts ?? DEFAULT_MAX_CLAIM_ATTEMPTS
+  let candidate = draft
+  for (let attempt = 1; ; attempt++) {
+    try {
+      store.save(candidate)
+      syncTaskIdFloor(parseTaskId(candidate.task_id))
+      return candidate
+    } catch (error) {
+      if (!(error instanceof TaskRecordCollisionError) || attempt >= maxAttempts) throw error
+      const nextId = bumpTaskId(error.taskId)
+      candidate = { ...candidate, task_id: nextId, ...(options?.nameFollowsId === true ? { name: nextId } : {}) }
+    }
+  }
+}

--- a/packages/senpi-task/src/store/index.ts
+++ b/packages/senpi-task/src/store/index.ts
@@ -1,3 +1,5 @@
+export { claimTaskRecord } from "./claim"
+export type { ClaimOptions } from "./claim"
 export { TaskRecordCollisionError, createTaskRecordStore } from "./record-store"
 export { resolveStateDir } from "./state-dir"
 export type {

--- a/packages/senpi-task/src/tools/task/execute-collision.test.ts
+++ b/packages/senpi-task/src/tools/task/execute-collision.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { collisionStore } from "../../manager/__fixtures__/collision-store"
+import { FakeRunner, categoryPlanner, cleanupProjects, settings, tempProject } from "../../manager/__fixtures__/manager-fakes"
+import { createTaskManager } from "../../manager"
+import { createTaskRecordStore } from "../../store"
+import { CTX, makeDeps } from "./__fixtures__/task-tool-fakes"
+import { buildTaskExecute } from "./execute"
+
+afterEach(cleanupProjects)
+
+function buildCollisionExecute() {
+  const project = tempProject()
+  const inner = createTaskRecordStore({ project_dir: project })
+  const manager = createTaskManager({
+    store: collisionStore(inner).store,
+    runners: { "in-process": new FakeRunner(), process: new FakeRunner() },
+    planner: categoryPlanner(),
+    config: settings({ default_concurrency: 5, max_depth: 1 }),
+    cwd: project,
+  })
+  return buildTaskExecute(makeDeps(manager))
+}
+
+describe("buildTaskExecute collision handling", () => {
+  test("#given a first-save collision #when one background task executes #then it reports a normal started result without the raw collision", async () => {
+    // given
+    const execute = buildCollisionExecute()
+
+    // when
+    const result = await execute("collision-single", { prompt: "work", category: "quick", run_in_background: true }, undefined, undefined, CTX)
+
+    // then
+    expect(result.details.status).toBe("running")
+    expect(result.details.task_id).toMatch(/^st_[0-9a-f]{8}$/)
+    expect(JSON.stringify(result)).not.toContain("already exists")
+  })
+
+  test("#given a first-save collision #when a two-item background batch executes #then both tasks start without the raw collision", async () => {
+    // given
+    const execute = buildCollisionExecute()
+
+    // when
+    const result = await execute(
+      "collision-batch",
+      {
+        tasks: [
+          { prompt: "first", category: "quick" },
+          { prompt: "second", category: "quick" },
+        ],
+        run_in_background: true,
+      },
+      undefined,
+      undefined,
+      CTX,
+    )
+
+    // then
+    expect(result.details.status).toBe("running")
+    expect(result.details.items).toHaveLength(2)
+    expect(result.details.items?.every((item) => item.status === "running")).toBe(true)
+    expect(JSON.stringify(result)).not.toContain("already exists")
+  })
+})

--- a/packages/senpi-task/src/tools/team/lifecycle-collision.test.ts
+++ b/packages/senpi-task/src/tools/team/lifecycle-collision.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import type { ExtensionContext } from "@code-yeongyu/senpi"
+
+import { collisionStore } from "../../manager/__fixtures__/collision-store"
+import { FakeRunner, categoryPlanner, cleanupProjects, settings, tempProject } from "../../manager/__fixtures__/manager-fakes"
+import { createTaskManager } from "../../manager"
+import { createTeam, normalizeSenpiTeamSpec } from "../../team"
+import { stateDirConfig, taskSettings } from "../../team/__fixtures__/runtime-fakes"
+import { createTaskRecordStore } from "../../store"
+import { createFakeTeamService } from "./__fixtures__/team-tool-fakes"
+import { createTeamCreateTool } from "./lifecycle"
+
+afterEach(cleanupProjects)
+
+describe("team_create collision handling", () => {
+  test("#given a first-save collision #when the real team_create tool creates a team #then the team activates without a member rejection or raw collision", async () => {
+    // given
+    const project = tempProject()
+    const inner = createTaskRecordStore({ project_dir: project })
+    const manager = createTaskManager({
+      store: collisionStore(inner).store,
+      runners: { "in-process": new FakeRunner(), process: new FakeRunner() },
+      planner: categoryPlanner(),
+      config: settings({ default_concurrency: 5, max_depth: 2 }),
+      cwd: project,
+    })
+    let teamStatus: string | undefined
+    const service = createFakeTeamService({
+      createTeam: async (input) => {
+        if (input.inlineSpec === undefined) throw new Error("expected inline team spec")
+        const spec = normalizeSenpiTeamSpec(input.inlineSpec, "collision-team")
+        const created = await createTeam(spec, "project", {
+          manager,
+          stateDir: stateDirConfig(project),
+          taskSettings: taskSettings(),
+          leadSessionId: "lead-session",
+          spawnDepth: 1,
+        })
+        teamStatus = created.runtimeState.status
+        return created
+      },
+    })
+    const tool = createTeamCreateTool({ service })
+    const context = {} as unknown as ExtensionContext
+
+    // when
+    const result = await tool.execute(
+      "collision-team-create",
+      { inline_spec: { name: "collision-team", members: [{ name: "alpha", kind: "category", category: "quick", prompt: "work" }] } },
+      undefined,
+      undefined,
+      context,
+    )
+
+    // then
+    expect(result).toMatchObject({ details: { kind: "created", members: [{ name: "alpha", status: "running" }] } })
+    expect(teamStatus).toBe("active")
+    expect(JSON.stringify(result)).not.toContain("member_start_rejected")
+    expect(JSON.stringify(result)).not.toContain("already exists")
+  })
+})


### PR DESCRIPTION
## Summary

Spawning subagents from several senpi/coding-agent windows in the same project could fail with `Task record already exists` (or silently hand you a task id owned by another window), because task ids were allocated from per-process in-memory state against a shared `<project>/.omo/senpi-task` store. This PR makes allocation contention-proof: the task record file itself (created with `wx`, so the OS guarantees a single winner) is now the arbiter of id ownership. Everything that depends on the shared task state — crash recovery, TTL cleanup, cross-window inspection — works unchanged; the store contract, id format (`st_[0-9a-f]{8}`, sortable time prefix), and state-dir layout are untouched.

The bug reproduced live **five times inside the very session that planned and implemented this fix** (three failed `task` dispatches, one swept `lost` child, one batch of two simultaneous collisions), all captured in the evidence bundle.

## Changes

**Allocation core (packages/senpi-task)**
- `src/store/claim.ts` (new): `claimTaskRecord()` — an fs-arbitrated allocation loop. It attempts `store.save()` (atomic `wx` create); on `TaskRecordCollisionError` it advances the candidate past the observed owner via `bumpTaskId`, up to 4096 attempts. A `nameFollowsId` option keeps id-derived fallback names equal to the final claimed id, and a `nameAvailable` callback skips candidates whose id-as-name is already registered (closes a transient duplicate-name window found in review).
- `src/state/id.ts`: additive `bumpTaskId()` and `syncTaskIdFloor()`; `createTaskRecord()` gains an optional trailing `nowMs` parameter (existing call sites compile unchanged). `createTaskId`, `parseTaskId`, `TASK_ID_PATTERN` untouched.
- `src/manager/manager.ts` (confined to constructor + `start()`): the constructor seeds the id floor from persisted records (`max(task_id)` from `store.list()`, log-and-continue on diagnostics) so a fresh process never re-issues ids older records already hold; `start()` now pre-reserves requested names, allocates inside a boundary that catches both `createTaskRecord()` and claim failures into a **sanitized** `start_failed` (`task_id: ""`, message "task id allocation failed under contention; retry the spawn" — the raw collision string never reaches any tool surface), registers fallback names after the claim, and merges the rename/spawn_spec into one `replace()`. Bookkeeping failures legally transition the claimed record `pending -> running -> error` and never delete records.
- `src/manager/names.ts`: additive `release()` (unwind a name that never reached disk) and `isAvailable()`.

**Tests (RED → GREEN, mutation-proven)**
- Characterization pins of the pre-change `start()` contract (incl. D6: persisted records keep their name reservation on launch failure).
- Child-process-isolated floor/exhaustion tests with exact expected ids (the module-global floor makes in-process floor assertions vacuous).
- Incident reproduction: an intercepting store that persists a foreign winner mid-`save()` flips from raw `TaskRecordCollisionError` (before) to a clean retried start (after); plus an every-save uniqueness-invariant store proving no duplicate names within a manager.
- Cross-process race regression: two child processes, frozen id bucket, READY/GO barrier, 100 claims → 100 unique ids, ≥1 retry, zero collision text. Mutation-proven (raw `save()` instead of claim fails with the exact incident error).
- Tool-surface proofs at all three spawn surfaces: single `task`, `tasks:[...]` batch, and the real `team_create` tool boundary — each asserting zero "already exists" in serialized results. Pre-fix worktree run captured failing with the raw collision.
- TTL pin: freshly claimed non-terminal records are retained by `cleanupExpiredRecords`.

**Real-harness QA (packages/omo-senpi/scripts/qa/)**
- `task-id-race-qa.mjs` + `task-id-race-mock-provider.mjs` (new): a two-parent driver that launches two real senpi harness processes against one shared project, synchronizes them with an event-driven (no polling) READY/GO file gate inside a single 65.536s id bucket, and asserts unique ids + zero collision text. All process waits and exec calls are bounded; teardown always kills process groups and writes cleanup receipts.

## QA & Evidence

- **What was tested:** two real senpi parents spawning concurrently in one id bucket on the final tree.
  **Observed:** PASS — unique ids (`st_019f7e69`, `st_019f7e6a`), stable bucket, zero "Task record already exists".
  **Artifact:** `.omo/evidence/20260720-senpi-task-id-claim/f3-final/verdict.json` (+ transcripts, tasks listings, cleanup receipt).
- **What was tested:** the identical driver against a base-SHA worktree (revision-honest: qa files copied in, plugin entry resolved per worktree, same senpi binary recorded).
  **Observed:** exit 1 citing `Task record already exists: st_019f7e55` — the driver can fail, and does on unfixed code.
  **Artifact:** `.omo/evidence/20260720-senpi-task-id-claim/f3-real-harness/base-run/verdict.json`.
- **What was tested:** `cd packages/senpi-task && bun test` (bare, recursive), `bun run typecheck`, `cd packages/omo-senpi && bun test src/components/task`.
  **Observed:** 795 pass / 0 fail; typecheck clean. **Artifact:** `task-9-gates.md`.
- **Per-todo raw RED/GREEN captures:** `task-1` … `task-10`, `f2-fixes.md`, `summary.md` under the same evidence dir.
  **Why sufficient:** every behavior change has a failing-first proof (or mutation proof for test-only work), the incident shape is covered at unit, cross-process, tool-surface, and real-harness levels, and two independent review loops (plan-level Momus ×3 rounds; code-level F1/F2/F4 auditors) approved the final tree.

## Risks & Residuals

- **P1 (accepted, pre-existing, documented):** `NameRegistry` is per-manager in-memory; two processes (or one session resumed elsewhere) can each register the same task *name*. This PR guarantees no *new* duplicate-name windows within one manager; cross-process name hydration is out of scope (no call site consults persisted names).
- **P2 (accepted, pre-existing, documented):** the TTL cleaner's blind `remove()` can theoretically unlink a freshly claimed record under a sub-bucket (<65.536s) `ttl_ms` with two concurrent cleaners. Pre-existing (and *less* likely after this PR, since ids no longer collide trivially); fixing it needs a store-contract change this PR deliberately avoids. The TTL non-terminal retention guard is pinned by test.
- **P3 (noted, pre-existing):** a concurrent session's startup reconcile marked another live process's in-process child `lost` during this work — cross-process reconcile cannot distinguish dead vs. live owners. Separate follow-up.
- Store `save()` still throws `TaskRecordCollisionError` on EEXIST (chaos suite and store wrappers depend on it) — verified by the full suite including `src/__adversarial__/`.

## Related

Plan: `.omo/plans/senpi-task-id-collision-free-allocation.md` (Momus-reviewed, 3 rounds).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-process task-id collisions in `senpi-task` by making the task record file the single source of ownership via atomic create, ensuring unique ids and removing “already exists” errors from user-facing outputs.

- **Bug Fixes**
  - Allocation is now fs-arbitrated: `claimTaskRecord()` (`packages/senpi-task`) atomically saves with `wx`, retries with `bumpTaskId`, and advances the id floor via `syncTaskIdFloor`.
  - Manager seeds the id floor from disk on startup, claims ids inside `start()`, aligns fallback names to the final id, and returns a sanitized `start_failed` on contention; bookkeeping failures now transition `pending -> running -> error` without deleting records.
  - Name handling adds `NameRegistry.isAvailable()` and `release()` to avoid transient duplicate names within one manager and to unwind reservations on allocation failure.

- **New Features**
  - Added `bumpTaskId()`, `syncTaskIdFloor()`, optional `nowMs` for `createTaskRecord()`, and `TaskIdSpaceExhaustedError`.
  - QA driver and mock provider in `packages/omo-senpi/scripts/qa/` prove 100 concurrent claims → 100 unique ids with no collision text; added unit and tool-surface tests (single task, batch, `team_create`), plus TTL retention pins.

<sup>Written for commit 89a9cf9a667f1cac3e4c3626e0fc7fb450d49388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

