### PR TITLE
fix(opencode): remove incompatible process listener helper

### DIFF
--- a/.omo/evidence/20260729-process-cleanup-node24/README.md
+++ b/.omo/evidence/20260729-process-cleanup-node24/README.md
@@ -1,0 +1,70 @@
+# Process cleanup Node 24 declaration compatibility evidence
+
+## Scope
+
+The declaration build failed when `bun-types@1.3.14` resolved its wildcard
+`@types/node` dependency to 24.12.0. The unused `getNewListener` helper mixed
+event-specific process listener overloads into a single `() => void` contract.
+
+## RED / GREEN
+
+- Compatibility compiler:
+  `/tmp/omo-node-types-24/node_modules/.bin/tsc -p /tmp/omo-node-types-24/tsconfig.json`
+- Before the fix: exit 1 with TS2769 and TS2322. See `red-node24.txt`.
+- After the fix: exit 0 with no diagnostics. See `green-node24.txt`.
+- Current dependency declaration emit:
+  `/tmp/omo-process-cleanup-pr/node_modules/.bin/tsc -p /tmp/omo-process-cleanup-pr/tsconfig.json --emitDeclarationOnly`
+  exited 0.
+
+## Automated verification
+
+- `bun test /tmp/omo-process-cleanup-pr/packages/omo-opencode/src/features/background-agent/process-cleanup.test.ts`
+  - Result: PASS - 44 tests, 0 failures, 83 expectations.
+- `bun install` in the patched isolated worktree
+  - Result: PASS - full prepare build completed.
+- `bun run build:senpi-plugin` in the patched isolated worktree
+  - Result: PASS - Senpi extension and LSP runtime built successfully.
+- `bun install` in `/home/thewind/.local/share/oh-my-openagent`
+  - Result: PASS - exact installed-checkout update surface completed.
+- `bun run build:senpi-plugin` in `/home/thewind/.local/share/oh-my-openagent`
+  - Result: PASS - exact installed-checkout Senpi plugin build completed.
+- `bun install` in Senpi's generated updater worktree after applying the patch
+  - Result: PASS - exact worker dependency/build environment reported
+    `build: all steps completed`.
+
+## Why this is sufficient
+
+The compatibility compiler reproduces the exact diagnostics and line locations
+from the failed updater. Removing the zero-consumer helper makes the same
+compiler surface pass without changing production cleanup behavior. The focused
+cleanup suite verifies all used signal and shutdown helpers remain intact, and
+the install/build commands exercise the package scripts used by `senpi update`.
+
+## Senpi update command
+
+`senpi update` exited 0 and launched its OMO update worker. The worker correctly
+continued to fail while building unpatched `origin/dev`; its log reproduced the
+same TS2769/TS2322 diagnostics. Applying this patch to that generated worktree
+made its exact `bun install` command pass. The background update will therefore
+remain blocked for users until this change reaches `dev`.
+
+## Live QA
+
+The repository wrapper scripts could not reach their assertions in this host
+environment: the default mode blocked while copying the unrelated host Codex
+profile, and `--no-config` blocked in its unbounded readiness curl. Both
+disposable containers were forcibly removed before continuing.
+
+The equivalent bounded HTTP smoke ran against a direct disposable `omo-qa`
+container:
+
+- Container command:
+  `docker run --rm --name omo-process-cleanup-qa -p 127.0.0.1:56609:56609 -e OPENCODE_SERVER_PASSWORD=omo-qa omo-qa opencode serve --port 56609 --hostname 0.0.0.0`
+- Authenticated `GET /global/health`: HTTP 200,
+  `{"healthy":true,"version":"1.18.9"}`.
+- Authenticated `GET /doc`: 162 documented paths.
+- Unauthenticated `GET /session?directory=/tmp/omo-qa`: HTTP 401.
+- Cleanup: `docker rm -f omo-process-cleanup-qa`; no matching container
+  remained and port 56609 refused connections.
+
+See `live-opencode-qa.txt` for the exact probes and results.

--- a/.omo/evidence/20260729-process-cleanup-node24/green-node24.txt
+++ b/.omo/evidence/20260729-process-cleanup-node24/green-node24.txt
@@ -1,0 +1,19 @@
+Command:
+/tmp/omo-node-types-24/node_modules/.bin/tsc -p /tmp/omo-node-types-24/tsconfig.json
+
+Result: exit 0
+Output: none
+
+Command:
+/tmp/omo-process-cleanup-pr/node_modules/.bin/tsc -p /tmp/omo-process-cleanup-pr/tsconfig.json --emitDeclarationOnly
+
+Result: exit 0
+Output: none
+
+Command:
+bun test /tmp/omo-process-cleanup-pr/packages/omo-opencode/src/features/background-agent/process-cleanup.test.ts
+
+Result: exit 0
+44 pass
+0 fail
+83 expect() calls

