### PR TITLE
fix(installer): guard plugin predicates against tuple entries (#6555)

### DIFF
--- a/packages/omo-opencode/src/cli/config-manager/add-plugin-to-opencode-config.ts
+++ b/packages/omo-opencode/src/cli/config-manager/add-plugin-to-opencode-config.ts
@@ -1,13 +1,13 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs"
 import { basename, dirname, join } from "node:path"
 import type { ConfigMergeResult } from "../types"
-import { PLUGIN_NAME, LEGACY_PLUGIN_NAME } from "../../shared"
+import { PLUGIN_NAME } from "../../shared"
 import { backupConfigFile } from "./backup-config"
 import { getConfigDir } from "./config-context"
 import { ensureConfigDirectoryExists } from "./ensure-config-directory-exists"
 import { formatErrorWithSuggestion } from "./format-error-with-suggestion"
 import { detectConfigFormat, type ConfigFormat } from "./opencode-config-format"
-import { parseOpenCodeConfigFileWithError, type OpenCodeConfig } from "./parse-opencode-config-file"
+import { isPackageOmoPluginEntry, parseOpenCodeConfigFileWithError, type OpenCodeConfig } from "./parse-opencode-config-file"
 import { getPluginNameWithVersion } from "./plugin-name-with-version"
 import { checkVersionCompatibility, extractVersionFromPluginEntry } from "./version-compatibility"
 
@@ -68,23 +68,21 @@ function getConfigTargets(): ConfigTarget[] {
   })
 }
 
