### PR TITLE
docs(agents-md): init-deep refresh to v4.19.4 snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **HOLD THE FUCK UP. THIS ENTIRE GODDAMN CODEBASE IS BEING RIPPED APART AND REBUILT RIGHT NOW. A MASSIVE MULTI-HARNESS AGENT OS REFACTOR IS IN PROGRESS — WE ARE RESTRUCTURING EVERYTHING TO SUPPORT MULTIPLE AGENT HARNESSES (OPENCODE, CODEX, PI, AND OTHERS). DO NOT TRUST THE STRUCTURE BELOW AS STABLE. READ THE [ROADMAP](./ROADMAP.md) BEFORE YOU TOUCH ANYTHING OR SO HELP ME GOD.**
 
-**Generated:** 2026-07-17 | **Source snapshot:** 7d664b96b | **Branch:** dev | **Release:** v4.18.2
+**Generated:** 2026-08-07 | **Source snapshot:** 51ab1e5b6 | **Branch:** dev | **Release:** v4.19.4
 
 ## STOP. QA IS MANDATORY. NON-NEGOTIABLE. EVERY SINGLE TIME YOU TOUCH AN OPENCODE- OR CODEX-CONNECTED COMPONENT.
 
@@ -58,27 +58,27 @@ Unless the user EXPLICITLY says otherwise, or the task is an urgent must-fix-now
 
 ## OVERVIEW
 
-OpenCode plugin (npm: `oh-my-opencode`, dual-published as `oh-my-openagent` during the rename transition) extending OpenCode with 11 agents, 53-62 lifecycle hooks (base / +goal / +monitor / +team-mode) across 62 dirs, 12-38 registry tools (gated by config flags including team-mode and goal; 8 `lsp_*` aliases served via the built-in lsp MCP), 3-tier MCP system (built-in + .mcp.json + skill-embedded), Hashline LINE#ID edit tool, IntentGate keyword detector, Team Mode (parallel multi-agent coordination, OFF by default), Boulder feature (boulder-state work tracking + cli/boulder subcommand), configurable agent ordering, and Claude Code compatibility.
+OpenCode plugin (npm: `oh-my-opencode`, dual-published as `oh-my-openagent` during the rename transition) extending OpenCode with 11 agents, ~50-62 lifecycle hooks (base / +goal / +monitor / +team-mode) across 62 dirs, 12-38 registry tools (gated by config flags including team-mode and goal; 8 `lsp_*` aliases served via the built-in lsp MCP), 3-tier MCP system (built-in + .mcp.json + skill-embedded), Hashline LINE#ID edit tool, IntentGate keyword detector, Team Mode (parallel multi-agent coordination, OFF by default), Boulder feature (boulder-state work tracking + cli/boulder subcommand), configurable agent ordering, and Claude Code compatibility.
 
