### PR TITLE
fix(lsp-core): allow read-only symlink paths

### DIFF
--- a/packages/lsp-core/src/lsp/client-wrapper.test.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.test.ts
@@ -4,8 +4,9 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "bun:test";
 
 import { createStandaloneMcpRequestContext, runWithRequestContext } from "../request-context.js";
-import { findWorkspaceRoot, resolvePathInsideContext } from "./client-wrapper.js";
+import { findWorkspaceRoot, resolvePathInsideContext, withLspClient } from "./client-wrapper.js";
 import { LspInvalidPathError } from "./errors.js";
+import { LspManager } from "./manager.js";
 
 const tempDirectories: string[] = [];
 
@@ -48,16 +49,41 @@ describe("LSP client path confinement", () => {
 		).toThrow(LspInvalidPathError);
 	});
 
-	it("#given a symlink inside cwd that points outside #when resolving #then rejects the escape", () => {
+	it("#given a symlink inside cwd that points outside #when resolving read path #then keeps lexical path and cwd root", () => {
 		const root = tempRoot("lsp-client-wrapper-symlink-root-");
 		const outside = tempRoot("lsp-client-wrapper-symlink-outside-");
+		mkdirSync(join(root, ".git"), { recursive: true });
+		mkdirSync(join(outside, ".git"), { recursive: true });
 		writeFileSync(join(outside, "file.ts"), "export const outside = true;\n");
 		symlinkSync(outside, join(root, "linked"));
 
-		expect(() =>
+		const result = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () => ({
+			filePath: resolvePathInsideContext("linked/file.ts"),
+			workspaceRoot: findWorkspaceRoot("linked/file.ts"),
+		}));
+
+		expect(result.filePath).toBe(join(realpathSync(root), "linked", "file.ts"));
+		expect(result.workspaceRoot).toBe(realpathSync(root));
+	});
+
+	it("#given a symlink inside cwd that points outside #when starting rename #then rejects before client acquisition", async () => {
+		const root = tempRoot("lsp-client-wrapper-rename-root-");
+		const outside = tempRoot("lsp-client-wrapper-rename-outside-");
+		writeFileSync(join(outside, "file.ts"), "export const outside = true;\n");
+		symlinkSync(outside, join(root, "linked"));
+		let clientFactoryCalls = 0;
+		const manager = new LspManager({
+			clientFactory: () => {
+				clientFactoryCalls += 1;
+				throw new Error("client acquisition must not start");
+			},
+		});
+
+		await expect(
 			runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
-				resolvePathInsideContext("linked/file.ts"),
+				withLspClient("linked/file.ts", async () => undefined, "rename", { manager }),
 			),
-		).toThrow(LspInvalidPathError);
+		).rejects.toThrow(LspInvalidPathError);
+		expect(clientFactoryCalls).toBe(0);
 	});
 });

--- a/packages/lsp-core/src/lsp/client-wrapper.test.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "bun:test";
 
 import { createStandaloneMcpRequestContext, runWithRequestContext } from "../request-context.js";
-import { findWorkspaceRoot, resolvePathInsideContext, withLspClient } from "./client-wrapper.js";
+import { findWorkspaceRoot, resolveReadablePathInsideContext, withLspClient } from "./client-wrapper.js";
 import { LspInvalidPathError } from "./errors.js";
 import { LspManager } from "./manager.js";
 
