### PR TITLE
test(auto-update-checker): mock npm registry fetch to fix CI timeout flake

### DIFF
--- a/packages/omo-opencode/src/hooks/auto-update-checker/checker.test.ts
+++ b/packages/omo-opencode/src/hooks/auto-update-checker/checker.test.ts
@@ -1,24 +1,80 @@
-import { describe, test, expect } from "bun:test"
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { NPM_REGISTRY_URL } from "./constants"
 import { getLatestVersion } from "./checker"
 
 describe("auto-update-checker/checker", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    mock.restore()
+  })
+
+  function mockDistTags(distTags: Record<string, string>) {
+    globalThis.fetch = mock(async () =>
+      new Response(JSON.stringify(distTags), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    ) as typeof fetch
+  }
+
   describe("getLatestVersion", () => {
     test("accepts channel parameter", async () => {
+      // given
+      mockDistTags({ latest: "1.0.0", beta: "2.0.0-beta.1" })
+
+      // when
       const result = await getLatestVersion("beta")
-      
-      expect(typeof result === "string" || result === null).toBe(true)
+
+      // then
+      expect(result).toBe("2.0.0-beta.1")
     })
 
     test("accepts latest channel", async () => {
+      // given
+      mockDistTags({ latest: "1.0.0", beta: "2.0.0-beta.1" })
+
+      // when
       const result = await getLatestVersion("latest")
-      
-      expect(typeof result === "string" || result === null).toBe(true)
+
+      // then
+      expect(result).toBe("1.0.0")
     })
 
     test("works without channel (defaults to latest)", async () => {
+      // given
+      mockDistTags({ latest: "1.0.0", beta: "2.0.0-beta.1" })
+
+      // when
       const result = await getLatestVersion()
-      
-      expect(typeof result === "string" || result === null).toBe(true)
+
+      // then
+      expect(result).toBe("1.0.0")
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+      expect((globalThis.fetch as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(NPM_REGISTRY_URL)
+    })
+
+    test("falls back to latest when the channel is missing", async () => {
+      // given
+      mockDistTags({ latest: "1.0.0" })
+
+      // when
+      const result = await getLatestVersion("nonexistent-channel")
+
+      // then
+      expect(result).toBe("1.0.0")
+    })
+
+    test("returns null when the registry responds with an error status", async () => {
+      // given
+      globalThis.fetch = mock(async () => new Response("upstream error", { status: 502 })) as typeof fetch
+
+      // when
+      const result = await getLatestVersion()
+
+      // then
+      expect(result).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Summary
CI on `dev` went red because `packages/omo-opencode/src/hooks/auto-update-checker/checker.test.ts` fetched the real npm registry in unit tests. `NPM_FETCH_TIMEOUT` (5000ms) equals the bun test timeout (5000ms), so any stalled network hangs a test past its deadline — observed in CI run 30537361033 (`test (macos-latest)`), where `getLatestVersion > works without channel (defaults to latest)` timed out after 5000ms. This PR mocks `globalThis.fetch` in those tests, making them deterministic and network-free. No production code changes; runtime behavior is identical.

## Changes
- **Test-only rewrite of `checker.test.ts`**: mocks `globalThis.fetch` per test, following the existing sibling pattern in `checker/catch-fallbacks.test.ts`. Assertions are strengthened from trivially-true (`typeof result === "string" || result === null`) to exact behavior: channel selection, default `latest` channel, fallback to `latest` for unknown channels, `null` on non-ok responses, and the registry URL used.

## QA & Evidence
- **What was tested (RED):** original `checker.test.ts` run with a bun preload that makes `globalThis.fetch` hang forever (simulating CI's stalled network): `bun test --preload /tmp/ulw-hang-fetch-preload.ts packages/omo-opencode/src/hooks/auto-update-checker/checker.test.ts`
- **Observed result (RED):** `(fail) accepts channel parameter [5001.52ms] this test timed out after 5000ms` — same failure class as the CI timeout (which of the 3 network tests hits the 5s wall first is a timing race).
- **What was tested (GREEN):** identical command on the rewritten test.
- **Observed result (GREEN):** 5 pass / 0 fail in 150ms total under the hanging-network preload — zero real fetch dependency.
- **What was tested (regression):** `bun test packages/omo-opencode/src/hooks/auto-update-checker/` → 81 pass / 0 fail across 12 files. `bun run typecheck` (tsgo, root + script + all packages) → clean.
- **Artifact:** `.omo/evidence/20260730-auto-update-checker-network-test/README.md`
- **Why sufficient:** the failure was a test-only network flake; the rewrite removes the network dependency entirely and the new assertions fail on real regressions (exact dist-tag values), unlike the old tautological checks. PR CI (`test (macos-latest)`) is the final real-surface proof.

## Risks & Residuals
- Residual: other dev-branch flakes seen in earlier runs (`sisyphus-task` windows title test, `reconcileOnSessionStart` reattach race) are separate issues, not addressed here — this PR fixes the current red only.
- No runtime impact: test file only.

## Related Issues
- Failing run: https://github.com/code-yeongyu/oh-my-openagent/actions/runs/30537361033


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mocked `globalThis.fetch` in `checker.test.ts` for `getLatestVersion` to remove real `npm` registry calls and stop CI timeouts. Tests are now deterministic; runtime code is unchanged.

- **Bug Fixes**
  - Mock fetch per test to avoid network stalls that matched `NPM_FETCH_TIMEOUT` and `bun` test timeout.
  - Strengthened assertions: channel selection, default `latest`, fallback to `latest` for unknown channels, `null` on non-ok, and checks `NPM_REGISTRY_URL`.

<sup>Written for commit 64524483f06bb025f092f42fad8793484f98bce4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

