### PR TITLE
feat(shared-skills): find oh-my-pi and gajae-code coding-agent sessions

### DIFF
--- a/packages/omo-codex/src/python-migration-inventory.test.ts
+++ b/packages/omo-codex/src/python-migration-inventory.test.ts
@@ -18,6 +18,7 @@ const optionalGeneratedPythonFiles = [
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/jsonio.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/kiro_scanner.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/opencode.py",
+  "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/pi_family.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/scanners.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/sqlite_optional_scanners.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/sqlite_scanners.py",

--- a/packages/shared-skills/skills/coding-agent-sessions/SKILL.md
+++ b/packages/shared-skills/skills/coding-agent-sessions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-agent-sessions
-description: "MUST USE when asked to find, read, list, search, inspect, fetch, export, or reconstruct coding-agent sessions across Codex, Claude Code/Desktop, OpenCode, Senpi/pi, OpenClaw, Factory Droid, Amp, Gemini/Kimi/Qwen CLIs, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, or unknown local agent logs. Covers transcripts, session IDs, rollout JSONL, state SQLite, Claude projects/pre-compact histories, OpenCode messages/parts, child/subagent linkage, cwd/model/time/token filters, archives, and cost clues. Expands fuzzy recall into parallel query lanes and first probes known stores so absent platforms are skipped cheaply. Triggers: coding agent sessions, Codex/Claude/OpenCode/Senpi/pi/OpenClaw/Droid/Amp/Kodu/Cursor/Aider sessions, transcript search, session history, session ID, read transcript, token usage, subagent sessions, what did I do yesterday, did we already do this."
+description: "MUST USE when asked to find, read, list, search, inspect, fetch, export, or reconstruct coding-agent sessions across Codex, Claude Code/Desktop, OpenCode, Senpi/pi, oh-my-pi (omp), gajae-code (gjc), OpenClaw, Factory Droid, Amp, Gemini/Kimi/Qwen CLIs, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, or unknown local agent logs. Covers transcripts, session IDs, rollout JSONL, state SQLite, Claude projects/pre-compact histories, OpenCode messages/parts, child/subagent linkage, cwd/model/time/token filters, archives, and cost clues. Expands fuzzy recall into parallel query lanes and first probes known stores so absent platforms are skipped cheaply. Triggers: coding agent sessions, Codex/Claude/OpenCode/Senpi/pi/oh-my-pi/omp/gajae-code/gjc/OpenClaw/Droid/Amp/Kodu/Cursor/Aider sessions, transcript search, session history, session ID, read transcript, token usage, subagent sessions, what did I do yesterday, did we already do this."
 ---
 
 # Coding Agent Sessions
@@ -16,6 +16,7 @@ Find local coding-agent sessions across agent products before answering from mem
    | Codex / OpenAI Codex CLI | `references/codex.md` |
    | Claude Code / Claude Desktop histories | `references/claude.md` |
    | Senpi / pi coding-agent logs | `references/senpi.md` |
+   | oh-my-pi (`omp`, `~/.omp`) and gajae-code (`gjc`, `~/.gjc`) logs | `references/senpi.md` |
    | OpenCode / oh-my-openagent (formerly oh-my-opencode) storage | `references/opencode.md` |
    | OpenClaw, Droid, Amp, Gemini, Kimi, Qwen, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, Kiro, Goose, Hermes, Crush, Zed | `references/all-platforms.md` |
    | Unknown / "any session" / cross-agent search | `references/all-platforms.md` |
@@ -28,6 +29,7 @@ When the user remembers a task vaguely ("that OpenCode bug", "the dashboard PR",
 python3 scripts/find-agent-sessions.py list --limit 20
 python3 scripts/find-agent-sessions.py find "commit" --from 7d --platform senpi --platform opencode
 python3 scripts/find-agent-sessions.py find "proxy" --platform openclaw --platform droid --platform amp
+python3 scripts/find-agent-sessions.py find "refactor" --platform oh-my-pi --platform gajae-code
 python3 scripts/find-agent-sessions.py find --query "deploy" --query "token usage" --workers 64
 python3 scripts/find-agent-sessions.py find --query "opencode bug" --query "fix opencode" --query "OpenCode parent session" --include-subagents --workers 64
 python3 scripts/find-agent-sessions.py read <session-id>
@@ -49,7 +51,7 @@ The finder prints JSON for stdout and `jq`. Every result includes:
 
 | Field | Meaning |
 |---|---|
-| `platform` | Registered platform key such as `codex`, `claude`, `opencode`, `openclaw`, `droid`, `amp`, `kodu`, `cursor-cli`, `aider`, `roo-code`, `kilo-code`, `kilo-cli`, or `kiro` |
+| `platform` | Registered platform key such as `codex`, `claude`, `senpi`, `oh-my-pi`, `gajae-code`, `opencode`, `openclaw`, `droid`, `amp`, `kodu`, `cursor-cli`, `aider`, `roo-code`, `kilo-code`, `kilo-cli`, or `kiro` |
 | `id` | Session ID or stable file-derived ID |
 | `path` | Raw transcript/index file |
 | `cwd` | Working directory when recoverable |
@@ -117,6 +119,7 @@ Use `references/codex.md` for Codex storage details.
 | Problem | Fix |
 |---|---|
 | Missing Codex sessions | Set `CODEX_HOME` or pass `--root /path/to/.codex`. |
+| Missing oh-my-pi / gajae-code sessions | Those stores live in `~/.omp/agent/sessions` and `~/.gjc/agent/sessions`. For a custom `PI_CONFIG_DIR` / `PI_CODING_AGENT_DIR`, pass that agent dir with `--root`. |
 | Missing OpenCode sessions | Pass the data dir that contains `messages/` and `parts/`, often `~/.opencode` or `~/.local/share/opencode`. |
 | Missing Claude sessions | Search `~/.claude/projects`, `~/.claude/transcripts`, and `~/.claude/pre-compact-session-histories`; use `--root` for nonstandard config dirs. |
 | Missing optional platform sessions | Check `references/all-platforms.md` for the exact local store. For project-local tools such as Aider, pass `--root /path/to/workspace` if the repo is outside the bounded default roots. |

--- a/packages/shared-skills/skills/coding-agent-sessions/references/all-platforms.md
+++ b/packages/shared-skills/skills/coding-agent-sessions/references/all-platforms.md
@@ -4,13 +4,15 @@
 
 Search these first, then add user-supplied roots with `--root`:
 
-Registered platform keys: `codex`, `claude`, `senpi`, `opencode`, `openclaw`, `droid`, `amp`, `gemini`, `kimi`, `qwen`, `codebuff`, `roo-code`, `kilo-code`, `cline`, `kodu`, `cursor-cli`, `aider`, `kilo-cli`, `hermes`, `goose`, `crush`, `zed`, `kiro`.
+Registered platform keys: `codex`, `claude`, `senpi`, `oh-my-pi`, `gajae-code`, `opencode`, `openclaw`, `droid`, `amp`, `gemini`, `kimi`, `qwen`, `codebuff`, `roo-code`, `kilo-code`, `cline`, `kodu`, `cursor-cli`, `aider`, `kilo-cli`, `hermes`, `goose`, `crush`, `zed`, `kiro`.
 
 | Platform | Unix/macOS | Windows |
 |---|---|---|
 | Codex | `$CODEX_HOME`, `~/.codex` | `%CODEX_HOME%`, `%USERPROFILE%\.codex` |
 | Claude | `~/.claude` | `%USERPROFILE%\.claude`, `%APPDATA%\Claude` |
 | Senpi / pi | `~/.senpi/agent`, `~/.pi/agent` | `%USERPROFILE%\.senpi\agent`, `%USERPROFILE%\.pi\agent` |
+| oh-my-pi (`omp`) | `~/.omp/agent`, `~/.omp/profiles/*/agent`, `$XDG_DATA_HOME/omp` | `%USERPROFILE%\.omp\agent` |
+| gajae-code (`gjc`) | `~/.gjc/agent`, `~/.gjc/profiles/*/agent`, `$XDG_DATA_HOME/gjc` | `%USERPROFILE%\.gjc\agent` |
 | OpenCode | `$OPENCODE_HOME`, `~/.opencode`, `~/.local/share/opencode` | `%OPENCODE_HOME%`, `%APPDATA%\opencode`, `%USERPROFILE%\.opencode` |
 | OpenClaw | `~/.openclaw/agents/*/sessions`, `~/.openclaw/session-backups` | pass `--root` |
 | Factory Droid | `~/.factory/sessions/*/*.jsonl` | pass `--root` |

--- a/packages/shared-skills/skills/coding-agent-sessions/references/senpi.md
+++ b/packages/shared-skills/skills/coding-agent-sessions/references/senpi.md
@@ -1,10 +1,20 @@
-# Senpi / pi Coding-Agent Sessions
+# Senpi / pi Family Coding-Agent Sessions
 
-Observed Senpi layout:
+The pi family (Senpi, oh-my-pi, gajae-code) shares one session format, so one scanner serves all three under separate platform keys.
 
-- `~/.senpi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`
-- `~/.senpi/agent/settings.json`, `models.json`, and `auth.json` provide environment context.
-- `~/.pi/agent/sessions/**` can use the same family of JSONL formats.
+| Platform key | Aliases | Config root | Sessions |
+|---|---|---|---|
+| `senpi` | - | `~/.senpi`, `~/.pi` | `<root>/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl` |
+| `oh-my-pi` | `omp`, `ohmypi` | `~/.omp` | `~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl` |
+| `gajae-code` | `gjc`, `gajae` | `~/.gjc` | `~/.gjc/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl` |
+
+Extra roots scanned for every pi-family platform:
+
+- Named profiles: `<config-root>/profiles/<profile>/agent/sessions/**`.
+- XDG stores (macOS/Linux, default profile): `$XDG_DATA_HOME/<app>/sessions/**` and `$XDG_DATA_HOME/<app>/profiles/<profile>/sessions/**`, where `<app>` is `senpi`, `omp`, or `gjc`. XDG flattens the `agent/` path segment.
+- A custom `PI_CONFIG_DIR` / `PI_CODING_AGENT_DIR` / `GJC_CONFIG_DIR` store: pass that agent directory with `--root`.
+
+`~/.senpi/agent/settings.json`, `models.json`, and `auth.json` provide environment context; oh-my-pi and gajae-code keep the same files plus `config.yml` and `models.yml` next to their sessions directory.
 
 Common event types:
 

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/pi_family.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/pi_family.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .transcript import env_path, existing, jsonl_parallel, recent, stem_id
+from .types import Session
+
+SENPI_CONFIG_DIRS = (".senpi", ".pi")
+OH_MY_PI_CONFIG_DIRS = (".omp",)
+GAJAE_CODE_CONFIG_DIRS = (".gjc",)
+
+__all__ = ["scan_gajae_code", "scan_oh_my_pi", "scan_senpi"]
+
+
+def scan_senpi(extra_roots: tuple[Path, ...], workers: int) -> list[Session]:
+    return _scan_pi_family("senpi", SENPI_CONFIG_DIRS, "senpi", extra_roots, workers)
+
+
+def scan_oh_my_pi(extra_roots: tuple[Path, ...], workers: int) -> list[Session]:
+    return _scan_pi_family("oh-my-pi", OH_MY_PI_CONFIG_DIRS, "omp", extra_roots, workers)
+
+
+def scan_gajae_code(extra_roots: tuple[Path, ...], workers: int) -> list[Session]:
+    return _scan_pi_family("gajae-code", GAJAE_CODE_CONFIG_DIRS, "gjc", extra_roots, workers)
+
+
+def _scan_pi_family(platform: str, config_dirs: tuple[str, ...], xdg_app: str, extra_roots: tuple[Path, ...], workers: int) -> list[Session]:
+    roots = _pi_family_roots(config_dirs, xdg_app, extra_roots)
+    paths = [path for root in roots for path in (root / "sessions").rglob("*.jsonl")]
+    return jsonl_parallel(recent(paths), workers, platform, lambda path: stem_id(path, "_"))
+
+
+def _pi_family_roots(config_dirs: tuple[str, ...], xdg_app: str, extra_roots: tuple[Path, ...]) -> list[Path]:
+    home = Path.home()
+    roots: list[Path] = []
+    for config_dir in config_dirs:
+        base = home / config_dir
+        roots.append(base / "agent")
+        roots.extend(sorted(base.glob("profiles/*/agent")))
+    xdg_data = env_path("XDG_DATA_HOME")
+    if xdg_data is not None:
+        app_root = xdg_data / xdg_app
+        roots.append(app_root)
+        roots.extend(sorted(app_root.glob("profiles/*")))
+    roots.extend(extra_roots)
+    return existing(roots)

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/scanners.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/scanners.py
@@ -21,9 +21,9 @@ from .file_scanners import (
 )
 from .kiro_scanner import scan_kiro
 from .opencode import scan_opencode
+from .pi_family import scan_gajae_code, scan_oh_my_pi, scan_senpi
 from .sqlite_optional_scanners import scan_crush, scan_goose, scan_hermes, scan_kilo_cli, scan_zed
 from .sqlite_scanners import scan_cursor_cli, scan_kodu
-from .transcript import existing, jsonl_parallel, recent, stem_id
 from .types import Session
 
 Scanner: TypeAlias = Callable[[tuple[Path, ...], int], list[Session]]
@@ -31,7 +31,9 @@ Scanner: TypeAlias = Callable[[tuple[Path, ...], int], list[Session]]
 PLATFORM_SCANNERS: dict[str, Scanner] = {
     "codex": scan_codex,
     "claude": scan_claude,
-    "senpi": lambda roots, workers: scan_senpi(roots, workers),
+    "senpi": scan_senpi,
+    "oh-my-pi": scan_oh_my_pi,
+    "gajae-code": scan_gajae_code,
     "opencode": scan_opencode,
     "openclaw": scan_openclaw,
     "droid": scan_droid,
@@ -54,9 +56,22 @@ PLATFORM_SCANNERS: dict[str, Scanner] = {
     "kiro": scan_kiro,
 }
 DEFAULT_PLATFORMS = frozenset(PLATFORM_SCANNERS)
-PLATFORM_ALIASES = {"cursor": "cursor-cli", "factory": "droid", "roo": "roo-code", "roocode": "roo-code", "kilocode": "kilo-code", "kilo": "kilo-cli"}
+PLATFORM_ALIASES = {
+    "cursor": "cursor-cli",
+    "factory": "droid",
+    "roo": "roo-code",
+    "roocode": "roo-code",
+    "kilocode": "kilo-code",
+    "kilo": "kilo-cli",
+    "omp": "oh-my-pi",
+    "ohmypi": "oh-my-pi",
+    "oh_my_pi": "oh-my-pi",
+    "gjc": "gajae-code",
+    "gajae": "gajae-code",
+    "gajaecode": "gajae-code",
+}
 
-__all__ = ["DEFAULT_PLATFORMS", "PLATFORM_SCANNERS", "scan", "scan_claude", "scan_codex", "scan_opencode", "scan_senpi"]
+__all__ = ["DEFAULT_PLATFORMS", "PLATFORM_SCANNERS", "scan", "scan_claude", "scan_codex", "scan_gajae_code", "scan_oh_my_pi", "scan_opencode", "scan_senpi"]
 
 
 def scan(platforms: frozenset[str], roots: tuple[Path, ...], workers: int) -> list[Session]:
@@ -70,12 +85,6 @@ def scan(platforms: frozenset[str], roots: tuple[Path, ...], workers: int) -> li
         for future in as_completed(futures):
             sessions.extend(future.result())
     return _dedupe(sessions)
-
-
-def scan_senpi(extra_roots: tuple[Path, ...], workers: int) -> list[Session]:
-    roots = existing([Path.home() / ".senpi" / "agent", Path.home() / ".pi" / "agent", *extra_roots])
-    paths = [path for root in roots for path in (root / "sessions").rglob("*.jsonl")]
-    return jsonl_parallel(recent(paths), workers, "senpi", lambda path: stem_id(path, "_"))
 
 
 def _dedupe(sessions: list[Session]) -> list[Session]:

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_extended_scanners.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_extended_scanners.py
@@ -37,6 +37,8 @@ def test_default_platforms_are_canonical_transcript_sources() -> None:
         "codex",
         "claude",
         "senpi",
+        "oh-my-pi",
+        "gajae-code",
         "opencode",
         "openclaw",
         "droid",

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_pi_family_scanners.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_pi_family_scanners.py
@@ -1,0 +1,130 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest"]
+# ///
+# --- How to run ---
+# uv run --with pytest pytest scripts/tests/test_pi_family_scanners.py -v
+# pyright: reportImplicitRelativeImport=false, reportMissingImports=false
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent_sessions import scanners
+from agent_sessions.types import JsonMap, Session
+
+PI_FAMILY = frozenset({"senpi", "oh-my-pi", "gajae-code"})
+
+
+def _write_session(path: Path, session_id: str, cwd: str, prompt: str) -> None:
+    rows: list[JsonMap] = [
+        {"type": "session", "version": 3, "id": session_id, "timestamp": "2026-07-20T00:00:00.000Z", "cwd": cwd},
+        {"type": "model_change", "id": "m1", "timestamp": "2026-07-20T00:00:00.100Z", "model": "anthropic/claude-fable-5"},
+        {
+            "type": "message",
+            "id": "e1",
+            "timestamp": "2026-07-20T00:00:01.000Z",
+            "message": {"role": "user", "content": [{"type": "text", "text": prompt}]},
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+
+def _by_platform(items: list[Session]) -> dict[str, Session]:
+    return {item.platform: item for item in items}
+
+
+def test_pi_family_platforms_and_aliases_are_registered() -> None:
+    assert PI_FAMILY <= scanners.DEFAULT_PLATFORMS
+    assert scanners.PLATFORM_ALIASES["omp"] == "oh-my-pi"
+    assert scanners.PLATFORM_ALIASES["ohmypi"] == "oh-my-pi"
+    assert scanners.PLATFORM_ALIASES["gjc"] == "gajae-code"
+    assert scanners.PLATFORM_ALIASES["gajae"] == "gajae-code"
+
+
+def test_pi_family_scanners_read_each_product_home_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    _write_session(
+        tmp_path / ".senpi" / "agent" / "sessions" / "-tmp-senpi" / "2026-07-20T00-00-00-000Z_senpi-1.jsonl",
+        "senpi-1",
+        "/tmp/senpi",
+        "senpi prompt",
+    )
+    _write_session(
+        tmp_path / ".omp" / "agent" / "sessions" / "-tmp-omp" / "2026-07-20T00-00-00-000Z_omp-1.jsonl",
+        "omp-1",
+        "/tmp/omp",
+        "oh-my-pi prompt",
+    )
+    _write_session(
+        tmp_path / ".gjc" / "agent" / "sessions" / "-tmp-gjc" / "2026-07-20T00-00-00-000Z_gjc-1.jsonl",
+        "gjc-1",
+        "/tmp/gjc",
+        "gajae-code prompt",
+    )
+
+    sessions = _by_platform(scanners.scan(PI_FAMILY, (), 4))
+
+    assert sessions["senpi"].first_user_message == "senpi prompt"
+    assert sessions["oh-my-pi"].id == "omp-1"
+    assert sessions["oh-my-pi"].first_user_message == "oh-my-pi prompt"
+    assert sessions["oh-my-pi"].cwd == "/tmp/omp"
+    assert sessions["oh-my-pi"].model == "anthropic/claude-fable-5"
+    assert sessions["gajae-code"].id == "gjc-1"
+    assert sessions["gajae-code"].first_user_message == "gajae-code prompt"
+
+
+def test_pi_family_scanners_cover_profile_and_xdg_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+
+    _write_session(
+        tmp_path / ".omp" / "profiles" / "work" / "agent" / "sessions" / "-repo" / "2026-07-20T00-00-00-000Z_omp-work.jsonl",
+        "omp-work",
+        "/repo",
+        "omp profile prompt",
+    )
+    _write_session(
+        tmp_path / "xdg-data" / "gjc" / "sessions" / "-repo" / "2026-07-20T00-00-00-000Z_gjc-xdg.jsonl",
+        "gjc-xdg",
+        "/repo",
+        "gjc xdg prompt",
+    )
+    _write_session(
+        tmp_path / "xdg-data" / "omp" / "profiles" / "work" / "sessions" / "-repo" / "2026-07-20T00-00-00-000Z_omp-xdg.jsonl",
+        "omp-xdg",
+        "/repo",
+        "omp xdg profile prompt",
+    )
+
+    found = {(item.platform, item.id) for item in scanners.scan(PI_FAMILY, (), 4)}
+
+    assert ("oh-my-pi", "omp-work") in found
+    assert ("gajae-code", "gjc-xdg") in found
+    assert ("oh-my-pi", "omp-xdg") in found
+
+
+def test_pi_family_stores_do_not_leak_across_platform_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    _write_session(
+        tmp_path / ".omp" / "agent" / "sessions" / "-tmp-omp" / "2026-07-20T00-00-00-000Z_omp-only.jsonl",
+        "omp-only",
+        "/tmp/omp",
+        "oh-my-pi prompt",
+    )
+
+    senpi_sessions = scanners.scan(frozenset({"senpi"}), (), 4)
+    omp_sessions = scanners.scan(frozenset({"omp"}), (), 4)
+
+    assert senpi_sessions == []
+    assert [(item.platform, item.id) for item in omp_sessions] == [("oh-my-pi", "omp-only")]


### PR DESCRIPTION
## Summary
The `coding-agent-sessions` skill could not find sessions from two locally used coding agents: oh-my-pi (`omp`, `~/.omp`) and gajae-code (`gjc`, `~/.gjc`). Both are pi-family forks that write the same JSONL session format Senpi writes, so the finder already knew how to parse those transcripts but never looked in their stores. This PR registers them as first-class platform keys (`oh-my-pi`, `gajae-code`) with aliases, scans their home, named-profile, and XDG data roots, and documents the stores.

## Changes
- **Scanner (`scripts/agent_sessions/pi_family.py`, new)** — one pi-family scanner serving `senpi`, `oh-my-pi`, and `gajae-code`. Roots per product: `<config-root>/agent`, `<config-root>/profiles/*/agent`, and `$XDG_DATA_HOME/<app>` plus its `profiles/*` (XDG flattens the `agent/` segment, matching upstream `packages/utils/src/dirs.ts` in both repos). `scan_senpi` moved here from `scanners.py` unchanged in behavior apart from now also covering profile/XDG roots.
- **Registry (`scripts/agent_sessions/scanners.py`)** — registers the two new platform keys and the aliases `omp` / `ohmypi` / `oh_my_pi` and `gjc` / `gajae` / `gajaecode`, so `--platform omp` and the default all-platform scan both work.
- **Tests** — new `scripts/tests/test_pi_family_scanners.py` (registry + aliases, per-product home stores, profile and XDG roots, no cross-platform leakage); `test_extended_scanners.py` registry assertion extended.
- **Docs** — `SKILL.md` description/router/output-contract/troubleshooting rows, `references/senpi.md` rewritten as the pi-family reference with a store table, and the `references/all-platforms.md` platform list plus root table.

## QA & Evidence
Evidence lives in the worktree at `.omo/evidence/20260726-agent-sessions-pi-family/` (gitignored, local only).

- **What was tested:** `python3 scripts/find-agent-sessions.py list --platform oh-my-pi --limit 3` and `read <id> --platform oh-my-pi` against the real local `~/.omp/agent/sessions` store (3.6k files).
  **Observed:** before the change `count: 0` (`red-cli-list-oh-my-pi.txt`); after, 3 results with `"platform": "oh-my-pi"`, correct `cwd`, `model`, and token/cost usage, and `read` returning 8 events with first/last prompts (`green-cli-list-oh-my-pi.txt`, `green-cli-read-oh-my-pi.txt`).
  **Why sufficient:** proves root resolution, transcript parsing, and the detail read path end to end on a real store.
- **What was tested:** `HOME=<throwaway tmpdir> ... list --platform gjc --limit 5` and a default-scan `find --query "gajae-code session probe"` against a synthetic `~/.gjc/agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl` (no gajae-code store exists on this machine).
  **Observed:** the session is returned as `"platform": "gajae-code"` through both the alias and the default scan (`green-cli-gajae-code.txt`).
  **Why sufficient:** covers the alias, the platform key, and inclusion in the no-`--platform` default search for a product with no local store.
- **What was tested:** `uv run --with pytest pytest scripts/tests -q` (skill Python suite) and `bun test packages/omo-opencode/src/shared-skills-package.test.ts packages/shared-skills`.
  **Observed:** pytest went 5 failed / 27 passed (RED, `red-pytest.txt`) to 32 passed (GREEN, `green-pytest.txt`); bun suite 69 pass / 0 fail.
  **Why sufficient:** locks profile/XDG roots and platform isolation that the manual runs do not exercise, and confirms skill packaging still parses.

Both upstream repos were `git fetch` + `git pull`-ed before implementation so the documented layouts match current code (oh-my-pi `667111575`, gajae-code `b0fd6a7e` / v0.11.10).

## Risks & Residuals
- gajae-code has no local store, so its coverage is synthetic-HOME CLI + unit level rather than a real transcript — mitigated by the shared format with oh-my-pi, which is proven on a real store.
- Adding profile/XDG roots to the existing `senpi` platform widens its scan slightly; `existing()` skips absent roots and `_dedupe()` collapses duplicates, and the isolation test proves no store bleeds across platform keys.
- Custom `PI_CONFIG_DIR` / `PI_CODING_AGENT_DIR` / `GJC_CONFIG_DIR` stores are not auto-detected by design; the troubleshooting row tells the user to pass `--root`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for oh-my-pi (`omp`) and gajae-code (`gjc`) session stores in the `coding-agent-sessions` skill with a shared pi-family scanner. Both are now first-class platforms in default scans, and `senpi` scanning now includes profile and XDG roots.

- **New Features**
  - Added a shared pi-family scanner (`scripts/agent_sessions/pi_family.py`) for `senpi`, `oh-my-pi`, and `gajae-code` that searches home `agent/`, `profiles/*/agent`, and `$XDG_DATA_HOME/<app>` stores; registered new platforms and aliases in `scanners.py` and added them to defaults; updated docs and tests.

- **Bug Fixes**
  - Listed the generated `pi_family.py` in `packages/omo-codex/src/python-migration-inventory.test.ts` to keep the sync-skills gate passing.

<sup>Written for commit 57d6e01c4d687dc2d23b1ae5a91456046de1eca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

