### PR TITLE
fix(shared-skills): discover OMO Senpi sessions

### DIFF
--- a/.omo/evidence/20260811-coding-agent-sessions-omo/cleanup.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/cleanup.txt
@@ -1,0 +1,28 @@
+WHAT WAS CLEANED
+- Removed isolated CLI QA HOME:
+  `/var/folders/.../coding-agent-sessions-omo-qa.XXXXXX.a6N8xVY7iH`
+- Removed the failed disposable Senpi toggle clone:
+  `/var/folders/.../omo-senpi-toggle.9ZOYrJ`
+- Disposable Docker QA containers used `--rm`.
+- Codex QA mock-model teardown completed during the passing script.
+
+WHAT WAS VERIFIED
+  MATCHING-TEMP-DIRS: empty
+  LIVE-QA-PROCESSES: empty
+  LIVE-QA-CONTAINERS: empty
+
+The isolated CLI HOME no longer exists.
+
+DISK RECOVERY
+The failed debug clone consumed 5.8 GB on the system volume. Removing it
+increased available space from 147 MB to 4.4 GB.
+
+REMAINING NON-QA WORKTREE STATE
+Tracked generated bundle differences from the initial Bun 1.4 bootstrap remain
+as an explicit later cleanup task. They are not live QA resources and will be
+regenerated with the CI toolchain before commit.
+
+WHY IT IS ENOUGH
+Every runtime resource created by the OpenCode, Codex, Senpi, and isolated CLI
+scenarios is terminated or removed, and direct process/container/temp searches
+show no leftovers.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/cli-omo-session.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/cli-omo-session.txt
@@ -1,0 +1,36 @@
+WHAT WAS TESTED
+Fixture:
+  <isolated-home>/.omo/agent/sessions/-tmp-omo/
+    2026-08-11T00-00-00-000Z_omo-only.jsonl
+
+Command:
+  cd packages/shared-skills/skills/coding-agent-sessions
+  env -u XDG_DATA_HOME \
+    HOME=<isolated-home> \
+    UV_CACHE_DIR=<isolated-home>/.uv-cache \
+    uv run python scripts/find-agent-sessions.py \
+      list --platform senpi --query omo-only --limit 10
+
+WHAT WAS OBSERVED
+Exit code: 0
+
+Parsed result:
+  status: PASS
+  count: 1
+  id: omo-only
+  platform: senpi
+  cwd: /tmp/omo
+  first_user_message: isolated omo sentinel
+  path: <isolated-home>/.omo/agent/sessions/-tmp-omo/
+        2026-08-11T00-00-00-000Z_omo-only.jsonl
+
+WHY IT IS ENOUGH
+This drives the actual shipped Python CLI entry point with the exact requested
+`list --platform senpi --query omo-only --limit 10` surface. The isolated HOME
+contains no legacy store or unrelated sessions, so the single result proves
+automatic discovery from `.omo/agent/sessions` and correct Senpi labeling.
+
+WHAT WAS OMITTED
+The random isolated-home suffix was retained only in the private execution log
+and summarized here. No real user session store, credentials, or private
+transcript was read.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/codex-gate.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/codex-gate.txt
@@ -1,0 +1,41 @@
+WHAT WAS TESTED
+Canonical direct-host gate:
+  cd <task-worktree>
+  OMO_SKIP_MATERIALIZE=1 npx -y bun@1.3.12 run test:codex
+
+Focused process-test diagnostics:
+  Node 24.19.0 direct macOS:
+    node node_modules/vitest/vitest.mjs --run test/process.test.ts
+  Node 26.6.0 direct macOS:
+    node node_modules/vitest/vitest.mjs --run test/process.test.ts
+
+WHAT WAS OBSERVED
+Canonical Codex gate exit code: 0
+
+Final Node test summary:
+  tests: 519
+  pass: 519
+  fail: 0
+  cancelled: 0
+  skipped: 0
+  todo: 0
+
+The gate also completed installer, Git Bash MCP, LSP MCP, LSP daemon, Codex
+plugin/component builds, CodeGraph tests, third-party notice verification,
+Bun installer/core tests, and Node plugin/script tests.
+
+Focused process test:
+  Node 24: 5 pass, 0 fail
+  Node 26: 5 pass, 0 fail
+
+WHY IT IS ENOUGH
+The canonical repository gate passes on the direct host process surface used
+by CI. A prior Docker-only run failed one pre-existing PID-liveness assertion
+whose test waits on fixed 2-second and 200-ms sleeps. The package and lockfiles
+match `origin/dev`, direct Node 24/26 runs pass, and the complete host gate is
+green, proving that failure was container/load-sensitive rather than caused by
+the coding-agent-session change.
+
+WHAT WAS OMITTED
+Full 519-test output, dependency install logs, and generated bundle bodies were
+summarized. No credentials or private data were captured.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/codex-qa.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/codex-qa.txt
@@ -1,0 +1,32 @@
+WHAT WAS TESTED
+Command:
+  bash .agents/skills/codex-qa/scripts/app-server-drive.sh --plugin
+
+Surface:
+  Real `codex app-server`, local worktree plugin, isolated `CODEX_HOME`, and a
+  local mock model. The script shasums the real `~/.codex/config.toml` before
+  and after.
+
+WHAT WAS OBSERVED
+Exit code: 0
+
+  assistantText: "Hello from the codex-qa mock model."
+  hook/started: sessionStart
+  hook/completed: sessionStart
+  hook/started: userPromptSubmit
+  hook/completed: userPromptSubmit
+  failedHooks: []
+
+The mock model process received SIGTERM during the script's intentional
+teardown. The QA script completed with exit code 0.
+
+WHY IT IS ENOUGH
+Generated-copy tests prove the changed shared skill reaches the Codex package.
+This first-party app-server run proves the local plugin still installs and
+executes live session hooks in strict isolation without a real model call.
+
+WHAT WAS OMITTED
+The complete notification stream, isolated home path, raw config, tokens, and
+environment data were summarized or omitted. A prior Docker attempt failed
+before QA began with container transport `unexpected EOF` (exit 125); the
+documented local isolated fallback produced the passing evidence above.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/final-validation.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/final-validation.txt
@@ -1,0 +1,54 @@
+WHAT WAS TESTED
+Final settled-input commands:
+
+  cd packages/shared-skills/skills/coding-agent-sessions
+  uv run --with pytest pytest scripts/tests -q
+
+  uv run --with basedpyright basedpyright \
+    scripts/agent_sessions/pi_family.py \
+    scripts/tests/test_pi_family_scanners.py
+
+  cd <repo>
+  bun test \
+    packages/omo-opencode/src/shared-skills-package.test.ts \
+    packages/omo-senpi/src/skills-sync.test.ts
+
+  git diff --check
+  git diff --exit-code -- <generated artifact paths>
+  git diff --name-only
+
+WHAT WAS OBSERVED
+Python suite:
+  37 passed
+
+BasedPyright:
+  0 errors, 0 warnings, 0 notes
+
+Package and sync tests:
+  25 pass, 0 fail
+
+Pure LOC:
+  pi_family.py: 32
+  test_pi_family_scanners.py: 150
+
+Diff checks:
+  git diff --check: clean
+  generated artifact diff: clean
+  tracked scope: exactly five requested files
+
+Tracked files:
+  packages/shared-skills/skills/coding-agent-sessions/SKILL.md
+  packages/shared-skills/skills/coding-agent-sessions/references/all-platforms.md
+  packages/shared-skills/skills/coding-agent-sessions/references/senpi.md
+  packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/pi_family.py
+  packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_pi_family_scanners.py
+
+WHY IT IS ENOUGH
+All source inputs had settled after debugging and generated-artifact cleanup.
+This final pass rechecks the changed behavior, strict Python diagnostics,
+cross-harness package synchronization, formatting safety, architectural file
+size, and exact diff scope.
+
+WHAT WAS OMITTED
+Repeated passing test lines and generated output bodies were summarized. No
+credentials or private session data were captured.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/green-full-python-suite.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/green-full-python-suite.txt
@@ -1,0 +1,17 @@
+WHAT WAS TESTED
+Command:
+  cd packages/shared-skills/skills/coding-agent-sessions
+  uv run --with pytest pytest scripts/tests -q
+
+WHAT WAS OBSERVED
+Exit code: 0
+Result: 37 passed in 1.30s
+
+WHY IT IS ENOUGH
+This executes every Python test shipped with the coding-agent-sessions skill,
+covering CLI contracts, transcript parsing, all registered scanners, optional
+SQLite stores, pi-family products, and the new `.omo` behavior.
+
+WHAT WAS OMITTED
+The repeated dot-progress line was summarized. No secrets or private session
+contents were captured.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/green-pi-family-suite.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/green-pi-family-suite.txt
@@ -1,0 +1,24 @@
+WHAT WAS TESTED
+Command:
+  cd packages/shared-skills/skills/coding-agent-sessions
+  uv run --with pytest pytest scripts/tests/test_pi_family_scanners.py -vv
+
+WHAT WAS OBSERVED
+Exit code: 0
+Result: 6 passed in 0.02s
+
+Passing coverage:
+- Platform and alias registration.
+- Existing product home stores.
+- Current `.omo` plus legacy `.senpi` stores.
+- Same-ID overlap deduplication.
+- Profile and XDG roots.
+- Cross-platform store isolation.
+
+WHY IT IS ENOUGH
+This is the complete pi-family scanner regression file, including the two new
+tests and every adjacent existing root/isolation test.
+
+WHAT WAS OMITTED
+Repeated pytest environment headers were summarized. No secrets or private
+session contents were captured.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/green-pytest.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/green-pytest.txt
@@ -1,0 +1,29 @@
+WHAT WAS TESTED
+Commands:
+  cd packages/shared-skills/skills/coding-agent-sessions
+  uv run --with pytest pytest scripts/tests/test_pi_family_scanners.py \
+    -k 'senpi_scanner_reads_omo_and_legacy_home_stores' -vv
+  uv run --with pytest pytest scripts/tests/test_pi_family_scanners.py \
+    -k 'senpi_scanner_deduplicates_overlapping_omo_and_legacy_sessions' -vv
+
+WHAT WAS OBSERVED
+Both commands exited 0.
+
+Happy-path result:
+  1 passed, 5 deselected
+
+Overlap result:
+  1 passed, 5 deselected
+
+The first test returned both `omo-current` and `senpi-legacy` as platform
+`senpi`. The second emitted one `shared` session and retained the `.omo`
+fixture carrying parsed agent linkage `sisyphus`.
+
+WHY IT IS ENOUGH
+The exact tests that failed before the production change now pass after only
+adding `.omo` to the Senpi config-root tuple. This proves the intended root
+coverage and preserves the existing dedupe contract.
+
+WHAT WAS OMITTED
+Repeated pytest headers were summarized. No secrets or private session data
+were captured.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/opencode-qa.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/opencode-qa.txt
@@ -1,0 +1,30 @@
+WHAT WAS TESTED
+Command:
+  script/agent/qa-docker.sh exec \
+    bash .agents/skills/opencode-qa/scripts/server-smoke.sh --self-test
+
+Isolation proof:
+  The host OpenCode DB session count was queried before and after the disposable
+  Docker run.
+
+WHAT WAS OBSERVED
+Exit code: 0
+
+  PASS: GET /global/health healthy=true version=1.17.20
+  PASS: GET /doc lists 162 documented paths
+  PASS: unauthenticated GET /session rejected with HTTP 401
+  PASS: server-smoke
+  OPENCODE_SERVER_QA_PASS before=5826 after=5826
+
+WHY IT IS ENOUGH
+The change ships through the OpenCode shared-skill package but does not modify
+an OpenCode lifecycle hook. Package and generated-copy tests prove the changed
+skill is shipped; this isolated live-server smoke proves the adjacent OpenCode
+harness still boots, documents routes, and enforces auth without touching the
+real session DB.
+
+WHAT WAS OMITTED
+An earlier attempted `opencode debug skill` assertion was discarded because
+that command does not list plugin-provided shared skills in the disposable
+container. It was a QA-surface mismatch, not a product failure. Container IDs,
+configuration copies, credentials, and raw environment data were omitted.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/python-diagnostics.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/python-diagnostics.txt
@@ -1,0 +1,36 @@
+WHAT WAS TESTED
+Commands:
+  cd packages/shared-skills/skills/coding-agent-sessions
+  uv run --with basedpyright basedpyright \
+    scripts/agent_sessions/pi_family.py \
+    scripts/tests/test_pi_family_scanners.py
+
+  uv run /Users/yeongyu/.bun/install/global/node_modules/omo-ai/plugin/skills/programming/scripts/python/check-no-excuse-rules.py \
+    scripts/agent_sessions/pi_family.py \
+    scripts/tests/test_pi_family_scanners.py
+
+  awk pure-LOC count for both changed Python files.
+
+WHAT WAS OBSERVED
+BasedPyright:
+  0 errors, 0 warnings, 0 notes
+
+No-excuse audit:
+  no violations in 2 file(s)
+
+Pure LOC:
+  pi_family.py: 32
+  test_pi_family_scanners.py: 150
+
+Built-in LSP limitation:
+  The session LSP is rooted at the main checkout and rejected the task-worktree
+  paths as outside request cwd. This is recorded as unavailable, not as a pass.
+  BasedPyright CLI provided the authoritative changed-file diagnostics.
+
+WHY IT IS ENOUGH
+The repository-configured Python checker reports no diagnostics, the mandatory
+programming-skill audit reports no banned patterns, and both edited Python
+files remain below the 250 pure-LOC ceiling.
+
+WHAT WAS OMITTED
+No environment dumps or credentials were captured.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/red-dedupe.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/red-dedupe.txt
@@ -1,0 +1,28 @@
+WHAT WAS TESTED
+Command:
+  cd packages/shared-skills/skills/coding-agent-sessions
+  uv run --with pytest pytest scripts/tests/test_pi_family_scanners.py \
+    -k 'senpi_scanner_deduplicates_overlapping_omo_and_legacy_sessions' -vv
+
+Purpose:
+  Prove the unchanged scanner cannot compare overlapping current and legacy
+  Senpi sessions because it never reads the .omo copy.
+
+WHAT WAS OBSERVED
+Exit code: 1
+
+Failure excerpt:
+  assert sessions[0].agent == "sisyphus"
+  E AssertionError: assert None == 'sisyphus'
+
+The result came from the legacy .senpi fixture. The higher-linkage .omo fixture
+with agent "sisyphus" was absent from scanner input.
+
+WHY IT IS ENOUGH
+The existing dedupe rule keeps the higher-linkage row for a shared
+(platform, id). This assertion fails specifically because .omo is not scanned,
+so it is a faithful RED proof for the multi-root regression.
+
+WHAT WAS OMITTED
+Pytest formatting and repeated stack context were summarized. No credentials,
+environment dumps, or private session contents were captured.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/red-pytest.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/red-pytest.txt
@@ -1,0 +1,27 @@
+WHAT WAS TESTED
+Command:
+  cd packages/shared-skills/skills/coding-agent-sessions
+  uv run --with pytest pytest scripts/tests/test_pi_family_scanners.py \
+    -k 'senpi_scanner_reads_omo_and_legacy_home_stores' -vv
+
+Purpose:
+  Prove the unchanged Senpi scanner does not discover the current
+  $HOME/.omo/agent/sessions store while it still discovers legacy
+  $HOME/.senpi/agent/sessions.
+
+WHAT WAS OBSERVED
+Exit code: 1
+
+Failure excerpt:
+  assert set(sessions) == {"omo-current", "senpi-legacy"}
+  E AssertionError: assert {'senpi-legacy'} == {'senpi-legacy', 'omo-current'}
+  E Extra items in the right set:
+  E 'omo-current'
+
+WHY IT IS ENOUGH
+The test reached the real scanner with valid JSONL fixtures and failed on the
+missing .omo result, not on setup, imports, syntax, or fixture parsing.
+
+WHAT WAS OMITTED
+Pytest formatting and repeated stack context were summarized. No credentials,
+environment dumps, or private session contents were captured.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/review-verdicts.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/review-verdicts.txt
@@ -1,0 +1,43 @@
+POST-IMPLEMENTATION REVIEW VERDICT: PASS
+
+Five independent read-only lanes completed:
+
+1. Goal and constraint coverage: PASS
+   - Independently re-executed GREEN tests, mutation-style RED proof, full
+     Python suite, BasedPyright, package/sync tests, and fresh CLI QA.
+   - Confirmed exact five-file tracked scope and no out-of-scope aliases/env
+     behavior.
+
+2. Code quality: PASS
+   - One-line production change is minimal.
+   - Same-ID test is deterministic by linkage score, not thread completion
+     timing.
+   - Docs match implementation; type discipline and scope are clean.
+
+3. Security and privacy: PASS
+   - Hardcoded root under Path.home; no traversal or broader directory walk.
+   - Scan remains bounded to session JSONL files and the existing 2000-file cap.
+   - No cross-platform leakage or new parser/execution boundary.
+   - Evidence contains no secret-bearing real sessions.
+
+4. Hands-on QA: PASS
+   - Focused tests: 2 passed.
+   - Full Python suite: 37 passed.
+   - Fresh isolated HOME with `.omo` and `.senpi`: both sessions returned as
+     platform `senpi`; cleanup verified.
+
+5. Integration context: PASS
+   - Current-first root order matches OMO conventions.
+   - Generated skill copies remain ignored and sync-tested.
+   - HEAD matches origin/dev; no conflicting active branch found.
+   - Generated bundle and evidence policies are satisfied.
+
+Notes without criterion impact:
+- The registered goal's exact CLI command uses `.omo` only with
+  `--query omo-only --limit 10`; this is captured in `cli-omo-session.txt`.
+  Reviewers also executed the stricter two-store unfiltered scenario.
+- SKILL.md description is 984 characters, under the 1024 limit.
+- Equal-linkage duplicate selection is pre-existing behavior and the new test
+  deliberately proves deterministic higher-linkage selection.
+
+No reviewer requested a code change or fresh evidence.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/self-review.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/self-review.txt
@@ -1,0 +1,28 @@
+SELF-REVIEW VERDICT: PASS
+
+Success criteria:
+1. PASS - `.omo` discovery is covered RED then GREEN and through the real CLI.
+2. PASS - legacy `.senpi` remains and same-ID overlap emits one higher-linkage row.
+3. PASS - exact isolated-HOME command returned `omo-only` as platform `senpi`.
+4. PASS - Python, BasedPyright, package/sync, build, Senpi, Codex, and harness QA are green.
+
+Seven-question architecture review:
+1. Single responsibility: yes. Production change only extends the existing
+   Senpi config-root tuple; no abstraction was added.
+2. Boundaries: yes. The scanner remains a pi-family implementation and no
+   platform key or cross-platform route changed.
+3. Types: yes. New test helper input is `str | None`; BasedPyright is clean.
+4. Errors: yes. No new error path, suppression, or swallowed failure exists.
+5. Performance: yes. One bounded root/profile glob is added under the existing
+   2000-file recent cap and dedupe pipeline.
+6. Security: yes. Existing `Path.home()` and scanner parsing boundaries are
+   reused; no new execution or external write is introduced.
+7. Scope: yes. Exactly five requested tracked files changed. The unrelated
+   documented environment-variable gap and an `omo` CLI alias remain out of
+   scope.
+
+Additional checks:
+- HEAVY tier remains justified by session-store and dedupe behavior.
+- SKILL.md description length: 984 characters (under 1024).
+- Pure LOC: production 32, test 150 (both under 250).
+- Diff size: 172 lines.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/senpi-gate.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/senpi-gate.txt
@@ -1,0 +1,41 @@
+WHAT WAS TESTED
+Initial gate:
+  npx -y bun@1.3.12 run test:senpi
+
+Clean exact-version gate:
+  canonical deep cleanup
+  Docker Node 24.18.0 / Bun 1.3.12
+  bun install --frozen-lockfile --ignore-scripts
+  bun run script/remove-stale-self-package-tests.ts
+  OMO_SKIP_MATERIALIZE=1 bun run test:senpi
+
+Bundle-only causal toggle:
+  keep the clean Bun 1.3.12 install
+  regenerate only Senpi extension bytes with host Bun 1.4.0
+  run Bun 1.3.12 `bun test packages/omo-senpi`
+
+WHAT WAS OBSERVED
+Initial mixed-state gate:
+  969 pass, 18 fail
+  Failures clustered in unrelated memory trigger/journal wiring tests.
+
+Exact-version branch gate:
+  986 pass, 1 expected Darwin sandbox skip, 0 fail
+  2973 expect() calls
+  987 tests across 152 files
+
+Bundle-only toggle:
+  986 pass, 1 expected Darwin sandbox skip, 0 fail
+  Previously failing trigger and journal wiring tests passed.
+
+WHY IT IS ENOUGH
+The same branch toggled from red to green when Bun 1.4-created dependency state
+was replaced with a clean Bun 1.3.12 install. Reintroducing Bun 1.4-generated
+bundle bytes did not reintroduce the failure. This confirms local dependency
+state contamination and refutes both the requested session-skill patch and
+generated bundle bytes as causes. No unrelated Senpi source fix is justified.
+
+WHAT WAS OMITTED
+Full 987-test logs and dependency manifests were summarized. A disposable
+clean-clone attempt that hit ENOSPC before tests was removed; it contributed no
+product verdict. No credentials or private data were captured.

