### PR TITLE
fix(omo-native): repair legacy Bun global manifests

### DIFF
--- a/packages/omo-native/bin/lib/launcher.js
+++ b/packages/omo-native/bin/lib/launcher.js
@@ -3,6 +3,7 @@ import { homedir } from "node:os"
 import { delimiter, join } from "node:path"
 import { spawnNode } from "./child-process.js"
 import { runDoctor } from "./doctor.js"
+import { migrateLegacyBunGlobalManifest } from "./legacy-bun-global-migration.js"
 import { nearestNodeBin, packageManifest, packageRoot, readJson, resolveSenpi, updateTarget } from "./package-paths.js"
 import { detectHarnesses, needsSetupSuggestion } from "./setup-detect.js"
 import { printSetupReport } from "./setup-report.js"
@@ -90,6 +91,7 @@ function isInteractiveDefault(args) {
 }
 
 export async function runLauncher(args = process.argv.slice(2)) {
+  migrateLegacyBunGlobalManifest()
   const command = args[0]
   if (command === "ulw-loop") {
     spawnNode(join(packageRoot, "plugin", "runtime", "agent-toolkit", "ulw-loop", "cli.js"), args.slice(1))

--- a/packages/omo-native/bin/lib/legacy-bun-global-migration.js
+++ b/packages/omo-native/bin/lib/legacy-bun-global-migration.js
@@ -1,0 +1,21 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join, resolve } from "node:path"
+import { packageRoot } from "./package-paths.js"
+
+export function migrateLegacyBunGlobalManifest(root = packageRoot, home = homedir()) {
+  if (resolve(root) !== resolve(home, "node_modules", "omo-ai")) return false
+
+  const manifestPath = join(home, "package.json")
+  let manifest
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
+  } catch {
+    return false
+  }
+
+  if (manifest?.dependencies?.[""] !== ".") return false
+  delete manifest.dependencies[""]
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  return true
+}

--- a/packages/omo-native/bin/lib/legacy-bun-global-migration.js
+++ b/packages/omo-native/bin/lib/legacy-bun-global-migration.js
@@ -3,7 +3,10 @@ import { homedir } from "node:os"
 import { join, resolve } from "node:path"
 import { packageRoot } from "./package-paths.js"
 
