### PR TITLE
test(omo-senpi): pin the production owned-team-member binding

### DIFF
--- a/.omo/evidence/20260808-goal-resumption-channels-laneG-team-binding/evidence.md
+++ b/.omo/evidence/20260808-goal-resumption-channels-laneG-team-binding/evidence.md
@@ -1,0 +1,78 @@
+# Evidence: pin the production owned-team-member binding (lane G)
+
+## What was tested
+
+`packages/omo-senpi/src/components/task/resumption-channel-emitter.ts` publishes
+`resumption_channel_state` with `source: "senpi-task"`; a binding user decision counts OWNED
+TEAM MEMBERS toward that count even when the member task is foreground (not background).
+The production wiring is `deps.isOwnedTeamMember ?? isOwnedTeamMemberTask` — a fallback to the
+real ownership helper from `@oh-my-opencode/senpi-task`.
+
+The pre-existing test ("foreground owned team member ... counts as active") injected its own
+`isOwnedTeamMember` resolver, so it pinned only "if an injected resolver returns true, the
+record is counted" — never the production fallback. A disconnected or always-false fallback
+would regress owned-team-member liveness while every test stayed green.
+
+The new test
+("#given a foreground owned team member resolved through the real ownership helper ...")
+closes that gap end to end:
+
+1. Creates a temp team runtime state dir (`mkdtemp`, cleaned up in `afterEach`).
+2. Persists a durable active team runtime (`saveRuntimeState`) whose `leadSessionId` is the
+   emitter session and whose members include `reviewer` — the same fixture approach as
+   `owned-member-liveness.test.ts`.
+3. Builds the emitter with real parsed settings (`OmoTaskSettingsSchema.parse({})`) and that
+   state dir, WITHOUT passing `isOwnedTeamMember`, so the production default binding to
+   `isOwnedTeamMemberTask` is exercised.
+4. Drives a foreground (`notify_on_terminal: false`) member record named
+   `team:<runId>:reviewer` through `emitSessionStart()`.
+5. Asserts one `senpi-task` snapshot with `activeCount: 1`.
+
+## What was observed
+
+### Mutation proof (RED)
+
+Mutation (never committed): in `resumption-channel-emitter.ts`,
+`deps.isOwnedTeamMember ?? isOwnedTeamMemberTask` was replaced with
+`deps.isOwnedTeamMember ?? (async () => false)`.
+
+Result: the NEW test FAILED (`activeCount: 0`, `channels: []` vs expected 1) while ALL FIVE
+pre-existing tests — including the injected-resolver team-member test — still PASSED.
+Full capture: `red-capture.txt` in this directory. This simultaneously proves the new test
+detects the named regression and that the pre-existing suite could not.
+
+### Revert + GREEN
+
+Mutation reverted via `git checkout -- packages/omo-senpi/src/components/task/resumption-channel-emitter.ts`
+(post-revert `git diff --stat` shows only the test file modified). The new test passes with
+`activeCount: 1`. Full capture: `green-capture.txt` in this directory.
+
+### Suite, typecheck, bundle
+
+- `bun test packages/omo-senpi`: 596 pass, 0 fail (93 files).
+- `bun run typecheck` (tsgo root + script + all workspace packages): clean.
+- `node packages/omo-senpi/plugin/scripts/build-extension.mjs --check`: exit 0,
+  "omo-senpi extension build is current" — the change is test-only, so the committed bundle
+  `plugin/extensions/omo.js` needs no regeneration. Worktree `git status` stayed clean of
+  bundle drift afterwards (stray `.build-extension-test-*` temp dir removed).
+
+## Why it is enough
+
+The named regression is "the production default binding to `isOwnedTeamMemberTask` is
+disconnected or replaced". The mutation is exactly that regression in its strongest form
+(always-false resolver). The test goes RED under it and GREEN without it, and it reaches the
+real helper through the real durable-state path (temp state dir + `saveRuntimeState` +
+real parsed settings), not a stub — so it pins the binding user decision (foreground owned
+team members count toward `senpi-task` liveness) against the actual production wiring.
+No existing test was weakened or deleted; the injected-resolver test remains as unit coverage
+of the counting logic itself.
+
+## What was omitted
+
+- No live senpi harness session was driven: the change adds one unit-level test file; the
+  real-surface behavior (event shape, counting) was already QA'd when the emitter landed
+  (`feat(omo-senpi): publish task resumption-channel liveness`). The new coverage is
+  deliberately scoped to the binding seam.
+- Root `bun test` (full repo suite) was not run locally; it is long and CI runs it. The
+  scoped package suite (596 tests) plus repo-wide typecheck passed.
+- No secrets, tokens, or env dumps appear in the captures; outputs are test-runner text only.

