### PR TITLE
test(codegraph): stub process sweep in SessionStart tests

### DIFF
--- a/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
+++ b/packages/omo-codex/plugin/components/codegraph/test/hook.test.ts
@@ -115,6 +115,7 @@ describe("CodeGraph SessionStart hook", () => {
 			env: {},
 			stdin: Readable.from(["{}"]),
 			stdout: { write: (chunk) => stdout.push(chunk) },
+			sweepZombies: () => undefined,
 			spawnWorker: (invocation) => spawned.push(invocation),
 		});
 
@@ -143,6 +144,7 @@ describe("CodeGraph SessionStart hook", () => {
 				env: { HOME: homeDir },
 				stdin: Readable.from(["{}"]),
 				stdout: { write: (chunk) => stdout.push(chunk) },
+				sweepZombies: () => undefined,
 				spawnWorker: (invocation) => spawned.push(invocation),
 			});
 
@@ -174,6 +176,7 @@ describe("CodeGraph SessionStart hook", () => {
 				env: { HOME: homeDir },
 				stdin: Readable.from(["{}"]),
 				stdout: { write: (chunk) => stdout.push(chunk) },
+				sweepZombies: () => undefined,
 				spawnWorker: (invocation) => spawned.push(invocation),
 			});
 
@@ -201,6 +204,7 @@ describe("CodeGraph SessionStart hook", () => {
 				env: { CODEX_CODEGRAPH_ENABLED: "0", HOME: homeDir },
 				stdin: Readable.from(["{}"]),
 				stdout: { write: (chunk) => stdout.push(chunk) },
+				sweepZombies: () => undefined,
 				spawnWorker: (invocation) => spawned.push(invocation),
 			});
 
@@ -278,6 +282,7 @@ describe("CodeGraph SessionStart hook", () => {
 				env: { HOME: homeDir, KEEP: "1" },
 				stdin: Readable.from(["{}"]),
 				stdout: { write: (chunk) => stdout.push(chunk) },
+				sweepZombies: () => undefined,
 				spawnWorker: (invocation) => spawned.push(invocation),
 			});
 
@@ -302,6 +307,7 @@ describe("CodeGraph SessionStart hook", () => {
 			env: {},
 			stdin: Readable.from(["{not-json"]),
 			stdout: { write: (chunk) => stdout.push(chunk) },
+			sweepZombies: () => undefined,
 			spawnWorker: (invocation) => spawned.push(invocation),
 		});
 


### PR DESCRIPTION
## Summary

The last remaining flake from #6374: four `CodeGraph SessionStart hook` tests fail together on Windows CI at ~5015ms against the 5000ms file budget.

Root cause, reproduced on a real Windows 11 host: `executeCodegraphSessionStartHook` runs `sweepCodegraphZombiesBestEffort` before it decides anything, and 7 of the 10 tests in this file never stubbed that seam. On Windows the default sweep shells out to a real OS process enumeration, so every unstubbed call paid a fixed ~300ms.

The tests already had a `sweepZombies` injection point; it was simply only used by 2 of them.

## Root-cause measurements (Windows 11, bun 1.3.14)

Same fixture, only the seam differs:

```text
default_sweep   304 ms
default_sweep   302 ms
stubbed_sweep     1 ms
stubbed_sweep     1 ms
```

## Changes

- Pass `sweepZombies: () => undefined` at the 7 `executeCodegraphSessionStartHook` call sites that lacked it.

Test-only. No production behavior changes: the real sweep still runs unchanged outside tests, and the two tests that already stubbed it are untouched.

## QA & Evidence

Real Windows host (`ssh windows.minpeter.internal`), clone at merged `dev` tip `b6d047382`:

- Before: the target test took `606.03ms`, whole file ~1.9s
- After: the target test takes `2.75ms`, whole file `223ms`, `10 pass / 0 fail`

Linux, same component the way CI invokes it:

- `bun test ./test/hook.test.ts` → `10 pass / 0 fail` in `97ms`
- `npm run typecheck` → clean

## Risks & Residuals

Low. The change removes an unintended dependency on live OS process enumeration from unit tests; it does not weaken any assertion. Real sweep behavior stays covered by its own suites in `packages/utils`.

The two other flakes listed in #6374 are already resolved: `command-runner.test.ts` in #6461, and `createTeamIdleWakeHint` by `0cc89af96`. With this change, all cases enumerated in that issue are addressed.

## Related Issues

Related #6374 — this addresses the last case enumerated there. Leaving the umbrella issue open on purpose.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stubs the zombie-process sweep in CodeGraph SessionStart tests to remove a Windows-only flake caused by real process enumeration. Test-only change that speeds up the suite and leaves production behavior unchanged.

- **Bug Fixes**
  - Pass sweepZombies: () => undefined to the 7 executeCodegraphSessionStartHook call sites that were missing it, eliminating ~300ms per call on Windows and stabilizing CI.

<sup>Written for commit 9049f1847ad6abb712ac8742163628e3dddaca3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->