### PR TITLE
feat(omo-senpi): disable dead-chain categories with TUI/RPC warnings and suppression config

### DIFF
--- a/packages/omo-senpi/scripts/qa/task-category-unavailable-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/task-category-unavailable-e2e.mjs
@@ -1,0 +1,365 @@
+#!/usr/bin/env node
+// Live RPC probe for the dead-chain category warning (plan todo 6). Drives a sandboxed senpi in
+// --mode rpc against the lane-private omo-mock provider (registry = omo-mock only, so every builtin
+// category chain is dead), spawns the quick category TWICE via scripted task tool calls, and proves:
+//   happy:    exactly ONE {method:"notify",notifyType:"warning"} frame on the RPC stdout stream AND
+//             exactly ONE senpi-task.category-unavailable custom message in the session JSONL;
+//   negative: task.warnings.unavailable_categories=false -> neither frame nor message.
+// Isolation: real ~/.senpi/agent credential files must stay byte-identical; the sandbox is removed.
+import { spawn } from "node:child_process"
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
+import { homedir } from "node:os"
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { createHash } from "node:crypto"
+
+import { createSandbox, credentialDigest, seedSandbox } from "./drive.mjs"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const mockProviderEntry = join(scriptDir, "task-category-unavailable-mock-provider.ts")
+const realSenpiAgentDir = join(homedir(), ".senpi", "agent")
+const realOmoDir = join(homedir(), ".omo")
+
+const WARNING_TEXT = 'Category "quick" has no usable model: none of its fallback-chain providers are connected'
+const CUSTOM_TYPE = "senpi-task.category-unavailable"
+
+// Fingerprint only the omo config layer (~/.omo/omo.jsonc + omo.json) - the files a config
+// migration or category write could touch. Runtime state under ~/.omo can be multi-GiB.
+function digestOmoConfigLayer() {
+  const hash = createHash("sha256")
+  for (const name of ["omo.jsonc", "omo.json"]) {
+    const path = join(realOmoDir, name)
+    hash.update(name)
+    hash.update("\0")
+    hash.update(existsSync(path) ? readFileSync(path) : Buffer.from("absent"))
+    hash.update("\0")
+  }
+  return hash.digest("hex")
+}
+
+function findOnPath(bin) {
+  if (bin.includes("/")) return existsSync(bin) ? bin : null
+  for (const pathEntry of (process.env.PATH ?? "").split(delimiter)) {
+    const candidate = resolve(pathEntry || ".", bin)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+function parseArgs(argv) {
+  const output = { evidenceDir: undefined, selfTest: false }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--self-test") {
+      output.selfTest = true
+      continue
+    }
+    if (arg === "--evidence-dir") {
+      const value = argv[index + 1]
+      if (value === undefined) throw new Error("--evidence-dir requires a path")
+      output.evidenceDir = isAbsolute(value) ? value : resolve(process.cwd(), value)
+      index += 1
+      continue
+    }
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+  return output
+}
+
+function scenarioScript() {
+  return {
+    models: ["mock-parent"],
+    parentSteps: [
+      {
+        type: "tool_call",
+        name: "task",
+        arguments: { category: "quick", prompt: "first dead-chain spawn", run_in_background: true },
+      },
+      {
+        type: "tool_call",
+        name: "task",
+        arguments: { category: "quick", prompt: "second dead-chain spawn", run_in_background: true },
+      },
+      { type: "text", text: "category-unavailable probe complete" },
+    ],
+    childSteps: [{ type: "text", text: "unreachable: dead-chain spawns never start a child" }],
+  }
+}
+
+function seedScenario(omoConfig) {
+  const sandbox = createSandbox()
+  seedSandbox(sandbox)
+  // Sandbox HOME: the omo config user layer resolves at $HOME/.omo (omo-config-core paths.ts), so
+  // an inherited real HOME leaks the developer's real categories into category resolution and lets
+  // startup migrations write there. A sandbox HOME makes the probe hermetic.
+  const home = join(sandbox.root, "home")
+  mkdirSync(home, { recursive: true })
+  const sessionDir = join(sandbox.root, "sessions")
+  mkdirSync(sessionDir, { recursive: true })
+  const omoDir = join(sandbox.cwd, ".omo")
+  mkdirSync(omoDir, { recursive: true })
+  writeFileSync(join(omoDir, "omo.json"), `${JSON.stringify(omoConfig, null, 2)}\n`)
+  writeFileSync(join(sandbox.cwd, "mock-script.json"), `${JSON.stringify(scenarioScript(), null, 2)}\n`)
+  return { sandbox: { ...sandbox, home }, sessionDir }
+}
+
+function jsonLines(text) {
+  return text
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      try {
+        return JSON.parse(line)
+      } catch {
+        return undefined
+      }
+    })
+    .filter((line) => line !== undefined)
+}
+
+function count(text, needle) {
+  return text.split(needle).length - 1
+}
+
+function readSessionTranscript(sessionDir) {
+  const files = []
+  const walk = (dir) => {
+    if (!existsSync(dir)) return
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) walk(path)
+      else if (entry.isFile() && entry.name.endsWith(".jsonl")) files.push(path)
+    }
+  }
+  walk(sessionDir)
+  return files.map((path) => readFileSync(path, "utf8")).join("\n")
+}
+
+// Drive one RPC session: subscribe to stdout FIRST, then send the prompt command, then wait for the
+// prompt response frame (bounded) so no notify/custom-message frame can race past the collector.
+function driveRpc(senpiBin, scenario) {
+  return new Promise((resolvePromise) => {
+    const child = spawn(
+      senpiBin,
+      [
+        "-e",
+        mockProviderEntry,
+        "--mode",
+        "rpc",
+        "--provider",
+        "omo-mock",
+        "--model",
+        "mock-parent",
+        "--session-dir",
+        scenario.sessionDir,
+      ],
+      {
+        cwd: scenario.sandbox.cwd,
+        env: {
+          ...process.env,
+          // HOME must be sandboxed: senpi resolves its settings/tips paths from HOME even when the
+          // agent-dir env is set, and the omo user config layer lives at $HOME/.omo. Both agent-dir
+          // env spellings are set (the installed binary reads PI_CODING_AGENT_DIR; the workspace
+          // source reads SENPI_CODING_AGENT_DIR).
+          HOME: scenario.sandbox.home,
+          USERPROFILE: scenario.sandbox.home,
+          SENPI_CODING_AGENT_DIR: scenario.sandbox.agentDir,
+          PI_CODING_AGENT_DIR: scenario.sandbox.agentDir,
+          SENPI_CODING_AGENT_SESSION_DIR: scenario.sessionDir,
+          XDG_CONFIG_HOME: scenario.sandbox.xdgConfigHome,
+          OMO_SENPI_QA: "1",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    )
+    let stdout = ""
+    let stderr = ""
+    let responded = false
+    const finish = (reason) => {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL")
+      resolvePromise({ stdout, stderr, responded, reason })
+    }
+    const deadline = setTimeout(() => finish("timeout"), 90_000)
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString()
+      if (responded) return
+      const frames = jsonLines(stdout)
+      if (frames.some((frame) => frame.type === "response" && frame.command === "prompt")) {
+        responded = true
+        // Grace window for trailing notify/custom-message frames, then shut the RPC session down.
+        setTimeout(() => {
+          child.stdin.end()
+          setTimeout(() => finish("completed"), 2_000)
+        }, 1_000)
+      }
+    })
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString()
+    })
+    child.on("exit", () => {
+      clearTimeout(deadline)
+      finish(responded ? "completed" : "exit-before-response")
+    })
+    child.on("error", (error) => {
+      clearTimeout(deadline)
+      stderr += String(error)
+      finish("spawn-error")
+    })
+    child.stdin.write(`${JSON.stringify({ id: "probe-1", type: "prompt", message: "spawn the quick task twice and stop" })}\n`)
+  })
+}
+
+function assertScenario(run, sessionTranscript, expectWarning) {
+  const frames = jsonLines(run.stdout)
+  const notifyFrames = frames.filter(
+    (frame) =>
+      frame.method === "notify" &&
+      frame.notifyType === "warning" &&
+      typeof frame.message === "string" &&
+      frame.message.includes(WARNING_TEXT),
+  )
+  const customCount = count(sessionTranscript, CUSTOM_TYPE)
+  const checks = {
+    prompt_responded: run.responded,
+    notify_warning_frame_count: expectWarning ? notifyFrames.length === 1 : notifyFrames.length === 0,
+    custom_message_count: expectWarning ? customCount === 1 : customCount === 0,
+  }
+  if (expectWarning) {
+    checks.custom_message_reason = count(sessionTranscript, '"reason":"no_chain_rung_available"') === 1
+    checks.custom_message_chain_details =
+      sessionTranscript.includes('"attempted_chain"') && sessionTranscript.includes('"missing_providers"')
+  }
+  return {
+    result: Object.values(checks).every(Boolean) ? "PASS" : "FAIL",
+    checks,
+    notifyFrameCount: notifyFrames.length,
+    customCount,
+    stdout: run.stdout,
+    stderr: run.stderr,
+    sessionTranscript,
+  }
+}
+
+function writeEvidence(evidenceDir, label, result) {
+  if (evidenceDir === undefined) return
+  const dir = join(evidenceDir, label)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, "stdout.jsonl"), result.stdout)
+  writeFileSync(join(dir, "stderr.txt"), result.stderr)
+  writeFileSync(join(dir, "session.jsonl"), result.sessionTranscript)
+  writeFileSync(
+    join(dir, "summary.json"),
+    `${JSON.stringify(
+      {
+        result: result.result,
+        checks: result.checks,
+        notifyFrameCount: result.notifyFrameCount,
+        customCount: result.customCount,
+      },
+      null,
+      2,
+    )}\n`,
+  )
+}
+
+function selfTest() {
+  const script = scenarioScript()
+  if (script.parentSteps.filter((step) => step.type === "tool_call").length !== 2) {
+    throw new Error("probe must spawn the dead-chain category exactly twice")
+  }
+  if (count(`x ${CUSTOM_TYPE} y`, CUSTOM_TYPE) !== 1) throw new Error("counter failed")
+  console.log("SELF-TEST OK")
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.selfTest) {
+    selfTest()
+    return
+  }
+  const senpiBin = findOnPath(process.env.SENPI_BIN?.trim() || "senpi")
+  if (senpiBin === null) {
+    console.log(JSON.stringify({ result: "SKIP", reason: "senpi-binary-unavailable" }))
+    process.exitCode = 1
+    return
+  }
+
+  // Hard isolation gate: the sandbox must never alias the real dirs, and the real agent-dir
+  // credential files plus the real ~/.omo config layer must stay byte-identical across the probe.
+  // (~/.omo holds multi-GiB runtime state, so only the config files the plugin could write are
+  // fingerprinted, not the whole tree.)
+  const beforeCredentials = credentialDigest(realSenpiAgentDir)
+  const beforeOmoConfig = digestOmoConfigLayer()
+  const realSettingsPath = join(realSenpiAgentDir, "settings.json")
+  const beforeSettingsMtime = existsSync(realSettingsPath) ? statSync(realSettingsPath).mtimeMs : undefined
+  const scenarios = [
+    { label: "happy", omoConfig: {}, expectWarning: true },
+    {
+      label: "suppressed",
+      omoConfig: { task: { warnings: { unavailable_categories: false } } },
+      expectWarning: false,
+    },
+  ]
+  const reports = []
+  for (const scenario of scenarios) {
+    const seeded = seedScenario(scenario.omoConfig)
+    if (resolve(seeded.sandbox.agentDir) === resolve(realSenpiAgentDir)) {
+      throw new Error("sandbox agent dir aliases the real ~/.senpi/agent")
+    }
+    if (resolve(seeded.sandbox.home) === resolve(homedir())) {
+      throw new Error("sandbox home aliases the real HOME")
+    }
+    let result
+    try {
+      const run = await driveRpc(senpiBin, seeded)
+      const sessionTranscript = readSessionTranscript(seeded.sessionDir)
+      result = assertScenario(run, sessionTranscript, scenario.expectWarning)
+    } finally {
+      rmSync(seeded.sandbox.root, { recursive: true, force: true })
+    }
+    if (existsSync(seeded.sandbox.root)) result.result = "FAIL"
+    reports.push({ label: scenario.label, result })
+    writeEvidence(args.evidenceDir, scenario.label, result)
+  }
+  const afterCredentials = credentialDigest(realSenpiAgentDir)
+  const afterOmoConfig = digestOmoConfigLayer()
+  const afterSettingsMtime = existsSync(realSettingsPath) ? statSync(realSettingsPath).mtimeMs : undefined
+  const isolation = {
+    credentialDigestUnchanged: beforeCredentials === afterCredentials,
+    realOmoConfigUnchanged: beforeOmoConfig === afterOmoConfig,
+    realSettingsMtimeUnchanged: beforeSettingsMtime === afterSettingsMtime,
+  }
+  const allPass = reports.every((report) => report.result.result === "PASS")
+    && isolation.credentialDigestUnchanged
+    && isolation.realOmoConfigUnchanged
+    && isolation.realSettingsMtimeUnchanged
+  console.log(
+    JSON.stringify(
+      {
+        result: allPass ? "PASS" : "FAIL",
+        scenarios: reports.map((report) => ({
+          label: report.label,
+          result: report.result.result,
+          checks: report.result.checks,
+          notifyFrameCount: report.result.notifyFrameCount,
+          customCount: report.result.customCount,
+        })),
+        isolation,
+      },
+      null,
+      2,
+    ),
+  )
+  if (!allPass) process.exitCode = 1
+}
+
+await main()

