### PR TITLE
fix: preserve array-form plugin entries and symlinks when self-healing tui.json

### DIFF
--- a/packages/omo-opencode/src/cli/config-manager/add-tui-plugin-to-tui-config.test.ts
+++ b/packages/omo-opencode/src/cli/config-manager/add-tui-plugin-to-tui-config.test.ts
@@ -66,6 +66,21 @@ describe("ensureTuiPluginEntry", () => {
     expect(readTuiPlugins(dir)).toEqual([`${PLUGIN_NAME}@4.9.2`])
   })
 
+  it("#given array-form plugin entries #when ensuring TUI config #then it preserves them", () => {
+    // given
+    const dir = tempConfigDir()
+    const arrayEntry = ["opencode-copy-message", { editor: "nvim" }]
+    writeConfig(dir, "opencode.json", { plugin: [PLUGIN_NAME] })
+    writeConfig(dir, "tui.json", { plugin: [arrayEntry, "some-other/tui"] })
+
+    // when
+    const result = ensureTuiPluginEntry({ configDir: dir })
+
+    // then
+    expect(result).toEqual({ changed: true, reason: "added" })
+    expect(readTuiPlugins(dir)).toEqual([arrayEntry, "some-other/tui", PLUGIN_NAME])
+  })
+
   it("#given file server entry and stale named TUI entry #when ensuring #then it adds the matching file entry", () => {
     // given
     const dir = tempConfigDir()

--- a/packages/omo-opencode/src/cli/config-manager/add-tui-plugin-to-tui-config.ts
+++ b/packages/omo-opencode/src/cli/config-manager/add-tui-plugin-to-tui-config.ts
@@ -15,7 +15,7 @@ import {
 import { writeFileAtomically } from "../../shared/write-file-atomically"
 
 type ConfigShape = {
-  plugin?: string[]
+  plugin?: Array<string | [string, unknown]>
   [key: string]: unknown
 }
 
@@ -46,10 +46,8 @@ function readServerConfig(configDir: string): ConfigShape | null {
   return null
 }
 
-function pluginEntries(config: ConfigShape): string[] {
-  return Array.isArray(config.plugin)
-    ? config.plugin.filter((entry): entry is string => typeof entry === "string")
-    : []
+function pluginEntries(config: ConfigShape): Array<string | [string, unknown]> {
+  return Array.isArray(config.plugin) ? config.plugin : []
 }
 
 function desiredTuiEntry(serverEntry: string): string | null {

--- a/packages/omo-opencode/src/shared/write-file-atomically.test.ts
+++ b/packages/omo-opencode/src/shared/write-file-atomically.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, statSync } from "fs"
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, lstatSync, statSync, symlinkSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 import { writeFileAtomically } from "./write-file-atomically"
@@ -108,5 +108,21 @@ describe("writeFileAtomically", () => {
         },
       }),
     ).toThrow("EIO")
+  })
+
+  it("#given target is a symlink #when writeFileAtomically called #then writes through and keeps the symlink", () => {
+    // given
+    const targetPath = join(testDir, "real-target.txt")
+    writeFileSync(targetPath, "original", "utf-8")
+    const linkPath = join(testDir, "managed-link.json")
+    symlinkSync(targetPath, linkPath)
+
+    // when
+    writeFileAtomically(linkPath, "updated content")
+
+    // then
+    expect(lstatSync(linkPath).isSymbolicLink()).toBe(true)
+    expect(readFileSync(targetPath, "utf-8")).toBe("updated content")
+    expect(existsSync(`${linkPath}.tmp`)).toBe(false)
   })
 })

