### PR TITLE
fix(senpi-task): cross-process false-lost clobbering + silent empty child completions

### DIFF
--- a/packages/senpi-task/src/lifecycle/__fixtures__/lifecycle-fakes.ts
+++ b/packages/senpi-task/src/lifecycle/__fixtures__/lifecycle-fakes.ts
@@ -34,6 +34,7 @@ export type SeedInput = {
   readonly updated_at?: string
   readonly pid?: number
   readonly child_session_id?: string
+  readonly host_pid?: number
 }
 
 // Write a persisted record at an exact status/residency/timestamp so lifecycle logic can be driven
@@ -55,6 +56,7 @@ export function seedRecord(store: TaskRecordStore, input: SeedInput): TaskRecord
     notification: { run_epoch: 0, notified_epoch: -1 },
     ...(input.pid !== undefined ? { pid: input.pid } : {}),
     ...(input.child_session_id !== undefined ? { child_session_id: input.child_session_id } : {}),
+    ...(input.host_pid !== undefined ? { host_pid: input.host_pid } : {}),
   }
   store.save(record)
   return record

--- a/packages/senpi-task/src/lifecycle/context.ts
+++ b/packages/senpi-task/src/lifecycle/context.ts
@@ -14,6 +14,7 @@ export type LifecycleContext = {
   readonly now: () => number
   readonly signaller: ProcessSignaller
   readonly orphanKillDelayMs: number
+  readonly hostPid: number
   readonly reattachPorts: LifecycleReattachPorts | undefined
 }
 
@@ -46,6 +47,7 @@ export function resolveContext(deps: LifecycleDeps): LifecycleContext {
     now: deps.now ?? Date.now,
     signaller: deps.signaller ?? defaultSignaller,
     orphanKillDelayMs: deps.orphanKillDelayMs ?? DEFAULT_ORPHAN_KILL_DELAY_MS,
+    hostPid: deps.hostPid ?? process.pid,
     reattachPorts: injectedLifecycleReattachPorts(deps),
   }
 }

--- a/packages/senpi-task/src/lifecycle/port.ts
+++ b/packages/senpi-task/src/lifecycle/port.ts
@@ -79,6 +79,9 @@ export type LifecycleDeps = {
   readonly reattach?: ReattachPort
   // Delay before escalating an orphan SIGTERM to SIGKILL during reconciliation. Defaults to 5s.
   readonly orphanKillDelayMs?: number
+  // Pid of THIS host process. Defaults to process.pid; injectable so reconciliation tests can
+  // simulate cross-process ownership deterministically.
+  readonly hostPid?: number
 }
 
 export function injectedLifecycleReattachPorts(deps: LifecycleDeps): LifecycleReattachPorts | undefined {

--- a/packages/senpi-task/src/lifecycle/reconcile.test.ts
+++ b/packages/senpi-task/src/lifecycle/reconcile.test.ts
@@ -16,6 +16,7 @@ import {
   cleanupProjects,
   fakeHandle,
   FakeRegistry,
+  readEvents,
   seedRecord,
   settings,
   tempStore,
@@ -518,5 +519,98 @@ describe("reconcileOnSessionStart reattach", () => {
     inProcess.handles.get(firstQueued.task_id)?.settle({ status: "completed", finalResponse: "done" })
     await flush()
     expect(store.load(secondQueued.task_id)?.status).toBe("running")
+  })
+})
+
+
+describe("reconcileOnSessionStart cross-process ownership", () => {
+  const foreignPid = 4242
+  const thisPid = 1111
+
+  function crossProcessHarness(options: { readonly host_pid?: number; readonly ownerAlive: boolean }) {
+    const store = tempStore()
+    seedRecord(store, {
+      task_id: "st_00000021",
+      status: "running",
+      residency_state: "resident",
+      execution_mode: "in-process",
+      ...(options.host_pid === undefined ? {} : { host_pid: options.host_pid }),
+    })
+    const alive = options.ownerAlive && options.host_pid !== undefined ? new Set([options.host_pid]) : new Set<number>()
+    const lifecycle = createTaskLifecycle({
+      store,
+      registry: new FakeRegistry(),
+      config: settings(),
+      now,
+      signaller: fakeSignaller(alive, []),
+      hostPid: thisPid,
+    })
+    return { store, lifecycle }
+  }
+
+  test("#given a running in-process record owned by a LIVE foreign process #when reconciled #then it is skipped and stays running", async () => {
+    // given a sibling senpi process in the same project still owns this child
+    const { store, lifecycle } = crossProcessHarness({ host_pid: foreignPid, ownerAlive: true })
+
+    // when
+    const result = await lifecycle.reconcileOnSessionStart()
+
+    // then the sibling's live child is never falsely declared lost
+    expect(result.outcomes[0]?.kind).toBe("foreign_live_owner")
+    const record = store.load("st_00000021")
+    expect(record?.status).toBe("running")
+    expect(record?.residency_state).toBe("resident")
+    expect(readEvents(store, "st_00000021")).not.toContain("reconcile_lost")
+  })
+
+  test("#given a running in-process record whose owner process is DEAD #when reconciled #then it is lost as before", async () => {
+    // given
+    const { store, lifecycle } = crossProcessHarness({ host_pid: foreignPid, ownerAlive: false })
+
+    // when
+    const result = await lifecycle.reconcileOnSessionStart()
+
+    // then
+    expect(result.outcomes[0]?.kind).toBe("lost")
+    expect(store.load("st_00000021")?.status).toBe("lost")
+  })
+
+  test("#given a legacy running in-process record with no host_pid #when reconciled #then it is lost as before", async () => {
+    // given a record persisted before owner pids were recorded
+    const { store, lifecycle } = crossProcessHarness({ ownerAlive: false })
+
+    // when
+    const result = await lifecycle.reconcileOnSessionStart()
+
+    // then
+    expect(result.outcomes[0]?.kind).toBe("lost")
+    expect(store.load("st_00000021")?.status).toBe("lost")
+  })
+
+  test("#given a running in-process record owned by THIS process with no live handle #when reconciled #then it is lost", async () => {
+    // given a record this process created whose handle is gone
+    const store = tempStore()
+    seedRecord(store, {
+      task_id: "st_00000022",
+      status: "running",
+      residency_state: "resident",
+      execution_mode: "in-process",
+      host_pid: thisPid,
+    })
+    const lifecycle = createTaskLifecycle({
+      store,
+      registry: new FakeRegistry(),
+      config: settings(),
+      now,
+      signaller: fakeSignaller(new Set([thisPid]), []),
+      hostPid: thisPid,
+    })
+
+    // when
+    const result = await lifecycle.reconcileOnSessionStart()
+
+    // then a same-process record without a handle is genuinely unreachable
+    expect(result.outcomes[0]?.kind).toBe("lost")
+    expect(store.load("st_00000022")?.status).toBe("lost")
   })
 })

