### PR TITLE
fix(mcp): forward request cwd to LSP config

### DIFF
--- a/packages/omo-opencode/src/mcp/index.ts
+++ b/packages/omo-opencode/src/mcp/index.ts
@@ -52,7 +52,7 @@ export function createBuiltinMcps(disabledMcps: string[] = [], config?: BuiltinM
   }
 
   if (!disabledMcps.includes("lsp")) {
-    mcps.lsp = createLspMcpConfig({ resolveExecutable: options.resolveExecutable })
+    mcps.lsp = createLspMcpConfig({ cwd: options.cwd, resolveExecutable: options.resolveExecutable })
   }
 
   if (!disabledMcps.includes("codegraph") && config?.codegraph?.enabled !== false) {

--- a/packages/omo-opencode/src/mcp/zauc-mocks-mcp-index/index.test.ts
+++ b/packages/omo-opencode/src/mcp/zauc-mocks-mcp-index/index.test.ts
@@ -4,9 +4,12 @@ afterEach(() => {
   mock.restore()
 })
 
-function mockLocalMcps(): void {
+function mockLocalMcps(onLspConfig?: (options: { readonly cwd?: string }) => void): void {
   mock.module("../lsp", () => ({
-    createLspMcpConfig: () => ({ type: "local", command: ["node", "dist/cli.js", "mcp"], enabled: true }),
+    createLspMcpConfig: (options: { readonly cwd?: string } = {}) => {
+      onLspConfig?.(options)
+      return { type: "local", command: ["node", "dist/cli.js", "mcp"], enabled: true }
+    },
   }))
   mock.module("../codegraph", () => ({
     createCodegraphMcpConfig: () => ({ type: "local", command: ["codegraph", "serve", "--mcp"], enabled: true }),
@@ -61,6 +64,22 @@ describe("createBuiltinMcps", () => {
 
     // then
     expect(result.lsp).toBeDefined()
+  })
+
+  test("should forward cwd to the LSP config", () => {
+    // given
+    let receivedCwd: string | undefined
+    mockLocalMcps((options) => {
+      receivedCwd = options.cwd
+    })
+    const { createBuiltinMcps } = require("../index") as typeof import("../index")
+    const cwd = "/tmp/omo-lsp-request-cwd"
+
+    // when
+    createBuiltinMcps([], undefined, { cwd })
+
+    // then
+    expect(receivedCwd).toBe(cwd)
   })
 
   test("should return empty array when all MCPs are disabled", () => {


### PR DESCRIPTION
## Summary

- Forward OpenCode's request cwd into the built-in LSP MCP configuration so project LSP settings resolve from the active task worktree.
- Preserve the existing process-cwd fallback when OpenCode does not provide a cwd.

## Changes

- Pass `BuiltinMcpOptions.cwd` from `createBuiltinMcps()` to `createLspMcpConfig()`.
- Add a regression test that proves the LSP factory receives the distinct request cwd.

## QA & Evidence

- **What was tested:** `bun test packages/omo-opencode/src/mcp/zauc-mocks-mcp-index/index.test.ts` before and after the fix.
  **Observed result:** The new test failed before the production change with an undefined cwd and passed after it: 9 pass, 0 fail.
  **Artifact:** Local `.omo/evidence/20260730-lsp-request-cwd/qa.md`.
  **Why sufficient:** It locks the registry-to-LSP-factory contract that regressed.
- **What was tested:** Direct `createBuiltinMcps()` driver with a dedicated project directory.
  **Observed result:** `LSP_TOOLS_MCP_PROJECT_CONFIG` contained that directory's `.opencode/lsp.json`, `.omo/lsp.json`, and `.omo/lsp-client.json` paths.
  **Artifact:** Local `.omo/evidence/20260730-lsp-request-cwd/qa.md`.
  **Why sufficient:** It proves the real LSP config derives all project paths from the supplied cwd.
- **What was tested:** Local `dist/index.js` plugin loaded by `opencode mcp list` in an isolated disposable Docker container.
  **Observed result:** OpenCode registered five MCP servers and reported `lsp` connected through the bundled daemon CLI.
  **Artifact:** Local `.omo/evidence/20260730-lsp-request-cwd/opencode-mcp-list.txt`.
  **Why sufficient:** It drives the compiled plugin through a real OpenCode surface without changing host configuration.
- **What was tested:** `bun run typecheck` and isolated `bun test`.
  **Observed result:** Typecheck passed; full suite passed with 12547 pass, 3 skip, 0 fail.
  **Artifact:** Local `.omo/evidence/20260730-lsp-request-cwd/qa.md`.
  **Why sufficient:** It covers static compatibility and the repository regression suite.

## Risks & Residuals

- The change only affects the optional LSP cwd input. When absent, `createLspMcpConfig()` retains its existing process-cwd fallback.
- Evidence is intentionally local because `.omo/*` is ignored by this repository. No credentials, host configuration, or raw environment output was included.
- This PR does not restart or modify any deployed OpenCode service.

## Automated Checks

```bash
bun run typecheck
bun test
bun run build
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards the OpenCode request cwd to the LSP MCP config so project LSP settings load from the active worktree. Keeps the process-cwd fallback when no cwd is provided.

- **Bug Fixes**
  - Pass `cwd` from `createBuiltinMcps()` to `createLspMcpConfig()`.
  - Add a unit test to verify the LSP factory receives the request `cwd`.

<sup>Written for commit 7eff22ef87a8acdd41f1616ede7f4c7cadfe6188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

