### PR TITLE
fix(codex): update lazycodex agent model routing

### DIFF
--- a/.omo/evidence/20260721-lazycodex-model-routing/qa-summary.md
+++ b/.omo/evidence/20260721-lazycodex-model-routing/qa-summary.md
@@ -1,0 +1,47 @@
+# LazyCodex model routing QA
+
+## What was tested
+
+- `node --test packages/omo-codex/plugin/test/aggregate-agents.test.mjs`
+  - Verified each of the six bundled ultrawork agent TOMLs has its requested
+    model and reasoning effort.
+- `bun run --cwd packages/omo-codex typecheck`, `bun run typecheck`, and
+  `bun run build`
+  - Verified TypeScript diagnostics and the distributable installer bundle.
+- `bun run test:codex`
+  - Ran the Codex compatibility gate after the migration-default change.
+- `REPO_ROOT=<worktree> bash .../codex-qa/scripts/install-verify.sh --self-test`
+  - Drove the real installer into a temporary isolated `CODEX_HOME`.
+- `REPO_ROOT=<worktree> bash .../codex-qa/scripts/app-server-drive.sh --plugin`
+  - Drove a real isolated `codex app-server` session against the local mock
+    model and asserted plugin hook notifications.
+
+## What was observed
+
+- Aggregate routing test: 6 passing assertions.
+- Managed migration tests: 13 passing assertions, including every requested
+  legacy managed-route upgrade and preservation of user-customized values.
+- Package and repository typechecks passed; the build passed.
+- `bun run test:codex` passed: 510 Node tests and 382 Bun tests, with one
+  expected platform-specific skip.
+- The isolated installer found the plugin cache, enabled `omo@sisyphuslabs`,
+  linked nine component bins and agent TOMLs, and reported the real
+  `~/.codex/config.toml` checksum unchanged:
+  `e1213327752215e76048d840b74aa0cecf3504d7`.
+- The isolated app-server session completed a mock-backed turn and observed
+  `sessionStart`, `userPromptSubmit`, and `stop` hooks complete. It also
+  reported the same unchanged real-config checksum.
+
+## Why this is enough
+
+The aggregate contract proves the bundled role settings. The migration tests
+prove existing installations receive the revised defaults only when their
+configuration still matches a known managed value. The compatibility gate,
+isolated install, and real app-server session cover the shipped installer and
+live Codex plugin surface without using the real Codex home.
+
+## What was omitted
+
+Raw QA logs were not committed because they may contain temporary home paths
+and verbose runtime output. No credentials, tokens, auth headers, or
+environment dumps were captured.

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-clone-fidelity-reviewer.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-clone-fidelity-reviewer.toml
@@ -1,8 +1,8 @@
 name = "lazycodex-clone-fidelity-reviewer"
 description = "Read-only LazyCodex clone / design-system fidelity reviewer. Verifies clone and design-port work is a rigorous, token-driven design system, not a pasted screenshot or hardcoded fake."
 nickname_candidates = ["Clone Fidelity Reviewer"]
-model = "gpt-5.6-sol"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
 
 developer_instructions = """
 Role: clone / design-system fidelity reviewer. Read-only.

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-code-reviewer.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-code-reviewer.toml
@@ -1,8 +1,8 @@
 name = "lazycodex-code-reviewer"
 description = "Read-only LazyCodex code-quality reviewer. Audits diffs, tests, and risk with strict artifact-backed findings."
 nickname_candidates = ["Code Reviewer"]
-model = "gpt-5.6-sol"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
 
 developer_instructions = """
 Role: code quality reviewer. Read-only.

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-gate-reviewer.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-gate-reviewer.toml
@@ -2,7 +2,7 @@ name = "lazycodex-gate-reviewer"
 description = "Read-only LazyCodex gate reviewer. Re-audits executor, code review, and QA artifacts before final approval."
 nickname_candidates = ["Gate Reviewer"]
 model = "gpt-5.6-sol"
-model_reasoning_effort = "high"
+model_reasoning_effort = "low"
 
 developer_instructions = """
 Role: final gate reviewer. Read-only.

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-high.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-high.toml
@@ -2,7 +2,7 @@ name = "lazycodex-worker-high"
 description = "LazyCodex high-difficulty implementation worker, sized for LARGE changes: a new module or abstraction, a cross-module refactor, concurrency/security/migration work, or any real, complex, big problem that has ONE clear goal. Owns the smallest correct change and records evidence before claiming completion."
 nickname_candidates = ["High Worker"]
 model = "gpt-5.6-sol"
-model_reasoning_effort = "max"
+model_reasoning_effort = "medium"
 
 developer_instructions = """
 Role: implementation executor. You own the task end to end.

