### PR TITLE
fix(runtime-fallback): serialize watchdog fallback handoffs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -702,6 +702,7 @@ Auto-switches to backup models on API errors.
     "max_fallback_attempts": 3,
     "cooldown_seconds": 60,
     "timeout_seconds": 30,
+    "first_prompt_watchdog_seconds": 90,
     "notify_on_fallback": true
   }
 }
@@ -714,6 +715,7 @@ Auto-switches to backup models on API errors.
 | `max_fallback_attempts` | `3`                 | Max fallback attempts per session (1–20)                                                                                       |
 | `cooldown_seconds`      | `60`                | Seconds before retrying a failed model                                                                                         |
 | `timeout_seconds`       | `30`                | Seconds before forcing next fallback. **Set to `0` to disable timeout-based escalation and `message.updated` provider retry signal detection.** Structured `session.status` retry events can still trigger fallback. |
+| `first_prompt_watchdog_seconds` | `90`           | Seconds a subagent may remain silent before its first fallback is dispatched. **Set to `0` to disable this watchdog.** |
 | `notify_on_fallback`    | `true`              | Toast notification on model switch                                                                                             |
 
 #### Speeding Up Fallback (Proxy APIs)

--- a/packages/omo-opencode/src/config/schema/runtime-fallback.ts
+++ b/packages/omo-opencode/src/config/schema/runtime-fallback.ts
@@ -11,6 +11,8 @@ export const RuntimeFallbackConfigSchema = z.object({
   cooldown_seconds: z.number().min(0).optional(),
   /** Session-level timeout in seconds to advance fallback when provider hangs (default: 30). Set to 0 to disable timeout escalation and message.updated auto-retry signal detection. */
   timeout_seconds: z.number().min(0).optional(),
+  /** First-prompt watchdog timeout in seconds for silent subagents (default: 90). Set to 0 to disable this watchdog. */
+  first_prompt_watchdog_seconds: z.number().min(0).optional(),
   /** Show toast notification when switching to fallback model (default: true) */
   notify_on_fallback: z.boolean().optional(),
   restore_primary_after_cooldown: z.boolean().optional(),

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.test.ts
@@ -101,6 +101,20 @@ describe("createAbortSessionRequest reservation release", () => {
     expect(getPromptReservation(sessionID)).toBeUndefined()
   })
 
+  test("#given the first-prompt watchdog aborts a silent session #when the abort completes #then the session is marked internally aborted so fallback dispatch bypasses the stale assistant gate", async () => {
+    // given
+    const deps = createDeps()
+    const sessionID = "session-first-prompt-watchdog"
+    const abortSessionRequest = createAbortSessionRequest(deps)
+
+    // when
+    await abortSessionRequest(sessionID, "first-prompt-watchdog")
+
+    // then
+    expect(deps.internallyAbortedSessions.has(sessionID)).toBe(true)
+    expect(deps.sessionLastAccess.has(sessionID)).toBe(true)
+  })
+
   test("#given a session reserved by an unrelated user prompt #when the runtime-fallback abort fires #then the reservation is preserved (abort must not steal a foreground user turn)", async () => {
     // given
     const deps = createDeps()

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.ts
@@ -11,6 +11,7 @@ export function createAbortSessionRequest(deps: HookDeps) {
       source === "session.status.retry-signal" ||
       source === "message.updated.retry-signal" ||
       source === "message.updated.quota-fallback" ||
+      source === "first-prompt-watchdog" ||
       source === "session.timeout"
     ) {
       deps.internallyAbortedSessions.add(sessionID)

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_PROMPT_QUEUE_RETRY_MS, releaseAllPromptAsyncReservationsForTest
 import { setPromptReservation } from "../../shared/prompt-async-gate/reservations"
 import { createAutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
+import { releaseFallbackDispatchLease, supersedeFallbackDispatchLease } from "./fallback-dispatch-lease"
 import { installRuntimeFallbackTestClock, restoreRuntimeFallbackTestClock } from "./test-timeout-clock.test-support"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 
@@ -244,5 +245,65 @@ describe("createAutoRetryDispatcher reserved-session retry (#5109)", () => {
 
     // then
     expect(promptCalls.count).toBe(0)
+  })
+
+  test("#given an older fallback is waiting for session messages #when a provider retry signal supersedes it #then only the newer fallback prompt is dispatched", async () => {
+    // given
+    const promptCalls = { count: 0 }
+    const deps = createDeps(promptCalls)
+    const sessionID = "session-superseded-during-message-read"
+    const dispatchedModels: string[] = []
+    let releaseOlderMessages: ((value: unknown) => void) | undefined
+    let markOlderReadStarted: (() => void) | undefined
+    const olderReadStarted = new Promise<void>((resolve) => { markOlderReadStarted = resolve })
+    let messageReadCount = 0
+    const userMessages = {
+      data: [
+        {
+          info: { role: "user" },
+          parts: [{ type: "text", text: "retry this" }],
+        },
+      ],
+    }
+    deps.ctx.client.session.messages = async () => {
+      messageReadCount += 1
+      if (messageReadCount === 1) {
+        markOlderReadStarted?.()
+        return await new Promise<unknown>((resolve) => { releaseOlderMessages = resolve })
+      }
+      return userMessages
+    }
+    deps.ctx.client.session.promptAsync = async (input) => {
+      promptCalls.count += 1
+      dispatchedModels.push(`${input.body.model.providerID}/${input.body.model.modelID}`)
+      return {}
+    }
+    const helpers = createAutoRetryHelpers(deps)
+
+    // when
+    const olderRetry = helpers.autoRetryWithFallback(
+      sessionID,
+      "openai/gpt-older-fallback",
+      undefined,
+      "session.error",
+    )
+    await olderReadStarted
+    const newerLease = supersedeFallbackDispatchLease(deps, sessionID)
+    const newerRetry = helpers.autoRetryWithFallback(
+      sessionID,
+      "openai/gpt-newer-fallback",
+      undefined,
+      "session.status",
+      newerLease,
+    )
+    await newerRetry
+    releaseOlderMessages?.(userMessages)
+    const olderOutcome = await olderRetry
+    releaseFallbackDispatchLease(deps, sessionID, newerLease)
+
+    // then
+    expect(olderOutcome).toEqual({ accepted: false, status: "blocked", reason: "fallback dispatch superseded" })
+    expect(promptCalls.count).toBe(1)
+    expect(dispatchedModels).toEqual(["openai/gpt-newer-fallback"])
   })
 })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
@@ -12,6 +12,12 @@ import {
 } from "../shared/prompt-async-gate"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 import { resolveOriginalUserRetryMetadata } from "./auto-retry-metadata"
+import {
+  isFallbackDispatchLeaseOwner,
+  releaseFallbackDispatchLease,
+  tryAcquireFallbackDispatchLease,
+  type FallbackDispatchLease,
+} from "./fallback-dispatch-lease"
 
 export function createAutoRetryDispatcher(
   deps: HookDeps,
@@ -32,8 +38,9 @@ export function createAutoRetryDispatcher(
     newModel: string,
     resolvedAgent: string | undefined,
     source: string,
+    suppliedLease?: FallbackDispatchLease,
   ): Promise<AutoRetryDispatchOutcome> => {
-    if (sessionRetryInFlight.has(sessionID)) {
+    if (!suppliedLease && sessionRetryInFlight.has(sessionID)) {
       log(`[${HOOK_NAME}] Retry already in flight, skipping (${source})`, { sessionID })
       return { accepted: false, status: "blocked", reason: "retry already in flight" }
     }
@@ -57,6 +64,16 @@ export function createAutoRetryDispatcher(
       return { accepted: false, status: "invalid-model", reason: "missing provider prefix" }
     }
 
+    const dispatchLease = suppliedLease
+      ? (isFallbackDispatchLeaseOwner(deps, sessionID, suppliedLease) ? suppliedLease : undefined)
+      : tryAcquireFallbackDispatchLease(deps, sessionID)
+    if (!dispatchLease) {
+      log(`[${HOOK_NAME}] Fallback dispatch already owns session, skipping (${source})`, { sessionID })
+      return { accepted: false, status: "blocked", reason: "fallback dispatch already owns session" }
+    }
+    const acquiredLeaseHere = !suppliedLease
+    const isCurrentDispatch = (): boolean => isFallbackDispatchLeaseOwner(deps, sessionID, dispatchLease)
+
     const hadAwaitingFallbackResult = sessionAwaitingFallbackResult.has(sessionID)
     const previousPendingFallbackModel = sessionStates.get(sessionID)?.pendingFallbackModel
     const previousPendingFallbackPromptMayHaveBeenAccepted = sessionStates.get(sessionID)?.pendingFallbackPromptMayHaveBeenAccepted
@@ -69,6 +86,10 @@ export function createAutoRetryDispatcher(
         path: { id: sessionID },
         query: { directory: ctx.directory },
       })
+      if (!isCurrentDispatch()) {
+        log(`[${HOOK_NAME}] Fallback dispatch became stale while reading messages (${source})`, { sessionID })
+        return { accepted: false, status: "blocked", reason: "fallback dispatch superseded" }
+      }
       const retryPayload = getLastUserRetryPayload(messagesResp, sessionID)
       const originalRetryMetadata = resolveOriginalUserRetryMetadata(messagesResp)
       const fetchedParts = originalRetryMetadata.parts.length > 0
@@ -98,6 +119,10 @@ export function createAutoRetryDispatcher(
 
       const retryAgent = resolvedAgent ?? getSessionAgent(sessionID)
       const launchAgent = resolveRegisteredAgentName(retryAgent)
+      if (!isCurrentDispatch()) {
+        log(`[${HOOK_NAME}] Fallback dispatch became stale before prompt setup (${source})`, { sessionID })
+        return { accepted: false, status: "blocked", reason: "fallback dispatch superseded" }
+      }
       if (!hadAwaitingFallbackResult) {
         sessionAwaitingFallbackResult.add(sessionID)
         scheduleSessionFallbackTimeout(sessionID, retryAgent)
@@ -129,12 +154,28 @@ export function createAutoRetryDispatcher(
         input: retryPromptInput,
       })
 
+      if (!isCurrentDispatch()) {
+        log(`[${HOOK_NAME}] Fallback dispatch became stale before prompt submission (${source})`, { sessionID })
+        return { accepted: false, status: "blocked", reason: "fallback dispatch superseded" }
+      }
       let promptResult = await dispatchRetryPrompt(`runtime-fallback:${source}`, "defer")
+      if (!isCurrentDispatch()) {
+        log(`[${HOOK_NAME}] Fallback dispatch became stale after prompt submission (${source})`, { sessionID })
+        return { accepted: false, status: "blocked", reason: "fallback dispatch superseded" }
+      }
       if (promptResult.status === "active") {
         log(`[${HOOK_NAME}] Session active, queueing fallback dispatch (${source})`, {
           sessionID,
         })
+        if (!isCurrentDispatch()) {
+          log(`[${HOOK_NAME}] Fallback dispatch became stale before queued prompt submission (${source})`, { sessionID })
+          return { accepted: false, status: "blocked", reason: "fallback dispatch superseded" }
+        }
         promptResult = await dispatchRetryPrompt(`runtime-fallback:${source}:active-queue`)
+        if (!isCurrentDispatch()) {
+          log(`[${HOOK_NAME}] Fallback dispatch became stale after queued prompt submission (${source})`, { sessionID })
+          return { accepted: false, status: "blocked", reason: "fallback dispatch superseded" }
+        }
         acceptedStatus = "queued"
       }
       if (promptResult.status === "failed") {
@@ -162,10 +203,18 @@ export function createAutoRetryDispatcher(
             maxAttempts: MAX_RESERVED_RETRIES,
           })
           await new Promise((r) => setTimeout(r, delay))
+          if (!isCurrentDispatch()) {
+            log(`[${HOOK_NAME}] Fallback dispatch became stale during reserved retry (${source})`, { sessionID })
+            return { accepted: false, status: "blocked", reason: "fallback dispatch superseded" }
+          }
           reservedResult = await dispatchRetryPrompt(
             `runtime-fallback:${source}:reserved-retry-${attempt + 1}`,
             "defer",
           )
+          if (!isCurrentDispatch()) {
+            log(`[${HOOK_NAME}] Fallback dispatch became stale after reserved prompt submission (${source})`, { sessionID })
+            return { accepted: false, status: "blocked", reason: "fallback dispatch superseded" }
+          }
           if (reservedResult.status !== "reserved") break
         }
         if (reservedResult.status === "failed") {
@@ -194,6 +243,10 @@ export function createAutoRetryDispatcher(
         })
         return { accepted: false, status: "blocked", reason: `prompt gate returned ${promptResult.status}` }
       }
+      if (!isCurrentDispatch()) {
+        log(`[${HOOK_NAME}] Fallback dispatch became stale before accepting prompt result (${source})`, { sessionID })
+        return { accepted: false, status: "blocked", reason: "fallback dispatch superseded" }
+      }
       sessionAwaitingFallbackResult.add(sessionID)
       if (hadAwaitingFallbackResult) {
         scheduleSessionFallbackTimeout(sessionID, retryAgent)
@@ -212,30 +265,35 @@ export function createAutoRetryDispatcher(
       log(`[${HOOK_NAME}] Auto-retry failed (${source})`, { sessionID, error: String(retryError) })
       return { accepted: false, status: "failed", reason: retryError.message }
     } finally {
-      sessionRetryInFlight.delete(sessionID)
-      if (retryMayHaveBeenAccepted) {
-        const state = sessionStates.get(sessionID)
-        if (state) {
-          state.pendingFallbackPromptMayHaveBeenAccepted = true
-        }
-      }
-      if (!retryDispatched && !retryMayHaveBeenAccepted) {
-        if (hadAwaitingFallbackResult) {
-          sessionAwaitingFallbackResult.add(sessionID)
-        } else {
-          sessionAwaitingFallbackResult.delete(sessionID)
-          clearSessionFallbackTimeout(sessionID)
-        }
-        const state = sessionStates.get(sessionID)
-        if (state) {
-          if (hadAwaitingFallbackResult) {
-            state.pendingFallbackModel = previousPendingFallbackModel
-            state.pendingFallbackPromptMayHaveBeenAccepted = previousPendingFallbackPromptMayHaveBeenAccepted
-          } else if (state.pendingFallbackModel) {
-            state.pendingFallbackModel = undefined
-            state.pendingFallbackPromptMayHaveBeenAccepted = false
+      if (isCurrentDispatch()) {
+        sessionRetryInFlight.delete(sessionID)
+        if (retryMayHaveBeenAccepted) {
+          const state = sessionStates.get(sessionID)
+          if (state) {
+            state.pendingFallbackPromptMayHaveBeenAccepted = true
           }
         }
+        if (!retryDispatched && !retryMayHaveBeenAccepted) {
+          if (hadAwaitingFallbackResult) {
+            sessionAwaitingFallbackResult.add(sessionID)
+          } else {
+            sessionAwaitingFallbackResult.delete(sessionID)
+            clearSessionFallbackTimeout(sessionID)
+          }
+          const state = sessionStates.get(sessionID)
+          if (state) {
+            if (hadAwaitingFallbackResult) {
+              state.pendingFallbackModel = previousPendingFallbackModel
+              state.pendingFallbackPromptMayHaveBeenAccepted = previousPendingFallbackPromptMayHaveBeenAccepted
+            } else if (state.pendingFallbackModel) {
+              state.pendingFallbackModel = undefined
+              state.pendingFallbackPromptMayHaveBeenAccepted = false
+            }
+          }
+        }
+      }
+      if (acquiredLeaseHere) {
+        releaseFallbackDispatchLease(deps, sessionID, dispatchLease)
       }
     }
   }

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.test.ts
@@ -142,4 +142,33 @@ describe("createFallbackTimeoutHelpers", () => {
     expect(deps.sessionFallbackTimeouts.has(sessionID)).toBe(true)
     helpers.clearSessionFallbackTimeout(sessionID)
   })
+
+  test("#given timeout escalation supersedes an in-flight retry but no fallback remains #when the takeover exits early #then it clears the stale retry-in-flight marker", async () => {
+    // given
+    const sessionID = "session-timeout-no-fallback-cleanup"
+    const deps = createDeps()
+    deps.pluginConfig = undefined
+    deps.sessionRetryInFlight.add(sessionID)
+    deps.sessionStates.set(sessionID, createFallbackState("openai/gpt-5.4"))
+    let resolveAbort: (() => void) | undefined
+    const abortCalled = new Promise<void>((resolve) => { resolveAbort = resolve })
+    const helpers = createFallbackTimeoutHelpers(
+      deps,
+      async () => { resolveAbort?.() },
+      async () => ({ accepted: true, status: "dispatched" }),
+    )
+
+    // when
+    helpers.scheduleSessionFallbackTimeout(sessionID)
+    await Promise.race([
+      abortCalled,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("timer did not fire")), 1000)
+      }),
+    ])
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // then
+    expect(deps.sessionRetryInFlight.has(sessionID)).toBe(false)
+  })
 })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.ts
@@ -5,6 +5,12 @@ import { getFallbackModelsForSession } from "./fallback-models"
 import { prepareFallback } from "./fallback-state"
 import { restoreFallbackState, snapshotFallbackState } from "./fallback-state-snapshot"
 import { subagentSessions } from "../../features/claude-code-session-state"
+import {
+  isFallbackDispatchLeaseOwner,
+  releaseFallbackDispatchLease,
+  supersedeFallbackDispatchLease,
+  type FallbackDispatchLease,
+} from "./fallback-dispatch-lease"
 
 declare function setTimeout(callback: () => void | Promise<void>, delay?: number): RuntimeFallbackTimeout
 declare function clearTimeout(timeout: RuntimeFallbackTimeout): void
@@ -17,6 +23,7 @@ export function createFallbackTimeoutHelpers(
     newModel: string,
     resolvedAgent: string | undefined,
     source: string,
+    suppliedLease?: FallbackDispatchLease,
   ) => Promise<AutoRetryDispatchOutcome>,
 ) {
   const {
@@ -54,42 +61,61 @@ export function createFallbackTimeoutHelpers(
       const state = sessionStates.get(sessionID)
       if (!state) return
 
-      if (sessionRetryInFlight.has(sessionID)) {
-        log(`[${HOOK_NAME}] Overriding in-flight retry due to session timeout`, { sessionID })
-      }
+      // Timeout escalation must move to the next model even when a prior
+      // fallback is still waiting on OpenCode. Replacing its lease invalidates
+      // the older async branch before it can submit or roll back stale work.
+      const lease = supersedeFallbackDispatchLease(deps, sessionID)
 
-      await abortSessionRequest(sessionID, "session.timeout")
-      sessionRetryInFlight.delete(sessionID)
-
-      if (state.pendingFallbackModel) {
-        state.pendingFallbackModel = undefined
-      }
-      state.pendingFallbackPromptMayHaveBeenAccepted = false
-      const stateSnapshot = snapshotFallbackState(state)
-
-      const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, pluginConfig)
-      if (fallbackModels.length === 0) return
-
-      log(`[${HOOK_NAME}] Session fallback timeout reached`, {
-        sessionID,
-        timeoutSeconds: config.timeout_seconds,
-        currentModel: state.currentModel,
-      })
-
-      const result = prepareFallback(sessionID, state, fallbackModels, config)
-      if (result.success && result.newModel) {
-        const dispatchOutcome = await autoRetryWithFallback(sessionID, result.newModel, resolvedAgent, "session.timeout")
-        if (!dispatchOutcome.accepted) {
-          restoreFallbackState(state, stateSnapshot)
-          if (deps.sessionAwaitingFallbackResult.has(sessionID)) {
-            scheduleSessionFallbackTimeout(sessionID, resolvedAgent)
-          }
-          log(`[${HOOK_NAME}] Session timeout fallback dispatch was not accepted`, {
-            sessionID,
-            status: dispatchOutcome.status,
-            reason: dispatchOutcome.reason,
-          })
+      try {
+        if (sessionRetryInFlight.has(sessionID)) {
+          log(`[${HOOK_NAME}] Overriding in-flight retry due to session timeout`, { sessionID })
         }
+
+        await abortSessionRequest(sessionID, "session.timeout")
+        if (!isFallbackDispatchLeaseOwner(deps, sessionID, lease)) return
+
+        if (state.pendingFallbackModel) {
+          state.pendingFallbackModel = undefined
+        }
+        state.pendingFallbackPromptMayHaveBeenAccepted = false
+        const stateSnapshot = snapshotFallbackState(state)
+
+        const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, pluginConfig)
+        if (fallbackModels.length === 0) return
+
+        log(`[${HOOK_NAME}] Session fallback timeout reached`, {
+          sessionID,
+          timeoutSeconds: config.timeout_seconds,
+          currentModel: state.currentModel,
+        })
+
+        const result = prepareFallback(sessionID, state, fallbackModels, config)
+        if (result.success && result.newModel) {
+          const dispatchOutcome = await autoRetryWithFallback(
+            sessionID,
+            result.newModel,
+            resolvedAgent,
+            "session.timeout",
+            lease,
+          )
+          if (!isFallbackDispatchLeaseOwner(deps, sessionID, lease)) return
+          if (!dispatchOutcome.accepted) {
+            restoreFallbackState(state, stateSnapshot)
+            if (deps.sessionAwaitingFallbackResult.has(sessionID)) {
+              scheduleSessionFallbackTimeout(sessionID, resolvedAgent)
+            }
+            log(`[${HOOK_NAME}] Session timeout fallback dispatch was not accepted`, {
+              sessionID,
+              status: dispatchOutcome.status,
+              reason: dispatchOutcome.reason,
+            })
+          }
+        }
+      } finally {
+        if (isFallbackDispatchLeaseOwner(deps, sessionID, lease)) {
+          sessionRetryInFlight.delete(sessionID)
+        }
+        releaseFallbackDispatchLease(deps, sessionID, lease)
       }
     }, timeoutMs)
 

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry.ts
@@ -12,8 +12,8 @@ export function createAutoRetryHelpers(deps: HookDeps) {
   const { clearSessionFallbackTimeout, scheduleSessionFallbackTimeout } = createFallbackTimeoutHelpers(
     deps,
     abortSessionRequest,
-    (sessionID, newModel, resolvedAgent, source) =>
-      autoRetryWithFallback(sessionID, newModel, resolvedAgent, source),
+    (sessionID, newModel, resolvedAgent, source, lease) =>
+      autoRetryWithFallback(sessionID, newModel, resolvedAgent, source, lease),
   )
 
   autoRetryWithFallback = createAutoRetryDispatcher(

--- a/packages/omo-opencode/src/hooks/runtime-fallback/constants.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/constants.ts
@@ -15,6 +15,7 @@ export const DEFAULT_CONFIG: Required<RuntimeFallbackConfig> = {
   max_fallback_attempts: 3,
   cooldown_seconds: 60,
   timeout_seconds: 30,
+  first_prompt_watchdog_seconds: 90,
   notify_on_fallback: true,
   restore_primary_after_cooldown: false,
 }
@@ -65,4 +66,4 @@ export const HOOK_NAME = "runtime-fallback"
  * practice) yet much shorter than the 30-minute outer poll timeout that
  * would otherwise be the only safety net.
  */
-export const DEFAULT_FIRST_PROMPT_WATCHDOG_MS = 90_000
+export const DEFAULT_FIRST_PROMPT_WATCHDOG_MS = DEFAULT_CONFIG.first_prompt_watchdog_seconds * 1000

--- a/packages/omo-opencode/src/hooks/runtime-fallback/event-handler.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/event-handler.ts
@@ -12,6 +12,7 @@ import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
 import { normalizeModelToCanonicalString } from "./normalize-model"
+import { invalidateFallbackDispatchLease } from "./fallback-dispatch-lease"
 
 function isRuntimeFallbackRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
@@ -55,6 +56,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   const cancelledSessions = new Set<string>()
 
   const resetRetryState = (sessionID: string) => {
+    invalidateFallbackDispatchLease(deps, sessionID)
     const state = sessionStates.get(sessionID)
     if (state) {
       sessionStates.set(sessionID, createFallbackState(state.originalModel))
@@ -101,6 +103,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
 
     if (sessionID) {
       log(`[${HOOK_NAME}] Cleaning up session state`, { sessionID })
+      invalidateFallbackDispatchLease(deps, sessionID)
       cancelledSessions.delete(sessionID)
       sessionStates.delete(sessionID)
       sessionLastAccess.delete(sessionID)
@@ -117,6 +120,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
     const sessionID = resolveSessionEventID(props)
     if (!sessionID) return
 
+    invalidateFallbackDispatchLease(deps, sessionID)
     if (sessionRetryInFlight.has(sessionID) || sessionAwaitingFallbackResult.has(sessionID)) {
       await helpers.abortSessionRequest(sessionID, "session.stop")
     }

--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-dispatch-lease.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-dispatch-lease.ts
@@ -1,0 +1,92 @@
+import type { HookDeps } from "./types"
+
+export type FallbackDispatchLease = {
+  readonly sessionID: string
+  readonly token: symbol
+}
+
+type FallbackDispatchLeaseOptions = {
+  rejectAwaitingFallback?: boolean
+}
+
+const dispatchLeases = new WeakMap<HookDeps, Map<string, symbol>>()
+
+function getDispatchLeases(deps: HookDeps): Map<string, symbol> {
+  let leases = dispatchLeases.get(deps)
+  if (!leases) {
+    leases = new Map()
+    dispatchLeases.set(deps, leases)
+  }
+  return leases
+}
+
+export function tryAcquireFallbackDispatchLease(
+  deps: HookDeps,
+  sessionID: string,
+  options: FallbackDispatchLeaseOptions = {},
+): FallbackDispatchLease | undefined {
+  const leases = getDispatchLeases(deps)
+  if (leases.has(sessionID)) return undefined
+  if (deps.sessionRetryInFlight.has(sessionID)) return undefined
+  if (options.rejectAwaitingFallback && deps.sessionAwaitingFallbackResult.has(sessionID)) return undefined
+
+  const token = Symbol(sessionID)
+  leases.set(sessionID, token)
+  return { sessionID, token }
+}
+
+/**
+ * Take ownership from an older dispatch while advancing a fallback chain.
+ *
+ * Timeout escalation and provider retry signals intentionally supersede a
+ * request that is still awaiting OpenCode. Replacing the token lets every
+ * older async branch observe that it became stale before it can submit a
+ * prompt or restore obsolete state.
+ */
+export function supersedeFallbackDispatchLease(
+  deps: HookDeps,
+  sessionID: string,
+): FallbackDispatchLease {
+  const leases = getDispatchLeases(deps)
+  const token = Symbol(sessionID)
+  leases.set(sessionID, token)
+  return { sessionID, token }
+}
+
+export function isFallbackDispatchLeaseOwner(
+  deps: HookDeps,
+  sessionID: string,
+  lease: FallbackDispatchLease,
+): boolean {
+  return lease.sessionID === sessionID && dispatchLeases.get(deps)?.get(sessionID) === lease.token
+}
+
+export function releaseFallbackDispatchLease(
+  deps: HookDeps,
+  sessionID: string,
+  lease: FallbackDispatchLease,
+): void {
+  if (!isFallbackDispatchLeaseOwner(deps, sessionID, lease)) return
+
+  const leases = dispatchLeases.get(deps)
+  leases?.delete(sessionID)
+  if (leases?.size === 0) {
+    dispatchLeases.delete(deps)
+  }
+}
+
+/** Invalidate an active dispatch without granting a replacement owner. */
+export function invalidateFallbackDispatchLease(deps: HookDeps, sessionID: string): void {
+  const leases = dispatchLeases.get(deps)
+  if (!leases) return
+
+  leases.delete(sessionID)
+  if (leases.size === 0) {
+    dispatchLeases.delete(deps)
+  }
+}
+
+/** Invalidate every active dispatch during plugin disposal. */
+export function invalidateAllFallbackDispatchLeases(deps: HookDeps): void {
+  dispatchLeases.delete(deps)
+}

--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.ts
@@ -4,6 +4,12 @@ import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { prepareFallback } from "./fallback-state"
 import { restoreFallbackState, snapshotFallbackState } from "./fallback-state-snapshot"
+import {
+  isFallbackDispatchLeaseOwner,
+  releaseFallbackDispatchLease,
+  tryAcquireFallbackDispatchLease,
+  type FallbackDispatchLease,
+} from "./fallback-dispatch-lease"
 
 type DispatchFallbackRetryOptions = {
   sessionID: string
@@ -11,6 +17,7 @@ type DispatchFallbackRetryOptions = {
   fallbackModels: string[]
   resolvedAgent?: string
   source: string
+  lease?: FallbackDispatchLease
 }
 
 function resolveDispatchMessage(result: AutoRetryDispatchOutcome, newModel: string): string {
@@ -25,59 +32,84 @@ export async function dispatchFallbackRetry(
   helpers: AutoRetryHelpers,
   options: DispatchFallbackRetryOptions,
 ): Promise<void> {
-  const snapshot = snapshotFallbackState(options.state)
-  const result = prepareFallback(
-    options.sessionID,
-    options.state,
-    options.fallbackModels,
-    deps.config,
-  )
-
-  if (result.success && result.newModel) {
-    const rawDispatchOutcome = await helpers.autoRetryWithFallback(
-      options.sessionID,
-      result.newModel,
-      options.resolvedAgent,
-      options.source,
-    )
-    const dispatchOutcome = rawDispatchOutcome ?? {
-      accepted: true,
-      status: "dispatched",
-    }
-    if (rawDispatchOutcome === undefined) {
-      log(`[${HOOK_NAME}] Fallback dispatch returned no outcome; treating as accepted for compatibility`, {
-        sessionID: options.sessionID,
-        source: options.source,
-      })
-    }
-    if (!dispatchOutcome.accepted) {
-      restoreFallbackState(options.state, snapshot)
-      log(`[${HOOK_NAME}] Fallback dispatch was not accepted`, {
-        sessionID: options.sessionID,
-        source: options.source,
-        status: dispatchOutcome.status,
-        reason: dispatchOutcome.reason,
-      })
-      return
-    }
-    if (deps.config.notify_on_fallback) {
-      await deps.ctx.client.tui
-        .showToast({
-          body: {
-            title: "Model Fallback",
-            message: resolveDispatchMessage(dispatchOutcome, result.newModel),
-            variant: "warning",
-            duration: 5000,
-          },
-        })
-        .catch(() => {})
-    }
+  const lease = options.lease
+    ? (isFallbackDispatchLeaseOwner(deps, options.sessionID, options.lease) ? options.lease : undefined)
+    : tryAcquireFallbackDispatchLease(deps, options.sessionID)
+  if (!lease) {
+    log(`[${HOOK_NAME}] Fallback dispatch already owns session, skipping (${options.source})`, {
+      sessionID: options.sessionID,
+    })
     return
   }
+  const acquiredLeaseHere = !options.lease
+  const isCurrentDispatch = (): boolean => isFallbackDispatchLeaseOwner(deps, options.sessionID, lease)
 
-  log(`[${HOOK_NAME}] Fallback preparation failed`, {
-    sessionID: options.sessionID,
-    source: options.source,
-    error: result.error,
-  })
+  try {
+    const snapshot = snapshotFallbackState(options.state)
+    const result = prepareFallback(
+      options.sessionID,
+      options.state,
+      options.fallbackModels,
+      deps.config,
+    )
+
+    if (result.success && result.newModel) {
+      const rawDispatchOutcome = await helpers.autoRetryWithFallback(
+        options.sessionID,
+        result.newModel,
+        options.resolvedAgent,
+        options.source,
+        lease,
+      )
+      if (!isCurrentDispatch()) {
+        log(`[${HOOK_NAME}] Fallback dispatch became stale before completion (${options.source})`, {
+          sessionID: options.sessionID,
+        })
+        return
+      }
+      const dispatchOutcome = rawDispatchOutcome ?? {
+        accepted: true,
+        status: "dispatched",
+      }
+      if (rawDispatchOutcome === undefined) {
+        log(`[${HOOK_NAME}] Fallback dispatch returned no outcome; treating as accepted for compatibility`, {
+          sessionID: options.sessionID,
+          source: options.source,
+        })
+      }
+      if (!dispatchOutcome.accepted) {
+        restoreFallbackState(options.state, snapshot)
+        log(`[${HOOK_NAME}] Fallback dispatch was not accepted`, {
+          sessionID: options.sessionID,
+          source: options.source,
+          status: dispatchOutcome.status,
+          reason: dispatchOutcome.reason,
+        })
+        return
+      }
+      if (deps.config.notify_on_fallback) {
+        await deps.ctx.client.tui
+          .showToast({
+            body: {
+              title: "Model Fallback",
+              message: resolveDispatchMessage(dispatchOutcome, result.newModel),
+              variant: "warning",
+              duration: 5000,
+            },
+          })
+          .catch(() => {})
+      }
+      return
+    }
+
+    log(`[${HOOK_NAME}] Fallback preparation failed`, {
+      sessionID: options.sessionID,
+      source: options.source,
+      error: result.error,
+    })
+  } finally {
+    if (acquiredLeaseHere) {
+      releaseFallbackDispatchLease(deps, options.sessionID, lease)
+    }
+  }
 }

--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-state.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-state.ts
@@ -8,6 +8,11 @@ import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import type { RuntimeFallbackConfig } from "../../config"
 
+type FallbackSelectionConfig = Pick<
+  Required<RuntimeFallbackConfig>,
+  "max_fallback_attempts" | "cooldown_seconds"
+>
+
 export const stringifyRuntimeModel = stringifyRuntimeFallbackModel
 export const stringifyRuntimeModelWithVariant = stringifyRuntimeFallbackModelWithVariant
 
@@ -63,7 +68,7 @@ export function prepareFallback(
   sessionID: string,
   state: FallbackState,
   fallbackModels: string[],
-  config: Required<RuntimeFallbackConfig>
+  config: FallbackSelectionConfig,
 ): FallbackResult {
   if (state.attemptCount >= config.max_fallback_attempts) {
     log(`[${HOOK_NAME}] Max fallback attempts reached`, { sessionID, attempts: state.attemptCount })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -3,6 +3,7 @@ import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { createFirstPromptWatchdog, observeEventForWatchdog, type FirstPromptWatchdog } from "./first-prompt-watchdog"
+import { releaseFallbackDispatchLease, tryAcquireFallbackDispatchLease } from "./fallback-dispatch-lease"
 
 const WATCHDOG_MS = 100
 const SAFE_WAIT_BEFORE_FIRE_MS = 40
@@ -290,6 +291,229 @@ describe("first-prompt-watchdog", () => {
     const calls: RecordedCalls = { abort: [], autoRetry: [] }
     const helpers = createHelpers(calls, AGENT)
     const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+
+  it("#given a fallback is already awaiting its result #when its internal user prompt is observed #then the watchdog does not arm or abort the fallback", async () => {
+    // given
+    const sessionID = "session-awaiting-fallback"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const watchdog = createFirstPromptWatchdog(deps, createHelpers(calls, AGENT), WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+
+  it("#given a watchdog was armed before fallback dispatch begins #when its timer fires while awaiting fallback #then it does not abort or dispatch a second fallback", async () => {
+    // given
+    const sessionID = "session-watchdog-race"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const watchdog = createFirstPromptWatchdog(deps, createHelpers(calls, AGENT), WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+
+  it("#given another fallback takes ownership while the watchdog abort is pending #when the abort resolves #then the watchdog does not dispatch a second retry", async () => {
+    // given
+    const sessionID = "session-watchdog-interleaved-ownership"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    let releaseAbort: (() => void) | undefined
+    let markAbortStarted: (() => void) | undefined
+    const abortStarted = new Promise<void>((resolve) => { markAbortStarted = resolve })
+    const helpers = createHelpers(calls, AGENT)
+    helpers.abortSessionRequest = async (id, source) => {
+      calls.abort.push({ sessionID: id, source })
+      markAbortStarted?.()
+      await new Promise<void>((resolve) => { releaseAbort = resolve })
+    }
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    const fire = getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
+    await abortStarted
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    releaseAbort?.()
+    await fire
+
+    // then
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+
+  it("#given the watchdog fires #when the session terminates while agent context resolution is pending #then the stale watchdog generation does not abort or dispatch", async () => {
+    // given
+    const sessionID = "session-watchdog-terminal-during-resolution"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    let releaseResolution: (() => void) | undefined
+    let markResolutionStarted: (() => void) | undefined
+    const resolutionStarted = new Promise<void>((resolve) => { markResolutionStarted = resolve })
+    const helpers = createHelpers(calls, AGENT)
+    helpers.resolveAgentForSessionFromContext = async () => {
+      markResolutionStarted?.()
+      await new Promise<void>((resolve) => { releaseResolution = resolve })
+      return AGENT
+    }
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    const fire = getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
+    await resolutionStarted
+    watchdog.onSessionTerminal(sessionID)
+    releaseResolution?.()
+    await fire
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+
+  it("#given the watchdog fires #when it is disposed while agent context resolution is pending #then the stale watchdog generation does not abort or dispatch", async () => {
+    // given
+    const sessionID = "session-watchdog-dispose-during-resolution"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    let releaseResolution: (() => void) | undefined
+    let markResolutionStarted: (() => void) | undefined
+    const resolutionStarted = new Promise<void>((resolve) => { markResolutionStarted = resolve })
+    const helpers = createHelpers(calls, AGENT)
+    helpers.resolveAgentForSessionFromContext = async () => {
+      markResolutionStarted?.()
+      await new Promise<void>((resolve) => { releaseResolution = resolve })
+      return AGENT
+    }
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    const fire = getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
+    await resolutionStarted
+    watchdog.dispose()
+    releaseResolution?.()
+    await fire
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+  })
+
+  it("#given the watchdog abort produces session.error followed by session.idle #when the internal-abort marker is consumed before idle #then the watchdog keeps its generation and dispatches the fallback", async () => {
+    // given
+    const sessionID = "session-watchdog-internal-abort-terminal"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+    helpers.abortSessionRequest = async (id, source) => {
+      calls.abort.push({ sessionID: id, source })
+      deps.internallyAbortedSessions.add(id)
+      watchdog.onSessionTerminal(id, "session.error")
+      deps.internallyAbortedSessions.delete(id)
+      watchdog.onSessionTerminal(id, "session.idle")
+    }
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toHaveLength(1)
+
+    watchdog.dispose()
+  })
+
+  it("#given the watchdog fallback is dispatching #when the accepted fallback emits a real error #then the watchdog releases its lease for the normal error handler to advance the chain", async () => {
+    // given
+    const sessionID = "session-watchdog-fallback-real-error"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    let releaseFallbackDispatch: (() => void) | undefined
+    let markFallbackDispatchStarted: (() => void) | undefined
+    const fallbackDispatchStarted = new Promise<void>((resolve) => { markFallbackDispatchStarted = resolve })
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+    helpers.abortSessionRequest = async (id, source) => {
+      calls.abort.push({ sessionID: id, source })
+      deps.internallyAbortedSessions.add(id)
+      watchdog.onSessionTerminal(id, "session.error")
+      deps.internallyAbortedSessions.delete(id)
+      watchdog.onSessionTerminal(id, "session.idle")
+    }
+    helpers.autoRetryWithFallback = async (id, newModel, resolvedAgent, source) => {
+      calls.autoRetry.push({ sessionID: id, newModel, resolvedAgent, source })
+      markFallbackDispatchStarted?.()
+      await new Promise<void>((resolve) => { releaseFallbackDispatch = resolve })
+    }
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    const fire = getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
+    await fallbackDispatchStarted
+    watchdog.onSessionTerminal(sessionID, "session.error")
+    const nextLease = tryAcquireFallbackDispatchLease(deps, sessionID)
+    releaseFallbackDispatch?.()
+    await fire
+
+    // then
+    expect(calls.autoRetry).toHaveLength(1)
+    expect(nextLease).toBeDefined()
+    if (nextLease) {
+      releaseFallbackDispatchLease(deps, sessionID, nextLease)
+    }
+
+    watchdog.dispose()
+  })
+
+  it("#given the watchdog timeout is disabled #when a silent subagent user prompt arrives #then no watchdog timer is armed", async () => {
+    // given
+    const sessionID = "session-watchdog-disabled"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const watchdog = createFirstPromptWatchdog(deps, createHelpers(calls, AGENT), 0)
 
     // when
     watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.ts
@@ -10,6 +10,13 @@ import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
+import {
+  invalidateFallbackDispatchLease,
+  isFallbackDispatchLeaseOwner,
+  releaseFallbackDispatchLease,
+  tryAcquireFallbackDispatchLease,
+  type FallbackDispatchLease,
+} from "./fallback-dispatch-lease"
 
 const SOURCE = "first-prompt-watchdog"
 const SESSION_NEXT_EVENT_PREFIX = "session.next."
@@ -20,7 +27,7 @@ declare function clearTimeout(timeout: RuntimeFallbackTimeout): void
 export interface FirstPromptWatchdog {
   onUserMessage(sessionID: string, model?: string, agent?: string): void
   onAssistantProgress(sessionID: string): void
-  onSessionTerminal(sessionID: string): void
+  onSessionTerminal(sessionID: string, eventType?: string): void
   dispose(): void
 }
 
@@ -112,8 +119,15 @@ export function observeEventForWatchdog(
 
   if (TERMINAL_EVENT_TYPES.has(event.type)) {
     const sessionID = resolveSessionEventID(props)
-    if (sessionID) watchdog.onSessionTerminal(sessionID)
+    if (sessionID) watchdog.onSessionTerminal(sessionID, event.type)
   }
+}
+
+type WatchdogFirePhase = "resolving" | "aborting" | "dispatching"
+
+type ActiveWatchdogFire = {
+  generation: number
+  phase: WatchdogFirePhase
 }
 
 export function createFirstPromptWatchdog(
@@ -123,8 +137,12 @@ export function createFirstPromptWatchdog(
 ): FirstPromptWatchdog {
   const timers = new Map<string, RuntimeFallbackTimeout>()
   const armed = new Set<string>()
+  const generations = new Map<string, number>()
+  const activeFires = new Map<string, ActiveWatchdogFire>()
+  const pendingInternalAbortIdle = new Map<string, number>()
+  let disposed = false
 
-  const cancel = (sessionID: string): void => {
+  const clearTimer = (sessionID: string): void => {
     const timer = timers.get(sessionID)
     if (timer) {
       clearTimeout(timer)
@@ -133,96 +151,211 @@ export function createFirstPromptWatchdog(
     armed.delete(sessionID)
   }
 
-  const fire = async (sessionID: string, model: string | undefined, agent: string | undefined): Promise<void> => {
+  const advanceGeneration = (sessionID: string): number => {
+    const nextGeneration = (generations.get(sessionID) ?? 0) + 1
+    generations.set(sessionID, nextGeneration)
+    return nextGeneration
+  }
+
+  const hasTrackedWork = (sessionID: string): boolean => armed.has(sessionID) || activeFires.has(sessionID)
+
+  const finishGeneration = (sessionID: string, generation: number): void => {
+    const active = activeFires.get(sessionID)
+    if (active?.generation === generation) {
+      activeFires.delete(sessionID)
+    }
+    if (pendingInternalAbortIdle.get(sessionID) === generation) {
+      pendingInternalAbortIdle.delete(sessionID)
+    }
+    if (!armed.has(sessionID) && !activeFires.has(sessionID)) {
+      generations.delete(sessionID)
+    }
+  }
+
+  const cancelTrackedWork = (sessionID: string): void => {
+    if (!hasTrackedWork(sessionID)) return
+    clearTimer(sessionID)
+    pendingInternalAbortIdle.delete(sessionID)
+    advanceGeneration(sessionID)
+    invalidateFallbackDispatchLease(deps, sessionID)
+  }
+
+  const fire = async (
+    sessionID: string,
+    model: string | undefined,
+    agent: string | undefined,
+    generation: number,
+  ): Promise<void> => {
     timers.delete(sessionID)
     armed.delete(sessionID)
 
+    if (disposed || generations.get(sessionID) !== generation) return
+
     if (!subagentSessions.has(sessionID)) {
       log(`[${HOOK_NAME}] ${SOURCE}: session no longer a subagent at fire time, skipping`, { sessionID })
+      finishGeneration(sessionID, generation)
       return
     }
 
-    const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
-    const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, deps.pluginConfig)
-
-    if (fallbackModels.length === 0) {
-      log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms with no fallback configured`, {
-        sessionID,
-        model,
-        agent: resolvedAgent,
-      })
+    const lease = tryAcquireFallbackDispatchLease(deps, sessionID, { rejectAwaitingFallback: true })
+    if (!lease) {
+      log(`[${HOOK_NAME}] ${SOURCE}: fallback already owns session at fire time, skipping`, { sessionID })
+      finishGeneration(sessionID, generation)
       return
     }
 
-    let state = deps.sessionStates.get(sessionID)
-    if (!state) {
-      const initialModel = resolveFallbackBootstrapModel({
-        sessionID,
-        source: SOURCE,
-        eventModel: model,
-        resolvedAgent,
-        pluginConfig: deps.pluginConfig,
-      })
-      if (!initialModel) {
-        log(`[${HOOK_NAME}] ${SOURCE}: no model info available, cannot dispatch fallback`, { sessionID })
+    const activeFire: ActiveWatchdogFire = { generation, phase: "resolving" }
+    activeFires.set(sessionID, activeFire)
+
+    const canContinue = (activeLease: FallbackDispatchLease): boolean => (
+      !disposed
+      && generations.get(sessionID) === generation
+      && activeFires.get(sessionID)?.generation === generation
+      && isFallbackDispatchLeaseOwner(deps, sessionID, activeLease)
+      && !deps.sessionRetryInFlight.has(sessionID)
+      && !deps.sessionAwaitingFallbackResult.has(sessionID)
+    )
+
+    try {
+      const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
+      if (!canContinue(lease)) {
+        log(`[${HOOK_NAME}] ${SOURCE}: fallback ownership changed before abort, skipping`, { sessionID })
         return
       }
-      state = createFallbackState(initialModel)
-      deps.sessionStates.set(sessionID, state)
-      deps.sessionLastAccess.set(sessionID, Date.now())
+      const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, deps.pluginConfig)
+
+      if (fallbackModels.length === 0) {
+        log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms with no fallback configured`, {
+          sessionID,
+          model,
+          agent: resolvedAgent,
+        })
+        return
+      }
+
+      let state = deps.sessionStates.get(sessionID)
+      if (!state) {
+        const initialModel = resolveFallbackBootstrapModel({
+          sessionID,
+          source: SOURCE,
+          eventModel: model,
+          resolvedAgent,
+          pluginConfig: deps.pluginConfig,
+        })
+        if (!initialModel) {
+          log(`[${HOOK_NAME}] ${SOURCE}: no model info available, cannot dispatch fallback`, { sessionID })
+          return
+        }
+        state = createFallbackState(initialModel)
+        deps.sessionStates.set(sessionID, state)
+        deps.sessionLastAccess.set(sessionID, Date.now())
+      }
+
+      log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms, dispatching fallback`, {
+        sessionID,
+        model: state.currentModel,
+        fallbackCount: fallbackModels.length,
+      })
+
+      // Unlike the error-event path, the original request is still pending from
+      // OpenCode's perspective when the watchdog fires. Forcefully end it so the
+      // fallback prompt can take over cleanly. Network errors from abort are
+      // logged inside abortSessionRequest and do not block fallback dispatch.
+      activeFire.phase = "aborting"
+      await helpers.abortSessionRequest(sessionID, SOURCE)
+      if (!canContinue(lease)) {
+        log(`[${HOOK_NAME}] ${SOURCE}: fallback ownership changed during abort, skipping`, { sessionID })
+        return
+      }
+
+      activeFire.phase = "dispatching"
+      await dispatchFallbackRetry(deps, helpers, {
+        sessionID,
+        state,
+        fallbackModels,
+        resolvedAgent,
+        source: SOURCE,
+        lease,
+      })
+    } finally {
+      releaseFallbackDispatchLease(deps, sessionID, lease)
+      finishGeneration(sessionID, generation)
     }
-
-    log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms, dispatching fallback`, {
-      sessionID,
-      model: state.currentModel,
-      fallbackCount: fallbackModels.length,
-    })
-
-    // Unlike the error-event path, the original request is still pending from
-    // OpenCode's perspective when the watchdog fires. Forcefully end it so the
-    // fallback prompt can take over cleanly. Network errors from abort are
-    // logged inside abortSessionRequest and do not block fallback dispatch.
-    await helpers.abortSessionRequest(sessionID, SOURCE)
-
-    await dispatchFallbackRetry(deps, helpers, {
-      sessionID,
-      state,
-      fallbackModels,
-      resolvedAgent,
-      source: SOURCE,
-    })
   }
 
   return {
     onUserMessage(sessionID, model, agent) {
-      if (!sessionID) return
+      if (disposed || !sessionID || watchdogMs <= 0) return
       if (!subagentSessions.has(sessionID)) return
+      if (deps.sessionAwaitingFallbackResult.has(sessionID)) {
+        const activeFire = activeFires.get(sessionID)
+        if (armed.has(sessionID) || activeFire?.phase === "resolving" || activeFire?.phase === "aborting") {
+          cancelTrackedWork(sessionID)
+        }
+        log(`[${HOOK_NAME}] ${SOURCE}: fallback already owns session, skipping arm`, { sessionID })
+        return
+      }
       if (armed.has(sessionID)) return
+
+      cancelTrackedWork(sessionID)
+      const generation = advanceGeneration(sessionID)
 
       armed.add(sessionID)
       const timer = setTimeout(async () => {
-        await fire(sessionID, model, agent)
+        await fire(sessionID, model, agent, generation)
       }, watchdogMs)
       timers.set(sessionID, timer)
 
       log(`[${HOOK_NAME}] ${SOURCE}: armed for subagent`, { sessionID, model, agent, watchdogMs })
     },
     onAssistantProgress(sessionID) {
-      if (!sessionID || !armed.has(sessionID)) return
-      cancel(sessionID)
+      const activeFire = activeFires.get(sessionID)
+      if (!sessionID || (!armed.has(sessionID) && activeFire?.phase !== "resolving")) return
+      cancelTrackedWork(sessionID)
       log(`[${HOOK_NAME}] ${SOURCE}: cancelled (assistant progress observed)`, { sessionID })
     },
-    onSessionTerminal(sessionID) {
-      if (!sessionID || !armed.has(sessionID)) return
-      cancel(sessionID)
+    onSessionTerminal(sessionID, eventType) {
+      const activeFire = activeFires.get(sessionID)
+      if (!sessionID || (!armed.has(sessionID) && !activeFire)) return
+      if (
+        activeFire
+        && activeFire.phase !== "resolving"
+        && eventType === "session.error"
+        && deps.internallyAbortedSessions.has(sessionID)
+      ) {
+        // OpenCode emits session.error and then session.idle for the request
+        // that this watchdog just aborted. The error handler consumes the
+        // marker after this observer runs, so remember exactly one trailing
+        // idle rather than masking later fallback-model errors.
+        pendingInternalAbortIdle.set(sessionID, activeFire.generation)
+        log(`[${HOOK_NAME}] ${SOURCE}: ignoring internal abort error`, { sessionID, eventType })
+        return
+      }
+      if (
+        eventType === "session.idle"
+        && activeFire
+        && pendingInternalAbortIdle.get(sessionID) === activeFire.generation
+      ) {
+        pendingInternalAbortIdle.delete(sessionID)
+        log(`[${HOOK_NAME}] ${SOURCE}: ignoring trailing idle from its own abort`, { sessionID, eventType })
+        return
+      }
+      cancelTrackedWork(sessionID)
       log(`[${HOOK_NAME}] ${SOURCE}: cancelled (session terminal)`, { sessionID })
     },
     dispose() {
-      for (const timer of timers.values()) {
-        clearTimeout(timer)
+      disposed = true
+      const trackedSessions = new Set([...timers.keys(), ...activeFires.keys()])
+      for (const sessionID of trackedSessions) {
+        clearTimer(sessionID)
+        advanceGeneration(sessionID)
+        invalidateFallbackDispatchLease(deps, sessionID)
       }
       timers.clear()
       armed.clear()
+      activeFires.clear()
+      generations.clear()
+      pendingInternalAbortIdle.clear()
     },
   }
 }

--- a/packages/omo-opencode/src/hooks/runtime-fallback/hook.init.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/hook.init.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import type { OhMyOpenCodeConfig } from "../../config"
+import type { AutoRetryHelpers } from "./auto-retry"
+import type { FirstPromptWatchdog } from "./first-prompt-watchdog"
 import type { HookDeps, RuntimeFallbackInterval, RuntimeFallbackPluginInput } from "./types"
 
 type RuntimeFallbackModule = typeof import("./hook")
@@ -120,5 +122,33 @@ describe("createRuntimeFallbackHook initialization", () => {
 
     // then
     expect(setIntervalCalls).toBe(1)
+  })
+
+  test("#given a custom first-prompt watchdog timeout #when the hook factory initializes #then it passes the configured millisecond timeout to the watchdog", () => {
+    // given
+    let capturedWatchdogMs: number | undefined
+    const recordingWatchdogFactory = (
+      _deps: HookDeps,
+      _helpers: AutoRetryHelpers,
+      watchdogMs?: number,
+    ): FirstPromptWatchdog => {
+      capturedWatchdogMs = watchdogMs
+      return {
+        onUserMessage: () => {},
+        onAssistantProgress: () => {},
+        onSessionTerminal: () => {},
+        dispose: () => {},
+      }
+    }
+
+    // when
+    createRuntimeFallbackHook(
+      createMockContext(),
+      { config: { first_prompt_watchdog_seconds: 300 } },
+      { createFirstPromptWatchdog: recordingWatchdogFactory },
+    )
+
+    // then
+    expect(capturedWatchdogMs).toBe(300_000)
   })
 })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/hook.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/hook.ts
@@ -4,6 +4,7 @@ import { DEFAULT_CONFIG } from "./constants"
 import { createEventHandler } from "./event-handler"
 import { createFirstPromptWatchdog, observeEventForWatchdog } from "./first-prompt-watchdog"
 import { createMessageUpdateHandler } from "./message-update-handler"
+import { invalidateAllFallbackDispatchLeases } from "./fallback-dispatch-lease"
 import type { HookDeps, RuntimeFallbackHook, RuntimeFallbackInterval, RuntimeFallbackOptions, RuntimeFallbackPluginInput, RuntimeFallbackTimeout } from "./types"
 
 declare function setInterval(callback: () => void, delay?: number): RuntimeFallbackInterval
@@ -44,6 +45,10 @@ export function createRuntimeFallbackHook(
     notify_on_fallback: options?.config?.notify_on_fallback ?? DEFAULT_CONFIG.notify_on_fallback,
     restore_primary_after_cooldown: options?.config?.restore_primary_after_cooldown ?? DEFAULT_CONFIG.restore_primary_after_cooldown,
   }
+  const firstPromptWatchdogMs = (
+    options?.config?.first_prompt_watchdog_seconds
+    ?? DEFAULT_CONFIG.first_prompt_watchdog_seconds
+  ) * 1000
 
   const deps: HookDeps = {
     ctx,
@@ -63,7 +68,7 @@ export function createRuntimeFallbackHook(
   const baseEventHandler = factories.createEventHandler(deps, helpers)
   const messageUpdateHandler = factories.createMessageUpdateHandler(deps, helpers)
   const chatMessageHandler = factories.createChatMessageHandler(deps)
-  const firstPromptWatchdog = factories.createFirstPromptWatchdog(deps, helpers)
+  const firstPromptWatchdog = factories.createFirstPromptWatchdog(deps, helpers, firstPromptWatchdogMs)
 
   let cleanupInterval: RuntimeFallbackInterval | null = null
   let intervalStarted = false
@@ -105,6 +110,7 @@ export function createRuntimeFallbackHook(
     }
 
     firstPromptWatchdog.dispose()
+    invalidateAllFallbackDispatchLeases(deps)
 
     deps.sessionStates.clear()
     deps.sessionLastAccess.clear()

--- a/packages/omo-opencode/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/message-update-handler.ts
@@ -11,6 +11,12 @@ import { hasVisibleAssistantResponse } from "./visible-assistant-response"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID } from "../../shared/event-session-id"
 import { normalizeModelToCanonicalString } from "./normalize-model"
+import {
+  isFallbackDispatchLeaseOwner,
+  releaseFallbackDispatchLease,
+  supersedeFallbackDispatchLease,
+  type FallbackDispatchLease,
+} from "./fallback-dispatch-lease"
 
 export { hasVisibleAssistantResponse } from "./visible-assistant-response"
 
@@ -72,134 +78,147 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       let state = sessionStates.get(sessionID)
       const pendingFallbackModel = state?.pendingFallbackModel
       const wasAwaitingFallbackResult = sessionAwaitingFallbackResult.has(sessionID)
-      if (
-        wasAwaitingFallbackResult &&
-        pendingFallbackModel &&
-        !retrySignal &&
-        model !== pendingFallbackModel
-      ) {
-        log(`[${HOOK_NAME}] message.updated fallback skipped - awaiting fallback result`, {
+      let takeoverLease: FallbackDispatchLease | undefined
+      try {
+        if (
+          wasAwaitingFallbackResult &&
+          pendingFallbackModel &&
+          !retrySignal &&
+          model !== pendingFallbackModel
+        ) {
+          log(`[${HOOK_NAME}] message.updated fallback skipped - awaiting fallback result`, {
+            sessionID,
+            pendingFallbackModel,
+            model,
+          })
+          return
+        }
+        if (wasAwaitingFallbackResult) {
+          sessionAwaitingFallbackResult.delete(sessionID)
+        }
+        if (sessionRetryInFlight.has(sessionID) && !retrySignal) {
+          log(`[${HOOK_NAME}] message.updated fallback skipped (retry in flight)`, { sessionID })
+          return
+        }
+
+        if (retrySignal && timeoutEnabled && (sessionRetryInFlight.has(sessionID) || wasAwaitingFallbackResult)) {
+          log(`[${HOOK_NAME}] Overriding active retry due to provider auto-retry signal`, {
+            sessionID,
+            model,
+          })
+          takeoverLease = supersedeFallbackDispatchLease(deps, sessionID)
+          await helpers.abortSessionRequest(sessionID, "message.updated.retry-signal")
+          if (!isFallbackDispatchLeaseOwner(deps, sessionID, takeoverLease)) return
+        }
+
+        if (retrySignal && timeoutEnabled) {
+          log(`[${HOOK_NAME}] Detected provider auto-retry signal`, { sessionID, model })
+        }
+
+        if (!retrySignal) {
+          helpers.clearSessionFallbackTimeout(sessionID)
+        }
+
+        log(`[${HOOK_NAME}] message.updated with assistant error`, {
           sessionID,
-          pendingFallbackModel,
           model,
-        })
-        return
-      }
-      if (wasAwaitingFallbackResult) {
-        sessionAwaitingFallbackResult.delete(sessionID)
-      }
-      if (sessionRetryInFlight.has(sessionID) && !retrySignal) {
-        log(`[${HOOK_NAME}] message.updated fallback skipped (retry in flight)`, { sessionID })
-        return
-      }
-
-      if (retrySignal && timeoutEnabled && (sessionRetryInFlight.has(sessionID) || wasAwaitingFallbackResult)) {
-        log(`[${HOOK_NAME}] Overriding active retry due to provider auto-retry signal`, {
-          sessionID,
-          model,
-        })
-        await helpers.abortSessionRequest(sessionID, "message.updated.retry-signal")
-        sessionRetryInFlight.delete(sessionID)
-      }
-
-      if (retrySignal && timeoutEnabled) {
-        log(`[${HOOK_NAME}] Detected provider auto-retry signal`, { sessionID, model })
-      }
-
-      if (!retrySignal) {
-        helpers.clearSessionFallbackTimeout(sessionID)
-      }
-
-      log(`[${HOOK_NAME}] message.updated with assistant error`, {
-        sessionID,
-        model,
-        statusCode: extractStatusCode(error, config.retry_on_errors),
-        errorName: extractErrorName(error),
-        errorType: classifyErrorType(error),
-      })
-
-      if (!isRetryableError(error, config.retry_on_errors)) {
-        log(`[${HOOK_NAME}] message.updated error not retryable, skipping fallback`, {
-          sessionID,
           statusCode: extractStatusCode(error, config.retry_on_errors),
           errorName: extractErrorName(error),
           errorType: classifyErrorType(error),
         })
-        return
-      }
 
-      const agent = info?.agent as string | undefined
-      const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
-      const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, pluginConfig)
-
-      if (fallbackModels.length === 0) {
-        if (
-          subagentSessions.has(sessionID) &&
-          classifyErrorType(error) === "quota_exceeded"
-        ) {
-          log(`[${HOOK_NAME}] Aborting subagent on unrecoverable quota error (no fallback configured)`, {
+        if (!isRetryableError(error, config.retry_on_errors)) {
+          log(`[${HOOK_NAME}] message.updated error not retryable, skipping fallback`, {
             sessionID,
-            model,
-          })
-          await helpers.abortSessionRequest(sessionID, "message.updated.subagent-quota-no-fallback")
-        }
-        return
-      }
-
-      if (!state) {
-        const initialModel = resolveFallbackBootstrapModel({
-          sessionID,
-          source: "message.updated",
-          eventModel: model,
-          resolvedAgent,
-          pluginConfig,
-        })
-
-        if (!initialModel) {
-          log(`[${HOOK_NAME}] message.updated missing model info, cannot fallback`, {
-            sessionID,
+            statusCode: extractStatusCode(error, config.retry_on_errors),
             errorName: extractErrorName(error),
             errorType: classifyErrorType(error),
           })
           return
         }
 
-        state = createFallbackState(initialModel)
-        sessionStates.set(sessionID, state)
-        sessionLastAccess.set(sessionID, Date.now())
-      } else {
-        sessionLastAccess.set(sessionID, Date.now())
+        const agent = info?.agent as string | undefined
+        const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
+        if (takeoverLease && !isFallbackDispatchLeaseOwner(deps, sessionID, takeoverLease)) return
+        const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, pluginConfig)
 
-        if (state.pendingFallbackModel) {
-          if (retrySignal && timeoutEnabled) {
-            log(`[${HOOK_NAME}] Clearing pending fallback due to provider auto-retry signal`, {
+        if (fallbackModels.length === 0) {
+          if (
+            subagentSessions.has(sessionID) &&
+            classifyErrorType(error) === "quota_exceeded"
+          ) {
+            log(`[${HOOK_NAME}] Aborting subagent on unrecoverable quota error (no fallback configured)`, {
               sessionID,
-              pendingFallbackModel: state.pendingFallbackModel,
+              model,
             })
-            state.pendingFallbackModel = undefined
-            state.pendingFallbackPromptMayHaveBeenAccepted = false
-          } else {
-            log(`[${HOOK_NAME}] message.updated fallback skipped (pending fallback in progress)`, {
+            await helpers.abortSessionRequest(sessionID, "message.updated.subagent-quota-no-fallback")
+          }
+          return
+        }
+
+        if (!state) {
+          const initialModel = resolveFallbackBootstrapModel({
+            sessionID,
+            source: "message.updated",
+            eventModel: model,
+            resolvedAgent,
+            pluginConfig,
+          })
+
+          if (!initialModel) {
+            log(`[${HOOK_NAME}] message.updated missing model info, cannot fallback`, {
               sessionID,
-              pendingFallbackModel: state.pendingFallbackModel,
+              errorName: extractErrorName(error),
+              errorType: classifyErrorType(error),
             })
             return
           }
+
+          state = createFallbackState(initialModel)
+          sessionStates.set(sessionID, state)
+          sessionLastAccess.set(sessionID, Date.now())
+        } else {
+          sessionLastAccess.set(sessionID, Date.now())
+
+          if (state.pendingFallbackModel) {
+            if (retrySignal && timeoutEnabled) {
+              log(`[${HOOK_NAME}] Clearing pending fallback due to provider auto-retry signal`, {
+                sessionID,
+                pendingFallbackModel: state.pendingFallbackModel,
+              })
+              state.pendingFallbackModel = undefined
+              state.pendingFallbackPromptMayHaveBeenAccepted = false
+            } else {
+              log(`[${HOOK_NAME}] message.updated fallback skipped (pending fallback in progress)`, {
+                sessionID,
+                pendingFallbackModel: state.pendingFallbackModel,
+              })
+              return
+            }
+          }
+        }
+
+        if (classifyErrorType(error) === "quota_exceeded") {
+          await helpers.abortSessionRequest(sessionID, "message.updated.quota-fallback")
+          sessionRetryInFlight.delete(sessionID)
+        }
+
+        await dispatchFallbackRetry(deps, helpers, {
+          sessionID,
+          state,
+          fallbackModels,
+          resolvedAgent,
+          source: "message.updated",
+          lease: takeoverLease,
+        })
+      } finally {
+        if (takeoverLease) {
+          if (isFallbackDispatchLeaseOwner(deps, sessionID, takeoverLease)) {
+            sessionRetryInFlight.delete(sessionID)
+          }
+          releaseFallbackDispatchLease(deps, sessionID, takeoverLease)
         }
       }
-
-      if (classifyErrorType(error) === "quota_exceeded") {
-        await helpers.abortSessionRequest(sessionID, "message.updated.quota-fallback")
-        sessionRetryInFlight.delete(sessionID)
-      }
-
-      await dispatchFallbackRetry(deps, helpers, {
-        sessionID,
-        state,
-        fallbackModels,
-        resolvedAgent,
-        source: "message.updated",
-      })
     }
   }
 }

--- a/packages/omo-opencode/src/hooks/runtime-fallback/session-status-handler.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/session-status-handler.test.ts
@@ -4,6 +4,11 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+import {
+  isFallbackDispatchLeaseOwner,
+  releaseFallbackDispatchLease,
+  tryAcquireFallbackDispatchLease,
+} from "./fallback-dispatch-lease"
 
 function createContext(): RuntimeFallbackPluginInput {
   return {
@@ -147,6 +152,151 @@ describe("createSessionStatusHandler", () => {
     ])
     expect(state.currentModel).toBe("google/gemini-2.5-pro")
     expect(state.pendingFallbackModel).toBe("google/gemini-2.5-pro")
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given an accepted fallback awaits its result behind an outer lease #when session.status retries #then it supersedes the lease and advances the chain", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-awaiting-lease"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("anthropic/claude-opus-4-7")
+    state.currentModel = "openai/gpt-5.4"
+    state.fallbackIndex = 0
+    state.attemptCount = 1
+    state.pendingFallbackModel = "openai/gpt-5.4"
+    state.failedModels.set("anthropic/claude-opus-4-7", Date.now())
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const outerLease = tryAcquireFallbackDispatchLease(deps, sessionID)
+    if (!outerLease) throw new Error("expected outer fallback lease")
+
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      model: "openai/gpt-5.4",
+      status: {
+        type: "retry",
+        attempt: 2,
+        message: "All credentials for model gpt-5.4 are cooling down [retrying in 7m 56s attempt #2]",
+      },
+    })
+
+    // then
+    expect(isFallbackDispatchLeaseOwner(deps, sessionID, outerLease)).toBe(false)
+    expect(abortCalls).toEqual([sessionID])
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "google/gemini-2.5-pro",
+        source: "session.status",
+      },
+    ])
+    expect(state.currentModel).toBe("google/gemini-2.5-pro")
+    expect(state.pendingFallbackModel).toBe("google/gemini-2.5-pro")
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given an ambiguously accepted fallback awaits its result behind an outer lease #when session.status retries #then it preserves the pending fallback", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-ambiguous-awaiting-lease"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("anthropic/claude-opus-4-7")
+    state.currentModel = "openai/gpt-5.4"
+    state.fallbackIndex = 0
+    state.attemptCount = 1
+    state.pendingFallbackModel = "openai/gpt-5.4"
+    state.pendingFallbackPromptMayHaveBeenAccepted = true
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const outerLease = tryAcquireFallbackDispatchLease(deps, sessionID)
+    if (!outerLease) throw new Error("expected outer fallback lease")
+
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      model: "openai/gpt-5.4",
+      status: {
+        type: "retry",
+        attempt: 2,
+        message: "All credentials for model gpt-5.4 are cooling down [retrying in 7m 56s attempt #2]",
+      },
+    })
+
+    // then
+    expect(isFallbackDispatchLeaseOwner(deps, sessionID, outerLease)).toBe(true)
+    expect(abortCalls).toEqual([])
+    expect(retryCalls).toEqual([])
+    expect(state.currentModel).toBe("openai/gpt-5.4")
+    expect(state.pendingFallbackModel).toBe("openai/gpt-5.4")
+    expect(state.pendingFallbackPromptMayHaveBeenAccepted).toBe(true)
+    releaseFallbackDispatchLease(deps, sessionID, outerLease)
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given an accepted fallback awaits its result #when an old-model retry arrives before the current model retry #then only the current-model retry takes over", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-delayed-old-model"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("anthropic/claude-opus-4-7")
+    state.currentModel = "openai/gpt-5.4"
+    state.fallbackIndex = 0
+    state.attemptCount = 1
+    state.pendingFallbackModel = "openai/gpt-5.4"
+    state.failedModels.set("anthropic/claude-opus-4-7", Date.now())
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const outerLease = tryAcquireFallbackDispatchLease(deps, sessionID)
+    if (!outerLease) throw new Error("expected outer fallback lease")
+
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+    const retryStatus = {
+      type: "retry",
+      attempt: 2,
+      message: "All credentials for model gpt-5.4 are cooling down [retrying in 7m 56s attempt #2]",
+    }
+
+    // when: a late status from the original model arrives first
+    await handler({ sessionID, model: "anthropic/claude-opus-4-7", status: retryStatus })
+
+    // then: it does not consume the retry key or take over the current fallback
+    expect(isFallbackDispatchLeaseOwner(deps, sessionID, outerLease)).toBe(true)
+    expect(deps.sessionStatusRetryKeys.has(sessionID)).toBe(false)
+    expect(abortCalls).toEqual([])
+    expect(retryCalls).toEqual([])
+
+    // when: the same signal is then emitted by the accepted fallback model
+    await handler({ sessionID, model: "openai/gpt-5.4", status: retryStatus })
+
+    // then
+    expect(isFallbackDispatchLeaseOwner(deps, sessionID, outerLease)).toBe(false)
+    expect(abortCalls).toEqual([sessionID])
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "google/gemini-2.5-pro",
+        source: "session.status",
+      },
+    ])
+    expect(state.currentModel).toBe("google/gemini-2.5-pro")
     SessionCategoryRegistry.clear()
   })
 })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/session-status-handler.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/session-status-handler.ts
@@ -3,13 +3,19 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME, RETRYABLE_ERROR_PATTERNS } from "./constants"
 import { log } from "../../shared/logger"
 import { extractAutoRetrySignal } from "./error-classifier"
-import { createFallbackState } from "./fallback-state"
+import { areRuntimeModelsEquivalent, createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { normalizeRetryStatusMessage, extractRetryAttempt } from "../../shared/retry-status-utils"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { resolveSessionEventID } from "../../shared/event-session-id"
 import { normalizeModelToCanonicalString } from "./normalize-model"
+import {
+  isFallbackDispatchLeaseOwner,
+  releaseFallbackDispatchLease,
+  supersedeFallbackDispatchLease,
+  type FallbackDispatchLease,
+} from "./fallback-dispatch-lease"
 
 export function createSessionStatusHandler(
   deps: HookDeps,
@@ -54,94 +60,133 @@ export function createSessionStatusHandler(
       }
     }
 
-    const retryKey = `${extractRetryAttempt(status.attempt, retryMessage)}:${normalizeRetryStatusMessage(retryMessage)}`
+    const pendingFallbackModel = sessionStates.get(sessionID)?.pendingFallbackModel
+    if (
+      deps.sessionAwaitingFallbackResult.has(sessionID)
+      && pendingFallbackModel
+      && model
+      && !areRuntimeModelsEquivalent(model, pendingFallbackModel)
+    ) {
+      log(`[${HOOK_NAME}] session.status retry skipped - awaiting a different fallback model`, {
+        sessionID,
+        pendingFallbackModel,
+        model,
+      })
+      return
+    }
+
+    const retryKey = `${model ?? "unknown"}:${extractRetryAttempt(status.attempt, retryMessage)}:${normalizeRetryStatusMessage(retryMessage)}`
     if (sessionStatusRetryKeys.get(sessionID) === retryKey) {
       return
     }
     sessionStatusRetryKeys.set(sessionID, retryKey)
 
-    if (sessionRetryInFlight.has(sessionID)) {
+    const wasAwaitingFallbackResult = deps.sessionAwaitingFallbackResult.has(sessionID)
+    const pendingFallbackPromptMayHaveBeenAccepted = sessionStates.get(sessionID)?.pendingFallbackPromptMayHaveBeenAccepted === true
+    let takeoverLease: FallbackDispatchLease | undefined
+    if (
+      (sessionRetryInFlight.has(sessionID) || wasAwaitingFallbackResult)
+      && !pendingFallbackPromptMayHaveBeenAccepted
+    ) {
       if (timeoutEnabled) {
-        log(`[${HOOK_NAME}] Overriding in-flight retry due to provider auto-retry signal`, {
+        log(`[${HOOK_NAME}] Overriding active retry due to provider auto-retry signal`, {
           sessionID,
           model,
         })
-        await helpers.abortSessionRequest(sessionID, "session.status.retry-signal")
-        sessionRetryInFlight.delete(sessionID)
+        takeoverLease = supersedeFallbackDispatchLease(deps, sessionID)
       } else {
         log(`[${HOOK_NAME}] session.status retry skipped - retry already in flight`, { sessionID })
         return
       }
     }
 
-    const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
-    const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, pluginConfig)
-    if (fallbackModels.length === 0) {
-      if (!sessionStates.has(sessionID)) {
-        sessionStatusRetryKeys.delete(sessionID)
+    try {
+      if (takeoverLease) {
+        await helpers.abortSessionRequest(sessionID, "session.status.retry-signal")
+        if (!isFallbackDispatchLeaseOwner(deps, sessionID, takeoverLease)) return
       }
-      return
-    }
 
-    let state = sessionStates.get(sessionID)
-    if (!state) {
-      const initialModel = resolveFallbackBootstrapModel({
+      const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
+      if (takeoverLease && !isFallbackDispatchLeaseOwner(deps, sessionID, takeoverLease)) return
+      const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, pluginConfig)
+      if (fallbackModels.length === 0) {
+        if (!sessionStates.has(sessionID)) {
+          sessionStatusRetryKeys.delete(sessionID)
+        }
+        return
+      }
+
+      let state = sessionStates.get(sessionID)
+      if (!state) {
+        const initialModel = resolveFallbackBootstrapModel({
+          sessionID,
+          source: "session.status",
+          eventModel: model,
+          resolvedAgent,
+          pluginConfig,
+        })
+        if (!initialModel) {
+          sessionStatusRetryKeys.delete(sessionID)
+          log(`[${HOOK_NAME}] session.status retry missing model info, cannot fallback`, { sessionID })
+          return
+        }
+
+        state = createFallbackState(initialModel)
+        sessionStates.set(sessionID, state)
+      }
+
+      sessionLastAccess.set(sessionID, Date.now())
+
+      if (state.pendingFallbackModel) {
+        if (state.pendingFallbackPromptMayHaveBeenAccepted) {
+          log(`[${HOOK_NAME}] session.status retry skipped (pending fallback prompt may already be accepted)`, {
+            sessionID,
+            pendingFallbackModel: state.pendingFallbackModel,
+          })
+          return
+        }
+        if (timeoutEnabled) {
+          log(`[${HOOK_NAME}] Clearing pending fallback due to provider auto-retry signal`, {
+            sessionID,
+            pendingFallbackModel: state.pendingFallbackModel,
+          })
+          state.pendingFallbackModel = undefined
+          state.pendingFallbackPromptMayHaveBeenAccepted = false
+        } else {
+          log(`[${HOOK_NAME}] session.status retry skipped (pending fallback in progress)`, {
+            sessionID,
+            pendingFallbackModel: state.pendingFallbackModel,
+          })
+          return
+        }
+      }
+
+      log(`[${HOOK_NAME}] Detected provider auto-retry signal in session.status`, {
         sessionID,
-        source: "session.status",
-        eventModel: model,
-        resolvedAgent,
-        pluginConfig,
+        model: state.currentModel,
+        retryAttempt: status.attempt,
       })
-      if (!initialModel) {
-        sessionStatusRetryKeys.delete(sessionID)
-        log(`[${HOOK_NAME}] session.status retry missing model info, cannot fallback`, { sessionID })
-        return
+
+      if (!takeoverLease) {
+        await helpers.abortSessionRequest(sessionID, "session.status.retry-signal")
       }
+      if (takeoverLease && !isFallbackDispatchLeaseOwner(deps, sessionID, takeoverLease)) return
 
-      state = createFallbackState(initialModel)
-      sessionStates.set(sessionID, state)
-    }
-
-    sessionLastAccess.set(sessionID, Date.now())
-
-    if (state.pendingFallbackModel) {
-      if (state.pendingFallbackPromptMayHaveBeenAccepted) {
-        log(`[${HOOK_NAME}] session.status retry skipped (pending fallback prompt may already be accepted)`, {
-          sessionID,
-          pendingFallbackModel: state.pendingFallbackModel,
-        })
-        return
-      }
-      if (timeoutEnabled) {
-        log(`[${HOOK_NAME}] Clearing pending fallback due to provider auto-retry signal`, {
-          sessionID,
-          pendingFallbackModel: state.pendingFallbackModel,
-        })
-        state.pendingFallbackModel = undefined
-        state.pendingFallbackPromptMayHaveBeenAccepted = false
-      } else {
-        log(`[${HOOK_NAME}] session.status retry skipped (pending fallback in progress)`, {
-          sessionID,
-          pendingFallbackModel: state.pendingFallbackModel,
-        })
-        return
+      await dispatchFallbackRetry(deps, helpers, {
+        sessionID,
+        state,
+        fallbackModels,
+        resolvedAgent,
+        source: "session.status",
+        lease: takeoverLease,
+      })
+    } finally {
+      if (takeoverLease) {
+        if (isFallbackDispatchLeaseOwner(deps, sessionID, takeoverLease)) {
+          sessionRetryInFlight.delete(sessionID)
+        }
+        releaseFallbackDispatchLease(deps, sessionID, takeoverLease)
       }
     }
-
-    log(`[${HOOK_NAME}] Detected provider auto-retry signal in session.status`, {
-      sessionID,
-      model: state.currentModel,
-      retryAttempt: status.attempt,
-    })
-
-    await helpers.abortSessionRequest(sessionID, "session.status.retry-signal")
-
-    await dispatchFallbackRetry(deps, helpers, {
-      sessionID,
-      state,
-      fallbackModels,
-      resolvedAgent,
-      source: "session.status",
-    })
   }
 }

--- a/packages/omo-opencode/src/hooks/runtime-fallback/types.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/types.ts
@@ -1,5 +1,7 @@
 import type { RuntimeFallbackConfig, OhMyOpenCodeConfig } from "../../config"
 
+type ResolvedRuntimeFallbackConfig = Required<Omit<RuntimeFallbackConfig, "first_prompt_watchdog_seconds">>
+
 export interface RuntimeFallbackInterval {
   unref: () => void
 }
@@ -79,7 +81,7 @@ export interface RuntimeFallbackHook {
 
 export interface HookDeps {
   ctx: RuntimeFallbackPluginInput
-  config: Required<RuntimeFallbackConfig>
+  config: ResolvedRuntimeFallbackConfig
   options: RuntimeFallbackOptions | undefined
   pluginConfig: OhMyOpenCodeConfig | undefined
   sessionStates: Map<string, FallbackState>


### PR DESCRIPTION
## Summary
- add a configurable 90-second first-prompt watchdog for silent subagents (`0` disables it)
- serialize asynchronous watchdog, timeout, and provider-retry handoffs with per-session dispatch leases
- preserve the watchdog's own abort `error -> idle` tail while allowing real fallback errors and current-model retry signals to advance the chain
- ignore delayed retry status from an older model and retain ambiguous prompt-acceptance protection

## Validation
- `bun test packages/omo-opencode/src/hooks/runtime-fallback` (263 pass, 0 fail)
- `bun x tsgo --noEmit -p packages/omo-opencode/tsconfig.json`
- isolated real OpenCode 1.18.5 server/SSE watchdog probe: one primary abort, one fallback, one watchdog dispatch
- isolated real OpenCode error-chain probe: primary -> first fallback error -> second fallback, one watchdog dispatch

## Notes
- The real probes use a synchronized source mirror because this Windows Bun installation cannot load the Unicode-path worktree directly. The mirror was hash-verified against the worktree before testing.
- `opencode run --pure` hangs during core initialization on this Windows OpenCode 1.18.5 install and would skip the external plugin under test; the server API/SSE probe loads the plugin instead.
- Local QA evidence remains under ignored `.omo/evidence/` per repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable first-prompt watchdog for silent subagents. Serializes runtime fallback handoffs with per-session dispatch leases to prevent double-dispatch across watchdog, timeouts, and provider retry signals.

- **New Features**
  - `first_prompt_watchdog_seconds` config (default 90s; set to `0` to disable) to abort a silent subagent’s first turn and dispatch fallback. Docs updated in `docs/reference/configuration.md`.

- **Bug Fixes**
  - Introduced per-session fallback dispatch leases to ensure only the current dispatcher reads messages, submits prompts, and updates state; stale attempts return “fallback dispatch superseded.”
  - Timeout escalation, `session.status` retry signals, and `message.updated` errors now supersede older retries cleanly and release in-flight markers on early exits.
  - Watchdog keeps its own abort’s error→idle tail out of the chain, ignores delayed retry from older models, and won’t re-dispatch if a fallback already owns the session.
  - Leases are invalidated on session reset/stop and plugin dispose to avoid dangling ownership.

<sup>Written for commit ac3a38b98ea46e08bcae25ac4d9dca7dda2aab1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

