### PR TITLE
fix(build-binaries): emit the platform launcher as CommonJS so node loads it without type:module

### DIFF
--- a/.omo/evidence/20260721-fix-6231/green-6231.txt
+++ b/.omo/evidence/20260721-fix-6231/green-6231.txt
@@ -1,0 +1,16 @@
+﻿# GREEN - after fix (#6231) - both build-binaries suites - 2026-07-22T11:26:47.1032823+09:00
+
+bun test v1.3.14 (0d9b296a)
+bun : 
+At line:2 char:8
++ $out = bun test script/build-binaries-launcher.test.ts script/build-b ...
++        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+ 
+ 16 pass
+ 0 fail
+ 87 expect() calls
+Ran 16 tests across 2 files. [2.66s]
+
+EXIT=0

--- a/.omo/evidence/20260721-fix-6231/live-driver-after.txt
+++ b/.omo/evidence/20260721-fix-6231/live-driver-after.txt
@@ -1,0 +1,7 @@
+﻿# LIVE-SURFACE AFTER FIX (#6231) - 2026-07-22T11:28:44.6600045+09:00
+launcher import line: const { spawnSync } = require("node:child_process");
+node exit    : 2
+node stderr  : oh-my-opencode: OMO_WRAPPER_PACKAGE_ROOT is required to launch the packaged CLI.
+RESULT: PASS - launcher loads under node and reaches its own guard
+
+EXIT=0

--- a/.omo/evidence/20260721-fix-6231/live-driver-before.txt
+++ b/.omo/evidence/20260721-fix-6231/live-driver-before.txt
@@ -1,0 +1,7 @@
+﻿# LIVE-SURFACE BEFORE FIX (#6231) - 2026-07-22T11:28:45.5249990+09:00
+launcher import line: import { spawnSync } from "node:child_process";
+node exit    : 1
+node stderr  : (node:29388) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension. | (Use `node --trace-warnings ...` to show where the warning was created) | C:\Users\pss\AppData\Local\Temp\omo-6231-live-yuSTwB\oh-my-opencode.js:2
+RESULT: FAIL - launcher crashed with a module SyntaxError before running
+
+EXIT=1

--- a/.omo/evidence/20260721-fix-6231/live-driver.mjs
+++ b/.omo/evidence/20260721-fix-6231/live-driver.mjs
@@ -1,0 +1,36 @@
+// Live-surface driver for issue #6231 (run with: bun .omo/evidence/20260721-fix-6231/live-driver.mjs)
+//
+// Reproduces exactly how a platform package ships and how node loads the launcher on the
+// failing path: writes the REAL createPlatformLauncherSource() output as bin/oh-my-opencode.js
+// inside a directory whose package.json does NOT declare "type": "module" (the shipped
+// oh-my-openagent-<os>-<arch> layout), then loads it with `node --no-experimental-detect-module`
+// (the CJS interpretation used by node < 22.7 / detection-off, where the reporter hit the crash).
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { createPlatformLauncherSource } from "../../../script/build-binaries.ts";
+
+const dir = mkdtempSync(join(tmpdir(), "omo-6231-live-"));
+writeFileSync(
+	join(dir, "package.json"),
+	JSON.stringify({ name: "oh-my-openagent-windows-x64", version: "0.0.0", os: ["win32"], cpu: ["x64"], files: ["bin"] }),
+);
+const launcher = join(dir, "oh-my-opencode.js");
+writeFileSync(launcher, createPlatformLauncherSource());
+
+console.log("launcher import line:", createPlatformLauncherSource().split("\n")[1]);
+const r = spawnSync("node", ["--no-experimental-detect-module", launcher], {
+	encoding: "utf8",
+	env: { PATH: process.env.PATH ?? "" },
+});
+console.log("node exit    :", r.status);
+console.log("node stderr  :", (r.stderr || "").trim().split(/\r?\n/).slice(0, 3).join(" | "));
+
+const noSyntaxError = !(r.stderr || "").includes("Cannot use import statement outside a module");
+const reachedGuard = (r.stderr || "").includes("OMO_WRAPPER_PACKAGE_ROOT is required");
+const ok = noSyntaxError && reachedGuard;
+console.log(ok ? "RESULT: PASS - launcher loads under node and reaches its own guard" : "RESULT: FAIL - launcher crashed with a module SyntaxError before running");
+rmSync(dir, { recursive: true, force: true });
+process.exitCode = ok ? 0 : 1;