--- a/.omo/evidence/20260811-coding-agent-sessions-omo/skill-packaging.txt
+++ b/.omo/evidence/20260811-coding-agent-sessions-omo/skill-packaging.txt
@@ -1,0 +1,39 @@
+WHAT WAS TESTED
+Codex generated copy:
+  node packages/omo-codex/plugin/scripts/sync-skills.mjs
+  node --test packages/omo-codex/plugin/test/sync-skills.test.mjs
+
+Senpi generated copy:
+  node packages/omo-senpi/plugin/scripts/sync-skills.mjs
+  bun test packages/omo-senpi/src/skills-sync.test.ts
+
+Shared package shape:
+  bun test packages/omo-opencode/src/shared-skills-package.test.ts
+  npm pack --dry-run --ignore-scripts --json
+
+WHAT WAS OBSERVED
+Codex sync tests:
+  All generated-copy drift and aggregate skill tests passed.
+  Generated coding-agent-sessions `pi_family.py` contains:
+    SENPI_CONFIG_DIRS = (".omo", ".senpi", ".pi")
+
+Senpi sync tests:
+  11 pass, 0 fail
+  Generated coding-agent-sessions `pi_family.py` contains the same root tuple.
+
+Shared package test:
+  14 pass, 0 fail
+
+Dry-run package inspection:
+  24 coding-agent-sessions files ship.
+  `scripts/agent_sessions/pi_family.py` is present.
+  `scripts/tests/` and `__pycache__` are absent.
+
+WHY IT IS ENOUGH
+These checks prove the hand-authored shared source reaches both generated
+harness skill trees and the published package while source-only tests and
+caches remain excluded.
+
+WHAT WAS OMITTED
+The full npm file manifest and generated source bodies were summarized. No
+credentials or private session data were captured.

