### PR TITLE
fix(omo-opencode): stop doctor re-flagging provider_options passthrough

### DIFF
--- a/.omo/evidence/20260809-doctor-deprecated-key-scan/README.md
+++ b/.omo/evidence/20260809-doctor-deprecated-key-scan/README.md
@@ -1,0 +1,47 @@
+# QA Evidence — doctor deprecated-key scan fixes (2026-08-09)
+
+Discord report: https://discord.com/channels/1452487457085063218/1490536332961906829/1535893865901596673
+(jianli0321: docs show `fallback_models` as supported; `omo doctor` flags it as "Deprecated reasoning config key")
+
+## What was tested
+
+Surface: the real `oh-my-opencode doctor` CLI (`bun packages/omo-opencode/src/cli/index.ts doctor --json`)
+plus the `checkDeprecatedReasoningKeys` check imported directly, both against isolated sandbox HOMEs
+(mktemp dirs; the real `~/.omo` was never read or written — HOME was overridden for every run).
+
+Scenarios:
+1. `repro-omo.jsonc` — canonical MIGRATED config: `provider_options.thinking` / `provider_options.textVerbosity`
+   under `categories`, `agents`, the `models` catalog, and a `[codex]` block (`providerOptions`), plus one
+   genuinely deprecated key (`categories.deep.variant`) as a control.
+2. `reporter-shape-omo.jsonc` — the reporter's exact config shape: `[opencode].agents.<name>.fallback_models`
+   (string + object entries), mirroring the screenshots.
+
+## What was observed
+
+- BEFORE (pre-fix code, `before-check-output.json` + `before-cli-doctor.json`):
+  6 issues, message "6 deprecated reasoning key(s) found". 5 are bogus descents into
+  provider_options/providerOptions — including the self-referential
+  "Replace textVerbosity with provider_options.textVerbosity" on a key ALREADY at
+  provider_options.textVerbosity. The real CLI `doctor --json` shows the same 6 issues.
+- AFTER (fixed code, `after-check-output.json` + `after-cli-doctor.json`):
+  exactly 1 issue — the planted control `categories.deep.variant` — with accurate title
+  "Deprecated config key" and message "1 deprecated config key(s) found". Real CLI agrees (1 occurrence).
+- Reporter shape (`after-check-reporter-shape.json`): status "pass", 0 issues,
+  "No deprecated config keys found" — the user's documented `[opencode]` `fallback_models` config is clean.
+- Tests: `bun test packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts`
+  RED first (new case failed with the 5 bogus paths), GREEN after the fix (3 pass / 9 expects).
+  Full doctor dir: 163 pass / 0 fail across 27 files. `tsgo --noEmit -p packages/omo-opencode` exit 0.
+
+## Why it is enough
+
+The changed code path is entirely inside `collectIssues()` of one check file; both the unit seam
+(direct check import) and the user-visible surface (real CLI `doctor --json`) were driven before and after
+with identical sandbox configs, covering: false-positive removal, label accuracy, and non-regression of
+legitimate deprecation flagging (control key still reported; existing tests for top-level/[senpi]/[codex]/
+profiles expectations untouched and green).
+
+## What was omitted
+
+- `before/after-cli-doctor.json` include unrelated doctor categories (system/tools/models) that error in the
+  sandbox (no opencode binary etc.); only the Configuration section is relevant. No secrets are present:
+  sandbox HOMEs contain only the synthetic configs above.

--- a/.omo/evidence/20260809-doctor-deprecated-key-scan/after-check-output.json
+++ b/.omo/evidence/20260809-doctor-deprecated-key-scan/after-check-output.json
@@ -1,0 +1,19 @@
+{
+  "name": "Configuration",
+  "status": "warn",
+  "message": "1 deprecated config key(s) found",
+  "details": [
+    "Scanned: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc"
+  ],
+  "issues": [
+    {
+      "title": "Deprecated config key",
+      "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: categories.deep.variant",
+      "fix": "Replace variant with reasoning, or run: oh-my-openagent config migrate",
+      "severity": "warning",
+      "affects": [
+        "categories.deep.variant"
+      ]
+    }
+  ]
+}