--- a/packages/omo-opencode/src/shared/write-file-atomically.ts
+++ b/packages/omo-opencode/src/shared/write-file-atomically.ts
@@ -1,8 +1,10 @@
 import {
   chmodSync,
   closeSync,
+  existsSync,
   type fsyncSync as FsyncSync,
   openSync,
+  realpathSync,
   renameSync,
   unlinkSync,
   writeFileSync,
@@ -19,7 +21,10 @@ export function writeFileAtomically(
     beforeRenameSync?: (tempPath: string) => void
   } = {},
 ): void {
-  const tempPath = `${filePath}.tmp`
+  // Write through symlinks: renaming over the symlink itself would replace it
+  // with a regular file, breaking dotfiles/managed config setups.
+  const targetPath = existsSync(filePath) ? realpathSync(filePath) : filePath
+  const tempPath = `${targetPath}.tmp`
   const mode = deps.mode
   writeFileSync(tempPath, content, { encoding: "utf-8", mode })
   if (mode !== undefined) {
@@ -27,14 +32,14 @@ export function writeFileAtomically(
   }
   const tempFileDescriptor = openSync(tempPath, "r+")
   try {
-    tolerantFsyncSync(tempFileDescriptor, `writeFileAtomically:${filePath}`, deps.fsyncSync)
+    tolerantFsyncSync(tempFileDescriptor, `writeFileAtomically:${targetPath}`, deps.fsyncSync)
   } finally {
     closeSync(tempFileDescriptor)
   }
 
   try {
     deps.beforeRenameSync?.(tempPath)
-    renameSync(tempPath, filePath)
+    renameSync(tempPath, targetPath)
   } catch (error) {
     const isWindows = process.platform === "win32"
     const isPermissionError =
@@ -42,13 +47,13 @@ export function writeFileAtomically(
       (error.message.includes("EPERM") || error.message.includes("EACCES"))
 
     if (isWindows && isPermissionError) {
-      unlinkSync(filePath)
-      renameSync(tempPath, filePath)
+      unlinkSync(targetPath)
+      renameSync(tempPath, targetPath)
     } else {
       throw error
     }
   }
   if (mode !== undefined) {
-    chmodSync(filePath, mode)
+    chmodSync(targetPath, mode)
   }
 }


### PR DESCRIPTION
## Problem

The oh-my-openagent server plugin rewrites `tui.json` at every opencode startup via `ensureTuiPluginEntry()`. Two bugs make that rewrite destructive for users who manage their config with dotfiles/symlinks:

1. **Array-form plugin entries are dropped.** `pluginEntries()` filters `config.plugin` to `typeof entry === "string"` only. Entries like `["opencode-copy-message", { editor: "nvim", keybinds: {...} }]` silently disappear from `tui.json` on every self-heal.

2. **The dotbot/managed symlink is replaced by a regular file.** `writeFileAtomically()` writes to a `.tmp` file and `renameSync`s it over the target path. When `tui.json` is a symlink (dotbot `~/.config/opencode/tui.json -> ~/.dotfiles/config/opencode/tui.json`), the rename replaces the symlink itself with a plain file — breaking the "dotfiles are the source of truth" setup.

## Changes

- `add-tui-plugin-to-tui-config.ts`: `pluginEntries()` now returns all entries (strings + `[name, options]` tuples) instead of string-only; `ConfigShape.plugin` type widened to `Array<string | [string, unknown]>`.
- `write-file-atomically.ts`: resolve `realpathSync` before the atomic rename so writes go through symlinks to their target, preserving the link.
- Tests: array-form entry preservation; symlink write-through (link survives, target updated, no `.tmp` left behind).

## Verification

`bun test` on both affected test files: 14 pass / 0 fail. `tsgo --noEmit` on `packages/omo-opencode`: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix self-healing of `tui.json` to preserve array-form plugin entries and write through symlinks. Prevents losing plugin options and replacing symlinks with regular files in dotfile-managed setups.

- **Bug Fixes**
  - `pluginEntries` now keeps both string and `[name, options]` entries; `ConfigShape.plugin` widened to `Array<string | [string, unknown]>`.
  - `writeFileAtomically` resolves the real target path before rename, updating the symlink target and preserving the link.

<sup>Written for commit 78fd53b870a4e56fdc0d004b5181ba5b26c8bace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