--- a/.omo/evidence/20260808-goal-resumption-channels-laneG-team-binding/green-capture.txt
+++ b/.omo/evidence/20260808-goal-resumption-channels-laneG-team-binding/green-capture.txt
@@ -1,0 +1,18 @@
+MUTATION REVERTED: git checkout -- packages/omo-senpi/src/components/task/resumption-channel-emitter.ts
+
+$ bun test packages/omo-senpi/src/components/task/resumption-channel-emitter.test.ts
+
+bun test v1.4.0-canary.1 (45eda514f)
+
+packages/omo-senpi/src/components/task/resumption-channel-emitter.test.ts:
+(pass) createResumptionChannelEmitter > #given a background child #when it spawns and then reaches a terminal state #then snapshots transition from one channel to zero [0.74ms]
+(pass) createResumptionChannelEmitter > #given a foreground owned team member #when the snapshot is emitted #then the member counts as active [0.10ms]
+(pass) createResumptionChannelEmitter > #given a foreground owned team member resolved through the real ownership helper #when the session snapshot is emitted #then the member counts as active [3.15ms]
+(pass) createResumptionChannelEmitter > #given an active child count of one #when a store mutation preserves that count #then no duplicate snapshot is emitted [0.10ms]
+(pass) createResumptionChannelEmitter > #given an ExtensionAPI without events #when the emitter lifecycle is driven #then registration and emissions are harmless no-ops [0.09ms]
+(pass) createResumptionChannelEmitter > #given the local event contract #when the literal is inspected #then it exactly matches the harness event name [0.04ms]
+
+ 6 pass
+ 0 fail
+ 7 expect() calls
+Ran 6 tests across 1 file. [642.00ms]

--- a/.omo/evidence/20260808-goal-resumption-channels-laneG-team-binding/plan.md
+++ b/.omo/evidence/20260808-goal-resumption-channels-laneG-team-binding/plan.md
@@ -1,0 +1,31 @@
+# Plan: pin the production owned-team-member binding in resumption-channel-emitter
+
+## Gap
+`resumption-channel-emitter.test.ts` ("foreground owned team member ... counts as active")
+injects `isOwnedTeamMember`, so the production fallback
+`deps.isOwnedTeamMember ?? isOwnedTeamMemberTask` is never exercised. If the fallback is
+disconnected or replaced by an always-false resolver, owned-team-member liveness regresses
+undetected.
+
+## Steps
+1. Add a test to `packages/omo-senpi/src/components/task/resumption-channel-emitter.test.ts`
+   that builds the emitter WITHOUT `isOwnedTeamMember`, reusing the durable-team-runtime
+   fixture pattern from `owned-member-liveness.test.ts`:
+   - mkdtemp project dir (stateDir.project_dir), cleaned up in afterEach
+   - `saveRuntimeState` an active RuntimeState with `leadSessionId = SESSION_ID` and member `reviewer`
+   - foreground task record named `team:<runId>:reviewer` (`notify_on_terminal: false`)
+   - real parsed settings via `OmoTaskSettingsSchema.parse({})`
+   - `emitSessionStart()` -> assert one `senpi-task` snapshot with `activeCount: 1`
+2. Mutation proof (never committed): point the fallback at `async () => false`,
+   capture the new test FAILING (RED), revert, capture it PASSING (GREEN).
+3. Run `bun test packages/omo-senpi` and `bun run typecheck`.
+4. Run `node packages/omo-senpi/plugin/scripts/build-extension.mjs --check` to decide whether
+   the committed bundle needs regeneration (test-only change: expected no).
+5. Evidence file with RED/GREEN captures under this directory.
+6. Atomic commit(s), PR to `dev`, drive CI green, merge with merge commit, remove worktree.
+
+## Verification per step
+- 1: new test green against unmodified production code
+- 2: RED capture shows activeCount 0 under mutation; GREEN capture shows activeCount 1 after revert
+- 3: full omo-senpi suite + typecheck clean
+- 4: --check exit 0 (no bundle drift)