--- a/.omo/evidence/20260809-doctor-deprecated-key-scan/after-check-reporter-shape.json
+++ b/.omo/evidence/20260809-doctor-deprecated-key-scan/after-check-reporter-shape.json
@@ -1,0 +1,9 @@
+{
+  "name": "Configuration",
+  "status": "pass",
+  "message": "No deprecated config keys found",
+  "details": [
+    "Scanned: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-reporter-edobzybf/.omo/omo.jsonc"
+  ],
+  "issues": []
+}

--- a/.omo/evidence/20260809-doctor-deprecated-key-scan/after-cli-doctor.json
+++ b/.omo/evidence/20260809-doctor-deprecated-key-scan/after-cli-doctor.json
@@ -1,0 +1,214 @@
+{
+  "results": [
+    {
+      "name": "System",
+      "status": "fail",
+      "message": "1 system issue(s) detected",
+      "details": [
+        "OpenCode: 1.18.13",
+        "Plugin expected: 4.19.4",
+        "Plugin loaded: 4.19.4",
+        "Bun: 1.4.0"
+      ],
+      "issues": [
+        {
+          "title": "oh-my-openagent is not registered",
+          "description": "Plugin entry is missing from OpenCode configuration.",
+          "fix": "Run: bunx oh-my-openagent install",
+          "severity": "error",
+          "affects": [
+            "all agents"
+          ]
+        }
+      ],
+      "duration": 467
+    },
+    {
+      "name": "Configuration",
+      "status": "fail",
+      "message": "Configuration invalid (1 issue)",
+      "details": [
+        "Path: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc"
+      ],
+      "issues": [
+        {
+          "title": "Invalid configuration",
+          "description": "../../../../../var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: Invalid omo config at /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: agents.oracle, models.sol, [codex].agents.explore",
+          "severity": "error",
+          "affects": [
+            "plugin startup"
+          ]
+        }
+      ],
+      "duration": 14
+    },
+    {
+      "name": "TUI Plugin",
+      "status": "skip",
+      "message": "Plugin not registered (server or TUI)",
+      "details": [
+        "tui.json: /private/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.config/opencode/tui.json"
+      ],
+      "issues": [],
+      "duration": 9
+    },
+    {
+      "name": "Configuration",
+      "status": "warn",
+      "message": "1 deprecated config key(s) found",
+      "details": [
+        "Scanned: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc"
+      ],
+      "issues": [
+        {
+          "title": "Deprecated config key",
+          "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: categories.deep.variant",
+          "fix": "Replace variant with reasoning, or run: oh-my-openagent config migrate",
+          "severity": "warning",
+          "affects": [
+            "categories.deep.variant"
+          ]
+        }
+      ],
+      "duration": 9
+    },
+    {
+      "name": "Tools",
+      "status": "warn",
+      "message": "1 tools issue(s) detected",
+      "details": [
+        "AST-Grep CLI: yes",
+        "Comment checker: yes",
+        "LSP: 1 server(s)",
+        "GH CLI: installed",
+        "MCP: builtin=4, user=1"
+      ],
+      "issues": [
+        {
+          "title": "GitHub CLI not authenticated",
+          "description": "gh CLI is installed but not logged in.",
+          "fix": "Run: gh auth login",
+          "severity": "warning",
+          "affects": [
+            "GitHub automation"
+          ]
+        }
+      ],
+      "duration": 44
+    },
+    {
+      "name": "Models",
+      "status": "warn",
+      "message": "11 agents, 8 categories, 0 overrides",
+      "details": [
+        "═══ Available Models (from cache) ═══",
+        "",
+        "  ⚠ Cache not found. Run 'opencode' to populate.",
+        "",
+        "═══ Configured Models ═══",
+        "",
+        "Agents:",
+        "  ○ sisyphus: anthropic/claude-opus-5 (max) [capabilities: snapshot-backed]",
+        "  ○ hephaestus: openai/gpt-5.6-sol (medium) [capabilities: snapshot-backed]",
+        "  ○ oracle: openai/gpt-5.6-sol (xhigh) [capabilities: snapshot-backed]",
+        "  ○ librarian: openai/gpt-5.6-luna-fast (low) [capabilities: alias-backed]",
+        "  ○ explore: openai/gpt-5.6-luna-fast (low) [capabilities: alias-backed]",
+        "  ○ multimodal-looker: openai/gpt-5.6-sol (low) [capabilities: snapshot-backed]",
+        "  ○ prometheus: anthropic/claude-fable-5 (xhigh) [capabilities: snapshot-backed]",
+        "  ○ metis: anthropic/claude-opus-5 (high) [capabilities: snapshot-backed]",
+        "  ○ momus: openai/gpt-5.6-terra (high) [capabilities: snapshot-backed]",
+        "  ○ atlas: anthropic/claude-sonnet-5 [capabilities: snapshot-backed]",
+        "  ○ sisyphus-junior: anthropic/claude-sonnet-5 [capabilities: snapshot-backed]",
+        "",
+        "Categories:",
+        "  ○ visual-engineering: anthropic/claude-opus-5 (max) [capabilities: snapshot-backed]",
+        "  ○ ultrabrain: openai/gpt-5.6-sol (max) [capabilities: snapshot-backed]",
+        "  ○ deep: openai/gpt-5.6-sol (medium) [capabilities: snapshot-backed]",
+        "  ○ artistry: anthropic/claude-fable-5 (xhigh) [capabilities: snapshot-backed]",
+        "  ○ quick: kimi-for-coding/kimi-for-coding-highspeed [capabilities: snapshot-backed]",
+        "  ○ unspecified-low: openai/gpt-5.6-terra (high) [capabilities: snapshot-backed]",
+        "  ○ unspecified-high: kimi-for-coding/kimi-k3 (max) [capabilities: snapshot-backed]",
+        "  ○ writing: kimi-for-coding/kimi-k3 (low) [capabilities: snapshot-backed]",
+        "",
+        "● = user override, ○ = provider fallback"
+      ],
+      "issues": [
+        {
+          "title": "Model cache not found",
+          "description": "OpenCode model cache is missing, so model availability cannot be validated.",
+          "fix": "Run: opencode models --refresh",
+          "severity": "warning",
+          "affects": [
+            "model resolution"
+          ]
+        }
+      ],
+      "duration": 5
+    },
+    {
+      "name": "Telemetry",
+      "status": "pass",
+      "message": "Telemetry: enabled",
+      "details": [
+        "PostHog host: https://us.i.posthog.com",
+        "Last daily active date: never",
+        "State file: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.local/share/oh-my-opencode/posthog-activity.json"
+      ],
+      "issues": [],
+      "duration": 2
+    },
+    {
+      "name": "Team Mode",
+      "status": "skip",
+      "message": "team_mode: disabled",
+      "issues": [],
+      "duration": 2
+    }
+  ],
+  "systemInfo": {
+    "opencodeVersion": "1.18.13",
+    "opencodePath": "/Users/yeongyu/.bun/bin/opencode",
+    "pluginVersion": "4.19.4",
+    "loadedVersion": "4.19.4",
+    "bunVersion": "1.4.0",
+    "configPath": null,
+    "configValid": true,
+    "isLocalDev": false
+  },
+  "tools": {
+    "lspServers": [
+      {
+        "id": "lsp-tools-mcp",
+        "extensions": [
+          "*"
+        ]
+      }
+    ],
+    "astGrepCli": true,
+    "commentChecker": true,
+    "ghCli": {
+      "installed": true,
+      "authenticated": false,
+      "username": null
+    },
+    "mcpBuiltin": [
+      "websearch",
+      "context7",
+      "grep_app",
+      "lsp"
+    ],
+    "mcpUser": [
+      "codegraph"
+    ]
+  },
+  "summary": {
+    "total": 8,
+    "passed": 1,
+    "failed": 2,
+    "warnings": 3,
+    "skipped": 2,
+    "duration": 467
+  },
+  "exitCode": 1,
+  "target": "opencode"
+}

