### PR TITLE
fix(lsp-daemon): report cancelled and timed-out requests accurately

### DIFF
--- a/packages/lsp-daemon/src/daemon-client.ts
+++ b/packages/lsp-daemon/src/daemon-client.ts
@@ -5,6 +5,13 @@ import { type LspRequestContext, parseLspRequestContext } from "@oh-my-opencode/
 import type { ToolExecutionResult } from "@oh-my-opencode/lsp-core/tools";
 import { isPlainRecord } from "@oh-my-opencode/mcp-stdio-core/record";
 
+import { daemonFailureResult } from "./daemon-failure-result.js";
+import {
+	DaemonAuthenticationRejectedError,
+	DaemonRequestCancelledError,
+	DaemonRequestError,
+	DaemonRequestTimedOutError,
+} from "./daemon-request-error.js";
 import { ensureDaemonRunning } from "./ensure-daemon.js";
 import { authEnvelope, isAuthErrorResponse, readAuthToken } from "./ipc-protocol.js";
 import { type DaemonPaths, daemonPaths } from "./paths.js";
@@ -13,29 +20,6 @@ import { createLineDecoder, encodeJsonLine } from "./socket-jsonrpc.js";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 let nextProxyRequestId = 1;
-
-export class DaemonRequestError extends Error {
-	readonly requestWritten: boolean;
-	constructor(message: string, requestWritten: boolean) {
-		super(message);
-		this.name = "DaemonRequestError";
-		this.requestWritten = requestWritten;
-	}
-}
-
-export class DaemonAuthenticationRejectedError extends DaemonRequestError {
-	constructor() {
-		super("daemon authentication failed before dispatch", true);
-		this.name = "DaemonAuthenticationRejectedError";
-	}
-}
-
-export class DaemonRequestCancelledError extends DaemonRequestError {
-	constructor(requestWritten: boolean) {
-		super("daemon request cancelled", requestWritten);
-		this.name = "DaemonRequestCancelledError";
-	}
-}
 
 export type DaemonToolContext = LspRequestContext;
 
@@ -83,7 +67,7 @@ export async function callToolViaDaemon(
 		}
 	}
 
-	return daemonUnreachableResult(paths, lastError);
+	return daemonFailureResult(paths, lastError);
 }
 
 export function callDiagnosticsViaDaemon(filePath: string, options: CallToolOptions): Promise<ToolExecutionResult> {
@@ -140,17 +124,6 @@ function ensureDaemonAvailable(
 	});
 }
 
