### PR TITLE
fix(model-core): add "upstream request failed" to retryable patterns

### DIFF
--- a/packages/model-core/src/model-error-classifier.test.ts
+++ b/packages/model-core/src/model-error-classifier.test.ts
@@ -462,6 +462,17 @@ describe("model-error-classifier", () => {
     //#then
     expect(result).toBe(true)
   })
+
+  test("treats 'upstream request failed' provider error as retryable (issue #6313)", () => {
+    //#given
+    const error = { message: "Error from provider (Console Go): Upstream request failed" }
+
+    //#when
+    const result = shouldRetryError(error)
+
+    //#then
+    expect(result).toBe(true)
+  })
 })
 
 export {}

--- a/packages/model-core/src/model-error-classifier.ts
+++ b/packages/model-core/src/model-error-classifier.ts
@@ -85,6 +85,7 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   "服务不可用",         // "service unavailable"
   "server_error",
   "an error occurred while processing",
+  "upstream request failed",
 ]
 
 /**


### PR DESCRIPTION
## Summary

Fixes #6313.

Adds `"upstream request failed"` to `RETRYABLE_MESSAGE_PATTERNS` in `model-error-classifier.ts` so that OpenAI-compatible provider upstream failures trigger the fallback chain instead of being treated as terminal errors.

## Changes

- `packages/model-core/src/model-error-classifier.ts` — added pattern
- `packages/model-core/src/model-error-classifier.test.ts` — regression test asserting `"Error from provider (Console Go): Upstream request failed"` is classified as retryable

## Testing

`bun test packages/model-core/src/model-error-classifier.test.ts` — 39/39 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make "upstream request failed" errors retryable so the fallback chain runs instead of failing the request. Fixes #6313 for OpenAI‑compatible providers.

- **Bug Fixes**
  - Added "upstream request failed" to `RETRYABLE_MESSAGE_PATTERNS` in `packages/model-core/src/model-error-classifier.ts`.
  - Added a regression test in `packages/model-core/src/model-error-classifier.test.ts` to ensure the error is classified as retryable.

<sup>Written for commit a59ed082332443d706563e035f6c444a90e9f5d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

