### PR TITLE
fix(senpi): cap giant tool results so oversized strings cannot enter context

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -30,6 +30,7 @@
 | Rules-injector cross-module comparison | [docs/reference/rules-injection-cross-module-comparison.md](reference/rules-injection-cross-module-comparison.md) |
 | Codex telemetry internals | [docs/reference/codex-telemetry.md](reference/codex-telemetry.md) |
 | Monitor tool reference | [docs/reference/monitor.md](reference/monitor.md) |
+| Giant tool results vs compaction (incident + PR) | [docs/reference/senpi-giant-tool-result-compaction-failure.md](reference/senpi-giant-tool-result-compaction-failure.md) |
 | Web-terminal visual QA helper | [docs/reference/web-terminal-visual-qa.md](reference/web-terminal-visual-qa.md) |
 | Sample configs | [docs/examples/](examples) (default, coding-focused, planning-focused) |
 | Privacy & ToS | [docs/legal/](legal) |

--- a/docs/reference/senpi-giant-tool-result-compaction-failure.md
+++ b/docs/reference/senpi-giant-tool-result-compaction-failure.md
@@ -1,0 +1,116 @@
+# Giant tool results break provider requests and compaction — incident & fix
+
+**Date:** 2026-07-31
+**Status:** PR-ready (branch `fix/senpi-cap-giant-tool-results`)
+**Target repo:** `code-yeongyu/oh-my-openagent` (omo-senpi adapter)
+
+---
+
+## 1. Incident summary
+
+In 그림수세미 project sessions run with **GPT (gpt-5.6-sol via openai-codex) as the main model**,
+work repeatedly stalled: the harness looked like it was "compacting forever" while no progress was
+made. The user reported it as "GPT에서 계속 컴팩션하다 작업을 진행 못함". Two sessions show the
+full picture.
+
+| Session | Model | Context peak | Compaction events | Empty/failed assistant responses |
+|---|---|---|---|---|
+| `019faf4f` (576 MB, 23.5 h) | gpt-5.6-sol only | 255 K tokens | 3 | 20 (clustered after giant tool results) |
+| `019fb282` (11 MB, 6.5 h) | gpt-5.6-sol → deepseek-v4-pro | **654 K tokens** | 0 | 0 (stalled differently: admission deadlock) |
+
+Both sessions end with the user asking "왜 중지 되었니" / "왜 작업이 안대" / "멈추지 말고 끝까지".
+
+## 2. Root cause chain
+
+1. **`apply_patch` results carry full file contents.** One delete of a `.omo/evidence` file produced a
+   **476 MB single tool result** (session line 4069); ~30 more results were 200–740 KB. `read` with an
+   image and `eval`/`lsp_symbols` added more 200–450 KB entries.
+2. **Live tool results are not size-capped.** The core truncation (`tool-truncation.js`, 4 KB
+   threshold) runs only during compaction; results enter the conversation context uncapped. The
+   476 MB line has no truncation marker.
+3. **The provider request fails.** Serializing the giant context throws a JS **"Invalid string
+   length"** error. GPT (Codex) also added `servers overloaded`, 403 usage-limit, WebSocket, and
+   stream-timeout errors.
+4. **Compaction fails with the same error.** `session.log` shows the loop:
+   ```
+   09:31:50  provider_error           "Invalid string length"
+   09:38:04  compaction_decision      "Compaction failed: Invalid string length"  willRetry:false
+   09:38:05  provider_error           "Invalid string length"
+   09:38:30  compaction_decision      "Compaction failed: Invalid string length"
+   09:44:03  compaction_decision      "Compaction failed: Invalid string length"
+   09:44:04  provider_error           "Invalid string length"
+   ```
+   Provider attempt → compaction attempt → both fail → repeat. The user sees "compacting forever,
+   no progress". The goal state records `provider error ended the turn (retries exhausted)`.
+5. **Admission gate deadlocks once the threshold is exceeded.** In `019fb282` at 15:32:43 (the
+   second the user switched models):
+   ```
+   compaction_decision  reason:"threshold"  accepted:false  aborted:true
+   provider_error       "Context remains above the compaction threshold because compaction did not complete"
+   prompt_rejected      stage:"admission"  "RequiredCompactionError"
+   ```
+   Every request is rejected until compaction completes; compaction cannot complete with a 654 K-token
+   context that includes the uncapped results. Work is fully blocked.
+6. **Model switch is the escape hatch.** After switching to deepseek-v4-pro at 15:32:43, the same
+   context completed the work by 16:45 (server started). The failure is provider-request serialization
+   hitting the giant strings — any model with a smaller request path also fails, but the deepseek
+   provider accepted the payload.
+
+## 3. This PR (defense layer: cap giant tool results at the source)
+
+Adds a `result-size-cap` component to `packages/omo-senpi` that wraps every registered tool's
+`execute` (plugins load before builtin tools, so this reaches `apply_patch`/`read`/`bash`/… results)
+and truncates any single text block above **1 MB** to head + marker + tail, mirroring the core
+compaction truncation convention. The 476 MB / 23 MB disaster strings can no longer enter the context.
+
+- Threshold/head/tail are configurable via `createResultSizeCapComponent({ thresholdBytes, headChars,
+  tailChars })`; defaults 1 MB / 800 / 400.
+- Image blocks pass through untouched; unchanged results are returned by identity.
+- Disable flag: `--omo-senpi-result-size-cap-disabled` (compose registers it like every component).
+
+**Files**
+
+| File | Purpose |
+|---|---|
+| `packages/omo-senpi/src/components/result-size-cap/cap.ts` | pure capping functions |
+| `packages/omo-senpi/src/components/result-size-cap/component.ts` | execute wrapper |
+| `packages/omo-senpi/src/components/result-size-cap/*.test.ts` | 11 unit tests |
+| `packages/omo-senpi/src/extension/index.ts` | component registration (2 lines) |
+| `docs/reference/senpi-giant-tool-result-compaction-failure.md` | this report |
+| `plugin/extensions/omo.js` | **generated bundle — must be regenerated before merge** |
+
+**Verification:** 11 new tests pass; package typecheck passes. Full package suite retains the same
+pre-existing 15 dirty-worktree failures (unrelated, stash-compared). `bun run build` / `test:codex`
+not run locally (dirty generated bundles; CI should run them).
+
+## 4. Recommended senpi-core fixes (separate issues)
+
+The extension cap prevents the trigger for omo-senpi installs. The core (`@code-yeongyu/senpi`)
+should additionally:
+
+1. **Make compaction survive oversized single strings.** `Compaction failed: Invalid string length`
+   with `willRetry:false` leaves the session in an infinite provider↔compaction retry loop. Truncate
+   or stream the payload instead of failing, or surface a clear user-facing error + new-session
+   guidance when compaction cannot complete.
+2. **Never deadlock behind the admission gate.** `RequiredCompactionError` blocks every request until
+   compaction completes, and compaction can be unable to complete. Block with a bounded, visible
+   outcome (fail the turn with an actionable error) instead of an unbounded silent block.
+3. **Apply result truncation to live tool results**, not only during compaction
+   (`tool-truncation.js` currently runs in the reduction path only). This is the root prevention for
+   all providers, not just omo-senpi users.
+
+## 5. User guidance (until the core fix lands)
+
+- Do not use GPT as the main model for large autonomous sessions in this project (evidence: the same
+  work completed after switching to deepseek).
+- Do not run `apply_patch` on huge files (evidence bundles, `package-lock.json`); delete via `rm`/git
+  and keep diffs narrow.
+- Start a new session once the context approaches ~200 K tokens instead of continuing to grow it.
+
+## 6. Issue / PR handoff summary
+
+- **Issue title:** `[compaction] Giant tool results cause "Invalid string length" provider/compaction failure loop and admission deadlock`
+- **Issue body:** sections 1–2 (incident + root cause + session.log evidence) + section 4 (core fixes).
+- **PR title:** `fix(senpi): cap giant tool results so oversized strings cannot enter context`
+- **PR body:** section 3 (changes + verification) + section 4 (core follow-up). Note the
+  `plugin/extensions/omo.js` bundle regeneration requirement.

