### PR TITLE
fix(todo-continuation-enforcer): stop re-injecting after a non-retryable request error

### DIFF
--- a/.omo/evidence/20260805-continuation-stop-unrecoverable/README.md
+++ b/.omo/evidence/20260805-continuation-stop-unrecoverable/README.md
@@ -3,7 +3,13 @@
 Issue: https://github.com/code-yeongyu/oh-my-openagent/issues/6605 (also relieves #6303, #6528)
 Date: 2026-08-05
 Change scope: `packages/omo-opencode/src/hooks/todo-continuation-enforcer/`
-(`unrecoverable-request-error.ts` new, plus `handler.ts`, `idle-event.ts`, `non-idle-events.ts`, `types.ts`).
+(`unrecoverable-request-error.ts` new, plus `handler.ts`, `idle-event.ts`, `non-idle-events.ts`,
+`continuation-injection.ts`, `types.ts`).
+
+Two paths were added during review and are covered by the same classifier and by unit tests:
+`continuation-injection.ts` rethrows a failed `dispatchInternalPrompt` into its own catch, and a
+partless `message.updated` arriving after the flag is set now defers classification to the split
+part instead of clearing the flag eagerly. Suite after those additions: 145 pass, 0 fail.
 
 ## WHAT WAS TESTED
 

--- a/.omo/evidence/20260805-continuation-stop-unrecoverable/README.md
+++ b/.omo/evidence/20260805-continuation-stop-unrecoverable/README.md
@@ -1,0 +1,101 @@
+# Continuation fail-safe: stop re-injecting after a non-retryable request error
+
+Issue: https://github.com/code-yeongyu/oh-my-openagent/issues/6605 (also relieves #6303, #6528)
+Date: 2026-08-05
+Change scope: `packages/omo-opencode/src/hooks/todo-continuation-enforcer/`
+(`unrecoverable-request-error.ts` new, plus `handler.ts`, `idle-event.ts`, `non-idle-events.ts`, `types.ts`).
+
+## WHAT WAS TESTED
+
+1. **Unit, failing-first.** The two new `handler.test.ts` cases run against the OLD continuation
+   sources (checked out from `origin/dev`) to prove they catch the defect.
+   Artifact: `unit-red-before-fix.txt`. `unrecoverable-request-error.test.ts` is excluded from that
+   run because its module does not exist on `origin/dev`.
+2. **Unit, green.** The whole `todo-continuation-enforcer` suite against the new implementation.
+3. **Real OpenCode, hermetic sandbox.** Built the plugin from this worktree, loaded it into a real
+   `opencode` 1.18.13 run inside a sandbox that isolates both the XDG dirs and the user home, drove
+   a session that leaves two pending todos, and confirmed no behavioural regression plus DB isolation.
+   Artifact: `opencode-qa-plugin.log`.
+
+## WHAT WAS OBSERVED
+
+### 1. Failing-first (old code, new tests)
+
+```
+$ git checkout origin/dev -- .../todo-continuation-enforcer/{handler,idle-event,types,non-idle-events}.ts
+$ bun test packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.test.ts
+
+  expect(state.unrecoverableErrorDetected).toBe(true)
+  Expected: true
+  Received: undefined
+
+(fail) createTodoContinuationHandler > #given a compaction request rejected as non-retryable
+       #when the session error arrives #then it marks the session unrecoverable and cancels the countdown
+
+ 3 pass  1 fail
+```
+
+On `origin/dev` a non-retryable 400 leaves the state untouched, so the next `session.idle` re-injects
+the continuation directive and rebuilds the identical failing request.
+
+### 2. Green (new code)
+
+```
+bun test packages/omo-opencode/src/hooks/todo-continuation-enforcer
+  142 pass  0 fail  244 expect() calls  (17 files)
+
+bun run typecheck -> exit 0
+bun build packages/omo-opencode/src/index.ts --outdir dist --target bun --format esm --external zod -> exit 0
+```
+
+The error payload in `handler.test.ts` and `unrecoverable-request-error.test.ts` is the exact shape
+captured from the real incident: `{ name: "APIError", data: { message: "messages.2: \`tool_use\` ids
+were found without \`tool_result\` blocks immediately after: toolu_01PCXjcagoMAca32awicQHce.",
+statusCode: 400, isRetryable: false } }`.
+
+### 3. Real OpenCode, hermetic sandbox
+
+Sandbox `%TEMP%\omo-qa-sandbox3`, isolating `XDG_DATA_HOME` / `XDG_CONFIG_HOME` / `XDG_STATE_HOME` /
+`XDG_CACHE_HOME`, `TMP` / `TEMP`, and the user home (`USERPROFILE` / `HOME` / `HOMEDRIVE` / `HOMEPATH`).
+Only `auth.json` was copied in.
+
+```
+REAL_DB_SESSIONS_BEFORE=2864
+SANDBOX_DB_PATH=C:\Users\pss\AppData\Local\Temp\omo-qa-sandbox3\data\opencode\opencode.db
+{"type":"tool_use", ... "tool":"todowrite","state":{"status":"completed","input":{"todos":[{"content":"step one","status":"pending", ...
+{"type":"text", ... "text":"WAITING"}
+OPENCODE_EXIT=0
+REAL_DB_SESSIONS_AFTER=2864
+ISOLATION=OK
+HOST_CONFIG_REFERENCES=0
+```
+
+The plugin carrying the changed continuation hook loads and drives a real session end to end, leaves
+two pending todos, and produces no `[todo-continuation-enforcer]` skip lines, i.e. a healthy session
+is untouched by the new branch. Host-config leak scan is clean and the real
+`~/.local/share/opencode/opencode.db` session count is unchanged.
+
+## WHY IT IS ENOUGH
+
+- The failing-first run proves the new gate is genuinely absent on `origin/dev`, so the test is not
+  vacuous and the regression is pinned.
+- The decision logic is driven through the REAL `createTodoContinuationHandler` event router with the
+  REAL captured production payload, not a hand-shaped stand-in.
+- The hermetic run proves the changed module ships in the built plugin, loads in real opencode, and
+  does not perturb a healthy session, which is the regression risk this change carries.
+- The classifier is deliberately narrow (request-shape status code AND an explicit
+  `isRetryable: false`), and the negative cases pin that a 429/`isRetryable: false` and a bare 400
+  with no signal both stay retryable.
+
+## WHAT WAS OMITTED
+
+- **A live non-retryable 400 was not reproduced inside the sandbox.** Provoking one needs a provider
+  that rejects the request shape; the free sandbox models return 503 queue-full instead, and the
+  wedged production session that produced the original 400 cannot be replayed through a fresh
+  opencode instance. The branch is therefore proven by replaying the exact captured payload through
+  the real handler rather than by a live provider rejection.
+- `[todo-continuation-enforcer]` idle lines do not appear in the CLI `opencode run` transcript
+  because the process exits before the idle-driven continuation cycle; the healthy-session evidence
+  above is about the absence of a regression, not about the skip branch firing.
+- `auth.json` was copied into the sandbox but is not reproduced here. No tokens, API keys, or auth
+  headers appear in any artifact.

