### PR TITLE
fix(bg-agent): bound tool-wait defer and retain reply-required wakes (#6546 D1+D2)

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
@@ -247,7 +247,7 @@ describe("parent wake active defer ceiling", () => {
     }
   })
 
-  test("#given blocked tool history and aged wake while parent is busy #then it admits noReply", async () => {
+  test("#given blocked tool history and aged wake while parent is busy #then it force-dispatches the reply past the tool-wait ceiling", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier({
       sessionStatuses: { "parent-1": { type: "busy" } },
@@ -259,11 +259,11 @@ describe("parent wake active defer ceiling", () => {
       // when
       await notifier.flushPendingParentWake("parent-1")
 
-      // then
+      // then — the aged reply-required wake is force-dispatched instead of
+      // being admitted as noReply forever (issue #6546 D1)
       expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
-      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+      expect(promptAsyncCalls[0]?.body.noReply).not.toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {
       notifier.shutdown()
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -81,6 +81,22 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
+      // The tool-wait deferral path has no independent ceiling: a reply-required
+      // wake can be re-admitted as noReply forever while the parent history keeps
+      // reporting a stale tool call (issue #6546 D1). Apply the same age ceiling
+      // as the active-session path so the reply is eventually force-dispatched.
+      if (this.shouldForceDispatchAfterActiveDefer(latestWake)) {
+        await this.sendParentWakePrompt(sessionID, latestWake, {
+          emptyAssistantTurnRetry,
+          toolWaitDecision: { ...toolWaitDecision, skipPromptGateToolStateCheck: true },
+          skipPromptGateStatusCheck: true,
+        })
+        log("[background-agent] Sent parent wake after tool-wait defer ceiling:", {
+          sessionID,
+          queuedAgeMs: this.getQueuedAgeMs(latestWake),
+        })
+        return
+      }
       await this.sendParentWakePrompt(sessionID, latestWake, {
         emptyAssistantTurnRetry,
         toolWaitDecision: { ...toolWaitDecision, skipPromptGateToolStateCheck: true },
@@ -185,12 +201,17 @@ export class ParentWakeFlushRunner {
     this.deps.pendingQueue.clearTimer(sessionID)
   }
 
-  // A retained reply-required wake is only liveness insurance for a deposit the
-  // parent never saw. Assistant output created after the noReply admission means
-  // the live turn consumed the deposit — re-dispatching it would inject a
-  // duplicate notification and fork a concurrent assistant chain.
+  // A retained reply-required wake is liveness insurance for a deposit the
+  // parent never saw. Assistant output created after the noReply admission can
+  // be unrelated parent activity (timeout recovery, another task's output), so
+  // a reply-required wake must never be dropped here: the reply is still owed.
+  // Only non-reply wakes (noReplyAdmittedAt set, shouldReply false) can be
+  // consumed by later parent output.
   private async dropAdmittedWakeConsumedByParent(sessionID: string, latestWake: PendingParentWake): Promise<boolean> {
     if (latestWake.noReplyAdmittedAt === undefined) {
+      return false
+    }
+    if (latestWake.shouldReply) {
       return false
     }
     if (!(await this.deps.sessionInspector.hasAssistantOutputAfterAdmittedWake(sessionID, latestWake))) {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-noreply-liveness.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-noreply-liveness.test.ts
@@ -366,11 +366,11 @@ describe("parent wake admitted-consumption drop (duplicate ALL-COMPLETE regressi
       notifier.clearPendingParentWakeTimer("parent-1")
       await notifier.flushPendingParentWake("parent-1")
 
-      // then: the retained wake is dropped instead of re-dispatched as a
-      // reply prompt (which forked a concurrent assistant chain in production)
+      // then: no duplicate reply prompt is forked (the admitted wake was
+      // consumed by the live turn), and the reply-required wake is retained
+      // rather than destroyed (issue #6546 D2)
       expect(promptAsyncCalls).toHaveLength(1)
-      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
-      expect(notifier.getDispatchedParentWakes().has("parent-1")).toBe(false)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-reply-retention.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-reply-retention.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { ParentWakeNotifier } from "./parent-wake-notifier"
+import {
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "../../hooks/shared/prompt-async-gate"
+
+type PromptAsyncCall = {
+  path: { id: string }
+  body: {
+    noReply?: boolean
+    parts?: unknown[]
+  }
+  query?: {
+    directory: string
+  }
+}
+
+type SessionMessageStub = {
+  info?: {
+    role?: string
+    finish?: string
+    time?: { created?: number; completed?: number }
+  }
+  parts?: Array<{ type?: string; text?: string; synthetic?: boolean; state?: { status?: string } }>
+}
+
+const FINAL_WAKE = [
+  "<system-reminder>",
+  "[BACKGROUND TASK COMPLETED]",
+  "[ALL BACKGROUND TASKS COMPLETE]",
+  "",
+  "**Completed:**",
+  "- `task-a`: task A",
+  "",
+  'Use `background_output(task_id="<id>")` to retrieve each result.',
+  "</system-reminder>",
+].join("\n")
+
+const PARENT_MESSAGES: SessionMessageStub[] = [
+  {
+    info: { role: "user", time: { created: 80_000 } },
+    parts: [{ type: "text", text: "start work" }],
+  },
+  {
+    info: { role: "assistant", finish: "stop", time: { created: 90_000 } },
+    parts: [{ type: "text", text: "parent output" }],
+  },
+]
+
+// A parent turn whose latest assistant message blocks internal prompts with a
+// stale tool call (D1 trigger: toolWaitDecision.defer).
+const STALE_TOOL_CALL_MESSAGES: SessionMessageStub[] = [
+  {
+    info: { role: "user", time: { created: 80_000 } },
+    parts: [{ type: "text", text: "start work" }],
+  },
+  {
+    info: { role: "assistant", finish: "tool-calls", time: { created: 99_500 } },
+    parts: [{ type: "tool", state: { status: "running" } }],
+  },
+]
+
+function createNotifier(args: {
+  sessionStatuses: Record<string, { type: string }>
+  messagesProvider: () => SessionMessageStub[]
+  parentActivityWindowMs?: number
+}): {
+  notifier: ParentWakeNotifier
+  promptAsyncCalls: PromptAsyncCall[]
+} {
+  const promptAsyncCalls: PromptAsyncCall[] = []
+  const client = createOpencodeClient({ baseUrl: "http://127.0.0.1:1" })
+  Object.assign(client.session, {
+    messages: async () => ({ data: args.messagesProvider() }),
+    status: async () => ({ data: args.sessionStatuses }),
+    promptAsync: async (call: PromptAsyncCall) => {
+      promptAsyncCalls.push(call)
+      return { data: {} }
+    },
+    abort: async () => ({ data: {} }),
+  })
+
+  const notifier = new ParentWakeNotifier(
+    {
+      client,
+      directory: "/tmp/test-omo",
+      enqueueNotificationForParent: async (_sessionID, operation) => {
+        await operation()
+      },
+    },
+    {
+      pendingRetryMs: 1_000,
+      acceptedMessageSkewMs: 5_000,
+      toolCallDeferMaxMs: 5_000,
+      failureRequeueWindowMs: 5_000,
+      userMessageInProgressWindowMs: 2_000,
+      parentSessionActivityInProgressWindowMs: args.parentActivityWindowMs ?? 0,
+    },
+  )
+
+  return { notifier, promptAsyncCalls }
+}
+
+function queueAgedWake(notifier: ParentWakeNotifier, sessionID = "parent-1"): void {
+  notifier.queuePendingParentWake(sessionID, FINAL_WAKE, { agent: "sisyphus" }, true)
+  const wake = notifier.getPendingParentWakes().get(sessionID)
+  if (!wake) {
+    throw new Error("expected pending wake")
+  }
+  wake.queuedAt = Date.now() - 120_000
+}
+
+function releaseParentWakeHold(sessionID: string): void {
+  releasePromptAsyncReservation(sessionID, "test:simulate-expired-parent-wake-hold", {
+    reservedBy: "background-agent-parent-wake",
+  })
+}
+
+afterEach(() => {
+  releaseAllPromptAsyncReservationsForTesting()
+})
+
+describe("parent wake reply-required retention (#6546 D2)", () => {
+  test("#given a retained reply wake was admitted as noReply #when the parent produces output after admission #then the reply-required wake is NOT dropped", async () => {
+    // given
+    const originalDateNow = Date.now
+    let now = 100_000
+    Date.now = () => now
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => PARENT_MESSAGES,
+      parentActivityWindowMs: 180_000,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    notifier.recordParentSessionActivity("parent-1")
+
+    try {
+      // when — fresh parent activity admits the wake as noReply, retained
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeDefined()
+
+      // when — the parent produces unrelated assistant output after admission,
+      // then the flush runs again
+      PARENT_MESSAGES.push({
+        info: { role: "assistant", finish: "stop", time: { created: 200_000 } },
+        parts: [{ type: "text", text: "after admission output" }],
+      })
+      now = 220_000
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then — the reply-required wake survives the consumed-admission drop
+      // (D2 regression: it must not be deleted)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+    }
+  })
+})
+
+describe("parent wake stale tool-call defer ceiling (#6546 D1)", () => {
+  test("#given a reply wake ages past the ceiling while a stale tool call blocks #then it force-dispatches the reply instead of deferring forever", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => STALE_TOOL_CALL_MESSAGES,
+    })
+    queueAgedWake(notifier)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then — a reply is dispatched (noReply false) even though the history
+      // tool-wait decision would normally defer (D1 regression)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).not.toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      notifier.shutdown()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts
@@ -716,7 +716,7 @@ describe("createTeamSendMessageTool", () => {
     const [messageFile] = (await readdir(inboxDir)).filter((entry) => entry.endsWith(".json"))
     const message = MessageSchema.parse(JSON.parse(await readFile(path.join(inboxDir, messageFile), "utf8")))
     expect(message.from).toBe("m1")
-  })
+  }, { timeout: 15000 })
 
   test("keeps live-delivered messages reserved until the recipient idles", async () => {
     // given
@@ -741,7 +741,7 @@ describe("createTeamSendMessageTool", () => {
     const runtimeState = await loadState(fixture.teamRunId, fixture.config)
     const recipient = runtimeState.members.find((member) => member.name === "m2")
     expect(recipient?.pendingInjectedMessageIds).toHaveLength(1)
-  })
+  }, { timeout: 15000 })
 
   test("broadcast fans out live delivery to every member except the sender", async () => {
     // given
@@ -763,7 +763,7 @@ describe("createTeamSendMessageTool", () => {
       fixture.memberOneSessionId,
       fixture.memberTwoSessionId,
     ].sort())
-  })
+  }, { timeout: 15000 })
 
   test("broadcast still queues for members whose session has not spawned yet", async () => {
     // given
@@ -793,7 +793,7 @@ describe("createTeamSendMessageTool", () => {
     expect(targetedSessionIds).toEqual([fixture.memberOneSessionId])
     const memberTwoInbox = await readdir(getInboxDir(resolveBaseDir(fixture.config), fixture.teamRunId, "m2"))
     expect(memberTwoInbox.filter((entry) => entry.endsWith(".json") && !entry.startsWith("."))).toHaveLength(1)
-  })
+  }, { timeout: 15000 })
 
   test("inbox stays intact when live delivery fails so the fallback path still works", async () => {
     // given


### PR DESCRIPTION
## Summary

Follow-up to #6655 (fixes #6546). The maintainer confirmed two additional defects in the parent-wake flush machinery on top of the original report:

1. **D1 — stale tool-call deferral has no time ceiling.** The `toolWaitDecision.defer` branch sends a `forceNoReply` admit and retains the wake, but unlike the active-session path it has no `PENDING_PARENT_WAKE_MAX_ACTIVE_DEFER_MS` (60s) bound. A reply-required wake can be re-admitted as noReply forever while parent history keeps reporting a blocking/stale tool call — observed in edynasty's reproduction as `Holding parent wake during stale tool-call deferral` repeating every 1s for 21s+.

2. **D2 — `dropAdmittedWakeConsumedByParent` destroys reply-required wakes.** When the parent produces any assistant output after the noReply admission, the retained `shouldReply=true` wake is deleted. That output can be unrelated parent activity (timeout-based recovery, another task's result), so destroying the wake removes the last liveness signal that a reply is owed — the parent then re-dispatches duplicate work (observed twice in edynasty's repro).

## Changes

- **`parent-wake-flush-runner.ts`**
  - D1: in the `toolWaitDecision.defer` branch, a reply-required wake past the 60s age ceiling is force-dispatched (mirroring the active-session ceiling) instead of being re-admitted as noReply forever.
  - D2: `dropAdmittedWakeConsumedByParent` returns early when `latestWake.shouldReply === true` — reply-required wakes are never dropped by later parent output; only non-reply wakes can be consumed. The duplicate-reply hazard (forking a concurrent assistant chain) is still prevented because the admitted wake's `noReplyAdmittedAt` keeps `deferReplyWakeWhileUnsafe` deferring re-dispatch.

## QA & Evidence

Evidence dir: `.omo/evidence/20260809-6546-d1-d2-wake-defer-bounds/EVIDENCE.md`

- **TDD red phase** (fix stashed): both new tests fail — D2 test shows the reply-required wake dropped; D1 test shows noReply admission instead of force-dispatch.
- **TDD green phase**: `parent-wake-reply-retention.test.ts` — 2 pass / 0 fail.
- **Full background-agent suite**: **748 pass / 0 fail** (60 files). The two pre-existing tests that pinned the old behavior were updated to assert the new intended behavior; all other parent-wake tests (active-defer-ceiling, noreply-liveness, history-deferral, final-notification-merge, same-source-requeue, empty-turn-requeue, late-error-recovery) pass unchanged.
- **Duplicate-dispatch hazard still prevented**: traced the noreply-liveness consumed-admission scenario — with the D2 fix, the second flush produces no additional `promptAsync` call (calls stayed at 1); only the retention outcome changed.
- `bun run typecheck` clean; `bun run build` exit 0.

## Risks & Residuals

- The force-dispatch-past-tool-wait-ceiling path is exercised at unit level only; no live-harness run was executed (machine lacks the opencode-qa script deps). The dispatch goes through the same `sendParentWakePrompt` -> `dispatchInternalPrompt` gate as all other wakes, so the prompt-async gate is preserved.
- Behavior change is confined to `parent-wake-flush-runner.ts` plus its tests.

## Related Issues

- Fixes the two confirmed follow-up defects on #6546 (confirmed by code-yeongyu 2026-08-06)
- Related: #6655 (the reconciliation fix), #1582 (original recurrence)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two defects in the background agent’s parent-wake flow: cap tool-wait deferral at 60s and retain reply-required wakes after noReply admission. Prevents infinite noReply loops and lost replies; addresses #6546.

- **Bug Fixes**
  - D1: If a reply-required wake is blocked by a stale tool call and older than 60s, force-dispatch the reply instead of re-admitting as noReply.
  - D2: Never drop reply-required wakes in `dropAdmittedWakeConsumedByParent`; only non-reply wakes can be consumed by later parent output.
  - Tests: Added `parent-wake-reply-retention.test.ts`; updated active-defer-ceiling and noreply-liveness tests; raised timeouts in slow team-mode live-delivery messaging tests to reduce flakiness.

<sup>Written for commit af9462359ed68762f2e91ed48808b0a9e6684a6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

