### PR TITLE
fix(rules): add GPT-5.6 context budgets for PostCompact

### DIFF
--- a/packages/omo-codex/plugin/components/rules/src/post-compact-budget.ts
+++ b/packages/omo-codex/plugin/components/rules/src/post-compact-budget.ts
@@ -21,6 +21,17 @@ const POST_COMPACT_MIN_RESERVED_TOKENS = 8_000;
 const POST_COMPACT_MIN_GUIDE_CHARS = 500;
 const FALLBACK_CONTEXT_WINDOW_TOKENS = 200_000;
 const MODEL_CONTEXT_BUDGETS: readonly ModelContextBudget[] = [
+	{ slug: "gpt-5.6-sol", contextWindowTokens: 372_000, effectivePercent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT },
+	{
+		slug: "gpt-5.6-terra",
+		contextWindowTokens: 372_000,
+		effectivePercent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+	},
+	{
+		slug: "gpt-5.6-luna",
+		contextWindowTokens: 372_000,
+		effectivePercent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+	},
 	{ slug: "gpt-5.5", contextWindowTokens: 272_000, effectivePercent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT },
 	{ slug: "gpt-5.4-mini", contextWindowTokens: 272_000, effectivePercent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT },
 	{

--- a/packages/omo-codex/plugin/components/rules/test/post-compact-budget.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/post-compact-budget.test.ts
@@ -76,6 +76,66 @@ describe("post-compact context budget", () => {
 		expect(budget.maxRuleChars).toBeLessThanOrEqual(budget.maxResultChars);
 	});
 
+	it("#given gpt-5.6-sol within its 372k window #when resolving post-compact budget #then keeps configured post-compact cap", () => {
+		// given
+		const transcriptPath = writeCompactedTranscript("A".repeat(541_500));
+
+		// when
+		const budget = withPostCompactBudget(CONFIG, { model: "gpt-5.6-sol", transcriptPath });
+
+		// then
+		expect(budget.maxRuleChars).toBe(CONFIG.postCompactMaxRuleChars);
+		expect(budget.maxResultChars).toBe(CONFIG.postCompactMaxResultChars);
+	});
+
+	it("#given gpt-5.6-terra within its 372k window #when resolving post-compact budget #then keeps configured post-compact cap", () => {
+		// given
+		const transcriptPath = writeCompactedTranscript("A".repeat(541_500));
+
+		// when
+		const budget = withPostCompactBudget(CONFIG, { model: "gpt-5.6-terra", transcriptPath });
+
+		// then
+		expect(budget.maxRuleChars).toBe(CONFIG.postCompactMaxRuleChars);
+		expect(budget.maxResultChars).toBe(CONFIG.postCompactMaxResultChars);
+	});
+
+	it("#given gpt-5.6-luna within its 372k window #when resolving post-compact budget #then keeps configured post-compact cap", () => {
+		// given
+		const transcriptPath = writeCompactedTranscript("A".repeat(541_500));
+
+		// when
+		const budget = withPostCompactBudget(CONFIG, { model: "gpt-5.6-luna", transcriptPath });
+
+		// then
+		expect(budget.maxRuleChars).toBe(CONFIG.postCompactMaxRuleChars);
+		expect(budget.maxResultChars).toBe(CONFIG.postCompactMaxResultChars);
+	});
+
+	it("#given provider-prefixed gpt-5.6 variant within its 372k window #when resolving post-compact budget #then keeps configured post-compact cap", () => {
+		// given
+		const transcriptPath = writeCompactedTranscript("A".repeat(541_500));
+
+		// when
+		const budget = withPostCompactBudget(CONFIG, { model: "openai/gpt-5.6-sol", transcriptPath });
+
+		// then
+		expect(budget.maxRuleChars).toBe(CONFIG.postCompactMaxRuleChars);
+		expect(budget.maxResultChars).toBe(CONFIG.postCompactMaxResultChars);
+	});
+
+	it("#given unknown model with the same transcript #when resolving post-compact budget #then keeps the 200k fallback floor", () => {
+		// given
+		const transcriptPath = writeCompactedTranscript("A".repeat(541_500));
+
+		// when
+		const budget = withPostCompactBudget(CONFIG, { model: "unknown-model", transcriptPath });
+
+		// then
+		expect(budget.maxResultChars).toBe(500);
+		expect(budget.maxRuleChars).toBe(500);
+	});
+
 	it("#given context pressure marker after compaction #when resolving post-compact budget #then shrinks projected rule injection", () => {
 		// given
 		const transcriptPath = writeCompactedPressureTranscript("small compacted summary");


### PR DESCRIPTION
## Summary
Add GPT-5.6 context-window budgets so the rules PostCompact hook stops over-truncating recovery context for current Codex models.

## Root cause
`MODEL_CONTEXT_BUDGETS` had no gpt-5.6 slugs, so `gpt-5.6-sol` / `-terra` / `-luna` fell through the exact+suffix lookup to `FALLBACK_CONTEXT_WINDOW_TOKENS = 200_000` and the PostCompact guide was floored far below the real 372,000-token window.

## Fix
Add `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` at 372_000 tokens with the default effective percent. Unknown models keep the 200k fallback. The first-match exact/`.slug`/`/slug` suffix lookup is unchanged and none of the new slugs collide with existing entries.

## Verification
- New given/when/then cases: each gpt-5.6 variant (plus provider-prefixed `openai/gpt-5.6-sol`) on a ~180.5k-token transcript asserts the full caps (maxRuleChars 12_000, maxResultChars 20_000) instead of the 500-char floor; one unknown-model case asserts the 200k fallback is preserved.
- Full rules component suite: 30 files, 168 pass (independently re-run). tsc clean. Component `dist/` is not git-tracked (built at publish), so no dist change.

Reported by @andms9412-debug in code-yeongyu/lazycodex#125. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds context-window budgets for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` at 372k tokens so PostCompact stops using the 200k fallback and keeps the configured caps.

- **Bug Fixes**
  - Added 372,000-token budgets (default effective percent) for `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`.
  - Kept the 200k fallback for unknown models; lookup logic unchanged.
  - Added tests for each variant and `openai/gpt-5.6-sol` to confirm caps are retained; unknown model asserts the 500-char floor.

<sup>Written for commit 9e428f568800c0faca2767702e612f46db852fdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