-**The package layering refactor moved the entire plugin out of root `src/` into [`packages/omo-opencode/src/`](packages/omo-opencode/src/AGENTS.md)** (a 100% git rename — there is NO root `src/` anymore). That adapter tree is now the OpenCode-facing shim over 19 Core packages + 3 MCP packages + the Codex adapter. Build entry: `packages/omo-opencode/src/index.ts`, a thin wrapper that delegates to `packages/omo-opencode/src/testing/create-plugin-module.ts` `createPluginModule()` → staged plugin init (see INITIALIZATION FLOW). Ships in two editions of one product: **Ultimate** (omo for OpenCode, this plugin = `packages/omo-opencode/`) and **Light** (omo for Codex CLI = [`packages/omo-codex/`](packages/omo-codex/AGENTS.md), with `lazycodex` as the repository/bin identity and `lazycodex-ai` as the live npm alias; see CODEX LIGHT EDITION below).
+**The package layering refactor moved the entire plugin out of root `src/` into [`packages/omo-opencode/src/`](packages/omo-opencode/src/AGENTS.md)** (a 100% git rename — there is NO root `src/` anymore). That adapter tree is now the OpenCode-facing shim over 19 Core packages + 4 MCP packages + the Codex adapter. Build entry: `packages/omo-opencode/src/index.ts`, a thin wrapper that delegates to `packages/omo-opencode/src/testing/create-plugin-module.ts` `createPluginModule()` → staged plugin init (see INITIALIZATION FLOW). Ships in two editions of one product: **Ultimate** (omo for OpenCode, this plugin = `packages/omo-opencode/`) and **Light** (omo for Codex CLI = [`packages/omo-codex/`](packages/omo-codex/AGENTS.md), with `lazycodex` as the repository/bin identity and `lazycodex-ai` as the live npm alias; see CODEX LIGHT EDITION below).
 
 ## STRUCTURE
 
 ```
 oh-my-opencode/                      # workspace root (no root src/ — it moved into packages/omo-opencode)
-├── packages/                        # 42 sibling packages across Core/MCP/Skills/Adapters/Platform/Web. See packages/AGENTS.md
+├── packages/                        # 43 sibling packages across Core/MCP/Skills/Adapters/Platform/Web. See packages/AGENTS.md
 │   ├── omo-opencode/                # ★ THE OpenCode plugin adapter (formerly root src/). Build entry: src/index.ts
 │   │   └── src/                     # plugin source and OpenCode-facing adapter shims. Full breakdown → packages/omo-opencode/src/AGENTS.md
 │   │       ├── index.ts             # Plugin entry; thin wrapper re-exporting createPluginModule() from src/testing/
 │   │       ├── plugin-interface.ts  # 12 OpenCode hook handlers (+2 wired in testing/create-plugin-module.ts)
 │   │       ├── create-{managers,tools,hooks}.ts  # 4 managers / ToolRegistry / 5-tier hook composition
 │   │       ├── agents/              # 11 agents, 10 createXXXAgent factories (Prometheus special-cased via plugin-handlers/prometheus-agent-config-builder.ts)
-│   │       ├── hooks/               # 53-62 lifecycle hooks across 62 dirs (incl. 5 zauc-* mock dirs + shared/ + team-session-events/)
+│   │       ├── hooks/               # ~50-62 lifecycle hooks across 62 dirs (incl. 5 zauc-* mock dirs + shared/ + team-session-events/)
 │   │       ├── tools/               # 14 native tool dirs; LSP served via a built-in MCP, ast-grep via the bundled skill
 │   │       ├── features/            # 23 feature modules (team-mode, background-agent, skill-mcp-manager, opencode-skill-loader, mcp-oauth, claude-code-plugin-loader, boulder-state, …)
 │   │       ├── shared/              # cross-cutting utilities; logger → oh-my-opencode.log in os.tmpdir() (50 MB cap, .1/.2 backups)
 │   │       ├── config/             # Zod v4 schema system (36 schema files)
-│   │       ├── cli/                 # Commander.js CLI, 10 commands: install(setup), run, doctor, cleanup(uninstall), version, get-local-version, refresh-model-capabilities, boulder, ulw-loop, mcp (oauth login/logout/status)
+│   │       ├── cli/                 # Commander.js CLI, 11 commands: install(setup), run, doctor, cleanup(uninstall), version, get-local-version, refresh-model-capabilities, boulder, ulw-loop, config (migrate), mcp (oauth login/logout/status)
 │   │       ├── mcp/                 # 5 built-in MCPs (3 remote + local stdio lsp + codegraph)
 │   │       ├── plugin/ plugin-handlers/  # OpenCode hook handlers + 6-phase config loading pipeline
 │   │       ├── openclaw/            # Bidirectional Discord/Telegram/HTTP/shell integration + reply listener daemon
@@ -88,7 +88,7 @@ oh-my-opencode/                      # workspace root (no root src/ — it moved
 │   ├── senpi-task/                  # Senpi-coupled task engine: state machine, store, in-process/RPC runners, lifecycle, completion, teams, 7 task + 12 team tools
 │   ├── pi-goal/ pi-webfetch/        # Standalone Pi adapters: Codex-style goal tracking + bounded URL retrieval
 │   ├── utils/ model-core/ prompts-core/ rules-engine/ agents-md-core/ comment-checker-core/ hashline-core/ boulder-state/ telemetry-core/ lsp-core/ mcp-stdio-core/ tmux-core/ claude-code-compat-core/ skills-loader-core/ mcp-client-core/ openclaw-core/ team-core/ delegate-core/ omo-config-core/   # 19 Core (pure-TS) pkgs
-│   ├── lsp-tools-mcp/ git-bash-mcp/ lsp-daemon/   # 3 MCP-layer pkgs (stdio); LSP packages consume lsp-core + mcp-stdio-core
+│   ├── lsp-tools-mcp/ git-bash-mcp/ lsp-daemon/ ast-grep-mcp/   # 4 MCP-layer pkgs (stdio); LSP packages consume lsp-core + mcp-stdio-core
 │   ├── shared-skills/               # Cross-harness SKILL.md bundle shared by OpenCode + Codex
 │   ├── web/                         # Marketing site (Next.js 15 + Cloudflare Workers); own bun.lock; only @/* alias zone in the repo
 │   └── oh-my-opencode-<os>-<arch>[-variant]/   # 12 platform launcher packages (bin/ + package.json only; generated, never hand-edited)
@@ -274,7 +274,7 @@ Schema autocomplete: `"$schema": "https://raw.githubusercontent.com/code-yeongyu
 
 - **Canonical agent order:** Sisyphus → Hephaestus → Prometheus → Atlas. Enforced by `installAgentSortShim()` (patches `Array.prototype.toSorted`/`.sort` narrowly when the array contains ≥2 canonical core agents). See [`packages/omo-opencode/src/plugin-handlers/AGENTS.md`](packages/omo-opencode/src/plugin-handlers/AGENTS.md) for the full history of why this exists.
 - **Hashline edit + read pairing:** Every `Read` tool output is tagged with `LINE#ID` content hashes; `hashline_edit` validates the hash before applying. Stale hash → reject.
