### PR TITLE
fix(background-agent): sanitize platform prefix in checkSessionExistence ID (#5285, #6263)

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/session-existence.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-existence.ts
@@ -36,14 +36,19 @@ function isSessionNotFoundError(error: unknown): boolean {
   return message.includes("not found") || message.includes("missing")
 }
 
+export function sanitizeBareSessionId(sessionId: string): string {
+  return sessionId.replace(/^(opencode|codex|senpi):/, "")
+}
+
 export async function checkSessionExistence(
   client: OpencodeClient,
   sessionID: string,
   directory?: string
 ): Promise<SessionExistenceStatus> {
+  const rawId = sanitizeBareSessionId(sessionID)
   try {
     const response = await client.session.get({
-      path: { id: sessionID },
+      path: { id: rawId },
       ...(directory ? { query: { directory } } : {}),
     })
 


### PR DESCRIPTION
## Summary

Extends the fix from #5285 (`start-work-hook`) to `checkSessionExistence()` in the background task poller. Fixes #6263.

## Problem

`boulder.json` persists session IDs with platform prefixes (`opencode:ses_...`). When `checkSessionExistence()` forwards this verbatim to `client.session.get({ path: { id: sessionID } })`, the URL becomes `/session/opencode%3Ases_...`, which the OpenCode API server rejects with HTTP 400 (`Expected a string starting with "ses"`).

This causes `checkSessionExistence()` to return `"unknown"` instead of `"exists"`, misclassifying active subagent sessions as `sessionGone` and triggering the 10 s `sessionGoneTimeoutMs` — prematurely aborting in-progress background tasks.

## Fix

Add `sanitizeBareSessionId()` helper that strips `opencode:`, `codex:`, and `senpi:` prefixes before the SDK call. Use `rawId` in the `client.session.get` path.

## Verification

- `bun test packages/omo-opencode/src/features/background-agent/session-existence.test.ts` — 3 pass
- `bun run typecheck` — clean
- `bun run build` — clean
- Full pre-push suite — 11 960 pass, 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes platform-prefixed session IDs in background agent `checkSessionExistence()` to avoid OpenCode API 400s and prevent premature task aborts (fixes #6263).

- **Bug Fixes**
  - Added `sanitizeBareSessionId()` to strip `opencode:`, `codex:`, and `senpi:` prefixes from IDs persisted in `boulder.json`.
  - Use sanitized `rawId` in `client.session.get({ path: { id } })` so requests hit `/session/ses_...` and active sessions resolve correctly.

<sup>Written for commit 5088e004be427f7c5cdc7ab7b15bf4cae6a7e202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

