### PR TITLE
docs(memory-core): add package knowledge map

### DIFF
--- a/.omo/evidence/20260812-init-deep/hierarchy-green.txt
+++ b/.omo/evidence/20260812-init-deep/hierarchy-green.txt
@@ -1,0 +1,35 @@
+# Hierarchy GREEN audit
+
+## Exact scenario
+
+```bash
+test -f packages/memory-core/AGENTS.md
+test ! -f packages/omo-opencode/AGENTS.md
+grep -Fq '[`memory-core/`](memory-core/AGENTS.md)' packages/AGENTS.md
+test "$(find packages/memory-core -name AGENTS.md | wc -l | tr -d ' ')" = 1
+for d in packages/*; do
+  files=$(find "$d" -type f -not -path "*/node_modules/*" -not -path "*/dist/*" | wc -l)
+  if [ "$files" -ge 15 ] && [ ! -f "$d/AGENTS.md" ] && [ ! -f "$d/src/AGENTS.md" ]; then
+    exit 1
+  fi
+done
+```
+
+## Observed
+
+```
+HIERARCHY_GREEN
+```
+
+The selected map is exact:
+
+- `packages/memory-core/AGENTS.md` exists.
+- `packages/AGENTS.md` links to it.
+- No redundant `packages/omo-opencode/AGENTS.md` was created.
+- `memory-core` has one package-scoped instruction file, not nested duplicates.
+- Every package with at least 15 files has package-root or source-root coverage.
+
+## Why this is enough
+
+The same structural boundary that failed in `hierarchy-red.txt` now passes,
+while the negative assertions prove init-deep did not create redundant files.

--- a/.omo/evidence/20260812-init-deep/hierarchy-red.txt
+++ b/.omo/evidence/20260812-init-deep/hierarchy-red.txt
@@ -1,0 +1,41 @@
+# Hierarchy RED baseline
+Worktree: /Volumes/mengmotaStorage/local-workspaces/omo/.local-ignore/worktrees/init-deep-20260812
+Branch: docs/init-deep-20260812
+
+## Scale
+files=7546
+TypeScript lines=656586
+max directory depth=10
+TypeScript files over 500 lines=119
+
+## Existing local gap candidates
+2728 packages/omo-opencode
+96 packages/memory-core
+
+## Highest-scoring directories
+```
+files  lines    subdirs symbols local-AGENTS path
+2364   321015   19      8421    yes          packages/omo-opencode/src
+625    80162    2       8421    no           packages/omo-opencode
+417    54210    14      2113    no           packages/senpi-task/src
+283    47130    4       4995    yes          packages/omo-codex
+279    39057    4       2044    no           packages/omo-senpi/src
+248    36014    3       2202    yes          packages/senpi-task
+152    23632    5       3312    yes          packages/omo-senpi
+185    21439    1       917     yes          packages/utils
+182    21409    10      917     no           packages/utils/src
+136    17418    2       769     no           packages/omo-codex/src
+94     11333    13      489     no           packages/memory-core/src
+90     11019    1       489     no           packages/memory-core
+87     10543    3       494     no           packages/lsp-core/src
+90     10098    2       557     yes          script
+```
+
+## Binary RED observable
+FAIL: `packages/memory-core` has 96 files, 11,019 lines, 13 direct source
+subdirectories, and no package-scoped `AGENTS.md`.
+
+`packages/omo-opencode` lacks a package-root `AGENTS.md`, but its 2,364-file
+source tree already has `packages/omo-opencode/src/AGENTS.md`; scoring must
+decide whether package-root guidance adds distinct value rather than duplicate
+the source file.

