### PR TITLE
docs: make directory setup platform-neutral

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/skills/ulw-loop/references/full-workflow.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/skills/ulw-loop/references/full-workflow.md
@@ -100,7 +100,7 @@ elif [ -n "$ULW_LOOP_NODE" ]; then
 fi
 
 if [ -z "${ULW_LOOP_CLI:-}" ]; then
-  /bin/mkdir -p .omo/ulw-loop 2>/dev/null || mkdir -p .omo/ulw-loop 2>/dev/null || true
+  node -e "require('node:fs').mkdirSync('.omo/ulw-loop',{recursive:true})" 2>/dev/null || true
   NOTE="${NOTE:-.omo/ulw-loop/bootstrap-notepad.md}"
   printf '%s\n' "No ulw-loop-capable omo-agent-toolkit executable found; PATH omo-agent-toolkit may lack the Codex ulw-loop subcommand, and cached ulw-loop CLI was not found under ${CODEX_HOME:-$HOME/.codex}." >> "$NOTE" 2>/dev/null || true
   printf '%s\n' "Install with npx lazycodex-ai install or set CODEX_LOCAL_BIN_DIR to a PATH directory." >&2

--- a/packages/omo-senpi/skills/ulw-loop/references/full-workflow.md
+++ b/packages/omo-senpi/skills/ulw-loop/references/full-workflow.md
@@ -102,7 +102,7 @@ elif [ -n "$ULW_LOOP_NODE" ]; then
 fi
 
 if [ -z "${ULW_LOOP_CLI:-}" ]; then
-  /bin/mkdir -p .omo/ulw-loop 2>/dev/null || mkdir -p .omo/ulw-loop 2>/dev/null || true
+  node -e "require('node:fs').mkdirSync('.omo/ulw-loop',{recursive:true})" 2>/dev/null || true
   NOTE="${NOTE:-.omo/ulw-loop/bootstrap-notepad.md}"
   printf '%s\n' "No ulw-loop-capable omo-agent-toolkit executable found; PATH omo-agent-toolkit may be the OpenCode CLI without the omo-senpi ulw-loop subcommand, and cached ulw-loop CLI was not found under ${CODEX_HOME:-$HOME/.omo-senpi}." >> "$NOTE" 2>/dev/null || true
   printf '%s\n' "Install with npx omo-senpi-ai install or set CODEX_LOCAL_BIN_DIR to a PATH directory." >&2

--- a/packages/omo-senpi/skills/ulw-research/SKILL.md
+++ b/packages/omo-senpi/skills/ulw-research/SKILL.md
@@ -83,13 +83,18 @@ Debate need: <which claims will be contested, and which member perspectives atta
 </analysis>
 ```
 
-Then create the session directory and write the brief:
+Then create the session directory with the guaranteed Node runtime so the same
+command works under POSIX shells, PowerShell, and `cmd.exe`:
 
-```bash
-mkdir -p .omo/ulw-research/$(date +%Y%m%d-%H%M%S)
+```text
+node -e "const fs=require('node:fs');const s=new Date().toISOString().replace(/\D/g,'').slice(0,14);const d='.omo/ulw-research/'+s.slice(0,8)+'-'+s.slice(8);fs.mkdirSync(d,{recursive:true});console.log(d)"
 ```
 
-This is `$SESSION_DIR`. Write `brief.md` into it: the analysis block, the axis list with one named owner per axis, the expected truths seeding `intent-diff.md`, and the team roster you are about to create. The brief is what the team is built FROM — a team stood up before the brief exists is a failure mode (see the table at the end).
+Use the printed path as `$SESSION_DIR`. If a filesystem tool is available, it
+may create the same timestamped directory directly instead. Never pass POSIX
+flags such as `-p` to `cmd.exe`.
+
+Write `brief.md` into it: the analysis block, the axis list with one named owner per axis, the expected truths seeding `intent-diff.md`, and the team roster you are about to create. The brief is what the team is built FROM — a team stood up before the brief exists is a failure mode (see the table at the end).
 
 ### Run it as a loop, and journal in real time
 

--- a/packages/prompts-core/prompts/atlas/default.md
+++ b/packages/prompts-core/prompts/atlas/default.md
@@ -236,7 +236,7 @@ TASK ANALYSIS:
 - `issues.md` - Problems, gotchas
 - `problems.md` - Unresolved blockers
 
-If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
+If the directory is missing (e.g. plan predates auto-scaffold), create it recursively with a filesystem tool or Node's `fs.mkdirSync(path, { recursive: true })`; never pass the POSIX `-p` flag to Windows `cmd.exe`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 

