### PR TITLE
fix(lsp-core): prefer .git as workspace root over nearer sub-package markers

### DIFF
--- a/packages/lsp-core/src/lsp/client-wrapper.test.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.test.ts
@@ -61,3 +61,56 @@ describe("LSP client path confinement", () => {
 		).toThrow(LspInvalidPathError);
 	});
 });
+
+describe("findWorkspaceRoot marker priority", () => {
+	// given a project root with .git and a nested sub-package that has its own pyproject.toml
+	// when resolving workspace root for a file inside the sub-package
+	// then .git at the project root takes priority over the nearer pyproject.toml
+	it("#given .git at project root and nested pyproject.toml in sub-package #when resolving #then prefers .git over nearer pyproject.toml", () => {
+		const root = tempRoot("lsp-ws-priority-git-");
+		mkdirSync(join(root, ".git"), { recursive: true });
+		mkdirSync(join(root, "src", "modex_graph"), { recursive: true });
+		writeFileSync(join(root, "src", "modex_graph", "pyproject.toml"), "[project]\nname = 'modex-graph'\n");
+		writeFileSync(join(root, "src", "modex_graph", "compiled_graph.py"), "x = 1\n");
+
+		const workspace = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+			findWorkspaceRoot("src/modex_graph/compiled_graph.py"),
+		);
+
+		expect(workspace).toBe(realpathSync(root));
+	});
+
+	// given a sub-package with pyproject.toml but NO .git anywhere up the tree
+	// when resolving workspace root for a file inside the sub-package
+	// then falls back to the first non-.git marker (pyproject.toml directory)
+	it("#given nested pyproject.toml and no .git anywhere #when resolving #then falls back to first non-git marker", () => {
+		const root = tempRoot("lsp-ws-priority-fallback-");
+		mkdirSync(join(root, "src", "modex_graph"), { recursive: true });
+		writeFileSync(join(root, "src", "modex_graph", "pyproject.toml"), "[project]\nname = 'modex-graph'\n");
+		writeFileSync(join(root, "src", "modex_graph", "compiled_graph.py"), "x = 1\n");
+
+		const workspace = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+			findWorkspaceRoot("src/modex_graph/compiled_graph.py"),
+		);
+
+		expect(workspace).toBe(realpathSync(join(root, "src", "modex_graph")));
+	});
+
+	// given a directory with both .git and pyproject.toml at the same level
+	// when resolving workspace root
+	// then returns that directory (both markers agree)
+	it("#given .git and pyproject.toml at same level #when resolving #then returns that directory", () => {
+		const root = tempRoot("lsp-ws-priority-same-level-");
+		mkdirSync(join(root, ".git"), { recursive: true });
+		writeFileSync(join(root, "pyproject.toml"), "[project]\nname = 'my-project'\n");
+		mkdirSync(join(root, "src"), { recursive: true });
+		writeFileSync(join(root, "src", "main.py"), "x = 1\n");
+
+		const workspace = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+			findWorkspaceRoot("src/main.py"),
+		);
+
+		expect(workspace).toBe(realpathSync(root));
+	});
+
+});

--- a/packages/lsp-core/src/lsp/client-wrapper.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.ts
@@ -30,6 +30,11 @@ export function isDirectoryPath(filePath: string): boolean {
 	}
 }
 
