### PR TITLE
feat(senpi): add interactive question bridge

### DIFF
--- a/packages/omo-senpi/scripts/qa/ask-question-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/ask-question-e2e.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..")
+const tempRoot = await mkdtemp(join(tmpdir(), "omo-ask-question-e2e-"))
+
+try {
+  const bunfig = join(tempRoot, "bunfig.toml")
+  await writeFile(bunfig, "[test]\n", "utf8")
+  await run(
+    [
+      "test",
+      "--config",
+      bunfig,
+      join(packageRoot, "src", "components", "ask-question", "index.test.ts"),
+      join(packageRoot, "src", "components", "ask-question", "claude-sdk-bridge.test.ts"),
+    ],
+    {
+      cwd: packageRoot,
+      env: process.env,
+    },
+  )
+
+  const bundle = join(tempRoot, "ask-question.js")
+  await run(
+    [
+      "build",
+      join(packageRoot, "src", "components", "ask-question", "index.ts"),
+      "--target",
+      "node",
+      "--format",
+      "esm",
+      "--outfile",
+      bundle,
+      "--external",
+      "@code-yeongyu/senpi",
+      "--external",
+      "typebox",
+    ],
+    { cwd: packageRoot },
+  )
+
+  console.log(JSON.stringify({
+    result: "PASS",
+    surfaces: ["tui-select", "rpc-select", "custom-input", "multi-select", "claude-sdk-custom-tool"],
+    bundle,
+  }))
+} finally {
+  await rm(tempRoot, { recursive: true, force: true })
+}
+
+async function run(args, options) {
+  await mkdir(options.cwd, { recursive: true })
+  const child = Bun.spawn(["bun", ...args], {
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    stdout: "inherit",
+    stderr: "inherit",
+  })
+  const exitCode = await child.exited
+  if (exitCode !== 0) throw new Error(`bun ${args.join(" ")} exited ${exitCode}`)
+}

--- a/packages/omo-senpi/src/components/ask-question/claude-sdk-bridge.test.ts
+++ b/packages/omo-senpi/src/components/ask-question/claude-sdk-bridge.test.ts
@@ -1,0 +1,49 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+import { dirname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import type { ToolDefinition } from "@code-yeongyu/senpi"
+
+const senpiDistDir = dirname(fileURLToPath(import.meta.resolve("@code-yeongyu/senpi")))
+const toolsModule = await import(
+  pathToFileURL(join(
+    senpiDistDir,
+    "core",
+    "extensions",
+    "builtin",
+    "claude-sdk-oauth",
+    "tools.js",
+  )).href
+) as {
+  mapSdkToolNameToPi(name: string, customToolNameToPi?: ReadonlyMap<string, string>): string
+  resolveSdkTools(context: { tools?: ToolDefinition[] }): {
+    customTools: ToolDefinition[]
+    customToolNameToSdk: ReadonlyMap<string, string>
+    customToolNameToPi: ReadonlyMap<string, string>
+  }
+}
+
+describe("Claude SDK ask_question bridge", () => {
+  it("#given the active Omo question tool #when Claude SDK tools resolve #then it is captured as a host custom tool", () => {
+    const askQuestion = {
+      name: "ask_question",
+      label: "Ask Question",
+      description: "Ask the user a question",
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [{ type: "text" as const, text: "ok" }], details: {} }
+      },
+    } as unknown as ToolDefinition
+
+    const resolved = toolsModule.resolveSdkTools({ tools: [askQuestion] })
+
+    expect(resolved.customTools).toEqual([askQuestion])
+    expect(resolved.customToolNameToSdk.get("ask_question")).toBe("mcp__custom-tools__ask_question")
+    expect(toolsModule.mapSdkToolNameToPi(
+      "mcp__custom-tools__ask_question",
+      resolved.customToolNameToPi,
+    )).toBe("ask_question")
+  })
+})

