### PR TITLE
fix(ci): resolve audit root path on Windows

### DIFF
--- a/script/gpt-mini-reference-audit.test.ts
+++ b/script/gpt-mini-reference-audit.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, test } from "bun:test"
 import { readFile, stat } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, sep } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
-const REPOSITORY_ROOT = new URL("../", import.meta.url).pathname
+const REPOSITORY_ROOT = repositoryRootFromMetaUrl(import.meta.url)
 const OLD_MODEL_ID = ["gpt-5.4", "mini"].join("-")
 const OLD_DISPLAY_NAME = ["GPT 5.4", "Mini"].join(" ")
 
 describe("GPT Mini reference audit", () => {
+  test("repository root decodes a platform-native file URL", () => {
+    // given
+    const repositoryDir = join(tmpdir(), "gpt mini audit")
+    const scriptUrl = pathToFileURL(join(repositoryDir, "script", "audit.test.ts")).href
+
+    // when
+    const root = repositoryRootFromMetaUrl(scriptUrl)
+
+    // then
+    expect(root).toBe(`${repositoryDir}${sep}`)
+  })
+
   test("tracked shipped files no longer reference the retired GPT Mini model", async () => {
     // given
     const files = await trackedFiles()
@@ -41,4 +56,8 @@ async function trackedFiles(): Promise<string[]> {
     throw new Error(`git ls-files failed: ${stderr.trim()}`)
   }
   return stdout.split("\0").filter((file) => file.length > 0 && !file.startsWith(".omo/evidence/"))
+}
+
+function repositoryRootFromMetaUrl(metaUrl: string): string {
+  return fileURLToPath(new URL("../", metaUrl))
 }


### PR DESCRIPTION
## Summary

Use `fileURLToPath()` instead of a raw file URL pathname when deriving the repository root in the GPT Mini reference audit.

## Why

Windows CI passed the repository root as `/D:/a/...` to `Bun.spawn`, causing:

```text
ENOENT: no such file or directory
at trackedFiles (script/gpt-mini-reference-audit.test.ts:30)
```

The identical failure occurs on multiple unrelated PRs, including #6521 and #6522, so this is a base CI defect rather than a feature regression.

## Verification

- failing-first test: `repositoryRootFromMetaUrl is not defined`
- focused test: `2 pass, 0 fail`
- `bun run typecheck:script`: clean
- the new test uses `pathToFileURL()` with a platform-native path containing a space, so it exercises URL decoding and Windows drive-path conversion through the host platform


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repository root resolution in the GPT Mini reference audit so it works on Windows CI. Prevents ENOENT errors caused by `/D:/...` paths when spawning processes.

- **Bug Fixes**
  - Compute repo root with `fileURLToPath()` from `import.meta.url` instead of using the raw pathname.
  - Add a test that covers platform-native file URLs with spaces and Windows drive-letter paths.

<sup>Written for commit f4b1b0f935c44e45aa389c67ecbd873d82536af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