--- a/packages/prompts-core/prompts/atlas/gemini.md
+++ b/packages/prompts-core/prompts/atlas/gemini.md
@@ -269,7 +269,7 @@ TASK ANALYSIS:
 - `issues.md` - Problems, gotchas
 - `problems.md` - Unresolved blockers
 
-If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
+If the directory is missing (e.g. plan predates auto-scaffold), create it recursively with a filesystem tool or Node's `fs.mkdirSync(path, { recursive: true })`; never pass the POSIX `-p` flag to Windows `cmd.exe`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 

--- a/packages/prompts-core/prompts/atlas/glm.md
+++ b/packages/prompts-core/prompts/atlas/glm.md
@@ -220,7 +220,7 @@ TASK ANALYSIS:
 - `issues.md` - Problems, gotchas
 - `problems.md` - Unresolved blockers
 
-If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
+If the directory is missing (e.g. plan predates auto-scaffold), create it recursively with a filesystem tool or Node's `fs.mkdirSync(path, { recursive: true })`; never pass the POSIX `-p` flag to Windows `cmd.exe`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Implementation Tasks
 

--- a/packages/prompts-core/prompts/atlas/gpt.md
+++ b/packages/prompts-core/prompts/atlas/gpt.md
@@ -245,7 +245,7 @@ TASK ANALYSIS:
 - `issues.md` - Problems, gotchas
 - `problems.md` - Unresolved blockers
 
-If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
+If the directory is missing (e.g. plan predates auto-scaffold), create it recursively with a filesystem tool or Node's `fs.mkdirSync(path, { recursive: true })`; never pass the POSIX `-p` flag to Windows `cmd.exe`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 

--- a/packages/prompts-core/prompts/atlas/kimi-k2-7.md
+++ b/packages/prompts-core/prompts/atlas/kimi-k2-7.md
@@ -171,7 +171,7 @@ TASK ANALYSIS:
 - `issues.md` - Problems, gotchas
 - `problems.md` - Unresolved blockers
 
-If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
+If the directory is missing (e.g. plan predates auto-scaffold), create it recursively with a filesystem tool or Node's `fs.mkdirSync(path, { recursive: true })`; never pass the POSIX `-p` flag to Windows `cmd.exe`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 

--- a/packages/prompts-core/prompts/atlas/kimi-k3.md
+++ b/packages/prompts-core/prompts/atlas/kimi-k3.md
@@ -171,7 +171,7 @@ TASK ANALYSIS:
 - `issues.md` - Problems, gotchas
 - `problems.md` - Unresolved blockers
 
-If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
+If the directory is missing (e.g. plan predates auto-scaffold), create it recursively with a filesystem tool or Node's `fs.mkdirSync(path, { recursive: true })`; never pass the POSIX `-p` flag to Windows `cmd.exe`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 

--- a/packages/prompts-core/prompts/atlas/kimi.md
+++ b/packages/prompts-core/prompts/atlas/kimi.md
@@ -259,7 +259,7 @@ TASK ANALYSIS:
 - `issues.md` - Problems, gotchas
 - `problems.md` - Unresolved blockers
 
-If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
+If the directory is missing (e.g. plan predates auto-scaffold), create it recursively with a filesystem tool or Node's `fs.mkdirSync(path, { recursive: true })`; never pass the POSIX `-p` flag to Windows `cmd.exe`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 

--- a/packages/prompts-core/prompts/atlas/opus-4-7.md
+++ b/packages/prompts-core/prompts/atlas/opus-4-7.md
@@ -252,7 +252,7 @@ TASK ANALYSIS:
 - `issues.md` - Problems, gotchas
 - `problems.md` - Unresolved blockers
 
-If the directory is missing (e.g. plan predates auto-scaffold), create it with `mkdir -p`. Append findings after work; never overwrite.
+If the directory is missing (e.g. plan predates auto-scaffold), create it recursively with a filesystem tool or Node's `fs.mkdirSync(path, { recursive: true })`; never pass the POSIX `-p` flag to Windows `cmd.exe`. Append findings after work; never overwrite.
 
 ## Step 3: Execute Tasks
 

--- a/packages/shared-skills/skills/ultimate-browsing/SKILL.md
+++ b/packages/shared-skills/skills/ultimate-browsing/SKILL.md
@@ -99,14 +99,27 @@ agent-browser --cdp 9242 close
 
 ### Cookie login (cross-platform)
 
