### PR TITLE
fix(mcp-stdio-core): destroy stdin on idle timeout so abandoned servers exit

### DIFF
--- a/packages/mcp-stdio-core/src/server.test.ts
+++ b/packages/mcp-stdio-core/src/server.test.ts
@@ -316,6 +316,52 @@ describe("parent watchdog", () => {
   })
 })
 
+describe("idle timeout", () => {
+  test("#given a live parent that abandons stdin without closing it #when the idle timeout elapses #then the server settles instead of parking on the open pipe", async () => {
+    // The parent is alive and still holds the write end, so stdin never emits
+    // 'end' and the parent watchdog never fires. Only the idle timeout can end
+    // this server, and it must tear the read loop down rather than flag it.
+    const input = new PassThrough()
+    const output = new PassThrough()
+    let idleFired = false
+
+    const served = runJsonRpcStdioServer({
+      input,
+      output,
+      handlerOptions: undefined,
+      idleTimeoutMs: 20,
+      handler: async (message) => successResponse(message.id, { acknowledged: true }),
+      onIdleTimeout: () => {
+        idleFired = true
+      },
+    })
+
+    const outcome = await Promise.race([
+      served.then(() => "settled" as const),
+      Bun.sleep(1_000).then(() => "hung" as const),
+    ])
+
+    expect(idleFired).toBe(true)
+    expect(outcome).toBe("settled")
+  })
+
+  test("#given a real child whose parent holds stdin open and never writes #when the idle timeout elapses #then the child process exits", async () => {
+    // The in-process test above only proves the promise settles. A settled loop
+    // still leaves a live process if anything keeps the event loop alive, so
+    // assert the exit itself — the symptom users actually observe.
+    const child = spawnIdleChild(300)
+    try {
+      const outcome = await Promise.race([
+        child.exited.then(() => "exited" as const),
+        Bun.sleep(5_000).then(() => "alive" as const),
+      ])
+      expect(outcome).toBe("exited")
+    } finally {
+      killQuietly(child.pid)
+    }
+  })
+})
+
 describe("isProcessAlive", () => {
   test("#given a running process #when probed #then it reports alive", () => {
     expect(isProcessAlive(process.pid)).toBe(true)
@@ -429,6 +475,31 @@ async function waitForStderrEvent(
     Bun.sleep(5_000).then(() => false),
   ])
   if (!found) throw new Error(`timed out waiting for child event ${event}`)
+}
+
+function spawnIdleChild(idleTimeoutMs: number) {
+  const serverUrl = new URL("./server.ts", import.meta.url).href
+  const responsesUrl = new URL("./responses.ts", import.meta.url).href
+  const script = `
+    import { successResponse } from ${JSON.stringify(responsesUrl)};
+    import { runJsonRpcStdioServer } from ${JSON.stringify(serverUrl)};
+
+    await runJsonRpcStdioServer({
+      input: process.stdin,
+      output: process.stdout,
+      handlerOptions: undefined,
+      idleTimeoutMs: ${idleTimeoutMs},
+      handler: async (input) => successResponse(input.id, { acknowledged: true }),
+    });
+  `
+  // stdin stays piped and is never written to or closed: the test process is a
+  // live parent holding the write end, which is the case no other teardown
+  // path covers.
+  return Bun.spawn([process.execPath, "-e", script], {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  })
 }
 
 function killQuietly(pid: number): void {

--- a/packages/mcp-stdio-core/src/server.test.ts
+++ b/packages/mcp-stdio-core/src/server.test.ts
@@ -330,7 +330,7 @@ describe("idle timeout", () => {
       output,
       handlerOptions: undefined,
       idleTimeoutMs: 20,
-      handler: async (message) => successResponse(message.id, { acknowledged: true }),
+      handler: async () => successResponse("idle", { acknowledged: true }),
       onIdleTimeout: () => {
         idleFired = true
       },
@@ -404,10 +404,14 @@ describe("isProcessAlive", () => {
   })
 })
 
-function spawnWatchdogChild(parentPid: number, pollIntervalMs: number) {
+// Each teardown-path test needs a child running the real server over its own
+// stdio, and only the config driving that path differs. The boilerplate lives
+// here so the paths cannot drift; a caller supplies just the lines that make
+// its case, kept verbatim so the child's config still reads at the call site.
+function buildServerScript(config: string, trailer = ""): string {
   const serverUrl = new URL("./server.ts", import.meta.url).href
   const responsesUrl = new URL("./responses.ts", import.meta.url).href
-  const script = `
+  return `
     import { successResponse } from ${JSON.stringify(responsesUrl)};
     import { runJsonRpcStdioServer } from ${JSON.stringify(serverUrl)};
 
@@ -415,27 +419,39 @@ function spawnWatchdogChild(parentPid: number, pollIntervalMs: number) {
       input: process.stdin,
       output: process.stdout,
       handlerOptions: undefined,
-      idleTimeoutMs: 0,
       handler: async (input) => successResponse(input.id, { acknowledged: true }),
+${config}
+    });
+${trailer}
+  `
+}
+
+// Omitting env inherits the parent environment, so passing process.env through
+// unchanged is what the no-env case already did.
+function spawnServerChild(script: string, env?: Record<string, string>) {
+  return Bun.spawn([process.execPath, "-e", script], {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: env ? { ...process.env, ...env } : process.env,
+  })
+}
+
+function spawnWatchdogChild(parentPid: number, pollIntervalMs: number) {
+  const script = buildServerScript(
+    `      idleTimeoutMs: 0,
       log: (event, fields) => {
         process.stderr.write(JSON.stringify({ event, ...(fields ?? {}) }) + "\\n");
       },
       parentWatchdog: {
         parentPid: Number(process.env.WATCHDOG_PARENT_PID),
         pollIntervalMs: Number(process.env.WATCHDOG_POLL_MS),
-      },
-    });
-    process.stderr.write(JSON.stringify({ event: "server_settled" }) + "\\n");
-  `
-  return Bun.spawn([process.execPath, "-e", script], {
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-    env: {
-      ...process.env,
-      WATCHDOG_PARENT_PID: String(parentPid),
-      WATCHDOG_POLL_MS: String(pollIntervalMs),
-    },
+      },`,
+    `    process.stderr.write(JSON.stringify({ event: "server_settled" }) + "\\n");`,
+  )
+  return spawnServerChild(script, {
+    WATCHDOG_PARENT_PID: String(parentPid),
+    WATCHDOG_POLL_MS: String(pollIntervalMs),
   })
 }
 