--- a/.omo/evidence/20260805-continuation-stop-unrecoverable/opencode-qa-plugin.log
+++ b/.omo/evidence/20260805-continuation-stop-unrecoverable/opencode-qa-plugin.log
@@ -1,0 +1,45 @@
+[2026-08-05T09:32:20.836Z] [oh-my-openagent] ENTRY - plugin loading {"directory":"C:\\Users\\pss\\AppData\\Local\\Temp\\omo-qa-sandbox3\\project"}
+[2026-08-05T09:32:21.040Z] [config-migration] startup completed {"journalResumed":false,"migratedFrom":[],"skippedConflictCount":0}
+[2026-08-05T09:32:21.088Z] lsp-daemon stale-version sweep skipped: current lsp-daemon version is unknown 
+[2026-08-05T09:32:21.092Z] [live-server-route] registered {"directory":"C:\\Users\\pss\\AppData\\Local\\Temp\\omo-qa-sandbox3\\project","hasServerUrl":true,"registrationCount":1}
+[2026-08-05T09:32:21.125Z] [tmux-session-manager] initialized {"configEnabled":false,"tmuxConfig":{"enabled":false,"layout":"main-vertical","main_pane_size":60,"main_pane_min_width":120,"agent_pane_min_width":40,"isolation":"inline"},"projectDirectory":"C:\\Users\\pss\\AppData\\Local\\Temp\\omo-qa-sandbox3\\project","serverUrl":"http://localhost:4096/"}
+[2026-08-05T09:32:21.720Z] [tool-registry] Built tool registry {"totalTools":13,"teamModeEnabled":false,"teamToolCount":0}
+[2026-08-05T09:32:23.206Z] directory-agents-injector auto-disabled due to native OpenCode support {"currentVersion":"1.18.13","nativeVersion":"1.1.37"}
+[2026-08-05T09:32:23.296Z] Loaded 0 plugins with 0 commands, 0 skills, 0 agents, 0 MCP servers 
+[2026-08-05T09:32:23.781Z] [agent-source-loader] Agent sources loaded {"user":0,"project":0,"opencodeGlobal":0,"opencodeProject":0,"plugin":0,"agentDefinitions":0,"opencodeConfig":0,"config":0}
+[2026-08-05T09:32:23.783Z] [connected-providers-cache] Cache file not found {"cacheFile":"C:\\Users\\pss\\AppData\\Local\\Temp\\omo-qa-sandbox3\\cache\\oh-my-opencode\\connected-providers.json"}
+[2026-08-05T09:32:23.784Z] [fetchAvailableModels] CALLED {"connectedProvidersUnknown":true}
+[2026-08-05T09:32:23.784Z] [fetchAvailableModels] connected providers unknown, returning empty set for fallback resolution 
+[2026-08-05T09:32:23.804Z] [fetchAvailableModels] CALLED {"connectedProvidersUnknown":true}
+[2026-08-05T09:32:23.804Z] [fetchAvailableModels] connected providers unknown, returning empty set for fallback resolution 
+[2026-08-05T09:32:23.807Z] [config-handler] agents loaded {"agentKeys":["Sisyphus - ultraworker","Hephaestus - Deep Agent","Prometheus - Plan Builder","Atlas - Plan Executor","build","explore","librarian","Metis - Plan Consultant","Momus - Plan Critic","multimodal-looker","oracle","plan","Sisyphus-Junior"]}
+[2026-08-05T09:32:24.712Z] [config-handler] config handler applied {"agentCount":13,"commandCount":28}
+[2026-08-05T09:32:27.219Z] [connected-providers-cache] Provider-models cache file not found {"cacheFile":"C:\\Users\\pss\\AppData\\Local\\Temp\\omo-qa-sandbox3\\cache\\oh-my-opencode\\provider-models.json"}
+[2026-08-05T09:32:29.864Z] [auto-update-checker] Connected providers cache exists, updating in background 
+[2026-08-05T09:32:30.474Z] [connected-providers-cache] Fetched connected providers {"count":2,"providers":["openai","opencode"]}
+[2026-08-05T09:32:30.501Z] [connected-providers-cache] Cache written {"count":2,"updatedAt":"2026-08-05T09:32:30.474Z"}
+[2026-08-05T09:32:30.505Z] [connected-providers-cache] Extracted models from provider list {"providerCount":2,"totalModels":21}
+[2026-08-05T09:32:30.547Z] [connected-providers-cache] Provider-models cache written {"providerCount":2,"updatedAt":"2026-08-05T09:32:30.505Z"}
+[2026-08-05T09:32:30.650Z] [model-capabilities-cache] Cache written {"modelCount":2778,"generatedAt":"2026-08-05T09:32:30.613Z"}
+[2026-08-05T09:32:30.655Z] [auto-update-checker] Plugin not found in config 
+[2026-08-05T09:32:37.088Z] [auto-update-checker] Startup toast shown: v4.19.4 
+[2026-08-05T09:34:41.333Z] [oh-my-openagent] ENTRY - plugin loading {"directory":"C:\\Users\\pss\\AppData\\Local\\Temp\\omo-qa-sandbox3\\project"}
+[2026-08-05T09:34:41.392Z] [config-migration] startup completed {"journalResumed":false,"migratedFrom":[],"skippedConflictCount":0}
+[2026-08-05T09:34:41.410Z] lsp-daemon stale-version sweep skipped: current lsp-daemon version is unknown 
+[2026-08-05T09:34:41.415Z] [live-server-route] registered {"directory":"C:\\Users\\pss\\AppData\\Local\\Temp\\omo-qa-sandbox3\\project","hasServerUrl":true,"registrationCount":1}
+[2026-08-05T09:34:41.431Z] [tmux-session-manager] initialized {"configEnabled":false,"tmuxConfig":{"enabled":false,"layout":"main-vertical","main_pane_size":60,"main_pane_min_width":120,"agent_pane_min_width":40,"isolation":"inline"},"projectDirectory":"C:\\Users\\pss\\AppData\\Local\\Temp\\omo-qa-sandbox3\\project","serverUrl":"http://localhost:4096/"}
+[2026-08-05T09:34:41.907Z] [tool-registry] Built tool registry {"totalTools":13,"teamModeEnabled":false,"teamToolCount":0}
+[2026-08-05T09:34:42.931Z] directory-agents-injector auto-disabled due to native OpenCode support {"currentVersion":"1.18.13","nativeVersion":"1.1.37"}
+[2026-08-05T09:34:42.979Z] Loaded 0 plugins with 0 commands, 0 skills, 0 agents, 0 MCP servers 
+[2026-08-05T09:34:43.164Z] [agent-source-loader] Agent sources loaded {"user":0,"project":0,"opencodeGlobal":0,"opencodeProject":0,"plugin":0,"agentDefinitions":0,"opencodeConfig":0,"config":0}
+[2026-08-05T09:34:43.166Z] [connected-providers-cache] Read cache {"count":2,"updatedAt":"2026-08-05T09:32:30.474Z"}
+[2026-08-05T09:34:43.169Z] [connected-providers-cache] Read provider-models cache {"providerCount":2,"updatedAt":"2026-08-05T09:32:30.505Z"}
+[2026-08-05T09:34:43.170Z] [fetchAvailableModels] CALLED {"connectedProvidersUnknown":false,"connectedProviders":["openai","opencode"]}
+[2026-08-05T09:34:43.170Z] [fetchAvailableModels] using provider-models cache (whitelist-filtered) 
+[2026-08-05T09:34:43.170Z] [fetchAvailableModels] parsed from provider-models cache {"count":21,"connectedProviders":["openai","opencode"]}
+[2026-08-05T09:34:43.176Z] [isAnyProviderConnected] found model from required provider {"provider":"openai","model":"openai/gpt-5.3-codex-spark"}
+[2026-08-05T09:34:43.179Z] [fetchAvailableModels] CALLED {"connectedProvidersUnknown":false,"connectedProviders":["openai","opencode"]}
+[2026-08-05T09:34:43.180Z] [fetchAvailableModels] using provider-models cache (whitelist-filtered) 
+[2026-08-05T09:34:43.180Z] [fetchAvailableModels] parsed from provider-models cache {"count":21,"connectedProviders":["openai","opencode"]}
+[2026-08-05T09:34:43.181Z] [config-handler] agents loaded {"agentKeys":["Sisyphus - ultraworker","Hephaestus - Deep Agent","Prometheus - Plan Builder","Atlas - Plan Executor","build","explore","librarian","Metis - Plan Consultant","Momus - Plan Critic","multimodal-looker","oracle","plan","Sisyphus-Junior"]}
+[2026-08-05T09:34:43.947Z] [config-handler] config handler applied {"agentCount":13,"commandCount":28}

