### PR TITLE
fix(lazycodex): route flag-prefixed maintenance commands

### DIFF
--- a/bin/oh-my-opencode.js
+++ b/bin/oh-my-opencode.js
@@ -95,9 +95,22 @@ function getWrapperPackageRoot() {
   return fileURLToPath(new URL("..", import.meta.url));
 }
 
+function readInstallerCommand(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--platform" || arg === "--repo-root") {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    return arg;
+  }
+  return undefined;
+}
+
 function maybeRunLazyCodexNodeInstaller(invocationName) {
   if (invocationName !== "lazycodex" && invocationName !== "lazycodex-ai") return false;
-  const command = process.argv[2];
+  const command = readInstallerCommand(process.argv.slice(2));
   if (command !== "update" && command !== "uninstall") return false;
 
   const installerPath = fileURLToPath(new URL("../packages/omo-codex/scripts/install-local.mjs", import.meta.url));

--- a/bin/oh-my-opencode.test.ts
+++ b/bin/oh-my-opencode.test.ts
@@ -144,6 +144,27 @@ describe("lazycodex bin wrapper", () => {
       "/tmp/lazycodex-qa",
     ]);
   });
+
+  test("routes flag-prefixed lazycodex uninstall to the Node installer", async () => {
+    // #given
+    const fixture = await createLazyCodexFixture();
+    const nodePath = Bun.which("node") ?? "node";
+
+    // #when
+    const result = spawnSync(nodePath, [fixture.lazycodexBin, "--dry-run", "uninstall", "--project", "/tmp/lazycodex-qa"], {
+      encoding: "utf8",
+      env: createWrapperTestEnv(fixture),
+    });
+
+    // #then
+    expect(result.status).toBe(19);
+    expect((await readFile(join(fixture.captureDir, "node-installer-args"), "utf8")).trim().split("\n")).toEqual([
+      "--dry-run",
+      "uninstall",
+      "--project",
+      "/tmp/lazycodex-qa",
+    ]);
+  });
 });
 
 function createWrapperTestEnv(


### PR DESCRIPTION
## Summary

- discover the first positional LazyCodex command instead of assuming it is `argv[2]`
- keep flag-prefixed `update` and `uninstall` invocations on the Node installer path
- preserve the original argument vector when forwarding to the installer

## Root cause

The root wrapper only inspected `process.argv[2]`. A supported leading flag such as `--dry-run` therefore made `lazycodex --dry-run uninstall` bypass the Node installer and fall through to platform-package resolution. The generated launcher already scans for the first positional command, so this change aligns the root wrapper with that behavior.

## Verification

- regression test proves the old wrapper exits through the platform fixture and the fixed wrapper reaches the Node installer fixture with argv unchanged
- focused wrapper/platform/installer tests: 44 passed
- full suite: 12,666 passed, 3 skipped, 0 failed
- root typecheck passed
- independent manual QA covered option-order variants, the `lazycodex-ai` alias, the ordinary platform path, package payload, and non-destructive installer dry-run
- independent code review: approved with no findings

Live destructive uninstall was intentionally not run against user-managed state.

Tag: lazycodex-generated


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes routing for maintenance commands so flag-prefixed `update` and `uninstall` on `lazycodex`/`lazycodex-ai` go to the Node installer. Prevents falling through to the platform launcher and keeps original args unchanged.

- **Bug Fixes**
  - Discover the first positional command instead of assuming `argv[2]`, aligning the root wrapper with the generated launcher.
  - Preserve the original argv when forwarding to the installer (e.g., `--dry-run uninstall --project ...`).
  - Added a test to ensure `--dry-run uninstall` is handled by the Node installer with args intact.

<sup>Written for commit e67c528fe31929e59515979db9d1c7b0c4606822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

