### PR TITLE
fix(omo-native): share agent state with nested senpi

### DIFF
--- a/packages/omo-native/bin/lib/launcher.js
+++ b/packages/omo-native/bin/lib/launcher.js
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs"
+import { homedir } from "node:os"
 import { delimiter, join } from "node:path"
 import { spawnNode } from "./child-process.js"
 import { runDoctor } from "./doctor.js"
@@ -56,6 +57,7 @@ function senpiEnvironment(senpiRoot) {
   delete env.OMO_BIN
   delete env.SENPI_BIN
   env.OMO_AGENT_TOOLKIT_BIN = join(packageRoot, "bin", "omo-agent-toolkit.js")
+  env.SENPI_CODING_AGENT_DIR = join(env.HOME || homedir(), ".omo", "agent")
   // senpi's footer reads this marker to show the OmO Native badge for omo-ai installs, which load
   // the plugin via --extension and therefore never match the settings-packages detection gates.
   env.OMO_NATIVE = "1"

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -146,8 +146,9 @@ describe("omo launcher", () => {
 
       test("#then launcher environment points to existing hoisted shims", () => {
         const fixture = createFixture({ hoisted: true })
+        const home = join(fixture.root, "home")
         mkdirSync(join(fixture.packageRoot, "node_modules"), { recursive: true })
-        const result = run(fixture, ["say", "hi"], { OMO_BIN: "/must/not/leak" })
+        const result = run(fixture, ["say", "hi"], { HOME: home, OMO_BIN: "/must/not/leak" })
         const environment = capture(fixture).env
         expect(result.status).toBe(0)
         expect(environment.SENPI_BIN).toBe(fixture.shimPath)
@@ -158,6 +159,7 @@ describe("omo launcher", () => {
         expect(realpathSync.native(binDir ?? "")).toBe(realpathSync.native(dirname(fixture.shimPath ?? "")))
         expect(existsSync(binDir ?? "")).toBe(true)
         expect(environment.OMO_AGENT_TOOLKIT_BIN).toBe(join(fixture.packageRoot, "bin", "omo-agent-toolkit.js"))
+        expect(environment.SENPI_CODING_AGENT_DIR).toBe(join(home, ".omo", "agent"))
         // An inherited value must never survive; it is replaced by this launcher's own entry so
         // anything resolving the product by name re-enters here instead of the bare engine.
         // Windows reports this path in its long form while the fixture root may be the 8.3 short


### PR DESCRIPTION
## Problem

Detached memory-reflection children start the bare Senpi engine. The OMO
launcher supplied branding and model tooling, but it did not pin Senpi's
agent-state directory, so nested children read `~/.senpi/agent` instead of
OMO's `~/.omo/agent`. Models and credentials available to the parent then
failed as missing inside reflection.

## Fix

- export `SENPI_CODING_AGENT_DIR=$HOME/.omo/agent` from the OMO launcher
- preserve a caller-provided `HOME`, with `homedir()` as fallback
- lock the launcher environment contract in the cross-platform fixture

## Verification

- RED: launcher fixture received `undefined` instead of `<HOME>/.omo/agent`
- focused GREEN: 1/1
- full launcher suite: 32/32
- repository typecheck: pass
- real bare Senpi probes with the shared agent dir:
  - `apitopia/kimi-for-coding-highspeed` -> `APITOPIA_CHILD_GREEN`
  - `quotio-openai/gpt-5.4-mini-fast` -> `QUOTIO_CHILD_GREEN`
