### PR TITLE
fix(script): stop the marketplace sync dropping component CLIs via nested gitignore

### DIFF
--- a/script/lazycodex-marketplace-validation.pin.test.ts
+++ b/script/lazycodex-marketplace-validation.pin.test.ts
@@ -169,6 +169,63 @@ describe("lazycodex marketplace validation guards", () => {
     }
   })
 
+  test("#given a managed bin target is missing #when validating the plugin bundle #then the bin target is rejected once", async () => {
+    // given
+    const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-missing-bin-"))
+    await writeRootCliRuntime(pluginRoot)
+    await mkdir(join(pluginRoot, "components", "ulw-loop"), { recursive: true })
+    await writeFile(
+      join(pluginRoot, "components", "ulw-loop", "package.json"),
+      `${JSON.stringify(
+        {
+          name: "@code-yeongyu/codex-ulw-loop",
+          bin: { "omo-ulw-loop": "./dist/cli.js", ulw: "./dist/cli.js", "ulw-loop": "./dist/cli.js" },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    try {
+      // when
+      const validated = validateLazycodexPluginBundle(pluginRoot)
+
+      // then
+      await expect(validated).rejects.toThrow("missing managed bin target: components/ulw-loop/dist/cli.js")
+    } finally {
+      await rm(pluginRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("#given managed bin targets exist #when validating the plugin bundle #then the bin targets are accepted", async () => {
+    // given
+    const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-bin-"))
+    await writeRootCliRuntime(pluginRoot)
+    await mkdir(join(pluginRoot, "components", "start-work-continuation", "dist"), { recursive: true })
+    await writeFile(
+      join(pluginRoot, "components", "start-work-continuation", "package.json"),
+      `${JSON.stringify(
+        {
+          name: "@code-yeongyu/codex-start-work-continuation",
+          bin: { "omo-start-work-continuation": "./dist/cli.js" },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    await writeFile(join(pluginRoot, "components", "start-work-continuation", "dist", "cli.js"), "#!/usr/bin/env node\n")
+
+    try {
+      // when
+      const validated = validateLazycodexPluginBundle(pluginRoot)
+
+      // then
+      await expect(validated).resolves.toBeUndefined()
+    } finally {
+      await rm(pluginRoot, { recursive: true, force: true })
+    }
+  })
+
   test("#given an array mcpServers manifest #when validating the plugin bundle #then the manifest is rejected", async () => {
     // given
     const pluginRoot = await mkdtemp(join(tmpdir(), "omo-marketplace-array-manifest-"))

--- a/script/lazycodex-marketplace-validation.ts
+++ b/script/lazycodex-marketplace-validation.ts
@@ -98,7 +98,8 @@ async function validatePluginManagedBins(pluginRoot: string, issues: string[]): 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue
     for (const binTarget of await readBinTargets(join(componentsRoot, entry.name, "package.json"))) {
-      const relativePath = join("components", entry.name, binTarget)
+      // Marketplace payload paths are POSIX; join() would emit backslashes on win32.
+      const relativePath = join("components", entry.name, binTarget).split(sep).join("/")
       await collectBundleFileIssue(pluginRoot, pluginRoot, relativePath, "missing managed bin target", issues, {
         allowEscape: false,
       })

--- a/script/lazycodex-marketplace-validation.ts
+++ b/script/lazycodex-marketplace-validation.ts
@@ -16,6 +16,7 @@ export async function validateLazycodexPluginBundle(
   }
   await validatePluginMcpManifests(pluginRoot, issues)
   await validatePluginHookCommands(pluginRoot, issues)
+  await validatePluginManagedBins(pluginRoot, issues)
   if (issues.length > 0) {
     throw new Error(
       `lazycodex plugin bundle validation failed with ${issues.length} broken referenced target(s):\n${issues
@@ -80,6 +81,41 @@ async function validatePluginHookCommands(pluginRoot: string, issues: string[]):
       }
     }
   }
+}
+
+// Codex links every component package.json "bin" as a managed bin; a missing target leaves the
+// installer repairing a dangling bin on every session even when no hook references the CLI
+// (lazycodex#108: omo-start-work-continuation, omo-ulw-loop, ulw, ulw-loop).
+async function validatePluginManagedBins(pluginRoot: string, issues: string[]): Promise<void> {
+  const componentsRoot = join(pluginRoot, "components")
+  let entries
+  try {
+    entries = await readdir(componentsRoot, { withFileTypes: true })
+  } catch (error) {
+    if (error instanceof Error) return
+    return
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    for (const binTarget of await readBinTargets(join(componentsRoot, entry.name, "package.json"))) {
+      const relativePath = join("components", entry.name, binTarget)
+      await collectBundleFileIssue(pluginRoot, pluginRoot, relativePath, "missing managed bin target", issues, {
+        allowEscape: false,
+      })
+    }
+  }
+}
+
+async function readBinTargets(manifestPath: string): Promise<string[]> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(await readFile(manifestPath, "utf8"))
+  } catch (error) {
+    if (error instanceof Error) return []
+    return []
+  }
+  if (!isPlainRecord(parsed) || !isPlainRecord(parsed.bin)) return []
+  return Object.values(parsed.bin).filter((target): target is string => typeof target === "string")
 }
 
 async function findHookManifestPaths(root: string): Promise<string[]> {

--- a/script/lazycodex-runtime-dists.ts
+++ b/script/lazycodex-runtime-dists.ts
@@ -1,5 +1,7 @@
-import { cp, mkdir, stat } from "node:fs/promises"
+import { cp, mkdir, readdir, readFile, stat } from "node:fs/promises"
 import { dirname, join } from "node:path"
+
+import { isPlainRecord } from "@oh-my-opencode/utils"
 
 interface RuntimeDist {
   readonly label: string
@@ -41,10 +43,65 @@ const RUNTIME_DISTS: readonly RuntimeDist[] = [
   },
 ] as const
 
+const PLUGIN_COMPONENTS_SOURCE_PATH = join("packages", "omo-codex", "plugin", "components")
+const PLUGIN_COMPONENTS_DESTINATION_PATH = join("plugins", "omo", "components")
+
 export async function copyLazycodexRuntimeDists(input: CopyLazycodexRuntimeDistsInput): Promise<void> {
   for (const dist of RUNTIME_DISTS) {
     await copyRuntimeDist(input, dist)
   }
+  for (const dist of await collectComponentBinDists(input.sourceRoot)) {
+    await copyRuntimeDist(input, dist)
+  }
+}
+
+// Every component package.json "bin" becomes a Codex managed bin; when the component's gitignored
+// dist/ never reaches the marketplace payload the installer keeps repairing a dangling bin
+// (lazycodex#108). Bundle each bin-referenced component dist explicitly, the same way the MCP
+// runtime dists are bundled, so an unbuilt component fails the sync instead of silently shipping
+// a broken plugin.
+async function collectComponentBinDists(sourceRoot: string): Promise<RuntimeDist[]> {
+  const componentsRoot = join(sourceRoot, PLUGIN_COMPONENTS_SOURCE_PATH)
+  const dists: RuntimeDist[] = []
+  for (const componentName of await listComponentNames(componentsRoot)) {
+    if (!(await declaresDistBin(join(componentsRoot, componentName, "package.json")))) continue
+    dists.push({
+      label: `${componentName} component dist`,
+      sourcePath: join(PLUGIN_COMPONENTS_SOURCE_PATH, componentName, "dist"),
+      destinationPath: join(PLUGIN_COMPONENTS_DESTINATION_PATH, componentName, "dist"),
+    })
+  }
+  return dists
+}
+
+async function listComponentNames(componentsRoot: string): Promise<string[]> {
+  try {
+    const entries = await readdir(componentsRoot, { withFileTypes: true })
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+  } catch (error) {
+    if (error instanceof Error) return []
+    return []
+  }
+}
+
+async function declaresDistBin(manifestPath: string): Promise<boolean> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(await readFile(manifestPath, "utf8"))
+  } catch (error) {
+    if (error instanceof Error) return false
+    return false
+  }
+  if (!isPlainRecord(parsed) || !isPlainRecord(parsed.bin)) return false
+  return Object.values(parsed.bin).some((target) => typeof target === "string" && isDistTarget(target))
+}
+
+function isDistTarget(target: string): boolean {
+  const normalized = target.split("\\").join("/").replace(/^\.\//, "")
+  return normalized === "dist" || normalized.startsWith("dist/")
 }
 
 async function copyRuntimeDist(input: CopyLazycodexRuntimeDistsInput, dist: RuntimeDist): Promise<void> {

--- a/script/sync-lazycodex-marketplace.test.ts
+++ b/script/sync-lazycodex-marketplace.test.ts
@@ -111,6 +111,10 @@ async function writePluginFixture(sourceRoot: string, options: WritePluginFixtur
   await writeFile(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "bootstrap", "dist", "cli.js"), "#!/usr/bin/env node\n")
   await mkdir(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "bootstrap", "scripts"), { recursive: true })
   await writeFile(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "bootstrap", "scripts", "bootstrap.ps1"), "exit 0\n")
+  // Components whose managed bins point at a gitignored dist/cli.js (lazycodex#108): the sync must
+  // ship the built CLI and must not ship the nested .gitignore that re-ignores dist/ downstream.
+  await writeManagedBinComponentFixture(sourceRoot, "start-work-continuation", ["omo-start-work-continuation"])
+  await writeManagedBinComponentFixture(sourceRoot, "ulw-loop", ["omo-ulw-loop", "ulw", "ulw-loop"])
   await mkdir(join(sourceRoot, "packages", "git-bash-mcp", "dist"), { recursive: true })
   await writeFile(join(sourceRoot, "packages", "git-bash-mcp", "dist", "cli.js"), "#!/usr/bin/env node\n")
   await mkdir(join(sourceRoot, "packages", "lsp-tools-mcp", "dist"), { recursive: true })
@@ -127,6 +131,32 @@ async function writePluginFixture(sourceRoot: string, options: WritePluginFixtur
   await writeFile(join(sourceRoot, "packages", "omo-codex", "plugin", ".ulw", "evidence", "loop.json"), "{}\n")
   await mkdir(join(sourceRoot, "packages", "omo-codex", "plugin", ".claude"), { recursive: true })
   await writeFile(join(sourceRoot, "packages", "omo-codex", "plugin", ".claude", "settings.local.json"), "{}\n")
+}
+
+async function writeManagedBinComponentFixture(sourceRoot: string, componentName: string, binNames: string[]): Promise<void> {
+  const componentRoot = join(sourceRoot, "packages", "omo-codex", "plugin", "components", componentName)
+  await writeJson(join(componentRoot, "package.json"), {
+    name: `@code-yeongyu/codex-${componentName}`,
+    version: "1.2.3",
+    bin: Object.fromEntries(binNames.map((binName) => [binName, "./dist/cli.js"])),
+  })
+  await writeJson(join(componentRoot, "hooks", "hooks.json"), {
+    hooks: {
+      Stop: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `node "\${PLUGIN_ROOT}/components/${componentName}/dist/cli.js" hook stop`,
+            },
+          ],
+        },
+      ],
+    },
+  })
+  await mkdir(join(componentRoot, "dist"), { recursive: true })
+  await writeFile(join(componentRoot, "dist", "cli.js"), "#!/usr/bin/env node\n")
+  await writeFile(join(componentRoot, ".gitignore"), "dist/\nnode_modules/\n")
 }
 
 async function expectPathMissing(path: string): Promise<void> {
@@ -166,6 +196,12 @@ describe("sync-lazycodex-marketplace", () => {
     expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "git-bash-mcp", "dist", "cli.js"))).isFile()).toBe(true)
     expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "lsp-tools-mcp", "dist", "cli.js"))).isFile()).toBe(true)
     expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "lsp-daemon", "dist", "cli.js"))).isFile()).toBe(true)
+    // hook/bin-referenced component CLIs must ship even though their dist/ is gitignored upstream (lazycodex#108)
+    expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "start-work-continuation", "dist", "cli.js"))).isFile()).toBe(true)
+    expect((await stat(join(lazycodexRoot, "plugins", "omo", "components", "ulw-loop", "dist", "cli.js"))).isFile()).toBe(true)
+    // nested component .gitignore files re-ignore dist/ inside the lazycodex repo and must not ship
+    await expectPathMissing(join(lazycodexRoot, "plugins", "omo", "components", "start-work-continuation", ".gitignore"))
+    await expectPathMissing(join(lazycodexRoot, "plugins", "omo", "components", "ulw-loop", ".gitignore"))
     await expectPathMissing(join(lazycodexRoot, "plugins", "omo", "node_modules"))
     await expectPathMissing(join(lazycodexRoot, "plugins", "omo", ".ulw"))
     await expectPathMissing(join(lazycodexRoot, "plugins", "omo", ".claude"))
@@ -443,6 +479,17 @@ describe("sync-lazycodex-marketplace", () => {
     expect(message).toContain("missing hook command target")
     expect(message).toContain("components/bootstrap/dist/cli.js")
     expect(message).toContain("components/bootstrap/scripts/bootstrap.ps1")
+  })
+
+  test("#given a managed-bin component dist is not built #when syncing marketplace #then rejects naming the missing component dist", async () => {
+    // given
+    const sourceRoot = await mkdtemp(join(tmpdir(), "omo-sync-missing-component-dist-source-"))
+    const lazycodexRoot = await mkdtemp(join(tmpdir(), "omo-sync-missing-component-dist-lazycodex-"))
+    await writePluginFixture(sourceRoot)
+    await rm(join(sourceRoot, "packages", "omo-codex", "plugin", "components", "start-work-continuation", "dist"), { recursive: true, force: true })
+
+    // when/then
+    await expect(syncLazycodexMarketplace({ sourceRoot, lazycodexRoot })).rejects.toThrow(/missing built start-work-continuation component dist/)
   })
 
   test("#given a missing lsp-daemon dist without the flag #then still hard-throws", async () => {

--- a/script/sync-lazycodex-marketplace.ts
+++ b/script/sync-lazycodex-marketplace.ts
@@ -224,11 +224,20 @@ function shouldCopyPluginPath(path: string, root: string): boolean {
   if (relative.length === 0) return true
   const parts = relative.split(sep)
   if (parts.some((part) => PLUGIN_COPY_DENYLIST.has(part))) return false
+  if (parts.length <= 1) return true
+  const name = parts.at(-1)
   // Codex loads MCP servers only from the plugin-root .mcp.json (.codex-plugin/plugin.json declares
   // "mcpServers": "./.mcp.json"). A component's own nested .mcp.json is a standalone-plugin dev
   // manifest whose relative daemon path dangles once the plugin is flattened into the bundle, so it
   // must never ship in plugins/omo.
-  return !(parts.length > 1 && parts.at(-1) === ".mcp.json")
+  if (name === ".mcp.json") return false
+  // A component's nested .gitignore is a standalone-repository dev artifact. When it ships in the
+  // marketplace payload, a `dist/` rule in it overrides the lazycodex repository's root negation
+  // (`!plugins/omo/components/*/dist/**`), so `git add plugins/omo` silently drops the component's
+  // built CLI from the repo even though the file was copied and validated on disk. That is how
+  // start-work-continuation/dist/cli.js and ulw-loop/dist/cli.js went missing while rules and
+  // ultrawork (whose nested .gitignore has no `dist/` rule) survived (lazycodex#108).
+  return name !== ".gitignore"
 }
 
 


### PR DESCRIPTION
## Summary
Fix the lazycodex marketplace sync silently dropping two component CLIs (`start-work-continuation/dist/cli.js`, `ulw-loop/dist/cli.js`), which caused Codex to run endless "dangling managed bin" repairs.

## Root cause
The sync copied each component's own nested `.gitignore` into the marketplace payload. Exactly `start-work-continuation` and `ulw-loop` carry a `dist/` rule in their nested `.gitignore`; a nested ignore rule beats the lazycodex repo's root negation (`!plugins/omo/components/*/dist/**`), so the publish step's `git add plugins/omo` silently skipped those two dists while committing the other 10. Validation passed because the files existed on disk; the loss happened at staging.

## Fix (script/ only, no plugin source)
1. `sync-lazycodex-marketplace.ts`: drop nested `.gitignore` files from the payload (same treatment as nested `.mcp.json`) so the lazycodex repo's own root ignore rules govern.
2. `lazycodex-runtime-dists.ts`: explicitly bundle every component whose `package.json` `bin` targets `dist/` (like the MCP dists); an unbuilt bin component now hard-fails the sync instead of shipping broken.
3. `lazycodex-marketplace-validation.ts`: new `validatePluginManagedBins` asserting every bin target exists, is non-empty, and stays inside the plugin root.

## Verification
- `bun test` sync/validation suites: 25 pass; new tests assert both CLIs ship, no nested `.gitignore` ships, and an unbuilt bin component fails the sync.
- Publish simulation against the real lazycodex `.gitignore` + the workflow's exact `git add`: all 15 component CLIs (incl. both previously-missing) staged, `git check-ignore` clean.

Note: the next real sync deletes the 6 tracked nested `.gitignore` files from the lazycodex repo and adds the two missing dists (expected one-time payload diff).

Reported by @wmsyw in code-yeongyu/lazycodex#108. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the marketplace sync from skipping component CLIs when nested .gitignore files re-ignore dist/. We now bundle bin-based component dists, validate them, and fix Windows path handling so all CLIs stage correctly.

- **Bug Fixes**
  - Exclude nested `.gitignore` from the plugin payload (same treatment as `.mcp.json`) so root ignore rules apply.
  - Bundle every component whose `package.json` `bin` points to `dist/`; fail the sync if a required dist is missing.
  - Add managed-bin validation to ensure each bin target exists, is non-empty, and stays inside the plugin root.
  - Normalize managed-bin target paths to POSIX for consistent validation on Windows.

- **Migration**
  - Next sync deletes tracked nested `.gitignore` files in the lazycodex repo and adds the two previously missing dists.

<sup>Written for commit 855ff8f937f05ad18223c5b347891e00857d4cfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

