### PR TITLE
fix(mcp-oauth): set text/plain Content-Type on OAuth error responses

### DIFF
--- a/packages/mcp-client-core/src/mcp-oauth/callback-server.test.ts
+++ b/packages/mcp-client-core/src/mcp-oauth/callback-server.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test"
+import { startCallbackServer } from "./callback-server"
+
+const HOSTNAME = "127.0.0.1"
+const TEST_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 5_000
+
+describe("OAuth callback server HTTP responses", () => {
+  it("#given a running callback server #when requesting an unknown route #then it returns a plain-text 404", async () => {
+    // given
+    const server = await startCallbackServer(0)
+
+    try {
+      // when
+      const response = await fetch(`http://${HOSTNAME}:${server.port}/unknown`)
+
+      // then
+      expect(response.status).toBe(404)
+      expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8")
+      expect(await response.text()).toBe("Not Found")
+    } finally {
+      await server.close()
+    }
+  }, TEST_TIMEOUT_MS)
+
+  it("#given a running callback server #when OAuth returns an error #then it returns a plain-text 400 and rejects the callback", async () => {
+    // given
+    const server = await startCallbackServer(0)
+    const callbackResult = server.waitForCallback().then(
+      () => null,
+      (error: unknown) => error,
+    )
+
+    try {
+      // when
+      const response = await fetch(
+        `http://${HOSTNAME}:${server.port}/oauth/callback?error=access_denied&error_description=${encodeURIComponent("<script>alert(1)</script>")}`,
+      )
+
+      // then
+      expect(response.status).toBe(400)
+      expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8")
+      expect(await response.text()).toBe("Authorization failed: <script>alert(1)</script>")
+
+      const error = await callbackResult
+      expect(error).toBeInstanceOf(Error)
+      if (!(error instanceof Error)) {
+        throw new Error("Expected OAuth callback to reject with an Error")
+      }
+      expect(error.message).toBe("OAuth authorization failed: <script>alert(1)</script>")
+    } finally {
+      await server.close()
+    }
+  }, TEST_TIMEOUT_MS)
+
+  it("#given a running callback server #when OAuth returns code and state #then it returns HTML and resolves the callback", async () => {
+    // given
+    const server = await startCallbackServer(0)
+
+    try {
+      // when
+      const [callback, response] = await Promise.all([
+        server.waitForCallback(),
+        fetch(`http://${HOSTNAME}:${server.port}/oauth/callback?code=code-123&state=state-456`),
+      ])
+
+      // then
+      expect(callback).toEqual({ code: "code-123", state: "state-456" })
+      expect(response.status).toBe(200)
+      expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8")
+      expect(await response.text()).toContain("Authorization successful")
+    } finally {
+      await server.close()
+    }
+  }, TEST_TIMEOUT_MS)
+})

