### PR TITLE
fix(codex-bootstrap): skip duplicate agent registration for pre-declared roles

### DIFF
--- a/packages/omo-codex/plugin/components/bootstrap/src/setup.ts
+++ b/packages/omo-codex/plugin/components/bootstrap/src/setup.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readdir, rm, stat } from "node:fs/promises";
+import { copyFile, mkdir, readFile, readdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 // These relative imports resolve at BUILD time in the monorepo; esbuild
@@ -10,6 +10,7 @@ import {
 	linkCachedPluginAgents,
 } from "../../../../src/install/link-cached-plugin-agents.ts";
 import { linkCachedPluginBins, linkRootRuntimeBin } from "../../../../src/install/codex-cache-bins.ts";
+import { hasForeignAgentRegistration } from "../../../../src/install/codex-config-agents.ts";
 import { updateCodexConfig } from "../../../../src/install/codex-config-toml.ts";
 import { stampGitBashMcpEnv } from "../../../../src/install/codex-git-bash-mcp-env.ts";
 import { trustedHookStatesForPlugin } from "../../../../src/install/codex-hook-trust.ts";
@@ -141,6 +142,16 @@ async function updateConfigStep(
 	const configPath = join(options.codexHome, "config.toml");
 	try {
 		await assertWritableConfigIfPresent(configPath);
+		// Orca mirrors the system [agents.*] entries into its runtime CODEX_HOME
+		// without copying the agents directory. Re-stamping our own registration
+		// for such a role would collide with the mirrored entry once Codex
+		// discovers <codexHome>/agents/<name>.toml (two different file paths for
+		// one role name -> upstream warning), so foreign pre-existing blocks are
+		// left untouched; directory discovery still loads the linked toml.
+		const existingConfig = await readConfigIfPresent(configPath);
+		const agentConfigs = inputs.agentConfigs.filter(
+			(agentConfig) => !hasForeignAgentRegistration(existingConfig, agentConfig),
+		);
 		// Re-stamping trusted hook hashes after an upgrade is what makes the
 		// next session's hooks trusted again once the user re-approved the
 		// bootstrap hook itself.
@@ -150,7 +161,7 @@ async function updateConfigStep(
 			pluginRoot: options.pluginRoot,
 		});
 		await updateCodexConfig({
-			agentConfigs: inputs.agentConfigs,
+			agentConfigs,
 			// Hard invariant: the bootstrap worker NEVER writes permission keys
 			// (approval/sandbox/network policies stay installer-flag-only).
 			autonomousPermissions: false,
@@ -187,6 +198,15 @@ async function assertWritableConfigIfPresent(configPath: string): Promise<void> 
 
 function errorCode(error: unknown): string | undefined {
 	return error instanceof Error && "code" in error && typeof error.code === "string" ? error.code : undefined;
+}
+
+async function readConfigIfPresent(configPath: string): Promise<string> {
+	try {
+		return await readFile(configPath, "utf8");
+	} catch (error) {
+		if (errorCode(error) === "ENOENT") return "";
+		throw error;
+	}
 }
 
 async function linkComponentBinsStep(options: WorkerSetupOptions, degraded: BootstrapDegradedEntry[]): Promise<void> {

--- a/packages/omo-codex/plugin/test/bootstrap-setup.test.mjs
+++ b/packages/omo-codex/plugin/test/bootstrap-setup.test.mjs
@@ -127,6 +127,47 @@ test("#given a completed first run #when the worker setup runs again #then confi
 	});
 });
 
+test("#given a config.toml that already declares [agents.explorer] at a different path (Orca mirror) #when the worker setup runs #then no second colliding registration is added for that role", async () => {
+	await withSetupFixture(async (fixture) => {
+		const orcaMirrorPath = "/orca-mirrored-home/.codex/agents/explorer.toml";
+		await writeFile(
+			join(fixture.codexHome, "config.toml"),
+			`[marketplaces.sisyphuslabs]\n${MARKETPLACE_SOURCE_LINE}\n\n[agents.explorer]\nconfig_file = "${orcaMirrorPath}"\n`,
+		);
+
+		const outcome = await runWorkerSetup(setupOptions(fixture));
+
+		assert.deepEqual(outcome.degraded, []);
+		const config = await readConfig(fixture);
+		assert.equal(config.match(/\[agents\.explorer\]/g)?.length, 1, "exactly one [agents.explorer] block");
+		assert.ok(
+			config.includes(`[agents.explorer]\nconfig_file = "${orcaMirrorPath}"`),
+			"the pre-existing mirrored entry stays untouched",
+		);
+		assert.ok(
+			!config.includes('config_file = "./agents/explorer.toml"'),
+			"no colliding ./agents registration for the mirrored role",
+		);
+		assert.match(config, /\[agents\.metis\]\nconfig_file = "\.\/agents\/metis\.toml"/);
+		assert.equal(
+			await readFile(join(fixture.codexHome, "agents", "explorer.toml"), "utf8"),
+			BUNDLED_EXPLORER_TOML,
+			"the linked toml is still staged for Codex directory discovery",
+		);
+	});
+});
+
+test("#given a config.toml with no pre-existing agent entries #when the worker setup runs #then all bundled registrations are written", async () => {
+	await withSetupFixture(async (fixture) => {
+		const outcome = await runWorkerSetup(setupOptions(fixture));
+
+		assert.deepEqual(outcome.degraded, []);
+		const config = await readConfig(fixture);
+		assert.match(config, /\[agents\.explorer\]\nconfig_file = "\.\/agents\/explorer\.toml"/);
+		assert.match(config, /\[agents\.metis\]\nconfig_file = "\.\/agents\/metis\.toml"/);
+	});
+});
+
 test("#given a package-relative CodeGraph MCP path #when worker setup runs #then the path is stamped absolute", async () => {
 	await withSetupFixture(async (fixture) => {
 		await writeFile(

--- a/packages/omo-codex/src/install/codex-config-agents.ts
+++ b/packages/omo-codex/src/install/codex-config-agents.ts
@@ -34,6 +34,19 @@ export function removeStaleManagedAgentBlocks(config: string, keepAgentNames: Se
     .replace(/\n{3,}/g, "\n\n")
 }
 
+// A runtime mirror (e.g. Orca copying the system [agents.*] entries into a
+// runtime CODEX_HOME without the agents directory) already declares the role
+// name, pointing at a different file. Re-stamping our own registration on top
+// collides with that entry once Codex also discovers
+// <codexHome>/agents/<name>.toml, and upstream warns on two different file
+// paths declaring the same role. Callers use this to leave the foreign block
+// untouched; directory discovery still picks up the linked toml.
+export function hasForeignAgentRegistration(config: string, agentConfig: CodexAgentConfig): boolean {
+  const section = findTomlSection(config, `agents.${tomlKeySegment(agentConfig.name)}`)
+  if (!section) return false
+  return !section.text.includes(`config_file = ${JSON.stringify(agentConfig.configFile)}`)
+}
+
 export function ensureAgentConfig(config: string, agentConfig: CodexAgentConfig): string {
   const header = `agents.${tomlKeySegment(agentConfig.name)}`
   const section = findTomlSection(config, header)


### PR DESCRIPTION
## Summary
Stop LazyCodex bootstrap from emitting duplicate agent-role warnings when Codex runs through a runtime that mirrors `[agents.*]` into its materialized CODEX_HOME (e.g. Orca).

## Root cause
Orca materializes a separate runtime CODEX_HOME and mirrors the system `[agents.*]` config entries into it, but does not copy the agents directory. LazyCodex SessionStart bootstrap then linked bundled roles into `<codexHome>/agents/*.toml` AND wrote matching `./agents/<name>` config registrations. Codex loads explicit roles first, then discovers `<config>/agents`; two different file paths declaring the same role name intentionally warn, so every session started with 13 duplicate-role warnings.

## Fix
New `hasForeignAgentRegistration` helper detects an existing `[agents.<name>]` block that does not point at our exact `./agents/<name>.toml`. `updateConfigStep` reads the current config and skips writing a colliding registration for those roles; the bundled TOML is still linked into `<codexHome>/agents/`, so Codex's directory discovery still loads the role, with no duplicate registration and no warning. A fresh `$HOME/.codex` with no pre-existing `[agents.*]` is unaffected (all registrations written; second-run idempotency preserved).

## Verification
- New given/when/then tests: an Orca-mirrored `[agents.explorer]` (different path) leaves exactly one block with the mirrored path intact, adds no `./agents/explorer.toml` registration, still registers `metis`, and still stages the linked toml; a clean config still gets all bundled registrations.
- `node --test plugin/test/bootstrap-setup.test.mjs` 13 pass; installer agent tests 19 pass; typecheck clean. (Component `dist/` is gitignored, rebuilt at publish/CI.)

Reported by @Noobear in code-yeongyu/lazycodex#131. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops duplicate agent-role warnings by skipping re-registration when `config.toml` already declares a role at a different path (Orca mirror). Codex still loads the bundled TOML via directory discovery without a duplicate registration.

- **Bug Fixes**
  - Added `hasForeignAgentRegistration` and updated `updateConfigStep` to filter `agentConfigs` and avoid colliding registrations; still links TOML into `<codexHome>/agents/`.
  - Added tests for Orca-mirrored configs and clean configs to verify single registration and directory discovery behavior.

<sup>Written for commit 5b302c91f903864a7806149099f4ebdbc06361ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

