### PR TITLE
feat(skills): vendor the data-scientist skill into shared-skills

### DIFF
--- a/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills-test-support.mjs
@@ -8,6 +8,7 @@ export const expectedSkills = [
 	"ast-grep",
 	"coding-agent-sessions",
 	"comment-checker",
+	"data-scientist",
 	"debugging",
 	"frontend",
 	"git-master",

--- a/packages/omo-codex/src/python-migration-inventory.test.ts
+++ b/packages/omo-codex/src/python-migration-inventory.test.ts
@@ -27,6 +27,7 @@ const optionalGeneratedPythonFiles = [
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/transcript.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/agent_sessions/types.py",
   "packages/omo-codex/plugin/skills/coding-agent-sessions/scripts/find-agent-sessions.py",
+  "packages/omo-codex/plugin/skills/data-scientist/scripts/quick-query.py",
   "packages/omo-codex/plugin/skills/frontend/references/ui-ux-db/scripts/core.py",
   "packages/omo-codex/plugin/skills/frontend/references/ui-ux-db/scripts/design_system.py",
   "packages/omo-codex/plugin/skills/frontend/references/ui-ux-db/scripts/search.py",

--- a/packages/omo-senpi/src/skills-sync.test.ts
+++ b/packages/omo-senpi/src/skills-sync.test.ts
@@ -8,6 +8,7 @@ const skillsRoot = join(repoRoot, "packages", "omo-senpi", "plugin", "skills")
 const expectedSkillNames = [
   "ast-grep",
   "coding-agent-sessions",
+  "data-scientist",
   "debugging",
   "frontend",
   "git-master",

--- a/packages/shared-skills/depersonalization-gate.mjs
+++ b/packages/shared-skills/depersonalization-gate.mjs
@@ -12,6 +12,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 const DEFAULT_SCAN_DIRS = [
 	join(here, "skills", "ultimate-browsing"),
+	join(here, "skills", "data-scientist"),
 	join(here, "skills", "ulw-research"),
 ];
 

--- a/packages/shared-skills/depersonalization-gate.test.ts
+++ b/packages/shared-skills/depersonalization-gate.test.ts
@@ -10,7 +10,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 describe("#given the vendored shared skills #when the de-personalization gate runs", () => {
 	test("#then the cleaned ultimate-browsing + ulw-research tree has zero violations", async () => {
 		// given
-		const scanDirs = [join(here, "skills", "ultimate-browsing"), join(here, "skills", "ulw-research")];
+		const scanDirs = [join(here, "skills", "ultimate-browsing"), join(here, "skills", "data-scientist"), join(here, "skills", "ulw-research")];
 		// when
 		const violations = await runDepersonalizationGate(scanDirs, here);
 		// then

--- a/packages/shared-skills/skills/data-scientist/SKILL.md
+++ b/packages/shared-skills/skills/data-scientist/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: data-scientist
+description: "Expert data processing specialist with intelligent DuckDB/Polars selection for maximum performance. Always includes numpy, never uses pandas, runs everything through uv. Triggers: 'analyze the data', 'analyze this file', 'what is in this CSV/parquet/json', 'summarize this', 'group by', 'filter rows', 'sort by', 'join these files', 'merge datasets', 'time series trend', 'last 30 days data', 'compare yesterday and today', 'distribution/histogram', 'correlation', 'clean duplicates', 'handle missing values', 'dataset larger than RAM', 'SQL query on files', 'DataFrame operations', 'chart/plot this data', DuckDB vs Polars selection, quick data exploration CLI. NOT for plain text/code inspection, configs, or tiny inline math."
+---
+
+# Data Scientist: High-Performance Data Processing Expert
+
+## Role & Expertise
+
+Performance-obsessed data scientist with expertise in:
+- Intelligent tool selection: DuckDB vs Polars based on operation characteristics
+- Zero-copy data interchange via Apache Arrow
+- Memory-efficient processing for datasets exceeding RAM
+- SQL and DataFrame API mastery for analytical workloads
+
+## Environment Setup
+
+Everything runs through **uv**. If `uv` is not on PATH, set it up first — pick the path that matches the system and run it, no manual guesswork:
+
+```bash
+bash scripts/setup-uv.sh        # macOS / Linux / WSL / Git Bash — auto-detects OS + arch, installs or updates uv to latest
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/setup-uv.ps1   # native Windows — installs or updates uv to latest
+```
+
+Both scripts detect the platform, install uv when missing (official installer first, Homebrew/winget as fallback), upgrade it when present (`uv self update`), put it on PATH for the current shell, and verify with `uv --version`. The full per-platform matrix, PATH notes, and CI usage live in [references/uv-setup.md](references/uv-setup.md). Verify: `uv --version`.
+
+## Core Principles
+
+### ABSOLUTE RULES
+
+1. **ALWAYS include numpy** in all data processing operations (`uv run --with numpy ...`)
+2. **NEVER use pandas** - Polars and DuckDB beat it decisively on every operation; the entire skill assumes pandas is absent
+3. **ALWAYS use Python via `uv run`** for calculations and data processing
+4. **Intelligent tool selection**: Choose DuckDB or Polars based on operation types, NOT arbitrarily
+5. **Zero-copy conversions**: hand data across DuckDB and Polars through Arrow — `duckdb.sql(...).pl()`. Never call `.df()` (returns a pandas frame; crashes without pandas). Keep `pyarrow` in the package set or `.pl()` raises `ModuleNotFoundError`
+6. **Lazy evaluation**: Prefer `scan_csv`/`scan_parquet` and `.collect()` only when needed
+7. **Direct file queries**: Let DuckDB query files directly instead of loading to memory when possible
+
+### Standard Package Pattern
+
+```bash
+# Default for data tasks (numpy + pyarrow are mandatory parts of the set)
+uv run --with numpy --with duckdb --with polars --with pyarrow python -c "{code}"
+
+# With visualization (RECOMMENDED for most analysis requests)
+uv run --with numpy --with duckdb --with polars --with pyarrow --with matplotlib python -c "{code}"
+
+# Pure Polars
+uv run --with numpy --with polars python -c "{code}"
+
+# Pure DuckDB (with the Arrow handoff available)
+uv run --with numpy --with duckdb --with pyarrow python -c "{code}"
+```
+
+**When to include matplotlib:**
+- User requests visualization: "graph", "chart", "plot", "show me"
+- Exploratory data analysis (EDA): "analyze", "trends", "patterns"
+- Time-series analysis: "over time", "daily", "trends"
+- Distribution analysis: "distribution", "histogram", "statistics"
+- Comparison tasks: "compare", visual comparison implied
+- **Default to including matplotlib** when in doubt - overhead is minimal
+
+## Tool Selection Logic
+
+### Decision Tree (Apply in Order)
+
+1. **Is it a `.duckdb` file?** → **USE DUCKDB** (native format, optimal performance)
+2. **Simple one-off query without needing full data in memory?** → **USE DUCKDB** (direct file query, zero memory load)
+3. **Very heavy complex SQL query (multi-table joins, window functions)?** → **USE DUCKDB** (superior SQL optimizer)
+4. **Main operation is FILTERING?** → **USE POLARS** (typically the fastest by a wide margin — see benchmarks)
+5. **Main operation is SORTING?** → **USE POLARS** (typically the fastest)
+6. **Complex SQL JOINS needed?** → **USE DUCKDB** (stronger join engine, more join types)
+7. **Heavy GROUP BY AGGREGATIONS?** → **USE DUCKDB** (typically faster on large datasets)
+8. **Window functions with partitioning?** → **POLARS** (typically faster)
+9. **Complex TRANSFORMATIONS (pivot, melt, string ops)?** → **USE POLARS**
+10. **Dataset larger than available RAM?** → **USE POLARS** (streaming support) or **DUCKDB** (out-of-core)
+11. **Mixed operations?** → **USE HYBRID APPROACH** (leverage strengths of both)
+
+### Quick Reference
+
+```
+Simple query → DuckDB
+Heavy complex query → DuckDB
+Filter → Polars
+Sort → Polars
+Join → DuckDB
+Aggregate → DuckDB
+Window → Polars
+Transform → Polars
+Too large for RAM → Polars streaming
+Mixed operations → Hybrid
+```
+
+The exact multipliers these heuristics distill (with sources and caveats — routing heuristics, not guarantees) live in [performance-benchmarks.md](references/performance-benchmarks.md).
+
+## Essential Patterns
+
+### DuckDB Direct File Query
+
+```python
+import duckdb
+# Query file directly - no memory load
+result = duckdb.sql("""
+    SELECT category, SUM(amount) as total
+    FROM 'data.csv'
+    GROUP BY category
+""").pl()  # .pl() -> Polars via Arrow. Requires pyarrow. Never .df() (pandas).
+```
+
+### Polars Lazy Evaluation
+
+```python
+import polars as pl
+# Lazy scan - optimizes and executes once
+result = (
+    pl.scan_csv('data.csv')
+    .filter(pl.col('value') > 100)
+    .sort('value', descending=True)
+    .collect()
+)
+```
+
+### Zero-Copy DuckDB → Polars
+
+```python
+import duckdb
+# Direct conversion via Arrow (pyarrow required in the package set)
+df_polars = duckdb.sql("SELECT * FROM 'data.csv'").pl()
+```
+
+### Hybrid Approach
+
+```python
+import duckdb
+import polars as pl
+
+# Phase 1: DuckDB for joins
+joined = duckdb.sql(
+    "SELECT * FROM 'orders.csv' o "
+    "JOIN 'customers.csv' c ON o.customer_id = c.customer_id"
+).pl()
+
+# Phase 2: Polars for filtering
+filtered = joined.filter(pl.col('amount') > 100)
+
+# Phase 3: Back to DuckDB for aggregation
+duckdb.register('filtered_data', filtered)
+final = duckdb.sql('SELECT category, SUM(amount) FROM filtered_data GROUP BY category').pl()
+```
+
+## Quick Query CLI
+
+For ad-hoc data exploration, use the built-in query runner:
+
+```bash
+# SQL query (uses DuckDB)
+uv run scripts/quick-query.py data.csv "SELECT category, COUNT(*) FROM data GROUP BY category"
+
+# Filter expression — Polars SQL syntax, e.g. "amount > 100" (NOT Python: never passes through eval)
+uv run scripts/quick-query.py data.csv --filter "amount > 100"
+
+# Auto-describe (schema + stats)
+uv run scripts/quick-query.py data.parquet --describe
+```
+
+Supports CSV, Parquet, JSON, NDJSON. Cross-platform (macOS, Linux, Windows). Excel files are not read directly — export to CSV or Parquet first.
+
+## Reference Documentation
+
+For detailed guidance, consult these reference files:
+
+- **Environment setup per platform**: See [uv-setup.md](references/uv-setup.md) — install/update uv on macOS, Linux, Windows, WSL, CI; PATH fixes; `scripts/setup-uv.sh` / `scripts/setup-uv.ps1` automate it.
+- **Performance benchmarks and operation detection**: See [performance-benchmarks.md](references/performance-benchmarks.md)
+- **Integration patterns and best practices**: See [integration-patterns.md](references/integration-patterns.md)
+- **Execution templates**: See [execution-templates.md](references/execution-templates.md)
+- **Common scenarios**: See [common-scenarios.md](references/common-scenarios.md)
+
+## Quality Assurance Process
+
+### Before Execution
+1. **Analyze request** → Detect operation types (filter, join, aggregate, etc.)
+2. **Select optimal tool** → Apply decision tree based on detected operations
+3. **Verify approach** → Confirm tool selection matches the benchmark heuristics
+4. **Check package list** → Ensure numpy AND pyarrow are included
+
+### During Execution
+1. **Use lazy evaluation** when possible (Polars `scan_*`, DuckDB direct queries)
+2. **Monitor for errors** and have fallback strategy ready
+3. **Provide progress updates** for long operations
+
+### After Execution
+1. **Report performance** → Show processing time and row counts
+2. **Validate results** → Confirm output matches expectations
+3. **Document tool choice** → Explain why specific tool was selected
+
+## Activation Context
+
+**Automatic activation triggers:**
+
+### Exploratory Questions
+- "Analyze the data" / "What's in the data" / "What's in this file"
+- "Show me the data" / "Take a look at this file" / "Check the file contents"
+
+### Temporal/Historical Analysis
+- "What happened in the past N days?" / "How's last week's data?"
+- "What's the trend for the last 30 days?" / "Compare yesterday and today"
+
+### Aggregation/Summary Requests
+- "Summarize this" / "What's the total?" / "What's the average?"
+- "Show by category" / "Show statistics" / "How many?"
+
+### Filtering/Search Patterns
+- "Show only above 100" / "Find specific conditions" / "Top 10"
+
+### Comparison/Correlation
+- "Compare A and B" / "What's the difference?" / "Is there a correlation?" / "Merge two files"
+
+### Transformation/Cleaning
+- "Clean this up" / "Remove duplicates" / "Handle missing values" / "Convert format"
+
+### Technical Patterns
+- Working with CSV, Parquet, JSON, NDJSON, or `.duckdb` files
+- File paths ending in `.csv`, `.parquet`, `.json`, `.jsonl`, `.ndjson`, `.tsv`, `.duckdb`
+- Requests involving calculations or aggregations
+- Joining, filtering, sorting, or transforming datasets
+- Processing large datasets that may exceed memory
+- Comparing or analyzing data from multiple sources
+- Performance-critical data operations
+- SQL queries or DataFrame operations mentioned
+
+### When NOT to Activate
+- Simple file reading for text/code inspection (use the harness's file-read surface)
+- Non-data files (images, videos, binaries)
+- Configuration files (YAML, TOML, JSON configs) unless specifically for data analysis
+- Small inline calculations (run them directly)
+- Excel files — convert to CSV/Parquet first
+
+---
+
+**Core execution principle:** Always apply intelligent tool selection based on operation characteristics, never use pandas, and always include numpy and pyarrow in the execution environment.

--- a/packages/shared-skills/skills/data-scientist/references/common-scenarios.md
+++ b/packages/shared-skills/skills/data-scientist/references/common-scenarios.md
@@ -1,0 +1,176 @@
+# Common Scenarios with Tool Selection
+
+## Scenario 1: Simple Calculation
+
+**Decision: Python (always)**
+
+```python
+uv run --with numpy python -c "
+import numpy as np
+result = np.sum([1, 2, 3, 4, 5])
+print(f'Result: {result}')
+"
+```
+
+## Scenario 2: CSV Quick Analysis
+
+**Decision: DuckDB (direct query, no memory load)**
+
+```python
+uv run --with numpy --with duckdb python -c "
+import duckdb
+result = duckdb.sql('''
+    SELECT * FROM 'data.csv'
+    LIMIT 10
+''').pl()
+print(result)
+"
+```
+
+## Scenario 3: Filter + Sort on Large Dataset
+
+**Decision: Polars (128x faster filtering, 12x faster sorting)**
+
+```python
+uv run --with numpy --with polars python -c "
+import polars as pl
+result = (
+    pl.scan_csv('large.csv')
+    .filter(pl.col('value') > 1000)
+    .sort('value', descending=True)
+    .head(100)
+    .collect()
+)
+print(result)
+"
+```
+
+## Scenario 4: Multi-Table Join + Aggregation
+
+**Decision: DuckDB (best for joins and aggregations)**
+
+```python
+uv run --with numpy --with duckdb python -c "
+import duckdb
+result = duckdb.sql('''
+    SELECT
+        a.category,
+        COUNT(*) as count,
+        SUM(b.amount) as total
+    FROM 'table1.csv' a
+    JOIN 'table2.csv' b ON a.id = b.id
+    GROUP BY a.category
+    ORDER BY total DESC
+''').pl()
+print(result)
+"
+```
+
+## Scenario 5: Data Exploration
+
+**Decision: DuckDB for quick exploration**
+
+```python
+uv run --with numpy --with duckdb python -c "
+import duckdb
+
+# Show first few rows
+print('**Sample Data**')
+print(duckdb.sql('SELECT * FROM \"data.csv\" LIMIT 5').pl())
+
+# Show summary statistics
+print('\\n**Summary Statistics**')
+print(duckdb.sql('DESCRIBE SELECT * FROM \"data.csv\"').pl())
+
+# Show row count
+print('\\n**Row Count**')
+print(duckdb.sql('SELECT COUNT(*) as total_rows FROM \"data.csv\"').pl())
+"
+```
+
+## Scenario 6: Time-Series Analysis
+
+**Decision: DuckDB for aggregation + matplotlib for visualization**
+
+```python
+uv run --with numpy --with duckdb --with pyarrow --with matplotlib python -c "
+import duckdb
+import matplotlib.pyplot as plt
+
+# Aggregate by date
+result = duckdb.sql('''
+    SELECT
+        DATE_TRUNC('day', timestamp) as date,
+        COUNT(*) as count,
+        AVG(value) as avg_value
+    FROM 'timeseries.csv'
+    GROUP BY date
+    ORDER BY date
+''').pl()
+
+# Plot
+plt.figure(figsize=(12, 6))
+plt.subplot(2, 1, 1)
+plt.plot(result['date'], result['count'])
+plt.title('Daily Count')
+
+plt.subplot(2, 1, 2)
+plt.plot(result['date'], result['avg_value'])
+plt.title('Daily Average Value')
+
+plt.tight_layout()
+plt.savefig('timeseries.png')
+print('Saved to timeseries.png')
+"
+```
+
+## Scenario 7: Complex Transformation
+
+**Decision: Polars for efficient transformations**
+
+```python
+uv run --with numpy --with polars python -c "
+import polars as pl
+
+result = (
+    pl.scan_csv('data.csv')
+    .with_columns([
+        # Create new calculated columns
+        (pl.col('price') * pl.col('quantity')).alias('total'),
+        pl.col('date').str.strptime(pl.Date, '%Y-%m-%d').alias('parsed_date'),
+        pl.col('name').str.to_uppercase().alias('upper_name'),
+    ])
+    .filter(pl.col('total') > 100)
+    .select(['parsed_date', 'upper_name', 'total'])
+    .collect()
+)
+
+print(result)
+"
+```
+
+## Scenario 8: Large File Processing
+
+**Decision: Polars streaming mode**
+
+```python
+uv run --with numpy --with polars python -c "
+import polars as pl
+
+# Process file larger than RAM
+result = (
+    pl.scan_csv('huge_file.csv')
+    .filter(pl.col('active') == True)
+    .groupby('category')
+    .agg([
+        pl.count().alias('count'),
+        pl.sum('amount').alias('total'),
+        pl.mean('amount').alias('average'),
+    ])
+    .collect(streaming=True)  # Streaming mode
+)
+
+print(result)
+print(f'\\nProcessed {result[\"count\"].sum():,} rows')
+"
+```

--- a/packages/shared-skills/skills/data-scientist/references/execution-templates.md
+++ b/packages/shared-skills/skills/data-scientist/references/execution-templates.md
@@ -1,0 +1,197 @@
+# Execution Templates
+
+## Template 1: DuckDB for Simple/Complex SQL Queries
+
+**Use when:**
+- Simple aggregation on single file
+- Complex multi-table joins
+- Heavy GROUP BY operations
+- Window functions with complex SQL logic
+- Ad-hoc exploration queries
+
+```python
+uv run --with numpy --with duckdb python -c "
+import duckdb
+
+# Simple query - direct file access
+result = duckdb.sql('''
+    SELECT
+        category,
+        COUNT(*) as count,
+        AVG(amount) as avg_amount,
+        SUM(amount) as total
+    FROM 'data.csv'
+    WHERE date >= '2024-01-01'
+    GROUP BY category
+    ORDER BY total DESC
+    LIMIT 10
+''').pl()
+
+print('**Results**')
+print(result)
+print(f'\\nProcessed {len(result)} categories')
+"
+```
+
+## Template 2: Polars for Filtering & Sorting
+
+**Use when:**
+- Primary operation is filtering large dataset
+- Sorting required
+- Chain transformations
+- Memory-efficient processing needed
+
+```python
+uv run --with numpy --with polars python -c "
+import polars as pl
+
+# Lazy evaluation for optimal performance
+result = (
+    pl.scan_csv('data.csv')  # Lazy scan
+    .filter(
+        (pl.col('amount') > 1000) &
+        (pl.col('status') == 'active') &
+        (pl.col('date') >= '2024-01-01')
+    )
+    .sort('amount', descending=True)
+    .head(100)
+    .collect()  # Execute optimized plan
+)
+
+print('**Filtered and Sorted Results**')
+print(result)
+print(f'\\nFound {len(result)} matching rows')
+"
+```
+
+## Template 3: Hybrid Approach (Best of Both)
+
+**Use when:**
+- Need joins AND heavy filtering
+- Complex SQL followed by transformations
+- Optimize different operation stages
+
+```python
+uv run --with numpy --with duckdb --with polars --with pyarrow python -c "
+import duckdb
+import polars as pl
+
+print('Phase 1: DuckDB for complex join (3x faster)')
+# DuckDB excels at joins
+joined = duckdb.sql('''
+    SELECT
+        o.order_id,
+        o.amount,
+        c.customer_id,
+        c.region,
+        p.category
+    FROM 'orders.csv' o
+    JOIN 'customers.csv' c ON o.customer_id = c.customer_id
+    JOIN 'products.csv' p ON o.product_id = p.product_id
+    WHERE o.date >= '2024-01-01'
+''').pl()  # Convert to Polars
+
+print(f'Joined {len(joined):,} rows')
+
+print('\\nPhase 2: Polars for ultra-fast filtering (128x faster)')
+# Polars excels at filtering
+filtered = (
+    joined
+    .filter(
+        (pl.col('amount') > 100) &
+        (pl.col('region').is_in(['North', 'South', 'East']))
+    )
+    .with_columns([
+        (pl.col('amount') * 1.1).alias('amount_with_tax')
+    ])
+)
+
+print(f'Filtered to {len(filtered):,} rows')
+
+print('\\nPhase 3: DuckDB for final aggregation (4x faster)')
+# Back to DuckDB for aggregation
+duckdb.register('filtered_data', filtered)
+final = duckdb.sql('''
+    SELECT
+        region,
+        category,
+        COUNT(DISTINCT customer_id) as customers,
+        SUM(amount_with_tax) as total_revenue,
+        AVG(amount_with_tax) as avg_transaction
+    FROM filtered_data
+    GROUP BY region, category
+    HAVING total_revenue > 10000
+    ORDER BY total_revenue DESC
+''').pl()
+
+print('\\n**Final Results**')
+print(final)
+"
+```
+
+## Template 4: Polars Streaming for Large Files
+
+**Use when:**
+- Dataset larger than available RAM
+- Need to process data in batches
+- Memory constraints
+
+```python
+uv run --with numpy --with polars python -c "
+import polars as pl
+
+# Streaming mode - processes data in chunks
+result = (
+    pl.scan_csv('huge_file.csv')
+    .filter(pl.col('status') == 'active')
+    .with_columns([
+        (pl.col('amount') * 1.1).alias('adjusted_amount')
+    ])
+    .groupby('category')
+    .agg([
+        pl.sum('adjusted_amount').alias('total'),
+        pl.count().alias('count')
+    ])
+    .collect(streaming=True)  # Streaming mode for large data
+)
+
+print('**Streaming Results**')
+print(result)
+print(f'\\nProcessed {result[\"count\"].sum():,} total rows')
+"
+```
+
+## Template 5: Visualization with Matplotlib
+
+**Use when:**
+- User requests charts, graphs, or plots
+- Exploratory data analysis (EDA)
+- Time-series or distribution analysis
+
+```python
+uv run --with numpy --with duckdb --with polars --with pyarrow --with matplotlib python -c "
+import duckdb
+import matplotlib.pyplot as plt
+
+# Query data
+result = duckdb.sql('''
+    SELECT
+        date,
+        SUM(amount) as total
+    FROM 'data.csv'
+    GROUP BY date
+    ORDER BY date
+''').pl()
+
+# Create visualization
+plt.figure(figsize=(10, 6))
+plt.plot(result['date'], result['total'])
+plt.xlabel('Date')
+plt.ylabel('Total Amount')
+plt.title('Daily Total Trends')
+plt.xticks(rotation=45)
+plt.tight_layout()
+plt.savefig('output.png')
+print('Chart saved to output.png')
+"
+```

--- a/packages/shared-skills/skills/data-scientist/references/integration-patterns.md
+++ b/packages/shared-skills/skills/data-scientist/references/integration-patterns.md
@@ -1,0 +1,153 @@
+# Integration Patterns: DuckDB ↔ Polars
+
+## Zero-Copy Conversions (FASTEST)
+
+### DuckDB → Polars (Recommended)
+
+```python
+import duckdb
+import polars as pl
+
+# Direct conversion with .pl() - zero-copy via Arrow
+df_polars = duckdb.sql("""
+    SELECT * FROM 'data.parquet'
+    WHERE amount > 100
+""").pl()  # Returns Polars DataFrame directly
+
+# Lazy version for large datasets
+lazy_df = duckdb.sql("SELECT * FROM 'data.parquet'").pl(lazy=True)
+result = lazy_df.filter(pl.col('status') == 'active').collect()
+```
+
+### Polars → DuckDB (Direct Reference)
+
+```python
+import duckdb
+import polars as pl
+
+# DuckDB can query Polars DataFrames directly by name
+df = pl.read_parquet('data.parquet')
+
+result = duckdb.sql("""
+    SELECT category, SUM(amount) as total
+    FROM df
+    GROUP BY category
+    ORDER BY total DESC
+""").pl()  # Query df directly, return as Polars
+```
+
+### Via Arrow (When Needed)
+
+```python
+# Polars → Arrow → DuckDB
+df_polars = pl.read_csv('data.csv')
+duckdb.register('my_table', df_polars.to_arrow())
+
+# DuckDB → Arrow → Polars
+arrow_table = duckdb.sql("SELECT * FROM data").arrow()
+df_polars = pl.from_arrow(arrow_table)
+```
+
+## WRONG vs RIGHT Patterns
+
+### ❌ NEVER - Using Pandas
+
+```python
+# FORBIDDEN - decisively slower than Polars/DuckDB on every operation!
+import pandas as pd
+df = pd.read_csv('data.csv')
+result = df.groupby('category')['amount'].sum()
+```
+
+### ✅ CORRECT - DuckDB for simple aggregation query
+
+```python
+import duckdb
+# Direct file query - no memory loading!
+result = duckdb.sql("""
+    SELECT category, SUM(amount) as total
+    FROM 'data.csv'
+    GROUP BY category
+""").pl()  # Fast, memory-efficient
+```
+
+### ❌ NEVER - Loading file before DuckDB query
+
+```python
+# WRONG - Unnecessary memory usage
+import polars as pl
+import duckdb
+df = pl.read_csv('data.csv')  # Loads entire file
+result = duckdb.sql("SELECT * FROM df WHERE amount > 100").pl()
+```
+
+### ✅ CORRECT - Let DuckDB query directly
+
+```python
+import duckdb
+# DuckDB queries file directly - much faster!
+result = duckdb.sql("""
+    SELECT * FROM 'data.csv'
+    WHERE amount > 100
+""").pl()
+```
+
+### ❌ NEVER - Eager evaluation in Polars
+
+```python
+# WRONG - Loads everything immediately
+import polars as pl
+df = pl.read_csv('large_data.csv')  # Eager load
+filtered = df.filter(pl.col('value') > 100)
+```
+
+### ✅ CORRECT - Lazy evaluation
+
+```python
+import polars as pl
+# Lazy - builds query plan, optimizes, executes once
+df = pl.scan_csv('large_data.csv')  # Lazy
+result = (
+    df
+    .filter(pl.col('value') > 100)
+    .groupby('category')
+    .agg(pl.sum('value'))
+    .collect()  # Execute optimized plan
+)
+```
+
+### ❌ NEVER - Unnecessary Conversions
+
+```python
+# WASTEFUL (DuckDB → Pandas → Polars)
+import duckdb, pandas as pd, polars as pl
+df_pd = duckdb.sql("SELECT * FROM 'data.csv'").df()  # requires pandas - the skill never ships it
+df_pl = pl.from_pandas(df_pd)
+```
+
+### ✅ CORRECT - Direct conversion
+
+```python
+# DIRECT (DuckDB → Polars via Arrow)
+import duckdb
+df_pl = duckdb.sql("SELECT * FROM 'data.csv'").pl()
+```
+
+### ❌ NEVER - Wrong tool for heavy filtering
+
+```python
+# SLOW (DuckDB not optimal for filtering)
+import duckdb
+result = duckdb.sql("""
+    SELECT * FROM 'huge.csv'
+    WHERE complex_filter = true
+""").pl()
+```
+
+### ✅ CORRECT - Use Polars for filtering
+
+```python
+# FAST (Polars 128x faster for filtering)
+import polars as pl
+result = pl.scan_csv('huge.csv').filter(pl.col('complex_filter')).collect()
+```

--- a/packages/shared-skills/skills/data-scientist/references/performance-benchmarks.md
+++ b/packages/shared-skills/skills/data-scientist/references/performance-benchmarks.md
@@ -1,0 +1,37 @@
+# Performance Benchmarks
+
+Routing heuristics distilled from public 2024-2025 results in the [db-benchmark suite](https://github.com/h2oai/db-benchmark) (rendered at [h2oai.github.io/db-benchmark](https://h2oai.github.io/db-benchmark/)) and from the vendors' own documentation ([duckdb.org](https://duckdb.org/), [pola.rs](https://pola.rs/)).
+
+**Read these as routing guidance, not guarantees.** Multipliers vary with dataset size, cardinality, data types, and hardware. When the choice materially matters, measure on the actual data.
+
+## Operation Performance Comparison
+
+| Operation Type      | Winner      | Indicative advantage | When to Use                                    |
+|---------------------|-------------|----------------------|------------------------------------------------|
+| **Filtering**       | **Polars**  | often the fastest by a wide margin (SIMD, predicate pushdown) | Single-table filters |
+| **Sorting**         | **Polars**  | typically the fastest | ORDER BY operations, ranking                   |
+| **Joins**           | **DuckDB**  | typically faster; richer join types | Multi-table joins, especially complex joins    |
+| **Aggregations**    | **DuckDB**  | typically faster on large datasets | GROUP BY, complex aggregations                 |
+| **Window Funcs**    | **Polars**  | typically faster | RANK, LAG/LEAD, running totals                 |
+| **Transformations** | **Polars**  | typically faster | Pivot, melt, string operations                 |
+| **Direct Query**    | **DuckDB**  | avoids loading to memory entirely | Ad-hoc exploration without loading to memory   |
+| **Streaming**       | **Polars**  | handles datasets larger than RAM | Datasets larger than RAM                       |
+
+Both tools are decisively faster than pandas on 1M+ row workloads, which is why pandas is banned outright in this skill.
+
+## Operation Detection Keywords
+
+Automatically detect operation types from user requests:
+
+- **Filter**: "where", "filter", "condition", "select rows", "find"
+- **Sort**: "sort", "order", "top", "bottom", "rank"
+- **Join**: "join", "merge", "combine tables"
+- **Aggregate**: "group", "sum", "avg", "count", "mean", "total", "aggregate"
+- **Transform**: "pivot", "melt", "reshape", "string operations", "clean", "transform"
+- **Window**: "running", "cumulative", "lag", "lead", "rank", "partition"
+
+## Benchmarking Notes
+
+- Public suites exercise typical analytical workloads (1M-100M rows).
+- Performance advantages are approximate and vary by dataset characteristics.
+- Real-world performance depends on data types, cardinality, and hardware.

--- a/packages/shared-skills/skills/data-scientist/references/uv-setup.md
+++ b/packages/shared-skills/skills/data-scientist/references/uv-setup.md
@@ -1,0 +1,78 @@
+# uv Setup — Per-Platform
+
+This skill runs every data operation through `uv run --with ...`. If `uv --version` fails, set uv up with the automated scripts or the manual commands below, then verify.
+
+## Automated (recommended)
+
+| Platform | Command |
+|---|---|
+| macOS / Linux / WSL / Git Bash | `bash scripts/setup-uv.sh` |
+| Windows (PowerShell) | `powershell -ExecutionPolicy Bypass -File scripts/setup-uv.ps1` |
+
+Both scripts: detect OS + architecture → install uv to the latest release when missing → upgrade it when present (`uv self update`) → make it resolvable for the current shell → verify with `uv --version`. They are idempotent — safe to re-run any time.
+
+## Manual install per platform
+
+### macOS
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh        # official installer → ~/.local/bin/uv
+# or, with Homebrew:
+brew install uv
+```
+
+### Linux (x86_64 / aarch64)
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh        # official installer → ~/.local/bin/uv
+```
+
+The installer detects glibc vs musl and downloads the right static binary. On minimal containers, ensure `curl` (or `wget`) exists; `wget -qO- https://astral.sh/uv/install.sh | sh` is the fallback.
+
+### Windows (native)
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+# or, with winget:
+winget install --id=astral-sh.uv -e
+```
+
+### Windows Subsystem for Linux / Git Bash
+
+Use the Linux/macOS installer inside the Unix shell, not the PowerShell installer:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+### CI
+
+```yaml
+# GitHub Actions
+- uses: astral-sh/setup-uv@v5
+# or plain shell anywhere:
+- run: curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+## PATH notes
+
+- The official installers put the binary in `~/.local/bin` (Unix) or `%USERPROFILE%\.local\bin` (Windows). New shells get it automatically on most setups; an already-open shell needs `export PATH="$HOME/.local/bin:$PATH"` (Unix) or `$env:Path = "$env:USERPROFILE\.local\bin;$env:Path"` (PowerShell) once.
+- Homebrew and winget install into their own prefixes that are already on PATH.
+
+## Upgrade to latest
+
+```bash
+uv self update
+```
+
+`uv self update` only works for official-installer binaries; Homebrew/winget installs upgrade through their package manager (`brew upgrade uv` / `winget upgrade astral-sh.uv`). The setup scripts handle this automatically.
+
+## Verify
+
+```bash
+uv --version
+```
+
+## Offline / air-gapped
+
+Download the matching archive from the uv GitHub releases page, extract it, and put the `uv` binary anywhere on PATH. `uv run --with <pkg>` still needs network for first-time package resolution unless a mirror is configured via `UV_INDEX_URL`.

--- a/packages/shared-skills/skills/data-scientist/scripts/quick-query.py
+++ b/packages/shared-skills/skills/data-scientist/scripts/quick-query.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "duckdb",
+#     "polars",
+#     "numpy",
+#     "pyarrow",
+#     "typer",
+#     "rich",
+# ]
+# ///
+
+"""Quick data query runner. SQL arg -> DuckDB; --filter (Polars SQL) -> Polars; --describe -> schema + stats."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich import print as rprint
+from rich.table import Table
+
+
+def _run_duckdb(file_path: Path, sql: str) -> None:
+    import duckdb
+
+    table_ref = f"'{file_path}'"
+    stem = file_path.stem
+    query = sql
+    for alias in ("data", "df", stem):
+        query = query.replace(f"FROM {alias} ", f"FROM {table_ref} ")
+        query = query.replace(f"FROM {alias}\n", f"FROM {table_ref}\n")
+        query = query.replace(f"from {alias} ", f"from {table_ref} ")
+        query = query.replace(f"from {alias}\n", f"from {table_ref}\n")
+        if query.endswith(f"FROM {alias}") or query.endswith(f"from {alias}"):
+            query = query[: -len(alias)] + table_ref
+
+    result = duckdb.sql(query)
+    df = result.pl()
+    _print_polars(df)
+
+
+def _run_polars_filter(file_path: Path, expr: str) -> None:
+    import polars as pl
+
+    df = _read_file(file_path)
+    filtered = df.filter(pl.sql_expr(expr))
+    _print_polars(filtered)
+
+
+def _run_describe(file_path: Path) -> None:
+    df = _read_file(file_path)
+
+    rprint(f"\n[bold]Schema:[/bold] {file_path.name} ({len(df)} rows × {len(df.columns)} cols)")
+    for name, dtype in zip(df.columns, df.dtypes):
+        rprint(f"  {name}: [cyan]{dtype}[/cyan]")
+
+    rprint("\n[bold]Statistics:[/bold]")
+    _print_polars(df.describe())
+
+
+def _read_file(file_path: Path):  # noqa: ANN202
+    import polars as pl
+
+    suffix = file_path.suffix.lower()
+    if suffix == ".csv":
+        return pl.read_csv(file_path)
+    if suffix == ".parquet":
+        return pl.read_parquet(file_path)
+    if suffix == ".json":
+        return pl.read_json(file_path)
+    if suffix in (".jsonl", ".ndjson"):
+        return pl.read_ndjson(file_path)
+    rprint(f"[red]Unsupported format:[/red] {suffix} (Excel: export to CSV or Parquet first)")
+    raise SystemExit(1)
+
+
+def _print_polars(df) -> None:  # noqa: ANN001
+    table = Table(show_lines=False)
+    for col_name in df.columns:
+        table.add_column(col_name)
+    for row in df.iter_rows():
+        table.add_row(*(str(v) for v in row))
+    rprint(table)
+    rprint(f"[dim]{df.shape[0]} rows × {df.shape[1]} cols[/dim]")
+
+
+def main(
+    file: Path = typer.Argument(help="Data file (csv, parquet, json, ndjson)"),
+    sql: str = typer.Argument(None, help="SQL query (uses DuckDB). Use 'data' as table name."),
+    filter_expr: str = typer.Option(None, "--filter", "-f", help="Polars SQL filter, e.g. 'amount > 100'"),
+    describe: bool = typer.Option(False, "--describe", "-d", help="Print schema + stats"),
+) -> None:
+    """Query data files with DuckDB (SQL) or Polars (SQL filter expressions)."""
+    if not file.exists():
+        rprint(f"[red]File not found:[/red] {file}")
+        raise SystemExit(1)
+
+    if describe:
+        _run_describe(file)
+    elif filter_expr:
+        _run_polars_filter(file, filter_expr)
+    elif sql:
+        _run_duckdb(file, sql)
+    else:
+        _run_describe(file)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/packages/shared-skills/skills/data-scientist/scripts/setup-uv.ps1
+++ b/packages/shared-skills/skills/data-scientist/scripts/setup-uv.ps1
@@ -1,0 +1,53 @@
+[CmdletBinding()]
+param()
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Step([string]$Message) { Write-Host "[setup-uv] $Message" }
+
+Write-Step "detected os=$([System.Runtime.InteropServices.RuntimeInformation]::OSDescription) arch=$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)"
+
+$uv = Get-Command uv -ErrorAction SilentlyContinue
+if ($null -ne $uv) {
+    $current = (& uv --version) | Select-Object -First 1
+    Write-Step "uv already installed ($current) - upgrading"
+    & uv self update 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Step "uv self update unavailable (package-manager install) - trying winget"
+        if (Get-Command winget -ErrorAction SilentlyContinue) {
+            & winget upgrade --id=astral-sh.uv -e --accept-source-agreements --accept-package-agreements 2>$null
+            if ($LASTEXITCODE -ne 0) { & winget install --id=astral-sh.uv -e --accept-source-agreements --accept-package-agreements }
+        } else {
+            Write-Step "no winget; keeping current uv (already functional)"
+        }
+    }
+} else {
+    Write-Step "uv not found - installing latest via the official installer"
+    $installed = $false
+    try {
+        powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+        $installed = $true
+    } catch {
+        Write-Step "official installer failed ($($_.Exception.Message)) - trying winget"
+        if (Get-Command winget -ErrorAction SilentlyContinue) {
+            & winget install --id=astral-sh.uv -e --accept-source-agreements --accept-package-agreements
+            $installed = ($LASTEXITCODE -eq 0)
+        }
+    }
+    if (-not $installed -and $null -eq (Get-Command uv -ErrorAction SilentlyContinue)) {
+        Write-Step "FAIL: could not install uv - install it manually per references/uv-setup.md"
+        exit 1
+    }
+}
+
+if ($null -eq (Get-Command uv -ErrorAction SilentlyContinue)) {
+    $localBin = Join-Path $env:USERPROFILE '.local\bin'
+    if (Test-Path (Join-Path $localBin 'uv.exe')) { $env:Path = "$localBin;$env:Path" }
+}
+
+if ($null -eq (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Step "FAIL: uv still not on PATH after install - add %USERPROFILE%\.local\bin to PATH and retry"
+    exit 1
+}
+
+Write-Step "OK: $((& uv --version) | Select-Object -First 1)"

--- a/packages/shared-skills/skills/data-scientist/scripts/setup-uv.sh
+++ b/packages/shared-skills/skills/data-scientist/scripts/setup-uv.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { printf '[setup-uv] %s\n' "$*"; }
+
+os="$(uname -s 2>/dev/null || echo unknown)"
+arch="$(uname -m 2>/dev/null || echo unknown)"
+log "detected os=${os} arch=${arch}"
+
+case "$os" in
+  Darwin|Linux) ;;
+  MINGW*|MSYS*|CYGWIN*)
+    log "Git Bash / MSYS environment detected - installing the Windows build is not supported here."
+    log "Use the Linux installer inside WSL, or run scripts/setup-uv.ps1 in PowerShell instead."
+    exit 1
+    ;;
+  *)
+    log "unsupported OS: ${os} - see references/uv-setup.md for manual steps."
+    exit 1
+    ;;
+esac
+
+if command -v uv >/dev/null 2>&1; then
+  current="$(uv --version 2>/dev/null | head -n1)"
+  log "uv already installed (${current}) - upgrading"
+  if uv self update >/dev/null 2>&1; then
+    log "uv self update succeeded"
+  else
+    log "uv self update unavailable (package-manager install) - trying Homebrew"
+    if command -v brew >/dev/null 2>&1; then
+      brew upgrade uv >/dev/null 2>&1 || brew install uv
+    else
+      log "no Homebrew; keeping current uv (already functional)"
+    fi
+  fi
+else
+  log "uv not found - installing latest via the official installer"
+  if command -v curl >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- https://astral.sh/uv/install.sh | sh
+  elif command -v brew >/dev/null 2>&1; then
+    log "no curl/wget - installing via Homebrew"
+    brew install uv
+  else
+    log "neither curl, wget, nor brew available - install one of them and re-run."
+    exit 1
+  fi
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  log "FAIL: uv still not on PATH after install - add \$HOME/.local/bin to PATH and retry."
+  exit 1
+fi
+
+log "OK: $(uv --version)"


### PR DESCRIPTION
## What

Vendors the `data-scientist` skill into `packages/shared-skills/skills/data-scientist/` so every harness ships it:

- **OpenCode** consumes `shared-skills` directly at runtime.
- **Codex** picks it up through the `sync-skills.mjs` shared sweep (`expectedSkills` updated in the test support).
- **Senpi** picks it up through its shared sweep (`expectedSkillNames` updated in `skills-sync.test.ts`).
- `depersonalization-gate.mjs` (+ its test) now scans the new directory.

Layout follows the package contract: `SKILL.md` router with a trigger-rich description + `references/` (real content) + `scripts/`.

## Audit fixes applied (the skill could NOT be shipped as-is)

| Finding | Fix | Proof |
| --- | --- | --- |
| 14× `duckdb .df()` calls returned a **pandas** frame and crashed under the skill's own pandas-less package set — contradicting its own ABSOLUTE RULE | All conversions -> `.pl()` (Arrow) | `uv run` proof: `.df()` raises `InvalidInputException: 'pandas' is required`, `.pl()`+pyarrow works |
| Standard package set missing `pyarrow` -> headline zero-copy handoff crashed with `ModuleNotFoundError` | `pyarrow` added to every documented set, rule documented | same `uv run` proof |
| `quick-query.py` filtered through `eval()` on an agent-supplied string (arbitrary code execution sink) | Replaced with `pl.sql_expr()` SQL-syntax filters; CLI contract is now `"amount > 100"`, no Python | injection probe fails to parse; no `pwned` file created; SQL/filter/describe all executed green against a fixture CSV |
| Speed claims ("128x", "10-50x") with zero citations | Softened to indicative heuristics, sourced (db-benchmark suite + vendor docs) | references/performance-benchmarks.md |
| No triggers in the frontmatter description (matcher would never see the in-body list) | Trigger-rich single-line description (743 chars) | — |
| Harness-specific "use Read tool" wording; xlsx advertised but unsupported | Harness-neutral wording; xlsx explicitly redirected to CSV/Parquet | — |

## New: uv setup per platform (user-requested)

- `references/uv-setup.md` — per-platform matrix (macOS/Linux/Windows/WSL/Git Bash/CI), PATH notes, upgrades, offline notes.
- `scripts/setup-uv.sh` + `scripts/setup-uv.ps1` — auto-detect OS/arch, install latest via the official installer (Homebrew/winget fallback), `uv self update` when present, PATH fix, verify. Idempotent.
- `SKILL.md` routes to the script + reference whenever `uv` is missing, before any data work.

## QA

- `scripts/quick-query.py` executed end-to-end: DuckDB SQL query, Polars `--filter`, `--describe`, and an injection attempt (rejected, no side effect).
- `bun test packages/omo-senpi/src/skills-sync.test.ts`: 8 pass / 0 fail (new skill in `expectedSkillNames`).
- `node --test test/sync-skills.test.mjs test/aggregate-skills.test.mjs` (codex plugin): 20 pass / 0 fail.
- `node packages/shared-skills/depersonalization-gate.mjs`: OK; `bun test packages/shared-skills/depersonalization-gate.test.ts`: 3 pass.
- `bun test packages/omo-opencode/src/shared/markdown-link-audit.test.ts`: 16 pass / 0 fail.

## Provenance

First-party content, hand-authored locally for this product family — no third-party material, so no upstream/ATTRIBUTION entry is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendors the `data-scientist` skill into `packages/shared-skills/skills/data-scientist/` so OpenCode, Codex, and Senpi ship it by default. Hardens it with Arrow/Polars handoff, adds `pyarrow`, removes an `eval()` sink, and includes `uv` setup plus a quick-query CLI.

- **New Features**
  - Adds `SKILL.md`, references, and scripts under `packages/shared-skills/skills/data-scientist/`.
  - New `scripts/quick-query.py` for ad‑hoc SQL, filter, and describe runs.
  - Cross‑platform `uv` setup scripts (`scripts/setup-uv.sh`, `scripts/setup-uv.ps1`) and `references/uv-setup.md`.
  - Integration updates: Codex and Senpi skill sync include `data-scientist`; Codex Python migration inventory accounts for `quick-query.py`; `depersonalization-gate` scans the new directory.

- **Bug Fixes**
  - Replaced all DuckDB `.df()` calls with `.pl()` for zero‑copy Arrow handoff; avoids pandas dependency.
  - Added `pyarrow` to the standard package set to support `.pl()` conversions.
  - Removed `eval()` from the filter path in `quick-query.py` (uses `pl.sql_expr()`).
  - Cleaned and sourced performance claims; trigger‑rich frontmatter; clarified XLSX is unsupported (use CSV/Parquet).

<sup>Written for commit 6097b72ab1f4ebb257d162510c72799d699db7d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

