### PR TITLE
fix(omo-opencode): keep slash skills out of goal fallback

### DIFF
--- a/packages/omo-opencode/src/plugin/chat-message.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-message.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { randomUUID } from "node:crypto"
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -8,6 +8,7 @@ import type { OhMyOpenCodeConfig } from "../config"
 import { readBoulderState } from "../features/boulder-state"
 import { _resetForTesting, getSessionAgent, registerAgentName, setMainSession, subagentSessions, updateSessionAgent } from "../features/claude-code-session-state"
 import { createAutoSlashCommandHook } from "../hooks/auto-slash-command"
+import { validateObjective } from "../hooks/goal/validation"
 import { createStartWorkHook } from "../hooks/start-work"
 import { getAgentListDisplayName } from "../shared/agent-display-names"
 import { getOmoOpenCodeCacheDir, getOpenCodeCacheDir } from "../shared/data-path"
@@ -617,6 +618,40 @@ describe("createChatMessageHandler - goal command handling and stop continuation
 })
 
 describe("createChatMessageHandler - /goal raw slash fallback", () => {
+  test("does not route an auto-slash-expanded skill payload into goal handling", async () => {
+    // given
+    const setGoal = mock((_: string, objective: string) => {
+      validateObjective(objective)
+      return { objective, status: "active" }
+    })
+    const goalMock = createGoalHookMock()
+    const args = createMockHandlerArgs()
+    args.hooks.autoSlashCommand = createAutoSlashCommandHook({
+      skills: unsafeTestValue([{
+        name: "long-skill",
+        definition: {
+          description: "Long skill regression fixture",
+          template: "x".repeat(2_100),
+        },
+        scope: "user",
+      }]),
+    })
+    args.hooks.goal = { ...goalMock.hook, setGoal }
+    const handler = createChatMessageHandler(args)
+    const output: ChatMessageHandlerOutput = {
+      message: {},
+      parts: [{ type: "text", text: "/long-skill" }],
+    }
+
+    // when
+    const run = handler(createMockInput("sisyphus"), output)
+
+    // then
+    await expect(run).resolves.toBeUndefined()
+    expect(setGoal).not.toHaveBeenCalled()
+    expect(output.parts[0].text).toContain("<auto-slash-command>")
+  })
+
   test("sets goal when /goal <objective> arrives through chat.message without native command expansion", async () => {
     // given
     const goalMock = createGoalHookMock()

--- a/packages/omo-opencode/src/plugin/chat-message/loop-commands.ts
+++ b/packages/omo-opencode/src/plugin/chat-message/loop-commands.ts
@@ -1,5 +1,6 @@
 import type { OhMyOpenCodeConfig } from "../../config"
 
+import { AUTO_SLASH_COMMAND_TAG_OPEN } from "../../hooks/auto-slash-command/constants"
 import { parseGoalCommand } from "../../hooks/goal/command-arguments"
 import { log } from "../../shared"
 import { extractPromptText } from "./prompt-text"
@@ -19,6 +20,9 @@ export function handleGoalMessage(args: {
   }
 
   const promptText = extractPromptText(output.parts)
+  if (promptText.includes(AUTO_SLASH_COMMAND_TAG_OPEN)) {
+    return
+  }
   const parsed = parseGoalCommand(promptText)
 
   switch (parsed.kind) {


### PR DESCRIPTION
## Summary

- prevent Goal's raw `/goal` fallback from parsing auto-slash-expanded skill payloads
- keep native and raw `/goal` command handling unchanged
- add a regression test using a skill body over the Goal objective limit

## Root cause

`chat.message` runs auto-slash expansion before Goal's compatibility fallback. With Goal enabled, a `/skill-name` prompt became the full tagged skill template, then the fallback treated that expanded payload as a default goal objective. Skills over 2,000 characters raised `InvalidObjectiveError`, aborting the prompt and making the submitted message disappear.

## Verification

- `bun test packages/omo-opencode/src/plugin/chat-message.test.ts packages/omo-opencode/src/plugin/command-execute-before.test.ts --bail` (39 pass)
- `bun run typecheck`
- `bun run build`
- isolated OpenCode 1.18.12 CLI `/opencode-qa` smoke test with Goal enabled and a fake model
- isolated server/SSE probe observed `message.part.updated`
- fake model received the expanded skill prompt
- no `InvalidObjectiveError` in the plugin log
- live OpenCode database session count remained unchanged

## Full-suite note

The full `bun test` run was stopped after unrelated repository-wide scan and Codex installer tests repeatedly exceeded their existing 5s/20s timeouts under local machine load. The affected Goal/OpenCode test files pass independently.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Goal fallback in `omo-opencode` from treating auto-slash-expanded skill payloads as `/goal` objectives, fixing dropped messages and `InvalidObjectiveError` for long skills. Native and raw `/goal` handling stays the same.

- **Bug Fixes**
  - Skip Goal fallback when the prompt contains the auto-slash tag (`AUTO_SLASH_COMMAND_TAG_OPEN`).
  - Ensures `/skill-name` expansions are not parsed as objectives.
  - Adds a regression test with a 2,100-char skill to verify Goal isn’t called and the expanded prompt is preserved.

<sup>Written for commit 6d56a912056dfe3f5834ce6998d15e7704d25cb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