-- **5-tier hook composition:** Session (24) + ToolGuard (18) + Transform (7) + Continuation (7) + Skill (2) = 58 composed hook slots. 5 of those slots are config-gated null by default: `team-tool-gating` (ToolGuard) + `team-mode-status-injector`/`team-mailbox-injector` (Transform) via `team_mode.enabled`, `monitor-status-injector` (Transform) via `monitor.enabled`, and `goal` (Session) via `goal.enabled` → **53 active on default config**. Team mode also adds +4 direct event handlers in `packages/omo-opencode/src/plugin/event.ts` (`team-session-events/*`) → 62 max. Composed by `createCoreHooks()` + `createContinuationHooks()` + `createSkillHooks()`; the Transform tier also pulls `contextInjectorMessagesTransform` from `features/context-injector` (not a `hooks/` dir).
+- **5-tier hook composition:** Session (24) + ToolGuard (18) + Transform (7) + Continuation (7) + Skill (2) = 58 composed hook slots. At least 7 of those slots are config-gated null by default: `team-tool-gating` (ToolGuard) + `team-mode-status-injector`/`team-mailbox-injector` (Transform) via `team_mode.enabled`, `monitor-status-injector` (Transform) via `monitor.enabled`, `goal` (Session) via `goal.enabled`, plus Session-tier `model-fallback` (`model_fallback`, default off) and `preemptive-compaction` (`experimental.preemptive_compaction`), and `interactive-bash-session` when tmux integration is off → **~50-51 active on default config**. Team mode also adds +4 direct event handlers in `packages/omo-opencode/src/plugin/event.ts` (`team-session-events/*`) → 62 max. Composed by `createCoreHooks()` + `createContinuationHooks()` + `createSkillHooks()`; the Transform tier also pulls `contextInjectorMessagesTransform` from `features/context-injector` (not a `hooks/` dir).
 - **Per-session MCP isolation:** Tier-3 MCP clients keyed by `${sessionID}:${skillName}:${serverName}` so the same skill in two sessions does not share state.
 - **Two fallback systems:** `model-fallback` (proactive, chat.params) vs `runtime-fallback` (reactive, session.error). They operate independently — no direct integration.
 - **OpenClaw bidirectional:** Outbound dispatchers fire on session events; inbound daemon polls Discord/Telegram and `send-keys` replies into the tracked tmux pane.
@@ -322,7 +322,7 @@ Schema autocomplete: `"$schema": "https://raw.githubusercontent.com/code-yeongyu
 
 ```bash
 bun test                          # Root Bun test suite in one process
-bun run test:codex                # Codex Light gate: git-bash-mcp + lsp-tools-mcp + lsp-daemon + codegraph + omo-codex plugin + third-party notices (no ast-grep — that MCP was removed)
+bun run test:codex                # Codex Light gate: git-bash-mcp + lsp-tools-mcp + lsp-daemon + codegraph + omo-codex plugin + third-party notices (ast-grep-mcp is senpi-side, not in this gate)
 bun run build                     # Build plugin (ESM bundle ← packages/omo-opencode/src/index.ts + .d.ts + cli bundle + schema)
 bun run build:all                 # Build + 12 generated platform launchers
 bun run build:binaries            # 12 generated platform launchers only (script/build-binaries.ts)

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,17 +1,17 @@
 # packages/ - Monorepo Packages
 
