### PR TITLE
fix(goal): prevent native command blank terminal

### DIFF
--- a/packages/omo-opencode/src/plugin/chat-message.ts
+++ b/packages/omo-opencode/src/plugin/chat-message.ts
@@ -9,6 +9,7 @@ import { handleGoalMessage } from "./chat-message/loop-commands"
 import { notifyWhenModelCacheIsMissing } from "./chat-message/model-cache-warning"
 import { recordSessionModel, getStoredMainSessionModel } from "./chat-message/session-model"
 import { runStartWorkHookIfApplicable } from "./chat-message/start-work-message"
+import { consumeNativeGoalCommandMarker } from "./command-execute-before"
 import { stopContinuation } from "./stop-continuation"
 import type {
   ChatMessageHandlerOutput,
@@ -87,6 +88,7 @@ export function createChatMessageHandler(args: {
     input: ChatMessageInput,
     output: ChatMessageHandlerOutput,
   ): Promise<void> => {
+    const nativeGoalCommand = consumeNativeGoalCommandMarker(output.parts)
     if (isSyntheticOrInternalOnlyTextParts(output.parts)) {
       log("[chat-message] Skipping synthetic/internal-only message", {
         sessionID: input.sessionID,
@@ -135,6 +137,7 @@ export function createChatMessageHandler(args: {
       output,
       isFirstMessage,
       pluginConfig,
+      nativeGoalCommand,
     })
     await applyUltraworkModelOverrideOnMessage(
       pluginConfig,

--- a/packages/omo-opencode/src/plugin/chat-message/loop-commands.ts
+++ b/packages/omo-opencode/src/plugin/chat-message/loop-commands.ts
@@ -2,7 +2,6 @@ import type { OhMyOpenCodeConfig } from "../../config"
 
 import { parseGoalCommand } from "../../hooks/goal/command-arguments"
 import { log } from "../../shared"
-import { NATIVE_LOOP_TRIGGERED_FLAG } from "../command-execute-before"
 import { extractPromptText } from "./prompt-text"
 import type { ChatMessageHooks, ChatMessageHandlerOutput, ChatMessageInput } from "./types"
 
@@ -12,9 +11,10 @@ export function handleGoalMessage(args: {
   readonly output: ChatMessageHandlerOutput
   readonly isFirstMessage: boolean
   readonly pluginConfig: OhMyOpenCodeConfig
+  readonly nativeGoalCommand: boolean
 }): void {
-  const { hooks, input, output, isFirstMessage, pluginConfig } = args
-  if (!hooks.goal || output.message[NATIVE_LOOP_TRIGGERED_FLAG] === true) {
+  const { hooks, input, output, isFirstMessage, pluginConfig, nativeGoalCommand } = args
+  if (!hooks.goal || nativeGoalCommand) {
     return
   }
 

--- a/packages/omo-opencode/src/plugin/command-execute-before.test.ts
+++ b/packages/omo-opencode/src/plugin/command-execute-before.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, mock, test } from "bun:test"
 import { unsafeTestValue } from "../../../../test-support/unsafe-test-value"
 
-import { createCommandExecuteBeforeHandler } from "./command-execute-before"
+import { handleGoalMessage } from "./chat-message/loop-commands"
+import {
+  consumeNativeGoalCommandMarker,
+  createCommandExecuteBeforeHandler,
+} from "./command-execute-before"
 
 function createMockGoal() {
   return {
@@ -176,5 +180,56 @@ describe("createCommandExecuteBeforeHandler", () => {
     // then
     expect(setGoal).not.toHaveBeenCalled()
     expect(resumeGoal).toHaveBeenCalledWith("ses-resume")
+  })
+
+  test("#given native /goal #when command and chat hooks run #then output stays valid and goal is set once", async () => {
+    // given
+    const setGoal = mock(() => createMockGoal())
+    const hooks = unsafeTestValue({
+      goal: {
+        setGoal,
+        getGoal: mock(() => null),
+        pauseGoal: mock(() => null),
+        resumeGoal: mock(() => null),
+        clearGoal: mock(() => true),
+        markComplete: mock(() => null),
+        event: mock(async () => {}),
+      },
+    })
+    const handler = createCommandExecuteBeforeHandler({
+      directory: process.cwd(),
+      hooks,
+    })
+    const output = {
+      message: {},
+      parts: [{ type: "text", text: "create" }],
+    }
+
+    // when
+    await handler(
+      {
+        command: "goal",
+        sessionID: "ses-goal",
+        arguments: "create",
+      },
+      output,
+    )
+    const nativeGoalCommand = consumeNativeGoalCommandMarker(output.parts)
+    handleGoalMessage(unsafeTestValue({
+      hooks,
+      input: { sessionID: "ses-goal" },
+      output,
+      isFirstMessage: false,
+      pluginConfig: {},
+      nativeGoalCommand,
+    }))
+
+    // then
+    expect(setGoal).toHaveBeenCalledTimes(1)
+    expect(nativeGoalCommand).toBeTrue()
+    expect(output).toEqual({
+      message: {},
+      parts: [{ type: "text", text: "create" }],
+    })
   })
 })

--- a/packages/omo-opencode/src/plugin/command-execute-before.ts
+++ b/packages/omo-opencode/src/plugin/command-execute-before.ts
@@ -11,10 +11,36 @@ type CommandExecuteBeforeInput = {
 
 type CommandExecuteBeforeOutput = {
   parts: Array<{ type: string; text?: string; [key: string]: unknown }>
-  message?: Record<string, unknown>
 }
 
-const NATIVE_LOOP_TRIGGERED_FLAG = "__omoNativeLoopTriggered"
+const NATIVE_GOAL_COMMAND_MARKER = "<omo-native-goal-command>"
+
+export function markNativeGoalCommand(
+  parts: CommandExecuteBeforeOutput["parts"],
+): void {
+  parts.push({
+    type: "text",
+    text: NATIVE_GOAL_COMMAND_MARKER,
+    synthetic: true,
+  })
+}
+
+export function consumeNativeGoalCommandMarker(
+  parts: CommandExecuteBeforeOutput["parts"],
+): boolean {
+  const markerIndex = parts.findIndex(
+    (part) => (
+      part.type === "text"
+      && part.text === NATIVE_GOAL_COMMAND_MARKER
+      && part["synthetic"] === true
+    ),
+  )
+  if (markerIndex === -1) {
+    return false
+  }
+  parts.splice(markerIndex, 1)
+  return true
+}
 
 function hasPartsOutput(value: unknown): value is CommandExecuteBeforeOutput {
   if (typeof value !== "object" || value === null) return false
@@ -63,8 +89,7 @@ export function createCommandExecuteBeforeHandler(args: {
         default:
           break
       }
-      output.message ??= {}
-      output.message[NATIVE_LOOP_TRIGGERED_FLAG] = true
+      markNativeGoalCommand(output.parts)
     }
 
     if (
@@ -83,5 +108,3 @@ export function createCommandExecuteBeforeHandler(args: {
     }
   }
 }
-
-export { NATIVE_LOOP_TRIGGERED_FLAG }

--- a/packages/omo-opencode/src/plugin/native-goal-command-marker.test.ts
+++ b/packages/omo-opencode/src/plugin/native-goal-command-marker.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  consumeNativeGoalCommandMarker,
+  markNativeGoalCommand,
+} from "./command-execute-before"
+
+describe("native goal command marker", () => {
+  test("#given an interleaved same-session prompt #when markers are consumed #then only the native goal turn matches", () => {
+    // given
+    const nativeGoalParts = [{ type: "text", text: "goal command" }]
+    const unrelatedParts = [{ type: "text", text: "<omo-native-goal-command>" }]
+    markNativeGoalCommand(nativeGoalParts)
+
+    // when
+    const unrelatedMatched = consumeNativeGoalCommandMarker(unrelatedParts)
+    const nativeGoalMatched = consumeNativeGoalCommandMarker(nativeGoalParts)
+
+    // then
+    expect(unrelatedMatched).toBeFalse()
+    expect(unrelatedParts).toEqual([{ type: "text", text: "<omo-native-goal-command>" }])
+    expect(nativeGoalMatched).toBeTrue()
+    expect(nativeGoalParts).toEqual([{ type: "text", text: "goal command" }])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes a real OpenCode `/goal` failure reported in Discord. When the goal hook
was enabled, the native command handler added an unsupported
`output.message.__omoNativeLoopTriggered` field to the
`command.execute.before` result. OpenCode rejected the turn before message
persistence, leaving the TUI blank.

The fix keeps the official hook output shape intact. It carries command
provenance as a synthetic text part, consumes and removes that exact part at
the start of the paired `chat.message` hook, and skips only the duplicate goal
mutation for that command turn. User-authored text cannot spoof the marker
because consumption requires `synthetic: true`.

## Changes

- Remove the unsupported `message` mutation from `command.execute.before`.
- Add exact-turn native goal command marker helpers.
- Consume the marker before chat hooks, persistence, and model input.
- Preserve `/goal create` as the literal objective `create`; parser semantics
  and the documented command surface are unchanged.
- Add regression coverage for:
  - official command output remaining unpolluted;
  - exact-once command/chat handoff;
  - same-session interleaving;
  - user text colliding with the marker string.

## QA & Evidence

### RED -> GREEN regression

- **What was tested:** focused command/chat regression and marker collision
  tests.
- **Observed:** before the production fix, the composed regression received
  `message: { "__omoNativeLoopTriggered": true }` instead of `message: {}`.
  The collision test also failed when a user-authored part exactly matched the
  marker text.
- **After:** focused final suite passes with 54 tests and 0 failures.

### Real OpenCode TUI

- **What was tested:** OpenCode 1.18.4 in an isolated `HOME`/`XDG_*` sandbox,
  loading this branch's source plugin with the exact reported config:
  `goal.enabled=true`, `auto_start=false`,
  `default_max_iterations=100`. The real xterm.js terminal submitted
  `/goal create`.
- **Before:** the TUI returned to a blank conversation and persisted no
  message.
- **After:** the TUI displayed the command and a visible nonblank outcome.
  The isolated event store contained one user and one assistant message and
  zero persisted marker occurrences.
- **Isolation:** the real OpenCode DB session count remained `21931` before
  and after QA.

### Adjacent behavior

- `/goal adjacent qa`, pause, resume, bare show, clear, and unrelated
  `/stop-continuation` were driven in one isolated session.
- Six commands produced exactly six user messages.
- Pause/resume state persisted correctly and clear removed the goal state.

### Automated gates

- `bun run typecheck`: pass
- `bun run build`: pass
- focused spoof/interleaving/integration suites: pass
- Oracle final review: `APPROVED UNCONDITIONALLY`
- root `bun test`: 12,137 pass, 3 existing platform skips, 8 residual failures
  outside this diff:
  - existing full-load 5-second launcher/runner timeouts;
  - untouched MCP stdio close-path timeout;
  - untouched Senpi API tripwire timeout;
  - committed Codex installer version drift (`4.19.0` embedded vs root
    `4.19.1`).

Local reviewer-readable evidence was recorded under
`.omo/evidence/20260724-goal-blank-terminal/` as required by repository QA
policy. Secret-bearing logs and credentials were not copied.

## Risks & Residuals

- The marker is machine-consumed, exact-turn, and synthetic-only. It is removed
  before other chat hooks, persistence, or model input.
- No persistent/session-global dedup state is introduced, so unrelated
  same-session prompts cannot consume command provenance.
- No parser, config, prompt wording, or goal lifecycle semantics changed.

## Related report

https://discord.com/channels/1452487457085063218/1490536332961906829/1530076165614735430


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blank TUI after `/goal` by removing an unsupported message mutation and using a synthetic parts marker for native command provenance. The turn now persists and the response renders correctly.

- **Bug Fixes**
  - Replaced the `message` flag with a synthetic `parts` marker and consume it before chat hooks and persistence.
  - Skip the duplicate goal mutation on the paired chat turn; keep official hook output shape intact and preserve `/goal create` semantics.
  - Added regression tests for unpolluted output, exact-once handoff, and collision safety with user text.

<sup>Written for commit a6f7378bc96ea86b8cd309bcc9393d872b2684ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

