### PR TITLE
fix(omo-native): detect Bun-managed updates

### DIFF
--- a/.omo/evidence/20260812-omo-native-bun-update/README.md
+++ b/.omo/evidence/20260812-omo-native-bun-update/README.md
@@ -1,0 +1,41 @@
+# OMO Native Bun install and update-manager QA
+
+Started: 2026-08-12T02:46:04Z
+Tier: HEAVY - external package-manager integration and self-update behavior.
+Worktree: `/Volumes/mengmotaStorage/local-workspaces/omo-wt/fix-omo-native-bun-update`
+Branch: `fix/omo-native-bun-update`
+Base: `origin/dev@55326d2a8408920c8578a239aa39b9967595777f`
+Notepad: `/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/ulw-20260812-114604.XXXXXX.md.bPlvkdpqkX`
+
+## Criterion 1 - Bun global install
+
+PASS. RED reproduced with an unsafe empty dependency alias in the caller
+project: `bun install -g omo-ai@beta` exited 1 after partial installation.
+GREEN packed fix installed under Bun and emitted a package-root-anchored update
+command that exited 0 from the same polluted caller without unsafe-name output.
+
+## Criterion 2 - package-manager-aware update behavior
+
+PASS. Focused RED was 29 pass / 1 Bun-layout failure against npm-only
+production. GREEN is 30 pass / 0 fail with Bun, npm, and unknown-layout
+coverage.
+
+## Criterion 3 - adjacent regression and integrity
+
+PASS so far. OMO Native package: 74 pass / 6 documented environment skips /
+0 fail. Full root suite: 14,433 pass / 11 documented skips / 0 fail. Root
+typecheck, build, payload verifier, Senpi install/freshness tests, and packed
+manifest scan pass. Final LSP remains deferred because this session's LSP
+server rejects external-worktree and symlink paths; it is a merge-time
+completion gate on the clean main checkout.
+
+## Criterion 4 - PR delivery and cleanup
+
+Pending PR delivery. Behavior commit:
+`1676388eb fix(omo-native): detect Bun-managed updates`.
+
+## Omissions and cleanup
+
+All Bun/npm/unknown-layout prefixes, remote fixtures, tarballs, manifest-scan
+directories, and temporary transcripts used for completed QA were removed.
+Generated build noise remains unstaged and will be discarded before rebase/PR.

--- a/.omo/evidence/20260812-omo-native-bun-update/criterion-1-bun-install-green.txt
+++ b/.omo/evidence/20260812-omo-native-bun-update/criterion-1-bun-install-green.txt
@@ -1,0 +1,26 @@
+Fixed OMO Native Bun real-surface GREEN
+
+```text
+INSTALL_COMMAND=bun add -g .../omo-ai-5.0.0-0.beta.6.tgz
+INSTALL_EXIT=0
+installed omo-ai@.../omo-ai-5.0.0-0.beta.6.tgz with binaries:
+305 packages installed
+VERSION_OUTPUT=omo 5.0.0-0.beta.6 (engine: senpi 2026.8.11-4)
+UPDATE_OUTPUT=omo is updated via bun: bun add --cwd ".../bun/install/global/node_modules/omo-ai" -g omo-ai@beta
+POLLUTED_PACKAGE={"dependencies":{"":"."}}
+EXECUTING=bun add --cwd ".../bun/install/global/node_modules/omo-ai" -g omo-ai@beta
+UPDATE_EXIT=0
+Saved lockfile
+installed omo-ai@5.0.0-0.beta.6 with binaries:
+UNSAFE_NAME_ABSENT=PASS
+FINAL_VERSION=omo 5.0.0-0.beta.6 (engine: senpi 2026.8.11-4)
+```
+
+PASS:
+
+- fixed tarball installed under a custom `BUN_INSTALL`;
+- launcher detected Bun from the real global-layout suffix;
+- launcher emitted a package-root-anchored command;
+- the emitted command ran from a caller directory containing the exact unsafe
+  empty dependency alias;
+- exit was zero and no unsafe-name error appeared.