--- a/packages/senpi-task/src/lifecycle/reconcile.ts
+++ b/packages/senpi-task/src/lifecycle/reconcile.ts
@@ -29,6 +29,18 @@ async function reconcileRecord(context: LifecycleContext, record: TaskRecord): P
   }
 
   if (record.execution_mode !== "process") {
+    // The project store is shared by every senpi process in this project. A record owned by a LIVE
+    // sibling process is not orphaned: marking it lost here would clobber that process's running
+    // child (its completion would then be dropped as a late transition). Only a dead owner - or a
+    // legacy record with no owner pid - is genuinely unreachable from any process.
+    const ownerPid = record.host_pid
+    if (ownerPid !== undefined && ownerPid !== context.hostPid && context.signaller.isAlive(ownerPid)) {
+      return {
+        task_id: record.task_id,
+        kind: "foreign_live_owner",
+        reason: `in-process child owned by live process pid=${ownerPid}`,
+      }
+    }
     await markLost(context, record, "in-process task from a previous process cannot be reattached")
     return { task_id: record.task_id, kind: "lost", reason: "previous-process in-process" }
   }

--- a/packages/senpi-task/src/lifecycle/ttl.test.ts
+++ b/packages/senpi-task/src/lifecycle/ttl.test.ts
@@ -145,3 +145,46 @@ describe("cleanupExpiredRecords (TTL)", () => {
     expect(existsSync(recordPath(store, "st_00000006"))).toBe(false)
   })
 })
+
+describe("cleanupExpiredRecords (TTL) cross-process ownership", () => {
+  test("#given an expired resident record owned by a LIVE foreign process #when cleaning #then it is retained", () => {
+    // given a sibling senpi process still holds this child resident (revivable)
+    const store = tempStore()
+    seedRecord(store, { task_id: "st_00000010", status: "completed", residency_state: "resident", updated_at: iso(TTL + 1000), host_pid: 4242 })
+    const lifecycle = createTaskLifecycle({
+      store,
+      registry: new FakeRegistry(),
+      config: settings({ ttl_ms: TTL }),
+      now,
+      signaller: aliveSignaller(new Set([4242])),
+      hostPid: 1111,
+    })
+
+    // when
+    const result = lifecycle.cleanupExpiredRecords()
+
+    // then deleting it would orphan the sibling's live handle and let late appends recreate the log
+    expect(result.retained).toContain("st_00000010")
+    expect(existsSync(recordPath(store, "st_00000010"))).toBe(true)
+  })
+
+  test("#given an expired resident record whose foreign owner is DEAD #when cleaning #then it is deleted", () => {
+    // given
+    const store = tempStore()
+    seedRecord(store, { task_id: "st_00000011", status: "completed", residency_state: "resident", updated_at: iso(TTL + 1000), host_pid: 4242 })
+    const lifecycle = createTaskLifecycle({
+      store,
+      registry: new FakeRegistry(),
+      config: settings({ ttl_ms: TTL }),
+      now,
+      signaller: aliveSignaller(new Set()),
+      hostPid: 1111,
+    })
+
+    // when
+    const result = lifecycle.cleanupExpiredRecords()
+
+    // then
+    expect(result.deleted).toContain("st_00000011")
+  })
+})

--- a/packages/senpi-task/src/lifecycle/ttl.ts
+++ b/packages/senpi-task/src/lifecycle/ttl.ts
@@ -7,6 +7,8 @@ import type { CleanupResult } from "./types"
  * `lost` process record is NEVER deleted without pid-dead proof (its breadcrumbs may still be
  * needed). Records with a live resident handle in this process are also retained: deleting them
  * would orphan an in-memory handle and allow late transcript appends to recreate the deleted log.