-**Generated:** 2026-07-17 / 7d664b96b
+**Generated:** 2026-08-07 / 51ab1e5b6
 
 ## OVERVIEW
 
-42 sibling packages across 6 roles. `omo-opencode` is the **build entry** for the main npm dist (`packages/omo-opencode/src/index.ts` → bundled into root `dist/`). The root `package.json` `files` array ships `dist/` + `bin/` + `postinstall.mjs` plus selected sibling artifacts (`lsp-tools-mcp`, `lsp-daemon`, `git-bash-mcp` `dist/`; `shared-skills`; the `omo-codex` plugin bundle; and `.opencode`/`.agents` command+skill dirs). Everything else is a sibling with its own package boundary; check the package docs before assuming a publication, deployment, or local-install surface.
+43 sibling packages across 6 roles. `omo-opencode` is the **build entry** for the main npm dist (`packages/omo-opencode/src/index.ts` → bundled into root `dist/`). The root `package.json` `files` array ships `dist/` + `bin/` + `postinstall.mjs` plus selected sibling artifacts (`lsp-tools-mcp`, `lsp-daemon`, `git-bash-mcp` `dist/`; `shared-skills`; the `omo-codex` plugin bundle; and `.opencode`/`.agents` command+skill dirs). Everything else is a sibling with its own package boundary; check the package docs before assuming a publication, deployment, or local-install surface.
 
 ## ROLE MAP
 
 | Role | Count | Packages |
 |------|-------|----------|
 | **Platform launcher packages** | 12 | One per (OS × arch × variant). Uniform layout: `bin/` + `package.json` only. Selected at install time by `bin/` shim + `postinstall.mjs`. |
-| **MCP packages** | 3 | `lsp-tools-mcp`, `git-bash-mcp`, `lsp-daemon` |
+| **MCP packages** | 4 | `lsp-tools-mcp`, `git-bash-mcp`, `lsp-daemon`, `ast-grep-mcp` |
 | **Core packages** | 19 | `utils`, `model-core`, `prompts-core`, `rules-engine` (was `rules-core`), `agents-md-core`, `comment-checker-core`, `hashline-core`, `boulder-state`, `telemetry-core`, `lsp-core`, `mcp-stdio-core`, `tmux-core`, `claude-code-compat-core`, `skills-loader-core`, `mcp-client-core`, `openclaw-core`, `team-core`, `delegate-core`, `omo-config-core` |
 | **Adapters** | 5 (+1 adapter-support) | `omo-opencode` (OpenCode Ultimate edition; the former root `src/`, build entry for the main npm dist) + `omo-codex` (Codex CLI Light edition; live npm alias `lazycodex-ai`, repository/bin identity `lazycodex`; Codex marketplace `sisyphuslabs` / plugin `omo`) + `omo-senpi` (Senpi native TypeScript extension adapter; local-path Pi package under `packages/omo-senpi/plugin`) + [`pi-goal`](pi-goal/AGENTS.md) (persistent Codex-style goal tools + continuation) + [`pi-webfetch`](pi-webfetch/AGENTS.md) (bounded URL-to-markdown/text/HTML tool). Adapter-support: `senpi-task` (Senpi-coupled task engine consumed only by `omo-senpi`; not harness-neutral, so not a `*-core` package). See [`packages/omo-opencode/src/AGENTS.md`](omo-opencode/src/AGENTS.md), [`packages/omo-codex/AGENTS.md`](omo-codex/AGENTS.md), [`packages/omo-senpi/AGENTS.md`](omo-senpi/AGENTS.md), [`packages/pi-goal/AGENTS.md`](pi-goal/AGENTS.md), [`packages/pi-webfetch/AGENTS.md`](pi-webfetch/AGENTS.md), [`packages/senpi-task/AGENTS.md`](senpi-task/AGENTS.md) |
 | **Skills** | 1 | [`shared-skills`](shared-skills/AGENTS.md) (cross-harness SKILL.md bundle shared between OMO and Codex; shipped via root `files` array) |