--- a/.omo/evidence/20260812-omo-native-bun-update/criterion-2-manager-tests-green.txt
+++ b/.omo/evidence/20260812-omo-native-bun-update/criterion-2-manager-tests-green.txt
@@ -1,0 +1,19 @@
+Manager-aware launcher tests GREEN
+
+Command:
+`npm exec --yes --package=bun@1.3.12 -- bun test packages/omo-native/test/launcher.test.ts`
+
+```text
+30 pass
+0 fail
+116 expect() calls
+Ran 30 tests across 1 file.
+EXIT_CODE=0
+```
+
+The suite covers:
+
+- Bun-managed package layout -> `bun add --cwd "<packageRoot>" -g omo-ai@beta`
+- npm-managed package layout -> `npm i -g omo-ai@beta`
+- unknown package layout -> safe npm fallback
+- missing Senpi dependency -> manager-matched reinstall guidance

--- a/.omo/evidence/20260812-omo-native-bun-update/criterion-2-manager-tests-red.txt
+++ b/.omo/evidence/20260812-omo-native-bun-update/criterion-2-manager-tests-red.txt
@@ -1,0 +1,23 @@
+Manager-aware launcher tests RED
+
+Command:
+`npm exec --yes --package=bun@1.3.12 -- bun test packages/omo-native/test/launcher.test.ts`
+
+Observed:
+
+```text
+Expected: "omo is updated via bun: bun add --cwd <fixture>/.bun/install/global/node_modules/omo-ai -g omo-ai@beta"
+Received: "omo is updated via npm: npm i -g omo-ai@beta"
+
+1 tests failed:
+(fail) omo launcher > #given a fake senpi package > #when bare update is requested > #then a Bun-managed install uses a clean package cwd
+
+29 pass
+1 fail
+115 expect() calls
+Ran 30 tests across 1 file.
+EXIT_CODE=1
+```
+
+The npm-managed and unknown-layout cases passed, pinning the existing npm
+behavior and safe fallback. No production code was edited before this RED.

--- a/.omo/evidence/20260812-omo-native-bun-update/criterion-3-npm-unknown-surfaces.txt
+++ b/.omo/evidence/20260812-omo-native-bun-update/criterion-3-npm-unknown-surfaces.txt
@@ -1,0 +1,17 @@
+npm-managed real-surface QA
+
+```text
+NPM_INSTALL_EXIT=0
+added 5 packages
+VERSION_OUTPUT=omo 5.0.0-0.beta.6 (engine: senpi 2026.8.11-4)
+UPDATE_OUTPUT=omo is updated via npm: npm i -g omo-ai@beta
+NPM_GUIDANCE=PASS
+```
+
+Unknown-layout fallback QA
+
+```text
+UNKNOWN_OUTPUT=omo is updated via npm: npm i -g omo-ai@beta
+UNKNOWN_FALLBACK=PASS
+UNKNOWN_QA_CLEANUP=.../omo-native-unknown-green.XXXXXX.rN3gIFPiyb
+```

--- a/.omo/evidence/20260812-omo-native-bun-update/pack-precondition-failure.txt
+++ b/.omo/evidence/20260812-omo-native-bun-update/pack-precondition-failure.txt
@@ -1,0 +1,18 @@
+Pack integrity precondition failure
+
+Command:
+`node script/verify-omo-ai-payload.mjs && npm pack packages/omo-native`
+
+Result:
+The verifier failed before packing because the fresh task worktree had not yet
+staged `packages/omo-native/plugin`.
+
+Reported missing payload included:
+
+- `plugin/package.json`
+- extension and runtime artifacts
+- bundled skill files
+
+No tarball was created. The premature pack-integrity todo was superseded by
+explicit payload-build and retry tasks. The failed pack sandbox is registered
+for cleanup.

