### PR TITLE
fix(senpi): block self-terminating shell commands in bash/bash_input/monitor

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -30,6 +30,7 @@
 | Rules-injector cross-module comparison | [docs/reference/rules-injection-cross-module-comparison.md](reference/rules-injection-cross-module-comparison.md) |
 | Codex telemetry internals | [docs/reference/codex-telemetry.md](reference/codex-telemetry.md) |
 | Monitor tool reference | [docs/reference/monitor.md](reference/monitor.md) |
+| Self-kill command guard (incident + PR) | [docs/reference/senpi-self-kill-command-guard.md](reference/senpi-self-kill-command-guard.md) |
 | Web-terminal visual QA helper | [docs/reference/web-terminal-visual-qa.md](reference/web-terminal-visual-qa.md) |
 | Sample configs | [docs/examples/](examples) (default, coding-focused, planning-focused) |
 | Privacy & ToS | [docs/legal/](legal) |

--- a/docs/reference/senpi-self-kill-command-guard.md
+++ b/docs/reference/senpi-self-kill-command-guard.md
@@ -1,0 +1,150 @@
+# senpi host self-kill (taskkill) guard — incident & PR notes
+
+**Date:** 2026-07-31
+**Status:** PR-ready (branch `fix/senpi-self-kill-command-guard`)
+**Target repo:** `code-yeongyu/oh-my-openagent` (omo-senpi adapter)
+
+---
+
+## 1. Incident summary
+
+In a Senpi session (`019fb3f5`, "UIUX patch recovery investigation") for the 그림수세미 project,
+the agent tried to clean up stale Vite dev servers by killing every node process. Because the
+senpi/omo agent runtime itself runs as a node.exe process, the command terminated the session's own
+host — **the session was killed 4 times in a row**.
+
+- Session log: 2026-07-30 16:57 ~ 2026-07-31 11:42 UTC+9 (18.7 h, 475 turns)
+- Every termination was immediately preceded by a `taskkill`-family command (evidence table below)
+- The session file itself is intact (all 1218 JSONL events parse cleanly)
+
+## 2. Root cause
+
+| Layer | Cause |
+|---|---|
+| Direct cause | The agent ran `taskkill /F /IM node.exe` (and PID loops over node), force-killing every node.exe — including the senpi host |
+| Contributing accident | Git Bash's MSYS path conversion rewrote `/F` to `F:/`, so early attempts **silently failed**. The agent interpreted this as "the command is not working" and found syntax that actually executes (`//F`, `cmd //c`, per-PID loops) — the first success killed the host |
+| Systemic gap | The harness has no guard against shell commands that terminate its own host process. The default permission preset is `full-access`, so every bash command is allowed |
+
+### Commands immediately before each termination (verbatim from the session log)
+
+| Time | Command | Result |
+|---|---|---|
+| 07-31 08:01:53 | `cd /c && cmd //c "taskkill /F /IM node.exe /T" 2>&1 \| tail -5` | session died (196 min gap) |
+| 07-31 11:20:19 | `for pid in $(tasklist 2>/dev/null \| grep -i node \| awk '{print $2}'); do taskkill //F //PID "$pid" ...; done` | died (user: "system terminated") |
+| 07-31 11:27:10 | same PID kill loop over all node processes | died (user: "keeps terminating") |
+| 07-31 11:40:01 | same PID kill loop over all node processes | died mid-tool-call |
+
+Each resume reloaded a ~550K-token context, the agent saw the same symptom (stale node processes +
+dead 5173 server), and repeated the same command — a fatal loop.
+
+## 3. This PR (defense layer 1: omo-senpi extension guard)
+
+Adds a `self-kill-guard` component to `packages/omo-senpi`.
+
+**How it works**
+
+- Senpi loads plugin extensions (omo-senpi) **before** builtin extensions (including `terminal`), so a
+  `pi.registerTool` wrapper installed by the plugin intercepts the core `bash`/`bash_input`/`monitor`
+  tools at their registration time and wraps their `execute` closures.
+- The wrapped `execute` scans the command string for self-terminating patterns and, on a match,
+  **throws** (the runtime contract: tool failures are signaled by throwing — the executor converts the
+  throw into an error tool result).
+- A `tool_execution_start` observer emits a visible notice as a fallback if the wrapper ever misses.
+- Disable flag: `--omo-senpi-self-kill-guard-disabled`
+
+**Blocked patterns** (`detect.ts`, all derived from the incident log)
+
+- `taskkill ... /IM node.exe|bun(.exe)` (both `/IM` and `//IM`)
+- `taskkill ...` nested inside `cmd //c "..."` wrappers
+- PID loops over node: `tasklist | grep node` → `taskkill //F //PID` (whole-command heuristic)
+- `pkill`/`killall`/`tskill node`, `Stop-Process -Name node*`, `Get-Process node | Stop-Process`,
+  `wmic ... node.exe ... delete`
+
+**Still allowed:** `taskkill /F /PID <specific pid>` (no image-wide kill), dev-server starts, port checks.
+
+**Files**
+
+| File | Purpose |
+|---|---|
+| `packages/omo-senpi/src/components/self-kill-guard/detect.ts` | pure detector (patterns / segment splitter / reasons) |
+| `packages/omo-senpi/src/components/self-kill-guard/component.ts` | tool execute wrapper + event observer |
+| `packages/omo-senpi/src/components/self-kill-guard/*.test.ts` | 24 unit tests |
+| `packages/omo-senpi/src/extension/index.ts` | component registration (2 lines) |
+| `plugin/extensions/omo.js` | **generated bundle — must be regenerated before merge** (only source is committed) |
+
+**Verification:** 24 new unit tests pass; package typecheck (`tsgo --noEmit`) passes; root monorepo
+typecheck passes. Full package suite: 495 pass / 15 fail — the 15 are pre-existing failures from
+unrelated dirty-worktree artifact drift (ultrawork generated directive, package-shape audit, QA
+sandbox scripts), confirmed by stash comparison. `bun run build` and `bun run test:codex` were not run
+locally because this worktree carries unrelated in-progress generated bundles that those commands
+would overwrite; CI should run them, and the bundle regeneration is a merge requirement.
+
+## 4. Recommended senpi-core follow-up (defense layer 2, separate issue)
+
+The extension guard only applies where omo-senpi is installed. The root fix for all Senpi users lives
+in the senpi core (`@code-yeongyu/senpi`). Two proposals:
+
+1. **Guard inside the bash tool itself**
+   At the entry of `src/core/extensions/builtin/terminal/tools/bash.ts`, refuse self-terminating
+   patterns (the `detect.ts` detector can be ported as-is).
+2. **Default deny in the permission system**
+   In `src/core/extensions/builtin/permission-system/config.ts`, append default deny rules for the
+   `taskkill`/`pkill`/`killall`/`tskill`/`Stop-Process` bash prefixes after the `full-access` preset.
+   (Permission patterns are first-token based — `BashArity.prefix` returns `taskkill` for
+   `taskkill /F /IM node.exe`, so a `bash: { "taskkill": "deny" }` rule matches.)
+
+## 5. Immediate user mitigation (works before this PR ships)
+
+Adding deny rules to `~/.senpi/agent/settings.json` blocks the same incident today (permission
+evaluation gives later rules precedence over the default preset):
+
+```jsonc
+{
+  "permission": {
+    "bash": {
+      "taskkill": "deny",
+      "tskill": "deny",
+      "pkill": "deny",
+      "killall": "deny",
+      "Stop-Process": "deny"
+    },
+    "bash_input": {
+      "taskkill": "deny",
+      "tskill": "deny",
+      "pkill": "deny",
+      "killall": "deny",
+      "Stop-Process": "deny"
+    }
+  }
+}
+```
+
+Note: this also blocks targeted `taskkill /PID <pid>` (patterns are first-token based). For a
+targeted kill, run it yourself or temporarily remove the rule. Once this PR ships, targeted kills stay
+allowed while image-wide kills are blocked.
+
+## 6. New-session safety guidance
+
+Paste this as the first message of any new session:
+
+```text
+IMPORTANT safety rules — follow them strictly:
+1. NEVER run "kill all node processes" commands: taskkill /F /IM node.exe (or //IM),
+   taskkill PID loops over `tasklist | grep node`, cmd //c "taskkill /F /IM node.exe /T",
+   pkill/killall/tskill node, Stop-Process -Name node* are forbidden. The senpi/omo system
+   itself runs as node.exe, so these commands kill the session you are running in.
+2. To stop a dev server: use kill_bash({ bash_id }) for bash sessions, or find the exact
+   port owner with `netstat -ano | findstr :5173` and kill only that PID with
+   `taskkill /PID <pid> /F`.
+3. Do not leave background dev servers running; use bounded start-verify-stop patterns
+   (e.g. Playwright managed webServer).
+4. If a session dies, start a new session and re-state these rules.
+```
+
+## 7. Issue / PR handoff summary
+
+- **Issue title (proposal):** `[Windows] Agent can kill the senpi host itself via blanket taskkill, terminating the session`
+- **Body:** copy sections 1–2 (incident + root cause + evidence table).
+- **PR title (proposal):** `fix(senpi): block self-terminating shell commands in bash/bash_input/monitor`
+- **PR body:** copy section 3 (changes + verification) and section 4 (core follow-up). Note the
+  `plugin/extensions/omo.js` bundle regeneration requirement.

