### PR TITLE
fix(test): stabilize flaky CI tests timing out under load

### DIFF
--- a/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
+++ b/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
@@ -107,7 +107,7 @@ describe("LspClient diagnostics freshness", () => {
 					},
 				],
 			},
-			{ diagnosticsFreshnessTimeoutMs: 30, versionlessPublishQuiescenceMs: 5 },
+			{ diagnosticsFreshnessTimeoutMs: 100, versionlessPublishQuiescenceMs: 5 },
 		);
 		await stale.client.openFile(stale.source);
 		writeFileSync(stale.source, "const stale = 1;\n", "utf-8");
@@ -130,7 +130,7 @@ describe("LspClient diagnostics freshness", () => {
 					},
 				],
 			},
-			{ diagnosticsFreshnessTimeoutMs: 30, versionlessPublishQuiescenceMs: 5 },
+			{ diagnosticsFreshnessTimeoutMs: 100, versionlessPublishQuiescenceMs: 5 },
 		);
 		await future.client.openFile(future.source);
 		writeFileSync(future.source, "const future = 1;\n", "utf-8");

--- a/packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts
+++ b/packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { runCodexInstaller } from "./install-codex"
 
-const INSTALL_CODEX_INTEGRATION_TEST_TIMEOUT_MS = 20_000
+const INSTALL_CODEX_INTEGRATION_TEST_TIMEOUT_MS = 30_000
 
 const skipAstGrepInstall = async () => ({ kind: "skipped" as const, reason: "test" })
 

--- a/packages/omo-codex/src/install/install-codex-packaged.test.ts
+++ b/packages/omo-codex/src/install/install-codex-packaged.test.ts
@@ -139,7 +139,7 @@ test("#given packaged lazycodex tarball layout #when installing Codex plugin #th
   expect(cachedMcp.mcpServers.lsp.args[0]).not.toBe(join(lspRuntimeRoot, "dist", "cli.js"))
   expect((await stat(cachedLspCli)).isFile()).toBe(true)
   expect(await readlink(join(binDir, "omo"))).toBe(join(pluginPath, "dist", "cli.js"))
-})
+}, { timeout: 30_000 })
 
 test("#given packaged lazycodex tarball layout #when simulating Windows install #then links bin shims for that platform", async () => {
   // given

--- a/packages/omo-opencode/src/cli/config-manager/plugin-detection.test.ts
+++ b/packages/omo-opencode/src/cli/config-manager/plugin-detection.test.ts
@@ -97,6 +97,7 @@ describe("detectCurrentConfig - single package detection", () => {
 describe("addPluginToOpenCodeConfig - single package writes", () => {
   let testConfigDir = ""
   let testConfigPath = ""
+  let getPluginNameWithVersionSpy: ReturnType<typeof spyOn>
 
   beforeEach(() => {
     testConfigDir = join(tmpdir(), `omo-add-plugin-${Date.now()}-${Math.random().toString(36).slice(2)}`)
@@ -105,9 +106,14 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     mkdirSync(testConfigDir, { recursive: true })
     process.env.OPENCODE_CONFIG_DIR = testConfigDir
     resetConfigContext()
+    // Mock npm dist-tags lookup so tests don't make real network calls that
+    // timeout under CI load. Individual tests override this with version-pinned
+    // expectations when they need to assert on the version-tagged entry.
+    getPluginNameWithVersionSpy = spyOn(pluginNameWithVersion, "getPluginNameWithVersion").mockResolvedValue("oh-my-openagent")
   })
 
   afterEach(() => {
+    getPluginNameWithVersionSpy.mockRestore()
     rmSync(testConfigDir, { recursive: true, force: true })
     resetConfigContext()
     delete process.env.OPENCODE_CONFIG_DIR


### PR DESCRIPTION
## What changed

Three categories of flaky test failures have been breaking dev CI for 4+ consecutive dev-push runs (runs 30027014484, 30010639800, 30001856522, 29891115648). This PR stabilizes all three.

### 1. addPluginToOpenCodeConfig tests — network timeout (`plugin-detection.test.ts`)

Tests that call `addPluginToOpenCodeConfig("3.11.0")` without mocking `getPluginNameWithVersion` trigger a real `fetchNpmDistTags` network call (5s abort timeout in `npm-dist-tags.ts`). Under CI network load, this exceeds the default 5s test timeout, producing `result.success === false` or a timeout.

**Fix:** Add a `beforeEach` spy on `getPluginNameWithVersion` in the `addPluginToOpenCodeConfig` describe block that returns `"oh-my-openagent"` (the non-versioned fallback). Individual tests that assert on version-tagged entries ("updates a version-pinned legacy entry", "preserves a canonical entry", "blocks a downgrade") already override this with their own `spyOn` — they keep working as-is.

### 2. LspClient diagnostics freshness — 30ms timing flake (`client-diagnostics-freshness.integration.test.ts`)

The test `#given stale and future publish versions` used `diagnosticsFreshnessTimeoutMs: 30` (30ms). On a loaded CI runner, 30ms is too tight — the event loop may not schedule the timeout callback before the diagnostics request resolves, leaving `transientError` `undefined` instead of `{ kind: "freshness_timeout" }`.

**Fix:** Increase `diagnosticsFreshnessTimeoutMs` from 30 to 100 in both instances within the failing test. Other tests in the same file use 50-800ms; 100ms is consistent and still fast enough.

### 3. Codex install tests — FS I/O timeout (`install-codex-mcp-manifest.test.ts`, `install-codex-packaged.test.ts`)

`runCodexInstaller` does heavy filesystem operations (copying plugin trees, writing configs, linking bins). Under CI I/O load, the 5s default / 20s custom timeout was exceeded.

**Fix:** Increase `INSTALL_CODEX_INTEGRATION_TEST_TIMEOUT_MS` from 20s to 30s for the MCP manifest test, and add `{ timeout: 30_000 }` to the packaged tarball test.

## Observed behavior (local)

```
# plugin-detection.test.ts
13 pass, 0 fail (160ms — was 5-10s+ with network calls)

# client-diagnostics-freshness.integration.test.ts (run 3x)
Run 1: 12 pass, 0 fail (4.60s) — stale+future test: 265ms
Run 2: 12 pass, 0 fail — stale+future test: 263ms
Run 3: 12 pass, 0 fail — stale+future test: 271ms

# install-codex-mcp-manifest + install-codex-packaged
3 pass, 0 fail (1.77s)
```

## QA

This is a test-only change — no production code modified, no hook/tool/agent/config touched. The fix eliminates network and timing dependencies that were the root cause of the flakiness.

Plan: .omo/plans/fix-ci-flaky-tests.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes three flaky CI test groups by removing real network calls and relaxing tight timeouts that failed under load. Test-only changes; no production code affected.

- **Bug Fixes**
  - Mock `getPluginNameWithVersion` in `plugin-detection.test.ts` to avoid `fetchNpmDistTags` network calls.
  - Raise `diagnosticsFreshnessTimeoutMs` from 30ms to 100ms in `client-diagnostics-freshness.integration.test.ts` to avoid scheduling jitter.
  - Increase Codex install test timeouts to 30s in `install-codex-mcp-manifest.test.ts` and `install-codex-packaged.test.ts`.

<sup>Written for commit 4a84d2c3b83f7528701ce6c32fbdcfbfce059eb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