--- a/.omo/evidence/20260729-process-cleanup-node24/live-opencode-qa.txt
+++ b/.omo/evidence/20260729-process-cleanup-node24/live-opencode-qa.txt
@@ -1,0 +1,30 @@
+Server:
+docker run --rm --name omo-process-cleanup-qa -p 127.0.0.1:56609:56609 -e OPENCODE_SERVER_PASSWORD=omo-qa omo-qa opencode serve --port 56609 --hostname 0.0.0.0
+
+Readiness:
+opencode server listening on http://0.0.0.0:56609
+
+Probe:
+curl -i --max-time 10 -u opencode:omo-qa http://127.0.0.1:56609/global/health
+
+Result:
+HTTP/1.1 200 OK
+{"healthy":true,"version":"1.18.9"}
+
+Probe:
+curl -sS --max-time 10 -u opencode:omo-qa http://127.0.0.1:56609/doc | jq '.paths | length'
+
+Result:
+162
+
+Probe:
+curl -i --max-time 10 'http://127.0.0.1:56609/session?directory=/tmp/omo-qa'
+
+Result:
+HTTP/1.1 401 Unauthorized
+www-authenticate: Basic realm="Secure Area"
+
+Cleanup:
+docker rm -f omo-process-cleanup-qa
+docker ps -a --filter name=omo-process-cleanup-qa --format '{{.ID}}' -> empty
+curl --max-time 2 http://127.0.0.1:56609/global/health -> exit 7 (connection refused)

--- a/.omo/evidence/20260729-process-cleanup-node24/red-node24.txt
+++ b/.omo/evidence/20260729-process-cleanup-node24/red-node24.txt
@@ -1,0 +1,11 @@
+Command:
+/tmp/omo-node-types-24/node_modules/.bin/tsc -p /tmp/omo-node-types-24/tsconfig.json
+
+Result: exit 1
+
+../../../tmp/omo-process-cleanup-pr/packages/omo-opencode/src/features/background-agent/process-cleanup.test-helpers.ts(28,16): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type 'ProcessCleanupEvent' is not assignable to parameter of type 'Signals'.
+      Type '"beforeExit"' is not assignable to type 'Signals'.
+../../../tmp/omo-process-cleanup-pr/packages/omo-opencode/src/features/background-agent/process-cleanup.test-helpers.ts(35,3): error TS2322: Type 'BeforeExitListener' is not assignable to type '() => void'.
+  Target signature provides too few arguments. Expected 1 or more, but got 0.

--- a/packages/omo-opencode/src/features/background-agent/process-cleanup.test-helpers.ts
+++ b/packages/omo-opencode/src/features/background-agent/process-cleanup.test-helpers.ts
@@ -1,12 +1,5 @@
 import { __getProcessCleanupSignalListenerForTesting } from "./process-cleanup"
 
