### PR TITLE
fix(doctor): stop flagging canonical keys inside provider_options passthrough maps

### DIFF
--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
@@ -188,6 +188,7 @@ describe("deprecated reasoning keys check", () => {
                 model: "openai/gpt-5.6-sol",
                 provider_options: {
                   textVerbosity: "high",
+                  thinking: { type: "enabled" },
                 },
               },
             },
@@ -196,6 +197,7 @@ describe("deprecated reasoning keys check", () => {
                 model: "openai/gpt-5.6-sol",
                 providerOptions: {
                   textVerbosity: "high",
+                  thinking: { type: "disabled" },
                 },
               },
             },

--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
@@ -164,4 +164,149 @@ describe("deprecated reasoning keys check", () => {
       }
     }
   })
+
+  it("does not flag deprecated keys inside provider_options passthrough maps", async () => {
+    //#given canonical config where verbosity lives in the provider passthrough maps
+    const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+    const originalHome = process.env.HOME
+    const originalCwd = process.cwd()
+    const testRootDir = mkdtempSync(join(tmpdir(), "omo-doctor-provider-options-"))
+    const projectDir = join(testRootDir, "project")
+    const configPath = join(testRootDir, ".omo", "omo.jsonc")
+
+    try {
+      mkdirSync(projectDir, { recursive: true })
+      mkdirSync(join(testRootDir, ".omo"), { recursive: true })
+      process.env.HOME = testRootDir
+      delete process.env.OPENCODE_CONFIG_DIR
+      writeFileSync(
+        configPath,
+        JSON.stringify(
+          {
+            categories: {
+              deep: {
+                model: "openai/gpt-5.6-sol",
+                provider_options: {
+                  textVerbosity: "high",
+                },
+              },
+            },
+            agents: {
+              oracle: {
+                model: "openai/gpt-5.6-sol",
+                providerOptions: {
+                  textVerbosity: "high",
+                },
+              },
+            },
+            "[opencode]": {
+              categories: {
+                planner: {
+                  model: "minimax-coding-plan/MiniMax-M3",
+                  provider_options: {
+                    textVerbosity: "high",
+                  },
+                },
+              },
+            },
+            "[senpi]": {
+              categories: {
+                quick: {
+                  model: "openai/gpt-5.6-luna",
+                  provider_options: {
+                    textVerbosity: "low",
+                  },
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      )
+      process.chdir(projectDir)
+
+      //#when running the deprecated reasoning keys check
+      const { checkDeprecatedReasoningKeys } = await import("./deprecated-reasoning-keys")
+      const result = await checkDeprecatedReasoningKeys()
+
+      //#then the canonical passthrough keys are not reported
+      expect(result.status).toBe("pass")
+      expect(result.issues).toEqual([])
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(testRootDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+      }
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+    }
+  })
+
+  it("still reports deprecated keys next to provider passthrough maps", async () => {
+    //#given a config mixing canonical passthrough keys with a deprecated legacy key
+    const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+    const originalHome = process.env.HOME
+    const originalCwd = process.cwd()
+    const testRootDir = mkdtempSync(join(tmpdir(), "omo-doctor-provider-options-legacy-"))
+    const projectDir = join(testRootDir, "project")
+    const configPath = join(testRootDir, ".omo", "omo.jsonc")
+
+    try {
+      mkdirSync(projectDir, { recursive: true })
+      mkdirSync(join(testRootDir, ".omo"), { recursive: true })
+      process.env.HOME = testRootDir
+      delete process.env.OPENCODE_CONFIG_DIR
+      writeFileSync(
+        configPath,
+        JSON.stringify(
+          {
+            categories: {
+              deep: {
+                model: "openai/gpt-5.6-sol",
+                provider_options: {
+                  textVerbosity: "high",
+                },
+                variant: "high",
+              },
+            },
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      )
+      process.chdir(projectDir)
+
+      //#when running the deprecated reasoning keys check
+      const { checkDeprecatedReasoningKeys } = await import("./deprecated-reasoning-keys")
+      const result = await checkDeprecatedReasoningKeys()
+
+      //#then only the legacy key is reported, never the canonical passthrough key
+      expect(result.status).toBe("warn")
+      expect(result.issues.map((issue) => issue.description)).toEqual([
+        `${configPath}: categories.deep.variant`,
+      ])
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(testRootDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+      }
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+    }
+  })
 })

--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts
@@ -49,6 +49,9 @@ function collectIssues(configPath: string, value: unknown, prefix: string): Doct
       continue
     }
     if (key === "[opencode]") continue
+    // Provider option passthrough maps are not model definitions; keys inside
+    // them (e.g. provider_options.textVerbosity) are canonical, not deprecated.
+    if (key === "provider_options" || key === "providerOptions") continue
     if (TUNING_CONTAINERS.has(key) || isHarnessBlock(key) || prefix.length > 0) {
       issues.push(...collectIssues(configPath, child, path))
     }


### PR DESCRIPTION
## Summary

The doctor's deprecated-reasoning-keys check recursed into `provider_options` / `providerOptions` passthrough maps and flagged `textVerbosity` even in its canonical location (`provider_options.textVerbosity`). Users who ran `config migrate` were told to move `textVerbosity` into `provider_options` - and then the doctor immediately flagged that canonical placement as deprecated (false positive, observed live on a real config as `[opencode].categories.planner.provider_options.textVerbosity`). This PR stops the recursion into those passthrough maps; they are provider option passthrough, not model definitions.

## Changes

- **`packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts`** - skip recursion into `provider_options` (categories) and `providerOptions` (agents) when traversing the config; add a comment explaining why.
- **`packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts`** - two new regression tests:
  1. canonical `provider_options.textVerbosity` (category), `providerOptions.textVerbosity` (agent), plus the same key inside `[opencode]` and `[senpi]` harness blocks - check passes with zero issues;
  2. canonical passthrough key side by side with a legacy `variant` key - only the legacy key is reported, never the passthrough key.

## QA & Evidence

Evidence dir: `.omo/evidence/20260807-doctor-deprecated-keys-fix/` (local, gitignored).

- **What was tested:** the real `doctor` CLI from the worktree (`bun packages/omo-opencode/src/cli/index.ts doctor`) against two isolated `HOME` sandboxes - sandbox A with canonical `categories.deep.provider_options.textVerbosity`, sandbox B with legacy `categories.deep.textVerbosity`.
- **Observed result:**
  - Sandbox A: **0 deprecated-key issues** (only an unrelated host TUI-plugin warning) - the false positive is gone. Artifact: `doctor-sandbox-a.txt`.
  - Sandbox B: exactly 1 issue - `Deprecated reasoning config key ... sandbox-b/.omo/omo.jsonc: categories.deep.textVerbosity` - the check still fires for real legacy keys. Artifact: `doctor-sandbox-b.txt`.
  - Unit suite: `bun test packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts` - 4 pass / 0 fail (2 pre-existing + 2 new). Typecheck `bun run typecheck` - exit 0.
- **Why sufficient:** the surface driven is the real CLI command from the changed source; the before-bug config (A) is clean and the after-check config (B) still flags, so both halves of the behavior are proven on the real surface. The unit tests pin the traversal rule for CI permanence.
- **Note:** the local Windows package suite shows 29 pre-existing environmental failures (tmux-dependent tests, Node `MODULE_TYPELESS_PACKAGE_JSON` stderr warnings, perf-budget flakes) - none touch `cli/doctor/*`; CI on ubuntu is the gate.

## Risks & Residuals

- **Regression risk: mitigated.** Legacy deprecated keys (incl. `variant` inside `ultrawork`/`compaction` override blocks) are still traversed and reported; only the two passthrough map names are excluded. Covered by the second new test and the existing suite.
- **CI:** full `bun test` / typecheck / build run in this PR's checks.

## Related Issues

Reported from a live `doctor` run on a real user config after `config migrate` (56 to 11 issues, root cause in this check).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the doctor’s deprecated-reasoning-keys check from flagging canonical provider passthrough keys. We now ignore `provider_options`/`providerOptions`, so `textVerbosity` and `thinking` in those maps are accepted while real legacy keys still warn.

- **Bug Fixes**
  - Skip recursion into `provider_options` and `providerOptions` when scanning configs.
  - Add regression tests for `textVerbosity` and `thinking` in passthrough maps (categories, agents, harness blocks), and confirm legacy `variant` is still reported.

<sup>Written for commit e4cc2555f89a202f08c1b962a3efeedad38e8a37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

