### PR TITLE
docs(omo-senpi): credit letta-code as the memory architecture inspiration

### DIFF
--- a/packages/omo-senpi/src/components/memory/AGENTS.md
+++ b/packages/omo-senpi/src/components/memory/AGENTS.md
@@ -2,6 +2,10 @@
 
 Letta-Code-style persistent agent memory for omo-senpi, backed by `@oh-my-opencode/memory-core` (harness-neutral; zero Senpi imports). Parity target: letta-code@a75f4d93e's local-capable matrix, executed per `.omo/plans/letta-memory-parity-port.md` with the research corpus at `.omo/ulw-research/20260809-224128/`.
 
+## Attribution
+
+The memory architecture - the git-backed memory filesystem, the memory tool semantics, and background reflection - is inspired by [letta-code](https://github.com/letta-ai/letta-code), which is Apache-2.0 licensed (Copyright 2025, Letta authors). This component is an independent reimplementation written against the observable behavior of letta-code@a75f4d93e; no letta-code source was copied. "Letta" and "Letta Code" are trademarks of Letta, Inc., referenced only to describe origin.
+
 ## Anatomy
 
 | Path | Purpose |


### PR DESCRIPTION
Adds a formal Attribution section to `packages/omo-senpi/src/components/memory/AGENTS.md`: architecture inspired by [letta-code](https://github.com/letta-ai/letta-code) (Apache-2.0, Copyright 2025 Letta authors), independent reimplementation with no copied source, Letta trademark notice. License review: Apache-2.0 is compatible with the repo SUL-1.0 third-party carve-out; the work is a clean-room reimplementation, so "inspired by" is the accurate framing (no Derivative Work obligations triggered).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a formal Attribution section to `packages/omo-senpi/src/components/memory/AGENTS.md` crediting `letta-code` as the inspiration for the memory architecture. Notes Apache-2.0 licensing, confirms an independent reimplementation with no copied source, and includes a Letta trademark notice.

<sup>Written for commit d1f90909112b85d887fbfd9ffa920d21de41b105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

