### PR TITLE
docs(release): harden Native CLI transition notes

### DIFF
--- a/.agents/command/get-unpublished-changes.md
+++ b/.agents/command/get-unpublished-changes.md
@@ -22,6 +22,8 @@ Analyze every change against these exact layers:
 | `omo opencode` | Root `oh-my-opencode` / `oh-my-openagent`, `src/`, `.opencode/`, `.agents/`, CLI, config, hooks, tools, docs | What semver bump should the OpenCode/OpenAgent npm packages use? |
 | `omo codex` | `packages/omo-codex`, `lazycodex-ai`, Codex plugin metadata/hooks, bundled MCP runtimes, `code-yeongyu/lazycodex` marketplace payload | Does LazyCodex need the same bump, a Codex-only note, or a marketplace release? |
 
+Exclude commits and paths matching `senpi`, `omo-senpi`, `senpi-task`, `pi-goal`, or `pi-webfetch` from user-facing notes and version recommendations. Record them only in a separate internal-adapter exclusion ledger.
+
 ## Steps:
 1. Detect latest published versions for `oh-my-opencode`, `oh-my-openagent`, and `lazycodex-ai`.
 2. Run `git diff v{published-version}..HEAD` to see actual changes.

--- a/.agents/command/publish.md
+++ b/.agents/command/publish.md
@@ -209,6 +209,12 @@ After running the preview, present the output to the user and say:
 
 </decision-gate>
 
+### LAST RELEASE BEFORE THE OMO NATIVE CLI PUBLIC RELEASE
+
+When the user identifies this as the final release before the OmO Native CLI public release, the GitHub summary MUST begin with this dedicated heading and the Discord announcement MUST repeat it as a dedicated heading immediately after `@here`:
+
+`## LAST RELEASE BEFORE THE OMO NATIVE CLI PUBLIC RELEASE`
+
 ### What You're Writing (and What You're NOT)
 
 You are writing the **headline layer** — a product announcement that sits ABOVE the auto-generated commit log. Think "release blog post", not "git log".
@@ -219,6 +225,7 @@ You are writing the **headline layer** — a product announcement that sits ABOV
 - ALWAYS focus on USER IMPACT: what can users DO now that they couldn't before?
 - ALWAYS group by THEME or CAPABILITY, not by commit type (feat/fix/refactor).
 - ALWAYS use concrete language: "You can now do X" not "Added X feature".
+- NEVER include internal adapter changes matching `senpi`, `omo-senpi`, `senpi-task`, `pi-goal`, or `pi-webfetch` in either release-note variant.
 </rules>
 
 <examples>

--- a/.agents/skills/get-unpublished-changes/SKILL.md
+++ b/.agents/skills/get-unpublished-changes/SKILL.md
@@ -22,6 +22,8 @@ Analyze every change against these exact layers:
 | `omo opencode` | Root `oh-my-opencode` / `oh-my-openagent`, `src/`, `.opencode/`, `.agents/`, CLI, config, hooks, tools, docs | What semver bump should the OpenCode/OpenAgent npm packages use? |
 | `omo codex` | `packages/omo-codex`, `lazycodex-ai`, Codex plugin metadata/hooks, bundled MCP runtimes, `code-yeongyu/lazycodex` marketplace payload | Does LazyCodex need the same bump, a Codex-only note, or a marketplace release? |
 
+Exclude commits and paths matching `senpi`, `omo-senpi`, `senpi-task`, `pi-goal`, or `pi-webfetch` from user-facing notes and version recommendations. Record them only in a separate internal-adapter exclusion ledger.
+
 ## Steps:
 1. Detect latest published versions for `oh-my-opencode`, `oh-my-openagent`, and `lazycodex-ai`.
 2. Run `git diff v{published-version}..HEAD` to see actual changes.

--- a/.agents/skills/publish/SKILL.md
+++ b/.agents/skills/publish/SKILL.md
@@ -208,6 +208,12 @@ After running the preview, present the output to the user and say:
 
 </decision-gate>
 
