### PR TITLE
fix(codex-install): resolve codex .cmd shim on Windows for doctor spawn

### DIFF
--- a/packages/omo-codex/src/install/codex-process.test.ts
+++ b/packages/omo-codex/src/install/codex-process.test.ts
@@ -34,6 +34,36 @@ describe("codex-process", () => {
     })
   })
 
+  test("#given Windows codex command #when resolving run command invocation #then uses cmd shim so the npm-installed codex.cmd resolves instead of ENOENT", () => {
+    // given
+    const command = "codex"
+    const args = ["exec", "--ephemeral", "diagnose"] as const
+
+    // when
+    const invocation = resolveRunCommandInvocation(command, args, "win32")
+
+    // then
+    expect(invocation).toEqual({
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", "codex.cmd", "exec", "--ephemeral", "diagnose"],
+    })
+  })
+
+  test("#given non-Windows codex command #when resolving run command invocation #then preserves direct execution", () => {
+    // given
+    const command = "codex"
+    const args = ["exec", "--ephemeral", "diagnose"] as const
+
+    // when
+    const invocation = resolveRunCommandInvocation(command, args, "linux")
+
+    // then
+    expect(invocation).toEqual({
+      command: "codex",
+      args: ["exec", "--ephemeral", "diagnose"],
+    })
+  })
+
   test("#given Windows non-shim command #when resolving run command invocation #then preserves direct execution", () => {
     // given
     const command = "git"

--- a/packages/omo-codex/src/install/codex-process.ts
+++ b/packages/omo-codex/src/install/codex-process.ts
@@ -1,7 +1,7 @@
 import { spawn } from "../../../omo-opencode/src/shared/bun-spawn-shim"
 import type { RunCommand } from "./types"
 
-const WINDOWS_CMD_SHIM_COMMANDS = new Set(["npm", "npx"])
+const WINDOWS_CMD_SHIM_COMMANDS = new Set(["codex", "npm", "npx"])
 
 export type RunCommandInvocation = {
   readonly command: string


### PR DESCRIPTION
## Summary
Make the `lazycodex-ai doctor` codex spawn Windows-safe, fixing `spawn codex ENOENT` on Windows even when Codex is correctly installed.

## Root cause
`doctor` builds `codex exec ...` and spawns it via `defaultRunCommand` in `codex-process.ts`. That module already rewrites npm/npx to `cmd.exe /d /s /c <name>.cmd ...` on win32, but `codex` was not in the shim set, so a bare `spawn("codex", ...)` could not execute the npm-installed `codex.cmd`/`codex.ps1` shim and failed ENOENT.

## Fix
Add `codex` to `WINDOWS_CMD_SHIM_COMMANDS`, reusing the package's existing Windows shim convention. On win32 the doctor now spawns `cmd.exe /d /s /c codex.cmd exec ...`; non-Windows still spawns `codex` directly. Arguments and exit-code handling are unchanged, and this is the only bare-`codex` spawn in the package. No new dependency.

## Verification
- Given/when/then tests via the existing `resolveRunCommandInvocation` platform seam: win32 resolves the `.cmd` shim; linux is unchanged.
- `bun test src/install/codex-process.test.ts` 5 pass; routing + detection tests 11 pass; `bun run typecheck` clean.

Reported by @innopoiesis in code-yeongyu/lazycodex#138. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows ENOENT when `lazycodex-ai doctor` spawns `codex` by resolving the Windows `.cmd` shim; non-Windows behavior is unchanged.

- **Bug Fixes**
  - Add `codex` to `WINDOWS_CMD_SHIM_COMMANDS` so win32 runs `cmd.exe /d /s /c codex.cmd exec ...` instead of a bare `codex`.
  - Add tests for Windows and Linux resolution via `resolveRunCommandInvocation`.

<sup>Written for commit d477599730abadb9def7589e8f5cebf6c9326021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

