### PR TITLE
feat(skills): add long-task launch intake

### DIFF
--- a/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
@@ -12,6 +12,7 @@ export const expectedSkills = [
 	"frontend",
 	"git-master",
 	"init-deep",
+	"launch-long-task",
 	"lcx-contribute-bug-fix",
 	"lcx-doctor",
 	"lcx-report-bug",

--- a/packages/shared-skills/AGENTS.md
+++ b/packages/shared-skills/AGENTS.md
@@ -6,13 +6,13 @@
 
 Hand-authored, cross-harness skill bundle shared between the OpenCode and Codex editions. Mostly authored skill data, with skill-owned scripts/assets when required and no transform inside the package. `index.mjs` exports `sharedSkillsRootPath()` returning the absolute path to `skills/`. Package: `@oh-my-opencode/shared-skills` (`files`: `index.mjs`, `index.d.ts`, `skills`).
 
-## SKILLS (16 under `skills/<name>/`)
+## SKILLS (17 under `skills/<name>/`)
 
-`programming`, `debugging`, `frontend`, `visual-qa`, `ast-grep`, `coding-agent-sessions`, `git-master`, `refactor`, `review-work`, `start-work`, `ulw-plan`, `ulw-research`, `init-deep`, `remove-ai-slops`, `lsp-setup`, `ultimate-browsing`.
+`programming`, `debugging`, `frontend`, `visual-qa`, `ast-grep`, `coding-agent-sessions`, `git-master`, `refactor`, `review-work`, `launch-long-task`, `start-work`, `ulw-plan`, `ulw-research`, `init-deep`, `remove-ai-slops`, `lsp-setup`, `ultimate-browsing`.
 
 The Codex-only `lcx-report-bug`, `lcx-contribute-bug-fix`, and `lcx-doctor` skills live under `packages/omo-codex/plugin/components/lcx/skills/`; they are no longer authored in this package.
 
-Per-skill layout: `SKILL.md` (YAML frontmatter `name:` + single-line `description:` with triggers) + optional `references/` (the real content; SKILL.md is a router/index) + optional `scripts/` + optional `agents/openai.yaml` (3 skills carry the Codex agent role declaration).
+Per-skill layout: `SKILL.md` (YAML frontmatter `name:` + single-line `description:` with triggers) + optional `references/` (the real content; SKILL.md is a router/index) + optional `scripts/` + optional `agents/openai.yaml` (4 skills carry the Codex agent role declaration).
 
 ## PIPELINE
 

--- a/packages/shared-skills/skills/launch-long-task/SKILL.md
+++ b/packages/shared-skills/skills/launch-long-task/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: launch-long-task
+description: "Thin launch-readiness intake for safely routing substantial, long-running, or resumable work to the next capable handoff. Use when the user wants to assess, prepare, launch, or hand off work and the correct route through DIRECT, PLAN_THEN_EXECUTE, or DURABLE_CAMPAIGN is not yet explicit. Assesses readiness to start the selected handoff, not readiness to perform eventual implementation or production actions."
+---
+
+# Launch Long Task
+
+Select the next handoff, assess readiness to start that handoff, obtain explicit confirmation, and hand off once. Do not plan the product, execute the work, or manage its runtime.
+
+## Guardrails
+
+- Read `references/intake-and-routing.md` and `references/launch-contract.md` before intake.
+- Discover only enough read-only context to select and safely start the next handoff. Inspect the request, repository guidance, existing plans/state, relevant docs, and the visible skill/tool catalog. Do not mutate anything except a non-DIRECT contract.
+- Ask only unresolved owner decisions that determine whether the selected handoff itself may start, 1-3 questions per turn. Do not ask the owner to rediscover facts available locally.
+- Never ask product-scope, architecture, decomposition, dependency-order, implementation, or acceptance-design questions. Record them as downstream planning questions and route to `ulw-plan` as soon as the mission is sufficient for planning to begin.
+- Do not ask for or persist passwords, tokens, keys, cookies, auth headers, private credentials, raw environment dumps, or secret-bearing URLs. Record only whether required access is available through an approved mechanism.
+- Do not conduct the `ulw-plan` product interview, produce an execution plan, create a Goal, create checkpoint/evidence state, edit product code, execute product work, launch processes, or create runners, daemons, heartbeats, polling, or retry loops.
+- Do not promise a wall-clock duration. Record deadlines or service windows only when the owner declares them.
+
+## Workflow
+
+1. **Discover.** Establish the mission, repository constraints, existing plan or campaign state, authority to start the next handoff, and visible handoff capabilities. Redact any secret the user volunteers; never echo it into a contract.
+2. **Route early.** Select the route and target before evaluating readiness. A vague but intelligible mission is sufficient to begin `ulw-plan`; unresolved product or execution design belongs in downstream planning questions, not launcher questions or blockers.
+3. **Assess the selected handoff.** Apply the intake matrix only to starting that target. Select one readiness label: `READY`, `READY WITH DECLARED WATCHPOINTS`, or `BLOCKED`. Eventual implementation, deployment, migration, publication, or other irreversible work may remain gated while a read-only planning handoff is ready.
+4. **Handle DIRECT without durable overhead.** When work is small, bounded, clearly accepted, and fits ordinary execution, do not create `.omo/launches/` state or a launch contract. Explain briefly why the route is `DIRECT`, name the ordinary execution capability, and ask exactly: `This is a small bounded DIRECT task; proceed with ordinary execution via <capability>?` Treat only an unambiguous affirmative reply as confirmation. After confirmation, hand off once to that capability; do not execute inside this skill.
+5. **Write non-DIRECT contract.** For `PLAN_THEN_EXECUTE` or `DURABLE_CAMPAIGN`, create or update exactly one secret-free `.omo/launches/<slug>.md` using the contract schema. Derive a stable lowercase hyphen slug from the mission. Reuse it across intake turns; never create parallel drafts. If the slug already describes different work, choose a distinct slug.
+6. **Gate.** Show readiness for the selected handoff, route, contract path, target, and handoff-level watchpoints or blockers. For `BLOCKED`, stop without confirmation. Otherwise ask exactly: `Launch now via <handoff target> using <contract path>?` The original request is not confirmation.
+7. **Handoff once.** After explicit confirmation, capability-detect without probing. If direct invocation is available, invoke exactly one target with the contract path and mission, record `HANDED_OFF`, and stop. If the named skill cannot be invoked directly but the harness supports explicit `$skill-name` prompts, record `AWAITING_HANDOFF`, emit exactly the one next-turn prompt specified in the routing reference, and stop. Do not claim handoff or downstream completion. If neither mechanism is available, record `BLOCKED`; never downgrade the route or choose a second target.
+
+## Final Output
+
+Before confirmation, report the classification for the selected handoff and the gate question. For prompt-only handoff, output only the single next-turn prompt. After native handoff, report only the contract path, classification, target, and receipt. For `DIRECT`, report the route explanation and confirmation question without creating long-horizon state. Never claim downstream work completed.

--- a/packages/shared-skills/skills/launch-long-task/agents/openai.yaml
+++ b/packages/shared-skills/skills/launch-long-task/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Launch Long Task"
+  short_description: "Assess and route a safe long-task handoff"
+  default_prompt: "Use $launch-long-task to assess readiness for the next safe handoff and route this substantial or resumable task without doing downstream planning or execution."

--- a/packages/shared-skills/skills/launch-long-task/references/intake-and-routing.md
+++ b/packages/shared-skills/skills/launch-long-task/references/intake-and-routing.md
@@ -1,0 +1,66 @@
+# Intake And Routing
+
+Select the handoff target first, then use this matrix to judge readiness to start that target. Do not judge whether eventual risky work is ready. A required unresolved row blocks only when it prevents the selected handoff itself from starting safely.
+
+## Handoff Readiness Matrix
+
+| Dimension | Resolve from read-only discovery | Ask only when owner input is required | Ready for selected handoff | Block selected handoff only when |
+| --- | --- | --- | --- | --- |
+| Mission | User request and any authoritative brief | Which request is authoritative only when sources materially conflict? | The target has enough mission context to begin its own work; `ulw-plan` needs only an intelligible planning mission | The mission is absent, unintelligible, or contradictory enough that the target cannot begin |
+| Handoff authority | Side effects performed by the selected target itself | May this target start when that act itself crosses an owner-controlled boundary? | Starting the target is authorized; later execution gates may remain deferred | Even starting the target would exceed authority or trigger an unapproved external, destructive, or irreversible action |
+| Target capability | Visible skill/tool catalog and supported invocation form | Do not ask about capability facts visible to the harness | The named target is available through native invocation or a supported explicit `$skill-name` next-turn prompt | No safe target or invocation fallback exists |
+| Handoff inputs | Existing plan for `start-work`; runbook/state for `ulw-loop`; mission for `ulw-plan` | Which competing authoritative artifact should the target receive? | Inputs required by this target exist and are identifiable | This target cannot begin without a missing or contradictory authoritative input |
+| Handoff access | Non-secret indicators for access needed immediately by this target | Is immediate access provisioned through an approved mechanism? Ask only yes/no/unknown | Access needed to start this target is approved; access needed only for later execution is a deferred gate | Starting the target requires secret disclosure, unavailable access, or an unapproved mechanism |
+| Handoff constraints | Repository and owner rules that govern the selected target now | Which conflicting owner-controlled constraint governs this handoff? | The target can start without violating an applicable constraint | Constraints conflict or require unsafe behavior during the handoff itself |
+| Handoff watchpoints | Uncertainty that can affect the selected target before its next gate | Accept this handoff-level risk with its signal and response? | Each accepted handoff uncertainty has an observable signal, response, and owner/role | A material handoff risk has no observable signal, safe response, or authorized owner |
+
+## Planning-Owned Questions
+
+When `ulw-plan` is selected, record unresolved product outcome detail, scope boundaries, architecture, decomposition, dependency order, acceptance design, QA design, rollback design, and execution access as **downstream planning questions**. Do not ask them during launcher intake and do not convert them into launch blockers. Route immediately when the mission is sufficient for `ulw-plan` to explore.
+
+Planning may be ready while implementation or production execution is not. Record irreversible actions, production access, deploy/publish/merge authority, service windows, rollback conditions, and final acceptance as deferred execution gates for downstream resolution. Block only if starting `ulw-plan` itself would exceed authority or no safe planning handoff exists.
+
+## Readiness Labels
+
+- `READY`: The selected handoff can start safely and has no material handoff-level uncertainty. Downstream planning questions and deferred execution gates do not change this label.
+- `READY WITH DECLARED WATCHPOINTS`: The selected handoff can start safely, but a handoff-level uncertainty has an observable signal, response, and owner/role. Obtain owner acceptance only when that uncertainty affects the handoff itself.
+- `BLOCKED`: The selected handoff cannot safely begin because its mission is unusable, its immediate authority/input/access is missing, its own action is unsafe or irreversible without approval, or no safe capability/fallback exists. State only the minimum facts needed to reassess; do not ask for launch confirmation.
+
+Never downgrade a handoff blocker to a watchpoint merely to launch. Conversely, never promote a planning-owned unknown or deferred execution gate into a launcher blocker.
+
+## Route Selection
+
+Apply precedence from top to bottom:
+
+| Condition | Route | Preferred handoff target |
+| --- | --- | --- |
+| The mission is intelligible but product outcome detail, scope, architecture, decomposition, dependency order, acceptance design, or another planning decision remains open; no decision-complete plan exists | `PLAN_THEN_EXECUTE` | `ulw-plan` |
+| A decision-complete execution plan already exists and identifies work, dependencies, acceptance, and QA | `PLAN_THEN_EXECUTE` | `start-work` |
+| Outcome and acceptance are known, but delivery is iterative, multi-stage, evidence-heavy, interruption-prone, or must resume from durable checkpoints | `DURABLE_CAMPAIGN` | `ulw-loop` |
+| Work is small and bounded, has clear acceptance, fits one ordinary execution envelope, and does not need durable campaign state | `DIRECT` | One ordinary implementation/delegation capability |
+
+Do not label a route from the user's adjective "long" alone. Classify from uncertainty, boundedness, and continuity needs.
+
+## Boundary Examples
+
+| Request shape | Classification | Launcher behavior |
+| --- | --- | --- |
+| "Make repository authentication more secure" with product boundaries and acceptance still open | `READY` for `PLAN_THEN_EXECUTE` via `ulw-plan` when that handoff is available | Record the open security boundary, scope, and acceptance design as downstream planning questions; do not ask them |
+| Plan and later run a production user-table migration, but migration design, production access, rollback authority, and service-window detail remain open | `READY` for `PLAN_THEN_EXECUTE` via read-only `ulw-plan` when that handoff is available | Record migration design as downstream planning questions and production authority/access as deferred execution gates; never treat planning confirmation as production authorization |
+| A durable A/B campaign has invalid required commits or cases and no available `ulw-loop` or supported explicit invocation fallback | `BLOCKED` for `DURABLE_CAMPAIGN` | Report only the immediate input and capability blockers; do not downgrade to `DIRECT` |
+| Fix one identified typo in `README.md` | `DIRECT` | Explain that it is small, bounded, and ordinarily verifiable; create no contract and offer ordinary execution after explicit confirmation |
+
+## Capability-Aware Handoff
+
+Inspect only capabilities already visible in the harness catalog.
+
+- For a named skill target, use the harness-native skill invocation mechanism once and pass: `Read <contract path>; honor its mission, constraints, watchpoints, and launch confirmation.`
+- For `DIRECT`, after confirmation use one available ordinary implementation/delegation capability once and pass the mission plus discovered constraints directly. Do not split, supervise, retry, create a contract, or execute the assignment inside this skill.
+- `DIRECT` is not a fallback for missing planning or durable capability. Use it only for genuinely small, bounded work; create no launch contract or long-horizon state, explain the classification, and offer ordinary execution after explicit confirmation.
+- Do not load multiple candidate skills to test availability. Catalog presence is capability detection; invocation is the handoff.
+- If a named skill is cataloged but no direct skill-invocation tool is available, and the harness supports explicit `$skill-name` prompt invocation, do not downgrade or claim completion. After confirmation, set `Launch state: AWAITING_HANDOFF`, then emit exactly one line and nothing else:
+
+  `$<skill-name> Read <contract path>; honor its mission, constraints, downstream planning questions, watchpoints, deferred execution gates, and launch confirmation.`
+
+- The line above is a next-turn handoff prompt for the user to submit; it is not a receipt. Do not emit a second prompt, retry, or continue intake.
+- Treat a successful native tool acceptance or returned task/session identifier as the handoff receipt. Treat a native invocation error as `BLOCKED`; record it and stop without a second attempt.

--- a/packages/shared-skills/skills/launch-long-task/references/launch-contract.md
+++ b/packages/shared-skills/skills/launch-long-task/references/launch-contract.md
@@ -1,0 +1,70 @@
+# Launch Contract Schema
+
+For `PLAN_THEN_EXECUTE` and `DURABLE_CAMPAIGN`, write exactly one Markdown file at `.omo/launches/<slug>.md`. Never create a contract for `DIRECT`. Keep the file concise, reviewer-readable, and secret-free. Use `Unknown - blocks selected handoff` only when the unknown prevents that handoff from starting; otherwise record it under downstream planning questions or deferred execution gates. Omit optional rows that do not apply.
+
+```markdown
+# Launch Contract: <mission title>
+
+- Contract version: 2
+- Readiness: <READY | READY WITH DECLARED WATCHPOINTS | BLOCKED>
+- Route: <PLAN_THEN_EXECUTE | DURABLE_CAMPAIGN>
+- Handoff target: <skill or delegation capability | unavailable>
+- Readiness for: <starting the selected handoff>
+- Launch state: <AWAITING_CONFIRMATION | CONFIRMED | AWAITING_HANDOFF | BLOCKED | HANDED_OFF>
+- Updated: <ISO-8601 timestamp>
+
+## Mission
+
+- Request: <authoritative mission in the owner's words or a faithful concise summary>
+- Handoff objective: <what the selected target will produce or begin>
+- Authoritative inputs: <paths, issue/plan identifiers, or non-secret references>
+
+## Selected Handoff Envelope
+
+- Immediate constraints: <rules governing this handoff itself>
+- Permitted handoff side effects: <none or explicitly authorized actions by this target>
+- Immediate access readiness: <available through approved mechanism | not required | unavailable>
+- Why this handoff is ready or blocked: <target-relative reason>
+
+## Downstream Planning Questions
+
+- <product scope, architecture, decomposition, dependency, acceptance, QA, rollback, or execution-access question owned by ulw-plan; or None>
+
+## Deferred Execution Gates
+
+- <eventual irreversible action, authority, access, service window, acceptance, or rollback gate; or None>
+
+## Continuity
+
+- Durable source of truth: <existing plan/campaign artifact or downstream target that will create it>
+- Resume anchor: <existing artifact or downstream-owned future anchor; do not invent runtime state>
+
+## Watchpoints
+
+| Risk | Observable signal | Required response | Owner/role |
+| --- | --- | --- | --- |
+| <risk or None> | <signal> | <response> | <owner/role> |
+
+## Decisions
+
+- Discovered facts: <facts verified read-only and relevant to handoff selection>
+- Owner decisions: <explicit choices about the handoff>
+- Handoff blockers: <None or minimum immediate decision/capability needed>
+
+## Launch Gate
+
+- Confirmation asked: `Launch now via <handoff target> using .omo/launches/<slug>.md?`
+- Confirmation: <pending | confirmed by owner in current conversation | not requested because blocked>
+- Next-turn handoff prompt: <not applicable | pending | exact single `$skill-name` prompt emitted>
+- Handoff receipt: <pending | target plus returned task/session identifier | invocation error; AWAITING_HANDOFF is not a receipt>
+```
+
+## Safety Rules
+
+- Store paths, identifiers, booleans, and approved mechanism names; never store credential values, auth headers, cookies, private URLs, raw environment output, or secret-bearing command output.
+- Summarize discovery instead of pasting logs. Redact a volunteered secret and do not repeat it.
+- Evaluate every readiness field against the selected handoff. Do not write `Unknown - blocks selected handoff` for questions that `ulw-plan` owns or for authority/access needed only by eventual execution.
+- When reusing a version 1 contract, upgrade it in place to version 2. Preserve confirmed owner decisions and the furthest valid launch state; reclassify old execution-readiness blockers as downstream planning questions or deferred execution gates when they do not block the selected handoff. Never reset confirmation or create a replacement contract solely for migration.
+- Keep `Launch state` monotonic: `AWAITING_CONFIRMATION` to `CONFIRMED`, then to either `HANDED_OFF` after native acceptance or `AWAITING_HANDOFF` after emitting the one explicit next-turn prompt; any pre-handoff state may move to `BLOCKED`. Never record `HANDED_OFF` merely because a prompt was emitted.
+- Record only one handoff receipt. An invocation error is terminal for this launcher turn; do not retry or choose another target.
+- Use the contract as a launch decision record, not a progress ledger, plan, Goal, checkpoint database, heartbeat, or retry state.


### PR DESCRIPTION
## Summary

Add a cross-harness `launch-long-task` skill that turns an underspecified substantial task into one safe, explicit handoff. It selects `DIRECT`, `PLAN_THEN_EXECUTE`, or `DURABLE_CAMPAIGN`, assesses readiness only for the next handoff, requires confirmation, and never duplicates planner, Goal, runner, checkpoint, heartbeat, or retry-loop ownership.

## Changes

- Add the launcher skill, target-relative readiness matrix, capability-aware routing, and versioned launch-contract schema.
- Keep production authority, credentials, rollback, and irreversible work as deferred execution gates when they do not block a read-only planning handoff.
- Distinguish native `HANDED_OFF` receipts from prompt-only `AWAITING_HANDOFF`, and keep bounded `DIRECT` work free of durable launcher state.
- Register the new shared skill in the Codex synchronization expectation and shared-skills catalog.

## QA & Evidence

- **Semantic forward tests:** vague planning, production migration, durable PilotDeck A/B, scheduled monitoring, two-turn DIRECT confirmation, and prompt-only handoff all passed independent second-pass review. Artifacts: `.omo/evidence/20260726-launch-long-task/forward-tests.md` and `adversarial-boundaries.md`.
- **Codex live isolation:** local install into a temporary `CODEX_HOME`, byte-matching installed skill copies, and a real `codex app-server` turn against a local mock model proved plugin hook start/completion; real `~/.codex/config.toml` remained unchanged. Artifact: `.omo/evidence/20260726-launch-long-task/codex-qa/qa-summary.md`.
- **OpenCode live isolation:** a real pinned OpenCode server loaded the local source plugin, exposed the OMO `skill` tool and `/launch-long-task`, preserved real DB count `0 -> 0`, and cleaned up. Artifact: `.omo/evidence/20260726-launch-long-task/opencode-qa/SUMMARY.md`.
- **Automated gates:** `quick_validate.py` passed; OpenCode shared-skills package tests passed 3/3; Codex sync tests passed 28/28; `env -u CODEX_THREAD_ID -u CODEX_SESSION_ID -u OMO_ULW_LOOP_SESSION_ID bun run test:codex` passed; `bun run typecheck` passed; `bun run build` passed; `git diff --check` passed.

## Risks & Residuals

- The skill is declarative, so future behavior still depends on model instruction-following. Adversarial forward tests cover the highest-risk boundary cases.
- Native downstream `ulw-plan` and `ulw-loop` execution was intentionally not performed; this launcher owns only intake, confirmation, and one handoff.
- A separate standalone explanatory HTML artifact passed structural checks, but in-app Browser policy blocked `file://` visual QA. No visual-pass claim is made, and that file is outside this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `launch-long-task` skill to safely intake and route substantial or resumable work to the next capable handoff. It picks a route (`DIRECT`, `PLAN_THEN_EXECUTE`, or `DURABLE_CAMPAIGN`), checks readiness only for that handoff, requires confirmation, and writes a versioned launch contract for non-`DIRECT` routes.

- **New Features**
  - Target-relative readiness matrix and capability-aware routing; defer production authority/credentials as execution gates when planning can start read‑only.
  - Contract schema v2 at `.omo/launches/<slug>.md`; monotonic launch states and watchpoints; no contract for `DIRECT`.
  - Clear receipts: `HANDED_OFF` (native) vs `AWAITING_HANDOFF` (prompt-only); emits one next-turn prompt when native invocation is unavailable.
  - Cataloged in `@oh-my-opencode/shared-skills` (docs and `agents/openai.yaml`) and added to Codex sync expectations/tests.

<sup>Written for commit a0f03c89c21481bffa2a36f3ebf62d0d49a8b1fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