--- a/.omo/plans/fix-coding-agent-sessions-omo.md
+++ b/.omo/plans/fix-coding-agent-sessions-omo.md
@@ -1,0 +1,100 @@
+# Fix coding-agent session discovery for `~/.omo`
+
+## Goal and tier
+
+Deliver a merged PR that makes the shared `coding-agent-sessions` skill discover Senpi-format sessions from the current `~/.omo/agent/sessions` store while preserving legacy `~/.senpi` and `~/.pi` behavior.
+
+Tier: **HEAVY** because this changes coding-agent session-store discovery and multi-root deduplication behavior.
+
+## Scope
+
+Required behavior and tests:
+
+- `packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/pi_family.py`
+- `packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_pi_family_scanners.py`
+
+Documentation consistency:
+
+- `packages/shared-skills/skills/coding-agent-sessions/SKILL.md`
+- `packages/shared-skills/skills/coding-agent-sessions/references/senpi.md`
+- `packages/shared-skills/skills/coding-agent-sessions/references/all-platforms.md`
+
+Evidence:
+
+- `.omo/evidence/20260811-coding-agent-sessions-omo/`
+
+Explicitly out of scope:
+
+- Adding `omo` as a new platform key or CLI alias.
+- Implementing unrelated `PI_CONFIG_DIR`, `PI_CODING_AGENT_DIR`, or `GJC_CONFIG_DIR` behavior.
+- Hand-editing generated skill copies under Codex, Senpi, or `dist/`.
+
+## Delegation topology
+
+- `senpi-scanner-audit` (`explore`, completed): mapped the root cause, scanner flow, and dedupe risks.
+- `session-skill-delivery-audit` (`deep`, completed): mapped failing-first tests, packaging obligations, documentation scope, and isolated-HOME CLI QA.
+- Lead session: owns all shared-file edits, RED/GREEN execution, evidence capture, generated-copy validation, harness QA, commits, PR lifecycle, merge, and cleanup. These steps are sequential and share the same worktree.
+- Post-implementation review: run independent reviewer-shaped tasks through `review-work`; do not use Momus per the user's instruction.
+
+## Execution plan
+
+### TDD and implementation
+
+1. Re-read `pi_family.py`, `scanners.py`, `transcript.py`, and the pi-family tests in the task worktree; confirm `_dedupe()` and `recent()` ordering before defining the duplicate assertion.
+2. Add a focused test proving one scan returns distinct sessions from both `$HOME/.omo/agent/sessions` and `$HOME/.senpi/agent/sessions`.
+3. Add a focused same-ID test proving the scanner emits one deterministic Senpi result when current and legacy roots overlap.
+4. Run only the new tests before production edits and capture the expected assertion failures in `red-pytest.txt` and `red-dedupe.txt`.
+5. Change only `SENPI_CONFIG_DIRS` so the common Senpi scanner includes `.omo` without adding a new platform.
+6. Re-run the focused tests and capture `green-pytest.txt`.
+7. Update the skill and Senpi storage references to document `.omo`, `.senpi`, and `.pi`; do not add prose-pinning tests.
+
+### Verification and real-surface QA
+
+8. Run the full pi-family scanner suite and capture `green-pi-family-suite.txt`.
+9. Run the full coding-agent-sessions Python suite and capture its output.
+10. Run changed-file Python diagnostics with the configured Pyright/BasedPyright command and capture clean output.
+11. Regenerate Codex and Senpi skill copies locally, verify their sync tests, and confirm generated trees remain uncommitted.
+12. Run the shared-skills package-shape test and dry-run package inspection.
+13. Run the relevant OpenCode, Codex, and Senpi gates required by repository policy, using the mandatory isolated QA workflows where applicable.
+14. Create an isolated HOME containing concrete `.omo` and `.senpi` JSONL sessions; invoke the real `find-agent-sessions.py list --platform senpi --limit 20` CLI; assert both IDs, Senpi platform labeling, and source paths; capture `cli-omo-session.txt`.
+15. Remove the isolated HOME and every generated QA resource; capture `cleanup.txt` and verify no processes, ports, tmux sessions, or temp directories remain.
+16. Run changed-file diagnostics and the final relevant full validation set once after all inputs settle.
+
+### Discovered Senpi gate debugging
+
+The CI-Bun Senpi gate produced 18 failures in two unrelated memory wiring test files. Before continuing delivery:
+
+1. Create `.debug-journal.md` and record every debug artifact.
+2. Run focused files under Bun 1.3.12 to distinguish local test-order leakage.
+3. Compare an untouched `origin/dev` baseline in a disposable detached worktree.
+4. Test whether exact-version dependency/bootstrap state or generated bundles toggle the failures.
+5. Confirm the root cause with a toggle proof, fix only if this branch caused it, and clean every debug artifact.
+6. Re-run the Senpi gate after the cause is resolved or the base branch is repaired.
+
+### Review, delivery, and merge
+
+17. Self-review the diff against every success criterion and record why the HEAVY tier remained appropriate.
+18. Run the `review-work` independent review lanes; verify and fix every criterion-cited blocker, then re-run affected evidence.
+19. Inspect repository commit history for the touched paths and create atomic green commits with the plan footer.
+20. Push the branch and open an English PR targeting `dev`, including behavior, RED/GREEN proof, real-surface QA, evidence paths, and residual risk.
+21. Monitor CI and reviewer gates without polling or bypasses; fix failures in the worktree and re-run scoped QA until all required checks are green.
+22. Merge with `gh pr merge --merge --delete-branch`.
+23. Verify the merge commit on `origin/dev`, remove the task worktree and local branch, and record the final cleanup receipt.
+24. Mark the registered goal complete only after all todo items are reconciled.
+
+## Success criteria and exact scenarios
+
+1. Happy path: `cd packages/shared-skills/skills/coding-agent-sessions && uv run --with pytest pytest scripts/tests/test_pi_family_scanners.py -k omo -vv`.
+   - RED: new `.omo` session assertion fails before production changes.
+   - GREEN: exit code 0 and the expected `senpi` session is present.
+2. Edge and regression: the same focused run includes legacy `.senpi` plus same-ID overlap coverage.
+   - RED: `.omo` is absent and overlap assertion fails before production changes.
+   - GREEN: legacy and current roots are both covered and duplicate IDs emit once according to the existing deterministic dedupe rule.
+3. Real surface: `HOME=<fixture> python3 packages/shared-skills/skills/coding-agent-sessions/scripts/find-agent-sessions.py list --platform senpi --limit 20`.
+   - PASS: exit code 0; JSON contains `omo-current` and `senpi-legacy`, all rows are platform `senpi`, and paths prove both stores.
+4. Regression/build:
+   - PASS: diagnostics, full skill tests, package/sync tests, and mandatory harness QA exit 0 with no suppressions or generated source changes committed.
+
+## Stop condition
+
+Stop immediately when the PR is merged, all criteria have captured RED/GREEN and real-surface evidence, required checks are green, and the task worktree plus QA resources are removed.

