### PR TITLE
fix(codex): raise cold-start SessionStart hook timeouts to 15s

### DIFF
--- a/packages/omo-codex/plugin/hooks/session-start-checking-auto-update.json
+++ b/packages/omo-codex/plugin/hooks/session-start-checking-auto-update.json
@@ -6,7 +6,7 @@
 					{
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/scripts/auto-update.mjs\" hook session-start",
-						"timeout": 5,
+						"timeout": 15,
 						"statusMessage": "(OmO 4.19.0) Checking Auto Update",
 						"commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\node-dispatch.ps1\" \"${PLUGIN_ROOT}\\scripts\\auto-update.mjs\" hook session-start"
 					}

--- a/packages/omo-codex/plugin/hooks/session-start-checking-codegraph-bootstrap.json
+++ b/packages/omo-codex/plugin/hooks/session-start-checking-codegraph-bootstrap.json
@@ -6,7 +6,7 @@
 					{
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/codegraph/dist/cli.js\" hook session-start",
-						"timeout": 5,
+						"timeout": 15,
 						"statusMessage": "(OmO 4.19.0) Checking CodeGraph Bootstrap",
 						"commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\node-dispatch.ps1\" \"${PLUGIN_ROOT}\\components\\codegraph\\dist\\cli.js\" hook session-start"
 					}

--- a/packages/omo-codex/plugin/hooks/session-start-recording-session-telemetry.json
+++ b/packages/omo-codex/plugin/hooks/session-start-recording-session-telemetry.json
@@ -6,7 +6,7 @@
 					{
 						"type": "command",
 						"command": "node \"${PLUGIN_ROOT}/components/telemetry/dist/cli.js\" hook session-start",
-						"timeout": 5,
+						"timeout": 15,
 						"statusMessage": "(OmO 4.19.0) Recording Session Telemetry",
 						"commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\components\\bootstrap\\scripts\\node-dispatch.ps1\" \"${PLUGIN_ROOT}\\components\\telemetry\\dist\\cli.js\" hook session-start"
 					}

--- a/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate-hooks.test.mjs
@@ -225,6 +225,32 @@ test("#given aggregate SessionStart hooks #when inspected #then LazyCodex auto-u
 	assert(sessionStartCommands.some((command) => command.includes("scripts/auto-update.mjs")));
 });
 
+test("#given aggregate SessionStart hooks #when inspected #then cold-start-prone hooks carry 15s timeout headroom", async () => {
+	// given
+	const manifests = await readAggregateHookManifests();
+
+	// when
+	const sessionStartHooks = manifests
+		.filter(({ hooks }) => hooks.hooks.SessionStart)
+		.flatMap(({ source, hooks }) =>
+			hooks.hooks.SessionStart.flatMap((group) =>
+				group.hooks.map((handler) => ({ source, command: handler.command, timeout: handler.timeout })),
+			),
+		);
+	const coldStartHooks = sessionStartHooks.filter(
+		({ command }) =>
+			command.includes("components/telemetry/dist/cli.js") ||
+			command.includes("scripts/auto-update.mjs") ||
+			command.includes("components/codegraph/dist/cli.js"),
+	);
+
+	// then
+	assert.equal(coldStartHooks.length, 3);
+	for (const hook of coldStartHooks) {
+		assert.equal(hook.timeout, 15, `${hook.source} must carry timeout 15 for cold-start headroom`);
+	}
+});
+
 test("#given aggregate PostToolUse hooks #when inspected #then CodeGraph init guidance is registered for CodeGraph tools", async () => {
 	// given
 	const commandHooks = await readAggregateCommandHooks();


### PR DESCRIPTION
## Summary
Raise the cold-start SessionStart hook timeouts from 5s to 15s so Windows cold starts stop tripping `SessionStart hook (failed): hook timed out after 5s`.

## Root cause
On Windows, cold PowerShell + Node startup for the telemetry, auto-update, and codegraph SessionStart handlers can exceed the 5s manifest limit (reporter measured telemetry cold 9.1s, auto-update 6.1s) even with optional work disabled, before any real work runs.

## Fix
Set `timeout: 15` in the three cold-start-prone SessionStart hook manifests (telemetry, auto-update, codegraph-bootstrap). The other SessionStart hooks were already above 5s (bootstrap-provisioning 30s, project-rules 10s) and are untouched.

Scope note: this is the minimal timeout-headroom fix. The doctor hook-attribution enhancement requested in the same issue is a separate, larger change and is not included here.

## Verification
- Deterministic test in `plugin/test/aggregate-hooks.test.mjs` asserts exactly those three SessionStart hooks carry `timeout: 15`, so the headroom cannot silently regress.
- `node --test test/aggregate-hooks.test.mjs` 15 pass.

Reported by @idnotbe in code-yeongyu/lazycodex#133. Partially addresses it (timeout headroom); the doctor hook-attribution ask is tracked separately. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise `SessionStart` hook timeouts from 5s to 15s for telemetry, auto-update, and codegraph bootstrap to stop Windows cold-start timeouts. Adds a test to lock these values and prevent regressions.

- **Bug Fixes**
  - Set `timeout: 15` in three `omo-codex` SessionStart manifests (telemetry, auto-update, codegraph-bootstrap) to handle slow Windows cold starts.
  - Added a deterministic test that asserts these three hooks use a 15s timeout; other SessionStart hooks remain unchanged.

<sup>Written for commit 401dda2d20081534272e736a73c8eaff7387b412. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

