### PR TITLE
fix(omo-opencode): honor canonical agent model chains

### DIFF
--- a/packages/omo-opencode/src/config/schema/agent-overrides.ts
+++ b/packages/omo-opencode/src/config/schema/agent-overrides.ts
@@ -1,11 +1,14 @@
 import { OmoReasoningSchema } from "@oh-my-opencode/omo-config-core"
 import { z } from "zod"
-import { FallbackModelsSchema } from "./fallback-models"
+import { FallbackModelObjectSchema, FallbackModelsSchema } from "./fallback-models"
 import { AgentPermissionSchema } from "./internal/permission"
 
 export const AgentOverrideConfigSchema = z.object({
   /** @deprecated Use `category` instead. Model is inherited from category defaults. */
   model: z.string().optional(),
+  /** Ordered model chain; the first entry is the primary model and the rest are fallbacks. */
+  models: z.array(z.union([z.string(), FallbackModelObjectSchema])).optional(),
+  /** @deprecated Use `models` instead. */
   fallback_models: FallbackModelsSchema.optional(),
   reasoning: OmoReasoningSchema.optional(),
   /** @deprecated Use `reasoning` instead. */

--- a/packages/omo-opencode/src/config/validate.ts
+++ b/packages/omo-opencode/src/config/validate.ts
@@ -95,6 +95,46 @@ function protectUserFields(
   }
 }
 
+function materializeAgentModelChains(config: OhMyOpenCodeConfig): OhMyOpenCodeConfig {
+  if (config.agents === undefined) return config
+
+  let changed = false
+  const agents = Object.fromEntries(Object.entries(config.agents).map(([name, agent]) => {
+    if (agent?.models === undefined) return [name, agent]
+
+    const [primary, ...fallbacks] = agent.models
+    const {
+      model: _model,
+      fallback_models: _fallbackModels,
+      reasoning: _reasoning,
+      variant: _variant,
+      reasoningEffort: _reasoningEffort,
+      temperature: _temperature,
+      top_p: _topP,
+      maxTokens: _maxTokens,
+      thinking: _thinking,
+      providerOptions: _providerOptions,
+      textVerbosity: _textVerbosity,
+      ...rest
+    } = agent
+    const primarySettings = primary === undefined
+      ? {}
+      : typeof primary === "string"
+        ? { model: primary }
+        : primary
+    changed = true
+    return [name, {
+      ...rest,
+      ...primarySettings,
+      fallback_models: fallbacks,
+    }]
+  })) as typeof config.agents
+
+  // Older execution paths still consume `model` and `fallback_models`. Keep the
+  // canonical `models` chain intact while providing an equivalent runtime view.
+  return changed ? { ...config, agents } : config
+}
+
 function migrateRalphLoopConfig(config: OhMyOpenCodeConfig): OhMyOpenCodeConfig {
   const legacy = config.ralph_loop
   if (legacy === undefined) return config
@@ -126,7 +166,9 @@ export function validatePluginConfig(
   const firstFailingView = views.find((view) => view.messages.length > 0)
   const firstView = views[0]
   const userConfig = parseConfig(chain.protectedUserView)
-  const config = applyDisabledProviders(protectUserFields(mergeViews(views), userConfig))
+  const config = materializeAgentModelChains(applyDisabledProviders(
+    protectUserFields(mergeViews(views), userConfig),
+  ))
 
   return {
     valid: messages.length === 0,

--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
@@ -163,6 +163,12 @@ export async function tryFallbackRetry(args: {
     providerID,
     modelID: transformedModelId,
     variant: nextFallback.variant,
+    reasoning: nextFallback.reasoning,
+    reasoningEffort: nextFallback.reasoningEffort,
+    temperature: nextFallback.temperature,
+    top_p: nextFallback.top_p,
+    maxTokens: nextFallback.maxTokens,
+    thinking: nextFallback.thinking,
   }
   task.attemptCount = selectedAttemptCount
   const failedAttemptID = ensureCurrentAttempt(task, previousModel).attemptId

--- a/packages/omo-opencode/src/hooks/model-fallback/chat-message-fallback-handler.ts
+++ b/packages/omo-opencode/src/hooks/model-fallback/chat-message-fallback-handler.ts
@@ -1,11 +1,13 @@
 import { log } from "../../shared/logger"
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import type { ChatMessageHandlerOutput, ChatMessageInput } from "../../plugin/chat-message"
+import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
+import type { ResolvedFallbackModel } from "./hook"
 
 export async function applyFallbackToChatMessage(params: {
   input: ChatMessageInput
   output: ChatMessageHandlerOutput
-  fallback: { providerID: string; modelID: string; variant?: string }
+  fallback: ResolvedFallbackModel
   toast?: (input: {
     title: string
     message: string
@@ -28,17 +30,19 @@ export async function applyFallbackToChatMessage(params: {
     providerID: fallback.providerID,
     modelID: fallback.modelID,
   }
-  if (fallback.variant !== undefined) {
-    output.message["variant"] = fallback.variant
+  const loweredReasoning = applySessionPromptParams(sessionID, fallback)
+  const variant = fallback.variant ?? loweredReasoning.variant
+  if (variant !== undefined) {
+    output.message["variant"] = variant
   } else {
     delete output.message["variant"]
   }
 
   if (toast) {
-    const key = `${sessionID}:${fallback.providerID}/${fallback.modelID}:${fallback.variant ?? ""}`
+    const key = `${sessionID}:${fallback.providerID}/${fallback.modelID}:${variant ?? ""}`
     if (lastToastKey.get(sessionID) !== key) {
       lastToastKey.set(sessionID, key)
-      const variantLabel = fallback.variant ? ` (${fallback.variant})` : ""
+      const variantLabel = variant ? ` (${variant})` : ""
       await Promise.resolve(
         toast({
           title: "Model fallback",
@@ -56,14 +60,14 @@ export async function applyFallbackToChatMessage(params: {
         sessionID,
         providerID: fallback.providerID,
         modelID: fallback.modelID,
-        variant: fallback.variant,
+        variant,
       }),
     )
   }
 
   const toastManager = getTaskToastManager()
   if (toastManager) {
-    const variantLabel = fallback.variant ? ` (${fallback.variant})` : ""
+    const variantLabel = variant ? ` (${variant})` : ""
     toastManager.updateTaskModelBySession(sessionID, {
       model: `${fallback.providerID}/${fallback.modelID}${variantLabel}`,
       type: "runtime-fallback",

--- a/packages/omo-opencode/src/hooks/model-fallback/hook.ts
+++ b/packages/omo-opencode/src/hooks/model-fallback/hook.ts
@@ -21,6 +21,18 @@ type FallbackCallback = (input: {
   variant?: string
 }) => void | Promise<void>
 
+export type ResolvedFallbackModel = {
+  providerID: string
+  modelID: string
+  variant?: string
+  reasoning?: string
+  reasoningEffort?: string
+  temperature?: number
+  top_p?: number
+  maxTokens?: number
+  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+}
+
 export type ModelFallbackState = {
   providerID: string
   modelID: string
@@ -104,7 +116,7 @@ export function setPendingModelFallback(
 export function getNextFallback(
   controller: Pick<ModelFallbackStateController, "getNextFallback">,
   sessionID: string,
-): { providerID: string; modelID: string; variant?: string } | null {
+): ResolvedFallbackModel | null {
   return controller.getNextFallback(sessionID)
 }
 

--- a/packages/omo-opencode/src/plugin-config/omo-config-chain.ts
+++ b/packages/omo-opencode/src/plugin-config/omo-config-chain.ts
@@ -66,7 +66,7 @@ function recordFields(value: unknown, fields: readonly string[]): Record<string,
 function modelInput(view: Readonly<Record<string, unknown>>): Record<string, unknown> {
   const agents = isPlainRecord(view.agents)
     ? Object.fromEntries(Object.entries(view.agents).flatMap(([name, definition]) => {
-      const fields = recordFields(definition, ["description", "prompt", "model", "variant", "reasoningEffort", "tools", "temperature", "disable"])
+      const fields = recordFields(definition, ["description", "prompt", "model", "models", "variant", "reasoningEffort", "tools", "temperature", "disable"])
       return fields === undefined ? [] : [[name, fields]]
     }))
     : undefined

--- a/packages/omo-opencode/src/shared/disabled-providers.ts
+++ b/packages/omo-opencode/src/shared/disabled-providers.ts
@@ -37,6 +37,7 @@ export function filterDisabledProviderModels<T extends string | FallbackModelObj
 
 type ModelHolder = {
   model?: string | unknown
+  models?: (string | FallbackModelObject)[]
   fallback_models?: string | (string | FallbackModelObject)[]
 }
 
@@ -53,6 +54,27 @@ function findFirstAllowedReplacement(
 }
 
 function applyToHolder(label: string, holder: ModelHolder, disabled: readonly string[]): void {
+  if (holder.models !== undefined) {
+    const filteredModels = filterDisabledProviderModels(holder.models, disabled)
+    if (filteredModels.length !== holder.models.length) {
+      log(`[${HOOK_NAME}] Filtered disabled-provider entries from canonical model chain`, {
+        label,
+        removed: holder.models.length - filteredModels.length,
+        remaining: filteredModels.length,
+      })
+    }
+    holder.models = filteredModels
+
+    if (filteredModels.length === 0) {
+      const message =
+        `${label} has no allowed entry in its canonical models chain after disabled_providers filtering. ` +
+        "Either remove the provider from disabled_providers or add an allowed model to models."
+      addConfigLoadError({ path: `disabled_providers:${label}`, error: message })
+      log(`[${HOOK_NAME}] ${message}`, { label })
+    }
+    return
+  }
+
   const normalizedChain = normalizeFallbackModels(holder.fallback_models)
   if (normalizedChain) {
     const filteredChain = filterDisabledProviderModels(normalizedChain, disabled)


### PR DESCRIPTION
Closes #6515

## Summary

- accept canonical `agents.<name>.models` chains produced by the reasoning-unification migration;
- materialize their primary and fallback entries for existing OMO runtime consumers, preserving per-entry settings;
- apply canonical fallback settings in both synchronous and background retry paths;
- filter disabled providers before selecting the canonical primary model.

## Validation

- `bun run typecheck`
- `bun test packages/omo-opencode/src/hooks/model-fallback/hook.test.ts`
- `bun test packages/omo-opencode/src/features/background-agent/fallback-retry-handler.test.ts packages/omo-opencode/src/features/background-agent/fallback-retry-provider-exhaustion.test.ts`
- `bun run build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for canonical agent model chains via `agents.<name>.models` and maps them to legacy fields for the `omo-opencode` runtime. Fallback selection now applies per-model settings and skips disabled providers in both sync and background retries. Closes #6515.

- New Features
  - Support `agents.<name>.models` and keep the canonical chain while materializing `model` and `fallback_models` for legacy paths, preserving per-entry settings.

- Bug Fixes
  - Apply per-fallback settings (variant, reasoning, effort, temperature, top_p, maxTokens, thinking) in both the synchronous path and background retry handler.
  - Filter disabled providers from canonical chains before choosing the primary; raise a config error if no allowed models remain.

<sup>Written for commit 0e21d5d9b3fa4815f5b8ac20dc4186e3d0ab2cd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

