### PR TITLE
chore(skills): drop contract-test guidance from the programming skill

### DIFF
--- a/packages/shared-skills/skills/programming/SKILL.md
+++ b/packages/shared-skills/skills/programming/SKILL.md
@@ -238,8 +238,7 @@ Logging is part of the code you ship, and it has iron rules of its own: levels c
 ## DEPENDENCY UPGRADES — CROSS-CUTTING RULES
 
 - **`0.x` minor = major.** Semver promises nothing below 1.0: treat `0.N → 0.N+1` as a breaking upgrade — read the changelog, build, and run the full suite before trusting it. A required field appearing in a public options type is a routine `0.x` "minor".
-- **Version literals live outside the manifest.** Before committing a bump, grep the repo for the old version string: Dockerfiles pinning a global CLI, CI workflows, docs, and contract tests all carry copies. A bump that updates only the package manifest ships a split-brain deploy.
-- **Pin-parity contract tests are a pattern, not a nuisance.** A small test asserting the lockfile-resolved version equals the deploy artifact's pin (Dockerfile, image tag) turns silent drift into a red test. If the project has one, update it deliberately; if the bump reveals unguarded drift, add the test with the bump.
+- **Version literals live outside the manifest.** Before committing a bump, grep the repo for the old version string: Dockerfiles pinning a global CLI, CI workflows, and docs all carry copies. A bump that updates only the package manifest ships a split-brain deploy.
 - **Never hand-merge a lockfile.** On conflict, take either side whole and regenerate with the package manager — the resolver owns that file, not you.
 
 ---


### PR DESCRIPTION
## What

Removes the contract-test-family guidance from the `programming` skill (shared source):

- deletes the **"Pin-parity contract tests are a pattern, not a nuisance"** bullet entirely;
- drops "and contract tests" from the version-literals enumeration in the same section.

## Why

Product decision: contract-test-style guidance should not ship in the skills.

## Scope / propagation

`packages/shared-skills/skills/programming/SKILL.md` is the single source; the senpi plugin copy (untracked, regenerated by `packages/omo-senpi/plugin/scripts/sync-skills.mjs`) and the codex plugin copy (untracked, regenerated by `packages/omo-codex/plugin/scripts/sync-skills.mjs`) pick this up at build time. Remaining `contract test` hits in the repo are vendored `packages/shared-skills/upstreams/**` third-party specs and the shared-skills AGENTS.md note that documents the earlier removal of prose-pinning contract tests — neither is skill content.

## QA

- `rg -i 'contract[- ]test'` over `packages/shared-skills/skills`, `packages/omo-senpi/skills`, `packages/omo-senpi/plugin/skills` (regenerated), `packages/omo-codex/plugin/skills`: 0 hits.
- `bun test packages/omo-senpi/src/skills-sync.test.ts`: 8 pass / 0 fail after regeneration.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed contract-test guidance from the `programming` skill. Updated `packages/shared-skills/skills/programming/SKILL.md` by deleting the pin-parity bullet and removing “contract tests” from the version-literals rule; plugin copies in `packages/omo-senpi` and `packages/omo-codex` update on build.

<sup>Written for commit 8b8eb7120e7a8d9b5b08d0c02388c0d2424e5596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

