### PR TITLE
fix(publish): consolidate approval gate into single binary decision

### DIFF
--- a/.agents/command/publish.md
+++ b/.agents/command/publish.md
@@ -192,9 +192,7 @@ After running the preview, present the output to the user and say:
 >
 > **For all release types**, an enhanced summary is **required** — I'll draft one in the next step.
 
-Wait for the user to acknowledge before proceeding.
-
-If the user already confirmed the publish workflow and did not explicitly ask to review the generated changelog before release-note editing, treat the publish confirmation as sufficient acknowledgement and continue. Do not end the assistant turn here.
+**APPROVAL GATE (single, binary):** The user's initial publish request with a named bump type IS the only approval this workflow requires. Do NOT wait for a separate acknowledgement here. Present the preview, then IMMEDIATELY proceed to Step 6. The only exception: if the user explicitly said "let me review the changelog before you continue" (or equivalent), stop and wait. Otherwise continue without ending the turn.
 </agent-instruction>
 
 ---
@@ -266,10 +264,10 @@ cat /tmp/release-summary-v${NEW_VERSION}.md
 ```
 
 <agent-instruction>
-After drafting, ask the user:
-> "Here's the release summary I drafted. This will appear AT THE TOP of the release notes, above the auto-generated commit changelog and contributor thanks. Want me to adjust anything before applying?"
+Present the draft to the user:
+> "Here's the release summary I drafted. This will appear AT THE TOP of the release notes, above the auto-generated commit changelog and contributor thanks."
 
-If the user already confirmed the publish workflow and did not explicitly request a release-note review hold, proceed to Step 7 after presenting the draft. Do not stop before Step 7.5, because the Discord announcement is mandatory.
+**APPROVAL GATE (same single gate):** The initial publish confirmation covers this step too. Present the draft, then IMMEDIATELY proceed to Step 7 (apply) and Step 7.5 (Discord). Do NOT stop to wait for approval unless the user explicitly requested a release-note review hold before the publish started. The Discord announcement (Step 7.5) is mandatory and must not be blocked by a review hold that was never requested.
 </agent-instruction>
 
 ---

--- a/.agents/skills/publish/SKILL.md
+++ b/.agents/skills/publish/SKILL.md
@@ -191,9 +191,7 @@ After running the preview, present the output to the user and say:
 >
 > **For all release types**, an enhanced summary is **required** — I'll draft one in the next step.
 
-Wait for the user to acknowledge before proceeding.
-
-If the user already confirmed the publish workflow and did not explicitly ask to review the generated changelog before release-note editing, treat the publish confirmation as sufficient acknowledgement and continue. Do not end the assistant turn here.
+**APPROVAL GATE (single, binary):** The user's initial publish request with a named bump type IS the only approval this workflow requires. Do NOT wait for a separate acknowledgement here. Present the preview, then IMMEDIATELY proceed to Step 6. The only exception: if the user explicitly said "let me review the changelog before you continue" (or equivalent), stop and wait. Otherwise continue without ending the turn.
 </agent-instruction>
 
 ---
@@ -265,10 +263,10 @@ cat /tmp/release-summary-v${NEW_VERSION}.md
 ```
 
 <agent-instruction>
-After drafting, ask the user:
-> "Here's the release summary I drafted. This will appear AT THE TOP of the release notes, above the auto-generated commit changelog and contributor thanks. Want me to adjust anything before applying?"
+Present the draft to the user:
+> "Here's the release summary I drafted. This will appear AT THE TOP of the release notes, above the auto-generated commit changelog and contributor thanks."
 
-If the user already confirmed the publish workflow and did not explicitly request a release-note review hold, proceed to Step 7 after presenting the draft. Do not stop before Step 7.5, because the Discord announcement is mandatory.
+**APPROVAL GATE (same single gate):** The initial publish confirmation covers this step too. Present the draft, then IMMEDIATELY proceed to Step 7 (apply) and Step 7.5 (Discord). Do NOT stop to wait for approval unless the user explicitly requested a release-note review hold before the publish started. The Discord announcement (Step 7.5) is mandatory and must not be blocked by a review hold that was never requested.
 </agent-instruction>
 
 ---

--- a/.opencode/command/publish.md
+++ b/.opencode/command/publish.md
@@ -192,9 +192,7 @@ After running the preview, present the output to the user and say:
 >
 > **For all release types**, an enhanced summary is **required** — I'll draft one in the next step.
 
