### PR TITLE
feat(omo-opencode): fall back to opencode default model for subagent delegation

### DIFF
--- a/packages/omo-opencode/src/tools/delegate-task/subagent-model-resolution.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/subagent-model-resolution.ts
@@ -24,6 +24,7 @@ export async function resolveSubagentModel(
   agentToUse: string,
   matchedAgent: AgentInfo,
   executorCtx: ExecutorContext,
+  systemDefaultModel?: string,
 ): Promise<ResolvedSubagentModel> {
   let categoryModel = undefined
   let fallbackChain = undefined
@@ -56,7 +57,7 @@ export async function resolveSubagentModel(
       categoryDefaultModel: matchedAgentModelStr,
       fallbackChain: agentRequirement?.fallbackChain,
       availableModels,
-      systemDefaultModel: undefined,
+      systemDefaultModel,
     })
 
     const resolutionSkipped = resolution && "skipped" in resolution

--- a/packages/omo-opencode/src/tools/delegate-task/subagent-resolver.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/subagent-resolver.ts
@@ -14,6 +14,7 @@ export async function resolveSubagentExecution(
   parentAgent: string | undefined,
   categoryExamples: string,
   options: ResolveSubagentExecutionOptions = {},
+  systemDefaultModel?: string,
 ): Promise<ResolveSubagentExecutionResult> {
   const preflight = validateSubagentRequest(args, parentAgent, categoryExamples, options)
   if (preflight.kind === "invalid") {
@@ -29,7 +30,7 @@ export async function resolveSubagentExecution(
     }
 
     agentToUse = agentMatch.agentToUse
-    const { categoryModel, fallbackChain } = await resolveSubagentModel(agentToUse, agentMatch.matchedAgent, executorCtx)
+    const { categoryModel, fallbackChain } = await resolveSubagentModel(agentToUse, agentMatch.matchedAgent, executorCtx, systemDefaultModel)
     return { agentToUse, categoryModel, fallbackChain }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)

--- a/packages/omo-opencode/src/tools/delegate-task/tools.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.ts
@@ -194,7 +194,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
           return executeUnstableAgentTask(delegateTaskArgs, ctx, options, parentContext, agentToUse, categoryModel, systemContent, actualModel)
         }
       } else {
-        const resolution = await resolveSubagentExecution(delegateTaskArgs, options, parentContext.agent, categoryExamples)
+        const resolution = await resolveSubagentExecution(delegateTaskArgs, options, parentContext.agent, categoryExamples, undefined, systemDefaultModel)
         if (resolution.error) {
           return resolution.error
         }

--- a/packages/omo-opencode/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver-system-default.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver-system-default.test.ts
@@ -1,0 +1,190 @@
+/// <reference types="bun-types" />
+
+// Focused sibling test: subagent (subagent_type=...) model resolution must fall back to the
+// opencode default/global model (systemDefaultModel) when no user/category/fallback-chain
+// model resolves — parity with the category path. Live behavior of resolveModelForDelegateTask
+// itself (systemDefaultModel as final step) is covered in ../model-selection.test.ts.
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import type { DelegateTaskArgs } from "../types"
+import type { ExecutorContext } from "../executor-types"
+
+type SubagentResolverModule = typeof import("../subagent-resolver")
+
+const logMock = mock((..._args: unknown[]) => {})
+
+const readConnectedProvidersCacheMock = mock(() => null as string[] | null)
+const readProviderModelsCacheMock = mock(
+  () => null as {
+    models: Record<string, string[]>
+    connected: string[]
+    updatedAt: string
+  } | null,
+)
+
+const loadUserAgentsMock = mock(() => ({}))
+const loadProjectAgentsMock = mock((_directory?: string) => ({}))
+
+async function importFreshSubagentResolverModule(): Promise<SubagentResolverModule> {
+  return await import(`../subagent-resolver?test=${Date.now()}-${Math.random()}`)
+}
+
+function createBaseArgs(overrides?: Partial<DelegateTaskArgs>): DelegateTaskArgs {
+  return {
+    description: "Run review",
+    prompt: "Review the current changes",
+    run_in_background: false,
+    load_skills: [],
+    ...overrides,
+  }
+}
+
+function createExecutorContext(
+  agentsFn: () => Promise<unknown>,
+  overrides?: Partial<ExecutorContext>,
+): ExecutorContext {
+  const client = {
+    app: { agents: agentsFn },
+  } as ExecutorContext["client"]
+
+  return {
+    client,
+    manager: {} as ExecutorContext["manager"],
+    directory: "/tmp/test",
+    ...overrides,
+  }
+}
+
+describe("resolveSubagentExecution - system default model fallback", () => {
+  let resolveSubagentExecution: SubagentResolverModule["resolveSubagentExecution"]
+
+  beforeEach(async () => {
+    mock.restore()
+    logMock.mockClear()
+    readConnectedProvidersCacheMock.mockReset()
+    readProviderModelsCacheMock.mockReset()
+    readConnectedProvidersCacheMock.mockReturnValue(null)
+    readProviderModelsCacheMock.mockReturnValue(null)
+    loadUserAgentsMock.mockReset()
+    loadProjectAgentsMock.mockReset()
+    loadUserAgentsMock.mockImplementation(() => ({}))
+    loadProjectAgentsMock.mockImplementation(() => ({}))
+    mock.module("../../../shared/logger", () => ({
+      log: logMock,
+    }))
+    mock.module("../../../shared/connected-providers-cache", () => ({
+      readConnectedProvidersCache: readConnectedProvidersCacheMock,
+      readProviderModelsCache: readProviderModelsCacheMock,
+      hasConnectedProvidersCache: () => readConnectedProvidersCacheMock() !== null,
+      hasProviderModelsCache: () => readProviderModelsCacheMock() !== null,
+      _resetMemCacheForTesting: () => {},
+    }))
+    mock.module("../../../features/claude-code-agent-loader/loader", () => ({
+      loadUserAgents: loadUserAgentsMock,
+      loadProjectAgents: loadProjectAgentsMock,
+    }))
+    mock.module("../../../features/claude-code-agent-loader", () => ({
+      loadUserAgents: loadUserAgentsMock,
+      loadProjectAgents: loadProjectAgentsMock,
+    }))
+    ;({ resolveSubagentExecution } = await importFreshSubagentResolverModule())
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test("#given no reachable agent-default or fallback-chain model and a system default #when delegating #then categoryModel falls back to the opencode default model", async () => {
+    //#given - warm cache: only 'minimaxi' connected, agent default model on disconnected 'openai'
+    readProviderModelsCacheMock.mockReturnValue({
+      models: { minimaxi: ["MiniMax-M2.7"] },
+      connected: ["minimaxi"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    readConnectedProvidersCacheMock.mockReturnValue(["minimaxi"])
+    const args = createBaseArgs({ subagent_type: "oracle" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "oracle", mode: "subagent", model: "openai/gpt-5.5" },
+    ]))
+    const systemDefaultModel = "openai/gpt-5.4"
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep", {}, systemDefaultModel)
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+  })
+
+  test("#given a reachable agent default model #when delegating #then the agent default wins over the system default", async () => {
+    //#given - warm cache: 'openai' connected and the agent's own default is available
+    readProviderModelsCacheMock.mockReturnValue({
+      models: { openai: ["gpt-5.5"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    readConnectedProvidersCacheMock.mockReturnValue(["openai"])
+    const args = createBaseArgs({ subagent_type: "oracle" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "oracle", mode: "subagent", model: "openai/gpt-5.5" },
+    ]))
+    const systemDefaultModel = "openai/gpt-5.4"
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep", {}, systemDefaultModel)
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+  })
+
+  test("#given no system default #when delegating with an unreachable agent default #then categoryModel stays undefined (current behavior)", async () => {
+    //#given - warm cache: only 'minimaxi' connected, agent default model on disconnected 'openai'
+    readProviderModelsCacheMock.mockReturnValue({
+      models: { minimaxi: ["MiniMax-M2.7"] },
+      connected: ["minimaxi"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    readConnectedProvidersCacheMock.mockReturnValue(["minimaxi"])
+    const args = createBaseArgs({ subagent_type: "oracle" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "oracle", mode: "subagent", model: "openai/gpt-5.5" },
+    ]))
+
+    //#when - no systemDefaultModel passed (6th arg omitted)
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toBeUndefined()
+  })
+
+  test("#given an explicit per-agent model override #when delegating #then the override wins over the system default", async () => {
+    //#given
+    readProviderModelsCacheMock.mockReturnValue({
+      models: { quotio: ["claude-haiku-4-5"] },
+      connected: ["quotio"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    readConnectedProvidersCacheMock.mockReturnValue(["quotio"])
+    const args = createBaseArgs({ subagent_type: "explore" })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "explore", mode: "subagent", model: "quotio/claude-haiku-4-5" },
+      ]),
+      {
+        agentOverrides: {
+          explore: { model: "quotio/claude-haiku-4-5" },
+        } as ExecutorContext["agentOverrides"],
+      }
+    )
+    const systemDefaultModel = "openai/gpt-5.4"
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep", {}, systemDefaultModel)
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({ providerID: "quotio", modelID: "claude-haiku-4-5" })
+  })
+})


### PR DESCRIPTION
## Summary

When you delegate to a **named subagent** via `task(subagent_type="explore")` (as opposed to a category), the model resolver dropped the opencode default model: `resolveModelForDelegateTask` was called with `systemDefaultModel: undefined`, so a subagent whose agent default and fallback chain are all unreachable returned `undefined` and only implicitly inherited the default. The category path already threads `systemDefaultModel` as its last-resort fallback.

This change makes the **subagent path symmetric with the category path**: the opencode default/global model (already read from `client.config.get().data.model` for categories) now flows through `resolveSubagentExecution` -> `resolveSubagentModel` -> `resolveModelForDelegateTask`, so a `task(subagent_type=...)` that can't resolve any model deterministically falls back to the opencode default model. Explicit agent/category overrides and reachable agent defaults still win (unchanged). This is most useful for single-model setups (e.g. a local model) where, with no per-agent config, a named-subagent delegation now explicitly resolves onto the same model the main session uses.

## Changes

- `tools.ts` — pass the already-discovered `systemDefaultModel` into `resolveSubagentExecution` for the `subagent_type` path (mirrors the existing `resolveCategoryExecution` call).
- `subagent-resolver.ts` — accept `systemDefaultModel?: string` and forward it to `resolveSubagentModel`.
- `subagent-model-resolution.ts` — accept `systemDefaultModel?: string` and pass it as `systemDefaultModel` to `resolveModelForDelegateTask` (was hardcoded `undefined`).
- `zauc-mocks-subagent-resolver/subagent-resolver-system-default.test.ts` — new focused sibling test: (S1) fallback to the opencode default when agent default + fallback chain are unreachable; (S2) reachable agent default still wins; (S3) absent default keeps current behavior (`undefined`); (S4) explicit per-agent override still wins.

## QA & Evidence

Per the contributing guide (`CONTRIBUTING.md`), all checklist items were run:

- **Unit (RED->GREEN):** S1 in `subagent-resolver-system-default.test.ts` — warm cache, oracle's default + fallback chain unreachable, `systemDefaultModel` provided -> expects `categoryModel = { providerID, modelID }` of the default. RED before the change (`undefined`), GREEN after (4/4 pass).
- **`bun run typecheck`** — clean.
- **`bun run build`** — SUCCESS (full repo build, `BUILD_EXIT=0`, "build: all steps completed"). The fresh worktree initially hit a stale un-initialized `open-design` submodule during materialize; per the guide's non-fatal submodule setup this is resolved by `git submodule update --init` and the build then passes.
- **`bun test`** (full root suite after build) — **13235 pass / 10 fail**; all 10 failures are pre-existing Windows-platform assertions (`shell-env`/`executeOnCompleteHook` PowerShell/`cmd.exe`/`$env:` on Linux) and `codex components doctor` requiring the `sg`/ast-grep binary on PATH. **None touch delegate-task/model-selection/subagent-resolver or the new test** (that area is 487/487 plus the 4 new tests).
- **Real harness (opencode-qa, isolated XDG sandbox):** booted a real `opencode run` with the built plugin and only a local model; a `task(run_in_background=false, subagent_type="explore", ...)` delegation (no per-agent model) resolved the subagent onto the opencode default model — task metadata `"model": { "providerID": "local", "modelID": "deepseek-ai/DeepSeek-V4-Flash-0731" }` — and the subagent completed.
- **Artifacts:** `.omo/evidence/2026-08-04-subagent-system-default-fallback/` (EVIDENCE.md incl. addendum, delegate-run.json, unit summary).
- `bun run test:codex` — **N/A**: no Codex-side (`packages/omo-codex`) change; the guide scopes it to Codex-side changes.

## Risks & Residuals

- Residual regression risk is low: the change only adds a final last-resort fallback (systemDefaultModel is step 6 of the resolver, after user/category/fallback-chain), so it never changes a resolution that already succeeds.
- The 10 remaining `bun test` failures are pre-existing platform/environment issues (Windows-only assertions on Linux; `sg` binary absent) and are not introduced by this PR.
- **Merge is currently gated externally:** the PR is opened from a fork (`Marker689/oh-my-openagent`), and the upstream `ci.yml` workflow run is in `action_required` state, i.e. it awaits approval to run on the fork PR from a repo maintainer. CLA / GitGuardian / labels already pass.

## Related Issues

No issue filed; request originated as a user-reported gap for local-model setups.