### PR TITLE
fix(ulw-loop): contain stop-resume writes to the session state dir

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/src/stop-resume-hook.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/stop-resume-hook.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, resolve, sep } from "node:path";
 
 import { normalizeUlwLoopSessionId, ulwLoopDir } from "./paths.js";
 import type { UlwLoopItem, UlwLoopPlan } from "./types.js";
@@ -73,15 +73,23 @@ function isResumableStatus(status: UlwLoopItem["status"]): boolean {
 // a separate file — a ledger append would change the count and self-reset.
 function consumeResumeBudget(stateDir: string, goalId: string): boolean {
 	const ledgerLineCount = countLedgerLines(join(stateDir, "ledger.jsonl"));
-	const counterPath = join(stateDir, `auto-resume-${goalId}.json`);
+	const counterPath = resolve(stateDir, `auto-resume-${goalId}.json`);
+	const stuckPath = resolve(stateDir, `auto-resume-${goalId}.stuck`);
+	// goals.json is untrusted input: a crafted goal id (e.g. `../../x`) must
+	// never drive a write outside the session state dir. Deny the resume.
+	if (!isInsideDir(stateDir, counterPath) || !isInsideDir(stateDir, stuckPath)) return false;
 	const previous = readCounter(counterPath);
 	const count = previous !== null && previous.ledgerLineCount === ledgerLineCount ? previous.count : 0;
 	if (count >= RESUME_CAP) {
-		writeFileSync(join(stateDir, `auto-resume-${goalId}.stuck`), `no ledger progress after ${count} resumes\n`);
+		writeFileSync(stuckPath, `no ledger progress after ${count} resumes\n`);
 		return false;
 	}
 	writeFileSync(counterPath, JSON.stringify({ count: count + 1, ledgerLineCount }));
 	return true;
+}
+
+function isInsideDir(dir: string, candidate: string): boolean {
+	return candidate.startsWith(resolve(dir) + sep);
 }
 
 function renderResumeDirective(plan: UlwLoopPlan, goal: UlwLoopItem, sessionId: string): string {

--- a/packages/omo-codex/plugin/components/ulw-loop/test/stop-resume-hook.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/stop-resume-hook.test.ts
@@ -179,6 +179,35 @@ describe("runStopResumeHook", () => {
 		expect(JSON.parse(output).reason).toContain("--session-id s1");
 	});
 
+	it("#given a goal id with path traversal #when the hook runs #then nothing is written outside the state dir and the resume is denied", () => {
+		writeGoals([pendingGoal("../../../escaped-marker")]);
+		const outsideDir = join(workDir, ".omo", "ulw-loop");
+		const sentinel = join(outsideDir, "escaped-marker.json");
+		writeFileSync(sentinel, "sentinel\n");
+
+		const output = runStopResumeHook(stopPayload());
+
+		expect(output).toBe("");
+		expect(readFileSync(sentinel, "utf8")).toBe("sentinel\n");
+		expect(existsSync(join(outsideDir, "escaped-marker.stuck"))).toBe(false);
+		expect(existsSync(join(outsideDir, "auto-resume-escaped-marker.json"))).toBe(false);
+	});
+
+	it("#given a normal goal id #when the hook runs past the cap #then the counter and stuck marker are written inside the state dir", () => {
+		writeGoals([pendingGoal("goal-abc")]);
+
+		runStopResumeHook(stopPayload());
+		runStopResumeHook(stopPayload());
+		const third = runStopResumeHook(stopPayload());
+
+		expect(third).toBe("");
+		const counter = JSON.parse(readFileSync(join(sessionDir(), "auto-resume-goal-abc.json"), "utf8"));
+		expect(counter.count).toBe(2);
+		expect(readFileSync(join(sessionDir(), "auto-resume-goal-abc.stuck"), "utf8")).toBe(
+			"no ledger progress after 2 resumes\n",
+		);
+	});
+
 	it("#given ledger movement between stops #when the hook fires again #then the cap resets", () => {
 		writeGoals([pendingGoal()]);
 


### PR DESCRIPTION
## Summary
Contain the ulw-loop Stop resume hook's file writes to the session state directory, fixing a path-traversal write primitive reported on lazycodex.

## Root cause
`consumeResumeBudget(stateDir, goalId)` built `auto-resume-${goalId}.json` and `.stuck` paths with `join(stateDir, ...)` and no validation, then `writeFileSync`. A crafted `.omo/ulw-loop/<session>/goals.json` with a goal id like `../../../escaped-marker` made the hook create/truncate a `.json`/`.stuck` file outside the session state dir.

## Fix
`consumeResumeBudget` now resolves both candidate paths against `resolve(stateDir)` and asserts containment (prefix + separator boundary) before any write. An escaping goal id is a safe no-op that returns `false`, denying the resume. The two-strike ledger-progress cap and the happy path are unchanged.

## Verification
- New given/when/then tests: (1) a `../../..` goal id leaves a sentinel above stateDir untouched, writes no file outside stateDir, and denies the resume; (2) a normal goal id still writes the counter and `.stuck` marker inside stateDir past RESUME_CAP.
- Full ulw-loop component suite: 40 files, 420/420 pass (independently re-run). tsc build + biome clean. Component `dist/` is not git-tracked (built at publish), so no dist change.

Reported by @01022694274a-ai in code-yeongyu/lazycodex#129. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents path traversal in the `ulw-loop` stop-resume hook by containing all writes to the session state directory. Resumes are denied when a crafted goal id would write outside the session dir; normal behavior is unchanged.

- **Bug Fixes**
  - Resolve candidate counter/marker paths and assert they stay inside `stateDir`; if not, skip writes and return `false`.
  - Added tests for traversal attempts and for normal behavior at the resume cap.

<sup>Written for commit 60415873e9ecd846f9fe8cf5fc244b7d33c06152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