--- a/packages/shared-skills/skills/coding-agent-sessions/SKILL.md
+++ b/packages/shared-skills/skills/coding-agent-sessions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-agent-sessions
-description: "MUST USE when asked to find, read, list, search, inspect, fetch, export, or reconstruct coding-agent sessions across Codex, Claude Code/Desktop, OpenCode, Senpi/pi, oh-my-pi (omp), gajae-code (gjc), OpenClaw, Factory Droid, Amp, Gemini/Kimi/Qwen CLIs, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, Aside browser-agent sessions, or unknown local agent logs. Covers transcripts, session IDs, rollout JSONL, state SQLite, Claude projects/pre-compact histories, OpenCode messages/parts, child/subagent linkage, cwd/model/time/token filters, archives, and cost clues. Expands fuzzy recall into parallel query lanes and first probes known stores so absent platforms are skipped cheaply. Triggers: coding agent sessions, Codex/Claude/OpenCode/Senpi/pi/oh-my-pi/omp/gajae-code/gjc/OpenClaw/Droid/Amp/Kodu/Cursor/Aider/Aside sessions, transcript search, session history, session ID, read transcript, token usage, subagent sessions, what did I do yesterday, did we already do this."
+description: "MUST USE when asked to find, read, list, search, inspect, fetch, export, or reconstruct coding-agent sessions across Codex, Claude Code/Desktop, OpenCode, OMO/Senpi/pi, oh-my-pi (omp), gajae-code (gjc), OpenClaw, Factory Droid, Amp, Gemini/Kimi/Qwen CLIs, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, Aside browser-agent sessions, or unknown local agent logs. Covers transcripts, session IDs, rollout JSONL, state SQLite, Claude projects/pre-compact histories, OpenCode messages/parts, child/subagent linkage, cwd/model/time/token filters, archives, and cost clues. Expands fuzzy recall into parallel query lanes and first probes known stores so absent platforms are skipped cheaply. Triggers: coding agent sessions, Codex/Claude/OpenCode/OMO/Senpi/pi/oh-my-pi/omp/gajae-code/gjc/OpenClaw/Droid/Amp/Kodu/Cursor/Aider/Aside sessions, transcript search, session history, session ID, read transcript, token usage, subagent sessions, what did I do yesterday, did we already do this."
 ---
 
 # Coding Agent Sessions
