### PR TITLE
test(senpi-task): widen Windows CI timing budgets

### DIFF
--- a/.omo/evidence/omo-senpi-adapter/20260722-windows-ci-timing-flakes/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260722-windows-ci-timing-flakes/README.md
@@ -1,0 +1,44 @@
+# Windows CI timing flake QA
+
+## What was tested
+
+1. `bun test packages/senpi-task/src/team/member-extension/index.test.ts packages/senpi-task/src/team/tasks.test.ts --rerun-each 20`
+   - Proves both adjusted tests preserve their assertions across 20 consecutive executions.
+2. `bun --cwd packages/senpi-task run typecheck`
+   - Proves the package remains type-correct.
+3. `bun --cwd packages/senpi-task test`
+   - Proves the complete `senpi-task` package suite.
+4. `bun run test:senpi`
+   - Proves the mandatory Senpi plugin build, adapter typecheck, and package test gate.
+5. `bun packages/senpi-task/scripts/manual-qa.ts /tmp/omo-windows-ci-flake-manual-qa`
+   - Drives task record persistence, transitions, traversal rejection, redaction, corruption handling, and cleanup.
+6. `SENPI_BIN=packages/senpi-task/node_modules/.bin/senpi node packages/omo-senpi/scripts/qa/team-e2e.mjs`
+   - Drives the real pinned Senpi CLI through member injection, team wait, task claim/update, shutdown, durability, reclaim, and crash recovery.
+7. `SENPI_BIN=packages/senpi-task/node_modules/.bin/senpi node packages/omo-senpi/scripts/qa/task-e2e.mjs`
+   - Drives the real pinned Senpi CLI through background, follow-up revive, blocking output, batch, sync, and invalid-input paths.
+
+## What was observed
+
+- Focused stress: 140 passed, 0 failed.
+- `senpi-task` package: 823 passed, 0 failed.
+- Mandatory `test:senpi` gate: 304 passed, 0 failed.
+- Team live QA: `PASS`, all 25 behavioral checks true, no leaked processes.
+- Task live QA: `PASS`, all 12 checks passed, no leaked processes, and the real Senpi agent directory was unchanged.
+- Manual task-store QA completed with identical reload, redaction, traversal rejection, no outside write, final completed status, and successful cleanup.
+
+Exact structured results are recorded in:
+
+- `team-e2e.json`
+- `task-e2e.json`
+- `manual-task-store.json`
+
+## Why this is enough
+
+The code change only widens bounded test budgets. The focused stress run exercises the two exact assertions repeatedly, the package and adapter gates cover their surrounding implementation, and the live Senpi drivers prove that member polling, task claiming, message delivery, and recovery still work through the actual CLI surface.
+
+## Isolation and omissions
+
+- Live passing QA used the repository-pinned Senpi `2026.7.5-2`, matching `packages/senpi-task/package.json`.
+- An initial run accidentally selected global Senpi `2026.7.22`; that runtime compacted immediately because of a compatibility mismatch and never reached the scripted actions. Those failed `/tmp` debug logs are not committed because they are not evidence about this change.
+- The passing task QA reported `realSenpiUntouched: true`, no changed real paths, and four sandbox `SENPI_CODING_AGENT_DIR` values.
+- No credentials, auth files, environment dumps, or raw private session transcripts are included.

--- a/.omo/evidence/omo-senpi-adapter/20260722-windows-ci-timing-flakes/manual-task-store.json
+++ b/.omo/evidence/omo-senpi-adapter/20260722-windows-ci-timing-flakes/manual-task-store.json
@@ -1,0 +1,22 @@
+{
+  "reloadIdentical": true,
+  "redactedApiKey": true,
+  "sentinelAbsent": true,
+  "corruptSkipped": true,
+  "malformedOptionalSkipped": true,
+  "illegalTransitionApplied": false,
+  "completedResidentMessageability": "revive",
+  "evictedCompletedApplied": true,
+  "evictedCompletedStatus": "completed",
+  "evictedCompletedMessageability": "not-continuable",
+  "normalLostApplied": false,
+  "normalLostStatus": "running",
+  "traversalRejected": true,
+  "outsideWriteCreated": false,
+  "finalStatus": "completed",
+  "cleanup": {
+    "existedBeforeCleanup": true,
+    "outsidePathExistsBeforeCleanup": false,
+    "existsAfterCleanup": false
+  }
+}

--- a/.omo/evidence/omo-senpi-adapter/20260722-windows-ci-timing-flakes/task-e2e.json
+++ b/.omo/evidence/omo-senpi-adapter/20260722-windows-ci-timing-flakes/task-e2e.json
@@ -1,0 +1,26 @@
+{
+  "result": "PASS",
+  "runtime": "@code-yeongyu/senpi 2026.7.5-2",
+  "checks": {
+    "spawn_background": "PASS",
+    "unconditional_wake": "PASS",
+    "followup_revive": "PASS",
+    "task_output_full": "PASS",
+    "task_output_block": "PASS",
+    "jsonl_sequence": "PASS",
+    "extension_suppression": "PASS",
+    "batch_fanout_two_children": "PASS",
+    "sync_inline_no_notification": "PASS",
+    "negative_category_error": "PASS",
+    "real_senpi_untouched": "PASS",
+    "no_leaked_pids": "PASS"
+  },
+  "leakedPids": 0,
+  "realSenpiUntouched": true,
+  "realSenpiChangedPaths": [],
+  "concurrentRealSenpiChangedPaths": [],
+  "realSenpiDigestUnchanged": true,
+  "providedAgentDir": "unset",
+  "sandboxCount": 4,
+  "mainExit": 0
+}

