### PR TITLE
feat(codegraph): bump vendored CodeGraph to 1.4.1 with store-compat and guidance parity (wave 1)

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-// components/codegraph/src/cli.ts
+// src/cli.ts
 import { realpathSync as realpathSync6 } from "node:fs";
 import { basename as basename5, resolve as resolve7 } from "node:path";
 import { stderr as processStderr4 } from "node:process";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
 
-// components/codegraph/src/hook.ts
+// src/hook.ts
 import { execFile as execFile4, spawn } from "node:child_process";
 import { homedir as homedir13 } from "node:os";
 import { join as join13 } from "node:path";
@@ -19,7 +19,7 @@ import {
 } from "node:process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
-// ../../utils/src/codegraph/env.ts
+// ../../../../utils/src/codegraph/env.ts
 import { homedir } from "node:os";
 import { join } from "node:path";
 var CODEGRAPH_INSTALL_DIR_ENV = "CODEGRAPH_INSTALL_DIR";
@@ -94,15 +94,15 @@ function buildCodegraphChildEnv(options = {}) {
   return env;
 }
 
-// ../../utils/src/codegraph/guidance.ts
+// ../../../../utils/src/codegraph/guidance.ts
 import { homedir as homedir5 } from "node:os";
 
-// ../../utils/src/codegraph/workspace.ts
+// ../../../../utils/src/codegraph/workspace.ts
 import { execFileSync } from "node:child_process";
 import { appendFileSync, existsSync as existsSync2, lstatSync as lstatSync2, mkdirSync, realpathSync as realpathSync3, readFileSync as readFileSync2, statSync, symlinkSync } from "node:fs";
 import { dirname, join as join5, resolve as resolve3 } from "node:path";
 
-// ../../utils/src/codegraph/paths.ts
+// ../../../../utils/src/codegraph/paths.ts
 import { createHash } from "node:crypto";
 import { realpathSync } from "node:fs";
 import { homedir as homedir2 } from "node:os";
@@ -139,7 +139,7 @@ function resolveCodegraphWorkspacePaths(workspace, options = {}) {
   };
 }
 
-// ../../utils/src/codegraph/store.ts
+// ../../../../utils/src/codegraph/store.ts
 import { existsSync, lstatSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir as homedir3 } from "node:os";
 import { join as join3 } from "node:path";
@@ -192,7 +192,7 @@ function pruneDeadCodegraphProjectStores(options = {}) {
   return { remainingBytes: 0, removed };
 }
 
-// ../../utils/src/codegraph/exclusion.ts
+// ../../../../utils/src/codegraph/exclusion.ts
 import { realpathSync as realpathSync2 } from "node:fs";
 import { homedir as homedir4, tmpdir as osTmpdir } from "node:os";
 import { isAbsolute, join as join4, resolve as resolve2 } from "node:path";
@@ -258,7 +258,7 @@ function shouldExcludeCodegraphProject(workspace, options = {}) {
   return { excluded: false };
 }
 
-// ../../utils/src/codegraph/workspace.ts
+// ../../../../utils/src/codegraph/workspace.ts
 function fallbackResult(dataRoot, projectLink, reason) {
   return { dataDir: projectLink, dataRoot, linked: false, mode: "in-place-fallback", projectLink, reason };
 }
@@ -393,12 +393,15 @@ function gitMarkerOwnsGitDir(gitMarkerPath, workspace, gitDir) {
   return coreWorktree.length > 0 && realpathSync3.native(resolve3(resolvedGitDir, coreWorktree)) === realpathSync3.native(workspace);
 }
 
-// ../../utils/src/codegraph/guidance.ts
+// ../../../../utils/src/codegraph/guidance.ts
 var CODEGRAPH_UNINITIALIZED_PATTERN = /CodeGraph not initialized in ([\s\S]*?)\.\s*Run ['`]codegraph init['`] in that project first\./i;
 var ANSI_ESCAPE_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 var CODEGRAPH_STATUS_PROJECT_PATTERN = /^.*?\bProject:\s*(.+?)\s*$/im;
 var CODEGRAPH_STATUS_UNINITIALIZED_PATTERN = /^.*?\bNot initialized\s*$/im;
 var CODEGRAPH_INIT_HINT_PATTERN = /Run\s+["'`]codegraph init["'`]\s+(?:in that project first|to initialize)\.?/i;
+var CODEGRAPH_PROJECT_NOT_INDEXED_PATTERN = /The project at (.+?) isn't indexed with codegraph\b/i;
+var CODEGRAPH_NO_PROJECT_LOADED_PATTERN = /No CodeGraph project is loaded for this session\./i;
+var CODEGRAPH_NO_PROJECT_SEARCHED_FROM_PATTERN = /^Searched for a \.codegraph\/ directory starting from:\s*(.+?)\s*$/im;
 function getCodegraphUninitializedProject(input) {
   const output = textFromUnknown(input.toolOutput);
   if (!isCodegraphTool(input.toolName))
@@ -439,6 +442,16 @@ function extractProjectPath(output) {
   const uninitializedProject = uninitializedMatch?.[1]?.trim();
   if (uninitializedProject && uninitializedProject.length > 0)
     return uninitializedProject;
+  const notIndexedMatch = normalizedOutput.match(CODEGRAPH_PROJECT_NOT_INDEXED_PATTERN);
+  const notIndexedProject = notIndexedMatch?.[1]?.trim();
+  if (notIndexedProject && notIndexedProject.length > 0)
+    return notIndexedProject;
+  if (CODEGRAPH_NO_PROJECT_LOADED_PATTERN.test(normalizedOutput)) {
+    const searchedFromMatch = normalizedOutput.match(CODEGRAPH_NO_PROJECT_SEARCHED_FROM_PATTERN);
+    const searchedFromProject = searchedFromMatch?.[1]?.trim();
+    if (searchedFromProject && searchedFromProject.length > 0)
+      return searchedFromProject;
+  }
   if (!looksLikeCodegraphUninitializedOutput(normalizedOutput))
     return null;
   const statusMatch = normalizedOutput.match(CODEGRAPH_STATUS_PROJECT_PATTERN);
@@ -479,14 +492,14 @@ function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-// ../../utils/src/codegraph/resolve.ts
+// ../../../../utils/src/codegraph/resolve.ts
 import { existsSync as existsSync3 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { spawnSync } from "node:child_process";
 import { basename as basename2, dirname as dirname2, join as join7 } from "node:path";
 import { createRequire } from "node:module";
 
-// ../../utils/src/runtime/which.ts
+// ../../../../utils/src/runtime/which.ts
 import { accessSync, constants } from "node:fs";
 import { delimiter, join as join6 } from "node:path";
 var runtime = globalThis;
@@ -551,7 +564,7 @@ function bunWhich(commandName) {
   return null;
 }
 
-// ../../utils/src/codegraph/node-support.ts
+// ../../../../utils/src/codegraph/node-support.ts
 var CODEGRAPH_MIN_NODE_MAJOR = 20;
 var CODEGRAPH_BLOCKED_NODE_MAJOR = 25;
 var CODEGRAPH_UNSAFE_NODE_ENV = "CODEGRAPH_ALLOW_UNSAFE_NODE";
@@ -580,7 +593,7 @@ function parseNodeMajor(version) {
   return Number.isNaN(major) ? 0 : major;
 }
 
-// ../../utils/src/codegraph/resolve.ts
+// ../../../../utils/src/codegraph/resolve.ts
 function codegraphCommandRequiresSupportedLocalNode(resolution) {
   return resolution.source !== "bundled" && resolution.source !== "env" && resolution.source !== "provisioned";
 }
@@ -712,17 +725,17 @@ function resolveCodegraphCommand(options = {}) {
   };
 }
 
-// shared/src/config-loader.ts
+// ../../shared/src/config-loader.ts
 import { homedir as homedir8 } from "node:os";
 
-// ../../utils/src/omo-config/loader.ts
+// ../../../../utils/src/omo-config/loader.ts
 import { existsSync as existsSync5 } from "node:fs";
 import { homedir as homedir7 } from "node:os";
 
-// ../../utils/src/omo-config/body.ts
+// ../../../../utils/src/omo-config/body.ts
 import { readFileSync as readFileSync3 } from "node:fs";
 
-// ../../utils/src/deep-merge.ts
+// ../../../../utils/src/deep-merge.ts
 var DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 function isUnsafeObjectKey(key) {
   return DANGEROUS_KEYS.has(key);
@@ -731,7 +744,7 @@ function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value) && Object.prototype.toString.call(value) === "[object Object]";
 }
 
-// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/scanner.js
+// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/scanner.js
 function createScanner(text, ignoreTrivia = false) {
   const len = text.length;
   let pos = 0, value = "", tokenOffset = 0, token = 16, lineNumber = 0, lineStartOffset = 0, tokenLineStartOffset = 0, prevTokenLineStartOffset = 0, scanError = 0;
@@ -1146,7 +1159,7 @@ var CharacterCodes;
   CharacterCodes2[CharacterCodes2["tab"] = 9] = "tab";
 })(CharacterCodes || (CharacterCodes = {}));
 
-// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/string-intern.js
+// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/string-intern.js
 var cachedSpaces = new Array(20).fill(0).map((_, index) => {
   return " ".repeat(index);
 });
@@ -1180,7 +1193,7 @@ var cachedBreakLinesWithSpaces = {
   }
 };
 
-// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/parser.js
+// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/impl/parser.js
 var ParseOptions;
 (function(ParseOptions2) {
   ParseOptions2.DEFAULT = {
@@ -1483,7 +1496,7 @@ function visit(text, visitor, options = ParseOptions.DEFAULT) {
   return true;
 }
 
-// ../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/main.js
+// ../../../../../node_modules/.bun/jsonc-parser@3.3.1/node_modules/jsonc-parser/lib/esm/main.js
 var ScanError;
 (function(ScanError2) {
   ScanError2[ScanError2["None"] = 0] = "None";
@@ -1572,7 +1585,7 @@ function printParseErrorCode(code) {
   return "<unknown ParseErrorCode>";
 }
 
-// ../../utils/src/jsonc-parser.ts
+// ../../../../utils/src/jsonc-parser.ts
 var pluginConfigFileDetectionCache = new Map;
 function stripBom(content) {
   return content.charCodeAt(0) === 65279 ? content.slice(1) : content;
@@ -1593,7 +1606,7 @@ function parseJsoncSafe(content) {
   };
 }
 
-// ../../utils/src/omo-config.ts
+// ../../../../utils/src/omo-config.ts
 var HARNESS_IDS = ["codex", "opencode", "omo"];
 var SETTING_HARNESS_SUPPORT = {
   "codegraph.auto_provision": HARNESS_IDS,
@@ -1604,7 +1617,7 @@ var SETTING_HARNESS_SUPPORT = {
   "codegraph.watch_debounce_ms": ["opencode", "omo"]
 };
 
-// ../../utils/src/omo-config/body.ts
+// ../../../../utils/src/omo-config/body.ts
 var BUILT_IN_DEFAULTS = {
   codegraph: {
     auto_provision: true,
@@ -1807,7 +1820,7 @@ function validateHarnessApplicability(config, harness) {
   return warnings;
 }
 
-// ../../utils/src/omo-config/env-overrides.ts
+// ../../../../utils/src/omo-config/env-overrides.ts
 var CODEGRAPH_ENV_KEYS = [
   ["auto_provision", "AUTO_PROVISION", "boolean"],
   ["enabled", "ENABLED", "boolean"],
@@ -1884,7 +1897,7 @@ function buildEnvOverrides(harness, env, warnings, merge) {
   return config;
 }
 
-// ../../utils/src/omo-config/resolve.ts
+// ../../../../utils/src/omo-config/resolve.ts
 import { existsSync as existsSync4 } from "node:fs";
 import { dirname as dirname3, isAbsolute as isAbsolute2, join as join8, relative, resolve as resolve4 } from "node:path";
 function containsPath(parent, child) {
@@ -1927,7 +1940,7 @@ function toMissingSource(candidate) {
   };
 }
 
-// ../../utils/src/omo-config/loader.ts
+// ../../../../utils/src/omo-config/loader.ts
 function loadOmoConfig(options) {
   const cwd = options.cwd ?? process.cwd();
   const homeDir = options.homeDir ?? process.env["HOME"] ?? process.env["USERPROFILE"] ?? homedir7();
@@ -1958,7 +1971,7 @@ function loadOmoConfig(options) {
   return { config, sources, warnings };
 }
 
-// shared/src/config-loader.ts
+// ../../shared/src/config-loader.ts
 function getCodexOmoConfig(options = {}) {
   const env = options.env ?? process.env;
   const homeDir = resolveHomeDir(options);
@@ -1987,7 +2000,7 @@ function resolveHomeDir(options) {
   return options.homeDir ?? env["HOME"] ?? env["USERPROFILE"] ?? homedir8();
 }
 
-// components/codegraph/src/cache-gc.ts
+// src/cache-gc.ts
 var NON_FATAL_GC_ERROR_CODES = new Set(["EACCES", "EBUSY", "ENOENT", "ENOTEMPTY", "ENOTDIR", "EPERM"]);
 function pruneCodegraphProjectStoresBestEffort(homeDir, options = {}) {
   try {
@@ -2005,17 +2018,17 @@ function isNonFatalCodegraphGcError(error) {
   return typeof code === "string" && NON_FATAL_GC_ERROR_CODES.has(code);
 }
 
-// components/codegraph/src/hook-sweep.ts
+// src/hook-sweep.ts
 import { fileURLToPath } from "node:url";
-// ../../utils/src/codegraph/process-sweeper.ts
+// ../../../../utils/src/codegraph/process-sweeper.ts
 import { existsSync as existsSync7, mkdirSync as mkdirSync2, statSync as statSync2, utimesSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir10 } from "node:os";
 import { dirname as dirname4, join as join10 } from "node:path";
 
-// ../../utils/src/codegraph/process-exec.ts
+// ../../../../utils/src/codegraph/process-exec.ts
 import { execFile } from "node:child_process";
 
-// ../../utils/src/codegraph/process-match.ts
+// ../../../../utils/src/codegraph/process-match.ts
 import { posix, win32 } from "node:path";
 var SERVE_WRAPPER_SUFFIX = "/components/codegraph/dist/serve.js";
 var UPSTREAM_PACKAGE_SEGMENT = "/@colbymchenry/codegraph/";
@@ -2171,7 +2184,7 @@ function isRecord3(value) {
   return typeof value === "object" && value !== null;
 }
 
-// ../../utils/src/codegraph/process-exec.ts
+// ../../../../utils/src/codegraph/process-exec.ts
 function enumerateCodegraphProcesses(platform = process.platform) {
   return platform === "win32" ? enumerateWindowsProcesses() : enumeratePosixProcesses();
 }
@@ -2252,7 +2265,7 @@ function processKillErrorMeansAlive(error) {
   return false;
 }
 
-// ../../utils/src/codegraph/process-roots.ts
+// ../../../../utils/src/codegraph/process-roots.ts
 import { existsSync as existsSync6, readdirSync as readdirSync2, realpathSync as realpathSync4 } from "node:fs";
 import { homedir as homedir9 } from "node:os";
 import { join as join9, resolve as resolve5 } from "node:path";
@@ -2319,7 +2332,7 @@ function isNonFatalFsError(error) {
 }
 var OMO_CODEX_PLUGIN_CACHE_PUBLISHERS = new Set(["sisyphuslabs"]);
 
-// ../../utils/src/codegraph/process-sweeper.ts
+// ../../../../utils/src/codegraph/process-sweeper.ts
 var DEFAULT_GRACE_MS = 2000;
 var DEFAULT_THROTTLE_MS = 60 * 60 * 1000;
 var SWEEP_STAMP_FILE = "zombie-sweep.stamp";
@@ -2408,7 +2421,7 @@ function delay(ms) {
     setTimeout(resolvePromise, ms);
   });
 }
-// components/codegraph/src/hook-sweep.ts
+// src/hook-sweep.ts
 async function sweepCodegraphZombiesBestEffort(options, sweep = sweepCodegraphZombies) {
   try {
     await sweep({
@@ -2424,14 +2437,52 @@ function defaultPluginRoot() {
   return fileURLToPath(new URL("../../..", import.meta.url));
 }
 
-// components/codegraph/src/session-start-worker.ts
+// src/session-start-worker.ts
 import { execFile as execFile3 } from "node:child_process";
 import { appendFileSync as appendFileSync2, existsSync as existsSync9, mkdirSync as mkdirSync3 } from "node:fs";
 import { homedir as homedir12 } from "node:os";
 import { extname, join as join12 } from "node:path";
 import { cwd as processCwd, env as processEnv, execPath as processExecPath, stderr as processStderr } from "node:process";
 
-// ../../utils/src/codegraph/provision.ts
+// ../../../../utils/src/codegraph/manifest.ts
+var CODEGRAPH_PINNED_VERSION = "1.4.1";
+var CODEGRAPH_PROVISION_MANIFEST = {
+  assets: {
+    "darwin-arm64": {
+      executableName: "codegraph",
+      sha256: "4a679ae5a5cb9fff900dd59bb786da6a581b7f68f4cf713bdedd137e347d34dc",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-darwin-arm64.tar.gz"
+    },
+    "darwin-x64": {
+      executableName: "codegraph",
+      sha256: "436f96943cfd926ea6d0a8454f18833d21254d5fd9b3d224317b1426132def95",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-darwin-x64.tar.gz"
+    },
+    "linux-arm64": {
+      executableName: "codegraph",
+      sha256: "0d62c5eb2722f8d19d20f7a1bd974445e18d5294cb59be116a0c3d55ce87591f",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-linux-arm64.tar.gz"
+    },
+    "linux-x64": {
+      executableName: "codegraph",
+      sha256: "fb585ff5018d6faaa46d282b61f4f689bc7967ed8a1b467a5c556dd7ced9b542",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-linux-x64.tar.gz"
+    },
+    "win32-arm64": {
+      executableName: "codegraph.cmd",
+      sha256: "e2a2a28c802a79804c7df203afa50bd461309c6c180ce3f76079fdc7cddc7697",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.4.1.tgz"
+    },
+    "win32-x64": {
+      executableName: "codegraph.cmd",
+      sha256: "4f08700fda5f4a03ad5b2956135c5788d739a351b3433db2b5820e5d5224c30d",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.4.1.tgz"
+    }
+  },
+  version: CODEGRAPH_PINNED_VERSION
+};
+
+// ../../../../utils/src/codegraph/provision.ts
 import { createHash as createHash2, randomUUID } from "node:crypto";
 import { execFile as execFile2 } from "node:child_process";
 import { chmod, mkdir, readdir, readFile, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
@@ -2439,45 +2490,6 @@ import { existsSync as existsSync8 } from "node:fs";
 import { homedir as homedir11, hostname } from "node:os";
 import { basename as basename3, join as join11 } from "node:path";
 import { promisify } from "node:util";
-
-// ../../utils/src/codegraph/manifest.ts
-var CODEGRAPH_PROVISION_MANIFEST = {
-  assets: {
-    "darwin-arm64": {
-      executableName: "codegraph",
-      sha256: "95bb27bf6382b69659e158e0c04d71cc394778951e1317d582be7807e7866908",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-darwin-arm64.tar.gz"
-    },
-    "darwin-x64": {
-      executableName: "codegraph",
-      sha256: "3311cc1d1f0f0ad742709b6a43d8a9187b1ef0af0dd30e0b58008dc673e29478",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-darwin-x64.tar.gz"
-    },
-    "linux-arm64": {
-      executableName: "codegraph",
-      sha256: "e16f612bc96c2ebccd04574cbed500c9939147c80666ad6bb024398dff7992ae",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-linux-arm64.tar.gz"
-    },
-    "linux-x64": {
-      executableName: "codegraph",
-      sha256: "d45a068f44596a85c7ba7d0ef924eaf7103fbbf3cafbeb668127daff60a52228",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-linux-x64.tar.gz"
-    },
-    "win32-arm64": {
-      executableName: "codegraph.cmd",
-      sha256: "8d57ced73b24d35f758f2ede2318e80e1d7241987f37a999e3d80edb6fddf961",
-      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.0.1.tgz"
-    },
-    "win32-x64": {
-      executableName: "codegraph.cmd",
-      sha256: "52607fe73b05e741fd1087da2ceca9d3c8f565e36bf1a7070600bdbdf3931e32",
-      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.0.1.tgz"
-    }
-  },
-  version: "1.0.1"
-};
-
-// ../../utils/src/codegraph/provision.ts
 var DEFAULT_LOCK_WAIT_MS = 5000;
 var DEFAULT_LOCK_STALE_MS = 120000;
 var DEFAULT_DOWNLOAD_TIMEOUT_MS = 60000;
@@ -2650,9 +2662,9 @@ async function ensureCodegraphProvisioned(options) {
   }
 }
 
-// components/codegraph/src/session-start-worker.ts
+// src/session-start-worker.ts
 var SESSION_START_CWD_ENV = "OMO_CODEGRAPH_SESSION_START_CWD";
-var CODEGRAPH_VERSION = "1.0.1";
+var CODEGRAPH_VERSION = CODEGRAPH_PINNED_VERSION;
 var COMMAND_TIMEOUT_MS = 60000;
 var WINDOWS_CMD_EXTENSIONS = new Set([".bat", ".cmd"]);
 var WINDOWS_NODE_SCRIPT_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
@@ -2831,7 +2843,7 @@ function isRecord4(value) {
   return typeof value === "object" && value !== null;
 }
 
-// components/codegraph/src/hook.ts
+// src/hook.ts
 var CODEGRAPH_SESSION_START_NOTICE = "LazyCodex CodeGraph bootstrap scheduled in background";
 var STATUS_PROBE_TIMEOUT_MS = 2000;
 async function runCodegraphSessionStartHook(options = {}) {
@@ -3026,7 +3038,7 @@ function defaultWorkerCliPath() {
   return fileURLToPath2(import.meta.url);
 }
 
-// components/codegraph/src/serve.ts
+// src/serve.ts
 import { existsSync as existsSync10, realpathSync as realpathSync5 } from "node:fs";
 import { homedir as homedir14 } from "node:os";
 import { basename as basename4, join as join14, resolve as resolve6 } from "node:path";
@@ -3039,14 +3051,14 @@ import {
 } from "node:process";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
-// components/codegraph/src/mcp-bridge.ts
+// src/mcp-bridge.ts
 import { spawn as spawn2 } from "node:child_process";
 
-// ../../mcp-stdio-core/src/record.ts
+// ../../../../mcp-stdio-core/src/record.ts
 function isPlainRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-// ../../mcp-stdio-core/src/responses.ts
+// ../../../../mcp-stdio-core/src/responses.ts
 function successResponse(id, result) {
   return { jsonrpc: "2.0", id, result };
 }
@@ -3059,7 +3071,7 @@ function jsonRpcId(value) {
 function messageFromError(error) {
   return error instanceof Error ? error.message : String(error);
 }
-// ../../mcp-stdio-core/src/transport.ts
+// ../../../../mcp-stdio-core/src/transport.ts
 var HEADER_SEPARATOR = Buffer.from(`\r
 \r
 `);
@@ -3200,7 +3212,7 @@ function bufferFromChunk(chunk) {
   throw new TypeError(`Unsupported stdio chunk type: ${typeof chunk}`);
 }
 
-// ../../mcp-stdio-core/src/server.ts
+// ../../../../mcp-stdio-core/src/server.ts
 var DEFAULT_IDLE_TIMEOUT_MS = 10 * 60000;
 var noopLog = () => {};
 async function runJsonRpcStdioServer(config) {
@@ -3304,7 +3316,7 @@ function createIdleTimer(idleTimeoutMs, log, onIdleTimeout) {
     closed: () => isClosed
   };
 }
-// components/codegraph/src/serve-invocation.ts
+// src/serve-invocation.ts
 import { extname as extname2 } from "node:path";
 import { execPath as processExecPath2 } from "node:process";
 var WINDOWS_CMD_EXTENSIONS2 = new Set([".bat", ".cmd"]);
@@ -3322,7 +3334,7 @@ function resolveServeProcessInvocation(command, args, platform = process.platfor
   return { args: [...args], command };
 }
 
-// components/codegraph/src/mcp-bridge.ts
+// src/mcp-bridge.ts
 class CodegraphBridgeStdioError extends Error {
   streamName;
   name = "CodegraphBridgeStdioError";
@@ -3535,7 +3547,7 @@ async function writeLine(output, line) {
   });
 }
 
-// components/codegraph/src/mcp-unavailable.ts
+// src/mcp-unavailable.ts
 async function runUnavailableCodegraphMcpServer(options) {
   await runJsonRpcStdioServer({
     handler: handleUnavailableCodegraphMcpRequest,
@@ -3581,14 +3593,14 @@ function requestedProtocolVersion(params) {
   return params["protocolVersion"];
 }
 
-// components/codegraph/src/serve.ts
+// src/serve.ts
 var CODEGRAPH_SKIP_HINT = `CodeGraph MCP skipped: codegraph binary not found. Install CodeGraph or set OMO_CODEGRAPH_BIN.
 `;
 var CODEGRAPH_DISABLED_HINT = `CodeGraph MCP skipped: disabled by OMO SOT config. Set [codex].codegraph.enabled=true to enable it.
 `;
 var CODEGRAPH_EXCLUDED_HINT = `CodeGraph MCP skipped: project excluded by OMO CodeGraph policy.
 `;
-var CODEGRAPH_VERSION2 = "1.0.1";
+var CODEGRAPH_VERSION2 = CODEGRAPH_PINNED_VERSION;
 var PROJECT_CWD_ENV_KEYS = ["OMO_CODEGRAPH_PROJECT_CWD", SESSION_START_CWD_ENV, "PWD"];
 async function runCodegraphServe(options = {}) {
   const env = options.env ?? processEnv3;
@@ -3723,7 +3735,7 @@ function isDirectInvocation(argvPath) {
   return realpathSync5(resolve6(argvPath)) === realpathSync5(modulePath);
 }
 
-// components/codegraph/src/sweep-cli.ts
+// src/sweep-cli.ts
 async function runCodegraphSweepCli(options = {}) {
   const args = parseSweepCliArgs(options.argv ?? process.argv);
   const result = await sweepCodegraphZombies({
@@ -3780,7 +3792,7 @@ function formatProcess(processInfo) {
   };
 }
 
-// components/codegraph/src/cli.ts
+// src/cli.ts
 async function runCodegraphCli(options = {}) {
   const argv = options.argv ?? process.argv;
   const command = argv[2];

--- a/packages/omo-codex/plugin/components/codegraph/dist/serve.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/serve.js
@@ -88,6 +88,44 @@ function buildCodegraphChildEnv(options = {}) {
   return env;
 }
 
+// ../../../../utils/src/codegraph/manifest.ts
+var CODEGRAPH_PINNED_VERSION = "1.4.1";
+var CODEGRAPH_PROVISION_MANIFEST = {
+  assets: {
+    "darwin-arm64": {
+      executableName: "codegraph",
+      sha256: "4a679ae5a5cb9fff900dd59bb786da6a581b7f68f4cf713bdedd137e347d34dc",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-darwin-arm64.tar.gz"
+    },
+    "darwin-x64": {
+      executableName: "codegraph",
+      sha256: "436f96943cfd926ea6d0a8454f18833d21254d5fd9b3d224317b1426132def95",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-darwin-x64.tar.gz"
+    },
+    "linux-arm64": {
+      executableName: "codegraph",
+      sha256: "0d62c5eb2722f8d19d20f7a1bd974445e18d5294cb59be116a0c3d55ce87591f",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-linux-arm64.tar.gz"
+    },
+    "linux-x64": {
+      executableName: "codegraph",
+      sha256: "fb585ff5018d6faaa46d282b61f4f689bc7967ed8a1b467a5c556dd7ced9b542",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-linux-x64.tar.gz"
+    },
+    "win32-arm64": {
+      executableName: "codegraph.cmd",
+      sha256: "e2a2a28c802a79804c7df203afa50bd461309c6c180ce3f76079fdc7cddc7697",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.4.1.tgz"
+    },
+    "win32-x64": {
+      executableName: "codegraph.cmd",
+      sha256: "4f08700fda5f4a03ad5b2956135c5788d739a351b3433db2b5820e5d5224c30d",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.4.1.tgz"
+    }
+  },
+  version: CODEGRAPH_PINNED_VERSION
+};
+
 // ../../../../utils/src/codegraph/node-support.ts
 var CODEGRAPH_MIN_NODE_MAJOR = 20;
 var CODEGRAPH_BLOCKED_NODE_MAJOR = 25;
@@ -125,45 +163,6 @@ import { existsSync } from "node:fs";
 import { homedir as homedir2, hostname } from "node:os";
 import { basename, join as join2 } from "node:path";
 import { promisify } from "node:util";
-
-// ../../../../utils/src/codegraph/manifest.ts
-var CODEGRAPH_PROVISION_MANIFEST = {
-  assets: {
-    "darwin-arm64": {
-      executableName: "codegraph",
-      sha256: "95bb27bf6382b69659e158e0c04d71cc394778951e1317d582be7807e7866908",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-darwin-arm64.tar.gz"
-    },
-    "darwin-x64": {
-      executableName: "codegraph",
-      sha256: "3311cc1d1f0f0ad742709b6a43d8a9187b1ef0af0dd30e0b58008dc673e29478",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-darwin-x64.tar.gz"
-    },
-    "linux-arm64": {
-      executableName: "codegraph",
-      sha256: "e16f612bc96c2ebccd04574cbed500c9939147c80666ad6bb024398dff7992ae",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-linux-arm64.tar.gz"
-    },
-    "linux-x64": {
-      executableName: "codegraph",
-      sha256: "d45a068f44596a85c7ba7d0ef924eaf7103fbbf3cafbeb668127daff60a52228",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-linux-x64.tar.gz"
-    },
-    "win32-arm64": {
-      executableName: "codegraph.cmd",
-      sha256: "8d57ced73b24d35f758f2ede2318e80e1d7241987f37a999e3d80edb6fddf961",
-      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.0.1.tgz"
-    },
-    "win32-x64": {
-      executableName: "codegraph.cmd",
-      sha256: "52607fe73b05e741fd1087da2ceca9d3c8f565e36bf1a7070600bdbdf3931e32",
-      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.0.1.tgz"
-    }
-  },
-  version: "1.0.1"
-};
-
-// ../../../../utils/src/codegraph/provision.ts
 var DEFAULT_LOCK_WAIT_MS = 5000;
 var DEFAULT_LOCK_STALE_MS = 120000;
 var DEFAULT_DOWNLOAD_TIMEOUT_MS = 60000;
@@ -2434,7 +2433,7 @@ var CODEGRAPH_DISABLED_HINT = `CodeGraph MCP skipped: disabled by OMO SOT config
 `;
 var CODEGRAPH_EXCLUDED_HINT = `CodeGraph MCP skipped: project excluded by OMO CodeGraph policy.
 `;
-var CODEGRAPH_VERSION = "1.0.1";
+var CODEGRAPH_VERSION = CODEGRAPH_PINNED_VERSION;
 var PROJECT_CWD_ENV_KEYS = ["OMO_CODEGRAPH_PROJECT_CWD", SESSION_START_CWD_ENV, "PWD"];
 async function runCodegraphServe(options = {}) {
   const env = options.env ?? processEnv;

--- a/packages/omo-codex/plugin/components/codegraph/package.json
+++ b/packages/omo-codex/plugin/components/codegraph/package.json
@@ -25,7 +25,7 @@
 		"typescript": "^6.0.3"
 	},
 	"optionalDependencies": {
-		"@colbymchenry/codegraph": "1.0.1"
+		"@colbymchenry/codegraph": "1.4.1"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/packages/omo-codex/plugin/components/codegraph/src/hook-types.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/hook-types.ts
@@ -1,6 +1,7 @@
 import type { Readable } from "node:stream";
 
 import type { CodexOmoConfig as SharedCodexOmoConfig } from "../../../shared/src/config-loader.ts";
+import type { CODEGRAPH_PINNED_VERSION } from "../../../../../utils/src/codegraph/manifest.ts";
 import type { SweepCodegraphZombiesOptions } from "../../../../../utils/src/codegraph/process-sweep.ts";
 import type { CodegraphProvisionResult as SharedCodegraphProvisionResult } from "../../../../../utils/src/codegraph/provision.ts";
 import type {
@@ -58,7 +59,7 @@ export interface CodegraphSessionStartOutcome {
 
 export interface CodegraphSessionStartDeps {
 	readonly ensureGitignored: (projectRoot: string) => boolean;
-	readonly ensureProvisioned: (options: { readonly installDir?: string; readonly lockDir: string; readonly version: "1.0.1" }) => Promise<CodegraphProvisionResult>;
+	readonly ensureProvisioned: (options: { readonly installDir?: string; readonly lockDir: string; readonly version: typeof CODEGRAPH_PINNED_VERSION }) => Promise<CodegraphProvisionResult>;
 	readonly prepareWorkspace: (projectRoot: string, options: { readonly homeDir: string }) => CodegraphWorkspacePreparation;
 	readonly resolveCommand: (options?: ResolveCodegraphCommandOptions) => CodegraphCommandResolution;
 	readonly runCommand: (

--- a/packages/omo-codex/plugin/components/codegraph/src/serve.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/serve.ts
@@ -17,6 +17,7 @@ import {
 	buildCodegraphChildEnv,
 	buildCodegraphEnv,
 } from "../../../../../utils/src/codegraph/env.ts";
+import { CODEGRAPH_PINNED_VERSION } from "../../../../../utils/src/codegraph/manifest.ts";
 import {
 	buildCodegraphNodeSkipHint,
 	evaluateCodegraphNodeSupport,
@@ -84,7 +85,7 @@ const CODEGRAPH_SKIP_HINT =
 const CODEGRAPH_DISABLED_HINT =
 	"CodeGraph MCP skipped: disabled by OMO SOT config. Set [codex].codegraph.enabled=true to enable it.\n";
 const CODEGRAPH_EXCLUDED_HINT = "CodeGraph MCP skipped: project excluded by OMO CodeGraph policy.\n";
-const CODEGRAPH_VERSION = "1.0.1";
+const CODEGRAPH_VERSION = CODEGRAPH_PINNED_VERSION;
 const PROJECT_CWD_ENV_KEYS = ["OMO_CODEGRAPH_PROJECT_CWD", SESSION_START_CWD_ENV, "PWD"] as const;
 
 export async function runCodegraphServe(options: RunCodegraphServeOptions = {}): Promise<number> {

--- a/packages/omo-codex/plugin/components/codegraph/src/session-start-worker.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/session-start-worker.ts
@@ -6,6 +6,7 @@ import { cwd as processCwd, env as processEnv, execPath as processExecPath, stde
 
 import { getCodexOmoConfig } from "../../../shared/src/config-loader.ts";
 import { buildCodegraphChildEnv, buildCodegraphEnv } from "../../../../../utils/src/codegraph/env.ts";
+import { CODEGRAPH_PINNED_VERSION } from "../../../../../utils/src/codegraph/manifest.ts";
 import { evaluateCodegraphNodeSupport, type CodegraphNodeSupport } from "../../../../../utils/src/codegraph/node-support.ts";
 import { ensureCodegraphProvisioned } from "../../../../../utils/src/codegraph/provision.ts";
 import {
@@ -25,7 +26,7 @@ import type {
 
 export const SESSION_START_CWD_ENV = "OMO_CODEGRAPH_SESSION_START_CWD";
 
-const CODEGRAPH_VERSION = "1.0.1";
+const CODEGRAPH_VERSION = CODEGRAPH_PINNED_VERSION;
 const COMMAND_TIMEOUT_MS = 60_000;
 const WINDOWS_CMD_EXTENSIONS = new Set([".bat", ".cmd"]);
 const WINDOWS_NODE_SCRIPT_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);

--- a/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
@@ -42,10 +42,17 @@ function createAllowedWorkspace(prefix: string): string {
 	return mkdtempSync(join(pluginRoot, `.tmp-${prefix}-`));
 }
 
-function createFakeCodegraphBin(script: string): { readonly binPath: string; readonly dir: string } {
+// On win32 execFile cannot run a #!/bin/sh script, so emit a codegraph.cmd batch file instead;
+// resolveCodegraphCommandInvocation wraps .cmd in `cmd.exe /d /s /c`, exactly like the real codegraph.cmd.
+function createFakeCodegraphBin(scripts: { readonly posix: string; readonly win32: string }): { readonly binPath: string; readonly dir: string } {
 	const dir = mkdtempSync(join(tmpdir(), "omo-codegraph-fake-bin-"));
+	if (process.platform === "win32") {
+		const binPath = join(dir, "codegraph.cmd");
+		writeFileSync(binPath, scripts.win32);
+		return { binPath, dir };
+	}
 	const binPath = join(dir, "codegraph");
-	writeFileSync(binPath, script, { mode: 0o755 });
+	writeFileSync(binPath, scripts.posix, { mode: 0o755 });
 	chmodSync(binPath, 0o755);
 	return { binPath, dir };
 }
@@ -56,7 +63,11 @@ describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1
 		const stdout: string[] = [];
 		const spawned: WorkerSpawnInvocation[] = [];
 		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-upgrade-home-"));
-		const fake = createFakeCodegraphBin(`#!/bin/sh\nprintf '%s\\n' '${MIGRATED_1_0_1_STORE_STATUS_JSON}'\n`);
+		// The payload is a single JSON line with no cmd metacharacters (% ^ & < > |), so a plain echo is safe.
+		const fake = createFakeCodegraphBin({
+			posix: `#!/bin/sh\nprintf '%s\\n' '${MIGRATED_1_0_1_STORE_STATUS_JSON}'\n`,
+			win32: `@echo off\r\n@echo ${MIGRATED_1_0_1_STORE_STATUS_JSON}\r\n`,
+		});
 		const workspace = createAllowedWorkspace("codegraph-upgrade-workspace");
 		mkdirSync(join(workspace, ".codegraph"), { recursive: true });
 
@@ -87,7 +98,10 @@ describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1
 		const stdout: string[] = [];
 		const spawned: WorkerSpawnInvocation[] = [];
 		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-slow-home-"));
-		const fake = createFakeCodegraphBin("#!/bin/sh\nsleep 30\n");
+		const fake = createFakeCodegraphBin({
+			posix: "#!/bin/sh\nsleep 30\n",
+			win32: '@powershell -NoProfile -Command "Start-Sleep -Seconds 30"\r\n',
+		});
 		const workspace = createAllowedWorkspace("codegraph-slow-probe-workspace");
 
 		try {

--- a/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
@@ -106,7 +106,7 @@ describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1
 		} finally {
 			rmSync(homeDir, { recursive: true, force: true });
 			rmSync(fake.dir, { recursive: true, force: true });
-			rmSync(workspace, { recursive: true, force: true });
+			rmSync(workspace, { recursive: true, force: true, maxRetries: 10, retryDelay: 500 });
 		}
 	});
 
@@ -117,7 +117,7 @@ describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1
 		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-slow-home-"));
 		const fake = createFakeCodegraphBin({
 			posix: "#!/bin/sh\nsleep 30\n",
-			win32: '@powershell -NoProfile -Command "Start-Sleep -Seconds 30"\r\n',
+			win32: '@powershell -NoProfile -Command "Start-Sleep -Seconds 4"\r\n',
 		});
 		const workspace = createAllowedWorkspace("codegraph-slow-probe-workspace");
 
@@ -142,7 +142,7 @@ describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1
 		} finally {
 			rmSync(homeDir, { recursive: true, force: true });
 			rmSync(fake.dir, { recursive: true, force: true });
-			rmSync(workspace, { recursive: true, force: true });
+			rmSync(workspace, { recursive: true, force: true, maxRetries: 10, retryDelay: 500 });
 		}
 	});
 });

--- a/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
+
+import { executeCodegraphSessionStartHook, type WorkerSpawnInvocation } from "../src/hook.ts";
+
+const pluginRoot = resolve(fileURLToPath(new URL("../../..", import.meta.url)));
+
+// Observed verbatim from a REAL codegraph 1.4.1 binary running `status --json` (exit 0)
+// against a project store built by a REAL codegraph 1.0.1 binary
+// (see .omo/evidence/codegraph-daemon-process-hygiene/task-2-store-upgrade.txt).
+const MIGRATED_1_0_1_STORE_STATUS_JSON = JSON.stringify({
+	initialized: true,
+	version: "1.4.1",
+	projectPath: "/private/tmp/cg-task2/fixture",
+	indexPath: "/private/tmp/cg-task2/fixture/.codegraph",
+	lastIndexed: "2026-07-21T04:28:09.593Z",
+	fileCount: 2,
+	nodeCount: 5,
+	edgeCount: 4,
+	dbSizeBytes: 159744,
+	backend: "node-sqlite",
+	journalMode: "wal",
+	nodesByKind: { file: 2, function: 3 },
+	languages: ["typescript"],
+	pendingChanges: { added: 0, modified: 0, removed: 0 },
+	worktreeMismatch: null,
+	index: {
+		builtWithVersion: "1.0.1",
+		builtWithExtractionVersion: 24,
+		currentExtractionVersion: 24,
+		reindexRecommended: false,
+		state: null,
+		pendingRefs: 0,
+	},
+});
+
+function createAllowedWorkspace(prefix: string): string {
+	return mkdtempSync(join(pluginRoot, `.tmp-${prefix}-`));
+}
+
+function createFakeCodegraphBin(script: string): { readonly binPath: string; readonly dir: string } {
+	const dir = mkdtempSync(join(tmpdir(), "omo-codegraph-fake-bin-"));
+	const binPath = join(dir, "codegraph");
+	writeFileSync(binPath, script, { mode: 0o755 });
+	chmodSync(binPath, 0o755);
+	return { binPath, dir };
+}
+
+describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1.4.1 binary", () => {
+	it("#given a real 1.4.1 status payload for a migrated 1.0.1 store #when SessionStart probes via the default probe #then it stays silent without spawning a re-init worker", async () => {
+		// given
+		const stdout: string[] = [];
+		const spawned: WorkerSpawnInvocation[] = [];
+		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-upgrade-home-"));
+		const fake = createFakeCodegraphBin(`#!/bin/sh\nprintf '%s\\n' '${MIGRATED_1_0_1_STORE_STATUS_JSON}'\n`);
+		const workspace = createAllowedWorkspace("codegraph-upgrade-workspace");
+		mkdirSync(join(workspace, ".codegraph"), { recursive: true });
+
+		try {
+			// when
+			const result = await executeCodegraphSessionStartHook({
+				config: { codegraph: { enabled: true }, sources: [], warnings: [] },
+				cwd: workspace,
+				env: { HOME: homeDir, OMO_CODEGRAPH_BIN: fake.binPath, PATH: "/usr/bin:/bin" },
+				stdin: Readable.from(["{}"]),
+				stdout: { write: (chunk) => stdout.push(chunk) },
+				spawnWorker: (invocation) => spawned.push(invocation),
+			});
+
+			// then
+			expect(result).toEqual({ action: "skipped-initialized", exitCode: 0 });
+			expect(spawned).toEqual([]);
+			expect(stdout.join("")).toBe("");
+		} finally {
+			rmSync(homeDir, { recursive: true, force: true });
+			rmSync(fake.dir, { recursive: true, force: true });
+			rmSync(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("#given the status probe hangs past its 2s timeout #when SessionStart fires #then it exits zero promptly and spawns at most one bounded worker", async () => {
+		// given
+		const stdout: string[] = [];
+		const spawned: WorkerSpawnInvocation[] = [];
+		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-slow-home-"));
+		const fake = createFakeCodegraphBin("#!/bin/sh\nsleep 30\n");
+		const workspace = createAllowedWorkspace("codegraph-slow-probe-workspace");
+
+		try {
+			// when
+			const startedAt = Date.now();
+			const result = await executeCodegraphSessionStartHook({
+				config: { codegraph: { enabled: true }, sources: [], warnings: [] },
+				cwd: workspace,
+				env: { HOME: homeDir, OMO_CODEGRAPH_BIN: fake.binPath, PATH: "/usr/bin:/bin" },
+				stdin: Readable.from(["{}"]),
+				stdout: { write: (chunk) => stdout.push(chunk) },
+				spawnWorker: (invocation) => spawned.push(invocation),
+			});
+			const elapsedMs = Date.now() - startedAt;
+
+			// then
+			expect(result.exitCode).toBe(0);
+			expect(result.action).toBe("spawned");
+			expect(spawned).toHaveLength(1);
+			expect(elapsedMs).toBeLessThan(15_000);
+		} finally {
+			rmSync(homeDir, { recursive: true, force: true });
+			rmSync(fake.dir, { recursive: true, force: true });
+			rmSync(workspace, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
@@ -117,7 +117,7 @@ describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1
 		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-slow-home-"));
 		const fake = createFakeCodegraphBin({
 			posix: "#!/bin/sh\nsleep 30\n",
-			win32: '@powershell -NoProfile -Command "Start-Sleep -Seconds 4"\r\n',
+			win32: "@echo off\r\nset /p _probe_hang=\r\n",
 		});
 		const workspace = createAllowedWorkspace("codegraph-slow-probe-workspace");
 

--- a/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
@@ -67,8 +67,8 @@ function probeEnv(homeDir: string, binPath: string): Record<string, string> {
 			HOME: homeDir,
 			OMO_CODEGRAPH_BIN: binPath,
 		};
-		if (process.env.PATH !== undefined) env.PATH = process.env.PATH;
-		if (process.env.SystemRoot !== undefined) env.SystemRoot = process.env.SystemRoot;
+		if (process.env["PATH"] !== undefined) env["PATH"] = process.env["PATH"];
+		if (process.env["SystemRoot"] !== undefined) env["SystemRoot"] = process.env["SystemRoot"];
 		return env;
 	}
 	return { HOME: homeDir, OMO_CODEGRAPH_BIN: binPath, PATH: "/usr/bin:/bin" };

--- a/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook-store-upgrade.test.ts
@@ -57,6 +57,23 @@ function createFakeCodegraphBin(scripts: { readonly posix: string; readonly win3
 	return { binPath, dir };
 }
 
+// Keep the probe hermetic on POSIX but viable on win32: resolveCodegraphCommandInvocation wraps
+// the fake .cmd in `cmd.exe /d /s /c`, and Windows can only resolve cmd.exe when the child env
+// carries the real system PATH (System32) plus SystemRoot (both whitelisted in SAFE_AMBIENT_ENV_KEYS).
+// A POSIX-only PATH makes the probe spawn fail, so the hook reports not-initialized and spawns.
+function probeEnv(homeDir: string, binPath: string): Record<string, string> {
+	if (process.platform === "win32") {
+		const env: Record<string, string> = {
+			HOME: homeDir,
+			OMO_CODEGRAPH_BIN: binPath,
+		};
+		if (process.env.PATH !== undefined) env.PATH = process.env.PATH;
+		if (process.env.SystemRoot !== undefined) env.SystemRoot = process.env.SystemRoot;
+		return env;
+	}
+	return { HOME: homeDir, OMO_CODEGRAPH_BIN: binPath, PATH: "/usr/bin:/bin" };
+}
+
 describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1.4.1 binary", () => {
 	it("#given a real 1.4.1 status payload for a migrated 1.0.1 store #when SessionStart probes via the default probe #then it stays silent without spawning a re-init worker", async () => {
 		// given
@@ -76,7 +93,7 @@ describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1
 			const result = await executeCodegraphSessionStartHook({
 				config: { codegraph: { enabled: true }, sources: [], warnings: [] },
 				cwd: workspace,
-				env: { HOME: homeDir, OMO_CODEGRAPH_BIN: fake.binPath, PATH: "/usr/bin:/bin" },
+				env: probeEnv(homeDir, fake.binPath),
 				stdin: Readable.from(["{}"]),
 				stdout: { write: (chunk) => stdout.push(chunk) },
 				spawnWorker: (invocation) => spawned.push(invocation),
@@ -110,7 +127,7 @@ describe("CodeGraph SessionStart hook with a 1.0.1-era project store under the 1
 			const result = await executeCodegraphSessionStartHook({
 				config: { codegraph: { enabled: true }, sources: [], warnings: [] },
 				cwd: workspace,
-				env: { HOME: homeDir, OMO_CODEGRAPH_BIN: fake.binPath, PATH: "/usr/bin:/bin" },
+				env: probeEnv(homeDir, fake.binPath),
 				stdin: Readable.from(["{}"]),
 				stdout: { write: (chunk) => stdout.push(chunk) },
 				spawnWorker: (invocation) => spawned.push(invocation),

--- a/packages/omo-codex/plugin/components/codegraph/test/mcp-bridge-fixtures.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/mcp-bridge-fixtures.ts
@@ -12,7 +12,7 @@ export function writeFakeNewlineCodegraph(filePath: string): void {
 			"rl.on('line', (line) => {",
 			"  const request = JSON.parse(line);",
 			"  if (request.method === 'initialize') {",
-			"    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { capabilities: { tools: { listChanged: false } }, protocolVersion: request.params.protocolVersion, serverInfo: { name: 'codegraph', version: '1.0.1' } } }) + '\\n');",
+			"    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { capabilities: { tools: { listChanged: false } }, protocolVersion: request.params.protocolVersion, serverInfo: { name: 'codegraph', version: '1.4.1' } } }) + '\\n');",
 			"  }",
 			"  if (request.method === 'tools/list') {",
 			"    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { tools: [{ name: 'codegraph_search' }, { name: 'codegraph_node' }, { name: 'codegraph_explore' }, { name: 'codegraph_callers' }] } }) + '\\n');",

--- a/packages/omo-codex/plugin/components/codegraph/test/mcp-bridge-fixtures.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/mcp-bridge-fixtures.ts
@@ -1,5 +1,34 @@
 import { chmodSync, writeFileSync } from "node:fs";
 
+export const CODEGRAPH_141_DEFAULT_TOOLS: readonly Record<string, unknown>[] = [
+	{
+		name: "codegraph_explore",
+		description:
+			"PRIMARY TOOL — call FIRST for almost any question OR before an edit: how does X work, architecture, a bug, where/what is X, surveying an area, or the symbols you are about to change. Returns the verbatim source of the relevant symbols grouped by file in ONE capped call (Read-equivalent — treat the shown source as already Read; do NOT re-open those files), plus the call path among them. Query can be a natural-language question OR a bag of symbol/file names. Usually the ONLY call you need — more accurate context, in far fewer tokens and round-trips than a search/Read/Grep loop.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				query: {
+					type: "string",
+					description:
+						'Symbol names, file names, or short code terms to explore (e.g., "AuthService loginUser session-manager", "GraphTraverser BFS impact traversal.ts"). For a flow question, name the symbols spanning the flow (e.g. "mutateElement renderScene"). A natural-language question works too — no prior codegraph_search needed.',
+				},
+				maxFiles: {
+					type: "number",
+					description: "Maximum number of files to include source code from (default: 12)",
+					default: 12,
+				},
+				projectPath: {
+					type: "string",
+					description:
+						"Absolute path to the project to query (or any directory inside it) — codegraph uses the nearest .codegraph/ index at or above that path. Omit to use this session's default project. Pass it to query a second codebase, or when the server root has no index of its own (e.g. a monorepo where only sub-projects are indexed, so there is no default project).",
+				},
+			},
+			required: ["query"],
+		},
+	},
+];
+
 export function writeFakeNewlineCodegraph(filePath: string): void {
 	writeFileSync(
 		filePath,
@@ -15,7 +44,7 @@ export function writeFakeNewlineCodegraph(filePath: string): void {
 			"    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { capabilities: { tools: { listChanged: false } }, protocolVersion: request.params.protocolVersion, serverInfo: { name: 'codegraph', version: '1.4.1' } } }) + '\\n');",
 			"  }",
 			"  if (request.method === 'tools/list') {",
-			"    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { tools: [{ name: 'codegraph_search' }, { name: 'codegraph_node' }, { name: 'codegraph_explore' }, { name: 'codegraph_callers' }] } }) + '\\n');",
+			`    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { tools: ${JSON.stringify(CODEGRAPH_141_DEFAULT_TOOLS)} } }) + '\\n');`,
 			"  }",
 			"});",
 		].join("\n"),

--- a/packages/omo-codex/plugin/components/codegraph/test/package-runtime.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/package-runtime.test.ts
@@ -43,7 +43,7 @@ describe("CodeGraph component runtime package metadata", () => {
 		const files = packageJson.files ?? [];
 
 		// then
-		expect(optionalDependencies["@colbymchenry/codegraph"]).toBe("1.0.1");
+		expect(optionalDependencies["@colbymchenry/codegraph"]).toBe("1.4.1");
 		expect(files).toContain("LICENSE");
 		expect(files).toContain("NODE-RUNTIME-LICENSES.md");
 		expect(files).toContain("NOTICE");

--- a/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge.test.ts
@@ -86,7 +86,7 @@ describe("runCodegraphServe MCP protocol bridge", () => {
 					result: {
 						capabilities: { tools: { listChanged: false } },
 						protocolVersion: "2025-06-18",
-						serverInfo: { name: "codegraph", version: "1.0.1" },
+						serverInfo: { name: "codegraph", version: "1.4.1" },
 					},
 				},
 				{

--- a/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-bridge.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { runCodegraphServe } from "../src/serve.ts";
 import {
 	arrayProperty,
+	CODEGRAPH_141_DEFAULT_TOOLS,
 	findTool,
 	frameMcpRequest,
 	parseMcpBodies,
@@ -93,12 +94,7 @@ describe("runCodegraphServe MCP protocol bridge", () => {
 					id: 2,
 					jsonrpc: "2.0",
 					result: {
-						tools: [
-							{ name: "codegraph_search" },
-							{ name: "codegraph_node" },
-							{ name: "codegraph_explore" },
-							{ name: "codegraph_callers" },
-						],
+						tools: CODEGRAPH_141_DEFAULT_TOOLS,
 					},
 				},
 			]);

--- a/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-facade.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/serve-mcp-facade.test.ts
@@ -47,7 +47,7 @@ describe("runCodegraphServe MCP unavailable facade", () => {
 			result: {
 				capabilities: { tools: { listChanged: false } },
 				protocolVersion: "2025-06-18",
-				serverInfo: { name: "codegraph", version: "1.0.1" },
+				serverInfo: { name: "codegraph", version: "1.4.1" },
 			},
 		});
 	});

--- a/packages/omo-codex/plugin/components/codegraph/test/session-start-node-support.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/session-start-node-support.test.ts
@@ -52,7 +52,7 @@ describe("CodeGraph SessionStart worker Node support", () => {
 		const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-worker-node-provision-home-"));
 		const binPath = join(homeDir, ".omo", "codegraph", "bin", "codegraph");
 		const calls: Array<{ readonly args: readonly string[]; readonly command: string }> = [];
-		const provisionCalls: Array<{ readonly installDir?: string; readonly lockDir: string; readonly version: "1.0.1" }> = [];
+		const provisionCalls: Array<{ readonly installDir?: string; readonly lockDir: string; readonly version: "1.4.1" }> = [];
 		const outcomes: unknown[] = [];
 
 		try {
@@ -90,7 +90,7 @@ describe("CodeGraph SessionStart worker Node support", () => {
 				{ args: ["init"], command: binPath },
 			]);
 			expect(provisionCalls).toEqual([
-				{ installDir: join(homeDir, ".omo", "codegraph"), lockDir: join(homeDir, ".omo", "codegraph", ".locks"), version: "1.0.1" },
+				{ installDir: join(homeDir, ".omo", "codegraph"), lockDir: join(homeDir, ".omo", "codegraph", ".locks"), version: "1.4.1" },
 			]);
 			expect(outcomes).toEqual([{ action: "initialized", exitCode: 0, projectRoot: workspace, source: "provisioned", timedOut: false }]);
 		} finally {

--- a/packages/omo-codex/plugin/package-lock.json
+++ b/packages/omo-codex/plugin/package-lock.json
@@ -114,7 +114,7 @@
 				"node": ">=20.0.0"
 			},
 			"optionalDependencies": {
-				"@colbymchenry/codegraph": "1.0.1"
+				"@colbymchenry/codegraph": "1.4.1"
 			}
 		},
 		"components/comment-checker": {
@@ -512,27 +512,27 @@
 			"link": true
 		},
 		"node_modules/@colbymchenry/codegraph": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph/-/codegraph-1.0.1.tgz",
-			"integrity": "sha512-Y4ZMk7wxSRI9g2wQTcW21TfLr+fw7td1Dadkll6Udl9Ll8wX3H6qtov7K/VGtHG2AFX2j1e5Lm48PTHi74mImg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph/-/codegraph-1.4.1.tgz",
+			"integrity": "sha512-xZayboJt6T3QBzBsBsI0eJ3J/tN4vYs6LMuvrxJVdM71yQFjrFKFeV3KsbicAgkj6AHnTXxUNk26g9BYwkNMgg==",
 			"license": "MIT",
 			"optional": true,
 			"bin": {
 				"codegraph": "npm-shim.js"
 			},
 			"optionalDependencies": {
-				"@colbymchenry/codegraph-darwin-arm64": "1.0.1",
-				"@colbymchenry/codegraph-darwin-x64": "1.0.1",
-				"@colbymchenry/codegraph-linux-arm64": "1.0.1",
-				"@colbymchenry/codegraph-linux-x64": "1.0.1",
-				"@colbymchenry/codegraph-win32-arm64": "1.0.1",
-				"@colbymchenry/codegraph-win32-x64": "1.0.1"
+				"@colbymchenry/codegraph-darwin-arm64": "1.4.1",
+				"@colbymchenry/codegraph-darwin-x64": "1.4.1",
+				"@colbymchenry/codegraph-linux-arm64": "1.4.1",
+				"@colbymchenry/codegraph-linux-x64": "1.4.1",
+				"@colbymchenry/codegraph-win32-arm64": "1.4.1",
+				"@colbymchenry/codegraph-win32-x64": "1.4.1"
 			}
 		},
 		"node_modules/@colbymchenry/codegraph-darwin-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-darwin-arm64/-/codegraph-darwin-arm64-1.0.1.tgz",
-			"integrity": "sha512-4z3aNzR3Ml31MBVzAvFQm+bk83erdHkjnaJ0PoeM6I9T7xuTIcdAGV36i3qYwgBE4tdrghRdR0mP5MNM+OrGFA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-darwin-arm64/-/codegraph-darwin-arm64-1.4.1.tgz",
+			"integrity": "sha512-USSpExjuxZWN0OeNexZp2V5fCfOI4ZekqE79CJiBdGdPbqGTB+857ImIqzWGyF/rAyyED94Wc0Cd82t+uWD30w==",
 			"cpu": [
 				"arm64"
 			],
@@ -543,9 +543,9 @@
 			]
 		},
 		"node_modules/@colbymchenry/codegraph-darwin-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-darwin-x64/-/codegraph-darwin-x64-1.0.1.tgz",
-			"integrity": "sha512-KBSKl+tLCSIgV4iyi21SqYlpXL0P8DPqAnVHvvStdyYsCmkc2Heqf4oQIko+TYyFmuo65m4VpX989JkYZVGIVQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-darwin-x64/-/codegraph-darwin-x64-1.4.1.tgz",
+			"integrity": "sha512-syLC7QPsNui2hPrK58El0XQrjjdSYhsoKS5i26ieD8DVrb0adzFQrBRP8qId/wfGp078xdC54rdKvqgmbIL1WQ==",
 			"cpu": [
 				"x64"
 			],
@@ -556,9 +556,9 @@
 			]
 		},
 		"node_modules/@colbymchenry/codegraph-linux-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-linux-arm64/-/codegraph-linux-arm64-1.0.1.tgz",
-			"integrity": "sha512-2TOeL/Lx3kME+dmv2Q9hbIQFBvT6uKLdZONDRaYto+1Bcl3GrJuIu6bsu3jiJuifPhnYIL2xwUV6y+TZQ8MbTw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-linux-arm64/-/codegraph-linux-arm64-1.4.1.tgz",
+			"integrity": "sha512-XC6GJ9/fTicW9CE3k2fOcUOcbtDU8mS53t+PUfzq3Py9+JiX3PtJgtBB8bmf6e45NZUF5foaLUwFXfxTTl961g==",
 			"cpu": [
 				"arm64"
 			],
@@ -569,9 +569,9 @@
 			]
 		},
 		"node_modules/@colbymchenry/codegraph-linux-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-linux-x64/-/codegraph-linux-x64-1.0.1.tgz",
-			"integrity": "sha512-UENXSURJJUhcvdKoYsB5Wj6Z6O9C2afhYfG0LnL13KFWJhGXugqYKjF4KwkaeE8Po8TFul9k3f+8eXjmJwwwaQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-linux-x64/-/codegraph-linux-x64-1.4.1.tgz",
+			"integrity": "sha512-bjfa+0IyjbxpZz7ghznN4qMPoYVSiZafeZu/rXGdg3VI+kEPOPZrk2vmtWIU9tBPGVJbeU2Kwa/0Z2DkUGOJ9A==",
 			"cpu": [
 				"x64"
 			],
@@ -582,9 +582,9 @@
 			]
 		},
 		"node_modules/@colbymchenry/codegraph-win32-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.0.1.tgz",
-			"integrity": "sha512-ZEG+HOakHiAe1AWMa2LgD52HyIEbWsY2FyNvDmon4Ss2889OghqUyA8BOLu5hNW+EI42JwwSXijVevn2Zn0hlg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.4.1.tgz",
+			"integrity": "sha512-mb5bFDhwcP49U0P2IBRhH1O5ZmnlgE8lIXTlg2dqpfLeL+XfxzyeJ+i4I0KU0h1hlNWP/u3d2k+1EGem2swDBw==",
 			"cpu": [
 				"arm64"
 			],
@@ -595,9 +595,9 @@
 			]
 		},
 		"node_modules/@colbymchenry/codegraph-win32-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.0.1.tgz",
-			"integrity": "sha512-qU6jjyma635qKJ0aaL8XU8QtYUGkWly0Mu4Wm2cSWRcNDL1v6sVoHMElgfUY7E9tK0gnU+/LbZW3MfmtqLG1GA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.4.1.tgz",
+			"integrity": "sha512-ipN6WvTKa0cSXIL6DTdACq57WnNYTjVq2wtC5uPT8F22o6Ucbcu3/w3OzKkkfwP4mkXv2cDMbuvExbnYNULyuw==",
 			"cpu": [
 				"x64"
 			],

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 
 import {
+  CODEGRAPH_PINNED_VERSION,
   buildCodegraphEnv,
   ensureCodegraphGitignored,
   ensureCodegraphProvisioned,
@@ -42,7 +43,7 @@ export interface CodegraphBootstrapDeps {
   readonly ensureProvisioned: (options: {
     readonly installDir?: string
     readonly lockDir: string
-    readonly version: "1.0.1"
+    readonly version: typeof CODEGRAPH_PINNED_VERSION
   }) => Promise<CodegraphProvisionResult>
   readonly log: (message: string, data?: Record<string, unknown>) => void
   readonly nodeSupport: () => CodegraphNodeSupport
@@ -60,7 +61,7 @@ export interface CodegraphBootstrapDeps {
   readonly schedule: (task: () => Promise<void>) => void
 }
 
-const CODEGRAPH_VERSION = "1.0.1"
+const CODEGRAPH_VERSION = CODEGRAPH_PINNED_VERSION
 const COMMAND_TIMEOUT_MS = 60_000
 const bootstrappedProjects = new Set<string>()
 

--- a/packages/utils/src/codegraph-guidance.test.ts
+++ b/packages/utils/src/codegraph-guidance.test.ts
@@ -91,6 +91,54 @@ describe("CodeGraph initialization guidance", () => {
     expect(projectPath).toBe("/Users/me/project")
   })
 
+  test("#given CodeGraph 1.4.1 MCP reports an explicit projectPath that is not indexed #when parsed #then the project path is extracted", () => {
+    // given
+    const output =
+      "The project at /Users/me/project isn't indexed with codegraph (no .codegraph/ directory found walking up from it), so codegraph cannot query it. Use your built-in tools (Read/Grep/Glob) for that codebase instead, and don't call codegraph for it again this session. Indexing is the user's decision — they can run 'codegraph init' in that project to enable it."
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      toolName: "codegraph_explore",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBe("/Users/me/project")
+  })
+
+  test("#given CodeGraph 1.4.1 MCP reports no project loaded for the session #when parsed #then the searched-from path is extracted", () => {
+    // given
+    const output = [
+      "No CodeGraph project is loaded for this session.",
+      "Searched for a .codegraph/ directory starting from: /Users/me/project",
+      "Either the server root has no index of its own (e.g. a monorepo where only sub-projects are indexed), or the MCP client launched the server outside your project without reporting the workspace root. Either way, target the project explicitly:",
+    ].join("\n")
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      toolName: "codegraph_explore",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBe("/Users/me/project")
+  })
+
+  test("#given CodeGraph 1.4.1 MCP reports a non-indexed project for a non-CodeGraph tool #when parsed #then no guidance is emitted", () => {
+    // given
+    const output =
+      "The project at /Users/me/project isn't indexed with codegraph (no .codegraph/ directory found walking up from it), so codegraph cannot query it."
+
+    // when
+    const projectPath = getCodegraphUninitializedProject({
+      toolName: "bash",
+      toolOutput: output,
+    })
+
+    // then
+    expect(projectPath).toBeNull()
+  })
+
   test("#given an uninitialized project #when guidance is built #then it points to the OMO global store", () => {
     // when
     const guidance = normalizeDisplayPaths(buildCodegraphInitGuidance("/Users/me/project", { homeDir: "/Users/me" }))

--- a/packages/utils/src/codegraph-provision.test.ts
+++ b/packages/utils/src/codegraph-provision.test.ts
@@ -43,13 +43,13 @@ describe("ensureCodegraphProvisioned", () => {
       installDir,
       lockDir: tempDir("locks"),
       platformKey: "darwin-arm64",
-      version: "1.0.1",
+      version: "1.4.1",
     })
 
     // then
     expect(result.provisioned).toBe(false)
     expect(result.error).toContain("checksum mismatch")
-    expect(result.error).not.toContain("no CodeGraph 1.0.1 asset")
+    expect(result.error).not.toContain("no CodeGraph 1.4.1 asset")
 
     rmSync(installDir, { force: true, recursive: true })
   })
@@ -72,10 +72,10 @@ describe("ensureCodegraphProvisioned", () => {
             url: "memory://codegraph-darwin-arm64.tar.gz",
           },
         },
-        version: "1.0.1",
+        version: "1.4.1",
       },
       platformKey: "darwin-arm64",
-      version: "1.0.1",
+      version: "1.4.1",
     })
 
     // then
@@ -96,13 +96,13 @@ describe("ensureCodegraphProvisioned", () => {
     // then
     expect(win32X64).toEqual({
       executableName: "codegraph.cmd",
-      sha256: "52607fe73b05e741fd1087da2ceca9d3c8f565e36bf1a7070600bdbdf3931e32",
-      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.0.1.tgz",
+      sha256: "4f08700fda5f4a03ad5b2956135c5788d739a351b3433db2b5820e5d5224c30d",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.4.1.tgz",
     })
     expect(win32Arm64).toEqual({
       executableName: "codegraph.cmd",
-      sha256: "8d57ced73b24d35f758f2ede2318e80e1d7241987f37a999e3d80edb6fddf961",
-      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.0.1.tgz",
+      sha256: "e2a2a28c802a79804c7df203afa50bd461309c6c180ce3f76079fdc7cddc7697",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.4.1.tgz",
     })
   })
 
@@ -121,13 +121,13 @@ describe("ensureCodegraphProvisioned", () => {
           "win32-x64": {
             executableName: "codegraph.cmd",
             sha256: archive.sha256,
-            url: "memory://codegraph-win32-x64-1.0.1.tgz",
+            url: "memory://codegraph-win32-x64-1.4.1.tgz",
           },
         },
-        version: "1.0.1",
+        version: "1.4.1",
       },
       platformKey: "win32-x64",
-      version: "1.0.1",
+      version: "1.4.1",
     })
 
     // then
@@ -159,20 +159,20 @@ describe("ensureCodegraphProvisioned", () => {
             url: "memory://codegraph-darwin-arm64.tar.gz",
           },
         },
-        version: "1.0.1",
+        version: "1.4.1",
       },
       platformKey: "darwin-arm64",
-      version: "1.0.1",
+      version: "1.4.1",
     })
     const second = await ensureCodegraphProvisioned({
       installDir,
       lockDir: tempDir("locks-2"),
       manifest: {
         assets: {},
-        version: "1.0.1",
+        version: "1.4.1",
       },
       platformKey: "darwin-arm64",
-      version: "1.0.1",
+      version: "1.4.1",
     })
 
     // then
@@ -210,10 +210,10 @@ describe("ensureCodegraphProvisioned", () => {
             url: "memory://codegraph-darwin-arm64.tar.gz",
           },
         },
-        version: "1.0.1",
+        version: "1.4.1",
       },
       platformKey: "darwin-arm64",
-      version: "1.0.1",
+      version: "1.4.1",
     })
     const releaseDownload = await releaseDownloadReady
     const second = ensureCodegraphProvisioned({
@@ -227,10 +227,10 @@ describe("ensureCodegraphProvisioned", () => {
             url: "memory://codegraph-darwin-arm64.tar.gz",
           },
         },
-        version: "1.0.1",
+        version: "1.4.1",
       },
       platformKey: "darwin-arm64",
-      version: "1.0.1",
+      version: "1.4.1",
     })
 
     // when
@@ -263,10 +263,10 @@ describe("ensureCodegraphProvisioned", () => {
             url: "memory://codegraph",
           },
         },
-        version: "1.0.1",
+        version: "1.4.1",
       },
       platformKey: "darwin-arm64",
-      version: "1.0.1",
+      version: "1.4.1",
     })
 
     // then

--- a/packages/utils/src/codegraph/guidance.ts
+++ b/packages/utils/src/codegraph/guidance.ts
@@ -10,6 +10,12 @@ const CODEGRAPH_STATUS_UNINITIALIZED_PATTERN =
   /^.*?\bNot initialized\s*$/im
 const CODEGRAPH_INIT_HINT_PATTERN =
   /Run\s+["'`]codegraph init["'`]\s+(?:in that project first|to initialize)\.?/i
+const CODEGRAPH_PROJECT_NOT_INDEXED_PATTERN =
+  /The project at (.+?) isn't indexed with codegraph\b/i
+const CODEGRAPH_NO_PROJECT_LOADED_PATTERN =
+  /No CodeGraph project is loaded for this session\./i
+const CODEGRAPH_NO_PROJECT_SEARCHED_FROM_PATTERN =
+  /^Searched for a \.codegraph\/ directory starting from:\s*(.+?)\s*$/im
 
 export interface CodegraphInitGuidanceInput {
   readonly cwd?: unknown
@@ -66,6 +72,16 @@ function extractProjectPath(output: string): string | null {
   const uninitializedMatch = normalizedOutput.match(CODEGRAPH_UNINITIALIZED_PATTERN)
   const uninitializedProject = uninitializedMatch?.[1]?.trim()
   if (uninitializedProject && uninitializedProject.length > 0) return uninitializedProject
+
+  const notIndexedMatch = normalizedOutput.match(CODEGRAPH_PROJECT_NOT_INDEXED_PATTERN)
+  const notIndexedProject = notIndexedMatch?.[1]?.trim()
+  if (notIndexedProject && notIndexedProject.length > 0) return notIndexedProject
+
+  if (CODEGRAPH_NO_PROJECT_LOADED_PATTERN.test(normalizedOutput)) {
+    const searchedFromMatch = normalizedOutput.match(CODEGRAPH_NO_PROJECT_SEARCHED_FROM_PATTERN)
+    const searchedFromProject = searchedFromMatch?.[1]?.trim()
+    if (searchedFromProject && searchedFromProject.length > 0) return searchedFromProject
+  }
 
   if (!looksLikeCodegraphUninitializedOutput(normalizedOutput)) return null
   const statusMatch = normalizedOutput.match(CODEGRAPH_STATUS_PROJECT_PATTERN)

--- a/packages/utils/src/codegraph/index.ts
+++ b/packages/utils/src/codegraph/index.ts
@@ -1,5 +1,6 @@
 export * from "./env"
 export * from "./guidance"
+export * from "./manifest"
 export * from "./node-support"
 export * from "./provision"
 export * from "./process-sweep"

--- a/packages/utils/src/codegraph/manifest.test.ts
+++ b/packages/utils/src/codegraph/manifest.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test"
+
+import { CODEGRAPH_PINNED_VERSION, CODEGRAPH_PROVISION_MANIFEST } from "./manifest"
+
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/
+const EXPECTED_PLATFORMS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-arm64", "win32-x64"] as const
+
+describe("CODEGRAPH_PROVISION_MANIFEST", () => {
+  it("pins CodeGraph 1.4.1 across the manifest version and every asset URL", () => {
+    // given
+    const manifest = CODEGRAPH_PROVISION_MANIFEST
+
+    // when
+    const platforms = Object.keys(manifest.assets).sort()
+    const urls = Object.values(manifest.assets).map((asset) => asset.url)
+
+    // then
+    expect(CODEGRAPH_PINNED_VERSION).toBe("1.4.1")
+    expect(manifest.version).toBe("1.4.1")
+    expect(platforms).toEqual([...EXPECTED_PLATFORMS].sort())
+    for (const url of urls) {
+      expect(url).toContain("1.4.1")
+    }
+  })
+
+  it("declares a 64-hex sha256 for every pinned asset", () => {
+    // given
+    const assets = CODEGRAPH_PROVISION_MANIFEST.assets
+
+    // when
+    const entries = Object.entries(assets)
+
+    // then
+    expect(entries).toHaveLength(6)
+    for (const [platform, asset] of entries) {
+      expect(asset.sha256, `${platform} sha256`).toMatch(SHA256_HEX_PATTERN)
+    }
+  })
+
+  it("keeps the npm .tgz scheme for win32 assets and github releases for darwin/linux", () => {
+    // given
+    const assets = CODEGRAPH_PROVISION_MANIFEST.assets
+
+    // when
+    const win32Arm64 = assets["win32-arm64"]
+    const win32X64 = assets["win32-x64"]
+    const darwinArm64 = assets["darwin-arm64"]
+    const darwinX64 = assets["darwin-x64"]
+    const linuxArm64 = assets["linux-arm64"]
+    const linuxX64 = assets["linux-x64"]
+
+    // then
+    expect(win32Arm64?.url).toBe(
+      "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.4.1.tgz",
+    )
+    expect(win32X64?.url).toBe(
+      "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.4.1.tgz",
+    )
+    expect(win32Arm64?.executableName).toBe("codegraph.cmd")
+    expect(win32X64?.executableName).toBe("codegraph.cmd")
+
+    expect(darwinArm64?.url).toBe(
+      "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-darwin-arm64.tar.gz",
+    )
+    expect(darwinX64?.url).toBe(
+      "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-darwin-x64.tar.gz",
+    )
+    expect(linuxArm64?.url).toBe(
+      "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-linux-arm64.tar.gz",
+    )
+    expect(linuxX64?.url).toBe(
+      "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-linux-x64.tar.gz",
+    )
+  })
+})

--- a/packages/utils/src/codegraph/manifest.ts
+++ b/packages/utils/src/codegraph/manifest.ts
@@ -1,37 +1,39 @@
 import type { CodegraphProvisionManifest } from "./provision"
 
+export const CODEGRAPH_PINNED_VERSION = "1.4.1"
+
 export const CODEGRAPH_PROVISION_MANIFEST: CodegraphProvisionManifest = {
   assets: {
     "darwin-arm64": {
       executableName: "codegraph",
-      sha256: "95bb27bf6382b69659e158e0c04d71cc394778951e1317d582be7807e7866908",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-darwin-arm64.tar.gz",
+      sha256: "4a679ae5a5cb9fff900dd59bb786da6a581b7f68f4cf713bdedd137e347d34dc",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-darwin-arm64.tar.gz",
     },
     "darwin-x64": {
       executableName: "codegraph",
-      sha256: "3311cc1d1f0f0ad742709b6a43d8a9187b1ef0af0dd30e0b58008dc673e29478",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-darwin-x64.tar.gz",
+      sha256: "436f96943cfd926ea6d0a8454f18833d21254d5fd9b3d224317b1426132def95",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-darwin-x64.tar.gz",
     },
     "linux-arm64": {
       executableName: "codegraph",
-      sha256: "e16f612bc96c2ebccd04574cbed500c9939147c80666ad6bb024398dff7992ae",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-linux-arm64.tar.gz",
+      sha256: "0d62c5eb2722f8d19d20f7a1bd974445e18d5294cb59be116a0c3d55ce87591f",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-linux-arm64.tar.gz",
     },
     "linux-x64": {
       executableName: "codegraph",
-      sha256: "d45a068f44596a85c7ba7d0ef924eaf7103fbbf3cafbeb668127daff60a52228",
-      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.0.1/codegraph-linux-x64.tar.gz",
+      sha256: "fb585ff5018d6faaa46d282b61f4f689bc7967ed8a1b467a5c556dd7ced9b542",
+      url: "https://github.com/colbymchenry/codegraph/releases/download/v1.4.1/codegraph-linux-x64.tar.gz",
     },
     "win32-arm64": {
       executableName: "codegraph.cmd",
-      sha256: "8d57ced73b24d35f758f2ede2318e80e1d7241987f37a999e3d80edb6fddf961",
-      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.0.1.tgz",
+      sha256: "e2a2a28c802a79804c7df203afa50bd461309c6c180ce3f76079fdc7cddc7697",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.4.1.tgz",
     },
     "win32-x64": {
       executableName: "codegraph.cmd",
-      sha256: "52607fe73b05e741fd1087da2ceca9d3c8f565e36bf1a7070600bdbdf3931e32",
-      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.0.1.tgz",
+      sha256: "4f08700fda5f4a03ad5b2956135c5788d739a351b3433db2b5820e5d5224c30d",
+      url: "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.4.1.tgz",
     },
   },
-  version: "1.0.1",
+  version: CODEGRAPH_PINNED_VERSION,
 }

--- a/packages/utils/src/codegraph/provision.ts
+++ b/packages/utils/src/codegraph/provision.ts
@@ -6,7 +6,7 @@ import { homedir, hostname } from "node:os"
 import { basename, join } from "node:path"
 import { promisify } from "node:util"
 
-import { CODEGRAPH_PROVISION_MANIFEST } from "./manifest"
+import { CODEGRAPH_PINNED_VERSION, CODEGRAPH_PROVISION_MANIFEST } from "./manifest"
 
 export interface CodegraphProvisionAsset {
   readonly executableName: string
@@ -29,7 +29,7 @@ export interface EnsureCodegraphProvisionedOptions {
   readonly lockWaitMs?: number
   readonly manifest?: CodegraphProvisionManifest
   readonly platformKey?: string
-  readonly version: "1.0.1"
+  readonly version: typeof CODEGRAPH_PINNED_VERSION
 }
 
 export interface CodegraphProvisionResult {


### PR DESCRIPTION
## Summary

Wave 1 of the codegraph daemon + process-hygiene plan (`.omo/plans/codegraph-daemon-process-hygiene.md`): bump the vendored CodeGraph pin from 1.0.1 to 1.4.1 and align all guidance/tests with real 1.4.1 behavior.

## What changed

- **Provision manifest + pins** (`build(codegraph)` commit): all 6 platform assets now point at 1.4.1 (darwin/linux via GitHub release tarballs, win32 via npm tgz to keep the existing extractor). Every sha256 was computed locally from the downloaded asset. A single `CODEGRAPH_PINNED_VERSION` const replaces the scattered `"1.0.1"` literals (provision options type, codex serve/session-start-worker/hook-types, opencode bootstrap hook, all test literals).
- **1.0.1-era store compatibility** (`test(codegraph)` commit): empirical proof with REAL binaries that 1.4.1 reads 1.0.1 project stores in place (status exit 0 `initialized:true`, `reindexRecommended:false`, sync no-op, queries answer; SessionStart hook reports `skipped-initialized` with zero spawns). No production change needed; two regression pins added (migrated-store status JSON + bounded hung-probe behavior).
- **Guidance parity** (`fix(codegraph)` commit): real-binary probe found 1.4.1 emits new uninitialized-project message shapes; `getCodegraphUninitializedProject` now extracts the project path from both. Update-check suppression: `DO_NOT_TRACK=1` (already set) is empirically sufficient; env unchanged.

## Key findings from the 1.4.1 probe (sha256-verified binary)

- Default `tools/list` surface is exactly `codegraph_explore` (with `projectPath`); `codegraph_node`/`codegraph_search`/`codegraph_callers` are hidden upstream but **remain callable** (verified live: `tools/call` returns correct results for both), so the Codex bridge surface is unaffected.
- New uninitialized message shapes: "No CodeGraph project is loaded for this session." and "The project at <path> isn't indexed with codegraph ..." — both now handled in guidance extraction.
- The 1.4.1 background update check is notification-only and fully suppressed by `DO_NOT_TRACK=1`.

## QA / evidence

All evidence on disk under `.omo/evidence/codegraph-daemon-process-hygiene/` (task-1 through task-4):

- TDD RED→GREEN for the manifest pin (assertion-level RED captured).
- Live provisioner run: downloads + checksum-verifies + `codegraph --version` prints `1.4.1`; corrupted sha256 rejected with `checksum mismatch`.
- Real 1.0.1 store -> real 1.4.1 binary migration transcript (status/sync/explore + hook `skipped-initialized`).
- `bun test packages/utils` 406 pass; codex codegraph component 59 pass; opencode bootstrap hook 18 pass.
- **Live adapter QA (wave-1 gate), all in strict isolation**:
  - codex (codex-qa skill, isolated CODEX_HOME + mock model): SessionStart provisions 1.4.1 + initializes fixture; `codegraph_explore` AND hidden `codegraph_search` answer through the plugin wrapper; degrade path prints CODEGRAPH_SKIP_HINT without crashing; real `~/.codex/config.toml` shasum + session counts identical before/after. QA also caught stale committed dist (still pinned 1.0.1) - fixed in the dist-rebuild commit in this PR.
  - opencode (opencode-qa skill, isolated XDG): codegraph MCP `connected`; real `codegraph_codegraph_explore` returns fixture source; real opencode.db session count 21875 -> 21875.
  - senpi: `bun run test:senpi` green (267); live senpi session (isolated SENPI_CODING_AGENT_DIR, worktree-built extension) invoked `mcp_codegraph_codegraph_explore` against a 1.4.1-indexed fixture; RPC-child skip pinned.

## Residual risk

- `packages/omo-opencode/src/tools/skill-mcp/constants.ts` still hints 8 codegraph_* tools while 1.4.1 lists 1 by default (tools remain callable; follow-up candidate, deliberately out of scope here).
- Stale `.provisioned/codegraph-1.0.1.json` markers are left in place (version-keyed markers force a one-time re-download; cleanup is a documented follow-up).

Plan: .omo/plans/codegraph-daemon-process-hygiene.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the vendored CodeGraph to 1.4.1 and align provision, guidance, and tests with upstream behavior. Rebuilt dist so we ship 1.4.1; confirmed 1.0.1 stores work as-is.

- **Dependencies**
  - Pin CodeGraph `1.4.1` via exported `CODEGRAPH_PINNED_VERSION` and update all call sites.
  - Refresh provision manifest with new URLs and sha256 for all platforms; keep Windows via npm `.tgz`.
  - Bump `@colbymchenry/codegraph` to `1.4.1`, regenerate the lockfile, and rebuild the component `dist`.

- **Bug Fixes**
  - Update guidance parsing for 1.4.1 outputs, including “not indexed,” “no project loaded,” and project path extraction.
  - Reflect the 1.4.1 `tools/list` surface (only `codegraph_explore`), while keeping hidden tools callable.
  - Harden cross‑platform tests: prove 1.4.1 reads 1.0.1 stores; add manifest pin tests; inherit system `PATH`/`SystemRoot` in win32 probes; make the hang probe block in `cmd.exe` stdin with bounded timeouts; retry probe‑dir cleanup.

<sup>Written for commit 44f56d504802e3cab15fad44e72855b018a12316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

