### PR TITLE
ci(workflows): add repository guard checks to deployment workflows

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -35,6 +35,7 @@ jobs:
   # - Uploads compressed artifacts for the publish job
   # =============================================================================
   build:
+    if: github.repository == 'code-yeongyu/oh-my-openagent'
     runs-on: ${{ startsWith(matrix.platform, 'windows-') && 'windows-latest' || startsWith(matrix.platform, 'darwin-') && 'macos-latest' || 'ubuntu-latest' }}
     defaults:
       run:
@@ -198,7 +199,7 @@ jobs:
 
   publish:
     needs: build
-    if: always() && !cancelled()
+    if: always() && !cancelled() && github.repository == 'code-yeongyu/oh-my-openagent'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'code-yeongyu/oh-my-openagent'
     runs-on: ubuntu-latest
     environment:
       name: web-production


### PR DESCRIPTION
Adds `if: github.repository == 'code-yeongyu/oh-my-openagent'` guard checks to the jobs in `web-deploy.yml` and `publish-platform.yml`.

### Why this is needed
Currently, pushes touching `docs/` or `packages/web/` trigger `web-deploy.yml` on contributor forks, queueing unnecessary Cloudflare Workers deployment jobs that fail due to missing fork secrets.

Adding the explicit repository ownership check aligns these workflows with the existing guard pattern used in `publish.yml` and `stats.yml`, preventing wasteful runner executions on contributor forks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `if: github.repository == 'code-yeongyu/oh-my-openagent'` guards to jobs in `web-deploy.yml` and `publish-platform.yml` so deployments only run on the main repo. This stops fork pushes from triggering failing Cloudflare Workers runs and aligns guards with `publish.yml` and `stats.yml`.

<sup>Written for commit 6d53e7d399e5fbb5c78c0a2ad15b1a293e0871c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