-type ProcessCleanupEvent =
-  | NodeJS.Signals
-  | "beforeExit"
-  | "exit"
-  | "uncaughtException"
-  | "unhandledRejection"
-
 type ProcessCleanupSignal = Parameters<typeof __getProcessCleanupSignalListenerForTesting>[0]
 
 export function getRegisteredProcessCleanupSignalListener(
@@ -15,21 +8,6 @@ export function getRegisteredProcessCleanupSignalListener(
   const listener = __getProcessCleanupSignalListenerForTesting(signal)
   if (!listener) {
     throw new Error(`Expected this module to register a ${signal} listener`)
-  }
-
-  return listener
-}
-
-export function getNewListener(
-  signal: ProcessCleanupEvent,
-  existingListeners: Function[],
-): () => void {
-  const listener = process
-    .listeners(signal)
-    .find((registeredListener) => !existingListeners.includes(registeredListener))
-
-  if (typeof listener !== "function") {
-    throw new Error(`Expected a ${signal} listener to be registered`)
   }
 
   return listener


### PR DESCRIPTION
## Summary

- Fixes the OMO declaration build failure that can make `senpi update` fail with TS2769/TS2322 when `bun-types@1.3.14` resolves `@types/node@24.12.0`.
- Removes an unused test helper whose single `() => void` contract was incompatible with Node's event-specific process listener overloads.
- Leaves production cleanup behavior and every used cleanup test seam unchanged.

## Changes

- Removed the zero-consumer `getNewListener` export and its private `ProcessCleanupEvent` union from the process-cleanup test helper.
- Added sanitized RED/GREEN, build, and disposable OpenCode HTTP QA evidence under `.omo/evidence/20260729-process-cleanup-node24/`.

## QA & Evidence

- **What was tested:** Node 24 compatibility compile via `/tmp/omo-node-types-24/node_modules/.bin/tsc -p /tmp/omo-node-types-24/tsconfig.json` before and after the change.
  **Observed result:** Before: exact TS2769 at line 28 and TS2322 at line 35. After: exit 0 with no diagnostics.
  **Artifact:** `.omo/evidence/20260729-process-cleanup-node24/red-node24.txt`, `.omo/evidence/20260729-process-cleanup-node24/green-node24.txt`
  **Why sufficient:** Reproduces the exact compiler/type surface reported by the updater and proves the same surface turns green.

- **What was tested:** `bun test /tmp/omo-process-cleanup-pr/packages/omo-opencode/src/features/background-agent/process-cleanup.test.ts`
  **Observed result:** 44 pass, 0 fail, 83 expectations.
  **Artifact:** `.omo/evidence/20260729-process-cleanup-node24/green-node24.txt`
  **Why sufficient:** Covers the remaining used signal registration and shutdown helper behavior.

- **What was tested:** `bun install` and `bun run build:senpi-plugin` in both the patched contribution worktree and `/home/thewind/.local/share/oh-my-openagent`; also `bun install` in Senpi's generated updater worktree after applying this patch.
  **Observed result:** All commands exited 0; full builds completed without TS2769/TS2322.
  **Artifact:** `.omo/evidence/20260729-process-cleanup-node24/README.md`
  **Why sufficient:** Exercises the exact package/install scripts used by the local OMO updater and the Senpi plugin build.

- **What was tested:** Disposable `omo-qa` OpenCode server with bounded authenticated/unauthenticated HTTP probes.
  **Observed result:** `/global/health` HTTP 200 with `healthy:true`, `/doc` exposed 162 paths, unauthenticated `/session` returned HTTP 401; container removed and port closed afterward.
  **Artifact:** `.omo/evidence/20260729-process-cleanup-node24/live-opencode-qa.txt`
  **Why sufficient:** Confirms the adjacent OpenCode runtime surface remains healthy with the built repository.

## Risks & Residuals

- Production runtime risk: not applicable; the deleted export has no in-repository consumers and is test-only.
- `bun-types` still declares `@types/node` as `*`; this patch removes the incompatible unused code rather than changing the repository's dependency policy.
- The foreground `senpi update` command launches an asynchronous worker. Until this PR reaches `dev`, that worker still builds the unpatched upstream ref and reproduces the known failure; the patched worker environment passes.
- The repository wrapper Docker smoke scripts blocked in host-profile copy/readiness stages on this machine. The same assertions were run directly against the disposable `omo-qa` image with bounded probes; both stalled containers were removed.

## Automated Checks

```bash
/tmp/omo-node-types-24/node_modules/.bin/tsc -p /tmp/omo-node-types-24/tsconfig.json
/tmp/omo-process-cleanup-pr/node_modules/.bin/tsc -p /tmp/omo-process-cleanup-pr/tsconfig.json --noEmit
/tmp/omo-process-cleanup-pr/node_modules/.bin/tsc -p /tmp/omo-process-cleanup-pr/tsconfig.json --emitDeclarationOnly
bun test /tmp/omo-process-cleanup-pr/packages/omo-opencode/src/features/background-agent/process-cleanup.test.ts
bun install
bun run build:senpi-plugin
```

## Related Issues

No exact duplicate issue or pull request was found.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes an unused process listener test helper that conflicted with Node 24 types, fixing declaration builds when `bun-types@1.3.14` resolves `@types/node@24.12.0`. Unblocks `senpi update` (TS2769/TS2322) without changing runtime cleanup behavior.

- **Bug Fixes**
  - Deleted `getNewListener` and its private `ProcessCleanupEvent` from `packages/omo-opencode/src/features/background-agent/process-cleanup.test-helpers.ts`.
  - Added build/test evidence under `.omo/evidence/20260729-process-cleanup-node24/`; declaration emit and tests pass with Node 24 types.

<sup>Written for commit c116b422cac4a35a9da104267c9191de81e00cf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

