### PR TITLE
fix(omo-opencode): accept migrated agent model chains

### DIFF
--- a/.omo/evidence/20260804-discord-config-migration/green.md
+++ b/.omo/evidence/20260804-discord-config-migration/green.md
@@ -1,0 +1,141 @@
+# Targeted GREEN Evidence
+
+## Migrated canonical agent model chain
+
+Command:
+
+```text
+bun test packages/omo-opencode/src/config/validate.test.ts -t 'migrated canonical agent model chain'
+```
+
+Observed:
+
+```text
+1 pass
+0 fail
+5 expect() calls
+```
+
+The resolved runtime config contains:
+
+- primary `model: "provider/primary"`
+- primary `reasoning: "low"`
+- `fallback_models: [{ model: "provider/fallback", reasoning: "medium" }]`
+- no unknown-key diagnostics for `agents.explore.models`
+
+## Doctor plugin-harness warning behavior
+
+Command:
+
+```text
+bun test packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts -t 'ignores plugin-supported'
+```
+
+Observed:
+
+```text
+1 pass
+0 fail
+2 expect() calls
+```
+
+Doctor continues to report deprecated canonical base keys, but skips OpenCode plugin harness blocks where `variant` and `fallback_models` remain supported.
+
+## Implementation scope
+
+- OpenCode agent override schema accepts the canonical `models` chain.
+- Config-chain model input preserves `models` through unified schema resolution.
+- Runtime validation materializes the chain to existing `model`, `reasoning`, and `fallback_models` consumers before disabled-provider filtering.
+- Doctor deprecation scanning does not recurse into harness blocks.
+
+## Scoped regression suite
+
+Command:
+
+```text
+bun test \
+  packages/omo-opencode/src/config-migration/reasoning-unification.test.ts \
+  packages/omo-opencode/src/config/validate.test.ts \
+  packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts \
+  packages/omo-opencode/src/startup-migration.test.ts \
+  packages/omo-opencode/src/shared/disabled-providers.test.ts
+```
+
+Observed:
+
+```text
+37 pass
+0 fail
+116 expect() calls
+```
+
+Strict package TypeScript diagnostic:
+
+```text
+bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json
+exit 0
+```
+
+The built-in LSP tool could not inspect the task-owned sibling worktree because it only accepts paths under the session’s original checkout. No LSP-clean claim is made; strict `tsgo` is the recorded substitute.
+
+Pure code-line measurements for every changed TypeScript file are below the 250-line limit. Highest: `config/validate.test.ts` at 238.
+
+## Repository gates
+
+Schema generation:
+
+```text
+bun run build:schema
+✓ JSON Schemas generated: assets/omo.schema.json, assets/oh-my-opencode.schema.json
+```
+
+Full typecheck:
+
+```text
+bun run typecheck
+exit 0
+```
+
+Full build:
+
+```text
+bun run build
+build: all steps completed
+```
+
+The build regenerated unrelated vendored Codex/Senpi artifacts. Those build-only changes were removed from the branch; the final tracked scope contains only the required two schema assets plus six OpenCode source/test files.
+
+## Self-review adjacent-harness GREEN
+
+The doctor exemption was narrowed from every harness block to `[opencode]` only.
+
+Command:
+
+```text
+bun test packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
+```
+
+Observed:
+
+```text
+2 pass
+0 fail
+4 expect() calls
+```
+
+This proves:
+
+- plugin-supported `[opencode]` tuning keys are ignored;
+- canonical `[senpi]` and `[codex]` deprecated keys remain reported.
+
+After that correction:
+
+```text
+bun run typecheck
+exit 0
+
+bun run build
+build: all steps completed
+```
+
+The four unrelated rebuild-only Codex/Senpi artifacts were removed from the final diff.