--- a/packages/omo-senpi/scripts/qa/task-category-unavailable-mock-provider.ts
+++ b/packages/omo-senpi/scripts/qa/task-category-unavailable-mock-provider.ts
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+// Lane-private mock provider for task-category-unavailable-e2e.mjs (cross-lane contract: named after
+// its driver, never the shared mock-provider/). Variant of task-e2e-mock-provider.ts: the probe parent
+// itself runs in --mode rpc, so the argv rpc child heuristic is dropped - the dead-chain category
+// failure happens at planning, no child process ever spawns, and the identity line stays the only
+// parent/child selector.
+declare const process: {
+  argv: string[]
+  cwd(): string
+  exit(code: number): never
+  getBuiltinModule<T>(id: string): T
+}
+
+interface FsModule {
+  existsSync(path: string): boolean
+  readFileSync(path: string, encoding: string): string
+}
+
+interface PathModule {
+  join(...paths: string[]): string
+}
+
+interface UrlModule {
+  pathToFileURL(path: string): { href: string }
+}
+
+const { existsSync, readFileSync } = process.getBuiltinModule<FsModule>("fs")
+const { join } = process.getBuiltinModule<PathModule>("path")
+const { pathToFileURL } = process.getBuiltinModule<UrlModule>("url")
+
+// The child identity line lives ONLY in a child session's message thread (buildSubagentPrompt). The
+// parent's task tool-call arguments never contain it, so this is a leak-proof parent/child selector.
+const CHILD_IDENTITY = "running as an omo senpi-task child"
+
+interface MockStepUsage {
+  input?: number
+  output?: number
+  totalTokens?: number
+}
+
+type MockStep =
+  | { type: "text"; text: string; usage?: MockStepUsage }
+  | { type: "tool_call"; name: string; arguments: Record<string, unknown>; id?: string; usage?: MockStepUsage }
+
+interface MockScript {
+  parentSteps: MockStep[]
+  childSteps: MockStep[]
+  models?: readonly string[]
+  failChildModels?: readonly string[]
+  customMessages?: ReadonlyArray<{
+    readonly customType: string
+    readonly content: string
+    readonly details: Readonly<Record<string, unknown>>
+  }>
+}
+
+type Api = "openai-completions"
+type StopReason = "stop" | "toolUse" | "aborted" | "error"
+
+interface Model<TApi extends string = Api> {
+  id: string
+  api?: TApi
+}
+
+interface Message {
+  role: string
+  content: string | Array<{ type?: string; text?: string }>
+}
+
+interface Context {
+  cwd?: string
+  messages?: Message[]
+}
+
+interface SimpleStreamOptions {
+  signal?: AbortSignal
+}
+
+type AssistantContent =
+  | { type: "text"; text: string }
+  | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
+
+interface AssistantMessage {
+  role: "assistant"
+  content: AssistantContent[]
+  api: Api
+  provider: "omo-mock"
+  model: string
+  usage: { input: number; output: number; cacheRead: number; cacheWrite: number; totalTokens: number; cost: number }
+  stopReason: StopReason
+  errorMessage?: string
+  timestamp: number
+}
+
+interface MockModel {
+  id: string
+  name: string
+  reasoning: boolean
+  input: Array<"text" | "image">
+  cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
+  contextWindow: number
+  maxTokens: number
+}
+
+interface MockProvider {
+  name: string
+  baseUrl: string
+  apiKey: string
+  api: Api
+  models: MockModel[]
+  streamSimple(
+    model: Model<Api>,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ): AsyncIterable<unknown> & { result(): Promise<AssistantMessage> }
+}
+
+interface ExtensionAPI {
+  registerProvider(id: string, provider: MockProvider): void
+  on?(event: string, handler: () => void): void
+  sendMessage?(message: Record<string, unknown>, options?: Record<string, unknown>): void
+}
+
+interface LocalAssistantMessageEventStream extends AsyncIterable<unknown> {
+  push(event: unknown): void
+  end(message: AssistantMessage): void
+  result(): Promise<AssistantMessage>
+}
+
+function mockModel(id: string): MockModel {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 4096,
+  }
+}
+
+export default function registerMockProvider(pi: ExtensionAPI): void {
+  const script = loadMockScript(process.cwd())
+  pi.registerProvider("omo-mock", {
+    name: "omo mock provider",
+    baseUrl: "file://mock-provider",
+    apiKey: "mock",
+    api: "openai-completions",
+    models: (script.models ?? ["mock-1"]).map(mockModel),
+    streamSimple(streamModel: Model<Api>, context: Context, options?: SimpleStreamOptions) {
+      return streamMockResponse(streamModel, context, options)
+    },
+  })
+  if (pi.on === undefined || pi.sendMessage === undefined) return
+  pi.on("session_start", () => {
+    const script = loadMockScript(process.cwd())
+    for (const message of script.customMessages ?? []) {
+      pi.sendMessage?.(
+        { customType: message.customType, content: message.content, display: true, details: message.details },
+        {},
+      )
+    }
+  })
+}
+
+export function loadMockScript(cwd: string): MockScript {
+  const scriptPath = join(cwd, "mock-script.json")
+  if (!existsSync(scriptPath)) {
+    return { parentSteps: [{ type: "text", text: "no script" }], childSteps: [{ type: "text", text: "child done" }] }
+  }
+  const parsed = JSON.parse(readFileSync(scriptPath, "utf8")) as MockScript
+  return parsed
+}
+
+export function messagesContainChild(context: Context): boolean {
+  for (const message of context.messages ?? []) {
+    if (typeof message.content === "string") {
+      if (message.content.includes(CHILD_IDENTITY)) return true
+      continue
+    }
+    for (const part of message.content) {
+      if (typeof part.text === "string" && part.text.includes(CHILD_IDENTITY)) return true
+    }
+  }
+  return false
+}
+
+export function stepToAssistantMessage(
+  step: MockStep,
+  callCount: number,
+  modelId = "mock-1",
+): AssistantMessage {
+  const content: AssistantContent[] =
+    step.type === "text"
+      ? [{ type: "text", text: step.text }]
+      : [{ type: "toolCall", id: step.id ?? `omo-mock-tool-${callCount}`, name: step.name, arguments: step.arguments }]
+  return {
+    role: "assistant",
+    content,
+    api: "openai-completions",
+    provider: "omo-mock",
+    model: modelId,
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: 0, ...step.usage },
+    stopReason: step.type === "tool_call" ? "toolUse" : "stop",
+    timestamp: Date.now(),
+  }
+}
+
+let parentCallCount = 0
+let childCallCount = 0
+
+function streamMockResponse(streamModel: Model<Api>, context: Context, options?: SimpleStreamOptions) {
+  const stream = createLocalAssistantMessageEventStream()
+  const script = loadMockScript(context.cwd ?? process.cwd())
+  const isChild = messagesContainChild(context)
+  if (isChild && script.failChildModels?.includes(streamModel.id)) {
+    if (process.argv.includes("rpc")) {
+      queueMicrotask(() => process.exit(42))
+      return stream
+    }
+    const failure: AssistantMessage = {
+      ...stepToAssistantMessage(
+        { type: "text", text: "" },
+        1,
+        streamModel.id,
+      ),
+      stopReason: "error",
+      errorMessage: "mock provider capacity exhausted",
+    }
+    queueMicrotask(() => {
+      stream.push({ type: "start", partial: failure })
+      stream.push({ type: "error", reason: "error", error: failure })
+      stream.end(failure)
+    })
+    return stream
+  }
+  const steps = isChild ? script.childSteps : script.parentSteps
+  const index = isChild ? childCallCount : parentCallCount
+  const step = steps[Math.min(index, steps.length - 1)]
+  if (isChild) childCallCount += 1
+  else parentCallCount += 1
+  const message = stepToAssistantMessage(step, index + 1, streamModel.id)
+
+  queueMicrotask(() => {
+    if (options?.signal?.aborted) {
+      const aborted = { ...message, stopReason: "aborted" as const }
+      stream.push({ type: "error", reason: "aborted", error: aborted })
+      stream.end(aborted)
+      return
+    }
+    stream.push({ type: "start", partial: { ...message, content: [] } })
+    if (step.type === "text") {
+      const partial = { ...message, content: [{ type: "text" as const, text: "" }] }
+      stream.push({ type: "text_start", contentIndex: 0, partial })
+      stream.push({ type: "text_delta", contentIndex: 0, delta: step.text, partial: message })
+      stream.push({ type: "text_end", contentIndex: 0, content: step.text, partial: message })
+    } else {
+      const toolCall = message.content[0]
+      stream.push({ type: "toolcall_start", contentIndex: 0, partial: { ...message, content: [] } })
+      stream.push({ type: "toolcall_delta", contentIndex: 0, delta: JSON.stringify(step.arguments), partial: message })
+      stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial: message })
+    }
+    stream.push({ type: "done", reason: message.stopReason, message })
+    stream.end(message)
+  })
+
+  return stream
+}
+
+function createLocalAssistantMessageEventStream(): LocalAssistantMessageEventStream {
+  const queue: unknown[] = []
+  const waiters: Array<(value: IteratorResult<unknown>) => void> = []
+  let done = false
+  let settleResult: (message: AssistantMessage) => void = () => {}
+  const finalMessage = new Promise<AssistantMessage>((resolve) => {
+    settleResult = resolve
+  })
+  finalMessage.catch(() => {})
+
+  return {
+    push(event: unknown) {
+      if (done) return
+      if (isTerminalAssistantMessageEvent(event)) {
+        done = true
+        settleResult(extractAssistantMessageResult(event))
+      }
+      const waiter = waiters.shift()
+      if (waiter) waiter({ value: event, done: false })
+      else queue.push(event)
+    },
+    end(message: AssistantMessage) {
+      if (done) return
+      done = true
+      settleResult(message)
+      while (waiters.length > 0) {
+        const waiter = waiters.shift()
+        if (waiter) waiter({ value: undefined, done: true })
+      }
+    },
+    result() {
+      return finalMessage
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          if (queue.length > 0) return Promise.resolve({ value: queue.shift(), done: false })
+          if (done) return Promise.resolve({ value: undefined, done: true })
+          return new Promise<IteratorResult<unknown>>((resolve) => waiters.push(resolve))
+        },
+      }
+    },
+  }
+}
+
+function isTerminalAssistantMessageEvent(
+  event: unknown,
+): event is { type: "done"; message: AssistantMessage } | { type: "error"; error: AssistantMessage } {
+  if (typeof event !== "object" || event === null) return false
+  const candidate = event as { type?: unknown; message?: unknown; error?: unknown }
+  if (candidate.type === "done") return isAssistantMessage(candidate.message)
+  if (candidate.type === "error") return isAssistantMessage(candidate.error)
+  return false
+}
+
+function extractAssistantMessageResult(
+  event: { type: "done"; message: AssistantMessage } | { type: "error"; error: AssistantMessage },
+): AssistantMessage {
+  return event.type === "done" ? event.message : event.error
+}
+
+function isAssistantMessage(value: unknown): value is AssistantMessage {
+  if (typeof value !== "object" || value === null) return false
+  const candidate = value as { role?: unknown; content?: unknown; stopReason?: unknown }
+  return candidate.role === "assistant" && Array.isArray(candidate.content) && typeof candidate.stopReason === "string"
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  if (process.argv.includes("--self-test")) {
+    // given a parent tool step
+    const parent = stepToAssistantMessage({ type: "tool_call", name: "task", arguments: {} }, 1)
+    // then it stops with toolUse
+    if (parent.stopReason !== "toolUse") throw new Error("tool step must stop with toolUse")
+    // given a child-identity context / when detected / then true
+    const childCtx: Context = { messages: [{ role: "user", content: `You are ${CHILD_IDENTITY}. Task: x` }] }
+    if (!messagesContainChild(childCtx)) throw new Error("child identity detection failed")
+    // given a parent context / when detected / then false
+    const parentCtx: Context = { messages: [{ role: "user", content: "ulw parent prompt" }] }
+    if (messagesContainChild(parentCtx)) throw new Error("parent must not detect child identity")
+    console.log("SELF-TEST OK")
+  }
+}