--- a/.omo/evidence/20260812-omo-native-bun-update/post-rebase-verification.txt
+++ b/.omo/evidence/20260812-omo-native-bun-update/post-rebase-verification.txt
@@ -1,0 +1,24 @@
+Post-rebase verification
+
+Base: `origin/dev@0d90f168d`
+Behavior commit: `634864ac0`
+Evidence commit: `d11778317`
+
+- Focused launcher: 30 pass, 0 fail, 116 assertions.
+- OMO Native package: 74 pass, 6 documented environment skips, 0 fail,
+  292 assertions.
+- Full root suite: 14,433 pass, 11 documented skips, 0 fail, 1 snapshot,
+  72,410 assertions across 1,865 files.
+- Full repository typecheck: PASS.
+- Root production build: PASS.
+- OMO Native payload verifier: PASS (346 paths, 0 offenders,
+  4,596,353 bytes).
+- Senpi extension freshness check: PASS.
+- Packed manifest scan: 4 manifests, zero unsafe dependency names.
+- Bun/npm/unknown real-surface QA: PASS.
+- All QA prefixes, tarballs, remote fixtures, temporary transcripts, and
+  symlinks: CLEAN.
+
+LSP limitation: the current LSP server rejects external-worktree paths even
+through a main-root symlink. Final changed-file diagnostics remain an explicit
+post-merge completion gate on the clean main checkout.

--- a/.omo/evidence/20260812-omo-native-bun-update/security-quoting-red-green.txt
+++ b/.omo/evidence/20260812-omo-native-bun-update/security-quoting-red-green.txt
@@ -1,0 +1,19 @@
+Security reviewer quoting delta
+
+RED before renderer change:
+
+- A POSIX path containing `$HOME` and a single quote received JSON double
+  quotes, leaving shell expansion active.
+- Windows paths were JSON-escaped, producing doubled backslashes that shell
+  users could not paste as a valid path.
+
+GREEN after renderer change:
+
+- POSIX paths are single-quoted with embedded quote escaping.
+- Windows paths are normalized to forward slashes and double-quoted.
+- Launcher suite: 32 pass, 0 fail.
+- OMO Native suite: 74 pass, 6 documented environment skips, 0 fail.
+- Full repository typecheck: PASS.
+
+The command remains display-only in OMO/Senpi. The delta makes the displayed
+guidance functionally correct when copied on both platform families.

--- a/.omo/evidence/20260812-omo-native-bun-update/surface-cleanup.txt
+++ b/.omo/evidence/20260812-omo-native-bun-update/surface-cleanup.txt
@@ -1,0 +1,11 @@
+SURFACE_QA_CLEANUP=PASS
+
+Removed and verified absent:
+
+- isolated Bun `HOME` / `BUN_INSTALL` prefix and polluted caller fixture;
+- isolated npm prefix;
+- packed tarball directory;
+- focused RED/GREEN temporary transcripts;
+- unknown-layout fixture, removed by trap;
+- remote `mengmotaMac` fixtures, removed earlier;
+- Bunshin client, closed after remote QA.

--- a/.omo/evidence/20260812-omo-native-bun-update/windows-ci-fix.txt
+++ b/.omo/evidence/20260812-omo-native-bun-update/windows-ci-fix.txt
@@ -1,0 +1,31 @@
+PR #6775 Windows CI repair
+
+Failed run:
+https://github.com/code-yeongyu/oh-my-openagent/actions/runs/31561555844
+
+Branch-caused RED:
+
+```text
+Expected: omo is updated via bun: bun add --cwd 'C:\...\omo-ai' -g omo-ai@beta
+Received: omo is updated via bun: bun add --cwd "C:/.../omo-ai" -g omo-ai@beta
+```
+
+Two launcher integration tests hardcoded POSIX quoting when running on Windows.
+Production output was the intended Windows-compatible form.
+
+Fix:
+
+- derive the expected integration command from `process.platform`;
+- POSIX expects single-quoted native paths;
+- Windows expects forward-slash paths inside double quotes;
+- keep the direct `updateTarget(root, "win32")` contract test.
+
+GREEN:
+
+- launcher suite: 32 pass, 0 fail;
+- OMO Native suite: 74 pass, 6 documented environment skips, 0 fail;
+- full repository typecheck: PASS.
+
+The same Windows run also timed out in an unrelated OmO Native telemetry
+tight-loop test after 5 seconds. That test is not changed or suppressed here;
+the fresh CI rerun will determine whether it recurs independently.