@@ -15,7 +15,7 @@ Find local coding-agent sessions across agent products before answering from mem
    |---|---|
    | Codex / OpenAI Codex CLI | `references/codex.md` |
    | Claude Code / Claude Desktop histories | `references/claude.md` |
-   | Senpi / pi coding-agent logs | `references/senpi.md` |
+   | OMO / Senpi / pi coding-agent logs | `references/senpi.md` |
    | oh-my-pi (`omp`, `~/.omp`) and gajae-code (`gjc`, `~/.gjc`) logs | `references/senpi.md` |
    | OpenCode / oh-my-openagent (formerly oh-my-opencode) storage | `references/opencode.md` |
    | OpenClaw, Droid, Amp, Gemini, Kimi, Qwen, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, Kiro, Goose, Hermes, Crush, Zed, Aside | `references/all-platforms.md` |
@@ -120,6 +120,7 @@ Use `references/codex.md` for Codex storage details.
 |---|---|
 | Missing Codex sessions | Set `CODEX_HOME` or pass `--root /path/to/.codex`. |
 | Missing oh-my-pi / gajae-code sessions | Those stores live in `~/.omp/agent/sessions` and `~/.gjc/agent/sessions`. For a custom `PI_CONFIG_DIR` / `PI_CODING_AGENT_DIR`, pass that agent dir with `--root`. |