@@ -58,12 +58,35 @@ describe("LSP client path confinement", () => {
 		symlinkSync(outside, join(root, "linked"));
 
 		const result = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () => ({
-			filePath: resolvePathInsideContext("linked/file.ts"),
+			filePath: resolveReadablePathInsideContext("linked/file.ts"),
 			workspaceRoot: findWorkspaceRoot("linked/file.ts"),
 		}));
 
 		expect(result.filePath).toBe(join(realpathSync(root), "linked", "file.ts"));
 		expect(result.workspaceRoot).toBe(realpathSync(root));
+	});
+
+	it("#given an absolute macOS alias path through an outside symlink #when resolving read path #then preserves the lexical suffix", () => {
+		const root = tempRoot("lsp-client-wrapper-alias-root-");
+		const outside = tempRoot("lsp-client-wrapper-alias-outside-");
+		mkdirSync(join(root, ".git"), { recursive: true });
+		writeFileSync(join(outside, "file.ts"), "export const outside = true;\n");
+		symlinkSync(outside, join(root, "linked"));
+
+		const result = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+			resolveReadablePathInsideContext(join(root, "linked", "file.ts")),
+		);
+
+		expect(result).toBe(join(realpathSync(root), "linked", "file.ts"));
+	});
+
+	it("#given missing parent directories without markers #when resolving workspace #then uses an existing directory", () => {
+		const root = tempRoot("lsp-client-wrapper-missing-root-");
+		const workspace = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+			findWorkspaceRoot("missing/deep/file.ts"),
+		);
+
+		expect(workspace).toBe(realpathSync(root));
 	});
 
 	it("#given a symlink inside cwd that points outside #when starting rename #then rejects before client acquisition", async () => {
@@ -79,11 +102,15 @@ describe("LSP client path confinement", () => {
 			},
 		});
 
-		await expect(
-			runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
-				withLspClient("linked/file.ts", async () => undefined, "rename", { manager }),
-			),
-		).rejects.toThrow(LspInvalidPathError);
-		expect(clientFactoryCalls).toBe(0);
+		try {
+			await expect(
+				runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+					withLspClient("linked/file.ts", async () => undefined, "rename", { manager }),
+				),
+			).rejects.toThrow(LspInvalidPathError);
+			expect(clientFactoryCalls).toBe(0);
+		} finally {
+			await manager.stopAll();
+		}
 	});
 });