--- a/.omo/evidence/omo-senpi-adapter/20260722-windows-ci-timing-flakes/team-e2e.json
+++ b/.omo/evidence/omo-senpi-adapter/20260722-windows-ci-timing-flakes/team-e2e.json
@@ -1,0 +1,33 @@
+{
+  "result": "PASS",
+  "runtime": "@code-yeongyu/senpi 2026.7.5-2",
+  "checks": {
+    "createTwoMembersActive": true,
+    "createListsActiveMembers": true,
+    "leadToMemberEnqueued": true,
+    "memberEnvelopeEchoed": true,
+    "teamWaitReceivedMemberMessage": true,
+    "teamWaitProcessedLedger": true,
+    "teamWaitEventLoggedOnce": true,
+    "taskCreateClaimUpdate": true,
+    "shutdownApproved": true,
+    "shutdown_via_task_send": true,
+    "rejectRestoredMember": true,
+    "leadExitClean": true,
+    "duraBacklogSeeded": true,
+    "duraMessagesEnqueued": true,
+    "duraUnreadDrainedToZero": true,
+    "reclaimReservationRestored": true,
+    "reclaimNoLeak": true,
+    "crashHoldReached": true,
+    "crashKilledMemberAtHold": true,
+    "crashReservationUncommittedAtKill": true,
+    "crashRestartExitClean": true,
+    "crashProcessedLedgerExactlyOnce": true,
+    "crashDeliveredEventExactlyOnce": true,
+    "crashSessionEnvelopeExactlyOnce": true
+  },
+  "failed": [],
+  "credentialIsolationClean": true,
+  "leakedPids": 0
+}

--- a/packages/senpi-task/src/team/member-extension/index.test.ts
+++ b/packages/senpi-task/src/team/member-extension/index.test.ts
@@ -76,7 +76,7 @@ describe("member extension lifecycle", () => {
 
       loading = false
       await dispatch(handlers, "session_start")
-      await withTimeout(injection, 1_500)
+      await withTimeout(injection, 5_000)
 
       expect(injected).toHaveLength(1)
       expect(injected[0]).toContain(MESSAGE_ID)

--- a/packages/senpi-task/src/team/tasks.test.ts
+++ b/packages/senpi-task/src/team/tasks.test.ts
@@ -82,7 +82,7 @@ describe("team tasklist orchestration", () => {
     const claimed = await claimTeamTask(ctx, blocked.id, "alpha")
     expect(claimed.status).toBe("claimed")
     expect(claimed.owner).toBe("alpha")
-  })
+  }, 15_000)
 
   test("#given a claimed task #when a non-owner updates its status #then a typed cross-owner error is raised", async () => {
     // given


### PR DESCRIPTION
## Summary

Widen the bounded test budgets for the two known `windows-latest` timing flakes in `senpi-task`.

This is a clean, test-only extraction of the timing repair proposed in #6267. It intentionally excludes the unrelated production change currently present in that PR.

Closes #6266.

## Failure history

- PR #6278, CI run `29886444412`, attempt 1:
  - `member-extension/index.test.ts` failed after 2.656 seconds because its exact-signal timeout was 1.5 seconds.
  - The rerun passed without a code change, confirming runner timing jitter.
- CI run `29849679363`:
  - The dependency-claim task-store test exceeded Bun's default 5-second test limit on Windows while performing NTFS-backed atomic state transitions.
- Coding-agent session history confirmed these failures were unrelated to the product changes in PRs #6278 and #6279.

## Change

- Raise the member injection assertion timeout from 1.5 seconds to 5 seconds.
- Give the dependency-claim test a 15-second Bun test budget.
- Keep the exact event/state assertions unchanged.
- Add no sleeps, retries, production fallbacks, or production code changes.

## Verification

- Focused stress: 140 passed, 0 failed.
- Rebase verification: 35 passed, 0 failed.
- `senpi-task` package: 823 passed, 0 failed.
- `bun --cwd packages/senpi-task run typecheck`: passed.
- `bun run test:senpi`: 304 passed, 0 failed.
- Pinned Senpi team E2E: PASS across all 25 checks.
- Pinned Senpi task E2E: PASS across all 12 checks, real Senpi agent directory unchanged, no leaked processes.
- Standalone task-store manual QA: passed persistence, transition, traversal, redaction, corruption, and cleanup checks.

## Evidence

`.omo/evidence/omo-senpi-adapter/20260722-windows-ci-timing-flakes/`

## Residual risk

The local machine runs Bun 1.3.14 and Node 26 while CI pins Bun 1.3.12 and Node 24. The PR's Windows matrix is the final platform-specific proof.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widen Windows CI timing budgets for two `senpi-task` tests to deflake runs on `windows-latest`. Test-only change with no production code; closes #6266.

- **Bug Fixes**
  - Increase member injection assertion timeout from 1.5s to 5s in `member-extension/index.test.ts`.
  - Set a 15s test timeout for the dependency-claim path in `team/tasks.test.ts` to avoid Bun’s 5s default on Windows.

<sup>Written for commit c29f65f082401ab04ed47352de1225c7abff6ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

