### PR TITLE
feat(shared-skills): add Aside browser-agent support to coding-agent-sessions finder

### DIFF
--- a/packages/omo-codex/src/python-migration-inventory.test.ts
+++ b/packages/omo-codex/src/python-migration-inventory.test.ts
@@ -11,6 +11,7 @@ const requiredRetainedPythonFiles = [
 const optionalGeneratedPythonFiles = [
   "packages/omo-codex/plugin/skills/ast-grep/scripts/ast_grep_helper.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/__init__.py",
+  "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/aside_scanner.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/claude.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/cli.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/codex.py",

--- a/packages/shared-skills/skills/coding-agent-sessions/SKILL.md
+++ b/packages/shared-skills/skills/coding-agent-sessions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-agent-sessions
-description: "MUST USE when asked to find, read, list, search, inspect, fetch, export, or reconstruct coding-agent sessions across Codex, Claude Code/Desktop, OpenCode, Senpi/pi, oh-my-pi (omp), gajae-code (gjc), OpenClaw, Factory Droid, Amp, Gemini/Kimi/Qwen CLIs, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, or unknown local agent logs. Covers transcripts, session IDs, rollout JSONL, state SQLite, Claude projects/pre-compact histories, OpenCode messages/parts, child/subagent linkage, cwd/model/time/token filters, archives, and cost clues. Expands fuzzy recall into parallel query lanes and first probes known stores so absent platforms are skipped cheaply. Triggers: coding agent sessions, Codex/Claude/OpenCode/Senpi/pi/oh-my-pi/omp/gajae-code/gjc/OpenClaw/Droid/Amp/Kodu/Cursor/Aider sessions, transcript search, session history, session ID, read transcript, token usage, subagent sessions, what did I do yesterday, did we already do this."
+description: "MUST USE when asked to find, read, list, search, inspect, fetch, export, or reconstruct coding-agent sessions across Codex, Claude Code/Desktop, OpenCode, Senpi/pi, oh-my-pi (omp), gajae-code (gjc), OpenClaw, Factory Droid, Amp, Gemini/Kimi/Qwen CLIs, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, Aside browser-agent sessions, or unknown local agent logs. Covers transcripts, session IDs, rollout JSONL, state SQLite, Claude projects/pre-compact histories, OpenCode messages/parts, child/subagent linkage, cwd/model/time/token filters, archives, and cost clues. Expands fuzzy recall into parallel query lanes and first probes known stores so absent platforms are skipped cheaply. Triggers: coding agent sessions, Codex/Claude/OpenCode/Senpi/pi/oh-my-pi/omp/gajae-code/gjc/OpenClaw/Droid/Amp/Kodu/Cursor/Aider/Aside sessions, transcript search, session history, session ID, read transcript, token usage, subagent sessions, what did I do yesterday, did we already do this."
 ---
 
 # Coding Agent Sessions
@@ -18,7 +18,7 @@ Find local coding-agent sessions across agent products before answering from mem
    | Senpi / pi coding-agent logs | `references/senpi.md` |
    | oh-my-pi (`omp`, `~/.omp`) and gajae-code (`gjc`, `~/.gjc`) logs | `references/senpi.md` |
    | OpenCode / oh-my-openagent (formerly oh-my-opencode) storage | `references/opencode.md` |
-   | OpenClaw, Droid, Amp, Gemini, Kimi, Qwen, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, Kiro, Goose, Hermes, Crush, Zed | `references/all-platforms.md` |
+   | OpenClaw, Droid, Amp, Gemini, Kimi, Qwen, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, Kiro, Goose, Hermes, Crush, Zed, Aside | `references/all-platforms.md` |
    | Unknown / "any session" / cross-agent search | `references/all-platforms.md` |
 
 2. **Run the broad finder first unless the user gave an exact file path. For fuzzy recall, expand the query first.**
@@ -51,7 +51,7 @@ The finder prints JSON for stdout and `jq`. Every result includes:
 
 | Field | Meaning |
 |---|---|
-| `platform` | Registered platform key such as `codex`, `claude`, `senpi`, `oh-my-pi`, `gajae-code`, `opencode`, `openclaw`, `droid`, `amp`, `kodu`, `cursor-cli`, `aider`, `roo-code`, `kilo-code`, `kilo-cli`, or `kiro` |
+| `platform` | Registered platform key such as `codex`, `claude`, `senpi`, `oh-my-pi`, `gajae-code`, `opencode`, `openclaw`, `droid`, `amp`, `kodu`, `cursor-cli`, `aider`, `roo-code`, `kilo-code`, `kilo-cli`, `kiro`, or `aside` |
 | `id` | Session ID or stable file-derived ID |
 | `path` | Raw transcript/index file |
 | `cwd` | Working directory when recoverable |
@@ -122,6 +122,7 @@ Use `references/codex.md` for Codex storage details.
 | Missing oh-my-pi / gajae-code sessions | Those stores live in `~/.omp/agent/sessions` and `~/.gjc/agent/sessions`. For a custom `PI_CONFIG_DIR` / `PI_CODING_AGENT_DIR`, pass that agent dir with `--root`. |
 | Missing OpenCode sessions | Pass the data dir that contains `messages/` and `parts/`, often `~/.opencode` or `~/.local/share/opencode`. |
 | Missing Claude sessions | Search `~/.claude/projects`, `~/.claude/transcripts`, and `~/.claude/pre-compact-session-histories`; use `--root` for nonstandard config dirs. |
+| Missing Aside sessions | The Aside browser agent stores per-user data under `~/.aside/u/<n>/` (`sessions/<date>_<id>/messages.jsonl` transcripts + a `state.db` index; `agents/*/sessions/` is just a hardlink mirror). Pass `--root` for a nonstandard `.aside` dir or an exported user dir. |
 | Missing optional platform sessions | Check `references/all-platforms.md` for the exact local store. For project-local tools such as Aider, pass `--root /path/to/workspace` if the repo is outside the bounded default roots. |
 | Date filter misses local sessions | Timestamps are compared as UTC instants when parseable; otherwise file mtime is used. |
 | Search is slow | Narrow with repeated `--platform` flags or date/cwd filters. Optional stores are probed before parsing; avoid passing your whole home as `--root` unless you really want every bounded project-local scan. |

--- a/packages/shared-skills/skills/coding-agent-sessions/references/all-platforms.md
+++ b/packages/shared-skills/skills/coding-agent-sessions/references/all-platforms.md
@@ -4,7 +4,7 @@
 
 Search these first, then add user-supplied roots with `--root`:
 
-Registered platform keys: `codex`, `claude`, `senpi`, `oh-my-pi`, `gajae-code`, `opencode`, `openclaw`, `droid`, `amp`, `gemini`, `kimi`, `qwen`, `codebuff`, `roo-code`, `kilo-code`, `cline`, `kodu`, `cursor-cli`, `aider`, `kilo-cli`, `hermes`, `goose`, `crush`, `zed`, `kiro`.
+Registered platform keys: `codex`, `claude`, `senpi`, `oh-my-pi`, `gajae-code`, `opencode`, `openclaw`, `droid`, `amp`, `gemini`, `kimi`, `qwen`, `codebuff`, `roo-code`, `kilo-code`, `cline`, `kodu`, `cursor-cli`, `aider`, `kilo-cli`, `hermes`, `goose`, `crush`, `zed`, `kiro`, `aside`.
 
 | Platform | Unix/macOS | Windows |
 |---|---|---|
@@ -25,6 +25,7 @@ Registered platform keys: `codex`, `claude`, `senpi`, `oh-my-pi`, `gajae-code`, 
 | Aider | bounded project roots containing `.aider.chat.history.md`; use `--root` for other repos | pass `--root` |
 | Kilo CLI (`kilo-cli`) / Hermes / Goose / Crush / Zed | Known SQLite roots are probed cheaply; unsupported schemas return empty | pass `--root` |
 | Kiro | `~/.kiro/sessions/cli/*.json` plus paired `*.jsonl` prompt events | pass `--root` |
+| Aside (browser agent) | `~/.aside/u/*/sessions/<date>_<id>/messages.jsonl`, joined with the per-user `state.db` `sessions` table (title, parent_id, cwd, model, timestamps). `~/.aside/u/*/agents/*/sessions/` is a hardlink mirror of `sessions/` and is intentionally not scanned | pass `--root` |
 
 ## Excluded usage-only sources
 
@@ -52,6 +53,7 @@ Do not add these as default transcript platforms without a separate prompt-recon
 | Claude | `projects/<proj>/<sid>/subagents/**/agent-<agentId>.jsonl` | directory `<sid>` | `agent-*.meta.json` `agentType` |
 | Codex | thread row + own rollout JSONL | `thread_spawn_edges` / `source.subagent.thread_spawn.parent_thread_id` | `agent_nickname (agent_role)` |
 | OpenCode | `session` table row / `storage/session/**.json` | `parent_id` column / `parentID` field | `agent` column |
+| Aside | own `sessions/<date>_<id>/messages.jsonl` transcript | `parent_id` column in `state.db` `sessions` | child session's `title` column (task description) |
 
 ## Parallelism
 

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/aside_scanner.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/aside_scanner.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+from .jsonio import as_map, iter_jsonl, parse_json_text, text
+from .timeparse import file_time, unix_millis, unix_seconds
+from .transcript import content_text, existing, flat_parallel, merge_usage, recent
+from .types import JsonMap, Session
+
+SqlValue: TypeAlias = str | int | float | bytes | None
+SqlRow: TypeAlias = tuple[SqlValue, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _StateRow:
+    parent_id: str | None
+    title: str | None
+    cwd: str | None
+    provider: str | None
+    model: str | None
+    created_at: str | None
+    updated_at: str | None
+
+
+def scan_aside(extra_roots: tuple[Path, ...], workers: int) -> list[Session]:
+    roots = _roots([Path.home() / ".aside"], extra_roots, (".aside",))
+    sessions: list[Session] = []
+    for user_dir in _user_dirs(roots):
+        index = _state_index(user_dir / "state.db")
+        paths = list((user_dir / "sessions").glob("*/messages.jsonl"))
+        sessions.extend(flat_parallel(recent(paths), workers, lambda path, rows=index: [_aside_session(path, rows)]))
+    return sessions
+
+
+def _user_dirs(roots: list[Path]) -> list[Path]:
+    dirs: list[Path] = []
+    for root in roots:
+        users = sorted(path for path in (root / "u").glob("*") if path.is_dir())
+        if users:
+            dirs.extend(users)
+        elif (root / "sessions").exists():
+            dirs.append(root)
+    return dirs
+
+
+def _state_index(db_path: Path) -> dict[str, _StateRow]:
+    if not db_path.exists():
+        return {}
+    try:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+            rows: list[SqlRow] = conn.execute("select id, parent_id, title, cwd, model, created_at, updated_at from sessions").fetchall()
+    except sqlite3.Error:
+        return {}
+    index: dict[str, _StateRow] = {}
+    for row in rows:
+        sid = _cell_text(row, 0)
+        if sid is None:
+            continue
+        provider, model = _model_fields(_cell_text(row, 4))
+        index[sid] = _StateRow(
+            _cell_text(row, 1),
+            _cell_text(row, 2),
+            _cell_text(row, 3),
+            provider,
+            model,
+            unix_seconds(_cell_number(row, 5)),
+            unix_seconds(_cell_number(row, 6)),
+        )
+    return index
+
+
+def _cell_text(row: SqlRow, index: int) -> str | None:
+    value = row[index] if index < len(row) else None
+    return value if isinstance(value, str) else None
+
+
+def _cell_number(row: SqlRow, index: int) -> int | float | None:
+    value = row[index] if index < len(row) else None
+    return value if isinstance(value, int | float) else None
+
+
+def _model_fields(model_json: str | None) -> tuple[str | None, str | None]:
+    data = as_map(parse_json_text(model_json)) if model_json else None
+    if data is None:
+        return None, None
+    return text(data.get("provider")), text(data.get("modelId")) or text(data.get("model"))
+
+
+def _aside_session(path: Path, index: dict[str, _StateRow]) -> Session:
+    sid = _dir_session_id(path.parent.name)
+    row = index.get(sid)
+    first_user = last_user = ""
+    provider = model = None
+    created = updated = None
+    usage: JsonMap = {}
+    for data in iter_jsonl(path):
+        stamp = data.get("timestamp")
+        moment = unix_millis(int(stamp)) if isinstance(stamp, int | float) else None
+        created = created or moment
+        updated = moment or updated
+        role = text(data.get("role"))
+        if role == "user":
+            prompt = content_text(data.get("content"))
+            if prompt:
+                first_user = first_user or prompt
+                last_user = prompt
+        elif role == "assistant":
+            provider = provider or text(data.get("provider"))
+            model = model or text(data.get("model"))
+            merge_usage(usage, as_map(data.get("usage")))
+    return Session(
+        "aside",
+        sid,
+        str(path),
+        row.cwd if row is not None else None,
+        (row.created_at if row is not None else None) or created or file_time(path),
+        (row.updated_at if row is not None else None) or updated or created or file_time(path),
+        (row.provider if row is not None else None) or provider,
+        (row.model if row is not None else None) or model,
+        first_user,
+        usage,
+        row.parent_id if row is not None else None,
+        row.title if row is not None and row.parent_id is not None else None,
+        last_user,
+    )
+
+
+def _dir_session_id(name: str) -> str:
+    return name.split("_", 1)[-1]
+
+
+def _roots(defaults: list[Path], extra_roots: tuple[Path, ...], children: tuple[str, ...]) -> list[Path]:
+    candidates = [*defaults]
+    for root in extra_roots:
+        candidates.append(root)
+        candidates.extend(root / child for child in children)
+    return existing(candidates)

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/scanners.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/scanners.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Callable, TypeAlias
 
+from .aside_scanner import scan_aside
 from .claude import scan_claude
 from .codex import scan_codex
 from .file_scanners import (
@@ -54,6 +55,7 @@ PLATFORM_SCANNERS: dict[str, Scanner] = {
     "crush": scan_crush,
     "zed": scan_zed,
     "kiro": scan_kiro,
+    "aside": scan_aside,
 }
 DEFAULT_PLATFORMS = frozenset(PLATFORM_SCANNERS)
 PLATFORM_ALIASES = {
@@ -69,6 +71,7 @@ PLATFORM_ALIASES = {
     "gjc": "gajae-code",
     "gajae": "gajae-code",
     "gajaecode": "gajae-code",
+    "aside-browser": "aside",
 }
 
 __all__ = ["DEFAULT_PLATFORMS", "PLATFORM_SCANNERS", "scan", "scan_claude", "scan_codex", "scan_gajae_code", "scan_oh_my_pi", "scan_opencode", "scan_senpi"]

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_aside_scanner.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_aside_scanner.py
@@ -1,0 +1,131 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest"]
+# ///
+# --- How to run ---
+# uv run --with pytest pytest scripts/tests/test_aside_scanner.py -v
+# pyright: reportImplicitRelativeImport=false, reportMissingImports=false
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent_sessions.aside_scanner import scan_aside
+from agent_sessions.types import JsonMap, Session
+
+
+def _write_jsonl(path: Path, rows: list[JsonMap]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+
+def _write_state_db(path: Path, rows: list[tuple[str, str | None, str, str, str, int, int]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        _ = conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, parent_id TEXT, title TEXT NOT NULL, cwd TEXT NOT NULL, model TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)")
+        _ = conn.executemany("INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?)", rows)
+
+
+def _by_id(sessions: list[Session]) -> dict[str, Session]:
+    return {item.id: item for item in sessions}
+
+
+def test_scan_aside_reads_messages_and_state_db_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # given: a main session, a state.db-linked child, and a hardlink-mirror agents dir
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    user = tmp_path / ".aside" / "u" / "0"
+    model = json.dumps({"provider": "quotio", "modelId": "gpt-5.6-sol", "thinkingLevel": "medium"})
+    _write_state_db(
+        user / "state.db",
+        [
+            ("main1", None, "Ambassador research", "/tmp/aside-main", model, 1785295598, 1785377046),
+            ("child1", "main1", "Check settings context", "/tmp/aside-main", model, 1785295600, 1785295700),
+        ],
+    )
+    _write_jsonl(
+        user / "sessions" / "2026-07-29_main1" / "messages.jsonl",
+        [
+            {"role": "system-message", "content": "skill docs", "timestamp": 1785295598327},
+            {"role": "user", "content": "find the ambassador benefits", "timestamp": 1785295598204},
+            {"role": "assistant", "content": [{"type": "text", "text": "on it"}], "provider": "apitopia", "model": "kimi-k3", "usage": {"input": 28019, "output": 406, "totalTokens": 28425, "cost": {"total": 0.090147}}, "timestamp": 1785295598449},
+            {"role": "user", "content": "now summarize it", "timestamp": 1785295599000},
+        ],
+    )
+    _write_jsonl(
+        user / "sessions" / "2026-07-29_child1" / "messages.jsonl",
+        [{"role": "user", "content": "verify the settings page", "timestamp": 1785295600000}],
+    )
+    _write_jsonl(
+        user / "agents" / "main" / "sessions" / "2026-07-29_main1" / "messages.jsonl",
+        [{"role": "user", "content": "mirror copy that must not be scanned", "timestamp": 1785295601000}],
+    )
+
+    # when
+    sessions = _by_id(scan_aside((), 4))
+
+    # then: state.db metadata wins, transcript supplies prompts and usage
+    assert len(sessions) == 2
+    main = sessions["main1"]
+    assert main.platform == "aside"
+    assert main.agent is None
+    assert "/agents/" not in main.path
+    assert main.first_user_message == "find the ambassador benefits"
+    assert main.last_user_message == "now summarize it"
+    assert main.cwd == "/tmp/aside-main"
+    assert main.provider == "quotio"
+    assert main.model == "gpt-5.6-sol"
+    assert main.parent_id is None
+    assert main.usage["totalTokens"] == 28425
+    assert main.usage["cost_total"] == 0.090147
+    assert (main.created_at or "").startswith("2026-07-29")
+
+    child = sessions["child1"]
+    assert child.parent_id == "main1"
+    assert child.agent == "Check settings context"
+    assert child.first_user_message == "verify the settings page"
+
+
+def test_scan_aside_without_state_db_falls_back_to_transcript(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # given: only messages.jsonl, no state.db
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    user = tmp_path / ".aside" / "u" / "1"
+    _write_jsonl(
+        user / "sessions" / "2026-07-30_solo1" / "messages.jsonl",
+        [
+            {"role": "user", "content": "bare prompt", "timestamp": 1785295598204},
+            {"role": "assistant", "content": [{"type": "text", "text": "ok"}], "provider": "apitopia", "model": "kimi-k3", "timestamp": 1785295598449},
+        ],
+    )
+
+    # when
+    sessions = _by_id(scan_aside((), 4))
+
+    # then
+    solo = sessions["solo1"]
+    assert solo.first_user_message == "bare prompt"
+    assert solo.provider == "apitopia"
+    assert solo.model == "kimi-k3"
+    assert solo.cwd is None
+    assert (solo.created_at or "").startswith("2026-07-29")
+
+
+def test_scan_aside_accepts_root_pointing_at_user_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # given: an extra root that is itself a user dir (sessions/ directly inside)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "nowhere")
+    user = tmp_path / "exported-aside-user"
+    _write_jsonl(
+        user / "sessions" / "2026-07-30_rooted1" / "messages.jsonl",
+        [{"role": "user", "content": "rooted prompt", "timestamp": 1785295598204}],
+    )
+
+    # when
+    sessions = _by_id(scan_aside((user,), 4))
+
+    # then
+    assert sessions["rooted1"].first_user_message == "rooted prompt"

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_extended_scanners.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_extended_scanners.py
@@ -59,6 +59,7 @@ def test_default_platforms_are_canonical_transcript_sources() -> None:
         "crush",
         "zed",
         "kiro",
+        "aside",
     }
     forbidden = {"copilot", "mux", "antigravity", "synthetic", "cursor"}
 


### PR DESCRIPTION
## Summary

The `coding-agent-sessions` skill's cross-platform finder can now locate, search, and read sessions from the **Aside** browser agent (`~/.aside`), which it previously did not recognize. Aside stores per-user transcripts as `~/.aside/u/<n>/sessions/<date>_<id>/messages.jsonl` plus a `state.db` SQLite index holding titles, `parent_id` subagent linkage, cwd, model, and timestamps. After this PR, `--platform aside` (alias `aside-browser`) works like every other registered platform, and default no-platform scans now include Aside sessions, including their subagent trees.

## Changes

- **New scanner** (`scripts/agent_sessions/aside_scanner.py`): joins the jsonl transcripts with the `state.db` `sessions` table opened read-only (`file:...?mode=ro`) for cwd/provider/model/timestamps and `parent_id`; child sessions get their state.db `title` as the agent label; usage/cost merged from assistant messages; `--root` accepts either a `.aside` dir or an exported `u/<n>` user dir.
- **Registration** (`scripts/agent_sessions/scanners.py`): `aside` platform key + `aside-browser` alias in the canonical default platform set.
- **Store-layout trap handled**: `~/.aside/u/<n>/agents/<agent>/sessions/` is a byte-identical hardlink mirror of `sessions/` (verified by inode on a real store) — scanning it double-counted and mislabeled every session, so it is deliberately excluded; verified by a dedicated test.
- **Tests** (`test_aside_scanner.py` + `test_extended_scanners.py`): 3 given/when/then tests (state.db join, transcript-only fallback without state.db, custom `--root`, mirror exclusion) and `aside` added to the canonical platform-set test.
- **Docs** (`SKILL.md`, `references/all-platforms.md`): router row, output-contract platform key, default-locations table, subagent linkage cheat-sheet row, and troubleshooting guidance (including the mirror note).

## QA & Evidence

Evidence dir: `.omo/evidence/20260730-aside-session-scanner/` (sanitized artifacts).

- **What was tested:** `uv run --with pytest pytest scripts/tests/ -q` — full finder unit suite incl. the 3 new aside tests.
  **Observed:** 35/35 passed in one run (`pytest.txt`).
  **Why sufficient:** pins the parsing contract for state.db joins, fallbacks, roots, and the mirror exclusion on synthetic fixtures.
- **What was tested:** live `find-agent-sessions.py list|find|read --platform aside` against a real `~/.aside` store (`live-list.json`, `live-search.json`, `live-subagents.json`).
  **Observed:** default-root discovery works; `find "혜택이 뭔지"` returns the exact user-named session `zqnu5g0mXBOTN1b4` with the canonical `sessions/` path (not the mirror); `read` on a parented session reports `subagent_count: 9` with correct `parent_id` and title labels.
  **Why sufficient:** the real on-disk store is the only integration surface for this self-contained CLI; end-to-end live runs cover discovery, search, and subagent reconstruction.
- **What was tested:** `bun test packages/omo-opencode/src/shared-skills-package.test.ts packages/shared-skills/depersonalization-gate.test.ts`.
  **Observed:** 6/6 pass — packaging + scrub gates unaffected.
- **Omitted:** no secret-bearing material in artifacts; live JSON previews contain only personal session prompt text (no tokens/credentials).

## Risks & Residuals

- **Older-session coverage:** the finder's pre-existing 2000-most-recent-files-per-platform cap applies to Aside too (the probed store holds ~4.8k sessions); older sessions need `--from`/`--root` narrowing — documented behavior shared with other platforms. Accepted.
- **state.db schema drift:** the scanner fails closed (returns transcript-only sessions) if the `sessions` table is absent or unreadable; covered by the no-db fallback test. Mitigated.
- No runtime OpenCode/Codex component changed; blast radius is confined to the skill's bundled finder.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Aside browser-agent support to the `coding-agent-sessions` finder. Scans `~/.aside` sessions, joins transcripts with `state.db`, and reconstructs subagent trees; enabled by default.

- **New Features**
  - Added `aside` scanner that reads `sessions/*/messages.jsonl` and enriches from `state.db` (cwd, provider/model, timestamps, `parent_id`); reconstructs subagent linkage.
  - Registered `aside` with alias `aside-browser` and added to default platforms; `--root` accepts a `.aside` dir or a `u/<n>` user dir.

- **Bug Fixes**
  - Excluded the `~/.aside/u/*/agents/*/sessions/` hardlink mirror to prevent double-counted and mislabeled sessions.
  - Registered `aside_scanner.py` in the `packages/omo-codex` Python migration inventory to classify it as generated and fix Codex plugin CI.

<sup>Written for commit 82f0efbed60169b52e7a4fbda782d2a4dc841dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

