### PR TITLE
docs(shared-skills): index interaction-skill in the design reference directory

### DIFF
--- a/.omo/evidence/20260728-beui-interaction-skill/index-discoverability.txt
+++ b/.omo/evidence/20260728-beui-interaction-skill/index-discoverability.txt
@@ -1,0 +1,11 @@
+# _INDEX.md operating-references section (discoverability fix)
+
+RED: `rg -c 'interaction-skill' _INDEX.md` on origin/dev = 0 hits — the canonical directory (loaded by the greenfield shortlist lane and by "read the index before loading anything") never mentioned interaction-skill.md, so agents shortlisting via _INDEX could never discover it.
+GREEN: same rg = 1 hit (operating-references row); Layer A (12) and 83-file library counts unchanged (2 count lines preserved, verified by rg).
+Battery unchanged (edit is a committed designOriginal markdown file; no machine consumer reads its prose):
+
+ 72 pass
+ 0 fail
+ 613 expect() calls
+Ran 72 tests across 14 files. [1265.00ms]
+

--- a/packages/shared-skills/skills/frontend/references/design/_INDEX.md
+++ b/packages/shared-skills/skills/frontend/references/design/_INDEX.md
@@ -5,7 +5,7 @@ All reference files live flat in this directory. Three layers:
 - **Layer A — taste skills** (12 files): how to execute. Discipline, motion, spacing, anti-slop, output completeness.
 - **Layer B — design systems** (70 files): what it should look like. Brand-specific color/type/component tokens.
 
-**Phase 0 runs first** (check/create `DESIGN.md`), then most non-trivial tasks load **one Layer A + one Layer B** together. See the routing flow in the sibling `README.md`.
+**Phase 0 runs first** (check/create `DESIGN.md`), then most non-trivial tasks load **one Layer A + one Layer B** together. See the routing flow in the sibling `README.md`. Specialized phases (interaction and motion, app-shell layout, URL clones, real-product screen research) load the matching project-original operating reference — see the final section of this index.
 
 ---
 
@@ -49,6 +49,19 @@ From [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill).
 2. **`output-skill.md` and `stitch-skill.md` stack on top of any style skill.** They add discipline and output format, not visual direction.
 3. **`image-to-code-skill.md` pairs with one imagegen skill** for the full flow.
 4. **Imagegen skills are image-only.** Do not load them when the user actually wants code.
+
+---
+
+## Operating references — interaction, layout, and research workflows (project-original)
+
+Beyond the 12-file Layer A library, the design ruleset carries project-original operating references for specialized phases. They stack on the routed Layer A + Layer B pair; they never replace a style skill, and they are not counted in the library totals above.
+
+| File | Purpose | Load when |
+|---|---|---|
+| `interaction-skill.md` | Interaction mechanics anchored to the beui.dev catalog: find the nearest pattern, read its real source through the curl recipe, extract the mechanism (spring config, layout strategy, enter/exit order, reduced-motion path), and adapt it to `DESIGN.md` motion tokens. | Any work adding or changing interaction or motion — micro-interactions, animated components, transitions, gestures, hover/press/state feedback, loading/success/error morphs, "make it feel alive". |
+| `layout-skill.md` | Layout mechanics: scroll ownership, the two silent CSS contracts, named primitives, content-stress matrix. Zero visual direction. | App shells, dashboards, split panes, or a layout that breaks under real content. |
+| `lazyweb.md` | Curl-only real-product screen research for design direction. | Greenfield design research lanes. |
+| `clone-from-url.md` | Runtime extraction workflow (browser + `getComputedStyle`) for cloning a named site. | A live site or URL is the visual reference. |
 
 ---
 


### PR DESCRIPTION
## What

`_INDEX.md` — the design ruleset's canonical directory ("A combined directory of all 83 reference files... read it before loading anything" and the greenfield shortlist lane) — never mentioned `interaction-skill.md`, so agents routing through the index could never discover the interaction reference. Add an **operating references** section listing the project-original operating guides (`interaction-skill.md`, `layout-skill.md`, `lazyweb.md`, `clone-from-url.md`) with purpose + load-when, plus a head note pointing specialized phases there. Layer A taste-skill count (12) and library totals (83) are unchanged by design — these operating references stack on the Layer A + Layer B pair like `output-skill.md` does.

## Why

The #6407 routing makes interaction work load `interaction-skill.md` from SKILL.md tables, but the index is a second discovery surface (and the one the greenfield research lane is required to read). One of the two surfaces omitted it — this closes the gap and also fixes the index's false completeness claim.

## QA / evidence

- RED→GREEN: `rg -c 'interaction-skill' _INDEX.md` 0 → 1; count lines unchanged (rg-verified). Recorded in `.omo/evidence/20260728-beui-interaction-skill/index-discoverability.txt`.
- Machine seams unchanged (the edit is a committed designOriginal markdown; manifest/materialize/byte-equivalence consumers read other files): `bun test packages/shared-skills/` + loader-core extraction pin + `omo-opencode/src/shared-skills-package.test.ts` — same green battery as #6407.
- Prose ships on review per `.omo/rules/test-discipline.md` PROMPT TESTS.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Operating References section to `packages/shared-skills/skills/frontend/references/design/_INDEX.md` so `interaction-skill.md` and other project-original guides are discoverable from the canonical directory. This fixes the omission without changing Layer A (12) or library totals (83).

- **Bug Fixes**
  - Indexed `interaction-skill.md`, `layout-skill.md`, `lazyweb.md`, and `clone-from-url.md` with purpose and load-when.
  - Added a head note pointing specialized phases to this section; counts unchanged and tests remain green.

<sup>Written for commit 6b57dc1169174aee5dcf5da667fedfb4ce8e5268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