--- a/.omo/evidence/20260805-continuation-stop-unrecoverable/unit-red-before-fix.txt
+++ b/.omo/evidence/20260805-continuation-stop-unrecoverable/unit-red-before-fix.txt
@@ -1,0 +1,36 @@
+# Failing-first: the two new handler cases run against origin/dev's continuation sources.
+# unrecoverable-request-error.test.ts is excluded: its module does not exist on origin/dev.
+
+$ git checkout origin/dev -- packages/omo-opencode/src/hooks/todo-continuation-enforcer/{handler,idle-event,types,non-idle-events}.ts
+$ bun test packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.test.ts
+
+bun test v1.3.14 (0d9b296a)
+bun : 
+At line:1 char:940
++ ... ii -Append; bun test packages/omo-opencode/src/hooks/todo-continuatio ...
++                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+ 
+packages\omo-opencode\src\hooks\todo-continuation-enforcer\handler.test.ts:
+115 |         },
+116 |       },
+117 |     })
+118 | 
+119 |     // then
+120 |     expect(state.unrecoverableErrorDetected).toBe(true)
+                                                   ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: undefined
+
+      at <anonymous> (C:\Users\pss\OneDrive\Documents\github\oh-my-openagent-wt\fix-continuation-stop\packages\omo-open
+code\src\hooks\todo-continuation-enforcer\handler.test.ts:120:46)
+(fail) createTodoContinuationHandler > #given a compaction request rejected as non-retryable #when the session error 
+arrives #then it marks the session unrecoverable and cancels the countdown [5.79ms]
+
+ 3 pass
+ 1 fail
+ 11 expect() calls
+Ran 4 tests across 1 file. [3.82s]

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/continuation-injection.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/continuation-injection.test.ts
@@ -337,4 +337,44 @@ describe("injectContinuation", () => {
     expect(state.consecutiveFailures).toBe(0)
     expect(state.lastInjectedAt).toBeGreaterThan(0)
   })
