### PR TITLE
fix(model-fallback): add provider-exhaustion policy to event-model-fallback

### DIFF
--- a/packages/omo-opencode/src/hooks/model-fallback/fallback-state-controller.ts
+++ b/packages/omo-opencode/src/hooks/model-fallback/fallback-state-controller.ts
@@ -37,6 +37,7 @@ export type ModelFallbackStateController = {
     currentModelID: string,
   ) => boolean
   getNextFallback: (sessionID: string) => ReturnType<typeof getNextReachableFallback>
+  peekNextFallback: (sessionID: string) => ReturnType<typeof getNextReachableFallback>
   clearPendingModelFallback: (sessionID: string) => void
   hasPendingModelFallback: (sessionID: string) => boolean
   getFallbackState: (sessionID: string) => ModelFallbackStateLike | undefined
@@ -93,8 +94,19 @@ export function createModelFallbackStateController(input: {
     }
 
     if (existing.pending) {
-      log(`[model-fallback] Pending fallback already armed for session: ${sessionID}`)
-      return false
+      // A fallback is already queued but not yet consumed by the chat.message
+      // hook. Block re-arm only when the failed model is the SAME as the one
+      // that armed it; a DIFFERENT failed model (e.g. the chain advanced to a
+      // new model that then also hit quota) must re-arm so the chain can
+      // advance again instead of stalling after the first fallback.
+      if (isSameFailedModel(existing, currentProviderID, currentModelID)) {
+        log(`[model-fallback] Pending fallback already armed for session: ${sessionID}`)
+        return false
+      }
+      existing.providerID = currentProviderID
+      existing.modelID = currentModelID
+      log(`[model-fallback] Re-armed pending fallback for changed failed model in session: ${sessionID}`)
+      return true
     }
 
     if (existing.attemptCount > 0 && isSameFailedModel(existing, currentProviderID, currentModelID)) {
@@ -125,6 +137,25 @@ export function createModelFallbackStateController(input: {
     return null
   }
 
+  function peekNextFallback(sessionID: string): ReturnType<typeof getNextReachableFallback> {
+    const state = pendingModelFallbacks.get(sessionID)
+    if (!state?.pending) return null
+
+    // Snapshot only the scalar fields getNextReachableFallback mutates
+    // (attemptCount, pending). fallbackChain is read-only inside the helper,
+    // so the array reference is safe to share. The snapshot lets the
+    // continuation dispatcher resolve the next fallback WITHOUT advancing
+    // the chain — the chat.message hook still owns chain consumption.
+    const snapshot: ModelFallbackStateLike = {
+      providerID: state.providerID,
+      modelID: state.modelID,
+      fallbackChain: state.fallbackChain,
+      attemptCount: state.attemptCount,
+      pending: state.pending,
+    }
+    return getNextReachableFallback(sessionID, snapshot)
+  }
+
   function clearPendingModelFallback(sessionID: string): void {
     pendingModelFallbacks.delete(sessionID)
     lastToastKey.delete(sessionID)
@@ -151,6 +182,7 @@ export function createModelFallbackStateController(input: {
     clearSessionFallbackChain,
     setPendingModelFallback,
     getNextFallback,
+    peekNextFallback,
     clearPendingModelFallback,
     hasPendingModelFallback,
     getFallbackState,

--- a/packages/omo-opencode/src/hooks/model-fallback/hook.ts
+++ b/packages/omo-opencode/src/hooks/model-fallback/hook.ts
@@ -37,6 +37,7 @@ type ModelFallbackControllerWithState = Pick<
   | "clearSessionFallbackChain"
   | "setPendingModelFallback"
   | "getNextFallback"
+  | "peekNextFallback"
   | "clearPendingModelFallback"
   | "hasPendingModelFallback"
   | "getFallbackState"
@@ -109,6 +110,20 @@ export function getNextFallback(
 }
 
 /**
+ * Peeks at the next fallback model for a session WITHOUT consuming it.
+ * Does not advance attemptCount or clear pending state. Use this when
+ * the caller needs to know which fallback would be selected (e.g. to
+ * build a continuation launch model) while leaving chain consumption to
+ * the chat.message hook.
+ */
+export function peekNextFallback(
+  controller: Pick<ModelFallbackStateController, "peekNextFallback">,
+  sessionID: string,
+): { providerID: string; modelID: string; variant?: string } | null {
+  return controller.peekNextFallback(sessionID)
+}
+
+/**
  * Clears the pending fallback for a session.
  * Called after fallback is successfully applied.
  */
@@ -164,6 +179,7 @@ export function createModelFallbackHook(args?: ModelFallbackHookArgs): ModelFall
     clearSessionFallbackChain: controller.clearSessionFallbackChain,
     setPendingModelFallback: controller.setPendingModelFallback,
     getNextFallback: controller.getNextFallback,
+    peekNextFallback: controller.peekNextFallback,
     clearPendingModelFallback: controller.clearPendingModelFallback,
     hasPendingModelFallback: controller.hasPendingModelFallback,
     getFallbackState: controller.getFallbackState,

--- a/packages/omo-opencode/src/plugin/event-model-fallback-state.ts
+++ b/packages/omo-opencode/src/plugin/event-model-fallback-state.ts
@@ -56,11 +56,12 @@ export function applyUserConfiguredFallbackChain(
 export function createModelFallbackContinuationController(args: {
   pluginConfig: OhMyOpenCodeConfig;
   pluginContext: PluginEventContext;
+  modelFallback: ModelFallbackHook | null | undefined;
   lastKnownModelBySession: Map<string, { providerID: string; modelID: string }>;
   continuationsInFlight: Set<string>;
   lastDispatchedContinuationKeys: Map<string, FallbackContinuationDedupeState>;
 }) {
-  const { pluginConfig, pluginContext, lastKnownModelBySession, continuationsInFlight } = args;
+  const { pluginConfig, pluginContext, modelFallback, lastKnownModelBySession, continuationsInFlight } = args;
   const lastDispatchedContinuationKeys = args.lastDispatchedContinuationKeys;
 
   const resolveFallbackProviderID = (sessionID: string, providerHint?: string): string => {
@@ -183,14 +184,57 @@ export function createModelFallbackContinuationController(args: {
       const launchAgent = fallbackContext?.agentName
         ? resolveRegisteredAgentName(fallbackContext.agentName)
         : undefined;
-      const launchModel = fallbackContext?.providerID && fallbackContext?.modelID
-        ? { providerID: fallbackContext.providerID, modelID: fallbackContext.modelID }
+
+      // Resolve the next fallback BEFORE dispatch so the continuation
+      // launches with the FALLBACK model (deepseek/deepseek-v4-pro, etc.),
+      // not the failed model from fallbackContext. PEEK does not advance
+      // attemptCount or clear pending — the chat.message hook still owns
+      // chain consumption when it fires for the continued prompt.
+      //
+      // Some legacy test stubs only mock setPendingModelFallback and do
+      // not expose peekNextFallback; for those, fall back to emitting the
+      // failed model (the chat.message hook still advances the chain).
+      const peekFn = modelFallback
+        ? (modelFallback as { peekNextFallback?: (sessionID: string) => { providerID: string; modelID: string; variant?: string } | null }).peekNextFallback
         : undefined;
+
+      let launchModel: { providerID: string; modelID: string } | undefined;
+      let launchVariantFromFallback: string | undefined;
+      if (typeof peekFn === "function") {
+        let peeked: { providerID: string; modelID: string; variant?: string } | null;
+        try {
+          peeked = peekFn(sessionID);
+        } catch (err) {
+          log("[event] model-fallback peekNextFallback threw", {
+            sessionID,
+            source,
+            error: err instanceof Error ? err : String(err),
+          });
+          peeked = null;
+        }
+        if (!peeked) {
+          log("[event] model-fallback continuation skipped because fallback chain is empty or exhausted", {
+            sessionID,
+            source,
+          });
+          return;
+        }
+        launchModel = { providerID: peeked.providerID, modelID: peeked.modelID };
+        launchVariantFromFallback = peeked.variant;
+      } else {
+        launchModel = fallbackContext?.providerID && fallbackContext?.modelID
+          ? { providerID: fallbackContext.providerID, modelID: fallbackContext.modelID }
+          : undefined;
+      }
+
       const agentConfigKey = fallbackContext?.agentName ? getAgentConfigKey(fallbackContext.agentName) : undefined;
       const agentSettings = agentConfigKey
         ? pluginConfig.agents?.[agentConfigKey as keyof NonNullable<typeof pluginConfig.agents>]
         : undefined;
-      const launchVariant = (agentSettings as { variant?: string } | undefined)?.variant;
+      // Prefer the fallback entry's own variant; fall back to the agent's
+      // configured variant when the chain entry does not specify one.
+      const launchVariant = launchVariantFromFallback
+        ?? (agentSettings as { variant?: string } | undefined)?.variant;
       const promptBody = {
         path: { id: sessionID },
         body: {

--- a/packages/omo-opencode/src/plugin/event-model-fallback.ts
+++ b/packages/omo-opencode/src/plugin/event-model-fallback.ts
@@ -7,6 +7,7 @@ import {
   type ModelFallbackHook,
 } from "../hooks/model-fallback/hook";
 import { shouldRetryError } from "../shared/model-error-classifier";
+import { shouldAttemptModelFallback } from "../shared/model-fallback-decision";
 import { extractRetryAttempt, normalizeRetryStatusMessage } from "../shared/retry-status-utils";
 import {
   extractErrorMessage,
@@ -32,7 +33,10 @@ export function createModelFallbackEventHandler(args: {
   isSessionStopped: (sessionID: string) => boolean;
 }) {
   const lastHandledModelErrorMessageID = new Map<string, string>();
-  const lastHandledRetryStatusKey = new Map<string, string>();
+  // Per-session set of handled retry keys. A Set (not a single last-key) so a
+  // sequence like A -> B -> stale A still dedups the stale A: its key remains
+  // in the set after B was added. Cleared on idle and on session teardown.
+  const lastHandledRetryStatusKey = new Map<string, Set<string>>();
   const lastKnownModelBySession = new Map<string, { providerID: string; modelID: string }>();
   const continuationsInFlight = new Set<string>();
   const lastDispatchedContinuationKeys = new Map<
@@ -46,6 +50,7 @@ export function createModelFallbackEventHandler(args: {
   const continuation = createModelFallbackContinuationController({
     pluginConfig: args.pluginConfig,
     pluginContext: args.pluginContext,
+    modelFallback: args.modelFallback,
     lastKnownModelBySession,
     continuationsInFlight,
     lastDispatchedContinuationKeys,
@@ -125,7 +130,7 @@ export function createModelFallbackEventHandler(args: {
 
     const providerHint = params.info.providerID as string | undefined;
     const currentProvider = continuation.resolveFallbackProviderID(params.sessionID, providerHint);
-    const rawModel = (params.info.modelID as string | undefined) ?? "claude-opus-4-7";
+    const rawModel = (params.info.modelID as string | undefined) ?? "";
     const currentModel = normalizeFallbackModelID(rawModel);
     const fallbackContext = { agentName, providerID: currentProvider, dedupeProviderID: providerHint, modelID: currentModel };
     const shouldAutoContinue = args.shouldAutoRetrySession(params.sessionID) && !args.isSessionStopped(params.sessionID);
@@ -151,13 +156,23 @@ export function createModelFallbackEventHandler(args: {
     if (params.status?.type !== "retry" || !shouldHandleModelFallback()) return false;
 
     const retryMessage = typeof params.status.message === "string" ? params.status.message : "";
-    const parsedForKey = extractProviderModelFromErrorMessage(retryMessage);
     const retryAttempt = extractRetryAttempt(params.status.attempt, retryMessage);
-    const retryKey = `${retryAttempt}:${parsedForKey.providerID ?? ""}/${parsedForKey.modelID ?? ""}:${normalizeRetryStatusMessage(retryMessage)}`;
-    if (lastHandledRetryStatusKey.get(params.sessionID) === retryKey) return true;
-    lastHandledRetryStatusKey.set(params.sessionID, retryKey);
 
-    if (!shouldRetryError({ name: undefined, message: retryMessage })) return false;
+    // Resolve the trusted failed-model identity from session state (not from
+    // the retry message, which for quota-style 429s carries no provider/model
+    // and would collapse distinct failed models to the same dedup key).
+    const parsed = extractProviderModelFromErrorMessage(retryMessage);
+    const lastKnown = lastKnownModelBySession.get(params.sessionID);
+    const currentProvider = continuation.resolveFallbackProviderID(params.sessionID, parsed.providerID);
+    const currentModel = normalizeFallbackModelID(parsed.modelID ?? lastKnown?.modelID ?? "");
+
+    const retryKey = `${retryAttempt}:${currentProvider}/${currentModel}:${normalizeRetryStatusMessage(retryMessage)}`;
+    const handledKeys = lastHandledRetryStatusKey.get(params.sessionID);
+    if (handledKeys?.has(retryKey)) return true;
+    if (handledKeys) handledKeys.add(retryKey);
+    else lastHandledRetryStatusKey.set(params.sessionID, new Set([retryKey]));
+
+    if (!shouldAttemptModelFallback({ name: undefined, message: retryMessage })) return false;
 
     const agentName = resolveFallbackAgentName({
       currentAgent: getSessionAgent(params.sessionID),
@@ -167,10 +182,6 @@ export function createModelFallbackEventHandler(args: {
     });
     if (!agentName) return false;
 
-    const parsed = extractProviderModelFromErrorMessage(retryMessage);
-    const lastKnown = lastKnownModelBySession.get(params.sessionID);
-    const currentProvider = continuation.resolveFallbackProviderID(params.sessionID, parsed.providerID);
-    const currentModel = normalizeFallbackModelID(parsed.modelID ?? lastKnown?.modelID ?? "claude-opus-4-7");
     const fallbackContext = { agentName, providerID: currentProvider, dedupeProviderID: parsed.providerID, modelID: currentModel };
     const shouldAutoContinue = args.shouldAutoRetrySession(params.sessionID) && !args.isSessionStopped(params.sessionID);
 
@@ -206,7 +217,7 @@ export function createModelFallbackEventHandler(args: {
     const providerHint = (params.props?.providerID as string | undefined) || parsed.providerID;
     const currentProvider = continuation.resolveFallbackProviderID(params.sessionID, providerHint);
     const currentModel = normalizeFallbackModelID(
-      (params.props?.modelID as string | undefined) || parsed.modelID || "claude-opus-4-7",
+      (params.props?.modelID as string | undefined) || parsed.modelID || "",
     );
     const fallbackContext = { agentName, providerID: currentProvider, dedupeProviderID: providerHint, modelID: currentModel };
     const shouldAutoContinue = args.shouldAutoRetrySession(params.sessionID) && !args.isSessionStopped(params.sessionID);

--- a/packages/omo-opencode/src/plugin/event.model-fallback.test.ts
+++ b/packages/omo-opencode/src/plugin/event.model-fallback.test.ts
@@ -36,12 +36,15 @@ describe("createEventHandler - model fallback", () => {
     hooks?: unknown
     pluginConfig?: unknown
     abort?: (input: { path: { id: string } }) => Promise<unknown>
-    promptAsync?: (input: { path: { id: string } }) => Promise<unknown>
+    promptAsync?: (input: { path: { id: string }; body?: { model?: unknown } }) => Promise<unknown>
   }) => {
     setupConnectedProviderCacheMocks()
     const abortCalls: string[] = []
     const promptCalls: string[] = []
     const promptAsyncCalls: string[] = []
+    // Captures `body.model` from each promptAsync call so Problem-B RED tests
+    // can assert which model the auto-continuation actually dispatched.
+    const promptAsyncBodies: unknown[] = []
 
     const sessionClient = {
       abort: async ({ path }: { path: { id: string } }) => {
@@ -57,8 +60,11 @@ describe("createEventHandler - model fallback", () => {
       },
       ...(args?.promptAsync
         ? {
-            promptAsync: async (input: { path: { id: string } }) => {
+            promptAsync: async (input: { path: { id: string }; body?: { model?: unknown } }) => {
               promptAsyncCalls.push(input.path.id)
+              if (input.body && typeof input.body === "object" && "model" in input.body) {
+                promptAsyncBodies.push(input.body.model)
+              }
               return args.promptAsync?.(input)
             },
           }
@@ -90,7 +96,7 @@ describe("createEventHandler - model fallback", () => {
     })
     const handler = (input: EventInput): Promise<void> => eventHandler(asEventHandlerInput(input))
 
-    return { handler, abortCalls, promptCalls, promptAsyncCalls }
+    return { handler, abortCalls, promptCalls, promptAsyncCalls, promptAsyncBodies }
   }
 
   afterEach(() => {
@@ -1149,5 +1155,487 @@ describe("createEventHandler - model fallback", () => {
     //#then - no abort or prompt calls should have been made
     expect(abortCalls).toEqual([])
     expect(promptCalls).toEqual([])
+  })
+
+  // ---------------------------------------------------------------------------
+  // RED tests for sync model-fallback bugs (Task 2.1).
+  //
+  // These tests pin the CURRENT (buggy) behavior of the sync session.status
+  // model-fallback path. They are expected to FAIL until Task 2.2 (Fix A),
+  // 2.3 (Fix B), and 2.4 (Fix D) land. Each test names the problem it proves.
+  //
+  //   Problem A: handleSessionStatus calls shouldRetryError({name: undefined,
+  //     message}) and STOP_MESSAGE_PATTERNS contains "monthly limit" so a Z.ai
+  //     "Weekly/Monthly Limit Exhausted" message returns false BEFORE the
+  //     statusCode check -> fallback never armed.
+  //   Problem B: autoContinueAfterFallback dispatches fallbackContext.
+  //     {providerID, modelID} (the FAILED model) instead of the next entry
+  //     from the configured chain -> ProviderModelNotFoundError zombie.
+  //   Problem D: retryKey = attempt:provider/model:normalizedMessage; quota
+  //     messages without provider/model collapse two different failed models
+  //     (GLM -> GPT) to the same key -> second event wrongly treated as dup.
+  // ---------------------------------------------------------------------------
+
+  test("PROBLEM A (RED): session.status with Z.ai Weekly/Monthly Limit Exhausted message arms model-fallback for main session", async () => {
+    //#given - Z.ai returns HTTP 429 with a quota-exhaustion message that
+    // currently matches STOP_MESSAGE_PATTERNS ("monthly limit"), so
+    // shouldRetryError returns false before the statusCode branch can run.
+    // After Task 2.2, the handler must recognize quota-exhaustion 429s as
+    // fallback-eligible regardless of the message pattern.
+    const sessionID = "ses_problem_a_quota_exhaustion"
+    setMainSession(sessionID)
+    const modelFallback = createModelFallbackHook()
+    clearPendingModelFallback(modelFallback, sessionID)
+    const { handler, abortCalls, promptCalls } = createHandler({ hooks: { modelFallback } })
+
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_user_problem_a",
+            sessionID,
+            role: "user",
+            modelID: "glm-5.2",
+            providerID: "zai-coding-plan",
+            agent: "Sisyphus - Ultraworker",
+          },
+        },
+      },
+    })
+
+    //#when - Z.ai quota exhaustion surfaces as session.status retry
+    await handler({
+      event: {
+        type: "session.status",
+        properties: {
+          sessionID,
+          status: {
+            type: "retry",
+            attempt: 1,
+            message:
+              "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-08-15 00:00:00",
+            next: 1234,
+          },
+        },
+      },
+    })
+
+    //#then - fallback MUST be armed and auto-continuation dispatched.
+    // EXPECTED ON CURRENT (BUGGY) CODE: FAIL — fallback is NOT armed because
+    // "monthly limit" in the message matches STOP_MESSAGE_PATTERNS and
+    // shouldRetryError returns false before the statusCode branch.
+    expect(abortCalls).toEqual([sessionID])
+    expect(promptCalls).toEqual([sessionID])
+    expect(modelFallback.hasPendingModelFallback(sessionID)).toBe(true)
+  })
+
+  test("PROBLEM B (RED): autoContinueAfterFallback dispatches the configured next model, not the failed model", async () => {
+    //#given - failed model = zai-coding-plan/glm-5.2; user-configured chain
+    // for sisyphus has exactly one next entry: deepseek/deepseek-v4-pro.
+    // autoContinueAfterFallback should pull that next entry via
+    // getNextFallback and dispatch it, NOT echo back the failed model.
+    const sessionID = "ses_problem_b_wrong_dispatched_model"
+    setMainSession(sessionID)
+    const modelFallback = createModelFallbackHook()
+    clearPendingModelFallback(modelFallback, sessionID)
+    const pluginConfig = {
+      agents: {
+        sisyphus: {
+          fallback_models: ["deepseek/deepseek-v4-pro"],
+        },
+      },
+    }
+    const { handler, promptAsyncBodies } = createHandler({
+      hooks: { modelFallback },
+      pluginConfig,
+      promptAsync: async () => ({}),
+    })
+
+    // Seed lastKnownModel so the failed model resolves to glm-5.2.
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_user_problem_b",
+            sessionID,
+            role: "user",
+            modelID: "glm-5.2",
+            providerID: "zai-coding-plan",
+            agent: "Sisyphus - Ultraworker",
+          },
+        },
+      },
+    })
+
+    //#when - session.status retry whose message carries NO model metadata
+    // (typical for Z.ai quota: the model is implied by lastKnown, not in the
+    // message text). shouldRetryError must still classify it as retryable so
+    // fallback arms and auto-continues.
+    await handler({
+      event: {
+        type: "session.status",
+        properties: {
+          sessionID,
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "Rate limit reached for this request. Please retry shortly.",
+            next: 60,
+          },
+        },
+      },
+    })
+
+    //#then - the dispatched promptAsync body.model MUST be the configured
+    // next entry deepseek/deepseek-v4-pro.
+    // EXPECTED ON CURRENT (BUGGY) CODE: FAIL — autoContinueAfterFallback
+    // builds launchModel from fallbackContext.{providerID, modelID} which is
+    // the FAILED model (zai-coding-plan/glm-5.2), so body.model echoes the
+    // failed model instead of advancing the chain.
+    expect(promptAsyncBodies).toHaveLength(1)
+    expect(promptAsyncBodies[0]).toEqual({
+      providerID: "deepseek",
+      modelID: "deepseek-v4-pro",
+    })
+  })
+
+  test("PROBLEM B (extra): abort failure before continuation does not consume a fallback rung via getNextFallback", async () => {
+    //#given - abort throws before promptAsync runs. getNextFallback must not
+    // be called yet (it is called later by the chat.message hook, not by
+    // autoContinueAfterFallback), so attemptCount must not advance when the
+    // abort fails and the continuation short-circuits. This is a baseline
+    // characterization test: it documents whether the current code path
+    // happens to advance the chain on abort failure.
+    const sessionID = "ses_problem_b_abort_before_continuation"
+    setMainSession(sessionID)
+    const modelFallback = createModelFallbackHook()
+    clearPendingModelFallback(modelFallback, sessionID)
+    const pluginConfig = {
+      agents: {
+        sisyphus: {
+          fallback_models: ["deepseek/deepseek-v4-pro"],
+        },
+      },
+    }
+    const { handler } = createHandler({
+      hooks: { modelFallback },
+      pluginConfig,
+      abort: async () => {
+        throw new Error("abort transport failed")
+      },
+      promptAsync: async () => ({}),
+    })
+
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_user_problem_b_abort",
+            sessionID,
+            role: "user",
+            modelID: "glm-5.2",
+            providerID: "zai-coding-plan",
+            agent: "Sisyphus - Ultraworker",
+          },
+        },
+      },
+    })
+
+    //#when - quota-style retry arrives; abort fails so continuation never
+    // dispatches.
+    await handler({
+      event: {
+        type: "session.status",
+        properties: {
+          sessionID,
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "Rate limit reached for this request. Please retry shortly.",
+            next: 60,
+          },
+        },
+      },
+    })
+
+    //#then - attemptCount must not have advanced (getNextFallback is only
+    // called by the chat.message hook, which never ran). The pending
+    // fallback may still be armed; only the chain index is asserted here.
+    // BASELINE: this should PASS on current code because the chain advances
+    // exclusively inside the chat.message hook, not inside abort handling.
+    const state = modelFallback.getFallbackState(sessionID)
+    expect(state?.attemptCount ?? 0).toBe(0)
+  })
+
+  test("PROBLEM D (RED): two consecutive session.status retries with the same quota message but different failed models are both processed", async () => {
+    //#given - retryKey is built as `${attempt}:${providerID ?? ""}/${modelID
+    // ?? ""}:${normalizeRetryStatusMessage(message)}`. When the quota message
+    // carries no provider/model text (typical for Z.ai 429s), the key
+    // collapses to `1:/:<normalized-message>` for BOTH events even when the
+    // failed model changed (GLM -> GPT). The second event is then wrongly
+    // treated as a duplicate and skipped.
+    const sessionID = "ses_problem_d_dedup_collision"
+    setMainSession(sessionID)
+    const modelFallback = createModelFallbackHook()
+    clearPendingModelFallback(modelFallback, sessionID)
+    const { handler, abortCalls, promptCalls } = createHandler({ hooks: { modelFallback } })
+
+    // First failed model: GLM via lastKnown.
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_user_problem_d_glm",
+            sessionID,
+            role: "user",
+            modelID: "glm-5.2",
+            providerID: "zai-coding-plan",
+            agent: "Sisyphus - Ultraworker",
+          },
+        },
+      },
+    })
+
+    //#when - first quota retry for GLM
+    await handler({
+      event: {
+        type: "session.status",
+        properties: {
+          sessionID,
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "Rate limit reached for this request. Please retry shortly.",
+            next: 60,
+          },
+        },
+      },
+    })
+
+    // Simulate the failed model changing to GPT before the next retry
+    // surfaces (e.g. the chat.message fallback advanced to a GPT model that
+    // then also hit the same provider quota).
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_user_problem_d_gpt",
+            sessionID,
+            role: "user",
+            modelID: "gpt-5.5",
+            providerID: "openai",
+            agent: "Sisyphus - Ultraworker",
+          },
+        },
+      },
+    })
+
+    //#when - second quota retry with the SAME normalized message but now for
+    // a DIFFERENT failed model (GPT). The two events have distinct
+    // semantics: the first triggers fallback for GLM, the second for GPT.
+    await handler({
+      event: {
+        type: "session.status",
+        properties: {
+          sessionID,
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "Rate limit reached for this request. Please retry shortly.",
+            next: 60,
+          },
+        },
+      },
+    })
+
+    //#then - BOTH retries must have triggered abort + prompt.
+    // EXPECTED ON CURRENT (BUGGY) CODE: FAIL - only the first event
+    // processes; the second collides on retryKey `1:/:rate limit reached...`
+    // and is dropped as a duplicate.
+    expect(abortCalls).toEqual([sessionID, sessionID])
+    expect(promptCalls).toEqual([sessionID, sessionID])
+  })
+
+  test("NEGATIVE (baseline): session.status with a benign non-retryable message does not arm model-fallback", async () => {
+    //#given - characterization baseline. The message below matches NO
+    // RETRYABLE_MESSAGE_PATTERNS and NO STOP patterns, so shouldRetryError
+    // returns false and no fallback is armed. This MUST stay green so the
+    // RED tests above cannot be accused of just arming fallback for any
+    // session.status event.
+    const sessionID = "ses_negative_benign_message"
+    setMainSession(sessionID)
+    const modelFallback = createModelFallbackHook()
+    clearPendingModelFallback(modelFallback, sessionID)
+    const { handler, abortCalls, promptCalls } = createHandler({ hooks: { modelFallback } })
+
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_user_negative_benign",
+            sessionID,
+            role: "user",
+            modelID: "glm-5.2",
+            providerID: "zai-coding-plan",
+            agent: "Sisyphus - Ultraworker",
+          },
+        },
+      },
+    })
+
+    //#when
+    await handler({
+      event: {
+        type: "session.status",
+        properties: {
+          sessionID,
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "Informational: session heartbeat acknowledged.",
+            next: 30,
+          },
+        },
+      },
+    })
+
+    //#then - no fallback, no abort/prompt.
+    expect(abortCalls).toEqual([])
+    expect(promptCalls).toEqual([])
+    expect(modelFallback.hasPendingModelFallback(sessionID)).toBe(false)
+  })
+
+  test("NEGATIVE (baseline): session.error with AbortError does not arm model-fallback", async () => {
+    //#given - AbortError is not in NON_RETRYABLE_ERROR_NAMES verbatim, but
+    // with an empty message no RETRYABLE pattern matches, so shouldRetryError
+    // returns false. This pins the contract that genuine abort-style errors
+    // do not consume a fallback rung.
+    const sessionID = "ses_negative_abort_error"
+    setMainSession(sessionID)
+    const modelFallback = createModelFallbackHook()
+    clearPendingModelFallback(modelFallback, sessionID)
+    const { handler, abortCalls, promptCalls } = createHandler({ hooks: { modelFallback } })
+
+    //#when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          error: {
+            name: "AbortError",
+            message: "Request aborted by user.",
+          },
+        },
+      },
+    })
+
+    //#then - no fallback armed.
+    expect(abortCalls).toEqual([])
+    expect(promptCalls).toEqual([])
+    expect(modelFallback.hasPendingModelFallback(sessionID)).toBe(false)
+  })
+
+  test("CHAIN EXHAUSTION: once the configured fallback chain is fully consumed, a second retry does not dispatch another continuation", async () => {
+    //#given - user-configured chain has exactly ONE entry. The first retry
+    // consumes it; the second retry must NOT spawn another promptAsync
+    // continuation (no orphan reservations, no zombie session).
+    const sessionID = "ses_chain_exhaustion"
+    setMainSession(sessionID)
+    const modelFallback = createModelFallbackHook()
+    clearPendingModelFallback(modelFallback, sessionID)
+    const pluginConfig = {
+      agents: {
+        sisyphus: {
+          fallback_models: ["deepseek/deepseek-v4-pro"],
+        },
+      },
+    }
+    const { handler, abortCalls, promptAsyncCalls } = createHandler({
+      hooks: { modelFallback },
+      pluginConfig,
+      promptAsync: async () => ({}),
+    })
+
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_user_chain_exhaustion_1",
+            sessionID,
+            role: "user",
+            modelID: "glm-5.2",
+            providerID: "zai-coding-plan",
+            agent: "Sisyphus - Ultraworker",
+          },
+        },
+      },
+    })
+
+    //#when - first quota retry; auto-continuation dispatches once.
+    await handler({
+      event: {
+        type: "session.status",
+        properties: {
+          sessionID,
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "Rate limit reached for this request. Please retry shortly.",
+            next: 60,
+          },
+        },
+      },
+    })
+
+    // Surface a different failed model so the second retry is NOT dropped by
+    // the Problem-D dedup collision (we want to isolate chain-exhaustion
+    // behavior from the dedup bug).
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_user_chain_exhaustion_2",
+            sessionID,
+            role: "user",
+            modelID: "deepseek-v4-pro",
+            providerID: "deepseek",
+            agent: "Sisyphus - Ultraworker",
+          },
+        },
+      },
+    })
+
+    await handler({
+      event: {
+        type: "session.status",
+        properties: {
+          sessionID,
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "Rate limit reached for this request. Please retry shortly.",
+            next: 60,
+          },
+        },
+      },
+    })
+
+    //#then - exactly ONE continuation was dispatched. The second retry must
+    // not spawn another promptAsync (the configured chain is exhausted).
+    // BASELINE/RED: see /tmp/omo-task21-report.txt for the observed outcome;
+    // current code may dispatch twice (Problem B echoes the failed model
+    // instead of consulting the chain, so exhaustion is invisible to
+    // autoContinueAfterFallback). After Task 2.3, this should PASS.
+    expect(promptAsyncCalls).toEqual([sessionID])
+    expect(abortCalls.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/packages/omo-opencode/src/shared/model-fallback-decision.ts
+++ b/packages/omo-opencode/src/shared/model-fallback-decision.ts
@@ -1,0 +1,9 @@
+import { isProviderExhaustionFallbackEligible, shouldRetryError } from "@oh-my-opencode/model-core"
+
+export function shouldAttemptModelFallback(errorInfo: {
+  name?: string
+  message?: string
+  statusCode?: number
+}): boolean {
+  return shouldRetryError(errorInfo) || isProviderExhaustionFallbackEligible(errorInfo)
+}


### PR DESCRIPTION
## Summary

Three coupled fixes (A/B/D) for the model-fallback event recovery path. Together they fix silent fallback-chain breakage when Z.ai (GLM) and OpenAI (GPT) both return "Weekly/Monthly Limit Exhausted" (429).

## Problem

`event-model-fallback` was silently broken in three places, causing `ProviderModelNotFoundError` and zombie sessions when consumers hit provider quota limits:

1. **Fallback never armed** for the Z.ai exhaustion pattern — `shouldRetryError` returns `false` because STOP_MESSAGE_PATTERNS matches `"monthly limit"`. Background `fallback-retry-handler` already has `isProviderExhaustionFallbackEligible` (#5508); the event path was omitted.
2. **Continuation launched with the failed model** — `autoContinueAfterFallback` read from `fallbackContext` instead of peeking the resolved next fallback, causing `ProviderModelNotFoundError`.
3. **Dedup collision when GLM and GPT both return "Monthly Limit Exhausted"** — `Map<string, string>` produced identical keys (`1:/:monthly...`), so the second hop was treated as a duplicate and the chain stopped after the first fallback.

## Fixes

### A) `shouldAttemptModelFallback()` wrapper — provider-exhaustion parity
New `packages/omo-opencode/src/shared/model-fallback-decision.ts` mirrors the background handler's decision semantics:

```ts
shouldAttemptModelFallback = shouldRetryError || isProviderExhaustionFallbackEligible
```

### B) `autoContinueAfterFallback` — peek before dispatch
Now uses `peekNextFallback` (non-mutating) **before** dispatch, so continuation launches with the fallback model (e.g. `deepseek/deepseek-v4-pro`), not the failed model from `fallbackContext`. The toxic hardcoded default was removed.

New exports added to the hook (`peekNextFallback`) and controller (`peekNextFallback` + `setPendingModelFallback` relaxed to allow re-arm for a *different* failed model).

### D) Model-aware dedup
- `Map<string, string>` → `Map<string, Set<string>>`
- Trusted session state (`lastKnownModelBySession`) replaces quota-message parsing
- Prevents collision when GLM and GPT share the same error message

## Files Changed

| File | Fix | Status |
|------|-----|--------|
| `packages/omo-opencode/src/shared/model-fallback-decision.ts` | A | NEW |
| `packages/omo-opencode/src/plugin/event-model-fallback.ts` | A+B+D | modified |
| `packages/omo-opencode/src/plugin/event-model-fallback-state.ts` | B | modified |
| `packages/omo-opencode/src/hooks/model-fallback/fallback-state-controller.ts` | B+D | modified |
| `packages/omo-opencode/src/hooks/model-fallback/hook.ts` | B | modified |
| `packages/omo-opencode/src/plugin/event.model-fallback.test.ts` | tests | modified |

6 files / +621 / -21.

## Verification

- **Tests**: 22 pass / 0 fail (3 new RED→GREEN for A/B/D + 4 baselines)
- **Typecheck**: exit 0
- **Build**: exit 0

## Test Plan

- [x] All 22 unit tests pass (3 new tests demonstrate the bug → fix flow for each of A, B, D)
- [x] Typecheck clean
- [x] Build clean
- [ ] Live verification: trigger Z.ai "Weekly/Monthly Limit Exhausted" → confirm fallback chain continues with `deepseek-v4-pro`
- [ ] Live verification: GLM + GPT exhaustion in same session → confirm no dedup collision

## Related Issues

- #5508 — Architectural template (background `isProviderExhaustionFallbackEligible`)
- #5451 — RFC structured provider-error contract
- #6349 — Rolling-hour usage limits
- #6636 — `runtime_fallback` regexes (different consumer, related pattern)
- #6579 — Dedup key ignores model
- #6611 — Runtime-fallback dedup pattern


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the event-driven model fallback so quota 429s don’t stall sessions. Continuations now launch with the actual fallback model, and deduping no longer collapses different failed models.

- **Bug Fixes**
  - Provider exhaustion: `shouldAttemptModelFallback` combines `shouldRetryError` with `isProviderExhaustionFallbackEligible` to allow fallback on Z.ai/OpenAI “Weekly/Monthly Limit Exhausted” (429).
  - Correct continuation model: `autoContinueAfterFallback` peeks the next rung via `peekNextFallback` before dispatch, so it uses the fallback model (not the failed one); removed the hardcoded default and allowed `setPendingModelFallback` to re-arm when the failed model changes.
  - Model-aware dedup: per-session `Set` of retry keys plus trusted `lastKnownModelBySession` prevent collisions when different providers share the same quota message.

<sup>Written for commit 5579c8b11db01f777d005df5b06a6a37642e17dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

