### PR TITLE
fix: dedup $id and restore backward-compat required keys in JSON schema

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -9928,8 +9928,5 @@
       }
     }
   },
-  "required": [
-    "git_master"
-  ],
   "additionalProperties": false
 }

--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -1212,7 +1212,6 @@
     },
     "[opencode]": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
       "title": "Oh My OpenCode Configuration",
       "description": "Configuration schema for oh-my-opencode plugin",
       "type": "object",
@@ -11140,9 +11139,6 @@
           }
         }
       },
-      "required": [
-        "git_master"
-      ],
       "additionalProperties": false
     },
     "[senpi]": {
@@ -14573,7 +14569,6 @@
           },
           "[opencode]": {
             "$schema": "http://json-schema.org/draft-07/schema#",
-            "$id": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
             "title": "Oh My OpenCode Configuration",
             "description": "Configuration schema for oh-my-opencode plugin",
             "type": "object",
@@ -24501,9 +24496,6 @@
                 }
               }
             },
-            "required": [
-              "git_master"
-            ],
             "additionalProperties": false
           },
           "[senpi]": {
@@ -26806,8 +26798,5 @@
       "additionalProperties": {}
     }
   },
-  "required": [
-    "profiles"
-  ],
   "additionalProperties": false
 }

--- a/packages/omo-config-core/src/schema/config.ts
+++ b/packages/omo-config-core/src/schema/config.ts
@@ -45,7 +45,7 @@ export const OmoConfigSchema = z.object({
   "[opencode]": OmoOpenCodeHarnessConfigSchema.optional(),
   "[senpi]": OmoTypedHarnessConfigSchema.optional(),
   "[codex]": OmoTypedHarnessConfigSchema.optional(),
-  profiles: z.record(z.string(), OmoConfigProfileSchema).default({}),
+  profiles: z.record(z.string(), OmoConfigProfileSchema).default({}).optional(),
   _migrations: z.array(z.string()).optional(),
   legacy_migrations: z.record(z.string(), z.unknown()).optional(),
 }).strict()

--- a/packages/omo-opencode/src/config/schema/oh-my-opencode-config.ts
+++ b/packages/omo-opencode/src/config/schema/oh-my-opencode-config.ts
@@ -94,7 +94,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
     commit_footer: true,
     include_co_authored_by: true,
     git_env_prefix: "GIT_MASTER=1",
-  }),
+  }).optional(),
   browser_automation_engine: BrowserAutomationConfigSchema.optional(),
   websearch: WebsearchConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),

--- a/script/build-omo-schema-document.ts
+++ b/script/build-omo-schema-document.ts
@@ -25,8 +25,14 @@ export function createOmoJsonSchema(): Record<string, unknown> {
   const profileProperties = requiredRecord(profile.properties, "properties.profiles.additionalProperties.properties")
   const openCodeSchema = createOhMyOpenCodeJsonSchema()
 
-  properties["[opencode]"] = openCodeSchema
-  profileProperties["[opencode]"] = openCodeSchema
+  // Strip $id from embedded schemas — they are inline copies, not standalone
+  // entry points. A shared $id in two locations causes Ajv 2020 compilation
+  // failure ("resolves to more than one schema") in both strict and
+  // non-strict modes.
+  const { $id: _unused, ...openCodeSchemaNoId } = openCodeSchema as { $id?: unknown; [key: string]: unknown }
+
+  properties["[opencode]"] = openCodeSchemaNoId
+  profileProperties["[opencode]"] = { ...openCodeSchemaNoId }
 
   return {
     $schema: "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
## Summary
Fixes the confirmed bugs **#1** (duplicate `$id`) and **#2** (backward-incompatible required keys) from issue **#6626**.

Closes #6626

## What changed

### #1 — Duplicate `$id` (blocks Ajv compilation)
`assets/omo.schema.json` embedded the full `oh-my-opencode.schema.json` schema inline in **two** places (top-level `[opencode]` and each profile's `[opencode]`), both carrying the same `$id`. Ajv 2020 fails to compile the schema in **both** strict and non-strict modes with `reference ".../oh-my-opencode.schema.json" resolves to more than one schema`.

**Fix:** In `script/build-omo-schema-document.ts`, strip `$id` from the inline embedded copies (they are not standalone entry points — only the root `omo.schema.json` keeps its `$id`). Verified: `assets/omo.schema.json` now has exactly one `$id`.

### #2 — Backward-incompatible required keys
Two top-level `required` keys silently invalidated previously-valid configs:
- `assets/omo.schema.json` → `required: ['profiles']`
- `assets/oh-my-opencode.schema.json` → `required: ['git_master']`

**Fix:** Made both fields optional (with their existing defaults) in the Zod sources, then regenerated the assets:
- `packages/omo-config-core/src/schema/config.ts` → `profiles: ...default({}).optional()`
- `packages/omo-opencode/src/config/schema/oh-my-opencode-config.ts` → `git_master: ...default({...}).optional()`

## Out of scope (per triage)
- **#3** `_comment` whitelist — acknowledged as our own internal config artifact, not a tool bug. Not touched.
- **#4** stable versioned schema URL — reasonable ask, larger scope; left as future work.

## Verification
Regenerated both assets via `bun run build:omo-schema` + `bun run build:schema`, then compiled with **ajv@8.20.0**:

| Schema | strict=true | strict=false |
|--------|-------------|--------------|
| `assets/omo.schema.json` | ✅ PASS | ✅ PASS |
| `assets/oh-my-opencode.schema.json` | ✅ PASS | ✅ PASS |

Backward-compat: a config **without** `profiles` and one **without** `git_master` both now validate successfully (previously rejected).

Files changed: 5 (2 regenerated assets + 2 Zod sources + 1 codegen script).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate `$id` in embedded schemas and restores backward-compatible optional keys so configs validate and `ajv` compiles cleanly. Addresses #6626.

- **Bug Fixes**
  - Strip `$id` from inline `[opencode]` schemas in `assets/omo.schema.json` via `script/build-omo-schema-document.ts` to avoid duplicate `$id` collisions.
  - Make `profiles` optional with default `{}` in `packages/omo-config-core/src/schema/config.ts`, removing `required: ['profiles']` from the generated schema.
  - Make `git_master` optional (kept default) in `packages/omo-opencode/src/config/schema/oh-my-opencode-config.ts`, removing `required: ['git_master']` from generated schemas.

<sup>Written for commit 41d7282fdd4e5d6e3164a6c45f5019a71bd2a928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