--- a/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-medium.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/lazycodex-worker-medium.toml
@@ -1,8 +1,8 @@
 name = "lazycodex-worker-medium"
 description = "LazyCodex medium-difficulty implementation worker, sized for MID-SIZED changes: a standard feature inside existing layers, touching a few files along established patterns. Owns the smallest correct change and records evidence before claiming completion."
 nickname_candidates = ["Medium Worker"]
-model = "gpt-5.6-luna"
-model_reasoning_effort = "max"
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
 
 developer_instructions = """
 Role: implementation executor. You own the task end to end.

--- a/packages/omo-codex/plugin/components/ultrawork/agents/plan.toml
+++ b/packages/omo-codex/plugin/components/ultrawork/agents/plan.toml
@@ -2,7 +2,7 @@ name = "plan"
 description = "Strategic planning consultant for work with unresolved design uncertainty after discovery. Produces one executable plan; never implements. Writes the plan to .omo/plans/<slug>.md."
 nickname_candidates = ["Planner"]
 model = "gpt-5.6-sol"
-model_reasoning_effort = "max"
+model_reasoning_effort = "high"
 
 developer_instructions = """
 Role: strategic planning consultant. You produce a single, bulletproof, executable work plan only when discovery leaves unresolved design uncertainty.

--- a/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-agents.test.mjs
@@ -52,7 +52,7 @@ const lazycodexAgentInvariants = new Map([
 		"plan.toml",
 		{
 			model: "gpt-5.6-sol",
-			effort: "max",
+			effort: "high",
 			includes: [/strategic planning consultant/i, /\.omo\/plans\/<slug>\.md/, /never implements/i],
 		},
 	],
@@ -67,8 +67,8 @@ const lazycodexAgentInvariants = new Map([
 	[
 		"lazycodex-worker-medium.toml",
 		{
-			model: "gpt-5.6-luna",
-			effort: "max",
+			model: "gpt-5.6-terra",
+			effort: "high",
 			includes: [/EVIDENCE_RECORDED: <path>/, /medium-difficulty/i, /smallest correct change/i],
 		},
 	],
@@ -76,23 +76,23 @@ const lazycodexAgentInvariants = new Map([
 		"lazycodex-worker-high.toml",
 		{
 			model: "gpt-5.6-sol",
-			effort: "max",
+			effort: "medium",
 			includes: [/EVIDENCE_RECORDED: <path>/, /high-difficulty/i, /smallest correct change/i],
 		},
 	],
 	[
 		"lazycodex-clone-fidelity-reviewer.toml",
 		{
-			model: "gpt-5.6-sol",
-			effort: "xhigh",
+			model: "gpt-5.6-terra",
+			effort: "high",
 			includes: [/recommendation/, /blockers/, /\.omo\/evidence\/<goal>-clone-fidelity\.md/],
 		},
 	],
 	[
 		"lazycodex-code-reviewer.toml",
 		{
-			model: "gpt-5.6-sol",
-			effort: "xhigh",
+			model: "gpt-5.6-terra",
+			effort: "medium",
 			includes: [/codeQualityStatus/, /recommendation/, /<attemptDir>\/<goalId>-code-review\.md/, /currentAttemptDir/],
 		},
 	],
@@ -108,7 +108,7 @@ const lazycodexAgentInvariants = new Map([
 		"lazycodex-gate-reviewer.toml",
 		{
 			model: "gpt-5.6-sol",
-			effort: "high",
+			effort: "low",
 			includes: [/APPROVE\/REJECT/, /blockers/, /<attemptDir>\/<goalId>-gate-review\.md/, /currentAttemptDir/],
 		},
 	],

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -5903,7 +5903,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "4.18.2",
+    version: "4.19.0",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -9392,6 +9392,10 @@ var MANAGED_REASONING_DEFAULT_UPGRADES = new Map([
       {
         previous: { model: "gpt-5.5", effort: "xhigh" },
         current: { model: "gpt-5.6-sol", effort: "ultra" }
+      },
+      {
+        previous: { model: "gpt-5.6-sol", effort: "ultra" },
+        current: { model: "gpt-5.6-terra", effort: "high" }
       }
     ]
   ],
@@ -9401,6 +9405,10 @@ var MANAGED_REASONING_DEFAULT_UPGRADES = new Map([
       {
         previous: { model: "gpt-5.6-sol", effort: "xhigh" },
         current: { model: "gpt-5.6-sol", effort: "max" }
+      },
+      {
+        previous: { model: "gpt-5.6-sol", effort: "max" },
+        current: { model: "gpt-5.6-sol", effort: "high" }
       }
     ]
   ],
@@ -9410,6 +9418,37 @@ var MANAGED_REASONING_DEFAULT_UPGRADES = new Map([
       {
         previous: { model: "gpt-5.6-sol", effort: "high" },
         current: { model: "gpt-5.6-luna", effort: "max" }
+      },
+      {
+        previous: { model: "gpt-5.6-luna", effort: "max" },
+        current: { model: "gpt-5.6-terra", effort: "high" }
+      }
+    ]
+  ],
+  [
+    "lazycodex-worker-high",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "max" },
+        current: { model: "gpt-5.6-sol", effort: "medium" }
+      }
+    ]
+  ],
+  [
+    "lazycodex-code-reviewer",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "xhigh" },
+        current: { model: "gpt-5.6-terra", effort: "medium" }
+      }
+    ]
+  ],
+  [
+    "lazycodex-clone-fidelity-reviewer",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "xhigh" },
+        current: { model: "gpt-5.6-terra", effort: "high" }
       }
     ]
   ],