+### LAST RELEASE BEFORE THE OMO NATIVE CLI PUBLIC RELEASE
+
+When the user identifies this as the final release before the OmO Native CLI public release, the GitHub summary MUST begin with this dedicated heading and the Discord announcement MUST repeat it as a dedicated heading immediately after `@here`:
+
+`## LAST RELEASE BEFORE THE OMO NATIVE CLI PUBLIC RELEASE`
+
 ### What You're Writing (and What You're NOT)
 
 You are writing the **headline layer** — a product announcement that sits ABOVE the auto-generated commit log. Think "release blog post", not "git log".
@@ -218,6 +224,7 @@ You are writing the **headline layer** — a product announcement that sits ABOV
 - ALWAYS focus on USER IMPACT: what can users DO now that they couldn't before?
 - ALWAYS group by THEME or CAPABILITY, not by commit type (feat/fix/refactor).
 - ALWAYS use concrete language: "You can now do X" not "Added X feature".
+- NEVER include internal adapter changes matching `senpi`, `omo-senpi`, `senpi-task`, `pi-goal`, or `pi-webfetch` in either release-note variant.
 </rules>
 
 <examples>

--- a/.omo/evidence/20260801-release-guidance-native-cli/README.md
+++ b/.omo/evidence/20260801-release-guidance-native-cli/README.md
@@ -1,0 +1,28 @@
+# Release guidance QA evidence
+
+## What was tested
+
+- Failing-first validation of deliberately invalid GitHub and Discord drafts.
+- Static policy validation across the six drift-synced skill and command files.
+- Existing contained-surface changelog tests.
+- Repository markdown link audit.
+- OpenCode QA harness dependency and isolation self-check.
+- Isolated `opencode run --command get-unpublished-changes` real-surface invocation.
+
+## What was observed
+
+- RED: the initial draft failed because it lacked the dedicated Native CLI transition heading and contained excluded internal adapter wording.
+- RED: `v4.19.4` and all three matching npm package versions were absent.
+- GREEN: all six guidance files contain the required transition and exclusion policies; both command copies are byte-identical.
+- GREEN: `script/generate-changelog.test.ts` passes its contained-surface cases.
+- GREEN: `packages/omo-opencode/src/shared/markdown-link-audit.test.ts` passes.
+- GREEN: the OpenCode QA harness confirmed required dependencies and removed its isolated sandbox.
+- The real OpenCode command transcript is recorded separately after completion.
+
+## Why it is enough
+
+The change is prompt-only. The guidance files are validated directly, the shipped changelog exclusion seam remains green, the markdown audit covers committed documentation integrity, and the actual OpenCode command surface is driven in an isolated XDG sandbox.
+
+## What was omitted
+
+Raw environment values, credentials, provider configuration, and secret-bearing logs are not recorded.

--- a/.omo/evidence/20260801-release-guidance-native-cli/green-policy-and-tests.txt
+++ b/.omo/evidence/20260801-release-guidance-native-cli/green-policy-and-tests.txt
@@ -1,0 +1,12 @@
+PASS required transition and exclusion policy in six guidance files
+PASS .agents and .opencode command copies are byte-identical
+PASS git diff --check
+
+bun test script/generate-changelog.test.ts
+Result: all contained-surface exclusion tests passed.
+
+bun test packages/omo-opencode/src/shared/markdown-link-audit.test.ts
+Result: all markdown link audit tests passed.
+
+bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check
+Result: dependencies, DB path, SQL escaping, free port, isolated XDG/HOME, and automatic sandbox cleanup passed.

--- a/.omo/evidence/20260801-release-guidance-native-cli/initial-discord.md
+++ b/.omo/evidence/20260801-release-guidance-native-cli/initial-discord.md
@@ -1,0 +1,5 @@
+@here
+
+**oh-my-opencode v4.19.4**
+
+This release includes model-routing improvements and omo-senpi updates.

--- a/.omo/evidence/20260801-release-guidance-native-cli/initial-github.md
+++ b/.omo/evidence/20260801-release-guidance-native-cli/initial-github.md
@@ -1,0 +1,3 @@
+## What's New
+
+This release includes OpenCode reliability updates and Senpi task improvements.

