### PR TITLE
fix(omo-senpi): keep Senpi as authoritative Goal runtime

### DIFF
--- a/packages/omo-senpi/AGENTS.md
+++ b/packages/omo-senpi/AGENTS.md
@@ -14,7 +14,7 @@ This package is adapter-only. It may depend on harness-neutral core packages plu
 | `src/install/` | Local Senpi installer and uninstaller helpers. They add or remove the absolute plugin path in `SENPI_CODING_AGENT_DIR` or `~/.senpi/agent` settings. |
 | `scripts/qa/` | Live Senpi QA drivers, continuation probe, and mock provider used by task 13 validation. |
 | `skills/` | Native Senpi skills authored directly against the Senpi tool surface (not ported from Codex or the shared pool); currently `hyperplan`, `ultrawork`, `ulw-loop`, and `ulw-research`. `sync-skills.mjs` ships them verbatim. |
-| `plugin/` | The single Pi package `@code-yeongyu/omo-senpi`. It contains generated `extensions/omo.js`, generated skills, package metadata, and plugin-local build scripts. |
+| `plugin/` | The single Pi package `@code-yeongyu/omo-senpi`. It contains generated `extensions/omo.js`, generated skills, package metadata, and plugin-local build scripts. Senpi's builtin goal extension owns goal tools. |
 
 The v1 install surface is local-path only. Install the built Pi package from `packages/omo-senpi/plugin`; do not document npm, git, or marketplace distribution for this adapter until that exists in code.
 