--- a/packages/omo-senpi/src/components/result-size-cap/cap.test.ts
+++ b/packages/omo-senpi/src/components/result-size-cap/cap.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test"
+
+import { capResultContent, capTextBlock, type CappedTextBlock } from "./cap"
+
+const big = "x".repeat(2000)
+
+describe("capTextBlock", () => {
+  it("returns the block unchanged when under the threshold", () => {
+    const block: CappedTextBlock = { type: "text", text: "hello" }
+    expect(capTextBlock(block, { thresholdBytes: 100 })).toBe(block)
+  })
+
+  it("keeps the head and tail and inserts a marker when over the threshold", () => {
+    const capped = capTextBlock({ type: "text", text: big }, { thresholdBytes: 100, headChars: 8, tailChars: 4 })
+    expect(capped.text).toContain("<truncated:2000 bytes original")
+    expect(capped.text.startsWith("xxxxxxxx")).toBe(true)
+    expect(capped.text.endsWith("xxxx")).toBe(true)
+    expect(capped.text.length).toBeLessThan(200)
+  })
+
+  it("does not re-cap an already-capped block", () => {
+    const once = capTextBlock({ type: "text", text: big }, { thresholdBytes: 100, headChars: 8, tailChars: 4 })
+    const twice = capTextBlock(once, { thresholdBytes: 100, headChars: 8, tailChars: 4 })
+    expect(twice).toBe(once)
+  })
+
+  it("caps by utf8 bytes, not characters", () => {
+    const korean = "가".repeat(2000)
+    const capped = capTextBlock({ type: "text", text: korean }, { thresholdBytes: 100, headChars: 4, tailChars: 2 })
+    expect(capped.text).toContain("<truncated:")
+  })
+})
+
+describe("capResultContent", () => {
+  it("caps oversized text blocks and leaves image blocks untouched", () => {
+    const imageBlock = { type: "image", data: "base64" }
+    const smallBlock = { type: "text", text: "small" }
+    const result = { content: [{ type: "text", text: big }, imageBlock, smallBlock] }
+    const capped = capResultContent(result, { thresholdBytes: 100, headChars: 8, tailChars: 4 })
+    expect((capped.content[0] as CappedTextBlock).text).toContain("<truncated:")
+    expect(capped.content[1]).toBe(imageBlock)
+    expect(capped.content[2]).toBe(smallBlock)
+  })
+
+  it("returns the same object when nothing exceeds the threshold", () => {
+    const result = { content: [{ type: "text", text: "small" }] }
+    expect(capResultContent(result, { thresholdBytes: 100 })).toBe(result)
+  })
+
+  it("handles an empty content array", () => {
+    const result = { content: [] }
+    expect(capResultContent(result)).toBe(result)
+  })
+})

