### PR TITLE
fix(mcp-client-core): propagate request timeouts to the MCP SDK (#6631)

### DIFF
--- a/.omo/evidence/20260808-fix-6631/driver-after-fix.txt
+++ b/.omo/evidence/20260808-fix-6631/driver-after-fix.txt
@@ -1,0 +1,2 @@
+[no-timeout-config] FAILED after 60.1s -> McpError: MCP error -32001: Request timed out
+[requestTimeoutMs=120000] OK after 65.1s -> [{"type":"text","text":"waited 65s"}]

--- a/.omo/evidence/20260808-fix-6631/driver.ts
+++ b/.omo/evidence/20260808-fix-6631/driver.ts
@@ -1,0 +1,25 @@
+import type { ClaudeCodeMcpServer } from "@oh-my-opencode/claude-code-compat-core/claude-code-mcp-loader/types"
+import { SkillMcpManager } from "@oh-my-opencode/mcp-client-core/skill-mcp-manager/manager"
+
+const serverPath = new URL("./slow-server.ts", import.meta.url).pathname
+const waitSeconds = 65
+
+async function run(label: string, timeouts?: ClaudeCodeMcpServer["timeouts"]) {
+  const manager = new SkillMcpManager()
+  const config: ClaudeCodeMcpServer = { command: "bun", args: [serverPath], ...(timeouts ? { timeouts } : {}) }
+  const info = { sessionID: `ses-${label}`, skillName: "qa-skill", serverName: "slow-server" }
+  const context = { config, skillName: "qa-skill" }
+  const startedAt = Date.now()
+  try {
+    const result = await manager.callTool(info, context, "wait", { seconds: waitSeconds })
+    console.log(`[${label}] OK after ${((Date.now() - startedAt) / 1000).toFixed(1)}s ->`, JSON.stringify(result))
+  } catch (error) {
+    console.log(`[${label}] FAILED after ${((Date.now() - startedAt) / 1000).toFixed(1)}s ->`, String(error))
+  } finally {
+    await manager.disconnectAll()
+  }
+}
+
+await run("no-timeout-config")
+await run("requestTimeoutMs=120000", { requestTimeoutMs: 120_000 })
+process.exit(0)

--- a/.omo/evidence/20260808-fix-6631/full-suite.txt
+++ b/.omo/evidence/20260808-fix-6631/full-suite.txt
@@ -1,0 +1,15 @@
+Full root suite, unmodified dev (baseline):
+ 13295 pass
+ 28 fail
+Ran 13357 tests across 1725 files. [180.86s]
+
+Full root suite, with this change:
+ 13303 pass
+ 28 fail
+Ran 13365 tests across 1726 files. [203.85s]
+
+diff of the failing-test name sets (baseline vs change): empty
+The 28 failures are identical on both sides and are local-environment only:
+  - unbuilt senpi/codex runtime bundles (plugin/runtime/*, dist/cli)
+  - uninitialized frontend provenance submodules (ATTRIBUTION pins)
+This checkout ran 'bun install --frozen-lockfile --ignore-scripts' without submodules.

--- a/.omo/evidence/20260808-fix-6631/green.txt
+++ b/.omo/evidence/20260808-fix-6631/green.txt
@@ -1,0 +1,6 @@
+bun test v1.3.12 (700fc117)
+
+ 8 pass
+ 0 fail
+ 13 expect() calls
+Ran 8 tests across 1 file. [265.00ms]

--- a/.omo/evidence/20260808-fix-6631/negative-control.txt
+++ b/.omo/evidence/20260808-fix-6631/negative-control.txt
@@ -1,0 +1,34 @@
+--- unit + manager tests with the threading reverted ---
+
+- Expected  - 4
++ Received  + 1
+
+      at <anonymous> (/Users/kumarprateek/projects/opensource-work/oh-my-openagent/packages/mcp-client-core/src/skill-mcp-manager/request-timeouts.test.ts:130:49)
+(fail) SkillMcpManager request option propagation > #given a server with configured timeouts #when driving every operation #then each SDK call receives the request options [3.63ms]
+149 | 
+150 |     // when
+151 |     await manager.callTool(info, context, "wait", { seconds: 65 }, { timeouts: { requestTimeoutMs: 300_000 } })
+152 | 
+153 |     // then
+154 |     expect(client.callTool.mock.calls[0]?.[2]).toEqual({ timeout: 300_000 })
+                                                     ^
+error: expect(received).toEqual(expected)
+
+- {
+-   "timeout": 300000,
+- }
++ undefined
+
+- Expected  - 3
++ Received  + 1
+
+      at <anonymous> (/Users/kumarprateek/projects/opensource-work/oh-my-openagent/packages/mcp-client-core/src/skill-mcp-manager/request-timeouts.test.ts:154:48)
+(fail) SkillMcpManager request option propagation > #given a per-call timeout override #when calling a tool #then the override reaches the SDK [0.20ms]
+
+ 6 pass
+ 2 fail
+ 8 expect() calls
+Ran 8 tests across 1 file. [284.00ms]
+--- live driver with the threading reverted ---
+[no-timeout-config] FAILED after 60.1s -> McpError: MCP error -32001: Request timed out
+[requestTimeoutMs=120000] FAILED after 60.1s -> McpError: MCP error -32001: Request timed out

--- a/.omo/evidence/20260808-fix-6631/qa-summary.md
+++ b/.omo/evidence/20260808-fix-6631/qa-summary.md
@@ -1,0 +1,91 @@
+# QA Evidence - fix(mcp-client-core): propagate request timeouts to the SDK (#6631)
+
+## What was tested
+
+- A live stdio MCP server (`slow-server.ts`) exposing a `wait` tool that sleeps
+  for a given number of seconds, driven through the real `SkillMcpManager`
+  (`driver.ts`). This is the exact reproduction the issue describes: a 65 second
+  tool call over the direct MCP execution path.
+- A negative control that reverts only the `manager.ts` threading and re-runs
+  both the driver and the new unit tests.
+- The new co-located test file
+  `packages/mcp-client-core/src/skill-mcp-manager/request-timeouts.test.ts`.
+- `bun run typecheck` and the full root `bun test` suite, plus the MCP client and
+  skill loader suites on their own.
+
+## What was observed
+
+### Live surface, with the fix (`driver-after-fix.txt`)
+
+```
+[no-timeout-config]         FAILED after 60.1s -> McpError: MCP error -32001: Request timed out
+[requestTimeoutMs=120000]   OK     after 65.1s -> [{"type":"text","text":"waited 65s"}]
+```
+
+The first line reproduces the reported defect against a real server: with no
+timeout configured the SDK default of 60000 ms still applies, so a 65 second
+tool dies at 60.1 seconds. The second line is the fix: a server that sets
+`timeouts.requestTimeoutMs` to 120000 completes the same call at 65.1 seconds.
+
+### Negative control (`negative-control.txt`)
+
+With only the `manager.ts` call-site threading reverted, and the config type,
+the resolver, and the tests left in place:
+
+```
+6 pass / 2 fail   (both manager propagation tests fail)
+[no-timeout-config]         FAILED after 60.1s
+[requestTimeoutMs=120000]   FAILED after 60.1s
+```
+
+The configured 120 second timeout has no effect without the threading, which
+proves the tests and the driver depend on the change rather than on the new
+config field existing.
+
+### Unit tests, with the fix (`green.txt`)
+
+`8 pass / 0 fail`. Coverage: no config resolves to `undefined` so the SDK default
+stands, server fields map onto the SDK option names, a per-call override wins
+field by field, non-positive and non-finite values are dropped,
+`resetTimeoutOnProgress: false` is still forwarded, and all six operations
+(`listTools`, `listResources`, `listPrompts`, `callTool`, `readResource`,
+`getPrompt`) forward the resolved options.
+
+### Typecheck (`typecheck.txt`)
+
+`bun run typecheck` exit 0, no diagnostics.
+
+### Related suites (`related-suites.txt`)
+
+`bun test` over `packages/mcp-client-core`, the `omo-opencode`
+`skill-mcp-manager` shim tests, the `claude-code-mcp-loader`, and
+`skills-loader-core`: `399 pass / 0 fail`.
+
+### Full root suite (`full-suite.txt`)
+
+Baseline `13295 pass / 28 fail`, with this change `13303 pass / 28 fail`. The
+failing-test name sets are identical on both sides. Those 28 are local
+environment failures only: this checkout installed with `--ignore-scripts` and
+without the frontend provenance submodules, so the senpi and codex runtime
+bundles and the ATTRIBUTION pins are absent.
+
+## Why it is enough
+
+The defect is a dropped argument at six SDK call sites, and there was no config
+field to drop in the first place. The driver exercises the real production path
+end to end against a real MCP server over stdio, shows the 60 second ceiling
+before the fix and a successful 65 second call after it, and the negative
+control shows the ceiling returns the moment the threading is removed. The unit
+tests pin the resolution rules that the driver cannot cover cheaply, in
+particular that an unconfigured server sends no request options at all, so the
+SDK default is untouched for everyone who does not opt in.
+
+## What was omitted
+
+- No OpenCode harness drive. The change is confined to a Core package with no
+  OpenCode surface: it adds an optional config field and forwards it, and the
+  `packages/omo-opencode/src/features/skill-mcp-manager/` files are re-export
+  shims that are unchanged. The maintainer should say so if a harness-level QA
+  run is still wanted here.
+- No secrets, tokens, or env dumps appear in any artifact. The test server is
+  local and needs no credentials.

--- a/.omo/evidence/20260808-fix-6631/related-suites.txt
+++ b/.omo/evidence/20260808-fix-6631/related-suites.txt
@@ -1,0 +1,6 @@
+bun test v1.3.12 (700fc117)
+
+ 399 pass
+ 0 fail
+ 1003 expect() calls
+Ran 399 tests across 55 files. [1.79s]

--- a/.omo/evidence/20260808-fix-6631/slow-server.ts
+++ b/.omo/evidence/20260808-fix-6631/slow-server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { z } from "zod"
+
+const server = new McpServer({ name: "slow-server", version: "1.0.0" })
+
+server.registerTool(
+  "wait",
+  { description: "Sleeps for the given number of seconds, then returns", inputSchema: { seconds: z.number() } },
+  async ({ seconds }) => {
+    await new Promise((resolve) => setTimeout(resolve, seconds * 1000))
+    return { content: [{ type: "text" as const, text: `waited ${seconds}s` }] }
+  },
+)
+
+await server.connect(new StdioServerTransport())

--- a/.omo/evidence/20260808-fix-6631/typecheck.txt
+++ b/.omo/evidence/20260808-fix-6631/typecheck.txt
@@ -1,0 +1,3 @@
+$ bun run typecheck
+(no diagnostics emitted)
+exit=0

--- a/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/types.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/types.ts
@@ -5,6 +5,16 @@ export interface McpOAuthConfig {
   scopes?: string[]
 }
 
+/**
+ * Per-server request timeouts for skill-embedded (tier-3) MCP operations.
+ * Every field is optional; an unset field leaves the MCP SDK default in place.
+ */
+export interface McpRequestTimeoutConfig {
+  requestTimeoutMs?: number
+  resetTimeoutOnProgress?: boolean
+  maxTotalTimeoutMs?: number
+}
+
 export interface ClaudeCodeMcpServer {
   type?: "http" | "sse" | "stdio"
   url?: string
@@ -16,6 +26,7 @@ export interface ClaudeCodeMcpServer {
   scope?: McpScope
   projectPath?: string
   disabled?: boolean
+  timeouts?: McpRequestTimeoutConfig
 }
 
 export interface ClaudeCodeMcpConfig {

--- a/packages/mcp-client-core/src/skill-mcp-manager/manager.ts
+++ b/packages/mcp-client-core/src/skill-mcp-manager/manager.ts
@@ -1,9 +1,13 @@
 import type { Prompt, Resource, Tool } from "@modelcontextprotocol/sdk/types.js"
-import type { ClaudeCodeMcpServer } from "@oh-my-opencode/claude-code-compat-core/claude-code-mcp-loader/types"
+import type {
+  ClaudeCodeMcpServer,
+  McpRequestTimeoutConfig,
+} from "@oh-my-opencode/claude-code-compat-core/claude-code-mcp-loader/types"
 import { McpOAuthProvider } from "../mcp-oauth/provider"
 import { disconnectAll, disconnectSession, forceReconnect } from "./cleanup"
 import { getOrCreateClient, getOrCreateClientWithRetryImpl } from "./connection"
 import { handlePostRequestAuthError, handleStepUpIfNeeded } from "./oauth-handler"
+import { resolveMcpRequestOptions } from "./request-timeouts"
 import type {
   McpClient,
   OAuthProviderFactory,
@@ -14,6 +18,7 @@ import type {
 
 export interface SkillMcpClientOptions {
   cdpUrl?: string
+  timeouts?: McpRequestTimeoutConfig
 }
 
 export function buildSkillMcpClientKey(info: SkillMcpClientInfo, options?: SkillMcpClientOptions): string {
@@ -36,6 +41,10 @@ function withInjectedCdpEndpoint(
   const configWithCdpEndpoint = structuredClone(config)
   configWithCdpEndpoint.args = [...(configWithCdpEndpoint.args ?? []), "--cdp-endpoint", options.cdpUrl]
   return configWithCdpEndpoint
+}
+
+function buildRequestOptions(config: ClaudeCodeMcpServer, options?: SkillMcpClientOptions) {
+  return resolveMcpRequestOptions(config.timeouts, options?.timeouts)
 }
 
 export class SkillMcpManager {
@@ -87,19 +96,19 @@ export class SkillMcpManager {
 
   async listTools(info: SkillMcpClientInfo, context: SkillMcpServerContext, options?: SkillMcpClientOptions): Promise<Tool[]> {
     const client = await this.getOrCreateClientWithRetry(info, context.config, options)
-    const result = await client.listTools()
+    const result = await client.listTools(undefined, buildRequestOptions(context.config, options))
     return result.tools
   }
 
   async listResources(info: SkillMcpClientInfo, context: SkillMcpServerContext, options?: SkillMcpClientOptions): Promise<Resource[]> {
     const client = await this.getOrCreateClientWithRetry(info, context.config, options)
-    const result = await client.listResources()
+    const result = await client.listResources(undefined, buildRequestOptions(context.config, options))
     return result.resources
   }
 
   async listPrompts(info: SkillMcpClientInfo, context: SkillMcpServerContext, options?: SkillMcpClientOptions): Promise<Prompt[]> {
     const client = await this.getOrCreateClientWithRetry(info, context.config, options)
-    const result = await client.listPrompts()
+    const result = await client.listPrompts(undefined, buildRequestOptions(context.config, options))
     return result.prompts
   }
 
@@ -110,15 +119,17 @@ export class SkillMcpManager {
     args: Record<string, unknown>,
     options?: SkillMcpClientOptions
   ): Promise<unknown> {
+    const requestOptions = buildRequestOptions(context.config, options)
     return await this.withOperationRetry(info, context.config, options, async (client) => {
-      const result = await client.callTool({ name, arguments: args })
+      const result = await client.callTool({ name, arguments: args }, undefined, requestOptions)
       return result.content
     })
   }
 
   async readResource(info: SkillMcpClientInfo, context: SkillMcpServerContext, uri: string, options?: SkillMcpClientOptions): Promise<unknown> {
+    const requestOptions = buildRequestOptions(context.config, options)
     return await this.withOperationRetry(info, context.config, options, async (client) => {
-      const result = await client.readResource({ uri })
+      const result = await client.readResource({ uri }, requestOptions)
       return result.contents
     })
   }
@@ -130,8 +141,9 @@ export class SkillMcpManager {
     args: Record<string, string>,
     options?: SkillMcpClientOptions
   ): Promise<unknown> {
+    const requestOptions = buildRequestOptions(context.config, options)
     return await this.withOperationRetry(info, context.config, options, async (client) => {
-      const result = await client.getPrompt({ name, arguments: args })
+      const result = await client.getPrompt({ name, arguments: args }, requestOptions)
       return result.messages
     })
   }

--- a/packages/mcp-client-core/src/skill-mcp-manager/request-timeouts.test.ts
+++ b/packages/mcp-client-core/src/skill-mcp-manager/request-timeouts.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js"
+import type { ClaudeCodeMcpServer } from "@oh-my-opencode/claude-code-compat-core/claude-code-mcp-loader/types"
+import * as connectionModule from "./connection"
+import { SkillMcpManager } from "./manager"
+import { resolveMcpRequestOptions } from "./request-timeouts"
+import type { McpClient, SkillMcpClientInfo, SkillMcpServerContext } from "./types"
+
+function createRecordingClient() {
+  return {
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    listTools: mock(async (_params?: unknown, _options?: RequestOptions) => ({ tools: [] })),
+    listResources: mock(async (_params?: unknown, _options?: RequestOptions) => ({ resources: [] })),
+    listPrompts: mock(async (_params?: unknown, _options?: RequestOptions) => ({ prompts: [] })),
+    callTool: mock(async (_params?: unknown, _resultSchema?: unknown, _options?: RequestOptions) => ({
+      content: [],
+    })),
+    readResource: mock(async (_params?: unknown, _options?: RequestOptions) => ({ contents: [] })),
+    getPrompt: mock(async (_params?: unknown, _options?: RequestOptions) => ({ messages: [] })),
+  }
+}
+
+const info: SkillMcpClientInfo = {
+  serverName: "slow-server",
+  skillName: "slow-skill",
+  sessionID: "session-1",
+}
+
+describe("resolveMcpRequestOptions", () => {
+  it("#given no timeout config #when resolving #then returns undefined so the SDK default applies", () => {
+    // given
+    const serverTimeouts = undefined
+
+    // when
+    const resolved = resolveMcpRequestOptions(serverTimeouts)
+
+    // then
+    expect(resolved).toBeUndefined()
+  })
+
+  it("#given per-server timeouts #when resolving #then they map onto the SDK request option names", () => {
+    // given
+    const serverTimeouts = {
+      requestTimeoutMs: 120_000,
+      maxTotalTimeoutMs: 600_000,
+      resetTimeoutOnProgress: true,
+    }
+
+    // when
+    const resolved = resolveMcpRequestOptions(serverTimeouts)
+
+    // then
+    expect(resolved).toEqual({
+      timeout: 120_000,
+      maxTotalTimeout: 600_000,
+      resetTimeoutOnProgress: true,
+    })
+  })
+
+  it("#given a per-call override #when resolving #then it wins field by field over the server config", () => {
+    // given
+    const serverTimeouts = { requestTimeoutMs: 120_000, maxTotalTimeoutMs: 600_000 }
+    const callTimeouts = { requestTimeoutMs: 300_000 }
+
+    // when
+    const resolved = resolveMcpRequestOptions(serverTimeouts, callTimeouts)
+
+    // then
+    expect(resolved).toEqual({ timeout: 300_000, maxTotalTimeout: 600_000 })
+  })
+
+  it("#given non-positive or non-finite timeouts #when resolving #then they are dropped instead of forwarded", () => {
+    // given
+    const serverTimeouts = { requestTimeoutMs: 0, maxTotalTimeoutMs: Number.NaN }
+    const callTimeouts = { requestTimeoutMs: -1 }
+
+    // when
+    const resolved = resolveMcpRequestOptions(serverTimeouts, callTimeouts)
+
+    // then
+    expect(resolved).toBeUndefined()
+  })
+
+  it("#given only resetTimeoutOnProgress set to false #when resolving #then the flag is still forwarded", () => {
+    // given
+    const serverTimeouts = { resetTimeoutOnProgress: false }
+
+    // when
+    const resolved = resolveMcpRequestOptions(serverTimeouts)
+
+    // then
+    expect(resolved).toEqual({ resetTimeoutOnProgress: false })
+  })
+})
+
+describe("SkillMcpManager request option propagation", () => {
+  afterEach(() => {
+    spyOn(connectionModule, "getOrCreateClientWithRetryImpl").mockRestore()
+  })
+
+  function stubClient(client: ReturnType<typeof createRecordingClient>) {
+    spyOn(connectionModule, "getOrCreateClientWithRetryImpl").mockImplementation(
+      async () => client as unknown as McpClient,
+    )
+  }
+
+  it("#given a server with configured timeouts #when driving every operation #then each SDK call receives the request options", async () => {
+    // given
+    const client = createRecordingClient()
+    stubClient(client)
+    const config: ClaudeCodeMcpServer = {
+      command: "node",
+      args: ["slow-server.js"],
+      timeouts: { requestTimeoutMs: 120_000, resetTimeoutOnProgress: true },
+    }
+    const context: SkillMcpServerContext = { config, skillName: "slow-skill" }
+    const expected = { timeout: 120_000, resetTimeoutOnProgress: true }
+    const manager = new SkillMcpManager()
+
+    // when
+    await manager.listTools(info, context)
+    await manager.listResources(info, context)
+    await manager.listPrompts(info, context)
+    await manager.callTool(info, context, "wait", { seconds: 65 })
+    await manager.readResource(info, context, "file:///report.txt")
+    await manager.getPrompt(info, context, "summarize", {})
+
+    // then
+    expect(client.listTools.mock.calls[0]?.[1]).toEqual(expected)
+    expect(client.listResources.mock.calls[0]?.[1]).toEqual(expected)
+    expect(client.listPrompts.mock.calls[0]?.[1]).toEqual(expected)
+    expect(client.callTool.mock.calls[0]?.[2]).toEqual(expected)
+    expect(client.readResource.mock.calls[0]?.[1]).toEqual(expected)
+    expect(client.getPrompt.mock.calls[0]?.[1]).toEqual(expected)
+  })
+
+  it("#given a per-call timeout override #when calling a tool #then the override reaches the SDK", async () => {
+    // given
+    const client = createRecordingClient()
+    stubClient(client)
+    const config: ClaudeCodeMcpServer = {
+      command: "node",
+      args: ["slow-server.js"],
+      timeouts: { requestTimeoutMs: 120_000 },
+    }
+    const context: SkillMcpServerContext = { config, skillName: "slow-skill" }
+    const manager = new SkillMcpManager()
+
+    // when
+    await manager.callTool(info, context, "wait", { seconds: 65 }, { timeouts: { requestTimeoutMs: 300_000 } })
+
+    // then
+    expect(client.callTool.mock.calls[0]?.[2]).toEqual({ timeout: 300_000 })
+  })
+
+  it("#given a server without timeout config #when calling a tool #then no request options are sent and the SDK default stands", async () => {
+    // given
+    const client = createRecordingClient()
+    stubClient(client)
+    const config: ClaudeCodeMcpServer = { command: "node", args: ["server.js"] }
+    const context: SkillMcpServerContext = { config, skillName: "slow-skill" }
+    const manager = new SkillMcpManager()
+
+    // when
+    await manager.callTool(info, context, "wait", {})
+
+    // then
+    expect(client.callTool.mock.calls[0]?.[2]).toBeUndefined()
+  })
+})

--- a/packages/mcp-client-core/src/skill-mcp-manager/request-timeouts.ts
+++ b/packages/mcp-client-core/src/skill-mcp-manager/request-timeouts.ts
@@ -1,0 +1,51 @@
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js"
+import type { McpRequestTimeoutConfig } from "@oh-my-opencode/claude-code-compat-core/claude-code-mcp-loader/types"
+
+function toPositiveMilliseconds(value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!Number.isFinite(value) || value <= 0) {
+    return undefined
+  }
+
+  return value
+}
+
+/**
+ * Merges the per-call timeout overrides over the per-server timeout config and
+ * maps the result onto the MCP SDK request options.
+ *
+ * Returns undefined when nothing resolves, so the SDK keeps applying its own
+ * DEFAULT_REQUEST_TIMEOUT_MSEC.
+ */
+export function resolveMcpRequestOptions(
+  serverTimeouts: McpRequestTimeoutConfig | undefined,
+  callTimeouts?: McpRequestTimeoutConfig
+): RequestOptions | undefined {
+  const timeout =
+    toPositiveMilliseconds(callTimeouts?.requestTimeoutMs) ??
+    toPositiveMilliseconds(serverTimeouts?.requestTimeoutMs)
+  const maxTotalTimeout =
+    toPositiveMilliseconds(callTimeouts?.maxTotalTimeoutMs) ??
+    toPositiveMilliseconds(serverTimeouts?.maxTotalTimeoutMs)
+  const resetTimeoutOnProgress = callTimeouts?.resetTimeoutOnProgress ?? serverTimeouts?.resetTimeoutOnProgress
+
+  const requestOptions: RequestOptions = {}
+  if (timeout !== undefined) {
+    requestOptions.timeout = timeout
+  }
+  if (maxTotalTimeout !== undefined) {
+    requestOptions.maxTotalTimeout = maxTotalTimeout
+  }
+  if (resetTimeoutOnProgress !== undefined) {
+    requestOptions.resetTimeoutOnProgress = resetTimeoutOnProgress
+  }
+
+  if (Object.keys(requestOptions).length === 0) {
+    return undefined
+  }
+
+  return requestOptions
+}


### PR DESCRIPTION
## Summary

`SkillMcpManager` called the MCP SDK without request options, so every tier-3 skill-embedded MCP operation fell through to `DEFAULT_REQUEST_TIMEOUT_MSEC` (60000 ms). A tool that legitimately runs longer than a minute failed at about 60 seconds.

As noted on the issue, there was also nothing to propagate: no timeout field existed anywhere in the client config path. So this is two parts. It adds the config surface, then threads it into the SDK request options at every call site in that class, not just `callTool`.

## Changes

- `claude-code-compat-core` gains `McpRequestTimeoutConfig` and an optional `timeouts` block on `ClaudeCodeMcpServer`. One grouped key rather than three loose ones. Fields map straight onto the SDK: `requestTimeoutMs` to `timeout`, `resetTimeoutOnProgress` passthrough, `maxTotalTimeoutMs` to `maxTotalTimeout`.
- New `mcp-client-core/src/skill-mcp-manager/request-timeouts.ts` with `resolveMcpRequestOptions`. It merges the per-call override over the per-server config field by field, drops non-finite and non-positive values, and returns `undefined` when nothing resolves.
- `SkillMcpClientOptions` gains `timeouts`, so a caller can raise the limit for one call without restating the server config.
- `manager.ts` passes the resolved options to `listTools`, `listResources`, `listPrompts`, `callTool`, `readResource`, and `getPrompt`.

A skill's `mcp.json` opts in like this:

```json
{
  "mcpServers": {
    "slow-server": {
      "command": "node",
      "args": ["server.js"],
      "timeouts": {
        "requestTimeoutMs": 300000,
        "resetTimeoutOnProgress": true,
        "maxTotalTimeoutMs": 1800000
      }
    }
  }
}
```

Defaults are unchanged. An unconfigured server sends no request options at all, so the SDK keeps applying its own default. I did not pick a new default number.

## Verification

Live stdio MCP server with a `wait` tool, driven through the real `SkillMcpManager`, 65 second call:

```
[no-timeout-config]         FAILED after 60.1s -> McpError: MCP error -32001: Request timed out
[requestTimeoutMs=120000]   OK     after 65.1s -> [{"type":"text","text":"waited 65s"}]
```

The first line reproduces the reported defect against a real server. The second is the fix.

Negative control, with only the `manager.ts` threading reverted and everything else left in place:

```
6 pass / 2 fail
[requestTimeoutMs=120000]   FAILED after 60.1s
```

The configured timeout has no effect without the threading, so the tests and the driver depend on the change and not just on the new field existing.

- `bun run typecheck`: exit 0.
- New co-located tests: 8 pass / 0 fail.
- `mcp-client-core`, the `omo-opencode` skill-mcp-manager shim tests, `claude-code-mcp-loader`, and `skills-loader-core`: 399 pass / 0 fail.
- Full root `bun test`: 13303 pass / 28 fail, against a 13295 pass / 28 fail baseline on unmodified `dev`. The failing-test name sets are identical. Those 28 are local environment only, from installing with `--ignore-scripts` and without the frontend provenance submodules.

## QA & Evidence

`.omo/evidence/20260808-fix-6631/`, including the test server, the driver, the before and after output, the negative control, and `qa-summary.md`.

I did not run the OpenCode harness QA. The change is confined to a Core package: it adds an optional config field and forwards it, and the `packages/omo-opencode/src/features/skill-mcp-manager/` files are unchanged re-export shims. Say the word if a harness-level run is wanted here anyway and I will add it.

## Risks & Residuals

- `ClaudeCodeMcpServer` is shared with the tier-2 `.mcp.json` loader, where `timeouts` has no effect because those servers go to OpenCode directly. The field is optional and inert there, but it is a surface that could read as supported. Happy to move it to a tier-3-only type if you would rather keep the compat type clean.
- Per-tool overrides are available through `SkillMcpClientOptions`, but nothing in the `skill_mcp` tool exposes them to users yet. That felt like a separate change. The per-server config path works end to end today.
- Cancellation semantics are the SDK's own. On timeout the SDK raises `McpError` with code `RequestTimeout` and cancels the request, which the driver output confirms.

## Related Issues

Fix #6631