--- a/.omo/evidence/20260809-doctor-deprecated-key-scan/before-check-output.json
+++ b/.omo/evidence/20260809-doctor-deprecated-key-scan/before-check-output.json
@@ -1,0 +1,64 @@
+{
+  "name": "Configuration",
+  "status": "warn",
+  "message": "6 deprecated reasoning key(s) found",
+  "details": [
+    "Scanned: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc"
+  ],
+  "issues": [
+    {
+      "title": "Deprecated reasoning config key",
+      "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: categories.deep.variant",
+      "fix": "Replace variant with reasoning, or run: oh-my-openagent config migrate",
+      "severity": "warning",
+      "affects": [
+        "categories.deep.variant"
+      ]
+    },
+    {
+      "title": "Deprecated reasoning config key",
+      "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: categories.deep.provider_options.thinking",
+      "fix": "Replace thinking with reasoning, or run: oh-my-openagent config migrate",
+      "severity": "warning",
+      "affects": [
+        "categories.deep.provider_options.thinking"
+      ]
+    },
+    {
+      "title": "Deprecated reasoning config key",
+      "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: categories.deep.provider_options.textVerbosity",
+      "fix": "Replace textVerbosity with provider_options.textVerbosity, or run: oh-my-openagent config migrate",
+      "severity": "warning",
+      "affects": [
+        "categories.deep.provider_options.textVerbosity"
+      ]
+    },
+    {
+      "title": "Deprecated reasoning config key",
+      "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: agents.oracle.provider_options.thinking",
+      "fix": "Replace thinking with reasoning, or run: oh-my-openagent config migrate",
+      "severity": "warning",
+      "affects": [
+        "agents.oracle.provider_options.thinking"
+      ]
+    },
+    {
+      "title": "Deprecated reasoning config key",
+      "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: models.sol.provider_options.textVerbosity",
+      "fix": "Replace textVerbosity with provider_options.textVerbosity, or run: oh-my-openagent config migrate",
+      "severity": "warning",
+      "affects": [
+        "models.sol.provider_options.textVerbosity"
+      ]
+    },
+    {
+      "title": "Deprecated reasoning config key",
+      "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: [codex].agents.explore.providerOptions.textVerbosity",
+      "fix": "Replace textVerbosity with provider_options.textVerbosity, or run: oh-my-openagent config migrate",
+      "severity": "warning",
+      "affects": [
+        "[codex].agents.explore.providerOptions.textVerbosity"
+      ]
+    }
+  ]
+}