--- a/.omo/evidence/20260812-init-deep/manual-review.md
+++ b/.omo/evidence/20260812-init-deep/manual-review.md
@@ -1,0 +1,47 @@
+# Manual instruction-surface review
+
+## What was reviewed
+
+- `packages/AGENTS.md`, especially the Core package table.
+- `packages/memory-core/AGENTS.md` from top to bottom.
+- `packages/memory-core/src/index.ts` to verify the documented public barrel.
+- `packages/omo-senpi/src/components/memory/AGENTS.md` to check the adapter/core
+  boundary and avoid duplicated adapter instructions.
+
+## Exact checks
+
+```bash
+for p in src/git src/identity src/locks src/memfs src/tools src/journal \
+  src/reflection src/compile src/search src/sync src/reminders src/seeds \
+  src/concurrency src/index.ts src/harness-neutrality.test.ts; do
+  test -e "packages/memory-core/$p"
+done
+
+for sym in runMemoryTool runMemoryApplyPatch GitMemoryRepo \
+  evaluateTransitions reserveTransition completeTransition \
+  compileMemoryBlock compileMemoryBlockAtRevision; do
+  git grep -q "$sym" -- packages/memory-core/src
+done
+```
+
+Observed:
+
+```
+NAMED_PATHS_OK
+NAMED_SYMBOLS_OK
+STYLE_OK
+```
+
+## Review verdict
+
+- The guide is package-scoped: it maps the 13 source domains, core invariants,
+  public surfaces, consumers, package QA, and local anti-patterns.
+- It does not restate root OpenCode/Codex QA instructions or the full adapter
+  architecture.
+- The Senpi component remains the owner of adapter-specific registration and
+  lifecycle behavior.
+- Every named path and symbol exists in the current source.
+- The guide avoids prohibited dash characters and repository-banned filler.
+- The package table link is the only ancestor edit.
+
+PASS.

--- a/.omo/evidence/20260812-init-deep/qa-summary.md
+++ b/.omo/evidence/20260812-init-deep/qa-summary.md
@@ -1,0 +1,51 @@
+# QA evidence summary
+
+## What was tested
+
+1. Pre-change hierarchy audit:
+   `.omo/evidence/20260812-init-deep/hierarchy-red.txt`.
+2. Location scoring:
+   `.omo/evidence/20260812-init-deep/scoring.md`.
+3. Post-change hierarchy audit:
+   `.omo/evidence/20260812-init-deep/hierarchy-green.txt`.
+4. Package tests, typecheck, markdown links, AGENTS contract, and diff hygiene:
+   `.omo/evidence/20260812-init-deep/validation-green.txt`.
+5. Manual instruction-surface review:
+   `.omo/evidence/20260812-init-deep/manual-review.md`.
+
+## What was observed
+
+- RED: `memory-core` was a 96-file, 11,019-line, 13-subsystem Core package
+  without local instructions.
+- GREEN: `packages/memory-core/AGENTS.md` exists, the package table links to it,
+  no redundant `packages/omo-opencode/AGENTS.md` exists, and all substantial
+  packages have package-root or source-root coverage.
+- 319 memory-core tests passed; typecheck passed.
+- 16 markdown-link audit tests passed; 4 AGENTS dev-environment tests passed.
+- Manual path, symbol, scope, and style checks passed.
+
+## Why it is enough
+
+The hierarchy scenario directly proves the requested init-deep outcome. Package
+tests and typecheck prove the documented implementation remains green. The
+repository markdown audit proves the new link and instruction file integrate
+with the checked-in knowledge base. Manual review proves the prose is accurate,
+scoped, and non-duplicative.
+
+## What was omitted
+
+- No OpenCode/Codex runtime QA: no adapter/runtime surface changed.
+- No prose-string tests: repository rules classify those as pretend coverage.
+- Raw environment dumps and unrelated submodule deletion lists are summarized,
+  not copied beyond the diagnostic note.
+
+## Cleanup receipt
+
+- No server, browser, tmux session, container, socket, or bound port was created.
+- No QA temp directory was created outside the committed evidence directory.
+- Read-only explore children are terminal; lost lanes were recorded
+  inconclusive and do not hold resources.
+- The unrelated dirty `designpowers` submodule is excluded from task pathspecs
+  and remains untouched.
+- The main checkout's unrelated
+  `packages/omo-senpi/plugin/extensions/omo.js` modification remains unchanged.