--- a/packages/lsp-core/src/lsp/client-wrapper.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.ts
@@ -31,6 +31,7 @@ export function isDirectoryPath(filePath: string): boolean {
 }
 
 export function findWorkspaceRoot(filePath: string): string {
+	const cwd = contextCwd();
 	const abs = resolvePathInsideContext(filePath);
 	let dir = abs;
 
@@ -38,28 +39,47 @@ export function findWorkspaceRoot(filePath: string): string {
 		dir = dirname(dir);
 	}
 
-	let prevDir = "";
-	while (dir !== prevDir) {
-		for (const marker of WORKSPACE_MARKERS) {
-			if (existsSync(join(dir, marker))) {
-				return dir;
+	const fallbackRoot = canonicalDirectoryInsideContext(dir, cwd) ?? cwd;
+	while (isPathInside(cwd, dir)) {
+		const canonicalDir = canonicalDirectoryInsideContext(dir, cwd);
+		if (canonicalDir !== undefined) {
+			for (const marker of WORKSPACE_MARKERS) {
+				if (existsSync(join(dir, marker))) {
+					return canonicalDir;
+				}
 			}
 		}
-		prevDir = dir;
+		if (dir === cwd) break;
 		dir = dirname(dir);
 	}
 
-	return dirname(abs);
+	return fallbackRoot;
 }
 
 export function resolvePathInsideContext(filePath: string): string {
 	const cwd = contextCwd();
 	const abs = resolve(cwd, filePath);
+	if (isPathInside(cwd, abs)) return abs;
+
+	const canonical = canonicalizeExistingOrNearestAncestor(abs);
+	if (isPathInside(cwd, canonical)) return canonical;
+
+	throw new LspInvalidPathError(`LSP file path must be inside request cwd: ${filePath}`);
+}
+
+function resolveWritablePathInsideContext(filePath: string): string {
+	const cwd = contextCwd();
+	const abs = resolvePathInsideContext(filePath);
 	const canonical = canonicalizeExistingOrNearestAncestor(abs);
 	if (!isPathInside(cwd, canonical)) {
 		throw new LspInvalidPathError(`LSP file path must be inside request cwd: ${filePath}`);
 	}
 	return canonical;
+}
+
+function canonicalDirectoryInsideContext(directory: string, cwd: string): string | undefined {
+	const canonical = canonicalizeExistingOrNearestAncestor(directory);
+	return isPathInside(cwd, canonical) ? canonical : undefined;
 }
 
 export function formatServerLookupError(result: Exclude<ServerLookupResult, { status: "found" }>): string {
@@ -143,7 +163,7 @@ export interface WithLspClientOptions {
 	manager?: LspManager;
 }
 
-const READ_ONLY_RETRY_TOOLS = new Set([
+const READ_ONLY_TOOLS = new Set([
 	"diagnostics",
 	"definition",
 	"references",
@@ -158,7 +178,9 @@ export async function withLspClient<T>(
 	toolName: string,
 	options: WithLspClientOptions = {},
 ): Promise<T> {
-	const absPath = resolvePathInsideContext(filePath);
+	const absPath = READ_ONLY_TOOLS.has(toolName)
+		? resolvePathInsideContext(filePath)
+		: resolveWritablePathInsideContext(filePath);
 
 	if (isDirectoryPath(absPath)) {
 		throw new LspInvalidPathError(
@@ -183,7 +205,7 @@ export async function withLspClient<T>(
 		try {
 			return await fn(client, root);
 		} catch (err) {
-			if (allowRetry && READ_ONLY_RETRY_TOOLS.has(toolName) && isLspDeadConnectionError(err)) {
+			if (allowRetry && READ_ONLY_TOOLS.has(toolName) && isLspDeadConnectionError(err)) {
 				manager.invalidateClient(root, server.id, client);
 				return acquireAndCall(false);
 			}

--- a/packages/lsp-core/src/lsp/client-wrapper.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.ts
@@ -1,5 +1,5 @@
-import { existsSync, statSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import {
 	canonicalizeExistingOrNearestAncestor,
 	contextCwd,
@@ -32,16 +32,16 @@ export function isDirectoryPath(filePath: string): boolean {
 
 export function findWorkspaceRoot(filePath: string): string {
 	const cwd = contextCwd();
-	const abs = resolvePathInsideContext(filePath);
+	const abs = resolveReadablePathInsideContext(filePath);
 	let dir = abs;
 
 	if (!isDirectoryPath(dir)) {
 		dir = dirname(dir);
 	}
 
-	const fallbackRoot = canonicalDirectoryInsideContext(dir, cwd) ?? cwd;
+	const fallbackRoot = nearestExistingDirectoryInsideContext(dir, cwd) ?? cwd;
 	while (isPathInside(cwd, dir)) {
-		const canonicalDir = canonicalDirectoryInsideContext(dir, cwd);
+		const canonicalDir = existingDirectoryInsideContext(dir, cwd);
 		if (canonicalDir !== undefined) {
 			for (const marker of WORKSPACE_MARKERS) {
 				if (existsSync(join(dir, marker))) {
@@ -56,10 +56,13 @@ export function findWorkspaceRoot(filePath: string): string {
 	return fallbackRoot;
 }
 
-export function resolvePathInsideContext(filePath: string): string {
+export function resolveReadablePathInsideContext(filePath: string): string {
 	const cwd = contextCwd();
 	const abs = resolve(cwd, filePath);
 	if (isPathInside(cwd, abs)) return abs;
+
+	const rebased = rebaseThroughCanonicalAncestor(abs, cwd);
+	if (rebased !== undefined) return rebased;
 
 	const canonical = canonicalizeExistingOrNearestAncestor(abs);
 	if (isPathInside(cwd, canonical)) return canonical;
@@ -67,9 +70,9 @@ export function resolvePathInsideContext(filePath: string): string {
 	throw new LspInvalidPathError(`LSP file path must be inside request cwd: ${filePath}`);
 }
 
-function resolveWritablePathInsideContext(filePath: string): string {
+export function resolvePathInsideContext(filePath: string): string {
 	const cwd = contextCwd();
-	const abs = resolvePathInsideContext(filePath);
+	const abs = resolveReadablePathInsideContext(filePath);
 	const canonical = canonicalizeExistingOrNearestAncestor(abs);
 	if (!isPathInside(cwd, canonical)) {
 		throw new LspInvalidPathError(`LSP file path must be inside request cwd: ${filePath}`);
@@ -77,9 +80,37 @@ function resolveWritablePathInsideContext(filePath: string): string {
 	return canonical;
 }
 
-function canonicalDirectoryInsideContext(directory: string, cwd: string): string | undefined {
-	const canonical = canonicalizeExistingOrNearestAncestor(directory);
+function rebaseThroughCanonicalAncestor(path: string, cwd: string): string | undefined {
+	let current = path;
+	const suffix: string[] = [];
+	while (true) {
+		if (existsSync(current)) {
+			const canonical = realpathSync(current);
+			if (isPathInside(cwd, canonical)) return suffix.length === 0 ? canonical : join(canonical, ...suffix);
+		}
+		const parent = dirname(current);
+		if (parent === current) return undefined;
+		suffix.unshift(basename(current));
+		current = parent;
+	}
+}
+
+function existingDirectoryInsideContext(directory: string, cwd: string): string | undefined {
+	if (!existsSync(directory)) return undefined;
+	const canonical = realpathSync(directory);
+	if (!statSync(canonical).isDirectory()) return undefined;
 	return isPathInside(cwd, canonical) ? canonical : undefined;
+}
+
+function nearestExistingDirectoryInsideContext(directory: string, cwd: string): string | undefined {
+	let current = directory;
+	while (isPathInside(cwd, current)) {
+		const canonical = existingDirectoryInsideContext(current, cwd);
+		if (canonical !== undefined) return canonical;
+		if (current === cwd) return undefined;
+		current = dirname(current);
+	}
+	return undefined;
 }
 
 export function formatServerLookupError(result: Exclude<ServerLookupResult, { status: "found" }>): string {
@@ -174,13 +205,13 @@ const READ_ONLY_TOOLS = new Set([
 
 export async function withLspClient<T>(
 	filePath: string,
-	fn: (client: LspClient, workspaceRoot: string) => Promise<T>,
+	fn: (client: LspClient, workspaceRoot: string, resolvedFilePath: string) => Promise<T>,
 	toolName: string,
 	options: WithLspClientOptions = {},
 ): Promise<T> {
 	const absPath = READ_ONLY_TOOLS.has(toolName)
-		? resolvePathInsideContext(filePath)
-		: resolveWritablePathInsideContext(filePath);
+		? resolveReadablePathInsideContext(filePath)
+		: resolvePathInsideContext(filePath);
 
 	if (isDirectoryPath(absPath)) {
 		throw new LspInvalidPathError(
@@ -203,7 +234,7 @@ export async function withLspClient<T>(
 		const client = await manager.getClient(root, server, options.signal);
 
 		try {
-			return await fn(client, root);
+			return await fn(client, root, absPath);
 		} catch (err) {
 			if (allowRetry && READ_ONLY_TOOLS.has(toolName) && isLspDeadConnectionError(err)) {
 				manager.invalidateClient(root, server.id, client);

--- a/packages/lsp-core/src/lsp/workspace-edit-adversarial.test.ts
+++ b/packages/lsp-core/src/lsp/workspace-edit-adversarial.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -84,6 +84,25 @@ describe("workspace edit adversarial inputs", () => {
 		expect(result.success).toBe(false);
 		expect(result.errors.join("\n")).toContain("outside workspace");
 		expect(readFileSync(dirty, "utf-8")).toBe("user-owned dirty bytes\n");
+		expect(readFileSync(outsideFile, "utf-8")).toBe("outside bytes\n");
+	});
+
+	it("#given an in-workspace symlink to an outside file #when applying an edit #then rejects without modifying target", () => {
+		const workspace = makeTempDirectory("lsp-workspace-");
+		const outside = makeTempDirectory("lsp-outside-");
+		const outsideFile = join(outside, "outside.ts");
+		const canonicalWorkspace = realpathSync(workspace);
+		const linkedDirectory = join(canonicalWorkspace, "linked");
+		writeFileSync(outsideFile, "outside bytes\n", "utf-8");
+		symlinkSync(outside, linkedDirectory);
+
+		const result = applyWorkspaceEdit(
+			{ changes: { [pathToFileURL(join(linkedDirectory, "outside.ts")).href]: [insertion()] } },
+			{ workspaceRoot: canonicalWorkspace },
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.errors.join("\n")).toContain("outside workspace");
 		expect(readFileSync(outsideFile, "utf-8")).toBe("outside bytes\n");
 	});
 

--- a/packages/lsp-core/src/tools/diagnostics.ts
+++ b/packages/lsp-core/src/tools/diagnostics.ts
@@ -1,4 +1,4 @@
-import { isDirectoryPath, resolvePathInsideContext, withLspClient } from "../lsp/client-wrapper.js";
+import { isDirectoryPath, resolveReadablePathInsideContext, withLspClient } from "../lsp/client-wrapper.js";
 import { DEFAULT_MAX_DIAGNOSTICS } from "../lsp/constants.js";
 import { aggregateDiagnosticsForDirectory } from "../lsp/directory-diagnostics.js";
 import { filterDiagnosticsBySeverity, formatDiagnostic } from "../lsp/formatters.js";
@@ -23,7 +23,7 @@ export async function executeLspDiagnostics(
 	const severity = severityFilter(params);
 
 	try {
-		const absPath = resolvePathInsideContext(filePath);
+		const absPath = resolveReadablePathInsideContext(filePath);
 		if (isDirectoryPath(absPath)) {
 			const extension = inferExtensionFromDirectory(absPath);
 			if (!extension) {
@@ -62,7 +62,7 @@ export async function executeLspDiagnostics(
 
 		const result = await withLspClient(
 				filePath,
-				async (client) => client.diagnostics(filePath, signal),
+				async (client, _workspaceRoot, resolvedFilePath) => client.diagnostics(resolvedFilePath, signal),
 				"diagnostics",
 				clientOptions(signal),
 			);

--- a/packages/lsp-core/src/tools/navigation.ts
+++ b/packages/lsp-core/src/tools/navigation.ts
@@ -17,7 +17,8 @@ export async function executeLspGotoDefinition(
 	try {
 			const result = await withLspClient(
 				filePath,
-				async (client) => client.definition(filePath, line, character, signal),
+				async (client, _workspaceRoot, resolvedFilePath) =>
+					client.definition(resolvedFilePath, line, character, signal),
 				"definition",
 				clientOptions(signal),
 			);
@@ -49,7 +50,8 @@ export async function executeLspFindReferences(
 	try {
 			const result = await withLspClient(
 				filePath,
-				async (client) => client.references(filePath, line, character, includeDeclaration, signal),
+				async (client, _workspaceRoot, resolvedFilePath) =>
+					client.references(resolvedFilePath, line, character, includeDeclaration, signal),
 				"references",
 				clientOptions(signal),
 			);

--- a/packages/lsp-core/src/tools/rename.ts
+++ b/packages/lsp-core/src/tools/rename.ts
@@ -16,7 +16,8 @@ export async function executeLspPrepareRename(
 	try {
 			const result = await withLspClient(
 				filePath,
-				async (client) => client.prepareRename(filePath, line, character, signal),
+				async (client, _workspaceRoot, resolvedFilePath) =>
+					client.prepareRename(resolvedFilePath, line, character, signal),
 				"prepareRename",
 				clientOptions(signal),
 			);
@@ -46,7 +47,8 @@ export async function executeLspRename(
 	try {
 		const result = await withLspClient(
 			filePath,
-			async (client) => client.rename(filePath, line, character, newName, signal),
+			async (client, _workspaceRoot, resolvedFilePath) =>
+				client.rename(resolvedFilePath, line, character, newName, signal),
 			"rename",
 			clientOptions(signal),
 		);

--- a/packages/lsp-core/src/tools/symbols.ts
+++ b/packages/lsp-core/src/tools/symbols.ts
@@ -47,7 +47,7 @@ export async function executeLspSymbols(
 
 			const symbols = await withLspClient(
 				filePath,
-				async (client) => client.documentSymbols(filePath, signal),
+				async (client, _workspaceRoot, resolvedFilePath) => client.documentSymbols(resolvedFilePath, signal),
 				"documentSymbols",
 				clientOptions(signal),
 			);

--- a/packages/lsp-tools-mcp/test/client-wrapper.test.ts
+++ b/packages/lsp-tools-mcp/test/client-wrapper.test.ts
@@ -178,4 +178,63 @@ describe("withLspClient", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	it("#given a relative file below a nested workspace #when callback runs #then callback receives the resolved file path", async () => {
+		// given
+		const previousUserConfig = process.env["LSP_TOOLS_MCP_USER_CONFIG"];
+		const root = mkdtempSync(join(tmpdir(), "lsp-client-wrapper-resolved-path-"));
+		const nestedWorkspace = join(root, "parent", "nested");
+		const filePath = join(nestedWorkspace, "src", "fixture.cbpath");
+		const relativeFilePath = join("parent", "nested", "src", "fixture.cbpath");
+		const userConfig = join(root, "user-lsp.json");
+		const pathsSeen: Array<string | undefined> = [];
+		const clients: FakeLspClient[] = [];
+
+		mkdirSync(join(nestedWorkspace, "src"), { recursive: true });
+		writeFileSync(join(nestedWorkspace, "package.json"), "{}");
+		writeFileSync(filePath, "const value = 1;\n");
+		writeFileSync(
+			userConfig,
+			JSON.stringify({
+				lsp: {
+					callbackPath: {
+						command: [process.execPath],
+						extensions: [".cbpath"],
+					},
+				},
+			}),
+		);
+		process.env["LSP_TOOLS_MCP_USER_CONFIG"] = userConfig;
+
+		const manager = new LspManager({
+			clientFactory: (workspaceRoot: string, server: ResolvedServer): LspClient => {
+				const client = new FakeLspClient(workspaceRoot, server);
+				clients.push(client);
+				return client;
+			},
+		});
+
+		try {
+			// when
+			const context = createStandaloneMcpRequestContext({ cwd: root });
+			await runWithRequestContext(context, () =>
+				withLspClient(
+					relativeFilePath,
+					async (_client, _workspaceRoot, resolvedFilePath) => {
+						pathsSeen.push(resolvedFilePath);
+					},
+					"diagnostics",
+					{ manager },
+				),
+			);
+
+			// then
+			expect(pathsSeen).toEqual([realpathSync(filePath)]);
+			expect(clients[0]?.stopCallCount).toBe(0);
+		} finally {
+			restoreEnv("LSP_TOOLS_MCP_USER_CONFIG", previousUserConfig);
+			await manager.stopAll();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 });


### PR DESCRIPTION
## Summary

- preserve lexical paths inside the LSP request cwd for read-only tools, even when a symlink resolves outside that cwd
- constrain workspace-root discovery to canonical directories inside the request cwd
- keep rename and workspace-edit writes physically confined, with regression tests for external-target symlinks

## Background

The reported Korean sentence was not present verbatim in any searched coding-agent transcript. Session evidence shows it was a composite of:

- Senpi/pi session `019fe96d-15ab-7b6a-94ad-b067df511330`, where the built-in LSP rejected a path as outside request cwd
- Claude/OpenCode transcript `ses_3cdfeac39ffezNuFT1LnTkgYpl`, where an in-worktree symlink was used as the workaround

The old shared path resolver canonicalized every file before admission. That was appropriate for writes, but it also rejected read-only LSP requests whose lexical path was inside the worktree.

## Behavior

Read-only tools now:

1. resolve the requested path lexically against request cwd
2. accept it when that lexical path is inside cwd
3. rebase absolute macOS `/var` aliases through the canonical cwd ancestor while preserving the remaining lexical suffix
4. pass the resolved absolute path into the LSP client so nested workspace roots cannot duplicate relative path prefixes
5. choose a workspace root only from existing canonical directories inside cwd

Write-capable tools still canonicalize before acquiring a client. Rename through an external-target symlink rejects before client acquisition, and workspace edits continue to reject external targets.

## Tests and QA

- targeted RED: unchanged code rejected `linked/file.ts` with `LspInvalidPathError`
- review RED additionally proved:
  - absolute `/var` alias paths through the symlink were rejected
  - missing parent paths selected a nonexistent workspace root
  - nested-workspace callbacks discarded the resolved file path
- targeted GREEN:
  - `bun test packages/lsp-core/src/lsp/client-wrapper.test.ts`
  - `bun test packages/lsp-core/src/lsp/workspace-edit-adversarial.test.ts`
- package suites:
  - `bun run --cwd packages/lsp-core test` - 96 passed
  - `npm --prefix packages/lsp-tools-mcp test` - 97 passed
- typechecks:
  - `bun run --cwd packages/lsp-core typecheck`
  - `npm --prefix packages/lsp-tools-mcp run typecheck`
- `bun run build`
- changed-file worktree-native LSP diagnostics - zero errors on all seven changed files
- real stdio MCP QA:
  - diagnostics through an in-worktree external-target symlink returned normal TypeScript diagnostic 2322 with `isError:false`
  - rename returned `isError:true`
  - external target SHA-256 was unchanged
- isolated OpenCode LSP E2E - PASS, SSE tool observed, real DB unchanged
- isolated Codex LSP E2E - PASS, hook notifications observed, real config unchanged
- Codex first-party app-server hook drive - PASS
- Senpi adapter - 53 tests passed and typecheck exited 0
- `bun run test:codex` - exit 0

Reviewer-readable artifacts are under `.omo/evidence/20260811-lsp-symlink-worktree/` in the task worktree.

## Security notes

- absolute paths outside cwd and lexical `..` escapes still reject
- rename uses physical containment before client acquisition
- workspace edits retain their independent canonical containment check
- this PR does not attempt to redesign the pre-existing workspace-edit commit-time symlink TOCTOU surface

## Residual risk

Read-only LSP access is intentionally not a filesystem sandbox for explicitly named lexical descendants. The patch does not broaden any write route.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow read-only LSP tools to open files via in-worktree symlinks while keeping all writes physically confined. Fixes path rejection for files lexically inside the request cwd and improves workspace-root selection.

- **Bug Fixes**
  - Read-only tools accept lexical paths inside cwd, including symlinks that point outside.
  - Absolute macOS `/var` alias paths are rebased through a canonical cwd ancestor while keeping the lexical suffix.
  - Workspace-root discovery only uses existing canonical directories inside cwd, with safe fallbacks when parents are missing.
  - Write routes remain confined: rename rejects external-target symlinks before client acquisition; workspace edits reject outside targets.
  - LSP callbacks now receive the resolved absolute file path to prevent duplicate relative prefixes under nested workspaces.

<sup>Written for commit b542b7c2cfc941a9e79b4576daddccaa784791da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