-function daemonUnreachableResult(paths: DaemonPaths, error: unknown): ToolExecutionResult {
-	const text = [
-		`LSP daemon unreachable: ${errorText(error)}.`,
-		"The MCP server is a thin proxy and never runs language servers in-process.",
-		`Socket: ${paths.socket}`,
-		`Logs: ${paths.log}`,
-		"The daemon is auto-started on demand and will be retried on the next request.",
-	].join("\n");
-	return { content: [{ type: "text", text }], isError: true };
-}
-
 function sendToolCall(
 	paths: DaemonPaths,
 	token: string,
@@ -195,7 +168,7 @@ function sendToolCall(
 		};
 		const timer = setTimeout(() => {
 			sendCancel();
-			finish(() => reject(new DaemonRequestError("daemon request timed out", requestWritten)));
+			finish(() => reject(new DaemonRequestTimedOutError(requestWritten, options.timeoutMs)));
 		}, options.timeoutMs);
 		timer.unref();
 		if (options.signal?.aborted) {
@@ -252,8 +225,4 @@ function allocateProxyRequestId(): number {
 
 function isRetryableTool(name: string): boolean {
 	return name !== "rename" && name !== "lsp_rename";
-}
-
-function errorText(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
 }

--- a/packages/lsp-daemon/src/daemon-failure-result.ts
+++ b/packages/lsp-daemon/src/daemon-failure-result.ts
@@ -1,0 +1,44 @@
+import type { ToolExecutionResult } from "@oh-my-opencode/lsp-core/tools";
+
+import { DaemonRequestCancelledError, DaemonRequestTimedOutError } from "./daemon-request-error.js";
+import type { DaemonPaths } from "./paths.js";
+
+export function daemonFailureResult(paths: DaemonPaths, error: unknown): ToolExecutionResult {
+	if (error instanceof DaemonRequestCancelledError) return daemonCancelledResult(paths);
+	if (error instanceof DaemonRequestTimedOutError) return daemonTimedOutResult(paths, error.timeoutMs);
+	return daemonUnreachableResult(paths, error);
+}
+
+function daemonCancelledResult(paths: DaemonPaths): ToolExecutionResult {
+	const text = [
+		"LSP daemon request cancelled: the caller aborted this request (for example, the turn was interrupted).",
+		"The daemon stays available; no LSP work was applied. Retry when you are ready.",
+		`Socket: ${paths.socket}`,
+	].join("\n");
+	return { content: [{ type: "text", text }], isError: true };
+}
+
+function daemonTimedOutResult(paths: DaemonPaths, timeoutMs: number): ToolExecutionResult {
+	const text = [
+		`LSP daemon request timed out after ${timeoutMs}ms: the daemon did not respond in time.`,
+		"The daemon stays available but may be busy. Retry when you are ready.",
+		`Socket: ${paths.socket}`,
+		`Logs: ${paths.log}`,
+	].join("\n");
+	return { content: [{ type: "text", text }], isError: true };
+}
+
+function daemonUnreachableResult(paths: DaemonPaths, error: unknown): ToolExecutionResult {
+	const text = [
+		`LSP daemon unreachable: ${errorText(error)}.`,
+		"The MCP server is a thin proxy and never runs language servers in-process.",
+		`Socket: ${paths.socket}`,
+		`Logs: ${paths.log}`,
+		"The daemon is auto-started on demand and will be retried on the next request.",
+	].join("\n");
+	return { content: [{ type: "text", text }], isError: true };
+}
+
+function errorText(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/lsp-daemon/src/daemon-request-error.ts
+++ b/packages/lsp-daemon/src/daemon-request-error.ts
@@ -1,0 +1,31 @@
+export class DaemonRequestError extends Error {
+	readonly requestWritten: boolean;
+	constructor(message: string, requestWritten: boolean) {
+		super(message);
+		this.name = "DaemonRequestError";
+		this.requestWritten = requestWritten;
+	}
+}
+
+export class DaemonAuthenticationRejectedError extends DaemonRequestError {
+	constructor() {
+		super("daemon authentication failed before dispatch", true);
+		this.name = "DaemonAuthenticationRejectedError";
+	}
+}
+
+export class DaemonRequestCancelledError extends DaemonRequestError {
+	constructor(requestWritten: boolean) {
+		super("daemon request cancelled", requestWritten);
+		this.name = "DaemonRequestCancelledError";
+	}
+}
+
+export class DaemonRequestTimedOutError extends DaemonRequestError {
+	readonly timeoutMs: number;
+	constructor(requestWritten: boolean, timeoutMs: number) {
+		super("daemon request timed out", requestWritten);
+		this.name = "DaemonRequestTimedOutError";
+		this.timeoutMs = timeoutMs;
+	}
+}

--- a/packages/lsp-daemon/test/daemon-client-retry.test.ts
+++ b/packages/lsp-daemon/test/daemon-client-retry.test.ts
@@ -87,14 +87,14 @@ function recordMessages(socket: Socket, recorder: ReturnType<typeof createMessag
 	socket.on("data", (chunk: Buffer) => decoder.push(chunk));
 }
 
-	describe("daemon-client retry discipline", () => {
-		it("#given a server that never answers in time #when the call times out #then the request is executed exactly once", async () => {
-			const paths = tempPaths();
-			let requestCount = 0;
-			const server = createServer((socket) => {
-				const decoder = createLineDecoder(() => {
-					requestCount += 1;
-				});
+describe("daemon-client retry discipline", () => {
+	it("#given a server that never answers in time #when the call times out #then the request is executed exactly once", async () => {
+		const paths = tempPaths();
+		let requestCount = 0;
+		const server = createServer((socket) => {
+			const decoder = createLineDecoder(() => {
+				requestCount += 1;
+			});
 			socket.on("data", (chunk) => decoder.push(chunk));
 		});
 		servers.push(server);
@@ -111,69 +111,77 @@ function recordMessages(socket: Socket, recorder: ReturnType<typeof createMessag
 			},
 		);
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0]?.text).toContain("daemon request timed out");
-			expect(requestCount).toBe(1);
-		});
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain("daemon request timed out");
+		expect(result.content[0]?.text).not.toContain("unreachable");
+		expect(requestCount).toBe(1);
+	});
 
-		it("#given a daemon request timeout #when request bytes were written #then an authenticated cancel is sent for the proxy id before close", async () => {
-			const paths = tempPaths();
-			const recorder = createMessageRecorder();
-			const server = createServer((socket) => {
-				recordMessages(socket, recorder);
+	it("#given a daemon request timeout #when request bytes were written #then an authenticated cancel is sent for the proxy id before close", async () => {
+		const paths = tempPaths();
+		const recorder = createMessageRecorder();
+		const server = createServer((socket) => {
+			recordMessages(socket, recorder);
+		});
+		servers.push(server);
+		await new Promise<void>((resolve) => server.listen(paths.socket, resolve));
+
+		const result = await callToolViaDaemon(
+			"status",
+			{},
+			{ paths, ensure: async () => {}, requestTimeoutMs: 50, context: defaultContext() },
+		);
+		await recorder.waitForCount(2);
+
+		const request = recorder.messages.find((message) => jsonRpcMethod(message) === "tools/call");
+		const cancel = recorder.messages.find((message) => jsonRpcMethod(message) === "$/cancelRequest");
+		expect(result.isError).toBe(true);
+		expect(jsonRpcId(request)).not.toBe(1);
+		expect(cancelTargetId(cancel)).toBe(jsonRpcId(request));
+		expect(extractToken(cancel)).toBe("retry-test-token");
+	});
+
+	it("#given a caller abort #when request bytes were written #then the daemon client sends authenticated cancellation for the same proxy id", async () => {
+		const paths = tempPaths();
+		const controller = new AbortController();
+		const recorder = createMessageRecorder();
+		const server = createServer((socket) => {
+			const decoder = createLineDecoder((message) => {
+				recorder.push(message);
+				if (jsonRpcMethod(message) === "tools/call") controller.abort();
 			});
-			servers.push(server);
-			await new Promise<void>((resolve) => server.listen(paths.socket, resolve));
-
-			const result = await callToolViaDaemon("status", {}, { paths, ensure: async () => {}, requestTimeoutMs: 50, context: defaultContext() });
-			await recorder.waitForCount(2);
-
-			const request = recorder.messages.find((message) => jsonRpcMethod(message) === "tools/call");
-			const cancel = recorder.messages.find((message) => jsonRpcMethod(message) === "$/cancelRequest");
-			expect(result.isError).toBe(true);
-			expect(jsonRpcId(request)).not.toBe(1);
-			expect(cancelTargetId(cancel)).toBe(jsonRpcId(request));
-			expect(extractToken(cancel)).toBe("retry-test-token");
+			socket.on("data", (chunk) => decoder.push(chunk));
 		});
+		servers.push(server);
+		await new Promise<void>((resolve) => server.listen(paths.socket, resolve));
 
-		it("#given a caller abort #when request bytes were written #then the daemon client sends authenticated cancellation for the same proxy id", async () => {
-			const paths = tempPaths();
-			const controller = new AbortController();
-			const recorder = createMessageRecorder();
-			const server = createServer((socket) => {
-				const decoder = createLineDecoder((message) => {
-					recorder.push(message);
-					if (jsonRpcMethod(message) === "tools/call") controller.abort();
-				});
-				socket.on("data", (chunk) => decoder.push(chunk));
+		const result = await callToolViaDaemon(
+			"status",
+			{},
+			{ paths, ensure: async () => {}, requestTimeoutMs: 100, signal: controller.signal, context: defaultContext() },
+		);
+		await recorder.waitForCount(2);
+
+		const request = recorder.messages.find((message) => jsonRpcMethod(message) === "tools/call");
+		const cancel = recorder.messages.find((message) => jsonRpcMethod(message) === "$/cancelRequest");
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain("cancelled");
+		expect(result.content[0]?.text).not.toContain("unreachable");
+		expect(cancelTargetId(cancel)).toBe(jsonRpcId(request));
+		expect(extractToken(cancel)).toBe("retry-test-token");
+	});
+
+	it("#given the socket appears only after the first connect failure #when retrying #then the second attempt succeeds with one delivered request", async () => {
+		const paths = tempPaths();
+		let requestCount = 0;
+		let ensureCallCount = 0;
+
+		const server = createServer((socket) => {
+			const decoder = createLineDecoder((message) => {
+				requestCount += 1;
+				const id = jsonRpcId(message);
+				socket.write(encodeJsonLine({ jsonrpc: "2.0", id, result: { content: [{ type: "text", text: "ok" }] } }));
 			});
-			servers.push(server);
-			await new Promise<void>((resolve) => server.listen(paths.socket, resolve));
-
-			const result = await callToolViaDaemon("status", {}, { paths, ensure: async () => {}, requestTimeoutMs: 100, signal: controller.signal, context: defaultContext() });
-			await recorder.waitForCount(2);
-
-			const request = recorder.messages.find((message) => jsonRpcMethod(message) === "tools/call");
-			const cancel = recorder.messages.find((message) => jsonRpcMethod(message) === "$/cancelRequest");
-			expect(result.isError).toBe(true);
-			expect(result.content[0]?.text).toContain("cancelled");
-			expect(cancelTargetId(cancel)).toBe(jsonRpcId(request));
-			expect(extractToken(cancel)).toBe("retry-test-token");
-		});
-
-		it("#given the socket appears only after the first connect failure #when retrying #then the second attempt succeeds with one delivered request", async () => {
-			const paths = tempPaths();
-			let requestCount = 0;
-			let ensureCallCount = 0;
-
-			const server = createServer((socket) => {
-				const decoder = createLineDecoder((message) => {
-					requestCount += 1;
-					const id = jsonRpcId(message);
-					socket.write(
-						encodeJsonLine({ jsonrpc: "2.0", id, result: { content: [{ type: "text", text: "ok" }] } }),
-					);
-				});
 			socket.on("data", (chunk) => decoder.push(chunk));
 		});
 		servers.push(server);
@@ -258,11 +266,11 @@ function recordMessages(socket: Socket, recorder: ReturnType<typeof createMessag
 	}) => {
 		const paths = tempPaths();
 		let requestCount = 0;
-			const server = createServer((socket) => {
-				const decoder = createLineDecoder((message) => {
-					requestCount += 1;
-					socket.write(encodeJsonLine({ jsonrpc: "2.0", id: jsonRpcId(message), result: invalidResult }));
-				});
+		const server = createServer((socket) => {
+			const decoder = createLineDecoder((message) => {
+				requestCount += 1;
+				socket.write(encodeJsonLine({ jsonrpc: "2.0", id: jsonRpcId(message), result: invalidResult }));
+			});
 			socket.on("data", (chunk) => decoder.push(chunk));
 		});
 		servers.push(server);
@@ -293,42 +301,46 @@ function recordMessages(socket: Socket, recorder: ReturnType<typeof createMessag
 				requestCount += 1;
 				const token = extractToken(message);
 				if (token) seenTokens.push(token);
-					if (requestCount === 1) {
-						writeFileSync(paths.auth, `${freshToken}\n`, { mode: 0o600 });
-						socket.write(
-							encodeJsonLine({
-								jsonrpc: "2.0",
-								id: jsonRpcId(message),
-								error: {
+				if (requestCount === 1) {
+					writeFileSync(paths.auth, `${freshToken}\n`, { mode: 0o600 });
+					socket.write(
+						encodeJsonLine({
+							jsonrpc: "2.0",
+							id: jsonRpcId(message),
+							error: {
 								code: -32001,
 								message: "daemon authentication failed",
 								data: { code: "daemon_authentication_failed" },
 							},
 						}),
 					);
-						return;
-					}
-					socket.write(
-						encodeJsonLine({
-							jsonrpc: "2.0",
-							id: jsonRpcId(message),
-							result: { content: [{ type: "text", text: "ok" }] },
-						}),
-					);
-				});
+					return;
+				}
+				socket.write(
+					encodeJsonLine({
+						jsonrpc: "2.0",
+						id: jsonRpcId(message),
+						result: { content: [{ type: "text", text: "ok" }] },
+					}),
+				);
+			});
 			socket.on("data", (chunk) => decoder.push(chunk));
 		});
 		servers.push(server);
 		await new Promise<void>((resolve) => server.listen(paths.socket, resolve));
 
-		const result = await callToolViaDaemon("status", {}, { paths, ensure: async () => {}, requestTimeoutMs: 2000, context: defaultContext() });
+		const result = await callToolViaDaemon(
+			"status",
+			{},
+			{ paths, ensure: async () => {}, requestTimeoutMs: 2000, context: defaultContext() },
+		);
 
 		expect(result.content[0]?.text).toBe("ok");
 		expect(requestCount).toBe(2);
 		expect(seenTokens).toEqual(["retry-test-token", freshToken]);
 		expect(readFileSync(paths.auth, "utf8").trim()).toBe(freshToken);
 	});
-	});
+});
 
 function extractToken(message: unknown): string | null {
 	if (!message || typeof message !== "object" || Array.isArray(message)) return null;

--- a/packages/lsp-daemon/test/daemon-failure-result.test.ts
+++ b/packages/lsp-daemon/test/daemon-failure-result.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { daemonFailureResult } from "../src/daemon-failure-result.js";
+import {
+	DaemonAuthenticationRejectedError,
+	DaemonRequestCancelledError,
+	DaemonRequestError,
+	DaemonRequestTimedOutError,
+} from "../src/daemon-request-error.js";
+import { daemonTestPaths } from "./daemon-path-fixture.js";
+
+const paths = daemonTestPaths("/tmp/lsp-daemon-failure-result");
+
+function failureText(error: unknown): string {
+	const result = daemonFailureResult(paths, error);
+	expect(result.isError).toBe(true);
+	return result.content[0]?.text ?? "";
+}
+
+describe("daemonFailureResult", () => {
+	it("#given a caller-cancelled request #when mapping the failure #then it reports cancellation, not unreachability", () => {
+		const text = failureText(new DaemonRequestCancelledError(true));
+
+		expect(text).toContain("cancelled");
+		expect(text).not.toContain("unreachable");
+		expect(text).not.toContain("timed out");
+	});
+
+	it("#given a timed-out request #when mapping the failure #then it reports the timeout budget, not unreachability", () => {
+		const text = failureText(new DaemonRequestTimedOutError(true, 30_000));
+
+		expect(text).toContain("timed out");
+		expect(text).toContain("30000ms");
+		expect(text).not.toContain("unreachable");
+	});
+
+	it("#given a genuine transport failure #when mapping the failure #then it still reports the daemon as unreachable", () => {
+		const text = failureText(new DaemonRequestError("daemon connection closed", true));
+
+		expect(text).toContain("unreachable");
+		expect(text).toContain("daemon connection closed");
+	});
+
+	it("#given an authentication rejection #when mapping the failure #then it reports unreachability, not cancellation or timeout", () => {
+		const text = failureText(new DaemonAuthenticationRejectedError());
+
+		expect(text).toContain("unreachable");
+		expect(text).not.toContain("cancelled");
+		expect(text).not.toContain("timed out");
+	});
+
+	it("#given a non-Error rejection value #when mapping the failure #then it stringifies the cause into the unreachable report", () => {
+		const text = failureText("socket vanished");
+
+		expect(text).toContain("unreachable");
+		expect(text).toContain("socket vanished");
+	});
+});


### PR DESCRIPTION
## Summary
LSP tool calls that were **cancelled by the caller** (e.g. a turn interrupted mid LSP fan-out) or that **timed out** were surfaced to the agent as `LSP daemon unreachable: <cause>`. That wording implies the shared per-user daemon crashed, when it actually stayed reachable and only the single request ended early — which recently misled a session into reporting a local LSP daemon connection failure that never happened. `callToolViaDaemon` now classifies the terminal failure and labels cancellation and timeout accurately, reserving "unreachable" for genuine transport/startup failures.

## Changes
- **Accurate failure labels** (`packages/lsp-daemon/src/daemon-failure-result.ts`, new): `daemonFailureResult()` routes a caller-cancelled request to a "request cancelled — the daemon stays available" message, a timed-out request to a "request timed out after <ms>ms" message, and every other failure to the unchanged "unreachable" message.
- **Typed timeout error** (`daemon-request-error.ts`, new): the four daemon request error classes now live in one file; adds `DaemonRequestTimedOutError` carrying the timeout budget.
- **Client rewire** (`daemon-client.ts`): imports the extracted taxonomy + mapping, throws `DaemonRequestTimedOutError` on timeout, and returns `daemonFailureResult(...)` at the terminal. The split keeps the file under the 250 pure-LOC ceiling (237 -> 211); no public export removed.

## QA & Evidence
- **Socket-integration** (`test/daemon-client-retry.test.ts`): strengthened the caller-abort and timeout cases to assert the text is **not** "unreachable". RED before (`expected 'LSP daemon unreachable: daemon request timed out.' not to contain 'unreachable'`), GREEN after.
- **Classifier unit** (`test/daemon-failure-result.test.ts`, new): cancelled / timed-out / genuine-unreachable + auth-rejection + non-Error-cause guards. Mutation-checked: forcing the classifier to always return unreachable failed exactly the cancel/timeout assertions and nothing else.
- **Real-surface driver** (`scripts/qa/cancellation-smoke.mjs`, live unix socket + request-routing + fake-LSP `$/cancelRequest`): now returns `LSP daemon request cancelled: the caller aborted this request ... The daemon stays available; no LSP work was applied.` with `daemonActiveRequestsAfter: 0`.
- **Gates**: full `packages/lsp-daemon` vitest 133/133; `tsc --noEmit` clean; biome clean on all changed files.
- Evidence: `.omo/evidence/20260721-lsp-daemon-failure-labels/`.

## Risks & Residuals
- Change is limited to the message + which result builder is returned for terminal failures; `isError: true` and the retry/cancel/timeout control flow are unchanged, and genuine transport/startup failures still report "unreachable" (test-guarded). Shared runtime contract for Codex/OpenCode/Senpi preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LSP daemon error reporting so cancelled and timed-out requests are labeled correctly instead of “unreachable,” avoiding false daemon-failure reports. Adds a typed timeout error and centralizes failure-to-result mapping to keep `daemon-client` small and clear.

- Bug Fixes
  - Classify cancellation and timeout and show precise messages; include timeout budget in text.
  - Reserve “unreachable” for real transport/startup failures only.

- Refactors
  - Extracted error types to `packages/lsp-daemon/src/daemon-request-error.ts` (adds `DaemonRequestTimedOutError`).
  - Moved failure mapping to `packages/lsp-daemon/src/daemon-failure-result.ts`; `callToolViaDaemon` returns `daemonFailureResult(...)`.
  - Strengthened tests to assert cancel/timeout are not labeled “unreachable.”

<sup>Written for commit 9c7d4c1dfa7937f7c5045ea1fd36e43b9a4ce48a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

