### PR TITLE
test(omo-senpi): stabilize run command fixture

### DIFF
--- a/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/README.md
@@ -1,0 +1,42 @@
+# Senpi runOmoCommand timeout QA
+
+## Objective audit
+
+| Requirement | Artifact | Evidence |
+|---|---|---|
+| Fix the final local `bun run test:senpi` timeout | `packages/omo-senpi/src/components/ulw-loop/ulw-loop.test-support.ts` | Fake `omo` commands now execute an absolute Node binary instead of nesting Bun under the Bun test runner. |
+| Preserve the exact `runOmoCommand` behavior | `packages/omo-senpi/src/components/ulw-loop/runtime.test.ts` | Existing stdout/cwd assertions remain and now assert the child runtime is not Bun. |
+| Prove RED before the fix | `red-green.txt` | PR #6310 recorded the actual 20-second full-gate timeout; a stale old-style fixture contained the Bun wrapper but no `cwd.txt`; unchanged code deterministically reported Bun `1.3.14`. |
+| Prove deterministic completion | `red-green.txt` | 100 repeated runtime-test executions passed; duration fell from 147.81 seconds to 74.78 seconds. |
+| Prove full gate | `verification.txt` | `bun run test:senpi` passed twice consecutively, 323 tests each. |
+| Prove matching command surface | `manual-qa.txt` | Real `omo ulw-loop status --json` covered missing-plan and valid-plan paths and left no process behind. |
+| Pass the HEAVY reviewer gate | `review.txt` | Goal, quality, security, hands-on, and history/context reviewers all passed the final diff with no blockers. |
+| New worktree, PR, merge, cleanup | PR evidence after delivery | Branch `fix/senpi-run-command-timeout`; task worktree is removed after merge. |
+
+## Root cause
+
+`createTempOmoBin()` used `process.execPath`. Under `bun test`, that value is the Bun executable, so every fake status command launched another Bun process through `/bin/sh`. The original full gate recorded the exact runtime test timing out after 20 seconds. A pre-existing fixture directory from that failure class contained the old Bun wrapper and runner source but no `cwd.txt`, showing the runner did not reach its first write. The unchanged helper's runtime-identity assertion then deterministically failed with Bun `1.3.14`.
+
+The fixture now resolves the installed Node executable once with `node -p process.execPath` and invokes that absolute binary. Shell-wrapper behavior is deliberately unchanged, isolating the fix to one causal toggle: Bun child startup versus Node child startup. Production `runOmoCommand()` behavior and deadlines are unchanged.
+
+The timeout itself is load-sensitive: a fresh unchanged gate and 100 isolated reruns completed successfully. The evidence therefore does not claim a new deterministic timeout reproduction. It combines the actual prior timeout, the incomplete old fixture artifact, deterministic wrong-runtime RED, independent hands-on process inspection, and the two-times faster stress result.
+
+## Validation summary
+
+- Focused runtime test: 5 pass, 0 fail.
+- Complete ulw-loop component suite: 27 pass, 0 fail.
+- OMO Senpi package typecheck: exit 0.
+- Runtime stress: 500 pass across 100 reruns in 77.34 seconds.
+- Full Senpi gate: two consecutive runs, 323 pass / 0 fail each.
+- Manual missing-plan status: expected structured error, exit 1, no leftover process.
+- Manual valid-plan status: create exit 0, status exit 0, temporary state removed, no leftover process.
+- Five-lane reviewer gate: unconditional PASS across all lanes.
+
+## Cleanup
+
+- Runtime helper removes every `omo-senpi-ulw-loop-*` directory in `finally`; the final 100-run stress check reported zero leftover fixture directories.
+- Manual QA removed `/tmp/omo-senpi-run-command-qa.KL6n7S`.
+- No matching `omo ulw-loop status` process remained.
+- No production source or generated bundle change is included.
+- Setup resolves Node before creating the fixture directory, so discovery failure cannot leak a new `omo-senpi-ulw-loop-*` directory.
+- The eleven stale fixture directories found during review were removed; the final verification baseline is zero.