+
+  test("#given promptAsync rejects with a non-retryable request error #when the injection fails #then the session is marked unrecoverable", async () => {
+    // given
+    const state = { inFlight: false, lastInjectedAt: 0, consecutiveFailures: 0 } as Record<string, unknown>
+    const ctx = {
+      directory: "/tmp/test",
+      client: {
+        session: {
+          todo: async () => ({ data: [{ id: "1", content: "todo", status: "pending", priority: "high" }] }),
+          promptAsync: async () => {
+            throw Object.assign(new Error("APIError"), {
+              name: "APIError",
+              data: {
+                message:
+                  "messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_01PCXjcagoMAca32awicQHce.",
+                statusCode: 400,
+                isRetryable: false,
+              },
+            })
+          },
+        },
+      },
+    }
+
+    // when
+    await injectContinuation({
+      ctx: ctx as never,
+      sessionID: "ses_injection_non_retryable",
+      resolvedInfo: {
+        agent: "Sisyphus - ultraworker",
+        model: { providerID: "anthropic", modelID: "claude-opus-5" },
+      },
+      sessionStateStore: { getExistingState: () => state } as never,
+    })
+
+    // then
+    expect(state["unrecoverableErrorDetected"]).toBe(true)
+    expect(state["tokenLimitDetected"]).toBeUndefined()
+    expect(state["inFlight"]).toBe(false)
+  })
 })

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -34,6 +34,7 @@ import {
 import { isCompactionGuardActive } from "./compaction-guard"
 import { getMessageDir } from "./message-directory"
 import { isTokenLimitError } from "./token-limit-detection"
+import { isUnrecoverableRequestError } from "./unrecoverable-request-error"
 import { getIncompleteCount } from "./todo"
 import type { ResolvedMessageInfo, Todo } from "./types"
 import type { SessionStateStore } from "./session-state"
@@ -282,6 +283,9 @@ ${todoList}`
       if (isTokenLimitError(errorObj)) {
         injectionState.tokenLimitDetected = true
         log(`[${HOOK_NAME}] Token limit error detected during injection, stopping continuation`, { sessionID })
+      } else if (isUnrecoverableRequestError(error)) {
+        injectionState.unrecoverableErrorDetected = true
+        log(`[${HOOK_NAME}] Non-retryable request error detected during injection, stopping continuation`, { sessionID })
       }
     }
   }

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.test.ts
@@ -87,4 +87,63 @@ describe("createTodoContinuationHandler", () => {
     expect(state.stagnationCount).toBe(0)
     expect(state.consecutiveFailures).toBe(0)
   })
+
+  test("#given a compaction request rejected as non-retryable #when the session error arrives #then it marks the session unrecoverable and cancels the countdown", async () => {
+    // given
+    const sessionID = "ses_compaction_tool_pair_400"
+    const { cancelCalls, state, store } = createRecordingStateStore()
+    const handler = createTodoContinuationHandler({
+      ctx: {} as never,
+      sessionStateStore: store,
+    })
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          error: {
+            name: "APIError",
+            data: {
+              message:
+                "messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_01PCXjcagoMAca32awicQHce.",
+              statusCode: 400,
+              isRetryable: false,
+            },
+          },
+        },
+      },
+    })
+
+    // then
+    expect(state.unrecoverableErrorDetected).toBe(true)
+    expect(state.tokenLimitDetected).toBeUndefined()
+    expect(cancelCalls).toEqual([sessionID])
+  })
+
+  test("#given a retryable provider error #when the session error arrives #then the session is not marked unrecoverable", async () => {
+    // given
+    const sessionID = "ses_retryable_provider_error"
+    const { cancelCalls, state, store } = createRecordingStateStore()
+    const handler = createTodoContinuationHandler({
+      ctx: {} as never,
+      sessionStateStore: store,
+    })
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          error: { name: "APIError", data: { message: "overloaded", statusCode: 529, isRetryable: true } },
+        },
+      },
+    })
+
+    // then
+    expect(state.unrecoverableErrorDetected).toBeUndefined()
+    expect(cancelCalls).toEqual([])
+  })
 })

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.ts
@@ -14,6 +14,7 @@ import type { SessionStateStore } from "./session-state"
 import { handleSessionIdle } from "./idle-event"
 import { handleNonIdleEvent } from "./non-idle-events"
 import { isTokenLimitError } from "./token-limit-detection"
+import { isUnrecoverableRequestError } from "./unrecoverable-request-error"
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null ? value as Record<string, unknown> : undefined
@@ -97,6 +98,15 @@ export function createTodoContinuationHandler(args: {
         state.tokenLimitDetected = true
         shouldCancelCountdown = true
         log(`[${HOOK_NAME}] Token limit error detected via session.error`, { sessionID, errorName: error?.name, errorMessage: error?.message })
+      } else if (isUnrecoverableRequestError(props?.error)) {
+        const state = sessionStateStore.getState(sessionID)
+        state.unrecoverableErrorDetected = true
+        shouldCancelCountdown = true
+        log(`[${HOOK_NAME}] Non-retryable request error detected via session.error`, {
+          sessionID,
+          errorName: error?.name,
+          errorMessage: error?.message,
+        })
       }
 
       if (shouldCancelCountdown) {

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -64,6 +64,11 @@ export async function handleSessionIdle(args: {
     return
   }
 
+  if (state.unrecoverableErrorDetected) {
+    log(`[${HOOK_NAME}] Skipped: non-retryable request error detected, re-injecting would rebuild the same request`, { sessionID })
+    return
+  }
+
   if (state.abortDetectedAt) {
     const timeSinceAbort = Date.now() - state.abortDetectedAt
     if (timeSinceAbort < ABORT_WINDOW_MS) {

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
@@ -214,4 +214,60 @@ describe("handleNonIdleEvent", () => {
     // then
     expect(state.continuationBlockReason).toBe("user-interruption")
   })
+
+  test("#given an unrecoverable error and a partless user message #when the split part proves it internal #then the stop flag survives", () => {
+    // given
+    const sessionID = "ses_unrecoverable_split_internal"
+    const state = sessionStateStore.getState(sessionID)
+    state.unrecoverableErrorDetected = true
+
+    // when
+    handleNonIdleEvent({
+      eventType: "message.updated",
+      properties: { sessionID, info: { role: "user", id: "msg_split_internal" } },
+      sessionStateStore,
+    })
+    handleNonIdleEvent({
+      eventType: "message.part.updated",
+      properties: {
+        sessionID,
+        part: {
+          type: "text",
+          messageID: "msg_split_internal",
+          text: `${OMO_INTERNAL_INITIATOR_MARKER}\ncontinuation echo`,
+        },
+      },
+      sessionStateStore,
+    })
+
+    // then
+    expect(state.pendingUserMessageID).toBeUndefined()
+    expect(state.unrecoverableErrorDetected).toBe(true)
+  })
+
+  test("#given an unrecoverable error and a partless user message #when the split part proves it genuine #then the stop flag is cleared", () => {
+    // given
+    const sessionID = "ses_unrecoverable_split_genuine"
+    const state = sessionStateStore.getState(sessionID)
+    state.unrecoverableErrorDetected = true
+
+    // when
+    handleNonIdleEvent({
+      eventType: "message.updated",
+      properties: { sessionID, info: { role: "user", id: "msg_split_genuine" } },
+      sessionStateStore,
+    })
+    handleNonIdleEvent({
+      eventType: "message.part.updated",
+      properties: {
+        sessionID,
+        part: { type: "text", messageID: "msg_split_genuine", text: "please carry on" },
+      },
+      sessionStateStore,
+    })
+
+    // then
+    expect(state.pendingUserMessageID).toBeUndefined()
+    expect(state.unrecoverableErrorDetected).toBe(false)
+  })
 })

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.ts
@@ -118,7 +118,9 @@ export function handleNonIdleEvent(args: {
       }
       const state = sessionStateStore.getExistingState(sessionID)
       const messageID = typeof info?.id === "string" ? info.id : undefined
-      if (parts === undefined && state && hasAcceptedContinuationLifecycle(state) && messageID) {
+      const shouldDeferClassification = state !== undefined &&
+        (hasAcceptedContinuationLifecycle(state) || state.unrecoverableErrorDetected === true)
+      if (parts === undefined && state && shouldDeferClassification && messageID) {
         state.pendingUserMessageID = messageID
         log(`[${HOOK_NAME}] Deferred user interruption classification until message part`, {
           sessionID,
@@ -181,6 +183,12 @@ export function handleNonIdleEvent(args: {
               sessionID: targetSessionID,
               sessionStateStore,
             })
+          } else {
+            state.abortDetectedAt = undefined
+            state.wasCancelled = false
+            state.tokenLimitDetected = false
+            state.unrecoverableErrorDetected = false
+            sessionStateStore.cancelCountdown(targetSessionID)
           }
           return
         }

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.ts
@@ -68,6 +68,7 @@ function pauseForGenuineUserInterruption(args: {
   state.abortDetectedAt = undefined
   state.wasCancelled = false
   state.tokenLimitDetected = false
+  state.unrecoverableErrorDetected = false
   sessionStateStore.cancelCountdown(sessionID)
   log(`[${HOOK_NAME}] Paused continuation after genuine user interruption`, { sessionID })
 }
@@ -140,6 +141,7 @@ export function handleNonIdleEvent(args: {
         state.abortDetectedAt = undefined
         state.wasCancelled = false
         state.tokenLimitDetected = false
+        state.unrecoverableErrorDetected = false
       }
       sessionStateStore.cancelCountdown(sessionID)
       return

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/types.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/types.ts
@@ -28,6 +28,7 @@ export interface SessionState {
   isRecovering?: boolean
   wasCancelled?: boolean
   tokenLimitDetected?: boolean
+  unrecoverableErrorDetected?: boolean
   countdownStartedAt?: number
   abortDetectedAt?: number
   lastIncompleteCount?: number

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/unrecoverable-request-error.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/unrecoverable-request-error.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test"
+
+import { isUnrecoverableRequestError } from "./unrecoverable-request-error"
+
+const COMPACTION_TOOL_PAIR_400 = {
+  name: "APIError",
+  data: {
+    message:
+      "messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_01PCXjcagoMAca32awicQHce. Each `tool_use` block must have a corresponding `tool_result` block in the next message.",
+    statusCode: 400,
+    isRetryable: false,
+  },
+}
+
+describe("isUnrecoverableRequestError", () => {
+  describe("#given the Anthropic compaction tool_use/tool_result 400", () => {
+    it("#then it is classified as unrecoverable", () => {
+      // given / when / then
+      expect(isUnrecoverableRequestError(COMPACTION_TOOL_PAIR_400)).toBe(true)
+    })
+  })
+
+  describe("#given a retryable provider error", () => {
+    it("#then it is not classified as unrecoverable", () => {
+      // given
+      const error = { name: "APIError", data: { message: "overloaded", statusCode: 529, isRetryable: true } }
+
+      // when / then
+      expect(isUnrecoverableRequestError(error)).toBe(false)
+    })
+  })
+
+  describe("#given a 400 with no explicit retryable signal", () => {
+    it("#then it is left alone so only provider-confirmed dead ends stop the loop", () => {
+      // given
+      const error = { name: "APIError", data: { message: "bad request", statusCode: 400 } }
+
+      // when / then
+      expect(isUnrecoverableRequestError(error)).toBe(false)
+    })
+  })
+
+  describe("#given a non-retryable error with a retryable status code", () => {
+    it("#then it is not classified as unrecoverable", () => {
+      // given
+      const error = { name: "APIError", data: { message: "rate limited", statusCode: 429, isRetryable: false } }
+
+      // when / then
+      expect(isUnrecoverableRequestError(error)).toBe(false)
+    })
+  })
+
+  describe("#given a 422 unprocessable request the provider marked final", () => {
+    it("#then it is classified as unrecoverable", () => {
+      // given
+      const error = { statusCode: 422, isRetryable: false }
+
+      // when / then
+      expect(isUnrecoverableRequestError(error)).toBe(true)
+    })
+  })
+
+  describe("#given empty or shapeless input", () => {
+    it("#then it is not classified as unrecoverable", () => {
+      // given / when / then
+      expect(isUnrecoverableRequestError(undefined)).toBe(false)
+      expect(isUnrecoverableRequestError(null)).toBe(false)
+      expect(isUnrecoverableRequestError("boom")).toBe(false)
+      expect(isUnrecoverableRequestError({ name: "MessageAbortedError" })).toBe(false)
+    })
+  })
+})

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/unrecoverable-request-error.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/unrecoverable-request-error.ts
@@ -1,0 +1,24 @@
+import { getRuntimeFallbackRetryableSignal, getRuntimeFallbackStatusCode } from "@oh-my-opencode/model-core"
+
+const UNRECOVERABLE_REQUEST_STATUS_CODES = new Set([400, 422])
+
+/**
+ * A malformed-request error the provider will reject identically on every retry, for
+ * example the Anthropic 400 raised when a compaction request carries a `tool_use`
+ * block without its `tool_result`. Re-injecting a continuation directive after one of
+ * these rebuilds the same request and wedges the session, so the loop must stop.
+ * Deliberately narrow: only a request-shape status code paired with an explicit
+ * `isRetryable: false` from the provider counts.
+ */
+export function isUnrecoverableRequestError(error: unknown): boolean {
+  if (!error) {
+    return false
+  }
+
+  const statusCode = getRuntimeFallbackStatusCode(error)
+  if (statusCode === undefined || !UNRECOVERABLE_REQUEST_STATUS_CODES.has(statusCode)) {
+    return false
+  }
+
+  return getRuntimeFallbackRetryableSignal(error) === false
+}


### PR DESCRIPTION
## Summary

When a provider rejects a request as **non-retryable** (`statusCode: 400`, `isRetryable: false`), the next continuation directive rebuilds the exact same request, which fails identically, forever. That is how a session dies: in the incident behind #6605 the compaction `tool_use` / `tool_result` 400 came back every few seconds until the user killed the session.

`todo-continuation-enforcer` already had a stop flag for this class of problem, but it only covered **token-limit** errors (`isTokenLimitError`). A malformed-request 400 is just as final and was not covered, so the loop kept firing. This PR adds a narrow classifier for provider-confirmed dead ends and stops the continuation loop when one is seen.

Not a fix for the 400 itself. It stops the session from being wedged by it.

## Changes

**New classifier (`unrecoverable-request-error.ts`)**
- `isUnrecoverableRequestError()` returns true only for a request-shape status code (`400` / `422`) **paired with an explicit `isRetryable: false`** from the provider. Reuses `getRuntimeFallbackStatusCode` / `getRuntimeFallbackRetryableSignal` from `model-core`, so it reads the same nested error shapes runtime-fallback already handles.
- Deliberately narrow: a bare 400 with no retryable signal, and a `429` marked `isRetryable: false`, both stay retryable.

**Wiring**
- `types.ts`: new `unrecoverableErrorDetected` flag on `SessionState`, sitting next to `tokenLimitDetected`.
- `handler.ts`: on `session.error`, after the abort and token-limit branches, set the flag and cancel the countdown.
- `idle-event.ts`: skip the idle continuation while the flag is set, with a log line that says why.
- `non-idle-events.ts`: clear the flag everywhere `tokenLimitDetected` is cleared, so a genuine user turn re-arms the loop and the session is recoverable rather than dead.

## QA & Evidence

Full bundle: [`.omo/evidence/20260805-continuation-stop-unrecoverable/`](.omo/evidence/20260805-continuation-stop-unrecoverable/README.md)

**1. Failing-first**
- *What was tested:* the two new `handler.test.ts` cases against the OLD continuation sources (`git checkout origin/dev -- handler.ts idle-event.ts types.ts non-idle-events.ts`).
- *Observed:* `3 pass / 1 fail` - `expect(state.unrecoverableErrorDetected).toBe(true)` got `undefined`. On `dev` the 400 leaves the state untouched, so the next idle re-injects.
- *Artifact:* `unit-red-before-fix.txt`

**2. Real captured payload through the real handler**
- *What was tested:* the classifier and the `createTodoContinuationHandler` event router, driven with the exact error object captured from the incident: `{ name: "APIError", data: { message: "messages.2: \`tool_use\` ids were found without \`tool_result\` blocks immediately after: toolu_01PCXjcagoMAca32awicQHce.", statusCode: 400, isRetryable: false } }`.
- *Observed:* flag set, countdown cancelled, `tokenLimitDetected` untouched. A `529 / isRetryable: true` leaves both flags clear and does not cancel the countdown.

**3. Real OpenCode, hermetic sandbox**
- *What was tested:* plugin built from this worktree, loaded into real `opencode` 1.18.13 with `XDG_*`, `TMP`/`TEMP` **and the user home** isolated. Drove a session that leaves two pending todos.
- *Observed:* `todowrite` completed with two pending items, model replied `WAITING`, `OPENCODE_EXIT=0`, zero `[todo-continuation-enforcer]` skip lines (healthy sessions are untouched by the new branch), `HOST_CONFIG_REFERENCES=0`, `REAL_DB_SESSIONS_BEFORE=2864` / `AFTER=2864`, `ISOLATION=OK`.
- *Artifact:* `opencode-qa-plugin.log`

**4. Automated gates**
- `bun test packages/omo-opencode/src/hooks/todo-continuation-enforcer` - 142 pass, 0 fail (17 files)
- `bun run typecheck` - exit 0
- `bun build packages/omo-opencode/src/index.ts ...` - exit 0

## Risks & Residuals

- **A live non-retryable 400 was not reproduced in the sandbox** - accepted and documented. Provoking one needs a provider that rejects the request shape; the free sandbox models return 503 queue-full instead, and the wedged production session cannot be replayed through a fresh opencode instance. The branch is proven by replaying the exact captured payload through the real handler.
- **Stopping too eagerly** - mitigated by the narrowness of the classifier (status code AND explicit `isRetryable: false`) and by the negative tests. A user turn clears the flag, so the worst case is one skipped auto-continuation, not a stuck session.
- **The atlas / boulder continuation path still lacks this guard** (#6303). Out of scope here; this PR covers the main-session enforcer, which is the path that actually re-fired in the captured logs.
- **Full `bun run build` on Windows** - blocked by a pre-existing `'rm' is not recognized` failure in the vendored `packages/lsp-tools-mcp` build, unrelated to this change. The plugin bundle step was run directly and passes; CI covers the rest.

## Related Issues

Part of #6605. Relieves the loop symptom in #6303 and #6528 for the main-session enforcer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the todo continuation loop from re-injecting after a provider‑marked non‑retryable request error, preventing infinite failures and wedged sessions. This addresses the loop symptom in #6605 and does not change how the original `400`/`422` error is handled.

- **Bug Fixes**
  - Added `isUnrecoverableRequestError` to classify request‑shape errors (`400`/`422`) only when the provider sets `isRetryable: false` (via `getRuntimeFallbackStatusCode` and `getRuntimeFallbackRetryableSignal` from `@oh-my-opencode/model-core`).
  - Applied the stop flag across both dispatch paths and split-message flows: set on `session.error` and on continuation‑injection failures; `session.idle` skips while set; defer partless user messages and clear only on a genuine user part.
  - Added tests for the classifier, handler, injection, and split‑message deferral; typecheck/build pass. Healthy sessions are unchanged.

<sup>Written for commit 1d1249035826415c40f9e694786a140bd5c3a1e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