+| Missing OMO / Senpi sessions | The `senpi` platform searches `~/.omo/agent/sessions`, `~/.senpi/agent/sessions`, and `~/.pi/agent/sessions` (plus matching profile roots). Pass a nonstandard agent directory with `--root`. |
 | Missing OpenCode sessions | Pass the data dir that contains `messages/` and `parts/`, often `~/.opencode` or `~/.local/share/opencode`. |
 | Missing Claude sessions | Search `~/.claude/projects`, `~/.claude/transcripts`, and `~/.claude/pre-compact-session-histories`; use `--root` for nonstandard config dirs. |
 | Missing Aside sessions | The Aside browser agent stores per-user data under `~/.aside/u/<n>/` (`sessions/<date>_<id>/messages.jsonl` transcripts + a `state.db` index; `agents/*/sessions/` is just a hardlink mirror). Pass `--root` for a nonstandard `.aside` dir or an exported user dir. |

--- a/packages/shared-skills/skills/coding-agent-sessions/references/all-platforms.md
+++ b/packages/shared-skills/skills/coding-agent-sessions/references/all-platforms.md
@@ -10,7 +10,7 @@ Registered platform keys: `codex`, `claude`, `senpi`, `oh-my-pi`, `gajae-code`, 
 |---|---|---|
 | Codex | `$CODEX_HOME`, `~/.codex` | `%CODEX_HOME%`, `%USERPROFILE%\.codex` |
 | Claude | `~/.claude` | `%USERPROFILE%\.claude`, `%APPDATA%\Claude` |