-`scripts/extract_cookies.py` reads cookies from a local Chromium-family or Firefox-family browser and optionally injects them into the running CDP session. It resolves browser profile paths and decrypts cookie values per-OS (macOS Keychain, Linux libsecret, Windows DPAPI):
+`scripts/extract_cookies.py` reads cookies from a local Chromium-family or Firefox-family browser and optionally injects them into the running CDP session. It resolves browser profile paths and decrypts cookie values per-OS (macOS Keychain, Linux libsecret, Windows DPAPI).
+
+The extractor creates the output parent directory recursively. Use the example
+for the active shell; no separate `mkdir` command is needed:
 
 ```bash
-# Extract cookies to a file:
-mkdir -p ~/.local/state/omo-cookies
-python3 scripts/extract_cookies.py --browser chrome --domain youtube.com --output ~/.local/state/omo-cookies/youtube.cookies.json
-# Extract and inject into the running CDP session:
+# POSIX shell: extract cookies to a file, or inject into the running CDP session
+python3 scripts/extract_cookies.py --browser chrome --domain youtube.com --output "${XDG_STATE_HOME:-$HOME/.local/state}/omo-cookies/youtube.cookies.json"
 python3 scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
+```
+
+```powershell
+# Windows PowerShell
+python scripts/extract_cookies.py --browser chrome --domain youtube.com --output "$env:LOCALAPPDATA\omo-cookies\youtube.cookies.json"
+python scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
+```
+
+```bat
+:: Windows cmd.exe
+python scripts/extract_cookies.py --browser chrome --domain youtube.com --output "%LOCALAPPDATA%\omo-cookies\youtube.cookies.json"
+python scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
 ```
 
 Cookie export files are written with owner-only `0600` permissions. Do not place live auth cookies in shared temp directories or commit them to a repo. Cookie injection sends values to CDP over stdin rather than argv. Cookies apply on next navigation — reload after injecting. Google services use fingerprint-bound tokens that may not transfer across browser profiles. Full detail in [references/chrome-stealth.md](references/chrome-stealth.md).

--- a/packages/shared-skills/skills/ultimate-browsing/references/chrome-stealth.md
+++ b/packages/shared-skills/skills/ultimate-browsing/references/chrome-stealth.md
@@ -90,12 +90,25 @@ Verified 2026-07 with CloakBrowser 0.5.7 + agent-browser 0.34.0: `navigator.webd
 | Linux | `~/.config/<app>/` (Chromium), `~/.mozilla/firefox/` (Firefox) | libsecret/SecretService, then PBKDF2 + AES-128-CBC |
 | Windows | `%LOCALAPPDATA%\<app>\User Data\` | DPAPI (`CryptUnprotectData`) + AES-256-GCM (`os_crypt` key) |
 
+The extractor creates the output parent directory recursively. Use the example
+for the active shell; no separate `mkdir` command is needed:
+
 ```bash
-# Extract to a file:
-mkdir -p ~/.local/state/omo-cookies
-python3 ../scripts/extract_cookies.py --browser chrome --domain youtube.com --output ~/.local/state/omo-cookies/youtube.cookies.json
-# Extract and inject into the running CDP session:
+# POSIX shell: extract to a file, or inject into the running CDP session
+python3 ../scripts/extract_cookies.py --browser chrome --domain youtube.com --output "${XDG_STATE_HOME:-$HOME/.local/state}/omo-cookies/youtube.cookies.json"
 python3 ../scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
+```
+
+```powershell
+# Windows PowerShell
+python ../scripts/extract_cookies.py --browser chrome --domain youtube.com --output "$env:LOCALAPPDATA\omo-cookies\youtube.cookies.json"
+python ../scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
+```
+
+```bat
+:: Windows cmd.exe
+python ../scripts/extract_cookies.py --browser chrome --domain youtube.com --output "%LOCALAPPDATA%\omo-cookies\youtube.cookies.json"
+python ../scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
 ```
 
 Cookie export files are written with owner-only `0600` permissions. Do not place live auth cookies in shared temp directories or commit them to a repo. Cookie injection sends values to CDP over stdin rather than argv, so live cookie values do not appear in process listings. Cookies apply on next navigation — reload after injecting. Google services use fingerprint-bound tokens (SIDTS) that may not transfer across browser profiles. Firefox-family profiles store cookies unencrypted; Chromium-family profiles trigger a one-time OS-keyring prompt on macOS/Linux.

--- a/packages/shared-skills/skills/ulw-research/SKILL.md
+++ b/packages/shared-skills/skills/ulw-research/SKILL.md
@@ -124,13 +124,18 @@ Scale: <axis count, source territories, target document length> · Precision dem
 </analysis>
 ```
 