--- a/.omo/evidence/20260721-fix-6231/negative-control-6231.txt
+++ b/.omo/evidence/20260721-fix-6231/negative-control-6231.txt
@@ -1,0 +1,42 @@
+﻿# NEGATIVE CONTROL - product stashed, #6231 test must fail again - 2026-07-22T11:27:11.2682377+09:00
+
+bun test v1.3.14 (0d9b296a)
+bun : 
+At line:3 char:8
++ $out = bun test script/build-binaries-launcher.test.ts 2>&1 | Out-Str ...
++        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+ 
+script\build-binaries-launcher.test.ts:
+172 |       encoding: "utf8",
+173 |       env: { PATH: process.env.PATH ?? "" },
+174 |     });
+175 | 
+176 |     // then: it must not fail to parse as a module, and must reach its own missing-root guard
+177 |     expect(result.stderr).not.toContain("Cannot use import statement outside a module");
+                                    ^
+error: expect(received).not.toContain(expected)
+
+Expected to not contain: "Cannot use import statement outside a module"
+Received: "(node:24216) Warning: To load an ES module, set \"type\": \"module\" in the package.json or use the .mjs 
+extension.\n(Use `node --trace-warnings ...` to show where the warning was 
+created)\nC:\\Users\\pss\\AppData\\Local\\Temp\\omo-launcher-modsys-CbqTkR\\oh-my-opencode.js:2\r\nimport { spawnSync 
+} from \"node:child_process\";\r\n^^^^^^\r\n\r\nSyntaxError: Cannot use import statement outside a module\r\n    at 
+wrapSafe (node:internal/modules/cjs/loader:1486:18)\r\n    at Module._compile 
+(node:internal/modules/cjs/loader:1528:20)\r\n    at Object..js (node:internal/modules/cjs/loader:1706:10)\r\n    at 
+Module.load (node:internal/modules/cjs/loader:1289:32)\r\n    at Function._load 
+(node:internal/modules/cjs/loader:1108:12)\r\n    at TracingChannel.traceSync (node:diagnostics_channel:322:14)\r\n    
+at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)\r\n    at Function.executeUserEntryPoint [as runMain] 
+(node:internal/modules/run_main:170:5)\r\n    at node:internal/main/run_main_module:36:49\r\n\r\nNode.js v22.14.0\r\n"
+
+      at <anonymous> (C:\Users\pss\.omo-contrib\work\dev-baseline\script\build-binaries-launcher.test.ts:177:31)
+(fail) platform launcher module system (#6231) > #given the launcher shipped as .js in a package without type:module 
+#when node loads it directly #then it parses as a module instead of throwing a SyntaxError [149.57ms]
+
+ 5 pass
+ 1 fail
+ 15 expect() calls
+Ran 6 tests across 1 file. [2.04s]
+
+EXIT=1

--- a/.omo/evidence/20260721-fix-6231/qa-summary.md
+++ b/.omo/evidence/20260721-fix-6231/qa-summary.md
@@ -1,0 +1,74 @@
+# QA & Evidence — fix(build-binaries) issue #6231
+
+The generated platform launcher (`bin/oh-my-opencode.js`) is written by
+`createPlatformLauncherSource()` as an **ES module** (`#!/usr/bin/env node` + `import { spawnSync }`),
+but every platform package (`oh-my-openagent-<os>-<arch>` / `oh-my-opencode-<os>-<arch>`) ships a
+`package.json` with **no `"type": "module"`**. When a node that does not auto-detect module syntax
+loads the `.js` directly (node < 22.7, or with detection disabled — the Windows `bunx`/npm wrapper
+path in the report), it parses the file as CommonJS and throws
+`SyntaxError: Cannot use import statement outside a module`, so `bunx oh-my-openagent doctor` crashes
+before running. Fix: make the tiny bootstrap launcher CommonJS (`require`) so it loads regardless of
+node version, `"type"` field, or syntax detection.
+
+## Competing hypotheses / fix-shape options
+
+- **H1 — add `"type": "module"` to the 12 platform `package.json` files.** Matches the reporter's
+  wording but touches 12 files, keeps the ESM-`.js`-under-node footgun for any future non-detecting
+  node, and leaves the test suite still masking the bug. Rejected (broad, symptom-metadata).
+- **H2 — rename the launcher output to `.mjs`.** Forces ESM everywhere, but requires editing 11
+  `binary:` entries plus every consumer that references `oh-my-opencode.js` by name. Rejected
+  (bigger blast radius, distribution-filename change).
+- **H3 — make the launcher CommonJS (`require`) — CHOSEN.** One product change in the single source
+  (`createPlatformLauncherSource`) fixes all 12 platforms at once; the launcher has no ESM-only
+  features (no top-level await / import.meta), so `require` is a drop-in; same filename, same
+  runtime behaviour; loads deterministically under every node (no `"type"` field or detection
+  dependency). A `require`-only file has no `import`/`export`, so node's syntax detection classifies
+  it as CommonJS on modern node too.
+- **Why the tests hid it:** `build-binaries.test.ts` runs the launcher under `process.execPath`
+  (= bun during `bun test`, which parses `.js` as ESM), and `build-binaries-launcher.test.ts` wrote
+  it as `.mjs` (forces ESM). Neither exercised `.js` under real node. Switching the launcher-test
+  fixture to the production `.js` filename makes those tests exercise the real path going forward.
+
+## Changes (product: 3 insertions / 3 deletions, 1 file)
+
+- `script/build-binaries.ts`: `createPlatformLauncherSource()` — the 3 `import { … } from "node:*"`
+  lines become `const { … } = require("node:*")`. `state`/filename/behaviour otherwise unchanged.
+- `script/build-binaries-launcher.test.ts`: launcher fixture `launcher.mjs` → `launcher.js` (so the
+  existing runtime tests exercise the shipped `.js`), plus a focused regression test that loads the
+  launcher as `.js` under `node --no-experimental-detect-module` and asserts it parses and reaches
+  its own missing-root guard instead of a module `SyntaxError`.
+
+## What was tested / observed
+
+- **RED** `red-6231.txt`: new test fails with `SyntaxError: Cannot use import statement outside a
+  module` (5 pass / 1 fail, EXIT=1) on unmodified dev.
+- **GREEN** `green-6231.txt`: both build-binaries suites → 16 pass / 0 fail, EXIT=0.
+- **Negative control** `negative-control-6231.txt`: product change stashed → the #6231 test fails
+  again (SyntaxError), EXIT=1; restored after.
+- **Typecheck** `typecheck-6231.txt`: `bun run typecheck` (full monorepo) → EXIT=0.
+- **Live surface** `live-driver.mjs` + `live-driver-before.txt` / `live-driver-after.txt`: the REAL
+  `createPlatformLauncherSource()` output written as `oh-my-opencode.js` inside a directory whose
+  `package.json` omits `"type": "module"` (the shipped platform layout), loaded with
+  `node --no-experimental-detect-module`. BEFORE fix: node exit 1, ES-module Warning +
+  `SyntaxError`. AFTER fix: node exit 2, reaches `OMO_WRAPPER_PACKAGE_ROOT is required` (parsed and
+  ran). Isolated `mktemp` dir, removed by the driver.
+
+## Why this is enough
+
+The unit RED→GREEN pins the exact regression at the launcher generator, the negative control proves
+the test is coupled to the fix, and the live driver reproduces the reporter's crash and its
+resolution through the real production artifact (the generated `oh-my-opencode.js` in a no-`type`
+package) on Windows. The empirical reproduction (`node --no-experimental-detect-module`) faithfully
+matches the reporter's CJS-loader stack trace. Full typecheck and both build-binaries suites confirm
+no regression.
+
+## Residuals / out of scope
+
+- Platform `package.json` files still omit `"type": "module"`; this is now harmless because the
+  launcher is CommonJS. Adding it is unnecessary and would be redundant with this fix.
+- Only the launcher bootstrap is converted; the packaged CLI bundles (`dist/cli`, `dist/cli-node`)
+  are unaffected — the launcher spawns them as child processes.
+
+## Omitted
+
+No secrets, tokens, or credentials are present. Temp paths in logs are ordinary Windows temp dirs.

--- a/.omo/evidence/20260721-fix-6231/red-6231.txt
+++ b/.omo/evidence/20260721-fix-6231/red-6231.txt
@@ -1,0 +1,42 @@
+﻿# RED - before fix (#6231) - launcher .js under node(no-detect) - 2026-07-22T11:25:51.7002587+09:00
+
+bun test v1.3.14 (0d9b296a)
+bun : 
+At line:2 char:8
++ $out = bun test script/build-binaries-launcher.test.ts 2>&1 | Out-Str ...
++        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+ 
+script\build-binaries-launcher.test.ts:
+172 |       encoding: "utf8",
+173 |       env: { PATH: process.env.PATH ?? "" },
+174 |     });
+175 | 
+176 |     // then: it must not fail to parse as a module, and must reach its own missing-root guard
+177 |     expect(result.stderr).not.toContain("Cannot use import statement outside a module");
+                                    ^
+error: expect(received).not.toContain(expected)
+
+Expected to not contain: "Cannot use import statement outside a module"
+Received: "(node:40188) Warning: To load an ES module, set \"type\": \"module\" in the package.json or use the .mjs 
+extension.\n(Use `node --trace-warnings ...` to show where the warning was 
+created)\nC:\\Users\\pss\\AppData\\Local\\Temp\\omo-launcher-modsys-BB1qHS\\oh-my-opencode.js:2\r\nimport { spawnSync 
+} from \"node:child_process\";\r\n^^^^^^\r\n\r\nSyntaxError: Cannot use import statement outside a module\r\n    at 
+wrapSafe (node:internal/modules/cjs/loader:1486:18)\r\n    at Module._compile 
+(node:internal/modules/cjs/loader:1528:20)\r\n    at Object..js (node:internal/modules/cjs/loader:1706:10)\r\n    at 
+Module.load (node:internal/modules/cjs/loader:1289:32)\r\n    at Function._load 
+(node:internal/modules/cjs/loader:1108:12)\r\n    at TracingChannel.traceSync (node:diagnostics_channel:322:14)\r\n    
+at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)\r\n    at Function.executeUserEntryPoint [as runMain] 
+(node:internal/modules/run_main:170:5)\r\n    at node:internal/main/run_main_module:36:49\r\n\r\nNode.js v22.14.0\r\n"
+
+      at <anonymous> (C:\Users\pss\.omo-contrib\work\dev-baseline\script\build-binaries-launcher.test.ts:177:31)
+(fail) platform launcher module system (#6231) > #given the launcher shipped as .js in a package without type:module 
+#when node loads it directly #then it parses as a module instead of throwing a SyntaxError [231.59ms]
+
+ 5 pass
+ 1 fail
+ 15 expect() calls
+Ran 6 tests across 1 file. [3.35s]
+
+EXIT=1

--- a/.omo/evidence/20260721-fix-6231/typecheck-6231.txt
+++ b/.omo/evidence/20260721-fix-6231/typecheck-6231.txt
@@ -1,0 +1,26 @@
+﻿# TYPECHECK (#6231) - 2026-07-22T11:28:28.7108815+09:00
+
+bun : $ tsgo --noEmit && bun run typecheck:script && bun run typecheck:packages
+At line:2 char:8
++ $out = bun run typecheck 2>&1 | Out-String
++        ~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: ($ tsgo --noEmit...echeck:packages:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+ 
+$ tsgo --noEmit -p script/tsconfig.json
+$ tsgo --noEmit -p packages/rules-engine/tsconfig.json && tsgo --noEmit -p packages/delegate-core/tsconfig.json && 
+tsgo --noEmit -p packages/mcp-stdio-core/tsconfig.json && tsgo --noEmit -p packages/mcp-client-core/tsconfig.json && 
+tsgo --noEmit -p packages/git-bash-mcp/tsconfig.json && tsgo --noEmit -p packages/lsp-core/tsconfig.json && tsgo 
+--noEmit -p packages/utils/tsconfig.json && tsgo --noEmit -p packages/model-core/tsconfig.json && tsgo --noEmit -p 
+packages/omo-config-core/tsconfig.json && tsgo --noEmit -p packages/prompts-core/tsconfig.json && tsgo --noEmit -p 
+packages/comment-checker-core/tsconfig.json && tsgo --noEmit -p packages/hashline-core/tsconfig.json && tsgo --noEmit 
+-p packages/tmux-core/tsconfig.json && tsgo --noEmit -p packages/team-core/tsconfig.json && tsgo --noEmit -p 
+packages/openclaw-core/tsconfig.json && tsgo --noEmit -p packages/boulder-state/tsconfig.json && tsgo --noEmit -p 
+packages/telemetry-core/tsconfig.json && tsgo --noEmit -p packages/claude-code-compat-core/tsconfig.json && tsgo 
+--noEmit -p packages/skills-loader-core/tsconfig.json && tsgo --noEmit -p packages/agents-md-core/tsconfig.json && 
+tsgo --noEmit -p packages/omo-codex/plugin/shared/tsconfig.json && tsgo --noEmit -p packages/omo-codex/tsconfig.json 
+&& tsgo --noEmit -p packages/omo-senpi/tsconfig.json && tsgo --noEmit -p packages/senpi-task/tsconfig.json && tsgo 
+--noEmit -p packages/pi-goal/tsconfig.json && tsgo --noEmit -p packages/pi-webfetch/tsconfig.json && tsgo --noEmit -p 
+packages/omo-opencode/tsconfig.json
+
+EXIT=0

--- a/script/build-binaries-launcher.test.ts
+++ b/script/build-binaries-launcher.test.ts
@@ -34,7 +34,7 @@ async function createLauncherFixture(
       'console.log("OMO_NODE_OK", process.argv.slice(2).join(" "));\n',
     );
   }
-  const launcherPath = join(root, "launcher.mjs");
+  const launcherPath = join(root, "launcher.js");
   await writeFile(launcherPath, createPlatformLauncherSource());
   return { launcherPath, wrapperPackageRoot, root };
 }