--- a/.omo/evidence/20260808-goal-resumption-channels-laneG-team-binding/red-capture.txt
+++ b/.omo/evidence/20260808-goal-resumption-channels-laneG-team-binding/red-capture.txt
@@ -1,0 +1,52 @@
+MUTATION: packages/omo-senpi/src/components/task/resumption-channel-emitter.ts
+  -const resolveOwnedTeamMember = deps.isOwnedTeamMember ?? isOwnedTeamMemberTask
+  +const resolveOwnedTeamMember = deps.isOwnedTeamMember ?? (async () => false)
+
+$ bun test packages/omo-senpi/src/components/task/resumption-channel-emitter.test.ts
+
+bun test v1.4.0-canary.1 (45eda514f)
+
+packages/omo-senpi/src/components/task/resumption-channel-emitter.test.ts:
+(pass) createResumptionChannelEmitter > #given a background child #when it spawns and then reaches a terminal state #then snapshots transition from one channel to zero [0.66ms]
+(pass) createResumptionChannelEmitter > #given a foreground owned team member #when the snapshot is emitted #then the member counts as active [0.11ms]
+200 | 
+201 |     // when
+202 |     await emitter.emitSessionStart()
+203 | 
+204 |     // then
+205 |     expect(emitted).toEqual([{
+                          ^
+error: expect(received).toEqual(expected)
+
+  [
+    {
+      "data": {
+-       "activeCount": 1,
+-       "channels": [
+-         {
+-           "description": "Review the implementation",
+-           "id": "st_00000003",
+-           "startedAtMs": 1786150923000,
+-         },
+-       ],
++       "activeCount": 0,
++       "channels": [],
+        "source": "senpi-task",
+      },
+      "name": "resumption_channel_state",
+    },
+  ]
+
+- Expected  - 8
++ Received  + 2
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt-team-binding/packages/omo-senpi/src/components/task/resumption-channel-emitter.test.ts:205:21)
+(fail) createResumptionChannelEmitter > #given a foreground owned team member resolved through the real ownership helper #when the session snapshot is emitted #then the member counts as active [5.04ms]
+(pass) createResumptionChannelEmitter > #given an active child count of one #when a store mutation preserves that count #then no duplicate snapshot is emitted [0.10ms]
+(pass) createResumptionChannelEmitter > #given an ExtensionAPI without events #when the emitter lifecycle is driven #then registration and emissions are harmless no-ops [0.09ms]
+(pass) createResumptionChannelEmitter > #given the local event contract #when the literal is inspected #then it exactly matches the harness event name [0.06ms]
+
+ 5 pass
+ 1 fail
+ 7 expect() calls
+Ran 6 tests across 1 file. [644.00ms]

--- a/packages/omo-senpi/src/components/task/resumption-channel-emitter.test.ts
+++ b/packages/omo-senpi/src/components/task/resumption-channel-emitter.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, it } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
-import type { OmoTaskSettings } from "@oh-my-opencode/omo-config-core"
-import type { ListScope, ListedTask, TaskRecord } from "@oh-my-opencode/senpi-task"
+import { afterEach, describe, expect, it } from "bun:test"
+
+import { OmoTaskSettingsSchema, type OmoTaskSettings } from "@oh-my-opencode/omo-config-core"
+import { saveRuntimeState } from "@oh-my-opencode/team-core/team-state-store"
+import type { RuntimeState } from "@oh-my-opencode/team-core/types"
+import {
+  resolveTeamRuntimeDirs,
+  teamStorageBaseDir,
+  toTeamCoreConfig,
+  type ListScope,
+  type ListedTask,
+  type TaskRecord,
+} from "@oh-my-opencode/senpi-task"
 
 import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
 import {
@@ -10,6 +23,33 @@ import {
 } from "./resumption-channel-emitter"
 
 const SESSION_ID = "parent-session"
+const TEAM_RUN_ID = "11111111-1111-4111-8111-111111111111"
+const tempRoots: string[] = []
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function ownedTeamRuntime(): RuntimeState {
+  return {
+    version: 1,
+    teamRunId: TEAM_RUN_ID,
+    teamName: "squad",
+    specSource: "project",
+    createdAt: 1_000,
+    status: "active",
+    leadSessionId: SESSION_ID,
+    members: [{ name: "reviewer", agentType: "general-purpose", status: "running", pendingInjectedMessageIds: [] }],
+    shutdownRequests: [],
+    bounds: {
+      maxMembers: 8,
+      maxParallelMembers: 4,
+      maxMessagesPerRun: 10_000,
+      maxWallClockMinutes: 120,
+      maxMemberTurns: 500,
+    },
+  }
+}
 
 function taskRecord(overrides: Partial<TaskRecord> = {}): TaskRecord {
   return {
@@ -112,6 +152,57 @@ describe("createResumptionChannelEmitter", () => {
 
     // then
     expect(harness.emitted).toEqual([{
+      name: "resumption_channel_state",
+      data: {
+        source: "senpi-task",
+        activeCount: 1,
+        channels: [{
+          id: member.task_id,
+          description: "Review the implementation",
+          startedAtMs: Date.parse(member.created_at),
+        }],
+      },
+    }])
+  })
+
+  it("#given a foreground owned team member resolved through the real ownership helper #when the session snapshot is emitted #then the member counts as active", async () => {
+    // given a durable team runtime owned by this session and no injected ownership resolver
+    const project = mkdtempSync(join(tmpdir(), "omo-resumption-channel-binding-"))
+    tempRoots.push(project)
+    const settings = OmoTaskSettingsSchema.parse({})
+    const stateDir = { project_dir: project }
+    mkdirSync(resolveTeamRuntimeDirs(stateDir, TEAM_RUN_ID).runtimeDir, { recursive: true })
+    await saveRuntimeState(ownedTeamRuntime(), toTeamCoreConfig(settings, teamStorageBaseDir(stateDir)))
+    const member = taskRecord({
+      task_id: "st_00000003",
+      name: `team:${TEAM_RUN_ID}:reviewer`,
+      task_summary: undefined,
+      description: "Review the implementation",
+      notify_on_terminal: false,
+    })
+    const emitted: Array<{ name: string; data: unknown }> = []
+    const pi = new FakeExtensionAPI()
+    pi.events = {
+      emit: (name, data) => emitted.push({ name, data }),
+      on: () => () => {},
+    }
+    const manager = {
+      list: (_scope: ListScope): readonly ListedTask[] => [{ record: member }],
+      wasBackground: () => false,
+    }
+    const emitter = createResumptionChannelEmitter({
+      pi,
+      manager,
+      sessionId: () => SESSION_ID,
+      stateDir,
+      settings,
+    })
+
+    // when
+    await emitter.emitSessionStart()
+
+    // then
+    expect(emitted).toEqual([{
       name: "resumption_channel_state",
       data: {
         source: "senpi-task",


### PR DESCRIPTION
## Coverage gap

`packages/omo-senpi/src/components/task/resumption-channel-emitter.ts` publishes `resumption_channel_state` (`source: "senpi-task"`) so the senpi harness holds goal-continuation while background task children run. A binding user decision extends that count to OWNED TEAM MEMBERS even when foreground.

The production wiring is:

```ts
const resolveOwnedTeamMember = deps.isOwnedTeamMember ?? isOwnedTeamMemberTask
```

But the existing test ("foreground owned team member ... counts as active") builds the emitter with an INJECTED `isOwnedTeamMember` resolver. It proves only "if an injected resolver returns true, the record is counted" — the production fallback to `isOwnedTeamMemberTask` is never exercised. If that fallback were disconnected or replaced by an always-false resolver, owned-team-member liveness would silently regress with the whole suite still green.

## Fix

One new test in `resumption-channel-emitter.test.ts` that exercises the real binding end to end, reusing the durable-runtime fixture pattern from `owned-member-liveness.test.ts`:

1. Temp team runtime state dir (`mkdtemp`, cleaned up in `afterEach`).
2. `saveRuntimeState` an active team whose `leadSessionId` is the emitter session, with member `reviewer`.
3. Emitter built with real parsed settings (`OmoTaskSettingsSchema.parse({})`) and that state dir, WITHOUT `isOwnedTeamMember`.
4. Foreground (`notify_on_terminal: false`) record named `team:<runId>:reviewer` → `emitSessionStart()`.
5. Asserts one `senpi-task` snapshot with `activeCount: 1`.

## Mutation proof (failing-first)

Production code is currently correct, so the RED was proven by mutation (never committed): the fallback was pointed at `async () => false`.

- RED: the new test FAILED (`activeCount: 0`) while ALL FIVE pre-existing tests — including the injected-resolver team-member test — still PASSED. This confirms both that the new test catches the named regression and that the previous suite could not.
- GREEN: mutation reverted; new test passes with `activeCount: 1`.

Captures: `.omo/evidence/20260808-goal-resumption-channels-laneG-team-binding/{red-capture.txt,green-capture.txt}` (plus `evidence.md`, `plan.md`).

## Verification

- `bun test packages/omo-senpi`: 596 pass, 0 fail (93 files)
- `bun run typecheck`: clean (tsgo root + script + all workspace packages)
- `node packages/omo-senpi/plugin/scripts/build-extension.mjs --check`: exit 0 — test-only change, committed bundle needs no regeneration

No existing test was weakened or deleted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an end-to-end test to `resumption-channel-emitter.test.ts` to pin the production owned-team-member binding. It verifies the fallback to `@oh-my-opencode/senpi-task`'s `isOwnedTeamMemberTask` (when no `isOwnedTeamMember` is injected) so foreground owned members still count toward `resumption_channel_state` activeCount.

<sup>Written for commit a407d1d4254ee419a2abad3bf68b0dbaa13a3462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

