### PR TITLE
docs: add edition choice guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ Pick the edition(s) you want.
 
 `lazycodex-ai` defaults to the Codex Light installer and runs through Node/npm. `--platform` on the shared `omo-agent-toolkit` CLI still defaults to `opencode` (Ultimate).
 
+### Which edition should I pick?
+
+- Already use OpenCode, or want the most-tested path? Choose **Ultimate**: `bunx oh-my-openagent install`.
+- Already use Codex CLI? Choose **Light**: `npx lazycodex-ai install`.
+- Want one command without installing a host first? Choose **Senpi/native (beta)**: `npm i -g omo-ai@beta`.
+
+Ultimate and Light are plugins that load into a host you already run. Senpi is standalone: it ships a pinned Senpi engine with OMO built in.
+
+For Senpi, the `@beta` tag is required; bare `npm i -g omo-ai` fails by design. Do not install plain `omo` from npm: it is an unrelated package by a different author.
+
 ### For Humans
 
 **Strongly recommended: let an LLM agent install this for you.** The Ultimate edition setup involves subscription detection, model selection across 11 agents, and per-provider authentication — humans fat-finger these. An LLM agent reads the full guide and walks every step correctly.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -15,6 +15,16 @@ Most users want **Ultimate**. Pick **Light** if you are already invested in Code
 
 Both `lazycodex-ai` and `lazycodex` are shipped bin aliases that default to the Codex Light installer and run through Node/npm. `--platform` on the shared `omo-agent-toolkit` CLI still defaults to `opencode` (Ultimate). `lazycodex` is also the repository identity that hosts the marketplace bundle. Neither alias is the Codex marketplace name.
 
+## Which edition should I pick?
+
+- Already use OpenCode, or want the most-tested path? Choose **Ultimate**: `bunx oh-my-openagent install`.
+- Already use Codex CLI? Choose **Light**: `npx lazycodex-ai install`.
+- Want one command without installing a host first? Choose **Senpi/native (beta)**: `npm i -g omo-ai@beta`.
+
+Ultimate and Light are plugins that load into a host you already run. Senpi is standalone: it ships a pinned Senpi engine with OMO built in.
+
+For Senpi, the `@beta` tag is required; bare `npm i -g omo-ai` fails by design. Do not install plain `omo` from npm: it is an unrelated package by a different author.
+
 ## For Humans
 
 **Strongly recommended: let an LLM agent install Ultimate for you.** Ultimate setup involves subscription detection, model selection across 11 agents, provider authentication, and config migration — humans fat-finger these. An LLM agent reads the full guide and walks every step correctly.


### PR DESCRIPTION
## Summary

- add a purpose-based three-way edition decision to README and the install guide
- distinguish the two host plugins from standalone Senpi/native
- warn that Senpi requires `omo-ai@beta` and plain npm `omo` is unrelated

Closes #6731

## Verification

- `bun test packages/omo-opencode/src/shared/markdown-link-audit.test.ts` (16 pass, 0 fail)
- QA-by-read across `README.md` and `docs/guide/installation.md`
- evidence: `.omo/evidence/20260811-issue-6731/` in the task worktree (local QA artifact, not committed)

## Risk

Documentation only. No installer, package identity, command routing, schema, or runtime behavior changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add clear edition-picking guidance to the README and installation guide so users can choose between Ultimate, Light, and Senpi/native with confidence. Clarifies that Ultimate/Light are host plugins, Senpi is standalone, and Senpi requires `omo-ai@beta` (do not install `omo`), addressing #6731.

<sup>Written for commit 2dea9d69485dcf332d9055782c02a5e4479cbf0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

