### PR TITLE
test(omo-codex): isolate git bash hook fixture

### DIFF
--- a/packages/omo-codex/src/install/install-codex-git-bash-hooks.test.ts
+++ b/packages/omo-codex/src/install/install-codex-git-bash-hooks.test.ts
@@ -2,79 +2,94 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, stat } from "node:fs/promises"
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { runCodexInstaller } from "./install-codex"
+import { createRepoWithGitBashHooksFixture, EXPECTED_GIT_BASH_HOOKS } from "./install-codex-test-fixtures"
 
-const INSTALL_CODEX_GIT_BASH_TEST_TIMEOUT_MS = process.platform === "win32" ? 60_000 : 20_000
-const GIT_BASH_PRE_TOOL_USE_HOOK = "./hooks/pre-tool-use-recommending-git-bash-mcp.json"
-const GIT_BASH_POST_COMPACT_HOOK = "./hooks/post-compact-resetting-git-bash-mcp-reminder.json"
+const [GIT_BASH_PRE_TOOL_USE_HOOK, GIT_BASH_POST_COMPACT_HOOK] = EXPECTED_GIT_BASH_HOOKS
 
 const skipAstGrepInstall = async () => ({ kind: "skipped" as const, reason: "test" })
 
 describe("install-codex Git Bash hooks", () => {
   test("#given simulated Windows Codex install #when installing omo #then enables git_bash MCP and trusts shell hooks", async () => {
     // given
-    const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-home-git-bash-win-"))
-    const binDir = await mkdtemp(join(tmpdir(), "omo-codex-bin-git-bash-win-"))
-    const repoRoot = process.cwd()
+    const testRoot = await mkdtemp(join(tmpdir(), "omo-codex-git-bash-win-"))
+    const repoRoot = await createRepoWithGitBashHooksFixture(process.cwd())
+    const codexHome = join(testRoot, "codex")
+    const binDir = join(testRoot, "bin")
 
-    // when
-    const result = await runCodexInstaller({
-      codexHome,
-      binDir,
-      repoRoot,
-      platform: "win32",
-      astGrepInstaller: skipAstGrepInstall,
-      gitBashResolver: () => ({ found: true, path: "C:\\Program Files\\Git\\bin\\bash.exe", source: "program-files" }),
-      runCommand: async () => undefined,
-    })
+    try {
+      // when
+      const result = await runCodexInstaller({
+        codexHome,
+        binDir,
+        repoRoot,
+        platform: "win32",
+        astGrepInstaller: skipAstGrepInstall,
+        gitBashResolver: () => ({ found: true, path: "C:\\Program Files\\Git\\bin\\bash.exe", source: "program-files" }),
+        runCommand: async () => undefined,
+      })
 
-    // then
-    const configContent = await readFile(join(codexHome, "config.toml"), "utf8")
-    expect(configContent).toContain('[plugins."omo@sisyphuslabs".mcp_servers.git_bash]')
-    expect(configContent).toContain("enabled = true")
-    expect(configContent).toContain(GIT_BASH_PRE_TOOL_USE_HOOK.slice(2))
-    expect(configContent).toContain(GIT_BASH_POST_COMPACT_HOOK.slice(2))
-    expect(result.gitBashPath).toBe("C:\\Program Files\\Git\\bin\\bash.exe")
-    const pluginPath = result.installed[0]?.path ?? ""
-    const hooks = await readInstalledPluginHooks(pluginPath)
-    expect(hooks).toContain(GIT_BASH_PRE_TOOL_USE_HOOK)
-    expect(hooks).toContain(GIT_BASH_POST_COMPACT_HOOK)
-    const gitBashMcpPath = await readGitBashMcpPath(pluginPath)
-    expect(gitBashMcpPath).toBe(join(pluginPath, "components", "git-bash-mcp", "dist", "cli.js"))
-    expect((await stat(gitBashMcpPath)).isFile()).toBe(true)
-  }, { timeout: INSTALL_CODEX_GIT_BASH_TEST_TIMEOUT_MS })
+      // then
+      const configContent = await readFile(join(codexHome, "config.toml"), "utf8")
+      expect(configContent).toContain('[plugins."omo@sisyphuslabs".mcp_servers.git_bash]')
+      expect(configContent).toContain("enabled = true")
+      expect(configContent).toContain(GIT_BASH_PRE_TOOL_USE_HOOK.slice(2))
+      expect(configContent).toContain(GIT_BASH_POST_COMPACT_HOOK.slice(2))
+      expect(result.gitBashPath).toBe("C:\\Program Files\\Git\\bin\\bash.exe")
+      const pluginPath = result.installed[0]?.path ?? ""
+      const hooks = await readInstalledPluginHooks(pluginPath)
+      expect(hooks).toContain(GIT_BASH_PRE_TOOL_USE_HOOK)
+      expect(hooks).toContain(GIT_BASH_POST_COMPACT_HOOK)
+      const gitBashMcpPath = await readGitBashMcpPath(pluginPath)
+      expect(gitBashMcpPath).toBe(join(pluginPath, "components", "git-bash-mcp", "dist", "cli.js"))
+      expect((await stat(gitBashMcpPath)).isFile()).toBe(true)
+    } finally {
+      await Promise.all([
+        rm(testRoot, { recursive: true, force: true }),
+        rm(repoRoot, { recursive: true, force: true }),
+      ])
+    }
+  })
 
   test("#given simulated Linux Codex install #when installing omo #then keeps git_bash MCP disabled without registering shell reminder hooks", async () => {
     // given
-    const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-home-git-bash-linux-"))
-    const binDir = await mkdtemp(join(tmpdir(), "omo-codex-bin-git-bash-linux-"))
-    const repoRoot = process.cwd()
+    const testRoot = await mkdtemp(join(tmpdir(), "omo-codex-git-bash-linux-"))
+    const repoRoot = await createRepoWithGitBashHooksFixture(process.cwd())
+    const codexHome = join(testRoot, "codex")
+    const binDir = join(testRoot, "bin")
 
-    // when
-    const result = await runCodexInstaller({
-      codexHome,
-      binDir,
-      repoRoot,
-      platform: "linux",
-      astGrepInstaller: skipAstGrepInstall,
-      runCommand: async () => undefined,
-    })
+    try {
+      // when
+      const result = await runCodexInstaller({
+        codexHome,
+        binDir,
+        repoRoot,
+        platform: "linux",
+        astGrepInstaller: skipAstGrepInstall,
+        runCommand: async () => undefined,
+      })
 
-    // then
-    const configContent = await readFile(join(codexHome, "config.toml"), "utf8")
-    expect(configContent).toContain('[plugins."omo@sisyphuslabs".mcp_servers.git_bash]')
-    expect(configContent).toContain("enabled = false")
-    expect(configContent).not.toContain(GIT_BASH_PRE_TOOL_USE_HOOK.slice(2))
-    expect(configContent).not.toContain(GIT_BASH_POST_COMPACT_HOOK.slice(2))
-    const pluginPath = result.installed[0]?.path ?? ""
-    const hooks = await readInstalledPluginHooks(pluginPath)
-    expect(hooks).not.toContain(GIT_BASH_PRE_TOOL_USE_HOOK)
-    expect(hooks).not.toContain(GIT_BASH_POST_COMPACT_HOOK)
-    expect(await readGitBashMcpPath(pluginPath)).toBe(join(pluginPath, "components", "git-bash-mcp", "dist", "cli.js"))
-  }, { timeout: INSTALL_CODEX_GIT_BASH_TEST_TIMEOUT_MS })
+      // then
+      const configContent = await readFile(join(codexHome, "config.toml"), "utf8")
+      expect(configContent).toContain('[plugins."omo@sisyphuslabs".mcp_servers.git_bash]')
+      expect(configContent).toContain("enabled = false")
+      expect(configContent).not.toContain(GIT_BASH_PRE_TOOL_USE_HOOK.slice(2))
+      expect(configContent).not.toContain(GIT_BASH_POST_COMPACT_HOOK.slice(2))
+      const pluginPath = result.installed[0]?.path ?? ""
+      const hooks = await readInstalledPluginHooks(pluginPath)
+      expect(hooks).not.toContain(GIT_BASH_PRE_TOOL_USE_HOOK)
+      expect(hooks).not.toContain(GIT_BASH_POST_COMPACT_HOOK)
+      expect(await readGitBashMcpPath(pluginPath)).toBe(join(pluginPath, "components", "git-bash-mcp", "dist", "cli.js"))
+    } finally {
+      await Promise.all([
+        rm(testRoot, { recursive: true, force: true }),
+        rm(repoRoot, { recursive: true, force: true }),
+      ])
+    }
+  })
 })
 
 async function readInstalledPluginHooks(pluginPath: string): Promise<readonly string[]> {

--- a/packages/omo-codex/src/install/install-codex-test-fixtures.ts
+++ b/packages/omo-codex/src/install/install-codex-test-fixtures.ts
@@ -1,6 +1,11 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { copyFile, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+
+export const EXPECTED_GIT_BASH_HOOKS = [
+  "./hooks/pre-tool-use-recommending-git-bash-mcp.json",
+  "./hooks/post-compact-resetting-git-bash-mcp-reminder.json",
+] as const
 
 export const EXPECTED_OMO_COMPONENT_BINS = [
   { name: "omo", target: join("dist", "cli", "index.js"), kind: "runtime-wrapper" },
@@ -24,6 +29,7 @@ export function expectedBinName(name: string): string {
 export async function createRepoWithBuiltComponentBins(
   input: {
     readonly includeBundledGitBashMcp?: boolean
+    readonly includeComponentBins?: boolean
     readonly includeRootCliDist?: boolean
   } = {},
 ): Promise<string> {
@@ -70,10 +76,51 @@ export async function createRepoWithBuiltComponentBins(
   for (const [componentName, bins] of componentBins) {
     const componentRoot = join(pluginRoot, "components", componentName)
     await mkdir(join(componentRoot, "dist"), { recursive: true })
-    await writeFile(join(componentRoot, "package.json"), JSON.stringify({ name: `@sisyphuslabs/${componentName}`, bin: bins }))
+    await writeFile(
+      join(componentRoot, "package.json"),
+      JSON.stringify({
+        name: `@sisyphuslabs/${componentName}`,
+        ...(input.includeComponentBins === false ? {} : { bin: bins }),
+      }),
+    )
     await writeFile(join(componentRoot, "dist", "cli.js"), "#!/usr/bin/env node\n")
   }
 
+  return repoRoot
+}
+
+export async function createRepoWithGitBashHooksFixture(sourceRepoRoot: string): Promise<string> {
+  const repoRoot = await createRepoWithBuiltComponentBins({
+    includeBundledGitBashMcp: true,
+    includeComponentBins: false,
+    includeRootCliDist: false,
+  })
+  const sourcePluginRoot = join(sourceRepoRoot, "packages", "omo-codex", "plugin")
+  const fixturePluginRoot = join(repoRoot, "packages", "omo-codex", "plugin")
+  const sourceManifest: unknown = JSON.parse(
+    await readFile(join(sourcePluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+  )
+  if (!isRecord(sourceManifest) || !Array.isArray(sourceManifest.hooks)) {
+    throw new Error("shipped Codex plugin manifest must declare hook files")
+  }
+
+  const sourceHooks = new Set(sourceManifest.hooks.filter((hook): hook is string => typeof hook === "string"))
+  if (!EXPECTED_GIT_BASH_HOOKS.every((hook) => sourceHooks.has(hook))) {
+    throw new Error("shipped Codex plugin manifest is missing Git Bash hook declarations")
+  }
+  const gitBashHooks = EXPECTED_GIT_BASH_HOOKS
+
+  await writeFile(
+    join(fixturePluginRoot, ".codex-plugin", "plugin.json"),
+    JSON.stringify({ name: "omo", version: "0.1.0", hooks: gitBashHooks }),
+  )
+  for (const hook of gitBashHooks) {
+    const relativeHookPath = hook.startsWith("./") ? hook.slice(2) : hook
+    await copyFile(join(sourcePluginRoot, relativeHookPath), join(fixturePluginRoot, relativeHookPath))
+  }
+  const bootstrapScriptPath = join("components", "bootstrap", "scripts", "node-dispatch.ps1")
+  await mkdir(join(fixturePluginRoot, "components", "bootstrap", "scripts"), { recursive: true })
+  await copyFile(join(sourcePluginRoot, bootstrapScriptPath), join(fixturePluginRoot, bootstrapScriptPath))
   return repoRoot
 }
 
@@ -110,4 +157,8 @@ async function createBundledGitBashMcpFixture(input: { readonly pluginRoot: stri
   )
   await mkdir(join(input.repoRoot, "packages", "git-bash-mcp", "dist"), { recursive: true })
   await writeFile(join(input.repoRoot, "packages", "git-bash-mcp", "dist", "cli.js"), "#!/usr/bin/env node\n")
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }


### PR DESCRIPTION
## Summary

Fix the Windows Codex compatibility timeout without increasing timeouts, adding retries, or skipping coverage.

The two Git Bash hook installer tests copied the full 1,164-file Codex plugin payload twice even though their contract only needs the shipped Git Bash hook declarations/files, the Git Bash MCP runtime, and the Windows dispatch script. On a slow Windows runner, both copies hit the exact 60-second test ceiling.

## Changes

- Build a minimal packaged Git Bash hook fixture from the shipped plugin manifest.
- Copy the real hook JSON files and Windows `node-dispatch.ps1` target into the fixture.
- Omit unrelated component bin links and root runtime links from this focused test fixture.
- Preserve all 16 existing installer assertions.
- Remove the platform-specific 60-second timeout and clean fixture roots in `finally`.

## RED -> GREEN

- RED: CI run [30617317044](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/30617317044), job [91113400076](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/30617317044/job/91113400076)
  - both Git Bash hook tests timed out at `60016ms`
  - `389 pass`, `2 fail`
- GREEN on a real Windows 11 VM:
  - `bun test packages\omo-codex\src\install\install-codex-git-bash-hooks.test.ts`
  - `2 pass`, `0 fail`, `16 expect() calls`, `1.252s`

## QA and evidence

Evidence directory: `.omo/evidence/20260731-ci-root-fix/`

- `red-ci.log`: exact pre-fix Windows CI failure.
- `green-narrow.log`: final-tree Windows GREEN.
- `local-gates.txt`: scoped tests, typecheck, build, and full Codex gate.
- `codex-qa-self-check.txt`: isolated Codex QA harness and unchanged real home.
- `install-verify.txt`: local installer QA in isolated `CODEX_HOME`.
- `self-review.txt`: final diff and criterion review.
- `cleanup-receipt.txt`: Windows VM, Codex sandbox, and build-artifact teardown.

Verified commands:

- scoped fixture callers: `19 pass`, `0 fail`, `180 assertions`
- `bunx tsgo --noEmit -p packages/omo-codex/tsconfig.json`
- `bun run typecheck`
- `bun run build`
- `bun run test:codex` (`515 pass`, `0 fail` in the final Node phase)
- `bash .agents/skills/codex-qa/scripts/lib/common.sh --self-check`
- `bash .agents/skills/codex-qa/scripts/install-verify.sh --self-test`

## Risk

Low. This changes test infrastructure only. Production installer behavior and CI policy are unchanged. Existing bin-link and full installer behavior remain covered by the complete `test:codex` suite.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates a minimal Git Bash hook test fixture for `omo-codex` to stop Windows CI timeouts without raising timeouts or adding retries. Copies only the shipped hook files and required runtime bits; all installer assertions remain.

- **Bug Fixes**
  - Build fixture from the plugin manifest with only the expected hook files, Git Bash MCP runtime, and `node-dispatch.ps1`.
  - Add and use `createRepoWithGitBashHooksFixture` to avoid copying the full plugin payload.
  - Remove the Windows-specific 60s test timeout; clean temp roots with `rm` in `finally`.
  - No production behavior changes; full installer and bin-link coverage remains in the main Codex test suite.

<sup>Written for commit 10b839953f68bb34d95410f7ff002a7e6b61d36c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