--- a/.omo/evidence/20260801-release-guidance-native-cli/opencode-command-green.txt
+++ b/.omo/evidence/20260801-release-guidance-native-cli/opencode-command-green.txt
@@ -1,0 +1,13 @@
+Surface:
+source script/agent/qa-sandbox.sh
+opencode run --command get-unpublished-changes --format json \
+  "Analyze only commit d16c27b94. Return one sentence naming whether contained internal adapter surfaces belong in user-facing release notes. Do not modify files or external state."
+
+Observed final response:
+The OpenCode runtime-fallback change is a user-facing behavioral fix and belongs in the OpenCode release notes, while the canonical pattern extraction is an internal pure-component refactor with no standalone user note.
+
+Result:
+PASS. The real OpenCode command loaded and completed successfully in an isolated XDG sandbox without modifying files or external state.
+
+Cleanup:
+The QA sandbox was created under the system temporary directory and removed by the sandbox cleanup trap.

--- a/.omo/evidence/20260801-release-guidance-native-cli/red-guidance.txt
+++ b/.omo/evidence/20260801-release-guidance-native-cli/red-guidance.txt
@@ -1,0 +1,9 @@
+Publish guidance checks:
+RED missing Native CLI transition guidance
+RED missing human-summary Senpi exclusion
+
+Public artifact checks:
+GitHub release v4.19.4: release not found
+oh-my-opencode@4.19.4: npm E404
+oh-my-openagent@4.19.4: npm E404
+lazycodex-ai@4.19.4: npm E404

--- a/.omo/evidence/20260801-release-guidance-native-cli/red-notes-validation.txt
+++ b/.omo/evidence/20260801-release-guidance-native-cli/red-notes-validation.txt
@@ -1,0 +1,9 @@
+Command:
+python3 .omo/evidence/20260801-release-guidance-native-cli/validate-release-notes.py \
+  .omo/evidence/20260801-release-guidance-native-cli/initial-github.md \
+  .omo/evidence/20260801-release-guidance-native-cli/initial-discord.md
+
+Observed:
+AssertionError: initial-github.md: missing dedicated Native CLI transition heading
+
+The initial drafts also contained excluded internal adapter references.

--- a/.omo/evidence/20260801-release-guidance-native-cli/validate-release-notes.py
+++ b/.omo/evidence/20260801-release-guidance-native-cli/validate-release-notes.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import re
+import sys
+
+for raw_path in sys.argv[1:]:
+    path = Path(raw_path)
+    text = path.read_text()
+    assert re.search(
+        r"(?im)^#{1,3}\s+.*LAST RELEASE BEFORE.*OMO NATIVE CLI PUBLIC RELEASE",
+        text,
+    ), f"{path}: missing dedicated Native CLI transition heading"
+    assert not re.search(
+        r"senpi|omo-senpi|senpi-task|pi-goal|pi-webfetch",
+        text,
+        re.IGNORECASE,
+    ), f"{path}: contains an excluded internal adapter reference"
+    print(f"PASS {path}")

--- a/.opencode/command/get-unpublished-changes.md
+++ b/.opencode/command/get-unpublished-changes.md
@@ -22,6 +22,8 @@ Analyze every change against these exact layers:
 | `omo opencode` | Root `oh-my-opencode` / `oh-my-openagent`, `src/`, `.opencode/`, `.agents/`, CLI, config, hooks, tools, docs | What semver bump should the OpenCode/OpenAgent npm packages use? |
 | `omo codex` | `packages/omo-codex`, `lazycodex-ai`, Codex plugin metadata/hooks, bundled MCP runtimes, `code-yeongyu/lazycodex` marketplace payload | Does LazyCodex need the same bump, a Codex-only note, or a marketplace release? |
 
+Exclude commits and paths matching `senpi`, `omo-senpi`, `senpi-task`, `pi-goal`, or `pi-webfetch` from user-facing notes and version recommendations. Record them only in a separate internal-adapter exclusion ledger.
+
 ## Steps:
 1. Detect latest published versions for `oh-my-opencode`, `oh-my-openagent`, and `lazycodex-ai`.
 2. Run `git diff v{published-version}..HEAD` to see actual changes.

