### PR TITLE
fix(ultrawork): stop ulw-plan/ulw-research from triggering ultrawork mode

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/src/codex-hook.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 
 import { buildUltraworkAdditionalContext, type UltraworkAdditionalContextOptions } from "./skill-pointer.js";
 
-const ULTRAWORK_CURRENT_PROMPT_PATTERN = /(?:ultrawork|ulw)/i;
+const ULTRAWORK_CURRENT_PROMPT_PATTERN = /(?:ultrawork|ulw(?!-(?:plan|research)))/i;
 const ULTRAWORK_DIRECTIVE_MARKER = "<ultrawork-mode>";
 const TRANSCRIPT_SEARCH_BYTES = 512_000;
 const CONTEXT_PRESSURE_MARKERS = [

--- a/packages/omo-codex/plugin/components/ultrawork/test/codex-hook-trigger-policy.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/codex-hook-trigger-policy.test.ts
@@ -88,6 +88,48 @@ describe("codex ultrawork trigger policy", () => {
 		expect(isUltraworkPrompt(prompt)).toBe(true);
 	});
 
+	it("#given prompt invokes ulw-plan or ulw-research skills #when hook runs #then does not emit directive", () => {
+		// given
+		const prompts = [
+			"$omo:ulw-plan refactor the auth module",
+			"omo:ulw-plan",
+			"/ulw-plan",
+			"ulw-plan",
+			"$omo:ulw-research how does the hook pipeline work",
+			"ulw-research",
+			"please run ULW-PLAN for this",
+		] as const;
+
+		// when
+		const outputs = prompts.map((prompt) => runUserPromptSubmitHook({ hook_event_name: "UserPromptSubmit", prompt }));
+
+		// then
+		expect(outputs).toEqual(["", "", "", "", "", "", ""]);
+		expect(prompts.map((prompt) => isUltraworkPrompt(prompt))).toEqual([false, false, false, false, false, false, false]);
+	});
+
+	it("#given prompt contains ultrawork or standalone ulw #when hook runs #then emits directive", () => {
+		// given
+		const prompts = [
+			"ultrawork this change",
+			"ulw",
+			"ulw ",
+			"ulw fix this failing test",
+			"ulw-loop keep iterating until green",
+		] as const;
+
+		// when
+		const outputs = prompts.map((prompt) => runUserPromptSubmitHook({ hook_event_name: "UserPromptSubmit", prompt }));
+
+		// then
+		for (const output of outputs) {
+			const parsed = parseHookOutput(output);
+			expect(parsed.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
+			expect(parsed.hookSpecificOutput.additionalContext).toMatch(/^<ultrawork-mode>/);
+		}
+		expect(prompts.map((prompt) => isUltraworkPrompt(prompt))).toEqual([true, true, true, true, true]);
+	});
+
 	it("#given prior transcript contains triggers but current prompt does not #when hook runs #then does not emit directive", () => {
 		// given
 		const payload = {


### PR DESCRIPTION
## Summary
Stop the Codex ultrawork UserPromptSubmit hook from injecting the full `<ultrawork-mode>` directive when the user invokes the planning-only `ulw-plan` (or `ulw-research`) skill, fixing the routing collision and multi-hour planning stalls reported on lazycodex.

## Root cause
`ULTRAWORK_CURRENT_PROMPT_PATTERN = /(?:ultrawork|ulw)/i` matched the `ulw` inside the skill name `ulw-plan`, so `$omo:ulw-plan` activated two conflicting contracts (planning-only + full ultrawork execution) in one turn.

## Fix
Carve out the two planning/research skill tokens with a negative lookahead: `/(?:ultrawork|ulw(?!-(?:plan|research)))/i`. Bare `ultrawork`, standalone `ulw`, `ulw `, and `ulw-loop` still trigger (ulw-loop legitimately runs in ultrawork mode); `ulw-plan` and `ulw-research` no longer do.

## Verification
- Extended `test/codex-hook-trigger-policy.test.ts` (given/when/then): `$omo:ulw-plan` / `omo:ulw-plan` / `/ulw-plan` / `ulw-plan` / `ulw-research` / `ULW-PLAN` inject nothing; `ultrawork` / `ulw` / `ulw ` / `ulw-loop ...` still inject the pointer.
- `npm test` ultrawork component: 5 files, 30 tests pass (independently re-run). Component `dist/` is not git-tracked (built at publish).

Reported by @ameforce in code-yeongyu/lazycodex#124. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `ulw-plan` and `ulw-research` from triggering ultrawork mode, fixing the routing collision and long planning stalls. The trigger now ignores those skill tokens while keeping `ultrawork`, standalone `ulw`, and `ulw-loop` active.

- **Bug Fixes**
  - Update `ULTRAWORK_CURRENT_PROMPT_PATTERN` to `/(?:ultrawork|ulw(?!-(?:plan|research)))/i` so planning-only skills do not inject `<ultrawork-mode>`.
  - Extend tests to confirm no directive for `ulw-plan`/`ulw-research`, and directive remains for `ultrawork`, `ulw`, `ulw `, and `ulw-loop`.

<sup>Written for commit d0b86901e907d6311d1c0c2f82d21992183bd937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