--- a/.omo/evidence/20260809-doctor-deprecated-key-scan/before-cli-doctor.json
+++ b/.omo/evidence/20260809-doctor-deprecated-key-scan/before-cli-doctor.json
@@ -1,0 +1,259 @@
+{
+  "results": [
+    {
+      "name": "System",
+      "status": "fail",
+      "message": "1 system issue(s) detected",
+      "details": [
+        "OpenCode: 1.18.13",
+        "Plugin expected: 4.19.4",
+        "Plugin loaded: 4.19.4",
+        "Bun: 1.4.0"
+      ],
+      "issues": [
+        {
+          "title": "oh-my-openagent is not registered",
+          "description": "Plugin entry is missing from OpenCode configuration.",
+          "fix": "Run: bunx oh-my-openagent install",
+          "severity": "error",
+          "affects": [
+            "all agents"
+          ]
+        }
+      ],
+      "duration": 466
+    },
+    {
+      "name": "Configuration",
+      "status": "fail",
+      "message": "Configuration invalid (1 issue)",
+      "details": [
+        "Path: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc"
+      ],
+      "issues": [
+        {
+          "title": "Invalid configuration",
+          "description": "../../../../var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: Invalid omo config at /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: agents.oracle, models.sol, [codex].agents.explore",
+          "severity": "error",
+          "affects": [
+            "plugin startup"
+          ]
+        }
+      ],
+      "duration": 45
+    },
+    {
+      "name": "TUI Plugin",
+      "status": "skip",
+      "message": "Plugin not registered (server or TUI)",
+      "details": [
+        "tui.json: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.config/opencode/tui.json"
+      ],
+      "issues": [],
+      "duration": 40
+    },
+    {
+      "name": "Configuration",
+      "status": "warn",
+      "message": "6 deprecated reasoning key(s) found",
+      "details": [
+        "Scanned: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc"
+      ],
+      "issues": [
+        {
+          "title": "Deprecated reasoning config key",
+          "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: categories.deep.variant",
+          "fix": "Replace variant with reasoning, or run: oh-my-openagent config migrate",
+          "severity": "warning",
+          "affects": [
+            "categories.deep.variant"
+          ]
+        },
+        {
+          "title": "Deprecated reasoning config key",
+          "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: categories.deep.provider_options.thinking",
+          "fix": "Replace thinking with reasoning, or run: oh-my-openagent config migrate",
+          "severity": "warning",
+          "affects": [
+            "categories.deep.provider_options.thinking"
+          ]
+        },
+        {
+          "title": "Deprecated reasoning config key",
+          "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: categories.deep.provider_options.textVerbosity",
+          "fix": "Replace textVerbosity with provider_options.textVerbosity, or run: oh-my-openagent config migrate",
+          "severity": "warning",
+          "affects": [
+            "categories.deep.provider_options.textVerbosity"
+          ]
+        },
+        {
+          "title": "Deprecated reasoning config key",
+          "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: agents.oracle.provider_options.thinking",
+          "fix": "Replace thinking with reasoning, or run: oh-my-openagent config migrate",
+          "severity": "warning",
+          "affects": [
+            "agents.oracle.provider_options.thinking"
+          ]
+        },
+        {
+          "title": "Deprecated reasoning config key",
+          "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: models.sol.provider_options.textVerbosity",
+          "fix": "Replace textVerbosity with provider_options.textVerbosity, or run: oh-my-openagent config migrate",
+          "severity": "warning",
+          "affects": [
+            "models.sol.provider_options.textVerbosity"
+          ]
+        },
+        {
+          "title": "Deprecated reasoning config key",
+          "description": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.omo/omo.jsonc: [codex].agents.explore.providerOptions.textVerbosity",
+          "fix": "Replace textVerbosity with provider_options.textVerbosity, or run: oh-my-openagent config migrate",
+          "severity": "warning",
+          "affects": [
+            "[codex].agents.explore.providerOptions.textVerbosity"
+          ]
+        }
+      ],
+      "duration": 40
+    },
+    {
+      "name": "Tools",
+      "status": "warn",
+      "message": "1 tools issue(s) detected",
+      "details": [
+        "AST-Grep CLI: yes",
+        "Comment checker: yes",
+        "LSP: 1 server(s)",
+        "GH CLI: installed",
+        "MCP: builtin=4, user=1"
+      ],
+      "issues": [
+        {
+          "title": "GitHub CLI not authenticated",
+          "description": "gh CLI is installed but not logged in.",
+          "fix": "Run: gh auth login",
+          "severity": "warning",
+          "affects": [
+            "GitHub automation"
+          ]
+        }
+      ],
+      "duration": 75
+    },
+    {
+      "name": "Models",
+      "status": "warn",
+      "message": "11 agents, 8 categories, 0 overrides",
+      "details": [
+        "═══ Available Models (from cache) ═══",
+        "",
+        "  ⚠ Cache not found. Run 'opencode' to populate.",
+        "",
+        "═══ Configured Models ═══",
+        "",
+        "Agents:",
+        "  ○ sisyphus: anthropic/claude-opus-5 (max) [capabilities: snapshot-backed]",
+        "  ○ hephaestus: openai/gpt-5.6-sol (medium) [capabilities: snapshot-backed]",
+        "  ○ oracle: openai/gpt-5.6-sol (xhigh) [capabilities: snapshot-backed]",
+        "  ○ librarian: openai/gpt-5.6-luna-fast (low) [capabilities: alias-backed]",
+        "  ○ explore: openai/gpt-5.6-luna-fast (low) [capabilities: alias-backed]",
+        "  ○ multimodal-looker: openai/gpt-5.6-sol (low) [capabilities: snapshot-backed]",
+        "  ○ prometheus: anthropic/claude-fable-5 (xhigh) [capabilities: snapshot-backed]",
+        "  ○ metis: anthropic/claude-opus-5 (high) [capabilities: snapshot-backed]",
+        "  ○ momus: openai/gpt-5.6-terra (high) [capabilities: snapshot-backed]",
+        "  ○ atlas: anthropic/claude-sonnet-5 [capabilities: snapshot-backed]",
+        "  ○ sisyphus-junior: anthropic/claude-sonnet-5 [capabilities: snapshot-backed]",
+        "",
+        "Categories:",
+        "  ○ visual-engineering: anthropic/claude-opus-5 (max) [capabilities: snapshot-backed]",
+        "  ○ ultrabrain: openai/gpt-5.6-sol (max) [capabilities: snapshot-backed]",
+        "  ○ deep: openai/gpt-5.6-sol (medium) [capabilities: snapshot-backed]",
+        "  ○ artistry: anthropic/claude-fable-5 (xhigh) [capabilities: snapshot-backed]",
+        "  ○ quick: kimi-for-coding/kimi-for-coding-highspeed [capabilities: snapshot-backed]",
+        "  ○ unspecified-low: openai/gpt-5.6-terra (high) [capabilities: snapshot-backed]",
+        "  ○ unspecified-high: kimi-for-coding/kimi-k3 (max) [capabilities: snapshot-backed]",
+        "  ○ writing: kimi-for-coding/kimi-k3 (low) [capabilities: snapshot-backed]",
+        "",
+        "● = user override, ○ = provider fallback"
+      ],
+      "issues": [
+        {
+          "title": "Model cache not found",
+          "description": "OpenCode model cache is missing, so model availability cannot be validated.",
+          "fix": "Run: opencode models --refresh",
+          "severity": "warning",
+          "affects": [
+            "model resolution"
+          ]
+        }
+      ],
+      "duration": 5
+    },
+    {
+      "name": "Telemetry",
+      "status": "pass",
+      "message": "Telemetry: enabled",
+      "details": [
+        "PostHog host: https://us.i.posthog.com",
+        "Last daily active date: never",
+        "State file: /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/omo-doctor-qa-g6ckm78t/.local/share/oh-my-opencode/posthog-activity.json"
+      ],
+      "issues": [],
+      "duration": 2
+    },
+    {
+      "name": "Team Mode",
+      "status": "skip",
+      "message": "team_mode: disabled",
+      "issues": [],
+      "duration": 2
+    }
+  ],
+  "systemInfo": {
+    "opencodeVersion": "1.18.13",
+    "opencodePath": "/Users/yeongyu/.bun/bin/opencode",
+    "pluginVersion": "4.19.4",
+    "loadedVersion": "4.19.4",
+    "bunVersion": "1.4.0",
+    "configPath": null,
+    "configValid": true,
+    "isLocalDev": false
+  },
+  "tools": {
+    "lspServers": [
+      {
+        "id": "lsp-tools-mcp",
+        "extensions": [
+          "*"
+        ]
+      }
+    ],
+    "astGrepCli": true,
+    "commentChecker": true,
+    "ghCli": {
+      "installed": true,
+      "authenticated": false,
+      "username": null
+    },
+    "mcpBuiltin": [
+      "websearch",
+      "context7",
+      "grep_app",
+      "lsp"
+    ],
+    "mcpUser": [
+      "codegraph"
+    ]
+  },
+  "summary": {
+    "total": 8,
+    "passed": 1,
+    "failed": 2,
+    "warnings": 3,
+    "skipped": 2,
+    "duration": 466
+  },
+  "exitCode": 1,
+  "target": "opencode"
+}

