### PR TITLE
fix(lsp): send initialized notification params

### DIFF
--- a/packages/lsp-core/src/lsp/connection.ts
+++ b/packages/lsp-core/src/lsp/connection.ts
@@ -71,7 +71,7 @@ export class LspClientConnection extends LspClientTransport {
 			{ timeoutMs: this.initializeTimeoutMs },
 		);
 		this.setDiagnosticPullSupported(supportsDiagnosticPull(result?.capabilities));
-		await this.sendNotification("initialized");
+		await this.sendNotification("initialized", {});
 		await this.sendNotification("workspace/didChangeConfiguration", {
 			settings: { json: { validate: { enable: true } } },
 		});

--- a/packages/lsp-tools-mcp/test/initialize-timeout.test.ts
+++ b/packages/lsp-tools-mcp/test/initialize-timeout.test.ts
@@ -10,6 +10,7 @@ import type { ResolvedServer } from "../src/lsp/types.js";
 
 const FAKE_LSP_SERVER_SCRIPT = `
 let buffer = Buffer.alloc(0);
+let initialized = false;
 const initializeDelayMs = Number(process.env.FAKE_LSP_INITIALIZE_DELAY_MS ?? "0");
 function send(message) {
 	const body = Buffer.from(JSON.stringify(message), "utf8");
@@ -19,6 +20,15 @@ function send(message) {
 function onMessage(message) {
 	if (message.method === "initialize") {
 		setTimeout(() => send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } }), initializeDelayMs);
+		return;
+	}
+	if (message.method === "initialized") {
+		initialized = message.params !== null && typeof message.params === "object" && !Array.isArray(message.params);
+		return;
+	}
+	if (message.method === "textDocument/documentSymbol") {
+		if (initialized) send({ jsonrpc: "2.0", id: message.id, result: [] });
+		else send({ jsonrpc: "2.0", id: message.id, error: { code: -32002, message: "Server not initialized" } });
 		return;
 	}
 	if (message.method === "shutdown") {
@@ -116,5 +126,24 @@ describe("LspClientConnection timeouts", () => {
 		// then
 		await expect(request).rejects.toThrow(LspRequestTimeoutError);
 		expect(Date.now() - startedAt).toBeLessThan(2_000);
+	});
+
+	it("#given a server that requires initialized params #when initialize completes #then subsequent requests succeed", async () => {
+		// given
+		const connection = new TestConnection(root, fakeServer(0), {
+			requestTimeoutMs: 1_000,
+			initializeTimeoutMs: 5_000,
+		});
+		connections.push(connection);
+		await connection.start();
+
+		// when
+		await connection.initialize();
+		const result = connection.request<unknown[]>("textDocument/documentSymbol", {
+			textDocument: { uri: "file:///strict.fake" },
+		});
+
+		// then
+		await expect(result).resolves.toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

- The LSP client sent the `initialized` notification without a `params` field. The LSP specification defines `InitializedParams` as an empty object, and strict servers such as the Dart language server reject a missing `params` field with `JsonRpcError(-32002): Server not initialized`. This change sends an explicit `{}` to support strict servers without changing the initialization sequence.

## Changes

- `packages/lsp-core/src/lsp/connection.ts`: send `initialized` with `{}`. This is the entire production change.
- `packages/lsp-tools-mcp/test/initialize-timeout.test.ts`: extend the fake LSP server to require object params and verify that a request after initialization succeeds.
- No documentation or configuration changes.

## QA & Evidence

- **What was tested:** Regression test against a fake strict LSP server.
  **Observed result:** RED before the fix with `JsonRpcError(-32002): Server not initialized`; GREEN 3/3 after the fix.
  **Artifact:** `.omo/evidence/20260722-lsp-initialized-param/QA.md`
  **Why sufficient:** Directly reproduces the missing-params failure and proves the one-line fix resolves it.

- **What was tested:** Full `packages/lsp-tools-mcp` suite.
  **Observed result:** 96/96 passing.
  **Artifact:** `.omo/evidence/20260722-lsp-initialized-param/QA.md`
  **Why sufficient:** Covers the MCP package consuming the shared LSP core and its neighboring behavior.

- **What was tested:** Root `bun run typecheck`.
  **Observed result:** Passed.
  **Artifact:** `.omo/evidence/20260722-lsp-initialized-param/typecheck-local.log`
  **Why sufficient:** Confirms the change typechecks across all workspace packages.

- **What was tested:** Root `bun test` in the Ghostty environment.
  **Observed result:** 12,031 passed, 3 skipped, 0 failed.
  **Artifact:** `.omo/evidence/20260722-lsp-initialized-param/bun-test-ghostty-full.log`
  **Why sufficient:** Confirms the repo-wide behavioral suite remains green.

- **What was tested:** Real Dart language server through the stdio MCP.
  **Observed result:** `lsp_symbols` returned `HomeDeviceMapper` and its members; `lsp_diagnostics` returned no errors.
  **Artifact:** `.omo/evidence/20260722-lsp-initialized-param/dart-mcp-roundtrip.txt`
  **Why sufficient:** Exercises the strict server that motivated the fix through the real LSP transport.

- **What was tested:** Manual local OpenCode verification.
  **Observed result:** Dart LSP initializes successfully and Kotlin LSP remains functional.
  **Artifact:** `.omo/evidence/20260722-lsp-initialized-param/QA.md`
  **Why sufficient:** Confirms the behavior through the user-facing harness and checks an existing server for regressions.

- **What was tested:** Local `bun run test:codex` from the normal repository path.
  **Observed result:** Reached the final Node suite with 510 passing and 3 failures in `packages/omo-codex/scripts/install-bin-links.test.mjs`. No LSP-related failures were observed.
  **Artifact:** `.omo/evidence/20260722-lsp-initialized-param/test-codex-local.log`
  **Why sufficient:** Confirms the Codex LSP tests did not report a regression. The remaining environment-specific failures are documented below and canonical CI is pending.

## Risks & Residuals

- **Local `test:codex` gate: blocked locally, pending CI.** Three runtime-wrapper tests assume Bun is absent, but the generated wrapper intentionally discovers the host `/opt/homebrew/bin/bun`. These tests therefore fail on this machine before reaching their expected missing-Bun branches. The failures are unrelated to LSP and are recorded in `test-codex-local.log`.
- **Explicit empty params compatibility: mitigated.** The LSP specification defines `InitializedParams` as an empty object. The change was validated with strict fake and real Dart servers, while Kotlin remained functional.
- **Historical relationship: informational.** Issue [#2185](https://github.com/code-yeongyu/oh-my-openagent/issues/2185) and merged PR [#2481](https://github.com/code-yeongyu/oh-my-openagent/pull/2481) fixed an older `[null]` serialization problem by omitting undefined params. They did not send the empty object required by `InitializedParams`. This is a stricter protocol-compliance gap, not a regression caused by the later LSP extraction.

## Automated Checks

```bash
npm --prefix packages/lsp-tools-mcp test
bun run typecheck
bun test
bun run test:codex
```

## Related Issues

- [#2185](https://github.com/code-yeongyu/oh-my-openagent/issues/2185)
- [#2481](https://github.com/code-yeongyu/oh-my-openagent/pull/2481)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the LSP initialized notification with an explicit empty params object to comply with the spec and fix “Server not initialized” errors on strict servers like Dart. No change to the initialization flow.

- Bug Fixes
  - `packages/lsp-core/src/lsp/connection.ts`: send "initialized" with {} instead of omitting params.
  - `packages/lsp-tools-mcp/test/initialize-timeout.test.ts`: extend fake server to require object params and verify a post-init request succeeds.

<sup>Written for commit 1b1211fcb3de68ab092988c5bedd2628e158ba8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

