### PR TITLE
docs: explain the three OMO editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ Install oh-my-openagent. Type `ultrawork`. Done.
 
 ## Installation
 
-oh-my-openagent ships in two editions of the same product:
+oh-my-openagent ships in three editions of the same product: two plugins that load into a host you already run, plus one standalone edition.
 
 - **Ultimate Edition (omo for OpenCode)** — full omo. 11 agents, 54+ lifecycle hooks, 5 built-in MCPs, all slash commands, Team Mode, ulw-loop, ultrawork, hashline edits — everything.
 - **Light Edition (omo for Codex CLI)** — the portable components that fit Codex's plugin system: `rules`, `comment-checker`, `git-bash`, `lsp`, `ultrawork`, `ulw-loop`, `start-work-continuation`, and `telemetry`, plus plugin-scoped MCPs for `grep_app`, `context7`, `codegraph`, `git_bash`, and `lsp`, and the shared `ast-grep` skill. No agent orchestration and no `team_*` tools — Codex CLI's own surface does that work.
+- **Senpi Edition (standalone, beta)** — the native `omo` command with the OMO extension built in. It installs from `omo-ai@beta` rather than loading into OpenCode or Codex.
 
 Pick the edition(s) you want.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,9 +1,10 @@
 # Installation
 
-oh-my-openagent ships in **two editions** of the same product:
+oh-my-openagent ships in **three editions** of the same product: two plugins that load into a host you already run, plus one standalone edition.
 
 - **Ultimate Edition (omo for [OpenCode](https://opencode.ai))** — the full omo experience. 11 discipline agents, 54+ lifecycle hooks, all built-in MCPs, every slash command, Team Mode, ulw-loop, hashline edits, the works.
 - **Light Edition (omo for [OpenAI Codex CLI](https://github.com/openai/codex))** - the portable components that fit Codex's plugin system: `codegraph`, `comment-checker`, `git-bash`, `lazycodex-executor-verify`, `rules`, `lsp`, `telemetry`, `teammode`, `start-work-continuation`, `ulw-loop`, and `ultrawork`, plus plugin-scoped MCPs for `grep_app`, `context7`, `codegraph`, `git_bash`, and `lsp`, and the shared `ast-grep` skill. It has no OpenCode agent registry or `team_*` tool family, but ships Codex-native agent roles and the script-and-skill-driven `teammode` component.
+- **Senpi Edition (standalone, beta)** — the native `omo` command with the OMO extension built in. It installs from `omo-ai@beta` instead of loading as a plugin into OpenCode or Codex.
 
 Most users want **Ultimate**. Pick **Light** if you are already invested in Codex CLI. Pick **both** if you want OMO available wherever you happen to be working that day.
 


### PR DESCRIPTION
## Summary

- describe Ultimate and Light as host plugins
- add Senpi as the standalone beta edition in both installation openings
- make the edition count match the existing install tables

Closes #6726

## Verification

- `bun test packages/omo-opencode/src/shared/markdown-link-audit.test.ts` (16 pass, 0 fail)
- QA-by-read across `README.md` and `docs/guide/installation.md`
- evidence: `.omo/evidence/20260811-issue-6726/` in the task worktree (local QA artifact, not committed)

## Risk

Documentation only. No install command, package, schema, or runtime behavior changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified docs to explain all three OMO editions: Ultimate and Light as host plugins, plus the standalone Senpi (beta) installed via `omo-ai@beta`. Aligns edition count and wording in README and Installation guide to match existing install tables, addressing #6726.

<sup>Written for commit 7a1ac37d449648764e497d05356be39bc7ec2ed3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

