### PR TITLE
feat: forward managed bash checkpoints to parent sessions

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint-manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint-manager.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
+import { join } from "node:path"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { readContinuationMarker } from "../run-continuation-state"
 import { BackgroundManager } from "./manager"
 import type { PendingParentWake } from "./parent-wake-dedupe"
 import type { ParentWakeNotifier } from "./parent-wake-notifier"
@@ -298,9 +301,10 @@ describe("BackgroundManager managed-bash checkpoint events", () => {
     }
   })
 
-  test("#given queued checkpoint progress #when cancellation skips notification #then observer and wake state are purged", async () => {
+  test("#given queued checkpoint progress #when cancellation skips notification #then wake state is purged and the persisted marker is idle", async () => {
     // given
-    const manager = new BackgroundManager({ pluginContext: createPluginContext() })
+    const directory = mkdtempSync(join(tmpdir(), "omo-bg-checkpoint-marker-"))
+    const manager = new BackgroundManager({ pluginContext: createPluginContext(undefined, directory) })
     const internals = unsafeTestValue<CheckpointManager>(manager)
     const task = createRunningTask()
     internals.tasks.set(task.id, task)
@@ -313,8 +317,12 @@ describe("BackgroundManager managed-bash checkpoint events", () => {
       // then
       expect(cancelled).toBe(true)
       expect(internals.parentWakeNotifier.getPendingParentWakes().has(task.parentSessionId)).toBe(false)
+      const marker = readContinuationMarker(directory, task.parentSessionId)
+      expect(marker?.sources["background-task"]?.state).toBe("idle")
+      expect(marker?.sources["background-task"]?.reason).toBeUndefined()
     } finally {
       await manager.shutdown()
+      rmSync(directory, { recursive: true, force: true })
     }
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint-manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint-manager.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "node:os"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { BackgroundManager } from "./manager"
+import type { PendingParentWake } from "./parent-wake-dedupe"
+import type { ParentWakeNotifier } from "./parent-wake-notifier"
+import type { BackgroundTask } from "./types"
+
+const CHECKPOINT = {
+  schema_version: 1,
+  event: "wait_checkpoint",
+  job_id: "job-1",
+  status: "running",
+  captured_bytes: 8_192,
+  start_cursor_bytes: 4_096,
+  next_cursor_bytes: 8_192,
+} as const
+
+type CheckpointManager = {
+  readonly tasks: Map<string, BackgroundTask>
+  readonly parentWakeNotifier: ParentWakeNotifier
+  readonly processKey: (key: string) => Promise<void>
+  readonly tryFallbackRetry: (
+    task: BackgroundTask,
+    errorInfo: { readonly name?: string; readonly message?: string },
+    source: string,
+  ) => Promise<boolean>
+  readonly notifyParentSession: (task: BackgroundTask) => Promise<void>
+  readonly flushPendingParentWake: (sessionID: string) => Promise<void>
+  readonly enqueueNotificationForParent: (sessionID: string, operation: () => Promise<void>) => Promise<void>
+}
+
+function createPluginContext(
+  promptAsync: () => Promise<unknown> = async () => ({ data: {} }),
+  directory: string = tmpdir(),
+): PluginInput {
+  return unsafeTestValue<PluginInput>({
+    project: { id: "test-project", worktree: directory, time: { created: Date.now() } },
+    directory,
+    worktree: directory,
+    serverUrl: new URL("http://localhost:4096"),
+    $: {},
+    client: {
+      session: {
+        status: async () => ({ data: {} }),
+        messages: async () => ({ data: [{ info: { role: "assistant", finish: "stop", time: { created: Date.now() - 10_000 } } }] }),
+        promptAsync,
+        abort: async () => ({ data: {} }),
+      },
+    },
+  })
+}
+
+function createRunningTask(): BackgroundTask {
+  return {
+    id: "bg_task_1",
+    sessionId: "ses-current",
+    parentSessionId: "parent-session",
+    parentMessageId: "parent-message",
+    description: "checkpoint task",
+    prompt: "run a managed job",
+    agent: "sisyphus-junior",
+    status: "running",
+    startedAt: new Date(),
+    currentAttemptID: "att-current",
+    attempts: [
+      {
+        attemptId: "att-old",
+        attemptNumber: 1,
+        sessionId: "ses-old",
+        status: "error",
+      },
+      {
+        attemptId: "att-current",
+        attemptNumber: 2,
+        sessionId: "ses-current",
+        status: "running",
+      },
+    ],
+  }
+}
+
+function checkpointText(manager: CheckpointManager): string | undefined {
+  return manager.parentWakeNotifier
+    .getPendingParentWakes()
+    .get("parent-session")
+    ?.notifications[0]
+}
+
+function queueCheckpoint(manager: BackgroundManager): void {
+  manager.handleEvent({
+    type: "message.part.updated",
+    properties: {
+      sessionID: "ses-current",
+      part: {
+        type: "tool",
+        tool: "managed_bash",
+        state: {
+          status: "completed",
+          input: { action: "wait" },
+          metadata: { managed_bash_checkpoint: CHECKPOINT },
+        },
+      },
+    },
+  })
+}
+
+describe("BackgroundManager managed-bash checkpoint events", () => {
+  test("#given a current running child calls managed_bash wait #when its success event carries v1 metadata #then parent progress is queued", async () => {
+    // given
+    const manager = new BackgroundManager({ pluginContext: createPluginContext() })
+    const internals = unsafeTestValue<CheckpointManager>(manager)
+    internals.tasks.set("bg_task_1", createRunningTask())
+    manager.handleEvent({
+      type: "session.next.tool.called",
+      properties: {
+        sessionID: "ses-current",
+        callID: "call-1",
+        tool: "managed_bash",
+        input: { action: "wait", job_id: "job-1" },
+      },
+    })
+
+    try {
+      // when
+      manager.handleEvent({
+        type: "session.next.tool.success",
+        properties: {
+          sessionID: "ses-current",
+          callID: "call-1",
+          structured: { managed_bash_checkpoint: CHECKPOINT },
+        },
+      })
+
+      // then
+      expect(checkpointText(internals)).toContain("[MANAGED BASH CHECKPOINT]")
+      expect(checkpointText(internals)).toContain("8192")
+    } finally {
+      await manager.shutdown()
+    }
+  })
+
+  test("#given a checkpoint arrives from a historical retry session #when handled #then current parent progress stays empty", async () => {
+    // given
+    const manager = new BackgroundManager({ pluginContext: createPluginContext() })
+    const internals = unsafeTestValue<CheckpointManager>(manager)
+    internals.tasks.set("bg_task_1", createRunningTask())
+    manager.handleEvent({
+      type: "session.next.tool.called",
+      properties: {
+        sessionID: "ses-old",
+        callID: "call-old",
+        tool: "managed_bash",
+        input: { action: "wait", job_id: "job-1" },
+      },
+    })
+
+    try {
+      // when
+      manager.handleEvent({
+        type: "session.next.tool.success",
+        properties: {
+          sessionID: "ses-old",
+          callID: "call-old",
+          structured: { managed_bash_checkpoint: CHECKPOINT },
+        },
+      })
+
+      // then
+      expect(internals.parentWakeNotifier.getPendingParentWakes().has("parent-session")).toBe(false)
+    } finally {
+      await manager.shutdown()
+    }
+  })
+
+  test("#given only a persisted completed managed_bash part is retained #when handled #then it queues the compatibility checkpoint", async () => {
+    // given
+    const manager = new BackgroundManager({ pluginContext: createPluginContext() })
+    const internals = unsafeTestValue<CheckpointManager>(manager)
+    internals.tasks.set("bg_task_1", createRunningTask())
+
+    try {
+      // when
+      manager.handleEvent({
+        type: "message.part.updated",
+        properties: {
+          sessionID: "ses-current",
+          part: {
+            sessionID: "ses-current",
+            type: "tool",
+            callID: "call-fallback",
+            tool: "managed_bash",
+            state: {
+              status: "completed",
+              input: { action: "wait", job_id: "job-1" },
+              output: "rendered output must not be parsed",
+              metadata: { managed_bash_checkpoint: CHECKPOINT },
+            },
+          },
+        },
+      })
+
+      // then
+      expect(checkpointText(internals)).toContain("[MANAGED BASH CHECKPOINT]")
+      expect(checkpointText(internals)).not.toContain("rendered output")
+    } finally {
+      await manager.shutdown()
+    }
+  })
+
+  test("#given queued checkpoint progress #when actual fallback retry succeeds #then the failed attempt checkpoint is purged", async () => {
+    // given
+    const manager = new BackgroundManager({ pluginContext: createPluginContext() })
+    const internals = unsafeTestValue<CheckpointManager>(manager)
+    const task = createRunningTask()
+    task.model = { providerID: "openai", modelID: "gpt-5" }
+    task.fallbackChain = [{ model: "claude-haiku-4-5", providers: ["anthropic"] }]
+    task.attemptCount = 0
+    internals.tasks.set(task.id, task)
+    queueCheckpoint(manager)
+    Reflect.set(manager, "processKey", async () => {})
+
+    try {
+      // when
+      const retried = await internals.tryFallbackRetry(task, {
+        name: "APIError",
+        message: "Forbidden: Selected provider is forbidden",
+      }, "test")
+
+      // then
+      expect(retried).toBe(true)
+      expect(internals.parentWakeNotifier.getPendingParentWakes().get(task.parentSessionId)?.notifications)
+        .not.toContainEqual(expect.stringContaining("[MANAGED BASH CHECKPOINT]"))
+    } finally {
+      await manager.shutdown()
+    }
+  })
+
+  test("#given queued checkpoint progress #when actual completion notification runs #then final wake supersedes and purges checkpoint state", async () => {
+    // given
+    const manager = new BackgroundManager({ pluginContext: createPluginContext() })
+    const internals = unsafeTestValue<CheckpointManager>(manager)
+    const task = createRunningTask()
+    task.status = "completed"
+    task.completedAt = new Date()
+    internals.tasks.set(task.id, task)
+    queueCheckpoint(manager)
+
+    try {
+      // when
+      await internals.enqueueNotificationForParent(task.parentSessionId, () => internals.notifyParentSession(task))
+
+      // then
+      const wake = internals.parentWakeNotifier.getPendingParentWakes().get(task.parentSessionId)
+      expect(wake?.notifications.some((notification) => notification.includes("[MANAGED BASH CHECKPOINT]"))).toBe(false)
+      expect(wake?.latestOnlyNotifications).toBeUndefined()
+    } finally {
+      await manager.shutdown()
+    }
+  })
+
+  test("#given checkpoint dispatch is in flight #when retry purge queues before dispatch failure #then stale attempt cannot requeue", async () => {
+    // given
+    let rejectDispatch = (_error: Error): void => {}
+    let markDispatchStarted = (): void => {}
+    const dispatchStarted = new Promise<void>((resolve) => { markDispatchStarted = resolve })
+    const dispatchResult = new Promise<unknown>((_resolve, reject) => { rejectDispatch = reject })
+    const manager = new BackgroundManager({ pluginContext: createPluginContext(async () => {
+      markDispatchStarted()
+      return dispatchResult
+    }) })
+    const internals = unsafeTestValue<CheckpointManager>(manager)
+    const task = createRunningTask()
+    task.model = { providerID: "openai", modelID: "gpt-5" }
+    task.fallbackChain = [{ model: "claude-haiku-4-5", providers: ["anthropic"] }]
+    task.attemptCount = 0
+    internals.tasks.set(task.id, task)
+    queueCheckpoint(manager)
+    internals.parentWakeNotifier.clearPendingParentWakeTimer(task.parentSessionId)
+    Reflect.set(manager, "processKey", async () => {})
+    const flush = internals.enqueueNotificationForParent(task.parentSessionId, () => internals.flushPendingParentWake(task.parentSessionId))
+    await dispatchStarted
+
+    try {
+      // when
+      const retry = internals.tryFallbackRetry(task, { name: "APIError", message: "Forbidden: Selected provider is forbidden" }, "test")
+      rejectDispatch(new Error("dispatch failed"))
+      await flush
+      await retry
+
+      // then
+      expect(internals.parentWakeNotifier.getPendingParentWakes().get(task.parentSessionId)?.notifications
+        .some((notification) => notification.includes("[MANAGED BASH CHECKPOINT]"))).toBe(false)
+    } finally {
+      rejectDispatch(new Error("cleanup"))
+      await manager.shutdown()
+    }
+  })
+
+  test("#given queued checkpoint progress #when cancellation skips notification #then observer and wake state are purged", async () => {
+    // given
+    const manager = new BackgroundManager({ pluginContext: createPluginContext() })
+    const internals = unsafeTestValue<CheckpointManager>(manager)
+    const task = createRunningTask()
+    internals.tasks.set(task.id, task)
+    queueCheckpoint(manager)
+
+    try {
+      // when
+      const cancelled = await manager.cancelTask(task.id, { skipNotification: true, source: "test" })
+
+      // then
+      expect(cancelled).toBe(true)
+      expect(internals.parentWakeNotifier.getPendingParentWakes().has(task.parentSessionId)).toBe(false)
+    } finally {
+      await manager.shutdown()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint-parent-wake.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint-parent-wake.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, test } from "bun:test"
+import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+import { ParentWakeDispatchedTracker } from "./parent-wake-dispatched-tracker"
+import { ParentWakeNotifier } from "./parent-wake-notifier"
+
+type NotifierClient = ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
+type PromptAsyncCall = Parameters<NotifierClient["session"]["promptAsync"]>[0]
+
+const FINAL_WAKE = "<system-reminder>\n[BACKGROUND TASK COMPLETED]\n[ALL BACKGROUND TASKS COMPLETE]\n</system-reminder>"
+const ORDINARY_NO_REPLY_WAKE = "<system-reminder>\n[BACKGROUND TASK RESULT READY]\n</system-reminder>"
+const FIRST_CHECKPOINT = "<system-reminder>\n[MANAGED BASH CHECKPOINT]\n**Captured bytes:** 10\n</system-reminder>"
+const LATEST_CHECKPOINT = "<system-reminder>\n[MANAGED BASH CHECKPOINT]\n**Captured bytes:** 20\n</system-reminder>"
+const LATEST_ONLY_KEY = "managed-bash:bg_task_1:att_1:job-1"
+
+function createNotifier(promptAsyncImpl?: (call: PromptAsyncCall) => Promise<unknown>): {
+  readonly notifier: ParentWakeNotifier
+  readonly promptAsyncCalls: PromptAsyncCall[]
+} {
+  const promptAsyncCalls: PromptAsyncCall[] = []
+  const client: NotifierClient = {
+    session: {
+      messages: async () => ({
+        data: [{ info: { role: "assistant", finish: "stop", time: { created: Date.now() - 10_000 } } }],
+      }),
+      status: async () => ({ data: {} }),
+      promptAsync: async (call) => {
+        promptAsyncCalls.push(call)
+        return promptAsyncImpl?.(call) ?? { data: {} }
+      },
+    },
+  }
+  const notifier = new ParentWakeNotifier(
+    {
+      client,
+      directory: "/tmp/test-omo",
+      enqueueNotificationForParent: async (_sessionID, operation) => operation(),
+    },
+    {
+      pendingRetryMs: 1_000,
+      acceptedMessageSkewMs: 100,
+      toolCallDeferMaxMs: 5_000,
+      failureRequeueWindowMs: 5_000,
+      userMessageInProgressWindowMs: 0,
+    },
+  )
+  return { notifier, promptAsyncCalls }
+}
+
+describe("managed-bash checkpoint parent wakes", () => {
+  test("#given two pending checkpoints for one task attempt and job #when queued #then only the latest checkpoint is retained", () => {
+    // given
+    const { notifier } = createNotifier()
+    const sessionID = "parent-latest-checkpoint"
+
+    try {
+      notifier.queueLatestParentWake({ sessionID, notification: FIRST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+
+      // when
+      notifier.queueLatestParentWake({ sessionID, notification: LATEST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+
+      // then
+      expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([LATEST_CHECKPOINT])
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a pure checkpoint noReply wake #when accepted #then it is terminal best-effort and is not recovery tracked", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-checkpoint-noreply"
+    notifier.queueLatestParentWake({ sessionID, notification: LATEST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+
+    try {
+      // when
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls[0]?.body.parts[0]?.text).toContain("[MANAGED BASH CHECKPOINT]")
+      expect(notifier.getDispatchedParentWakes().has(sessionID)).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given an ordinary noReply background notification #when accepted #then dispatched recovery tracking is preserved", async () => {
+    // given
+    const { notifier } = createNotifier()
+    const sessionID = "parent-ordinary-noreply"
+    notifier.queuePendingParentWake(sessionID, ORDINARY_NO_REPLY_WAKE, {}, false)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      expect(notifier.getDispatchedParentWakes().get(sessionID)?.notifications).toEqual([ORDINARY_NO_REPLY_WAKE])
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given checkpoint progress is mixed with an ordinary noReply notification #when accepted #then the whole wake retains recovery tracking", async () => {
+    // given
+    const { notifier } = createNotifier()
+    const sessionID = "parent-mixed-noreply"
+    notifier.queueLatestParentWake({ sessionID, notification: LATEST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+    notifier.queuePendingParentWake(sessionID, ORDINARY_NO_REPLY_WAKE, {}, false)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      expect(notifier.getDispatchedParentWakes().get(sessionID)?.notifications).toEqual([
+        LATEST_CHECKPOINT,
+        ORDINARY_NO_REPLY_WAKE,
+      ])
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given aggregate checkpoints exceed 1 KiB #when flushed #then the exact noReply prompt is bounded and keeps newest progress", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-checkpoint-bound"
+    for (let index = 0; index < 12; index += 1) {
+      notifier.queueLatestParentWake({
+        sessionID,
+        notification: `<system-reminder>\n[MANAGED BASH CHECKPOINT]\n**Job:** job-${index}\n**Captured bytes:** ${index}\n${"x".repeat(120)}\n</system-reminder>`,
+        promptContext: {},
+        latestOnlyKey: `managed-bash:bg_task_1:att_1:job-${index}`,
+      })
+    }
+
+    try {
+      // when
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      const promptText = promptAsyncCalls[0]?.body.parts[0]?.text ?? ""
+      expect(Buffer.byteLength(promptText, "utf8")).toBeLessThanOrEqual(1_024)
+      expect(promptText).toContain("**Job:** job-11")
+      expect(promptText).not.toContain("**Job:** job-0\n")
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given an oversized ordinary wake follows checkpoint progress #when flushed #then checkpoint eviction is not undone", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-oversized-ordinary"
+    const oversizedOrdinaryWake = `<system-reminder>\n[BACKGROUND TASK RESULT READY]\n${"x".repeat(1_200)}\n</system-reminder>`
+    notifier.queueLatestParentWake({ sessionID, notification: LATEST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+    notifier.queuePendingParentWake(sessionID, oversizedOrdinaryWake, {}, false)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      const promptText = promptAsyncCalls[0]?.body.parts[0]?.text ?? ""
+      expect(promptText).toContain("[BACKGROUND TASK RESULT READY]")
+      expect(promptText).not.toContain("[MANAGED BASH CHECKPOINT]")
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given two latest-only keys reference identical text #when one key is removed #then the other reference retains the notification", () => {
+    // given
+    const { notifier } = createNotifier()
+    const sessionID = "parent-identical-checkpoints"
+    const otherKey = "managed-bash:bg_task_1:att_1:job-2"
+    notifier.queueLatestParentWake({ sessionID, notification: LATEST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+    notifier.queueLatestParentWake({ sessionID, notification: LATEST_CHECKPOINT, promptContext: {}, latestOnlyKey: otherKey })
+
+    try {
+      // when
+      notifier.removeLatestParentWakes(sessionID, [LATEST_ONLY_KEY])
+
+      // then
+      expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([LATEST_CHECKPOINT])
+      expect(notifier.getPendingParentWakes().get(sessionID)?.latestOnlyNotifications?.has(otherKey)).toBe(true)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a dispatched wake has identical text under two keys #when one key is removed #then recovery tracking retains the other reference", () => {
+    // given
+    const tracker = new ParentWakeDispatchedTracker({
+      failureRequeueWindowMs: 5_000,
+      onFailureRequeueWindowElapsed: () => {},
+    })
+    const sessionID = "parent-dispatched-identical-checkpoints"
+    const otherKey = "managed-bash:bg_task_1:att_1:job-2"
+    tracker.trackWake(sessionID, {
+      promptContext: {},
+      notifications: [LATEST_CHECKPOINT],
+      latestOnlyNotifications: new Map([
+        [LATEST_ONLY_KEY, LATEST_CHECKPOINT],
+        [otherKey, LATEST_CHECKPOINT],
+      ]),
+      shouldReply: false,
+    }, Date.now())
+
+    try {
+      // when
+      tracker.removeLatestOnlyNotifications(sessionID, [LATEST_ONLY_KEY])
+
+      // then
+      expect(tracker.getWake(sessionID)?.notifications).toEqual([LATEST_CHECKPOINT])
+      expect(tracker.getWake(sessionID)?.latestOnlyNotifications?.has(otherKey)).toBe(true)
+    } finally {
+      tracker.shutdown()
+    }
+  })
+
+  test("#given an old noReply checkpoint is pending #when a reply-required final wake is merged #then reply safety timing starts at escalation", () => {
+    // given
+    const { notifier } = createNotifier()
+    const sessionID = "parent-reply-escalation"
+    notifier.queueLatestParentWake({ sessionID, notification: LATEST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+    const pendingWake = notifier.getPendingParentWakes().get(sessionID)
+    if (!pendingWake) throw new Error("expected pending wake")
+    pendingWake.queuedAt = Date.now() - 120_000
+    pendingWake.noReplyAdmittedAt = 1
+    pendingWake.toolCallDeferralStartedAt = 2
+    pendingWake.noAssistantOutputRetryCount = 1
+    const escalatedAt = Date.now()
+
+    try {
+      // when
+      notifier.queuePendingParentWake(sessionID, FINAL_WAKE, {}, true)
+
+      // then
+      const escalatedWake = notifier.getPendingParentWakes().get(sessionID)
+      expect(escalatedWake?.queuedAt).toBeGreaterThanOrEqual(escalatedAt)
+      expect(escalatedWake?.noReplyAdmittedAt).toBeUndefined()
+      expect(escalatedWake?.toolCallDeferralStartedAt).toBeUndefined()
+      expect(escalatedWake?.noAssistantOutputRetryCount).toBeUndefined()
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given an older checkpoint is requeued after dispatch failure #when a newer checkpoint is already pending #then requeue preserves only the newer checkpoint", async () => {
+    // given
+    let rejectDispatch = (_error: Error): void => {}
+    let markDispatchStarted = (): void => {}
+    const dispatchStarted = new Promise<void>((resolve) => {
+      markDispatchStarted = resolve
+    })
+    const dispatchResult = new Promise<unknown>((_resolve, reject) => {
+      rejectDispatch = reject
+    })
+    const { notifier } = createNotifier(async () => {
+      markDispatchStarted()
+      return dispatchResult
+    })
+    const sessionID = "parent-checkpoint-requeue"
+    notifier.queueLatestParentWake({ sessionID, notification: FIRST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+    const flush = notifier.flushPendingParentWake(sessionID)
+    await dispatchStarted
+
+    try {
+      // when
+      notifier.queueLatestParentWake({ sessionID, notification: LATEST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+      rejectDispatch(new Error("dispatch failed"))
+      await flush
+
+      // then
+      expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([LATEST_CHECKPOINT])
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given pending checkpoint keys from a failed attempt #when retry purges the attempt #then stale progress is removed", () => {
+    // given
+    const { notifier } = createNotifier()
+    const sessionID = "parent-checkpoint-retry"
+    notifier.queueLatestParentWake({ sessionID, notification: FIRST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+
+    try {
+      // when
+      notifier.removeLatestParentWakes(sessionID, [LATEST_ONLY_KEY])
+
+      // then
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a checkpoint is pending #when a final task wake is queued #then final supersedes checkpoint progress", () => {
+    // given
+    const { notifier } = createNotifier()
+    const sessionID = "parent-final-supersedes-checkpoint"
+    notifier.queueLatestParentWake({ sessionID, notification: FIRST_CHECKPOINT, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+
+    try {
+      // when
+      notifier.queuePendingParentWake(sessionID, FINAL_WAKE, {}, true)
+
+      // then
+      expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([FINAL_WAKE])
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given terminal checkpoint progress is pending #when a final task wake is queued #then final still supersedes terminal progress", () => {
+    // given
+    const { notifier } = createNotifier()
+    const sessionID = "parent-final-supersedes-terminal-checkpoint"
+    const terminalCheckpoint = "<system-reminder>\n[MANAGED BASH CHECKPOINT]\n**Status:** succeeded\n</system-reminder>"
+    notifier.queueLatestParentWake({ sessionID, notification: terminalCheckpoint, promptContext: {}, latestOnlyKey: LATEST_ONLY_KEY })
+
+    try {
+      // when
+      notifier.queuePendingParentWake(sessionID, FINAL_WAKE, {}, true)
+
+      // then
+      expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([FINAL_WAKE])
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, test } from "bun:test"
+import {
+  ManagedBashCheckpointObserver,
+  formatManagedBashCheckpointNotification,
+  parseManagedBashCheckpoint,
+} from "./managed-bash-checkpoint"
+
+const CHECKPOINT = {
+  schema_version: 1,
+  event: "wait_checkpoint",
+  job_id: "job-1",
+  status: "running",
+  captured_bytes: 8_192,
+  start_cursor_bytes: 4_096,
+  next_cursor_bytes: 8_192,
+  finished_at_unix_ms: 1_785_081_600_000,
+} as const
+
+const SCOPE = {
+  taskID: "bg_task_1",
+  attemptID: "att_1",
+} as const
+
+describe("managed-bash checkpoint parsing", () => {
+  test("#given a closed v1 running checkpoint #when parsed #then its bounded fields are retained", () => {
+    // given / when
+    const checkpoint = parseManagedBashCheckpoint(CHECKPOINT)
+
+    // then
+    expect(checkpoint).toEqual(CHECKPOINT)
+  })
+
+  test.each([
+    ["unknown schema", { ...CHECKPOINT, schema_version: 2 }],
+    ["unknown event", { ...CHECKPOINT, event: "job_progress" }],
+    ["unknown status", { ...CHECKPOINT, status: "paused" }],
+    ["unknown field", { ...CHECKPOINT, output: "secret log text" }],
+    ["invalid cursor order", { ...CHECKPOINT, next_cursor_bytes: 9_000 }],
+    ["invalid job id", { ...CHECKPOINT, job_id: "job id" }],
+  ])("#given %s payload #when parsed #then it is rejected", (_name, payload) => {
+    // given / when / then
+    expect(parseManagedBashCheckpoint(payload)).toBeUndefined()
+  })
+
+  test.each([
+    "running",
+    "succeeded",
+    "nonzero_exit",
+    "signal_exit",
+    "cancelled",
+    "hard_timeout",
+    "output_limit",
+    "runner_lost",
+  ] as const)("#given producer status %s #when parsed and formatted #then the actual status is retained", (status) => {
+    // given
+    const payload = { ...CHECKPOINT, status }
+
+    // when
+    const checkpoint = parseManagedBashCheckpoint(payload)
+    const notification = checkpoint && formatManagedBashCheckpointNotification(checkpoint, SCOPE.taskID)
+
+    // then
+    expect(checkpoint?.status).toBe(status)
+    expect(notification).toContain(`**Status:** ${status}`)
+  })
+
+  test("#given every bounded field is at its schema maximum #when parsed #then the valid payload remains within 512 bytes", () => {
+    // given
+    const payload = {
+      ...CHECKPOINT,
+      job_id: "j".repeat(64),
+      captured_bytes: 104_857_600,
+      start_cursor_bytes: 104_857_600,
+      next_cursor_bytes: 104_857_600,
+      finished_at_unix_ms: Number.MAX_SAFE_INTEGER,
+    }
+
+    // when / then
+    expect(Buffer.byteLength(JSON.stringify(payload), "utf8")).toBeLessThanOrEqual(512)
+    expect(parseManagedBashCheckpoint(payload)).toEqual(payload)
+  })
+})
+
+describe("ManagedBashCheckpointObserver", () => {
+  test("#given a current-attempt managed_bash wait call #when success carries a checkpoint #then it is correlated and accepted", () => {
+    // given
+    const observer = new ManagedBashCheckpointObserver()
+    observer.observeCalled({
+      sessionID: "ses-child",
+      callID: "call-1",
+      tool: "managed_bash",
+      input: { action: "wait", job_id: "job-1" },
+    }, SCOPE)
+
+    // when
+    const observation = observer.observeSuccess({
+      sessionID: "ses-child",
+      callID: "call-1",
+      structured: { managed_bash_checkpoint: CHECKPOINT },
+    }, SCOPE)
+
+    // then
+    expect(observation?.checkpoint).toEqual(CHECKPOINT)
+    expect(observation?.latestOnlyKey).toBe("managed-bash:bg_task_1:att_1:job-1")
+  })
+
+  test("#given a persisted completed managed_bash wait part #when observed without a success event #then it is accepted as fallback", () => {
+    // given
+    const observer = new ManagedBashCheckpointObserver()
+
+    // when
+    const observation = observer.observeCompletedPart({
+      sessionID: "ses-child",
+      part: {
+        type: "tool",
+        callID: "call-1",
+        tool: "managed_bash",
+        state: {
+          status: "completed",
+          input: { action: "wait", job_id: "job-1" },
+          metadata: { managed_bash_checkpoint: CHECKPOINT },
+        },
+      },
+    }, SCOPE)
+
+    // then
+    expect(observation?.checkpoint.job_id).toBe("job-1")
+  })
+
+  test("#given success and completed-part forms contain the same checkpoint #when both are observed #then the fallback is deduplicated", () => {
+    // given
+    const observer = new ManagedBashCheckpointObserver()
+    observer.observeCalled({
+      sessionID: "ses-child",
+      callID: "call-1",
+      tool: "managed_bash",
+      input: { action: "wait" },
+    }, SCOPE)
+    const success = observer.observeSuccess({
+      sessionID: "ses-child",
+      callID: "call-1",
+      structured: { managed_bash_checkpoint: CHECKPOINT },
+    }, SCOPE)
+
+    // when
+    const fallback = observer.observeCompletedPart({
+      sessionID: "ses-child",
+      part: {
+        type: "tool",
+        callID: "call-1",
+        tool: "managed_bash",
+        state: {
+          status: "completed",
+          input: { action: "wait" },
+          metadata: { managed_bash_checkpoint: CHECKPOINT },
+        },
+      },
+    }, SCOPE)
+
+    // then
+    expect(success).toBeDefined()
+    expect(fallback).toBeUndefined()
+  })
+
+  test("#given a newer checkpoint was accepted #when a delayed completed-part fallback carries older cursors #then it cannot replace current progress", () => {
+    // given
+    const observer = new ManagedBashCheckpointObserver()
+    const newerCheckpoint = {
+      ...CHECKPOINT,
+      captured_bytes: 12_288,
+      start_cursor_bytes: 8_192,
+      next_cursor_bytes: 12_288,
+    }
+    observer.observeCalled({
+      sessionID: "ses-child",
+      callID: "call-new",
+      tool: "managed_bash",
+      input: { action: "wait" },
+    }, SCOPE)
+    const current = observer.observeSuccess({
+      sessionID: "ses-child",
+      callID: "call-new",
+      structured: { managed_bash_checkpoint: newerCheckpoint },
+    }, SCOPE)
+
+    // when
+    const delayedFallback = observer.observeCompletedPart({
+      sessionID: "ses-child",
+      part: {
+        type: "tool",
+        tool: "managed_bash",
+        state: {
+          status: "completed",
+          input: { action: "wait" },
+          metadata: { managed_bash_checkpoint: CHECKPOINT },
+        },
+      },
+    }, SCOPE)
+
+    // then
+    expect(current?.checkpoint).toEqual(newerCheckpoint)
+    expect(delayedFallback).toBeUndefined()
+  })
+
+  test.each([
+    ["wrong tool", "bash", { action: "wait" }],
+    ["wrong action", "managed_bash", { action: "status" }],
+  ])("#given a %s call #when success carries checkpoint-shaped metadata #then it is ignored", (_name, tool, input) => {
+    // given
+    const observer = new ManagedBashCheckpointObserver()
+    observer.observeCalled({ sessionID: "ses-child", callID: "call-1", tool, input }, SCOPE)
+
+    // when
+    const observation = observer.observeSuccess({
+      sessionID: "ses-child",
+      callID: "call-1",
+      structured: { managed_bash_checkpoint: CHECKPOINT },
+    }, SCOPE)
+
+    // then
+    expect(observation).toBeUndefined()
+  })
+
+  test("#given a call belongs to an earlier attempt #when its success arrives under the current scope #then it is ignored", () => {
+    // given
+    const observer = new ManagedBashCheckpointObserver()
+    observer.observeCalled({
+      sessionID: "ses-old",
+      callID: "call-1",
+      tool: "managed_bash",
+      input: { action: "wait" },
+    }, { taskID: SCOPE.taskID, attemptID: "att_old" })
+
+    // when
+    const observation = observer.observeSuccess({
+      sessionID: "ses-old",
+      callID: "call-1",
+      structured: { managed_bash_checkpoint: CHECKPOINT },
+    }, SCOPE)
+
+    // then
+    expect(observation).toBeUndefined()
+  })
+
+  test("#given an accepted attempt has checkpoint replacement keys #when the attempt is purged for retry #then all stale keys are returned once", () => {
+    // given
+    const observer = new ManagedBashCheckpointObserver()
+    const part = (jobID: string, callID: string) => ({
+      sessionID: "ses-child",
+      part: {
+        type: "tool",
+        callID,
+        tool: "managed_bash",
+        state: {
+          status: "completed",
+          input: { action: "wait" },
+          metadata: { managed_bash_checkpoint: { ...CHECKPOINT, job_id: jobID } },
+        },
+      },
+    })
+    observer.observeCompletedPart(part("job-1", "call-1"), SCOPE)
+    observer.observeCompletedPart(part("job-2", "call-2"), SCOPE)
+
+    // when
+    const removedKeys = observer.purgeAttempt(SCOPE)
+
+    // then
+    expect(removedKeys).toEqual([
+      "managed-bash:bg_task_1:att_1:job-1",
+      "managed-bash:bg_task_1:att_1:job-2",
+    ])
+    expect(observer.purgeAttempt(SCOPE)).toEqual([])
+  })
+
+  test("#given observer correlation and checkpoint state #when cleared for shutdown #then no attempt state remains", () => {
+    // given
+    const observer = new ManagedBashCheckpointObserver()
+    observer.observeCompletedPart({
+      part: {
+        type: "tool",
+        tool: "managed_bash",
+        state: {
+          status: "completed",
+          input: { action: "wait" },
+          metadata: { managed_bash_checkpoint: CHECKPOINT },
+        },
+      },
+    }, SCOPE)
+    observer.observeCalled({ sessionID: "ses-child", callID: "pending-call", tool: "managed_bash", input: { action: "wait" } }, SCOPE)
+
+    // when
+    observer.clear()
+
+    // then
+    expect(observer.purgeAttempt(SCOPE)).toEqual([])
+    expect(observer.observeSuccess({ sessionID: "ses-child", callID: "pending-call", structured: { managed_bash_checkpoint: CHECKPOINT } }, SCOPE)).toBeUndefined()
+  })
+})
+
+test("#given the largest valid checkpoint #when its parent notification is formatted #then it is log-free and at most 1 KiB", () => {
+  // given
+  const checkpoint = {
+    ...CHECKPOINT,
+    job_id: "j".repeat(64),
+    captured_bytes: 104_857_600,
+    start_cursor_bytes: 104_857_599,
+    next_cursor_bytes: 104_857_600,
+    finished_at_unix_ms: Number.MAX_SAFE_INTEGER,
+  }
+
+  // when
+  const notification = formatManagedBashCheckpointNotification(checkpoint, "t".repeat(256))
+
+  // then
+  expect(Buffer.byteLength(notification, "utf8")).toBeLessThanOrEqual(1_024)
+  expect(notification).toContain("[MANAGED BASH CHECKPOINT]")
+  expect(notification).toContain("104857600")
+  expect(notification).not.toContain("output")
+  expect(notification).not.toContain("command")
+})

--- a/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint.ts
+++ b/packages/omo-opencode/src/features/background-agent/managed-bash-checkpoint.ts
@@ -1,0 +1,226 @@
+import { z } from "zod"
+import { isRecord } from "../../shared"
+
+const MAX_CHECKPOINT_BYTES = 512
+const MAX_TRACKED_ENTRIES = 256
+const MAX_PARENT_NOTIFICATION_BYTES = 1_024
+const checkpointStatusSchema = z.enum([
+  "running",
+  "succeeded",
+  "nonzero_exit",
+  "signal_exit",
+  "cancelled",
+  "hard_timeout",
+  "output_limit",
+  "runner_lost",
+])
+
+const byteCursorSchema = z.number().int().min(0).max(104_857_600)
+const checkpointSchema = z.strictObject({
+  schema_version: z.literal(1),
+  event: z.literal("wait_checkpoint"),
+  job_id: z.string().min(1).max(64).regex(/^[a-zA-Z0-9_-]+$/),
+  status: checkpointStatusSchema,
+  captured_bytes: byteCursorSchema,
+  start_cursor_bytes: byteCursorSchema,
+  next_cursor_bytes: byteCursorSchema,
+  finished_at_unix_ms: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).optional(),
+}).superRefine((checkpoint, context) => {
+  if (checkpoint.start_cursor_bytes > checkpoint.next_cursor_bytes) {
+    context.addIssue({ code: "custom", message: "start cursor exceeds next cursor" })
+  }
+  if (checkpoint.next_cursor_bytes > checkpoint.captured_bytes) {
+    context.addIssue({ code: "custom", message: "next cursor exceeds captured bytes" })
+  }
+})
+
+export type ManagedBashCheckpoint = Readonly<z.infer<typeof checkpointSchema>>
+
+export type ManagedBashCheckpointScope = {
+  readonly taskID: string
+  readonly attemptID: string
+}
+
+export type ManagedBashCheckpointObservation = {
+  readonly checkpoint: ManagedBashCheckpoint
+  readonly latestOnlyKey: string
+  readonly notification: string
+}
+
+type CorrelatedCall = {
+  readonly scope: ManagedBashCheckpointScope
+}
+
+function stringField(record: Record<string, unknown> | undefined, field: string): string | undefined {
+  const value = record?.[field]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function recordField(record: Record<string, unknown> | undefined, field: string): Record<string, unknown> | undefined {
+  const value = record?.[field]
+  return isRecord(value) ? value : undefined
+}
+
+function scopeKey(scope: ManagedBashCheckpointScope): string {
+  return `${scope.taskID}:${scope.attemptID}`
+}
+
+function callKey(sessionID: string, callID: string): string {
+  return `${sessionID}:${callID}`
+}
+
+function scopesMatch(left: ManagedBashCheckpointScope, right: ManagedBashCheckpointScope): boolean {
+  return left.taskID === right.taskID && left.attemptID === right.attemptID
+}
+
+function trimOldestEntry<K, V>(entries: Map<K, V>): void {
+  if (entries.size < MAX_TRACKED_ENTRIES) return
+  const oldestKey = entries.keys().next().value
+  if (oldestKey !== undefined) entries.delete(oldestKey)
+}
+
+export function parseManagedBashCheckpoint(value: unknown): ManagedBashCheckpoint | undefined {
+  const parsed = checkpointSchema.safeParse(value)
+  if (!parsed.success) return undefined
+  if (Buffer.byteLength(JSON.stringify(parsed.data), "utf8") > MAX_CHECKPOINT_BYTES) return undefined
+  return parsed.data
+}
+
+export function formatManagedBashCheckpointNotification(
+  checkpoint: ManagedBashCheckpoint,
+  taskID: string,
+): string {
+  const finishedLine = checkpoint.finished_at_unix_ms === undefined
+    ? ""
+    : `\n**Observed timestamp:** ${checkpoint.finished_at_unix_ms}`
+  const notification = `<system-reminder>
+[MANAGED BASH CHECKPOINT]
+**Task:** \`${taskID.slice(0, 128)}\`
+**Job:** \`${checkpoint.job_id}\`
+**Status:** ${checkpoint.status}
+**Captured bytes:** ${checkpoint.captured_bytes}
+**Cursor:** ${checkpoint.start_cursor_bytes} -> ${checkpoint.next_cursor_bytes}${finishedLine}
+The child task remains responsible for this managed job.
+</system-reminder>`
+  if (Buffer.byteLength(notification, "utf8") > MAX_PARENT_NOTIFICATION_BYTES) {
+    return `<system-reminder>\n[MANAGED BASH CHECKPOINT]\n**Job:** \`${checkpoint.job_id}\`\n**Status:** ${checkpoint.status}\n</system-reminder>`
+  }
+  return notification
+}
+
+export class ManagedBashCheckpointObserver {
+  private readonly calls = new Map<string, CorrelatedCall>()
+  private readonly fingerprintsByAttempt = new Map<string, Set<string>>()
+  private readonly latestKeysByAttempt = new Map<string, Set<string>>()
+  private readonly latestCheckpointByKey = new Map<string, ManagedBashCheckpoint>()
+
+  observeCalled(properties: unknown, scope: ManagedBashCheckpointScope): void {
+    const props = isRecord(properties) ? properties : undefined
+    const sessionID = stringField(props, "sessionID")
+    const callID = stringField(props, "callID")
+    const input = recordField(props, "input")
+    if (!sessionID || !callID) return
+    if (stringField(props, "tool") !== "managed_bash" || stringField(input, "action") !== "wait") return
+
+    trimOldestEntry(this.calls)
+    this.calls.set(callKey(sessionID, callID), { scope })
+  }
+
+  observeSuccess(
+    properties: unknown,
+    scope: ManagedBashCheckpointScope,
+  ): ManagedBashCheckpointObservation | undefined {
+    const props = isRecord(properties) ? properties : undefined
+    const sessionID = stringField(props, "sessionID")
+    const callID = stringField(props, "callID")
+    if (!sessionID || !callID) return undefined
+
+    const key = callKey(sessionID, callID)
+    const call = this.calls.get(key)
+    this.calls.delete(key)
+    if (!call || !scopesMatch(call.scope, scope)) return undefined
+
+    return this.acceptCheckpoint(
+      recordField(props, "structured")?.managed_bash_checkpoint,
+      scope,
+    )
+  }
+
+  observeCompletedPart(
+    properties: unknown,
+    scope: ManagedBashCheckpointScope,
+  ): ManagedBashCheckpointObservation | undefined {
+    const props = isRecord(properties) ? properties : undefined
+    const part = recordField(props, "part") ?? props
+    const state = recordField(part, "state")
+    if (stringField(part, "type") !== "tool" || stringField(part, "tool") !== "managed_bash") return undefined
+    if (stringField(state, "status") !== "completed") return undefined
+    if (stringField(recordField(state, "input"), "action") !== "wait") return undefined
+
+    return this.acceptCheckpoint(
+      recordField(state, "metadata")?.managed_bash_checkpoint,
+      scope,
+    )
+  }
+
+  purgeAttempt(scope: ManagedBashCheckpointScope): readonly string[] {
+    const attemptKey = scopeKey(scope)
+    for (const [key, call] of this.calls) {
+      if (scopesMatch(call.scope, scope)) this.calls.delete(key)
+    }
+    this.fingerprintsByAttempt.delete(attemptKey)
+    const latestKeys = [...(this.latestKeysByAttempt.get(attemptKey) ?? [])]
+    for (const latestKey of latestKeys) this.latestCheckpointByKey.delete(latestKey)
+    this.latestKeysByAttempt.delete(attemptKey)
+    return latestKeys
+  }
+
+  clear(): void {
+    this.calls.clear()
+    this.fingerprintsByAttempt.clear()
+    this.latestKeysByAttempt.clear()
+    this.latestCheckpointByKey.clear()
+  }
+
+  private acceptCheckpoint(
+    value: unknown,
+    scope: ManagedBashCheckpointScope,
+  ): ManagedBashCheckpointObservation | undefined {
+    const checkpoint = parseManagedBashCheckpoint(value)
+    if (!checkpoint) return undefined
+
+    const attemptKey = scopeKey(scope)
+    const latestOnlyKey = `managed-bash:${scope.taskID}:${scope.attemptID}:${checkpoint.job_id}`
+    const latestKeys = this.latestKeysByAttempt.get(attemptKey) ?? new Set<string>()
+    if (!latestKeys.has(latestOnlyKey) && latestKeys.size >= MAX_TRACKED_ENTRIES) return undefined
+    const previousCheckpoint = this.latestCheckpointByKey.get(latestOnlyKey)
+    if (
+      previousCheckpoint
+      && (
+        checkpoint.captured_bytes < previousCheckpoint.captured_bytes
+        || checkpoint.next_cursor_bytes < previousCheckpoint.next_cursor_bytes
+      )
+    ) {
+      return undefined
+    }
+
+    const fingerprint = JSON.stringify(checkpoint)
+    const fingerprints = this.fingerprintsByAttempt.get(attemptKey) ?? new Set<string>()
+    if (fingerprints.has(fingerprint)) return undefined
+    if (fingerprints.size >= MAX_TRACKED_ENTRIES) {
+      const oldestFingerprint = fingerprints.values().next().value
+      if (oldestFingerprint !== undefined) fingerprints.delete(oldestFingerprint)
+    }
+    fingerprints.add(fingerprint)
+    this.fingerprintsByAttempt.set(attemptKey, fingerprints)
+
+    latestKeys.add(latestOnlyKey)
+    this.latestKeysByAttempt.set(attemptKey, latestKeys)
+    this.latestCheckpointByKey.set(latestOnlyKey, checkpoint)
+    return {
+      checkpoint,
+      latestOnlyKey,
+      notification: formatManagedBashCheckpointNotification(checkpoint, scope.taskID),
+    }
+  }
+}

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -2454,6 +2454,7 @@ The task was re-queued on a fallback model after a retryable failure.
         await this.purgeManagedBashCheckpointAttempt(task, checkpointAttemptID)
       }
       this.cleanupPendingByParent(task)
+      this.updateBackgroundTaskMarker(task.parentSessionId)
       this.scheduleTaskRemoval(task.id)
       log(`[background-agent] Task cancelled via ${source} (notification skipped):`, task.id)
       return true

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -74,6 +74,10 @@ import { isEmptyNoProgressAssistantTurnInfo } from "./empty-assistant-turn"
 import { tryFallbackRetry } from "./fallback-retry-handler"
 import { messageUpdatedInfoHasParentWakeOutput } from "./message-updated-parent-wake-output"
 import {
+  ManagedBashCheckpointObserver,
+  type ManagedBashCheckpointScope,
+} from "./managed-bash-checkpoint"
+import {
   type CircuitBreakerSettings,
   detectRepetitiveToolUse,
   recordToolCall,
@@ -283,6 +287,7 @@ export class BackgroundManager {
   private cachedCircuitBreakerSettings?: CircuitBreakerSettings
   private readonly scheduledFlushSettledCounts = new Map<string, number>()
   private readonly scheduledFlushSettledWaiters = new Map<string, Array<() => void>>()
+  private readonly managedBashCheckpointObserver = new ManagedBashCheckpointObserver()
 
   constructor(config: BackgroundManagerConfig) {
     const { pluginContext, ...options } = config
@@ -1602,6 +1607,8 @@ The fallback retry session is now created and can be inspected directly.
   handleEvent(event: Event): void {
     const props = event.properties
 
+    this.handleManagedBashCheckpointEvent(event)
+
     if (event.type.startsWith(SESSION_NEXT_EVENT_PREFIX)) {
       const sessionID = resolveSessionEventID(props)
       const partInfo = resolveSessionNextPartInfo(event.type, props)
@@ -2144,6 +2151,7 @@ The fallback retry session is now created and can be inspected directly.
     source: string,
   ): Promise<boolean> {
     const previousSessionID = task.sessionId
+    const previousCheckpointAttemptID = getCurrentAttempt(task)?.attemptId ?? previousSessionID
     let retryingNotification: string | undefined
     const result = tryFallbackRetry({
       task,
@@ -2173,6 +2181,9 @@ The task was re-queued on a fallback model after a retryable failure.
       },
     })
     const retried = await result
+    if (retried && previousCheckpointAttemptID) {
+      await this.purgeManagedBashCheckpointAttempt(task, previousCheckpointAttemptID)
+    }
     if (retried && retryingNotification) {
       const parentPromptContext = await this.resolveParentWakePromptContext(task)
       this.queuePendingParentWake(
@@ -2438,6 +2449,10 @@ The task was re-queued on a fallback model after a retryable failure.
     }
 
     if (options?.skipNotification) {
+      const checkpointAttemptID = task.currentAttemptID ?? task.sessionId
+      if (checkpointAttemptID) {
+        await this.purgeManagedBashCheckpointAttempt(task, checkpointAttemptID)
+      }
       this.cleanupPendingByParent(task)
       this.scheduleTaskRemoval(task.id)
       log(`[background-agent] Task cancelled via ${source} (notification skipped):`, task.id)
@@ -2668,55 +2683,60 @@ The task was re-queued on a fallback model after a retryable failure.
       completedTasks,
     })
 
-      if (this.enableParentSessionNotifications) {
-        const parentPromptContext = await this.resolveParentWakePromptContext(task)
+    const checkpointAttemptID = task.currentAttemptID ?? task.sessionId
+    if (checkpointAttemptID) {
+      this.purgeManagedBashCheckpointAttemptAlreadySerialized(task, checkpointAttemptID)
+    }
 
-        log("[background-agent] notifyParentSession context:", {
+    if (this.enableParentSessionNotifications) {
+      const parentPromptContext = await this.resolveParentWakePromptContext(task)
+
+      log("[background-agent] notifyParentSession context:", {
+        taskId: task.id,
+        resolvedAgent: parentPromptContext.agent,
+        resolvedModel: parentPromptContext.model,
+      })
+
+      const isTaskFailure = task.status === "error" || task.status === "cancelled" || task.status === "interrupt"
+      const shouldReply = allComplete || isTaskFailure
+
+      const shouldDeferNotification = await this.isSessionActive(task.parentSessionId)
+
+      if (shouldDeferNotification) {
+        this.queuePendingParentWake(
+          task.parentSessionId,
+          notification,
+          parentPromptContext,
+          shouldReply,
+          PENDING_PARENT_WAKE_DEBOUNCE_MS,
+        )
+        log("[background-agent] Queued notification while parent session is active:", {
           taskId: task.id,
-          resolvedAgent: parentPromptContext.agent,
-          resolvedModel: parentPromptContext.model,
+          allComplete,
+          isTaskFailure,
+          shouldReply,
         })
-
-        const isTaskFailure = task.status === "error" || task.status === "cancelled" || task.status === "interrupt"
-        const shouldReply = allComplete || isTaskFailure
-
-        const shouldDeferNotification = await this.isSessionActive(task.parentSessionId)
-
-        if (shouldDeferNotification) {
-          this.queuePendingParentWake(
-            task.parentSessionId,
-            notification,
-            parentPromptContext,
-            shouldReply,
-            PENDING_PARENT_WAKE_DEBOUNCE_MS,
-          )
-          log("[background-agent] Queued notification while parent session is active:", {
-            taskId: task.id,
-            allComplete,
-            isTaskFailure,
-            shouldReply,
-          })
-        } else {
-          this.queuePendingParentWake(
-            task.parentSessionId,
-            notification,
-            parentPromptContext,
-            shouldReply,
-            PENDING_PARENT_WAKE_DEBOUNCE_MS,
-          )
-          log("[background-agent] Queued notification for short-debounce flush to idle parent:", {
-            taskId: task.id,
-            allComplete,
-            isTaskFailure,
-            shouldReply,
-          })
-        }
       } else {
-        log("[background-agent] Parent session notifications disabled, skipping prompt injection:", {
+        this.queuePendingParentWake(
+          task.parentSessionId,
+          notification,
+          parentPromptContext,
+          shouldReply,
+          PENDING_PARENT_WAKE_DEBOUNCE_MS,
+        )
+        log("[background-agent] Queued notification for short-debounce flush to idle parent:", {
           taskId: task.id,
-          parentSessionID: task.parentSessionId,
+          allComplete,
+          isTaskFailure,
+          shouldReply,
         })
       }
+    } else {
+      log("[background-agent] Parent session notifications disabled, skipping prompt injection:", {
+        taskId: task.id,
+        parentSessionID: task.parentSessionId,
+      })
+    }
 
     if (task.status !== "running" && task.status !== "pending") {
       this.scheduleTaskRemoval(task.id)
@@ -2842,6 +2862,71 @@ The task was re-queued on a fallback model after a retryable failure.
   ): void {
     this.parentWakeNotifier.queuePendingParentWake(sessionID, notification, promptContext, shouldReply, delayMs)
     this.updateBackgroundTaskMarker(sessionID)
+  }
+
+  private queueLatestParentWake(input: {
+    readonly sessionID: string
+    readonly notification: string
+    readonly promptContext: ParentWakePromptContext
+    readonly latestOnlyKey: string
+  }): void {
+    this.parentWakeNotifier.queueLatestParentWake({
+      ...input,
+      delayMs: PENDING_PARENT_WAKE_DEBOUNCE_MS,
+    })
+    this.updateBackgroundTaskMarker(input.sessionID)
+  }
+
+  private handleManagedBashCheckpointEvent(event: Event): void {
+    if (!this.enableParentSessionNotifications) return
+    if (
+      event.type !== "session.next.tool.called"
+      && event.type !== "session.next.tool.success"
+      && event.type !== "message.part.updated"
+    ) return
+
+    const sessionID = event.type === "message.part.updated"
+      ? resolveMessageEventSessionID(event.properties)
+      : resolveSessionEventID(event.properties)
+    if (!sessionID) return
+    const resolved = this.resolveTaskAttemptBySession(sessionID)
+    if (!resolved?.isCurrent || resolved.task.status !== "running") return
+
+    const scope: ManagedBashCheckpointScope = {
+      taskID: resolved.task.id,
+      attemptID: resolved.attemptID ?? resolved.task.currentAttemptID ?? sessionID,
+    }
+    if (event.type === "session.next.tool.called") {
+      this.managedBashCheckpointObserver.observeCalled(event.properties, scope)
+      return
+    }
+
+    const observation = event.type === "session.next.tool.success"
+      ? this.managedBashCheckpointObserver.observeSuccess(event.properties, scope)
+      : this.managedBashCheckpointObserver.observeCompletedPart(event.properties, scope)
+    if (!observation) return
+
+    this.queueLatestParentWake({
+      sessionID: resolved.task.parentSessionId,
+      notification: observation.notification,
+      promptContext: {
+        ...(resolved.task.parentAgent ? { agent: resolved.task.parentAgent } : {}),
+        ...(resolved.task.parentModel ? { model: resolved.task.parentModel } : {}),
+        ...(resolved.task.parentTools ? { tools: resolved.task.parentTools } : {}),
+      },
+      latestOnlyKey: observation.latestOnlyKey,
+    })
+  }
+
+  private purgeManagedBashCheckpointAttempt(task: BackgroundTask, attemptID: string): Promise<void> {
+    return this.enqueueNotificationForParent(task.parentSessionId, async () => {
+      this.purgeManagedBashCheckpointAttemptAlreadySerialized(task, attemptID)
+    })
+  }
+
+  private purgeManagedBashCheckpointAttemptAlreadySerialized(task: BackgroundTask, attemptID: string): void {
+    const keys = this.managedBashCheckpointObserver.purgeAttempt({ taskID: task.id, attemptID })
+    if (keys.length > 0) this.parentWakeNotifier.removeLatestParentWakes(task.parentSessionId, keys)
   }
 
   private async flushPendingParentWake(sessionID: string): Promise<void> {
@@ -3178,6 +3263,7 @@ The task was re-queued on a fallback model after a retryable failure.
     this.idleDeferralTimers.clear()
 
     this.parentWakeNotifier.shutdown()
+    this.managedBashCheckpointObserver.clear()
 
     for (const sessionID of trackedSessionIDs) {
       subagentSessions.delete(sessionID)

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
@@ -10,6 +10,7 @@ export type ParentWakePromptContext = {
 export type PendingParentWake = {
   promptContext: ParentWakePromptContext
   notifications: string[]
+  latestOnlyNotifications?: Map<string, string>
   shouldReply: boolean
   queuedAt?: number
   dispatchedAt?: number
@@ -34,6 +35,9 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
   return {
     promptContext,
     notifications: [...wake.notifications],
+    ...(wake.latestOnlyNotifications
+      ? { latestOnlyNotifications: new Map(wake.latestOnlyNotifications) }
+      : {}),
     shouldReply: wake.shouldReply,
     ...(wake.queuedAt !== undefined ? { queuedAt: wake.queuedAt } : {}),
     ...(wake.dispatchedAt !== undefined ? { dispatchedAt: wake.dispatchedAt } : {}),
@@ -63,6 +67,7 @@ export function mergeParentWakeNotifications(existingNotifications: readonly str
       ...existingNotifications.filter((notification) =>
         notification !== nextNotification
         && !isBackgroundTaskProgressNotification(notification)
+        && !isManagedBashCheckpointNotification(notification)
       ),
     ]
   }
@@ -72,13 +77,17 @@ export function mergeParentWakeNotifications(existingNotifications: readonly str
   }
 
   if (
-    isBackgroundTaskProgressNotification(nextNotification)
+    (isBackgroundTaskProgressNotification(nextNotification) || isManagedBashCheckpointNotification(nextNotification))
     && existingNotifications.some(isFinalBackgroundTaskNotification)
   ) {
     return [...existingNotifications]
   }
 
   return [...existingNotifications, nextNotification]
+}
+
+export function isManagedBashCheckpointNotification(notification: string): boolean {
+  return getSystemReminderHeaderLines(notification).includes("[MANAGED BASH CHECKPOINT]")
 }
 
 function parentWakePromptContextMatches(left: PendingParentWake, right: PendingParentWake): boolean {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dispatched-tracker.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dispatched-tracker.ts
@@ -85,6 +85,20 @@ export class ParentWakeDispatchedTracker {
     this.dispatchedParentWakes.delete(sessionID)
   }
 
+  removeLatestOnlyNotifications(sessionID: string, keys: readonly string[]): void {
+    const wake = this.dispatchedParentWakes.get(sessionID)
+    if (!wake?.latestOnlyNotifications) return
+    for (const key of keys) {
+      const notification = wake.latestOnlyNotifications.get(key)
+      wake.latestOnlyNotifications.delete(key)
+      if (notification !== undefined && ![...wake.latestOnlyNotifications.values()].includes(notification)) {
+        wake.notifications = wake.notifications.filter((candidate) => candidate !== notification)
+      }
+    }
+    if (wake.latestOnlyNotifications.size === 0) delete wake.latestOnlyNotifications
+    if (wake.notifications.length === 0) this.clearWake(sessionID)
+  }
+
   trackWake(sessionID: string, wake: PendingParentWake, dispatchedAt: number): void {
     this.clearWake(sessionID)
     const dispatchedWake = cloneParentWake(wake)

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
@@ -15,6 +15,14 @@ import {
 
 export type { ParentWakePromptContext, PendingParentWake } from "./parent-wake-dedupe"
 
+type LatestParentWakeInput = {
+  readonly sessionID: string
+  readonly notification: string
+  readonly promptContext: ParentWakePromptContext
+  readonly latestOnlyKey: string
+  readonly delayMs?: number
+}
+
 export class ParentWakeNotifier {
   private readonly pendingQueue: ParentWakePendingQueue
   private readonly dispatchedTracker: ParentWakeDispatchedTracker
@@ -114,6 +122,16 @@ export class ParentWakeNotifier {
   ): void {
     this.pendingQueue.queueWake(sessionID, notification, promptContext, shouldReply)
     this.schedulePendingParentWakeFlush(sessionID, delayMs)
+  }
+
+  queueLatestParentWake(input: LatestParentWakeInput): void {
+    this.pendingQueue.queueLatestWake({ ...input, shouldReply: false })
+    this.schedulePendingParentWakeFlush(input.sessionID, input.delayMs)
+  }
+
+  removeLatestParentWakes(sessionID: string, keys: readonly string[]): void {
+    this.pendingQueue.removeLatestOnlyNotifications(sessionID, keys)
+    this.dispatchedTracker.removeLatestOnlyNotifications(sessionID, keys)
   }
 
   async flushPendingParentWake(sessionID: string): Promise<void> {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -16,6 +16,18 @@ type ParentWakePendingQueueOptions = {
   ) => Promise<void>
 }
 
+type LatestParentWake = {
+  readonly sessionID: string
+  readonly notification: string
+  readonly promptContext: ParentWakePromptContext
+  readonly shouldReply: boolean
+  readonly latestOnlyKey: string
+}
+
+type ParentWakeToStore = Omit<LatestParentWake, "latestOnlyKey"> & {
+  readonly latestOnlyKey?: string
+}
+
 export class ParentWakePendingQueue {
   private pendingParentWakes: Map<string, PendingParentWake> = new Map()
   private pendingParentWakeTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
@@ -48,17 +60,46 @@ export class ParentWakePendingQueue {
     promptContext: ParentWakePromptContext,
     shouldReply: boolean,
   ): void {
+    this.storeWake({ sessionID, notification, promptContext, shouldReply })
+  }
+
+  queueLatestWake(wake: LatestParentWake): void {
+    this.storeWake(wake)
+  }
+
+  private storeWake(wake: ParentWakeToStore): void {
+    const { sessionID, notification, promptContext, shouldReply, latestOnlyKey } = wake
     const now = Date.now()
     const resolvedPromptContext = resolveParentWakePromptContext(promptContext)
     const pendingWake = this.pendingParentWakes.get(sessionID)
     if (pendingWake) {
       pendingWake.queuedAt ??= now
-      const mergedNotifications = mergeParentWakeNotifications(pendingWake.notifications, notification)
+      const replyEscalated = !pendingWake.shouldReply && shouldReply
+      const previousLatest = latestOnlyKey
+        ? pendingWake.latestOnlyNotifications?.get(latestOnlyKey)
+        : undefined
+      let notificationsWithoutPrevious = pendingWake.notifications
+      if (latestOnlyKey && previousLatest !== undefined && previousLatest !== notification) {
+        notificationsWithoutPrevious = this.removeLatestOnlyReference(pendingWake, latestOnlyKey)
+      }
+      const mergedNotifications = mergeParentWakeNotifications(notificationsWithoutPrevious, notification)
       const notificationsChanged = mergedNotifications.length !== pendingWake.notifications.length
         || mergedNotifications.some((merged, index) => merged !== pendingWake.notifications[index])
       pendingWake.notifications = mergedNotifications
+      if (latestOnlyKey && mergedNotifications.includes(notification)) {
+        pendingWake.latestOnlyNotifications ??= new Map()
+        pendingWake.latestOnlyNotifications.set(latestOnlyKey, notification)
+      }
+      this.pruneLatestOnlyNotifications(pendingWake)
       pendingWake.promptContext = resolvedPromptContext
       pendingWake.shouldReply = pendingWake.shouldReply || shouldReply
+      if (replyEscalated) {
+        pendingWake.queuedAt = now
+        delete pendingWake.noReplyAdmittedAt
+        delete pendingWake.toolCallDeferralStartedAt
+        delete pendingWake.allowEmptyAssistantTurnRetry
+        delete pendingWake.noAssistantOutputRetryCount
+      }
       if (notificationsChanged) {
         delete pendingWake.noReplyAdmittedAt
         delete pendingWake.noAssistantOutputRetryCount
@@ -69,6 +110,7 @@ export class ParentWakePendingQueue {
     this.pendingParentWakes.set(sessionID, {
       promptContext: resolvedPromptContext,
       notifications: [notification],
+      ...(latestOnlyKey ? { latestOnlyNotifications: new Map([[latestOnlyKey, notification]]) } : {}),
       shouldReply,
       queuedAt: now,
     })
@@ -78,30 +120,70 @@ export class ParentWakePendingQueue {
     const now = Date.now()
     const pendingWake = this.pendingParentWakes.get(sessionID)
     if (pendingWake) {
+      const replyEscalated = !pendingWake.shouldReply && latestWake.shouldReply
       const existingQueuedAt = pendingWake.queuedAt ?? now
       const latestQueuedAt = latestWake.queuedAt ?? now
       pendingWake.queuedAt = Math.min(existingQueuedAt, latestQueuedAt)
-      pendingWake.notifications = pendingWake.notifications.reduce(
-        (notifications, notification) => mergeParentWakeNotifications(notifications, notification),
-        [...latestWake.notifications],
-      )
+      const latestOnlyNotifications = new Map(latestWake.latestOnlyNotifications)
+      let mergedNotifications = [...latestWake.notifications]
+      for (const [key, notification] of pendingWake.latestOnlyNotifications ?? []) {
+        const previous = latestOnlyNotifications.get(key)
+        if (previous !== undefined && previous !== notification) {
+          latestOnlyNotifications.delete(key)
+          if (![...latestOnlyNotifications.values()].includes(previous)) {
+            mergedNotifications = mergedNotifications.filter((candidate) => candidate !== previous)
+          }
+        }
+        mergedNotifications = mergeParentWakeNotifications(mergedNotifications, notification)
+        latestOnlyNotifications.set(key, notification)
+      }
+      const pendingLatestValues = new Set(pendingWake.latestOnlyNotifications?.values() ?? [])
+      for (const notification of pendingWake.notifications) {
+        if (!pendingLatestValues.has(notification)) {
+          mergedNotifications = mergeParentWakeNotifications(mergedNotifications, notification)
+        }
+      }
+      pendingWake.notifications = mergedNotifications
+      pendingWake.latestOnlyNotifications = latestOnlyNotifications
+      this.pruneLatestOnlyNotifications(pendingWake)
       pendingWake.shouldReply = pendingWake.shouldReply || latestWake.shouldReply
       pendingWake.promptContext = latestWake.promptContext
-      pendingWake.noReplyAdmittedAt ??= latestWake.noReplyAdmittedAt
-      pendingWake.toolCallDeferralStartedAt ??= latestWake.toolCallDeferralStartedAt
-      pendingWake.allowEmptyAssistantTurnRetry ||= latestWake.allowEmptyAssistantTurnRetry
-      const noAssistantOutputRetryCount = Math.max(
-        pendingWake.noAssistantOutputRetryCount ?? 0,
-        latestWake.noAssistantOutputRetryCount ?? 0,
-      )
-      if (noAssistantOutputRetryCount > 0) {
-        pendingWake.noAssistantOutputRetryCount = noAssistantOutputRetryCount
+      if (replyEscalated) {
+        pendingWake.queuedAt = now
+        delete pendingWake.noReplyAdmittedAt
+        delete pendingWake.toolCallDeferralStartedAt
+        delete pendingWake.allowEmptyAssistantTurnRetry
+        delete pendingWake.noAssistantOutputRetryCount
+      } else {
+        pendingWake.noReplyAdmittedAt ??= latestWake.noReplyAdmittedAt
+        pendingWake.toolCallDeferralStartedAt ??= latestWake.toolCallDeferralStartedAt
+        pendingWake.allowEmptyAssistantTurnRetry ||= latestWake.allowEmptyAssistantTurnRetry
+        const noAssistantOutputRetryCount = Math.max(
+          pendingWake.noAssistantOutputRetryCount ?? 0,
+          latestWake.noAssistantOutputRetryCount ?? 0,
+        )
+        if (noAssistantOutputRetryCount > 0) {
+          pendingWake.noAssistantOutputRetryCount = noAssistantOutputRetryCount
+        }
       }
       return
     }
     const clonedWake = cloneParentWake(latestWake)
     clonedWake.queuedAt ??= now
     this.pendingParentWakes.set(sessionID, clonedWake)
+  }
+
+  removeLatestOnlyNotifications(sessionID: string, keys: readonly string[]): void {
+    const wake = this.pendingParentWakes.get(sessionID)
+    if (!wake?.latestOnlyNotifications) return
+    for (const key of keys) {
+      wake.notifications = this.removeLatestOnlyReference(wake, key)
+    }
+    if (wake.latestOnlyNotifications.size === 0) delete wake.latestOnlyNotifications
+    if (wake.notifications.length === 0) {
+      this.deleteWake(sessionID)
+      this.clearTimer(sessionID)
+    }
   }
 
   scheduleFlush(sessionID: string, operation: () => Promise<void>, delayMs?: number): void {
@@ -136,5 +218,24 @@ export class ParentWakePendingQueue {
     }
     this.pendingParentWakeTimers.clear()
     this.pendingParentWakes.clear()
+  }
+
+  private pruneLatestOnlyNotifications(wake: PendingParentWake): void {
+    if (!wake.latestOnlyNotifications) return
+    const retained = new Set(wake.notifications)
+    for (const [key, notification] of wake.latestOnlyNotifications) {
+      if (!retained.has(notification)) wake.latestOnlyNotifications.delete(key)
+    }
+    if (wake.latestOnlyNotifications.size === 0) delete wake.latestOnlyNotifications
+  }
+
+  private removeLatestOnlyReference(wake: PendingParentWake, key: string): string[] {
+    const notification = wake.latestOnlyNotifications?.get(key)
+    if (notification === undefined) return wake.notifications
+    wake.latestOnlyNotifications?.delete(key)
+    if ([...(wake.latestOnlyNotifications?.values() ?? [])].includes(notification)) {
+      return wake.notifications
+    }
+    return wake.notifications.filter((candidate) => candidate !== notification)
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -8,8 +8,15 @@ import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../
 import type { PromptDispatchClient } from "../../shared/prompt-async-gate/types"
 import { getErrorText } from "./error-classifier"
 import { createEmptyAssistantTurnRetryDedupeKey } from "./parent-wake-history-state"
-import { cloneParentWake, isRedundantParentWake, type PendingParentWake } from "./parent-wake-dedupe"
+import {
+  cloneParentWake,
+  isManagedBashCheckpointNotification,
+  isRedundantParentWake,
+  type PendingParentWake,
+} from "./parent-wake-dedupe"
 import type { ToolWaitDeferralDecision } from "./parent-wake-session-history"
+
+const MAX_CHECKPOINT_PARENT_PROMPT_BYTES = 1_024
 
 type ParentWakePromptDispatchInput = {
   readonly client: PromptDispatchClient
@@ -29,7 +36,9 @@ type ParentWakePromptDispatchInput = {
 }
 
 export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput): Promise<void> {
-  const notificationContent = input.latestWake.notifications.join("\n\n")
+  const noReply = input.forceNoReply === true || !input.latestWake.shouldReply
+  const dispatchWake = createBoundedCheckpointDispatchWake(input.latestWake, noReply)
+  const promptPart = createParentWakePromptPart(dispatchWake.notifications, noReply)
   let dispatchStartedAt = Date.now()
   try {
     dispatchStartedAt = Date.now()
@@ -48,24 +57,20 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
       input: {
         path: { id: input.sessionID },
         body: {
-          noReply: input.forceNoReply === true || !input.latestWake.shouldReply,
+          noReply,
           ...input.latestWake.promptContext,
-          parts: [
-            input.forceNoReply === true || !input.latestWake.shouldReply
-              ? withInternalNoReplyMarker(createInternalAgentTextPart(notificationContent))
-              : createInternalAgentTextPart(notificationContent),
-          ],
+          parts: [promptPart],
         },
         query: { directory: input.directory },
       },
     })
     if (promptResult.status === "failed") {
       if (isAmbiguousPostDispatchPromptFailure(promptResult)) {
-        const dispatchedWake = cloneParentWake(input.latestWake)
+        const dispatchedWake = cloneParentWake(dispatchWake)
         dispatchedWake.dispatchedAt = dispatchStartedAt
         if (await input.hasRecordedPromptAfterDispatch(dispatchedWake)) {
           markRetainedNoReplyAdmission(input, dispatchStartedAt)
-          input.trackDispatchedWake(createTrackedDispatchedWake(input.latestWake, input.forceNoReply), dispatchStartedAt)
+          trackAcceptedWake(input, dispatchWake, dispatchStartedAt)
           log("[background-agent] Treated failed parent wake prompt as accepted after observing session history:", {
             sessionID: input.sessionID,
             error: promptResult.error,
@@ -102,13 +107,50 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
     log("[background-agent] Sent deferred parent wake:", { sessionID: input.sessionID })
     delete input.latestWake.allowEmptyAssistantTurnRetry
     markRetainedNoReplyAdmission(input, dispatchStartedAt)
-    input.trackDispatchedWake(createTrackedDispatchedWake(input.latestWake, input.forceNoReply), dispatchStartedAt)
+    trackAcceptedWake(input, dispatchWake, dispatchStartedAt)
   } catch (error) {
     const errorText = error instanceof Error ? `${error.name}: ${error.message}` : getErrorText(error) || String(error)
     input.requeueWake(input.latestWake)
     input.scheduleFlush()
     log("[background-agent] Failed to send deferred parent wake:", { sessionID: input.sessionID, error: errorText })
   }
+}
+
+function createParentWakePromptPart(notifications: readonly string[], noReply: boolean) {
+  const part = createInternalAgentTextPart(notifications.join("\n\n"))
+  return noReply ? withInternalNoReplyMarker(part) : part
+}
+
+function createBoundedCheckpointDispatchWake(wake: PendingParentWake, noReply: boolean): PendingParentWake {
+  const notifications = [...wake.notifications]
+  let promptPart = createParentWakePromptPart(notifications, noReply)
+  while (Buffer.byteLength(promptPart.text, "utf8") > MAX_CHECKPOINT_PARENT_PROMPT_BYTES) {
+    const checkpointIndex = notifications.findIndex(isManagedBashCheckpointNotification)
+    if (checkpointIndex === -1) break
+    notifications.splice(checkpointIndex, 1)
+    promptPart = createParentWakePromptPart(notifications, noReply)
+  }
+  if (notifications.length === wake.notifications.length) return wake
+
+  const boundedWake = cloneParentWake(wake)
+  boundedWake.notifications = notifications
+  if (boundedWake.latestOnlyNotifications) {
+    const retained = new Set(notifications)
+    for (const [key, notification] of boundedWake.latestOnlyNotifications) {
+      if (!retained.has(notification)) boundedWake.latestOnlyNotifications.delete(key)
+    }
+    if (boundedWake.latestOnlyNotifications.size === 0) delete boundedWake.latestOnlyNotifications
+  }
+  return boundedWake
+}
+
+function trackAcceptedWake(
+  input: ParentWakePromptDispatchInput,
+  wake: PendingParentWake,
+  dispatchedAt: number,
+): void {
+  if (!input.latestWake.shouldReply && wake.notifications.every(isManagedBashCheckpointNotification)) return
+  input.trackDispatchedWake(createTrackedDispatchedWake(wake, input.forceNoReply), dispatchedAt)
 }
 
 function markRetainedNoReplyAdmission(input: ParentWakePromptDispatchInput, dispatchStartedAt: number): void {


### PR DESCRIPTION
## Summary

- Forward structured `managed_bash` wait checkpoints from child sessions to their immediate parent before the child completes.
- Send bounded, log-free progress as `noReply` parent wakes while keeping managed-job ownership in the child.
- Preserve the existing parent-wake retry, active-session, completion, and polling behavior.

## Changes

- Parse the closed checkpoint v1 payload from OpenCode tool-result metadata and correlate it with the current child attempt.
- Support both `session.next.tool.success` and persisted completed-part metadata without parsing rendered output.
- Keep only the latest pending checkpoint for each task attempt and job. Reject duplicate and stale progress.
- Bound checkpoint metadata to 512 bytes and checkpoint parent prompts to 1 KiB.
- Purge pending and in-flight checkpoint state on retry, completion, silent cancellation, and shutdown.
- Let final task notifications supersede pending checkpoint progress.

## QA & Evidence

- **What was tested:** Focused checkpoint parser, manager, queue, dispatch, retry, cancellation, and marker tests.
  **Observed result:** 46 tests passed.
  **Artifact:** `.omo/evidence/20260726-managed-bash-checkpoint-v4192-handoff/`
  **Why sufficient:** Covers malformed payloads, every job status, event correlation, dedupe, bounds, in-flight failure, retry, terminal completion, and silent cancellation cleanup.

- **What was tested:** Entire `packages/omo-opencode/src/features/background-agent` suite.
  **Observed result:** 792 tests passed across 62 files.
  **Artifact:** `.omo/evidence/20260726-managed-bash-checkpoint-v4192-handoff/`
  **Why sufficient:** Exercises the existing background-task lifecycle and parent-wake behavior alongside the new path.

- **What was tested:** Isolated OpenCode 1.18.5 run with the modified OMO plugin and managed-bash producer.
  **Observed result:** 37/37 assertions passed. The parent received latest-only running and terminal `noReply` checkpoints before child completion. Final wakes contained no stale checkpoint. Polling, cursors, authorization, workspace isolation, marker cleanup, database isolation, and process cleanup passed.
  **Artifact:** `.omo/evidence/20260726-managed-bash-checkpoint-v4192-handoff/`
  **Why sufficient:** Drives the real plugin, event, prompt, session, and managed-job surfaces together.

## Risks & Residuals

- Checkpoint delivery is best-effort. Event loss does not change job state; `.managed_bash` remains authoritative.
- The parent receives no command output, workspace path, owner session, or mutation capability.
- Existing task and tool-call limits bound notification volume. A separate rate budget can be added later if operational evidence requires it.

## Automated Checks

```bash
bun test ./packages/omo-opencode/src/features/background-agent
bun run --cwd packages/omo-opencode typecheck
bun run build
```

## Related Issues

- https://github.com/k911mipt/agent-managed-bash/issues/10


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward structured `managed_bash` wait checkpoints from child sessions to their parent as latest‑only, noReply progress updates before the child completes. Preserves parent‑wake, retry, and completion behavior while bounding checkpoint payloads and prompt size. Addresses issue #10.

- **New Features**
  - Parse v1 `managed_bash` wait checkpoints from `session.next.tool.success` and persisted completed parts; correlate to the current attempt.
  - Forward latest‑only, log‑free checkpoints to the parent via `noReply` wakes; dedupe by task/attempt/job; bound metadata to 512 B and the parent prompt to 1 KiB.
  - Final task notifications supersede checkpoint progress; state pruned on retry, completion, cancellation, and shutdown.

- **Bug Fixes**
  - Prevent stale checkpoint requeues during in‑flight dispatch failures and after retries; refresh continuation marker on silent cancellation.
  - Keep recovery tracking for ordinary `noReply` wakes; skip tracking for checkpoint‑only wakes.

<sup>Written for commit 78934a20ce38e9cdaf102aacb251be4e1c6f1d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

