### PR TITLE
fix(prompt-async-gate): classify inspection timeout as inconclusive, not active (#6534)

### DIFF
--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
@@ -144,8 +144,9 @@ describe("ralph-loop continuation prompt injector", () => {
       apiTimeoutMs: 50,
     })
 
-    // then
-    expect(result).toEqual({ status: "deferred", reason: "active" })
+    // then — a failed inspection is inconclusive, not active (issue #6534);
+    // the continuation is deferred so it can be retried, not rejected
+    expect(result).toEqual({ status: "deferred", reason: "inconclusive" })
     expect(promptCalls).toBe(0)
   })
 

--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -23,9 +23,9 @@ type MessageInfo = {
 }
 
 export type ContinuationPromptResult =
-	| { status: "dispatched" }
-	| { status: "deferred"; reason: "active" | "reserved" }
-	| { status: "rejected"; error: Error }
+  | { status: "dispatched" }
+  | { status: "deferred"; reason: "active" | "reserved" | "inconclusive" }
+  | { status: "rejected"; error: Error }
 
 function extractPromptAsyncError(response: unknown): unknown | undefined {
 	if (!isRecord(response) || !Object.hasOwn(response, "error")) {
@@ -167,6 +167,9 @@ export async function injectContinuationPrompt(
 		}
 		if (promptResult.status === "active" || promptResult.status === "reserved") {
 			return { status: "deferred", reason: promptResult.status }
+		}
+		if (promptResult.status === "inconclusive") {
+			return { status: "deferred", reason: "inconclusive" }
 		}
 		if (promptResult.status !== "dispatched") {
 			return {

--- a/packages/omo-opencode/src/hooks/ralph-loop/iteration-continuation.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/iteration-continuation.ts
@@ -18,7 +18,7 @@ type ContinuationOptions = {
 
 export type ContinuationResult =
   | { status: "dispatched"; sessionID: string }
-  | { status: "dispatch_deferred"; reason: "active" | "reserved" }
+  | { status: "dispatch_deferred"; reason: "active" | "reserved" | "inconclusive" }
   | { status: "session_creation_rejected" }
   | { status: "dispatch_rejected"; error: unknown }
 

--- a/packages/omo-opencode/src/hooks/shared/prompt-async-gate-message-fetch.test.ts
+++ b/packages/omo-opencode/src/hooks/shared/prompt-async-gate-message-fetch.test.ts
@@ -40,8 +40,9 @@ describe("dispatchInternalPrompt message fetch safety", () => {
       dispatchTimeoutMs: 50,
     })
 
-    // then
-    expect(result.status).toBe("queued")
+    // then — the stalled inspection is reported as inconclusive, never
+    // dispatched as a prompt (issue #6534)
+    expect(result.status).toBe("inconclusive")
     expect(promptCalls).toBe(0)
   })
 
@@ -72,8 +73,9 @@ describe("dispatchInternalPrompt message fetch safety", () => {
       dispatchTimeoutMs: 50,
     })
 
-    // then
-    expect(result.status).toBe("queued")
+    // then — the failed inspection is reported as inconclusive, never
+    // dispatched as a prompt (issue #6534)
+    expect(result.status).toBe("inconclusive")
     expect(promptCalls).toBe(0)
   })
 })