--- a/packages/omo-senpi/src/components/result-size-cap/cap.ts
+++ b/packages/omo-senpi/src/components/result-size-cap/cap.ts
@@ -1,0 +1,67 @@
+export const RESULT_CAP_THRESHOLD_BYTES = 1_000_000
+export const RESULT_CAP_HEAD_CHARS = 800
+export const RESULT_CAP_TAIL_CHARS = 400
+
+const CAP_MARKER_RE = /<truncated:\d+ bytes original[^>]*>/
+
+export interface CapTextBlockOptions {
+  readonly thresholdBytes?: number
+  readonly headChars?: number
+  readonly tailChars?: number
+}
+
+export interface CappedTextBlock {
+  type: string
+  text: string
+}
+
+interface ContentBlockLike {
+  type: string
+  text?: unknown
+  data?: unknown
+}
+
+export interface CappedResultLike {
+  readonly content: readonly ContentBlockLike[]
+}
+
+function utf8Bytes(text: string): number {
+  return new TextEncoder().encode(text).length
+}
+
+function buildMarker(originalBytes: number): string {
+  return `<truncated:${originalBytes} bytes original; middle elided to save context - re-run this tool with a narrower range (read offset/limit or a filtered command) to retrieve the elided content>`
+}
+
+/**
+ * Cap an oversized single text result so no tool output above the threshold
+ * can enter the conversation context. Mirrors the core compaction truncation
+ * convention (head + marker + tail) so the model gets consistent guidance.
+ */
+export function capTextBlock(block: CappedTextBlock, options: CapTextBlockOptions = {}): CappedTextBlock {
+  const thresholdBytes = options.thresholdBytes ?? RESULT_CAP_THRESHOLD_BYTES
+  const headChars = options.headChars ?? RESULT_CAP_HEAD_CHARS
+  const tailChars = options.tailChars ?? RESULT_CAP_TAIL_CHARS
+  const bytes = utf8Bytes(block.text)
+  if (bytes <= thresholdBytes) return block
+  if (CAP_MARKER_RE.test(block.text)) return block
+  const head = block.text.slice(0, headChars)
+  const tail = block.text.slice(block.text.length - tailChars)
+  return { ...block, text: `${head}\n${buildMarker(bytes)}\n${tail}` }
+}
+
+/**
+ * Cap oversized text blocks of a tool result. Image blocks pass through
+ * untouched. Returns the same object when nothing exceeded the threshold.
+ */
+export function capResultContent<T extends CappedResultLike>(result: T, options: CapTextBlockOptions = {}): T {
+  let changed = false
+  const content = result.content.map((block) => {
+    if (block.type !== "text" || typeof block.text !== "string") return block
+    const capped = capTextBlock(block as CappedTextBlock, options)
+    if (capped !== block) changed = true
+    return capped
+  })
+  if (!changed) return result
+  return { ...result, content } as unknown as T
+}

