### PR TITLE
fix(codex): reject unknown bootstrap step filters

### DIFF
--- a/packages/omo-codex/plugin/components/bootstrap/src/worker.ts
+++ b/packages/omo-codex/plugin/components/bootstrap/src/worker.ts
@@ -167,6 +167,9 @@ export async function runBootstrapWorker(options: RunBootstrapWorkerOptions = {}
 	const platform = options.platform ?? process.platform;
 	const flags = parseWorkerFlags(options.argv ?? []);
 	const steps = options.steps ?? defaultWorkerSteps();
+	if (flags.only !== undefined && !steps.some((step) => step.name === flags.only)) {
+		throw new Error(`unknown --only flag value: ${flags.only}`);
+	}
 	const pluginRoot = resolvePluginRoot(env);
 	const pluginData = resolvePluginDataRoot(env);
 	const statePath = resolveBootstrapStatePath(pluginData);

--- a/packages/omo-codex/plugin/test/bootstrap-orchestration.test.mjs
+++ b/packages/omo-codex/plugin/test/bootstrap-orchestration.test.mjs
@@ -321,7 +321,7 @@ test("#given a completed marker #when the worker runs with --once #then the mark
 	});
 });
 
-test("#given --only sg #when the worker runs #then only the matching step executes", async () => {
+test("#given --only names an injected custom step #when the worker runs #then only the matching step executes", async () => {
 	await withFixture(async (fixture) => {
 		const ran = [];
 		const step = (name) => ({
@@ -333,13 +333,45 @@ test("#given --only sg #when the worker runs #then only the matching step execut
 		});
 
 		const result = await runBootstrapWorker({
-			argv: ["--only", "sg"],
+			argv: ["--only", "custom"],
 			env: fixture.env,
-			steps: [step("setup"), step("sg")],
+			steps: [step("other"), step("custom")],
 		});
 
 		assert.equal(result.ran, true);
-		assert.deepEqual(ran, ["sg"]);
+		assert.deepEqual(ran, ["custom"]);
+	});
+});
+
+test("#given an unknown --only value #when the worker starts #then it rejects before steps or bootstrap artifacts", async () => {
+	await withFixture(async (fixture) => {
+		let stepRuns = 0;
+
+		await assert.rejects(
+			() =>
+				runBootstrapWorker({
+					argv: ["--only", "bogus"],
+					env: fixture.env,
+					steps: [
+						{
+							name: "custom",
+							run: async () => {
+								stepRuns += 1;
+								return { degraded: [] };
+							},
+						},
+					],
+				}),
+			/unknown --only flag value: bogus/,
+		);
+		assert.equal(stepRuns, 0);
+		await assert.rejects(() => stat(join(fixture.pluginData, "bootstrap")));
+		await Promise.all([
+			assert.rejects(() => stat(join(fixture.pluginData, "bootstrap", "state.json"))),
+			assert.rejects(() => stat(join(fixture.pluginData, "bootstrap", "bootstrap.log"))),
+			assert.rejects(() => stat(join(fixture.pluginData, "bootstrap", "state.json.lock"))),
+			assert.rejects(() => stat(join(fixture.pluginData, "auto-update.json.lock"))),
+		]);
 	});
 });
 


### PR DESCRIPTION
## Summary

Reject an unknown bootstrap worker `--only` value before the worker creates locks, runs steps, writes logs, or stamps `completedForVersion`.

Previously, a typo such as `worker --only bogus` matched zero steps but still returned `success` and marked the current plugin version complete. That could make later SessionStart hooks skip provisioning that never ran.

## Changes

- Validate `--only` against the effective worker step list before resolving paths or acquiring locks.
- Keep injected custom step names valid instead of hard-coding the built-in `setup`/`sg` names.
- Add a regression proving an invalid selector runs no step and creates no state, log, or lock artifacts.

## Verification

- RED on the unmodified bundle: 16 passed, 1 failed with `Missing expected rejection`.
- Bootstrap orchestration: 17/17 passed.
- Bootstrap setup/bin-link/orchestration integration: 36/36 passed.
- Default `sg` worker wiring: 2/2 passed.
- Isolated bundled CLI:
  - `--only bogus`: exit 1, clear flag error, no bootstrap artifacts.
  - `--only sg --once`: exit 0, success state persisted.
- Independent code review: CLEAR.
- Independent manual QA and final gate: APPROVE on `50540275be27e633f71a0fad330f13aa09e2bdf3`.

## Residual risk

Low. The bootstrap bundle is ignored source output and must continue to be rebuilt by the existing packaging pipeline. Broader component diagnostics in this checkout retain unrelated missing-manifest/marketplace-fixture prerequisites; the scoped and integration suites above are green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unknown `--only` values in the bootstrap worker before any locks, logs, or state are created. This prevents typos from marking a plugin version as completed and skipping needed provisioning later.

- **Bug Fixes**
  - Validate `--only` against the effective step list (supports injected custom step names).
  - Fail fast with exit 1 and a clear error; run no steps and write no bootstrap artifacts.
  - Added tests for invalid selectors and for selecting a custom injected step.

<sup>Written for commit 50540275be27e633f71a0fad330f13aa09e2bdf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