@@ -31,6 +31,7 @@ Each contains only a `bin/oh-my-opencode.js` launcher and a `package.json`. [`sc
 | `lsp-tools-mcp/` | Vendored standalone project (`.github/`, `CHANGELOG.md`, `LICENSE`, `src/`, `test/`, `biome.json`, `vitest.config.ts`) | Serves the 8 aliases `lsp_status`, `lsp_diagnostics`, `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols`, `lsp_prepare_rename`, `lsp_rename`, `lsp_install_decision` via stdio MCP. Registered as tier-1 MCP `lsp` in [`packages/omo-opencode/src/mcp/`](omo-opencode/src/mcp/AGENTS.md). Node-targeted, built with `npm` + vitest, and consumes `lsp-core` + `mcp-stdio-core`. |
 | [`git-bash-mcp/`](git-bash-mcp/AGENTS.md) | Internal package (`src/`, `dist/`, `tsconfig.json`) | stdio MCP serving the Windows-only `git_bash` tool for the Codex edition (Bun-targeted, unlike the other two). Tier-1 MCP. |
 | `lsp-daemon/` | Vendored standalone project (`src/`, `test/`, `scripts/`, `biome.json`, `package-lock.json`) | Shared per-user LSP **daemon** over a unix socket (Windows named pipe) + a stdio MCP **proxy** + a tool client, consuming `lsp-core` + `mcp-stdio-core`. Lets multiple Codex sessions share one warm LSP process. Bin `omo-lsp-daemon`. Node-targeted (`npm` + vitest). See [`packages/lsp-daemon/AGENTS.md`](lsp-daemon/AGENTS.md). |
+| [`ast-grep-mcp/`](ast-grep-mcp/AGENTS.md) | Internal package (`src/`, `tsconfig.json`) | stdio MCP `ast_grep` (tools `search`/`rewrite`/`scan`) wrapping the `sg` CLI. Bin `omo-ast-grep`. Bun-targeted, consumes `mcp-stdio-core` + `utils`. Built by `build:ast-grep-mcp` and staged into the Senpi plugin runtime by `build:senpi-plugin`. |
 
 ## CORE PACKAGES
 

--- a/packages/ast-grep-mcp/AGENTS.md
+++ b/packages/ast-grep-mcp/AGENTS.md
@@ -1,0 +1,39 @@
+# packages/ast-grep-mcp - ast-grep stdio MCP
+
+## OVERVIEW
+
+Local stdio MCP server (`@oh-my-opencode/ast-grep-mcp`, private, bin `omo-ast-grep`) exposing structural code search/rewrite via the `sg` (ast-grep) CLI. Server name `ast_grep`, 3 tools: `search`, `rewrite`, `scan`. Built on `mcp-stdio-core` + `utils`.
+
+## STRUCTURE
+
+```
+src/
+├── cli.ts          # stdio entry (bundled to dist/cli.js by `bun run build`)
+├── index.ts        # barrel: AST_GREP_MCP_NAME + mcp exports
+├── mcp.ts          # tool defs, JSON-RPC handling, runMcpStdioServer
+├── sg-runner.ts    # spawns sg with JSON output, bounded timeout
+├── normalize.ts    # match/diagnostic normalization
+├── pattern-hints.ts# rejects likely-invalid patterns ($$NAME etc.); `force` bypasses
+└── tools/          # search.ts / rewrite.ts / scan.ts implementations
+```
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Add/modify a tool schema | `src/mcp.ts` (tool defs) + `src/tools/*.ts` |
+| sg process invocation, timeouts | `src/sg-runner.ts` |
+| Pattern validation hints | `src/pattern-hints.ts` |
+| Senpi plugin staging | `packages/omo-senpi/plugin/scripts/stage-ast-grep-mcp-runtime.mjs` (copies `dist/cli.js` to plugin `runtime/ast-grep-mcp/`) |
+
+## CONVENTIONS
+
+- Rewrite/scan apply is two-phase: bounded JSON preview first, then a separate `--update-all` pass; truncated previews are never applied.
+- `rewrite` may only reference metavariables captured by the pattern; empty replacement deletes the match.
+- Byte-counted limits: pattern 16 KiB, rewrite/inlineRules 64 KiB (UTF-8 bytes, not chars).
+- Build with `bun run build:ast-grep-mcp` (root) before staging into the senpi plugin (`build:senpi-plugin` chains it).
+
+## ANTI-PATTERNS
+
+- Never combine JSON output and mutation in one `sg` invocation (sg cannot do both safely).
+- No ambient `sgconfig.yml` discovery in `scan`: exactly one explicit rule source (`ruleFile` XOR `inlineRules`).

--- a/packages/omo-opencode/src/AGENTS.md
+++ b/packages/omo-opencode/src/AGENTS.md
@@ -1,6 +1,6 @@
 # src/ - Plugin Source
 
-**Generated:** 2026-07-17 / 7d664b96b
+**Generated:** 2026-08-07 / 51ab1e5b6
 
 ## STOP. THIS IS THE OPENCODE PLUGIN. QA IS MANDATORY. EVERY SINGLE TIME YOU CHANGE ANYTHING HERE.
 
@@ -118,9 +118,11 @@ Total: 53 base, 60 with team-mode. Each tier produces an object whose values are
 | `config/` | Zod v4 schema files | yes |
 | `plugin-handlers/` | 6-phase config loading pipeline | yes |
 | `openclaw/` | Bidirectional Discord/Telegram/HTTP integration | yes |
-| `__tests__/` | Plugin-level integration tests + perf fixtures | no |
+| `__tests__/` | Plugin-level integration tests + perf fixtures | yes |
 | `mcp/` | 5 built-in MCPs (3 remote + local stdio lsp + codegraph) | yes |
-| `testing/` | Test utilities + `create-plugin-module.ts` | no |
+| `testing/` | Test utilities + `create-plugin-module.ts` | yes |
+| `config-migration/` | Legacy config discovery + transform plans (consumed by senpi config-startup + codex startup) | yes |
+| `types/` | Ambient `.d.ts` declarations (markdown modules) | no |
 | `help/` | CLI help schema definitions (acp, doctor, sandbox, status) | no |
 | `locales/` | i18n strings (en, zh): toasts + model-fallback labels | no |
 

--- a/packages/omo-opencode/src/config-migration/AGENTS.md
+++ b/packages/omo-opencode/src/config-migration/AGENTS.md
@@ -1,0 +1,27 @@
+# src/config-migration/ - Legacy Config Discovery + Transforms
+
+## OVERVIEW
+
+Discovers legacy config files (oh-my-opencode/oh-my-openagent JSON[C], `~/.omo/config.jsonc`) and builds migration plans that transform them into the unified `omo.json[c]` chain. The migration *engine* (lock, journal, no-clobber merge, atomic commit) lives in `packages/omo-config-core/src/migration/`; this directory owns the OpenCode-side discovery and content transforms. Consumed at plugin startup (opencode + senpi config-startup) and codex startup.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Which files count as legacy | `discovery.ts` + `discovery-roots.ts` + `discovery-paths.ts` (ids `OPENCODE_CONFIG_MIGRATION_ID`, `CONFIG_JSONC_MIGRATION_ID`) |
+| Plan building | `migration-plans.ts` (`createLegacyConfigMigrationPlans`) |
+| Plan execution | `migration-executor.ts` (`executeLegacyConfigMigrationPlan`) |
+| Content transforms | `transform-opencode.ts` / `transform-config-jsonc.ts` |
+| Reasoning-key unification | `reasoning-unification.ts` (`REASONING_UNIFICATION_MIGRATION_ID`, fixtures under `2026-08-reasoning-unification/`) |
+| Historical migration ids | `legacy-history.ts` |
+
+## CONVENTIONS
+
+- Transforms are pure: they take loaded sources and return `ConfigMigrationTransformResult`; all filesystem side effects go through the omo-config-core engine.
+- Every migration is identified by a stable id recorded in `_migrations`; never reuse or rename shipped ids (append to `legacy-history.ts` instead).
+- `deep-diff.ts` backs no-clobber semantics: existing target values always win over migrated values.
+
+## ANTI-PATTERNS
+
+- Never write config files directly from here; hand plans to the engine (`runMigration`).
+- Never delete legacy sources; migration copies forward and leaves timestamped backups.

--- a/packages/omo-opencode/src/features/AGENTS.md
+++ b/packages/omo-opencode/src/features/AGENTS.md
@@ -1,6 +1,6 @@
-# src/features/ — 22 Feature Modules
+# src/features/ — 23 Feature Modules
 
-**Generated:** 2026-06-08
+**Generated:** 2026-08-07
 
 ## OVERVIEW
 
@@ -31,6 +31,8 @@ Standalone feature modules wired into `plugin/` layer. Each is self-contained wi
 | **claude-tasks** | MEDIUM | yes | Sisyphus task schema + atomic file storage + OpenCode todo API sync |
 | **task-toast-manager** | MEDIUM | no | Task progress notifications |
 | **claude-code-session-state** | LOW | no | Subagent session state tracking |
+| **monitor** | MEDIUM | no | `monitor_*` tools backend: managed watcher processes, line filtering, ring buffer, batched output injection (gated on `monitor.enabled`) |
+| **tui-sidebar** | MEDIUM | no | TUI sidebar snapshot builder + mirror manager (roster/state derivers rendered into the OpenCode TUI; gated on `tui.sidebar.enabled`) |
 
 ## KEY MODULES
 


### PR DESCRIPTION
## What

`init-deep` update pass over the hierarchical AGENTS.md knowledge base: refresh stale facts to the current `dev` HEAD (51ab1e5b6, v4.19.4) and fill two documentation gaps.

## Why

The root and packages knowledge-base docs were stamped 2026-07-17 / v4.18.2 and had drifted from the codebase: the `ast-grep-mcp` workspace package existed but was undocumented (the root doc even claimed "that MCP was removed"), the CLI list missed `config (migrate)`, the active-hook count was overstated, and `src/config-migration/` was referenced by 3 other AGENTS.md files while having none of its own.

## Changes

- **Root `AGENTS.md`**: header restamped to 2026-08-07 / 51ab1e5b6 / v4.19.4; 42 -> 43 packages; 3 -> 4 MCP-layer packages (+`ast-grep-mcp/` in the tree); CLI 10 -> 11 commands (+`config (migrate)`); hook invariant corrected — at least 7 of the 58 composed slots are config-gated null by default (team x3, monitor, goal, model-fallback, preemptive-compaction, plus interactive-bash without tmux), so ~50-51 active on defaults, not 53; `test:codex` note reworded (ast-grep-mcp is senpi-side, not removed).
- **`packages/AGENTS.md`**: counts updated; new MCP-table row for `ast-grep-mcp` (stdio MCP `ast_grep` with `search`/`rewrite`/`scan`, bin `omo-ast-grep`, staged into the Senpi plugin by `build:senpi-plugin`).
- **NEW `packages/ast-grep-mcp/AGENTS.md`**: structure, where-to-look, two-phase apply convention, byte-counted limits.
- **NEW `packages/omo-opencode/src/config-migration/AGENTS.md`**: discovery/transform vs omo-config-core engine boundary, migration-id conventions.
- **`packages/omo-opencode/src/AGENTS.md`**: subsystem inventory fixed — `__tests__/` and `testing/` do have AGENTS.md; added `config-migration/` and `types/` rows.
- **`packages/omo-opencode/src/features/AGENTS.md`**: 22 -> 23 modules; added the missing `monitor` and `tui-sidebar` rows.

## How it was verified

Discovery ran as 3 parallel explore agents (root-drift audit against composer/tool-registry/CLI sources, full 112-file AGENTS.md staleness inventory, new-package summaries) plus main-session structural analysis; every changed number was verified against the code (workspaces array, `cli-program.ts`, hook composer files, `features/` listing, `config-migration/` contents).

Tests in the worktree:

```
bun test packages/omo-opencode/src/shared/markdown-link-audit.test.ts \
         script/agents-md-dev-env.test.ts \
         script/package-registration-audit.test.ts \
         script/agent-env.test.ts
# 30 pass, 0 fail (local-link audit covers the two new AGENTS.md files)
```

## Residual risk

Docs-only change; no runtime code touched, so no opencode-qa/codex-qa evidence run applies. Known remaining drift NOT addressed here (pre-existing, needs its own verified pass): `src/AGENTS.md` HOOK COMPOSITION tier lists (22/17/4) disagree with the composer files (24/18/7), and several 2026-05-15-stamped subdir docs under `src/{tools,hooks,features}` lag the snapshot.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the AGENTS.md knowledge base to the dev v4.19.4 snapshot to remove drift and fill gaps. Highlights: add docs for `ast-grep-mcp`, introduce `packages/omo-opencode/src/config-migration/AGENTS.md`, update package/MCP/feature counts (43/4/23), add the `config (migrate)` CLI, mark `__tests__` and `testing` as documented, and correct the default active hook count to ~50–51.

<sup>Written for commit afebde982164dfb26322c5f0b1911ae6701a5047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