--- a/packages/omo-senpi/src/components/result-size-cap/component.test.ts
+++ b/packages/omo-senpi/src/components/result-size-cap/component.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test"
+
+import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
+import { createResultSizeCapComponent } from "./component"
+
+interface FakeTool extends Record<string, unknown> {
+  name: string
+  execute: (...args: unknown[]) => Promise<unknown>
+}
+
+function fakeTool(name: string, execute: FakeTool["execute"]): FakeTool {
+  return { name, label: name, parameters: {}, execute }
+}
+
+describe("result-size-cap component", () => {
+  it("#given a tool registered after the cap #when its result is oversized #then the result is truncated with a marker", async () => {
+    const pi = new FakeExtensionAPI()
+    const tool = fakeTool("apply_patch", async () => ({ content: [{ type: "text", text: "x".repeat(5000) }] }))
+
+    const component = createResultSizeCapComponent({ thresholdBytes: 100, headChars: 8, tailChars: 4 })
+    await component.register(pi, { logger: console, config: { getFlag: () => false } })
+    pi.registerTool(tool)
+
+    const result = (await tool.execute("call-1", {}, undefined, undefined, {})) as { content: Array<{ text: string }> }
+    expect(result.content[0].text).toContain("<truncated:")
+    expect(result.content[0].text.length).toBeLessThan(200)
+  })
+
+  it("#given a tool registered after the cap #when its result is small #then it passes through unchanged", async () => {
+    const pi = new FakeExtensionAPI()
+    const tool = fakeTool("bash", async () => ({ content: [{ type: "text", text: "ok" }] }))
+
+    const component = createResultSizeCapComponent({ thresholdBytes: 100 })
+    await component.register(pi, { logger: console, config: { getFlag: () => false } })
+    pi.registerTool(tool)
+
+    const result = (await tool.execute("call-1", {}, undefined, undefined, {})) as { content: Array<{ text: string }> }
+    expect(result.content[0].text).toBe("ok")
+  })
+
+  it("#given a tool whose execute throws #then the error still propagates", async () => {
+    const pi = new FakeExtensionAPI()
+    const tool = fakeTool("bash", async () => {
+      throw new Error("boom")
+    })
+
+    const component = createResultSizeCapComponent({ thresholdBytes: 100 })
+    await component.register(pi, { logger: console, config: { getFlag: () => false } })
+    pi.registerTool(tool)
+
+    await expect(tool.execute("call-1", {}, undefined, undefined, {})).rejects.toThrow("boom")
+  })
+
+  it("#given a guarded tool registration #then the tool still reaches the underlying registry", () => {
+    const pi = new FakeExtensionAPI()
+    const tool = fakeTool("bash", async () => ({ content: [] }))
+
+    const component = createResultSizeCapComponent()
+    void component.register(pi, { logger: console, config: { getFlag: () => false } })
+    pi.registerTool(tool)
+
+    expect(pi.tools).toHaveLength(1)
+    expect(pi.tools[0]).toBe(tool)
+  })
+})

