### PR TITLE
test(senpi-task): make overlapping-reconcile assertions order-independent

### DIFF
--- a/packages/senpi-task/src/lifecycle/reconcile.test.ts
+++ b/packages/senpi-task/src/lifecycle/reconcile.test.ts
@@ -60,7 +60,13 @@ function persistSessions(store: TaskRecordStore, taskId: string): string {
   return newest
 }
 
-type RespawnControl = { readonly switchCalls: string[]; settle(): void; readonly terminated: () => number; readonly disposed: () => number }
+type RespawnControl = {
+  readonly pid: number
+  readonly switchCalls: string[]
+  settle(): void
+  readonly terminated: () => number
+  readonly disposed: () => number
+}
 
 class FakeRespawnRunner {
   readonly startedSpecs: RpcRunnerSpec[] = []
@@ -95,7 +101,7 @@ class FakeRespawnRunner {
         return { cancelled: this.cancelSwitch }
       },
     }
-    this.controls.push({ switchCalls, settle: resolveIdle, terminated: () => terminated, disposed: () => disposed })
+    this.controls.push({ pid, switchCalls, settle: resolveIdle, terminated: () => terminated, disposed: () => disposed })
     return handle
   }
 }
@@ -393,11 +399,21 @@ describe("reconcileOnSessionStart reattach", () => {
 
     // then
     expect(respawnRunner.startedSpecs).toHaveLength(2)
-    expect(respawnRunner.controls[1]?.terminated()).toBe(1)
-    expect(respawnRunner.controls[1]?.disposed()).toBe(1)
+    const controlStates = respawnRunner.controls.map((control) => ({
+      pid: control.pid,
+      terminated: control.terminated(),
+      disposed: control.disposed(),
+    }))
+    const discardedControls = controlStates.filter((control) => control.terminated === 1 && control.disposed === 1)
+    const survivingControls = controlStates.filter((control) => control.terminated === 0 && control.disposed === 0)
+    expect(controlStates).toHaveLength(2)
+    expect(discardedControls).toHaveLength(1)
+    expect(survivingControls).toHaveLength(1)
     expect(results.flatMap((result) => result.outcomes.map((outcome) => outcome.kind))).toEqual(["resumed", "resumed"])
     expect(store.load("st_0000000b")?.notification.run_epoch).toBe(1)
-    expect(manager.getResidentHandle("st_0000000b")?.pid).toBe(1001)
+    const survivingControl = survivingControls[0]
+    if (survivingControl === undefined) throw new Error("expected one surviving respawn control")
+    expect(manager.getResidentHandle("st_0000000b")?.pid).toBe(survivingControl.pid)
   })
 
   test(" w2reattach #given a process runner reports effective launch inputs #when persisted record is reloaded #then only safe spawn facts survive", async () => {


### PR DESCRIPTION
## Problem

`reconcileOnSessionStart reattach > w2reattach #given overlapping reconcile sweeps` is flaky on macOS CI and has been failing unrelated PRs and `dev`.

The test races two concurrent sweeps:

```ts
await Promise.all([lifecycle.reconcileOnSessionStart(), lifecycle.reconcileOnSessionStart()])
expect(respawnRunner.controls[1]?.terminated()).toBe(1)
```

It then hardcodes the assumption that the second-started respawn (`controls[1]`) is always the loser. Since this is a genuine race, which sweep wins is nondeterministic. On a loaded runner the ordering flips, the loser becomes `controls[0]`, and `controls[1].terminated()` returns `0` — failing at `reconcile.test.ts:396` with `Expected: 1 / Received: 0`.

**Production behavior was already correct** (exactly one child survives, `startedSpecs` is 2, `run_epoch` is 1). Only the assertion was order-dependent, so this change touches the test only.

## Observed impact

Same test, same line, across unrelated branches:

- #6464 `fix/mcp-oauth-callback-xss`
- #6465 `chore/workflow-permissions-hardening`
- #6466 `dependabot/.../next-15.5.21`
- #6467 `fix/hashline-test-multi-model-syntax`
- `dev` (run 30512418870)

Reproduced locally at **~7.5% (3/40 runs)** on an idle machine with the identical signature.

## Fix

Assert that **exactly one** respawn control is terminated+disposed and **one survives**, independent of start order, and tie the resident pid to the actual survivor instead of hardcoding `1001`.

## Verification

- 50/50 passes idle (baseline before fix: 37/40)
- 30/30 passes under 8-core CPU contention — the condition that triggered the original flake
- Full `senpi-task` suite: **1035 pass / 0 fail**
- `tsc --noEmit` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the overlapping reattach reconcile test order-independent to stop flaky macOS CI failures. This change only affects tests; production behavior is unchanged.

- **Bug Fixes**
  - Update `packages/senpi-task/src/lifecycle/reconcile.test.ts` to assert that exactly one respawn control is terminated and one survives, regardless of start order in `reconcileOnSessionStart`.
  - Add `pid` to `RespawnControl` and assert the resident handle’s `pid` matches the actual survivor instead of hardcoding `1001`.

<sup>Written for commit 345ceb54f0f4b490cfa40c98eb52b3c0290821f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