@@ -153,5 +153,29 @@ describe("platform launcher runtime fallback (lazycodex#47)", () => {
 
     expect(result.status).toBe(2);
     expect(result.stderr).toContain("failed to execute Bun");
+  });
+});
+
+describe("platform launcher module system (#6231)", () => {
+  it("#given the launcher shipped as .js in a package without type:module #when node loads it directly #then it parses as a module instead of throwing a SyntaxError", async () => {
+    // given: the launcher written with the production filename (bin/oh-my-opencode.js) in a
+    // directory with no package.json - exactly how each platform package ships it, since the
+    // platform package.json does not declare "type": "module"
+    const dir = await mkdtemp(join(tmpdir(), "omo-launcher-modsys-"));
+    const launcherPath = join(dir, "oh-my-opencode.js");
+    await writeFile(launcherPath, createPlatformLauncherSource());
+
+    // when: node loads the file directly, as the Windows npm/bunx wrapper does.
+    // --no-experimental-detect-module reproduces the CJS interpretation used by node < 22.7
+    // (and any node with syntax detection disabled), which is where the SyntaxError manifests.
+    const result = spawnSync("node", ["--no-experimental-detect-module", launcherPath], {
+      encoding: "utf8",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+
+    // then: it must not fail to parse as a module, and must reach its own missing-root guard
+    expect(result.stderr).not.toContain("Cannot use import statement outside a module");
+    expect(result.stderr).toContain("OMO_WRAPPER_PACKAGE_ROOT is required");
+    expect(result.status).toBe(2);
   });
 });

--- a/script/build-binaries.ts
+++ b/script/build-binaries.ts
@@ -35,9 +35,9 @@ const CLI_DIST_ENTRY = "dist/cli/index.js";
 
 export function createPlatformLauncherSource(): string {
   return `#!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+const { spawnSync } = require("node:child_process");
+const { existsSync } = require("node:fs");
+const { join } = require("node:path");
 
 const wrapperPackageRoot = process.env.OMO_WRAPPER_PACKAGE_ROOT;
 const lazyCodexInvocationNames = new Set(["lazycodex", "lazycodex-ai"]);


### PR DESCRIPTION
Fixes #6231

## Summary

`bunx oh-my-openagent doctor` (and any CLI entry through the platform package) crashes on Windows with `SyntaxError: Cannot use import statement outside a module`. The generated platform launcher `bin/oh-my-opencode.js` is written as an ES module, but the platform package's `package.json` declares no `"type": "module"`, so a node that does not auto-detect module syntax parses the `.js` as CommonJS and fails before running. This makes the tiny bootstrap launcher CommonJS so it loads under any node regardless of the `"type"` field or syntax detection.

## Root Cause

`script/build-binaries.ts` `createPlatformLauncherSource()` emits:

```js
#!/usr/bin/env node
import { spawnSync } from "node:child_process";
import { existsSync } from "node:fs";
import { join } from "node:path";
```

That source is written to `packages/oh-my-opencode-<os>-<arch>/bin/oh-my-opencode.js` for all 12 platform targets. Each platform `package.json` (e.g. `oh-my-opencode-windows-x64/package.json`) has no `"type": "module"`. Node decides ESM vs CJS from the nearest `package.json`:

- node >= 22.7 with default syntax detection auto-detects the `import` and runs it as ESM (so it works there), which is why the repo's own launcher tests pass;
- node < 22.7, or any node with `--no-experimental-detect-module`, parses a no-`type` `.js` as CommonJS and throws the `SyntaxError` (the reporter's stack trace is the CJS loader: `node:internal/modules/cjs/loader`). On Windows the `#!/usr/bin/env node` shebang is not honored and npm/bunx invoke `node` directly, so this path is hit.

The existing tests hid the bug: `build-binaries.test.ts` runs the launcher under `process.execPath` (= bun during `bun test`, which parses `.js` as ESM), and `build-binaries-launcher.test.ts` wrote it as `.mjs` (forces ESM). Neither exercised `.js` under real node.

## Changes

| File | Change |
|------|--------|
| `script/build-binaries.ts` | `createPlatformLauncherSource()` — the 3 `import { … } from "node:*"` lines become `const { … } = require("node:*")`. Same filename, same runtime behaviour; fixes all 12 platform packages at the single source. 3 insertions / 3 deletions. |
| `script/build-binaries-launcher.test.ts` | Launcher fixture `launcher.mjs` → `launcher.js` (exercise the shipped `.js` path), plus a regression test that loads the launcher as `.js` under `node --no-experimental-detect-module` and asserts it parses and reaches its own missing-root guard instead of a module `SyntaxError`. |

A `require`-only file has no `import`/`export`, so node's syntax detection also classifies it as CommonJS on modern node — the launcher now loads deterministically everywhere.

## QA & Evidence

Committed under `.omo/evidence/20260721-fix-6231/`. Reproduced and fixed on Windows 11.

RED on unmodified `dev` (`red-6231.txt`):
```text
177 | expect(result.stderr).not.toContain("Cannot use import statement outside a module");
Expected to not contain: "Cannot use import statement outside a module"
SyntaxError: Cannot use import statement outside a module
(fail) platform launcher module system (#6231) ...
 1 fail   EXIT=1
```

GREEN on head (`green-6231.txt`): both build-binaries suites → 16 pass / 0 fail, EXIT=0. Negative control (`negative-control-6231.txt`): product change stashed → the test fails again → restored.

Live real-surface proof — the real `createPlatformLauncherSource()` output written as `oh-my-opencode.js` in a directory whose `package.json` omits `"type": "module"` (the shipped platform layout), loaded with `node --no-experimental-detect-module` (`live-driver.mjs`):

Before (`live-driver-before.txt`):
```text
launcher import line: import { spawnSync } from "node:child_process";
node exit    : 1
node stderr  : Warning: To load an ES module, set "type": "module" ... | ... SyntaxError
RESULT: FAIL - launcher crashed with a module SyntaxError before running
```

After (`live-driver-after.txt`):
```text
launcher import line: const { spawnSync } = require("node:child_process");
node exit    : 2
node stderr  : oh-my-opencode: OMO_WRAPPER_PACKAGE_ROOT is required to launch the packaged CLI.
RESULT: PASS - launcher loads under node and reaches its own guard
```

- `bun run typecheck` (full monorepo) — EXIT=0 (`typecheck-6231.txt`)

## Risks & Residuals

- Scoped to the generated launcher's module system. Same output filename (`oh-my-opencode.js`), same behaviour; the launcher spawns the packaged CLI (`dist/cli`, `dist/cli-node`) as child processes, which are unaffected.
- The launcher bootstrap uses no ESM-only features (no top-level `await`, no `import.meta`), so `require` is a faithful drop-in.
- Platform `package.json` files still omit `"type": "module"`; this is now harmless (the launcher is CommonJS) and left unchanged to keep the diff minimal, rather than editing 12 metadata files.

## Automated Checks

- `bun test script/build-binaries-launcher.test.ts script/build-binaries.test.ts` green on head (16 pass); CI runs the full matrix.
- `bun run typecheck` green.

AI-assisted (Sisyphus / oh-my-openagent); I have reviewed and understand every line.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits the platform launcher as CommonJS so Node loads it without `"type": "module"`, fixing Windows CLI crashes like `bunx oh-my-openagent doctor` with “Cannot use import statement outside a module.” Also updates tests to exercise the shipped `.js` path and prevent regressions. Fixes #6231.

- **Bug Fixes**
  - Generate `bin/oh-my-opencode.js` as CommonJS via `require(...)` in `createPlatformLauncherSource()`; loads under any Node regardless of package `"type"`.
  - Switch launcher test fixture to `.js` and add a regression test using `node --no-experimental-detect-module` to ensure the launcher parses and reaches its guard.

<sup>Written for commit 948dec6f4202da8ff1ef88a04a715664e69fc367. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

