### PR TITLE
fix(programming): resolve typescript from the caller project in no-excuse script

### DIFF
--- a/packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.test.ts
+++ b/packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+// Regression for lazycodex#111: the script must resolve `typescript` from the
+// caller project (cwd), not from the script's own location, so it works when
+// executed from an installed `~/.codex/...` skill cache.
+
+const scriptSource = join(import.meta.dir, "check-no-excuse-rules.ts")
+const repoRequire = createRequire(import.meta.url)
+const typescriptPackageDir = dirname(repoRequire.resolve("typescript/package.json"))
+
+let tempRoot = ""
+let cachedScript = ""
+let callerDir = ""
+let callerWithoutTypescriptDir = ""
+
+function runNoExcuse(cwd: string, target: string) {
+	return spawnSync(process.execPath, ["--no-install", cachedScript, target], {
+		cwd,
+		encoding: "utf8",
+		timeout: 60_000,
+	})
+}
+
+describe("#given the no-excuse script is executed from an installed ~/.codex-style skill cache", () => {
+	beforeAll(() => {
+		// given a cache copy of the script outside any project, and two caller projects:
+		// one providing node_modules/typescript, one without typescript at all
+		tempRoot = mkdtempSync(join(tmpdir(), "no-excuse-cache-repro-"))
+		const cacheDir = join(tempRoot, ".codex", "skills", "programming", "scripts", "typescript")
+		mkdirSync(cacheDir, { recursive: true })
+		cachedScript = join(cacheDir, "check-no-excuse-rules.ts")
+		copyFileSync(scriptSource, cachedScript)
+
+		callerDir = join(tempRoot, "caller-project")
+		mkdirSync(join(callerDir, "node_modules"), { recursive: true })
+		symlinkSync(typescriptPackageDir, join(callerDir, "node_modules", "typescript"), "junction")
+		writeFileSync(join(callerDir, "clean.ts"), "export const answer: number = 42\n")
+		writeFileSync(join(callerDir, "violating.ts"), "const x = foo as any\nexport default x\n")
+
+		callerWithoutTypescriptDir = join(tempRoot, "caller-without-typescript")
+		mkdirSync(callerWithoutTypescriptDir, { recursive: true })
+		writeFileSync(join(callerWithoutTypescriptDir, "clean.ts"), "export const answer: number = 42\n")
+	})
+
+	afterAll(() => {
+		rmSync(tempRoot, { recursive: true, force: true })
+	})
+
+	// A generous timeout: the first run does a cold TypeScript program load in a
+	// spawned subprocess, which can exceed bun test's 5s default on a cold cache
+	// (matches the 60s spawnSync ceiling). This bounds the subprocess, it does not
+	// wait on wall-clock time as behavior.
+	test("#when the caller project provides typescript #then it resolves the caller's typescript and exits 0", () => {
+		// when no-excuse runs from the cache copy against the caller project
+		const result = runNoExcuse(callerDir, "clean.ts")
+
+		// then the caller's own typescript is used and the clean file passes
+		expect(result.error).toBeUndefined()
+		expect(result.status).toBe(0)
+		expect(result.stdout).toContain("No violations in 1 file(s).")
+	}, 60_000)
+
+	test("#when a checked file violates the rules #then violations are still reported with exit 1", () => {
+		// when no-excuse runs against a file containing `as any`
+		const result = runNoExcuse(callerDir, "violating.ts")
+
+		// then the existing CLI behavior is unchanged
+		expect(result.error).toBeUndefined()
+		expect(result.status).toBe(1)
+		expect(result.stderr).toContain("[no-any-assertion]")
+	}, 60_000)
+
+	test("#when the caller project genuinely lacks typescript #then it fails with a clear error and exit 2", () => {
+		// when no-excuse runs from a caller project with no local typescript
+		const result = runNoExcuse(callerWithoutTypescriptDir, "clean.ts")
+
+		// then it reports the resolution problem instead of crashing mid-analysis
+		expect(result.error).toBeUndefined()
+		expect(result.status).toBe(2)
+		expect(result.stderr).toContain('cannot resolve "typescript" from the caller project')
+	}, 60_000)
+})

--- a/packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts
+++ b/packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts
@@ -19,6 +19,10 @@
  * Usage:
  *   bun run scripts/check-no-excuse-rules.ts <file-or-dir>...
  *
+ * The `typescript` package is resolved from the caller project (process.cwd()),
+ * not from this script's location, so the script works when executed from an
+ * installed skill-cache path (e.g. ~/.codex/...) against a project checkout.
+ *
  * Exit codes:
  *   0 - no violations
  *   1 - violations found
@@ -26,9 +30,35 @@
  */
 
 import fs from "node:fs"
+import { createRequire } from "node:module"
 import path from "node:path"
 import process from "node:process"
