### PR TITLE
fix(omo-opencode): preserve session cwd for LSP MCP

### DIFF
--- a/packages/omo-opencode/src/mcp/index.ts
+++ b/packages/omo-opencode/src/mcp/index.ts
@@ -52,7 +52,7 @@ export function createBuiltinMcps(disabledMcps: string[] = [], config?: BuiltinM
   }
 
   if (!disabledMcps.includes("lsp")) {
-    mcps.lsp = createLspMcpConfig({ resolveExecutable: options.resolveExecutable })
+    mcps.lsp = createLspMcpConfig({ cwd: options.cwd, resolveExecutable: options.resolveExecutable })
   }
 
   if (!disabledMcps.includes("codegraph") && config?.codegraph?.enabled !== false) {

--- a/packages/omo-opencode/src/mcp/zauc-mocks-mcp-index/index.test.ts
+++ b/packages/omo-opencode/src/mcp/zauc-mocks-mcp-index/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test"
+import { delimiter, join } from "node:path"
 
 afterEach(() => {
   mock.restore()
@@ -148,5 +149,25 @@ describe("createBuiltinMcps", () => {
     if (result.lsp?.type !== "local") throw new Error("expected local MCP config")
     expect(["node", "bun"]).not.toContain(result.lsp.command[0])
     expect([nodePath, bunPath]).toContain(result.lsp.command[0])
+  })
+
+  test("forwards the session cwd to the LSP MCP config", async () => {
+    // given
+    mock.restore()
+    const sessionCwd = join(process.cwd(), "session-cwd")
+    const nodePath = join(sessionCwd, "node")
+    const { createBuiltinMcps } = await import(`../index?lsp-cwd=${Date.now()}-${Math.random()}`)
+
+    // when
+    const result = createBuiltinMcps([], undefined, {
+      cwd: sessionCwd,
+      resolveExecutable: (commandName: string) =>
+        commandName === "node" ? { command: nodePath, available: true } : { command: commandName, available: false },
+    })
+
+    // then
+    expect(result.lsp?.environment?.LSP_TOOLS_MCP_PROJECT_CONFIG).toBe(
+      [join(sessionCwd, ".opencode", "lsp.json"), join(sessionCwd, ".omo", "lsp.json"), join(sessionCwd, ".omo", "lsp-client.json")].join(delimiter),
+    )
   })
 })


### PR DESCRIPTION
## Summary
- Forward the existing OpenCode session cwd from createBuiltinMcps() to createLspMcpConfig().
- Add a regression test that verifies LSP project config paths derive from the supplied session cwd.

## Root cause
applyMcpConfig() already supplied ctx.directory to createBuiltinMcps(), but the LSP registration dropped it and fell back to the Desktop process cwd. On Windows this made the LSP request cwd C:\\Users\\<user> and rejected project files on another drive with [1mLSP file path must be inside request cwd[0m.

## Verification
- bun test packages/omo-opencode/src/plugin-handlers/mcp-config-handler.test.ts packages/omo-opencode/src/mcp/zauc-mocks-mcp-index/index.test.ts (15 passing)
- bun run typecheck (passing)
- bun x biome check on changed files (passing)
- Isolated OpenCode source-plugin QA: opencode debug config from D:\\Workspace\\mindbases produced LSP_TOOLS_MCP_PROJECT_CONFIG rooted at D:\\Workspace\\mindbases.

## Known environment limitations
- The full suite has unrelated Windows failures in tmux, Docker/CodeGraph, Codex installer, and generated-payload tests.
- bun run build reaches the vendored LSP package then fails on its existing Unix-only rm -rf dist script on Windows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make LSP MCP use the OpenCode session cwd by passing it from `createBuiltinMcps()` to `createLspMcpConfig()`. Fixes Windows path errors when projects live outside the Desktop process cwd.

- **Bug Fixes**
  - Resolved Windows rejection of project files outside the process cwd.
  - Added a regression test to ensure `LSP_TOOLS_MCP_PROJECT_CONFIG` paths derive from the session cwd.

<sup>Written for commit 9b837eeb273b10261e2dd3cbc43aac9765383b5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

