### PR TITLE
fix(lsp-core): catch async spawn errors and bound init timeout (#6486)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -693,6 +693,11 @@ and reads the server map from that file. The schema lives in the
 `packages/lsp-tools-mcp` vendored package (upstream:
 [code-yeongyu/lsp-tools-mcp](https://github.com/code-yeongyu/lsp-tools-mcp)).
 
+A language server that spawns but then hangs on `initialize` or fails
+asynchronously right after spawn is bounded by `OMO_LSP_START_TIMEOUT_MS`
+(default `10000`; see [Environment Variables](#environment-variables)) rather
+than stalling for the 60s init ceiling.
+
 To disable the LSP MCP entirely:
 
 ```json
@@ -1107,6 +1112,7 @@ When enabled, OmO registers the hash-anchored `edit` tool and activates the `has
 | `LAZYCODEX_CONFIG_MIGRATION_DISABLED` | Set to `1` to skip the Codex config migration that runs on every session start (including the `multi_agent_v2` force-disable and managed reasoning-profile sync), leaving `config.toml` untouched |
 | `OMO_CODEX_CONFIG_MIGRATION_DISABLED` | Alias of `LAZYCODEX_CONFIG_MIGRATION_DISABLED` |
 | `LSP_TOOLS_MCP_INSTALL_DECISIONS` | Override the path of the LSP install-decisions file (default `~/.codex/lsp-install-decisions.json`) |
+| `OMO_LSP_START_TIMEOUT_MS` | Timeout in milliseconds bounding a language server's `start()` + `initialize()`. A server that spawns but hangs or crashes asynchronously fails after this bound instead of stalling for the 60s init ceiling. Defaults to `10000` (10s); empty, non-numeric, zero, or negative values fall back to `10000` |
 | `POSTHOG_API_KEY` | Optional override for the built-in PostHog project API key |
 | `POSTHOG_HOST` | Override the PostHog ingestion host. Defaults to `https://us.i.posthog.com` |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1112,7 +1112,7 @@ When enabled, OmO registers the hash-anchored `edit` tool and activates the `has
 | `LAZYCODEX_CONFIG_MIGRATION_DISABLED` | Set to `1` to skip the Codex config migration that runs on every session start (including the `multi_agent_v2` force-disable and managed reasoning-profile sync), leaving `config.toml` untouched |
 | `OMO_CODEX_CONFIG_MIGRATION_DISABLED` | Alias of `LAZYCODEX_CONFIG_MIGRATION_DISABLED` |
 | `LSP_TOOLS_MCP_INSTALL_DECISIONS` | Override the path of the LSP install-decisions file (default `~/.codex/lsp-install-decisions.json`) |
-| `OMO_LSP_START_TIMEOUT_MS` | Timeout in milliseconds bounding a language server's `start()` + `initialize()`. A server that spawns but hangs or crashes asynchronously fails after this bound instead of stalling for the 60s init ceiling. Defaults to `10000` (10s); empty, non-numeric, zero, or negative values fall back to `10000` |
+| `OMO_LSP_START_TIMEOUT_MS` | Timeout in milliseconds bounding a language server's `start()` + `initialize()`. A server that spawns but hangs or crashes asynchronously fails after this bound instead of stalling for the 60s init ceiling. Defaults to `10000` (10s); any non-positive or non-numeric value falls back to the default |
 | `POSTHOG_API_KEY` | Optional override for the built-in PostHog project API key |
 | `POSTHOG_HOST` | Override the PostHog ingestion host. Defaults to `https://us.i.posthog.com` |
 

--- a/packages/lsp-core/src/lsp/constants.ts
+++ b/packages/lsp-core/src/lsp/constants.ts
@@ -5,6 +5,7 @@ export const DEFAULT_MAX_DIRECTORY_FILES = 50;
 
 export const REQUEST_TIMEOUT_MS = 15_000;
 export const INIT_TIMEOUT_MS = 60_000;
+export const START_TIMEOUT_MS = Number(process.env["OMO_LSP_START_TIMEOUT_MS"]) || 10_000;
 export const IDLE_TIMEOUT_MS = 5 * 60_000;
 export const REAPER_INTERVAL_MS = 60_000;
 export const STOP_HARD_KILL_TIMEOUT_MS = 5_000;

--- a/packages/lsp-core/src/lsp/constants.ts
+++ b/packages/lsp-core/src/lsp/constants.ts
@@ -5,16 +5,10 @@ export const DEFAULT_MAX_DIRECTORY_FILES = 50;
 
 export const REQUEST_TIMEOUT_MS = 15_000;
 export const INIT_TIMEOUT_MS = 60_000;
-export const START_TIMEOUT_MS = resolveStartTimeoutMs();
+export const START_TIMEOUT_MS = Number(process.env["OMO_LSP_START_TIMEOUT_MS"]) > 0
+	? Number(process.env["OMO_LSP_START_TIMEOUT_MS"])
+	: 10_000;
 export const IDLE_TIMEOUT_MS = 5 * 60_000;
 export const REAPER_INTERVAL_MS = 60_000;
 export const STOP_HARD_KILL_TIMEOUT_MS = 5_000;
 export const STOP_SIGKILL_GRACE_MS = 1_000;
-
-function resolveStartTimeoutMs(): number {
-	const raw = process.env["OMO_LSP_START_TIMEOUT_MS"];
-	if (raw === undefined || raw === "") return 10_000;
-	const parsed = Number(raw);
-	if (!Number.isFinite(parsed) || parsed <= 0) return 10_000;
-	return parsed;
-}

--- a/packages/lsp-core/src/lsp/constants.ts
+++ b/packages/lsp-core/src/lsp/constants.ts
@@ -5,8 +5,16 @@ export const DEFAULT_MAX_DIRECTORY_FILES = 50;
 
 export const REQUEST_TIMEOUT_MS = 15_000;
 export const INIT_TIMEOUT_MS = 60_000;
-export const START_TIMEOUT_MS = Number(process.env["OMO_LSP_START_TIMEOUT_MS"]) || 10_000;
+export const START_TIMEOUT_MS = resolveStartTimeoutMs();
 export const IDLE_TIMEOUT_MS = 5 * 60_000;
 export const REAPER_INTERVAL_MS = 60_000;
 export const STOP_HARD_KILL_TIMEOUT_MS = 5_000;
 export const STOP_SIGKILL_GRACE_MS = 1_000;
+
+function resolveStartTimeoutMs(): number {
+	const raw = process.env["OMO_LSP_START_TIMEOUT_MS"];
+	if (raw === undefined || raw === "") return 10_000;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed <= 0) return 10_000;
+	return parsed;
+}

--- a/packages/lsp-core/src/lsp/manager-start-timeout.test.ts
+++ b/packages/lsp-core/src/lsp/manager-start-timeout.test.ts
@@ -91,6 +91,10 @@ class HangingInitLspClient extends LspClient {
 }
 
 class HealthyLspClient extends LspClient {
+	constructor(resolvedServer: ResolvedServer) {
+		super("/workspace", resolvedServer);
+	}
+
 	override async start(): Promise<void> {}
 	override async initialize(): Promise<void> {}
 	override async stop(): Promise<void> {}

--- a/packages/lsp-core/src/lsp/manager-start-timeout.test.ts
+++ b/packages/lsp-core/src/lsp/manager-start-timeout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { LspClient } from "./client.js";
+import { LspProcessSpawnError } from "./errors.js";
 import { LspManager } from "./manager.js";
 import type { ResolvedServer } from "./types.js";
 
@@ -34,6 +35,28 @@ describe("LspManager start timeout", () => {
 		} finally {
 			client.releaseInitialize();
 			await acquisition.catch(() => undefined);
+			await manager.stopAll();
+		}
+	});
+
+	it("#given a client whose start rejects asynchronously #when getClient runs #then it rejects with LspProcessSpawnError and cleans up", async () => {
+		// given
+		const client = new SpawnErrorLspClient(server);
+		const manager = new LspManager({
+			clientFactory: () => client,
+			reaperIntervalMs: 60_000,
+			startTimeoutMs: 500,
+		});
+
+		// when
+		const acquisition = manager.getClient("/workspace", server);
+
+		// then
+		try {
+			await expect(acquisition).rejects.toBeInstanceOf(LspProcessSpawnError);
+			expect(manager.clientCount()).toBe(0);
+			expect(client.stopCallCount).toBe(1);
+		} finally {
 			await manager.stopAll();
 		}
 	});
@@ -87,6 +110,29 @@ class HangingInitLspClient extends LspClient {
 
 	releaseInitialize(): void {
 		this.releaseInit?.();
+	}
+}
+
+class SpawnErrorLspClient extends LspClient {
+	stopCallCount = 0;
+
+	constructor(resolvedServer: ResolvedServer) {
+		super("/workspace", resolvedServer);
+	}
+
+	override async start(): Promise<void> {
+		await Promise.resolve();
+		throw new LspProcessSpawnError("spawn ENOENT");
+	}
+
+	override async initialize(): Promise<void> {}
+
+	override async stop(): Promise<void> {
+		this.stopCallCount += 1;
+	}
+
+	override isAlive(): boolean {
+		return false;
 	}
 }
 

--- a/packages/lsp-core/src/lsp/manager-start-timeout.test.ts
+++ b/packages/lsp-core/src/lsp/manager-start-timeout.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+
+import { LspClient } from "./client.js";
+import { LspManager } from "./manager.js";
+import type { ResolvedServer } from "./types.js";
+
+const server: ResolvedServer = {
+	id: "typescript",
+	command: ["typescript-language-server"],
+	extensions: [".ts"],
+	priority: 1,
+};
+
+describe("LspManager start timeout", () => {
+	it("#given a client whose initialize never settles #when getClient runs #then it rejects fast instead of hanging on INIT_TIMEOUT_MS", async () => {
+		// given
+		const client = new HangingInitLspClient(server);
+		const manager = new LspManager({
+			clientFactory: () => client,
+			reaperIntervalMs: 60_000,
+			startTimeoutMs: 100,
+		});
+
+		// when
+		const acquisition = manager.getClient("/workspace", server);
+		const settled = await settlesWithin(acquisition, 500);
+
+		// then
+		try {
+			expect(settled).toBe(true);
+			await expect(acquisition).rejects.toThrow("LSP start timed out");
+			expect(manager.clientCount()).toBe(0);
+			expect(client.stopCallCount).toBe(1);
+		} finally {
+			client.releaseInitialize();
+			await acquisition.catch(() => undefined);
+			await manager.stopAll();
+		}
+	});
+
+	it("#given a healthy client #when getClient runs #then it resolves before the start timeout", async () => {
+		// given
+		const client = new HealthyLspClient(server);
+		const manager = new LspManager({
+			clientFactory: () => client,
+			reaperIntervalMs: 60_000,
+		});
+
+		// when
+		const acquired = await manager.getClient("/workspace", server);
+
+		// then
+		try {
+			expect(acquired).toBe(client);
+			expect(manager.clientCount()).toBe(1);
+		} finally {
+			await manager.stopAll();
+		}
+	});
+});
+
+class HangingInitLspClient extends LspClient {
+	stopCallCount = 0;
+	private releaseInit: (() => void) | undefined;
+	private readonly initGate: Promise<void>;
+
+	constructor(resolvedServer: ResolvedServer) {
+		super("/workspace", resolvedServer);
+		this.initGate = new Promise<void>((resolve) => {
+			this.releaseInit = resolve;
+		});
+	}
+
+	override async start(): Promise<void> {}
+
+	override async initialize(): Promise<void> {
+		await this.initGate;
+	}
+
+	override async stop(): Promise<void> {
+		this.stopCallCount += 1;
+	}
+
+	override isAlive(): boolean {
+		return true;
+	}
+
+	releaseInitialize(): void {
+		this.releaseInit?.();
+	}
+}
+
+class HealthyLspClient extends LspClient {
+	override async start(): Promise<void> {}
+	override async initialize(): Promise<void> {}
+	override async stop(): Promise<void> {}
+	override isAlive(): boolean {
+		return true;
+	}
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise.then(
+				() => true,
+				() => true,
+			),
+			new Promise<boolean>((resolve) => {
+				timer = setTimeout(() => resolve(false), timeoutMs);
+				timer.unref();
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}

--- a/packages/lsp-core/src/lsp/manager.ts
+++ b/packages/lsp-core/src/lsp/manager.ts
@@ -28,19 +28,20 @@ export interface ClientSnapshot {
 export interface LspManagerOptions {
 	idleTimeoutMs?: number;
 	initTimeoutMs?: number;
+	startTimeoutMs?: number;
 	reaperIntervalMs?: number;
 	clientFactory?: (root: string, server: ResolvedServer) => LspClient;
 	now?: () => number;
 }
 
-function startAndInitializeClient(client: LspClient): Promise<void> {
+function startAndInitializeClient(client: LspClient, startTimeoutMs: number): Promise<void> {
 	return Promise.race([
 		(async () => {
 			await client.start();
 			await client.initialize();
 		})(),
 		new Promise<never>((_, reject) =>
-			setTimeout(() => reject(new Error("LSP start timed out")), START_TIMEOUT_MS).unref(),
+			setTimeout(() => reject(new Error("LSP start timed out")), startTimeoutMs).unref(),
 		),
 	]);
 }
@@ -92,6 +93,7 @@ export class LspManager {
 
 	private readonly idleTimeoutMs: number;
 	private readonly initTimeoutMs: number;
+	private readonly startTimeoutMs: number;
 	private readonly reaperIntervalMs: number;
 	private readonly clientFactory: (root: string, server: ResolvedServer) => LspClient;
 	private readonly now: () => number;
@@ -99,6 +101,7 @@ export class LspManager {
 	constructor(options: LspManagerOptions = {}) {
 		this.idleTimeoutMs = options.idleTimeoutMs ?? IDLE_TIMEOUT_MS;
 		this.initTimeoutMs = options.initTimeoutMs ?? INIT_TIMEOUT_MS;
+		this.startTimeoutMs = options.startTimeoutMs ?? START_TIMEOUT_MS;
 		this.reaperIntervalMs = options.reaperIntervalMs ?? REAPER_INTERVAL_MS;
 		this.clientFactory = options.clientFactory ?? ((root, server) => new LspClient(root, server));
 		this.now = options.now ?? (() => Date.now());
@@ -211,7 +214,7 @@ export class LspManager {
 
 		const client = this.clientFactory(root, server);
 		const initStartedAt = this.now();
-		const initPromise = startAndInitializeClient(client);
+		const initPromise = startAndInitializeClient(client, this.startTimeoutMs);
 
 		const newManaged: ManagedClient = {
 			client,
@@ -275,7 +278,7 @@ export class LspManager {
 
 		const client = this.clientFactory(root, server);
 		const initStartedAt = this.now();
-		const initPromise = startAndInitializeClient(client);
+		const initPromise = startAndInitializeClient(client, this.startTimeoutMs);
 
 		const managed: ManagedClient = {
 			client,

--- a/packages/lsp-core/src/lsp/manager.ts
+++ b/packages/lsp-core/src/lsp/manager.ts
@@ -1,6 +1,6 @@
 import { reportBestEffortCleanupError } from "./cleanup-errors.js";
 import { LspClient } from "./client.js";
-import { IDLE_TIMEOUT_MS, INIT_TIMEOUT_MS, REAPER_INTERVAL_MS } from "./constants.js";
+import { IDLE_TIMEOUT_MS, INIT_TIMEOUT_MS, REAPER_INTERVAL_MS, START_TIMEOUT_MS } from "./constants.js";
 import { installProcessSignalCleanup } from "./process-signal-cleanup.js";
 import type { ResolvedServer } from "./types.js";
 
@@ -31,6 +31,18 @@ export interface LspManagerOptions {
 	reaperIntervalMs?: number;
 	clientFactory?: (root: string, server: ResolvedServer) => LspClient;
 	now?: () => number;
+}
+
+function startAndInitializeClient(client: LspClient): Promise<void> {
+	return Promise.race([
+		(async () => {
+			await client.start();
+			await client.initialize();
+		})(),
+		new Promise<never>((_, reject) =>
+			setTimeout(() => reject(new Error("LSP start timed out")), START_TIMEOUT_MS).unref(),
+		),
+	]);
 }
 
 async function stopClientBestEffort(client: LspClient): Promise<void> {
@@ -199,10 +211,7 @@ export class LspManager {
 
 		const client = this.clientFactory(root, server);
 		const initStartedAt = this.now();
-		const initPromise = (async () => {
-			await client.start();
-			await client.initialize();
-		})();
+		const initPromise = startAndInitializeClient(client);
 
 		const newManaged: ManagedClient = {
 			client,
@@ -266,10 +275,7 @@ export class LspManager {
 
 		const client = this.clientFactory(root, server);
 		const initStartedAt = this.now();
-		const initPromise = (async () => {
-			await client.start();
-			await client.initialize();
-		})();
+		const initPromise = startAndInitializeClient(client);
 
 		const managed: ManagedClient = {
 			client,

--- a/packages/lsp-core/src/lsp/process.ts
+++ b/packages/lsp-core/src/lsp/process.ts
@@ -11,7 +11,9 @@ export interface SpawnedProcess {
 	stderr: NodeJS.ReadableStream;
 	pid: number | undefined;
 	exitCode: number | null;
+	spawnError: Error | null;
 	exited: Promise<number>;
+	onSpawnError(listener: (error: Error) => void): void;
 	kill(signal?: NodeJS.Signals): void;
 	killed: boolean;
 }
@@ -57,9 +59,18 @@ export function validateCwd(cwd: string): { valid: boolean; error?: string } {
 }
 
 function wrap(proc: ChildProcess): SpawnedProcess {
+	let spawnError: Error | null = null;
+	const spawnErrorListeners = new Set<(error: Error) => void>();
+
 	const exitedPromise = new Promise<number>((resolve) => {
 		proc.once("close", (code) => resolve(code ?? 0));
-		proc.once("error", () => resolve(1));
+		proc.once("error", (error) => {
+			spawnError = error;
+			for (const listener of spawnErrorListeners) {
+				listener(error);
+			}
+			resolve(1);
+		});
 	});
 
 	if (!proc.stdin || !proc.stdout || !proc.stderr) {
@@ -76,10 +87,20 @@ function wrap(proc: ChildProcess): SpawnedProcess {
 		get exitCode() {
 			return proc.exitCode;
 		},
+		get spawnError() {
+			return spawnError;
+		},
 		get killed() {
 			return proc.killed;
 		},
 		exited: exitedPromise,
+		onSpawnError(listener: (error: Error) => void) {
+			if (spawnError) {
+				listener(spawnError);
+				return;
+			}
+			spawnErrorListeners.add(listener);
+		},
 		kill(signal?: NodeJS.Signals) {
 			killProcessTree(proc, signal ?? "SIGTERM");
 		},

--- a/packages/lsp-core/src/lsp/transport.ts
+++ b/packages/lsp-core/src/lsp/transport.ts
@@ -1,6 +1,6 @@
 import { reportBestEffortCleanupError } from "./cleanup-errors.js";
 import { INIT_TIMEOUT_MS, REQUEST_TIMEOUT_MS, STOP_HARD_KILL_TIMEOUT_MS, STOP_SIGKILL_GRACE_MS } from "./constants.js";
-import { LspConnectionClosedError, LspProcessExitedError, LspRequestTimeoutError } from "./errors.js";
+import { LspConnectionClosedError, LspProcessExitedError, LspProcessSpawnError, LspRequestTimeoutError } from "./errors.js";
 import { JsonRpcConnection } from "./json-rpc-connection.js";
 import { type SpawnedProcess, spawnProcess } from "./process.js";
 import { createLspSpawnEnv, parseConfigurationItems, parseDiagnosticsParams } from "./transport-protocol.js";
@@ -32,6 +32,7 @@ export class LspClientTransport {
 	protected connection: JsonRpcConnection | null = null;
 	protected readonly stderrBuffer: string[] = [];
 	protected processExited = false;
+	protected spawnError: Error | null = null;
 	protected readonly diagnosticsStore = new Map<string, Diagnostic[]>();
 	protected readonly requestTimeoutMs: number;
 	protected readonly initializeTimeoutMs: number;
@@ -90,6 +91,17 @@ export class LspClientTransport {
 			env,
 		});
 		this.startStderrReading();
+
+		this.proc.onSpawnError((error) => {
+			this.spawnError = error;
+			this.processExited = true;
+		});
+
+		if (this.spawnError) {
+			throw new LspProcessSpawnError(
+				`Failed to spawn LSP server "${this.server.id}": ${this.spawnError.message}`,
+			);
+		}
 
 		if (this.proc.exitCode !== null) {
 			const stderr = this.stderrBuffer.join("\n");

--- a/packages/lsp-core/src/lsp/transport.ts
+++ b/packages/lsp-core/src/lsp/transport.ts
@@ -92,6 +92,9 @@ export class LspClientTransport {
 		});
 		this.startStderrReading();
 
+		// Spawn failures surface as an async "error" event, so this handler flags the
+		// process dead for the manager's start timeout to observe. onSpawnError also
+		// fires synchronously if the error already landed, covering the fast-ENOENT case.
 		this.proc.onSpawnError((error) => {
 			this.spawnError = error;
 			this.processExited = true;


### PR DESCRIPTION
Closes #6486

## Summary

An LSP server that spawns successfully but then either (a) never responds to `initialize`, or (b) fails asynchronously right after spawn (non-executable / wrong-arch binary emitting an async `ENOENT`/crash) blocked for the full `INIT_TIMEOUT_MS` (60s) before failing. There was no fast bound on `start()` + `initialize()`. On agent harnesses this stacks past background-task stale timeouts and silently cancels workers that already finished their real work.

Note: the *missing-binary* case is already handled cross-platform by `isServerInstalled()` in `server-resolution.ts`. This fix targets the binary that *passes* the existence check but then hangs or dies asynchronously.

## Root cause

`LspClientTransport.start()` only inspected `exitCode` **synchronously** right after spawn. A process that fails asynchronously has not exited yet at that point, so the guard passes and `start()` returns as if healthy. Control then reaches `initialize()`, whose only bound was `INIT_TIMEOUT_MS = 60_000`. The manager called `start()` then `initialize()` with no fast bound at both the `getClient()` and `warmupClient()` sites.

## Changes

1. **Surface async spawn failures (`transport.ts` + `process.ts`).**
   `SpawnedProcess` now exposes `spawnError` and `onSpawnError()`. The child's `'error'` event is captured in `wrap()` and fanned out to listeners. `LspClientTransport.start()` attaches a handler that flags the process dead (`processExited = true`) and throws `LspProcessSpawnError` when the error is already visible, instead of relying solely on the synchronous `exitCode` check.

2. **Bound `start()` + `initialize()` with a fast, env-overridable timeout (`constants.ts` + `manager.ts`).**
   Added `START_TIMEOUT_MS` (default 10s, overridable via `OMO_LSP_START_TIMEOUT_MS`). Both the `getClient()` and `warmupClient()` init promises now run through `startAndInitializeClient()`, which races `start()` + `initialize()` against `START_TIMEOUT_MS`. A silent hang now fails in ~10s instead of 60s. The timer is `.unref()`ed so it never keeps the process alive.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Server hangs on `initialize` | ~60s stall per call | fails in ~10s (`START_TIMEOUT_MS`) |
| Async spawn failure (ENOENT/crash) | missed by sync `exitCode` check -> 60s | `LspProcessSpawnError` surfaced; process flagged dead |
| Healthy server | works | works (adds a `.unref()`ed race timer only) |
| Missing binary | already fast (`isServerInstalled()`) | unchanged |

## Verification

Standalone runtime checks (bun):
- Hanging `initialize()` -> race rejects fast at the timeout (measured at the bound, not 60s).
- Healthy client -> resolves normally.
- `start()` that rejects -> error propagates.
- Real `spawn()` of a nonexistent binary -> `spawnError` is `null` synchronously (reproduces the bug), then the async `error` event fires and both `onSpawnError` and the `spawnError` getter capture the `ENOENT`.

All four changed files transpile clean (`bun build --target=node`). Scope limited to `lsp-core`; no tests/docs/other files touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LSP startup hangs by catching async spawn errors and adding a fast, configurable timeout around start + initialize. Servers that hang or crash right after spawn now fail in ~10s with a clear error instead of stalling for 60s.

- **Bug Fixes**
  - `SpawnedProcess` exposes `spawnError` and `onSpawnError()`; `LspClientTransport.start()` surfaces async spawn failures as `LspProcessSpawnError` and flags the process exited.
  - Bounded `start()` + `initialize()` with `START_TIMEOUT_MS` (default 10s) via a race in `LspManager`; overridable via `OMO_LSP_START_TIMEOUT_MS` or `LspManagerOptions.startTimeoutMs`. Empty/non-numeric/<=0 env values fall back to 10s; timer is `.unref()`ed.
  - Added regression tests for the start-timeout race and the async spawn-error path; fixed the `HealthyLspClient` test constructor to typecheck.
  - Documented `OMO_LSP_START_TIMEOUT_MS` in the LSP configuration docs and environment variables table.

<sup>Written for commit 517192b585d02e529f370ae5f1c83796994c0e4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

