### PR TITLE
fix(cmux): keep OMO subagent panes attached on focus

### DIFF
--- a/packages/tmux-core/src/tmux-utils/pane-activate.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-activate.ts
@@ -28,9 +28,14 @@ export async function activateTmuxPane(
   }
 
   const authEnvArgs = buildPaneAuthEnvironmentArgs()
-  if (isCmuxCompatEnvironment() && authEnvArgs.length > 0) {
+  const isCmuxOmoLaunch = process.env.CMUX_AGENT_LAUNCH_KIND === "omo"
+  if ((isCmuxCompatEnvironment() || isCmuxOmoLaunch) && authEnvArgs.length > 0) {
     deps.log("[activateTmuxPane] SKIP: authenticated cmux panes are unsupported", { paneId, sessionId })
     return false
+  }
+  if (isCmuxOmoLaunch) {
+    deps.log("[activateTmuxPane] SKIP: cmux OMO pane is already attached", { paneId, sessionId })
+    return true
   }
 
   const tmux = await deps.getTmuxPath()

--- a/packages/tmux-core/src/tmux-utils/pane-auth-env.test.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-auth-env.test.ts
@@ -10,6 +10,7 @@ import { spawnTmuxWindow } from "./window-spawn"
 
 const originalTmux = process.env.TMUX
 const originalCmuxSocketPath = process.env.CMUX_SOCKET_PATH
+const originalCmuxAgentLaunchKind = process.env.CMUX_AGENT_LAUNCH_KIND
 
 const enabledTmuxConfig = {
 	enabled: true,
@@ -96,6 +97,7 @@ describe("tmux pane auth environment propagation", () => {
 	beforeEach(() => {
 		process.env.TMUX = "/tmp/tmux-1000/default,1234,0"
 		delete process.env.CMUX_SOCKET_PATH
+		delete process.env.CMUX_AGENT_LAUNCH_KIND
 	})
 
 	afterEach(() => {
@@ -104,6 +106,35 @@ describe("tmux pane auth environment propagation", () => {
 		else process.env.TMUX = originalTmux
 		if (originalCmuxSocketPath === undefined) delete process.env.CMUX_SOCKET_PATH
 		else process.env.CMUX_SOCKET_PATH = originalCmuxSocketPath
+		if (originalCmuxAgentLaunchKind === undefined) delete process.env.CMUX_AGENT_LAUNCH_KIND
+		else process.env.CMUX_AGENT_LAUNCH_KIND = originalCmuxAgentLaunchKind
+	})
+
+	it("#given an official cmux OMO pane #when activated #then it stays attached without respawn", async () => {
+		// given
+		setAuthEnv()
+		process.env.CMUX_AGENT_LAUNCH_KIND = "omo"
+		let tmuxPathResolved = false
+		let runnerCalled = false
+
+		// when
+		const result = await activateTmuxPane("%42", "session-cmux-omo", "http://127.0.0.1:4321", "/tmp/project", {
+			isInsideTmux: () => true,
+			getTmuxPath: async () => {
+				tmuxPathResolved = true
+				return "tmux"
+			},
+			runTmuxCommand: async () => {
+				runnerCalled = true
+				return successResult()
+			},
+			log: () => undefined,
+		})
+
+		// then
+		expect(result).toBe(true)
+		expect(tmuxPathResolved).toBe(false)
+		expect(runnerCalled).toBe(false)
 	})
 
 	it("#given auth env vars with spaces #when activateTmuxPane respawns attach #then tmux receives env args and quoted attach values", async () => {

--- a/packages/tmux-core/src/tmux-utils/pane-command.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-command.ts
@@ -10,11 +10,12 @@ function shellQuoteForNestedCommand(value: string): string {
     .replace(/"/g, '\\"')
 }
 
-export function buildTmuxAttachCommand(serverUrl: string, sessionId: string, directory: string = process.cwd()): string {
+export function buildTmuxAttachCommand(serverUrl: string, sessionId: string, directory: string = process.cwd(), opencodePath?: string): string {
+  const executable = opencodePath ? shellQuoteForNestedCommand(opencodePath) : "opencode"
   const escapedUrl = shellQuoteForNestedCommand(serverUrl)
   const escapedSessionId = shellQuoteForNestedCommand(sessionId)
   const escapedDirectory = shellQuoteForNestedCommand(directory || process.cwd())
-  return `${TMUX_COMMAND_SHELL} -c "opencode attach ${escapedUrl} --session ${escapedSessionId} --dir ${escapedDirectory}"`
+  return `${TMUX_COMMAND_SHELL} -c "${executable} attach ${escapedUrl} --session ${escapedSessionId} --dir ${escapedDirectory}"`
 }
 
 export function buildTmuxPlaceholderCommand(description: string): string {

--- a/packages/tmux-core/src/tmux-utils/pane-spawn-runner.test.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-spawn-runner.test.ts
@@ -7,6 +7,8 @@ import type { TmuxCommandResult } from "../runner"
 import { isTmuxPaneCompatibleEnvironment } from "./environment"
 
 const paneSpawnSpecifier = import.meta.resolve("./pane-spawn")
+const originalCmuxAgentLaunchKind = process.env.CMUX_AGENT_LAUNCH_KIND
+const originalOpencodeBinPath = process.env.OPENCODE_BIN_PATH
 
 const enabledTmuxConfig = {
 	enabled: true,
@@ -81,6 +83,8 @@ async function loadSpawnTmuxPane(): Promise<typeof import("./pane-spawn").spawnT
 
 describe("spawnTmuxPane runner integration", () => {
 	beforeEach(() => {
+		delete process.env.CMUX_AGENT_LAUNCH_KIND
+		delete process.env.OPENCODE_BIN_PATH
 		mock.restore()
 		runTmuxCommandMock.mockClear()
 		isInsideTmuxMock.mockClear()
@@ -104,6 +108,13 @@ describe("spawnTmuxPane runner integration", () => {
 		isServerRunningMock.mockResolvedValue(true)
 		getTmuxPathMock.mockResolvedValue("sh")
 		isCmuxCompatEnvironmentMock.mockReturnValue(false)
+	})
+
+	afterEach(() => {
+		if (originalCmuxAgentLaunchKind === undefined) delete process.env.CMUX_AGENT_LAUNCH_KIND
+		else process.env.CMUX_AGENT_LAUNCH_KIND = originalCmuxAgentLaunchKind
+		if (originalOpencodeBinPath === undefined) delete process.env.OPENCODE_BIN_PATH
+		else process.env.OPENCODE_BIN_PATH = originalOpencodeBinPath
 	})
 
 	it("#given healthy tmux environment #when spawnTmuxPane called #then delegates split-window and select-pane to shared runner", async () => {
@@ -190,6 +201,25 @@ describe("spawnTmuxPane runner integration", () => {
 			expect(cmd).toContain("--dir")
 			expect(cmd).not.toContain("Focus this pane to attach.")
 			expect(cmd).not.toContain("while :; do sleep 86400; done")
+		})
+
+		it("#given official cmux OMO launch #when spawning a pane #then attaches eagerly with the resolved OpenCode path", async () => {
+			// given
+			process.env.CMUX_AGENT_LAUNCH_KIND = "omo"
+			process.env.OPENCODE_BIN_PATH = "/usr/bin/true"
+			const spawnTmuxPane = await loadSpawnTmuxPane()
+
+			// when
+			await spawnTmuxPane("session-cmux-omo", "worker", enabledTmuxConfig, "http://127.0.0.1:1234", "/tmp/omo-project", "%0", "-h", createDeps())
+
+			// then
+			const cmd = getSplitWindowCommand()
+			expect(cmd).toContain("'/usr/bin/true' attach")
+			expect(cmd).not.toContain("Focus this pane to attach.")
+			if (process.platform !== "win32") {
+				const cleanShellResult = Bun.spawnSync(["/bin/sh", "-c", cmd], { env: { PATH: "/usr/bin:/bin" } })
+				expect(cleanShellResult.exitCode).toBe(0)
+			}
 		})
 
 		it("#given CMUX_SOCKET_PATH without TMUX #when spawnTmuxPane called #then reaches eager split-window attach", async () => {

--- a/packages/tmux-core/src/tmux-utils/pane-spawn.ts
+++ b/packages/tmux-core/src/tmux-utils/pane-spawn.ts
@@ -2,6 +2,7 @@ import type { TmuxConfig } from "../types"
 import type { SpawnPaneResult } from "../types"
 import type { runTmuxCommand as RunTmuxCommand } from "../runner"
 import type { SplitDirection } from "./environment"
+import { bunWhich } from "@oh-my-opencode/utils/runtime"
 import { isInsideTmux } from "./environment"
 import { isServerRunning } from "./server-health"
 import { buildPaneAuthEnvironmentArgs, buildTmuxAttachCommand, buildTmuxPlaceholderCommand } from "./pane-command"
@@ -79,13 +80,15 @@ export async function spawnTmuxPane(
 	log("[spawnTmuxPane] all checks passed, spawning...")
 
 	const authEnvArgs = buildPaneAuthEnvironmentArgs()
-	if (deps.isCmuxCompatEnvironment() && authEnvArgs.length > 0) {
+	const isCmuxOmoLaunch = process.env.CMUX_AGENT_LAUNCH_KIND === "omo"
+	if ((deps.isCmuxCompatEnvironment() || isCmuxOmoLaunch) && authEnvArgs.length > 0) {
 		log("[spawnTmuxPane] SKIP: authenticated cmux panes are unsupported")
 		return { success: false }
 	}
 
-	const initialCmd = deps.isCmuxCompatEnvironment()
-		? buildTmuxAttachCommand(serverUrl, sessionId, _directory)
+	const opencodePath = isCmuxOmoLaunch ? process.env.OPENCODE_BIN_PATH || bunWhich("opencode") || undefined : undefined
+	const initialCmd = deps.isCmuxCompatEnvironment() || isCmuxOmoLaunch
+		? buildTmuxAttachCommand(serverUrl, sessionId, _directory, opencodePath)
 		: buildTmuxPlaceholderCommand(description)
 
 	const args = [


### PR DESCRIPTION
## Summary

- Recognize cmux's official `CMUX_AGENT_LAUNCH_KIND=omo` marker at the inline-pane spawn and focus decisions.
- Resolve the current OpenCode executable once for official OMO panes, quote its absolute path, and attach immediately at spawn.
- Treat focus as successful for the already-attached pane, avoiding `respawn-pane -k`.
- Keep native tmux behavior and authenticated-cmux fail-closed handling intact.

## Root cause

The official cmux launcher exports `CMUX_AGENT_LAUNCH_KIND=omo`, while its injected `TMUX` value may not match the existing cmux detector. OMO can therefore start a focus placeholder and later run `respawn-pane -k`, removing the cmux surface while the subagent continues in the background.

The eager attach command also used bare `opencode`. cmux launches the string command through a clean shell, so an NVM-installed OpenCode binary is absent from that shell's PATH and the pane exits with `opencode: command not found`.

## Scope

The production change is limited to the two lifecycle branches and the attach command builder. The absolute path is resolved only for the official OMO marker. The remaining changes are two direct regression tests; there is no detector helper, runner change, or QA artifact.

## Validation

- Failing-first lifecycle run: 13 pass, 2 expected failures.
- Failing-first clean-shell run: the official OMO command still contained bare `opencode`.
- `packages/tmux-core`: 100 pass, 0 fail, 214 assertions.
- Repository `bun run typecheck`: passed.
- The official OMO spawn test executes the generated command with `PATH=/usr/bin:/bin` and passes.
- Real cmux 0.64.21 with OpenCode 1.18.11 and OMO 4.19.4: the pane visibly launched with the absolute OpenCode path, survived pointer focus, logged `SKIP: cmux pane already attached`, and remained tracked as busy through later polls.

## Relationship to #6390

#6390 changes broader cmux detection and executable routing. This PR stays lifecycle-scoped and can land independently; if #6390 lands first and verifies the same focus behavior in a release, this can be closed as superseded.