--- a/packages/omo-senpi/src/components/result-size-cap/component.ts
+++ b/packages/omo-senpi/src/components/result-size-cap/component.ts
@@ -1,0 +1,39 @@
+import type { ToolDefinition } from "@code-yeongyu/senpi"
+
+import type { OmoSenpiComponent } from "../../extension/types"
+import { capResultContent, type CapTextBlockOptions } from "./cap"
+
+function capExecute(execute: ToolDefinition["execute"], options: CapTextBlockOptions): ToolDefinition["execute"] {
+  return async function cappedExecute(this: unknown, toolCallId, params, signal, onUpdate, execCtx) {
+    const result = await execute.call(this, toolCallId, params, signal, onUpdate, execCtx)
+    return capResultContent(result, options)
+  }
+}
+
+export interface ResultSizeCapOptions extends CapTextBlockOptions {}
+
+/**
+ * Cap oversized tool results at the registration boundary so no single result
+ * above the threshold can enter the conversation context. Plugins load before
+ * builtin tools, so this wrapper reaches apply_patch/read/bash results and
+ * prevents the giant-string contexts that break provider serialization and
+ * compaction (observed: a 476MB apply_patch result -> "Invalid string length"
+ * -> compaction failure loop, 2026-07-30).
+ */
+export function createResultSizeCapComponent(options: ResultSizeCapOptions = {}): OmoSenpiComponent {
+  return {
+    name: "result-size-cap",
+    register(pi) {
+      const wrapped = new Set<unknown>()
+      const originalRegisterTool = pi.registerTool.bind(pi)
+      pi.registerTool = (tool: Record<string, unknown>): void => {
+        const execute = Reflect.get(tool, "execute")
+        if (typeof execute === "function" && !wrapped.has(tool)) {
+          wrapped.add(tool)
+          Reflect.set(tool, "execute", capExecute(execute as ToolDefinition["execute"], options))
+        }
+        originalRegisterTool(tool)
+      }
+    },
+  }
+}

--- a/packages/omo-senpi/src/components/result-size-cap/index.ts
+++ b/packages/omo-senpi/src/components/result-size-cap/index.ts
@@ -1,0 +1,10 @@
+export {
+  capResultContent,
+  capTextBlock,
+  RESULT_CAP_HEAD_CHARS,
+  RESULT_CAP_TAIL_CHARS,
+  RESULT_CAP_THRESHOLD_BYTES,
+} from "./cap"
+export type { CappedResultLike, CappedTextBlock, CapTextBlockOptions } from "./cap"
+export { createResultSizeCapComponent } from "./component"
+export type { ResultSizeCapOptions } from "./component"

--- a/packages/omo-senpi/src/extension/index.ts
+++ b/packages/omo-senpi/src/extension/index.ts
@@ -11,6 +11,7 @@ import { createStartWorkContinuationComponent } from "../components/start-work-c
 import { createUltraworkComponent } from "../components/ultrawork"
 import { createUlwLoopComponent } from "../components/ulw-loop"
 import { createFallbackArchitectComponent } from "../components/fallback-architect"
