### PR TITLE
fix(codegraph): trust provisioned OpenCode launcher

### DIFF
--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/codegraph-bootstrap.test.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/codegraph-bootstrap.test.ts
@@ -217,47 +217,53 @@ describe("createCodegraphBootstrapHook", () => {
     }
   })
 
-  test("#given CodeGraph is missing and auto provision is enabled on unsupported Node #when background work runs #then it does not provision or mutate the project", async () => {
+  test("#given a provisioned launcher and unsupported host Node #when background work runs #then it bootstraps through the managed launcher", async () => {
     // given
-    const workspace = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-provision-"))
-    const homeDir = mkdtempSync(join(tmpdir(), "omo-codegraph-opencode-unsupported-provision-home-"))
     const events: string[] = []
     const hook = createCodegraphBootstrapHook(
-      { directory: workspace },
+      { directory: "/repo" },
       { auto_provision: true, enabled: true },
-      {
-        ensureProvisioned: async () => {
-          throw new Error("codegraph provisioning should not run")
-        },
-        excludeProject: () => ({ excluded: false }),
-        log: (message) => {
-          events.push(`log:${message}`)
-        },
+      createDeps(events, {
         nodeSupport: () => ({ major: 26, override: false, reason: "too-new", supported: false }),
-        prepareWorkspace: (projectRoot) => prepareCodegraphWorkspace(projectRoot, { homeDir }),
-        resolveCommand: () => ({ argsPrefix: [], command: "codegraph", exists: false, source: "path" }),
-        runCommand: async () => {
-          throw new Error("codegraph command should not run")
-        },
-        schedule: (task) => {
-          void task()
-        },
-      },
+        resolveCommand: () => ({ argsPrefix: [], command: "/managed/codegraph", exists: true, source: "provisioned" }),
+      }),
     )
 
-    try {
-      // when
-      hook.event({ event: { type: "session.created", properties: { worktree: workspace } } })
-      await waitForBackground()
+    // when
+    hook.event({ event: { type: "session.created", properties: {} } })
+    await waitForBackground()
 
-      // then
-      expect(events).toContain("log:[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap")
-      expect(existsSync(join(workspace, ".codegraph"))).toBe(false)
-      expect(existsSync(join(workspace, ".git", "info", "exclude"))).toBe(false)
-    } finally {
-      rmSync(workspace, { recursive: true, force: true })
-      rmSync(homeDir, { recursive: true, force: true })
-    }
+    // then
+    expect(events).toContain("run:/managed/codegraph:status --json")
+    expect(events).toContain("run:/managed/codegraph:init")
+    expect(events).not.toContain("log:[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap")
+  })
+
+  test("#given CodeGraph is missing and auto provision is enabled on unsupported Node #when background work runs #then it provisions and bootstraps the managed launcher", async () => {
+    // given
+    const events: string[] = []
+    const hook = createCodegraphBootstrapHook(
+      { directory: "/repo" },
+      { auto_provision: true, enabled: true },
+      createDeps(events, {
+        ensureProvisioned: async () => {
+          events.push("provision")
+          return { binPath: "/managed/codegraph", provisioned: true }
+        },
+        nodeSupport: () => ({ major: 26, override: false, reason: "too-new", supported: false }),
+        resolveCommand: () => ({ argsPrefix: [], command: "codegraph", exists: false, source: "path" }),
+      }),
+    )
+
+    // when
+    hook.event({ event: { type: "session.created", properties: {} } })
+    await waitForBackground()
+
+    // then
+    expect(events).toContain("provision")
+    expect(events).toContain("run:/managed/codegraph:status --json")
+    expect(events).toContain("run:/managed/codegraph:init")
+    expect(events).not.toContain("log:[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap")
   })
 
   test("#given CodeGraph is unavailable and auto provisioning is disabled #when background work runs #then it leaves the project untouched", async () => {

--- a/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
+++ b/packages/omo-opencode/src/hooks/codegraph-bootstrap/hook.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import {
   CODEGRAPH_PINNED_VERSION,
   buildCodegraphEnv,
+  codegraphCommandRequiresSupportedLocalNode,
   ensureCodegraphGitignored,
   ensureCodegraphProvisioned,
   prepareCodegraphWorkspace,
@@ -111,15 +112,6 @@ async function resolveOrProvisionCommand(
   const resolved = resolveInitialCommand(deps, config)
   if (resolved.exists) return resolved
   if (config.auto_provision === false) return null
-  const nodeSupport = deps.nodeSupport()
-  if (!nodeSupport.supported) {
-    deps.log("[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap", {
-      major: nodeSupport.major,
-      reason: nodeSupport.reason,
-      source: resolved.source,
-    })
-    return null
-  }
 
   const installDir = config.install_dir ?? defaultInstallDir()
   const provisioned = await deps.ensureProvisioned({
@@ -158,14 +150,16 @@ async function runBootstrap(
       deps.log("[codegraph-bootstrap] CodeGraph unavailable; skipping bootstrap", { projectRoot })
       return
     }
-    const nodeSupport = deps.nodeSupport()
-    if (command.source !== "bundled" && command.source !== "env" && !nodeSupport.supported) {
-      deps.log("[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap", {
-        major: nodeSupport.major,
-        projectRoot,
-        reason: nodeSupport.reason,
-      })
-      return
+    if (codegraphCommandRequiresSupportedLocalNode(command)) {
+      const nodeSupport = deps.nodeSupport()
+      if (!nodeSupport.supported) {
+        deps.log("[codegraph-bootstrap] CodeGraph unsupported on this Node runtime; skipping bootstrap", {
+          major: nodeSupport.major,
+          projectRoot,
+          reason: nodeSupport.reason,
+        })
+        return
+      }
     }
 
     const workspace = deps.prepareWorkspace(projectRoot)

--- a/packages/omo-opencode/src/mcp/codegraph.test.ts
+++ b/packages/omo-opencode/src/mcp/codegraph.test.ts
@@ -194,6 +194,42 @@ describe("createCodegraphMcpConfig", () => {
     }
   })
 
+  it("#given a provisioned launcher and unsupported host Node #when creating the MCP config #then it trusts the managed launcher", () => {
+    // given
+    const installDir = mkdtempSync(join(tmpdir(), "omo-codegraph-provisioned-unsupported-node-"))
+    const provisionedPath = join(installDir, "bin", process.platform === "win32" ? "codegraph.cmd" : "codegraph")
+    const markerPath = join(installDir, ".provisioned", `codegraph-${CODEGRAPH_PINNED_VERSION}.json`)
+    const nodePath = "/opt/node26/bin/node"
+    mkdirSync(join(installDir, "bin"), { recursive: true })
+    mkdirSync(join(installDir, ".provisioned"), { recursive: true })
+    writeFileSync(provisionedPath, "")
+    writeFileSync(markerPath, `${JSON.stringify({ binPath: provisionedPath, version: CODEGRAPH_PINNED_VERSION })}\n`)
+
+    try {
+      // when
+      const config = createCodegraphMcpConfig({
+        cwd: "/workspace/project",
+        config: { enabled: true, install_dir: installDir },
+        env: {},
+        homeDir: "/tmp/omo-codegraph-test-home",
+        nodeVersionForExecutable: () => "26.3.0",
+        requireResolve: () => {
+          throw new Error("bundled package absent")
+        },
+        resolveExecutable: createResolver({ node: nodePath }),
+      })
+
+      // then
+      expect(config).toMatchObject({
+        type: "local",
+        command: [provisionedPath, "serve", "--mcp"],
+        enabled: true,
+      })
+    } finally {
+      rmSync(installDir, { force: true, recursive: true })
+    }
+  })
+
   it("omits CODEGRAPH_NO_DAEMON from the MCP environment by default", () => {
     // given
     const codegraphPath = "/opt/omo/codegraph/bin/codegraph"

--- a/packages/omo-opencode/src/mcp/codegraph.ts
+++ b/packages/omo-opencode/src/mcp/codegraph.ts
@@ -1,5 +1,11 @@
 import { existsSync } from "node:fs"
-import { buildCodegraphEnv, resolveCodegraphCommand, resolveCodegraphNodeSupport, shouldExcludeCodegraphProject } from "@oh-my-opencode/utils"
+import {
+  buildCodegraphEnv,
+  codegraphCommandRequiresSupportedLocalNode,
+  resolveCodegraphCommand,
+  resolveCodegraphNodeSupport,
+  shouldExcludeCodegraphProject,
+} from "@oh-my-opencode/utils"
 import { resolvePinnedCodegraphBin } from "@oh-my-opencode/utils/codegraph"
 import type { ResolveCodegraphCommandOptions } from "@oh-my-opencode/utils"
 import type { CodegraphConfig } from "../config/schema/codegraph"
@@ -60,16 +66,18 @@ export function createCodegraphMcpConfig(options: CodegraphMcpConfigOptions = {}
     requireResolve: options.requireResolve,
     which,
   })
-  const nodeSupport = resolveCodegraphNodeSupport({
-    env,
-    fileExists,
-    nodeVersion: options.nodeVersionForExecutable,
-    which,
-  })
   const enabled =
     !isProjectExcluded(options.config, options)
     && resolvedCommand.exists
-    && (resolvedCommand.source === "bundled" || resolvedCommand.source === "env" || nodeSupport.supported)
+    && (
+      !codegraphCommandRequiresSupportedLocalNode(resolvedCommand)
+      || resolveCodegraphNodeSupport({
+        env,
+        fileExists,
+        nodeVersion: options.nodeVersionForExecutable,
+        which,
+      }).supported
+    )
 
   return {
     type: "local",


### PR DESCRIPTION
## Summary

- Allow OpenCode to use an OMO-provisioned CodeGraph launcher without requiring a separate Node.js executable on PATH.
- Keep the existing Node guard for arbitrary PATH-resolved CodeGraph commands.

## Changes

- Route MCP configuration and bootstrap checks through the shared provisioned-launcher trust decision.
- Allow cold managed provisioning to proceed, while keeping the restart requirement before a newly provisioned MCP becomes available.
- Add focused coverage for provisioned launchers, PATH commands, cold provisioning, and restart behavior.

## QA & Evidence

- **What was tested:** Focused CodeGraph MCP and bootstrap tests.
  **Observed result:** 33 tests passed with 71 assertions.
  **Artifact:** Local test output; raw machine-specific validation logs are intentionally not committed.
  **Why sufficient:** Covers the trusted provisioned path, the guarded arbitrary PATH path, cold provisioning, and restart semantics.
- **What was tested:** Root typecheck and full build.
  **Observed result:** Both passed.
  **Artifact:** Local command output.
  **Why sufficient:** Verifies cross-package typing and generated deliverables.
- **What was tested:** Live OpenCode scenarios for a preprovisioned launcher, a PATH-only negative case, cold provisioning, and post-restart availability.
  **Observed result:** All expected behaviors were observed.
  **Artifact:** Sanitized conclusions are recorded here; local paths and user-state hashes are omitted.
  **Why sufficient:** Exercises the actual launcher discovery and provisioning boundary beyond unit tests.

## Risks & Residuals

- A launcher created during the current OpenCode process still requires an OpenCode restart before the new MCP is available; this is existing lifecycle behavior and is covered by tests.
- The full Windows suite encountered unrelated baseline failures involving symlink privileges and POSIX assumptions. Focused tests, typecheck, build, and live scenarios passed.

## Automated Checks

```bash
npx bun@1.3.12 test packages/omo-opencode/src/hooks/codegraph-bootstrap/codegraph-bootstrap.test.ts packages/omo-opencode/src/mcp/codegraph.test.ts
npx bun@1.3.12 run typecheck
npx bun@1.3.12 run build
```

## Related Issues

Closes #6624

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trusts the OMO‑provisioned CodeGraph launcher in OpenCode even when the host Node is unsupported, so MCP config and bootstrap proceed via the managed launcher. Previously, OpenCode skipped bootstrap/MCP on unsupported Node; now it proceeds for a provisioned launcher, while PATH‑resolved commands still require a supported local Node. Addresses Linear #6624.

- Centralizes the trust decision via `codegraphCommandRequiresSupportedLocalNode` in `@oh-my-opencode/utils`, applied in both MCP config and bootstrap.
- `createCodegraphMcpConfig` enables MCP when the launcher is provisioned regardless of host Node support; commands that require a local Node remain guarded.
- Bootstrap provisions on unsupported Node when `auto_provision` is true and runs `status --json` and `init` through the managed launcher; it only logs “unsupported” for commands that require a local Node.
- Adds tests for MCP config trust on unsupported Node, managed bootstrap on unsupported Node, cold provisioning, PATH negatives, and restart semantics.

**Rollout**
- No migration for users already using the provisioned launcher.
- Restart OpenCode after cold provisioning to load the new MCP.
- If relying on a PATH‑resolved CodeGraph, ensure a supported local Node or switch to the provisioned launcher.

<sup>Written for commit c2288a31485bbcfd228909412990dac1b0079b35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

