### PR TITLE
fix(ast-grep-mcp): make scan oneOf branches object-typed

### DIFF
--- a/packages/ast-grep-mcp/src/mcp-schema.test.ts
+++ b/packages/ast-grep-mcp/src/mcp-schema.test.ts
@@ -54,8 +54,8 @@ describe("ast_grep scan descriptor: rule-source exclusivity", () => {
   it("#given the scan schema #when inspected #then it publishes the ruleFile XOR inlineRules oneOf", () => {
     const schema = schemaOf("scan");
     expect(schema.oneOf).toEqual([
-      { required: ["ruleFile"], not: { required: ["inlineRules"] } },
-      { required: ["inlineRules"], not: { required: ["ruleFile"] } },
+      { type: "object", required: ["ruleFile"], not: { required: ["inlineRules"] } },
+      { type: "object", required: ["inlineRules"], not: { required: ["ruleFile"] } },
     ]);
     expect(schema.required).toEqual(["paths"]);
   });

--- a/packages/ast-grep-mcp/src/mcp.ts
+++ b/packages/ast-grep-mcp/src/mcp.ts
@@ -191,8 +191,8 @@ export const AST_GREP_MCP_TOOLS: readonly McpToolDescriptor[] = [
       // Exactly one explicit rule source per call (ub §11): ruleFile XOR inlineRules.
       // Advertised so a client sees the contract before the parser rejects the call.
       oneOf: [
-        { required: ["ruleFile"], not: { required: ["inlineRules"] } },
-        { required: ["inlineRules"], not: { required: ["ruleFile"] } },
+        { type: "object", required: ["ruleFile"], not: { required: ["inlineRules"] } },
+        { type: "object", required: ["inlineRules"], not: { required: ["ruleFile"] } },
       ],
       additionalProperties: false,
     },


### PR DESCRIPTION
## Problem
When using Grok/xAI Responses, Senpi fails before the first turn with:

`OpenAI API error (400): 400 "mcp__ast_grep_scan: tool parameter root must be an object type (root schema is an anyOf/oneOf union with a non-object branch)"`

The advertised `scan` inputSchema keeps `type: "object"` at the root, but its `oneOf` XOR branches for `ruleFile`/`inlineRules` were constraint-only (`{ required: ..., not: ... }`) with no `type: "object"`. Strict Responses validators reject those branches as non-object.

## Fix
Add `type: "object"` to both `oneOf` branches. No runtime behavior change: `scanInputSchema`/`executeScan` still reject calls with neither or both rule sources.

## Verification
- `bun test src/mcp-schema.test.ts src/tools/scan.test.ts`
- `bun run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `ast-grep-mcp` `scan` tool schema so Grok/xAI Responses no longer reject it with a 400. Added `type: "object"` to both `oneOf` branches (`ruleFile`/`inlineRules`); runtime XOR contract remains unchanged.

<sup>Written for commit 22216269805005768e281d36ae7d5c6f00d65932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