--- a/packages/omo-opencode/src/shared/model-suggestion-retry.ts
+++ b/packages/omo-opencode/src/shared/model-suggestion-retry.ts
@@ -77,35 +77,58 @@ export async function promptWithModelSuggestionRetry(
   const timeoutMs = options.timeoutMs ?? PROMPT_TIMEOUT_MS
   const timeoutContext = createPromptTimeoutContext(args, timeoutMs)
 
+  // A gate inspection that times out is "inconclusive", not "active": the child
+  // session may be idle while the session.messages read stalls under load
+  // (issue #6534). Retry the dispatch with backoff instead of interrupting the
+  // launch; a verified active assistant turn still fails immediately.
+  const maxInconclusiveAttempts = 5
+  let inconclusiveAttempt = 0
+
   try {
-    const promptResult = await dispatchInternalPrompt({
-      mode: "async",
-      client,
-      sessionID: args.path.id,
-      input: {
-        ...args,
-        signal: timeoutContext.signal,
-      },
-      source: "model-suggestion-retry",
-      settleMs: 0,
-      ...(options.queueBehavior ? { queueBehavior: options.queueBehavior } : {}),
-      ...(options.checkStatus !== undefined ? { checkStatus: options.checkStatus } : {}),
-      ...(options.checkToolState !== undefined ? { checkToolState: options.checkToolState } : {}),
-    })
-    if (promptResult.status === "failed") {
+    for (;;) {
+      const promptResult = await dispatchInternalPrompt({
+        mode: "async",
+        client,
+        sessionID: args.path.id,
+        input: {
+          ...args,
+          signal: timeoutContext.signal,
+        },
+        source: "model-suggestion-retry",
+        settleMs: 0,
+        ...(options.queueBehavior ? { queueBehavior: options.queueBehavior } : {}),
+        ...(options.checkStatus !== undefined ? { checkStatus: options.checkStatus } : {}),
+        ...(options.checkToolState !== undefined ? { checkToolState: options.checkToolState } : {}),
+      })
+      if (promptResult.status === "failed") {
+        if (timeoutContext.wasTimedOut()) {
+          throw new Error(`promptAsync timed out after ${timeoutMs}ms`)
+        }
+        if (isAmbiguousPostDispatchPromptFailure(promptResult)) {
+          return
+        }
+        throw promptResult.error
+      }
+      if (promptResult.status === "inconclusive") {
+        inconclusiveAttempt += 1
+        releasePromptAsyncReservation(args.path.id, "model-suggestion-retry")
+        if (inconclusiveAttempt >= maxInconclusiveAttempts) {
+          throw new Error(`promptAsync skipped by gate: inconclusive after ${maxInconclusiveAttempts} inspection retries`)
+        }
+        log("[model-suggestion-retry] Gate inspection inconclusive; retrying dispatch", {
+          sessionID: args.path.id,
+          attempt: inconclusiveAttempt,
+        })
+        await new Promise((resolve) => setTimeout(resolve, Math.min(250 * 2 ** (inconclusiveAttempt - 1), 2_000)))
+        continue
+      }
+      if (!isInternalPromptDispatchAccepted(promptResult)) {
+        throw new Error(`promptAsync skipped by gate: ${promptResult.status}`)
+      }
       if (timeoutContext.wasTimedOut()) {
         throw new Error(`promptAsync timed out after ${timeoutMs}ms`)
       }
-      if (isAmbiguousPostDispatchPromptFailure(promptResult)) {
-        return
-      }
-      throw promptResult.error
-    }
-    if (!isInternalPromptDispatchAccepted(promptResult)) {
-      throw new Error(`promptAsync skipped by gate: ${promptResult.status}`)
-    }
-    if (timeoutContext.wasTimedOut()) {
-      throw new Error(`promptAsync timed out after ${timeoutMs}ms`)
+      return
     }
   } catch (error) {
     if (timeoutContext.wasTimedOut()) {

--- a/packages/utils/src/prompt-async-gate-message-fetch.test.ts
+++ b/packages/utils/src/prompt-async-gate-message-fetch.test.ts
@@ -40,8 +40,9 @@ describe("dispatchInternalPrompt message fetch safety", () => {
       dispatchTimeoutMs: 50,
     })
 
-    // then
-    expect(result.status).toBe("queued")
+    // then — the stalled inspection is reported as inconclusive, never
+    // dispatched as a prompt (issue #6534)
+    expect(result.status).toBe("inconclusive")
     expect(promptCalls).toBe(0)
   })
 
@@ -72,8 +73,9 @@ describe("dispatchInternalPrompt message fetch safety", () => {
       dispatchTimeoutMs: 50,
     })
 
-    // then
-    expect(result.status).toBe("queued")
+    // then — the failed inspection is reported as inconclusive, never
+    // dispatched as a prompt (issue #6534)
+    expect(result.status).toBe("inconclusive")
     expect(promptCalls).toBe(0)
   })
 })