-| Senpi / pi | `~/.senpi/agent`, `~/.pi/agent` | `%USERPROFILE%\.senpi\agent`, `%USERPROFILE%\.pi\agent` |
+| OMO / Senpi / pi | `~/.omo/agent`, `~/.senpi/agent`, `~/.pi/agent` | `%USERPROFILE%\.omo\agent`, `%USERPROFILE%\.senpi\agent`, `%USERPROFILE%\.pi\agent` |
 | oh-my-pi (`omp`) | `~/.omp/agent`, `~/.omp/profiles/*/agent`, `$XDG_DATA_HOME/omp` | `%USERPROFILE%\.omp\agent` |
 | gajae-code (`gjc`) | `~/.gjc/agent`, `~/.gjc/profiles/*/agent`, `$XDG_DATA_HOME/gjc` | `%USERPROFILE%\.gjc\agent` |
 | OpenCode | `$OPENCODE_HOME`, `~/.opencode`, `~/.local/share/opencode` | `%OPENCODE_HOME%`, `%APPDATA%\opencode`, `%USERPROFILE%\.opencode` |

--- a/packages/shared-skills/skills/coding-agent-sessions/references/senpi.md
+++ b/packages/shared-skills/skills/coding-agent-sessions/references/senpi.md
@@ -1,10 +1,10 @@
-# Senpi / pi Family Coding-Agent Sessions
+# OMO / Senpi / pi Family Coding-Agent Sessions
 
-The pi family (Senpi, oh-my-pi, gajae-code) shares one session format, so one scanner serves all three under separate platform keys.
+The pi family (OMO/Senpi, oh-my-pi, gajae-code) shares one session format, so one scanner serves all three under separate platform keys.
 
 | Platform key | Aliases | Config root | Sessions |
 |---|---|---|---|
-| `senpi` | - | `~/.senpi`, `~/.pi` | `<root>/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl` |
+| `senpi` | - | `~/.omo`, `~/.senpi`, `~/.pi` | `<root>/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl` |
 | `oh-my-pi` | `omp`, `ohmypi` | `~/.omp` | `~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl` |
 | `gajae-code` | `gjc`, `gajae` | `~/.gjc` | `~/.gjc/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl` |
 
@@ -14,7 +14,7 @@ Extra roots scanned for every pi-family platform:
 - XDG stores (macOS/Linux, default profile): `$XDG_DATA_HOME/<app>/sessions/**` and `$XDG_DATA_HOME/<app>/profiles/<profile>/sessions/**`, where `<app>` is `senpi`, `omp`, or `gjc`. XDG flattens the `agent/` path segment.
 - A custom `PI_CONFIG_DIR` / `PI_CODING_AGENT_DIR` / `GJC_CONFIG_DIR` store: pass that agent directory with `--root`.
 
-`~/.senpi/agent/settings.json`, `models.json`, and `auth.json` provide environment context; oh-my-pi and gajae-code keep the same files plus `config.yml` and `models.yml` next to their sessions directory.
+`~/.omo/agent` and `~/.senpi/agent` are the current and legacy OMO/Senpi stores. Their `settings.json`, `models.json`, and `auth.json` files provide environment context; oh-my-pi and gajae-code keep the same files plus `config.yml` and `models.yml` next to their sessions directory.
 
 Common event types:
 

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/pi_family.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/agent_sessions/pi_family.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from .transcript import env_path, existing, jsonl_parallel, recent, stem_id
 from .types import Session
 
-SENPI_CONFIG_DIRS = (".senpi", ".pi")
+SENPI_CONFIG_DIRS = (".omo", ".senpi", ".pi")
 OH_MY_PI_CONFIG_DIRS = (".omp",)
 GAJAE_CODE_CONFIG_DIRS = (".gjc",)
 

--- a/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_pi_family_scanners.py
+++ b/packages/shared-skills/skills/coding-agent-sessions/scripts/tests/test_pi_family_scanners.py
@@ -21,7 +21,7 @@ from agent_sessions.types import JsonMap, Session
 PI_FAMILY = frozenset({"senpi", "oh-my-pi", "gajae-code"})
 
 
-def _write_session(path: Path, session_id: str, cwd: str, prompt: str) -> None:
+def _write_session(path: Path, session_id: str, cwd: str, prompt: str, agent: str | None = None) -> None:
     rows: list[JsonMap] = [
         {"type": "session", "version": 3, "id": session_id, "timestamp": "2026-07-20T00:00:00.000Z", "cwd": cwd},
         {"type": "model_change", "id": "m1", "timestamp": "2026-07-20T00:00:00.100Z", "model": "anthropic/claude-fable-5"},
@@ -32,6 +32,15 @@ def _write_session(path: Path, session_id: str, cwd: str, prompt: str) -> None:
             "message": {"role": "user", "content": [{"type": "text", "text": prompt}]},
         },
     ]
+    if agent is not None:
+        rows.insert(
+            1,
+            {
+                "type": "session_meta",
+                "timestamp": "2026-07-20T00:00:00.050Z",
+                "payload": {"id": session_id, "source": {"subagent": agent}},
+            },
+        )
     path.parent.mkdir(parents=True, exist_ok=True)
     _ = path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
 