--- a/packages/omo-native/bin/lib/launcher.js
+++ b/packages/omo-native/bin/lib/launcher.js
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs"
 import { delimiter, join } from "node:path"
 import { spawnNode } from "./child-process.js"
 import { runDoctor } from "./doctor.js"
-import { nearestNodeBin, packageManifest, packageRoot, readJson, resolveSenpi } from "./package-paths.js"
+import { nearestNodeBin, packageManifest, packageRoot, readJson, resolveSenpi, updateTarget } from "./package-paths.js"
 import { detectHarnesses, needsSetupSuggestion } from "./setup-detect.js"
 import { printSetupReport } from "./setup-report.js"
 
@@ -25,6 +25,7 @@ function isSelfUpdate(args) {
 // updates. The engine consumes this once and scrubs it, so nested engine processes are
 // unaffected.
 function brandProfile() {
+  const update = updateTarget()
   return {
     name: "omo",
     displayVersion: packageManifest().version,
@@ -36,7 +37,7 @@ function brandProfile() {
     update: {
       packageName: "omo-ai",
       distTag: "beta",
-      command: "npm i -g omo-ai@beta",
+      command: update.command,
       changelogUrl: "https://github.com/code-yeongyu/oh-my-openagent/releases",
     },
   }
@@ -109,7 +110,8 @@ export async function runLauncher(args = process.argv.slice(2)) {
   // The engine is pinned by this package, so a self-update would break the pairing; every
   // self-update spelling is answered with the command that actually updates the product.
   if (isSelfUpdate(args)) {
-    console.log(`omo is updated via npm: ${brandProfile().update.command}`)
+    const update = updateTarget()
+    console.log(`omo is updated via ${update.manager}: ${update.command}`)
     process.exitCode = 0
     return
   }

--- a/packages/omo-native/bin/lib/package-paths.js
+++ b/packages/omo-native/bin/lib/package-paths.js
@@ -12,17 +12,32 @@ export function packageManifest() {
   return readJson(join(packageRoot, "package.json"))
 }
 
+export function updateTarget() {
+  const updateCwd = dirname(join(packageRoot, "package.json"))
+  const normalizedRoot = updateCwd.replaceAll("\\", "/")
+  if (normalizedRoot.endsWith("/install/global/node_modules/omo-ai")) {
+    return {
+      manager: "bun",
+      command: `bun add --cwd ${JSON.stringify(updateCwd)} -g omo-ai@beta`,
+    }
+  }
+  if (existsSync(join(dirname(packageRoot), ".package-lock.json"))) {
+    return { manager: "npm", command: "npm i -g omo-ai@beta" }
+  }
+  return { manager: "npm", command: "npm i -g omo-ai@beta" }
+}
+
 export function resolveSenpi() {
   let indexPath
   try {
     indexPath = fileURLToPath(import.meta.resolve("@code-yeongyu/senpi"))
   } catch (error) {
-    throw new Error(`could not resolve @code-yeongyu/senpi; reinstall with: npm i -g omo-ai@beta (${error.message})`)
+    throw new Error(`could not resolve @code-yeongyu/senpi; reinstall with: ${updateTarget().command} (${error.message})`)
   }
 
   const cliPath = join(dirname(indexPath), "cli.js")
   if (!existsSync(cliPath)) {
-    throw new Error(`senpi CLI is missing at ${cliPath}; reinstall with: npm i -g omo-ai@beta`)
+    throw new Error(`senpi CLI is missing at ${cliPath}; reinstall with: ${updateTarget().command}`)
   }
   return { cliPath, packageRoot: dirname(dirname(indexPath)) }
 }

--- a/packages/omo-native/bin/lib/package-paths.js
+++ b/packages/omo-native/bin/lib/package-paths.js
@@ -12,17 +12,21 @@ export function packageManifest() {
   return readJson(join(packageRoot, "package.json"))
 }
 
-export function updateTarget() {
-  const updateCwd = dirname(join(packageRoot, "package.json"))
+function quotePosix(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+export function updateTarget(root = packageRoot, platform = process.platform) {
+  const updateCwd = dirname(join(root, "package.json"))
   const normalizedRoot = updateCwd.replaceAll("\\", "/")
   if (normalizedRoot.endsWith("/install/global/node_modules/omo-ai")) {
+    const quotedCwd = platform === "win32"
+      ? `"${normalizedRoot}"`
+      : quotePosix(updateCwd)
     return {
       manager: "bun",
-      command: `bun add --cwd ${JSON.stringify(updateCwd)} -g omo-ai@beta`,
+      command: `bun add --cwd ${quotedCwd} -g omo-ai@beta`,
     }
-  }
-  if (existsSync(join(dirname(packageRoot), ".package-lock.json"))) {
-    return { manager: "npm", command: "npm i -g omo-ai@beta" }
   }
   return { manager: "npm", command: "npm i -g omo-ai@beta" }
 }

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -16,6 +16,8 @@ type Fixture = {
   shimPath?: string
 }
 
+type InstallLayout = "bun" | "npm" | "unknown"
+
 function writeFile(path: string, content: string, mode?: number): void {
   mkdirSync(dirname(path), { recursive: true })
   writeFileSync(path, content, mode === undefined ? undefined : { mode })
@@ -35,14 +37,18 @@ function expandShortPath(path: string): string {
   }
 }
 
-function createFixture(options: { hoisted?: boolean; shim?: boolean } = {}): Fixture {
+function createFixture(options: { hoisted?: boolean; shim?: boolean; installLayout?: InstallLayout } = {}): Fixture {
   // Windows hands back the 8.3 short form (RUNNER~1) here while the launcher reports the long path, so
   // the fixture root is canonicalized once and every derived path inherits the same spelling.
   const root = expandShortPath(realpathSync(mkdtempSync(join(tmpdir(), "omo-launcher-"))))
   roots.push(root)
-  const packagePath = options.hoisted
-    ? join(root, "node_modules", "omo-ai")
-    : join(root, "app")
+  const packagePath = options.installLayout === "bun"
+    ? join(root, "custom-bun", "install", "global", "node_modules", "omo-ai")
+    : options.installLayout === "npm"
+      ? join(root, "prefix", "lib", "node_modules", "omo-ai")
+      : options.hoisted
+        ? join(root, "node_modules", "omo-ai")
+        : join(root, "app")
   mkdirSync(packagePath, { recursive: true })
   const packageRoot = expandShortPath(realpathSync(packagePath))
   cpSync(join(SOURCE_ROOT, "bin"), join(packageRoot, "bin"), { recursive: true })
@@ -52,6 +58,9 @@ function createFixture(options: { hoisted?: boolean; shim?: boolean } = {}): Fix
     type: "module",
     dependencies: { "@code-yeongyu/senpi": "2026.8.9" },
   }))
+  if (options.installLayout === "npm") {
+    writeFile(join(root, "prefix", "lib", "node_modules", ".package-lock.json"), "{}\n")
+  }
 
   const modulesRoot = options.hoisted ? join(root, "node_modules") : join(packageRoot, "node_modules")
   const senpiRoot = join(modulesRoot, "@code-yeongyu", "senpi")
@@ -246,6 +255,35 @@ describe("omo launcher", () => {
         const result = run(fixture, ["update"])
         expect(result.status).toBe(0)
         expect(result.stdout).toContain("omo is updated via npm: npm i -g omo-ai@beta")
+        expect(existsSync(fixture.captureFile)).toBe(false)
+      })
+
+      test("#then a Bun-managed install uses a clean package cwd", () => {
+        const fixture = createFixture({ installLayout: "bun" })
+        const result = run(fixture, ["update"])
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.trim()).toBe(
+          `omo is updated via bun: bun add --cwd ${JSON.stringify(fixture.packageRoot)} -g omo-ai@beta`,
+        )
+        expect(existsSync(fixture.captureFile)).toBe(false)
+      })
+
+      test("#then an npm-managed install keeps the npm update command", () => {
+        const fixture = createFixture({ installLayout: "npm" })
+        const result = run(fixture, ["update"])
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.trim()).toBe("omo is updated via npm: npm i -g omo-ai@beta")
+        expect(existsSync(fixture.captureFile)).toBe(false)
+      })
+
+      test("#then an unknown install layout fails safe to npm", () => {
+        const fixture = createFixture({ installLayout: "unknown" })
+        const result = run(fixture, ["update"])
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.trim()).toBe("omo is updated via npm: npm i -g omo-ai@beta")
         expect(existsSync(fixture.captureFile)).toBe(false)
       })
     })

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -121,6 +121,13 @@ function capture(fixture: Fixture): { argv: string[]; env: NodeJS.ProcessEnv; ta
   return JSON.parse(readFileSync(fixture.captureFile, "utf8"))
 }
 
