### PR TITLE
fix(omo-opencode): lower canonical reasoning to variant at agent config build time

### DIFF
--- a/packages/omo-opencode/src/agents/builtin-agents/agent-overrides.test.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/agent-overrides.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test"
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { CategoryConfig } from "../../config/schema"
+import { applyCategoryOverride, applyOverrides, mergeAgentConfig } from "./agent-overrides"
+import type { AgentOverrideConfig } from "../types"
+
+function makeBase(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    instructions: "test prompt",
+    model: "openai/gpt-5.6-sol",
+    mode: "primary",
+    ...overrides,
+  } as AgentConfig
+}
+
+describe("applyCategoryOverride", () => {
+  describe("#given canonical reasoning on category", () => {
+    test("lowers category reasoning to variant on the agent config", () => {
+      // given
+      const base = makeBase()
+      const categories: Record<string, CategoryConfig> = {
+        "ultrabrain": { reasoning: "xhigh" } as CategoryConfig,
+      }
+
+      // when
+      const result = applyCategoryOverride(base, "ultrabrain", categories)
+
+      // then
+      expect(result.variant).toBe("xhigh")
+    })
+
+    test("reasoning takes precedence over deprecated variant", () => {
+      // given
+      const base = makeBase()
+      const categories: Record<string, CategoryConfig> = {
+        "ultrabrain": { reasoning: "high", variant: "medium" } as CategoryConfig,
+      }
+
+      // when
+      const result = applyCategoryOverride(base, "ultrabrain", categories)
+
+      // then
+      expect(result.variant).toBe("high")
+    })
+
+    test("deprecated variant still applied when reasoning is absent", () => {
+      // given
+      const base = makeBase()
+      const categories: Record<string, CategoryConfig> = {
+        "ultrabrain": { variant: "medium" } as CategoryConfig,
+      }
+
+      // when
+      const result = applyCategoryOverride(base, "ultrabrain", categories)
+
+      // then
+      expect(result.variant).toBe("medium")
+    })
+  })
+})
+
+describe("mergeAgentConfig", () => {
+  describe("#given canonical reasoning on agent override", () => {
+    test("lowers reasoning to variant on the merged config", () => {
+      // given
+      const base = makeBase()
+      const override: AgentOverrideConfig = { reasoning: "high" }
+
+      // when
+      const result = mergeAgentConfig(base, override)
+
+      // then
+      expect(result.variant).toBe("high")
+    })
+
+    test("reasoning takes precedence over deprecated variant in override", () => {
+      // given
+      const base = makeBase()
+      const override: AgentOverrideConfig = { reasoning: "high", variant: "medium" }
+
+      // when
+      const result = mergeAgentConfig(base, override)
+
+      // then
+      expect(result.variant).toBe("high")
+    })
+
+    test("deprecated variant still applied when reasoning is absent", () => {
+      // given
+      const base = makeBase()
+      const override: AgentOverrideConfig = { variant: "medium" }
+
+      // when
+      const result = mergeAgentConfig(base, override)
+
+      // then
+      expect(result.variant).toBe("medium")
+    })
+
+    test("reasoning overrides base variant from factory defaults", () => {
+      // given
+      const base = makeBase({ variant: "low" })
+      const override: AgentOverrideConfig = { reasoning: "high" }
+
+      // when
+      const result = mergeAgentConfig(base, override)
+
+      // then
+      expect(result.variant).toBe("high")
+    })
+
+    test("does not set variant when neither reasoning nor variant is in override", () => {
+      // given
+      const base = makeBase({ variant: "low" })
+      const override: AgentOverrideConfig = { temperature: 0.5 }
+
+      // when
+      const result = mergeAgentConfig(base, override)
+
+      // then
+      expect(result.variant).toBe("low")
+    })
+  })
+})
+
+describe("applyOverrides", () => {
+  describe("#given both category and agent reasoning", () => {
+    test("agent reasoning takes precedence over category reasoning", () => {
+      // given
+      const base = makeBase()
+      const categories: Record<string, CategoryConfig> = {
+        "ultrabrain": { reasoning: "medium" } as CategoryConfig,
+      }
+      const override: AgentOverrideConfig = {
+        category: "ultrabrain",
+        reasoning: "high",
+      }
+
+      // when
+      const result = applyOverrides(base, override, categories)
+
+      // then
+      expect(result.variant).toBe("high")
+    })
+
+    test("agent reasoning takes precedence over category variant", () => {
+      // given
+      const base = makeBase()
+      const categories: Record<string, CategoryConfig> = {
+        "ultrabrain": { variant: "medium" } as CategoryConfig,
+      }
+      const override: AgentOverrideConfig = {
+        category: "ultrabrain",
+        reasoning: "high",
+      }
+
+      // when
+      const result = applyOverrides(base, override, categories)
+
+      // then
+      expect(result.variant).toBe("high")
+    })
+
+    test("category reasoning applied when agent has no reasoning or variant", () => {
+      // given
+      const base = makeBase()
+      const categories: Record<string, CategoryConfig> = {
+        "ultrabrain": { reasoning: "high" } as CategoryConfig,
+      }
+      const override: AgentOverrideConfig = {
+        category: "ultrabrain",
+        temperature: 0.3,
+      }
+
+      // when
+      const result = applyOverrides(base, override, categories)
+
+      // then
+      expect(result.variant).toBe("high")
+    })
+  })
+})

