### PR TITLE
test(memory): stabilize Windows Git integration suites

### DIFF
--- a/packages/memory-core/src/facts/recovery-setter-race.test.ts
+++ b/packages/memory-core/src/facts/recovery-setter-race.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -12,6 +12,8 @@ import { applyFactsRecovery } from "./recovery"
 const AUTHOR = { agentId: "facts-setter-race", authorName: "Facts Setter Race" }
 const WINDOWS_INTEGRATION_TEST_TIMEOUT = process.platform === "win32" ? 20_000 : 5_000
 const tempDirs: string[] = []
+
+setDefaultTimeout(WINDOWS_INTEGRATION_TEST_TIMEOUT)
 
 function batch(batchId = "11111111-1111-4111-8111-111111111111"): FactsBatch {
   return {

--- a/packages/memory-core/src/reflection/worktree-integration.test.ts
+++ b/packages/memory-core/src/reflection/worktree-integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test"
+import { afterEach, describe, expect, it, setDefaultTimeout } from "bun:test"
 import { existsSync, realpathSync } from "node:fs"
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -14,7 +14,10 @@ import {
 import { createReflectionWorktree, type ReflectionWorktree } from "./worktree"
 
 const roots: string[] = []
+const WINDOWS_INTEGRATION_TEST_TIMEOUT = process.platform === "win32" ? 20_000 : 5_000
 const exec = createNodeGitExec()
+
+setDefaultTimeout(WINDOWS_INTEGRATION_TEST_TIMEOUT)
 const unlocked = <T>(operation: () => Promise<T>) => operation()
 
 async function fixture(runId = "run-123") {

--- a/packages/memory-core/src/reflection/worktree.test.ts
+++ b/packages/memory-core/src/reflection/worktree.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test"
+import { afterEach, describe, expect, it, setDefaultTimeout } from "bun:test"
 import { existsSync, realpathSync } from "node:fs"
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -12,7 +12,10 @@ import {
 } from "./worktree"
 
 const roots: string[] = []
+const WINDOWS_INTEGRATION_TEST_TIMEOUT = process.platform === "win32" ? 20_000 : 5_000
 const exec = createNodeGitExec()
+
+setDefaultTimeout(WINDOWS_INTEGRATION_TEST_TIMEOUT)
 
 async function fixture() {
   const root = realpathSync.native(await mkdtemp(join(tmpdir(), "reflection-worktree-")))

--- a/packages/memory-core/src/tools/soul-edit.test.ts
+++ b/packages/memory-core/src/tools/soul-edit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test"
+import { afterEach, describe, expect, it, setDefaultTimeout } from "bun:test"
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
@@ -16,6 +16,9 @@ const AUTHOR: GitCommitAuthor = {
 }
 
 const roots: string[] = []
+const WINDOWS_INTEGRATION_TEST_TIMEOUT = process.platform === "win32" ? 20_000 : 5_000
+
+setDefaultTimeout(WINDOWS_INTEGRATION_TEST_TIMEOUT)
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))


### PR DESCRIPTION
## Summary

- give the Git-heavy memory-core integration suites a Windows-only 20 second Bun test budget
- keep the existing 5 second deadline on macOS and Linux
- leave production Git timeouts and all behavior assertions unchanged

## Root cause

`packages/memory-core/src/reflection/worktree-integration.test.ts` was failing at the owned interrupted-merge case with:

```text
(fail) reflection worktree integration > #given an owned interrupted merge #when auto integration retries #then it aborts that merge and lands one clean merge [5032.00ms]
  ^ this test timed out after 5000ms.
```

The failure is the Bun per-test deadline, not the 30 second Git child deadline. The Git exec wrapper waits for the child `close` event before settling, but Bun aborts the test at 5 seconds while its awaited Git sequence is still active. The timed-out test then overlaps teardown and later cases, which accounts for the secondary `EBUSY`, `cannot lock ref 'HEAD'`, failed integration, and invalid-reflection errors.

The same Windows-only runtime pattern is present in:

- `reflection/worktree-integration.test.ts`
- `reflection/worktree.test.ts`
- `tools/soul-edit.test.ts`
- `facts/recovery-setter-race.test.ts`

Each now uses the repository's established platform-scoped integration-test budget pattern. Assertions, cleanup retries, and production Git behavior are unchanged.

## Pre-existing evidence

The failing Windows jobs were on feature PRs that did not modify these memory-core files, including #6803 and #6804. On #6803, the failing test stopped at exactly 5 seconds and emitted the secondary teardown `EBUSY`; the same suite passed on macOS and Linux.

## Verification

- `bun test packages/memory-core/src/reflection/` - 46 pass, 0 fail
- `bun test packages/memory-core/src/tools/soul-edit.test.ts` - 6 pass, 0 fail
- `bun test packages/memory-core/src/facts/recovery-setter-race.test.ts` - 3 pass, 0 fail
- `bunx tsgo --noEmit -p packages/memory-core/tsconfig.json` - pass

Windows verification is provided by this PR's `test (windows-latest)` CI job.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Windows Git-heavy `memory-core` integration tests by raising the Bun per-test timeout to 20s on Windows while keeping 5s on macOS/Linux. Previously all platforms used 5s, causing Windows flakes when Bun aborted long Git sequences and overlapped teardown.

- Adds `setDefaultTimeout(WINDOWS_INTEGRATION_TEST_TIMEOUT)` to:
  - `reflection/worktree-integration.test.ts`
  - `reflection/worktree.test.ts`
  - `tools/soul-edit.test.ts`
  - `facts/recovery-setter-race.test.ts`
- No changes to production Git timeouts, exec behavior, or assertions; only test budget adjusts.
- Side effect: Windows CI may run longer; flake from `EBUSY`/ref lock errors should stop.

<sup>Written for commit 3b7fec5ed6d01d29776c7740864f6ab74c642822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

