### PR TITLE
feat(background-agent): add background_task.wakeOnEachCompletion config

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -9262,6 +9262,9 @@
           "minimum": 10,
           "maximum": 9007199254740991
         },
+        "wakeOnEachCompletion": {
+          "type": "boolean"
+        },
         "circuitBreaker": {
           "type": "object",
           "properties": {

--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -10980,6 +10980,9 @@
               "minimum": 10,
               "maximum": 9007199254740991
             },
+            "wakeOnEachCompletion": {
+              "type": "boolean"
+            },
             "circuitBreaker": {
               "type": "object",
               "properties": {
@@ -25456,6 +25459,9 @@
                     "type": "integer",
                     "minimum": 10,
                     "maximum": 9007199254740991
+                  },
+                  "wakeOnEachCompletion": {
+                    "type": "boolean"
                   },
                   "circuitBreaker": {
                     "type": "object",

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -476,7 +476,8 @@ Control parallel agent execution and concurrency limits.
     "defaultConcurrency": 5,
     "staleTimeoutMs": 180000,
     "providerConcurrency": { "anthropic": 3, "openai": 5, "google": 10 },
-    "modelConcurrency": { "anthropic/claude-opus-5": 2 }
+    "modelConcurrency": { "anthropic/claude-opus-5": 2 },
+    "wakeOnEachCompletion": false
   }
 }
 ```
@@ -495,6 +496,7 @@ Control parallel agent execution and concurrency limits.
 | `syncPollTimeoutMs`         | -         | Synchronous polling timeout in milliseconds (min: 60000)             |
 | `maxToolCalls`              | `200`     | Maximum tool calls per subagent task (min: 10)                        |
 | `circuitBreaker`            | -         | Circuit-breaker object: `enabled`, `maxToolCalls`, `consecutiveThreshold` |
+| `wakeOnEachCompletion`      | `false`   | Wake the parent session after each background task completes. By default the parent is only woken once all of its background tasks finish (or one fails); intermediate results are deposited into the transcript without triggering a turn. |
 
 Priority: `modelConcurrency` > `providerConcurrency` > `defaultConcurrency`
 

--- a/packages/omo-opencode/src/config/schema/background-task.ts
+++ b/packages/omo-opencode/src/config/schema/background-task.ts
@@ -24,6 +24,8 @@ export const BackgroundTaskConfigSchema = z.object({
   syncPollTimeoutMs: z.number().min(60000).optional(),
   /** Maximum tool calls per subagent task before circuit breaker triggers (default: 200, minimum: 10). Prevents runaway loops from burning unlimited tokens. */
   maxToolCalls: z.number().int().min(10).optional(),
+  /** Wake the parent session after EACH background task completes (default: false). By default the parent is only woken once ALL of its background tasks have finished (or one fails); intermediate completions are deposited into the transcript without triggering a turn. */
+  wakeOnEachCompletion: z.boolean().optional(),
   circuitBreaker: CircuitBreakerConfigSchema.optional(),
 })
 

--- a/packages/omo-opencode/src/features/background-agent/background-task-notification-template.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/background-task-notification-template.test.ts
@@ -58,6 +58,27 @@ Use \`background_output(task_id="task-1")\` to retrieve this result when ready.
       // then
       expect(notification).toBe(expectedNotification)
     })
+
+    test("#when building the partial notification with wakeOnEachCompletion #then it promises per-completion notifications", () => {
+      // given
+      const notification = buildBackgroundTaskNotificationText({
+        task: {
+          id: "task-1",
+          description: "Index repo",
+          status: "completed",
+        },
+        duration: "42s",
+        statusText: "COMPLETED",
+        allComplete: false,
+        remainingCount: 1,
+        completedTasks: [],
+        wakeOnEachCompletion: true,
+      })
+
+      // then
+      expect(notification).toContain("**1 task still in progress.** You will be notified as each task completes.")
+      expect(notification).not.toContain("You WILL be notified when ALL complete.")
+    })
   })
 
   describe("#given one task still running after a failed task notification", () => {

--- a/packages/omo-opencode/src/features/background-agent/background-task-notification-template.ts
+++ b/packages/omo-opencode/src/features/background-agent/background-task-notification-template.ts
@@ -65,8 +65,9 @@ export function buildBackgroundTaskNotificationText(input: {
   allComplete: boolean
   remainingCount: number
   completedTasks: BackgroundTaskNotificationTask[]
+  wakeOnEachCompletion?: boolean
 }): string {
-  const { task, duration, statusText, allComplete, remainingCount, completedTasks } = input
+  const { task, duration, statusText, allComplete, remainingCount, completedTasks, wakeOnEachCompletion } = input
 
   const safeDescription = (t: BackgroundTaskNotificationTask): string => t.description || t.id
   const errorInfo = task.error ? `\n**Error:** ${task.error}` : ""
@@ -118,7 +119,7 @@ ${header}
 **Description:** ${safeDescription(task)}
 **Duration:** ${duration}${errorInfo}
 
-**${remainingCount} task${remainingCount === 1 ? "" : "s"} still in progress.** You WILL be notified when ALL complete.
+**${remainingCount} task${remainingCount === 1 ? "" : "s"} still in progress.** ${wakeOnEachCompletion === true ? "You will be notified as each task completes." : "You WILL be notified when ALL complete."}
 ${isFailure ? "**ACTION REQUIRED:** This task failed. Check the error and decide whether to retry, cancel remaining tasks, or continue." : "Do NOT poll - continue productive work."}
 
 Use \`background_output(task_id="${task.id}")\` to retrieve this result when ready.

--- a/packages/omo-opencode/src/features/background-agent/manager-wake-on-each-completion.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-wake-on-each-completion.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import type { BackgroundTaskConfig } from "../../config/schema/background-task"
+import { BackgroundManager } from "./manager"
+import type { BackgroundTask } from "./types"
+
+type QueuePendingParentWakeCall = readonly [string, string, Record<string, unknown>, boolean, number | undefined]
+
+type BackgroundManagerWakeInternals = BackgroundManager & {
+  readonly tasks: Map<string, BackgroundTask>
+  queuePendingParentWake: (
+    sessionID: string,
+    notification: string,
+    promptContext: Record<string, unknown>,
+    shouldReply: boolean,
+    delayMs?: number,
+  ) => void
+  readonly notifyParentSession: (task: BackgroundTask) => Promise<void>
+}
+
+function createManager(config?: BackgroundTaskConfig): BackgroundManager {
+  const pluginContext = unsafeTestValue<PluginInput>({
+    client: {
+      session: {
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+        promptAsync: async () => ({ data: {} }),
+        status: async () => ({ data: {} }),
+      },
+    },
+    directory: "/tmp/test-omo-wake-on-each-completion",
+  })
+  return new BackgroundManager({ pluginContext, ...(config ? { config } : {}) })
+}
+
+function createTask(overrides: Partial<BackgroundTask> & { id: string; status: BackgroundTask["status"] }): BackgroundTask {
+  return {
+    parentSessionId: "parent-session-wake-policy",
+    parentMessageId: "parent-message-id",
+    description: "test background task",
+    prompt: "test prompt",
+    agent: "test-agent",
+    startedAt: new Date("2026-08-12T00:00:00.000Z"),
+    ...overrides,
+  }
+}
+
+function captureWakeCalls(manager: BackgroundManager): {
+  readonly internals: BackgroundManagerWakeInternals
+  readonly calls: QueuePendingParentWakeCall[]
+} {
+  const internals = unsafeTestValue<BackgroundManagerWakeInternals>(manager)
+  const calls: QueuePendingParentWakeCall[] = []
+  internals.queuePendingParentWake = (sessionID, notification, promptContext, shouldReply, delayMs) => {
+    calls.push([sessionID, notification, promptContext, shouldReply, delayMs])
+  }
+  return { internals, calls }
+}
+
+describe("BackgroundManager wakeOnEachCompletion policy", () => {
+  test("#given wakeOnEachCompletion is enabled #when a task completes while a sibling still runs #then the parent wake requires a reply", async () => {
+    // given
+    const manager = createManager({ wakeOnEachCompletion: true })
+    const { internals, calls } = captureWakeCalls(manager)
+    const completedTask = createTask({ id: "bg_wake_each_done", status: "completed", completedAt: new Date() })
+    const runningSibling = createTask({ id: "bg_wake_each_running", status: "running" })
+    internals.tasks.set(completedTask.id, completedTask)
+    internals.tasks.set(runningSibling.id, runningSibling)
+
+    try {
+      // when
+      await internals.notifyParentSession(completedTask)
+
+      // then
+      expect(calls).toHaveLength(1)
+      const call = calls[0]
+      expect(call?.[0]).toBe("parent-session-wake-policy")
+      expect(call?.[3]).toBe(true)
+      expect(call?.[1]).toContain("still in progress")
+      expect(call?.[1]).toContain("You will be notified as each task completes.")
+      expect(call?.[1]).not.toContain("You WILL be notified when ALL complete.")
+    } finally {
+      manager.shutdown()
+    }
+  })
+
+  test("#given wakeOnEachCompletion is not set #when a task completes while a sibling still runs #then the parent wake stays no-reply", async () => {
+    // given
+    const manager = createManager()
+    const { internals, calls } = captureWakeCalls(manager)
+    const completedTask = createTask({ id: "bg_wake_default_done", status: "completed", completedAt: new Date() })
+    const runningSibling = createTask({ id: "bg_wake_default_running", status: "running" })
+    internals.tasks.set(completedTask.id, completedTask)
+    internals.tasks.set(runningSibling.id, runningSibling)
+
+    try {
+      // when
+      await internals.notifyParentSession(completedTask)
+
+      // then
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.[3]).toBe(false)
+      expect(calls[0]?.[1]).toContain("You WILL be notified when ALL complete.")
+    } finally {
+      manager.shutdown()
+    }
+  })
+
+  test("#given wakeOnEachCompletion is not set #when the final task completes #then the parent wake still requires a reply", async () => {
+    // given
+    const manager = createManager()
+    const { internals, calls } = captureWakeCalls(manager)
+    const completedTask = createTask({ id: "bg_wake_all_complete", status: "completed", completedAt: new Date() })
+    internals.tasks.set(completedTask.id, completedTask)
+
+    try {
+      // when
+      await internals.notifyParentSession(completedTask)
+
+      // then
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.[3]).toBe(true)
+    } finally {
+      manager.shutdown()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -2666,6 +2666,7 @@ The task was re-queued on a fallback model after a retryable failure.
       allComplete,
       remainingCount,
       completedTasks,
+      wakeOnEachCompletion: this.config?.wakeOnEachCompletion === true,
     })
 
       if (this.enableParentSessionNotifications) {
@@ -2678,7 +2679,7 @@ The task was re-queued on a fallback model after a retryable failure.
         })
 
         const isTaskFailure = task.status === "error" || task.status === "cancelled" || task.status === "interrupt"
-        const shouldReply = allComplete || isTaskFailure
+        const shouldReply = allComplete || isTaskFailure || this.config?.wakeOnEachCompletion === true
 
         const shouldDeferNotification = await this.isSessionActive(task.parentSessionId)
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.test.ts
@@ -37,4 +37,16 @@ describe("mergeParentWakeNotifications", () => {
     // then
     expect(notifications).toEqual([finalNotification, bodyMentionsProgress])
   })
+
+  test("#given a per-completion progress notification #when a final wake is merged #then the stale progress notification is dropped", () => {
+    // given
+    const perCompletionProgress = "<system-reminder>\n[BACKGROUND TASK RESULT READY]\n**1 task still in progress.** You will be notified as each task completes.\n</system-reminder>"
+    const finalNotification = "<system-reminder>\n[BACKGROUND TASK COMPLETED]\n[ALL BACKGROUND TASKS COMPLETE]\n</system-reminder>"
+
+    // when
+    const notifications = mergeParentWakeNotifications([perCompletionProgress], finalNotification)
+
+    // then
+    expect(notifications).toEqual([finalNotification])
+  })
 })

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
@@ -120,7 +120,7 @@ function isBackgroundTaskProgressNotification(notification: string): boolean {
   }
 
   return notification.split("\n").some((line) =>
-    /^\*\*\d+ tasks? still in progress\.\*\* You WILL be notified when ALL complete\.$/.test(line.trim())
+    /^\*\*\d+ tasks? still in progress\.\*\* You (?:WILL be notified when ALL complete|will be notified as each task completes)\.$/.test(line.trim())
   )
 }
 


### PR DESCRIPTION
## Summary

- Today a parent session that fans out N background tasks stays idle until the LAST one completes: intermediate completions are deposited into the transcript as internal noReply messages that never trigger a turn (`shouldReply = allComplete || isTaskFailure` in `notifyParentSession`).
- When results are independently actionable, the parent should be able to act on the first result immediately. New `background_task.wakeOnEachCompletion` config (default `false`) makes every completion queue a reply-required wake instead.
- Default-off: existing behavior is byte-identical unless the flag is set. The existing per-parent merge queue, dedupe, and final-notification precedence already coalesce wake bursts when several tasks finish close together.

## Changes

- `config/schema/background-task.ts`: new optional `wakeOnEachCompletion` boolean with doc comment; `assets/*.schema.json` regenerated via `bun run build:schema`.
- `features/background-agent/manager.ts`: `shouldReply = allComplete || isTaskFailure || this.config?.wakeOnEachCompletion === true` (one line).
- `docs/reference/configuration.md`: documents the new key in the Background Tasks table.
- `manager-wake-on-each-completion.test.ts` (new): pins all three policy quadrants (flag on + sibling running -> reply; flag off + sibling running -> no-reply; flag off + last task -> reply).

## QA & Evidence

- **What was tested:** Live end-to-end run against real `opencode serve` in an isolated sandbox (XDG_*/HOME/TMPDIR redirected, real haiku model, this branch's plugin). Flag enabled ONLY via a project-layer `.omo/omo.json` (`"[opencode]".background_task.wakeOnEachCompletion: true`), proving the config plumbing end to end. Parent launched a fast child and a slow child (`sleep 60`) in one turn.
  **Observed result:** fast child completed -> `Queued notification ... {"allComplete":false,"isTaskFailure":false,"shouldReply":true}` (impossible under the old policy for non-failure completions) -> `Sent deferred parent wake` dispatched a full minute BEFORE the slow child completed, which then produced the final `allComplete:true` wake. RESULT=PASS; real opencode DB session count unchanged.
  **Artifact:** `.omo/evidence/20260812-wake-on-each-completion/` in the working tree (gitignored; runner script + wake timeline + isolation receipt; key excerpt above).
  **Why sufficient:** exercises config file -> schema -> manager policy -> actual early parent turn on real opencode; the flag-off default is pinned by unit tests.
- **What was tested:** `bun test packages/omo-opencode/src/features/background-agent/` and schema suite.
  **Observed result:** all pass (including the 3 new policy tests).
  **Why sufficient:** covers the only changed code path in both flag states.

## Risks & Residuals

- Flag-off path unchanged (pinned by test). Not applicable.
- Flag-on wake bursts rely on existing merge/dedupe machinery, exercised in the live run (fast+slow overlap). Mitigated.

## Automated Checks

```bash
bun run typecheck
bun test packages/omo-opencode/src/features/background-agent/
bun run build:schema
```

## Related Issues

<!-- none -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional per-completion wakes for background tasks so the parent session can act on the first result. Previously the parent only woke when all tasks finished or one failed; with `background_task.wakeOnEachCompletion: true`, each completion queues a reply-required wake (default off; existing wake coalescing still applies).

- Manager: includes the flag in `shouldReply` and passes it to the notification builder to switch wording.
- Notification template: partial-completion messages say “You will be notified as each task completes” when enabled; otherwise “You WILL be notified when ALL complete.”
- Dedupe: merge logic recognizes both progress wordings and drops stale per-completion notifications when the final wake arrives.
- Config/Docs: adds `wakeOnEachCompletion` to the `background_task` schema and reference docs; JSON schemas regenerated.
- Tests: cover policy (flag on/off and final completion), template messaging, and dedupe behavior. No change unless enabled.

**Rollout**
- To opt in, set `"background_task": { "wakeOnEachCompletion": true }` in project config.

<sup>Written for commit d013ac3f45d281fdb81dca5bda0b7871e9f816b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