--- a/packages/mcp-client-core/src/mcp-oauth/callback-server.test.ts
+++ b/packages/mcp-client-core/src/mcp-oauth/callback-server.test.ts
@@ -16,6 +16,7 @@ describe("OAuth callback server HTTP responses", () => {
       // then
       expect(response.status).toBe(404)
       expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8")
+      expect(response.headers.get("x-content-type-options")).toBe("nosniff")
       expect(await response.text()).toBe("Not Found")
     } finally {
       await server.close()
@@ -39,6 +40,7 @@ describe("OAuth callback server HTTP responses", () => {
       // then
       expect(response.status).toBe(400)
       expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8")
+      expect(response.headers.get("x-content-type-options")).toBe("nosniff")
       expect(await response.text()).toBe("Authorization failed: <script>alert(1)</script>")
 
       const error = await callbackResult
@@ -47,6 +49,31 @@ describe("OAuth callback server HTTP responses", () => {
         throw new Error("Expected OAuth callback to reject with an Error")
       }
       expect(error.message).toBe("OAuth authorization failed: <script>alert(1)</script>")
+    } finally {
+      await server.close()
+    }
+  }, TEST_TIMEOUT_MS)
+
+  it("#given a running callback server #when the callback misses code or state #then it returns a plain-text nosniff 400 and rejects the callback", async () => {
+    // given
+    const server = await startCallbackServer(0)
+    const callbackResult = server.waitForCallback().then(
+      () => null,
+      (error: unknown) => error,
+    )
+
+    try {
+      // when
+      const response = await fetch(`http://${HOSTNAME}:${server.port}/oauth/callback`)
+
+      // then
+      expect(response.status).toBe(400)
+      expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8")
+      expect(response.headers.get("x-content-type-options")).toBe("nosniff")
+      expect(await response.text()).toBe("Missing code or state parameter")
+
+      const error = await callbackResult
+      expect(error).toBeInstanceOf(Error)
     } finally {
       await server.close()
     }

--- a/packages/mcp-client-core/src/mcp-oauth/callback-server.ts
+++ b/packages/mcp-client-core/src/mcp-oauth/callback-server.ts
@@ -147,6 +147,7 @@ export async function startCallbackServer(
     if (url.pathname !== "/oauth/callback") {
       response.statusCode = 404
       response.setHeader("Content-Type", "text/plain; charset=utf-8")
+      response.setHeader("X-Content-Type-Options", "nosniff")
       response.end("Not Found")
       return
     }
@@ -158,6 +159,7 @@ export async function startCallbackServer(
       rejectCallback?.(new Error(`OAuth authorization failed: ${description}`))
       response.statusCode = 400
       response.setHeader("Content-Type", "text/plain; charset=utf-8")
+      response.setHeader("X-Content-Type-Options", "nosniff")
       response.end(`Authorization failed: ${description}`)
       timer.setTimeout(scheduleClose, 100)
       return
@@ -171,6 +173,7 @@ export async function startCallbackServer(
       rejectCallback?.(new Error("OAuth callback missing code or state parameter"))
       response.statusCode = 400
       response.setHeader("Content-Type", "text/plain; charset=utf-8")
+      response.setHeader("X-Content-Type-Options", "nosniff")
       response.end("Missing code or state parameter")
       timer.setTimeout(scheduleClose, 100)
       return

--- a/packages/mcp-client-core/src/mcp-oauth/callback-server.ts
+++ b/packages/mcp-client-core/src/mcp-oauth/callback-server.ts
@@ -146,6 +146,7 @@ export async function startCallbackServer(
 
     if (url.pathname !== "/oauth/callback") {
       response.statusCode = 404
+      response.setHeader("Content-Type", "text/plain; charset=utf-8")
       response.end("Not Found")
       return
     }
@@ -156,6 +157,7 @@ export async function startCallbackServer(
       timer.clearTimeout(timeoutId)
       rejectCallback?.(new Error(`OAuth authorization failed: ${description}`))
       response.statusCode = 400
+      response.setHeader("Content-Type", "text/plain; charset=utf-8")
       response.end(`Authorization failed: ${description}`)
       timer.setTimeout(scheduleClose, 100)
       return
@@ -168,6 +170,7 @@ export async function startCallbackServer(
       timer.clearTimeout(timeoutId)
       rejectCallback?.(new Error("OAuth callback missing code or state parameter"))
       response.statusCode = 400
+      response.setHeader("Content-Type", "text/plain; charset=utf-8")
       response.end("Missing code or state parameter")
       timer.setTimeout(scheduleClose, 100)
       return


### PR DESCRIPTION
## Summary

Sets `Content-Type: text/plain; charset=utf-8` on all HTTP 400/404 error responses in the MCP OAuth callback server (`packages/mcp-client-core/src/mcp-oauth/callback-server.ts`), preventing reflected XSS via the `error_description` query parameter.

## Problem

The OAuth error handling path reflected the untrusted `error_description` URL query parameter directly into the HTTP response body without setting an explicit `Content-Type` header:

```ts
const description = url.searchParams.get("error_description") ?? oauthError
// ...
response.statusCode = 400
response.end(`Authorization failed: ${description}`)
```

Without an explicit `Content-Type`, browsers may MIME-sniff the response body as HTML, rendering any injected markup from `error_description` — a classic reflected XSS vector ([CWE-79](https://cwe.mitre.org/data/definitions/79.html)). Flagged by CodeQL as `js/reflected-xss`.

## Fix

Adds `response.setHeader("Content-Type", "text/plain; charset=utf-8")` before every `response.end()` call in error response paths (HTTP 400 and 404). Success responses that intentionally serve HTML are unchanged.

## Verification

- `bun test` in `packages/mcp-client-core` — all tests pass
- Callback server tests in `packages/omo-opencode` — 21/21 passing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets `text/plain` and `nosniff` headers on all OAuth callback error responses so browsers can't MIME-sniff the reflected `error_description` parameter as HTML. Fixes the CodeQL `js/reflected-xss` alert.

- Applies the headers to all 400/404 paths, including missing code/state.
- Adds tests asserting plain-text + nosniff on every error path and HTML on success.

<sup>Written for commit 2b3cba1bb345703eb45db0ac96f63c729579ad8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