+ * The same protection extends across processes: a resident record owned by a LIVE sibling process
+ * (host_pid alive) is that process's revivable handle and must not be expunged from under it.
  */
 export function cleanupExpiredRecords(context: LifecycleContext): CleanupResult {
   const deleted: string[] = []
@@ -26,10 +28,20 @@ export function cleanupExpiredRecords(context: LifecycleContext): CleanupResult 
 
 function isExpungeable(context: LifecycleContext, record: TaskRecord, cutoff: number): boolean {
   if (context.registry.get(record.task_id) !== undefined) return false
+  if (hasLiveForeignOwner(context, record)) return false
   if (!TERMINAL_STATUSES.has(record.status)) return false
   if (Date.parse(record.updated_at) > cutoff) return false
   if (record.status === "lost" && record.execution_mode === "process") {
     return record.pid !== undefined && !context.signaller.isAlive(record.pid)
   }
   return true
+}
+
+function hasLiveForeignOwner(context: LifecycleContext, record: TaskRecord): boolean {
+  return (
+    record.residency_state === "resident" &&
+    record.host_pid !== undefined &&
+    record.host_pid !== context.hostPid &&
+    context.signaller.isAlive(record.host_pid)
+  )
 }

--- a/packages/senpi-task/src/lifecycle/types.ts
+++ b/packages/senpi-task/src/lifecycle/types.ts
@@ -6,7 +6,7 @@ export type AdmissionResult =
   | { readonly kind: "evicted"; readonly evicted_task_id: string }
   | { readonly kind: "rejected"; readonly error: AgentLimitReached }
 
-export type ReconcileOutcomeKind = "resumed" | "lost" | "lost_and_terminated"
+export type ReconcileOutcomeKind = "resumed" | "lost" | "lost_and_terminated" | "foreign_live_owner"
 
 export type ReconcileOutcome = {
   readonly task_id: string

--- a/packages/senpi-task/src/manager/manager.ts
+++ b/packages/senpi-task/src/manager/manager.ts
@@ -98,6 +98,7 @@ function publicStartFailureMessage(error: unknown): string {
 class TaskManagerImpl implements TaskManager {
   readonly #options: TaskManagerImplOptions
   readonly #now: () => number
+  readonly #hostPid: number
   readonly #concurrency: TaskConcurrency
   readonly #rpcRespawnRunner: RpcRespawnRunner
   readonly #names = new NameRegistry()
@@ -130,6 +131,7 @@ class TaskManagerImpl implements TaskManager {
       log("senpi-task manager failed to seed task id floor", { error: String(error) })
     }
     this.#now = options.now ?? Date.now
+    this.#hostPid = options.hostPid ?? process.pid
     this.#rpcRespawnRunner = options.rpcRespawnRunner ?? new RpcProcessRunner()
     this.#concurrency = new TaskConcurrency({
       default_concurrency: options.config.default_concurrency,
@@ -200,7 +202,7 @@ class TaskManagerImpl implements TaskManager {
     let claimed: TaskRecord
     try {
       const draft = createTaskRecord(buildRecordInput({ spec, plan, name: "", executionMode }), this.#now())
-      const claimDraft: TaskRecord = { ...draft, name: requestedRegistration?.name ?? draft.task_id }
+      const claimDraft: TaskRecord = { ...draft, name: requestedRegistration?.name ?? draft.task_id, host_pid: this.#hostPid }
       claimed = claimTaskRecord(this.#options.store, claimDraft, {
         nameFollowsId: requestedRegistration === undefined,
         ...(requestedRegistration === undefined
@@ -434,6 +436,7 @@ class TaskManagerImpl implements TaskManager {
         this.#options.store.replace({
           ...record,
           residency_state: "resident",
+          host_pid: this.#hostPid,
           updated_at: nowIso(this.#now),
           ...(handle.pid === undefined ? {} : { pid: handle.pid }),
         })
@@ -445,6 +448,7 @@ class TaskManagerImpl implements TaskManager {
         ...rest,
         status: "running",
         residency_state: "resident",
+        host_pid: this.#hostPid,
         updated_at: nowIso(this.#now),
         notification: { ...record.notification, run_epoch: record.notification.run_epoch + 1 },
         ...(handle.pid === undefined ? {} : { pid: handle.pid }),

--- a/packages/senpi-task/src/manager/transcript-log.test.ts
+++ b/packages/senpi-task/src/manager/transcript-log.test.ts
@@ -103,3 +103,22 @@ describe("subscribeTranscriptLog", () => {
     expect(unsubscribed).toBe(true)
   })
 })
+
+describe("logTranscriptEvent child errors", () => {
+  test("#given an assistant message_end carrying a stopReason error #when logged #then a child_error transcript event is appended with the diagnostic", () => {
+    // given a provider failure surfaced as an assistant message with stopReason error
+    const store = recordingStore()
+    const event: ManagedChildEvent = {
+      type: "message_end",
+      message: { role: "assistant", content: [], stopReason: "error", errorMessage: "upstream gateway timeout" },
+    }
+
+    // when
+    logTranscriptEvent(store, "st_3", event)
+
+    // then the failure leaves a transcript breadcrumb instead of vanishing
+    expect(store.appended.length).toBe(1)
+    expect(store.appended[0]?.event.type).toBe("child_error")
+    expect(store.appended[0]?.event.payload).toEqual({ message: "upstream gateway timeout", stop_reason: "error" })
+  })
+})

--- a/packages/senpi-task/src/manager/transcript-log.ts
+++ b/packages/senpi-task/src/manager/transcript-log.ts
@@ -6,14 +6,16 @@ import type { ManagedChildEvent, ManagedChildHandle } from "./child-handle"
 // names are the contract between writer and reader.
 export const TRANSCRIPT_ASSISTANT_EVENT = "assistant_message"
 export const TRANSCRIPT_TOOL_EVENT = "tool_execution"
+export const TRANSCRIPT_ERROR_EVENT = "child_error"
 
 export type TranscriptLogStore = {
   readonly appendEvent: (taskId: string, event: PersistedTaskEvent) => string
 }
 
-// Persist the transcript-relevant slice of a child event: assistant prose from message_end and a
-// tool marker from tool_execution_end. Every other event (user/tool-result messages, lifecycle,
-// tool_execution_start) is ignored so the log stays a clean assistant/tool transcript.
+// Persist the transcript-relevant slice of a child event: assistant prose from message_end, a tool
+// marker from tool_execution_end, and a child_error breadcrumb when the assistant message carries a
+// stopReason "error" diagnostic (otherwise a failed turn leaves NO trace and task_output reads an
+// empty transcript). Every other event is ignored so the log stays a clean transcript.
 export function logTranscriptEvent(store: TranscriptLogStore, taskId: string, event: ManagedChildEvent): void {
   const persisted = toPersistedEvent(event)
   if (persisted !== undefined) store.appendEvent(taskId, persisted)
@@ -27,6 +29,8 @@ export function subscribeTranscriptLog(handle: ManagedChildHandle, store: Transc
 
 function toPersistedEvent(event: ManagedChildEvent): PersistedTaskEvent | undefined {
   if (event.type === "message_end") {
+    const failure = assistantFailure(event.message)
+    if (failure !== undefined) return { type: TRANSCRIPT_ERROR_EVENT, payload: failure }
     const text = assistantText(event.message)
     return text === undefined ? undefined : { type: TRANSCRIPT_ASSISTANT_EVENT, payload: { text } }
   }
@@ -34,6 +38,15 @@ function toPersistedEvent(event: ManagedChildEvent): PersistedTaskEvent | undefi
     return { type: TRANSCRIPT_TOOL_EVENT, payload: { tool: event.toolName, is_error: event.isError === true } }
   }
   return undefined
+}
+
+function assistantFailure(message: unknown): { readonly message: string; readonly stop_reason: string } | undefined {
+  if (!isRecord(message) || message.role !== "assistant") return undefined
+  if (message.stopReason !== "error") return undefined
+  const diagnostic = typeof message.errorMessage === "string" && message.errorMessage.length > 0
+    ? message.errorMessage
+    : "child turn failed without a diagnostic message"
+  return { message: diagnostic, stop_reason: "error" }
 }
 
 function assistantText(message: unknown): string | undefined {

--- a/packages/senpi-task/src/manager/types.ts
+++ b/packages/senpi-task/src/manager/types.ts
@@ -167,6 +167,9 @@ export type TaskManagerOptions = {
   // Resolves launch inputs from the current runtime. Persisted task records never supply executable
   // extensions or environment during a respawn.
   readonly trustedRespawnLaunch?: TrustedRespawnLaunchResolver
+  // Pid recorded as host_pid on every claimed record so sibling processes sharing the project store
+  // can tell a live owner from a dead one. Defaults to process.pid; injectable for tests.
+  readonly hostPid?: number
 }
 
 export type TaskManager = {

--- a/packages/senpi-task/src/runners/in-process.test.ts
+++ b/packages/senpi-task/src/runners/in-process.test.ts
@@ -161,10 +161,10 @@ describe("InProcessRunner", () => {
 
   test("#given a completing child #when idle #then the last assistant text is extracted", async () => {
     const fake = createFakeSession()
-    fake.lastText.value = "final answer"
     const runner = new InProcessRunner({ createSession: async () => fake.session })
     const handle = await runner.start(baseSpec())
 
+    fake.lastText.value = "final answer"
     fake.resolvePrompt()
     const outcome = await handle.waitForIdle()
 

--- a/packages/senpi-task/src/runners/in-process/child-handle-outcome.test.ts
+++ b/packages/senpi-task/src/runners/in-process/child-handle-outcome.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test"
+
+import { createChildHandle, type ChildSession, type ChildSessionEvent, type ChildSessionListener } from "./child-handle"
+
+type EmittingSessionControls = {
+  readonly session: ChildSession
+  readonly lastText: { value: string | undefined }
+  emit(event: ChildSessionEvent): void
+  resolvePrompt(): void
+}
+
+// Controllable ChildSession that also emits subscribed events, so turn outcomes can be driven the
+// way a real senpi AgentSession drives them: message_end events first, then prompt() resolution.
+function createEmittingSession(sessionId = "child-session-1"): EmittingSessionControls {
+  const listeners = new Set<ChildSessionListener>()
+  const lastText = { value: undefined as string | undefined }
+  let settle: (() => void) | undefined
+  const session: ChildSession = {
+    sessionId,
+    prompt() {
+      return new Promise<void>((resolve) => {
+        settle = resolve
+      })
+    },
+    async steer() {},
+    async followUp() {},
+    async abort() {},
+    subscribe(listener: ChildSessionListener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    getLastAssistantText() {
+      return lastText.value
+    },
+    dispose() {},
+  }
+  return {
+    session,
+    lastText,
+    emit: (event) => {
+      for (const listener of listeners) listener(event)
+    },
+    resolvePrompt: () => settle?.(),
+  }
+}
+
+function assistantEnd(text: string, stopReason: string, errorMessage?: string): ChildSessionEvent {
+  return {
+    type: "message_end",
+    message: {
+      role: "assistant",
+      content: text.length > 0 ? [{ type: "text", text }] : [],
+      stopReason,
+      ...(errorMessage === undefined ? {} : { errorMessage }),
+    },
+  } as ChildSessionEvent
+}
+
+describe("createChildHandle turn outcomes", () => {
+  test("#given a turn ending with a stopReason error message #when the prompt resolves #then the outcome is an error carrying the provider message", async () => {
+    // given a child whose provider request failed; senpi surfaces this as an event, prompt() resolves cleanly
+    const fake = createEmittingSession()
+    const handle = createChildHandle({ taskId: "task-1", session: fake.session, promptText: "review this" })
+
+    // when the failed turn settles
+    fake.emit(assistantEnd("", "error", "upstream gateway timeout"))
+    fake.resolvePrompt()
+    const outcome = await handle.waitForIdle()
+
+    // then the failure is NOT recorded as a silent empty completion
+    expect(outcome.status).toBe("error")
+    if (outcome.status !== "error") throw new Error("expected error outcome")
+    expect(outcome.failure.message).toContain("upstream gateway timeout")
+  })
+
+  test("#given a turn that produces no assistant output at all #when the prompt resolves #then the outcome is an error, never completed with empty text", async () => {
+    // given a child that hung and settled without a single assistant message
+    const fake = createEmittingSession()
+    const handle = createChildHandle({ taskId: "task-1", session: fake.session, promptText: "review this" })
+
+    // when the silent turn settles
+    fake.resolvePrompt()
+    const outcome = await handle.waitForIdle()
+
+    // then
+    expect(outcome.status).toBe("error")
+    if (outcome.status !== "error") throw new Error("expected error outcome")
+    expect(outcome.failure.message).toContain("no assistant output")
+  })
+
+  test("#given a revived child whose new turn produces nothing #when the revive turn resolves #then the stale previous response is NOT reused as a fresh completion", async () => {
+    // given a first turn that completed with real output
+    const fake = createEmittingSession()
+    const handle = createChildHandle({ taskId: "task-1", session: fake.session, promptText: "first run" })
+    fake.emit(assistantEnd("first verdict", "stop"))
+    fake.lastText.value = "first verdict"
+    fake.resolvePrompt()
+    expect(await handle.waitForIdle()).toEqual({ status: "completed", finalResponse: "first verdict" })
+
+    // when a revive turn produces no new output
+    await handle.followUp("re-emit your verdict")
+    fake.resolvePrompt()
+    const outcome = await handle.waitForIdle()
+
+    // then the previous run's text must not masquerade as the revive result
+    expect(outcome.status).toBe("error")
+  })
+
+  test("#given a healthy turn with assistant text #when the prompt resolves #then the outcome completes with this turn's text", async () => {
+    // given
+    const fake = createEmittingSession()
+    const handle = createChildHandle({ taskId: "task-1", session: fake.session, promptText: "do the work" })
+
+    // when
+    fake.emit(assistantEnd("all done", "stop"))
+    fake.resolvePrompt()
+
+    // then
+    expect(await handle.waitForIdle()).toEqual({ status: "completed", finalResponse: "all done" })
+  })
+})

--- a/packages/senpi-task/src/runners/in-process/child-handle-revive.test.ts
+++ b/packages/senpi-task/src/runners/in-process/child-handle-revive.test.ts
@@ -72,9 +72,9 @@ describe("createChildHandle revive", () => {
     expect(await handle.waitForIdle()).toEqual({ status: "completed", finalResponse: "first" })
     expect(fake.promptCalls()).toBe(1)
 
-    // when a follow-up revives the idle child
-    fake.lastText.value = "second"
+    // when a follow-up revives the idle child and the new turn produces fresh output
     await handle.followUp("again")
+    fake.lastText.value = "second"
 
     // then a fresh turn is driven and waitForIdle re-arms to the SECOND turn's outcome
     expect(fake.promptCalls()).toBe(2)

--- a/packages/senpi-task/src/runners/in-process/child-handle.ts
+++ b/packages/senpi-task/src/runners/in-process/child-handle.ts
@@ -1,5 +1,6 @@
 export type ChildSessionEvent = {
   readonly type: string
+  readonly message?: unknown
 }
 
 export type ChildSessionListener = (event: ChildSessionEvent) => void
@@ -18,7 +19,7 @@ export type ChildSession = {
 }
 
 export type RunnerFailure = {
-  readonly kind: "child-prompt-failed" | "session-create-failed" | "depth-exceeded"
+  readonly kind: "child-prompt-failed" | "child-turn-failed" | "session-create-failed" | "depth-exceeded"
   readonly message: string
   readonly cause?: unknown
 }
@@ -46,10 +47,80 @@ export type CreateChildHandleInput = {
   readonly promptText: string
 }
 
+// Per-turn facts observed from the session's event stream. senpi surfaces provider/stream failures
+// as an assistant message with stopReason "error"/"aborted" + errorMessage while prompt() resolves
+// cleanly, so the turn outcome must be derived from what the turn actually EMITTED, never assumed
+// from prompt() resolution alone (the silent-empty-completion bug).
+type TurnObservation = {
+  text: string | undefined
+  stopReason: string | undefined
+  errorMessage: string | undefined
+  baseline: string | undefined
+}
+
+function observeTurnEvent(observation: TurnObservation, event: ChildSessionEvent): void {
+  if (event.type !== "message_end") return
+  const message = event.message
+  if (!isRecord(message) || message.role !== "assistant") return
+  const text = assistantText(message)
+  if (text !== undefined) observation.text = text
+  observation.stopReason = typeof message.stopReason === "string" ? message.stopReason : undefined
+  observation.errorMessage = typeof message.errorMessage === "string" ? message.errorMessage : undefined
+}
+
+function assistantText(message: Record<string, unknown>): string | undefined {
+  if (!Array.isArray(message.content)) return undefined
+  const text = message.content
+    .filter((part: unknown): part is { readonly type: "text"; readonly text: string } => isTextPart(part))
+    .map((part) => part.text)
+    .join("")
+  return text.length > 0 ? text : undefined
+}
+
+function isTextPart(part: unknown): part is { readonly type: "text"; readonly text: string } {
+  return isRecord(part) && part.type === "text" && typeof part.text === "string"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+// Derive the settled turn's outcome from what it emitted. The session-level getLastAssistantText()
+// is only trusted when it CHANGED during this turn (baseline diff): on a revive, the previous run's
+// text must never masquerade as a fresh completion.
+function turnOutcome(session: ChildSession, observation: TurnObservation): RunnerOutcome {
+  if (observation.stopReason === "error" || observation.stopReason === "aborted") {
+    return {
+      status: "error",
+      failure: {
+        kind: "child-turn-failed",
+        message: observation.errorMessage ?? `child turn ended with stopReason "${observation.stopReason}"`,
+      },
+    }
+  }
+  if (observation.text !== undefined) return { status: "completed", finalResponse: observation.text }
+  const final = session.getLastAssistantText()
+  if (final !== undefined && final.length > 0 && final !== observation.baseline) {
+    return { status: "completed", finalResponse: final }
+  }
+  return {
+    status: "error",
+    failure: {
+      kind: "child-turn-failed",
+      message: observation.errorMessage ?? "child turn produced no assistant output",
+    },
+  }
+}
+
 // A prompt turn is a TRACKED async op: the promise is created and its rejection handled at the
 // call site, so steering can happen WHILE it runs and no rejection ever escapes. The same routine
 // drives the initial prompt and every revive follow-up (a fresh turn on an idle resident session).
-async function runTurn(session: ChildSession, text: string, isAborted: () => boolean): Promise<RunnerOutcome> {
+async function runTurn(
+  session: ChildSession,
+  text: string,
+  isAborted: () => boolean,
+  observation: TurnObservation,
+): Promise<RunnerOutcome> {
   try {
     await session.prompt(text)
   } catch (error) {
@@ -67,7 +138,7 @@ async function runTurn(session: ChildSession, text: string, isAborted: () => boo
     }
   }
   if (isAborted()) return { status: "cancelled" }
-  return { status: "completed", finalResponse: session.getLastAssistantText() ?? "" }
+  return turnOutcome(session, observation)
 }
 
 export function createChildHandle(input: CreateChildHandleInput): ChildHandle {
@@ -76,13 +147,19 @@ export function createChildHandle(input: CreateChildHandleInput): ChildHandle {
   let disposed = false
   let turnActive = false
   let running: Promise<RunnerOutcome>
+  const observation: TurnObservation = { text: undefined, stopReason: undefined, errorMessage: undefined, baseline: undefined }
+  const unsubscribeObserver = session.subscribe((event) => observeTurnEvent(observation, event))
 
   // Start a fresh tracked turn and mark it active until it settles. waitForIdle() always returns the
   // CURRENT turn, so a revive follow-up re-arms it to the new turn instead of a stale resolved one.
   const beginTurn = (text: string): void => {
     aborted = false
     turnActive = true
-    running = runTurn(session, text, () => aborted)
+    observation.text = undefined
+    observation.stopReason = undefined
+    observation.errorMessage = undefined
+    observation.baseline = session.getLastAssistantText()
+    running = runTurn(session, text, () => aborted, observation)
     void running.then(
       () => {
         turnActive = false
@@ -118,6 +195,7 @@ export function createChildHandle(input: CreateChildHandleInput): ChildHandle {
     dispose: () => {
       if (disposed) return
       disposed = true
+      unsubscribeObserver()
       session.dispose()
     },
   }

--- a/packages/senpi-task/src/state/types.ts
+++ b/packages/senpi-task/src/state/types.ts
@@ -67,6 +67,10 @@ export type TaskRecord = TaskRecordInput & {
   readonly created_at: string
   readonly updated_at: string
   readonly pid?: number
+  // Pid of the host process that spawned (and owns) this child. Lets a sibling process in the same
+  // project distinguish "previous process died" from "a live process still owns this child" during
+  // reconciliation, so cross-process session starts never falsely mark live in-process children lost.
+  readonly host_pid?: number
   readonly child_session_id?: string
   readonly spawn_spec?: TaskSpawnSpec
   readonly final_response?: string

--- a/packages/senpi-task/src/store/record-parse.ts
+++ b/packages/senpi-task/src/store/record-parse.ts
@@ -16,6 +16,7 @@ export function parseTaskRecord(value: unknown, path: string): TaskRecord {
   const toolAllow = readOptionalStringArray(value, "tool_allow")
   const toolDeny = readOptionalStringArray(value, "tool_deny")
   const pid = readOptionalNumber(value, "pid")
+  const hostPid = readOptionalNumber(value, "host_pid")
   const childSessionId = readOptionalString(value, "child_session_id")
   const finalResponse = readOptionalString(value, "final_response")
   const errorMessage = readOptionalString(value, "error_message")
@@ -43,6 +44,7 @@ export function parseTaskRecord(value: unknown, path: string): TaskRecord {
     ...(resolvedModel === undefined ? {} : { resolved_model: resolvedModel }),
     ...(spawnSpec === undefined ? {} : { spawn_spec: spawnSpec }),
     ...(pid === undefined ? {} : { pid }),
+    ...(hostPid === undefined ? {} : { host_pid: hostPid }),
     ...(childSessionId === undefined ? {} : { child_session_id: childSessionId }),
     ...(finalResponse === undefined ? {} : { final_response: finalResponse }),
     ...(errorMessage === undefined ? {} : { error_message: errorMessage }),

--- a/packages/senpi-task/src/tools/output/render.test.ts
+++ b/packages/senpi-task/src/tools/output/render.test.ts
@@ -58,3 +58,16 @@ describe("renderTranscript", () => {
     expect(rendered.text.length).toBeGreaterThan(0)
   })
 })
+
+describe("renderTranscript error entries", () => {
+  test("#given an error transcript entry #when rendered #then it is shown as an error line", () => {
+    // given
+    const entries = [{ kind: "error", message: "upstream gateway timeout" }] as unknown as Parameters<typeof renderTranscript>[0]
+
+    // when
+    const rendered = renderTranscript(entries, { mode: "full", tailLines: 0 })
+
+    // then
+    expect(rendered.text).toBe("error: upstream gateway timeout")
+  })
+})

--- a/packages/senpi-task/src/tools/output/render.ts
+++ b/packages/senpi-task/src/tools/output/render.ts
@@ -28,6 +28,7 @@ export function renderTranscript(entries: readonly TranscriptEntry[], options: R
 
 function renderEntry(entry: TranscriptEntry): readonly string[] {
   if (entry.kind === "assistant") return [`assistant: ${entry.text}`]
+  if (entry.kind === "error") return [`error: ${entry.message}`]
   const marker = entry.is_error ? "tool[error]" : "tool"
   return [`${marker}: ${entry.tool}`]
 }

--- a/packages/senpi-task/src/tools/output/transcript/event-log.test.ts
+++ b/packages/senpi-task/src/tools/output/transcript/event-log.test.ts
@@ -1,0 +1,35 @@
+import { mkdirSync, writeFileSync } from "node:fs"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+import { readEventLogTranscript } from "./event-log"
+
+function writeLog(lines: readonly string[]): string {
+  const stateDir = mkdtempSync(join(tmpdir(), "senpi-task-event-log-"))
+  mkdirSync(join(stateDir, "logs"), { recursive: true })
+  writeFileSync(join(stateDir, "logs", "st_1.jsonl"), lines.join("\n") + "\n")
+  return stateDir
+}
+
+describe("readEventLogTranscript", () => {
+  test("#given a log with assistant, tool, and child_error events #when read #then all three are lifted in order", () => {
+    // given
+    const stateDir = writeLog([
+      JSON.stringify({ type: "assistant_message", payload: { text: "working on it" } }),
+      JSON.stringify({ type: "tool_execution", payload: { tool: "bash", is_error: false } }),
+      JSON.stringify({ type: "child_error", payload: { message: "upstream gateway timeout", stop_reason: "error" } }),
+    ])
+
+    // when
+    const entries = readEventLogTranscript(stateDir, "st_1")
+
+    // then the error breadcrumb is part of the transcript
+    expect(entries).toEqual([
+      { kind: "assistant", text: "working on it" },
+      { kind: "tool", tool: "bash", is_error: false },
+      { kind: "error", message: "upstream gateway timeout" },
+    ])
+  })
+})

--- a/packages/senpi-task/src/tools/output/transcript/event-log.ts
+++ b/packages/senpi-task/src/tools/output/transcript/event-log.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 
-import { TRANSCRIPT_ASSISTANT_EVENT, TRANSCRIPT_TOOL_EVENT } from "../../../manager/transcript-log"
+import { TRANSCRIPT_ASSISTANT_EVENT, TRANSCRIPT_ERROR_EVENT, TRANSCRIPT_TOOL_EVENT } from "../../../manager/transcript-log"
 import type { TranscriptEntry } from "../types"
 
 // Re-exported from the writer (manager/transcript-log.ts) so reader and writer share ONE contract for
 // the event-type names and can never drift.
-export { TRANSCRIPT_ASSISTANT_EVENT, TRANSCRIPT_TOOL_EVENT }
+export { TRANSCRIPT_ASSISTANT_EVENT, TRANSCRIPT_ERROR_EVENT, TRANSCRIPT_TOOL_EVENT }
 
 // Reconstruct a child's transcript from OUR event log (logs/<taskId>.jsonl). Only the two transcript
 // event types are lifted; lifecycle/audit events on the same log are ignored. A missing log is an
@@ -51,6 +51,9 @@ function transcriptEntryOf(entry: unknown): TranscriptEntry | undefined {
   }
   if (entry.type === TRANSCRIPT_TOOL_EVENT && typeof payload.tool === "string") {
     return { kind: "tool", tool: payload.tool, is_error: payload.is_error === true }
+  }
+  if (entry.type === TRANSCRIPT_ERROR_EVENT && typeof payload.message === "string") {
+    return { kind: "error", message: payload.message }
   }
   if (entry.type === "team_message_waited" && typeof payload.from === "string" && typeof payload.body === "string") {
     return { kind: "assistant", text: `[team message from ${payload.from}] ${payload.body}` }

--- a/packages/senpi-task/src/tools/output/types.ts
+++ b/packages/senpi-task/src/tools/output/types.ts
@@ -10,6 +10,7 @@ export type OutputManager = Pick<TaskManager, "get" | "list" | "waitFor">
 export type TranscriptEntry =
   | { readonly kind: "assistant"; readonly text: string }
   | { readonly kind: "tool"; readonly tool: string; readonly is_error: boolean }
+  | { readonly kind: "error"; readonly message: string }
 
 export type TranscriptSource = "event-log" | "session-jsonl" | "none"
 


### PR DESCRIPTION
## What changed

Two field-observed senpi-task engine bugs, both reproduced from on-disk task stores:

**1. Cross-process false `lost` (the "T13 also lost!" bug).** Every senpi process in a project shares one `.omo/senpi-task` store, and `reconcileOnSessionStart` marked ANY non-terminal in-process record lost when this process's registry lacked a handle. Starting a second senpi session in the same project therefore clobbered the first session's running children: the record went `lost`+`disposed` mid-run, the owner's later `complete` transition was dropped as `late_transition_ignored` (final response never persisted), and the lost terminal state made the child LRU-evictable (the "evicted early, left nothing on disk" symptom). Evidence: `st_019f8439`'s event log shows `reconcile_lost` fired mid-run with assistant/tool events continuing to append AFTER `destroyed`; `st_019f8422` even spawned children after being declared lost.

Fix: records persist the owning process pid (`host_pid`, written at claim and reattach). Reconcile skips non-terminal in-process records owned by a live foreign pid (new outcome kind `foreign_live_owner`), and the TTL sweep retains resident records owned by a live foreign process. Dead-owner and legacy no-`host_pid` records keep the existing lost behavior, pinned by tests.

**2. Silent empty completion (the "oracle finished with no result and no transcript, exactly 515s" bug).** `session.prompt()` resolves cleanly even when the provider request fails - senpi surfaces the failure as an assistant `message_end` with `stopReason: "error"` + `errorMessage` - so the in-process handle recorded `completed` with `final_response: ""` and a zero-event transcript (`task_output` → `source:none`). Observed on `st_019f8427`/`st_019f842a` (both died at ~515s, an upstream gateway timeout) and `st_019f8415`/`st_019f8432`.

Fix: the child handle now observes its own turn events. A `stopReason error/aborted` turn maps to an `error` outcome carrying the provider diagnostic; a turn with no assistant output maps to `error` instead of `completed ""`; and the session-level `getLastAssistantText()` is only trusted when it changed during the turn, so a revive that produces nothing can no longer replay the previous run's text as a fresh completion. Failed turns also leave a `child_error` transcript breadcrumb that `task_output` renders as an `error:` line.

## QA / evidence

Evidence dir: `.omo/evidence/20260721-senpi-task-false-lost/` (on `dev`, committed separately? No - captured under the main checkout's evidence tree; scripts + raw outputs copied verbatim).

- **Real cross-process QA** (real OS processes, production `process.kill` signaller): owner process (pid 48777) spawns an in-process child through the real `createTaskManager`; a second process (pid 48900) runs `reconcileOnSessionStart` on the same store → outcome `foreign_live_owner`, record stays `running`/`resident`, no `reconcile_lost` event. After `kill -9` of the owner (`kill -0` verified dead), reconcile #2 → `lost` with the legacy reason.
- **Errored-turn QA**: real manager + runner with a session emitting the exact senpi failure signature → record `status: "error"`, `error_message: "upstream gateway timeout after 515s"`, transcript log contains `child_error` with the diagnostic payload (previously: `completed`, `""`, empty log).
- `bun test packages/senpi-task`: 820 pass / 0 fail. `tsgo --noEmit -p packages/senpi-task/tsconfig.json`: clean. Each of the 3 commits is individually green (813/0, 817/0, 820/0).

## Residual risk

- `host_pid` liveness uses `kill(pid, 0)`; pid reuse could in theory keep a stale record `running` until the recycled pid exits. Reconcile re-runs at every session start, and the record was previously being falsely LOST while its owner was alive - strictly better trade.
- A child whose turn legitimately ends with zero assistant text is now reported as `error` ("child turn produced no assistant output") instead of a silent empty success; that is the intended contract change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two `senpi-task` bugs: cross‑process sessions no longer mark live in‑process children as lost, and failed turns no longer record as silent empty completions. Also adds clear error breadcrumbs to transcripts.

- **Bug Fixes**
  - Cross‑process false "lost": persist `host_pid` on claim/reattach; reconcile skips non‑terminal in‑process records owned by a live foreign PID (new outcome `foreign_live_owner`); TTL keeps resident records owned by a live foreign process. Dead owners and legacy records without `host_pid` still become `lost`.
  - Silent empty completions: child handle derives outcomes from emitted events. `stopReason` of `error`/`aborted` becomes an `error` with the provider diagnostic; turns with no assistant output now error; stale `getLastAssistantText()` is ignored unless it changed during the turn.
  - Transcript: log a `child_error` event for failed turns; the reader lifts it and the renderer shows it as `error: <message>`.

- **Migration**
  - Turns that produce no assistant text now return `error` instead of `completed ""`. Update callers that relied on empty-string completions.
  - Reconcile may return `foreign_live_owner`. Handle this outcome if you inspect reconcile results.

<sup>Written for commit 33f52de04d60ea2a85145017958a060f2745d09a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

