### PR TITLE
fix(lsp): make built-in LSP MCP work on desktop app, multi-project and Windows

### DIFF
--- a/packages/lsp-core/src/lsp/client.ts
+++ b/packages/lsp-core/src/lsp/client.ts
@@ -6,6 +6,7 @@ import { contextCwd } from "../request-context.js";
 import { LspClientConnection } from "./connection.js";
 import { effectiveExtension } from "./effective-extension.js";
 import { getLanguageId } from "./language-mappings.js";
+import { canonicalUri } from "./transport.js";
 import type {
 	Diagnostic,
 	DocumentSymbol,
@@ -20,6 +21,8 @@ import type {
 
 const POST_OPEN_DELAY_MS = 1000;
 const POST_DIAGNOSTICS_WAIT_MS = 500;
+const DIAGNOSTICS_PUSH_POLL_ATTEMPTS = 10;
+const DIAGNOSTICS_PUSH_POLL_INTERVAL_MS = 1000;
 
 export class LspClient extends LspClientConnection {
 	private readonly openedFiles = new Set<string>();
@@ -124,16 +127,28 @@ export class LspClient extends LspClientConnection {
 
 	async diagnostics(filePath: string): Promise<{ items: Diagnostic[] }> {
 		const absPath = resolve(contextCwd(), filePath);
-		const uri = pathToFileURL(absPath).href;
+		const uri = canonicalUri(pathToFileURL(absPath).href);
 		await this.openFile(absPath);
 		await new Promise((r) => setTimeout(r, POST_DIAGNOSTICS_WAIT_MS));
+
+		// Poll for pushed diagnostics: on first use the language server may still
+		// be loading the project (tsserver on large workspaces can take seconds),
+		// so a single short wait frequently returns nothing.
+		for (let attempt = 0; attempt < DIAGNOSTICS_PUSH_POLL_ATTEMPTS; attempt++) {
+			const pushed = this.getStoredDiagnostics(uri);
+			if (pushed.length > 0) {
+				return { items: pushed };
+			}
+			await new Promise((r) => setTimeout(r, DIAGNOSTICS_PUSH_POLL_INTERVAL_MS));
+		}
 
 		try {
 			const result = await this.sendRequest<{ items?: Diagnostic[] }>("textDocument/diagnostic", {
 				textDocument: { uri },
 			});
-			if (result.items) {
-				return { items: result.items };
+			const pulled = result.items;
+			if (pulled && pulled.length > 0) {
+				return { items: pulled };
 			}
 		} catch (error) {
 			if (!this.isUnsupportedDiagnosticPullError(error)) {

--- a/packages/lsp-core/src/lsp/transport.ts
+++ b/packages/lsp-core/src/lsp/transport.ts
@@ -90,7 +90,7 @@ export class LspClientTransport {
 		this.connection.onNotification("textDocument/publishDiagnostics", (params) => {
 			const diagnosticsParams = parseDiagnosticsParams(params);
 			if (diagnosticsParams?.uri) {
-				this.diagnosticsStore.set(diagnosticsParams.uri, diagnosticsParams.diagnostics);
+				this.diagnosticsStore.set(canonicalUri(diagnosticsParams.uri), diagnosticsParams.diagnostics);
 			}
 		});
 
@@ -275,8 +275,24 @@ export class LspClientTransport {
 	}
 
 	getStoredDiagnostics(uri: string): Diagnostic[] {
-		return this.diagnosticsStore.get(uri) ?? [];
+		return this.diagnosticsStore.get(canonicalUri(uri)) ?? [];
 	}
+}
+
+/**
+ * Normalizes a document URI so that push diagnostics (published by the server)
+ * and client-side lookups share the same key.
+ *
+ * Language servers commonly emit URIs with a lowercased Windows drive letter
+ * and percent-encoded colon (e.g. `file:///d%3A/project/...`), while the client
+ * generates `file:///D:/project/...`. On Windows these strings must match
+ * exactly for diagnostics to be found; on POSIX systems no drive letter or
+ * `%3A` exists, so the URI is returned unchanged.
+ */
+export function canonicalUri(uri: string): string {
+	return uri
+		.replace(/%3A/g, ":")
+		.replace(/^file:\/\/\/([a-zA-Z]):/, (_, drive: string) => `file:///${drive.toLowerCase()}:`);
 }
 
 export function createLspSpawnEnv(

--- a/packages/omo-opencode/src/mcp/index.ts
+++ b/packages/omo-opencode/src/mcp/index.ts
@@ -52,7 +52,7 @@ export function createBuiltinMcps(disabledMcps: string[] = [], config?: BuiltinM
   }
 
   if (!disabledMcps.includes("lsp")) {
-    mcps.lsp = createLspMcpConfig({ resolveExecutable: options.resolveExecutable })
+    mcps.lsp = createLspMcpConfig({ resolveExecutable: options.resolveExecutable, cwd: options.cwd })
   }
 
   if (!disabledMcps.includes("codegraph") && config?.codegraph?.enabled !== false) {

--- a/packages/omo-opencode/src/mcp/lsp.ts
+++ b/packages/omo-opencode/src/mcp/lsp.ts
@@ -44,6 +44,7 @@ export type LocalMcpConfig = {
   command: string[]
   enabled: boolean
   environment?: Record<string, string>
+  cwd?: string
 }
 
 function getModuleDirectory(moduleUrl: string): string | null {
@@ -112,13 +113,15 @@ function resolveLspCommand(options: LspMcpConfigOptions = {}): AncestorCliCandid
 
 export function createLspMcpConfig(options: LspMcpConfigOptions = {}): LocalMcpConfig {
   const resolvedCommand = resolveLspCommand(options)
+  const cwd = resolve(options.cwd ?? process.cwd())
 
   return {
     type: "local",
     command: resolvedCommand.command,
+    cwd,
     enabled: resolvedCommand.exists,
     environment: {
-      LSP_TOOLS_MCP_PROJECT_CONFIG: PROJECT_LSP_CONFIGS.join(delimiter),
+      LSP_TOOLS_MCP_PROJECT_CONFIG: PROJECT_LSP_CONFIGS.map((configPath) => resolve(cwd, configPath)).join(delimiter),
     },
   }
 }


### PR DESCRIPTION
## Problem

Two bugs made the built-in LSP MCP unusable in realistic setups (desktop app, multi-project, Windows):

### 1. Wrong project root (cwd)

`createBuiltinMcps` calls `createLspMcpConfig` without passing `cwd` (unlike `createCodegraphMcpConfig`). `createLspMcpConfig` falls back to `process.cwd()` — which on the desktop app is the app's launch directory (e.g. `C:\Users\xxx`), not the opened project.

Result: `LSP_TOOLS_MCP_PROJECT_CONFIG` points at the wrong directory and all LSP tools fail with cwd errors:

```
[lsp] Working directory does not exist: C:\Users\xxx\apps\api\src
LSP file path must be inside request cwd
```

### 2. Diagnostics always empty on Windows

Even after fixing cwd, `lsp_diagnostics` always returned 0 diagnostics for files that clearly have type errors (tsc confirms). Two root causes:

- **URI key mismatch**: tsserver publishes diagnostics with a lowercased drive letter and percent-encoded colon (`file:///d%3A/...`), while the client stores/reads with `file:///D:/...`. Pushed diagnostics were stored under a different key than the lookup key, so they were silently dropped (`lookup=MISS`).
- **First-publish timing**: tsserver needs seconds to load a large project before pushing diagnostics, but `diagnostics()` waited only 500ms. Pull (`textDocument/diagnostic`) is not implemented by typescript-language-server (-32601), so the fallback was always empty.

POSIX is unaffected (no drive letter / `%3A` in URIs), which is why this only shows up on Windows.

## Fix

1. `packages/omo-opencode/src/mcp/index.ts`: pass `cwd: options.cwd` to `createLspMcpConfig` (matches the existing `createCodegraphMcpConfig` pattern).

2. `packages/omo-opencode/src/mcp/lsp.ts`: `createLspMcpConfig` resolves `PROJECT_LSP_CONFIGS` against the provided `cwd` and returns a `cwd` field so opencode spawns the MCP subprocess in the correct working directory.

3. `packages/lsp-core/src/lsp/transport.ts`: canonicalize document URIs on both publish and lookup (decode `%3A`, lowercase drive letter) so pushed diagnostics are found.

4. `packages/lsp-core/src/lsp/client.ts`: poll for pushed diagnostics (up to ~10s) before falling back to the (unsupported) pull request; only treat non-empty pull results as authoritative.

## Why it works

`options.cwd` comes from `params.ctx.directory` — the currently opened project, dynamic per project and per session. URI canonicalization fixes the Windows-specific key mismatch. Polling covers slow first project load.

Verified on Windows desktop app: probe file with two TS2322 errors now returns both diagnostics (previously always "No diagnostics found"); goto-definition works; multi-project switching works.
