### PR TITLE
fix(cli): keep ZAI-only installer fallbacks resolvable (fixes #6799)

### DIFF
--- a/.omo/evidence/20260813-fix-6799/installer-output.txt
+++ b/.omo/evidence/20260813-fix-6799/installer-output.txt
@@ -1,0 +1,21 @@
+command:
+  bun packages/omo-opencode/src/cli/index.ts install --no-tui
+    --platform=opencode
+    --claude=no --openai=no --gemini=no --copilot=no
+    --opencode-zen=no --zai-coding-plan=yes
+    --kimi-for-coding=no --opencode-go=no
+    --bailian-coding-plan=no
+    --minimax-cn-coding-plan=no --minimax-coding-plan=no
+    --vercel-ai-gateway=no --skip-auth
+
+sandbox:
+  C:/Users/pss/OneDrive/Documents/github/oh-my-openagent-6799/.omo/qa-sandbox-6799
+
+observed:
+  exit_code=0
+  generated file: home/.omo/omo.jsonc
+  agents.sisyphus.model=zai-coding-plan/glm-5.2
+  agents.explore.model=zai-coding-plan/glm-5.2
+  agents.multimodal-looker.model=zai-coding-plan/glm-4.6v
+  every other generated agent/category model=zai-coding-plan/glm-5.2
+  opencode model count=0

--- a/.omo/evidence/20260813-fix-6799/qa-summary.md
+++ b/.omo/evidence/20260813-fix-6799/qa-summary.md
@@ -1,0 +1,48 @@
+# QA summary - issue #6799 ZAI-only installer fallback
+
+Captured 2026-08-13 on Windows 11 with Bun 1.3.14.
+
+## What was tested
+
+1. A red-green regression that generates installer configuration with ZAI as
+   the only provider and rejects every `opencode/` model.
+2. The complete `model-fallback.test.ts` and
+   `model-fallback-providers.test.ts` suites.
+3. The TypeScript no-excuse audit for both changed files.
+4. The OpenCode adapter package typecheck against the same upstream base.
+5. The real non-interactive installer in an isolated HOME and XDG sandbox
+   with only `--zai-coding-plan=yes`.
+
+## What was observed
+
+- Before the source fix, the regression failed and printed fourteen
+  `opencode/gpt-5-nano` routes across agents and categories.
+- After deriving the unresolved-route fallback for ZAI-only installs, both
+  installer suites passed: 53 pass, 0 fail.
+- The no-excuse audit reported no violations.
+- The main upstream OpenCode adapter typecheck exited zero; the sparse issue
+  clone cannot run a standalone package typecheck because its untouched
+  workspace package links are intentionally absent. The changed module is
+  covered by the strict source audit and the fully loaded Bun tests.
+- The isolated real installer exited zero and wrote
+  `.omo/omo.jsonc` with every generated agent/category model under
+  `zai-coding-plan/`; no `opencode/` model appears.
+
+Exact concise captures:
+
+- `red-green.txt`
+- `verification.txt`
+- `installer-output.txt`
+
+## Why it is enough
+
+The regression toggles the reported installer output directly. The complete
+fallback suites protect all established native, Copilot, Zen, and mixed
+provider routes. The non-interactive installer is the matching user surface
+and proves the shipped config writer persists the corrected ZAI-only result in
+an isolated environment.
+
+## What was omitted
+
+No credentials, tokens, authentication headers, or host configuration were
+used. The isolated cache files and verbose passing test lines were summarized.

--- a/.omo/evidence/20260813-fix-6799/red-green.txt
+++ b/.omo/evidence/20260813-fix-6799/red-green.txt
@@ -1,0 +1,13 @@
+red command:
+  bun --cwd C:/Users/pss/OneDrive/Documents/github/oh-my-openagent-6799 test ./packages/omo-opencode/src/cli/model-fallback.test.ts --test-name-pattern "keeps every generated fallback on ZAI"
+
+red observation:
+  0 pass, 1 fail
+  The generated JSON contained fourteen `"model":"opencode/gpt-5-nano"`
+  routes while only ZAI was configured.
+
+green command:
+  bun --cwd C:/Users/pss/OneDrive/Documents/github/oh-my-openagent-6799 test ./packages/omo-opencode/src/cli/model-fallback.test.ts --test-name-pattern "keeps every generated fallback on ZAI"
+
+green observation:
+  1 pass, 0 fail

--- a/.omo/evidence/20260813-fix-6799/verification.txt
+++ b/.omo/evidence/20260813-fix-6799/verification.txt
@@ -1,0 +1,15 @@
+installer suites:
+  bun --cwd C:/Users/pss/OneDrive/Documents/github/oh-my-openagent-6799 test ./packages/omo-opencode/src/cli/model-fallback.test.ts ./packages/omo-opencode/src/cli/model-fallback-providers.test.ts
+  53 pass, 0 fail, 95 expect calls
+
+TypeScript audit:
+  bun --cwd C:/Users/pss/OneDrive/Documents/github/oh-my-openagent-6799 packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-opencode/src/cli/model-fallback.ts packages/omo-opencode/src/cli/model-fallback.test.ts
+  No violations in 2 files.
+
+upstream package typecheck baseline:
+  C:/Users/pss/OneDrive/Documents/github/oh-my-openagent/node_modules/.bin/tsgo.exe --noEmit -p C:/Users/pss/OneDrive/Documents/github/oh-my-openagent/packages/omo-opencode/tsconfig.json
+  exit code 0
+
+patch check:
+  git -C C:/Users/pss/OneDrive/Documents/github/oh-my-openagent-6799 diff --check
+  exit code 0

--- a/packages/omo-opencode/src/cli/model-fallback.test.ts
+++ b/packages/omo-opencode/src/cli/model-fallback.test.ts
@@ -89,6 +89,18 @@ describe("generateModelConfig", () => {
       expect(JSON.stringify(result)).not.toContain("zai-coding-plan/glm-4.7")
     })
 
+    test("keeps every generated fallback on ZAI when it is the only provider", () => {
+      // #given only ZAI is available
+      const config = createConfig({ hasZaiCodingPlan: true })
+
+      // #when generateModelConfig is called
+      const result = generateModelConfig(config)
+
+      // #then no generated route depends on an unavailable provider
+      expect(JSON.stringify(result)).not.toContain('"model":"opencode/')
+      expect(result.agents?.explore?.model).toBe("zai-coding-plan/glm-5.2")
+    })
+
     test("omits librarian when only ZAI is available with isMax20 flag", () => {
       // #given ZAI is available with Max 20 plan
       const config = createConfig({ hasZaiCodingPlan: true, isMax20: true })

--- a/packages/omo-opencode/src/cli/model-fallback.ts
+++ b/packages/omo-opencode/src/cli/model-fallback.ts
@@ -147,7 +147,26 @@ function attachAllFallbackModels<T extends AgentConfig | CategoryConfig>(
   }
 }
 
+function resolveUltimateFallback(
+  availability: ReturnType<typeof toProviderAvailability>,
+): string {
+  const isZaiOnly =
+    availability.zai &&
+    !availability.native.claude &&
+    !availability.native.openai &&
+    !availability.native.gemini &&
+    !availability.opencodeZen &&
+    !availability.copilot &&
+    !availability.kimiForCoding &&
+    !availability.opencodeGo &&
+    !availability.bailianCodingPlan &&
+    !availability.minimaxCnCodingPlan &&
+    !availability.minimaxCodingPlan &&
+    !availability.vercelAiGateway
 
+  if (isZaiOnly) return "zai-coding-plan/glm-5.2"
+  return ULTIMATE_FALLBACK
+}
 
 export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
   const avail = toProviderAvailability(config)
@@ -178,6 +197,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
     }
   }
 