@@ -9428,6 +9467,10 @@ var MANAGED_REASONING_DEFAULT_UPGRADES = new Map([
       {
         previous: { model: "gpt-5.6-sol", effort: "xhigh" },
         current: { model: "gpt-5.6-sol", effort: "high" }
+      },
+      {
+        previous: { model: "gpt-5.6-sol", effort: "high" },
+        current: { model: "gpt-5.6-sol", effort: "low" }
       }
     ]
   ]

--- a/packages/omo-codex/src/install/managed-agent-reasoning-defaults.test.ts
+++ b/packages/omo-codex/src/install/managed-agent-reasoning-defaults.test.ts
@@ -51,28 +51,28 @@ describe("resolveManagedAgentReasoning", () => {
 		expect(effort).toBe("medium")
 	})
 
-	test("#given a preserved plan sol/xhigh default #when resolving against sol/max #then the new bundled effort wins", () => {
+	test("#given a preserved plan sol/max default #when resolving against sol/high #then the new bundled effort wins", () => {
 		// when
 		const effort = resolveManagedAgentReasoning({
 			agentName: "plan",
 			bundledModel: "gpt-5.6-sol",
-			bundledEffort: "max",
-			preserved: { model: "gpt-5.6-sol", effort: "xhigh" },
+			bundledEffort: "high",
+			preserved: { model: "gpt-5.6-sol", effort: "max" },
 		})
 		// then
-		expect(effort).toBe("max")
+		expect(effort).toBe("high")
 	})
 
-	test("#given a preserved worker-medium sol/high default #when resolving against luna/max #then the new bundled effort wins", () => {
+	test("#given a preserved worker-medium luna/max default #when resolving against terra/high #then the new bundled effort wins", () => {
 		// when
 		const effort = resolveManagedAgentReasoning({
 			agentName: "lazycodex-worker-medium",
-			bundledModel: "gpt-5.6-luna",
-			bundledEffort: "max",
-			preserved: { model: "gpt-5.6-sol", effort: "high" },
+			bundledModel: "gpt-5.6-terra",
+			bundledEffort: "high",
+			preserved: { model: "gpt-5.6-luna", effort: "max" },
 		})
 		// then
-		expect(effort).toBe("max")
+		expect(effort).toBe("high")
 	})
 
 	test("#given a preserved qa-executor terra/medium default #when resolving against luna/high #then the new bundled effort wins", () => {
@@ -87,16 +87,37 @@ describe("resolveManagedAgentReasoning", () => {
 		expect(effort).toBe("high")
 	})
 
-	test("#given a preserved gate-reviewer sol/xhigh default #when resolving against sol/high #then the new bundled effort wins", () => {
+	test("#given a preserved gate-reviewer sol/high default #when resolving against sol/low #then the new bundled effort wins", () => {
 		// when
 		const effort = resolveManagedAgentReasoning({
 			agentName: "lazycodex-gate-reviewer",
 			bundledModel: "gpt-5.6-sol",
-			bundledEffort: "high",
-			preserved: { model: "gpt-5.6-sol", effort: "xhigh" },
+			bundledEffort: "low",
+			preserved: { model: "gpt-5.6-sol", effort: "high" },
 		})
 		// then
-		expect(effort).toBe("high")
+		expect(effort).toBe("low")
+	})
+
+	test("#given old high worker and reviewer defaults #when resolving #then each new bundled effort wins", () => {
+		expect(resolveManagedAgentReasoning({
+			agentName: "lazycodex-worker-high",
+			bundledModel: "gpt-5.6-sol",
+			bundledEffort: "medium",
+			preserved: { model: "gpt-5.6-sol", effort: "max" },
+		})).toBe("medium")
+		expect(resolveManagedAgentReasoning({
+			agentName: "lazycodex-code-reviewer",
+			bundledModel: "gpt-5.6-terra",
+			bundledEffort: "medium",
+			preserved: { model: "gpt-5.6-sol", effort: "xhigh" },
+		})).toBe("medium")
+		expect(resolveManagedAgentReasoning({
+			agentName: "lazycodex-clone-fidelity-reviewer",
+			bundledModel: "gpt-5.6-terra",
+			bundledEffort: "high",
+			preserved: { model: "gpt-5.6-sol", effort: "xhigh" },
+		})).toBe("high")
 	})
 
 	test("#given a second resolve over already-migrated values #when resolving #then the result is stable", () => {

--- a/packages/omo-codex/src/install/managed-agent-reasoning-defaults.ts
+++ b/packages/omo-codex/src/install/managed-agent-reasoning-defaults.ts
@@ -55,6 +55,10 @@ const MANAGED_REASONING_DEFAULT_UPGRADES = new Map<string, readonly ManagedReaso
         previous: { model: "gpt-5.6-sol", effort: "xhigh" },
         current: { model: "gpt-5.6-sol", effort: "max" },
       },
+      {
+        previous: { model: "gpt-5.6-sol", effort: "max" },
+        current: { model: "gpt-5.6-sol", effort: "high" },
+      },
     ],
   ],
   [
@@ -63,6 +67,37 @@ const MANAGED_REASONING_DEFAULT_UPGRADES = new Map<string, readonly ManagedReaso
       {
         previous: { model: "gpt-5.6-sol", effort: "high" },
         current: { model: "gpt-5.6-luna", effort: "max" },
+      },
+      {
+        previous: { model: "gpt-5.6-luna", effort: "max" },
+        current: { model: "gpt-5.6-terra", effort: "high" },
+      },
+    ],
+  ],
+  [
+    "lazycodex-worker-high",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "max" },
+        current: { model: "gpt-5.6-sol", effort: "medium" },
+      },
+    ],
+  ],
+  [
+    "lazycodex-code-reviewer",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "xhigh" },
+        current: { model: "gpt-5.6-terra", effort: "medium" },
+      },
+    ],
+  ],
+  [
+    "lazycodex-clone-fidelity-reviewer",
+    [
+      {
+        previous: { model: "gpt-5.6-sol", effort: "xhigh" },
+        current: { model: "gpt-5.6-terra", effort: "high" },
       },
     ],
   ],
