### PR TITLE
fix(codex): isolate packaged plugin installs from workspaces

### DIFF
--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// omo-codex-install:7bc4b0f020f0a1b4448cc75385a7e3c60042e3b270e304d4c1a43a859e81a4c2:e3e8cf6fc61cb0fb389d319dce31f73f8b2ebcb823ff09f8eee44a107186771b
+// omo-codex-install:01cee1543387564c19d57124ed5c708be20e8c0e409b36188fc82ab181528082:ed4f745d3e591add9448d9066317a87c547d3c4c3ee0f9ec2659c88d0f82d7c8
 var __defProp = Object.defineProperty;
 var __returnValue = (v) => v;
 function __exportSetter(name, newValue) {
@@ -5927,7 +5927,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "5.0.0-beta.5",
+    version: "5.0.0-beta.6",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -7180,6 +7180,38 @@ async function rewriteCachedPackageLocalFileDependencies(pluginRoot, sourceRoot)
 `);
   return rewroteAnyPackageJson;
 }
+async function removeCachedPackageWorkspaces(pluginRoot) {
+  const packageJsonPath = join8(pluginRoot, "package.json");
+  let packageJson;
+  try {
+    packageJson = JSON.parse(await readFile5(packageJsonPath, "utf8"));
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT")
+      return false;
+    throw error;
+  }
+  if (!isPlainRecord(packageJson))
+    return false;
+  let changed = false;
+  if (Array.isArray(packageJson.workspaces) && packageJson.workspaces.length > 0) {
+    packageJson.workspaces = [];
+    await writeFile2(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}
+`);
+    changed = true;
+  }
+  const packageLock = await readPackageLock(pluginRoot);
+  const packages = getPackageLockPackages(packageLock.value);
+  const lockRoot = packages?.[""];
+  if (isPlainRecord(lockRoot) && Array.isArray(lockRoot.workspaces) && lockRoot.workspaces.length > 0) {
+    lockRoot.workspaces = [];
+    packageLock.changed = true;
+    changed = true;
+  }
+  if (packageLock.changed)
+    await writeFile2(packageLock.path, `${JSON.stringify(packageLock.value, null, "\t")}
+`);
+  return changed;
+}
 async function readPackageLock(pluginRoot) {
   const path = join8(pluginRoot, "package-lock.json");
   try {
@@ -7600,9 +7632,10 @@ async function installCachedPlugin(input) {
   try {
     await copyDirectory(input.sourcePath, tempPath);
     const rewroteLocalFileDependencies = await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath);
+    const removedCachedWorkspaces = input.buildSource === false ? await removeCachedPackageWorkspaces(tempPath) : false;
     await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath });
     await copyRootRuntimeDists({ pluginRoot: tempPath, sourcePath: input.sourcePath });
-    const installArgs = rewroteLocalFileDependencies ? ["install", "--omit=dev", "--no-audit", "--no-fund"] : ["ci", "--omit=dev"];
+    const installArgs = rewroteLocalFileDependencies || removedCachedWorkspaces ? ["install", "--omit=dev", "--no-audit", "--no-fund"] : ["ci", "--omit=dev"];
     await maybeRunNpmInstall(tempPath, input.runCommand, npmInstallEnv, installArgs);
     await removeCachedManagedNpmBinShims(tempPath);
     if (input.buildSource === false)

--- a/packages/omo-codex/src/install/codex-cache-install.test.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.test.ts
@@ -129,6 +129,74 @@ describe("codex-cache install", () => {
   )
 
   test(
+    "#given a packaged plugin has source workspace metadata #when caching plugin #then npm ignores the workspace graph",
+    async () => {
+      // given
+      const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-workspaces-"))
+      const codexHome = join(root, "codex-home")
+      const sourceRoot = join(root, "plugin")
+      const sharedRoot = join(root, "shared-lib")
+      await mkdir(sourceRoot, { recursive: true })
+      await mkdir(sharedRoot, { recursive: true })
+      await writeFile(
+        join(sourceRoot, "package.json"),
+        JSON.stringify({
+          name: "@scope/omo",
+          version: "0.1.0",
+          workspaces: ["components/local-tool"],
+          dependencies: { "shared-lib": "file:../shared-lib" },
+        }),
+      )
+      await writeFile(join(sharedRoot, "package.json"), JSON.stringify({ name: "shared-lib", version: "0.1.0" }))
+      await writeFile(
+        join(sourceRoot, "package-lock.json"),
+        JSON.stringify({
+          name: "@scope/omo",
+          version: "0.1.0",
+          lockfileVersion: 3,
+          requires: true,
+          packages: {
+            "": {
+              name: "@scope/omo",
+              version: "0.1.0",
+              workspaces: ["components/local-tool"],
+              dependencies: { "shared-lib": "file:../shared-lib" },
+            },
+          },
+        }),
+      )
+      let cachedPackageWorkspaces: unknown
+      let cachedLockWorkspaces: unknown
+
+      // when
+      const installed = await installCachedPlugin({
+        buildSource: false,
+        codexHome,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async (command, args, options) => {
+          if (command !== "npm" || args[0] !== "install") return
+          const cachedPackage = JSON.parse(await readFile(join(options.cwd, "package.json"), "utf8")) as { readonly workspaces?: unknown }
+          const cachedLock = JSON.parse(await readFile(join(options.cwd, "package-lock.json"), "utf8")) as {
+            readonly packages?: { readonly ""?: { readonly workspaces?: unknown } }
+          }
+          cachedPackageWorkspaces = cachedPackage.workspaces
+          cachedLockWorkspaces = cachedLock.packages?.[""]?.workspaces
+        },
+      })
+
+      // then
+      expect(cachedPackageWorkspaces).toEqual([])
+      expect(cachedLockWorkspaces).toEqual([])
+      const installedPackage = JSON.parse(await readFile(join(installed.path, "package.json"), "utf8")) as { readonly workspaces?: unknown }
+      expect(installedPackage.workspaces).toEqual([])
+    },
+    15000,
+  )
+
+  test(
     "#given the local file: dependency rewrite changed nothing #when caching plugin #then the install stays npm ci --omit=dev",
     async () => {
       // given

--- a/packages/omo-codex/src/install/codex-cache-install.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join, sep } from "node:path"
 import { copyBundledMcpRuntimeDists } from "./codex-cache-bundled-mcps"
 import { removeCachedManagedNpmBinShims } from "./codex-cache-bins"
 import { fileExistsStrict, isPlainRecord } from "./codex-cache-fs"
-import { rewriteCachedPackageLocalFileDependencies } from "./codex-cache-local-dependencies"
+import { removeCachedPackageWorkspaces, rewriteCachedPackageLocalFileDependencies } from "./codex-cache-local-dependencies"
 import { rewriteCachedManifestRoot, rewriteCachedMcpManifest } from "./codex-cache-mcp-manifest"
 import { assertHookCommandTargets } from "./codex-hook-targets"
 import type { InstalledPlugin, RunCommand } from "./types"
@@ -34,13 +34,15 @@ export async function installCachedPlugin(input: {
   try {
     await copyDirectory(input.sourcePath, tempPath)
     const rewroteLocalFileDependencies = await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath)
+    const removedCachedWorkspaces = input.buildSource === false ? await removeCachedPackageWorkspaces(tempPath) : false
     await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath })
     await copyRootRuntimeDists({ pluginRoot: tempPath, sourcePath: input.sourcePath })
-    // Rewriting local file: dependencies desyncs package.json from package-lock.json, and npm ci
-    // aborts with EUSAGE on that drift (lazycodex#137; approach credited to the community fix in
-    // oh-my-openagent#6202). The temp cache dir is throwaway, so let npm install reconcile the lock
-    // when the rewrite changed package.json; keep the deterministic npm ci fast path otherwise.
-    const installArgs = rewroteLocalFileDependencies
+    // Rewriting local file: dependencies or removing source-only workspace metadata desyncs
+    // package.json from package-lock.json, and npm ci aborts with EUSAGE on that drift
+    // (lazycodex#137; approach credited to the community fix in oh-my-openagent#6202). The temp
+    // cache dir is throwaway, so let npm install reconcile the lock when either rewrite occurs;
+    // keep the deterministic npm ci fast path otherwise.
+    const installArgs = rewroteLocalFileDependencies || removedCachedWorkspaces
       ? ["install", "--omit=dev", "--no-audit", "--no-fund"]
       : ["ci", "--omit=dev"]
     await maybeRunNpmInstall(tempPath, input.runCommand, npmInstallEnv, installArgs)

--- a/packages/omo-codex/src/install/codex-cache-local-dependencies.ts
+++ b/packages/omo-codex/src/install/codex-cache-local-dependencies.ts
@@ -48,6 +48,42 @@ export async function rewriteCachedPackageLocalFileDependencies(pluginRoot: stri
   return rewroteAnyPackageJson
 }
 
+/**
+ * A published Codex plugin contains prebuilt workspace components, not a runnable npm workspace.
+ * Keep npm from traversing the source workspace graph while it installs the small production
+ * dependency set needed by the cached plugin. The source tree keeps its workspace metadata so
+ * development and release builds remain unchanged.
+ */
+export async function removeCachedPackageWorkspaces(pluginRoot: string): Promise<boolean> {
+  const packageJsonPath = join(pluginRoot, "package.json")
+  let packageJson: unknown
+  try {
+    packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"))
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false
+    throw error
+  }
+  if (!isPlainRecord(packageJson)) return false
+
+  let changed = false
+  if (Array.isArray(packageJson.workspaces) && packageJson.workspaces.length > 0) {
+    packageJson.workspaces = []
+    await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`)
+    changed = true
+  }
+
+  const packageLock = await readPackageLock(pluginRoot)
+  const packages = getPackageLockPackages(packageLock.value)
+  const lockRoot = packages?.[""]
+  if (isPlainRecord(lockRoot) && Array.isArray(lockRoot.workspaces) && lockRoot.workspaces.length > 0) {
+    lockRoot.workspaces = []
+    packageLock.changed = true
+    changed = true
+  }
+  if (packageLock.changed) await writeFile(packageLock.path, `${JSON.stringify(packageLock.value, null, "\t")}\n`)
+  return changed
+}
+
 type PackageLockState = {
   readonly path: string
   readonly value: Record<string, unknown> | null


### PR DESCRIPTION
## Summary

The published lazycodex-ai Codex installer treats the bundled plugin as an npm workspace. Its lockfile points at source-only workspace packages outside the published plugin payload, so npm fails before the plugin can be cached.

When installing a packaged plugin, this change removes the root workspace metadata from the temporary cache copy (including the lockfile root) before the production dependency install. Source/repository installs keep their workspace metadata unchanged.

## Verification

- bun test packages/omo-codex/src/install/codex-cache-install.test.ts packages/omo-codex/src/install/install-codex-packaged.test.ts
- node --test packages/omo-codex/scripts/install-generated-bundle.test.mjs packages/omo-codex/scripts/install-packaged-local.test.mjs
- End-to-end smoke test using the lazycodex-ai@4.19.4 tarball and a fresh CODEX_HOME completed successfully with the generated installer.

The local package-layout runtime test remains dependent on the repository's interrupted LSP build; the affected dist files are generated before that test in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent npm failures when installing packaged Codex plugins by stripping workspace metadata from the cached copy before install. Packaged installs now use `npm install --omit=dev`, while source installs keep workspaces and `npm ci`.

- **Bug Fixes**
  - Remove `workspaces` from cached `package.json` and lockfile root for packaged plugins in `@oh-my-opencode/omo-codex`.
  - Switch to `npm install --omit=dev --no-audit --no-fund` when local file: deps are rewritten or workspaces are removed; otherwise use `npm ci --omit=dev`.
  - Added tests to confirm workspace removal and the correct install path for packaged vs. source installs.

<sup>Written for commit 9399a103259a748994eba8ede9dfa5b4dd04fcc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