+  const ultimateFallback = resolveUltimateFallback(avail)
   const agents: Record<string, AgentConfig> = {}
   const categories: Record<string, CategoryConfig> = {}
 
@@ -209,7 +229,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
           const variant = resolved.variant ?? req.variant
           agentConfig = toCompatibleModelConfig(resolved.model, { variant })
         } else {
-          agentConfig = { model: "opencode/gpt-5-nano" }
+          agentConfig = { model: ultimateFallback }
         }
       }
       agents[role] = attachAllFallbackModels(agentConfig, req.fallbackChain, avail)
@@ -243,7 +263,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
       const agentConfig = toCompatibleModelConfig(resolved.model, { variant })
       agents[role] = attachFallbackModels(agentConfig, req.fallbackChain, avail)
     } else {
-      agents[role] = { model: ULTIMATE_FALLBACK }
+      agents[role] = { model: ultimateFallback }
     }
   }
 
@@ -267,7 +287,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
       const categoryConfig = toCompatibleModelConfig(resolved.model, { variant })
       categories[cat] = attachFallbackModels(categoryConfig, fallbackChain, avail)
     } else {
-      categories[cat] = { model: ULTIMATE_FALLBACK }
+      categories[cat] = { model: ultimateFallback }
     }
   }
 


### PR DESCRIPTION
## Summary
- keep unresolved installer routes on ZAI when ZAI Coding Plan is the only configured provider
- remove the invalid `opencode/gpt-5-nano` entries without changing native or mixed-provider routing
- add red-green regression coverage and isolated installer evidence

