### PR TITLE
feat(skills): add a LaTeX final-materials route to ulw-research

### DIFF
--- a/packages/omo-senpi/skills/ulw-research/ATTRIBUTION.md
+++ b/packages/omo-senpi/skills/ulw-research/ATTRIBUTION.md
@@ -1,0 +1,61 @@
+# ATTRIBUTION / NOTICE
+
+This skill (`ulw-research`, authored natively for omo-senpi) is authored by
+the oh-my-openagent project. Design ideas are adapted from the third-party
+projects credited below. No third-party source is vendored here — only ideas
+are adapted into this skill's prompt contract.
+
+---
+
+## 1. insane-research (fivetaku) — inspiration for the claim-graph verification gate
+
+The non-code claim-graph verification gate (Phase 4b: a data-flow-lock where the
+synthesis may assert a high-risk non-code claim only after it clears `>= 2 independent
+source domains + 1 counter-search + a primary source`, otherwise it is abstained to an
+unresolved/refuted annex) is inspired by the data-flow-lock verification design in
+**insane-research** by fivetaku.
+
+- Source: https://github.com/fivetaku/insane-research
+- License: MIT (declared in the project's `README.md`).
+- **What is adapted:** the IDEA only — a verification gate whose output is the sole
+  allowlist the synthesis draws from, so skipping verification leaves nothing to
+  synthesize. No insane-research code is copied or redistributed.
+
+```
+MIT License
+
+Copyright (c) 2026 renocrypt
+```
+
+## 2. latex-paper-skills (yunshenwuchuxun) — citation verification + prose rhythm discipline
+
+The verified-citation contract in `references/latex-report.md` (every bibliography
+entry traces 1:1 to a source actually retrieved during the run, and citation
+attachment is re-verified after any prose pass) and the citation-preserving rhythm
+polish pass (vary sentence and paragraph length, kill filler phrases, minimize
+structure-implied transitions, never move a `\cite`) are inspired by the gated
+citation-verification workflow and the `latex-rhythm-refiner` skill in
+**latex-paper-skills**.
+
+- Source: https://github.com/yunshenwuchuxun/latex-paper-skills (snapshot d0f1061, 2026-03-25)
+- License: MIT (Copyright (c) 2026 renocrypt; declared in the project's `LICENSE`).
+- **What is adapted:** IDEAS only — no code, templates, or text are copied or
+  redistributed. The upstream skills are agent-oriented prompt specs with Python
+  validators; this skill translates the concepts into a runtime-agnostic reference
+  read by the assembly lane.
+
+## 3. latex-document-skill (ndpvt-web) — compile loop, page previews, scaling, long-form hygiene
+
+The toolchain-detection order (latexmk, then xelatex/pdflatex, then tectonic), the
+multi-pass compile loop with log-first debugging and PNG page previews for visual
+QA, the empirical page-count scaling rule (1-10 / 11-20 / 21+ pages), the
+engine-agnostic preamble pattern (`iftex`; XeLaTeX + fontspec for CJK), the report
+template anatomy (geometry/fancyhdr/titlesec/hyperref/booktabs/pgfplots), and the
+long-form anti-pattern list in `references/latex-report.md` are inspired by
+**latex-document-skill**.
+
+- Source: https://github.com/ndpvt-web/latex-document-skill (snapshot 54279f7, 2026-08-08)
+- License: MIT.
+- **What is adapted:** IDEAS only — no code, templates, or text are copied or
+  redistributed. The upstream compile script and templates are not vendored; the
+  reference describes the equivalent loop in plain shell + LaTeX.

--- a/packages/omo-senpi/skills/ulw-research/SKILL.md
+++ b/packages/omo-senpi/skills/ulw-research/SKILL.md
@@ -100,7 +100,7 @@ ulw-loop is ON by default for this mode: register the research axes as loop goal
 Never guess the shape of the deliverable. After the brief and before `team_create`, propose the final materials and WAIT for the user's answer:
 
 - **Default pair: PDF + DOCX.** Offer both as the baseline for any report/document request.
-- Name the alternatives that actually fit THIS domain — slides for a briefing, standalone HTML for a living page, Markdown for a working note, several at once when the audience differs.
+- Name the alternatives that actually fit THIS domain — slides for a briefing, standalone HTML for a living page, Markdown for a working note, LaTeX for a typeset or citation-heavy document, several at once when the audience differs.
 - Propose the TEMPLATE too, chosen from the domain and the user's own context: section skeleton, citation style, length target, language, and any house style they have used before. A prior document the user points at is the strongest template signal — read it and mirror its structure and tagging.
 - Ask once, compactly: proposed format + proposed template + what each option costs. Then stop and wait. Guessing here wastes the entire assembly pass.
 
@@ -314,6 +314,7 @@ The format answered at the Phase 0 gate is binding. Absent an explicit user over
 |---|---|
 | PDF (default) | Author the report as one self-contained HTML file, then print it headless: `chrome --headless --disable-gpu --no-pdf-header-footer --print-to-pdf=<out.pdf> file://<report.html>`. Embed the `design-spec.md` fonts as real webfonts (CJK included) instead of trusting system fallbacks. `uv run --with weasyprint python` is the fallback renderer. |
 | DOCX (default) | `pandoc <report.md> -o <out.docx>`, adding `--reference-doc=<template.docx>` when the user has a house style; `uv run --with python-docx python` when pandoc is unavailable. Charts and Mermaid renders go in as images. |
+| LaTeX (.tex + PDF) | Read [references/latex-report.md](references/latex-report.md) first and follow it end to end: scaffold from its preamble, write per-section `.tex`, compile with the detected engine (XeLaTeX when the report language needs CJK), iterate to a clean multi-pass log, then render page PNGs for the visual-QA gate. |
 | Slides / deck | `uv run --with python-pptx python` — one claim per slide, a chart or diagram per claim. |
 | Standalone HTML / Markdown | The authored source itself. |
 
@@ -350,7 +351,6 @@ The last thing the user reads states, in one compact block, what the answer is m
 - **Elapsed time, always.** Minutes from the run's start to delivery, derived from the session directory's own timestamp so it cannot be guessed: `python3 -c "import datetime,os,sys; s=datetime.datetime.strptime(os.path.basename(sys.argv[1]),'%Y%m%d-%H%M%S'); print(round((datetime.datetime.now()-s).total_seconds()/60))" "$SESSION_DIR"`.
 
 Never ship the artifact without this block, and never fill it from memory — every number in it is read off the journal.
-
 
 **Teardown is part of the deliverable.** Once the materials are delivered: `team_delete({ team_run_id, force: true })` for every team you stood up, confirm each lane is terminal (`/tasks`), and only then write the final answer. A live team left running past the final answer is a failed run, not a finished one.
 

--- a/packages/omo-senpi/skills/ulw-research/references/latex-report.md
+++ b/packages/omo-senpi/skills/ulw-research/references/latex-report.md
@@ -1,0 +1,176 @@
+# LaTeX Report Reference (ulw-research Phase 6)
+
+Read this end to end when Phase 6 routes the final materials to LaTeX. It is the operational contract for producing a typeset research report: scaffold, compile, verify, polish. The deliverable is the compiled PDF plus the `.tex` sources, and the same two delivery gates apply (visual QA on rendered pages, then the `writing` proofread pass).
+
+## When this route runs
+
+LaTeX fits typeset, citation-heavy, or math-heavy reports: academic-flavored research deliverables, long documents that need a real table of contents and numbered bibliography, anything the user will print or submit. For a living page choose standalone HTML; for a working note choose Markdown. When the user asks for "LaTeX", ".tex", "academic paper style", or a typeset PDF, this is the route.
+
+## Toolchain detection — run first, in one command
+
+```bash
+for b in latexmk xelatex pdflatex lualatex tectonic bibtex biber texfot pdftoppm; do command -v $b >/dev/null && echo "OK $b" || echo "-- $b"; done
+```
+
+- `latexmk` present → preferred backend (dependency-driven multi-pass, bibliography included).
+- No `latexmk` → manual multi-pass with the detected engine.
+- `tectonic` alone → usable as a zero-config fallback (`tectonic main.tex` self-manages passes and packages), but it is not a full TeX Live; avoid exotic packages.
+- No engine at all → do NOT silently downgrade the deliverable. Ship the `.tex` sources, state plainly that no TeX toolchain exists on the machine, and offer the HTML→PDF route as the fallback. A promised PDF that was never compiled is a failed run.
+
+## Engine choice
+
+- Report language needs CJK (Korean/Japanese/Chinese) or heavy Unicode → **XeLaTeX**. Never force CJK through pdfLaTeX: it fails as silent mojibake, the worst class of error.
+- Otherwise → pdfLaTeX is fine and fastest. LuaLaTeX when the user asks for it or Lua scripting is needed.
+
+## The compile loop — non-negotiable
+
+Compile from the report root (where `main.tex` lives):
+
+```bash
+# preferred
+latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex        # add -xelatex for CJK
+# manual fallback (engine = xelatex for CJK, else pdflatex)
+<engine> -interaction=nonstopmode -halt-on-error main.tex
+bibtex main            # or: biber main   (only when a .bib workflow is used)
+<engine> -interaction=nonstopmode main.tex && <engine> -interaction=nonstopmode main.tex
+```
+
+1. Read the log every pass. Errors are lines starting with `!` — fix the FIRST one and re-run; later errors are usually cascade. When `texfot` exists, pipe through it to suppress package noise.
+2. After errors: clear every `Undefined control sequence`, `Undefined references`, and `Citation ... undefined` (those mean another pass or a missing bib step), and every `Overfull \hbox` over 20pt (long URLs get `\url{}` or the `xurl` package; narrow columns get reworded or `\sloppy` locally).
+3. Multi-pass is mandatory: TOC, cross-references, and citations only stabilize after 2-3 engine passes. latexmk does this for you; manual means you own the count.
+4. Render page previews and LOOK at them — this is the visual-QA gate for this route:
+
+```bash
+pdftoppm -png -r 110 main.pdf page && ls page-*.png
+```
+
+Inspect every page: broken figures, overflowing tables, clipped CJK, blank pages, bad page breaks, unlabeled charts. Reading the `.tex` source is not visual QA. Fix and re-render until the pages are clean.
+5. Remove aux files only after the PDF is accepted (`latexmk -c` or delete `*.aux *.log *.out *.toc *.bbl *.blg`).
+
+## Preamble scaffold
+
+Start from this, not from memory. It is engine-agnostic and carries the packages a research report actually needs:
+
+```latex
+\documentclass[11pt,a4paper]{article}
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[utf8]{inputenc}
+  \usepackage[T1]{fontenc}
+  \usepackage{lmodern}
+\else
+  \usepackage{fontspec}
+\fi
+\usepackage[a4paper,margin=1in]{geometry}
+\usepackage{microtype}
+\usepackage{xcolor}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{tabularx}
+\usepackage{longtable}
+\usepackage{float}
+\usepackage{enumitem}
+\usepackage{titlesec}
+\usepackage{fancyhdr}
+\usepackage{pgfplots}
+\pgfplotsset{compat=1.18}
+\usepackage{tikz}
+\usepackage{listings}
+\definecolor{accent}{RGB}{0,102,204}   % the design-spec accent, one palette everywhere
+\usepackage[colorlinks=true,linkcolor=accent,urlcolor=accent,citecolor=accent]{hyperref}
+
+\pagestyle{fancy}\fancyhf{}
+\fancyhead[L]{\small\textcolor{gray}{<Report title>}}
+\fancyhead[R]{\small\textcolor{gray}{\today}}
+\fancyfoot[C]{\small\thepage}
+\titleformat{\section}{\Large\bfseries\color{accent}}{\thesection}{0.5em}{}
+```
+
+**CJK variant** — compile with XeLaTeX and replace the font block with a real installed CJK font (verify first with `fc-list | grep -i "cjk\|pretendard"`):
+
+```latex
+\usepackage{fontspec}
+\setmainfont{Noto Serif CJK KR}      % or Pretendard, Noto Sans CJK KR — whatever fc-list proves exists
+\setmainfont{Latin Modern Roman}     % optional: keep Latin in the report's serif
+```
+
+Fonts, colors, and heading style come from `design-spec.md` when one exists — one palette and one font family govern prose, charts, and diagrams alike; a figure in a random default font inside a styled report is a defect.
+
+## Report skeleton
+
+Map the ulw-research deliverable structure onto sections:
+
+```latex
+\title{\textbf{<Report title>}\\ \large <one-line scope>}
+\author{ulw-research --- <members> members, <lanes> lanes, <waves> waves, <sources> sources}
+\date{\today}
+\begin{document}
+\maketitle
+\thispagestyle{empty}
+\newpage
+\tableofcontents
+\newpage
+\section{Executive Summary}      % 2-3 paragraphs answering the core question
+\section{Key Findings by Theme}  % one subsection per theme; every claim carries \cite{srcN}
+\section{Detailed Analysis}      % charts, tables, rendered diagrams, verification results
+\section{Comparative Analysis}   % only when options compete
+\section{Methodology}            % members, lanes, waves, searches, verifications, debate rounds
+\section{Correction Log}         % what verification overturned
+% bibliography at the end — see the citations section
+\end{document}
+```
+
+Write the skeleton into `main.tex` FIRST with a `% STATUS: draft — <n> sections open` comment at the top, then fill sections as claims lock. An interrupted run leaves a partial report on disk, never an empty directory.
+
+## Citations and the sources ledger
+
+Every `[Source N]` in `SYNTHESIS.md` becomes a numbered bibliography entry, 1:1 with `sources-ledger.md`, in citation order, each carrying its access date. Two workable setups:
+
+- **BibTeX/biblatex (preferred when bibtex/biber exists):** generate `refs.bib` from the ledger (`@misc` entries with `title`, `author` when known, `howpublished={\url{...}}`, `urldate`), cite with `\cite{srcN}`, style `plainnat` (natbib) or `style=numeric` (biblatex).
+- **Manual `thebibliography` (zero extra tooling):** acceptable for pure web-source reports; one `\bibitem{srcN}` per ledger row.
+
+The verification rule is absolute: **every bibliography entry was actually retrieved during the run.** An entry invented from memory, or one whose URL was never fetched, is a defect — the same standard the claim-graph gate enforces on prose. No citation without a ledger row; no ledger row without a citation.
+
+## Figures, tables, code
+
+- **Charts:** compute from real data (CSV/JSON under `$SESSION_DIR`), plot with matplotlib, save as **PDF vector** (PNG at 200+ dpi only when vector fails). Include with `\includegraphics[width=0.9\textwidth,keepaspectratio]{...}` inside `figure` with `\caption` + `\label`, and reference every figure in prose (`Figure~\ref{fig:x}`). A figure the text never references is a defect.
+- **pgfplots** for native charts when the data is small and already in the preamble's style; matplotlib for anything computed. Never screenshot a chart from another tool.
+- **Mermaid/diagrams:** render the `.mmd` to PNG or PDF FIRST (`mmdc -i in.mmd -o out.png -b white`), then include the image. Mermaid source never goes into the `.tex`.
+- **Tables:** booktabs only — `\toprule`, `\midrule`, `\bottomrule`, NO vertical rules. `tabularx` for full-width text columns, `longtable` when rows can exceed a page, numeric columns right-aligned (`siunitx`'s `S` column when units matter). Every table gets `\caption` + `\label` + an in-text reference.
+- **Code:** `listings` with a styled block (`basicstyle=\ttfamily\small`, `breaklines=true`, `frame=single`, `numbers=left`). Avoid `minted` unless `--shell-escape` is acceptable — prefer portability.
+- **Float placement:** big figures/tables float with `[!htbp]`; reserve `[H]` (float package) for small exhibits that must sit exactly here. Never fight the float engine with `\newpage` spam.
+
+## Long reports: split and scale
+
+Empirical scaling holds here: 1-10 pages one assembly lane; 11-20 pages split at a section boundary across two lanes; 21+ pages batch ~7 pages per lane. Mechanically:
+
+- One file per section under `sections/` (`sections/executive-summary.tex`, ...), `\input{sections/<name>}` from `main.tex`. Lanes own disjoint section files — no two lanes write the same file.
+- The lead owns `main.tex`, the preamble, and the bibliography, and runs the compile loop after each merge.
+- Compile after EVERY section merge, not once at the end — a 30-page report whose first compile happens at page 30 debugs thirty pages at once.
+
+## The polish pass — after content, before final compile
+
+Run one citation-preserving prose pass per section (the rhythm discipline):
+
+- Vary sentence length: no 3+ consecutive sentences of similar length; mix short (5-12 words), medium (13-22), long (23-35).
+- Alternate paragraph lengths: short for emphasis, medium for exposition, long for complex argument.
+- Kill fillers: "in order to" → "to", "it is worth noting that" → delete, "due to the fact that" → "because", "a large number of" → "many".
+- Drop transitions the structure already implies ("However,", "Moreover,", "As mentioned above,").
+- Active voice; one main idea per paragraph with a clear first sentence.
+- **Never add, move, or delete a `\cite{...}` while polishing.** Citation count and attachment are verified per section after the pass, not assumed.
+
+## Pitfalls — the errors that actually happen
+
+| Symptom in the log | Cause | Fix |
+|---|---|---|
+| `! Undefined control sequence` | typo'd command or missing `\usepackage` | read the line number; add the package or fix the command |
+| `! Missing $ inserted` | `_`, `^`, or math chars in text mode | escape as `\_`, or wrap math in `$...$` |
+| `! Misplaced alignment tab character &` | bare `&` in text | escape as `\&` (also `\%`, `\#`) |
+| `! Illegal unit of measure` / `! Missing number` | typo'd dimension (`10 px`, `0.5\\textwidth` with `\` lost) | use real units and `\textwidth` fractions |
+| `! LaTeX Error: Environment X undefined` | missing package or typo | add the package that owns the environment |
+| Silent mojibake, no error | CJK under pdfLaTeX | switch to XeLaTeX + the CJK font block |
+| `Overfull \hbox` (>20pt) | unbreakable long content (URLs, code, wide tables) | `\url{}`/`xurl`, `breaklines` in listings, shrink or restructure the table |
+| `Citation 'srcN' undefined` | bib step missing or key typo | run bibtex/biber, then two more engine passes |
+| `File not found` on `\includegraphics` | wrong relative path | paths are relative to `main.tex`, not to the section file |
+
+Long-form anti-patterns to refuse while writing: walls of bullets where prose analysis belongs; `\newpage` after every section; oversized images without `keepaspectratio`; `[H]` on every float; uncompacted lists (`enumitem`'s `nosep` in tight spots); monotonous same-shape sections; hardcoded pixel dimensions instead of `\textwidth` fractions; widow/orphan lines at page breaks (`\usepackage[all]{nowidow}` when it matters).


### PR DESCRIPTION
## Summary
The omo-senpi native `ulw-research` skill can now deliver its final research report as LaTeX (`.tex` sources + compiled PDF), offered exactly the way Markdown is offered today: an explicit alternative at the Phase 0 format-proposal gate, and a row in the Phase 6 format table that routes the assembly lane to a dedicated reference guide. The guide is distilled from a fresh research pass over two community LaTeX skills plus standard report-typesetting practice.

## Changes
- `packages/omo-senpi/skills/ulw-research/SKILL.md` (+2/-2): the Phase 0 format-gate alternatives bullet and the Phase 6 format table each gain the LaTeX option inside the existing enumerations; no other wording touched. One triple-newline collapsed so the shipped copy is byte-identical to source.
- `packages/omo-senpi/skills/ulw-research/references/latex-report.md` (new, 176 lines): the LaTeX report contract — toolchain detection (latexmk > xelatex/pdflatex > tectonic, explicit no-toolchain fallback), engine choice (XeLaTeX for CJK), the compile loop (multi-pass mandatory, log-first debugging, Overfull-hbox bar, `pdftoppm` PNG page previews as the visual-QA gate), engine-agnostic preamble scaffold, report skeleton mapped to the ulw-research deliverable, citations 1:1 with the sources ledger (no invented entries), figure/table/code standards, page-count scaling (1-10 / 11-20 / 21+), the citation-preserving rhythm polish pass, and a pitfalls table.
- `packages/omo-senpi/skills/ulw-research/ATTRIBUTION.md` (new): ports the existing insane-research credit from the shared pool into the native source (`syncSkills()` regenerates the shipped tree from sources, so the credit previously survived only in the stale shipped copy), and credits `latex-paper-skills` (MIT, renocrypt) and `latex-document-skill` (MIT) for adapted ideas. Ideas only; no code, templates, or text vendored.

## QA & Evidence
Evidence root: `.omo/evidence/omo-senpi-adapter/20260808-ulw-research-latex/`
- **What was tested:** RED→GREEN on the shipped-artifact seam. Pre-generation, the LaTeX route existed in no shipped copy (fresh worktree: `plugin/skills/` absent, `diff` rc=2 — `red-diff.txt`; plus a 528-line pre-existing source↔shipped drift at base `a5cdb6ac0`, classified pre-existing — `baseline-diff-prior-drift.txt`). After `node packages/omo-senpi/plugin/scripts/sync-skills.mjs`, `diff -r` source vs shipped is EMPTY (`green-diff.txt`).
- **Observed:** `green-latex-present.txt` (route + reference present in the shipped tree), `frontmatter-parse.txt` (frontmatter YAML parses; `name` + `description` present), `green-skills-sync-test.txt` (`bun test packages/omo-senpi/src/skills-sync.test.ts`: 9/9, including the native-verbatim and no-foreign-harness-token tests — the latter caught a "Codex-oriented" wording in the first ATTRIBUTION.md draft, reworded and re-verified), `test-senpi.log` (`bun run test:senpi` full package gate: **590 pass / 0 fail across 92 files**).
- **Why sufficient:** this is prose/skill content with no runtime code path; the machine-consumed seams are byte-equality of the shipped copy and the package gate, both proven on the artifacts the Senpi harness actually loads.
- Research provenance: `research/repo-a-full-dump.txt`, `research/repo-b-full-dump.txt`, `research/lessons-learned.md`.

## Risks & Residuals
- The next build's sync regenerates the shipped tree from the native source, which also resolves the noted pre-existing drift (the shipped copy now matches the team-first native source and carries its ATTRIBUTION.md). Generated-output correctness, not a behavior change beyond intent.
- No live Senpi session QA: the change is markdown content only — no adapter code, hook, or runtime path was touched. Residual risk is limited to how future research runs read the new reference.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a LaTeX final-materials route to `ulw-research`, delivering `.tex` sources plus a compiled PDF. The option is offered at the Phase 0 format gate and routed in Phase 6 via a new reference guide with proper attribution.

- **New Features**
  - LaTeX added to `SKILL.md` at Phase 0 and Phase 6.
  - New `references/latex-report.md` with toolchain detection (`latexmk` → `xelatex`/`pdflatex` → `tectonic`), XeLaTeX for CJK, multi-pass compile, `pdftoppm` visual QA, preamble/skeleton, and strict 1:1 citations to the sources ledger.
  - New `ATTRIBUTION.md` crediting `insane-research`, `latex-paper-skills`, and `latex-document-skill` (ideas only; nothing vendored).
  - No runtime code changed; skills sync is green and package tests pass.

<sup>Written for commit 4655571ec81a93b60cc7a8fe3d46180b16485fa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

