### PR TITLE
test(hashline): fix missing closing brace in multi-model test runner

### DIFF
--- a/tests/hashline/test-multi-model.ts
+++ b/tests/hashline/test-multi-model.ts
@@ -29,6 +29,7 @@ for (let i = 0; i < rawArgs.length; i++) {
     }
     perModelTimeoutSec = parsed;
     i++;
+  }
 }
 
 // ── Colors ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a genuine syntax error in `tests/hashline/test-multi-model.ts` — an unclosed `for` loop in the CLI argument parsing block (lines 23–32) that left the remaining ~246 lines of the file improperly nested inside the loop body, causing the file to end without a closing brace.

## Problem

The `for` loop parsing `--timeout` CLI arguments was missing its closing `}`:

```ts
for (let i = 0; i < rawArgs.length; i++) {
  // ... argument parsing ...
// ← missing } here — everything below became loop body
```

This caused two observable failures:

1. **CodeQL scan warning**: "Could not process some files due to syntax errors — A parse error occurred: '}' expected" at line 278 (end of file)
2. **`bun build` failure**: `error: Unexpected end of file` at line 277

The error went unnoticed because the script is a manual test orchestrator (`bun run test-multi-model.ts`) not exercised in CI, and Bun's runtime may have been executing an older cached version.

## Fix

Added the missing closing brace `}` at line 32, restoring the intended structure: the `for` loop closes after argument parsing, and the remaining test orchestration code runs at top level as designed.

## Verification

- `bun build tests/hashline/test-multi-model.ts --target=node` — Bundled 1 module in 15ms, 0 errors
- File now parses cleanly — CodeQL extractor will process it on the next scan, clearing the tool status warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a missing closing brace in `tests/hashline/test-multi-model.ts`, closing the CLI arg parsing for-loop and restoring valid syntax. This clears the CodeQL parse warning and fixes `bun build` failures.

<sup>Written for commit 3679d4ad8a0985724a6c00b16fa0ff126638d0ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