## Root Cause
`generateModelConfig()` used the global `opencode/gpt-5-nano` sentinel whenever a role-specific fallback chain had no ZAI entry. With ZAI as the only provider, that wrote fourteen routes for a provider the user did not configure and a Zen model that does not exist.

## Changes
| File | Change |
|------|--------|
| `packages/omo-opencode/src/cli/model-fallback.ts` | Use `zai-coding-plan/glm-5.2` for unresolved routes only when ZAI is the sole provider. |
| `packages/omo-opencode/src/cli/model-fallback.test.ts` | Assert every ZAI-only generated route remains on ZAI. |
| `.omo/evidence/20260813-fix-6799/` | Record red-green tests and isolated real installer output. |

## Reproduction (before fix)
~~~
0 pass, 1 fail
Generated JSON contained fourteen "model":"opencode/gpt-5-nano" routes while only ZAI was configured.
~~~

## Verification (after fix)
~~~
53 pass, 0 fail, 95 expect calls
No violations in 2 changed TypeScript files.
Isolated non-interactive installer: exit_code=0
All persisted agent/category models use zai-coding-plan/; opencode model count=0.
~~~

## Test
- Regression: `model-fallback.test.ts`
- Related suite: `bun test model-fallback.test.ts model-fallback-providers.test.ts` - 53 pass
- Typecheck baseline: current upstream `packages/omo-opencode` package - clean
- Manual QA: isolated `install --no-tui --platform=opencode --zai-coding-plan=yes` - persisted only resolvable ZAI models

Fixes #6799

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps ZAI-only installer fallbacks resolvable. Previously, unresolved routes defaulted to `opencode/gpt-5-nano` and wrote invalid models when only ZAI Coding Plan was configured; now those routes use `zai-coding-plan/glm-5.2` without changing mixed-provider behavior. Fixes #6799.

- **Review notes**
  - Updates `packages/omo-opencode/src/cli/model-fallback.ts` to compute a provider-aware ultimate fallback and apply it for agents and categories.
  - Adds a test in `model-fallback.test.ts` that ensures ZAI-only installs emit no `opencode/` models and set `agents.explore.model` to `zai-coding-plan/glm-5.2`.
  - Records verification under `.omo/evidence/20260813-fix-6799/`; full fallback suites pass (53/53), and an isolated non-interactive installer run writes only ZAI models.

<sup>Written for commit fd04835b3dc68d681bdb8c8652a0003c0f80f59f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