--- a/packages/omo-senpi/src/components/task/category-unavailable-warning.test.ts
+++ b/packages/omo-senpi/src/components/task/category-unavailable-warning.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test } from "bun:test"
+
+import type { DelegateFallbackEntry } from "@oh-my-opencode/delegate-core"
+import { OmoTaskSettingsSchema, type OmoConfig } from "@oh-my-opencode/omo-config-core"
+import type { ChildPlanner, PlanResolution, PlanResolutionError } from "@oh-my-opencode/senpi-task"
+
+import type { SenpiExtensionAPI } from "../../extension/types"
+import {
+  CATEGORY_UNAVAILABLE_MESSAGE_TYPE,
+  createCategoryUnavailableWarningPlanner,
+} from "./category-unavailable-warning"
+import { createTaskChildPlanner } from "./planner"
+import { TaskRuntimeContext } from "./runtime-context"
+
+type SentMessage = {
+  readonly message: Record<string, unknown>
+  readonly options: Record<string, unknown>
+}
+
+type CapturedNotify = {
+  readonly message: string
+  readonly type?: string
+}
+
+const QUICK_CHAIN: readonly DelegateFallbackEntry[] = [
+  { providers: ["kimi-coding", "kimi-for-coding"], model: "kimi-for-coding-highspeed" },
+  { providers: ["openai"], model: "gpt-5.4-mini", variant: "minimal" },
+]
+
+function deadChainError(category: string): PlanResolutionError {
+  return {
+    code: "model_unavailable",
+    message: `No available model for category "${category}".`,
+    category,
+    attempted_chain: QUICK_CHAIN,
+    missing_providers: ["kimi-coding", "kimi-for-coding"],
+    availableCategories: ["deep", "writing"],
+  }
+}
+
+function plainUnavailableError(category: string): PlanResolutionError {
+  return {
+    code: "model_unavailable",
+    message: `No available model for category "${category}".`,
+    availableCategories: ["deep", "writing"],
+  }
+}
+
+function setup(options: {
+  readonly error: PlanResolutionError
+  readonly omoConfig?: OmoConfig
+  readonly settings?: ReturnType<typeof OmoTaskSettingsSchema.parse>
+  readonly sessionId?: string
+  readonly withUi?: boolean
+}) {
+  const messages: SentMessage[] = []
+  const notifies: CapturedNotify[] = []
+  const pi = {
+    sendMessage: (message: Record<string, unknown>, options: Record<string, unknown>) => {
+      messages.push({ message, options })
+    },
+  } as unknown as SenpiExtensionAPI
+  const runtime = new TaskRuntimeContext("/tmp/category-unavailable-warning-test")
+  const ui = {
+    notify: (message: string, type?: string) => { notifies.push({ message, type }) },
+  }
+  runtime.captureFrom({
+    sessionManager: { getSessionId: () => options.sessionId ?? "session-1" },
+    ...(options.withUi === false
+      ? {}
+      : { ui: ui as unknown as Parameters<TaskRuntimeContext["captureFrom"]>[0]["ui"] }),
+  })
+  const inner: ChildPlanner = () => ({ kind: "error", error: options.error })
+  const planner = createCategoryUnavailableWarningPlanner({
+    planner: inner,
+    pi,
+    runtime,
+    omoConfig: options.omoConfig ?? {},
+    settings: options.settings ?? OmoTaskSettingsSchema.parse({}),
+  })
+  return { planner, messages, notifies, runtime }
+}
+
+function plan(planner: ChildPlanner, category: string): PlanResolution {
+  return planner({ prompt: "p", parent_session_id: "parent-1", depth: 0, category })
+}
+
+const EXPECTED_TEXT =
+  'Category "quick" has no usable model: none of its fallback-chain providers are connected (kimi-coding, kimi-for-coding).'
+
+describe("createCategoryUnavailableWarningPlanner", () => {
+  test("#given a dead-chain model_unavailable #when planned #then it notifies and sends the custom message", () => {
+    // given
+    const { planner, messages, notifies } = setup({ error: deadChainError("quick") })
+
+    // when
+    plan(planner, "quick")
+
+    // then
+    expect(notifies).toEqual([{ message: EXPECTED_TEXT, type: "warning" }])
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.message).toEqual({
+      customType: CATEGORY_UNAVAILABLE_MESSAGE_TYPE,
+      content: EXPECTED_TEXT,
+      display: true,
+      details: {
+        category: "quick",
+        reason: "no_chain_rung_available",
+        attempted_chain: QUICK_CHAIN,
+        missing_providers: ["kimi-coding", "kimi-for-coding"],
+        available_categories: ["deep", "writing"],
+      },
+    })
+    expect(messages[0]?.options).toEqual({})
+  })
+
+  test("#given repeated dead-chain failures #when planned #then it warns exactly once per session per category", () => {
+    // given
+    const { planner, messages, notifies, runtime } = setup({ error: deadChainError("quick") })
+
+    // when
+    plan(planner, "quick")
+    plan(planner, "quick")
+    runtime.captureFrom({ sessionManager: { getSessionId: () => "session-2" } })
+    plan(planner, "quick")
+
+    // then
+    expect(notifies).toHaveLength(2)
+    expect(messages).toHaveLength(2)
+  })
+
+  test("#given a non-dead-chain model_unavailable #when planned #then it stays silent", () => {
+    // given
+    const { planner, messages, notifies } = setup({ error: plainUnavailableError("quick") })
+
+    // when
+    plan(planner, "quick")
+
+    // then
+    expect(notifies).toHaveLength(0)
+    expect(messages).toHaveLength(0)
+  })
+
+  test("#given global suppression #when planned #then it stays silent", () => {
+    // given
+    const { planner, messages, notifies } = setup({
+      error: deadChainError("quick"),
+      settings: OmoTaskSettingsSchema.parse({ warnings: { unavailable_categories: false } }),
+    })
+
+    // when
+    plan(planner, "quick")
+
+    // then
+    expect(notifies).toHaveLength(0)
+    expect(messages).toHaveLength(0)
+  })
+
+  test("#given a per-category opt-in over global suppression #when planned #then it warns", () => {
+    // given
+    const { planner, messages, notifies } = setup({
+      error: deadChainError("quick"),
+      omoConfig: { categories: { quick: { warn_unavailable: true } } },
+      settings: OmoTaskSettingsSchema.parse({ warnings: { unavailable_categories: false } }),
+    })
+
+    // when
+    plan(planner, "quick")
+
+    // then
+    expect(notifies).toHaveLength(1)
+    expect(messages).toHaveLength(1)
+  })
+
+  test("#given a per-category opt-out over global default #when planned #then it stays silent", () => {
+    // given
+    const { planner, messages, notifies } = setup({
+      error: deadChainError("quick"),
+      omoConfig: { categories: { quick: { warn_unavailable: false } } },
+    })
+
+    // when
+    plan(planner, "quick")
+
+    // then
+    expect(notifies).toHaveLength(0)
+    expect(messages).toHaveLength(0)
+  })
+
+  test("#given a user-configured category with an explicit model #when a chain error arrives #then it stays silent", () => {
+    // given
+    const { planner, messages, notifies } = setup({
+      error: deadChainError("quick"),
+      omoConfig: { categories: { quick: { model: "omo-mock/mock-parent", warn_unavailable: true } } },
+    })
+
+    // when
+    plan(planner, "quick")
+
+    // then
+    expect(notifies).toHaveLength(0)
+    expect(messages).toHaveLength(0)
+  })
+
+  test("#given no captured ui #when planned #then the custom message still fires", () => {
+    // given
+    const { planner, messages, notifies } = setup({ error: deadChainError("quick"), withUi: false })
+
+    // when
+    plan(planner, "quick")
+
+    // then
+    expect(notifies).toHaveLength(0)
+    expect(messages).toHaveLength(1)
+  })
+
+  test("#given the real child planner and a stripped registry #when a dead-chain category is planned #then the error carries chain details", () => {
+    // given
+    const stripped = {
+      getAvailable: () => [{ provider: "omo-mock", id: "mock-parent" }],
+      find: () => undefined,
+    }
+    const planner = createTaskChildPlanner({}, {}, () => stripped)
+
+    // when
+    const result = plan(planner, "quick")
+
+    // then
+    expect(result.kind).toBe("error")
+    if (result.kind !== "error") throw new Error("Expected error plan")
+    expect(result.error.code).toBe("model_unavailable")
+    expect(result.error.category).toBe("quick")
+    expect(result.error.attempted_chain).toBeDefined()
+    expect(result.error.missing_providers).toContain("openai")
+  })
+})

