### PR TITLE
fix(memory): ensure agent skills dir on discover

### DIFF
--- a/packages/memory-core/src/seeds/seeds.test.ts
+++ b/packages/memory-core/src/seeds/seeds.test.ts
@@ -39,17 +39,18 @@ describe("default memory seeds", () => {
   })
 
   describe("#given buildDefaultSeedFiles", () => {
-    it("#then it produces two files with system/ paths and frontmatter", () => {
+    it("#then it produces persona/human memory files plus skills/.gitkeep", () => {
       const files = buildDefaultSeedFiles()
 
-      expect(files).toHaveLength(2)
+      expect(files).toHaveLength(3)
       const paths = files.map((f) => f.relativePath)
       expect(paths).toContain("system/persona.md")
       expect(paths).toContain("system/human.md")
+      expect(paths).toContain("skills/.gitkeep")
     })
 
-    it("#then every seed file has valid frontmatter with a description", () => {
-      const files = buildDefaultSeedFiles()
+    it("#then every memory seed file has valid frontmatter with a description", () => {
+      const files = buildDefaultSeedFiles().filter((file) => file.relativePath.endsWith(".md"))
 
       for (const file of files) {
         const parsed = parseMemoryFile(file.content)
@@ -113,7 +114,7 @@ describe("default memory seeds", () => {
     })
   })
 
-  describe("#given a fresh repository #when initMemoryWithSeeds runs #then it commits two seeded files in one initial commit", async () => {
+  describe("#given a fresh repository #when initMemoryWithSeeds runs #then it commits seeded files in one initial commit", async () => {
     // given
     const { dir, repo } = await createRepo()
 
@@ -126,7 +127,8 @@ describe("default memory seeds", () => {
     const tree = await repo.lsTree()
     expect(tree).toContain("system/persona.md")
     expect(tree).toContain("system/human.md")
-    expect(tree).toHaveLength(2)
+    expect(tree).toContain("skills/.gitkeep")
+    expect(tree).toHaveLength(3)
 
     const commitSubject = await gitLog(dir, "%s")
     expect(commitSubject).toBe("chore: initialize local memory")

--- a/packages/memory-core/src/seeds/seeds.ts
+++ b/packages/memory-core/src/seeds/seeds.ts
@@ -2,12 +2,13 @@
  * Default memory seeding — letta parity port (plan todo 33).
  *
  * Seeds a fresh memory repo with system/persona.md + system/human.md
- * rendered with frontmatter, then delegates to GitMemoryRepo.init which
- * writes, stages, and commits them as a single initial commit
- * ("chore: initialize local memory"). If the repo already has a HEAD
- * commit, GitMemoryRepo.init returns the existing HEAD unchanged — the
- * no-overwrite guarantee lives there (P4, letta memory-git.ts:1431-1492),
- * so this module never duplicates that guard.
+ * rendered with frontmatter, plus an empty skills/.gitkeep so the agent
+ * skills directory exists for resources_discover without warning noise,
+ * then delegates to GitMemoryRepo.init which writes, stages, and commits
+ * them as a single initial commit ("chore: initialize local memory"). If
+ * the repo already has a HEAD commit, GitMemoryRepo.init returns the
+ * existing HEAD unchanged — the no-overwrite guarantee lives there
+ * (P4, letta memory-git.ts:1431-1492), so this module never duplicates that guard.
  *
  * Alignment with P4 (GitMemoryRepo.init):
  * - P4's InitializeGitRepoOptions.seedFiles already accepts GitSeedFile[].
@@ -30,6 +31,7 @@ export { DEFAULT_MEMORY_BLOCK_LABELS } from "./default-memory"
 
 const PERSONA_PATH = "system/persona.md"
 const HUMAN_PATH = "system/human.md"
+const SKILLS_GITKEEP_PATH = "skills/.gitkeep"
 
 const PERSONA_DESCRIPTION = "Persona - who I am"
 const HUMAN_DESCRIPTION = "Human - what I know about the user"
@@ -41,8 +43,8 @@ export interface InitMemorySeedsOptions {
 }
 
 /**
- * Build the two default seed files (system/persona.md + system/human.md)
- * with frontmatter rendered from the content constants.
+ * Build the default seed files (system/persona.md + system/human.md + skills/.gitkeep)
+ * with frontmatter rendered from the content constants for memory blocks.
  *
  * Pure — no filesystem access. Safe to call repeatedly.
  */
@@ -55,6 +57,11 @@ export function buildDefaultSeedFiles(): readonly DefaultSeedFile[] {
     {
       relativePath: HUMAN_PATH,
       content: renderMemoryFile({ description: HUMAN_DESCRIPTION }, DEFAULT_HUMAN_BODY),
+    },
+    {
+      relativePath: SKILLS_GITKEEP_PATH,
+      // Keep the agent skills directory present for discovery; real skills land later.
+      content: "\n",
     },
   ]
 }

--- a/packages/omo-senpi/src/components/memory/AGENTS.md
+++ b/packages/omo-senpi/src/components/memory/AGENTS.md
@@ -23,7 +23,7 @@ The memory architecture - the git-backed memory filesystem, the memory tool sema
 | `palace/` | Self-contained HTML memory viewer (0600/0700, machine-gated inline-JSON assertions). |
 | `guard.ts` | Soft cross-identity guard via `tool_call` (file tools only; bash advisory-only). |
 | `policy-guard.ts` | Hard guard: registers a filesystem policy when the host exposes `registerFilesystemPolicy` (senpi >= feat/extension-fs-policy), soft guard otherwise. |
-| `skills-scope.ts` | Agent memfs `skills/` exposure via `resources_discover`. |
+| `skills-scope.ts` | Agent memfs `skills/` exposure via `resources_discover` (ensure-creates empty dir). |
 | `status.ts` | Footer status + committed-only token advisory at `compile_warn_tokens`. |
 | `binding.ts` / `bindings/` | Binding entry record + renderer. |
 | `capabilities.ts` | `appendEntry`/`registerEntryRenderer` capability narrowing (`MemoryExtensionAPI`). |
@@ -40,7 +40,7 @@ Every row is intentional; each was weighed against the research corpus (claim-gr
 5. **No mid-conversation `<memory_update>` one-shot.** Letta special-cases `anthropic/claude-opus-4-8` (C15/C27); omo recompiles per run for every model (generalized, per-run `before_agent_start` re-check of HEAD).
 6. **No `/reflect --auto` selector subagent, no external-transcript staging, no `letta dream --to` doc maintenance.** Manual reflection takes `--recent N` / `--conversation <ids>` / free-text focus.
 7. **No recall subagent or conversation-bootstrap injection.** `/search` is the recall surface (letta's local path already disables AI description generation, C46).
-8. **No onboarding tutorial personality / welcome hints.** Default seeds (`system/persona.md`, `system/human.md`) are the only first-run content.
+8. **No onboarding tutorial personality / welcome hints.** Default seeds (`system/persona.md`, `system/human.md`, `skills/.gitkeep`) are the only first-run content.
 9. **Reflection sandbox default is `auto`**, not letta's fail-closed `required` (C33): default-on reflection must not break hosts without seatbelt/bwrap. `memory.reflection.sandbox: "required"` restores letta semantics.
 10. **`memory_description`/`limit` frontmatter tolerance matches letta; block-scalar descriptions are rejected** (letta's cut-prefix accepted `>` — that acceptance is treated as a bug).
 11. **str_replace replaces the FIRST occurrence** (letta actual behavior, C21) — the advisory's exactly-one-match proposal was rejected for parity.

--- a/packages/omo-senpi/src/components/memory/skills-scope.test.ts
+++ b/packages/omo-senpi/src/components/memory/skills-scope.test.ts
@@ -23,10 +23,10 @@
  *    Extension paths are appended after the pre-existing set, so memory skills yield to
  *    project/user skills on name collision and otherwise load additively. Extension paths
  *    outside the user/project dirs classify as source "path".
- * 4. Missing dir tolerated: core/skills.ts loadSkills skips a nonexistent skill path with a
- *    { type: "warning", "skill path does not exist" } diagnostic and continues (no throw);
- *    loadSkillsFromDirInternal (:168+) likewise returns empty for a missing dir. => the
- *    create-free contract (return repo/skills even when absent) is safe.
+ * 4. Missing dir used to warn: core/skills.ts loadSkills emits
+ *    { type: "warning", "skill path does not exist" } for absent paths. This component now
+ *    ensure-creates repo/skills before contributing it, so first-run identities stay quiet
+ *    while remaining additive.
  * 5. Real-harness proof of the event round-trip: test/suite/hooks-builtin-extension.test.ts
  *    ("collects resource-discovered hook paths as runtime hook sources") and
  *    test/suite/hooks-lifecycle.test.ts:152 register pi.on("resources_discover", ...) via a
@@ -54,6 +54,7 @@ import { createMemoryIdentityContext, type MemoryIdentityContext } from "./conte
 import {
   MEMORY_SKILLS_DIRNAME,
   createMemorySkillsScopeHandler,
+  ensureMemorySkillsDir,
   memorySkillsDir,
   registerMemorySkillsScope,
   type MemorySkillsDiscoverResult,
@@ -186,9 +187,11 @@ describe("createMemorySkillsScopeHandler", () => {
     expect(result).toBeUndefined()
   })
 
-  test("returns the skills dir even when it does not exist on disk (create-free)", async () => {
+  test("creates the skills dir when missing, then returns it (ensure-on-discover)", async () => {
     // #given
     const { context, skillsDir } = await fixture()
+    const { existsSync } = await import("node:fs")
+    expect(existsSync(skillsDir)).toBe(false)
     const handler = createMemorySkillsScopeHandler({ resolveContext: () => context })
 
     // #when
@@ -196,8 +199,9 @@ describe("createMemorySkillsScopeHandler", () => {
 
     // #then
     expect(result).toEqual({ skillPaths: [skillsDir] })
-    const { existsSync } = await import("node:fs")
-    expect(existsSync(skillsDir)).toBe(false)
+    expect(existsSync(skillsDir)).toBe(true)
+    // Idempotent: a second ensure leaves the path stable.
+    expect(ensureMemorySkillsDir(context)).toBe(skillsDir)
   })
 
   test("ignores non-resources_discover payloads", async () => {

--- a/packages/omo-senpi/src/components/memory/skills-scope.ts
+++ b/packages/omo-senpi/src/components/memory/skills-scope.ts
@@ -1,3 +1,4 @@
+import { existsSync, mkdirSync } from "node:fs"
 import { join } from "node:path"
 
 import type { SenpiExtensionAPI } from "../../extension/types"
@@ -29,11 +30,12 @@ export interface MemorySkillsDiscoverResult {
  * discovery set. Memory skills therefore load additively and yield on name collision rather
  * than displacing any existing skill.
  *
- * Create-free contract: the skills dir is returned even when absent on disk. senpi's loader
- * tolerates missing skill paths with a warning diagnostic (no throw), so first-run identities
- * with no skills yet are safe. Reflection-authored skills committed under skills/<name>/SKILL.md
- * are picked up on the next session_start (reason "startup") or /reload (reason "reload");
- * dir shape is enforced by the memory repo pre-commit hooks, not by this component.
+ * Ensure-on-discover contract: first-run identities historically advertised repo/skills before
+ * the directory existed, which surfaced senpi's "skill path does not exist" warning on every
+ * new project. This handler now creates an empty skills directory when missing (no git commit)
+ * and then returns it, so discovery stays additive without warning noise. Reflection-authored
+ * skills under skills/<name>/SKILL.md are still picked up on the next session_start ("startup")
+ * or /reload ("reload"); dir shape remains enforced by memory repo pre-commit hooks.
  */
 
 export const MEMORY_SKILLS_DIRNAME = "skills"
@@ -51,6 +53,14 @@ export function memorySkillsDir(context: MemoryIdentityContext): string {
  * unreadable sessions return undefined so the handler chain passes through untouched and no
  * path is contributed.
  */
+export function ensureMemorySkillsDir(context: MemoryIdentityContext): string {
+  const dir = memorySkillsDir(context)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  return dir
+}
+
 export function createMemorySkillsScopeHandler(
   options: MemorySkillsScopeOptions,
 ): (payload: unknown, eventCtx?: unknown) => MemorySkillsDiscoverResult | undefined {
@@ -60,7 +70,7 @@ export function createMemorySkillsScopeHandler(
     if (sessionId === undefined) return undefined
     const context = options.resolveContext(sessionId)
     if (context === undefined) return undefined
-    return { skillPaths: [memorySkillsDir(context)] }
+    return { skillPaths: [ensureMemorySkillsDir(context)] }
   }
 }
 


### PR DESCRIPTION
## Summary
- New omo-senpi projects were advertising `<memory-repo>/skills` via `resources_discover` before that directory existed.
- senpi then emitted a startup `[Skill conflicts] skill path does not exist` warning on every fresh project registration.
- This change ensure-creates the empty skills directory on discover, seeds `skills/.gitkeep` in default memory init, and updates tests/docs.

## Test plan
- [x] Local install patched equivalently and existing agent dirs backfilled
- [ ] `bun test packages/omo-senpi/src/components/memory/skills-scope.test.ts packages/memory-core/src/seeds/seeds.test.ts`
- [ ] Start omo in a brand-new project cwd and confirm no skill-path warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops first-run “skill path does not exist” warnings by ensuring the agent `skills/` directory exists before it’s advertised. Creates the folder during `resources_discover` and seeds `skills/.gitkeep` in new memory repos.

- **Bug Fixes**
  - `packages/omo-senpi`: Discovery handler now ensures `skills/` exists (`ensureMemorySkillsDir`) and returns that path.
  - `packages/memory-core`: Default seeds now include `skills/.gitkeep` so fresh repos start with an empty skills dir.
  - Updated tests and `AGENTS.md` to reflect the ensure-on-discover behavior.

<sup>Written for commit 5b30d222b01c9a2ec3890ce9af71fd9853082e93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