--- a/.opencode/command/publish.md
+++ b/.opencode/command/publish.md
@@ -209,6 +209,12 @@ After running the preview, present the output to the user and say:
 
 </decision-gate>
 
+### LAST RELEASE BEFORE THE OMO NATIVE CLI PUBLIC RELEASE
+
+When the user identifies this as the final release before the OmO Native CLI public release, the GitHub summary MUST begin with this dedicated heading and the Discord announcement MUST repeat it as a dedicated heading immediately after `@here`:
+
+`## LAST RELEASE BEFORE THE OMO NATIVE CLI PUBLIC RELEASE`
+
 ### What You're Writing (and What You're NOT)
 
 You are writing the **headline layer** — a product announcement that sits ABOVE the auto-generated commit log. Think "release blog post", not "git log".
@@ -219,6 +225,7 @@ You are writing the **headline layer** — a product announcement that sits ABOV
 - ALWAYS focus on USER IMPACT: what can users DO now that they couldn't before?
 - ALWAYS group by THEME or CAPABILITY, not by commit type (feat/fix/refactor).
 - ALWAYS use concrete language: "You can now do X" not "Added X feature".
+- NEVER include internal adapter changes matching `senpi`, `omo-senpi`, `senpi-task`, `pi-goal`, or `pi-webfetch` in either release-note variant.
 </rules>
 
 <examples>


### PR DESCRIPTION
## Summary

This updates the release-manager guidance for the transition release before the OmO Native CLI public launch. It makes the transition banner mandatory in both GitHub and Discord notes and prevents internal adapter changes from leaking into user-facing release summaries or bump recommendations.

## Changes

- Require a dedicated `LAST RELEASE BEFORE THE OMO NATIVE CLI PUBLIC RELEASE` heading in both release-note variants when the user identifies the transition release.
- Exclude contained internal adapter surfaces from enhanced summaries and unpublished-change recommendations.
- Keep the `.agents` and `.opencode` command copies synchronized.

## QA & Evidence

- **What was tested:** deterministic validation against deliberately invalid release-note drafts.
  - **Observed result:** RED for a missing transition heading and excluded adapter wording.
  - **Artifact:** `.omo/evidence/20260801-release-guidance-native-cli/red-notes-validation.txt`
- **What was tested:** guidance policy and command-copy synchronization.
  - **Observed result:** all six files contain the required policy and command copies match.
  - **Artifact:** `.omo/evidence/20260801-release-guidance-native-cli/green-policy-and-tests.txt`
- **What was tested:** contained-surface changelog regression suite and markdown link audit.
  - **Observed result:** both scoped Bun test targets passed.
  - **Artifact:** `.omo/evidence/20260801-release-guidance-native-cli/green-policy-and-tests.txt`
- **What was tested:** real OpenCode `get-unpublished-changes` command in an isolated XDG sandbox.
  - **Observed result:** the command completed and separated a user-facing runtime fix from an internal component refactor.
  - **Artifact:** `.omo/evidence/20260801-release-guidance-native-cli/opencode-command-green.txt`

## Risks & Residuals

- Prompt growth is limited to genuinely missing transition and exclusion context.
- No runtime code, package versions, or workflow logic changes in this PR.

## Related Issues

Release preparation for v4.19.4.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened release-manager guidance for the OmO Native CLI transition release. Enforces a visible transition banner and keeps internal adapter changes out of user-facing notes and version bump recommendations.

- **New Features**
  - Require the `## LAST RELEASE BEFORE THE OMO NATIVE CLI PUBLIC RELEASE` heading in GitHub and Discord notes when this is the transition release.
  - Exclude internal adapter changes (`senpi`, `omo-senpi`, `senpi-task`, `pi-goal`, `pi-webfetch`) from summaries and unpublished-change bump suggestions.
  - Sync `.agents` and `.opencode` command copies.
  - Add a release-notes validator and QA evidence to verify the policy.

<sup>Written for commit 1d689fe645979a97ebf2f7f2e2c06d59bde7760b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