@@ -478,28 +494,10 @@ async function waitForStderrEvent(
 }
 
 function spawnIdleChild(idleTimeoutMs: number) {
-  const serverUrl = new URL("./server.ts", import.meta.url).href
-  const responsesUrl = new URL("./responses.ts", import.meta.url).href
-  const script = `
-    import { successResponse } from ${JSON.stringify(responsesUrl)};
-    import { runJsonRpcStdioServer } from ${JSON.stringify(serverUrl)};
-
-    await runJsonRpcStdioServer({
-      input: process.stdin,
-      output: process.stdout,
-      handlerOptions: undefined,
-      idleTimeoutMs: ${idleTimeoutMs},
-      handler: async (input) => successResponse(input.id, { acknowledged: true }),
-    });
-  `
   // stdin stays piped and is never written to or closed: the test process is a
   // live parent holding the write end, which is the case no other teardown
   // path covers.
-  return Bun.spawn([process.execPath, "-e", script], {
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-  })
+  return spawnServerChild(buildServerScript(`      idleTimeoutMs: ${idleTimeoutMs},`))
 }
 
 function killQuietly(pid: number): void {

--- a/packages/mcp-stdio-core/src/server.ts
+++ b/packages/mcp-stdio-core/src/server.ts
@@ -64,6 +64,11 @@ export async function runJsonRpcStdioServer<HandlerOptions>(
   const idleTimer = createIdleTimer(idleTimeoutMs, log, () => {
     isClosed = true
     void config.onIdleTimeout?.()
+    // isClosed alone cannot end the read loop: it is only consulted after a
+    // message arrives, and an idle stdio server is idle precisely because none
+    // does. A parent that stays alive while abandoning the pipe never closes
+    // the write end either, so this destroy is the only teardown left.
+    config.input.destroy()
   })
   const watchdog = createParentWatchdog(config.parentWatchdog, (parentPid, pollIntervalMs) => {
     isClosed = true


### PR DESCRIPTION
Addresses half of #6547.

## Problem

`runJsonRpcStdioServer`'s idle timeout sets `isClosed` and calls the hook, but never tears the read loop down. `isClosed` is only consulted after a message arrives (`for await ... if (isClosed) break`), and an idle server is idle precisely because none arrives — so the loop parks on the open pipe and the idle exit has never been able to fire.

Every other teardown path needs the parent to release the write end: stdin `close`/`end` (#5560) and `createParentWatchdog` (parent death). A parent that stays alive while abandoning the pipe hits none of them, and the child lives forever.

## Change

- `server.ts`: `config.input.destroy()` in the idle callback, mirroring the parent-exit callback six lines below. The resulting `ERR_STREAM_PREMATURE_CLOSE` is already swallowed by the existing catch because `isClosed` is set, so no new error handling is needed.
- `server.test.ts`: the first two tests that exercise the idle path. The second one spawns a real child process, because a settled read loop still leaves a live process if anything keeps the event loop alive — and the process, not the promise, is what users observe.

No call site in the repo passes `onIdleTimeout`, so nothing depends on the old no-op behaviour.

## Scope — what this does not fix

This only takes effect where an idle timeout is enabled. **Corrected 2026-08-02 (see comment below):** there are four call sites, and the only one taking the 10-minute default is `packages/omo-codex/plugin/components/codegraph/src/mcp-unavailable.ts`, the degraded stub; `lsp-core/src/mcp.ts`, `lsp-daemon/src/proxy.ts` and `git-bash-mcp/src/mcp.ts` all pass `idleTimeoutMs: 0`, and `createIdleTimer` treats `<= 0` as disabled. `mcp-bridge.ts` is not a call site at all and has no idle timer. My original wording here claimed codegraph's servers were fixed by this; that was wrong. Whether those should adopt a nonzero idle window is a separate call for the maintainers — see the issue.

## Verification

Both tests were written first and watched fail against unpatched `dev`:

```
(fail) idle timeout > #given a live parent that abandons stdin without closing it ... [1001ms]
(fail) idle timeout > #given a real child whose parent holds stdin open and never writes ... [5001ms]
 16 pass / 2 fail
```

The first fails with `Expected: "settled" / Received: "hung"` while its `onIdleTimeout` hook did fire — the shape of the bug. With the one-line change, `bun test src/*.test.ts` in `packages/mcp-stdio-core`:

```
 22 pass
 0 fail
```

Not run: `typecheck` (needs `tsgo` from a workspace install this environment could not afford) and the consumer packages' suites. The change is confined to one callback and adds no new types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Destroy stdin on idle timeout in `mcp-stdio-core` so abandoned JSON-RPC stdio servers exit instead of hanging on an open pipe. Adds tests for the idle path, including a real child process case, and shares child-spawn setup across tests.

- **Bug Fixes**
  - In `runJsonRpcStdioServer`, the idle timeout now calls `config.input.destroy()` after marking closed, tearing down the read loop; the resulting error is already swallowed.
  - Tests added: one in-process to confirm the server settles, and one that spawns a real child to confirm the process exits on idle.
  - Only applies when `idleTimeoutMs > 0`; callers passing `0` are unchanged.

- **Refactors**
  - Extracted `buildServerScript` and `spawnServerChild` (plus `spawnIdleChild`) so watchdog and idle tests share one spawn setup.
  - Dropped the unused handler param in the idle test to fix typecheck; unified env handling in child spawns.

<sup>Written for commit d2428a765b902c8b2581bb9dd7f24b52413c09f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