-export function migrateLegacyBunGlobalManifest(root = packageRoot, home = homedir()) {
+export function migrateLegacyBunGlobalManifest(
+  root = packageRoot,
+  home = process.env.HOME || process.env.USERPROFILE || homedir(),
+) {
   if (resolve(root) !== resolve(home, "node_modules", "omo-ai")) return false
 
   const manifestPath = join(home, "package.json")

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -17,7 +17,7 @@ type Fixture = {
   shimPath?: string
 }
 
-type InstallLayout = "bun" | "bun-posix-special" | "npm" | "unknown"
+type InstallLayout = "bun" | "bun-legacy" | "bun-posix-special" | "npm" | "unknown"
 
 function writeFile(path: string, content: string, mode?: number): void {
   mkdirSync(dirname(path), { recursive: true })
@@ -43,7 +43,9 @@ function createFixture(options: { hoisted?: boolean; shim?: boolean; installLayo
   // the fixture root is canonicalized once and every derived path inherits the same spelling.
   const root = expandShortPath(realpathSync(mkdtempSync(join(tmpdir(), "omo-launcher-"))))
   roots.push(root)
-  const packagePath = options.installLayout?.startsWith("bun")
+  const packagePath = options.installLayout === "bun-legacy"
+    ? join(root, "home", "node_modules", "omo-ai")
+    : options.installLayout?.startsWith("bun")
     ? join(
       root,
       options.installLayout === "bun-posix-special"
@@ -319,6 +321,53 @@ describe("omo launcher", () => {
         expect(result.status).toBe(0)
         expect(result.stdout.trim()).toBe("omo is updated via npm: npm i -g omo-ai@beta")
         expect(existsSync(fixture.captureFile)).toBe(false)
+      })
+    })
+
+    describe("#given a legacy Bun global manifest contains the empty dot dependency", () => {
+      test("#then launching omo removes only the invalid dependency entry", () => {
+        const fixture = createFixture({ installLayout: "bun-legacy" })
+        const home = join(fixture.root, "home")
+        const manifestPath = join(home, "package.json")
+        writeFile(manifestPath, JSON.stringify({
+          dependencies: {
+            "": ".",
+            "left-pad": "1.3.0",
+          },
+        }))
+
+        const result = run(fixture, ["--version"], { HOME: home })
+
+        expect(result.status).toBe(0)
+        expect(JSON.parse(readFileSync(manifestPath, "utf8")).dependencies).toEqual({
+          "left-pad": "1.3.0",
+        })
+      })
+
+      test("#then a different empty dependency value is preserved", () => {
+        const fixture = createFixture({ installLayout: "bun-legacy" })
+        const home = join(fixture.root, "home")
+        const manifestPath = join(home, "package.json")
+        const original = `${JSON.stringify({ dependencies: { "": "file:.", "left-pad": "1.3.0" } }, null, 2)}\n`
+        writeFile(manifestPath, original)
+
+        const result = run(fixture, ["--version"], { HOME: home })
+
+        expect(result.status).toBe(0)
+        expect(readFileSync(manifestPath, "utf8")).toBe(original)
+      })
+
+      test("#then malformed JSON is preserved", () => {
+        const fixture = createFixture({ installLayout: "bun-legacy" })
+        const home = join(fixture.root, "home")
+        const manifestPath = join(home, "package.json")
+        const original = "{ not-json\n"
+        writeFile(manifestPath, original)
+
+        const result = run(fixture, ["--version"], { HOME: home })
+
+        expect(result.status).toBe(0)
+        expect(readFileSync(manifestPath, "utf8")).toBe(original)
       })
     })
 


### PR DESCRIPTION
## Summary

Fix the Senpi/native `omo-ai` launcher so it repairs one exact legacy Bun global-install corruption before dispatching commands.

On `mengmotaMac`, Bun's legacy global root was `/Users/yeongyu/package.json` plus `/Users/yeongyu/bun.lock`. It contained `dependencies[""] = "."`, causing `bun install -g omo-ai@beta` to print `refusing to install dependency with unsafe name`, return 1, and still install the package.

## Change

- Detect only the legacy `$HOME/node_modules/omo-ai` install layout.
- Remove only the exact invalid empty-dot dependency.
- Preserve non-matching empty values, malformed JSON, and every other dependency.
- Run the migration before launcher command dispatch.

## Observed behavior

Before:
- `bun install -g omo-ai@beta` on `mengmotaMac`, Bun `1.4.0-canary.1 (45eda514f)`, returned 1.
- Output included the unsafe-name error and `Failed to install 1 package`.

After:
- Fixed tarball installed with exit 0.
- Reintroducing the legacy entry and running `omo --version` removed it automatically.
- All other global dependencies remained equal.
- The original `bun install -g omo-ai@beta` returned 0 with no unsafe-name error.
- `omo --help` returned 0.

## Verification

- Focused RED then GREEN launcher test.
- Launcher suite: green.
- `OMO_SKIP_MATERIALIZE=1 bun test packages/omo-native/test`: 85 pass, 0 fail.
- Publish contract tests: 13 pass, 0 fail.
- Script typecheck and Node syntax checks: pass.
- `OMO_SKIP_MATERIALIZE=1 bun run build:omo-native`: pass.
- `node script/verify-omo-ai-payload.mjs`: 352 packed paths, 0 offenders.
- Post-rebase focused and publish gates: pass.

Reviewer-readable evidence is under `.omo/evidence/20260813-bun-global-unsafe-name/` in the task worktree. The strict materialization path could not initialize the pinned open-design submodule revision in this worktree; the repository-sanctioned `OMO_SKIP_MATERIALIZE=1` path was used and recorded.

## Risk

Low and bounded: the migration activates only for the legacy Bun home-root install path and only deletes `dependencies[""]` when its value is exactly `"."`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs a legacy `bun` global-install manifest corruption in the `omo-ai` native launcher so installs and `omo` commands exit 0. Previously, legacy home-root manifests could include `dependencies[""] = "."` in `$HOME/package.json`, causing `bun install -g omo-ai@beta` to exit 1 with an unsafe-name error; now the launcher removes only that entry at start.

- Detects only the legacy `$HOME/node_modules/omo-ai` layout.
- Prefers `HOME` or `USERPROFILE` over `os.homedir()` to target the launcher runtime home on Windows.
- Removes only `dependencies[""] === "."`; preserves other dependencies, other empty values, and malformed JSON.
- Runs automatically at launcher start; no user action required.
- Adds targeted tests; non-legacy `bun`/`npm` installs are unchanged.

<sup>Written for commit c2b2375c41e08f99d80cf5c85a36bd1ed4fbb943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

