### PR TITLE
fix(omo-opencode): sync task poller stops trusting session.status()==busy forever

### DIFF
--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.test.ts
@@ -540,6 +540,111 @@ describe("pollSyncSession", () => {
     })
   })
 
+  describe("busy status does not hide real staleness", () => {
+    test("#given status stays busy forever with no message progress #when polling #then poll_timeout still fires", async () => {
+      // given
+      const { pollSyncSession } = require("./sync-session-poller")
+      __setTimingConfig({
+        POLL_INTERVAL_MS: 5,
+        MIN_STABILITY_TIME_MS: 0,
+        STABILITY_POLLS_REQUIRED: 1,
+        MAX_POLL_TIME_MS: 50,
+        BUSY_PROGRESS_RECHECK_MS: 5,
+      })
+      let abortCount = 0
+      const frozenMessages = {
+        data: [
+          { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+          {
+            info: { id: "msg_002", role: "assistant", time: { created: 2000 } },
+            parts: [{ type: "text", text: "still thinking" }],
+          },
+        ],
+      }
+      const mockClient = {
+        session: {
+          messages: async () => frozenMessages,
+          status: async () => ({ data: { ses_stuck: { type: "busy" } } }),
+          abort: async () => {
+            abortCount++
+          },
+        },
+      }
+
+      // when
+      const result = await pollSyncSession(createMockCtx(), mockClient, {
+        sessionID: "ses_stuck",
+        agentToUse: "test-agent",
+        toastManager: null,
+        taskId: undefined,
+      })
+
+      // then: a session.status() that never stops reporting "busy" must not
+      // be able to suppress the timeout forever when the message stream is
+      // frozen; this is the real-world hang this fix targets.
+      expect(abortCount).toBe(1)
+      expect(result).toContain("Poll inactivity timeout reached")
+    })
+
+    test("#given status stays busy but message content genuinely grows #when polling #then the clock keeps resetting and no timeout fires", async () => {
+      // given
+      const { pollSyncSession } = require("./sync-session-poller")
+      __setTimingConfig({
+        POLL_INTERVAL_MS: 5,
+        MIN_STABILITY_TIME_MS: 0,
+        STABILITY_POLLS_REQUIRED: 1,
+        MAX_POLL_TIME_MS: 30,
+        BUSY_PROGRESS_RECHECK_MS: 1,
+      })
+      let abortCount = 0
+      let statusCallCount = 0
+      const mockClient = {
+        session: {
+          messages: async () => {
+            const growing = statusCallCount
+            return {
+              data: [
+                { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+                {
+                  info: {
+                    id: "msg_002",
+                    role: "assistant",
+                    time: { created: 2000 },
+                    ...(growing >= 20 ? { finish: "end_turn" } : {}),
+                  },
+                  parts: [{ type: "text", text: "x".repeat(growing + 1) }],
+                },
+              ],
+            }
+          },
+          status: async () => {
+            statusCallCount++
+            return { data: { ses_progressing: { type: statusCallCount >= 20 ? "idle" : "busy" } } }
+          },
+          abort: async () => {
+            abortCount++
+          },
+        },
+      }
+
+      // when
+      const result = await pollSyncSession(createMockCtx(), mockClient, {
+        sessionID: "ses_progressing",
+        agentToUse: "test-agent",
+        toastManager: null,
+        taskId: undefined,
+      })
+
+      // then: the growing text length kept resetting the inactivity clock on
+      // every busy recheck despite total elapsed time exceeding
+      // MAX_POLL_TIME_MS; the loop only ends because status finally went
+      // idle with a terminal finish, never because it was treated as stale.
+      expect(abortCount).toBe(0)
+      expect(statusCallCount).toBeGreaterThanOrEqual(20)
+      expect(result).toBeNull()
+    })
+  })
+
   describe("isSessionComplete edge cases", () => {
     test("returns false when messages array is empty", () => {
       const { isSessionComplete } = require("./sync-session-poller")

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
@@ -30,6 +30,23 @@ function isActiveSessionStatus(status: { type: string } | undefined): boolean {
   return status !== undefined && ACTIVE_SESSION_STATUSES.has(status.type)
 }
 
+// Cheap fingerprint of "has anything actually moved": message count, the
+// identity of the last message, how many parts it has, how long its last
+// text/reasoning part is, and the last tool part's state. Deliberately
+// excludes full text content (avoids hashing/comparing potentially large
+// strings on every recheck).
+function computeProgressSignature(messages: SessionMessage[]): string {
+  const last = messages[messages.length - 1]
+  const lastParts = last?.parts ?? []
+  const lastPart = lastParts[lastParts.length - 1] as
+    | { type?: string; text?: string; state?: { status?: string } }
+    | undefined
+  const textLen =
+    lastPart?.type === "text" || lastPart?.type === "reasoning" ? (lastPart.text ?? "").length : 0
+  const toolState = lastPart?.type === "tool" ? lastPart.state?.status ?? "" : ""
+  return `${messages.length}:${last?.info?.id ?? ""}:${lastParts.length}:${textLen}:${toolState}`
+}
+
 async function fetchSessionMessages(
   client: OpencodeClient,
   sessionID: string
@@ -62,6 +79,8 @@ export async function pollSyncSession(
   const maxTurns = input.maxAssistantTurns ?? DEFAULT_MAX_ASSISTANT_TURNS
   const pollStart = Date.now()
   let inactiveStart = pollStart
+  let lastProgressSignature: string | null = null
+  let lastProgressCheckAt = pollStart
   let pollCount = 0
   let timedOut = false
   let assistantTurnCount = 0
@@ -165,7 +184,32 @@ export async function pollSyncSession(
     }
 
     if (isActiveSessionStatus(sessionStatus)) {
-      inactiveStart = Date.now()
+      // Do not trust "busy"/"retry"/"running" at face value forever: a
+      // provider call can get stuck in-flight (no error, no output, status
+      // never flips) and this status alone would then reset inactiveStart
+      // on every poll tick, permanently defeating the timeout below.
+      // Periodically verify the message stream actually moved; only reset
+      // the clock when it did. Throttled (not every tick) to avoid spamming
+      // session.messages() while a session is legitimately streaming.
+      const now = Date.now()
+      if (now - lastProgressCheckAt < syncTiming.BUSY_PROGRESS_RECHECK_MS) {
+        continue
+      }
+      lastProgressCheckAt = now
+      try {
+        const progressMessages = await fetchSessionMessages(client, input.sessionID)
+        const signature = computeProgressSignature(progressMessages)
+        if (lastProgressSignature === null || signature !== lastProgressSignature) {
+          lastProgressSignature = signature
+          inactiveStart = now
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        log("[task] Busy-progress recheck failed, keeping prior inactivity clock", {
+          sessionID: input.sessionID,
+          error: errorMessage,
+        })
+      }
       continue
     }
 

--- a/packages/omo-opencode/src/tools/delegate-task/timing.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/timing.ts
@@ -6,6 +6,7 @@ let WAIT_FOR_SESSION_TIMEOUT_MS = 60000
 const DEFAULT_POLL_TIMEOUT_MS = 30 * 60 * 1000
 let MAX_POLL_TIME_MS = DEFAULT_POLL_TIMEOUT_MS
 let SESSION_CONTINUATION_STABILITY_MS = 5000
+let BUSY_PROGRESS_RECHECK_MS = 30000
 
 export const DEFAULT_SYNC_POLL_TIMEOUT_MS = DEFAULT_POLL_TIMEOUT_MS
 
@@ -22,6 +23,7 @@ export function getTimingConfig() {
     WAIT_FOR_SESSION_TIMEOUT_MS,
     MAX_POLL_TIME_MS,
     SESSION_CONTINUATION_STABILITY_MS,
+    BUSY_PROGRESS_RECHECK_MS,
   }
 }
 
@@ -33,6 +35,7 @@ export function __resetTimingConfig(): void {
   WAIT_FOR_SESSION_TIMEOUT_MS = 60000
   MAX_POLL_TIME_MS = DEFAULT_POLL_TIMEOUT_MS
   SESSION_CONTINUATION_STABILITY_MS = 5000
+  BUSY_PROGRESS_RECHECK_MS = 30000
 }
 
 export function __setTimingConfig(overrides: Partial<ReturnType<typeof getTimingConfig>>): void {
@@ -43,4 +46,5 @@ export function __setTimingConfig(overrides: Partial<ReturnType<typeof getTiming
   if (overrides.WAIT_FOR_SESSION_TIMEOUT_MS !== undefined) WAIT_FOR_SESSION_TIMEOUT_MS = overrides.WAIT_FOR_SESSION_TIMEOUT_MS
   if (overrides.MAX_POLL_TIME_MS !== undefined) MAX_POLL_TIME_MS = overrides.MAX_POLL_TIME_MS
   if (overrides.SESSION_CONTINUATION_STABILITY_MS !== undefined) SESSION_CONTINUATION_STABILITY_MS = overrides.SESSION_CONTINUATION_STABILITY_MS
+  if (overrides.BUSY_PROGRESS_RECHECK_MS !== undefined) BUSY_PROGRESS_RECHECK_MS = overrides.BUSY_PROGRESS_RECHECK_MS
 }


### PR DESCRIPTION
## Summary

`pollSyncSession` (the loop `task()` uses to wait synchronously for a sync subagent) resets its inactivity clock on every poll tick whenever `session.status()` reports `busy`/`retry`/`running`, with no check that anything actually happened. When the underlying provider call gets stuck in-flight (no error, no new output, but the session status stays technically "busy"), the inactivity clock never accumulates and the existing 30-minute `poll_timeout` self-heal never fires. The subagent, and the parent waiting on it, hang indefinitely, with the log/status API insisting the whole time that everything is fine.

This PR makes the poller verify real progress (not just the status label) before trusting "busy" enough to reset the clock, so the existing timeout safety net actually gets to do its job.

## Changes

- **`sync-session-poller.ts`**: added `computeProgressSignature()` (message count, last message id, part count, last text/reasoning length, last tool part state; deliberately cheap, no full-text hashing). While `session.status()` is active, the poller now re-checks this fingerprint at most once per `BUSY_PROGRESS_RECHECK_MS` and only resets `inactiveStart` when it actually changed. If it never changes, the existing `poll_timeout` path fires as originally designed.
- **`timing.ts`**: new `BUSY_PROGRESS_RECHECK_MS` timing knob (default 30s), wired into `getTimingConfig()`/`__setTimingConfig()`/`__resetTimingConfig()` alongside the existing ones.
- **`sync-session-poller.test.ts`**: two new cases under "non-idle session status" pinning the exact bug and its regression guard (see QA below).

## QA & Evidence

- **What was tested:** `bun test packages/omo-opencode/src/tools/delegate-task/sync-session-poller*.test.ts` (31 tests: 29 pre-existing + 2 new), plus `bun x tsgo --noEmit -p packages/omo-opencode/tsconfig.json`, plus the full `bun run build` (via the workspace `prepare` hook).
  - **Observed:** 31/31 pass, 0 typecheck errors, build succeeds.
  - **Why sufficient:** the two new tests deterministically reproduce (a) the exact hang: status stays `busy` forever, message content frozen, `poll_timeout` still fires; and (b) the regression guard: status stays `busy` but message content genuinely grows every recheck, zero false aborts across 20+ polls that individually exceed `MAX_POLL_TIME_MS`. The pre-existing `"skips message check when session is not idle"` test is unaffected (its simulated run never crosses the 30s recheck window).
- **What was tested (manual, real harness):** built this exact change (`dist/index.js`) and loaded it as a `file://` plugin in a real OpenCode instance, inside an isolated XDG sandbox (own `XDG_DATA_HOME`/`XDG_CONFIG_HOME`/`XDG_CACHE_HOME`/`XDG_STATE_HOME` under a fresh `mktemp` dir; host `~/.config/opencode` and `~/.local/share/opencode` untouched).
  - **Observed:** plugin loaded cleanly (`init count=55`, no load errors); a real primary-agent turn completed against a real model; a real `task()` delegation to a subagent (`Sisyphus-Junior`) ran end-to-end through this exact modified poll loop: child session created, read a file, finished cleanly, parent received the correct result. Zero errors, zero false timeouts.
  - **Why sufficient:** confirms the change doesn't regress the fast/happy path for a real delegation, not just in mocks.
  - **What was omitted:** reproducing the full 30-60 minute real-world hang end-to-end (rather than via the unit tests) was not attempted, since it is impractical to wait out and the unit tests already pin the mechanism deterministically. This was originally caught live via two real stuck sessions (frozen 42 min and 65 min respectively, `session.status()` reporting "busy" the entire time); session IDs/logs from that repro are from an unrelated private codebase and are not included here.

## Risks & Residuals

- **False-positive risk (killing a legitimately slow session):** mitigated by the dedicated regression test, so only a message stream that is *actually* frozen (not just "busy") accumulates inactivity now.
- **Extra `session.messages()` calls while busy:** bounded by `BUSY_PROGRESS_RECHECK_MS` (default 30s): one extra fetch per recheck window, not per poll tick.
- **Scope:** this only covers the synchronous `task()` poller. The background-agent path and main-session path described in #4484 use different code and are not touched here; left for a separate PR.

## Related Issues

- Related to #4484 ("Add stale-progress watchdog for stalled agent sessions"): that issue's own examples cover the background-agent and main-session cases, not this specific sync `task()` poller path, so this PR does not close it, only addresses the same class of bug in one additional, real, reproduced location.
- Related to #5345 ("Sync task hangs when subagent is not_in_status but dispatched parent wake remains pending"): same symptom class (sync `task()` poller hang) but a different root cause; that issue is about a stale `dispatchedParentWake` never clearing while the session is `not_in_status`, which is a separate code path from the busy-status progress check this PR adds. Not addressed here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang in the sync task poller where `session.status()` staying “busy” forever prevented the inactivity timeout from firing. The poller now requires real message progress before resetting the inactivity clock, so stuck sessions time out instead of looping.

- **Bug Fixes**
  - Check for real progress while status is active using a cheap message “progress fingerprint”; only reset inactivity when it changes.
  - Throttle progress rechecks to once per `BUSY_PROGRESS_RECHECK_MS` (default 30s) to limit extra `messages()` calls.
  - Added `BUSY_PROGRESS_RECHECK_MS` to timing config.
  - Tests cover both cases: stuck-busy correctly times out; progressing-busy does not falsely time out.

<sup>Written for commit 2ca685487940bf9dd017d5ea4c2a9c2ea0100450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

