### PR TITLE
fix(momus): honor caller machine-readable output contracts

### DIFF
--- a/packages/omo-opencode/src/agents/momus-gpt-5-6.ts
+++ b/packages/omo-opencode/src/agents/momus-gpt-5-6.ts
@@ -50,6 +50,8 @@ Read the plan, then verify references by reading the cited files; parallelize in
 
 # Output
 
+When the caller requires a machine-readable response format, that contract replaces the default format below; all review rules still apply.
+
 **[OKAY]** or **[REJECT]**
 
 **Summary**: 1-2 sentences of prose explaining the verdict.

--- a/packages/omo-opencode/src/agents/momus.test.ts
+++ b/packages/omo-opencode/src/agents/momus.test.ts
@@ -2,6 +2,25 @@ import { describe, expect, test } from "bun:test";
 import { createMomusAgent } from "./momus";
 
 describe("createMomusAgent", () => {
+  test("#given a caller requires machine-readable output #when creating any Momus variant #then the caller format takes precedence", () => {
+    // given
+    const models = [
+      "openai/gpt-5.6-sol",
+      "openai/gpt-5.5",
+      "anthropic/claude-sonnet-4-6",
+    ];
+
+    // when
+    const prompts = models.map((model) => createMomusAgent(model).prompt);
+
+    // then
+    for (const prompt of prompts) {
+      expect(prompt).toContain(
+        "When the caller requires a machine-readable response format, that contract replaces the default format below; all review rules still apply.",
+      );
+    }
+  });
+
   describe("#given a GPT-5.6 family model", () => {
     test("#when creating the agent #then it runs high reasoning with a GPT-5.6 tuned prompt", () => {
       // given

--- a/packages/omo-opencode/src/agents/momus.ts
+++ b/packages/omo-opencode/src/agents/momus.ts
@@ -176,6 +176,8 @@ Issue **REJECT** ONLY when:
 
 ## Output Format
 
+When the caller requires a machine-readable response format, that contract replaces the default format below; all review rules still apply.
+
 **[OKAY]** or **[REJECT]**
 
 **Summary**: 1-2 sentences explaining the verdict.
@@ -264,6 +266,8 @@ These ARE blockers: "references \`auth/login.ts\` but file doesn't exist", "says
 Favor conciseness. Use prose, not bullets, for the summary. Do not default to bullet lists when a sentence suffices.
 
 NEVER open with filler: "Great question!", "That's a great idea!", "You're right to call that out", "Done -", "Got it".
+
+When the caller requires a machine-readable response format, that contract replaces the default format below; all review rules still apply.
 
 Format:
 **[OKAY]** or **[REJECT]**


### PR DESCRIPTION
## Summary

- Prevent Momus's built-in prose format from overriding an explicit caller-provided machine-readable response contract.
- Keep the existing `[OKAY]` / `[REJECT]` format unchanged when the caller does not request another format.

## Changes

- Add one caller-contract precedence rule to all three Momus prompt variants: default, GPT, and GPT-5.6.
- Add a regression test covering GPT-5.6, other GPT, and Claude/default model routing.
- Leave downstream structured-response parsing unchanged; malformed or prose responses still fail closed.

## QA & Evidence

- **What was tested:** `bun test packages/omo-opencode/src/agents/momus.test.ts`
  **Observed result:** 6 pass, 0 fail, 19 expectations on the rebased HEAD.
  **Artifact:** `packages/omo-opencode/src/agents/momus.test.ts`
  **Why sufficient:** Covers all three prompt-selection branches and asserts the caller-precedence contract is present.

- **What was tested:** clean archive from the rebased HEAD, `bun install --frozen-lockfile --ignore-scripts`, then `bun run typecheck`
  **Observed result:** Root typecheck passed with the current lockfile (`typescript@7.0.2`).
  **Artifact:** task-local sanitized receipt `.omo/evidence/20260731-run0007-momus-contract-revalidation/qa-report.md`
  **Why sufficient:** Avoids the task worktree's stale shared dependency links and checks the current upstream baseline.

- **What was tested:** focused OpenCode bundle from the clean archive
  **Observed result:** Bundle completed, contains the caller-precedence rule, and produced SHA-256 `5635e82e7f710cff87b3269d03411f4a9b003b7bd07fcdb4be19f48d70fb8455`.
  **Artifact:** task-local sanitized receipt `.omo/evidence/20260731-run0007-momus-contract-revalidation/qa-report.md`
  **Why sufficient:** Proves the changed producer prompt reaches the bundled OpenCode entrypoint.

- **What was tested:** isolated real OpenCode Momus child using the same one-commit prompt change before rebase
  **Observed result:** The child returned exactly `{"verdict":"approve","summary":"The plan is executable, and its QA command has concrete steps with an expected exit code of 0."}`; the host OpenCode session database count was unchanged.
  **Artifact:** task-local sanitized receipt `.omo/evidence/20260725-momus-structured-verdict/qa-report.md`
  **Why sufficient:** Demonstrates the producer obeys an explicit JSON contract without downstream prose reconstruction.

- **What was tested:** independent read-only code review
  **Observed result:** 0 findings; APPROVE / PR-ready.
  **Artifact:** review of `origin/dev...70e6da6fa7d5808d7f28e5ebcabefe7be8c8eac3`
  **Why sufficient:** Separately checked correctness, prompt coverage, default-format preservation, and root-cause placement.

## Risks & Residuals

- The real-model receipt predates the rebase, although the one-commit prompt diff is unchanged. Current-HEAD static tests, typecheck, and bundle checks pass; accepted pending CI.
- A full root `bun test` sample in the reused task worktree completed with 11,919 passes, 8 skips, 146 failures, and 104 errors because stale shared dependencies and unrelated generated runtime/frontend/submodule artifacts were absent. The clean current-lockfile archive passes root typecheck and the touched suite; CI remains authoritative for the fully materialized repository.
- Full root `bun run build` was not revalidated because `build:materialize-frontend` stalled on an unrelated `designpowers` submodule clone. The focused OpenCode bundle passed; accepted pending CI.
- No install, live worker mutation, merge, or production adoption is part of this PR preparation.

## Automated Checks

```bash
git diff --check origin/dev...HEAD
bun test packages/omo-opencode/src/agents/momus.test.ts
bun run typecheck  # clean current-lockfile archive
bun build packages/omo-opencode/src/index.ts --outdir <temporary-dir> --target bun --format esm --external zod
```

## Related Issues

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Momus now honors a caller-provided machine-readable response format instead of forcing its default prose. The `[OKAY]`/`[REJECT]` format remains the default when no contract is requested.

- **Bug Fixes**
  - Applied caller-contract precedence to all Momus prompt variants (default, GPT, GPT-5.6).
  - Added a regression test covering `openai/gpt-5.6-sol`, `openai/gpt-5.5`, and `anthropic/claude-sonnet-4-6`.
  - Left downstream structured-response parsing unchanged; malformed or prose responses still fail closed.

<sup>Written for commit 70e6da6fa7d5808d7f28e5ebcabefe7be8c8eac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

