### PR TITLE
fix(script): publish marketplace.json at the lazycodex repo root

### DIFF
--- a/script/sync-lazycodex-marketplace.test.ts
+++ b/script/sync-lazycodex-marketplace.test.ts
@@ -183,6 +183,10 @@ describe("sync-lazycodex-marketplace", () => {
     const marketplace = JSON.parse(await readFile(join(lazycodexRoot, ".agents", "plugins", "marketplace.json"), "utf8"))
     expect(marketplace.name).toBe("sisyphuslabs")
     expect(marketplace.plugins[0].source).toBe("./plugins/omo")
+    // `codex plugin marketplace add <repo>` scans the repo ROOT for the manifest,
+    // so it must ship at the root too, identical to the .agents/plugins copy (lazycodex#139).
+    const rootMarketplace = JSON.parse(await readFile(join(lazycodexRoot, "marketplace.json"), "utf8"))
+    expect(rootMarketplace).toEqual(marketplace)
     const manifest = JSON.parse(await readFile(join(lazycodexRoot, "plugins", "omo", ".codex-plugin", "plugin.json"), "utf8"))
     expect(manifest).toMatchObject({ name: "omo", version: "1.2.3" })
     const workflow = await readFile(join(lazycodexRoot, ".github", "workflows", "pr-source-guidance.yml"), "utf8")

--- a/script/sync-lazycodex-marketplace.ts
+++ b/script/sync-lazycodex-marketplace.ts
@@ -15,6 +15,7 @@ const LAZYCODEX_PR_SOURCE_GUIDANCE_SOURCE_PATH = join(
   "pr-source-guidance.yml",
 )
 const MARKETPLACE_DESTINATION_PATH = join(".agents", "plugins", "marketplace.json")
+const MARKETPLACE_ROOT_DESTINATION_PATH = "marketplace.json"
 const PLUGIN_DESTINATION_PATH = join("plugins", "omo")
 const LAZYCODEX_PR_SOURCE_GUIDANCE_DESTINATION_PATH = join(".github", "workflows", "pr-source-guidance.yml")
 const GIT_BASH_MCP_SOURCE_ARG = "../../git-bash-mcp/dist/cli.js"
@@ -63,9 +64,15 @@ export async function syncLazycodexMarketplace(input: SyncLazycodexMarketplaceIn
     throw new Error(`Sisyphus Labs plugin manifest must be named omo, got ${pluginManifest.name}`)
   }
 
+  const marketplaceContents = await readFile(marketplacePath, "utf8")
   const destinationMarketplacePath = join(lazycodexRoot, MARKETPLACE_DESTINATION_PATH)
   await mkdir(dirname(destinationMarketplacePath), { recursive: true })
-  await writeFile(destinationMarketplacePath, await readFile(marketplacePath, "utf8"))
+  await writeFile(destinationMarketplacePath, marketplaceContents)
+  // `codex plugin marketplace add <repo>` scans the repository ROOT for a
+  // supported manifest, so publish marketplace.json at the root as well (the
+  // .agents/plugins copy stays for back-compat). Its "source": "./plugins/omo"
+  // resolves correctly from the root, where the plugin payload is copied.
+  await writeFile(join(lazycodexRoot, MARKETPLACE_ROOT_DESTINATION_PATH), marketplaceContents)
 
   const destinationPluginRoot = join(lazycodexRoot, PLUGIN_DESTINATION_PATH)
   await rm(destinationPluginRoot, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
Publish `marketplace.json` at the lazycodex repo ROOT (in addition to `.agents/plugins/`) so `codex plugin marketplace add https://github.com/code-yeongyu/lazycodex` works with current Codex releases.

## Root cause
Codex 0.144.x scans the marketplace repository ROOT for a supported manifest, but the sync only wrote `marketplace.json` to `.agents/plugins/marketplace.json`. So `codex plugin list` / `codex plugin add omo@sisyphuslabs` found nothing ("marketplace root does not contain a supported manifest"), and the README's marketplace instructions failed. The npx installer path (`bunx lazycodex-ai install`) was unaffected.

## Fix
`syncLazycodexMarketplace` now writes the same `marketplace.json` to the repo root as well. Its `"source": "./plugins/omo"` resolves correctly from the root, where the plugin payload is copied. The `.agents/plugins/marketplace.json` copy is kept for back-compat, so nothing that relied on it breaks.

## Verification
- The sync test now asserts the root `marketplace.json` exists and is byte-identical to the `.agents/plugins` copy.
- `bun test script/sync-lazycodex-marketplace.test.ts` passes.

Reported by @innopoiesis in code-yeongyu/lazycodex#139. Fixed by [sisyphus-bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `marketplace.json` at the repo root in addition to `.agents/plugins/` so current `codex` releases discover the marketplace. Fixes #139.

- **Bug Fixes**
  - `syncLazycodexMarketplace` now writes an identical `marketplace.json` to the repo root; keeps the `.agents/plugins` copy for back-compat.
  - Root manifest works with `codex plugin marketplace add <repo>`; `"source": "./plugins/omo"` resolves from root.
  - Test updated to assert the root file exists and equals the `.agents/plugins` copy.

<sup>Written for commit c3d0e683ddf125c48538c7ea9dbbeea2c879f23f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

