### PR TITLE
fix(codex): skip codegraph sweep for excluded projects

### DIFF
--- a/.omo/evidence/20260727-codegraph-windows-exclusion/README.md
+++ b/.omo/evidence/20260727-codegraph-windows-exclusion/README.md
@@ -1,0 +1,125 @@
+# CodeGraph Windows exclusion release-blocker evidence
+
+## What was tested
+
+Release blocker: GitHub Actions publish run `30209883213` failed in `codex-compatibility (windows-latest)` because both CodeGraph exclusion tests reached the 5-second timeout.
+
+Changed behavior:
+
+- `.omo` and configured excluded workspaces must return `skipped-excluded`.
+- Excluded workspaces must not run global zombie-process cleanup before returning.
+- Eligible CodeGraph sessions must retain the managed sweep behavior.
+
+## RED proof
+
+Command:
+
+```text
+bun --cwd packages/omo-codex/plugin/components/codegraph test ./test/hook-exclusion.test.ts
+```
+
+Observed before the production fix:
+
+```text
+expect(received).toBe(expected)
+
+Expected: 0
+Received: 1
+
+at test/hook-exclusion.test.ts:48:23
+64 pass
+1 fail
+```
+
+This deterministic assertion proved that an excluded `.omo` workspace invoked `sweepZombies` before the exclusion decision.
+
+## GREEN proof
+
+Local component command:
+
+```text
+bun --cwd packages/omo-codex/plugin/components/codegraph test ./test/hook-exclusion.test.ts
+```
+
+Observed after moving the sweep below disabled/exclusion gates:
+
+```text
+65 pass
+0 fail
+Ran 65 tests across 14 files.
+tsc -p tsconfig.json --noEmit
+```
+
+Native Windows VM command:
+
+```text
+prlctl exec "Windows 11" --current-user cmd.exe /d /s /c "cd /d C:\Temp\omo-ci-fix\packages\omo-codex\plugin\components\codegraph && bun test .\test\hook-exclusion.test.ts"
+```
+
+Observed:
+
+```text
+3 pass
+0 fail
+Ran 3 tests across 1 file.
+```
+
+Full native Windows component command:
+
+```text
+prlctl exec "Windows 11" --current-user cmd.exe /d /s /c "cd /d C:\Temp\omo-ci-fix\packages\omo-codex\plugin\components\codegraph && bun test .\test"
+```
+
+Observed:
+
+```text
+65 pass
+0 fail
+213 expect() calls
+Ran 65 tests across 21 files.
+```
+
+The Windows proof uses a clean `dev` clone with only the candidate source and regression test copied into it. Running from the Parallels shared filesystem was rejected as invalid evidence because Bun hit an unrelated shared-filesystem `realpath` error; the native `C:\Temp` checkout removed that artifact.
+
+## Why this is enough
+
+- The new assertion fails deterministically on every platform against the faulty ordering.
+- The full CodeGraph component suite preserves eligible-session sweep behavior and package type safety.
+- The exact test file that timed out in GitHub Actions passes on a native Windows filesystem and Bun runtime.
+- The full Codex release gate passed:
+
+```text
+bun run test:codex
+exit code: 0
+final Node suite: 514 pass, 0 fail
+```
+
+- The first-party Codex app-server proof passed with a local mock model:
+
+```text
+bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin
+turnStatus: completed
+assistantText: Hello from the codex-qa mock model.
+missingHooks: []
+failedHooks: []
+hooks fired: sessionStart, stop, userPromptSubmit
+```
+
+- Isolation harness self-check passed:
+
+```text
+bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check
+PASS: isolated CODEX_HOME auto-removed on exit
+PASS: mock model serves Responses SSE
+PASS: real ~/.codex/config.toml unchanged
+```
+
+- LSP diagnostics requests timed out while the Deno server initialized. This is not hidden: package `tsc --noEmit`, the component suite, and the full Codex gate all passed and provide the type/diagnostic substitute.
+
+## Isolation and cleanup
+
+- Real `~/.codex` has not been used for QA.
+- The app-server driver removed its isolated `CODEX_HOME`; the real `~/.codex/config.toml` checksum stayed unchanged.
+- Windows temporary checkout: `C:\Temp\omo-ci-fix` (cleanup pending).
+- Windows VM: `Windows 11` (stop pending).
+- Local temporary release summary and ultrawork notepad are tracked separately in the release closeout.