--- a/packages/omo-senpi/src/components/task/category-unavailable-warning.ts
+++ b/packages/omo-senpi/src/components/task/category-unavailable-warning.ts
@@ -1,0 +1,84 @@
+import type { OmoConfig, OmoTaskSettings } from "@oh-my-opencode/omo-config-core"
+import type { ChildPlanner, PlanResolution, PlanResolutionError } from "@oh-my-opencode/senpi-task"
+
+import type { SenpiExtensionAPI } from "../../extension/types"
+import type { TaskRuntimeContext } from "./runtime-context"
+import { createOncePerSessionGuard } from "./usage-guidance"
+
+// The dead-chain warning custom-message type; the component registers a compact renderer for it.
+export const CATEGORY_UNAVAILABLE_MESSAGE_TYPE = "senpi-task.category-unavailable"
+
+export type CategoryUnavailableWarningDeps = {
+  readonly planner: ChildPlanner
+  readonly pi: SenpiExtensionAPI
+  readonly runtime: TaskRuntimeContext
+  readonly omoConfig: OmoConfig
+  readonly settings: OmoTaskSettings
+}
+
+type DeadChainError = PlanResolutionError & {
+  readonly category: string
+  readonly attempted_chain: NonNullable<PlanResolutionError["attempted_chain"]>
+}
+
+function asDeadChainError(resolution: PlanResolution): DeadChainError | undefined {
+  if (resolution.kind !== "error") return undefined
+  const error = resolution.error
+  if (error.code !== "model_unavailable") return undefined
+  if (error.category === undefined || error.attempted_chain === undefined) return undefined
+  return { ...error, category: error.category, attempted_chain: error.attempted_chain }
+}
+
+function warningSuppressed(config: OmoConfig, settings: OmoTaskSettings, category: string): boolean {
+  const perCategory = config.categories?.[category]?.warn_unavailable
+  const effective = perCategory ?? settings.warnings?.unavailable_categories ?? true
+  return effective === false
+}
+
+// A user category with its own model never warns: its failure is a plain user-model miss, not a
+// dead builtin chain (the resolver omits attempted_chain for it; this is the belt-and-braces guard).
+function hasUserModel(config: OmoConfig, category: string): boolean {
+  return config.categories?.[category]?.model !== undefined
+}
+
+/**
+ * Planner decorator that surfaces dead-chain category failures. On a model_unavailable plan error
+ * carrying attempted_chain, once per (session, category): a headless-safe ui notify (auto-bridged
+ * to RPC {method:"notify"} by senpi) plus a structured custom message for remote clients. It never
+ * steers or triggers a turn, never fires at tool registration (the planner only runs at spawn,
+ * when the registry is captured), and never warns for categories with a user-configured model.
+ * Suppression: categories.<name>.warn_unavailable ?? task.warnings.unavailable_categories ?? true.
+ */
+export function createCategoryUnavailableWarningPlanner(deps: CategoryUnavailableWarningDeps): ChildPlanner {
+  const warned = createOncePerSessionGuard()
+  return (spec): PlanResolution => {
+    const resolution = deps.planner(spec)
+    const error = asDeadChainError(resolution)
+    if (error === undefined) return resolution
+    const category = error.category
+    if (hasUserModel(deps.omoConfig, category)) return resolution
+    if (warningSuppressed(deps.omoConfig, deps.settings, category)) return resolution
+    const sessionId = deps.runtime.sessionId() ?? "unknown-session"
+    if (!warned(`${sessionId}:${category}`)) return resolution
+
+    const providers = (error.missing_providers ?? []).join(", ")
+    const text = `Category "${category}" has no usable model: none of its fallback-chain providers are connected (${providers}).`
+    deps.runtime.ui()?.notify(text, "warning")
+    deps.pi.sendMessage(
+      {
+        customType: CATEGORY_UNAVAILABLE_MESSAGE_TYPE,
+        content: text,
+        display: true,
+        details: {
+          category,
+          reason: "no_chain_rung_available",
+          attempted_chain: error.attempted_chain,
+          missing_providers: error.missing_providers ?? [],
+          available_categories: error.availableCategories ?? [],
+        },
+      },
+      {},
+    )
+    return resolution
+  }
+}