-Wait for the user to acknowledge before proceeding.
-
-If the user already confirmed the publish workflow and did not explicitly ask to review the generated changelog before release-note editing, treat the publish confirmation as sufficient acknowledgement and continue. Do not end the assistant turn here.
+**APPROVAL GATE (single, binary):** The user's initial publish request with a named bump type IS the only approval this workflow requires. Do NOT wait for a separate acknowledgement here. Present the preview, then IMMEDIATELY proceed to Step 6. The only exception: if the user explicitly said "let me review the changelog before you continue" (or equivalent), stop and wait. Otherwise continue without ending the turn.
 </agent-instruction>
 
 ---
@@ -266,10 +264,10 @@ cat /tmp/release-summary-v${NEW_VERSION}.md
 ```
 
 <agent-instruction>
-After drafting, ask the user:
-> "Here's the release summary I drafted. This will appear AT THE TOP of the release notes, above the auto-generated commit changelog and contributor thanks. Want me to adjust anything before applying?"
+Present the draft to the user:
+> "Here's the release summary I drafted. This will appear AT THE TOP of the release notes, above the auto-generated commit changelog and contributor thanks."
 
-If the user already confirmed the publish workflow and did not explicitly request a release-note review hold, proceed to Step 7 after presenting the draft. Do not stop before Step 7.5, because the Discord announcement is mandatory.
+**APPROVAL GATE (same single gate):** The initial publish confirmation covers this step too. Present the draft, then IMMEDIATELY proceed to Step 7 (apply) and Step 7.5 (Discord). Do NOT stop to wait for approval unless the user explicitly requested a release-note review hold before the publish started. The Discord announcement (Step 7.5) is mandatory and must not be blocked by a review hold that was never requested.
 </agent-instruction>
 
 ---


### PR DESCRIPTION
## What changed

The publish skill and both command-form mirrors carried **conflicting approval instructions** that caused the approval-forgetting mistake:

- **Step 5** said: "Wait for the user to acknowledge before proceeding."
- **Step 6** (skill form) said: "If the user already confirmed the publish workflow... proceed to Step 7."
- **Step 6** (command form) said: "Do NOT proceed to Step 7 without user confirmation."

An agent reading both could either stall forever waiting for an acknowledgement that was already covered by the initial publish confirmation, OR skip a hold that was meant to be a gate. Two soft gates in tension = the approval gets forgotten.

## The fix

Replaced both soft gates with a **single binary APPROVAL GATE**: the user's initial publish request with a named bump type IS the only approval this workflow requires. Present content, then immediately proceed. The only exception: if the user explicitly requested a review hold before the publish started.

## Files changed (3, drift-synced in one commit)

- `.agents/skills/publish/SKILL.md` — Step 5 + Step 6 agent-instructions
- `.agents/command/publish.md` — Step 5 + Step 6 agent-instructions (command form)
- `.opencode/command/publish.md` — Step 5 + Step 6 agent-instructions (legacy mirror)

All three mirrors updated in one commit per the drift-sync convention (AGENTS.md: "When you update a shared skill, update both copies in the SAME commit").

## QA

Prose-only change to skill/command docs. No code, no hooks, no tools, no config schema. QA-by-read: verified zero instances of the old conflicting language ("Wait for the user to acknowledge" / "Do NOT proceed without user confirmation" / "If the user already confirmed") remain in any of the three files, and exactly 2 APPROVAL GATE markers exist in each.

## Residual risk

None. The change tightens the approval flow from ambiguous to deterministic. If a user explicitly wants a review hold, they still get one by requesting it. If they don't, the workflow proceeds without stalling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated the publish workflow into a single binary approval gate so the initial bump-type request is the only approval needed. Removes conflicting instructions and prevents stalls or missed holds; only pause if the user explicitly asked for a review hold.

- **Bug Fixes**
  - Replaced Step 5/6 soft gates with one APPROVAL GATE; present the preview and release-summary draft, then proceed directly to Step 7 and mandatory Step 7.5 unless an explicit review hold was requested.
  - Updated mirrors: .agents/skills/publish/SKILL.md, .agents/command/publish.md, .opencode/command/publish.md.

<sup>Written for commit 88f3fe28e6454b29a2cdc8f1436d053904113c70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

