### PR TITLE
test(install): lock non-zero exit for failed codex-only install

### DIFF
--- a/packages/omo-opencode/src/cli/cli-installer.platform.test.ts
+++ b/packages/omo-opencode/src/cli/cli-installer.platform.test.ts
@@ -202,7 +202,9 @@ describe("runCliInstaller platform branching", () => {
     const result = await runCliInstaller({ tui: false, platform: "codex" }, "3.4.0")
 
     // then
+    const output = consoleLogMock.mock.calls.map((call) => call.join(" ")).join("\n")
     expect(result).toBe(1)
+    expect(output).toContain("Codex install failed: codex failed")
   })
 
   test("keeps OpenCode success when Codex fails for platform=both", async () => {
@@ -214,7 +216,9 @@ describe("runCliInstaller platform branching", () => {
     const result = await runCliInstaller(createOpenCodeArgs("both"), "3.4.0")
 
     // then
+    const output = consoleLogMock.mock.calls.map((call) => call.join(" ")).join("\n")
     expect(result).toBe(0)
+    expect(output).toContain("Codex install failed (OpenCode install is still complete): codex failed")
   })
 
   test("does not print star commands in noninteractive installs", async () => {

--- a/packages/omo-opencode/src/cli/tui-installer-codex-installation.test.ts
+++ b/packages/omo-opencode/src/cli/tui-installer-codex-installation.test.ts
@@ -3,7 +3,10 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import * as p from "@clack/prompts"
+import * as configManager from "./config-manager"
+import * as astGrepInstall from "./install-ast-grep-sg"
 import * as codexInstaller from "./install-codex"
+import * as tuiConfig from "./config-manager/add-tui-plugin-to-tui-config"
 import * as tuiInstallPrompts from "./tui-install-prompts"
 import { runTuiInstaller } from "./tui-installer"
 import type { CodexInstallResult } from "./install-codex"
@@ -159,6 +162,170 @@ describe("runTuiInstaller Codex installation detection", () => {
     }
     warnSpy.mockRestore()
     detectSpy.mockRestore()
+    installSpy.mockRestore()
+  })
+})
+
+describe("runTuiInstaller Codex install failure exit status", () => {
+  const originalIsStdinTty = process.stdin.isTTY
+  const originalIsStdoutTty = process.stdout.isTTY
+
+  beforeEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true })
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true })
+    spyOn(astGrepInstall, "installAstGrepForOpenCode").mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalIsStdinTty })
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: originalIsStdoutTty })
+  })
+
+  it("#given a Codex-only install whose Codex step fails #when the installer runs #then it reports failure and the exit status is non-zero", async () => {
+    // given
+    const errorSpy = spyOn(p.log, "error").mockImplementation(() => undefined)
+    const outroSpy = spyOn(p, "outro").mockImplementation(() => undefined)
+    const restoreSpies = [
+      spyOn(p, "spinner").mockReturnValue(createMockSpinner()),
+      spyOn(p, "intro").mockImplementation(() => undefined),
+      spyOn(p.log, "info").mockImplementation(() => undefined),
+      spyOn(p.log, "success").mockImplementation(() => undefined),
+      spyOn(p.log, "message").mockImplementation(() => undefined),
+      spyOn(p.log, "warn").mockImplementation(() => undefined),
+      spyOn(p, "note").mockImplementation(() => undefined),
+      spyOn(p, "confirm").mockResolvedValue(false),
+      spyOn(tuiInstallPrompts, "promptInstallPlatform").mockResolvedValue("codex"),
+      spyOn(tuiInstallPrompts, "promptInstallConfig").mockResolvedValue({
+        platform: "codex",
+        hasOpenCode: false,
+        hasClaude: false,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasCodex: true,
+        hasSenpi: false,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+        hasBailianCodingPlan: false,
+        hasMinimaxCnCodingPlan: false,
+        hasMinimaxCodingPlan: false,
+        hasVercelAiGateway: false,
+        codexAutonomous: true,
+      }),
+      spyOn(codexInstaller, "detectCodexInstallation").mockResolvedValue({
+        found: true,
+        source: "cli",
+        path: "/opt/homebrew/bin/codex",
+      }),
+    ]
+    const installSpy = spyOn(codexInstaller, "runCodexInstaller").mockRejectedValue(new Error("codex failed"))
+
+    // when
+    const result = await runTuiInstaller({ tui: true, platform: "codex" }, "3.16.0")
+
+    // then
+    const errorText = errorSpy.mock.calls.map((call) => String(call[0])).join("\n")
+    const outroText = outroSpy.mock.calls.map((call) => String(call[0])).join("\n")
+    expect(result).toBe(1)
+    expect(errorText).toContain("Codex install failed: codex failed")
+    expect(outroText).toContain("Installation failed.")
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+    errorSpy.mockRestore()
+    outroSpy.mockRestore()
+    installSpy.mockRestore()
+  })
+
+  it("#given platform=both where OpenCode succeeds and Codex fails #when the installer runs #then the partial-success warning path is preserved", async () => {
+    // given
+    const warnSpy = spyOn(p.log, "warn").mockImplementation(() => undefined)
+    const errorSpy = spyOn(p.log, "error").mockImplementation(() => undefined)
+    const restoreSpies = [
+      spyOn(p, "spinner").mockReturnValue(createMockSpinner()),
+      spyOn(p, "intro").mockImplementation(() => undefined),
+      spyOn(p.log, "info").mockImplementation(() => undefined),
+      spyOn(p.log, "success").mockImplementation(() => undefined),
+      spyOn(p.log, "message").mockImplementation(() => undefined),
+      spyOn(p, "note").mockImplementation(() => undefined),
+      spyOn(p, "confirm").mockResolvedValue(false),
+      spyOn(p, "outro").mockImplementation(() => undefined),
+      spyOn(tuiInstallPrompts, "promptInstallPlatform").mockResolvedValue("both"),
+      spyOn(tuiInstallPrompts, "promptInstallConfig").mockResolvedValue({
+        platform: "both",
+        hasOpenCode: true,
+        hasClaude: false,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasCodex: true,
+        hasSenpi: false,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+        hasBailianCodingPlan: false,
+        hasMinimaxCnCodingPlan: false,
+        hasMinimaxCodingPlan: false,
+        hasVercelAiGateway: false,
+        codexAutonomous: true,
+      }),
+      spyOn(configManager, "detectCurrentConfig").mockReturnValue({
+        isInstalled: true,
+        installedVersion: "1.4.0",
+        hasClaude: false,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasCodex: false,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+        hasBailianCodingPlan: false,
+        hasMinimaxCnCodingPlan: false,
+        hasMinimaxCodingPlan: false,
+        hasVercelAiGateway: false,
+      }),
+      spyOn(configManager, "isOpenCodeInstalled").mockResolvedValue(true),
+      spyOn(configManager, "getOpenCodeVersion").mockResolvedValue("1.4.0"),
+      spyOn(configManager, "addPluginToOpenCodeConfig").mockResolvedValue({
+        success: true,
+        configPath: "/tmp/opencode.jsonc",
+      }),
+      spyOn(configManager, "writeOmoConfig").mockReturnValue({
+        success: true,
+        configPath: "/tmp/oh-my-opencode.jsonc",
+      }),
+      spyOn(tuiConfig, "ensureTuiPluginEntry").mockReturnValue({ changed: false, reason: "no-server-entry" }),
+      spyOn(codexInstaller, "detectCodexInstallation").mockResolvedValue({
+        found: true,
+        source: "cli",
+        path: "/opt/homebrew/bin/codex",
+      }),
+    ]
+    const installSpy = spyOn(codexInstaller, "runCodexInstaller").mockRejectedValue(new Error("codex failed"))
+
+    // when
+    const result = await runTuiInstaller({ tui: true, platform: "both" }, "3.16.0")
+
+    // then
+    const warningText = warnSpy.mock.calls.map((call) => String(call[0])).join("\n")
+    expect(result).toBe(0)
+    expect(warningText).toContain("Codex install failed (OpenCode install remains successful): codex failed")
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
     installSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
Lock the install exit-code behavior for Codex-only installs with regression tests, addressing the "prints success then fails but exits 0" report.

## Context
The source-level fix is already present on `dev`: both `cli-installer.ts` and `tui-installer.ts` return a non-zero exit when the delegated Codex install fails on a codex-only install (`if (!config.hasOpenCode) { printError("Codex install failed: ..."); return 1 }`), while preserving the `platform=both` partial-success path (OpenCode succeeds, Codex fails -> warning, exit 0). The exit status reaches the process via `install.ts` -> `cli-program.ts` `process.exit(exitCode)`. The gap was test coverage proving it, so it could regress silently. No source change was needed.

## Changes (tests only)
- New `tui-installer-codex-installation.test.ts`: codex-only + Codex step fails -> returns 1, error output + `Installation failed.` outro; `platform=both` OpenCode-succeeds/Codex-fails -> returns 0 with the partial-success warning, no error.
- Extended `cli-installer.platform.test.ts` to assert the printed failure line (codex-only) and the partial-success warning (both), alongside the existing exit-code checks.

## Verification
- `bun test src/cli/cli-installer.test.ts src/cli/cli-installer.platform.test.ts src/cli/tui-installer.test.ts src/cli/tui-installer-codex-installation.test.ts` 28 pass, 0 fail.

Note: the "publish the newer version" half of the issue is a release action, not a code change. Reported by @shubing-joe in code-yeongyu/lazycodex#136. Verified + locked by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests that ensure Codex-only installs exit with a non-zero status when the Codex step fails. Keeps `platform=both` behavior unchanged: OpenCode succeeds, Codex fails -> partial-success warning and exit 0.

<sup>Written for commit 66a174fe325deecd4981fed72abd80c1180f6480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