@@ -81,6 +116,10 @@ const MANAGED_REASONING_DEFAULT_UPGRADES = new Map<string, readonly ManagedReaso
       {
         previous: { model: "gpt-5.6-sol", effort: "xhigh" },
         current: { model: "gpt-5.6-sol", effort: "high" },
+      },
+      {
+        previous: { model: "gpt-5.6-sol", effort: "high" },
+        current: { model: "gpt-5.6-sol", effort: "low" },
       },
     ],
   ],


### PR DESCRIPTION
## Summary
- Route medium workers, reviewers, and planning to the requested GPT-5.6 Terra/Sol model-effort pairs.
- Migrate recognized prior managed defaults while preserving user-customized settings.
- Retain the root managed profile at gpt-5.6-sol/high.

## QA
- bun run test:codex: 510 Node tests and 382 Bun tests; one expected platform-only skip.
- Package and repository typechecks plus build passed.
- Isolated install-verify self-test and mock-backed app-server plugin drive passed.
- Evidence: .omo/evidence/20260721-lazycodex-model-routing/qa-summary.md.

## Risk
Migration only rewrites recognized previous managed pairs; custom agent choices remain untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates LazyCodex agent routing to the new GPT-5.6 model/effort targets and adds installer migrations to upgrade known managed defaults while preserving any user overrides. This tunes reviewer/worker balance for cost and throughput without changing custom settings.

- **Bug Fixes**
  - Adjusted agent TOMLs:
    - `lazycodex-worker-medium`: `gpt-5.6-terra` + effort `high`
    - `lazycodex-worker-high`: effort `medium` on `gpt-5.6-sol`
    - `lazycodex-code-reviewer`: `gpt-5.6-terra` + effort `medium`
    - `lazycodex-clone-fidelity-reviewer`: `gpt-5.6-terra` + effort `high`
    - `lazycodex-gate-reviewer`: effort `low` on `gpt-5.6-sol`
    - `plan`: effort `high` on `gpt-5.6-sol`
  - Updated aggregate and migration tests to match new routing.
  - Bumped `@oh-my-opencode/omo-codex` to `4.19.0`.

- **Migration**
  - The installer auto-upgrades known managed defaults for the agents above to the new model/effort pairs when current values match prior managed settings. Custom choices are not changed and no manual action is needed.

<sup>Written for commit 67fb6a736cff13438dd80916b74a82437d9518f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