--- a/packages/omo-codex/plugin/components/codegraph/dist/cli.js
+++ b/packages/omo-codex/plugin/components/codegraph/dist/cli.js
@@ -3176,13 +3176,6 @@ async function executeCodegraphSessionStartHook(options = {}) {
   const projectRoot = resolveProjectRoot(input, options.cwd ?? processCwd2());
   const homeDir = resolveHomeDir3(env);
   const config = options.config ?? getCodexOmoConfig({ cwd: projectRoot, env, homeDir });
-  pruneCodegraphProjectStoresBestEffort(homeDir, { debugLog: writeDebugLog });
-  await sweepCodegraphZombiesBestEffort({
-    env,
-    homeDir,
-    ...config.trustedCodegraphInstallDir === undefined ? {} : { trustedCodegraphInstallDir: config.trustedCodegraphInstallDir },
-    log: writeDebugLog
-  }, options.sweepZombies);
   if (config.codegraph?.enabled === false) {
     return { action: "skipped-disabled", exitCode: 0 };
   }
@@ -3194,6 +3187,13 @@ async function executeCodegraphSessionStartHook(options = {}) {
   if (exclusion.excluded) {
     return { action: "skipped-excluded", exitCode: 0 };
   }
+  pruneCodegraphProjectStoresBestEffort(homeDir, { debugLog: writeDebugLog });
+  await sweepCodegraphZombiesBestEffort({
+    env,
+    homeDir,
+    ...config.trustedCodegraphInstallDir === undefined ? {} : { trustedCodegraphInstallDir: config.trustedCodegraphInstallDir },
+    log: writeDebugLog
+  }, options.sweepZombies);
   const isInitialized = await (options.statusProbe ?? isCodegraphProjectInitialized)({
     daemon: config.codegraph?.daemon !== false,
     env,

--- a/packages/omo-codex/plugin/components/codegraph/src/hook.ts
+++ b/packages/omo-codex/plugin/components/codegraph/src/hook.ts
@@ -67,13 +67,6 @@ export async function executeCodegraphSessionStartHook(options: SessionStartHook
 	const projectRoot = resolveProjectRoot(input, options.cwd ?? processCwd());
 	const homeDir = resolveHomeDir(env);
 	const config = options.config ?? getCodexOmoConfig({ cwd: projectRoot, env, homeDir });
-	pruneCodegraphProjectStoresBestEffort(homeDir, { debugLog: writeDebugLog });
-	await sweepCodegraphZombiesBestEffort({
-		env,
-		homeDir,
-		...(config.trustedCodegraphInstallDir === undefined ? {} : { trustedCodegraphInstallDir: config.trustedCodegraphInstallDir }),
-		log: writeDebugLog,
-	}, options.sweepZombies);
 
 	if (config.codegraph?.enabled === false) {
 		return { action: "skipped-disabled", exitCode: 0 };
@@ -86,6 +79,14 @@ export async function executeCodegraphSessionStartHook(options: SessionStartHook
 	if (exclusion.excluded) {
 		return { action: "skipped-excluded", exitCode: 0 };
 	}
+
+	pruneCodegraphProjectStoresBestEffort(homeDir, { debugLog: writeDebugLog });
+	await sweepCodegraphZombiesBestEffort({
+		env,
+		homeDir,
+		...(config.trustedCodegraphInstallDir === undefined ? {} : { trustedCodegraphInstallDir: config.trustedCodegraphInstallDir }),
+		log: writeDebugLog,
+	}, options.sweepZombies);
 
 	const isInitialized = await (options.statusProbe ?? isCodegraphProjectInitialized)({
 		daemon: config.codegraph?.daemon !== false,

--- a/packages/omo-codex/plugin/components/codegraph/test/hook-exclusion.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook-exclusion.test.ts
@@ -20,6 +20,7 @@ describe("CodeGraph SessionStart exclusion policy", () => {
 		// given
 		const stdout: string[] = [];
 		const spawned: WorkerSpawnInvocation[] = [];
+		let sweepCalls = 0;
 		const stateRoot = createAllowedWorkspace("codegraph-omo-state");
 		const workspace = join(stateRoot, ".omo", "ulw-research", "run", "clones", "repo");
 		mkdirSync(workspace, { recursive: true });
@@ -36,10 +37,14 @@ describe("CodeGraph SessionStart exclusion policy", () => {
 				statusProbe: () => {
 					throw new Error("excluded projects must not probe CodeGraph status");
 				},
+				sweepZombies: () => {
+					sweepCalls += 1;
+				},
 			});
 
 			// then
 			expect(result).toEqual({ action: "skipped-excluded", exitCode: 0 });
+			expect(sweepCalls).toBe(0);
 			expect(spawned).toEqual([]);
 			expect(stdout.join("")).toBe("");
 		} finally {


### PR DESCRIPTION
## Summary

- skip CodeGraph cache pruning and zombie-process sweeping for disabled or excluded SessionStart workspaces
- add a regression assertion that `.omo` workspaces return before process cleanup
- regenerate the shipped CodeGraph CLI bundle

## Why

Publish run `30209883213` failed only on `windows-latest`. The two exclusion tests hit Bun's 5-second timeout because the Windows zombie-process sweep ran before the exclusion gate. Excluded workspaces should perform no CodeGraph process work.

## Verification

- RED: `Expected: 0, Received: 1` for the injected `sweepZombies` counter
- local CodeGraph component: 65 pass, 0 fail
- native Windows VM exact test: 3 pass, 0 fail
- native Windows VM full CodeGraph suite: 65 pass, 0 fail
- `bun run test:codex`: exit 0, final Node suite 514 pass, 0 fail
- isolated `codex app-server`: turn completed; `sessionStart`, `userPromptSubmit`, and `stop` hooks fired
- real `~/.codex/config.toml` checksum unchanged

Evidence: `.omo/evidence/20260727-codegraph-windows-exclusion/README.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip CodeGraph cleanup for disabled or excluded SessionStart workspaces to prevent Windows CI timeouts in exclusion tests. Also rebuilds the CodeGraph CLI bundle.

- **Bug Fixes**
  - Run project-store prune and zombie sweep only after disabled/exclusion checks, so excluded workspaces do no process work.
  - Add a regression test: excluded `.omo` projects must return `skipped-excluded` and never call the sweep.
  - Regenerate the CodeGraph CLI dist bundle.

<sup>Written for commit b3e263b61eec6413f30fd426b4d5d907ef43b70d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

