### PR TITLE
docs(issue-template): update stale OpenCode version placeholder (fixes #6489)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -73,7 +73,7 @@ body:
         Paste the output of: bunx oh-my-openagent doctor
         
         Example:
-        ✓ OpenCode version: 1.0.150
+        ✓ OpenCode version: 1.18.10
         ✓ oh-my-openagent version: 1.2.3
         ✓ Plugin loaded successfully
         ...
@@ -126,6 +126,6 @@ body:
     attributes:
       label: OpenCode Version
       description: Run `opencode --version` to get your version
-      placeholder: "1.0.150"
+      placeholder: "1.18.10"
     validations:
       required: true

--- a/.omo/evidence/20260801-6489-bug-report-placeholder/qa-evidence.md
+++ b/.omo/evidence/20260801-6489-bug-report-placeholder/qa-evidence.md
@@ -1,0 +1,41 @@
+# QA Evidence — #6489 bug_report.yml OpenCode version placeholder
+
+**Date:** 2026-08-01
+**Change:** `docs: update stale 1.0.150 OpenCode version placeholder in bug report template`
+**Scope:** `.github/ISSUE_TEMPLATE/bug_report.yml` (docs/template only — not wired into any opencode/codex runtime component; `opencode-qa`/`codex-qa` harness skills not applicable).
+
+## WHAT WAS TESTED
+
+- The two stale `1.0.150` strings in `.github/ISSUE_TEMPLATE/bug_report.yml` were updated to the current OpenCode release.
+  - `doctor` output example line: `✓ OpenCode version: 1.0.150` → `1.18.10`.
+  - `opencode-version` input placeholder: `placeholder: "1.0.150"` → `"1.18.10"`.
+- The current OpenCode release was cross-checked against two independent sources.
+- The YAML template still parses after the edit.
+
+## WHAT WAS OBSERVED
+
+- `git diff` shows exactly two hunks, both pure version-string substitutions (no structural YAML change).
+- `grep -c "1\.0\.150"` on the file → `0` (no stale occurrence remains).
+- Current OpenCode version confirmed as **1.18.10** from two sources:
+  - `opencode --version` (local install) → `1.18.10`.
+  - GitHub `sst/opencode` releases page → latest tag `v1.18.10` (fetched 2026-08-01).
+- YAML validation via `yaml.safe_load` (PyYAML 6.0.2) → parses cleanly; assertions pass:
+  - `name: Bug Report`, `labels: ["bug", "needs-triage"]`.
+  - `opencode-version` input `placeholder == "1.18.10"`.
+  - `doctor` output example contains `1.18.10`.
+
+## WHY IT IS ENOUGH
+
+- The template is consumed by GitHub's issue-template YAML parser; a structural parse check + unchanged indentation covers the only failure mode.
+- The version value is pinned to the current stable OpenCode release at the time of writing, so the doctor example and the input placeholder no longer advertise a version below the plugin's own minimum (`MIN_OPENCODE_VERSION = 1.4.0`, verified in `packages/omo-opencode/src/cli/doctor/framework/constants.ts` and `postinstall.mjs`).
+- The change touches no build, runtime, or test surface; no `bun test` / typecheck run is meaningful here.
+
+## WHAT WAS OMITTED
+
+- No full `bun test` / `bun run typecheck` run: not applicable to a single YAML template string change.
+- No `opencode-qa` / `codex-qa` harness drive: this file never reaches the OpenCode or Codex runtime.
+- No screenshots of GitHub's rendered issue form (requires repo write access to preview; structural validation above covers correctness).
+
+## Residual risk
+
+Low. If OpenCode ships a newer stable before merge, the placeholder may need a one-line bump. It is an example/placeholder only and does not enforce any version.


### PR DESCRIPTION
## What changed

Updated `.github/ISSUE_TEMPLATE/bug_report.yml` so the bug-report template no longer advertises an outdated OpenCode version:

- Doctor-output example: `✓ OpenCode version: 1.0.150` → `1.18.10`
- `opencode-version` input placeholder: `"1.0.150"` → `"1.18.10"`

## Why

Fixes #6489. The previous placeholder `1.0.150` is stale and is even **below** the plugin's own minimum supported OpenCode version (`MIN_OPENCODE_VERSION = 1.4.0`, in `packages/omo-opencode/src/cli/doctor/framework/constants.ts` and `postinstall.mjs`), so it misleads reporters about the expected doctor output and the current OpenCode release.

## What was observed

- Current OpenCode stable is **1.18.10**, confirmed from two sources: `opencode --version` on a local install, and the `sst/opencode` releases page (latest tag `v1.18.10`).
- `git diff` shows exactly two hunks, both pure version-string substitutions.
- Template still parses: `yaml.safe_load` (PyYAML 6.0.2) succeeds; `name`, `labels`, and both updated placeholders verified.
- No stale `1.0.150` occurrence remains.

## QA / evidence

Docs/template-only change — not wired into any OpenCode/Codex runtime component, so the `opencode-qa` / `codex-qa` harness skills are not applicable. Evidence recorded under `.omo/evidence/20260801-6489-bug-report-placeholder/qa-evidence.md` (WHAT / OBSERVED / WHY-ENOUGH / OMITTED).

## Residual risk

Low. Placeholder is example-only and enforces nothing; if OpenCode ships a newer stable before merge, it is a one-line bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `.github/ISSUE_TEMPLATE/bug_report.yml` to replace the outdated OpenCode version `1.0.150` with `1.18.10` in the doctor-example and the OpenCode Version input placeholder, fixing #6489. This aligns the template with the current release and avoids misleading reporters with a version below the plugin’s minimum.

<sup>Written for commit b8b58f24823a6e02788dc5f8d640bc0824e11796. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