--- a/.omo/evidence/20260812-init-deep/scoring.md
+++ b/.omo/evidence/20260812-init-deep/scoring.md
@@ -1,0 +1,37 @@
+# Init-deep scoring decision
+
+## Create
+
+- `packages/memory-core/AGENTS.md`: selected despite a raw score below the
+  automatic `>15` threshold because the `8-15` rule permits distinct domains.
+  The package has 96 files, 11,019 lines, 13 source subsystems, package-specific
+  concurrency and git-backed storage invariants, its own test/typecheck
+  commands, and no local instruction file.
+
+## Skip
+
+- `packages/omo-opencode/AGENTS.md`: skip. The package is large, but
+  `packages/omo-opencode/src/AGENTS.md` plus its descendants already cover the
+  meaningful source surface. A package-root file would duplicate root,
+  `packages/AGENTS.md`, and `src/AGENTS.md`.
+- Source-only hotspots under `senpi-task`, `omo-senpi`, `utils`, `omo-codex`,
+  and `lsp-core`: skip. Their package-root `AGENTS.md` files already define the
+  package domain, and no distinct uncovered boundary was found.
+
+## Ancestor update
+
+- Update `packages/AGENTS.md` so the `memory-core` Core-table entry links to
+  `memory-core/AGENTS.md`, matching sibling packages.
+
+## Selected file map
+
+1. Create `packages/memory-core/AGENTS.md`.
+2. Update only the `memory-core` row in `packages/AGENTS.md`.
+3. Do not create `packages/omo-opencode/AGENTS.md`.
+
+## RED to GREEN contract
+
+- RED: `packages/memory-core` has no package-scoped instructions and its package
+  table entry points only to the directory.
+- GREEN: the selected file map exists, the ancestor link resolves, and no
+  redundant package/source instruction files are introduced.

--- a/.omo/evidence/20260812-init-deep/validation-green.txt
+++ b/.omo/evidence/20260812-init-deep/validation-green.txt
@@ -1,0 +1,34 @@
+# Validation GREEN
+
+## What was tested
+
+```bash
+bun test packages/memory-core/src/
+bun run --cwd packages/memory-core typecheck
+bun test packages/omo-opencode/src/shared/markdown-link-audit.test.ts
+bun test script/agents-md-dev-env.test.ts
+git diff --check
+```
+
+## What was observed
+
+- memory-core: 319 tests passed, 0 failed, across 36 files.
+- memory-core typecheck: `tsgo --noEmit -p tsconfig.json` exited 0.
+- markdown local-link audit: 16 tests passed, 0 failed; every checked-in local
+  target exists and no maintainer-local path was found.
+- AGENTS dev-environment audit: 4 tests passed, 0 failed.
+- `git diff --check`: no output.
+
+## Why it is enough
+
+The package suite and typecheck prove the documented commands and invariants
+still match a green package. The markdown audit proves the new ancestor link
+resolves and the new guide contains no machine-local link. The AGENTS audit
+protects the existing root instruction contract, and `git diff --check` catches
+formatting defects.
+
+## What was omitted
+
+No OpenCode or Codex runtime QA was run because this change adds package-local
+documentation and does not alter either adapter, hook, tool registry, prompt
+runtime, installer, or shipped machine-consumed configuration.