@@ -46,7 +46,7 @@ The adapter depends on `@oh-my-opencode/senpi-task` (task engine + tool factorie
 
 Build outputs under `plugin/extensions/` and `plugin/skills/` are generated. Do not hand-edit them.
 
-- `node packages/omo-senpi/plugin/scripts/build-extension.mjs` builds `plugin/extensions/omo.js`.
+- `node packages/omo-senpi/plugin/scripts/build-extension.mjs` builds `plugin/extensions/omo.js` and `plugin/extensions/omo-member.js`.
 - `node packages/omo-senpi/plugin/scripts/build-extension.mjs --check` verifies the generated extension is current.
 - `node packages/omo-senpi/plugin/scripts/sync-skills.mjs` syncs Senpi-ready skills into `plugin/skills/` from three pools: component-owned native sources shipped verbatim (`ulw-loop`), native `skills/` sources shipped verbatim (`hyperplan`, `ultrawork`, `ulw-research`), and the repo `shared-skills` pool (start-work gets a `codex:`->`senpi:` overlay; ulw-plan gets a senpi overlay adding a momus-only review override plus architect/ultrabrain advisory consultation lanes; shared skills get a Senpi tool-compatibility banner).
 - `node packages/omo-senpi/plugin/scripts/embed-directive.mjs --check` verifies the generated ultrawork directive is current.

--- a/packages/omo-senpi/plugin/README.md
+++ b/packages/omo-senpi/plugin/README.md
@@ -1,6 +1,6 @@
 # omo-senpi
 
-`@code-yeongyu/omo-senpi` is the Senpi edition of OMO packaged as one Pi package. It loads one generated extension entry from `extensions/omo.js` and generated skills from `skills/`.
+`@code-yeongyu/omo-senpi` is the Senpi edition of OMO packaged as one Pi package. It loads one generated extension entry from `extensions/omo.js` and generated skills from `skills/`. Goal execution is provided by Senpi's builtin Goal extension; OMO does not bundle a second goal runtime.
 
 ## Shipped skills
 

--- a/packages/omo-senpi/src/plugin-manifest.test.ts
+++ b/packages/omo-senpi/src/plugin-manifest.test.ts
@@ -40,7 +40,7 @@ function adapterVersionIfPresent(): string | undefined {
 }
 
 describe("OMO Senpi plugin manifest", () => {
-  it("#given a Pi package manifest #when loaded #then it points at exactly one bundled extension and skills directory", () => {
+  it("#given Senpi has a builtin goal extension #when loaded #then it does not shadow it with legacy ultragoal", () => {
     const manifest = readJsonObject(pluginManifestPath)
     const pi = manifest.pi
 

--- a/packages/pi-goal/AGENTS.md
+++ b/packages/pi-goal/AGENTS.md
@@ -55,8 +55,8 @@ The goal tool contract is aligned with codex `codex-rs/ext/goal`:
   at a non-zero epoch because Bun's `setSystemTime(new Date(0))` acts as a reset.
 - Peer deps (`@mariozechner/pi-*`, `typebox`) resolve from the host Pi runtime; pinned
   devDependencies exist only for typecheck + tests + live QA.
-- This package is not wired into any OpenCode/Codex/omo-senpi component. It ships as a
-  standalone Pi package surface (`pi.extensions` manifest field).
+- The source remains usable as a standalone Pi extension. Senpi's builtin goal extension
+  is authoritative; omo-senpi ships only its adapter and does not bundle this extension.
 
 ## QA
 

--- a/packages/pi-goal/src/index.ts
+++ b/packages/pi-goal/src/index.ts
@@ -123,9 +123,9 @@ export default function (pi: ExtensionAPI): void {
 		},
 	});
 
-	pi.registerCommand("goal", {
+	const goalCommand = {
 		description: "Set, inspect, pause, resume, or clear the persistent goal",
-		handler: async (rawArgs, ctx) => {
+		handler: async (rawArgs: string, ctx: ExtensionContext) => {
 			const command = parseGoalCommand(rawArgs);
 			try {
 				switch (command.kind) {
@@ -173,6 +173,11 @@ export default function (pi: ExtensionAPI): void {
 				ctx.ui.notify(errorMessage(error), "error");
 			}
 		},
+	};
+	pi.registerCommand("goal", goalCommand);
+	pi.registerCommand("ultragoal", {
+		...goalCommand,
+		description: "Compatibility alias for /goal",
 	});
 
 	pi.on("session_start", async (event, ctx) => {

--- a/packages/pi-goal/test/extension.test.ts
+++ b/packages/pi-goal/test/extension.test.ts
@@ -319,6 +319,13 @@ describe("pi-goal extension command UI parity", () => {
 		await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 	});
 
+	it("registers /goal and keeps /ultragoal as a compatibility alias", () => {
+		const harness = createHarness();
+
+		expect(() => harness.command("goal")).not.toThrow();
+		expect(() => harness.command("ultragoal")).not.toThrow();
+	});
+
 	it("shows Codex-style usage text for a bare /goal without a goal", async () => {
 		const harness = createHarness();
 		const ui = createMockUi();


### PR DESCRIPTION
## Summary

- document Senpi's builtin Goal extension as the authoritative goal runtime for the OMO Senpi package
- pin the plugin manifest contract so OMO cannot shadow the builtin with a second legacy Ultragoal extension
- keep the standalone `pi-goal` package on the `/goal` user surface while preserving `/ultragoal` as a compatibility alias

## Verification

- `bun test packages/pi-goal/test`: 9 files / 56 tests passed
- `bun run --cwd packages/pi-goal typecheck`: passed
- `packages/omo-senpi/src/plugin-manifest.test.ts`: 4 tests passed
- `node packages/pi-goal/scripts/qa/drive.mjs --self-test`: PASS
- pre-rebase Goal/manifest/build review gate: 11 files / 65 tests passed with final independent reviewer APPROVE

## Current dev baseline note

The branch is rebased onto current `dev`. The broader OMO adapter build/typecheck gate is already red outside this diff: the current workspace does not link `@oh-my-opencode/omo-opencode/config-migration` for `omo-senpi`, and current Senpi/Node type mismatches remain in `fallback-architect`, `senpi-task`, and `utils`. This PR does not suppress or modify those failures.

## Compatibility

- Senpi continues to load exactly `./extensions/omo.js` from OMO
- existing `/goal` behavior is unchanged
- standalone users of the previous `/ultragoal` command retain the same handler through the compatibility alias

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Senpi’s builtin Goal extension the single source of truth for Goal execution in OMO. Prevent `@code-yeongyu/omo-senpi` from bundling a legacy Ultragoal and keep `pi-goal` on `/goal` with `/ultragoal` as a compatibility alias.

- **Bug Fixes**
  - Pin the plugin manifest so OMO cannot declare a second Goal/Ultragoal extension.
  - Update tests to enforce that the builtin Goal is not shadowed.
  - Clarify docs that Senpi owns Goal tools.

- **Migration**
  - No changes required. `/goal` is unchanged; `/ultragoal` works via alias for compatibility.

<sup>Written for commit 9b9893cfa68af22a47a560594c7d5d225f9f06d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