+function expectedBunUpdateCommand(packageRoot: string): string {
+  const quotedRoot = process.platform === "win32"
+    ? `"${packageRoot.replaceAll("\\", "/")}"`
+    : `'${packageRoot.replaceAll("'", "'\\''")}'`
+  return `omo is updated via bun: bun add --cwd ${quotedRoot} -g omo-ai@beta`
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
@@ -273,21 +280,16 @@ describe("omo launcher", () => {
         const result = run(fixture, ["update"])
 
         expect(result.status).toBe(0)
-        expect(result.stdout.trim()).toBe(
-          `omo is updated via bun: bun add --cwd '${fixture.packageRoot}' -g omo-ai@beta`,
-        )
+        expect(result.stdout.trim()).toBe(expectedBunUpdateCommand(fixture.packageRoot))
         expect(existsSync(fixture.captureFile)).toBe(false)
       })
 
-      test("#then a Bun path with POSIX metacharacters is single-quoted", () => {
+      test("#then a Bun path with shell metacharacters is quoted for the host", () => {
         const fixture = createFixture({ installLayout: "bun-posix-special" })
         const result = run(fixture, ["update"])
-        const quotedRoot = `'${fixture.packageRoot.replaceAll("'", "'\\''")}'`
 
         expect(result.status).toBe(0)
-        expect(result.stdout.trim()).toBe(
-          `omo is updated via bun: bun add --cwd ${quotedRoot} -g omo-ai@beta`,
-        )
+        expect(result.stdout.trim()).toBe(expectedBunUpdateCommand(fixture.packageRoot))
       })
 
       test("#then a Windows-style Bun path uses shell-compatible forward slashes", () => {

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
+import { updateTarget } from "../bin/lib/package-paths.js"
 
 const SOURCE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
 const roots: string[] = []
@@ -16,7 +17,7 @@ type Fixture = {
   shimPath?: string
 }
 
-type InstallLayout = "bun" | "npm" | "unknown"
+type InstallLayout = "bun" | "bun-posix-special" | "npm" | "unknown"
 
 function writeFile(path: string, content: string, mode?: number): void {
   mkdirSync(dirname(path), { recursive: true })
@@ -42,8 +43,17 @@ function createFixture(options: { hoisted?: boolean; shim?: boolean; installLayo
   // the fixture root is canonicalized once and every derived path inherits the same spelling.
   const root = expandShortPath(realpathSync(mkdtempSync(join(tmpdir(), "omo-launcher-"))))
   roots.push(root)
-  const packagePath = options.installLayout === "bun"
-    ? join(root, "custom-bun", "install", "global", "node_modules", "omo-ai")
+  const packagePath = options.installLayout?.startsWith("bun")
+    ? join(
+      root,
+      options.installLayout === "bun-posix-special"
+        ? "custom $HOME's bun"
+        : "custom-bun",
+      "install",
+      "global",
+      "node_modules",
+      "omo-ai",
+    )
     : options.installLayout === "npm"
       ? join(root, "prefix", "lib", "node_modules", "omo-ai")
       : options.hoisted
@@ -264,9 +274,29 @@ describe("omo launcher", () => {
 
         expect(result.status).toBe(0)
         expect(result.stdout.trim()).toBe(
-          `omo is updated via bun: bun add --cwd ${JSON.stringify(fixture.packageRoot)} -g omo-ai@beta`,
+          `omo is updated via bun: bun add --cwd '${fixture.packageRoot}' -g omo-ai@beta`,
         )
         expect(existsSync(fixture.captureFile)).toBe(false)
+      })
+
+      test("#then a Bun path with POSIX metacharacters is single-quoted", () => {
+        const fixture = createFixture({ installLayout: "bun-posix-special" })
+        const result = run(fixture, ["update"])
+        const quotedRoot = `'${fixture.packageRoot.replaceAll("'", "'\\''")}'`
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.trim()).toBe(
+          `omo is updated via bun: bun add --cwd ${quotedRoot} -g omo-ai@beta`,
+        )
+      })
+
+      test("#then a Windows-style Bun path uses shell-compatible forward slashes", () => {
+        const root = String.raw`C:\Users\omo user\.bun\install\global\node_modules\omo-ai`
+
+        expect(updateTarget(root, "win32")).toEqual({
+          manager: "bun",
+          command: "bun add --cwd \"C:/Users/omo user/.bun/install/global/node_modules/omo-ai\" -g omo-ai@beta",
+        })
       })
 
       test("#then an npm-managed install keeps the npm update command", () => {


### PR DESCRIPTION
## What changed

- detect Bun-managed OMO Native installs from the real global package layout
- emit a Bun update command anchored to the installed `omo-ai` package root
- preserve npm guidance for npm-managed and unknown layouts
- quote POSIX paths safely and normalize Windows paths for Bun-compatible guidance
- reuse the detected manager command for missing-Senpi reinstall errors

## Why

A user running `bun install -g omo-ai@beta` saw Bun install the package but
exit 1 with `refusing to install dependency with unsafe name`. The published
`omo-ai` tarball is valid; the failure comes from an unsafe empty dependency
alias in the caller/global Bun project state. OMO then compounded the issue by
always printing an npm update command, even for Bun-managed installations.

## Observed behavior

### RED

- unsafe empty-alias fixture plus Bun global install: exit 1 after partial install
- pre-fix manager suite: 29 pass / 1 fail; Bun layout received npm guidance
- pre-fix quoting: POSIX metacharacters remained active and Windows paths were JSON-escaped

### GREEN

- fixed tarball installs under a custom `BUN_INSTALL`
- `omo update` prints `bun add --cwd '<installed omo-ai root>' -g omo-ai@beta`
- executing that command from the polluted caller exits 0 with no unsafe-name error
- npm and unknown layouts continue to print `npm i -g omo-ai@beta`
- POSIX adversarial paths survive shell parsing byte-for-byte; Windows paths use forward slashes

## Verification

- launcher tests: 32 pass, 0 fail
- OMO Native package: 74 pass, 6 documented environment skips, 0 fail
- full root suite: 14,433 pass, 11 documented skips, 0 fail
- full repository typecheck: pass
- production build: pass
- OMO Native payload: 346 paths, 0 offenders
- packed manifest scan: 4 manifests, 0 unsafe dependency names
- five-lane review: goal approved, quality pass, security approved after delta,
  QA pass, context pass

Evidence: `.omo/evidence/20260812-omo-native-bun-update/`

## Residual risk

Detection follows Bun's global layout suffix. If Bun changes that layout, OMO
fails safe to npm guidance. Final changed-file LSP diagnostics are deferred to
the clean merged main checkout because this session's LSP server rejects task
worktree paths even through a repository-root symlink.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects Bun-managed installs of `omo-ai` and prints the correct `bun add` self-update command anchored to the installed package, with safe path quoting on POSIX and Windows. Keeps `npm` guidance for npm/unknown layouts and fixes the wrong advice shown after Bun’s “unsafe name” failure.

- **Bug Fixes**
  - Detect Bun global layout and emit: `bun add --cwd '<installed omo-ai root>' -g omo-ai@beta`.
  - Keep `npm i -g omo-ai@beta` for npm and unknown layouts.
  - Quote paths safely for copy/paste (POSIX single-quoting; Windows forward slashes + double quotes); align tests per platform to fix Windows CI.
  - Reuse the manager-specific command in `@code-yeongyu/senpi` reinstall errors; added focused tests.

<sup>Written for commit 4706d8b509cf10e742e7619b52c72e5176c3d794. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