--- a/.omo/evidence/20260809-doctor-deprecated-key-scan/reporter-shape-omo.jsonc
+++ b/.omo/evidence/20260809-doctor-deprecated-key-scan/reporter-shape-omo.jsonc
@@ -1,0 +1,44 @@
+{
+  "[opencode]": {
+    "agents": {
+      "sisyphus": {
+        "model": "anthropic/claude-opus-5",
+        "fallback_models": [
+          "openai/gpt-5.6-sol",
+          {
+            "model": "google/gemini-3.1-pro",
+            "variant": "high",
+            "temperature": 0.2
+          },
+          {
+            "model": "anthropic/claude-sonnet-5",
+            "thinking": {
+              "type": "enabled",
+              "budgetTokens": 64000
+            }
+          }
+        ]
+      },
+      "oracle": {
+        "fallback_models": [
+          "openai/gpt-5.6-sol"
+        ]
+      },
+      "librarian": {
+        "fallback_models": [
+          "openai/gpt-5.6-sol"
+        ]
+      },
+      "explore": {
+        "fallback_models": [
+          "openai/gpt-5.6-sol"
+        ]
+      },
+      "multimodal-looker": {
+        "fallback_models": [
+          "openai/gpt-5.6-sol"
+        ]
+      }
+    }
+  }
+}

