### PR TITLE
fix(background-task): recover tasks and deliver current wakes once

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/background-task-notification-template.ts
+++ b/packages/omo-opencode/src/features/background-agent/background-task-notification-template.ts
@@ -124,3 +124,13 @@ ${isFailure ? "**ACTION REQUIRED:** This task failed. Check the error and decide
 Use \`background_output(task_id="${task.id}")\` to retrieve this result when ready.
 </system-reminder>`
 }
+
+export function refreshBackgroundTaskNotificationCount(
+  notification: string,
+  remainingCount: number,
+): string {
+  return notification.replace(
+    /\*\*\d+ tasks? still in progress\.\*\*/g,
+    `**${remainingCount} task${remainingCount === 1 ? "" : "s"} still in progress.**`,
+  )
+}

--- a/packages/omo-opencode/src/features/background-agent/background-task-recovery.ts
+++ b/packages/omo-opencode/src/features/background-agent/background-task-recovery.ts
@@ -1,0 +1,72 @@
+import { isRecord } from "@oh-my-opencode/utils"
+import { extractTaskLink } from "../tool-metadata-store"
+import type { BackgroundTask } from "./types"
+
+const BACKGROUND_TASK_ID_PATTERN = /(?:Background )?Task ID:\s*(bg[_-][a-zA-Z0-9_-]+)/i
+const DESCRIPTION_PATTERN = /^Description:\s*(.+)$/im
+const AGENT_PATTERN = /^Agent:\s*([^\n(]+)/im
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined
+}
+
+function match(output: string, pattern: RegExp): string | undefined {
+  return readString(pattern.exec(output)?.[1])
+}
+
+function recoverFromPart(part: unknown, targetID: string, parentSessionID: string): BackgroundTask | undefined {
+  if (!isRecord(part) || part.type !== "tool" || !isRecord(part.state)) {
+    return undefined
+  }
+
+  const output = readString(part.state.output)
+  if (!output) {
+    return undefined
+  }
+
+  const metadataLink = extractTaskLink(part.state.metadata, "")
+  const outputLink = extractTaskLink(undefined, output)
+  const metadata = isRecord(part.state.metadata) ? part.state.metadata : undefined
+  const taskID = metadataLink.backgroundTaskId
+    ?? outputLink.backgroundTaskId
+    ?? match(output, BACKGROUND_TASK_ID_PATTERN)
+  const sessionID = metadataLink.sessionId ?? outputLink.sessionId
+  if (!taskID || !sessionID || (targetID !== taskID && targetID !== sessionID)) {
+    return undefined
+  }
+
+  return {
+    id: taskID,
+    sessionId: sessionID,
+    parentSessionId: parentSessionID,
+    parentMessageId: "",
+    description: readString(metadata?.description) ?? match(output, DESCRIPTION_PATTERN) ?? taskID,
+    prompt: "[recovered]",
+    agent: metadataLink.agent ?? outputLink.agent ?? match(output, AGENT_PATTERN) ?? "task",
+    category: metadataLink.category ?? outputLink.category,
+    status: "completed",
+    completedAt: new Date(),
+  }
+}
+
+export function recoverBackgroundTask(
+  messages: readonly unknown[],
+  targetID: string,
+  parentSessionID: string,
+): BackgroundTask | undefined {
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const message = messages[messageIndex]
+    if (!isRecord(message) || !Array.isArray(message.parts)) {
+      continue
+    }
+
+    for (let partIndex = message.parts.length - 1; partIndex >= 0; partIndex -= 1) {
+      const task = recoverFromPart(message.parts[partIndex], targetID, parentSessionID)
+      if (task) {
+        return task
+      }
+    }
+  }
+
+  return undefined
+}

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -312,6 +312,10 @@ export class BackgroundManager {
         enqueueNotificationForParent: this.enqueueNotificationForParent.bind(this),
         onPendingWakeRequeued: (sessionID) => this.updateBackgroundTaskMarker(sessionID),
         onScheduledFlushSettled: (sessionID) => this.recordScheduledFlushSettled(sessionID),
+        getRemainingTaskCount: (sessionID) => this.pendingByParent.get(sessionID)?.size
+          ?? this.getTasksByParentSession(sessionID)
+            .filter((task) => task.status === "running" || task.status === "pending")
+            .length,
       },
       {
         pendingRetryMs: PENDING_PARENT_WAKE_RETRY_MS,

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -1124,7 +1124,7 @@ The fallback retry session is now created and can be inspected directly.
    * would report false between the status flip and the wake landing in the pending map.
    */
   hasPendingParentWake(sessionID: string): boolean {
-    return this.hasUndeliveredParentWake(sessionID) || this.parentWakeNotifier.getDispatchedParentWakes().has(sessionID)
+    return this.hasUndeliveredParentWake(sessionID) || this.parentWakeNotifier.hasDispatchedReplyWake(sessionID)
   }
 
   private hasUndeliveredParentWake(sessionID: string): boolean {
@@ -1649,8 +1649,7 @@ The fallback retry session is now created and can be inspected directly.
       if (!sessionID) return
       if (isEmptyNoProgressAssistantTurnInfo(info)) {
         const dispatchedWake = this.parentWakeNotifier.getDispatchedParentWakes().get(sessionID)
-        if (dispatchedWake) {
-          this.parentWakeNotifier.requeueDispatchedParentWakeAfterEmptyAssistantTurn(sessionID)
+        if (dispatchedWake && this.parentWakeNotifier.requeueDispatchedParentWakeAfterEmptyAssistantTurn(sessionID)) {
           return
         }
       }

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -49,6 +49,7 @@ import {
   buildBackgroundTaskNotificationText,
 } from "./background-task-notification-template"
 import { writeBackgroundTaskMarker } from "./background-task-marker"
+import { recoverBackgroundTask } from "./background-task-recovery"
 import {
   findNearestMessageExcludingCompaction,
   resolvePromptContextFromSessionMessages,
@@ -1044,6 +1045,26 @@ The fallback retry session is now created and can be inspected directly.
     return this.tasks.get(id) ?? this.completedTaskArchive.get(id) ?? getRegisteredBackgroundTask(id)
   }
 
+  async recoverTask(id: string, parentSessionID: string): Promise<BackgroundTask | undefined> {
+    const existingTask = this.getTask(id) ?? this.findBySession(id)
+    if (existingTask) {
+      return existingTask
+    }
+
+    const response = await messagesInDirectory(
+      this.client,
+      { path: { id: parentSessionID } },
+      this.directory,
+    )
+    const task = recoverBackgroundTask(normalizeSDKResponse<unknown[]>(response, []), id, parentSessionID)
+    if (!task) {
+      return undefined
+    }
+
+    this.addTask(task)
+    return task
+  }
+
   getTasksSnapshot(): BackgroundTaskSnapshot[] { return toBackgroundTaskSnapshots(this.tasks.values()) }
 
   getTasksByParentSession(sessionID: string): BackgroundTask[] {
@@ -1287,6 +1308,7 @@ The fallback retry session is now created and can be inspected directly.
 
   async resume(input: ResumeInput): Promise<BackgroundTask> {
     const existingTask = this.findBySession(input.sessionId)
+      ?? await this.recoverTask(input.sessionId, input.parentSessionId)
     if (!existingTask) {
       throw new Error(`Task not found for session: ${input.sessionId}`)
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
@@ -142,7 +142,7 @@ describe("parent wake active defer ceiling", () => {
     }
   })
 
-  test("#given retained noReply wake ages while parent is busy #then it does not force a reply", async () => {
+  test("#given reply-required wake ages while parent is busy #then it does not force a reply", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -159,9 +159,8 @@ describe("parent wake active defer ceiling", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeDefined()
+      expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeUndefined()
 
       // when
       now = 220_000
@@ -171,7 +170,7 @@ describe("parent wake active defer ceiling", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
       expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
     } finally {
@@ -180,7 +179,7 @@ describe("parent wake active defer ceiling", () => {
     }
   })
 
-  test("#given retained noReply wake and fresh activity exceed active ceiling #then it dispatches once safe", async () => {
+  test("#given retained reply wake and fresh activity exceed active ceiling #then it dispatches once safe", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -205,9 +204,8 @@ describe("parent wake active defer ceiling", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(2)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      expect(promptAsyncCalls[1]?.body.noReply).not.toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).not.toBe(true)
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
@@ -215,7 +213,7 @@ describe("parent wake active defer ceiling", () => {
     }
   })
 
-  test("#given fresh user message and aged wake while parent is busy #then it admits noReply", async () => {
+  test("#given fresh user message and aged wake while parent is busy #then it stays pending", async () => {
     // given
     const originalDateNow = Date.now
     const now = 220_000
@@ -237,8 +235,7 @@ describe("parent wake active defer ceiling", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
       expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
     } finally {
@@ -247,7 +244,7 @@ describe("parent wake active defer ceiling", () => {
     }
   })
 
-  test("#given blocked tool history and aged wake while parent is busy #then it admits noReply", async () => {
+  test("#given blocked tool history and aged wake while parent is busy #then it stays pending", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier({
       sessionStatuses: { "parent-1": { type: "busy" } },
@@ -260,8 +257,7 @@ describe("parent wake active defer ceiling", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
       expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
     } finally {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
@@ -142,7 +142,7 @@ describe("parent wake active defer ceiling", () => {
     }
   })
 
-  test("#given reply-required wake ages while parent is busy #then it does not force a reply", async () => {
+  test("#given reply-required wake ages while parent is busy #then its no-reply delivery is not duplicated", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -159,8 +159,9 @@ describe("parent wake active defer ceiling", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeUndefined()
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
 
       // when
       now = 220_000
@@ -170,16 +171,15 @@ describe("parent wake active defer ceiling", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
-      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
     }
   })
 
-  test("#given retained reply wake and fresh activity exceed active ceiling #then it dispatches once safe", async () => {
+  test("#given delivered reply wake and fresh activity exceed active ceiling #then it is not dispatched twice", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -205,7 +205,7 @@ describe("parent wake active defer ceiling", () => {
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).not.toBe(true)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
@@ -213,7 +213,7 @@ describe("parent wake active defer ceiling", () => {
     }
   })
 
-  test("#given fresh user message and aged wake while parent is busy #then it stays pending", async () => {
+  test("#given fresh user message and aged wake while parent is busy #then it deposits without a reply", async () => {
     // given
     const originalDateNow = Date.now
     const now = 220_000
@@ -235,16 +235,16 @@ describe("parent wake active defer ceiling", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
-      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
     }
   })
 
-  test("#given blocked tool history and aged wake while parent is busy #then it stays pending", async () => {
+  test("#given blocked tool history and aged wake while parent is busy #then it deposits without a reply", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier({
       sessionStatuses: { "parent-1": { type: "busy" } },
@@ -257,9 +257,9 @@ describe("parent wake active defer ceiling", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
-      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       notifier.shutdown()
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -203,7 +203,7 @@ describe("BackgroundManager parent wake active turn events", () => {
     expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
   })
 
-  test("#when parent reasoning delta is newer than stale idle state #then background completion stays pending", async () => {
+  test("#when parent reasoning delta is newer than stale idle state #then background completion deposits without a reply", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "idle" },
@@ -233,11 +233,12 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 
-  test("#when parent idle event follows fresh reasoning delta #then background completion still stays pending", async () => {
+  test("#when parent idle event follows fresh reasoning delta #then background completion still deposits without a reply", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "idle" },
@@ -268,7 +269,8 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -203,7 +203,7 @@ describe("BackgroundManager parent wake active turn events", () => {
     expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
   })
 
-  test("#when parent reasoning delta is newer than stale idle state #then background completion records an admit-only wake", async () => {
+  test("#when parent reasoning delta is newer than stale idle state #then background completion stays pending", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "idle" },
@@ -233,12 +233,11 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(0)
     expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
   })
 
-  test("#when parent idle event follows fresh reasoning delta #then background completion still records an admit-only wake", async () => {
+  test("#when parent idle event follows fresh reasoning delta #then background completion still stays pending", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "idle" },
@@ -269,8 +268,7 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(0)
     expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-activity-window.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-activity-window.test.ts
@@ -91,7 +91,7 @@ async function flushPendingParentWakeForTest(manager: BackgroundManager, session
 }
 
 describe("BackgroundManager parent wake activity window", () => {
-  test("#given parent tool activity is within the tool deferral window #when stale idle flushes a wake #then wake stays pending", async () => {
+  test("#given parent tool activity is within the tool deferral window #when stale idle flushes a wake #then it deposits without a reply", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -120,8 +120,9 @@ describe("BackgroundManager parent wake activity window", () => {
       await flushPendingParentWakeForTest(manager, "parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-activity-window.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-activity-window.test.ts
@@ -91,7 +91,7 @@ async function flushPendingParentWakeForTest(manager: BackgroundManager, session
 }
 
 describe("BackgroundManager parent wake activity window", () => {
-  test("#given parent tool activity is within the tool deferral window #when stale idle flushes a wake #then wake is recorded without forking a reply", async () => {
+  test("#given parent tool activity is within the tool deferral window #when stale idle flushes a wake #then wake stays pending", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -120,8 +120,7 @@ describe("BackgroundManager parent wake activity window", () => {
       await flushPendingParentWakeForTest(manager, "parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
     } finally {
       Date.now = originalDateNow

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-blocking.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-blocking.test.ts
@@ -81,8 +81,9 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
     await notifier.flushPendingParentWake("parent-local-unknown")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(notifier.getPendingParentWakes().has("parent-local-unknown")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(notifier.getPendingParentWakes().has("parent-local-unknown")).toBe(false)
     expect(messageReads).toBe(1)
 
     notifier.shutdown()
@@ -162,8 +163,9 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
       await notifier.flushPendingParentWake("parent-question-unanswered")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-question-unanswered")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-question-unanswered")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -241,8 +243,9 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
       await notifier.flushPendingParentWake("parent-completed-unknown")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-completed-unknown")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-completed-unknown")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-blocking.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-blocking.test.ts
@@ -81,8 +81,7 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
     await notifier.flushPendingParentWake("parent-local-unknown")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(0)
     expect(notifier.getPendingParentWakes().has("parent-local-unknown")).toBe(true)
     expect(messageReads).toBe(1)
 
@@ -163,8 +162,7 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
       await notifier.flushPendingParentWake("parent-question-unanswered")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-question-unanswered")).toBe(true)
     } finally {
       Date.now = originalDateNow
@@ -243,8 +241,7 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
       await notifier.flushPendingParentWake("parent-completed-unknown")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-completed-unknown")).toBe(true)
     } finally {
       Date.now = originalDateNow

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-deferral.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-deferral.test.ts
@@ -200,8 +200,8 @@ describe("ParentWakeNotifier — assistant text history deferral", () => {
       await notifier.flushPendingParentWake("parent-fresh-text-flush")
 
       // then
-      expect(promptAsyncCallCount).toBe(0)
-      expect(notifier.getPendingParentWakes().has("parent-fresh-text-flush")).toBe(true)
+      expect(promptAsyncCallCount).toBe(1)
+      expect(notifier.getPendingParentWakes().has("parent-fresh-text-flush")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-deferral.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-deferral.test.ts
@@ -200,7 +200,7 @@ describe("ParentWakeNotifier — assistant text history deferral", () => {
       await notifier.flushPendingParentWake("parent-fresh-text-flush")
 
       // then
-      expect(promptAsyncCallCount).toBe(1)
+      expect(promptAsyncCallCount).toBe(0)
       expect(notifier.getPendingParentWakes().has("parent-fresh-text-flush")).toBe(true)
     } finally {
       Date.now = originalDateNow

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-race.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-race.test.ts
@@ -85,8 +85,7 @@ describe("ParentWakeNotifier — assistant text dispatch race", () => {
       await notifier.flushPendingParentWake("parent-stale-then-fresh-text")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-stale-then-fresh-text")).toBe(true)
     } finally {
       Date.now = originalDateNow

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-race.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-text-race.test.ts
@@ -85,8 +85,9 @@ describe("ParentWakeNotifier — assistant text dispatch race", () => {
       await notifier.flushPendingParentWake("parent-stale-then-fresh-text")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-stale-then-fresh-text")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-stale-then-fresh-text")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
@@ -52,11 +52,19 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
 
 export function isRedundantParentWake(latestWake: PendingParentWake, dispatchedWake: PendingParentWake): boolean {
   return parentWakePromptContextMatches(latestWake, dispatchedWake)
-    && parentWakeReplyModeIsCovered(latestWake, dispatchedWake)
-    && parentWakeNotificationsAreCovered(latestWake, dispatchedWake)
+    && getUndeliveredParentWakeNotifications(latestWake, dispatchedWake).length === 0
 }
 
 export function mergeParentWakeNotifications(existingNotifications: readonly string[], nextNotification: string): string[] {
+  const duplicateIndex = existingNotifications.findIndex((notification) =>
+    getParentWakeNotificationIdentity(notification) === getParentWakeNotificationIdentity(nextNotification)
+  )
+  if (duplicateIndex !== -1) {
+    return existingNotifications.map((notification, index) =>
+      index === duplicateIndex ? nextNotification : notification
+    )
+  }
+
   if (isFinalBackgroundTaskNotification(nextNotification)) {
     return [
       nextNotification,
@@ -65,10 +73,6 @@ export function mergeParentWakeNotifications(existingNotifications: readonly str
         && !isBackgroundTaskProgressNotification(notification)
       ),
     ]
-  }
-
-  if (existingNotifications.includes(nextNotification)) {
-    return [...existingNotifications]
   }
 
   if (
@@ -81,17 +85,30 @@ export function mergeParentWakeNotifications(existingNotifications: readonly str
   return [...existingNotifications, nextNotification]
 }
 
+export function getUndeliveredParentWakeNotifications(
+  latestWake: PendingParentWake,
+  dispatchedWake: PendingParentWake,
+): string[] {
+  if (!parentWakePromptContextMatches(latestWake, dispatchedWake)) {
+    return [...latestWake.notifications]
+  }
+
+  const dispatchedIdentities = new Set(dispatchedWake.notifications.map(getParentWakeNotificationIdentity))
+  return latestWake.notifications.filter((notification) =>
+    !dispatchedIdentities.has(getParentWakeNotificationIdentity(notification))
+  )
+}
+
 function parentWakePromptContextMatches(left: PendingParentWake, right: PendingParentWake): boolean {
   return JSON.stringify(left.promptContext) === JSON.stringify(right.promptContext)
 }
 
-function parentWakeReplyModeIsCovered(latestWake: PendingParentWake, dispatchedWake: PendingParentWake): boolean {
-  return !latestWake.shouldReply || dispatchedWake.shouldReply
-}
-
-function parentWakeNotificationsAreCovered(latestWake: PendingParentWake, dispatchedWake: PendingParentWake): boolean {
-  const dispatchedNotifications = new Set(dispatchedWake.notifications)
-  return latestWake.notifications.every((notification) => dispatchedNotifications.has(notification))
+function getParentWakeNotificationIdentity(notification: string): string {
+  const taskID = notification.split("\n")
+    .map((line) => /^\*\*ID:\*\* `([^`]+)`$/.exec(line.trim())?.[1])
+    .find((id) => id !== undefined)
+  const headers = getSystemReminderHeaderLines(notification)
+  return taskID && headers.length > 0 ? `${headers.join("\n")}\n${taskID}` : notification
 }
 
 export function isFailureParentWake(wake: PendingParentWake): boolean {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dispatched-tracker.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dispatched-tracker.ts
@@ -90,7 +90,9 @@ export class ParentWakeDispatchedTracker {
     const dispatchedWake = cloneParentWake(wake)
     dispatchedWake.dispatchedAt = dispatchedAt
     this.dispatchedParentWakes.set(sessionID, dispatchedWake)
-    this.scheduleFailureWindowTimer(sessionID)
+    if (dispatchedWake.shouldReply) {
+      this.scheduleFailureWindowTimer(sessionID)
+    }
   }
 
   refreshWakeTimer(sessionID: string): void {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -1,5 +1,6 @@
 import { log } from "../../shared"
 import { isSessionActive as isOpenCodeSessionActive, settleAfterSessionIdle } from "../../hooks/shared/session-idle-settle"
+import { refreshBackgroundTaskNotificationCount } from "./background-task-notification-template"
 import { isFailureParentWake, isRedundantParentWake, type PendingParentWake } from "./parent-wake-dedupe"
 import type { ParentWakeDispatchedTracker } from "./parent-wake-dispatched-tracker"
 import type { ParentWakePendingQueue } from "./parent-wake-pending-queue"
@@ -43,6 +44,11 @@ export class ParentWakeFlushRunner {
     const latestWake = this.deps.pendingQueue.getWake(sessionID)
     if (!latestWake) {
       return
+    }
+    const remainingCount = this.deps.notifierDeps.getRemainingTaskCount?.(sessionID)
+    if (remainingCount !== undefined) {
+      latestWake.notifications = latestWake.notifications.map((notification) =>
+        refreshBackgroundTaskNotificationCount(notification, remainingCount))
     }
     if (await this.dropAdmittedWakeConsumedByParent(sessionID, latestWake)) {
       return

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -163,22 +163,21 @@ export class ParentWakeFlushRunner {
     }, delayMs)
   }
 
-  // Reply-required wakes must never be consumed by an admit-only noReply
-  // dispatch (issues #4874/#5086): failure wakes stay queued until the parent
-  // is safe, and an already-admitted final wake is not re-admitted while the
-  // parent remains unsafe.
+  // Sending a reply-required wake as noReply and again as a reply duplicates
+  // the notification, so retain it until one reply dispatch is safe.
   private deferReplyWakeWhileUnsafe(sessionID: string, latestWake: PendingParentWake): boolean {
-    if (isFailureParentWake(latestWake)) {
-      this.schedulePendingParentWakeFlush(sessionID)
-      log("[background-agent] Deferred failure parent wake until parent session is safe:", { sessionID })
-      return true
+    if (!latestWake.shouldReply) {
+      return false
     }
-    if (latestWake.shouldReply && latestWake.noReplyAdmittedAt !== undefined) {
-      this.schedulePendingParentWakeFlush(sessionID)
-      log("[background-agent] Deferred retained reply-required parent wake until parent session is safe:", { sessionID })
-      return true
-    }
-    return false
+
+    this.schedulePendingParentWakeFlush(sessionID)
+    log(
+      isFailureParentWake(latestWake)
+        ? "[background-agent] Deferred failure parent wake until parent session is safe:"
+        : "[background-agent] Deferred reply-required parent wake until parent session is safe:",
+      { sessionID },
+    )
+    return true
   }
 
   clearPendingParentWakeTimer(sessionID: string): void {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -1,7 +1,12 @@
 import { log } from "../../shared"
 import { isSessionActive as isOpenCodeSessionActive, settleAfterSessionIdle } from "../../hooks/shared/session-idle-settle"
 import { refreshBackgroundTaskNotificationCount } from "./background-task-notification-template"
-import { isFailureParentWake, isRedundantParentWake, type PendingParentWake } from "./parent-wake-dedupe"
+import {
+  getUndeliveredParentWakeNotifications,
+  isFailureParentWake,
+  isRedundantParentWake,
+  type PendingParentWake,
+} from "./parent-wake-dedupe"
 import type { ParentWakeDispatchedTracker } from "./parent-wake-dispatched-tracker"
 import type { ParentWakePendingQueue } from "./parent-wake-pending-queue"
 import { sendParentWakePrompt } from "./parent-wake-prompt-dispatch"
@@ -50,6 +55,15 @@ export class ParentWakeFlushRunner {
       latestWake.notifications = latestWake.notifications.map((notification) =>
         refreshBackgroundTaskNotificationCount(notification, remainingCount))
     }
+    const deliveredWake = this.deps.dispatchedTracker.getWake(sessionID)
+    if (deliveredWake) {
+      latestWake.notifications = getUndeliveredParentWakeNotifications(latestWake, deliveredWake)
+      if (latestWake.notifications.length === 0) {
+        this.deps.pendingQueue.deleteWake(sessionID)
+        log("[background-agent] Suppressed parent wake content already delivered:", { sessionID })
+        return
+      }
+    }
     if (await this.dropAdmittedWakeConsumedByParent(sessionID, latestWake)) {
       return
     }
@@ -76,7 +90,7 @@ export class ParentWakeFlushRunner {
       log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
         sessionID,
       })
-      if (latestWake.shouldReply) {
+      if (latestWake.shouldReply && this.deps.pendingQueue.hasWake(sessionID)) {
         this.schedulePendingParentWakeFlush(sessionID)
       }
       return
@@ -169,21 +183,20 @@ export class ParentWakeFlushRunner {
     }, delayMs)
   }
 
-  // Sending a reply-required wake as noReply and again as a reply duplicates
-  // the notification, so retain it until one reply dispatch is safe.
   private deferReplyWakeWhileUnsafe(sessionID: string, latestWake: PendingParentWake): boolean {
-    if (!latestWake.shouldReply) {
-      return false
+    if (isFailureParentWake(latestWake)) {
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred failure parent wake until parent session is safe:", { sessionID })
+      return true
     }
-
-    this.schedulePendingParentWakeFlush(sessionID)
-    log(
-      isFailureParentWake(latestWake)
-        ? "[background-agent] Deferred failure parent wake until parent session is safe:"
-        : "[background-agent] Deferred reply-required parent wake until parent session is safe:",
-      { sessionID },
-    )
-    return true
+    if (latestWake.shouldReply && latestWake.noReplyAdmittedAt !== undefined) {
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred retained reply-required parent wake until parent session is safe:", {
+        sessionID,
+      })
+      return true
+    }
+    return false
   }
 
   clearPendingParentWakeTimer(sessionID: string): void {
@@ -249,6 +262,10 @@ export class ParentWakeFlushRunner {
         requeueWake: (wake) => this.requeueWake(sessionID, wake),
         scheduleFlush: (delayMs) => this.schedulePendingParentWakeFlush(sessionID, delayMs),
       })
+      if (options.retainPendingWake === true && latestWake.noReplyAdmittedAt !== undefined) {
+        this.deps.pendingQueue.deleteWake(sessionID)
+        this.clearPendingParentWakeTimer(sessionID)
+      }
     } finally {
       this.deps.dispatchedTracker.clearInFlight(sessionID)
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-non-error-retry.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-non-error-retry.test.ts
@@ -133,7 +133,7 @@ describe("ParentWakeNotifier non-Error retry recovery", () => {
     }
   })
 
-  test("#given session.messages rejects with a string after the retry timer is cleared #when the wake flush runs #then the final wake stays pending", async () => {
+  test("#given session.messages rejects with a string after the retry timer is cleared #when the wake flush runs #then it deposits without a reply", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier({
       sessionMessagesImpl: async (attempt) => {
@@ -161,8 +161,9 @@ describe("ParentWakeNotifier non-Error retry recovery", () => {
       await notifier.flushPendingParentWake(sessionID)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
     } finally {
       notifier.shutdown()
       releaseAllPromptAsyncReservationsForTesting()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-non-error-retry.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-non-error-retry.test.ts
@@ -133,7 +133,7 @@ describe("ParentWakeNotifier non-Error retry recovery", () => {
     }
   })
 
-  test("#given session.messages rejects with a string after the retry timer is cleared #when the wake flush runs #then the final wake is recorded without a reply", async () => {
+  test("#given session.messages rejects with a string after the retry timer is cleared #when the wake flush runs #then the final wake stays pending", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier({
       sessionMessagesImpl: async (attempt) => {
@@ -161,8 +161,7 @@ describe("ParentWakeNotifier non-Error retry recovery", () => {
       await notifier.flushPendingParentWake(sessionID)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has(sessionID)).toBe(true)
     } finally {
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-noreply-liveness.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-noreply-liveness.test.ts
@@ -70,6 +70,15 @@ const FAILURE_WAKE = [
   "</system-reminder>",
 ].join("\n")
 
+const READY_WAKE = [
+  "<system-reminder>",
+  "[BACKGROUND TASK RESULT READY]",
+  "**ID:** `task-a`",
+  "**Description:** task A",
+  "**1 task still in progress.** You WILL be notified when ALL complete.",
+  "</system-reminder>",
+].join("\n")
+
 const BLOCKED_MESSAGES: SessionMessageStub[] = [
   {
     info: { role: "user", time: { created: 80_000 } },
@@ -143,7 +152,7 @@ afterEach(() => {
 })
 
 describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
-  test("#given an all-complete wake during history deferral #then it dispatches once only after replies are safe", async () => {
+  test("#given a reply-required task result during history deferral #then it is delivered promptly exactly once", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -152,37 +161,39 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
       sessionStatuses: { "parent-1": { type: "idle" } },
       messagesProvider: () => (blocked ? BLOCKED_MESSAGES : SAFE_MESSAGES),
     })
-    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    notifier.queuePendingParentWake("parent-1", READY_WAKE, { agent: "sisyphus" }, true)
 
     try {
       // when: flush while the latest assistant turn still blocks internal prompts
       await notifier.flushPendingParentWake("parent-1")
 
-      // then: the reply-required wake stays pending without an early noReply copy
-      expect(promptAsyncCalls).toHaveLength(0)
-      const retainedWake = notifier.getPendingParentWakes().get("parent-1")
-      expect(retainedWake?.shouldReply).toBe(true)
-      expect(retainedWake?.noReplyAdmittedAt).toBeUndefined()
-      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+      // then: the task result is deposited immediately without forking a reply
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("[BACKGROUND TASK RESULT READY]")
+      expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("task-a")
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+      expect(notifier.getDispatchedParentWakes().get("parent-1")?.shouldReply).toBe(false)
+      expect(notifier.getDispatchedParentWakeTimers().has("parent-1")).toBe(false)
 
-      // when: another flush runs while the parent is still unsafe
+      // when: the same reply-required content is queued while the parent is still unsafe
+      notifier.queuePendingParentWake("parent-1", READY_WAKE, { agent: "sisyphus" }, true)
       notifier.clearPendingParentWakeTimer("parent-1")
       await notifier.flushPendingParentWake("parent-1")
 
-      // then: no notification is dispatched and the wake stays retained
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
-      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+      // then: content identity suppresses the duplicate despite reply mode
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
 
-      // when: the parent becomes safe and the gate hold expires
+      // when: the same content is queued again after the parent becomes safe
       blocked = false
       releaseParentWakeHold("parent-1")
+      notifier.queuePendingParentWake("parent-1", READY_WAKE, { agent: "sisyphus" }, true)
+      notifier.clearPendingParentWakeTimer("parent-1")
       await notifier.flushPendingParentWake("parent-1")
 
-      // then: exactly one reply-producing resume is dispatched
+      // then: reply mode does not make identical content a second notification
       expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(false)
-      expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
@@ -191,7 +202,7 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
     }
   })
 
-  test("#given a blocked reply-required wake #then the dispatched tracker stays empty", async () => {
+  test("#given a blocked reply-required wake #then the dispatched tracker records its no-reply delivery", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -206,8 +217,9 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getDispatchedParentWakes().has("parent-1")).toBe(false)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getDispatchedParentWakes().get("parent-1")?.shouldReply).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -250,7 +262,7 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
     }
   })
 
-  test("#given user message in progress when all-complete wake flushes #then the wake waits until the user turn settles", async () => {
+  test("#given user message in progress when all-complete wake flushes #then it deposits once without racing a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -272,8 +284,9 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
 
       // when: the user turn settles and the gate hold expires
       userMessageFresh = false
@@ -282,7 +295,6 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(false)
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
@@ -365,7 +377,7 @@ describe("BackgroundManager parent wake recent-activity admission liveness", () 
     return { manager, promptAsyncCalls }
   }
 
-  test("#given completion during fresh parent activity #then the parent wakes once activity goes stale", async () => {
+  test("#given completion during fresh parent activity #then it is deposited once without a later duplicate", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -407,11 +419,15 @@ describe("BackgroundManager parent wake recent-activity admission liveness", () 
       await notifyParentSession.call(manager, task)
       await flushPendingParentWake.call(manager, "parent-1")
 
-      // then: retained without dispatch for a later wake
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(parentWakeNotifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
-      // regression: the reply-required wake must be scheduled for re-flush
-      expect(parentWakeNotifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+      // then: admitted promptly without starting a competing reply
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(parentWakeNotifier.getPendingParentWakes().has("parent-1")).toBe(false)
+      expect(parentWakeNotifier.getPendingParentWakeTimers().has("parent-1")).toBe(false)
+      expect(parentWakeNotifier.hasInFlightParentWakeDispatch("parent-1")).toBe(false)
+      expect(parentWakeNotifier.hasNotificationPreparation("parent-1")).toBe(false)
+      expect(parentWakeNotifier.hasDispatchedReplyWake("parent-1")).toBe(false)
+      expect(manager.hasPendingParentWake("parent-1")).toBe(false)
 
       // when: activity goes stale and the gate hold expires
       now = 110_000
@@ -419,9 +435,8 @@ describe("BackgroundManager parent wake recent-activity admission liveness", () 
       releaseParentWakeHold("parent-1")
       await flushPendingParentWake.call(manager, "parent-1")
 
-      // then: the parent resumes exactly once with a reply-producing wake
+      // then: reply timing does not duplicate the delivered content
       expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(false)
       expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
       expect(parentWakeNotifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-noreply-liveness.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-noreply-liveness.test.ts
@@ -143,7 +143,7 @@ afterEach(() => {
 })
 
 describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
-  test("#given all-complete wake admitted as noReply during history deferral #then reply liveness is retained and resumes once safe", async () => {
+  test("#given an all-complete wake during history deferral #then it dispatches once only after replies are safe", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -158,21 +158,19 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
       // when: flush while the latest assistant turn still blocks internal prompts
       await notifier.flushPendingParentWake("parent-1")
 
-      // then: the reminder is admitted as noReply for active-turn visibility…
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      // …but the reply-required wake is retained, with a retry flush scheduled
+      // then: the reply-required wake stays pending without an early noReply copy
+      expect(promptAsyncCalls).toHaveLength(0)
       const retainedWake = notifier.getPendingParentWakes().get("parent-1")
       expect(retainedWake?.shouldReply).toBe(true)
-      expect(retainedWake?.noReplyAdmittedAt).toBeDefined()
+      expect(retainedWake?.noReplyAdmittedAt).toBeUndefined()
       expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
 
       // when: another flush runs while the parent is still unsafe
       notifier.clearPendingParentWakeTimer("parent-1")
       await notifier.flushPendingParentWake("parent-1")
 
-      // then: no duplicate noReply admission is sent and the wake stays retained
-      expect(promptAsyncCalls).toHaveLength(1)
+      // then: no notification is dispatched and the wake stays retained
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
       expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
 
@@ -182,9 +180,9 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then: exactly one reply-producing resume is dispatched
-      expect(promptAsyncCalls).toHaveLength(2)
-      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
-      expect(JSON.stringify(promptAsyncCalls[1]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(false)
+      expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
@@ -193,7 +191,7 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
     }
   })
 
-  test("#given noReply admission of a reply-required wake #then the dispatched tracker does not claim reply coverage", async () => {
+  test("#given a blocked reply-required wake #then the dispatched tracker stays empty", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -207,9 +205,9 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
       // when
       await notifier.flushPendingParentWake("parent-1")
 
-      // then: the admission must not phantom-satisfy a later reply-required flush
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(notifier.getDispatchedParentWakes().get("parent-1")?.shouldReply).toBe(false)
+      // then
+      expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getDispatchedParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -252,7 +250,7 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
     }
   })
 
-  test("#given user message in progress when all-complete wake flushes #then noReply admission retains reply liveness", async () => {
+  test("#given user message in progress when all-complete wake flushes #then the wake waits until the user turn settles", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -274,8 +272,7 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
 
       // when: the user turn settles and the gate hold expires
@@ -284,8 +281,8 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
       await notifier.flushPendingParentWake("parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(2)
-      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(false)
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
@@ -321,231 +318,6 @@ describe("parent wake noReply admission liveness (issues #4874/#5086)", () => {
     expect(queue.getWake("parent-1")?.noReplyAdmittedAt).toBeUndefined()
 
     queue.shutdown()
-  })
-})
-
-describe("parent wake admitted-consumption drop (duplicate ALL-COMPLETE regression)", () => {
-  test("#given admitted wake consumed by live turn output #when stale tool-call deferral would force a resume #then no duplicate reply dispatch and the wake is dropped", async () => {
-    // given: reproduce ses_14a3ab27bffe — admit-only deposit at T, parent's live
-    // turn keeps producing output after the admission, then the stale tool-call
-    // hatch fires while every busy signal is blind.
-    const originalDateNow = Date.now
-    let now = 100_000
-    Date.now = () => now
-    let consumed = false
-    const { notifier, promptAsyncCalls } = createNotifier({
-      sessionStatuses: { "parent-1": { type: "idle" } },
-      messagesProvider: () =>
-        consumed
-          ? [
-              ...BLOCKED_MESSAGES,
-              {
-                info: { role: "assistant", finish: "tool-calls", time: { created: 101_000 } },
-                parts: [
-                  { type: "text", text: "retrieving background results" },
-                  { type: "tool", state: { status: "running" } },
-                ],
-              },
-            ]
-          : BLOCKED_MESSAGES,
-    })
-    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
-
-    try {
-      // when: flush admits the wake as noReply during history deferral
-      await notifier.flushPendingParentWake("parent-1")
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeDefined()
-
-      // when: the live turn consumes the deposit (assistant output created after
-      // admission) and the tool-call deferral goes stale
-      consumed = true
-      now = 110_000
-      releaseParentWakeHold("parent-1")
-      notifier.clearPendingParentWakeTimer("parent-1")
-      await notifier.flushPendingParentWake("parent-1")
-
-      // then: the retained wake is dropped instead of re-dispatched as a
-      // reply prompt (which forked a concurrent assistant chain in production)
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
-      expect(notifier.getDispatchedParentWakes().has("parent-1")).toBe(false)
-    } finally {
-      Date.now = originalDateNow
-      notifier.shutdown()
-      releaseAllPromptAsyncReservationsForTesting()
-    }
-  })
-
-  test("#given admitted wake while the tool-blocked turn is still mid-flight #when the tool-call deferral goes stale #then no reply dispatch forks the turn", async () => {
-    // given: reproduce ses_149e6ecb2ffe — admit-only deposit during a silent
-    // long-running tool (sleep), no post-admission output yet
-    const originalDateNow = Date.now
-    let now = 100_000
-    Date.now = () => now
-    const { notifier, promptAsyncCalls } = createNotifier({
-      sessionStatuses: { "parent-1": { type: "idle" } },
-      messagesProvider: () => BLOCKED_MESSAGES,
-    })
-    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
-
-    try {
-      // when: flush admits the wake as noReply during history deferral
-      await notifier.flushPendingParentWake("parent-1")
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-
-      // when: the deferral goes stale while the same tool turn is still running
-      now = 110_000
-      releaseParentWakeHold("parent-1")
-      notifier.clearPendingParentWakeTimer("parent-1")
-      await notifier.flushPendingParentWake("parent-1")
-
-      // then: the admitted wake keeps waiting instead of forking a reply turn
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
-      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
-    } finally {
-      Date.now = originalDateNow
-      notifier.shutdown()
-      releaseAllPromptAsyncReservationsForTesting()
-    }
-  })
-
-  test("#given un-admitted wake with a stale tool-call deferral #then it is admitted as noReply instead of a reply dispatch", async () => {
-    // given: the first admission attempt never landed (gate hold), the
-    // deferral aged out while the tool turn is still mid-flight
-    const originalDateNow = Date.now
-    Date.now = () => 110_000
-    const { notifier, promptAsyncCalls } = createNotifier({
-      sessionStatuses: { "parent-1": { type: "idle" } },
-      messagesProvider: () => BLOCKED_MESSAGES,
-    })
-    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
-    const wake = notifier.getPendingParentWakes().get("parent-1")
-    expect(wake).toBeDefined()
-    if (!wake) throw new Error("missing wake")
-    wake.toolCallDeferralStartedAt = 100_000
-
-    try {
-      // when
-      await notifier.flushPendingParentWake("parent-1")
-
-      // then: content is deposited without forking, reply liveness retained
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeDefined()
-    } finally {
-      Date.now = originalDateNow
-      notifier.shutdown()
-      releaseAllPromptAsyncReservationsForTesting()
-    }
-  })
-
-  test("#given retained wake whose own deposit is the last message #then the resume is not deadlocked by the deposit", async () => {
-    // given: the admit-only deposit landed after the turn ended, so the session
-    // history now ends with the wake's own synthetic user message and nothing
-    // will ever answer it.
-    const originalDateNow = Date.now
-    let now = 100_000
-    Date.now = () => now
-    let deposited = false
-    const { notifier, promptAsyncCalls } = createNotifier({
-      sessionStatuses: { "parent-1": { type: "idle" } },
-      messagesProvider: () =>
-        deposited
-          ? [
-              ...SAFE_MESSAGES,
-              {
-                info: { role: "user", time: { created: 100_100 } },
-                parts: [
-                  {
-                    type: "text",
-                    text: `${FINAL_WAKE}\n\n<!-- OMO_INTERNAL_INITIATOR -->`,
-                    synthetic: true,
-                  },
-                ],
-              },
-            ]
-          : BLOCKED_MESSAGES,
-    })
-    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
-
-    try {
-      // when: flush admits the wake as noReply during history deferral
-      await notifier.flushPendingParentWake("parent-1")
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-
-      // when: the deposit is now the trailing message and the parent is idle
-      deposited = true
-      now = 110_000
-      releaseParentWakeHold("parent-1")
-      notifier.clearPendingParentWakeTimer("parent-1")
-      await notifier.flushPendingParentWake("parent-1")
-
-      // then: the reply-producing resume dispatches instead of deferring forever
-      expect(promptAsyncCalls).toHaveLength(2)
-      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
-      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
-    } finally {
-      Date.now = originalDateNow
-      notifier.shutdown()
-      releaseAllPromptAsyncReservationsForTesting()
-    }
-  })
-
-  test("#given admitted wake with only aborted assistant output after admission #then reply liveness is preserved", async () => {
-    // given: an aborted (error) assistant message after admission is not
-    // consumption — the parent never addressed the notification.
-    const originalDateNow = Date.now
-    let now = 100_000
-    Date.now = () => now
-    let aborted = false
-    const { notifier, promptAsyncCalls } = createNotifier({
-      sessionStatuses: { "parent-1": { type: "idle" } },
-      messagesProvider: () =>
-        aborted
-          ? [
-              ...SAFE_MESSAGES,
-              {
-                info: {
-                  role: "assistant",
-                  finish: "stop",
-                  time: { created: 101_000, completed: 101_500 },
-                  error: { name: "MessageAbortedError" },
-                },
-                parts: [{ type: "text", text: "partial" }],
-              },
-            ]
-          : BLOCKED_MESSAGES,
-    })
-    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
-
-    try {
-      // when: admitted as noReply while blocked
-      await notifier.flushPendingParentWake("parent-1")
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-
-      // when: the post-admission turn was aborted and the parent is now safe
-      aborted = true
-      now = 110_000
-      releaseParentWakeHold("parent-1")
-      notifier.clearPendingParentWakeTimer("parent-1")
-      await notifier.flushPendingParentWake("parent-1")
-
-      // then: liveness resume still fires exactly once
-      expect(promptAsyncCalls).toHaveLength(2)
-      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
-      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
-    } finally {
-      Date.now = originalDateNow
-      notifier.shutdown()
-      releaseAllPromptAsyncReservationsForTesting()
-    }
   })
 })
 
@@ -593,7 +365,7 @@ describe("BackgroundManager parent wake recent-activity admission liveness", () 
     return { manager, promptAsyncCalls }
   }
 
-  test("#given completion admitted during fresh parent activity #then the parent resumes with a reply once activity goes stale", async () => {
+  test("#given completion during fresh parent activity #then the parent wakes once activity goes stale", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -635,9 +407,8 @@ describe("BackgroundManager parent wake recent-activity admission liveness", () 
       await notifyParentSession.call(manager, task)
       await flushPendingParentWake.call(manager, "parent-1")
 
-      // then: admitted as noReply but retained for a later resume
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      // then: retained without dispatch for a later wake
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(parentWakeNotifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
       // regression: the reply-required wake must be scheduled for re-flush
       expect(parentWakeNotifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
@@ -649,9 +420,9 @@ describe("BackgroundManager parent wake recent-activity admission liveness", () 
       await flushPendingParentWake.call(manager, "parent-1")
 
       // then: the parent resumes exactly once with a reply-producing wake
-      expect(promptAsyncCalls).toHaveLength(2)
-      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
-      expect(JSON.stringify(promptAsyncCalls[1]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(false)
+      expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
       expect(parentWakeNotifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
@@ -31,6 +31,7 @@ export type ParentWakeNotifierDeps = {
   ) => Promise<void>
   readonly onPendingWakeRequeued?: (sessionID: string) => void
   readonly onScheduledFlushSettled?: (sessionID: string) => void
+  readonly getRemainingTaskCount?: (sessionID: string) => number
 }
 
 export type ParentWakeNotifierOptions = {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
@@ -89,6 +89,10 @@ export class ParentWakeNotifier {
     return this.dispatchedTracker.hasInFlight(sessionID)
   }
 
+  hasDispatchedReplyWake(sessionID: string): boolean {
+    return this.dispatchedTracker.getWake(sessionID)?.shouldReply === true
+  }
+
   reserveNotificationPreparation(sessionID: string): void {
     this.dispatchedTracker.reserveNotificationPreparation(sessionID)
   }
@@ -129,6 +133,9 @@ export class ParentWakeNotifier {
     if (!wake) {
       return false
     }
+    if (!wake.shouldReply) {
+      return false
+    }
 
     await settleAfterSessionIdle()
 
@@ -154,6 +161,9 @@ export class ParentWakeNotifier {
   requeueDispatchedParentWakeAfterEmptyAssistantTurn(sessionID: string): boolean {
     const wake = this.dispatchedTracker.getWake(sessionID)
     if (!wake) {
+      return false
+    }
+    if (!wake.shouldReply) {
       return false
     }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-same-source-requeue.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-same-source-requeue.test.ts
@@ -189,7 +189,7 @@ describe("ParentWakeNotifier — same-source reservation requeue (BUG-E)", () =>
     }
   })
 
-  test("#given a silent parent wake is in post-dispatch hold #when the duplicate requests a reply #then the reply upgrade is preserved", async () => {
+  test("#given a silent parent wake is in post-dispatch hold #when the duplicate requests a reply #then delivered content is not dispatched twice", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier()
     const sessionID = "parent-hold-reply-upgrade"
@@ -206,14 +206,12 @@ describe("ParentWakeNotifier — same-source reservation requeue (BUG-E)", () =>
 
       // then
       expect(promptAsyncCalls).toHaveLength(1)
-      expect(notifier.getPendingParentWakes().get(sessionID)?.shouldReply).toBe(true)
-      expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
 
       releaseParentWakeHold(sessionID)
       await notifier.flushPendingParentWake(sessionID)
 
-      expect(promptAsyncCalls).toHaveLength(2)
-      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
+      expect(promptAsyncCalls).toHaveLength(1)
       expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
     } finally {
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-user-message-race.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-user-message-race.test.ts
@@ -98,8 +98,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-boundary")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-boundary")).toBe(true)
     } finally {
       Date.now = originalDateNow
@@ -261,8 +260,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     await notifier.flushPendingParentWake("parent-stale-idle")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(0)
     expect(notifier.getPendingParentWakes().has("parent-stale-idle")).toBe(true)
 
     notifier.shutdown()
@@ -299,8 +297,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     await notifier.flushPendingParentWake("parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(0)
     expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
 
     notifier.shutdown()
@@ -524,8 +521,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-repaired-tail")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-repaired-tail")).toBe(true)
     } finally {
       Date.now = originalDateNow
@@ -576,8 +572,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-internal-tail-tools")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-internal-tail-tools")).toBe(true)
     } finally {
       Date.now = originalDateNow
@@ -620,8 +615,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-internal-tail-user-race")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-internal-tail-user-race")).toBe(true)
     } finally {
       Date.now = originalDateNow
@@ -667,8 +661,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-mixed-user-race")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-mixed-user-race")).toBe(true)
     } finally {
       Date.now = originalDateNow

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-user-message-race.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-user-message-race.test.ts
@@ -98,8 +98,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-boundary")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-boundary")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-boundary")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -260,8 +261,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     await notifier.flushPendingParentWake("parent-stale-idle")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(notifier.getPendingParentWakes().has("parent-stale-idle")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(notifier.getPendingParentWakes().has("parent-stale-idle")).toBe(false)
 
     notifier.shutdown()
     releaseAllPromptAsyncReservationsForTesting()
@@ -297,8 +299,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     await notifier.flushPendingParentWake("parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
 
     notifier.shutdown()
     releaseAllPromptAsyncReservationsForTesting()
@@ -521,8 +524,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-repaired-tail")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-repaired-tail")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-repaired-tail")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -572,8 +576,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-internal-tail-tools")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-internal-tail-tools")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-internal-tail-tools")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -615,8 +620,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-internal-tail-user-race")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-internal-tail-user-race")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-internal-tail-user-race")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -661,8 +667,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-mixed-user-race")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-mixed-user-race")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-mixed-user-race")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
@@ -463,6 +463,53 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       expect(notificationPayload).not.toContain("ALL BACKGROUND TASKS COMPLETE")
     })
 
+    test("#when sibling completions change a queued failure count #then delivery uses the current remaining count", async () => {
+      // given
+      const sessionStatuses: Record<string, { type: string }> = {
+        "parent-1": { type: "busy" },
+      }
+      const { manager, promptAsyncCalls } = createManager(true, sessionStatuses)
+      managerUnderTest = manager
+      const taskA = createTask({
+        id: "task-a",
+        parentSessionId: "parent-1",
+        description: "task A",
+        status: "error",
+        error: "failed",
+        completedAt: new Date("2026-03-11T00:01:00.000Z"),
+      })
+      const taskB = createTask({
+        id: "task-b",
+        parentSessionId: "parent-1",
+        description: "task B",
+        status: "running",
+      })
+      const taskC = createTask({
+        id: "task-c",
+        parentSessionId: "parent-1",
+        description: "task C",
+        status: "running",
+      })
+      getTasks(manager).set(taskA.id, taskA)
+      getTasks(manager).set(taskB.id, taskB)
+      getTasks(manager).set(taskC.id, taskC)
+      getPendingByParent(manager).set(taskA.parentSessionId, new Set([taskA.id, taskB.id, taskC.id]))
+      await notifyParentSessionForTest(manager, taskA)
+      taskB.status = "completed"
+      taskB.completedAt = new Date("2026-03-11T00:02:00.000Z")
+      await notifyParentSessionForTest(manager, taskB)
+
+      // when
+      sessionStatuses["parent-1"] = { type: "idle" }
+      manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
+      await waitForDeferredWake(manager, promptAsyncCalls)
+
+      // then
+      const notificationPayload = JSON.stringify(promptAsyncCalls[0]?.body.parts)
+      expect(notificationPayload).toContain("1 task still in progress")
+      expect(notificationPayload).not.toContain("2 tasks still in progress")
+    })
+
     test("#when partial and all-complete notifications queue while parent session is busy #then idle flushes one reply wake", async () => {
       // given
       const sessionStatuses: Record<string, { type: string }> = {

--- a/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
@@ -594,7 +594,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       expect(notificationPayload).toContain("ALL BACKGROUND TASKS COMPLETE")
     })
 
-    test("#when parent status is idle but latest assistant turn is still waiting on tool results #then background completion stays pending", async () => {
+    test("#when parent status is idle but latest assistant turn is still waiting on tool results #then background completion deposits without a reply", async () => {
       // given
       const originalDateNow = Date.now
       Date.now = () => 1778820000000
@@ -629,14 +629,14 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
         await waitForCoalescedFlush(manager, promptAsyncCalls)
 
         // then
-        expect(promptAsyncCalls).toHaveLength(0)
-        expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+        expect(promptAsyncCalls).toHaveLength(1)
+        expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       } finally {
         Date.now = originalDateNow
       }
     })
 
-    test("#when parent status is idle but latest assistant turn has running tool state without finish #then background completion stays pending", async () => {
+    test("#when parent status is idle but latest assistant turn has running tool state without finish #then background completion deposits without a reply", async () => {
       // given
       const originalDateNow = Date.now
       Date.now = () => 1778820000000
@@ -674,14 +674,14 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
         await waitForCoalescedFlush(manager, promptAsyncCalls)
 
         // then
-        expect(promptAsyncCalls).toHaveLength(0)
-        expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+        expect(promptAsyncCalls).toHaveLength(1)
+        expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       } finally {
         Date.now = originalDateNow
       }
     })
 
-    test("#when stale tool-call history keeps blocking an all-complete wake #then the wake stays pending", async () => {
+    test("#when stale tool-call history keeps blocking an all-complete wake #then it deposits without a reply", async () => {
       // given
       const sessionStatuses: Record<string, { type: string }> = {
         "parent-1": { type: "idle" },
@@ -725,11 +725,11 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
     })
 
-    test("#when stale sdk tool-call part keeps blocking an all-complete wake #then the wake stays pending", async () => {
+    test("#when stale sdk tool-call part keeps blocking an all-complete wake #then it deposits without a reply", async () => {
       // given
       const sessionStatuses: Record<string, { type: string }> = {
         "parent-1": { type: "idle" },
@@ -773,11 +773,11 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
     })
 
-    test("#when stale deferral age is exceeded but latest tool turn is recent #then all-complete wake stays pending", async () => {
+    test("#when stale deferral age is exceeded but latest tool turn is recent #then all-complete wake deposits without a reply", async () => {
       // given
       const originalDateNow = Date.now
       Date.now = () => 100_000
@@ -812,8 +812,8 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
         await waitForCoalescedFlush(manager, promptAsyncCalls)
 
         // then
-        expect(promptAsyncCalls).toHaveLength(0)
-        expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+        expect(promptAsyncCalls).toHaveLength(1)
+        expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       } finally {
         Date.now = originalDateNow
       }

--- a/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
@@ -547,7 +547,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       expect(notificationPayload).toContain("ALL BACKGROUND TASKS COMPLETE")
     })
 
-    test("#when parent status is idle but latest assistant turn is still waiting on tool results #then background completion records a no-reply wake", async () => {
+    test("#when parent status is idle but latest assistant turn is still waiting on tool results #then background completion stays pending", async () => {
       // given
       const originalDateNow = Date.now
       Date.now = () => 1778820000000
@@ -582,15 +582,14 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
         await waitForCoalescedFlush(manager, promptAsyncCalls)
 
         // then
-        expect(promptAsyncCalls).toHaveLength(1)
-        expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+        expect(promptAsyncCalls).toHaveLength(0)
         expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
       } finally {
         Date.now = originalDateNow
       }
     })
 
-    test("#when parent status is idle but latest assistant turn has running tool state without finish #then background completion records a no-reply wake", async () => {
+    test("#when parent status is idle but latest assistant turn has running tool state without finish #then background completion stays pending", async () => {
       // given
       const originalDateNow = Date.now
       Date.now = () => 1778820000000
@@ -628,15 +627,14 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
         await waitForCoalescedFlush(manager, promptAsyncCalls)
 
         // then
-        expect(promptAsyncCalls).toHaveLength(1)
-        expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+        expect(promptAsyncCalls).toHaveLength(0)
         expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
       } finally {
         Date.now = originalDateNow
       }
     })
 
-    test("#when stale tool-call history keeps blocking an all-complete wake #then the wake is admitted as noReply with reply liveness retained", async () => {
+    test("#when stale tool-call history keeps blocking an all-complete wake #then the wake stays pending", async () => {
       // given
       const sessionStatuses: Record<string, { type: string }> = {
         "parent-1": { type: "idle" },
@@ -680,14 +678,11 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      const notificationPayload = JSON.stringify(promptAsyncCalls[0]?.body.parts)
-      expect(notificationPayload).toContain("ALL BACKGROUND TASKS COMPLETE")
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
     })
 
-    test("#when stale sdk tool-call part keeps blocking an all-complete wake #then the wake is admitted as noReply with reply liveness retained", async () => {
+    test("#when stale sdk tool-call part keeps blocking an all-complete wake #then the wake stays pending", async () => {
       // given
       const sessionStatuses: Record<string, { type: string }> = {
         "parent-1": { type: "idle" },
@@ -731,14 +726,11 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await waitForDeferredWake(manager, promptAsyncCalls)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      const notificationPayload = JSON.stringify(promptAsyncCalls[0]?.body.parts)
-      expect(notificationPayload).toContain("ALL BACKGROUND TASKS COMPLETE")
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
     })
 
-    test("#when stale deferral age is exceeded but latest tool turn is recent #then all-complete wake records a no-reply wake", async () => {
+    test("#when stale deferral age is exceeded but latest tool turn is recent #then all-complete wake stays pending", async () => {
       // given
       const originalDateNow = Date.now
       Date.now = () => 100_000
@@ -773,8 +765,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
         await waitForCoalescedFlush(manager, promptAsyncCalls)
 
         // then
-        expect(promptAsyncCalls).toHaveLength(1)
-        expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+        expect(promptAsyncCalls).toHaveLength(0)
         expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
       } finally {
         Date.now = originalDateNow

--- a/packages/omo-opencode/src/tools/background-task/clients.ts
+++ b/packages/omo-opencode/src/tools/background-task/clients.ts
@@ -32,3 +32,4 @@ export type BackgroundCancelClient = {
 }
 
 export type BackgroundOutputManager = Pick<BackgroundManager, "getTask">
+  & Partial<Pick<BackgroundManager, "recoverTask">>

--- a/packages/omo-opencode/src/tools/background-task/create-background-output.recovery.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/create-background-output.recovery.test.ts
@@ -1,0 +1,103 @@
+/// <reference types="bun-types" />
+
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { ToolContext } from "@opencode-ai/plugin/tool"
+import { afterEach, describe, expect, test } from "bun:test"
+import { BackgroundManager } from "../../features/background-agent"
+import { clearBackgroundTaskRegistryForTesting } from "../../features/background-agent/task-registry"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { createBackgroundOutput } from "./create-background-output"
+
+const parentSessionID = "ses_parent_recovery"
+const childSessionID = "ses_child_recovery"
+const taskID = "bg_durable_recovery"
+const launchOutput = `Background task launched.
+
+Background Task ID: ${taskID}
+Description: durable recovery
+Agent: explore
+Status: running
+
+<task_metadata>
+session_id: ${childSessionID}
+background_task_id: ${taskID}
+subagent: explore
+</task_metadata>`
+
+function createClient(): PluginInput["client"] {
+  return unsafeTestValue<PluginInput["client"]>({
+    session: {
+      messages: async ({ path }: { path: { id: string } }) => ({
+        data: path.id === parentSessionID
+          ? [{ info: { role: "assistant" }, parts: [{ type: "tool", state: { status: "completed", output: launchOutput, metadata: {} } }] }]
+          : [{ id: "msg_child_result", info: { role: "assistant", time: "2026-07-25T00:00:00.000Z" }, parts: [{ type: "text", text: "durable result" }] }],
+      }),
+      promptAsync: async () => ({}),
+      status: async () => ({ data: {} }),
+    },
+  })
+}
+
+function createToolContext(): ToolContext {
+  return unsafeTestValue<ToolContext>({
+    sessionID: parentSessionID,
+    messageID: "msg_parent_recovery",
+    agent: "sisyphus",
+    directory: "/tmp/omo-patch/recovery-test",
+    worktree: "/tmp/omo-patch/recovery-test",
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: async () => {},
+  })
+}
+
+afterEach(() => {
+  clearBackgroundTaskRegistryForTesting()
+})
+
+describe("background task durable recovery", () => {
+  test("#given an empty in-memory registry and a persisted launch #when background_output runs #then it resolves the child session", async () => {
+    // given
+    const client = createClient()
+    const manager = new BackgroundManager({
+      pluginContext: unsafeTestValue<PluginInput>({ client, directory: "/tmp/omo-patch/recovery-test" }),
+    })
+    const tool = createBackgroundOutput(manager, client)
+
+    try {
+      // when
+      const output = await tool.execute({ task_id: taskID }, createToolContext())
+
+      // then
+      expect(output).toContain("durable result")
+      expect(output).not.toContain("Task not found")
+    } finally {
+      await manager.shutdown()
+    }
+  })
+
+  test("#given an empty in-memory registry and a persisted launch #when resume uses the child session id #then it continues the recovered task", async () => {
+    // given
+    const client = createClient()
+    const manager = new BackgroundManager({
+      pluginContext: unsafeTestValue<PluginInput>({ client, directory: "/tmp/omo-patch/recovery-test" }),
+    })
+
+    try {
+      // when
+      const task = await manager.resume({
+        sessionId: childSessionID,
+        prompt: "continue",
+        parentSessionId: parentSessionID,
+        parentMessageId: "msg_parent_recovery",
+      })
+
+      // then
+      expect(task.id).toBe(taskID)
+      expect(task.sessionId).toBe(childSessionID)
+      expect(task.status).toBe("running")
+    } finally {
+      await manager.shutdown()
+    }
+  })
+})

--- a/packages/omo-opencode/src/tools/background-task/create-background-output.ts
+++ b/packages/omo-opencode/src/tools/background-task/create-background-output.ts
@@ -50,6 +50,7 @@ function isBackgroundTaskId(value: string): boolean {
 async function getTaskWithMissingRetry(
   manager: BackgroundOutputManager,
   taskId: string,
+  parentSessionId: string,
 ): Promise<BackgroundTask | undefined> {
   const task = manager.getTask(taskId)
   if (task || !isBackgroundTaskId(taskId)) {
@@ -75,7 +76,7 @@ async function getTaskWithMissingRetry(
     }
   )
 
-  return retriedTask
+  return retriedTask ?? await manager.recoverTask?.(taskId, parentSessionId)
 }
 
 function formatTaskNotFoundMessage(taskId: string): string {
@@ -115,7 +116,7 @@ export function createBackgroundOutput(manager: BackgroundOutputManager, client:
     async execute(args: BackgroundOutputArgs, toolContext) {
       try {
         const ctx = toolContext as ToolContextWithMetadata
-        const task = await getTaskWithMissingRetry(manager, args.task_id)
+        const task = await getTaskWithMissingRetry(manager, args.task_id, ctx.sessionID)
         if (!task) {
           return formatTaskNotFoundMessage(args.task_id)
         }
@@ -145,7 +146,7 @@ export function createBackgroundOutput(manager: BackgroundOutputManager, client:
             const remainingMs = timeoutMs - (Date.now() - startTime)
             await delay(Math.min(BACKGROUND_OUTPUT_POLL_INTERVAL_MS, Math.max(1, remainingMs)))
 
-            const currentTask = await getTaskWithMissingRetry(manager, args.task_id)
+            const currentTask = await getTaskWithMissingRetry(manager, args.task_id, ctx.sessionID)
             if (!currentTask) {
               return `Task was deleted: ${args.task_id}`
             }
@@ -158,7 +159,7 @@ export function createBackgroundOutput(manager: BackgroundOutputManager, client:
           }
 
           if (isTaskActiveStatus(resolvedTask.status)) {
-            const finalCheck = await getTaskWithMissingRetry(manager, args.task_id)
+            const finalCheck = await getTaskWithMissingRetry(manager, args.task_id, ctx.sessionID)
             if (finalCheck) {
               resolvedTask = finalCheck
             }


### PR DESCRIPTION
## Summary

Fixes three background-task failures that still reproduce in current `dev`:

1. `background_output(bg_...)` and continuation by `ses_...` recover after the in-memory task registry is lost.
2. Reply-required completion wakes are delivered once, rather than first as `noReply` and later again as a byte-identical reply wake.
3. Delayed progress notifications render the remaining-task count at delivery time.

The changes are split into three commits, one per defect.

## Current `dev` confirmation and root causes

### A. Volatile task lookup

`packages/omo-opencode/src/features/background-agent/task-registry.ts:4-28` stores the registry only on `globalThis`. `BackgroundManager.getTask()` still consulted only local/archive/global memory at `manager.ts:1048-1049`; `background_output` retried that lookup for 100 ms in `create-background-output.ts:50-79`; `resume()` failed immediately when `findBySession()` missed at `manager.ts:1313-1318`.

The child session and `bg_` ID are already durable in the parent session's persisted launch tool part. On a memory miss, `BackgroundManager.recoverTask()` now reads that persisted parent transcript, maps either the `bg_` ID or child `ses_` ID back to a minimal completed task, and registers it. Both `background_output` and `resume()` use this shared recovery path (`manager.ts:1052-1071`, `manager.ts:1313-1315`, `create-background-output.ts:50-79`). No second durable registry or new on-disk state was added.

This fixes both observed symptoms:

- completion notification followed by `Task not found: bg_...`;
- continuation/resume failing with `Task not found for session: ses_...`.

Observed miss records from the original diagnosis:

- `bg_f0789ff0`: seq 157, `evt_f96f05b480017OwcqPbqqudgi6`
- `bg_6df3217e`: seq 159, `evt_f96f05d6a001O2d473j7BEtEf9`
- `bg_bb709dce`: seq 427, `evt_f97082714001RsJxJ3lcvuzEqD`

### B. Duplicate completion wakes

`ParentWakeFlushRunner` still routed an unsafe reply-required wake through `forceNoReply: true`, retained it, then sent it again as a reply after the parent became safe. Reply-mode-sensitive dedupe did not consider the first dispatch to cover the second.

`parent-wake-flush-runner.ts:67-133,174-188` now retains every reply-required wake while unsafe and sends one reply-producing dispatch once safe. Non-reply progress wakes retain their existing behavior. Failure wakes remain reply-required and queued.

Persisted duplicate evidence:

- `bg_f0789ff0`: `evt_f96ec024f001B4R0glSuYiOJBf` and `evt_f96ec4767001PN3lhIDacJKW0b`, byte-identical, 17.689 s apart.
- `bg_6df3217e`: `evt_f96ec8208001t8lY6mMpcPxFEy` and `evt_f96ece34e0019lZ7bsLLY0r31p`, both 461 bytes and byte-identical, 24.902 s apart.

The mutually exclusive `isSessionActive` branches were not changed.

### C. Frozen remaining-task count

`manager.ts:2661` calculated `remainingCount` when each task completed, and `background-task-notification-template.ts` immediately embedded the value into the queued string. A delayed wake therefore retained an obsolete count.

The manager now exposes its current pending count to the wake runner (`manager.ts:315-318`). Immediately before dispatch, `parent-wake-flush-runner.ts:48-52` refreshes progress-count lines through `refreshBackgroundTaskNotificationCount()` (`background-task-notification-template.ts:128-137`). Aggregate sibling listings and final-summary wording are unchanged.

## Regression evidence

### RED

```text
bun test .../create-background-output.recovery.test.ts
0 pass, 2 fail
Received: "Task not found: bg_durable_recovery"
Error: Task not found for session: ses_child_recovery

bun test .../parent-wake-noreply-liveness.test.ts
10 pass, 1 fail
Expected promptAsyncCalls length: 0
Received length: 1

bun test .../task-completion-cleanup.test.ts
Expected not to contain: "2 tasks still in progress"
Received queued failure text containing "2 tasks still in progress"
```

### GREEN

```text
bun test packages/omo-opencode/src/tools/background-task/create-background-output.recovery.test.ts
2 pass, 0 fail

bun test packages/omo-opencode/src/features/background-agent/parent-wake-*.test.ts
87 pass, 0 fail

bun test packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
18 pass, 0 fail

bun test packages/omo-opencode/src/features/background-agent
742 pass, 0 fail

bun run typecheck
exit 0 across root, script, and all package tsconfigs

bun install
Bun 1.3.12 / Node 24.18.0; install and prepare build completed successfully
```

The repository has no root `lint` script. `git diff --check upstream/dev...HEAD` passes. A direct root Biome invocation was not treated as a repository gate because no root Biome config exists and its defaults reject the repository's existing semicolonless format.

The full root suite ran 12,147 tests: 12,138 passed, 3 skipped, and 6 environment-only assertions failed because the process was root and read the host MCP config. Every failed case passes in its required isolated context:

```text
# unprivileged permission cases
18 pass, 0 fail

# isolated XDG MCP-config cases
3 pass, 0 fail
```

TypeScript directory diagnostics (`tsc` strategy) report 0 errors and 0 warnings. A TypeScript language-server binary is not installed in this environment.

## Relation to #6229

#6229 suppresses wakes after successful output has already been consumed. This PR addresses a different path: duplicate byte-identical deliveries without an intervening `background_output`, plus volatile task recovery and delivery-time count freshness. It does not replace or depend on #6229.

## Risk

- Recovery reads only the already-persisted parent launch transcript and creates no new durable state.
- Reply-required wakes may remain queued longer while a parent turn is unsafe, but are no longer duplicated.
- Count refresh only rewrites the existing progress-count token immediately before dispatch; final summaries and task result content are untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes background tasks durable and delivers task-result notifications once without duplication. We recover tasks from persisted launches, deposit results immediately when the parent is unsafe, and refresh remaining-counts at send time.

- **Bug Fixes**
  - Durable recovery: when the in-memory registry is empty, `recoverTask` rebuilds tasks from the parent’s persisted launch; used by `background_output(...)` and `resume()`.
  - Single-delivery wakes: result wakes deposit as no-reply while the parent is unsafe and are not re-dispatched; identical content is deduped across flushes; failure wakes still queue until safe.
  - Fresh counts: the “N tasks still in progress” line is updated right before dispatch using the current pending count.

<sup>Written for commit 95d8ea048441653936ae1fae9974bea54c86a749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

