### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Block PRs targeting master branch (comment + auto-close, then fail the check)
   block-master-pr:

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   format-lint-typecheck-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds explicit least-privilege `permissions:` blocks to all GitHub Actions workflows that were missing them, fixing CodeQL `actions/missing-workflow-permissions` alerts.

## Problem

Three workflows ran jobs with the repository's default `GITHUB_TOKEN` permissions (broad read/write) instead of explicit least-privilege scoping:

- `.github/workflows/lint-workflows.yml` — no `permissions:` at any level
- `.github/workflows/web-ci.yml` — no `permissions:` at any level
- `.github/workflows/ci.yml` — partial job-level coverage, but 5 jobs (test, typecheck, codex-compatibility, senpi-compatibility, lazycodex-published-smoke) inherited implicit defaults

Flagged by CodeQL as `actions/missing-workflow-permissions`. Without explicit scoping, a compromised step or dependency in any of these jobs could use the default token to push code, modify PRs, or tamper with releases.

## Fix

- Added top-level `permissions: contents: read` to all three workflows
- Preserved the existing job-level `pull-requests: write` override on the `block-master-pr` job in `ci.yml` (job-level overrides top-level, so escalations remain intentional and visible)
- All other jobs now inherit read-only repository access

## Verification

- `actionlint` passes on all modified workflow files
- No behavioral change to any job — this only narrows the ambient token scope

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit least-privilege `permissions: contents: read` to all GitHub Actions workflows, making the default `GITHUB_TOKEN` read-only. Fixes CodeQL `actions/missing-workflow-permissions` and keeps the `block-master-pr` job’s `pull-requests: write` override intact.

<sup>Written for commit 7b8e876a86862155e39d67db5d82d787ce46358c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