--- a/packages/utils/src/prompt-async-gate/inspection-timeout.test.ts
+++ b/packages/utils/src/prompt-async-gate/inspection-timeout.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { dispatchInternalPrompt } from "../prompt-async-gate"
+import {
+  _setPromptGateMessagesFetchTimeoutMsForTesting,
+  resetPromptGateTimingForTesting,
+} from "./timing"
+import {
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "../prompt-async-gate"
+
+type PromptAsyncCall = {
+  path: { id: string }
+  body: { parts?: unknown[] }
+  query?: { directory: string }
+}
+
+function createClient(args: {
+  sessionStatus?: () => Promise<unknown>
+  messages: () => Promise<unknown>
+  promptAsync: (call: PromptAsyncCall) => Promise<unknown>
+}): {
+  client: {
+    session: {
+      status: () => Promise<unknown>
+      messages: () => Promise<unknown>
+      promptAsync: (call: PromptAsyncCall) => Promise<unknown>
+    }
+  }
+} {
+  const client = {
+    session: {
+      status: args.sessionStatus ?? (async () => ({ data: {} })),
+      messages: args.messages,
+      promptAsync: args.promptAsync,
+    },
+  }
+  return { client }
+}
+
+afterEach(() => {
+  resetPromptGateTimingForTesting()
+  releaseAllPromptAsyncReservationsForTesting()
+})
+
+describe("prompt-async-gate inspection timeout (#6534)", () => {
+  test("#given the session.messages inspection stalls past the gate timeout #when dispatching #then it returns inconclusive, not active", async () => {
+    // given
+    _setPromptGateMessagesFetchTimeoutMsForTesting(50)
+    let promptAsyncCalls = 0
+    const { client } = createClient({
+      sessionStatus: async () => ({ data: {} }),
+      messages: () => new Promise(() => {}), // never resolves
+      promptAsync: async () => {
+        promptAsyncCalls += 1
+        return { data: {} }
+      },
+    })
+
+    try {
+      // when
+      const result = await dispatchInternalPrompt({
+        mode: "async",
+        client: client as never,
+        sessionID: "ses-inspection-timeout",
+        source: "test",
+        settleMs: 0,
+        queueBehavior: "defer",
+        input: {
+          path: { id: "ses-inspection-timeout" },
+          body: { parts: [{ type: "text", text: "hi" }] },
+          query: { directory: "/tmp" },
+        },
+      })
+
+      // then — a stalled inspection must not be classified as "active"
+      expect(result.status).not.toBe("active")
+      expect(result.status).toBe("inconclusive")
+      expect(promptAsyncCalls).toBe(0)
+    } finally {
+      releasePromptAsyncReservation("ses-inspection-timeout", "test")
+    }
+  })
+
+  test("#given a verified idle session with no blocking assistant turn #when dispatching #then it dispatches", async () => {
+    // given
+    _setPromptGateMessagesFetchTimeoutMsForTesting(50)
+    let promptAsyncCalls = 0
+    const { client } = createClient({
+      sessionStatus: async () => ({ data: {} }),
+      messages: async () => ({ data: [] }),
+      promptAsync: async () => {
+        promptAsyncCalls += 1
+        return { data: {} }
+      },
+    })
+
+    try {
+      // when
+      const result = await dispatchInternalPrompt({
+        mode: "async",
+        client: client as never,
+        sessionID: "ses-idle-dispatch",
+        source: "test",
+        settleMs: 0,
+        queueBehavior: "defer",
+        input: {
+          path: { id: "ses-idle-dispatch" },
+          body: { parts: [{ type: "text", text: "hi" }] },
+          query: { directory: "/tmp" },
+        },
+      })
+
+      // then
+      expect(result.status).toBe("dispatched")
+      expect(promptAsyncCalls).toBe(1)
+    } finally {
+      releasePromptAsyncReservation("ses-idle-dispatch", "test")
+    }
+  })
+})

--- a/packages/utils/src/prompt-async-gate/pending-tool-turn.ts
+++ b/packages/utils/src/prompt-async-gate/pending-tool-turn.ts
@@ -115,6 +115,8 @@ export function latestAssistantTurnBlocksInternalPrompt(messages: unknown[]): bo
   return false
 }
 
