### PR TITLE
test(omo-senpi): make footer TUI capture deterministic

### DIFF
--- a/packages/omo-senpi/scripts/qa/ulw-goal-footer-tui.mjs
+++ b/packages/omo-senpi/scripts/qa/ulw-goal-footer-tui.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process"
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { basename, delimiter, dirname, join, resolve } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
@@ -9,8 +9,11 @@ import { createSandbox, seedSandbox } from "./drive.mjs"
 import { changedRealPaths, classifyRealSenpiChanges, snapshotDir } from "./task-e2e-analysis.mjs"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, "..", "..")
+const packagedPluginRoot = join(packageRoot, "plugin")
 const mockProviderEntry = join(scriptDir, "mock-provider", "index.ts")
 const realSenpiAgentDir = join(homedir(), ".senpi", "agent")
+const excludedSnapshotRoots = new Set(["omo-local-update", "omo-runtime-worktree"])
 const defaultReceiptDir = resolve(".omo/evidence/20260730-ulw-goal-footer/tui")
 const activeUlwStatus = JSON.stringify({
   ok: true,
@@ -43,14 +46,44 @@ function findOnPath(bin) {
   return null
 }
 
+function snapshotWriteSurface(root) {
+  return snapshotDir(root, {
+    readdir(dir, options) {
+      const entries = readdirSync(dir, options)
+      if (dir !== root) return entries
+      return entries.filter((entry) => !excludedSnapshotRoots.has(entry.name))
+    },
+  })
+}
+
 function prepareScenario() {
   const sandbox = createSandbox()
   seedSandbox(sandbox)
   const sessionDir = join(sandbox.root, "sessions")
   const fakeBinDir = join(sandbox.root, "bin")
+  const pluginRoot = join(sandbox.root, "plugin")
   const ulwActiveMarker = join(sandbox.root, "ulw-active")
   mkdirSync(sessionDir, { recursive: true })
   mkdirSync(fakeBinDir, { recursive: true })
+  mkdirSync(join(pluginRoot, "extensions"), { recursive: true })
+  copyFileSync(join(packagedPluginRoot, "extensions", "omo.js"), join(pluginRoot, "extensions", "omo.js"))
+  writeFileSync(
+    join(pluginRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "@code-yeongyu/omo-senpi-qa-minimal",
+        private: true,
+        type: "module",
+        pi: { extensions: ["./extensions/omo.js"] },
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  writeFileSync(
+    join(sandbox.agentDir, "settings.json"),
+    `${JSON.stringify({ defaultProjectTrust: "ask", packages: [pluginRoot] }, null, 2)}\n`,
+  )
   const omoBin = join(fakeBinDir, "omo")
   writeFileSync(
     omoBin,
@@ -79,7 +112,7 @@ function prepareScenario() {
       2,
     )}\n`,
   )
-  return { sandbox, sessionDir, omoBin }
+  return { sandbox, sessionDir, omoBin, pluginRoot }
 }
 
 function composeCommand(senpiBin, sessionDir) {
@@ -146,7 +179,7 @@ function runChild(command, args, options) {
 }
 
 async function runScenario() {
-  const beforeSnapshot = snapshotDir(realSenpiAgentDir)
+  const beforeSnapshot = snapshotWriteSurface(realSenpiAgentDir)
   const senpiBin = findOnPath(process.env.SENPI_BIN?.trim() || "senpi")
   const prepared = prepareScenario()
   const realLogPath = join(realSenpiAgentDir, "logs", "session.log")
@@ -165,7 +198,7 @@ async function runScenario() {
     cleaned = true
     child?.kill("SIGTERM")
     rmSync(prepared.sandbox.root, { recursive: true, force: true })
-    const changedReal = changedRealPaths(beforeSnapshot, snapshotDir(realSenpiAgentDir))
+    const changedReal = changedRealPaths(beforeSnapshot, snapshotWriteSurface(realSenpiAgentDir))
     const afterRealLog = existsSync(realLogPath) ? readFileSync(realLogPath, "utf8") : ""
     const qaLogWrite = afterRealLog.slice(beforeRealLog.length).includes(basename(prepared.sandbox.root))
     const concurrentLogPaths = changedReal.includes("logs/session.log") && !qaLogWrite ? ["logs/session.log"] : []
@@ -221,6 +254,23 @@ function runSelfTest() {
     throw new Error("self-test: environment isolation failed")
   }
   if (env.OMO_BIN !== prepared.omoBin || !existsSync(prepared.omoBin)) throw new Error("self-test: fake omo missing")
+  if (prepared.pluginRoot === undefined || !existsSync(join(prepared.pluginRoot, "extensions", "omo.js"))) {
+    throw new Error("self-test: minimal plugin missing")
+  }
+  const settings = JSON.parse(readFileSync(join(prepared.sandbox.agentDir, "settings.json"), "utf8"))
+  if (settings.packages?.[0] !== prepared.pluginRoot) throw new Error("self-test: minimal plugin not configured")
+  const manifest = JSON.parse(readFileSync(join(prepared.pluginRoot, "package.json"), "utf8"))
+  if (manifest.pi?.skills !== undefined) throw new Error("self-test: minimal plugin must not scan skills")
+  const excludedDir = join(prepared.sandbox.agentDir, "omo-runtime-worktree")
+  mkdirSync(excludedDir, { recursive: true })
+  writeFileSync(join(excludedDir, "ignored.txt"), "before\n")
+  const beforeSnapshot = snapshotWriteSurface(prepared.sandbox.agentDir)
+  writeFileSync(join(excludedDir, "ignored.txt"), "after\n")
+  writeFileSync(join(prepared.sandbox.agentDir, "settings.json"), "{}\n")
+  const snapshotChanges = changedRealPaths(beforeSnapshot, snapshotWriteSurface(prepared.sandbox.agentDir))
+  if (!snapshotChanges.includes("settings.json") || snapshotChanges.some((path) => path.startsWith("omo-runtime-worktree/"))) {
+    throw new Error("self-test: write-surface snapshot filter failed")
+  }
   rmSync(prepared.sandbox.root, { recursive: true, force: true })
   if (existsSync(prepared.sandbox.root)) throw new Error("self-test: sandbox cleanup failed")
   console.log("SELF-TEST OK")


### PR DESCRIPTION
## Summary

- stage a minimal extension-only Omo-Senpi package in the footer TUI sandbox
- bound the real-agent write snapshot to write-sensitive surfaces
- keep exact seven-second xterm.js RED/GREEN captures deterministic
- strengthen the driver self-test for package isolation and snapshot filtering

## Why

The footer behavior and project-goal compatibility are already merged in PRs #6521 and #6529.

The literal `--dwell-ms 7000` QA command could still capture an empty screen because the driver recursively hashed two large read-only runtime trees before launching Senpi. The settled 30-second capture passed, but the binding objective requires the exact seven-second command.

## Exact seven-second evidence

### RED

- Current runtime `c610832a1`
- Controlled disposable-worktree mutation: `ulwActive = false`
- `Pursuing goal (2s)` visible
- `ultraworking` absent
- xterm.js browser capture and PTY cleanup recorded
- sandbox removed
- zero QA-attributed writes to the real Senpi directory

### GREEN

- Current behavior
- `Pursuing goal (2s) ⚡ ultraworking..` visible
- xterm.js browser capture and PTY cleanup recorded
- sandbox removed
- zero QA-attributed writes to the real Senpi directory

## Verification

- `node packages/omo-senpi/scripts/qa/ulw-goal-footer-tui.mjs --self-test`
- `mise exec bun@1.3.12 -- bun test packages/omo-senpi/scripts/qa/task-e2e-analysis.test.mjs`
- `mise exec bun@1.3.12 -- bun run test:senpi`
- `git diff --check`

All passed.

## Isolation contract

- The minimal package contains the real generated `omo.js`.
- The minimal manifest omits skill scanning.
- Isolated Senpi settings point only at the sandbox package.
- The bounded snapshot still detects writes such as `settings.json`.
- Only `omo-local-update` and `omo-runtime-worktree` are excluded from content hashing; these are large read-only runtime trees for this scenario.

Evidence: `.omo/evidence/20260731-senpi-ulw-goal-footer/`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the footer TUI QA deterministic for the exact 7s capture in `omo-senpi`. Prevents empty-screen grabs by snapshotting only write surfaces and avoiding hashes of large read‑only trees.

- **Bug Fixes**
  - Bound agent snapshot to write surfaces; excluded `omo-local-update` and `omo-runtime-worktree`.
  - Added a minimal extension-only plugin with the real generated `omo.js`; sandbox settings point only to it (no skill scanning).
  - Ensured consistent RED/GREEN states within 7s (`--dwell-ms 7000`) with reliable `xterm.js` capture and PTY cleanup.
  - Strengthened self-test to verify isolation and snapshot filtering; detects real writes like `settings.json` and ensures zero QA writes to the real Senpi dir.

<sup>Written for commit da2a3b91f81c1133ddec44e5f61700cbb59d534d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