--- a/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/architecture-review.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/architecture-review.txt
@@ -1,0 +1,24 @@
+POST-WRITE ARCHITECTURAL REVIEW
+
+1. File size
+   runtime.test.ts is 77 total lines.
+   ulw-loop.test-support.ts is 197 total lines.
+   Pure LOC is necessarily below the 250-line hard ceiling for both files.
+
+2. Cohesion
+   Node executable discovery remains inside the test-support module that owns fake omo command creation.
+
+3. Hidden coupling
+   The fixture now depends explicitly on the repository's documented Node prerequisite rather than accidentally coupling to the Bun test runner.
+
+4. Cross-platform symmetry
+   Windows and POSIX wrapper quoting and lifecycle behavior are unchanged; only the resolved executable changes from Bun to Node.
+
+5. Failure model
+   Node resolution is bounded and occurs before temporary-directory creation. Discovery failure cannot leak fixture state.
+
+6. Consumer visibility
+   The change is test support only. Production `runOmoCommand`, its 30-second timeout, and shipped extension behavior are unchanged.
+
+7. Simplest form
+   One cached local resolver, one runtime marker, and one assertion pin the invariant. No shared abstraction, timeout increase, retry, sleep, or production seam was added.

--- a/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/manual-qa.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/manual-qa.txt
@@ -1,0 +1,19 @@
+MISSING-PLAN EDGE
+command:
+  omo ulw-loop status --json --cwd <worktree>
+observed:
+  code: ULW_LOOP_PLAN_MISSING
+  status_exit=1
+  cleanup: no status process remains
+
+VALID-PLAN HAPPY PATH
+command:
+  QA_DIR=$(mktemp -d)
+  omo ulw-loop create-goals --cwd "$QA_DIR" --session-id run-command-qa --brief "<status completion criterion>" --json
+  omo ulw-loop status --cwd "$QA_DIR" --session-id run-command-qa --json
+observed:
+  create_exit=0
+  status_exit=0
+  valid plan JSON returned
+  cleanup: removed /tmp/omo-senpi-run-command-qa.KL6n7S
+  cleanup: no matching status process remained

--- a/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/red-green.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/red-green.txt
@@ -1,0 +1,59 @@
+ACTUAL RED - prior full gate
+source:
+  https://github.com/code-yeongyu/oh-my-openagent/pull/6310
+observed:
+  `bun run test:senpi` completed 319/320 tests.
+  `default runOmoCommand executes status` timed out after 20 seconds.
+
+ACTUAL INCOMPLETE FIXTURE ARTIFACT
+path:
+  <os.tmpdir>/omo-senpi-ulw-loop-Qm7moX
+observed before cleanup:
+  generated `omo` wrapper invoked `/Users/yeongyu/.bun/bin/bun`
+  wrapper did not use `exec`
+  `cwd.txt` was absent, so the runner never reached its first write
+  artifact modification time: 2026-07-22T17:57:15+09:00
+
+BASELINE STRESS
+command:
+  bun test packages/omo-senpi/src/components/ulw-loop/runtime.test.ts --rerun-each 100
+observed:
+  500 pass
+  0 fail
+  duration 147.81 seconds
+
+DETERMINISTIC RED - child runtime identity
+instrumentation:
+  The fake runner records process.execPath and process.versions.bun.
+command:
+  bun test packages/omo-senpi/src/components/ulw-loop/runtime.test.ts
+observed:
+  Expected bunVersion to be null.
+  Received "1.3.14".
+  4 pass
+  1 fail
+
+scope:
+  This deterministic assertion pins the causal fixture invariant.
+  It does not claim that a fresh isolated run reproduces the load-sensitive 20-second timeout.
+
+GREEN - absolute Node runner
+change:
+  Resolve Node once with `node -p process.execPath`.
+  Invoke the absolute Node binary.
+  Leave shell-wrapper behavior unchanged to isolate the runtime-selection toggle.
+command:
+  bun test packages/omo-senpi/src/components/ulw-loop/runtime.test.ts
+observed:
+  5 pass
+  0 fail
+  child bunVersion is null
+
+GREEN STRESS
+command:
+  bun test packages/omo-senpi/src/components/ulw-loop/runtime.test.ts --rerun-each 100
+observed:
+  500 pass
+  0 fail
+  duration 77.34 seconds
+  leftover_fixture_dirs=0

--- a/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/review.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/review.txt
@@ -1,0 +1,27 @@
+FINAL FIVE-LANE REVIEW GATE
+
+Goal verification:
+  PASS, confidence 97%
+  No critical, major, or blocking issues.
+
+Code quality:
+  PASS
+  Single runtime-selection toggle, exception-safe setup, no timeout increase.
+
+Security:
+  PASS
+  No critical or major findings.
+  Ambient PATH/environment and unusual Windows batch expansion remain non-blocking defense-in-depth notes.
+
+Hands-on QA:
+  PASSED
+  Focused 5/0, 15 stress runs, typecheck, full 323/0 gate, independent Node-process observation.
+  Zero fixture directories and zero runner processes before/after.
+
+History/context:
+  PASS
+  Fix belongs in the test fixture introduced by the portable Windows runner change.
+  Production runOmoCommand and its existing timeout/leak hardening remain unchanged.
+
+Blocking issues:
+  none

