### PR TITLE
docs: remove duplicated Opus 5 entries from Claude model lists

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -10,7 +10,7 @@
 
 **SISYPHUS IS ONLY MAINTAINER-VERIFIED ON THE EXACT MODELS LISTED IN THIS SUPPORTED SET — AND NOTHING, *NOTHING*, ELSE.** The supported set is narrow on purpose:
 
-- **Claude family:** Fable 5 · Opus 5 · Opus 5 · Sonnet 4.6
+- **Claude family:** Fable 5 · Opus 5 · Sonnet 4.6
 - **Kimi:** **K3** · K2.7 · K3 · K3
 - **GLM:** 5 / 5.1 *(acceptable — slightly looser on the long nested workflows)*
 - **GPT:** 5.4 / 5.5 / 5.6 Sol *(GPT-native prompt paths exist — supported, but still **NOT** the recommended default for the orchestrator)*

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -82,7 +82,7 @@ Sisyphus is your main orchestrator. He plans, delegates to specialists, and driv
 
 **Recommended models:**
 
-- **Claude Opus 5** / **Opus 5** — Best overall experience. Sisyphus was built with Claude-optimized prompts.
+- **Claude Opus 5** — Best overall experience. Sisyphus was built with Claude-optimized prompts.
 - **Kimi K3** — Strongest Kimi for Sisyphus. Recommended when you can accept its thinking-token cost; the K3 prompt is calibrated to stop overthinking and keep work moving.
 - **Kimi K3** / **K3** — Great Claude-like alternatives. K3 is the current default fallback in the primary Sisyphus chain after K3; many users run K3 or the K3/K3 combo exclusively.
 - **GLM 5** — Solid option, especially via Z.ai. **GLM 5.2 is experimental:** Sisyphus uses a GLM-5.2-calibrated prompt for model IDs recognized as GLM, but current evidence is one community report without maintainer end-to-end validation. The automatic chain is configured with `glm-5`, and fuzzy availability matching may resolve that entry to GLM 5.1 or GLM 5.2.


### PR DESCRIPTION
## Summary

- Two places in the docs recommend the same Claude model twice — the Sisyphus "Recommended models" bullet reads **Claude Opus 5 / Opus 5**, and the maintainer-verified supported set reads **Fable 5 · Opus 5 · Opus 5 · Sonnet 4.6**. Both render on <https://omo.dev/docs>, so a reader is told the supported Claude set contains four models when it contains three.
- This is a leftover from the Opus 5 migration, not a missing model. Those slots used to hold two Opus generations: `Opus 4.8` / `Opus 4.7`. `e96b6f75` collapsed `4.7` into `4.8`, and `d422a21d` then rewrote `4.8` to `Opus 5`, leaving both halves naming the same model.
- `d422a21d` already deduplicated the other two restatements of this same list to `Claude (Fable 5 / Opus 5 / Sonnet 4.6)`. This PR brings the remaining two in line with that wording, so all four now agree.

## Changes

- `docs/guide/overview.md` (Sisyphus → Recommended models): `**Claude Opus 5** / **Opus 5**` → `**Claude Opus 5**`. Matches the sentence three lines below it, which already reads "Sisyphus works best on Claude Opus 5, Kimi K3 (or K3), and GLM 5."
- `docs/guide/agent-model-matching.md` (🚨 READ THIS FIRST → supported set): `Fable 5 · Opus 5 · Opus 5 · Sonnet 4.6` → `Fable 5 · Opus 5 · Sonnet 4.6`. Matches lines 60 and 545 of the same file and the Claude Family capability table, which lists Fable 5 / Opus 5 / Sonnet 4.6 / Haiku 4.5.

Docs-only. No source, config, prompt, or model-chain changes.

## QA & Evidence

- **What was tested:** All four restatements of the Claude supported set now agree — `grep -n "Claude family:|Claude Opus 5\*\* —|ONLY tested on Claude|supported set is Claude" docs/guide/overview.md docs/guide/agent-model-matching.md`
  **Observed result:** `overview.md:85 → **Claude Opus 5**`, `agent-model-matching.md:13 → Fable 5 · Opus 5 · Sonnet 4.6`, `:60 → Claude (Fable 5 / Opus 5 / Sonnet 4.6)`, `:545 → Claude (Fable 5 / Opus 5 / Sonnet 4.6)`. All four consistent.
  **Artifact:** command output reproducible from the branch head.
  **Why sufficient:** The defect is a stated-set inconsistency across four locations; showing all four converge on the same three models is direct proof it is resolved.
- **What was tested:** No duplicate survives anywhere in the tree — `grep -rn "Opus 5 · Opus 5\|Opus 5\*\* / \*\*Opus 5" . --exclude-dir=.git`
  **Observed result:** no matches.
  **Artifact:** command output reproducible from the branch head.
  **Why sufficient:** Confirms the two edited lines were the only occurrences, including the localized READMEs.
- **What was tested:** Site impact path — `packages/web/scripts/generate-docs-content.mjs` reads `docs/guide/*.md` from `DOCS_ROOT` at build time; `lib/docs-content.generated.ts` is not tracked by git.
  **Observed result:** No generated artifact needs regenerating or committing; the omo.dev pages pick this up on the next build.
  **Why sufficient:** Establishes that editing the markdown is the complete fix for the rendered site.

## Risks & Residuals

- **Wrong dedupe target — could the second slot have been meant as a different model (e.g. Sonnet 5) rather than a duplicate?** Investigated and rejected: "Sonnet 5" appears zero times in `docs/`, the localized READMEs, and `CHANGELOG.md`; curated chains use `claude-sonnet-4-6` (39 references), while `claude-sonnet-5` appears only in the auto-generated provider catalog and one `context-limit-resolver.test.ts` fixture. The pre-regression text was two Opus generations, and `d422a21d` itself deduped the parallel lines to three models. **Mitigated.** If maintainers did intend a fourth Claude model there, this is a one-word change — say the word and I will update it.
- **Semantic drift in the supported set.** None: the model set is unchanged, only the duplicate listing is removed. **Not applicable.**
- **Build/test gates.** `bun run typecheck`, `bun run build`, `bun test`, and `bun run test:codex` were not run — the diff touches only two markdown files with no code, schema, prompt, or generated-artifact impact, and the docs pipeline consumes these files as plain markdown. **Accepted.**

## Automated Checks

```bash
grep -rn "Opus 5 · Opus 5\|Opus 5\*\* / \*\*Opus 5" . --exclude-dir=.git   # no matches
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate "Opus 5" entries in the Claude model lists so docs show the correct three-model set and stay consistent across pages. Aligns the remaining lists with "Claude (Fable 5 / Opus 5 / Sonnet 4.6)".

- **Bug Fixes**
  - docs/guide/overview.md: "Claude Opus 5 / Opus 5" → "Claude Opus 5".
  - docs/guide/agent-model-matching.md: "Fable 5 · Opus 5 · Opus 5 · Sonnet 4.6" → "Fable 5 · Opus 5 · Sonnet 4.6".

<sup>Written for commit 549deec886e563851193336bbbddc06d2ee99cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