--- a/docs/reference/senpi-self-kill-command-guard.md
+++ b/docs/reference/senpi-self-kill-command-guard.md
@@ -123,6 +123,13 @@ Note: this also blocks targeted `taskkill /PID <pid>` (patterns are first-token 
 targeted kill, run it yourself or temporarily remove the rule. Once this PR ships, targeted kills stay
 allowed while image-wide kills are blocked.
 
+**Known limitation:** the permission system matches on the command's first token only
+(`BashArity.prefix`), so the settings rules do NOT cover `cmd //c "taskkill /F /IM node.exe /T"`
+(first token `cmd`) or `for pid in $(tasklist ...); do taskkill //F //PID ...; done` (first token
+`for`) — the two shapes that actually killed the host in the incident. The code guard in this PR
+detects those shapes regardless of position; until it ships, the new-session safety rules in section 6
+are the primary defense.
+
 ## 6. New-session safety guidance
 
 Paste this as the first message of any new session:

--- a/packages/omo-senpi/src/components/self-kill-guard/component.test.ts
+++ b/packages/omo-senpi/src/components/self-kill-guard/component.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test"
+
+import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
+import { createSelfKillGuardComponent, SELF_KILL_GUARD_NOTICE_CUSTOM_TYPE } from "./component"
+
+interface FakeTool extends Record<string, unknown> {
+  name: string
+  execute: (...args: unknown[]) => Promise<unknown>
+}
+
+function fakeBashTool(execute?: FakeTool["execute"]): FakeTool {
+  return {
+    name: "bash",
+    label: "bash",
+    parameters: {},
+    execute: execute ?? (async () => ({ content: [] })),
+  }
+}
+
+describe("self-kill-guard component", () => {
+  it("#given a bash tool registered after the guard #when a self-terminating command runs #then it is refused and the original execute is not called", async () => {
+    const pi = new FakeExtensionAPI()
+    let originalCalled = false
+    const tool = fakeBashTool(async () => {
+      originalCalled = true
+      return { content: [] }
+    })
+
+    const component = createSelfKillGuardComponent()
+    await component.register(pi, { logger: console, config: { getFlag: () => false } })
+    pi.registerTool(tool)
+
+    await expect(
+      tool.execute("call-1", { command: "taskkill /F /IM node.exe /T" }, undefined, undefined, {}),
+    ).rejects.toThrow(/omo-self-kill-guard/)
+    await expect(
+      tool.execute("call-1", { command: "taskkill /F /IM node.exe /T" }, undefined, undefined, {}),
+    ).rejects.toThrow(/kill_bash/)
+    expect(originalCalled).toBe(false)
+  })
+
+  it("#given a guarded bash tool #when a safe command runs #then it passes through to the original execute", async () => {
+    const pi = new FakeExtensionAPI()
+    const tool = fakeBashTool()
+
+    const component = createSelfKillGuardComponent()
+    await component.register(pi, { logger: console, config: { getFlag: () => false } })
+    pi.registerTool(tool)
+
+    const result = (await tool.execute("call-1", { command: "npm run dev -- --port 5173" }, undefined, undefined, {})) as {
+      isError?: boolean
+    }
+    expect(result.isError).toBeUndefined()
+  })
+
+  it("#given bash_input with a self-terminating input #then it is refused", async () => {
+    const pi = new FakeExtensionAPI()
+    const tool: FakeTool = {
+      name: "bash_input",
+      label: "bash_input",
+      parameters: {},
+      execute: async () => ({ content: [] }),
+    }
+
+    const component = createSelfKillGuardComponent()
+    await component.register(pi, { logger: console, config: { getFlag: () => false } })
+    pi.registerTool(tool)
+
+    await expect(tool.execute("call-1", { input: "taskkill //F //IM node.exe /T" }, undefined, undefined, {})).rejects.toThrow(
+      /omo-self-kill-guard/,
+    )
+  })
+
+  it("#given a tool_execution_start with a self-terminating command #then a visible notice is sent", () => {
+    const pi = new FakeExtensionAPI()
+
+    const component = createSelfKillGuardComponent()
+    void component.register(pi, { logger: console, config: { getFlag: () => false } })
+
+    const handler = pi.handlers.find((entry) => entry.event === "tool_execution_start")
+    expect(handler).toBeDefined()
+    handler?.handler({ toolName: "bash", args: { command: "pkill node" } })
+
+    expect(pi.messages).toHaveLength(1)
+    expect(pi.messages[0].message.customType).toBe(SELF_KILL_GUARD_NOTICE_CUSTOM_TYPE)
+    expect(pi.messages[0].message.display).toBe(true)
+    expect(String(pi.messages[0].message.content)).toContain("[omo-self-kill-guard]")
+  })
+
+  it("#given a tool_execution_start with a safe command #then no notice is sent", () => {
+    const pi = new FakeExtensionAPI()
+
+    const component = createSelfKillGuardComponent()
+    void component.register(pi, { logger: console, config: { getFlag: () => false } })
+
+    const handler = pi.handlers.find((entry) => entry.event === "tool_execution_start")
+    handler?.handler({ toolName: "bash", args: { command: "npm run dev" } })
+
+    expect(pi.messages).toHaveLength(0)
+  })
+
+  it("#given a guarded tool registration #then the tool still reaches the underlying registry", () => {
+    const pi = new FakeExtensionAPI()
+    const tool = fakeBashTool()
+
+    const component = createSelfKillGuardComponent()
+    void component.register(pi, { logger: console, config: { getFlag: () => false } })
+    pi.registerTool(tool)
+
+    expect(pi.tools).toHaveLength(1)
+    expect(pi.tools[0]).toBe(tool)
+  })
+})

--- a/packages/omo-senpi/src/components/self-kill-guard/component.ts
+++ b/packages/omo-senpi/src/components/self-kill-guard/component.ts
@@ -1,0 +1,98 @@
+import type { ToolDefinition } from "@code-yeongyu/senpi"
+
+import type { OmoSenpiComponent } from "../../extension/types"
+import { detectSelfTerminatingCommand, type SelfKillDetection } from "./detect"
+
+const GUARDED_TOOL_NAMES = new Set(["bash", "bash_input", "monitor"])
+
+export const SELF_KILL_GUARD_NOTICE_CUSTOM_TYPE = "omo-self-kill-guard:notice"
+
+function extractCommand(toolName: string, params: unknown): string {
+  const record = typeof params === "object" && params !== null ? (params as Record<string, unknown>) : {}
+  if (toolName === "bash_input") {
+    const input = record.input
+    return typeof input === "string" ? input : ""
+  }
+  const command = record.command
+  return typeof command === "string" ? command : ""
+}
+
+export function buildBlockMessage(toolName: string, detection: SelfKillDetection): string {
+  return [
+    `[omo-self-kill-guard] Refusing ${toolName} call: ${detection.reason}`,
+    "",
+    "The senpi/omo agent runtime runs as a node.exe (or bun) process on this machine. This command would kill every node/bun process, including the session that is executing it - the system would terminate mid-turn (observed 4x in one session with taskkill loops).",
+    "",
+    "Safe alternatives:",
+    "- Stop a dev server you started: use kill_bash({ bash_id }) for bash sessions, or kill only the port owner: netstat -ano | findstr :5173  then  taskkill /PID <pid> /F",
+    "- Never use taskkill with /IM node.exe (or //IM), pkill/killall/tskill node, Stop-Process -Name node*, or PID loops over 'tasklist | grep node'.",
+  ].join("\n")
+}
+
+function buildNoticeText(toolName: string, detection: SelfKillDetection): string {
+  return `[omo-self-kill-guard] ${detection.reason} Do not run this ${toolName} command - it would terminate the senpi session. Use kill_bash or a targeted port-owner PID instead.`
+}
+
+function guardExecute(toolName: string, execute: ToolDefinition["execute"]): ToolDefinition["execute"] {
+  return async function guardedExecute(this: unknown, toolCallId, params, signal, onUpdate, execCtx) {
+    const command = extractCommand(toolName, params)
+    const detection = detectSelfTerminatingCommand(command)
+    if (detection !== undefined) {
+      throw new Error(buildBlockMessage(toolName, detection))
+    }
+    return execute.call(this, toolCallId, params, signal, onUpdate, execCtx)
+  }
+}
+
+interface ToolExecutionStartPayload {
+  toolName?: string
+  args?: Record<string, unknown>
+}
+
+function isGuardedToolName(name: unknown): name is string {
+  return typeof name === "string" && GUARDED_TOOL_NAMES.has(name)
+}
+
+/**
+ * Refuse shell commands that would terminate the senpi host process.
+ *
+ * Plugins load before builtin extensions, so the `registerTool` wrapper below
+ * intercepts the core bash/bash_input/monitor tools at their registration time
+ * and wraps their execute closures. A `tool_execution_start` observer remains
+ * as a fallback notice in case a future load-order change skips the wrapper.
+ */
+export function createSelfKillGuardComponent(): OmoSenpiComponent {
+  return {
+    name: "self-kill-guard",
+    register(pi) {
+      const wrapped = new Set<unknown>()
+      const originalRegisterTool = pi.registerTool.bind(pi)
+      pi.registerTool = (tool: Record<string, unknown>): void => {
+        const name = Reflect.get(tool, "name")
+        const execute = Reflect.get(tool, "execute")
+        if (isGuardedToolName(name) && typeof execute === "function" && !wrapped.has(tool)) {
+          wrapped.add(tool)
+          Reflect.set(tool, "execute", guardExecute(name, execute as ToolDefinition["execute"]))
+        }
+        originalRegisterTool(tool)
+      }
+
+      pi.on("tool_execution_start", (payload: unknown) => {
+        const event = (payload ?? {}) as ToolExecutionStartPayload
+        if (!isGuardedToolName(event.toolName)) return
+        const command = extractCommand(event.toolName, event.args ?? {})
+        const detection = detectSelfTerminatingCommand(command)
+        if (detection === undefined) return
+        void pi.sendMessage(
+          {
+            customType: SELF_KILL_GUARD_NOTICE_CUSTOM_TYPE,
+            content: buildNoticeText(event.toolName, detection),
+            display: true,
+            details: detection,
+          },
+          { triggerTurn: false, deliverAs: "steer" },
+        )
+      })
+    },
+  }
+}

--- a/packages/omo-senpi/src/components/self-kill-guard/detect.test.ts
+++ b/packages/omo-senpi/src/components/self-kill-guard/detect.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test"
+
+import { detectSelfTerminatingCommand, splitCommandSegments } from "./detect"
+
+describe("splitCommandSegments", () => {
+  it("splits on logical command separators", () => {
+    expect(splitCommandSegments("taskkill /F /IM node.exe 2>&1 | tail -3; echo done")).toEqual([
+      "taskkill /F /IM node.exe 2>&1",
+      "tail -3",
+      "echo done",
+    ])
+  })
+
+  it("returns an empty list for an empty command", () => {
+    expect(splitCommandSegments("")).toEqual([])
+    expect(splitCommandSegments("   ")).toEqual([])
+  })
+})
+
+describe("detectSelfTerminatingCommand", () => {
+  const blockedKeys = [
+    "taskkill-image-node",
+    "node-pid-kill-loop",
+    "pkill-node",
+    "killall-node",
+    "tskill-node",
+    "stop-process-node",
+    "wmic-node-delete",
+    "powershell-get-process-stop",
+  ]
+
+  describe.each(blockedKeys)("rule %s", (key) => {
+    it("reports a stable key and reason", () => {
+      const command = blockedCommands()[key]
+      const detection = detectSelfTerminatingCommand(command)
+      expect(detection?.key).toBe(key)
+      expect(detection?.reason.length).toBeGreaterThan(0)
+    })
+  })
+
+  function blockedCommands(): Record<string, string> {
+    return {
+      // Verbatim from the 2026-07-30/31 incident session
+      "taskkill-image-node": "taskkill /F /IM node.exe /T 2>&1 | tail -3; sleep 3; echo done",
+      "node-pid-kill-loop":
+        "for pid in $(tasklist 2>/dev/null | grep -i node | awk '{print $2}'); do taskkill //F //PID \"$pid\" >/dev/null 2>&1; done",
+      "pkill-node": "pkill -9 -f node",
+      "killall-node": "killall node",
+      "tskill-node": "tskill node",
+      "stop-process-node": "Stop-Process -Name node*",
+      "wmic-node-delete": "wmic process where name='node.exe' delete",
+      "powershell-get-process-stop": "Get-Process node | Stop-Process",
+    }
+  }
+
+  it("blocks taskkill by image name regardless of slash style", () => {
+    expect(detectSelfTerminatingCommand("taskkill /F /IM node.exe /T")).toBeDefined()
+    expect(detectSelfTerminatingCommand("taskkill //F //IM node.exe /T")).toBeDefined()
+    expect(detectSelfTerminatingCommand("taskkill /IM node.exe")).toBeDefined()
+    expect(detectSelfTerminatingCommand("taskkill /F /IM node.exe 2>/dev/null; echo killed")).toBeDefined()
+  })
+
+  it("blocks taskkill on the bun image too", () => {
+    expect(detectSelfTerminatingCommand("taskkill /F /IM bun.exe")).toBeDefined()
+  })
+
+  it("blocks taskkill wrapped in cmd /c", () => {
+    expect(detectSelfTerminatingCommand('cd /c && cmd //c "taskkill /F /IM node.exe /T" 2>&1 | tail -5')).toBeDefined()
+  })
+
+  it("blocks a while-read PID loop over node", () => {
+    const command =
+      "tasklist 2>/dev/null | grep -i node | awk '{print $2}' | while read pid; do taskkill //F //PID \"$pid\" >/dev/null 2>&1; done"
+    expect(detectSelfTerminatingCommand(command)).toBeDefined()
+  })
+
+  it("allows targeted taskkill by PID without a node image", () => {
+    expect(detectSelfTerminatingCommand("taskkill /F /PID 1234 /T")).toBeUndefined()
+  })
+
+  it("allows ordinary dev commands", () => {
+    const safe = [
+      "npm run dev -- --host 127.0.0.1 --port 5173",
+      "curl -s -o /dev/null -w \"5173: %{http_code}\\n\" http://127.0.0.1:5173/",
+      "netstat -ano | findstr :5173",
+      "git log --oneline -5",
+      "rm -rf node_modules/.vite",
+      "tasklist 2>/dev/null | grep -i node | head -5",
+      "grep -rn taskkill packages --include=\"*.ts\"",
+      "npx serve dist -s -p 5199 &",
+      "ps aux | grep -i node",
+    ]
+    for (const command of safe) {
+      expect(detectSelfTerminatingCommand(command)).toBeUndefined()
+    }
+  })
+
+  it("allows listing node processes without a kill", () => {
+    const command = 'tasklist 2>/dev/null | grep -i "node" | head -5; echo "---"; curl -s -o /dev/null -w "5173: %{http_code}\\n" --max-time 3 http://127.0.0.1:5173/'
+    expect(detectSelfTerminatingCommand(command)).toBeUndefined()
+  })
+
+  it("blocks taskkill with quotes around the image name", () => {
+    expect(detectSelfTerminatingCommand('taskkill /F /IM "node.exe" /T')).toBeDefined()
+  })
+})

--- a/packages/omo-senpi/src/components/self-kill-guard/detect.ts
+++ b/packages/omo-senpi/src/components/self-kill-guard/detect.ts
@@ -1,0 +1,134 @@
+/**
+ * Self-kill command detection.
+ *
+ * The senpi/omo agent runtime executes as a node.exe (or bun) process on the
+ * host. A shell command that kills every node/bun process therefore terminates
+ * the session that is executing it - the agent kills its own host. This module
+ * recognizes those command shapes so a guard can refuse them before they run.
+ *
+ * Observed incident (2026-07-30/31, Windows): an agent trying to clean up stale
+ * Vite dev servers ran `taskkill /F /IM node.exe`, then per-PID loops over
+ * `tasklist | grep -i node`, killing the senpi host 4 times in one session.
+ */
+
+export interface SelfKillDetection {
+  /** Stable rule key (used for tests and the notice details). */
+  readonly key: string
+  /** Human-readable explanation of why the command was refused. */
+  readonly reason: string
+}
+
+/** Image names that host the agent runtime (Windows: node.exe; bun launcher). */
+const HOST_IMAGE = /["']?(?:node|bun)(?:\.exe)?["']?(?=\s|$|[^\w])/i
+
+/**
+ * taskkill by image name: `taskkill /F /IM node.exe /T` (Git-Bash mangles the
+ * leading slash into `//`, so both `/IM` and `//IM` must match).
+ */
+const TASKKILL_BY_IMAGE =
+  /\btaskkill\b[\s\S]{0,120}(?:\/\/?|-)IM\s+["']?(?:node|bun)(?:\.exe)?["']?(?=\s|$|[^\w])/i
+
+/** POSIX kill-by-name variants (WSL/MSYS/remote shells). */
+const PKILL_NODE = /\bpkill\b\s+(?:-\w+\s+)*["']?(?:node|bun)(?:\.exe)?["']?(?=\s|$|[^\w])/i
+const KILLALL_NODE = /\bkillall\b\s+["']?(?:node|bun)(?:\.exe)?["']?(?=\s|$|[^\w])/i
+const TSKILL_NODE = /\btskill\b\s+["']?(?:node|bun)(?:\.exe)?["']?(?=\s|$|[^\w])/i
+
+/** PowerShell: `Stop-Process -Name node*` or `Get-Process node | Stop-Process`. */
+const STOP_PROCESS_NODE =
+  /\bstop-process\b[\s\S]{0,200}?\bnode(?:\.exe)?\b|\bnode(?:\.exe)?\b[\s\S]{0,200}?\bstop-process\b/i
+
+/** WMIC: `wmic process where name='node.exe' delete`. */
+const WMIC_NODE_DELETE =
+  /\bwmic\b[\s\S]{0,240}?\bnode(?:\.exe)?\b[\s\S]{0,120}?\bdelete\b/i
+
+interface SegmentRule {
+  readonly key: string
+  readonly pattern: RegExp
+}
+
+const SEGMENT_RULES: readonly SegmentRule[] = [
+  { key: "taskkill-image-node", pattern: TASKKILL_BY_IMAGE },
+  { key: "pkill-node", pattern: PKILL_NODE },
+  { key: "killall-node", pattern: KILLALL_NODE },
+  { key: "tskill-node", pattern: TSKILL_NODE },
+  { key: "stop-process-node", pattern: STOP_PROCESS_NODE },
+  { key: "wmic-node-delete", pattern: WMIC_NODE_DELETE },
+]
+
+/**
+ * Whole-command rules for shapes that no single segment captures, e.g. a PID
+ * loop that lists node processes in one pipeline and taskkills them in another:
+ *
+ *   for pid in $(tasklist 2>/dev/null | grep -i node | awk '{print $2}'); do
+ *     taskkill //F //PID "$pid" >/dev/null 2>&1
+ *   done
+ */
+interface WholeCommandRule {
+  readonly key: string
+  readonly test: (command: string) => boolean
+}
+
+function hasNodeKillLoop(command: string): boolean {
+  if (!/\btaskkill\b/i.test(command)) return false
+  if (!HOST_IMAGE.test(command)) return false
+  return /\b(?:tasklist|wmic|get-process|for\s+\w+\s+in|while\s+read)\b/i.test(command)
+}
+
+function hasPowerShellPipeToStop(command: string): boolean {
+  if (!/\bnode(?:\.exe)?\b/i.test(command)) return false
+  return /\bget-process\b[\s\S]{0,200}?\bstop-process\b/i.test(command)
+}
+
+const WHOLE_COMMAND_RULES: readonly WholeCommandRule[] = [
+  { key: "node-pid-kill-loop", test: hasNodeKillLoop },
+  { key: "powershell-get-process-stop", test: hasPowerShellPipeToStop },
+]
+
+export const SELF_KILL_REASONS: Readonly<Record<string, string>> = {
+  "taskkill-image-node":
+    "taskkill by image name would kill every node/bun process, including the senpi host running this session.",
+  "node-pid-kill-loop":
+    "PID loop over node processes would include the senpi host PID and terminate this session.",
+  "pkill-node": "pkill node would kill the senpi host process running this session.",
+  "killall-node": "killall node would kill the senpi host process running this session.",
+  "tskill-node": "tskill node would kill the senpi host process running this session.",
+  "stop-process-node":
+    "Stop-Process/Get-Process on node would kill the senpi host process running this session.",
+  "wmic-node-delete":
+    "wmic delete on node.exe would kill the senpi host process running this session.",
+  "powershell-get-process-stop":
+    "Get-Process node | Stop-Process would kill the senpi host process running this session.",
+}
+
+/**
+ * Split a shell command into logical segments. Splitting is deliberately
+ * conservative (quoted `|` may split mid-string); for a kill guard a slight
+ * over-approximation is acceptable and a missed case is not.
+ */
+export function splitCommandSegments(command: string): readonly string[] {
+  return command
+    .split(/(?:&&|\|\||;|\n|\||\$\(|`)/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
+}
+
+/**
+ * Detect whether `command` would terminate the agent's own host process.
+ * Returns the matched rule (with a stable key and explanation) or undefined.
+ */
+export function detectSelfTerminatingCommand(command: string): SelfKillDetection | undefined {
+  for (const rule of WHOLE_COMMAND_RULES) {
+    if (rule.test(command)) {
+      return { key: rule.key, reason: SELF_KILL_REASONS[rule.key] }
+    }
+  }
+  for (const segment of splitCommandSegments(command)) {
+    for (const rule of SEGMENT_RULES) {
+      rule.pattern.lastIndex = 0
+      if (rule.pattern.test(segment)) {
+        return { key: rule.key, reason: SELF_KILL_REASONS[rule.key] }
+      }
+    }
+  }
+  return undefined
+}

--- a/packages/omo-senpi/src/components/self-kill-guard/index.ts
+++ b/packages/omo-senpi/src/components/self-kill-guard/index.ts
@@ -1,0 +1,2 @@
+export { buildBlockMessage, createSelfKillGuardComponent, SELF_KILL_GUARD_NOTICE_CUSTOM_TYPE } from "./component"
+export { detectSelfTerminatingCommand, splitCommandSegments } from "./detect"

--- a/packages/omo-senpi/src/extension/index.ts
+++ b/packages/omo-senpi/src/extension/index.ts
@@ -11,6 +11,7 @@ import { createStartWorkContinuationComponent } from "../components/start-work-c
 import { createUltraworkComponent } from "../components/ultrawork"
 import { createUlwLoopComponent } from "../components/ulw-loop"
 import { createFallbackArchitectComponent } from "../components/fallback-architect"
+import { createSelfKillGuardComponent } from "../components/self-kill-guard"
 
 const components: OmoSenpiComponent[] = [
   createConfigStartupComponent(),
@@ -18,6 +19,7 @@ const components: OmoSenpiComponent[] = [
   createStartWorkContinuationComponent(),
   createUlwLoopComponent(),
   createFallbackArchitectComponent(),
+  createSelfKillGuardComponent(),
   createCommentCheckerComponent(),
   createSenpiTelemetryComponent(),
   createLspComponent(),


### PR DESCRIPTION
## Summary

An agent session can kill the Senpi host itself: the omo/senpi runtime runs as a **node.exe (or bun)
process**, so a blanket `taskkill /F /IM node.exe` (or a per-PID loop over `tasklist | grep node`)
terminates the session mid-turn. Observed **4x in one 18.7h session on Windows** (2026-07-30/31);
every resume reloaded a ~550K-token context, saw the same stale dev-server symptom, repeated the same
command, and died again.

This PR adds an omo-senpi **`self-kill-guard`** component that refuses such commands at the tool level:

- Wraps the core `bash`, `bash_input`, and `monitor` tool `execute` closures (plugins load before
  builtin terminal tools, so registration-time wrapping reaches them).
- Blocks: `taskkill ... /IM node.exe|bun` (both `/IM` and `//IM`), `taskkill` PID loops over node,
  `cmd //c "taskkill ..."` wrappers, `pkill`/`killall`/`tskill node`, `Stop-Process -Name node*`,
  `Get-Process node | Stop-Process`, `wmic ... node.exe ... delete`.
- On a match the guard **throws**, so the runtime surfaces it as a tool error with guidance to use
  `kill_bash` or a targeted port-owner PID (`netstat -ano | findstr :5173`).
- A `tool_execution_start` observer emits a visible notice as a fallback.
- Disable flag: `--omo-senpi-self-kill-guard-disabled`.

## What changed

| File | Purpose |
|---|---|
| `packages/omo-senpi/src/components/self-kill-guard/detect.ts` | pure detector (patterns / segment splitter / reasons) |
| `packages/omo-senpi/src/components/self-kill-guard/component.ts` | tool execute wrapper + event observer |
| `packages/omo-senpi/src/components/self-kill-guard/detect.test.ts`, `component.test.ts` | 24 unit tests, including the verbatim incident commands |
| `packages/omo-senpi/src/extension/index.ts` | component registration (2 lines) |
| `docs/reference/senpi-self-kill-command-guard.md` | incident report + root cause + immediate settings mitigation |

## Verification

- 24 new unit tests pass (`bun test packages/omo-senpi`).
- Package typecheck passes (`tsgo --noEmit -p packages/omo-senpi/tsconfig.json`).
- Root monorepo typecheck passes (`bun run typecheck`, exit 0).
- Full `packages/omo-senpi` suite: 495 pass / 15 fail — the 15 failures are **pre-existing**
  dirty-worktree artifact drift (ultrawork generated directive, package-shape audit, QA sandbox
  scripts), confirmed identical with this change's wiring stashed.

## Residual risk / notes

- `plugin/extensions/omo.js` is a **generated bundle** and is not committed here — it must be
  regenerated before merge.
- A live-session smoke run of the wrapped core bash tool is recommended before merge (cannot be
  driven from this environment without terminating the running host).
- `bun run build` and `bun run test:codex` were not run locally: this worktree carries unrelated
  in-progress generated bundles that those commands would overwrite. CI should run them.
- Follow-up (separate issue): port the same guard into Senpi core
  (`src/core/extensions/builtin/terminal/tools/bash.ts`) and add default deny rules in the
  permission system so non-omo installs are protected too — see the linked report, section 4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Senpi from killing its own host by blocking blanket node/bun kill commands. Adds a guard in `packages/omo-senpi` that wraps `bash`, `bash_input`, and `monitor`, refuses risky commands, and still allows targeted PID kills.

- **Bug Fixes**
  - Wraps tool executes to detect and block: `taskkill ... /IM node.exe|bun(.exe)` (both `/IM` and `//IM`), PID loops over `tasklist | grep node` → `taskkill //PID`, `pkill`/`killall`/`tskill`, PowerShell `Stop-Process` and `Get-Process ... | Stop-Process`, WMIC delete; also blocks `cmd //c` wrappers.
  - On match: throws with guidance to use `kill_bash` or `taskkill /PID <pid>`; also emits a visible `tool_execution_start` notice.
  - 24 unit tests added; docs at `docs/reference/senpi-self-kill-command-guard.md`, including the settings-denial limitation (first-token matching) and why the guard still catches `cmd //c` and PID-loop shapes.

- **Migration**
  - Regenerate `plugin/extensions/omo.js` before merge. Optional disable flag: `--omo-senpi-self-kill-guard-disabled`.

<sup>Written for commit 035fbef1bad74bb3c74ab30942232d44d537ab92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

