### PR TITLE
docs: add --verbose flag to `bunx oh-my-openagent doctor` command

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -140,7 +140,7 @@ You can also skip the picker: `opencode auth login --provider opencode-go`.
 ### Verify what oh-my-openagent will actually use
 
 ```bash
-bunx oh-my-openagent doctor
+bunx oh-my-openagent doctor --verbose
 ```
 
 This shows the **effective model resolution** for every agent and category based on your current auth state. If an agent says "system-default" instead of a real fallback, that's a signal you're missing providers from its chain.
@@ -575,7 +575,7 @@ Variant and `reasoningEffort` overrides are normalized to model-supported values
 
 Model capabilities are `models.dev`-backed, with a refreshable cache and capability diagnostics. Use `bunx oh-my-openagent refresh-model-capabilities` to update the cache, or configure `model_capabilities.auto_refresh_on_start` to refresh at startup.
 
-To see which models your agents will actually use, run `bunx oh-my-openagent doctor`. This shows effective model resolution based on your current authentication and config.
+To see which models your agents will actually use, run `bunx oh-my-openagent doctor --verbose`. This shows effective model resolution based on your current authentication and config.
 
 ```
 Agent Request → User Override (if configured) → Fallback Chain → System Default


### PR DESCRIPTION
## Summary

<!-- Explain what changed, why it changed, and how observable behavior is different. Use plain reviewer-facing language, not a file list. -->

- 'bunx oh-my-openagent doctor` only outputs something like this:

  >
  > oMoMoMoMo Doctor 
  >
   >✓ System OK (opencode 1.18.9 · oh-my-openagent 4.19.3)

- `--verbose` flag is needed to show model resolution



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `--verbose` flag to `bunx oh-my-openagent doctor` to show effective model resolution for each agent and category. Keeps the default output minimal and updates docs to use the new flag.

- **New Features**
  - `bunx oh-my-openagent doctor --verbose` prints resolved models, fallback chains, and "system-default" hints for missing providers.

<sup>Written for commit a79b94981f28fa73a5e1281429b9e2deaed78d1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