--- a/.omo/evidence/20260804-discord-config-migration/legacy-input.jsonc
+++ b/.omo/evidence/20260804-discord-config-migration/legacy-input.jsonc
@@ -1,0 +1,16 @@
+{
+  "[opencode]": {
+    "agents": {
+      "explore": {
+        "model": "anthropic/claude-fable-5",
+        "variant": "high",
+        "fallback_models": [
+          {
+            "model": "openai/gpt-5.6-sol-fast",
+            "variant": "medium"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/.omo/evidence/20260804-discord-config-migration/qa.md
+++ b/.omo/evidence/20260804-discord-config-migration/qa.md
@@ -1,0 +1,155 @@
+# Isolated OpenCode CLI QA
+
+## What was tested
+
+Surface: real source CLI and runtime config loader in the task-owned worktree.
+
+Input artifact:
+
+`legacy-input.jsonc`
+
+```json
+{
+  "[opencode]": {
+    "agents": {
+      "explore": {
+        "model": "anthropic/claude-fable-5",
+        "variant": "high",
+        "fallback_models": [
+          {
+            "model": "openai/gpt-5.6-sol-fast",
+            "variant": "medium"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Isolation:
+
+- `source script/agent/qa-sandbox.sh`
+- isolated XDG data/config/cache/state directories
+- isolated `CODEX_HOME`
+- isolated `HOME` for `~/.omo/omo.jsonc`
+- `OPENCODE_DISABLE_AUTOUPDATE=1`
+- `OPENCODE_DISABLE_MODELS_FETCH=1`
+
+Actions:
+
+1. Run `bun run packages/omo-opencode/src/cli/index.ts config migrate --json`.
+2. Hash the migrated `~/.omo/omo.jsonc`.
+3. Run the same migration a second time and hash again.
+4. Run `bun run packages/omo-opencode/src/cli/index.ts doctor --json --platform=opencode`.
+5. Run `validatePluginConfig()` against a project directory under the isolated home.
+6. Compare OpenCode session counts before and after.
+
+## What was observed
+
+Migration:
+
+```text
+first exit: 0
+second exit: 0
+first hash:  355e7fec9b8481c9f312576e636bf975ea1807588e037c386d9212165664381a
+second hash: 355e7fec9b8481c9f312576e636bf975ea1807588e037c386d9212165664381a
+```
+
+The migrated config contains:
+
+```json
+{
+  "[opencode]": {
+    "agents": {
+      "explore": {
+        "models": [
+          {
+            "model": "anthropic/claude-fable-5",
+            "reasoning": "high"
+          },
+          {
+            "model": "openai/gpt-5.6-sol-fast",
+            "reasoning": "medium"
+          }
+        ]
+      }
+    }
+  },
+  "_migrations": [
+    "2026-08-reasoning-unification"
+  ]
+}
+```
+
+Doctor configuration checks:
+
+```text
+Configuration: pass — Configuration is valid
+Configuration: pass — No deprecated reasoning keys found
+hasUnknownModels: false
+hasDeprecatedHarness: false
+```
+
+The overall doctor exit was `1` only because the intentionally empty isolated OpenCode config does not register the plugin. That unrelated system check is expected in this hermetic scenario.
+
+Runtime-loaded agent config:
+
+```json
+{
+  "valid": true,
+  "messages": [],
+  "explore": {
+    "model": "anthropic/claude-fable-5",
+    "reasoning": "high",
+    "fallback_models": [
+      {
+        "model": "openai/gpt-5.6-sol-fast",
+        "reasoning": "medium"
+      }
+    ]
+  }
+}
+```
+
+OpenCode database isolation:
+
+```text
+sessions before: 0
+sessions after:  0
+```
+
+## Why it is enough
+
+- The exact legacy plugin keys reported in Discord and issue #6567 were passed through the real migration command.
+- Hash equality proves repeated migration is idempotent.
+- The real doctor configuration checks prove the canonical output is accepted and does not produce the reported warning spam.
+- The runtime loader proves the migrated canonical chain reaches the execution-facing `model`, `reasoning`, and `fallback_models` fields instead of falling back to defaults.
+- Session count equality proves the QA did not pollute the real or isolated OpenCode session database.
+
+## Cleanup receipt
+
+Removed and verified absent:
+
+- `/var/folders/nj/hqfr8ndn5q56cqw7jqgbrck40000gn/T/omo-qa-sandbox.XXXXXX.S4qmb1Nm5K`
+- `/var/folders/nj/hqfr8ndn5q56cqw7jqgbrck40000gn/T/omo-qa-sandbox.XXXXXX.yuwTgRcO5b`
+
+No server, port, tmux session, browser tab, container, socket, or QA-only environment remains.
+
+After the harness-scope correction, the affected isolated doctor scenario was re-run:
+
+```text
+migration exit: 0
+Configuration: pass — Configuration is valid
+Configuration: pass — No deprecated reasoning keys found
+hasUnknownModels: false
+hasDeprecatedHarness: false
+sessions: 0 → 0
+QA root removed: verified
+```
+
+## What was omitted
+
+- `.env` contents, provider credentials, auth headers, tokens, and private model-cache data.
+- Unrelated doctor output for missing plugin registration and absent model cache, except the summarized reason for the overall exit code.
+- The first dummy-model QA run is not used as runtime selection evidence because unknown model IDs correctly resolved to defaults; it is retained only in the cleanup receipt.

--- a/.omo/evidence/20260804-discord-config-migration/red.md
+++ b/.omo/evidence/20260804-discord-config-migration/red.md
@@ -1,0 +1,78 @@
+# Failing-First Evidence
+
+Base: `origin/dev` commit `b33a4250fa37973cd144947abb4db7ea0c13746e`
+Branch: `fix/config-migration-model-chains`
+
+## Migrated canonical agent model chain
+
+Command:
+
+```text
+bun test packages/omo-opencode/src/config/validate.test.ts -t 'migrated canonical agent model chain'
+```
+
+Observed RED:
+
+```text
+Expected: []
+Received:
+[
+  ".../.omo/omo.jsonc: Unknown config key: agents.explore.models",
+]
+
+0 pass
+1 fail
+```
+
+Binary verdict: FAIL, for the reported reason. The reasoning-unification migration emits `agents.*.models`, but the OpenCode plugin config surface rejects that key.
+
+## Doctor plugin-harness warnings
+
+Command:
+
+```text
+bun test packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts -t 'ignores plugin-supported'
+```
+
+Observed RED:
+
+```text
+Expected only:
+  categories.deep.variant
+
+Received additional warnings:
+  [opencode].agents.explore.variant
+  [opencode].agents.explore.fallback_models
+
+0 pass
+1 fail
+```
+
+Binary verdict: FAIL, for the reported reason. The doctor scanner applies canonical migration guidance inside the OpenCode plugin block where `variant` and `fallback_models` remain supported runtime keys.
+
+## Environment correction
+
+The first attempted test run failed before assertions because the fresh worktree lacked complete workspace package links. `bun install --force --ignore-scripts` repaired the isolated worktree dependency graph. That environment failure is not counted as RED evidence.
+
+## Cleanup
+
+- Test fixtures use temporary directories and remove them in `finally`.
+- No process, server, port, container, or tmux session was created.
+- The dirty main checkout was not modified.
+
+## Self-review adjacent-harness RED
+
+The first doctor implementation skipped every harness block. A new assertion required canonical `[senpi]` and `[codex]` blocks to remain scanned while `[opencode]` stays exempt.
+
+Observed before narrowing:
+
+```text
+Expected:
+  [senpi].agents.explore.variant
+  [codex].categories.deep.fallback_models
+
+Received neither entry.
+
+0 pass
+1 fail
+```

--- a/.omo/evidence/20260804-discord-config-migration/self-review.md
+++ b/.omo/evidence/20260804-discord-config-migration/self-review.md
@@ -1,0 +1,33 @@
+# Self Review
+
+Reviewer gate: not triggered. This is HEAVY work, but no user-requested `ulw-plan` plan artifact exists for this change, so the workflow requires a recorded self-review rather than `momus`/`metis`.
+
+## Criterion reconciliation
+
+1. Ownership/status: PASS in `triage.md`.
+2. Failing-first proof: PASS in `red.md`, including the self-review adjacent-harness RED.
+3. Targeted GREEN: PASS in `green.md`.
+4. Migration, startup, validator, doctor, and disabled-provider regression suite: PASS, 37 tests and 116 assertions before the final doctor-only correction; the affected doctor file then passed 2 tests and 4 assertions.
+5. Strict type safety: PASS, full `bun run typecheck` after the final source change.
+6. Build/schema: PASS, `bun run build:schema` and final `bun run build`.
+7. Real surface: PASS in `qa.md`.
+8. Cleanup: PASS for all QA sandboxes and browser resources.
+
+## Architectural self-review
+
+1. Root cause, not symptom: yes. The plugin schema/config-chain/runtime view now agrees with the migration’s canonical `models` output.
+2. Smallest correct change: yes. No fallback hook, background agent, or unrelated model-resolution behavior from draft PR #6516 was copied.
+3. Type safety: yes. Zod defines the new input shape; no `any`, ignore directive, or suppression was added.
+4. Boundary behavior: yes. Canonical input is accepted at the config boundary and materialized once into existing runtime fields.
+5. Adjacent policy preserved: yes. Only `[opencode]` is excluded from canonical deprecation scanning; `[senpi]` and `[codex]` remain covered.
+6. Tests can fail for the regressions: yes. Both original tests were observed RED for the named failure; the adjacent harness test was also observed RED before narrowing.
+7. Operational proof: yes. Real migration, idempotence, doctor configuration checks, runtime loading, DB isolation, and teardown were observed.
+
+## Diff review
+
+- `git diff --check`: clean.
+- Final tracked scope: two required generated schema assets and six OpenCode source/test files.
+- All changed TypeScript files are below 250 pure code lines.
+- No unrelated generated Codex/Senpi outputs remain.
+
+Tier remains HEAVY because the change affects persisted config migration and crosses validation, doctor, generated schemas, and runtime agent model selection.

--- a/.omo/evidence/20260804-discord-config-migration/triage.md
+++ b/.omo/evidence/20260804-discord-config-migration/triage.md
@@ -1,0 +1,38 @@
+# Discord Config Migration Triage
+
+Date: 2026-08-05 KST
+Repository: `code-yeongyu/oh-my-openagent`
+Discord report: `1534283281300979743`
+
+## What was inspected
+
+- Linked Discord message and surrounding migration/delegation discussion.
+- GitHub issue #6567 and related PRs #6560 and #6516.
+- Latest `origin/dev` migration, plugin schema, config-chain, doctor, and runtime-loading paths.
+
+## Ownership verdict
+
+PASS: this is a repository-owned defect.
+
+The `2026-08-reasoning-unification` migration writes canonical `agents.*.models`. Latest `origin/dev` still rejected that key in `AgentOverrideConfigSchema`, omitted it from config-chain model input, and warned about still-supported `[opencode]` `variant`/`fallback_models` keys. That matches the Discord reports that migration leaves invalid config and delegation stops honoring configured models.
+
+## Existing PR status
+
+- #6560 fixes generated JSON Schema identity/required-array issues and covers none of this runtime migration path. It remains separate.
+- #6516 targets canonical runtime model chains but is a draft external PR with no dedicated tests and broader fallback changes. This branch implements only the reproduced, tested subset on current `origin/dev`.
+
+## Source evidence
+
+- https://github.com/code-yeongyu/oh-my-openagent/issues/6567
+- https://github.com/code-yeongyu/oh-my-openagent/pull/6560
+- https://github.com/code-yeongyu/oh-my-openagent/pull/6516
+
+## Omitted or sanitized
+
+- Discord credentials, tokens, auth headers, and raw credential files.
+- Unrelated channel messages and issue/PR JSON.
+- The missing Discord visual payload; independent text, issue, code, and runtime evidence establish ownership.
+
+## Triage cleanup
+
+No linked Discord browser tab, Discord desktop window, server process, port, temp file, or login session remains.

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -105,6 +105,95 @@
             "model": {
               "type": "string"
             },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
             "fallback_models": {
               "anyOf": [
                 {
@@ -567,6 +656,95 @@
           "properties": {
             "model": {
               "type": "string"
+            },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
             },
             "fallback_models": {
               "anyOf": [
@@ -1031,6 +1209,95 @@
             "model": {
               "type": "string"
             },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
             "fallback_models": {
               "anyOf": [
                 {
@@ -1493,6 +1760,95 @@
           "properties": {
             "model": {
               "type": "string"
+            },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
             },
             "fallback_models": {
               "anyOf": [
@@ -1960,6 +2316,95 @@
             "model": {
               "type": "string"
             },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
             "fallback_models": {
               "anyOf": [
                 {
@@ -2422,6 +2867,95 @@
           "properties": {
             "model": {
               "type": "string"
+            },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
             },
             "fallback_models": {
               "anyOf": [
@@ -2886,6 +3420,95 @@
             "model": {
               "type": "string"
             },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
             "fallback_models": {
               "anyOf": [
                 {
@@ -3348,6 +3971,95 @@
           "properties": {
             "model": {
               "type": "string"
+            },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
             },
             "fallback_models": {
               "anyOf": [
@@ -3812,6 +4524,95 @@
             "model": {
               "type": "string"
             },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
             "fallback_models": {
               "anyOf": [
                 {
@@ -4274,6 +5075,95 @@
           "properties": {
             "model": {
               "type": "string"
+            },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
             },
             "fallback_models": {
               "anyOf": [
@@ -4738,6 +5628,95 @@
             "model": {
               "type": "string"
             },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
             "fallback_models": {
               "anyOf": [
                 {
@@ -5200,6 +6179,95 @@
           "properties": {
             "model": {
               "type": "string"
+            },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
             },
             "fallback_models": {
               "anyOf": [
@@ -5664,6 +6732,95 @@
             "model": {
               "type": "string"
             },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
             "fallback_models": {
               "anyOf": [
                 {
@@ -6126,6 +7283,95 @@
           "properties": {
             "model": {
               "type": "string"
+            },
+            "models": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "off",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "auto"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "reasoningEffort": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max"
+                        ]
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "maxTokens": {
+                        "type": "number"
+                      },
+                      "thinking": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "enabled",
+                              "disabled"
+                            ]
+                          },
+                          "budgetTokens": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "model"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
             },
             "fallback_models": {
               "anyOf": [
@@ -6590,6 +7836,95 @@
         "properties": {
           "model": {
             "type": "string"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": "string"
+                    },
+                    "reasoning": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "off",
+                            "minimal",
+                            "low",
+                            "medium",
+                            "high",
+                            "xhigh",
+                            "max",
+                            "auto"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "variant": {
+                      "type": "string"
+                    },
+                    "reasoningEffort": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max"
+                      ]
+                    },
+                    "temperature": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 2
+                    },
+                    "top_p": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "maxTokens": {
+                      "type": "number"
+                    },
+                    "thinking": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled"
+                          ]
+                        },
+                        "budgetTokens": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "model"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
           },
           "fallback_models": {
             "anyOf": [

--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -1309,6 +1309,95 @@
                 "model": {
                   "type": "string"
                 },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
                 "fallback_models": {
                   "anyOf": [
                     {
@@ -1771,6 +1860,95 @@
               "properties": {
                 "model": {
                   "type": "string"
+                },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
                 },
                 "fallback_models": {
                   "anyOf": [
@@ -2235,6 +2413,95 @@
                 "model": {
                   "type": "string"
                 },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
                 "fallback_models": {
                   "anyOf": [
                     {
@@ -2697,6 +2964,95 @@
               "properties": {
                 "model": {
                   "type": "string"
+                },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
                 },
                 "fallback_models": {
                   "anyOf": [
@@ -3164,6 +3520,95 @@
                 "model": {
                   "type": "string"
                 },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
                 "fallback_models": {
                   "anyOf": [
                     {
@@ -3626,6 +4071,95 @@
               "properties": {
                 "model": {
                   "type": "string"
+                },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
                 },
                 "fallback_models": {
                   "anyOf": [
@@ -4090,6 +4624,95 @@
                 "model": {
                   "type": "string"
                 },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
                 "fallback_models": {
                   "anyOf": [
                     {
@@ -4552,6 +5175,95 @@
               "properties": {
                 "model": {
                   "type": "string"
+                },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
                 },
                 "fallback_models": {
                   "anyOf": [
@@ -5016,6 +5728,95 @@
                 "model": {
                   "type": "string"
                 },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
                 "fallback_models": {
                   "anyOf": [
                     {
@@ -5478,6 +6279,95 @@
               "properties": {
                 "model": {
                   "type": "string"
+                },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
                 },
                 "fallback_models": {
                   "anyOf": [
@@ -5942,6 +6832,95 @@
                 "model": {
                   "type": "string"
                 },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
                 "fallback_models": {
                   "anyOf": [
                     {
@@ -6404,6 +7383,95 @@
               "properties": {
                 "model": {
                   "type": "string"
+                },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
                 },
                 "fallback_models": {
                   "anyOf": [
@@ -6868,6 +7936,95 @@
                 "model": {
                   "type": "string"
                 },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
                 "fallback_models": {
                   "anyOf": [
                     {
@@ -7330,6 +8487,95 @@
               "properties": {
                 "model": {
                   "type": "string"
+                },
+                "models": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "off",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max",
+                                  "auto"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
                 },
                 "fallback_models": {
                   "anyOf": [
@@ -7794,6 +9040,95 @@
             "properties": {
               "model": {
                 "type": "string"
+              },
+              "models": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "model": {
+                          "type": "string"
+                        },
+                        "reasoning": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "off",
+                                "minimal",
+                                "low",
+                                "medium",
+                                "high",
+                                "xhigh",
+                                "max",
+                                "auto"
+                              ]
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "variant": {
+                          "type": "string"
+                        },
+                        "reasoningEffort": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "minimal",
+                            "low",
+                            "medium",
+                            "high",
+                            "xhigh",
+                            "max"
+                          ]
+                        },
+                        "temperature": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 2
+                        },
+                        "top_p": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "maxTokens": {
+                          "type": "number"
+                        },
+                        "thinking": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "enabled",
+                                "disabled"
+                              ]
+                            },
+                            "budgetTokens": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "model"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
               },
               "fallback_models": {
                 "anyOf": [
@@ -13311,6 +14646,95 @@
                       "model": {
                         "type": "string"
                       },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "fallback_models": {
                         "anyOf": [
                           {
@@ -13773,6 +15197,95 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
                       },
                       "fallback_models": {
                         "anyOf": [
@@ -14237,6 +15750,95 @@
                       "model": {
                         "type": "string"
                       },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "fallback_models": {
                         "anyOf": [
                           {
@@ -14699,6 +16301,95 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
                       },
                       "fallback_models": {
                         "anyOf": [
@@ -15166,6 +16857,95 @@
                       "model": {
                         "type": "string"
                       },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "fallback_models": {
                         "anyOf": [
                           {
@@ -15628,6 +17408,95 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
                       },
                       "fallback_models": {
                         "anyOf": [
@@ -16092,6 +17961,95 @@
                       "model": {
                         "type": "string"
                       },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "fallback_models": {
                         "anyOf": [
                           {
@@ -16554,6 +18512,95 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
                       },
                       "fallback_models": {
                         "anyOf": [
@@ -17018,6 +19065,95 @@
                       "model": {
                         "type": "string"
                       },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "fallback_models": {
                         "anyOf": [
                           {
@@ -17480,6 +19616,95 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
                       },
                       "fallback_models": {
                         "anyOf": [
@@ -17944,6 +20169,95 @@
                       "model": {
                         "type": "string"
                       },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "fallback_models": {
                         "anyOf": [
                           {
@@ -18406,6 +20720,95 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
                       },
                       "fallback_models": {
                         "anyOf": [
@@ -18870,6 +21273,95 @@
                       "model": {
                         "type": "string"
                       },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "fallback_models": {
                         "anyOf": [
                           {
@@ -19332,6 +21824,95 @@
                     "properties": {
                       "model": {
                         "type": "string"
+                      },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "reasoning": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "off",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "auto"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "variant": {
+                                  "type": "string"
+                                },
+                                "reasoningEffort": {
+                                  "type": "string",
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ]
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "top_p": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "maxTokens": {
+                                  "type": "number"
+                                },
+                                "thinking": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "enabled",
+                                        "disabled"
+                                      ]
+                                    },
+                                    "budgetTokens": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "model"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
                       },
                       "fallback_models": {
                         "anyOf": [
@@ -19796,6 +22377,95 @@
                   "properties": {
                     "model": {
                       "type": "string"
+                    },
+                    "models": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "model": {
+                                "type": "string"
+                              },
+                              "reasoning": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "off",
+                                      "minimal",
+                                      "low",
+                                      "medium",
+                                      "high",
+                                      "xhigh",
+                                      "max",
+                                      "auto"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ]
+                              },
+                              "variant": {
+                                "type": "string"
+                              },
+                              "reasoningEffort": {
+                                "type": "string",
+                                "enum": [
+                                  "none",
+                                  "minimal",
+                                  "low",
+                                  "medium",
+                                  "high",
+                                  "xhigh",
+                                  "max"
+                                ]
+                              },
+                              "temperature": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 2
+                              },
+                              "top_p": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              },
+                              "maxTokens": {
+                                "type": "number"
+                              },
+                              "thinking": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "enabled",
+                                      "disabled"
+                                    ]
+                                  },
+                                  "budgetTokens": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "type"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "model"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
                     },
                     "fallback_models": {
                       "anyOf": [

--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -66,8 +66,88 @@ describe("deprecated reasoning keys check", () => {
       expect(result.issues.map((issue) => issue.description)).toEqual([
         `${configPath}: categories.deep.variant`,
         `${configPath}: agents.oracle.reasoningEffort`,
-        `${configPath}: [opencode].agents.sisyphus.thinking`,
-        `${configPath}: [opencode].agents.sisyphus.textVerbosity`,
+      ])
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(testRootDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+      }
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+    }
+  })
+
+  it("ignores plugin-supported reasoning keys inside opencode harness blocks", async () => {
+    //#given canonical base config plus plugin-specific opencode tuning
+    const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+    const originalHome = process.env.HOME
+    const originalCwd = process.cwd()
+    const testRootDir = mkdtempSync(join(tmpdir(), "omo-doctor-opencode-reasoning-"))
+    const projectDir = join(testRootDir, "project")
+    const configPath = join(testRootDir, ".omo", "omo.jsonc")
+
+    try {
+      mkdirSync(projectDir, { recursive: true })
+      mkdirSync(join(testRootDir, ".omo"), { recursive: true })
+      process.env.HOME = testRootDir
+      delete process.env.OPENCODE_CONFIG_DIR
+      writeFileSync(
+        configPath,
+        JSON.stringify(
+          {
+            categories: {
+              deep: {
+                model: "openai/gpt-5.6-sol",
+                variant: "high",
+              },
+            },
+            "[opencode]": {
+              agents: {
+                explore: {
+                  model: "openai/gpt-5.6-luna",
+                  variant: "low",
+                  fallback_models: ["openai/gpt-5.6-terra"],
+                },
+              },
+            },
+            "[senpi]": {
+              agents: {
+                explore: {
+                  variant: "medium",
+                },
+              },
+            },
+            "[codex]": {
+              categories: {
+                deep: {
+                  fallback_models: ["openai/gpt-5.6-terra"],
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      )
+      process.chdir(projectDir)
+
+      //#when running the deprecated reasoning keys check
+      const { checkDeprecatedReasoningKeys } = await import("./deprecated-reasoning-keys")
+      const result = await checkDeprecatedReasoningKeys()
+
+      //#then only canonical base keys are reported
+      expect(result.status).toBe("warn")
+      expect(result.issues.map((issue) => issue.description)).toEqual([
+        `${configPath}: categories.deep.variant`,
+        `${configPath}: [senpi].agents.explore.variant`,
+        `${configPath}: [codex].categories.deep.fallback_models`,
       ])
     } finally {
       process.chdir(originalCwd)

--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts
@@ -48,6 +48,7 @@ function collectIssues(configPath: string, value: unknown, prefix: string): Doct
       }
       continue
     }
+    if (key === "[opencode]") continue
     if (TUNING_CONTAINERS.has(key) || isHarnessBlock(key) || prefix.length > 0) {
       issues.push(...collectIssues(configPath, child, path))
     }

--- a/packages/omo-opencode/src/config/schema/agent-overrides.ts
+++ b/packages/omo-opencode/src/config/schema/agent-overrides.ts
@@ -1,11 +1,13 @@
 import { OmoReasoningSchema } from "@oh-my-opencode/omo-config-core"
 import { z } from "zod"
-import { FallbackModelsSchema } from "./fallback-models"
+import { FallbackModelObjectSchema, FallbackModelsSchema } from "./fallback-models"
 import { AgentPermissionSchema } from "./internal/permission"
 
 export const AgentOverrideConfigSchema = z.object({
   /** @deprecated Use `category` instead. Model is inherited from category defaults. */
   model: z.string().optional(),
+  /** Ordered model chain; the first entry is primary and the rest are fallbacks. */
+  models: z.array(z.union([z.string(), FallbackModelObjectSchema])).optional(),
   fallback_models: FallbackModelsSchema.optional(),
   reasoning: OmoReasoningSchema.optional(),
   /** @deprecated Use `reasoning` instead. */

--- a/packages/omo-opencode/src/config/validate.test.ts
+++ b/packages/omo-opencode/src/config/validate.test.ts
@@ -68,8 +68,8 @@ describe("validatePluginConfig", () => {
     withOmoConfig("defaults", (fixture) => {
       const result = validatePluginConfig(fixture.project)
 
-      expect(result.valid).toBe(true)
       expect(result.messages).toEqual([])
+      expect(result.valid).toBe(true)
       expect(result.path).toBeNull()
       expect(result.config.tui?.sidebar.enabled).toBe(true)
     })
@@ -245,6 +245,33 @@ describe("validatePluginConfig", () => {
       const result = validatePluginConfig(fixture.project)
 
       expect(result.config.agents?.sisyphus?.model).toBe("provider/kimi")
+    })
+  })
+
+  it("#given a migrated canonical agent model chain #when validating #then materializes the runtime model fields", () => {
+    withOmoConfig("canonical-agent-models", (fixture) => {
+      writeProjectConfig(fixture, {
+        "[opencode]": {
+          agents: {
+            explore: {
+              models: [
+                { model: "provider/primary", reasoning: "low" },
+                { model: "provider/fallback", reasoning: "medium" },
+              ],
+            },
+          },
+        },
+      })
+
+      const result = validatePluginConfig(fixture.project)
+
+      expect(result.messages).toEqual([])
+      expect(result.valid).toBe(true)
+      expect(result.config.agents?.explore?.model).toBe("provider/primary")
+      expect(result.config.agents?.explore?.reasoning).toBe("low")
+      expect(result.config.agents?.explore?.fallback_models).toEqual([
+        { model: "provider/fallback", reasoning: "medium" },
+      ])
     })
   })
 })

--- a/packages/omo-opencode/src/config/validate.ts
+++ b/packages/omo-opencode/src/config/validate.ts
@@ -95,6 +95,43 @@ function protectUserFields(
   }
 }
 
+function materializeAgentModelChains(config: OhMyOpenCodeConfig): OhMyOpenCodeConfig {
+  if (config.agents === undefined) return config
+
+  let changed = false
+  const agents = Object.fromEntries(Object.entries(config.agents).map(([name, agent]) => {
+    if (agent?.models === undefined) return [name, agent]
+
+    const [primary, ...fallbacks] = agent.models
+    const {
+      models: _models,
+      model: _model,
+      fallback_models: _fallbackModels,
+      reasoning: _reasoning,
+      variant: _variant,
+      reasoningEffort: _reasoningEffort,
+      temperature: _temperature,
+      top_p: _topP,
+      maxTokens: _maxTokens,
+      thinking: _thinking,
+      ...rest
+    } = agent
+    const primarySettings = primary === undefined
+      ? {}
+      : typeof primary === "string"
+        ? { model: primary }
+        : primary
+    changed = true
+    return [name, {
+      ...rest,
+      ...primarySettings,
+      fallback_models: fallbacks,
+    }]
+  })) as typeof config.agents
+
+  return changed ? { ...config, agents } : config
+}
+
 function migrateRalphLoopConfig(config: OhMyOpenCodeConfig): OhMyOpenCodeConfig {
   const legacy = config.ralph_loop
   if (legacy === undefined) return config
@@ -126,7 +163,9 @@ export function validatePluginConfig(
   const firstFailingView = views.find((view) => view.messages.length > 0)
   const firstView = views[0]
   const userConfig = parseConfig(chain.protectedUserView)
-  const config = applyDisabledProviders(protectUserFields(mergeViews(views), userConfig))
+  const config = applyDisabledProviders(materializeAgentModelChains(
+    protectUserFields(mergeViews(views), userConfig),
+  ))
 
   return {
     valid: messages.length === 0,

--- a/packages/omo-opencode/src/plugin-config/omo-config-chain.ts
+++ b/packages/omo-opencode/src/plugin-config/omo-config-chain.ts
@@ -66,7 +66,7 @@ function recordFields(value: unknown, fields: readonly string[]): Record<string,
 function modelInput(view: Readonly<Record<string, unknown>>): Record<string, unknown> {
   const agents = isPlainRecord(view.agents)
     ? Object.fromEntries(Object.entries(view.agents).flatMap(([name, definition]) => {
-      const fields = recordFields(definition, ["description", "prompt", "model", "variant", "reasoningEffort", "tools", "temperature", "disable"])
+      const fields = recordFields(definition, ["description", "prompt", "model", "models", "variant", "reasoningEffort", "tools", "temperature", "disable"])
       return fields === undefined ? [] : [[name, fields]]
     }))
     : undefined


### PR DESCRIPTION
## Summary

- accept the canonical `agents.*.models` chains produced by the reasoning-unification migration
- materialize those chains into the existing OpenCode runtime `model`, `reasoning`, and `fallback_models` fields
- stop doctor from flagging supported `[opencode]` tuning keys while preserving `[senpi]` and `[codex]` deprecation coverage
- regenerate both shipped config schemas

## Why

The migration wrote canonical model chains that the OpenCode adapter immediately rejected as:

```text
Unknown config key: agents.<name>.models
```

Doctor also recommended migrating `[opencode]` `variant` and `fallback_models` keys even though those keys remain supported by the plugin. This matches the invalid-config and delegation failures reported in #6567.

PR #6560 is a separate generated-schema identity fix. Draft PR #6516 overlaps the runtime model-chain layer, but has no dedicated tests and includes broader fallback behavior; this PR carries only the reproduced, verified subset on current `dev`.

## Observed behavior

Before:

- migrated `agents.explore.models` failed plugin validation
- doctor emitted false warnings for `[opencode].agents.explore.variant` and `.fallback_models`

After:

- migrated config validates without messages
- runtime loading resolves `anthropic/claude-fable-5 (high)` with `openai/gpt-5.6-sol-fast (medium)` as fallback
- doctor reports `Configuration is valid` and `No deprecated reasoning keys found`
- `[senpi]` and `[codex]` deprecated keys are still reported
- repeated migration is idempotent

## Verification

- `bun test packages/omo-opencode/src/config-migration/reasoning-unification.test.ts packages/omo-opencode/src/config/validate.test.ts packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts packages/omo-opencode/src/startup-migration.test.ts packages/omo-opencode/src/shared/disabled-providers.test.ts`
  - 37 pass, 0 fail, 116 assertions
- final doctor scope test
  - 2 pass, 0 fail, 4 assertions
- `bun run build:schema`
- `bun run typecheck`
- `bun run build`
- isolated source CLI QA
  - migration exits 0 twice
  - migrated file hash is unchanged on the second run
  - OpenCode session count stays 0 → 0
  - doctor configuration checks pass
  - runtime loader exposes the exact configured model chain

## Evidence

- `.omo/evidence/20260804-discord-config-migration/triage.md`
- `.omo/evidence/20260804-discord-config-migration/red.md`
- `.omo/evidence/20260804-discord-config-migration/green.md`
- `.omo/evidence/20260804-discord-config-migration/qa.md`
- `.omo/evidence/20260804-discord-config-migration/self-review.md`

## Residual risk

The overall isolated doctor command exits 1 because the hermetic OpenCode config intentionally has no plugin registration. Both configuration checks pass; that unrelated system check is documented in the QA evidence.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts canonical `agents.*.models` chains in `omo-opencode` and materializes them into runtime `model`, `reasoning`, and `fallback_models`. Also fixes doctor to ignore plugin-supported `[opencode]` tuning keys while keeping `[senpi]`/`[codex]` deprecation checks.

- **Bug Fixes**
  - Added `models` array to agent override schema and config chain; regenerated `assets/omo.schema.json` and `assets/oh-my-opencode.schema.json`.
  - Materialized model chains into runtime fields before disabled-provider filtering.
  - Updated doctor to skip deprecated-reasoning scans under `[opencode]`; scans still run for `[senpi]` and `[codex]`.
  - Expanded tests to cover migrated chain validation, runtime materialization, and doctor behavior.

<sup>Written for commit 989636bc59e26c0a39c183f70ca0aa27fd81cfbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