@@ -80,6 +89,60 @@ def test_pi_family_scanners_read_each_product_home_store(tmp_path: Path, monkeyp
     assert sessions["oh-my-pi"].model == "anthropic/claude-fable-5"
     assert sessions["gajae-code"].id == "gjc-1"
     assert sessions["gajae-code"].first_user_message == "gajae-code prompt"
+
+
+def test_senpi_scanner_reads_omo_and_legacy_home_stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    _write_session(
+        tmp_path / ".omo" / "agent" / "sessions" / "-tmp-omo" / "2026-07-20T00-00-00-000Z_omo-current.jsonl",
+        "omo-current",
+        "/tmp/omo",
+        "omo current prompt",
+    )
+    _write_session(
+        tmp_path / ".senpi" / "agent" / "sessions" / "-tmp-senpi" / "2026-07-20T00-00-00-000Z_senpi-legacy.jsonl",
+        "senpi-legacy",
+        "/tmp/senpi",
+        "senpi legacy prompt",
+    )
+
+    sessions = {item.id: item for item in scanners.scan(frozenset({"senpi"}), (), 4)}
+
+    assert set(sessions) == {"omo-current", "senpi-legacy"}
+    assert sessions["omo-current"].platform == "senpi"
+    assert sessions["omo-current"].cwd == "/tmp/omo"
+    assert sessions["senpi-legacy"].first_user_message == "senpi legacy prompt"
+
+
+def test_senpi_scanner_deduplicates_overlapping_omo_and_legacy_sessions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    _write_session(
+        tmp_path / ".omo" / "agent" / "sessions" / "-tmp-overlap" / "2026-07-20T00-00-00-000Z_shared.jsonl",
+        "shared",
+        "/tmp/omo",
+        "omo linked prompt",
+        agent="sisyphus",
+    )
+    _write_session(
+        tmp_path / ".senpi" / "agent" / "sessions" / "-tmp-overlap" / "2026-07-20T00-00-00-000Z_shared.jsonl",
+        "shared",
+        "/tmp/senpi",
+        "legacy prompt",
+    )
+
+    sessions = scanners.scan(frozenset({"senpi"}), (), 4)
+
+    assert len(sessions) == 1
+    assert sessions[0].id == "shared"
+    assert sessions[0].agent == "sisyphus"
+    assert sessions[0].cwd == "/tmp/omo"
 
 
 def test_pi_family_scanners_cover_profile_and_xdg_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What changed

- Add `~/.omo` to the existing Senpi/pi-family session roots, ahead of legacy
  `~/.senpi` and `~/.pi`.
- Add behavioral coverage for:
  - simultaneous current and legacy home stores
  - same-ID overlap deduplication using the existing linkage-score rule
- Update the coding-agent-sessions skill and storage references to document OMO.

## Why

OMO is the current Senpi distribution and stores coding-agent transcripts under
`~/.omo/agent/sessions`. The shared session finder only searched the legacy
`.senpi` and `.pi` stores, so current OMO sessions were invisible unless users
passed a manual root.

## Observed behavior

Before the production change:

- `.senpi` fixture discovered, `.omo` fixture missing
- overlapping same-ID result kept the legacy row because the `.omo` row never
  entered the dedupe pipeline

After the change:

- focused tests: 2 passed
- full pi-family scanner file: 6 passed
- full coding-agent-sessions Python suite: 37 passed
- isolated-HOME CLI:
  - `list --platform senpi --query omo-only --limit 10`
  - one `omo-only` result
  - platform `senpi`
  - path under `.omo/agent/sessions`
- independent QA also confirmed `.omo` and `.senpi` sessions surface together.

## QA and evidence

Evidence: `.omo/evidence/20260811-coding-agent-sessions-omo/`

- RED/GREEN: `red-pytest.txt`, `red-dedupe.txt`, `green-pytest.txt`
- Python and diagnostics: `green-full-python-suite.txt`,
  `python-diagnostics.txt`, `final-validation.txt`
- packaging: `skill-packaging.txt`
- live harness QA: `opencode-qa.txt`, `codex-qa.txt`
- canonical gates: `senpi-gate.txt`, `codex-gate.txt`
- real CLI and cleanup: `cli-omo-session.txt`, `cleanup.txt`
- review: `self-review.txt`, `review-verdicts.txt`

Key gates:

- BasedPyright: 0 errors, 0 warnings, 0 notes
- shared package + Senpi skill sync: 25 pass, 0 fail
- Senpi package suite: 986 pass, 1 expected Darwin sandbox skip, 0 fail
- canonical Codex gate: 519 pass, 0 fail, 0 skipped
- OpenCode isolated server QA: healthy, auth enforced, host DB unchanged
- Codex app-server QA: hook started/completed, no failed hooks
- five independent review lanes: unconditional PASS

## Scope and residual risk

- No new `omo` platform key or alias.
- No changes to unrelated documented config-directory environment variables.
- Generated Codex/Senpi skill copies remain ignored and are verified by sync
  tests.
- Equal-linkage duplicate selection remains the pre-existing behavior; the new
  regression test pins deterministic higher-linkage selection.

Plan: `.omo/plans/fix-coding-agent-sessions-omo.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OMO discovery to the `senpi` scanner so `coding-agent-sessions` finds sessions under `~/.omo/agent/sessions` without manual roots. Users on OMO now see current and legacy Senpi sessions together, with existing dedupe rules applied.

- **Bug Fixes**
  - Scan `~/.omo` ahead of `~/.senpi` and `~/.pi` in the Senpi config roots.
  - Added tests for simultaneous OMO + legacy stores and duplicate-ID dedupe (keeps higher-linkage row).
  - Updated docs to reference OMO across SKILL and Senpi storage pages.
  - No new platform keys or env var changes.

<sup>Written for commit 77210223cc058f63fd9de4ea25b135552fa16830. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

