### PR TITLE
test(background-agent): fix Windows-flaky coalesced-flush wait (poll-cap race)

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -284,6 +284,12 @@ function getDispatchedParentWakes(manager: BackgroundManager): Map<string, Pendi
   }>(manager)).parentWakeNotifier.getDispatchedParentWakes()
 }
 
+function getPendingParentWakeTimers(manager: BackgroundManager): Map<string, ReturnType<typeof setTimeout>> {
+  return (cast<{
+    parentWakeNotifier: { getPendingParentWakeTimers: () => Map<string, ReturnType<typeof setTimeout>> }
+  }>(manager)).parentWakeNotifier.getPendingParentWakeTimers()
+}
+
 function getCompletionTimers(manager: BackgroundManager): Map<string, ReturnType<typeof setTimeout>> {
   return (cast<{ completionTimers: Map<string, ReturnType<typeof setTimeout>> }>(manager)).completionTimers
 }
@@ -337,12 +343,39 @@ async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<v
   }
 }
 
-// Awaits the debounced parent-wake flush to settle by racing the real
-// onScheduledFlushSettled signal against a bounded state poll, so scheduled
-// flushes resolve on the signal (~100ms debounce) and direct-flush flows
-// resolve when their observable settles — replacing blind 400ms sleeps.
+// Awaits the debounced parent-wake flush to settle. Captures the settled-flush
+// count at entry (the flush is scheduled but still pending here), then awaits
+// count > captured — so a settle landing between this call and registration is
+// not missed.
+//
+// When a flush is armed (a pending wake or its debounce timer exists), the
+// scheduled flush's `finally` is GUARANTEED to fire onScheduledFlushSettled, so
+// await that real signal with no competing wall-clock deadline. Racing a fixed
+// state-poll timeout here is what made this flaky on slow (Windows CI) runners:
+// the ~100ms debounce plus the async dispatch could outlast the poll cap, so the
+// poll resolved by TIMEOUT — not by the predicate — tearing the test down before
+// promptAsync ran (observed as promptCalls.length 0). If the flush ever fails to
+// settle it now surfaces as a loud per-test timeout, never a silent false pass.
+//
+// Only when no flush is armed (settle can never fire) do we fall back to a
+// bounded state-drain so the helper never hangs.
 function waitForCoalescedFlush(manager: BackgroundManager, sessionID: string): Promise<void> {
-  return awaitFlushWithFallback(manager, sessionID)
+  const api = cast<{
+    getScheduledFlushSettledCount: (id: string) => number
+    awaitScheduledFlush: (id: string, sinceCount: number) => Promise<void>
+  }>(manager)
+  const sinceCount = api.getScheduledFlushSettledCount(sessionID)
+  const settled = api.awaitScheduledFlush(sessionID, sinceCount)
+  const flushArmed =
+    getPendingParentWakes(manager).has(sessionID) || getPendingParentWakeTimers(manager).has(sessionID)
+  if (flushArmed) {
+    return settled
+  }
+  const drained = waitUntil(
+    () => !getPendingParentWakes(manager).has(sessionID) || getDispatchedParentWakes(manager).has(sessionID),
+    600,
+  )
+  return Promise.race([settled, drained])
 }
 
 function waitForParentWakeRequeue(manager: BackgroundManager, sessionID: string): Promise<void> {
@@ -354,24 +387,6 @@ function waitForParentWakeRequeue(manager: BackgroundManager, sessionID: string)
 // the async late-error handling settles — instead of blindly sleeping 260ms.
 function waitForParentWakeErrorSettle(manager: BackgroundManager, sessionID: string): Promise<void> {
   return waitUntil(() => !getDispatchedParentWakes(manager).has(sessionID), 600)
-}
-
-// Capture the settled-flush count at entry (the debounced flush is scheduled but
-// still pending here), then await count > captured — so a settle that lands
-// between this call and registration is not missed. A bounded state-drain covers
-// flows that never schedule a flush (never hangs).
-function awaitFlushWithFallback(manager: BackgroundManager, sessionID: string): Promise<void> {
-  const api = cast<{
-    getScheduledFlushSettledCount: (id: string) => number
-    awaitScheduledFlush: (id: string, sinceCount: number) => Promise<void>
-  }>(manager)
-  const sinceCount = api.getScheduledFlushSettledCount(sessionID)
-  const settled = api.awaitScheduledFlush(sessionID, sinceCount)
-  const drained = waitUntil(
-    () => !getPendingParentWakes(manager).has(sessionID) || getDispatchedParentWakes(manager).has(sessionID),
-    600,
-  )
-  return Promise.race([settled, drained])
 }
 
 function createToastRemoveTaskTracker(): { removeTaskCalls: string[]; resetToastManager: () => void } {


### PR DESCRIPTION
## Summary
The `dev` CI is red on a Windows-only flaky test: `manager.test.ts` "variant propagation" asserts `expect(promptCalls).toHaveLength(1)` but intermittently sees length 0 on `test (windows-latest)`. This is a test-timing bug, not a product bug — the parent-wake flush is correct, but the test's wait for it was unreliable. This PR makes the wait deterministic so the test passes reliably on every platform. Production behavior is unchanged.

## Root cause
`waitForCoalescedFlush` (formerly via `awaitFlushWithFallback`) did:

```ts
Promise.race([ settled /* onScheduledFlushSettled */, drained /* waitUntil(pred, 600) */ ])
```

`waitUntil` resolves on **timeout regardless of its predicate**. Every call site first queues a pending parent-wake with a ~100ms debounce, then the flush dispatches `promptAsync` asynchronously. On a loaded Windows CI runner, debounce + dispatch can exceed the 600ms poll cap, so `drained` wins the race **by timing out** — before `promptAsync` ran — and the test asserts against empty `promptCalls`.

## Changes
- **`waitForCoalescedFlush` now awaits the guaranteed settle signal.** Since every call site arms a scheduled flush (a pending wake or its debounce timer is present), the flush's `finally` is guaranteed to fire `onScheduledFlushSettled`. When a flush is armed, the helper awaits that real signal with no competing wall-clock deadline. A genuinely stuck flush now fails loudly via the per-test timeout instead of passing falsely on the poll cap.
- **Bounded drain kept only for the no-flush-armed path**, so the helper still never hangs where a settle can never fire.
- **Merged the redundant `awaitFlushWithFallback` wrapper** into `waitForCoalescedFlush` (single call site, no durable contract).
- **Added a `getPendingParentWakeTimers` test accessor** mirroring the existing `getPendingParentWakes` / `getCompletionTimers` accessors.

## QA & Evidence
- **Full test file** — `bun test src/features/background-agent/manager.test.ts` → `195 pass, 0 fail` (macOS/arm64). Covers all 7 `waitForCoalescedFlush` call sites, including the previously-flaky variant-propagation tests.
- **Sibling suites** — `parent-wake-active-turn-event.test.ts` + `parent-wake-activity-window.test.ts` → `6 pass, 0 fail`.
- **Typecheck** — `bun run typecheck` (tsgo) → exit 0.
- **Deterministic race reproduction** — a faithful model of both helper implementations against a flush that settles at T=800ms (slow-Windows) vs. the old 600ms poll cap:
  - **OLD:** `resolved@604ms promptCalls=0` → `expect length 1` **FAILS** (reproduces the exact Windows symptom: Expected 1, Received 0).
  - **NEW:** `resolved@801ms promptCalls=1` → **PASSES** (waits for the real dispatch/settle).

  This proves the fix removes the timeout-wins race rather than merely being green on a fast runner.

## Risks & Residuals
- **Windows CI is the true gate** and cannot be reproduced locally; the deterministic model above stands in for the timing, and CI on this PR exercises the real Windows runner. Mitigated by CI.
- **Hang risk:** a flush that never settles now blocks until the 5s bun per-test timeout — a loud, correct failure, strictly better than the previous silent false pass. Accepted.
- **Scope:** test-only change; no runtime/product code touched. Regenerated `dist`/install bundles from `bun install` were intentionally excluded to keep the PR atomic.

## Related
Fixes the Windows-only flake on `dev` CI (run 29891115648, `test (windows-latest)`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows-only flaky test by awaiting the guaranteed flush-settle signal instead of racing a 600ms poll, making the variant propagation tests deterministic. No product code changes.

- **Bug Fixes**
  - `waitForCoalescedFlush` now awaits `onScheduledFlushSettled` when a flush is armed (pending wake or debounce timer present).
  - Keeps a bounded state drain only when no flush is armed to avoid hangs.
  - Merges `awaitFlushWithFallback` into `waitForCoalescedFlush`.
  - Adds a `getPendingParentWakeTimers` test accessor.

<sup>Written for commit ad0085b2be5057c8a7029cfabf9e725f261b89c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