-function isSourceOmoPluginEntry(plugin: string): boolean {
+function isSourceOmoPluginEntry(plugin: unknown): plugin is string {
+  if (typeof plugin !== "string") return false
   const normalized = plugin.toLowerCase().replaceAll("\\", "/")
   if (!normalized.startsWith("file://")) return false
 
   return /\/(omo(?:-[^/]*)?|oh-my-opencode|oh-my-openagent)\/(src|dist)\/index\.(ts|js)$/.test(normalized)
 }
 
-function isPackageOmoPluginEntry(plugin: string): boolean {
-  return plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`) ||
-    plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
-}
-
-function isOurPlugin(plugin: string): boolean {
+// `isPackageOmoPluginEntry` is shared from `parse-opencode-config-file.ts`;
+// the add-plugin path additionally matches `file://` source entries.
+function isOurPlugin(plugin: unknown): plugin is string {
   return isPackageOmoPluginEntry(plugin) || isSourceOmoPluginEntry(plugin)
 }
 
-function findOurPluginEntry(plugins: readonly string[]): string | undefined {
+function findOurPluginEntry(plugins: readonly (string | [string, unknown])[]): string | undefined {
   return plugins.find(isOurPlugin)
 }
 
@@ -94,6 +92,99 @@ function findSourcePluginEntryInTarget(target: ConfigTarget): string | null {
   const parseResult = parseOpenCodeConfigFileWithError(target.path)
   const plugins = parseResult.config?.plugin ?? []
   return plugins.find(isSourceOmoPluginEntry) ?? null
+}
+
+// Locate the bounds of the ROOT-level `plugin` array in a jsonc document.
+// The previous non-greedy regex `\[([\s\S]*?)\]` had two defects this fixes:
+//   1. It stopped at the first `]`, truncating the array whenever an entry
+//      was itself a nested array (the documented `[name, options]` tuple
+//      form), yielding a stray `]` and invalid JSON.
+//   2. It matched the first textual `plugin:` regardless of nesting depth,
+//      so a `plugin` key nested inside another object (e.g. an MCP server
+//      config) appearing before the root array would be rewritten instead,
+//      leaving the active root plugin array unchanged and omo unregistered.
+// The scanner balances brackets while respecting strings and jsonc comments,
+// and only accepts a `plugin:` header at object depth 1 (the root object).
+function findPluginArrayBounds(content: string): { readonly start: number; readonly end: number } | null {
+  const headerRegex = /(?:"plugin"|plugin)\s*:\s*(?=\[)/g
+  let headerMatch: RegExpExecArray | null
+  while ((headerMatch = headerRegex.exec(content)) !== null) {
+    if (objectDepthAt(content, headerMatch.index) === 1) {
+      const start = headerMatch.index + headerMatch[0].length
+      const end = balanceArrayBrackets(content, start)
+      if (end !== null) return { start, end }
+    }
+  }
+  return null
+}
+
+// Count `{`/`}` depth over [0, pos), skipping jsonc strings and comments.
+// depth 0 = outside any object; depth 1 = inside the root object; >=2 nested.
+function objectDepthAt(content: string, pos: number): number {
+  let depth = 0
+  let i = 0
+  let inString = false
+  while (i < pos) {
+    const ch = content[i]
+    if (inString) {
+      if (ch === "\\") { i += 2; continue }
+      if (ch === '"') inString = false
+      i += 1
+      continue
+    }
+    if (ch === '"') { inString = true; i += 1; continue }
+    if (ch === "/" && content[i + 1] === "/") {
+      const nl = content.indexOf("\n", i)
+      i = nl === -1 ? pos : Math.min(nl + 1, pos)
+      continue
+    }
+    if (ch === "/" && content[i + 1] === "*") {
+      const close = content.indexOf("*/", i + 2)
+      i = close === -1 ? pos : Math.min(close + 2, pos)
+      continue
+    }
+    if (ch === "{") depth += 1
+    else if (ch === "}") depth -= 1
+    i += 1
+  }
+  return depth
+}
+
+// Given `start` pointing at `[`, return index after the matching `]` (or null
+// if unbalanced), skipping jsonc strings and comments and balancing nested
+// arrays (e.g. tuple entries `[name, {...}]`).
+function balanceArrayBrackets(content: string, start: number): number | null {
+  if (content[start] !== "[") return null
+  let depth = 0
+  let i = start
+  let inString = false
+  while (i < content.length) {
+    const ch = content[i]
+    if (inString) {
+      if (ch === "\\") { i += 2; continue }
+      if (ch === '"') inString = false
+      i += 1
+      continue
+    }
+    if (ch === '"') { inString = true; i += 1; continue }
+    if (ch === "/" && content[i + 1] === "/") {
+      const nl = content.indexOf("\n", i)
+      i = nl === -1 ? content.length : nl + 1
+      continue
+    }
+    if (ch === "/" && content[i + 1] === "*") {
+      const close = content.indexOf("*/", i + 2)
+      i = close === -1 ? content.length : close + 2
+      continue
+    }
+    if (ch === "[") depth += 1
+    else if (ch === "]") {
+      depth -= 1
+      if (depth === 0) return i + 1
+    }
+    i += 1
+  }
+  return null
 }
 
 function choosePluginEntry(params: {
@@ -177,12 +268,11 @@ function writePluginEntryToTarget(params: {
 
     if (target.format === "jsonc") {
       const content = readFileSync(target.path, "utf-8")
-      const pluginArrayRegex = /((?:"plugin"|plugin)\s*:\s*)\[([\s\S]*?)\]/
-      const match = content.match(pluginArrayRegex)
+      const bounds = findPluginArrayBounds(content)
 
-      if (match) {
-        const formattedPlugins = normalizedPlugins.map((p) => `"${p}"`).join(",\n    ")
-        const newContent = content.replace(pluginArrayRegex, `$1[\n    ${formattedPlugins}\n  ]`)
+      if (bounds) {
+        const formattedPlugins = normalizedPlugins.map((p) => JSON.stringify(p)).join(",\n    ")
+        const newContent = content.slice(0, bounds.start) + `[\n    ${formattedPlugins}\n  ]` + content.slice(bounds.end)
         writeFileSync(target.path, newContent)
       } else {
         const newContent = content.replace(/(\{)/, `$1\n  "plugin": ["${nextPluginEntry}"],`)

--- a/packages/omo-opencode/src/cli/config-manager/detect-current-config.ts
+++ b/packages/omo-opencode/src/cli/config-manager/detect-current-config.ts
@@ -1,9 +1,9 @@
 import { existsSync, readFileSync } from "node:fs"
-import { parseJsonc, LEGACY_PLUGIN_NAME, PLUGIN_NAME } from "../../shared"
+import { parseJsonc } from "../../shared"
 import type { DetectedConfig } from "../types"
 import { getOmoConfigPath } from "./config-context"
 import { detectConfigFormat } from "./opencode-config-format"
-import { parseOpenCodeConfigFileWithError } from "./parse-opencode-config-file"
+import { isPackageOmoPluginEntry, parseOpenCodeConfigFileWithError } from "./parse-opencode-config-file"
 import { extractVersionFromPluginEntry } from "./version-compatibility"
 
 function detectProvidersFromOmoConfig(): {
@@ -99,12 +99,11 @@ function detectProvidersFromOmoConfig(): {
   }
 }
 
-function isOurPlugin(plugin: string): boolean {
-  return plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`) ||
-         plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+function isOurPlugin(plugin: unknown): plugin is string {
+  return isPackageOmoPluginEntry(plugin)
 }
 
-function findOurPluginEntry(plugins: string[]): string | null {
+function findOurPluginEntry(plugins: readonly (string | [string, unknown])[]): string | null {
   return plugins.find(isOurPlugin) ?? null
 }
 

--- a/packages/omo-opencode/src/cli/config-manager/parse-opencode-config-file.ts
+++ b/packages/omo-opencode/src/cli/config-manager/parse-opencode-config-file.ts
@@ -1,5 +1,5 @@
 import { readFileSync, statSync } from "node:fs"
-import { parseJsonc } from "../../shared"
+import { LEGACY_PLUGIN_NAME, PLUGIN_NAME, parseJsonc } from "../../shared"
 import { formatErrorWithSuggestion } from "./format-error-with-suggestion"
 
 interface ParseConfigResult {
@@ -8,8 +8,20 @@ interface ParseConfigResult {
 }
 
 export interface OpenCodeConfig {
-  plugin?: string[]
+  plugin?: (string | [string, unknown])[]
   [key: string]: unknown
+}
+
+// Shared package-name predicate for the omo plugin entry. Centralized here so
+// the installer's detect and add-plugin paths cannot drift apart (AGENTS.md
+// flags duplicate utilities for review). Accepts `unknown` because the parsed
+// `plugin` array may contain tuple entries `[name, options]`; the `typeof`
+// guard skips those without throwing.
+export function isPackageOmoPluginEntry(plugin: unknown): plugin is string {
+  return typeof plugin === "string" && (
+    plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`) ||
+    plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+  )
 }
 
 function isEmptyOrWhitespace(content: string): boolean {

--- a/packages/omo-opencode/src/cli/config-manager/plugin-detection.test.ts
+++ b/packages/omo-opencode/src/cli/config-manager/plugin-detection.test.ts
@@ -8,6 +8,7 @@ import { resetConfigContext } from "./config-context"
 import { detectCurrentConfig } from "./detect-current-config"
 import { addPluginToOpenCodeConfig } from "./add-plugin-to-opencode-config"
 import * as pluginNameWithVersion from "./plugin-name-with-version"
+import { parseJsonc } from "../../shared"
 
 const sourcePlugin = new URL("../../index.ts", import.meta.url).href
 
@@ -277,5 +278,224 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     expect(result.configPath).toBe(join(realpathSync(profileDir), "opencode.json"))
     const savedProfileConfig = JSON.parse(readFileSync(profileConfigPath, "utf-8"))
     expect(savedProfileConfig.plugin).toEqual([sourcePlugin])
+  })
+})
+
+// Regression for https://github.com/code-yeongyu/oh-my-openagent/issues/6555
+// OpenCode documents and supports tuple-style plugin entries `[name, options]`.
+// omo's installer predicates previously called `.startsWith`/`.toLowerCase`
+// without a `typeof` guard, so the first tuple entry crashed the installer
+// with `TypeError: plugin.startsWith is not a function`.
+describe("detectCurrentConfig - tuple plugin entries (#6555)", () => {
+  let testConfigDir = ""
+  let homeDirectory = ""
+  let originalHome: string | undefined
+  let testConfigPath = ""
+  let testOmoConfigPath = ""
+
+  beforeEach(() => {
+    testConfigDir = join(tmpdir(), `omo-tuple-detect-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    homeDirectory = join(testConfigDir, "home")
+    testConfigPath = join(testConfigDir, "opencode.json")
+    testOmoConfigPath = join(homeDirectory, ".omo", "omo.jsonc")
+
+    mkdirSync(join(testOmoConfigPath, ".."), { recursive: true })
+    originalHome = process.env.HOME
+    process.env.HOME = homeDirectory
+    process.env.OPENCODE_CONFIG_DIR = testConfigDir
+    resetConfigContext()
+  })
+
+  afterEach(() => {
+    rmSync(testConfigDir, { recursive: true, force: true })
+    resetConfigContext()
+    delete process.env.OPENCODE_CONFIG_DIR
+    if (originalHome === undefined) delete process.env.HOME
+    else process.env.HOME = originalHome
+  })
+
+  it("does not throw and reports not installed when plugin array has only a tuple entry", () => {
+    // given - a tuple-style entry (documented OpenCode format) and no omo entry
+    writeFileSync(
+      testConfigPath,
+      JSON.stringify({ plugin: [["@plannotator/opencode@latest", { workflow: "plan-agent" }]] }, null, 2) + "\n",
+      "utf-8",
+    )
+
+    // when
+    const result = detectCurrentConfig()
+
+    // then - previously this threw `plugin.startsWith is not a function`
+    expect(result.isInstalled).toBe(false)
+    expect(result.installedVersion).toBe(null)
+  })
+
+  it("detects an omo entry alongside a tuple entry", () => {
+    // given
+    writeFileSync(
+      testConfigPath,
+      JSON.stringify({
+        plugin: [
+          ["@plannotator/opencode@latest", { workflow: "plan-agent" }],
+          "oh-my-openagent@3.11.0",
+        ],
+      }, null, 2) + "\n",
+      "utf-8",
+    )
+
+    // when
+    const result = detectCurrentConfig()
+
+    // then
+    expect(result.isInstalled).toBe(true)
+    expect(result.installedVersion).toBe("3.11.0")
+  })
+})
+
+describe("addPluginToOpenCodeConfig - tuple plugin entries (#6555)", () => {
+  let testConfigDir = ""
+  let testConfigPath = ""
+  let getPluginNameWithVersionSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    testConfigDir = join(tmpdir(), `omo-tuple-add-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    testConfigPath = join(testConfigDir, "opencode.json")
+
+    mkdirSync(testConfigDir, { recursive: true })
+    process.env.OPENCODE_CONFIG_DIR = testConfigDir
+    resetConfigContext()
+    getPluginNameWithVersionSpy = spyOn(pluginNameWithVersion, "getPluginNameWithVersion").mockResolvedValue("oh-my-openagent")
+  })
+
+  afterEach(() => {
+    getPluginNameWithVersionSpy.mockRestore()
+    rmSync(testConfigDir, { recursive: true, force: true })
+    resetConfigContext()
+    delete process.env.OPENCODE_CONFIG_DIR
+  })
+
+  it("preserves a tuple entry when adding omo to a json config", async () => {
+    // given
+    const tuple = ["@plannotator/opencode@latest", { workflow: "plan-agent" }]
+    writeFileSync(testConfigPath, JSON.stringify({ plugin: [tuple] }, null, 2) + "\n", "utf-8")
+
+    // when
+    const result = await addPluginToOpenCodeConfig("3.11.0")
+
+    // then
+    expect(result.success).toBe(true)
+    const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
+    expect(savedConfig.plugin).toEqual([tuple, "oh-my-openagent"])
+  })
+
+  it("preserves a tuple entry when adding omo to a jsonc config", async () => {
+    // given - jsonc with a tuple entry; the jsonc rewriter previously
+    // template-stringified the tuple into `"name,[object Object]"`.
+    testConfigPath = join(testConfigDir, "opencode.jsonc")
+    writeFileSync(
+      testConfigPath,
+      '{\n  "plugin": [\n    ["@plannotator/opencode@latest", { "workflow": "plan-agent" }]\n  ]\n}\n',
+      "utf-8",
+    )
+
+    // when
+    const result = await addPluginToOpenCodeConfig("3.11.0")
+
+    // then
+    expect(result.success).toBe(true)
+    const savedContent = readFileSync(testConfigPath, "utf-8")
+    // tuple must survive as a JSON array, not be template-stringified to "name,[object Object]"
+    expect(savedContent.includes("[object Object]")).toBe(false)
+    expect(savedContent.includes('"oh-my-openagent"')).toBe(true)
+    // re-parse to confirm structural correctness (JSON.stringify emits compact tuples)
+    const savedConfig = JSON.parse(savedContent)
+    expect(savedConfig.plugin[0]).toEqual(["@plannotator/opencode@latest", { workflow: "plan-agent" }])
+    expect(savedConfig.plugin[1]).toBe("oh-my-openagent")
+  })
+
+  it("finds the real plugin array when `plugin:` appears in a comment before it (#6555 scanner)", async () => {
+    // given - jsonc where a line comment contains the literal `plugin:` text
+    // before the real array. Without the `(?=\[)` header anchor, the scanner
+    // matched the comment's `plugin:`, failed the bracket check, returned
+    // null, and the else branch inserted a duplicate `plugin` key while
+    // leaving the real array (with the tuple) untouched.
+    testConfigPath = join(testConfigDir, "opencode.jsonc")
+    writeFileSync(
+      testConfigPath,
+      [
+        "{",
+        "  // plugin: managed by oh-my-openagent",
+        '  /* block comment with plugin: text too */',
+        '  "$schema": "https://opencode.ai/config.json",',
+        '  "plugin": [',
+        '    ["@plannotator/opencode@latest", { "workflow": "plan-agent" }],',
+        "    // inner line comment inside the array",
+        "    /* inner block comment */",
+        '    "opencode-pty"',
+        "  ]",
+        "}",
+        "",
+      ].join("\n"),
+      "utf-8",
+    )
+
+    // when
+    const result = await addPluginToOpenCodeConfig("3.11.0")
+
+    // then
+    expect(result.success).toBe(true)
+    const savedContent = readFileSync(testConfigPath, "utf-8")
+    // exactly one plugin key (no duplicate inserted by the else branch)
+    expect((savedContent.match(/"plugin"\s*:/g) ?? []).length).toBe(1)
+    // tuple survived as a JSON array
+    expect(savedContent.includes("[object Object]")).toBe(false)
+    expect(savedContent.includes('"oh-my-openagent"')).toBe(true)
+    // re-parse via the jsonc parser (output retains header comments) to
+    // confirm structure: tuple + original string entry + omo entry
+    const savedConfig = parseJsonc<Record<string, unknown>>(savedContent)
+    const savedPlugin = savedConfig.plugin as unknown[]
+    expect(savedPlugin[0]).toEqual(["@plannotator/opencode@latest", { workflow: "plan-agent" }])
+    expect(savedPlugin[1]).toBe("opencode-pty")
+    expect(savedPlugin[2]).toBe("oh-my-openagent")
+  })
+
+  it("targets the root plugin array, not a nested plugin key (#6555 P1)", async () => {
+    // given - jsonc where a nested object carries a `plugin` key before the
+    // root plugin array. The first-match scanner previously rewrote the
+    // nested array and left the root array (the active one) unchanged,
+    // reporting success while omo was never registered. The depth-aware
+    // scanner must skip the nested header and update the root array only.
+    testConfigPath = join(testConfigDir, "opencode.jsonc")
+    writeFileSync(
+      testConfigPath,
+      [
+        "{",
+        '  "mcp": {',
+        '    "custom-server": { "plugin": ["nested-should-be-untouched"] }',
+        "  },",
+        '  "plugin": ["opencode-pty"]',
+        "}",
+        "",
+      ].join("\n"),
+      "utf-8",
+    )
+
+    // when
+    const result = await addPluginToOpenCodeConfig("3.11.0")
+
+    // then
+    expect(result.success).toBe(true)
+    const savedContent = readFileSync(testConfigPath, "utf-8")
+    // the nested plugin array is preserved verbatim (not rewritten)
+    expect(savedContent.includes('"nested-should-be-untouched"')).toBe(true)
+    // the root plugin array now contains omo
+    expect(savedContent.includes('"oh-my-openagent"')).toBe(true)
+    const savedConfig = parseJsonc<Record<string, unknown>>(savedContent)
+    const rootPlugin = savedConfig.plugin as unknown[]
+    expect(rootPlugin).toEqual(["opencode-pty", "oh-my-openagent"])
+    // the nested server's plugin array is untouched
+    const mcp = savedConfig.mcp as Record<string, Record<string, unknown>>
+    const nestedServer = mcp["custom-server"]
+    expect(nestedServer.plugin).toEqual(["nested-should-be-untouched"])
   })
 })


### PR DESCRIPTION
## Summary

- The installer crashed with `TypeError: plugin.startsWith is not a function` whenever `opencode.jsonc`'s `plugin` array contained a tuple-style `[name, options]` entry (a format OpenCode documents and supports at runtime). The crash aborted the install before any config was written.
- Root cause: omo's plugin-name predicates called `.startsWith` / `.toLowerCase` on every entry without a `typeof` guard. This is the same class of bug as #5786 (fixed in #5859 for the `omo doctor` TUI check), but #5859 only patched the doctor path — the installer detection (`isOurPlugin2`) and installer add-plugin (`isOurPlugin` / `isPackageOmoPluginEntry` / `isSourceOmoPluginEntry`) paths remained unguarded.
- After guarding the predicates, the jsonc plugin-array rewriter also mangled tuples: the non-greedy regex `\[([\s\S]*?)\]` stopped at the tuple's inner `]`, truncating the array and emitting a stray `]` (invalid JSON); and the per-entry serializer template-stringified tuples into `"name,[object Object]"`. Both are fixed so the install now succeeds end-to-end on jsonc configs with tuples.

## Changes

- **`parse-opencode-config-file.ts`** — Widened `OpenCodeConfig.plugin` from `string[]` to `(string | [string, unknown])[]` to reflect the documented runtime shape (mirrors the local `OpenCodeConfigShape` already used by the doctor check in `tui-plugin-config.ts`). Only two type-level consumers exist (`detect-current-config.ts` reads `.plugin`; `add-plugin-to-opencode-config.ts` creates `{ plugin: [stringEntry] }`, still valid), so the widening is safe.
- **`detect-current-config.ts`** — `isOurPlugin` / `findOurPluginEntry` converted to `plugin is string` type guards with `typeof plugin === "string"` guards, matching #5859's precedent.
- **`add-plugin-to-opencode-config.ts`** — Same `typeof` guard applied to `isSourceOmoPluginEntry`, `isPackageOmoPluginEntry`, `isOurPlugin`, `findOurPluginEntry`. Added `findPluginArrayBounds`, a bracket-balanced scanner that respects strings and jsonc comments, replacing the non-greedy regex. Per-entry serialization switched from `` `"${p}"` `` to `JSON.stringify(p)` (identical for strings; correct for tuples).
- **`plugin-detection.test.ts`** — Added regression tests for the four affected surfaces.

## QA & Evidence

- **What was tested:** `bun run typecheck` (package `omo-opencode`)
  **Observed result:** clean, zero errors
  **Artifact:** local run
  **Why sufficient:** confirms the type widening and `plugin is string` guards compile against the real `OpenCodeConfig` consumers
- **What was tested:** `bun test src/cli/config-manager/plugin-detection.test.ts`
  **Observed result:** 17 pass / 0 fail (4 new tuple regression tests green)
  **Artifact:** local run
  **Why sufficient:** the new "detect with tuple only" test reproduces the original `TypeError` crash on the unpatched bundle (red), and passes after the guards (green); the json/jsonc add-plugin tests confirm tuples round-trip structurally and the output re-parses as valid JSON
- **What was tested:** `bun test src/cli/config-manager/ src/cli/tui-installer.test.ts src/cli/cli-installer.test.ts src/cli/doctor/ src/cli/cli-program.test.ts src/cli/install.test.ts`
  **Observed result:** 212 pass / 2 fail — the 2 failures (`config.test.ts` › "does not flag reasoningEffort: 'max'...") are pre-existing on clean `dev` (verified by `git stash` + re-run), unrelated to plugins/tuples
  **Artifact:** local run
  **Why sufficient:** zero new failures introduced across the installer, tui-installer, doctor checks, and config-manager suites
- **What was tested:** confirmed the crash on the published `oh-my-openagent@4.19.4` bundle (issue #6555), and that `bunx oh-my-openagent doctor` runs clean against the same tuple-bearing `opencode.jsonc` (isolating the bug to the install path)

## Risks & Residuals

- **Risk: balanced scanner diverges from old regex on edge jsonc** — Mitigated. The scanner produces byte-identical output to the old regex for the all-string case (covered by the existing "rewrites quoted jsonc plugin field in place" test, still green), and correctly handles tuples, strings, line/block comments, and escaped quotes. Trailing commas inside the plugin array are normalized away (the old regex did the same).
- **Risk: type widening ripples to other consumers** — Mitigated. Grep confirmed only two files reference the `OpenCodeConfig` type or read `.plugin` from `parseOpenCodeConfigFileWithError`; both are updated. The doctor check already used an equivalent local shape.
- **Risk: `JSON.stringify` per-entry changes string output** — Not applicable. `JSON.stringify("x")` === `"\"x\""` (the old template output), verified by the passing all-string regression tests.
- **Accepted:** the two pre-existing `config.test.ts` failures are out of scope for this fix.

## Automated Checks

```bash
cd packages/omo-opencode
bun run typecheck
bun test src/cli/config-manager/plugin-detection.test.ts
bun test src/cli/config-manager/ src/cli/tui-installer.test.ts src/cli/cli-installer.test.ts src/cli/doctor/ src/cli/cli-program.test.ts src/cli/install.test.ts
```

Note: the repo-wide `bun test` was not run in full here (broad suite, some tests make network calls); the targeted suites covering every code path touched by this change all pass. The two `config.test.ts` failures are pre-existing on `dev` and unrelated.

## Related Issues

Closes #6555

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes installer crash when the `plugin` array contains tuple entries `[name, options]`. Also corrects JSONC rewriting to target the root `plugin` array and preserve tuples when adding `oh-my-openagent`. Closes #6555.

- **Bug Fixes**
  - Guarded plugin predicates with `typeof plugin === "string"` and widened `OpenCodeConfig.plugin` to `(string | [string, unknown])[]`.
  - Replaced the JSONC array regex with a bracket-balanced, depth-aware scanner that finds the root `plugin` array and respects strings/comments.
  - Used `JSON.stringify` per entry to keep tuples (no `"name,[object Object]"`).
  - Centralized `isPackageOmoPluginEntry` to avoid drift between detect/add paths; added regression tests for tuples, nested `plugin` keys, and comment-with-`plugin:` cases.

<sup>Written for commit 30d6ddbb76433445aed064ef3398dcb98b08842c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