--- a/packages/omo-senpi/src/components/task/engine.ts
+++ b/packages/omo-senpi/src/components/task/engine.ts
@@ -30,6 +30,7 @@ import {
 
 import type { IdleInjectionCoordinator } from "../../extension/idle-injection-coordinator"
 import type { SenpiExtensionAPI } from "../../extension/types"
+import { createCategoryUnavailableWarningPlanner } from "./category-unavailable-warning"
 import { createCompletionObservingStore } from "./completion-bridge"
 import { createParentNotifier } from "./parent-notifier"
 import { createTaskChildPlanner } from "./planner"
@@ -149,7 +150,14 @@ export function composeTaskEngine(deps: ComposeTaskEngineDeps): TaskEngine {
 
   const factories = deps.runnerFactories ?? DEFAULT_RUNNER_FACTORIES
   const runnerContext: RunnerBuildContext = { runtime, sharedParentTools: deps.sharedParentTools, settings }
-  const planner = createTaskChildPlanner(deps.omoConfig, agents, () => runtime.modelRegistry())
+  const basePlanner = createTaskChildPlanner(deps.omoConfig, agents, () => runtime.modelRegistry())
+  const planner = createCategoryUnavailableWarningPlanner({
+    planner: basePlanner,
+    pi: deps.pi,
+    runtime,
+    omoConfig: deps.omoConfig,
+    settings,
+  })
   const manager = createTaskManager({
     store: notifyingStore,
     runners: { "in-process": factories.inProcess(runnerContext), process: factories.process(runnerContext) },

--- a/packages/omo-senpi/src/components/task/index.test.ts
+++ b/packages/omo-senpi/src/components/task/index.test.ts
@@ -132,10 +132,12 @@ describe("omo-senpi task component wiring", () => {
     expect(toolNames(pi)).toEqual([...ALL_TOOL_NAMES].sort())
     // the /tasks and /task-kill commands registered
     expect(pi.commands.map((entry) => entry.name).sort()).toEqual([...TASK_COMMANDS].sort())
-    // Peer mail is a plain injected turn; completion and member liveness use structured renderers.
+    // Peer mail is a plain injected turn; completion, member liveness, and the dead-chain category
+    // warning use structured renderers.
     expect(pi.messageRenderers.map((entry) => entry.customType)).toEqual([
       "senpi-task.completion",
       "senpi-task.team-member-liveness",
+      "senpi-task.category-unavailable",
     ])
     // exactly the task event handlers (session lifecycle + transition-buffer edges) plus the
     // unconditional T16 hygiene sweep handler, which registers its own session_start listener

--- a/packages/omo-senpi/src/components/task/index.ts
+++ b/packages/omo-senpi/src/components/task/index.ts
@@ -17,13 +17,14 @@ import {
 } from "@oh-my-opencode/senpi-task"
 
 import type { ComponentContext, OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types"
+import { CATEGORY_UNAVAILABLE_MESSAGE_TYPE } from "./category-unavailable-warning"
 import { registerTaskCommands } from "./commands"
 import { composeTaskEngine, type TaskEngine } from "./engine"
 import { TASK_USAGE_HINT_FLAG, wireEventBridge } from "./event-bridge"
 import { createLeadPollerLifecycle, type LeadPollerLifecycle } from "./lead-poller-lifecycle"
 import { TEAM_MEMBER_LIVENESS_MESSAGE_TYPE } from "./member-liveness"
 import { TASK_COMPLETION_MESSAGE_TYPE } from "./parent-notifier"
-import { renderTaskCompletion, renderTeamMemberLiveness } from "./renderers"
+import { renderCategoryUnavailable, renderTaskCompletion, renderTeamMemberLiveness } from "./renderers"
 import { createTeamMailboxReconciler, createTeamService } from "./team-service"
 import { createSessionTransitionBridge } from "./session-transition-bridge"
 import { wireSessionStartProcessSweep } from "./process-sweep"
@@ -76,6 +77,7 @@ export function createTaskComponent(options: TaskComponentOptions = {}): OmoSenp
 
       pi.registerMessageRenderer?.(TASK_COMPLETION_MESSAGE_TYPE, renderTaskCompletion)
       pi.registerMessageRenderer?.(TEAM_MEMBER_LIVENESS_MESSAGE_TYPE, renderTeamMemberLiveness)
+      pi.registerMessageRenderer?.(CATEGORY_UNAVAILABLE_MESSAGE_TYPE, renderCategoryUnavailable)
       const teamTools = createTeamToolContext(pi, ctx, engine)
       registerTaskTools(pi, engine, teamTools.service, teamTools.leadPollers.resolveDefaultTeamRunId)
       registerTeamTools(pi, teamTools)

--- a/packages/omo-senpi/src/components/task/planner.test.ts
+++ b/packages/omo-senpi/src/components/task/planner.test.ts
@@ -304,7 +304,10 @@ describe("createTaskChildPlanner", () => {
     if (result.kind !== "error") throw new Error(`Expected error resolution, got ${result.kind}`)
     expect(result.error.code).toBe("unknown_target")
     expect(result.error.availableAgents).toEqual(["explore", "librarian", "metis", "momus"])
-    expect(result.error.availableCategories).toContain("ultrabrain")
+    // writing survives on a gemini-only registry (its gemini-3.1-pro rung resolves); ultrabrain's
+    // sol-only chain is dead, so the dead-chain gate excludes it.
+    expect(result.error.availableCategories).toContain("writing")
+    expect(result.error.availableCategories).not.toContain("ultrabrain")
   })
 
   test("#given subagent_type naming a builtin agent whose chain no registry model satisfies #when planned #then it reports model_unavailable with the agent list", () => {

--- a/packages/omo-senpi/src/components/task/planner.ts
+++ b/packages/omo-senpi/src/components/task/planner.ts
@@ -201,6 +201,10 @@ function toPlanResolution(
       code: "model_unavailable",
       message: `No available model for category "${categoryName}" (attempted ${resolution.attemptedModel ?? "none"}).`,
       availableCategories: resolution.availableCategories,
+      // Dead-chain detail rides the error so the warning layer can surface it without re-resolving.
+      category: categoryName,
+      ...(resolution.attempted_chain !== undefined && { attempted_chain: resolution.attempted_chain }),
+      ...(resolution.missing_providers !== undefined && { missing_providers: resolution.missing_providers }),
     },
   }
 }

--- a/packages/omo-senpi/src/components/task/renderers.ts
+++ b/packages/omo-senpi/src/components/task/renderers.ts
@@ -8,6 +8,13 @@ import {
 
 import type { TeamMemberLivenessDetails } from "./member-liveness"
 
+// Compact renderer for the dead-chain warning: one line, the same text the notify carried.
+export const renderCategoryUnavailable: MessageRenderer<Readonly<Record<string, unknown>>> = (message) => {
+  const content = (message as { readonly content?: unknown }).content
+  const text = typeof content === "string" && content.length > 0 ? content : "(category unavailable)"
+  return linesComponent([normalizeRendererText(text)])
+}
+
 // Render completion details as user-facing rows without exposing the LLM-facing notification envelope.
 export const renderTaskCompletion: MessageRenderer<readonly CompletionDetails[]> = (message) => {
   const details = message.details ?? []

--- a/packages/senpi-task/src/category/builtins.ts
+++ b/packages/senpi-task/src/category/builtins.ts
@@ -1,9 +1,11 @@
+import type { DelegateFallbackEntry } from "@oh-my-opencode/delegate-core"
 import type { OmoCategoryConfig } from "@oh-my-opencode/omo-config-core"
 
 import { ANTHROPIC_CATEGORIES } from "./anthropic-categories"
 import { GOOGLE_CATEGORIES } from "./google-categories"
 import { KIMI_CATEGORIES } from "./kimi-categories"
 import { OPENAI_CATEGORIES } from "./openai-categories"
+import { CATEGORY_FALLBACK_CHAINS } from "./fallback-chains"
 import type { BuiltinCategoryDefinition } from "./types"
 
 // Ported from packages/omo-opencode/src/tools/delegate-task/builtin-categories.ts.
@@ -50,6 +52,46 @@ export function isCategoryGateSatisfied(
   const gateModel = categoryGateModel(categoryName)
   if (gateModel === undefined || hasExplicitUserConfig) return true
   return availableModelIds.has(gateModel)
+}
+
+// Mirrors the kimi transform from model-core provider-model-id-transform.ts (kimi-k3 -> k3); the
+// other chain providers resolve by their bare model id. senpi-task cannot import model-core here
+// without adding a package dependency outside this task's scope (see fallback-chains.ts).
+function transformChainModelId(provider: string, model: string): string {
+  if (provider === "kimi-coding" || provider === "kimi-for-coding") {
+    if (model === "kimi-k3") return "k3"
+    if (model === "kimi-k3-256k") return "k3-256k"
+  }
+  return model
+}
+
+// A chain rung resolves when the live registry exposes its model id: either directly (the
+// gateway-prefix unwrap in resolver.modelIdsOf surfaces vercel/openai/gpt-5.6-sol as gpt-5.6-sol)
+// or through the provider-specific id transform (kimi-coding/k3 satisfies a kimi-k3 rung).
+export function isCategoryChainRungResolvable(
+  entry: DelegateFallbackEntry,
+  availableModelIds: ReadonlySet<string>,
+): boolean {
+  if (availableModelIds.has(entry.model)) return true
+  return entry.providers.some((provider) =>
+    availableModelIds.has(transformChainModelId(provider, entry.model))
+  )
+}
+
+// Dead-chain availability: a builtin-only category is usable only when at least one of its
+// fallback-chain rungs resolves against the live registry. User-configured categories (any explicit
+// categories.<name> entry) opt out - they are always listed and never gated.
+export function isCategoryChainViable(
+  categoryName: string,
+  hasExplicitUserConfig: boolean,
+  availableModelIds: ReadonlySet<string>,
+): boolean {
+  if (hasExplicitUserConfig) return true
+  const chain = Object.hasOwn(CATEGORY_FALLBACK_CHAINS, categoryName)
+    ? CATEGORY_FALLBACK_CHAINS[categoryName]
+    : undefined
+  if (chain === undefined || chain.length === 0) return true
+  return chain.some((rung) => isCategoryChainRungResolvable(rung, availableModelIds))
 }
 
 export const CATEGORY_PROMPT_APPEND_RESOLVERS: Readonly<Record<string, (model: string | undefined) => string>> =

--- a/packages/senpi-task/src/category/dead-chain.test.ts
+++ b/packages/senpi-task/src/category/dead-chain.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test"
+
+import { CATEGORY_FALLBACK_CHAINS } from "./fallback-chains"
+import { resolveCategory } from "./index"
+
+type FakeModel = {
+  readonly provider: string
+  readonly id: string
+}
+
+function model(provider: string, id: string): FakeModel {
+  return { provider, id }
+}
+
+function registry(models: readonly FakeModel[]) {
+  return {
+    getAvailable: () => models,
+    find: (provider: string, modelId: string) =>
+      models.find((candidate) => candidate.provider === provider && candidate.id === modelId),
+  }
+}
+
+// A registry whose only providers serve none of the quick chain rungs; claude-opus-5 keeps
+// visual-engineering/unspecified-high alive so the gated list is not simply empty.
+const OPUS_ONLY = registry([model("omo-mock", "mock-parent"), model("anthropic", "claude-opus-5")])
+
+describe("dead-chain category disabling", () => {
+  describe("#given a builtin category whose chain has no resolvable rung", () => {
+    test("#when spawned #then it fails model_unavailable with attempted_chain and missing_providers", () => {
+      // given / when
+      const result = resolveCategory("quick", {}, OPUS_ONLY)
+
+      // then
+      expect(result.kind).toBe("model_unavailable")
+      if (result.kind !== "model_unavailable") throw new Error("Expected model_unavailable")
+      expect(result.attempted_chain).toEqual(CATEGORY_FALLBACK_CHAINS.quick)
+      expect(result.missing_providers).toEqual([
+        "kimi-coding",
+        "kimi-for-coding",
+        "quotio-openai",
+        "openai",
+        "xai",
+        "xiaomi",
+      ])
+    })
+
+    test("#when the gated category list is computed #then the dead-chain builtin is excluded", () => {
+      // given / when
+      const result = resolveCategory("quick", {}, OPUS_ONLY)
+
+      // then
+      expect(result.availableCategories).not.toContain("quick")
+    })
+
+    test("#when other builtins still have a live rung #then they stay listed", () => {
+      // given / when
+      const result = resolveCategory("quick", {}, OPUS_ONLY)
+
+      // then
+      expect(result.availableCategories).toContain("visual-engineering")
+      expect(result.availableCategories).toContain("unspecified-high")
+    })
+
+    test("#when a gated builtin's chain is also dead #then the gate failure carries the chain details", () => {
+      // given / when
+      const result = resolveCategory("architect", {}, OPUS_ONLY)
+
+      // then
+      expect(result.kind).toBe("model_unavailable")
+      if (result.kind !== "model_unavailable") throw new Error("Expected model_unavailable")
+      expect(result.attempted_chain).toEqual(CATEGORY_FALLBACK_CHAINS.architect)
+      expect(result.missing_providers).toContain("anthropic-api")
+      expect(result.missing_providers).not.toContain("anthropic")
+    })
+  })
+
+  describe("#given a registry with one kimi-coding model", () => {
+    test("#when a chain rung needs the kimi transform #then the transformed id keeps the category alive", () => {
+      // given
+      const models = registry([model("kimi-coding", "k3")])
+
+      // when
+      const result = resolveCategory("unspecified-high", {}, models)
+
+      // then
+      expect(result.kind).toBe("resolved")
+      expect(result.availableCategories).toContain("unspecified-high")
+      expect(result.availableCategories).not.toContain("quick")
+    })
+  })
+
+  describe("#given a gateway-prefixed registry id", () => {
+    test("#when the unwrapped id matches a rung #then the category stays available", () => {
+      // given
+      const models = registry([model("vercel", "openai/gpt-5.6-sol")])
+
+      // when
+      const result = resolveCategory("deep", {}, models)
+
+      // then
+      expect(result.kind).toBe("resolved")
+      expect(result.availableCategories).toContain("deep")
+    })
+  })
+
+  describe("#given a user-configured category with an explicit model", () => {
+    test("#when the builtin chain is dead #then the category is never gated and still resolves", () => {
+      // given
+      const models = registry([model("omo-mock", "mock-parent")])
+
+      // when
+      const result = resolveCategory(
+        "quick",
+        { categories: { quick: { model: "omo-mock/mock-parent" } } },
+        models,
+      )
+
+      // then
+      expect(result.kind).toBe("resolved")
+      expect(result.availableCategories).toContain("quick")
+    })
+
+    test("#when the explicit model is missing #then the failure is a plain miss without chain details", () => {
+      // given
+      const models = registry([model("omo-mock", "mock-parent")])
+
+      // when
+      const result = resolveCategory(
+        "quick",
+        { categories: { quick: { model: "omo-mock/absent" } } },
+        models,
+      )
+
+      // then
+      expect(result.kind).toBe("model_unavailable")
+      if (result.kind !== "model_unavailable") throw new Error("Expected model_unavailable")
+      expect(result.attempted_chain).toBeUndefined()
+      expect(result.availableCategories).toContain("quick")
+    })
+  })
+
+  describe("#given disabled and unknown targets", () => {
+    test("#when the category is disabled #then the result still returns the gated list", () => {
+      // given / when
+      const result = resolveCategory("quick", { categories: { quick: { disable: true } } }, OPUS_ONLY)
+
+      // then
+      expect(result.kind).toBe("disabled")
+      expect(result.availableCategories).toContain("quick")
+      expect(result.availableCategories).toContain("visual-engineering")
+      expect(result.availableCategories).not.toContain("deep")
+    })
+
+    test("#when the category is unknown #then the result still returns the gated list", () => {
+      // given / when
+      const result = resolveCategory("nope", {}, OPUS_ONLY)
+
+      // then
+      expect(result.kind).toBe("not_found")
+      expect(result.availableCategories).toContain("visual-engineering")
+      expect(result.availableCategories).not.toContain("quick")
+      expect(result.availableCategories).not.toContain("deep")
+    })
+  })
+})

--- a/packages/senpi-task/src/category/index.ts
+++ b/packages/senpi-task/src/category/index.ts
@@ -5,6 +5,8 @@ export {
   CATEGORY_PROMPT_APPENDS,
   DEFAULT_CATEGORIES,
   categoryGateModel,
+  isCategoryChainRungResolvable,
+  isCategoryChainViable,
   isCategoryGateSatisfied,
 } from "./builtins"
 export { resolveCategory } from "./resolver"

--- a/packages/senpi-task/src/category/resolver.ts
+++ b/packages/senpi-task/src/category/resolver.ts
@@ -15,6 +15,8 @@ import {
   CATEGORY_PROMPT_APPENDS,
   DEFAULT_CATEGORIES,
   categoryGateModel,
+  isCategoryChainRungResolvable,
+  isCategoryChainViable,
   isCategoryGateSatisfied,
 } from "./builtins"
 import { buildRuntimeModelChain, type ModelChainCandidate } from "../model-chain"
@@ -162,9 +164,42 @@ function availableCategoryNames(config: OmoConfig, availableModelIds?: ReadonlyS
   const names = Array.from(new Set([...Object.keys(DEFAULT_CATEGORIES), ...Object.keys(config.categories ?? {})])).sort()
   if (availableModelIds === undefined) return names
   const userCategories = config.categories ?? {}
-  return names.filter((name) =>
-    isCategoryGateSatisfied(name, getOwnRecordValue(userCategories, name) !== undefined, availableModelIds)
-  )
+  return names.filter((name) => {
+    const hasExplicitUserConfig = getOwnRecordValue(userCategories, name) !== undefined
+    return isCategoryGateSatisfied(name, hasExplicitUserConfig, availableModelIds)
+      && isCategoryChainViable(name, hasExplicitUserConfig, availableModelIds)
+  })
+}
+
+// Gated listing for the disabled/not_found early returns. The registry is only consulted best
+// effort here: a throwing or malformed registry degrades to the ungated list (today's behavior),
+// since those results never resolve a model anyway.
+function gatedAvailableCategories<TModel extends SenpiModelPort>(
+  config: OmoConfig,
+  senpiModelRegistry: SenpiModelRegistryPort<TModel>,
+): readonly string[] {
+  try {
+    const parsed = parseAvailableModels(senpiModelRegistry.getAvailable())
+    if (!parsed.validContainer) return availableCategoryNames(config)
+    return availableCategoryNames(config, modelIdsOf(parsed.models))
+  } catch {
+    return availableCategoryNames(config)
+  }
+}
+
+// Chain providers with no model in the live registry, in chain order, deduplicated.
+function missingChainProviders(
+  chain: readonly DelegateFallbackEntry[],
+  availableModels: readonly string[],
+): readonly string[] {
+  const connected = new Set(availableModels.map((model) => model.slice(0, model.indexOf("/"))))
+  const missing: string[] = []
+  for (const rung of chain) {
+    for (const provider of rung.providers) {
+      if (!connected.has(provider) && !missing.includes(provider)) missing.push(provider)
+    }
+  }
+  return missing
 }
 
 // A gateway provider re-publishes an upstream model under `<gateway>/<upstream-vendor>/<model-id>`
@@ -242,13 +277,13 @@ export function resolveCategory<TModel extends SenpiModelPort>(
       kind: "disabled",
       category: categoryName,
       reason: `Category "${categoryName}" is disabled by omo.json`,
-      availableCategories,
+      availableCategories: gatedAvailableCategories(omoConfig, senpiModelRegistry),
     }
   }
 
   const builtinConfig = getOwnRecordValue(DEFAULT_CATEGORIES, categoryName)
   if (!builtinConfig && !userConfig) {
-    return { kind: "not_found", category: categoryName, availableCategories }
+    return { kind: "not_found", category: categoryName, availableCategories: gatedAvailableCategories(omoConfig, senpiModelRegistry) }
   }
 
   const config = { ...builtinConfig, ...userConfig }
@@ -264,18 +299,41 @@ export function resolveCategory<TModel extends SenpiModelPort>(
     }
   }
 
-  const gatedCategories = availableCategoryNames(omoConfig, modelIdsOf(availableModels))
-  if (!isCategoryGateSatisfied(categoryName, userConfig !== undefined, modelIdsOf(availableModels))) {
+  const availableModelIds = modelIdsOf(availableModels)
+  const gatedCategories = availableCategoryNames(omoConfig, availableModelIds)
+  const fallbackChain = getOwnRecordValue(CATEGORY_FALLBACK_CHAINS, categoryName)
+  const chainDead = fallbackChain !== undefined
+    && fallbackChain.length > 0
+    && !fallbackChain.some((rung) => isCategoryChainRungResolvable(rung, availableModelIds))
+  const deadChain = chainDead && fallbackChain !== undefined
+    ? { attempted_chain: fallbackChain, missing_providers: missingChainProviders(fallbackChain, availableModels) }
+    : undefined
+  if (!isCategoryGateSatisfied(categoryName, userConfig !== undefined, availableModelIds)) {
     return {
       kind: "model_unavailable",
       category: categoryName,
       attemptedModel: builtinConfig?.model ?? config.model,
       availableModels,
       availableCategories: gatedCategories,
+      ...(deadChain ?? {}),
     }
   }
 
-  const fallbackChain = getOwnRecordValue(CATEGORY_FALLBACK_CHAINS, categoryName)
+  // Dead-chain short-circuit: a builtin chain with zero resolvable rungs can never produce a model,
+  // so fail before resolution with the rungs that were attempted. An explicit user model or user
+  // fallback list opts the category out (its failure stays a plain user-model miss without chain
+  // details), and a caller-supplied system default remains the resolver's last resort.
+  if (deadChain !== undefined && userConfig?.model === undefined && userConfig?.fallback_models === undefined && options.systemDefaultModel === undefined) {
+    return {
+      kind: "model_unavailable",
+      category: categoryName,
+      attemptedModel: builtinConfig?.model ?? config.model,
+      availableModels,
+      availableCategories: gatedCategories,
+      ...deadChain,
+    }
+  }
+
   const resolution = resolveModelForDelegateTask(
     {
       userModel: userConfig?.model,

--- a/packages/senpi-task/src/category/types.ts
+++ b/packages/senpi-task/src/category/types.ts
@@ -79,4 +79,7 @@ export type CategoryResolutionResult<TModel extends SenpiModelPort> =
       readonly availableCategories: readonly string[]
       readonly nearestFallback?: string
       readonly fallbackEntry?: DelegateFallbackEntry
+      // Dead-chain detail: present when the builtin fallback chain had zero resolvable rungs.
+      readonly attempted_chain?: readonly DelegateFallbackEntry[]
+      readonly missing_providers?: readonly string[]
     }

--- a/packages/senpi-task/src/manager/types.ts
+++ b/packages/senpi-task/src/manager/types.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from "@code-yeongyu/senpi"
+import type { DelegateFallbackEntry } from "@oh-my-opencode/delegate-core"
 import type { OmoTaskSettings } from "@oh-my-opencode/omo-config-core"
 
 import type { ResolvedModelRecord, TaskRecord, TaskRunStats, TaskStatus } from "../state"
@@ -82,6 +83,11 @@ export type PlanResolutionError = {
   readonly message: string
   readonly availableAgents?: readonly string[]
   readonly availableCategories?: readonly string[]
+  // Dead-chain spawn detail: the category whose builtin fallback chain had zero resolvable rungs,
+  // the rungs that were attempted, and the chain providers missing from the live registry.
+  readonly category?: string
+  readonly attempted_chain?: readonly DelegateFallbackEntry[]
+  readonly missing_providers?: readonly string[]
 }
 
 export type PlanResolution =


### PR DESCRIPTION
## Summary

Plan todo 6 (PR-4b) of `.omo/plans/senpi-model-chain-overhaul.md`.

- **senpi-task chain viability**: a builtin-only category is available iff its `requiresModel` gate passes AND >=1 `CATEGORY_FALLBACK_CHAINS` rung resolves against the live registry (reuses the `modelIdsOf` gateway-prefix unwrap; kimi id transform mirrored from model-core). Applied in `availableCategoryNames`, so dead-chain builtins drop out of `gatedCategories`. User-configured categories (any explicit `categories.<name>` entry) are always listed and never gated.
- **Dead-chain spawn detail**: `model_unavailable` now carries `attempted_chain` (rungs) + `missing_providers`; `disabled`/`not_found` results return the gated list too.
- **omo-senpi surfacing**: once per (session, category) on a dead-chain spawn attempt: `ui.notify(..., "warning")` (auto-bridged to RPC `{method:"notify"}`) + `senpi-task.category-unavailable` custom message with a registered compact renderer. No emission at tool registration, no steer/triggerTurn, no warning for user-model categories.
- **Suppression**: `categories.<name>.warn_unavailable` ?? `task.warnings.unavailable_categories` ?? true (keys shipped in #6433).

## Tests

- `bun test packages/senpi-task packages/omo-senpi packages/omo-config-core`: **1545 pass / 0 fail** (baseline on origin/dev: 1526 pass / 0 fail, stash-proven; +19 net new tests).
- tsgo clean for all three packages.
- New: `dead-chain.test.ts` (11 tests: zero-rung exclusion, attempted_chain/missing_providers, kimi transform, gateway unwrap, user-model bypass, gated disabled/not_found lists) and `category-unavailable-warning.test.ts` (9 tests: once-per-session-per-category, global suppression, per-category override both directions, user-configured never warns, non-dead silent, no-ui path, real-planner integration).

## Live RPC evidence

`packages/omo-senpi/scripts/qa/task-category-unavailable-e2e.mjs` (task-rpc-e2e driver style, fully sandboxed agent dir + HOME + XDG): scripted parent spawns `quick` twice against a mock-only registry (all builtin chains dead). Happy run: exactly ONE `{method:"notify",notifyType:"warning"}` frame AND exactly ONE `senpi-task.category-unavailable` custom message in the session JSONL. Suppressed run (`task.warnings.unavailable_categories=false`): zero frames. Isolation gates: real `~/.senpi/agent` credential digest, real `~/.omo` config layer, and real settings.json mtime all unchanged.

Evidence: `.omo/evidence/task-6-senpi-model-chain-overhaul.txt`

Plan: .omo/plans/senpi-model-chain-overhaul.md


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables dead-chain builtin task categories and shows a one-time warning when a spawn fails, via TUI and RPC. Builtins now appear only if at least one fallback-chain rung resolves; errors include chain details; warning suppression is configurable.

- **New Features**
  - Category gating in `senpi-task`: a builtin is available only if its model gate passes and any fallback-chain rung resolves (supports gateway id unwrap and Kimi id transform). User-configured categories are always listed.
  - Error detail: dead-chain `model_unavailable` includes `category`, `attempted_chain`, `missing_providers`, and a gated `availableCategories`. `disabled`/`not_found` also return the gated list.
  - Warnings in `omo-senpi`: once per session per category, send `ui.notify(..., "warning")` and a `senpi-task.category-unavailable` custom message with a compact renderer. No warnings for user-model categories; safe without UI.
  - Suppression: `categories.<name>.warn_unavailable` overrides `task.warnings.unavailable_categories` (default true).

<sup>Written for commit 3fa23902066f880855048432ae0bd0afc9956cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