+export type AssistantTurnInspection = "blocking" | "clear" | "unknown"
+
 export async function sessionLatestAssistantBlocksInternalPrompt<TInput>(args: {
   readonly client: PromptDispatchClient
   readonly sessionID: string
@@ -122,10 +124,10 @@ export async function sessionLatestAssistantBlocksInternalPrompt<TInput>(args: {
   readonly sessionName: PromptSessionName
   readonly source: string
   readonly timeoutMs: number
-}): Promise<boolean> {
+}): Promise<AssistantTurnInspection> {
   const session = args.client.session
   if (typeof session?.messages !== "function") {
-    return false
+    return "clear"
   }
   const messages = session.messages.bind(session)
 
@@ -138,13 +140,17 @@ export async function sessionLatestAssistantBlocksInternalPrompt<TInput>(args: {
       args.timeoutMs,
       `[prompt-async-gate] ${args.sessionName} session.messages`,
     )
-    return latestAssistantTurnBlocksInternalPrompt(getMessagesData(response))
+    return latestAssistantTurnBlocksInternalPrompt(getMessagesData(response)) ? "blocking" : "clear"
   } catch (error) {
     log("[prompt-async-gate] latest assistant prompt-block check failed", {
       sessionID: args.sessionID,
       source: args.source,
       error: String(error),
     })
-    return !isPromptMessageInspectionAborted(error)
+    // A timed-out or failed inspection is NOT proof that the latest assistant
+    // turn blocks internal prompts (issue #6534): the read may have stalled
+    // under load while the session is genuinely idle. Report "unknown" so the
+    // caller can defer/retry instead of misclassifying the child as active.
+    return isPromptMessageInspectionAborted(error) ? "clear" : "unknown"
   }
 }

--- a/packages/utils/src/prompt-async-gate/session-idle-dispatch.ts
+++ b/packages/utils/src/prompt-async-gate/session-idle-dispatch.ts
@@ -88,10 +88,8 @@ export async function dispatchAfterSessionIdle<TInput>(args: {
       return { status: "active" }
     }
 
-    if (
-      checkToolState
-      && typeof client.session?.messages === "function"
-      && await sessionLatestAssistantBlocksInternalPrompt({
+    if (checkToolState && typeof client.session?.messages === "function") {
+      const inspection = await sessionLatestAssistantBlocksInternalPrompt({
         client,
         sessionID,
         input,
@@ -99,12 +97,20 @@ export async function dispatchAfterSessionIdle<TInput>(args: {
         source,
         timeoutMs: Math.min(dispatchTimeoutMs, getPromptGateMessagesFetchTimeoutMs()),
       })
-    ) {
-      log(`[prompt-async-gate] ${sessionName} skipped because latest assistant is still active`, {
-        sessionID,
-        source,
-      })
-      return { status: "active" }
+      if (inspection === "blocking") {
+        log(`[prompt-async-gate] ${sessionName} skipped because latest assistant is still active`, {
+          sessionID,
+          source,
+        })
+        return { status: "active" }
+      }
+      if (inspection === "unknown") {
+        log(`[prompt-async-gate] ${sessionName} inspection inconclusive; deferring`, {
+          sessionID,
+          source,
+        })
+        return { status: "inconclusive" }
+      }
     }
 
     log(`[prompt-async-gate] ${sessionName} dispatching`, { sessionID, source })

--- a/packages/utils/src/prompt-async-gate/types.ts
+++ b/packages/utils/src/prompt-async-gate/types.ts
@@ -67,6 +67,7 @@ export type InternalPromptDispatchResult =
   | { readonly status: "queued"; readonly queuedBy: string; readonly position: number }
   | { readonly status: "active" }
   | { readonly status: "reserved"; readonly reservedBy: string }
+  | { readonly status: "inconclusive" }
   | { readonly status: "unavailable" }
   | { readonly status: "failed"; readonly error: unknown; readonly dispatchAttempted: boolean }
 


### PR DESCRIPTION
## Summary

Fixes #6534. Background task launches intermittently died ~6s after dispatch with `[INTERRUPT] - promptAsync skipped by gate: active`, leaving zero-message child sessions. Root cause (confirmed against dev code + the reporter's captured logs):

The launch dispatch path (`promptWithRetryInDirectory` → `promptWithModelSuggestionRetry` with `queueBehavior:"defer"`) inspects the child's `session.messages` with a 5s timeout before dispatching. When the read stalled (SQLite single-connection contention under load), the catch in `sessionLatestAssistantBlocksInternalPrompt` returned `!isPromptMessageInspectionAborted(error)` — a timeout is not `MessageAbortedError`, so any read stall **failed closed to "latest assistant is still active"** → `status:"active"` → `promptAsync skipped by gate: active` thrown → launch interrupted, child aborted with zero messages, and **gate skips were never retried**.

## Changes

- **`packages/utils/src/prompt-async-gate/pending-tool-turn.ts`** — `sessionLatestAssistantBlocksInternalPrompt` now returns tri-state `"blocking" | "clear" | "unknown"`: verified blocking turn → `"blocking"`, idle → `"clear"`, timed-out/failed inspection → `"unknown"` (only `MessageAbortedError` → `"clear"`).
- **`packages/utils/src/prompt-async-gate/session-idle-dispatch.ts`** — `"unknown"` inspection returns the new `{ status: "inconclusive" }`; verified-blocking turns still return `"active"`.
- **`packages/utils/src/prompt-async-gate/types.ts`** — added `{ status: "inconclusive" }` to `InternalPromptDispatchResult`.
- **`packages/omo-opencode/src/shared/model-suggestion-retry.ts`** — `promptWithModelSuggestionRetry` retries `"inconclusive"` with bounded backoff (max 5 attempts, 250ms → 2s, releasing the reservation between attempts). Verified `"active"` stays terminal (genuinely active sessions are never double-prompted). Sync path unchanged (never runs the inspection).

## QA & Evidence

Evidence dir: `.omo/evidence/20260810-6534-gate-inspection-timeout/EVIDENCE.md`

- **TDD red** (fix stashed): stalled inspection produced `"active"` (the bug). **Green**: `inspection-timeout.test.ts` 2/2 — stalled fetch → `"inconclusive"`, no prompt; idle session → `"dispatched"`, exactly one prompt.
- **Suites:** `packages/utils/src/` 500 pass / 0 fail; background-agent 746 pass / 0 fail; `packages/omo-opencode/src/shared/` 1075 pass / 0 fail.
- **typecheck:** utils + omo-opencode clean; `bun run build` exit 0.
- **Updated:** `prompt-async-gate-message-fetch.test.ts` (2 tests) now assert `"inconclusive"` (was `"queued"`) for fetch hang/throw — the no-prompt-sent safety property is unchanged (`promptCalls === 0`).

## Risks & Residuals

- Worst case adds ~3.75s launch latency when the inspection repeatedly stalls (5 retries × backoff). The launch's overall `PROMPT_TIMEOUT_MS` still bounds the whole dispatch.
- If the inspection stalls persistently past 5 retries, the task interrupts with a clear `inconclusive after 5 inspection retries` error — strictly better than the old immediate interrupt, and the child is never abandoned without a retry attempt.
- Per the reporter's direction, this keeps the status/tool-state checks (no disabled checks) and distinguishes launch from resume by making the misclassification explicit rather than extending the timeout.

Closes #6534

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launch gating bug that misclassified stalled message inspections as "active". Timeouts are now "inconclusive" and retried with backoff, preventing aborted launches and zero-message child sessions; continuation prompts now defer on "inconclusive" instead of rejecting.

- **Bug Fixes**
  - Made assistant-turn inspection tri-state in `packages/utils` prompt-async-gate: "blocking" | "clear" | "unknown" (timeouts/errors → "unknown").
  - `session-idle-dispatch` now returns `{ status: "inconclusive" }` for "unknown"; verified "blocking" still returns "active".
  - `packages/omo-opencode` `promptWithModelSuggestionRetry` retries "inconclusive" up to 5 times with 250ms→2s backoff and releases the reservation between attempts; "active" remains terminal; sync path unchanged.
  - `packages/omo-opencode` ralph-loop: `continuation-prompt-injector` defers on "inconclusive"; types now include "inconclusive" in deferred reasons, and `iteration-continuation` forwards this reason.
  - Added `inspection-timeout.test.ts` and updated gate fetch tests in `packages/utils` and `packages/omo-opencode` to assert "inconclusive" with no prompt sent.

- **Migration**
  - If you switch on `InternalPromptDispatchResult.status`, handle the new `"inconclusive"` case. Also handle `"inconclusive"` in `ContinuationPromptResult` deferred reasons and `ContinuationResult`.

<sup>Written for commit 9ab7cdc2dca602c236dae5d0bbacddc4a267836e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