--- a/.omo/evidence/20260812-init-deep/validation-red.txt
+++ b/.omo/evidence/20260812-init-deep/validation-red.txt
@@ -1,0 +1,25 @@
+# Validation baseline
+Worktree: /Volumes/mengmotaStorage/local-workspaces/omo/.local-ignore/worktrees/init-deep-20260812
+
+## `bun test script/agents-md-dev-env.test.ts`
+The command did not reach the test assertions. The test preload attempted to
+build the vendored LSP daemon, and `npm ci` failed with:
+
+```
+npm error code EEXIST
+npm error syscall symlink
+npm error path ../../../mcp-stdio-core
+npm error dest packages/lsp-daemon/node_modules/@oh-my-opencode/mcp-stdio-core
+npm error errno -17
+```
+
+This is a worktree dependency-setup defect, not hierarchy evidence. The command
+must be rerun after safe worktree setup.
+
+## `bun test packages/omo-opencode/src/shared/markdown-link-audit.test.ts`
+PASS: 20 tests passed, 0 failed.
+
+## Interpretation
+The existing markdown audit is green before the change. RED for this prose
+target therefore comes from the faithful hierarchy coverage scenario in
+`hierarchy-red.txt`, not from pinning wording or inventing a prose-string test.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -45,7 +45,7 @@ Each contains only a `bin/oh-my-opencode.js` launcher and a `package.json`. [`sc
 | [`comment-checker-core/`](comment-checker-core/AGENTS.md) | `src/`, `tsconfig.json` | apply-patch parser and binary runner with injectable spawn. |
 | [`hashline-core/`](hashline-core/AGENTS.md) | `src/`, `tsconfig.json` | Hashline edit primitives and diff helpers shared by adapter shims. |
 | [`boulder-state/`](boulder-state/AGENTS.md) | `src/`, `tsconfig.json` | Work tracking state machine with split storage. |
-| [`memory-core/`](memory-core) | `src/`, `tsconfig.json` | Harness-neutral Letta-Code-parity memory engine: git MemFS substrate, memory tools, committed-HEAD compiler, reflection state machine, FTS-lite search, locks. |
+| [`memory-core/`](memory-core/AGENTS.md) | `src/`, `tsconfig.json` | Harness-neutral Letta-Code-parity memory engine: git MemFS substrate, memory tools, committed-HEAD compiler, reflection state machine, FTS-lite search, locks. |
 | [`telemetry-core/`](telemetry-core/AGENTS.md) | `src/`, `tsconfig.json` | Harness-neutral telemetry primitives and PostHog wrappers. |
 | [`lsp-core/`](lsp-core/AGENTS.md) | `src/`, `tsconfig.json` | Harness-neutral LSP engine, request context, tool definitions, and MCP entry helpers. |
 | [`mcp-stdio-core/`](mcp-stdio-core/AGENTS.md) | `src/`, `tsconfig.json` | Shared JSON-RPC stdio framing and dispatch primitives for MCP servers. |

--- a/packages/memory-core/AGENTS.md
+++ b/packages/memory-core/AGENTS.md
@@ -1,0 +1,92 @@
+# memory-core - Harness-Neutral Agent Memory Engine
+
+## OVERVIEW
+
+`@oh-my-opencode/memory-core` owns the shared memory domain used by harness
+adapters: a git-backed markdown MemFS, atomic memory tools, prompt compilation,
+reflection scheduling, transcript search, synchronization, and seed content.
+The public API is the barrel at `src/index.ts`.
+
+## ANATOMY
+
+| Directory | Responsibility |
+|-----------|----------------|
+| `src/git/` | Git command boundary, clean-tree checks, commits, merges, remotes, and typed git errors. |
+| `src/identity/` | Memory identity resolution and the `OMO_MEMORY_HOME` directory layout. |
+| `src/locks/` | Cross-process locks for memory writes, reflection scheduling, and transcript state. |
+| `src/memfs/` | Memory-path validation, markdown frontmatter parsing, and hook-script installation. |
+| `src/tools/` | `memory` and `memory_apply_patch` operations, patch parsing, typed tool errors, and auto-commit behavior. |
+| `src/journal/` | Per-conversation transcript cursors, reflection snapshots, and durable journal state. |
+| `src/reflection/` | Trigger evaluation, run reservation, worktree execution, completion validation, and merge outcomes. |
+| `src/compile/` | Compile committed memory revisions into marked system-prompt blocks and cache them by template hash. |
+| `src/search/` | Query parsing, transcript providers, and ranked memory/session search. |
+| `src/sync/` | Remote mirror synchronization and secret redaction. |
+| `src/reminders/` | Reflection and memory-maintenance reminder generation. |
+| `src/seeds/` | Default memory blocks and first-run repository seeding. |
+| `src/concurrency/` | Subprocess fixtures for lock and multi-writer tests; not a public runtime module. |
+
+## CORE INVARIANTS
+
+- **Stay harness-neutral.** Production code and package dependencies must not
+  import Senpi, Pi, OpenCode adapters, or other harness-specific packages.
+  `src/harness-neutrality.test.ts` enforces this boundary.
+- **Treat the memory repository as transactional state.** Write tools acquire
+  the `memory-write` lock, require a clean repository, validate paths, apply one
+  operation, and commit only the affected paths. Do not bypass
+  `GitMemoryRepo`, lock domains, or the tool entry points.
+- **Compile from committed state.** Prompt compilation may target `HEAD` or an
+  explicit revision. Uncommitted working-tree content is not authoritative
+  memory.
+- **Preserve markdown contracts.** Memory files require YAML frontmatter with a
+  non-empty `description`; `read_only: "true"` blocks mutation. Keep UTF-8,
+  normalized repository-relative paths, and LF output.
+- **Keep reflection transitions deterministic.** Manual triggers outrank
+  compaction, which outranks step-count triggers. Only one active run and one
+  merged pending reservation may exist.
+- **Keep locks domain-specific.** Use `memory-write`,
+  `reflection-scheduler`, or the transcript-specific lock. Do not replace them
+  with one global lock or add timing-based tests.
+- **Redact before external synchronization.** Remote mirror output must pass
+  through the sync redaction layer; never copy secret-bearing raw logs or
+  configuration into committed memory.
+
+## PUBLIC SURFACES
+
+- `runMemoryTool()` implements `create`, `str_replace`, `insert`, `delete`,
+  `rename`, and `update_description`.
+- `runMemoryApplyPatch()` applies multi-file Codex-style patches inside the
+  memory repository.
+- `GitMemoryRepo` owns repository initialization, clean checks, commits,
+  revisions, merge worktrees, and remote detection.
+- `evaluateTransitions()`, `reserveTransition()`, and
+  `completeTransition()` form the pure reflection state machine.
+- `compileMemoryBlock()` and `compileMemoryBlockAtRevision()` render the
+  committed memory projection injected into a harness prompt.
+
+## CONSUMERS
+
+Harness adapters provide identity, lifecycle events, tool registration, and
+sync orchestration. The Senpi adapter lives under
+`packages/omo-senpi/src/components/memory/`; keep adapter-specific behavior
+there rather than importing it back into this package.
+
+## QA
+
+```bash
+bun test packages/memory-core/src/
+bun run --cwd packages/memory-core typecheck
+```
+
+For a focused change, run the nearest co-located `*.test.ts` first, then the
+package suite. Concurrency tests must await exact state or process events with
+bounded timeouts; never add fixed sleeps or retry loops.
+
+## ANTI-PATTERNS
+
+- Importing a harness package into `memory-core`.
+- Writing directly to memory markdown without path validation, frontmatter
+  parsing, locking, and an atomic git commit.
+- Reading the dirty worktree as compiled memory.
+- Mutating `read_only` blocks or accepting non-UTF-8 memory files.
+- Swallowing git, lock, merge, or reflection failures.
+- Testing cross-process behavior with timing luck.


### PR DESCRIPTION
## Summary

- add the missing package-scoped knowledge map for `memory-core`
- link the Core package table to the new guide
- record RED/GREEN hierarchy, validation, manual-review, and cleanup evidence

## Why

`memory-core` is a 96-file, 11,019-line, 13-subsystem Core package with
package-specific git, locking, reflection, MemFS, tool, and synchronization
invariants. It was the only substantial Core package without local
`AGENTS.md` guidance.

`omo-opencode` was intentionally not given a redundant package-root guide
because its source tree already has comprehensive hierarchical coverage.

## Observed behavior

- pre-change hierarchy audit failed on missing `packages/memory-core/AGENTS.md`
- post-change hierarchy audit prints `HIERARCHY_GREEN`
- every documented path and public symbol was verified against current source
- the package table link resolves through the repository markdown audit

## QA and evidence

- `bun test packages/memory-core/src/`: 319 pass, 0 fail
- `bun run --cwd packages/memory-core typecheck`: pass
- `bun test packages/omo-opencode/src/shared/markdown-link-audit.test.ts`: 16 pass, 0 fail
- `bun test script/agents-md-dev-env.test.ts`: 4 pass, 0 fail
- `git diff --check`: pass
- evidence: `.omo/evidence/20260812-init-deep/`

## Residual risk

Low. The patch is documentation-only. The main maintenance risk is future
architecture drift in the new package guide; the guide points to stable
subsystem boundaries and package commands rather than volatile counts.

## Omitted

No OpenCode or Codex live runtime QA was run because no adapter, hook, tool,
prompt runtime, installer, or machine-consumed config changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a package-scoped knowledge map (`packages/memory-core/AGENTS.md`) for `memory-core` and updated the Core package table to link to it. Included RED/GREEN hierarchy, validation, and manual-review evidence to document coverage.

<sup>Written for commit dbd9e0c719ddfb913b28257735a9b5408d74b801. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

