### PR TITLE
fix(codex-install): tolerate lock drift after local file dependency rewrite

### DIFF
--- a/packages/omo-codex/scripts/install-marketplace-cache.test.mjs
+++ b/packages/omo-codex/scripts/install-marketplace-cache.test.mjs
@@ -94,7 +94,10 @@ test("#given local marketplace #when installing #then copies versioned plugins a
 		["npm", "run build", pluginRoot],
 	]);
 	assert.equal(commandLog[2][0], "npm");
-	assert.equal(commandLog[2][1], "ci --omit=dev");
+	// The @example/shared-lsp file: dep points outside the plugin, so the cache
+	// installer rewrites package.json and switches to `npm install` to avoid the
+	// npm ci lock-desync (lazycodex#137).
+	assert.equal(commandLog[2][1], "install --omit=dev --no-audit --no-fund");
 	assert.equal(commandLog[2][2].startsWith(join(codexHome, "plugins", "cache", "debug-marketplace", "alpha", ".tmp-1.2.3-")), true);
 
 	const config = await readFile(join(codexHome, "config.toml"), "utf8");

--- a/packages/omo-codex/src/install/codex-cache-install.test.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.test.ts
@@ -94,6 +94,75 @@ describe("codex-cache install", () => {
   )
 
   test(
+    "#given the local file: dependency rewrite changed package.json #when caching plugin #then npm install reconciles the lock drift instead of npm ci",
+    async () => {
+      // given
+      const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-lock-drift-"))
+      const codexHome = join(root, "codex-home")
+      const sourceRoot = join(root, "plugin")
+      const sharedRoot = join(root, "shared-lib")
+      const npmArgs: string[][] = []
+      await mkdir(sourceRoot, { recursive: true })
+      await mkdir(sharedRoot, { recursive: true })
+      await writeFile(
+        join(sourceRoot, "package.json"),
+        JSON.stringify({ name: "@scope/omo", version: "0.1.0", dependencies: { "shared-lib": "file:../shared-lib" } }),
+      )
+      await writeFile(join(sharedRoot, "package.json"), JSON.stringify({ name: "shared-lib", version: "0.1.0" }))
+
+      // when
+      await installCachedPlugin({
+        codexHome,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async (command, args) => {
+          if (command === "npm") npmArgs.push([...args])
+        },
+      })
+
+      // then
+      expect(npmArgs).toEqual([["install"], ["install", "--omit=dev", "--no-audit", "--no-fund"]])
+    },
+    15000,
+  )
+
+  test(
+    "#given the local file: dependency rewrite changed nothing #when caching plugin #then the install stays npm ci --omit=dev",
+    async () => {
+      // given
+      const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-lock-sync-"))
+      const codexHome = join(root, "codex-home")
+      const sourceRoot = join(root, "plugin")
+      const componentRoot = join(sourceRoot, "components", "local-tool")
+      const npmArgs: string[][] = []
+      await mkdir(componentRoot, { recursive: true })
+      await writeFile(
+        join(sourceRoot, "package.json"),
+        JSON.stringify({ name: "@scope/omo", version: "0.1.0", dependencies: { "local-tool": "file:./components/local-tool" } }),
+      )
+      await writeFile(join(componentRoot, "package.json"), JSON.stringify({ name: "local-tool", version: "0.1.0" }))
+
+      // when
+      await installCachedPlugin({
+        codexHome,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async (command, args) => {
+          if (command === "npm") npmArgs.push([...args])
+        },
+      })
+
+      // then
+      expect(npmArgs).toEqual([["install"], ["ci", "--omit=dev"]])
+    },
+    15000,
+  )
+
+  test(
     "#given a component ships its own nested .mcp.json #when caching plugin #then only the plugin-root .mcp.json is cached",
     async () => {
       // given

--- a/packages/omo-codex/src/install/codex-cache-install.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.ts
@@ -33,10 +33,17 @@ export async function installCachedPlugin(input: {
   await rm(tempPath, { recursive: true, force: true })
   try {
     await copyDirectory(input.sourcePath, tempPath)
-    await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath)
+    const rewroteLocalFileDependencies = await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath)
     await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath })
     await copyRootRuntimeDists({ pluginRoot: tempPath, sourcePath: input.sourcePath })
-    await maybeRunNpmInstall(tempPath, input.runCommand, npmInstallEnv, ["ci", "--omit=dev"])
+    // Rewriting local file: dependencies desyncs package.json from package-lock.json, and npm ci
+    // aborts with EUSAGE on that drift (lazycodex#137; approach credited to the community fix in
+    // oh-my-openagent#6202). The temp cache dir is throwaway, so let npm install reconcile the lock
+    // when the rewrite changed package.json; keep the deterministic npm ci fast path otherwise.
+    const installArgs = rewroteLocalFileDependencies
+      ? ["install", "--omit=dev", "--no-audit", "--no-fund"]
+      : ["ci", "--omit=dev"]
+    await maybeRunNpmInstall(tempPath, input.runCommand, npmInstallEnv, installArgs)
     await removeCachedManagedNpmBinShims(tempPath)
     if (input.buildSource === false) await maybeRunNpmSyncSkills(tempPath, input.runCommand, env)
     await assertNoRemovedSparkshellPromptReferences(tempPath)

--- a/packages/omo-codex/src/install/codex-cache-local-dependencies.ts
+++ b/packages/omo-codex/src/install/codex-cache-local-dependencies.ts
@@ -4,10 +4,11 @@ import { readFile, readdir, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path"
 import { isPathInside } from "./codex-cache-paths"
 
-export async function rewriteCachedPackageLocalFileDependencies(pluginRoot: string, sourceRoot: string): Promise<void> {
+export async function rewriteCachedPackageLocalFileDependencies(pluginRoot: string, sourceRoot: string): Promise<boolean> {
   const packageJsonPaths: string[] = []
   await collectPackageJsonPaths(pluginRoot, pluginRoot, packageJsonPaths)
   const packageLock = await readPackageLock(pluginRoot)
+  let rewroteAnyPackageJson = false
   for (const packageJsonPath of packageJsonPaths) {
     const raw = await readFile(packageJsonPath, "utf8")
     const parsed: unknown = JSON.parse(raw)
@@ -38,9 +39,13 @@ export async function rewriteCachedPackageLocalFileDependencies(pluginRoot: stri
         changed = true
       }
     }
-    if (changed) await writeFile(packageJsonPath, `${JSON.stringify(parsed, null, "\t")}\n`)
+    if (changed) {
+      await writeFile(packageJsonPath, `${JSON.stringify(parsed, null, "\t")}\n`)
+      rewroteAnyPackageJson = true
+    }
   }
   if (packageLock.changed) await writeFile(packageLock.path, `${JSON.stringify(packageLock.value, null, "\t")}\n`)
+  return rewroteAnyPackageJson
 }
 
 type PackageLockState = {


### PR DESCRIPTION
## Summary
Fix `npx lazycodex-ai install` aborting with `npm ci` EUSAGE after the cache installer rewrites local `file:` dependencies.

## Root cause
`installCachedPlugin` copies the plugin to a temp dir, rewrites its `package.json` local `file:` dependency specifiers, then runs `npm ci --omit=dev`. `npm ci` strictly requires `package.json` and `package-lock.json` to be in sync; the rewrite desyncs them, so npm aborts with EUSAGE before installing anything (and the temp dir is deleted, so it repeats every attempt).

## Fix
`rewriteCachedPackageLocalFileDependencies` now reports whether it changed any `package.json`. When it did, the post-rewrite install uses `npm install --omit=dev --no-audit --no-fund` (which reconciles the lock drift; the temp cache dir is throwaway so a regenerated lock is fine). When the rewrite changed nothing, it keeps the faster deterministic `npm ci --omit=dev`. The allow-scripts env sanitization is untouched. Credits the reporter's approach from oh-my-openagent#6202.

## Verification
- New given/when/then tests over the injected runCommand seam: an outside-plugin `file:` dep -> `npm install --omit=dev --no-audit --no-fund`; an inside-plugin `file:` dep (rewrite runs, changes nothing) -> `npm ci --omit=dev`.
- `bun test src/install/codex-cache-install.test.ts` 8 pass, 0 fail (re-run).

Reported by @innopoiesis in code-yeongyu/lazycodex#137 (fix approach from @innopoiesis in oh-my-openagent#6202). Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `npx lazycodex-ai install` aborting with `npm EUSAGE` after rewriting local `file:` dependencies by switching to `npm install` only when needed. Keeps `npm ci` when the rewrite makes no changes for speed.

- **Bug Fixes**
  - Choose installer based on rewrite result: `npm install --omit=dev --no-audit --no-fund` when `package.json` changed; otherwise `npm ci --omit=dev`.
  - Expanded tests to cover both paths and updated the marketplace parity test to expect `npm install` after an outside-plugin `file:` dep rewrite.

<sup>Written for commit 4368a37983c42db1f65e1b5bda89ce72f1ccd5f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