--- a/packages/omo-senpi/src/components/ask-question/index.test.ts
+++ b/packages/omo-senpi/src/components/ask-question/index.test.ts
@@ -1,0 +1,258 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+
+import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
+import type { ComponentLogger } from "../../extension/types"
+import { createAskQuestionComponent } from "./index"
+
+interface QuestionTool {
+  execute(
+    toolCallId: string,
+    params: {
+      questions: Array<{
+        question: string
+        header: string
+        options: Array<{ label: string; description: string }>
+        multiSelect: boolean
+      }>
+    },
+    signal: AbortSignal | undefined,
+    onUpdate: undefined,
+    ctx: {
+      mode: "tui" | "rpc" | "print"
+      hasUI: boolean
+      ui: {
+        select(title: string, options: string[]): Promise<string | undefined>
+        input(title: string, placeholder?: string): Promise<string | undefined>
+      }
+    },
+  ): Promise<{
+    content: Array<{ type: "text"; text: string }>
+    details: {
+      answers: Record<string, string>
+      cancelled: boolean
+    }
+  }>
+}
+
+function fakeContext() {
+  const logger: ComponentLogger = {
+    info() {},
+    warn() {},
+    error() {},
+  }
+  return {
+    logger,
+    config: { getFlag: () => undefined },
+  }
+}
+
+function registeredTool(pi: FakeExtensionAPI): QuestionTool {
+  return pi.tools.find((tool) => tool.name === "ask_question") as unknown as QuestionTool
+}
+
+describe("createAskQuestionComponent", () => {
+  it("#given the component registers #then exposes the Claude-compatible ask_question contract", async () => {
+    const pi = new FakeExtensionAPI()
+
+    await createAskQuestionComponent().register(pi, fakeContext())
+
+    expect(pi.tools).toHaveLength(1)
+    expect(pi.tools[0]).toMatchObject({
+      name: "ask_question",
+      label: "Ask Question",
+      executionMode: "sequential",
+    })
+    expect(pi.removedToolHints).toEqual(
+      ["AskUserQuestion", "askForQuestion"].map((name) => ({
+        name,
+        hint: "Use ask_question instead; it supports both TUI and RPC dialog hosts.",
+      })),
+    )
+  })
+
+  it.each(["tui", "rpc"] as const)(
+    "#given $mode dialog UI #when the user selects an option #then returns the answer",
+    async (mode) => {
+      const pi = new FakeExtensionAPI()
+      await createAskQuestionComponent().register(pi, fakeContext())
+      const selections: Array<{ title: string; options: string[] }> = []
+
+      const result = await registeredTool(pi).execute(
+        "call-1",
+        {
+          questions: [
+            {
+              question: "Which behavior should remain?",
+              header: "Behavior",
+              options: [
+                { label: "Keep", description: "Preserve current behavior" },
+                { label: "Replace", description: "Use the new behavior" },
+              ],
+              multiSelect: false,
+            },
+          ],
+        },
+        undefined,
+        undefined,
+        {
+          mode,
+          hasUI: true,
+          ui: {
+            async select(title, options) {
+              selections.push({ title, options })
+              return "Keep — Preserve current behavior"
+            },
+            async input() {
+              return undefined
+            },
+          },
+        },
+      )
+
+      expect(selections).toEqual([
+        {
+          title: "Behavior: Which behavior should remain?",
+          options: [
+            "Keep — Preserve current behavior",
+            "Replace — Use the new behavior",
+            "Type something.",
+          ],
+        },
+      ])
+      expect(result.details).toEqual({
+        answers: { "Which behavior should remain?": "Keep" },
+        cancelled: false,
+      })
+      expect(result.content[0]?.text).toContain("Which behavior should remain?: Keep")
+    },
+  )
+
+  it("#given the user chooses custom input #when text is entered #then returns that text", async () => {
+    const pi = new FakeExtensionAPI()
+    await createAskQuestionComponent().register(pi, fakeContext())
+
+    const result = await registeredTool(pi).execute(
+      "call-2",
+      {
+        questions: [
+          {
+            question: "What should the command be called?",
+            header: "Name",
+            options: [
+              { label: "ask_question", description: "Use snake case" },
+              { label: "question", description: "Use a short name" },
+            ],
+            multiSelect: false,
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      {
+        mode: "rpc",
+        hasUI: true,
+        ui: {
+          async select() {
+            return "Type something."
+          },
+          async input() {
+            return "ask_user"
+          },
+        },
+      },
+    )
+
+    expect(result.details).toEqual({
+      answers: { "What should the command be called?": "ask_user" },
+      cancelled: false,
+    })
+  })
+
+  it("#given a multi-select question #when choices are selected and submitted #then returns all labels", async () => {
+    const pi = new FakeExtensionAPI()
+    await createAskQuestionComponent().register(pi, fakeContext())
+    const choices = ["Tests — Add regression coverage", "Docs — Update the guide", "Done"]
+
+    const result = await registeredTool(pi).execute(
+      "call-3",
+      {
+        questions: [
+          {
+            question: "Which changes should be included?",
+            header: "Scope",
+            options: [
+              { label: "Tests", description: "Add regression coverage" },
+              { label: "Docs", description: "Update the guide" },
+            ],
+            multiSelect: true,
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      {
+        mode: "tui",
+        hasUI: true,
+        ui: {
+          async select() {
+            return choices.shift()
+          },
+          async input() {
+            return undefined
+          },
+        },
+      },
+    )
+
+    expect(result.details).toEqual({
+      answers: { "Which changes should be included?": "Tests, Docs" },
+      cancelled: false,
+    })
+  })
+
+  it("#given no dialog-capable UI #when executed #then fails without waiting", async () => {
+    const pi = new FakeExtensionAPI()
+    await createAskQuestionComponent().register(pi, fakeContext())
+
+    const result = await registeredTool(pi).execute(
+      "call-4",
+      {
+        questions: [
+          {
+            question: "Continue?",
+            header: "Confirm",
+            options: [
+              { label: "Yes", description: "Continue" },
+              { label: "No", description: "Stop" },
+            ],
+            multiSelect: false,
+          },
+        ],
+      },
+      undefined,
+      undefined,
+      {
+        mode: "print",
+        hasUI: false,
+        ui: {
+          async select() {
+            throw new Error("select must not be called")
+          },
+          async input() {
+            throw new Error("input must not be called")
+          },
+        },
+      },
+    )
+
+    expect(result.details).toEqual({ answers: {}, cancelled: true })
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "Unable to ask the user: interactive UI is not available in print mode.",
+      },
+    ])
+  })
+})

--- a/packages/omo-senpi/src/components/ask-question/index.ts
+++ b/packages/omo-senpi/src/components/ask-question/index.ts
@@ -1,0 +1,166 @@
+import type { ExtensionContext, ToolDefinition } from "@code-yeongyu/senpi"
+import { Type, type Static } from "typebox"
+
+import type { ComponentContext, OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types"
+
+const CUSTOM_OPTION = "Type something."
+const DONE_OPTION = "Done"
+
+const QuestionOptionSchema = Type.Object({
+  label: Type.String({
+    minLength: 1,
+    description: "Short option label displayed to the user",
+  }),
+  description: Type.String({
+    description: "Explanation of the option's effect or trade-off",
+  }),
+})
+
+const QuestionSchema = Type.Object({
+  question: Type.String({
+    minLength: 1,
+    description: "Complete question ending with a question mark",
+  }),
+  header: Type.String({
+    minLength: 1,
+    maxLength: 12,
+    description: "Short category label shown before the question",
+  }),
+  options: Type.Array(QuestionOptionSchema, {
+    minItems: 2,
+    maxItems: 4,
+    description: "Two to four concrete choices",
+  }),
+  multiSelect: Type.Boolean({
+    description: "Whether the user may choose more than one answer",
+  }),
+})
+
+const AskQuestionParams = Type.Object({
+  questions: Type.Array(QuestionSchema, {
+    minItems: 1,
+    maxItems: 4,
+    description: "One to four questions to present in order",
+  }),
+})
+
+type AskQuestionParams = Static<typeof AskQuestionParams>
+type Question = AskQuestionParams["questions"][number]
+
+interface QuestionResult {
+  answers: Record<string, string>
+  cancelled: boolean
+}
+
+type DialogContext = Pick<ExtensionContext, "mode" | "hasUI" | "ui">
+
+export function createAskQuestionComponent(): OmoSenpiComponent {
+  return {
+    name: "ask-question",
+    register(pi: SenpiExtensionAPI, _ctx: ComponentContext): void {
+      pi.registerRemovedToolHint?.(
+        "AskUserQuestion",
+        "Use ask_question instead; it supports both TUI and RPC dialog hosts.",
+      )
+      pi.registerRemovedToolHint?.(
+        "askForQuestion",
+        "Use ask_question instead; it supports both TUI and RPC dialog hosts.",
+      )
+      pi.registerTool(askQuestionTool)
+    },
+  }
+}
+
+const askQuestionTool = {
+  name: "ask_question",
+  label: "Ask Question",
+  description:
+    "Ask the user one to four clarifying questions and wait for their answers. " +
+    "Use this instead of Claude Code's AskUserQuestion tool. " +
+    "Each question supports two to four described options and optional free-text input.",
+  promptSnippet: "Ask the user structured clarifying questions through the interactive UI",
+  parameters: AskQuestionParams,
+  executionMode: "sequential",
+  async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+    if (!ctx.hasUI) {
+      return result(
+        `Unable to ask the user: interactive UI is not available in ${ctx.mode} mode.`,
+        {},
+        true,
+      )
+    }
+
+    const answers: Record<string, string> = {}
+    for (const question of params.questions) {
+      const answer = question.multiSelect
+        ? await askMultiple(ctx, question)
+        : await askSingle(ctx, question)
+      if (answer === undefined) return result("Question cancelled by the user.", answers, true)
+      answers[question.question] = answer
+    }
+
+    return result(formatAnswers(answers), answers, false)
+  },
+} satisfies ToolDefinition<typeof AskQuestionParams, QuestionResult>
+
+async function askSingle(ctx: DialogContext, question: Question): Promise<string | undefined> {
+  const choices = question.options.map(formatOption)
+  const selected = await ctx.ui.select(questionTitle(question), [...choices, CUSTOM_OPTION])
+  if (selected === undefined) return undefined
+  if (selected === CUSTOM_OPTION) return askCustom(ctx, question)
+
+  return question.options.find((option) => formatOption(option) === selected)?.label
+}
+
+async function askMultiple(ctx: DialogContext, question: Question): Promise<string | undefined> {
+  const selected: string[] = []
+  const remaining = [...question.options]
+
+  while (true) {
+    const choices = remaining.map(formatOption)
+    const doneLabel = selected.length === 0 ? `${DONE_OPTION} (select at least one)` : DONE_OPTION
+    const choice = await ctx.ui.select(questionTitle(question), [...choices, CUSTOM_OPTION, doneLabel])
+    if (choice === undefined) return undefined
+    if (choice === DONE_OPTION) return selected.join(", ")
+    if (choice === doneLabel) continue
+
+    if (choice === CUSTOM_OPTION) {
+      const custom = await askCustom(ctx, question)
+      if (custom === undefined) return undefined
+      selected.push(custom)
+      continue
+    }
+
+    const index = remaining.findIndex((option) => formatOption(option) === choice)
+    if (index < 0) return undefined
+    const [option] = remaining.splice(index, 1)
+    if (option !== undefined) selected.push(option.label)
+  }
+}
+
+async function askCustom(ctx: DialogContext, question: Question): Promise<string | undefined> {
+  const answer = await ctx.ui.input(questionTitle(question), "Type your answer")
+  const trimmed = answer?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function questionTitle(question: Question): string {
+  return `${question.header}: ${question.question}`
+}
+
+function formatOption(option: Question["options"][number]): string {
+  return option.description ? `${option.label} — ${option.description}` : option.label
+}
+
+function formatAnswers(answers: Record<string, string>): string {
+  return Object.entries(answers)
+    .map(([question, answer]) => `${question}: ${answer}`)
+    .join("\n")
+}
+
+function result(text: string, answers: Record<string, string>, cancelled: boolean) {
+  return {
+    content: [{ type: "text" as const, text }],
+    details: { answers, cancelled } satisfies QuestionResult,
+  }
+}

--- a/packages/omo-senpi/src/extension/component-list.ts
+++ b/packages/omo-senpi/src/extension/component-list.ts
@@ -1,4 +1,5 @@
 import { createAstGrepComponent } from "../components/ast-grep"
+import { createAskQuestionComponent } from "../components/ask-question"
 import { createCommentCheckerComponent } from "../components/comment-checker"
 import { createConfigStartupComponent } from "../components/config-startup"
 import { createConfigWatchComponent } from "../components/config-watch"
@@ -28,6 +29,7 @@ export function createOmoSenpiComponents(taskComponent: OmoSenpiComponent): OmoS
     createTodoFanoutReminderComponent(),
     createFallbackArchitectComponent(),
     createCommentCheckerComponent(),
+    createAskQuestionComponent(),
     createAstGrepComponent(),
     createLspComponent(),
     taskComponent,

--- a/packages/omo-senpi/src/extension/index.test.ts
+++ b/packages/omo-senpi/src/extension/index.test.ts
@@ -53,6 +53,14 @@ describe("omo-senpi extension entry", () => {
     expect(pi.handlers.map((handler) => handler.event)).toEqual(
       expect.arrayContaining(["input", "tool_result", "session_start", "model_select", "message_end"]),
     )
+    expect(pi.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "ask_question",
+          label: "Ask Question",
+        }),
+      ]),
+    )
   })
 
   it("#given open todo state #when ordinary input arrives #then the extension does not inject continuity guidance", async () => {

--- a/packages/omo-senpi/test-support/fake-extension-api.ts
+++ b/packages/omo-senpi/test-support/fake-extension-api.ts
@@ -46,6 +46,7 @@ export class FakeExtensionAPI implements SenpiExtensionAPI {
   readonly messageRenderers: FakeMessageRendererRegistration[] = []
   readonly mcpServers: Array<{ name: string; config: Record<string, unknown> }> = []
   readonly rpcEvents: FakeRpcEvent[] = []
+  readonly removedToolHints: Array<{ name: string; hint: string }> = []
   events?: SenpiExtensionAPI["events"]
   rpc?: { emit(name: string, data: unknown): void }
 
@@ -92,6 +93,10 @@ export class FakeExtensionAPI implements SenpiExtensionAPI {
 
   registerMcpServer(name: string, config: Record<string, unknown>): void {
     this.mcpServers.push({ name, config })
+  }
+
+  registerRemovedToolHint(name: string, hint: string): void {
+    this.removedToolHints.push({ name, hint })
   }
 
   async dispatch(event: string, payload: unknown, ctx?: unknown): Promise<unknown[]> {


### PR DESCRIPTION
## Summary

- Omo/Senpi가 Claude Code 전용 `AskUserQuestion`에 의존하지 않고 자체 `ask_question` 도구로 사용자에게 질문할 수 있게 했습니다.
- 표준 dialog API를 사용해 TUI와 RPC 호스트 모두에서 동일하게 선택·직접 입력·다중 선택 응답을 기다립니다.
- 기존 Claude SDK custom-tool 캡처 경로를 활용하므로 `permissionMode: dontAsk`의 SDK 승인 프롬프트를 거치지 않습니다.

## Changes

- `ask_question`을 기본 Omo Senpi 컴포넌트로 등록하고 1~4개 질문, 선택지 설명, 직접 입력, 다중 선택을 지원합니다.
- `AskUserQuestion` 및 `askForQuestion` 호출 실패 시 대체 도구를 알려주는 removed-tool hint를 등록했습니다.
- Claude SDK가 도구를 `mcp__custom-tools__ask_question`으로 노출하고 다시 호스트 도구명으로 매핑하는 계약을 회귀 테스트로 고정했습니다.
- TUI/RPC 질문 흐름과 번들 생성까지 한 번에 확인하는 QA 드라이버를 추가했습니다.

## QA & Evidence

- **What was tested:** `bun packages/omo-senpi/scripts/qa/ask-question-e2e.mjs`
  **Observed result:** 7 tests passed, 0 failed; TUI select, RPC select, custom input, multi-select, Claude SDK custom-tool mapping, standalone bundle all passed.
  **Artifact:** command output (temporary bundle cleaned automatically)
  **Why sufficient:** 질문의 모든 사용자 입력 분기와 SDK 권한 우회 경로를 실제 실행 함수 및 배포 가능한 bundle로 검증합니다.

- **What was tested:** focused TypeScript compile of `packages/omo-senpi/src/components/ask-question/index.ts`
  **Observed result:** exit code 0
  **Artifact:** command output
  **Why sufficient:** 새 프로덕션 컴포넌트의 strict type contract를 확인합니다.

## Risks & Residuals

- 전체 workspace `bun install`이 이 환경의 Bun resolver에서 반복적으로 멈춰 root typecheck/build는 실행하지 못했습니다. 변경 패키지의 strict compile, focused tests, standalone bundle로 해당 범위를 보완했습니다.
- print/json처럼 dialog UI가 없는 호스트에서는 즉시 취소 결과를 반환합니다. 이는 대기 불가능한 표면에 대한 의도된 동작입니다.
- Cloudinary MCP 설정은 이미 별도 수정되었으므로 이 PR에서 변경하지 않습니다.

## Automated Checks

```bash
bun packages/omo-senpi/scripts/qa/ask-question-e2e.mjs
bun tsc --noEmit  # focused ask-question component config
```

## Related Issues

- None

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an interactive `ask_question` tool to `omo-senpi` that asks users clarifying questions via the standard dialog API across TUI and RPC. It preserves Claude SDK custom-tool compatibility and avoids extra permission prompts.

- New Features
  - Registers `ask_question` as a core component; supports 1–4 questions, 2–4 options per question, custom input, and multi-select; returns structured answers or a cancelled state.
  - Works consistently in TUI and RPC; non-UI hosts return an immediate cancel result.
  - Claude SDK bridge: exposes as `mcp__custom-tools__ask_question` and maps back to `ask_question`, avoiding SDK permission prompts.
  - Adds removed-tool hints for `AskUserQuestion` and `askForQuestion`.

- Migration
  - Replace `AskUserQuestion`/`askForQuestion` with `ask_question`.

<sup>Written for commit 277e32061687980c708b8d5fce5a3c2bb482f651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

