### PR TITLE
fix: format the beta.7 changelog entry

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -30,6 +30,7 @@ All native Senpi workspace pins now use `2026.8.12-4` (root, native launcher, Om
 task engine), moving the omo-ai 5.0.0 beta line onto the Senpi 2026.8.12 engine train. The
 four-surface alignment rule above still holds: `packages/omo-native/test/senpi-pin.test.ts` fails any
 manifest that drifts from the shared pin, so all four move in one commit.
+
 ## 2026-08-13 — Record the OmO 5.0.0 beta.7 release
 
 Release PR #6797 merged the `v5.0.0-beta.7` source state at
@@ -43,4 +44,3 @@ The release also includes `d694add58dd1` (`fix(omo-native): emit doctor report
 atomically`). Doctor output now becomes visible only after a complete report is
 ready, so consumers must not reintroduce partially written report files or
 split the atomic write path during future release refactors.
-


### PR DESCRIPTION
Formats the merged beta.7 durable-memory entry. `bunx prettier --check changes.md` and `git diff --check` both pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats the OmO 5.0.0-beta.7 changelog entry in `changes.md` to conform to markdown and Prettier. Adds the required blank line before the header and removes an extra trailing line to keep tooling green and ensure correct section rendering.

- Docs-only change; no code, tests, or build impacts.
- `bunx prettier --check changes.md` and `git diff --check` pass.
- No changes to release note content.

<sup>Written for commit 2eea2f9c6d18e5393eab947f7d3837e87b8590e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