+// Prefer .git as the authoritative workspace boundary so that sub-package
+// markers (e.g. a nested pyproject.toml in a monorepo) don't shadow the real
+// project root. Only fall back to other markers when no .git is found.
+const PRIMARY_MARKER = ".git";
+
 export function findWorkspaceRoot(filePath: string): string {
 	const abs = resolvePathInsideContext(filePath);
 	let dir = abs;
@@ -39,17 +44,25 @@ export function findWorkspaceRoot(filePath: string): string {
 	}
 
 	let prevDir = "";
+	let fallbackRoot: string | undefined;
 	while (dir !== prevDir) {
-		for (const marker of WORKSPACE_MARKERS) {
-			if (existsSync(join(dir, marker))) {
-				return dir;
+		if (existsSync(join(dir, PRIMARY_MARKER))) {
+			return dir;
+		}
+		if (fallbackRoot === undefined) {
+			for (const marker of WORKSPACE_MARKERS) {
+				if (marker === PRIMARY_MARKER) continue;
+				if (existsSync(join(dir, marker))) {
+					fallbackRoot = dir;
+					break;
+				}
 			}
 		}
 		prevDir = dir;
 		dir = dirname(dir);
 	}
 
-	return dirname(abs);
+	return fallbackRoot ?? dirname(abs);
 }
 
 export function resolvePathInsideContext(filePath: string): string {


### PR DESCRIPTION
## Problem

In monorepo-style Python projects where a sub-package has its own `pyproject.toml` (e.g. `ModexAgent/src/modex_graph/pyproject.toml`), `findWorkspaceRoot()` in `packages/lsp-core/src/lsp/client-wrapper.ts` stopped at the sub-package directory instead of reaching the real project root where `.git` lives.

This caused Pyright to be spawned with `cwd=<sub-package-dir>` instead of the project root. Pyright could not find the project venv or resolve imports, so it exited immediately with code 0. The `lsp_diagnostics` tool then returned errors or timed out.

### Reproduction (before fix)

On `ModexAgent` (has nested `src/modex_graph/pyproject.toml`), calling `lsp_diagnostics` via `opencode run --format json` on `src/modex_graph/compiled_graph.py`:

```
"status":"error",
"error":"LSP server pyright at F:\tool\pythonProject\ModexAgent\src\modex_graph exited with code null"
```

- Workspace root resolved to `src\modex_graph` (wrong) instead of the project root
- Second call: 30-second timeout
- Total: ~46s across two failed attempts

A control project without nested `pyproject.toml` works fine on the old code, confirming the issue is specific to the nesting pattern.

## Fix

Prefer `.git` as the authoritative workspace boundary. Walk all the way up looking for `.git` first; only if no `.git` is found, fall back to the first directory matching any other marker (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle`).

**Changed file:** `packages/lsp-core/src/lsp/client-wrapper.ts` (+17/-4)

Key change in `findWorkspaceRoot()`:
- New constant `PRIMARY_MARKER = ".git"`
- Loop checks `.git` first at every level; if found, returns immediately
- Tracks a `fallbackRoot` (first non-`.git` marker found) but does NOT return it until the loop completes without finding `.git`
- Returns `fallbackRoot ?? dirname(abs)` at the end

## Tests

3 regression tests added to `packages/lsp-core/src/lsp/client-wrapper.test.ts` under `describe("findWorkspaceRoot marker priority")`:

1. **`.git` at project root vs nested `pyproject.toml`** — verifies `.git` wins over a nearer `pyproject.toml` in a sub-package
2. **Nested `pyproject.toml` with no `.git`** — verifies fallback to first non-`.git` marker
3. **`.git` and `pyproject.toml` at same level** — verifies both markers agree

### Test results

```
bun test packages/lsp-core/src/lsp/client-wrapper.test.ts

5 pass, 1 fail
```

The 1 failure is a **pre-existing** Windows EPERM symlink permission issue (`symlinkSync` requires admin privileges on Windows), unrelated to this change. The 3 new tests all pass.

## Verification

### Typecheck

```
node_modules/.bin/tsgo.exe --noEmit -p packages/lsp-core/tsconfig.json
```

Zero errors. (Global typecheck fails only due to `@code-yeongyu/senpi` 404 on npmmirror, unrelated to this change.)

### Build

```
bun run build
```

All steps completed. `packages/lsp-daemon/dist/{index,cli,client}.js` contain `PRIMARY_MARKER = ".git"` and `fallbackRoot` logic (verified via `grep -c "PRIMARY_MARKER"` = 3 in each file).

### End-to-end comparison (real project)

**Test project:** `ModexAgent` (has nested `src/modex_graph/pyproject.toml`)
**Method:** `opencode run --format json` calling `lsp_diagnostics` on `src/modex_graph/compiled_graph.py`

| | Old code (before fix) | New code (after fix) |
|---|---|---|
| **Status** | `error` | `completed` |
| **Error** | `pyright at ...\src\modex_graph exited with code null` | none |
| **Workspace root** | `src\modex_graph` (wrong sub-package dir) | project root (correct, `.git` location) |
| **Response time** | 15.8s fail + 30s timeout | 3.5s |
| **Pyright** | crashed immediately | stayed alive |
| **Daemon log** | pyright exit errors | clean (no errors) |

### Control group (no nested pyproject.toml)

Tested a project with `.git` + `pyproject.toml` at the same level (no nesting). Both old and new code work correctly, confirming the fix does not regress existing behavior.

## PR Checklist

- [x] Code follows project conventions (kebab-case, barrel exports, given/when/then test style)
- [x] `bun run typecheck` passes (lsp-core package; global failure is pre-existing `@code-yeongyu/senpi` 404)
- [x] `bun run build` succeeds
- [x] `bun test` passes (5 pass / 1 pre-existing Windows symlink fail)
- [ ] `bun run test:codex` — not applicable (no Codex-side changes)
- [x] Tested locally with OpenCode (end-to-end on real project)
- [x] QA evidence recorded under `.omo/evidence/20260803-lsp-workspace-root-git-priority/`
- [x] No version changes in `package.json`

## Residual risk

The "No diagnostics found" result (rather than actual Pyright diagnostics) is a **pre-existing** LSP daemon diagnostics-polling issue that affects all languages (TypeScript files also return empty). It is independent of this workspace-root fix — the fix ensures Pyright stays alive and the daemon responds within timeout, which is the scope of this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `.git` the top priority for workspace root detection in `lsp-core` so nested `pyproject.toml` files don’t shadow the real project root. This fixes Pyright cwd issues in monorepos and restores reliable, fast LSP diagnostics.

- **Bug Fixes**
  - Updated `findWorkspaceRoot()` to return the nearest `.git` first; only falls back to the first other marker (`package.json`, `pyproject.toml`, etc.) if no `.git` is found.
  - Added three tests to cover priority over nested `pyproject.toml`, fallback when no `.git` exists, and same-level agreement.

<sup>Written for commit f869cac503e2752327c63622a806908367092149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

