### PR TITLE
fix(background-agent): sanitize platform-prefixed session ids before existence check

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/session-existence.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-existence.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test"
 
 import type { OpencodeClient } from "./opencode-client"
-import { checkSessionExistence, verifySessionExists } from "./session-existence"
+import { checkSessionExistence, sanitizeBareSessionId, verifySessionExists } from "./session-existence"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 
 describe("verifySessionExists", () => {
@@ -39,5 +39,38 @@ describe("verifySessionExists", () => {
     const result = await checkSessionExistence(client, "session-123")
 
     expect(result).toBe("unknown")
+  })
+})
+
+describe("sanitizeBareSessionId", () => {
+  test("strips known platform prefixes", () => {
+    // given / when / then
+    expect(sanitizeBareSessionId("opencode:ses_abc123")).toBe("ses_abc123")
+    expect(sanitizeBareSessionId("codex:ses_abc123")).toBe("ses_abc123")
+    expect(sanitizeBareSessionId("senpi:ses_abc123")).toBe("ses_abc123")
+  })
+
+  test("leaves bare session ids untouched", () => {
+    // given / when / then
+    expect(sanitizeBareSessionId("ses_abc123")).toBe("ses_abc123")
+  })
+
+  test("checkSessionExistence queries with the bare id", async () => {
+    // given
+    const get = mock(async () => ({ data: { id: "ses_abc123" } }))
+    const client = unsafeTestValue<OpencodeClient>({
+      session: {
+        get,
+      },
+    })
+
+    // when
+    const result = await checkSessionExistence(client, "opencode:ses_abc123")
+
+    // then
+    expect(result).toBe("exists")
+    expect(get).toHaveBeenCalledWith({
+      path: { id: "ses_abc123" },
+    })
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/session-existence.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-existence.ts
@@ -36,14 +36,19 @@ function isSessionNotFoundError(error: unknown): boolean {
   return message.includes("not found") || message.includes("missing")
 }
 
+export function sanitizeBareSessionId(sessionId: string): string {
+  return sessionId.replace(/^(opencode|codex|senpi):/, "")
+}
+
 export async function checkSessionExistence(
   client: OpencodeClient,
   sessionID: string,
   directory?: string
 ): Promise<SessionExistenceStatus> {
+  const rawId = sanitizeBareSessionId(sessionID)
   try {
     const response = await client.session.get({
-      path: { id: sessionID },
+      path: { id: rawId },
       ...(directory ? { query: { directory } } : {}),
     })
 


### PR DESCRIPTION
## What

Rebased the session-ID prefix workaround onto v4.19.3. `boulder.json` stores IDs as `opencode:ses_*`; forwarding them to `client.session.get()` URL-encodes the colon and makes OpenCode return HTTP 400. The poller then treats the live session as gone after its grace window.

`checkSessionExistence()` now strips known harness prefixes (`opencode:`, `codex:`, `senpi:`) before the SDK lookup. Bare IDs are unchanged.

This is the same focused fix as #6264, retargeted onto the current release source so downstream users can move to 4.19.3 (including the new omo.jsonc config migration) without reintroducing the sessionGone regression.

## Tests

- `bun test packages/omo-opencode/src/features/background-agent/session-existence.test.ts`: 5 pass, 0 fail
- Added cases for all three known prefixes, bare IDs, and the exact ID passed to `client.session.get()`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize platform-prefixed session IDs before existence checks to prevent 400s from URL-encoded colons and stop false “session gone” states in the background agent. Reapplies the fix on v4.19.3 so users can upgrade without regressions.

- **Bug Fixes**
  - Strip `opencode:`, `codex:`, `senpi:` prefixes before the SDK lookup; bare IDs unchanged.
  - `checkSessionExistence` now calls `client.session.get()` with the bare ID; adds `sanitizeBareSessionId`.
  - Tests cover prefixed and bare IDs, plus the exact ID sent to the SDK.

<sup>Written for commit 9429090071a436ca985ce9349717b7556603fda2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