--- a/packages/omo-opencode/src/agents/builtin-agents/agent-overrides.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/agent-overrides.ts
@@ -21,6 +21,7 @@ export function applyCategoryOverride(
   const result = { ...config } as AgentConfig & Record<string, unknown>
   if (categoryConfig.model) result.model = categoryConfig.model
   if (categoryConfig.variant !== undefined) result.variant = categoryConfig.variant
+  if (categoryConfig.reasoning !== undefined) result.variant = categoryConfig.reasoning
   if (categoryConfig.temperature !== undefined) result.temperature = categoryConfig.temperature
   if (categoryConfig.reasoningEffort !== undefined) result.reasoningEffort = categoryConfig.reasoningEffort
   if (categoryConfig.textVerbosity !== undefined) result.textVerbosity = categoryConfig.textVerbosity
@@ -41,8 +42,16 @@ export function mergeAgentConfig(
   directory?: string
 ): AgentConfig {
   const migratedOverride = migrateAgentConfig(override as Record<string, unknown>) as AgentOverrideConfig
-  const { prompt_append, ...rest } = migratedOverride
+  const { prompt_append, reasoning, ...rest } = migratedOverride
   const merged = deepMerge(base, rest as Partial<AgentConfig>)
+
+  // Lower canonical `reasoning` to OpenCode's `variant` at build time so that
+  // the TUI status bar and OpenCode's pre-hook provider-option construction
+  // see the correct value. `reasoning` takes precedence over the deprecated
+  // `variant` and `reasoningEffort`, matching resolveAgentVariant precedence.
+  if (reasoning !== undefined) {
+    merged.variant = reasoning
+  }
 
   if (merged.prompt && typeof merged.prompt === 'string' && merged.prompt.startsWith('file://')) {
     merged.prompt = resolvePromptAppend(merged.prompt, directory)


### PR DESCRIPTION
## Summary

- Lower the canonical `reasoning` field to OpenCode's `variant` field at agent config build time in `applyCategoryOverride` and `mergeAgentConfig`
- `reasoning` takes precedence over the deprecated `variant` and `reasoningEffort`, matching `resolveAgentVariant` precedence
- Add tests for the build-time lowering, precedence, and override interactions

## Problem

The canonical `reasoning` field was added to `AgentOverrideConfigSchema` and `CategoryConfigSchema` (commits d2ccd712, 77135c42), and the chat-time `applyAgentVariant` hook was updated to resolve `reasoning` and lower it via `lowerReasoningForModel`. However, the **build-time** path — `applyCategoryOverride` and `mergeAgentConfig` in `agent-overrides.ts` — never translated `reasoning` to `variant` on the resulting `AgentConfig`.

This caused two observable symptoms:

1. **TUI status bar shows "no variant"** — `AgentConfig.variant` is undefined because `reasoning` was never lowered to `variant` at build time. The user must manually press Ctrl+T to switch.

2. **Stale provider options (#6614)** — OpenCode constructs `output.options.reasoningEffort` from `variant` *before* the `chat.params` hook runs. Since `variant` was unset, the provider request used the default reasoning effort instead of the configured level. The chat-time hook injects `message.variant` correctly, but the pre-computed provider options are not updated.

## Fix

In `mergeAgentConfig`: extract `reasoning` from the override before `deepMerge` (so it does not leak as an extra property on `AgentConfig`), then set `merged.variant = reasoning` after the merge. This makes `reasoning` take precedence over any `variant` that `deepMerge` carried through.

In `applyCategoryOverride`: add `reasoning` to `variant` translation after the existing `variant` assignment, so `reasoning` overrides the deprecated `variant` when both are present.

The chat-time `applyAgentVariant` hook remains unchanged — it still runs as a safety net. When the build-time fix sets `variant` on the `AgentConfig`, OpenCode populates `message.variant` before the hook, so the hook correctly skips (its `message.variant !== undefined` guard). The variant then flows through OpenCode's native option-construction path, which is the preferred fix direction noted in #6614.

## Verification

- `bun test packages/omo-opencode/src/agents/builtin-agents/agent-overrides.test.ts` — 11 pass, 0 fail
- `bun test packages/omo-opencode/src/config/schema/agent-overrides.test.ts packages/omo-opencode/src/shared/agent-variant.test.ts` — 25 pass, 0 fail (no regressions)

## Related issues

- Fixes the TUI "no variant" status bar symptom
- Addresses the build-time root cause of #6614 (configured reasoning reaches chat.params but stale provider options keep medium)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered canonical `reasoning` to `variant` at agent config build time so the TUI shows the correct variant and provider options use the configured reasoning effort. `reasoning` now overrides deprecated `variant` and `reasoningEffort`.

- **Bug Fixes**
  - Translate `reasoning` to `variant` in `applyCategoryOverride` and `mergeAgentConfig` (extracted before `deepMerge` to avoid leaking extra fields).
  - Ensure precedence: `reasoning` wins over deprecated `variant` and factory defaults.
  - Add tests for build-time lowering, precedence, and category/agent override interactions.

<sup>Written for commit fc107113a47143627b49a96ff8f5aadbe0317a24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