--- a/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/verification.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/verification.txt
@@ -1,0 +1,33 @@
+FOCUSED COMPONENT
+command:
+  bun test packages/omo-senpi/src/components/ulw-loop
+observed:
+  27 pass
+  0 fail
+
+TYPECHECK
+command:
+  bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json
+observed:
+  exit 0
+
+FULL GATE RUN 1
+command:
+  bun run test:senpi
+observed:
+  323 pass
+  0 fail
+
+FULL GATE RUN 2
+command:
+  bun run test:senpi
+observed:
+  323 pass
+  0 fail
+
+DIAGNOSTICS
+runtime.test.ts:
+  LSP: no diagnostics
+ulw-loop.test-support.ts:
+  LSP server fresh-diagnostic request timed out twice.
+  Package tsgo completed successfully and is the blocking semantic diagnostic.

--- a/packages/omo-senpi/src/components/ulw-loop/runtime.test.ts
+++ b/packages/omo-senpi/src/components/ulw-loop/runtime.test.ts
@@ -8,6 +8,7 @@ import {
   createLogger,
   createTempOmoBin,
   readRealCwd,
+  readRunnerRuntime,
   withEnv,
   withEnvAsync,
 } from "./ulw-loop.test-support"
@@ -37,6 +38,7 @@ describe("omo-senpi ulw-loop runtime", () => {
 
       expect(result).toEqual({ code: 0, stdout: `${activeStatus("NODE-RUNNER")}\n` })
       expect(readRealCwd(fake.dir)).toBe(realpathSync(fake.dir))
+      expect(readRunnerRuntime(fake.dir).bunVersion).toBeNull()
     } finally {
       fake.cleanup()
     }

--- a/packages/omo-senpi/src/components/ulw-loop/ulw-loop.test-support.ts
+++ b/packages/omo-senpi/src/components/ulw-loop/ulw-loop.test-support.ts
@@ -1,4 +1,5 @@
 import { chmodSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { execFileSync } from "node:child_process"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -125,6 +126,7 @@ export async function withEnvAsync<T>(patch: Record<string, string | undefined>,
 }
 
 export function createTempOmoBin(stdout = activeStatus()): { dir: string; bin: string; cleanup: () => void } {
+  const nodeExecutable = resolveNodeExecutable()
   const dir = mkdtempSync(join(tmpdir(), "omo-senpi-ulw-loop-"))
   const bin = join(dir, process.platform === "win32" ? "omo.cmd" : "omo")
   const runner = join(dir, "omo-runner.cjs")
@@ -133,14 +135,15 @@ export function createTempOmoBin(stdout = activeStatus()): { dir: string; bin: s
     [
       "const { realpathSync, writeFileSync } = require('node:fs')",
       `writeFileSync(${JSON.stringify(join(dir, "cwd.txt"))}, realpathSync(process.cwd()))`,
+      `writeFileSync(${JSON.stringify(join(dir, "runtime.json"))}, JSON.stringify({ bunVersion: process.versions.bun ?? null }))`,
       `process.stdout.write(${JSON.stringify(`${stdout}\n`)})`,
       "",
     ].join("\n"),
   )
   const script =
     process.platform === "win32"
-      ? `@echo off\r\n"${process.execPath}" "${runner}"\r\n`
-      : `#!/bin/sh\n'${process.execPath.replace(/'/g, "'\\''")}' '${runner.replace(/'/g, "'\\''")}'\n`
+      ? `@echo off\r\n"${nodeExecutable}" "${runner}"\r\n`
+      : `#!/bin/sh\n'${nodeExecutable.replace(/'/g, "'\\''")}' '${runner.replace(/'/g, "'\\''")}'\n`
   writeFileSync(bin, script)
   chmodSync(bin, 0o755)
   return {
@@ -152,6 +155,26 @@ export function createTempOmoBin(stdout = activeStatus()): { dir: string; bin: s
 
 export function readRealCwd(dir: string): string {
   return realpathSync(readFileSync(join(dir, "cwd.txt"), "utf8").trim())
+}
+
+export function readRunnerRuntime(dir: string): { bunVersion: string | null } {
+  return JSON.parse(readFileSync(join(dir, "runtime.json"), "utf8")) as {
+    bunVersion: string | null
+  }
+}
+
+let cachedNodeExecutable: string | undefined
+
+function resolveNodeExecutable(): string {
+  if (cachedNodeExecutable !== undefined) return cachedNodeExecutable
+  const executable = execFileSync("node", ["-p", "process.execPath"], {
+    encoding: "utf8",
+    timeout: 5_000,
+    windowsHide: true,
+  }).trim()
+  if (executable.length === 0) throw new Error("node did not report process.execPath")
+  cachedNodeExecutable = executable
+  return executable
 }
 
 export async function registerWithRunner(outputs: string[], logger = createLogger()): Promise<{


### PR DESCRIPTION
## Summary

- Fixes the load-sensitive `default runOmoCommand executes status` timeout observed in the local `bun run test:senpi` gate.
- Keeps production `runOmoCommand`, its timeout, and all shipped extension behavior unchanged.
- Makes the fake `omo` command honor its stated Node-compatible contract instead of recursively launching Bun under `bun test`.

## Root Cause

`createTempOmoBin()` embedded `process.execPath` into its generated wrapper. Under `bun test`, `process.execPath` is Bun, so each fake status command started another Bun process merely to execute a small CommonJS script.

The actual failure was recorded in PR #6310: the full Senpi gate completed 319/320 tests and this runtime test timed out after 20 seconds. A stale fixture from the same failure class contained the old Bun wrapper but no `cwd.txt`, showing the runner did not reach its first write.

## Changes

- Resolve the installed Node executable once with shell-free `node -p process.execPath`.
- Cache and use that absolute Node path in both POSIX and Windows fake wrappers.
- Resolve Node before creating the temporary fixture directory so discovery failure cannot leak state.
- Record the fake child's `process.versions.bun` value and assert it is `null`.
- Leave shell-wrapper behavior and all timeout values unchanged, isolating Bun-versus-Node as the only behavior toggle.

## RED -> GREEN

### Actual timeout

PR #6310 recorded:

```text
bun run test:senpi
319 pass
1 fail
default runOmoCommand executes status timed out after 20000ms
```

### Deterministic invariant RED

```text
Expected bunVersion to be null.
Received "1.3.14".
4 pass
1 fail
```

### GREEN

```text
bun test packages/omo-senpi/src/components/ulw-loop/runtime.test.ts
5 pass
0 fail
```

The unchanged 100-rerun stress took 147.81 seconds. The final Node-backed fixture completed the same 500 test executions in 77.34 seconds and left zero fixture directories.

## QA

```bash
bun test packages/omo-senpi/src/components/ulw-loop
# 27 pass, 0 fail

bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json
# exit 0

bun test packages/omo-senpi/src/components/ulw-loop/runtime.test.ts --rerun-each 100
# 500 pass, 0 fail, zero fixture directories

bun run test:senpi
bun run test:senpi
# two consecutive runs: 323 pass, 0 fail each
```

Manual command-surface QA covered:

- missing-plan `omo ulw-loop status --json`: expected structured error, no leftover process;
- valid isolated plan: create exit 0, status exit 0, valid JSON, temporary state removed;
- independent fake-command inspection observed Node 26.5.0, exact stdout/cwd, and no runner process after cleanup.

## Review

- Goal verification: PASS, 97% confidence
- Code quality: PASS
- Security: PASS
- Hands-on QA: PASSED
- History/context: PASS
- Blocking issues: none

## Evidence

- `.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/README.md`
- `.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/red-green.txt`
- `.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/verification.txt`
- `.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/manual-qa.txt`
- `.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/review.txt`
- `.omo/evidence/omo-senpi-adapter/20260723-run-command-timeout/architecture-review.txt`

## Risk

- Node is now an explicit fixture prerequisite. This repository already requires Node, and the Senpi compatibility workflow installs Node before running the package on Linux, macOS, and Windows.
- Windows wrapper behavior is unchanged and remains covered by the cross-platform CI matrix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the `runOmoCommand` test fixture in `omo-senpi` by running the fake `omo` command with Node instead of Bun, removing the load-sensitive timeout seen in `bun run test:senpi`. Production behavior and timeouts are unchanged.

- **Bug Fixes**
  - Resolve the absolute Node path once via `node -p process.execPath` and reuse it in POSIX/Windows wrappers.
  - Record the child runtime in `runtime.json` and assert `bunVersion` is null; update the runtime test accordingly.
  - Resolve Node before creating the temp fixture to avoid leaked directories; no changes to shipped code or `runOmoCommand` timeouts.

<sup>Written for commit b89f2692dba7cb07a4f5c6477418332e906486f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