-import ts from "typescript"
+import type * as tsTypes from "typescript"
+
+type TsModule = typeof import("typescript")
+
+function loadTypescriptFromCaller(): TsModule {
+  // A static `import ts from "typescript"` resolves from this script's location —
+  // an installed skill-cache path (e.g. ~/.codex/...) with no node_modules of its
+  // own — and fails even when the checked project has typescript. Resolve from the
+  // caller project (cwd) instead. When the caller has no local typescript, Bun
+  // falls back to a version-only stub from its global install cache instead of
+  // throwing, so the loaded module's API shape is verified as well.
+  const callerRequire = createRequire(path.join(process.cwd(), "no-excuse-anchor.cjs"))
+  try {
+    const loaded: Partial<TsModule> = callerRequire("typescript")
+    if (typeof loaded.createSourceFile === "function") return loaded as TsModule
+  } catch { // no-excuse-ok: catch
+    // fall through to the clear error below
+  }
+  console.error(
+    `error: cannot resolve "typescript" from the caller project (${process.cwd()}). ` +
+      "Install it in the project being checked (e.g. `bun add -d typescript`) and re-run.",
+  )
+  process.exit(2)
+}
+
+const ts: TsModule = loadTypescriptFromCaller()
 
 type RuleId =
   | "no-any-assertion"
@@ -95,7 +125,7 @@ function discoverFiles(inputs: string[]): string[] {
   return files
 }
 
-function getLineText(sourceFile: ts.SourceFile, line: number): string {
+function getLineText(sourceFile: tsTypes.SourceFile, line: number): string {
   const lineStarts = sourceFile.getLineStarts()
   const start = lineStarts[line]
   const end = line + 1 < lineStarts.length ? lineStarts[line + 1] : sourceFile.getEnd()
@@ -107,17 +137,17 @@ function analyzeFile(filePath: string): Violation[] {
   const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true)
   const violations: Violation[] = []
 
-  function pos(node: ts.Node): { line: number; column: number } {
+  function pos(node: tsTypes.Node): { line: number; column: number } {
     const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
     return { line: line + 1, column: character + 1 }
   }
 
-  function lineHasOptOut(node: ts.Node): boolean {
+  function lineHasOptOut(node: tsTypes.Node): boolean {
     const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
     return OPT_OUT_RE.test(getLineText(sourceFile, line))
   }
 
-  function visit(node: ts.Node): void {
+  function visit(node: tsTypes.Node): void {
     // ── as any / as unknown ──
     if (ts.isAsExpression(node)) {
       const typeText = node.type.getText(sourceFile)


### PR DESCRIPTION
## Summary
Make the bundled `check-no-excuse-rules` programming-skill script resolve `typescript` from the caller project instead of its own location, so it works when executed from an installed `~/.codex/...` skill cache.

## Root cause
The script used a static `import ts from "typescript"`. When Bun runs it from an installed skill-cache path, that import resolves from the cache/package context and fails `Cannot find package 'typescript'` even though the caller project (cwd) has typescript installed. This blocked the "run the script directly / through an existing project runner" fallback for checking changed TS files.

## Fix
Resolve `typescript` from the caller project (`process.cwd()`) via a caller-scoped `createRequire`/`require.resolve` and load it dynamically, with a clear error + exit 2 when the caller genuinely lacks typescript (guards against Bun's version-only cache stub). CLI behavior is otherwise identical (exit 0/1/2 semantics, report format). The canonical source lives in `packages/shared-skills/`; the omo-codex and omo-senpi plugin copies are generated by their `sync-skills` steps (not tracked), so only the source + test change here.

## Verification
- New given/when/then regression test (`check-no-excuse-rules.test.ts`) runs the script from a temp `~/.codex`-style cache against three callers: one providing typescript (exit 0), a violating file (exit 1, `[no-any-assertion]`), and one lacking typescript (exit 2, clear error). Regression-proven: with the fix stashed the resolve test fails; with it restored it passes.
- Each test carries a 60s timeout to bound the cold-cache TypeScript subprocess load (matches the 60s spawnSync ceiling), so it does not flake under bun test's 5s default on a cold cache.
- `bun test <test>` 3 pass, 0 fail (re-run).

Reported by @mupozg823 in code-yeongyu/lazycodex#111. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `check-no-excuse-rules` script resolve `typescript` from the caller project so it works when run from an installed `~/.codex` skill cache. CLI behavior stays the same, with a clear error and exit 2 if the caller lacks `typescript`.

- **Bug Fixes**
  - Resolve `typescript` from `process.cwd()` via `createRequire`, with an API-shape check to avoid Bun’s global stub; otherwise unchanged exit 0/1 behavior.
  - When the caller project doesn’t have `typescript`, print a clear message and exit 2.
  - Added regression tests that run the cached script against: a project with `typescript` (exit 0), a violating file (exit 1), and a project without `typescript` (exit 2), with a 60s timeout to cover cold loads.

<sup>Written for commit 90eb338c05e40b40e7fd87ab4c4536278b3b6c9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

