### PR TITLE
fix(model-core): keep antigravity-gemini-3-flash out of the -preview rewrite

### DIFF
--- a/packages/model-core/src/provider-model-id-transform.test.ts
+++ b/packages/model-core/src/provider-model-id-transform.test.ts
@@ -56,6 +56,39 @@ describe("provider model ID transforms", () => {
 		}
 	})
 
+	test("keeps antigravity-gemini-3-flash unchanged for google provider", () => {
+		// #given antigravity-prefixed gemini-3-flash model IDs
+		const provider = "google"
+		const models = [
+			"antigravity-gemini-3-flash",
+			"google/antigravity-gemini-3-flash",
+		] as const
+
+		for (const model of models) {
+			// #when transformed for the google provider
+			const result = transformModelForProvider(provider, model)
+
+			// #then it stays as the valid antigravity id (NOT -preview)
+			expect(result).toBe(model)
+		}
+	})
+
+	test("rewrites plain gemini-3-flash to gemini-3-flash-preview for google provider", () => {
+		// #given plain and google-prefixed gemini-3-flash model IDs
+		const scenarios = [
+			{ model: "gemini-3-flash", expected: "gemini-3-flash-preview" },
+			{ model: "google/gemini-3-flash", expected: "google/gemini-3-flash-preview" },
+		] as const
+
+		for (const scenario of scenarios) {
+			// #when transformed for the google provider
+			const result = transformModelForProvider("google", scenario.model)
+
+			// #then it becomes the -preview form (unchanged behavior)
+			expect(result).toBe(scenario.expected)
+		}
+	})
+
 	test("produces identical results for non-Anthropic providers", () => {
 		// #given non-Anthropic provider/model pairs
 		const scenarios = [

--- a/packages/model-core/src/provider-model-id-transform.ts
+++ b/packages/model-core/src/provider-model-id-transform.ts
@@ -11,7 +11,7 @@ function inferSubProvider(model: string): string | undefined {
 
 const CLAUDE_VERSION_DOT = /claude-(\w+)-(\d+)-(\d+)/g
 const GEMINI_31_PRO_PREVIEW = /gemini-3\.1-pro(?!-)/g
-const GEMINI_3_FLASH_PREVIEW = /gemini-3-flash(?!-)/g
+const GEMINI_3_FLASH_PREVIEW = /(?<!antigravity-)gemini-3-flash(?!-)/g
 
 function claudeVersionDot(model: string): string {
 	return model.replace(CLAUDE_VERSION_DOT, "claude-$1-$2.$3")

--- a/packages/omo-opencode/src/cli/provider-model-id-transform.test.ts
+++ b/packages/omo-opencode/src/cli/provider-model-id-transform.test.ts
@@ -182,6 +182,56 @@ describe("transformModelForProvider", () => {
     })
   })
 
+  describe("antigravity gemini-3-flash (issue #117)", () => {
+    test("keeps antigravity-gemini-3-flash unchanged for google provider", () => {
+      // #given google provider and antigravity-gemini-3-flash model
+      const provider = "google"
+      const model = "antigravity-gemini-3-flash"
+
+      // #when transformModelForProvider is called
+      const result = transformModelForProvider(provider, model)
+
+      // #then it stays as the valid antigravity id (NOT -preview)
+      expect(result).toBe("antigravity-gemini-3-flash")
+    })
+
+    test("keeps google/antigravity-gemini-3-flash unchanged for google provider", () => {
+      // #given google provider and google/antigravity-gemini-3-flash model
+      const provider = "google"
+      const model = "google/antigravity-gemini-3-flash"
+
+      // #when transformModelForProvider is called
+      const result = transformModelForProvider(provider, model)
+
+      // #then it stays as the valid antigravity id (NOT -preview)
+      expect(result).toBe("google/antigravity-gemini-3-flash")
+    })
+
+    test("still rewrites plain gemini-3-flash to gemini-3-flash-preview", () => {
+      // #given google provider and plain gemini-3-flash model
+      const provider = "google"
+      const model = "gemini-3-flash"
+
+      // #when transformModelForProvider is called
+      const result = transformModelForProvider(provider, model)
+
+      // #then it becomes the -preview form (unchanged behavior)
+      expect(result).toBe("gemini-3-flash-preview")
+    })
+
+    test("still rewrites google/gemini-3-flash to google/gemini-3-flash-preview", () => {
+      // #given google provider and google/gemini-3-flash model
+      const provider = "google"
+      const model = "google/gemini-3-flash"
+
+      // #when transformModelForProvider is called
+      const result = transformModelForProvider(provider, model)
+
+      // #then it becomes the -preview form (unchanged behavior)
+      expect(result).toBe("google/gemini-3-flash-preview")
+    })
+  })
+
   describe("anthropic provider", () => {
     test("preserves hyphenated claude-opus-4-7 for config output (regression: installer must not write dotted IDs)", () => {
       // #given anthropic provider and claude-opus-4-7 model


### PR DESCRIPTION
## Summary
Stop the provider model-id transform from rewriting Antigravity's `gemini-3-flash` into an invalid `-preview` id, fixing a team-mode retry failure reported on lazycodex.

## Root cause
`GEMINI_3_FLASH_PREVIEW = /gemini-3-flash(?!-)/g` matched the `gemini-3-flash` substring inside `antigravity-gemini-3-flash`, so a retry rewrote it to `antigravity-gemini-3-flash-preview` (the valid id has no `-preview`), producing `ProviderModelNotFoundError`.

## Fix
Add a negative lookbehind: `/(?<!antigravity-)gemini-3-flash(?!-)/g`. Plain `gemini-3-flash` / `google/gemini-3-flash` still becomes `gemini-3-flash-preview`; `antigravity-gemini-3-flash` (and `google/antigravity-gemini-3-flash`) is left unchanged; `gemini-3.1-pro` handling is untouched. The omo-opencode `shared/` and `cli/` copies are single-line re-exports of `@oh-my-opencode/model-core`, so the one fix covers all consumers.

## Verification
- New given/when/then cases in `model-core` and `omo-opencode/cli` transform tests: antigravity ids stay unchanged; plain gemini-3-flash still gets `-preview`.
- `bun test` model-core transform: 5 pass; omo-opencode/cli transform: 36 pass (independently re-run).

Reported by @napadayte in code-yeongyu/lazycodex#117. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the model ID transform from rewriting `antigravity-gemini-3-flash` to an invalid `-preview` ID, fixing retry failures with the Google provider.

- **Bug Fixes**
  - Update regex to `/(?<!antigravity-)gemini-3-flash(?!-)/g` so `antigravity-gemini-3-flash` (and `google/antigravity-gemini-3-flash`) is left unchanged; plain `gemini-3-flash` still becomes `gemini-3-flash-preview`.
  - Add tests in `@oh-my-opencode/model-core` and `@oh-my-opencode/omo-opencode` CLI for both antigravity and plain forms.

<sup>Written for commit 71557afabc25605745ee1282d72bc99e753157ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