+import { createResultSizeCapComponent } from "../components/result-size-cap"
 
 const components: OmoSenpiComponent[] = [
   createConfigStartupComponent(),
@@ -18,6 +19,7 @@ const components: OmoSenpiComponent[] = [
   createStartWorkContinuationComponent(),
   createUlwLoopComponent(),
   createFallbackArchitectComponent(),
+  createResultSizeCapComponent(),
   createCommentCheckerComponent(),
   createSenpiTelemetryComponent(),
   createLspComponent(),


### PR DESCRIPTION
## Summary

A single tool result can carry the full content of a file. In one 그림수세미 session an
`apply_patch` delete produced a **476 MB single result**; ~30 more were 200–740 KB. With GPT
(gpt-5.6-sol via openai-codex) as the main model these sessions repeatedly stalled:

- Provider request serialization throws a JS **"Invalid string length"** on the giant context.
- **Compaction fails with the same error** (`Compaction failed: Invalid string length`,
  `willRetry:false`), so the harness alternates failing provider attempts with failing compaction
  attempts — the user sees "compacting forever, no progress" (session.log evidence below).
- Once the context exceeds the compaction threshold, the **admission gate rejects every request**
  with `RequiredCompactionError` until compaction completes — which it cannot — so work is fully
  blocked (`019fb282`, 654 K tokens, 0 compaction events).
- Switching to deepseek-v4-pro unblocked the same context and the work completed.

This PR adds an omo-senpi **`result-size-cap`** component that wraps every registered tool's
`execute` (plugins load before builtin tools, so apply_patch/read/bash results are covered) and
truncates any single text block above **1 MB** to head + marker + tail, mirroring the core
compaction truncation convention. The disaster-class strings can no longer enter the context.

## Evidence (session.log)

```
09:31:50  provider_error           "Invalid string length"
09:38:04  compaction_decision      "Compaction failed: Invalid string length"  willRetry:false
09:38:05  provider_error           "Invalid string length"
09:38:30  compaction_decision      "Compaction failed: Invalid string length"
09:44:03  compaction_decision      "Compaction failed: Invalid string length"
09:44:04  provider_error           "Invalid string length"
15:32:43  compaction_decision      reason:"threshold"  accepted:false  aborted:true
15:32:43  provider_error           "Context remains above the compaction threshold because compaction did not complete"
15:32:43  prompt_rejected          stage:"admission"  "RequiredCompactionError"
```

## What changed

| File | Purpose |
|---|---|
| `packages/omo-senpi/src/components/result-size-cap/cap.ts` | pure capping functions (utf8-byte threshold, head/marker/tail, identity-preserving) |
| `packages/omo-senpi/src/components/result-size-cap/component.ts` | execute wrapper (configurable threshold/head/tail) |
| `packages/omo-senpi/src/components/result-size-cap/*.test.ts` | 11 unit tests |
| `packages/omo-senpi/src/extension/index.ts` | component registration (2 lines) |
| `docs/reference/senpi-giant-tool-result-compaction-failure.md` | incident report + root cause + core follow-up issues |

## Verification

- 11 new unit tests pass; package typecheck passes (`tsgo --noEmit`).
- Full `packages/omo-senpi` suite: 495 pass / 15 fail — the 15 are pre-existing dirty-worktree
  artifact drift, confirmed identical with this change's wiring stashed.

## Residual risk / notes

- `plugin/extensions/omo.js` is a **generated bundle** and is not committed here — regenerate
  before merge. A live-session smoke of the wrapped core tools is recommended.
- `bun run build` / `bun run test:codex` were not run locally (dirty generated bundles in this
  worktree; CI should run them).
- The cap prevents the trigger for omo-senpi installs. The core (`@code-yeongyu/senpi`) should
  additionally: (1) survive oversized strings during compaction instead of failing with
  `willRetry:false`, (2) never deadlock behind the `RequiredCompactionError` admission gate,
  (3) truncate live tool results, not only during compaction. See the report, section 4.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps oversized tool results at 1 MB by truncating to head + marker + tail so giant strings never enter context. Stops "Invalid string length" provider errors and compaction deadlocks seen with `apply_patch` and other tools.

- **New Features**
  - Added `result-size-cap` component in `packages/omo-senpi` that wraps all tool `execute` calls (covers `apply_patch`, `read`, `bash`, etc.).
  - Configurable via `createResultSizeCapComponent({ thresholdBytes, headChars, tailChars })` with defaults 1 MB / 800 / 400; image blocks pass through; already-capped text is skipped.
  - Mirrors core truncation format to keep guidance consistent; includes 11 unit tests and a reference incident doc.

- **Migration**
  - Regenerate the generated bundle `plugin/extensions/omo.js` before merge; no other changes needed.

<sup>Written for commit c1d031e837e039d2effe4372e1d7bcf26ba31ae5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

