### PR TITLE
fix(utils): keep sg version probe stderr out of the parent process

### DIFF
--- a/packages/utils/src/ast-grep/sg-resolver.test.ts
+++ b/packages/utils/src/ast-grep/sg-resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -75,6 +75,109 @@ describe("findSgBinarySync", () => {
 
     // then
     expect(result).toBeNull()
+  })
+
+  it("prefers ast-grep over sg on darwin without running the version probe", () => {
+    // given
+    let probeCalls = 0
+    const astGrep = "/usr/local/bin/ast-grep"
+    const sgAlias = "/usr/local/bin/sg"
+
+    // when
+    const result = findSgBinarySync({
+      env: {},
+      fileExists: () => true,
+      platform: "darwin",
+      runVersionProbeSync: () => {
+        probeCalls += 1
+        throw new Error("probe must not run when ast-grep resolves first")
+      },
+      which: (commandName) => (commandName === "ast-grep" ? astGrep : sgAlias),
+    })
+
+    // then
+    expect(result).toBe(astGrep)
+    expect(probeCalls).toBe(0)
+  })
+
+  it("prefers ast-grep over sg on win32 without running the version probe", () => {
+    // given
+    let probeCalls = 0
+    const astGrep = "C:\\tools\\ast-grep.exe"
+    const sgAlias = "C:\\tools\\sg.exe"
+
+    // when
+    const result = findSgBinarySync({
+      env: {},
+      fileExists: () => true,
+      platform: "win32",
+      runVersionProbeSync: () => {
+        probeCalls += 1
+        throw new Error("probe must not run when ast-grep resolves first")
+      },
+      which: (commandName) => (commandName === "ast-grep" ? astGrep : sgAlias),
+    })
+
+    // then
+    expect(result).toBe(astGrep)
+    expect(probeCalls).toBe(0)
+  })
+
+  it("falls back to the sg alias on darwin when ast-grep is absent", () => {
+    // given
+    const sgAlias = "/opt/homebrew/bin/sg"
+
+    // when
+    const result = findSgBinarySync({
+      env: {},
+      fileExists: () => true,
+      platform: "darwin",
+      runVersionProbeSync: () => "ast-grep 0.45.0",
+      which: (commandName) => (commandName === "sg" ? sgAlias : null),
+    })
+
+    // then
+    expect(result).toBe(sgAlias)
+  })
+
+  it("keeps the probed binary's stderr out of the parent process", () => {
+    // shell-script fixture; the leak under test is POSIX stderr inheritance
+    if (process.platform === "win32") return
+
+    // given: a fake sg that prints the ast-grep 0.45 deprecation banner on stderr and the version on stdout
+    const root = tempDir("sg-stderr")
+    mkdirSync(root, { recursive: true })
+    const fakeSg = join(root, "sg")
+    writeFileSync(
+      fakeSg,
+      "#!/bin/sh\nprintf 'WARNING: `sg` is deprecated. Use `ast-grep` instead.\\n' >&2\nprintf 'ast-grep 0.45.0\\n'\n",
+    )
+    chmodSync(fakeSg, 0o755)
+    const runnerPath = join(root, "runner.ts")
+    const resolverPath = join(import.meta.dir, "sg-resolver.ts")
+    writeFileSync(
+      runnerPath,
+      [
+        `import { findSgBinarySync } from ${JSON.stringify(resolverPath)}`,
+        `const result = findSgBinarySync({`,
+        `  env: {},`,
+        `  platform: "darwin",`,
+        `  which: (commandName) => (commandName === "sg" ? ${JSON.stringify(fakeSg)} : null),`,
+        `})`,
+        `console.log(JSON.stringify({ result }))`,
+      ].join("\n"),
+    )
+
+    // when: resolve with the DEFAULT version probe inside a child process so inherited stderr is observable
+    const child = Bun.spawnSync(["bun", runnerPath], { stderr: "pipe", stdout: "pipe" })
+    const childStdout = child.stdout.toString()
+    const childStderr = child.stderr.toString()
+
+    // then: the fake sg resolves, and nothing the probe wrote to stderr escapes the resolver
+    expect(JSON.parse(childStdout.trim())).toEqual({ result: fakeSg })
+    expect(childStderr).not.toMatch(/deprecated|WARNING/)
+
+    rmSync(root, { force: true, recursive: true })
   })
 
   it("prefers ast-grep over Linux setgroups sg collisions", () => {

--- a/packages/utils/src/ast-grep/sg-resolver.ts
+++ b/packages/utils/src/ast-grep/sg-resolver.ts
@@ -23,7 +23,13 @@ function defaultFileExists(filePath: string): boolean {
 }
 
 function defaultVersionProbe(binaryPath: string): string {
-  return String(execFileSync(binaryPath, ["--version"], { encoding: "utf8", timeout: 5_000 }))
+  return String(
+    execFileSync(binaryPath, ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    }),
+  )
 }
 
 function isAstGrepVersionOutput(output: string): boolean {
@@ -39,8 +45,8 @@ function hasAstGrepVersion(binaryPath: string, runVersionProbeSync: (binaryPath:
   }
 }
 
-function pathCommandCandidates(platform: NodeJS.Platform): readonly string[] {
-  return platform === "linux" ? ["ast-grep", "sg"] : ["sg", "ast-grep"]
+function pathCommandCandidates(): readonly string[] {
+  return ["ast-grep", "sg"]
 }
 
 export function findSgBinarySync(options: SgResolverOptions = {}): string | null {
@@ -59,7 +65,7 @@ export function findSgBinarySync(options: SgResolverOptions = {}): string | null
       if (fileExists(runtimeCandidate)) return runtimeCandidate
     }
 
-    for (const commandName of pathCommandCandidates(platform)) {
+    for (const commandName of pathCommandCandidates()) {
       const pathCandidate = which(commandName)
       if (pathCandidate === null || !fileExists(pathCandidate)) continue
       if (commandName !== "sg" || hasAstGrepVersion(pathCandidate, runVersionProbeSync)) return pathCandidate


### PR DESCRIPTION
## What changed

`packages/utils/src/ast-grep/sg-resolver.ts`, two edits:

1. **Silence the version probe.** `defaultVersionProbe()` now runs `execFileSync` with `stdio: ["ignore", "pipe", "ignore"]`. Previously the probed child inherited the parent's stderr, so any binary that writes there wrote straight into the OpenCode TUI.
2. **Prefer `ast-grep` over `sg` on every platform.** `pathCommandCandidates()` returns `["ast-grep", "sg"]` unconditionally (previously only Linux). `ast-grep` skips the probe entirely, so the common case no longer spawns a subprocess; `sg` remains the fallback with the #1365 identity guard intact.

## Why

ast-grep >= 0.45.0 prints a deprecation banner on **stderr** when invoked via the legacy `sg` alias (version stays on stdout). On macOS/Windows the resolver tried `sg` first, ran the probe, and the inherited stderr leaked the banner into the TUI on `session.created` via the `ast-grep-sg-provision` hook. Root cause, measurements, and prior art are in the excellent report by @4i3n6 in #6330.

## Tests

- New: probed-binary stderr containment (child-process assertion with the DEFAULT probe against a fake `sg` that reproduces the 0.45.0 banner), ast-grep-first on darwin/win32 with a probe-call counter pinned to 0, and sg-fallback-still-works on darwin. All written failing-first; RED captures recorded.
- Existing 4 resolver tests unmodified and green.
- Gates: full `bun test` 12150 pass / 0 fail, `bun run typecheck` clean, `bun run test:codex` green.

## QA / evidence (opencode-qa, isolated sandbox, real harness)

Real `opencode serve` 1.18.4 with this branch's built plugin loaded via `file://` (load proven via `GET /config`), fake `sg`/`ast-grep` shims on PATH with an invocation counter, `POST /session` driving `session.created`, sandboxed `XDG_*` + `HOME`:

| run | build | PATH | banner lines in output | fake `sg` invocations |
|---|---|---|---|---|
| before | pre-fix | sg + ast-grep | **1** (leak reproduced) | 1 |
| after | fixed | sg + ast-grep | **0** | **0** (probe skipped) |
| after, sg-only | fixed | sg only | **0** | 1 (probe ran, stderr contained) |
| after, TUI under tmux | fixed | sg only | **0** in rendered pane | 1 |

Real `~/.local/share/opencode/opencode.db` session count unchanged (21932) across every run. Evidence bundle (summaries, raw serve logs, TUI pane capture, gate logs, rig scripts) recorded under `.omo/evidence/20260725-sg-probe-banner-leak/` (gitignored path, retained in the maintainer checkout).

Codex side: no live drive needed — no codex hook behavior changes; the bootstrap's own post-provision probe already pipes stderr (`promisify(execFile)`), and the shared resolver is covered by the hermetic `bun run test:codex` gate.

## Residual risk / note for future maintainers

`SG_PINNED_VERSION` is 0.43.0 and the provisioned runtime binary is literally named `sg`. Bumping the pin to >= 0.45.0 will make the provisioned binary itself print the deprecation banner on every invocation; when that bump happens the binary should be renamed (or the banner otherwise handled). Out of scope here, flagged deliberately.

Fixes #6330


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the `sg` version probe from leaking deprecation banners into the TUI and prefers `ast-grep` across all platforms to skip the probe when possible. Fixes #6330.

- **Bug Fixes**
  - Run the `--version` probe with `stdio: ["ignore", "pipe", "ignore"]` so child stderr doesn’t reach the parent.
  - Try `ast-grep` before `sg` on all platforms; the guarded probe only runs for the `sg` fallback.

<sup>Written for commit 580cbeb0e40b9cfa1102725163eb7f8f1191be0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

