### PR TITLE
test(senpi-init-deep): budget Windows git helper fixtures

### DIFF
--- a/.omo/evidence/20260812-windows-git-commits-timeout/green/local-validation.md
+++ b/.omo/evidence/20260812-windows-git-commits-timeout/green/local-validation.md
@@ -1,0 +1,43 @@
+# GREEN: local validation
+
+## What was tested
+
+Commands were run from the task worktree:
+
+```text
+npx -y bun@1.3.12 test packages/omo-senpi/src/components/init-deep-advisor/git-helpers.test.ts
+bun test packages/omo-senpi/src/components/init-deep-advisor
+bun run --cwd packages/omo-senpi typecheck
+git diff --check
+```
+
+## What was observed
+
+```text
+14 pass
+0 fail
+17 expect() calls
+Ran 14 tests across 1 file. [1.59s]
+
+100 pass
+0 fail
+175 expect() calls
+Ran 100 tests across 7 files. [12.58s]
+
+$ tsgo --noEmit -p tsconfig.json
+```
+
+`git diff --check` produced no output.
+
+## Why this is enough
+
+The exact failing file passes under CI's Bun 1.3.12. The complete adjacent
+init-deep-advisor component suite and the omo-senpi package typecheck also pass.
+The behavioral count assertion is unchanged; only the test file's Windows
+circuit-breaker budget changed.
+
+## What was omitted
+
+No environment dump or dependency-install log is included. Setup-generated
+bundles were restored because this test-only change does not require bundle
+regeneration.

--- a/.omo/evidence/20260812-windows-git-commits-timeout/red/ci-failure.md
+++ b/.omo/evidence/20260812-windows-git-commits-timeout/red/ci-failure.md
@@ -1,0 +1,40 @@
+# RED: current `dev` CI failure
+
+## What was tested
+
+- Workflow: `CI`
+- Run: `31522065556`
+- Commit: `55326d2a8408920c8578a239aa39b9967595777f`
+- Command inspected: `gh run view 31522065556 --log-failed`
+- Failing surface: root `bun test` suite on `windows-latest`
+
+## What was observed
+
+The only failed job was `test (windows-latest)`. The root suite reported:
+
+```text
+1 tests failed:
+(fail) gitHead and gitCommitsSince > #given five commits after a base sha #when counting #then it returns five [5516.00ms]
+^ this test timed out after 5000ms.
+
+14379 pass
+61 skip
+1 fail
+Ran 14441 tests across 1865 files. [773.31s]
+Process completed with exit code 1.
+```
+
+Ubuntu and macOS root test jobs passed. Windows typecheck, Codex compatibility,
+and Senpi compatibility also passed.
+
+## Why this is enough
+
+This captures a right-reason failing-first proof from the exact required CI
+surface. The assertion did not fail and the implementation did not return an
+incorrect count. The test exceeded Bun's default five-second test budget while
+creating a six-commit fixture on Windows.
+
+## What was omitted
+
+The full 6,350-line job log is not copied here because it contains unrelated
+test output. No credentials or environment dumps are included.

--- a/.omo/evidence/20260812-windows-git-commits-timeout/validation/windows-qa-and-cleanup.md
+++ b/.omo/evidence/20260812-windows-git-commits-timeout/validation/windows-qa-and-cleanup.md
@@ -1,0 +1,45 @@
+# Windows QA attempt and cleanup
+
+## What was tested
+
+The Parallels `Windows 11` VM was started from its original stopped state.
+The task test file was staged in a detached remote Mac worktree exposed to the
+guest through the Parallels `\\Mac\Home` share.
+
+Three direct guest execution paths were attempted:
+
+1. Guest SSH: failed because SSH readiness flapped after boot.
+2. `prlctl exec --current-user` with PowerShell: `bun.ps1` was blocked by the
+   guest execution policy before tests started.
+3. `prlctl exec --current-user` with `bun.cmd`: PowerShell/cmd could not retain
+   the UNC share as the current directory, so Bun searched `C:\Windows`.
+
+## What was observed
+
+No test assertion ran or failed in these attempts. The direct VM lane was
+therefore recorded as inconclusive, not PASS.
+
+The faithful Windows proof remains the repository's required
+`test (windows-latest)` GitHub Actions job. The RED run failed only because this
+file used Bun's 5000 ms default. The PR run must pass that exact job before
+merge.
+
+## Why this is enough
+
+The local proof covers source correctness and adjacent regressions. The PR gate
+will execute the same full root suite on GitHub's native `windows-latest`
+runner, which is the exact surface that failed and the authoritative proof for
+this CI-only correction.
+
+## Cleanup receipt
+
+```text
+Windows 11 VM: restored to stopped
+Remote QA worktree: removed
+Temporary .cmd QA script: removed with worktree
+Local main checkout: clean
+Task worktree: only git-helpers.test.ts changed
+```
+
+No background guest command remained running because every failed invocation
+exited before test execution.

--- a/packages/omo-senpi/src/components/init-deep-advisor/git-helpers.test.ts
+++ b/packages/omo-senpi/src/components/init-deep-advisor/git-helpers.test.ts
@@ -3,7 +3,7 @@
 import { realpathSync } from "node:fs"
 import { join } from "node:path"
 
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 
 import {
   cleanupTempDirs,
@@ -25,6 +25,10 @@ import {
   gitTouchedFilesSince,
   gitTrackedFileCount,
 } from "./git-helpers"
+
+// This suite creates real Git repositories and commits. Keep the default strict on POSIX,
+// but give loaded Windows runners enough headroom for Git-for-Windows process startup.
+setDefaultTimeout(process.platform === "win32" ? 30_000 : 5_000)
 
 afterEach(() => {
   cleanupTempDirs()


### PR DESCRIPTION
## Summary

- apply the established file-local Windows timeout budget to the init-deep Git helper suite
- keep production Git helper behavior and all assertions unchanged
- preserve a strict 5-second POSIX budget

## Why

`dev` CI run 31522065556 failed only on `test (windows-latest)` because the six-commit real-Git fixture exceeded Bun's 5000 ms default at 5516 ms. The same root suites passed on Ubuntu and macOS, and `gitCommitsSince()` itself is one `git rev-list --count` call.

## Verification

- `npx -y bun@1.3.12 test packages/omo-senpi/src/components/init-deep-advisor/git-helpers.test.ts` - 14 pass
- `bun test packages/omo-senpi/src/components/init-deep-advisor` - 100 pass
- `bun run --cwd packages/omo-senpi typecheck` - pass
- `git diff --check` - pass
- independent code, QA, security, and context reviews - pass
- PR `test (windows-latest)` - required before merge

## Evidence

- `.omo/evidence/20260812-windows-git-commits-timeout/red/ci-failure.md`
- `.omo/evidence/20260812-windows-git-commits-timeout/green/local-validation.md`
- `.omo/evidence/20260812-windows-git-commits-timeout/validation/windows-qa-and-cleanup.md`

## Residual risk

The direct Parallels guest lane was inconclusive before test execution because npm's Bun shim could not run from the shared UNC worktree. The native GitHub `windows-latest` job is therefore the binding Windows proof and merge gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the Windows timeout for the init-deep Git helper tests to 30s via `setDefaultTimeout` in `bun:test` to stop CI timeouts on `windows-latest` when creating real Git fixtures. POSIX stays at a strict 5s; no behavior or assertions changed.

<sup>Written for commit f230ed7d4ae03dfa712e4e9192e189e548ba6591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