--- a/.omo/evidence/20260809-doctor-deprecated-key-scan/repro-omo.jsonc
+++ b/.omo/evidence/20260809-doctor-deprecated-key-scan/repro-omo.jsonc
@@ -1,0 +1,44 @@
+{
+  "categories": {
+    "deep": {
+      "model": "openai/gpt-5.6-sol",
+      "variant": "high",
+      "provider_options": {
+        "thinking": {
+          "type": "enabled",
+          "budgetTokens": 64000
+        },
+        "textVerbosity": "high"
+      }
+    }
+  },
+  "agents": {
+    "oracle": {
+      "models": [
+        "openai/gpt-5.6-sol"
+      ],
+      "provider_options": {
+        "thinking": {
+          "type": "enabled"
+        }
+      }
+    }
+  },
+  "models": {
+    "sol": {
+      "model": "openai/gpt-5.6-sol",
+      "provider_options": {
+        "textVerbosity": "low"
+      }
+    }
+  },
+  "[codex]": {
+    "agents": {
+      "explore": {
+        "providerOptions": {
+          "textVerbosity": "medium"
+        }
+      }
+    }
+  }
+}

--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
@@ -164,4 +164,95 @@ describe("deprecated reasoning keys check", () => {
       }
     }
   })
+
+  it("ignores canonical provider_options passthrough keys while keeping accurate labels", async () => {
+    //#given migrated canonical config using provider_options passthrough plus two genuinely deprecated keys
+    const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+    const originalHome = process.env.HOME
+    const originalCwd = process.cwd()
+    const testRootDir = mkdtempSync(join(tmpdir(), "omo-doctor-provider-options-"))
+    const projectDir = join(testRootDir, "project")
+    const configPath = join(testRootDir, ".omo", "omo.jsonc")
+
+    try {
+      mkdirSync(projectDir, { recursive: true })
+      mkdirSync(join(testRootDir, ".omo"), { recursive: true })
+      process.env.HOME = testRootDir
+      delete process.env.OPENCODE_CONFIG_DIR
+      writeFileSync(
+        configPath,
+        JSON.stringify(
+          {
+            categories: {
+              deep: {
+                model: "openai/gpt-5.6-sol",
+                variant: "high",
+                thinking: { type: "disabled" },
+                provider_options: {
+                  thinking: { type: "enabled", budgetTokens: 64000 },
+                  textVerbosity: "high",
+                },
+              },
+            },
+            agents: {
+              oracle: {
+                models: ["openai/gpt-5.6-sol"],
+                provider_options: { thinking: { type: "enabled" } },
+              },
+            },
+            models: {
+              sol: {
+                model: "openai/gpt-5.6-sol",
+                provider_options: { textVerbosity: "low" },
+              },
+            },
+            "[codex]": {
+              agents: {
+                explore: {
+                  providerOptions: { textVerbosity: "medium" },
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      )
+      process.chdir(projectDir)
+
+      //#when running the deprecated reasoning keys check
+      const { checkDeprecatedReasoningKeys } = await import("./deprecated-reasoning-keys")
+      const result = await checkDeprecatedReasoningKeys()
+
+      //#then only the genuinely deprecated keys are reported, with accurate titles and fixes
+      expect(result.status).toBe("warn")
+      expect(result.issues.map((issue) => issue.description)).toEqual([
+        `${configPath}: categories.deep.variant`,
+        `${configPath}: categories.deep.thinking`,
+      ])
+      expect(result.issues.map((issue) => issue.title)).toEqual([
+        "Deprecated config key",
+        "Deprecated config key",
+      ])
+      expect(result.issues.map((issue) => issue.fix)).toEqual([
+        "Replace variant with reasoning, or run: oh-my-openagent config migrate",
+        'Replace thinking with reasoning: "off" or provider_options.thinking, or run: oh-my-openagent config migrate',
+      ])
+      expect(result.message).toBe("2 deprecated config key(s) found")
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(testRootDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+      }
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+    }
+  })
 })

--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts
@@ -8,12 +8,15 @@ import type { CheckResult, DoctorIssue } from "../framework/types"
 const CANONICAL_REPLACEMENT = new Map([
   ["variant", "reasoning"],
   ["reasoningEffort", "reasoning"],
-  ["thinking", "reasoning"],
+  ["thinking", 'reasoning: "off" or provider_options.thinking'],
   ["textVerbosity", "provider_options.textVerbosity"],
   ["fallback_models", "models"],
 ])
 
 const TUNING_CONTAINERS = new Set(["agents", "categories", "models"])
+// Canonical migration output nests provider-native keys (thinking, textVerbosity) under these
+// containers; their children must never be re-flagged as deprecated top-level keys.
+const PASSTHROUGH_CONTAINERS = new Set(["provider_options", "providerOptions"])
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -32,7 +35,7 @@ function collectIssues(configPath: string, value: unknown, prefix: string): Doct
     const replacement = CANONICAL_REPLACEMENT.get(key)
     if (replacement !== undefined) {
       issues.push({
-        title: "Deprecated reasoning config key",
+        title: "Deprecated config key",
         description: `${configPath}: ${path}`,
         fix: `Replace ${key} with ${replacement}, or run: oh-my-openagent config migrate`,
         severity: "warning",
@@ -41,6 +44,7 @@ function collectIssues(configPath: string, value: unknown, prefix: string): Doct
       continue
     }
     if (!isRecord(child)) continue
+    if (PASSTHROUGH_CONTAINERS.has(key)) continue
     // A profile only scopes overrides; its own name is not part of the key path users edit.
     if (prefix.length === 0 && key === "profiles") {
       for (const profile of Object.values(child)) {
@@ -78,8 +82,8 @@ export async function checkDeprecatedReasoningKeys(): Promise<CheckResult> {
     name: CHECK_NAMES[CHECK_IDS.CONFIG],
     status: issues.length > 0 ? "warn" : "pass",
     message: issues.length > 0
-      ? `${issues.length} deprecated reasoning key(s) found`
-      : "No deprecated reasoning keys found",
+      ? `${issues.length} deprecated config key(s) found`
+      : "No deprecated config keys found",
     ...(scanned.length > 0 ? { details: scanned.map((path) => `Scanned: ${path}`) } : {}),
     issues,
   }


### PR DESCRIPTION
## What changed

`omo doctor`'s deprecated-key check (`deprecated-reasoning-keys.ts`) had two defects, found while resolving a Discord report (https://discord.com/channels/1452487457085063218/1490536332961906829/1535893865901596673) where doctor flagged documented `[opencode].agents.<name>.fallback_models` config as a "Deprecated reasoning config key":

1. **It re-flagged the migration's own canonical output.** The traversal descended into `provider_options` / `providerOptions`, so canonical passthrough keys were reported as deprecated -- e.g. `categories.deep.provider_options.thinking` -> "Replace thinking with reasoning", and the self-referential `provider_options.textVerbosity` -> "Replace textVerbosity with provider_options.textVerbosity". Running `config migrate` produced output doctor immediately complained about again. Fixed by skipping passthrough containers during traversal.
2. **Mislabeled titles.** `fallback_models` and `textVerbosity` are not reasoning keys, yet every issue was titled "Deprecated reasoning config key" (the exact confusing UX in the report's screenshot). Issues are now titled "Deprecated config key", the check message follows, and the `thinking` fix text names its real canonical targets (`reasoning: "off"` or `provider_options.thinking`).

The `[opencode]`-block false positive itself was already fixed on dev by 989636bc5 (unreleased); this PR removes the remaining doctor noise around the same surface.

## Why

Doctor advice must converge: after a user applies the suggested migration, doctor must report clean. Before this fix it never could -- migrated configs were permanently warned about.

## Observed behavior (QA / evidence)

Evidence: `.omo/evidence/20260809-doctor-deprecated-key-scan/` (committed).

- BEFORE (real CLI `doctor --json`, isolated sandbox HOME): 6 issues -- 5 bogus `provider_options`/`providerOptions` descents + 1 planted control (`categories.deep.variant`). `before-check-output.json`, `before-cli-doctor.json`.
- AFTER: exactly 1 issue (the control), titled "Deprecated config key", message "1 deprecated config key(s) found". `after-check-output.json`, `after-cli-doctor.json`.
- Reporter's exact config shape (`[opencode].agents.*.fallback_models`): status pass, 0 issues. `after-check-reporter-shape.json`.
- Tests: new failing-first case captured RED (5 bogus paths) then GREEN; doctor checks dir 163 pass / 0 fail; `tsgo --noEmit -p packages/omo-opencode` exit 0.

## Residual risk

Low. Change is confined to `collectIssues()` traversal + issue strings; no schema, migration, or plugin runtime paths touched. Legitimate deprecation flagging (top-level, `[senpi]`/`[codex]`, profiles) is pinned by existing tests which remain green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `omo doctor` deprecated-key check so it stops re-flagging canonical `provider_options` passthrough keys and uses accurate labels/fixes. Migrated configs now pass clean, and `[opencode].agents.*.fallback_models` is no longer mislabeled.

- **Bug Fixes**
  - Skip `provider_options`/`providerOptions` during traversal to avoid false positives (e.g., `provider_options.thinking`, self-referential `textVerbosity` advice).
  - Use title "Deprecated config key" and updated messages; the `thinking` fix now points to reasoning: "off" or `provider_options.thinking`.
  - Added a unit test and QA evidence; only real deprecations remain (e.g., `categories.deep.variant`).

<sup>Written for commit ac85d1f3c6d62143448389b38c99c1fe43137d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