-Then create the session directory:
+Then create the session directory with the guaranteed Node runtime so the same
+command works under POSIX shells, PowerShell, and `cmd.exe`:
 
-```bash
-mkdir -p .omo/ulw-research/$(date +%Y%m%d-%H%M%S)
+```text
+node -e "const fs=require('node:fs');const s=new Date().toISOString().replace(/\D/g,'').slice(0,14);const d='.omo/ulw-research/'+s.slice(0,8)+'-'+s.slice(8);fs.mkdirSync(d,{recursive:true});console.log(d)"
 ```
 
-This is `$SESSION_DIR`. The orchestrator owns the journal: you write every file in it; workers never do. Maintain:
+Use the printed path as `$SESSION_DIR`. If a filesystem tool is available, it
+may create the same timestamped directory directly instead. Never pass POSIX
+flags such as `-p` to `cmd.exe`.
+
+The orchestrator owns the journal: you write every file in it; workers never do. Maintain:
 
 - `wave-<N>-<kind>-<axis>.md` — your digest of each worker return: key findings, sources with URLs, and the worker's EXPAND markers verbatim.
 - `expansion-log.md` — per wave: workers spawned, markers gained, leads opened and closed.


### PR DESCRIPTION
## Summary

- Make directory-creation guidance in Atlas and ULW skills work in POSIX shells, PowerShell, and cmd.exe.
- Prevent Windows users from accidentally creating a literal `-p` directory when following generated setup instructions.

## Changes

- Replace generic `mkdir -p` instructions with filesystem-tool guidance and portable `node:fs` recursive directory creation.
- Add explicit POSIX, PowerShell, and cmd.exe cookie-directory examples where shell commands are useful.
- Remove redundant cookie-directory setup where the extractor already creates its parent directory.

## QA & Evidence

- **What was tested:** Typecheck, full build, focused prompt/skill packaging tests, ULW loop component tests, and isolated Codex installation verification.
  **Observed result:** Typecheck and build passed; 55 focused tests passed; ULW loop reported 421 passed and 1 skipped; the isolated install verification passed.
  **Artifact:** Command output reviewed locally; no machine-specific logs are included in this PR.
  **Why sufficient:** Covers every changed prompt/skill surface plus the generated packaging and install path.
- **What was tested:** Manual cmd.exe red/green probes.
  **Observed result:** `mkdir -p` created a literal `-p` directory, while the replacement Node commands created only the intended nested directories; nested cookie-parent creation also succeeded.
  **Artifact:** Manual local probe, not committed because it contains machine-specific paths.
  **Why sufficient:** Reproduces the reported Windows behavior and verifies the proposed portable form.

## Risks & Residuals

- Runtime risk is low because this changes documentation and prompt instructions, not application logic.
- Broader Windows suites still contain unrelated failures around symlink privileges, POSIX mode bits, and home-directory assumptions; focused suites, typecheck, build, and isolated installation passed.

## Automated Checks

```bash
npx bun@1.3.12 run typecheck
npx bun@1.3.12 run build
npx bun@1.3.12 test packages/prompts-core packages/shared-skills packages/omo-senpi
npx bun@1.3.12 test packages/omo-codex/plugin/components/ulw-loop
```

## Related Issues

Closes #6772

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make directory-creation instructions platform-neutral across Atlas prompts and ULW/ultimate-browsing docs. Previously we advised `mkdir -p`, which can create a literal “-p” directory on Windows `cmd.exe`; now we use Node’s `fs.mkdirSync(path, { recursive: true })` and shell-specific examples. No runtime changes. Fixes #6772.

- ULW loop bootstrap now creates `.omo/ulw-loop` with a Node one-liner instead of `mkdir -p`.
- ULW research docs use a Node one-liner that prints a timestamped `$SESSION_DIR` and warn not to pass POSIX flags to `cmd.exe`.
- Atlas prompts replace “use mkdir -p” with portable recursive creation guidance plus a Windows warning.
- Ultimate browsing docs (`SKILL.md` and `references/chrome-stealth.md`) add POSIX/PowerShell/cmd.exe cookie examples, remove a separate `mkdir` step, and document that the extractor creates the parent directory recursively.

**Migration**
- Replace remaining “mkdir -p” in downstream docs/scripts with Node `fs.mkdirSync(path, { recursive: true })` or platform-appropriate commands; never pass `-p` to Windows `cmd.exe`.

<sup>Written for commit 1cf0cce872340ea3cdc70fd2eeb32b7868c45a87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

