### PR TITLE
docs(codex): document and lock the explorer/librarian service-tier opt-out

### DIFF
--- a/packages/omo-codex/README.md
+++ b/packages/omo-codex/README.md
@@ -128,6 +128,17 @@ The installer does not write a global Codex shell config. On Windows it enables 
 
 To install both editions in one command, use `--platform=both`.
 
+### Subagent service tier (explorer/librarian)
+
+The bundled `explorer` and `librarian` agent TOMLs ship with `service_tier = "fast"` so recon subagents run on the cheaper Fast tier by default. To opt out, edit the tier in your installed agent files and the installer will preserve your choice across every reinstall and bootstrap:
+
+```toml
+# ~/.codex/agents/explorer.toml (and librarian.toml)
+service_tier = "standard"   # use the default/parent tier instead of Fast
+```
+
+Delete the `service_tier` line entirely to inherit the parent session's tier. On reinstall the bootstrap captures your current tier and re-applies it after relinking the bundled agents, so a changed or removed tier is never silently reset back to `fast`.
+
 ## Telemetry
 
 Anonymous telemetry uses the same PostHog project as oh-my-openagent but emits the distinct event `omo_codex_daily_active`. The event is sent at most once per UTC day per machine from two sources:

--- a/packages/omo-codex/src/install/preserved-agent-settings.test.ts
+++ b/packages/omo-codex/src/install/preserved-agent-settings.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { describe, expect, test } from "bun:test"
+
+import { restorePreservedServiceTier } from "./preserved-agent-settings"
+
+const BUNDLED_EXPLORER = 'name = "explorer"\nmodel = "gpt-5.6-luna"\nservice_tier = "fast"\n'
+
+async function writeAgent(content: string): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "omo-service-tier-"))
+	const path = join(dir, "explorer.toml")
+	await writeFile(path, content)
+	return path
+}
+
+describe("restorePreservedServiceTier", () => {
+	test("#given a user changed the tier to standard #when a reinstall relinks the bundled fast agent #then the user tier is restored", async () => {
+		// given
+		const linkPath = await writeAgent(BUNDLED_EXPLORER)
+		// when
+		await restorePreservedServiceTier({ linkPath, preserved: true, value: "standard" })
+		// then
+		expect(await readFile(linkPath, "utf8")).toContain('service_tier = "standard"')
+	})
+
+	test("#given a user removed the tier entirely #when a reinstall relinks the bundled fast agent #then the tier stays absent so the parent tier is inherited", async () => {
+		// given
+		const linkPath = await writeAgent(BUNDLED_EXPLORER)
+		// when
+		await restorePreservedServiceTier({ linkPath, preserved: true, value: null })
+		// then
+		expect(await readFile(linkPath, "utf8")).not.toContain("service_tier")
+	})
+
+	test("#given a fresh install with nothing preserved #when relinking #then the bundled fast tier is left unchanged", async () => {
+		// given
+		const linkPath = await writeAgent(BUNDLED_EXPLORER)
+		// when
+		await restorePreservedServiceTier({ linkPath, preserved: false, value: null })
+		// then
+		expect(await readFile(linkPath, "utf8")).toContain('service_tier = "fast"')
+	})
+})


### PR DESCRIPTION
## Summary
Document and regression-lock the opt-out for the forced Fast service tier on the `explorer` and `librarian` Codex subagents, addressing the "no documented opt-out that survives bootstrap/reinstallation" report on lazycodex.

## Context
The install path already captures a user-set `service_tier` from `~/.codex/agents/*.toml` before relinking bundled agents (`capturePreservedAgentServiceTier`) and re-applies it afterward (`restorePreservedServiceTier`), so a user-changed or user-removed tier survives every reinstall. That mechanism landed just after the 4.16.3 release the issue was filed against, was undocumented, and had no regression test. This PR closes both gaps.

## Changes
- `packages/omo-codex/README.md`: new "Subagent service tier (explorer/librarian)" section explaining that editing `service_tier` (to `standard`, or deleting the line to inherit the parent tier) in the installed agent TOMLs is preserved across reinstall/bootstrap.
- `packages/omo-codex/src/install/preserved-agent-settings.test.ts`: given/when/then regression tests locking `restorePreservedServiceTier` behavior: a changed tier is restored, a removed tier stays absent, and a fresh install keeps the bundled `fast` default.

No default behavior change: the bundled default is still `fast`; this makes the existing opt-out discoverable and prevents it from silently regressing.

## Verification
- `bun test src/install/preserved-agent-settings.test.ts` 3 pass, 0 fail.

Reported by @fede-oss in code-yeongyu/lazycodex#128. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the opt-out from the `fast` service tier for the `explorer` and `librarian` subagents and add tests to prevent regressions. Default remains `fast` on fresh installs.

- **Bug Fixes**
  - Docs: how to set or remove `service_tier` in `~/.codex/agents/{explorer,librarian}.toml`; preserved across reinstall/bootstrap.
  - Tests: `restorePreservedServiceTier` restores a changed tier, preserves deletion, and leaves bundled `fast` when nothing is preserved.

<sup>Written for commit 0d9180a547d769a6fd28bdf58a460fb98eb695be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

