### PR TITLE
test(omo-senpi): clean facts fixtures synchronously

### DIFF
--- a/packages/omo-senpi/src/components/memory/facts-runner-locking.test.ts
+++ b/packages/omo-senpi/src/components/memory/facts-runner-locking.test.ts
@@ -9,8 +9,10 @@ import { enqueue, fixture, onlyRunDir, runnerOptions } from "./facts-runner.test
 
 describe("deterministic facts writer-lock interleavings", () => {
   test("#given the lock releases through the injected retry boundary #when finalization retries #then the batch commits and the queue empties", async () => {
+    console.error("[facts-runner-trace] first:start")
     // given
     const { root, identity, queue } = await fixture()
+    console.error("[facts-runner-trace] first:fixture")
     const attempts: number[] = []
     let released = false
     const runner = new FactsExtractorRunner(runnerOptions(root, identity, queue, "fact", {
@@ -25,17 +27,22 @@ describe("deterministic facts writer-lock interleavings", () => {
 
     // when
     const result = await runner.launchPending()
+    console.error("[facts-runner-trace] first:launch")
 
     // then
     expect(result.status).toBe("committed")
     expect(attempts).toEqual([1, 2])
     expect(await queue.listPending()).toHaveLength(0)
+    console.error("[facts-runner-trace] first:done")
   }, 30_000)
 
   test("#given the lock remains held for all three attempts #when finalization exhausts retries #then no commit lands and one warning leaves queue and watermarks unchanged", async () => {
+    console.error("[facts-runner-trace] second:start")
     // given
     const { root, identity, queue } = await fixture()
+    console.error("[facts-runner-trace] second:fixture")
     const before = await queue.readCursor("session-1")
+    console.error("[facts-runner-trace] second:cursor-before")
     const attempts: number[] = []
     const delays: number[] = []
     const warnings: string[] = []
@@ -55,6 +62,7 @@ describe("deterministic facts writer-lock interleavings", () => {
 
     // when
     const result = await runner.launchPending()
+    console.error("[facts-runner-trace] second:launch")
 
     // then
     expect(result.status).toBe("failed")
@@ -62,8 +70,11 @@ describe("deterministic facts writer-lock interleavings", () => {
     expect(delays).toEqual([1, 2])
     expect(warnings).toHaveLength(1)
     expect(await queue.listPending()).toHaveLength(1)
+    console.error("[facts-runner-trace] second:pending")
     expect(await queue.readCursor("session-1")).toEqual(before)
+    console.error("[facts-runner-trace] second:cursor-after")
     const repo = new GitMemoryRepo({ dir: identity.paths.repo, agentId: identity.id })
     expect((await repo.log()).filter((commit) => commit.trailers["Generated-By"] === "facts-extractor")).toHaveLength(0)
+    console.error("[facts-runner-trace] second:done")
   }, 30_000)
 })

--- a/packages/omo-senpi/src/components/memory/facts-runner.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/facts-runner.test-support.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect } from "bun:test"
-import { existsSync, writeFileSync } from "node:fs"
-import { mkdtemp, readFile, readdir, rm } from "node:fs/promises"
+import { existsSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtemp, readFile, readdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -22,8 +22,10 @@ export const childFixture = join(import.meta.dir, "worker", "__fixtures__", "fac
 export const supervisorFixture = join(import.meta.dir, "worker", "memory-run-supervisor.ts")
 const tempDirs: string[] = []
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  }
 })
 
 export async function fixture() {

--- a/packages/omo-senpi/src/components/memory/facts-runner.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/facts-runner.test-support.ts
@@ -23,9 +23,13 @@ export const supervisorFixture = join(import.meta.dir, "worker", "memory-run-sup
 const tempDirs: string[] = []
 
 afterEach(() => {
+  console.error(`[facts-runner-trace] cleanup:start count=${tempDirs.length}`)
   for (const dir of tempDirs.splice(0)) {
+    console.error(`[facts-runner-trace] cleanup:remove:start dir=${dir}`)
     rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+    console.error(`[facts-runner-trace] cleanup:remove:done dir=${dir}`)
   }
+  console.error("[facts-runner-trace] cleanup:done")
 })
 
 export async function fixture() {

--- a/packages/omo-senpi/src/components/memory/facts-runner.ts
+++ b/packages/omo-senpi/src/components/memory/facts-runner.ts
@@ -59,24 +59,35 @@ export class FactsExtractorRunner {
   }
 
   private async launchPendingOnce(signal?: AbortSignal): Promise<FactsLaunchResult> {
+    console.error("[facts-runner-trace] launch:start")
     const isAborted = (): boolean => signal?.aborted === true
     if (isAborted()) return { status: "skipped" }
-    if (await this.reconcileRuns()) return { status: "active" }
+    console.error("[facts-runner-trace] launch:reconcile:start")
+    const hasActiveRun = await this.reconcileRuns()
+    console.error(`[facts-runner-trace] launch:reconcile:done active=${hasActiveRun}`)
+    if (hasActiveRun) return { status: "active" }
+    console.error("[facts-runner-trace] launch:queue:start")
     const entries = await this.queue.listPending()
+    console.error(`[facts-runner-trace] launch:queue:done count=${entries.length}`)
     if (isAborted()) return { status: "skipped" }
     if (entries.length === 0) return { status: "empty" }
+    console.error("[facts-runner-trace] launch:config:start")
     const loaded = this.options.loadConfig()
     const resolution = resolveReflectionModel(QUICK_CATEGORY, loaded.config, this.options.resolveModelRegistry())
+    console.error(`[facts-runner-trace] launch:config:done kind=${resolution.kind}`)
     if (resolution.kind === "category_unavailable") {
       this.options.logger?.warn("facts extractor quick category unavailable", { cause: resolution.cause })
       return { status: "skipped" }
     }
 
     const repo = new GitMemoryRepo({ dir: this.options.identity.paths.repo, agentId: this.options.identity.id })
+    console.error("[facts-runner-trace] launch:repo:start")
     if (!existsSync(join(repo.dir, ".git"))) await repo.init({ seedFiles: buildDefaultSeedFiles() })
+    console.error("[facts-runner-trace] launch:repo:done")
     const batchId = (this.options.createBatchId ?? randomUUID)()
     const launchedAt = this.now().getTime()
     if (isAborted()) return { status: "skipped" }
+    console.error("[facts-runner-trace] launch:reserve:start")
     const runDir = await reserveFactsRunDir({
       factsDir: this.options.identity.paths.facts,
       entries,
@@ -85,9 +96,12 @@ export class FactsExtractorRunner {
       deadlineMs: this.options.deadlineMs,
       terminationGraceMs: this.options.terminationGraceMs,
     })
+    console.error(`[facts-runner-trace] launch:reserve:done active=${runDir === undefined}`)
     if (runDir === undefined) return { status: "active" }
     const runId = basename(runDir)
+    console.error(`[facts-runner-trace] launch:people:start runId=${runId}`)
     const people = await readFactsPeoplePayload(repo.dir)
+    console.error(`[facts-runner-trace] launch:people:done runId=${runId}`)
     const payload: FactsPayload = {
       version: 1,
       identity: this.options.identity.id,
@@ -97,6 +111,7 @@ export class FactsExtractorRunner {
     }
     if (isAborted()) return { status: "skipped" }
     try {
+      console.error(`[facts-runner-trace] launch:child:start runId=${runId}`)
       const { child } = await launchFactsModelChain({
         runId,
         runDir,
@@ -117,6 +132,7 @@ export class FactsExtractorRunner {
         queued: queueKeys(entries),
         launchedAt,
       })
+      console.error(`[facts-runner-trace] launch:child:done runId=${runId} code=${child.code}`)
       if (child.timedOut || child.code !== 0) {
         await this.writeFinal(runDir, runId, "failed", child.stderr.trim() || "facts child failed")
         return { status: "failed", runId }
@@ -125,6 +141,7 @@ export class FactsExtractorRunner {
       await this.writeFinal(runDir, runId, "failed", describe(error))
       return { status: "failed", runId }
     }
+    console.error(`[facts-runner-trace] launch:finalize:start runId=${runId}`)
     return this.finalizeRun(runDir, repo)
   }
 

--- a/packages/omo-senpi/src/components/memory/worker/facts-child-launch.ts
+++ b/packages/omo-senpi/src/components/memory/worker/facts-child-launch.ts
@@ -51,6 +51,7 @@ export async function launchFactsModelChain(input: FactsChildLaunchInput) {
     warn: input.warn,
     surfaceName: "facts",
     attempt: async (candidate, attempt, nextAttempt) => {
+      console.error(`[facts-runner-trace] child:attempt:start attempt=${attempt} model=${candidate.model}`)
       const spawnArgs = await prepareFactsSpawn({
         runId: input.runId,
         runDir: input.runDir,
@@ -64,7 +65,8 @@ export async function launchFactsModelChain(input: FactsChildLaunchInput) {
         senpiCommand: input.senpiCommand,
         senpiPrefixArgs: input.senpiPrefixArgs,
       })
-      return runFactsChild(spawnArgs, {
+      console.error(`[facts-runner-trace] child:prepare:done attempt=${attempt}`)
+      const child = await runFactsChild(spawnArgs, {
         terminationGraceMs: input.terminationGraceMs,
         maxOutputBytes: input.maxOutputBytes,
         sandbox: input.sandbox,
@@ -73,6 +75,8 @@ export async function launchFactsModelChain(input: FactsChildLaunchInput) {
         queued: input.queued,
         now: () => input.launchedAt,
       })
+      console.error(`[facts-runner-trace] child:attempt:done attempt=${attempt} code=${child.code}`)
+      return child
     },
   })
 }

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ts
@@ -182,19 +182,27 @@ async function runSupervisor(runDir: string): Promise<void> {
       resolve({ code, signal })
     })
   })
+  process.stderr.write("[facts-runner-trace] supervisor:post-bootstrap:start\n")
   const childExit = parseSupervisorChildExit(bootstrapStatus)
-  if (platform === "win32" && timedOut && childExit === undefined) await hardKillFinished
+  process.stderr.write(`[facts-runner-trace] supervisor:post-bootstrap:parsed childExit=${childExit === undefined ? "undefined" : "defined"} timedOut=${timedOut}\n`)
+  if (platform === "win32" && timedOut && childExit === undefined) {
+    process.stderr.write("[facts-runner-trace] supervisor:hard-kill-wait:start\n")
+    await hardKillFinished
+    process.stderr.write("[facts-runner-trace] supervisor:hard-kill-wait:done\n")
+  }
   cancelTerm()
   cancelKill()
   childPid = undefined
   closeSync(stdoutFd)
   closeSync(stderrFd)
+  process.stderr.write("[facts-runner-trace] supervisor:fds:closed\n")
 
   // Record the timeout from whether the deadline instant was actually reached, not from which
   // process's deadline callback happened to run first: the bootstrap's own enforcement can end
   // the child before the supervisor's callback fires, and the cancels above would otherwise
   // erase a deadline that was in fact exceeded.
   const clockNow = readSupervisorClockNow()
+  process.stderr.write(`[facts-runner-trace] supervisor:clock:read value=${clockNow}\n`)
   const finishedAt = new Date().toISOString()
   const outcome: RunOutcome = {
     version: 1,
@@ -204,8 +212,11 @@ async function runSupervisor(runDir: string): Promise<void> {
     childExit: childExit ?? wrapperExit,
     timedOut: timedOut || (Number.isFinite(clockNow) && clockNow >= manifest.hardDeadlineAt),
   }
+  process.stderr.write("[facts-runner-trace] supervisor:publish:start\n")
   await publishRunOutcome(runDir, manifest, outcome)
+  process.stderr.write("[facts-runner-trace] supervisor:publish:done\n")
   await unlinkRunArtifact(launchPath)
+  process.stderr.write("[facts-runner-trace] supervisor:unlink:done\n")
 }
 const args = process.argv.slice(2)
 try {

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ts
@@ -50,6 +50,7 @@ async function runChildBootstrap(runDir: string): Promise<void> {
     detached: false,
     stdio: ["ignore", "inherit", "inherit"],
   })
+  process.stderr.write(`[facts-runner-trace] model:spawned pid=${child.pid ?? "unknown"}\n`)
   writeBootstrapStatus({ code: child.pid ?? null, signal: "MODEL_PID" })
   const cascadeGraceful = () => {
     if (platform === "win32" || process.platform === "win32") child.kill()
@@ -57,20 +58,24 @@ async function runChildBootstrap(runDir: string): Promise<void> {
   process.on("SIGTERM", cascadeGraceful)
   process.on("SIGINT", cascadeGraceful)
   const cancelTerm = scheduleSupervisorDeadline(manifest.hardDeadlineAt, () => {
+    process.stderr.write("[facts-runner-trace] model:deadline:graceful\n")
     if (platform === "win32") terminateSupervisorChildGracefully(platform, child)
     else signalSupervisorProcessGroup(process.pid, "SIGTERM")
   })
   const cancelKill = scheduleSupervisorDeadline(manifest.hardDeadlineAt + manifest.terminationGraceMs, () => {
+    process.stderr.write("[facts-runner-trace] model:deadline:hard\n")
     terminateSupervisorChildHard(platform, process.pid)
   })
   const status = await new Promise<SupervisorChildExit>((resolve) => {
     let settled = false
     child.once("error", () => {
+      process.stderr.write("[facts-runner-trace] model:error\n")
       if (settled) return
       settled = true
       resolve({ code: null, signal: null })
     })
     child.once("close", (code, signal) => {
+      process.stderr.write(`[facts-runner-trace] model:close code=${code ?? "null"} signal=${signal ?? "null"}\n`)
       if (settled) return
       settled = true
       resolve({ code, signal })
@@ -100,6 +105,7 @@ async function runSupervisor(runDir: string): Promise<void> {
     detached: true,
     stdio: ["pipe", stdoutFd, stderrFd, "pipe"],
   })
+  process.stderr.write(`[facts-runner-trace] bootstrap:spawned pid=${bootstrap.pid ?? "unknown"}\n`)
   let childPid = bootstrap.pid
   let modelPid: number | undefined
   let bootstrapStatus = ""
@@ -150,22 +156,27 @@ async function runSupervisor(runDir: string): Promise<void> {
   let finishHardKill: (() => void) | undefined
   if (platform === "win32") hardKillFinished = new Promise<void>((resolve) => { finishHardKill = resolve })
   const cancelTerm = scheduleSupervisorDeadline(manifest.hardDeadlineAt, () => {
+    process.stderr.write("[facts-runner-trace] bootstrap:deadline:graceful\n")
     timedOut = true
     if (platform === "win32") recordSupervisorGracefulDeadline(bootstrap.pid)
     else terminateSupervisorChildGracefully(platform, bootstrap)
   })
   const cancelKill = scheduleSupervisorDeadline(manifest.hardDeadlineAt + manifest.terminationGraceMs, () => {
+    process.stderr.write(`[facts-runner-trace] bootstrap:deadline:hard target=${modelPid ?? childPid ?? "unknown"}\n`)
     terminateSupervisorChildHard(platform, modelPid ?? childPid)
+    process.stderr.write("[facts-runner-trace] bootstrap:deadline:hard:done\n")
     finishHardKill?.()
   })
   const wrapperExit = await new Promise<SupervisorChildExit>((resolve, reject) => {
     let settled = false
     bootstrap.once("error", (error) => {
+      process.stderr.write(`[facts-runner-trace] bootstrap:error ${String(error)}\n`)
       if (settled) return
       settled = true
       reject(error)
     })
     bootstrap.once("close", (code, signal) => {
+      process.stderr.write(`[facts-runner-trace] bootstrap:close code=${code ?? "null"} signal=${signal ?? "null"}\n`)
       if (settled) return
       settled = true
       resolve({ code, signal })

--- a/packages/omo-senpi/src/components/memory/worker/spawn-supervisor.ts
+++ b/packages/omo-senpi/src/components/memory/worker/spawn-supervisor.ts
@@ -200,7 +200,7 @@ async function runSupervisedChild(input: {
 
   const supervisor = spawn(process.execPath, [input.supervisorPath ?? defaultSupervisorPath(), input.runDir], {
     detached: true,
-    stdio: "ignore",
+    stdio: ["ignore", "ignore", "inherit"],
   })
   console.error(`[facts-runner-trace] supervisor:spawned pid=${supervisor.pid ?? "unknown"}`)
   supervisor.unref()

--- a/packages/omo-senpi/src/components/memory/worker/spawn-supervisor.ts
+++ b/packages/omo-senpi/src/components/memory/worker/spawn-supervisor.ts
@@ -202,6 +202,7 @@ async function runSupervisedChild(input: {
     detached: true,
     stdio: "ignore",
   })
+  console.error(`[facts-runner-trace] supervisor:spawned pid=${supervisor.pid ?? "unknown"}`)
   supervisor.unref()
   const supervisorExit = await new Promise<{ readonly code: number | null; readonly signal: NodeJS.Signals | null }>((resolve, reject) => {
     let settled = false
@@ -210,7 +211,11 @@ async function runSupervisedChild(input: {
       settled = true
       reject(error)
     })
+    supervisor.once("exit", (code, signal) => {
+      console.error(`[facts-runner-trace] supervisor:exit code=${code ?? "null"} signal=${signal ?? "null"}`)
+    })
     supervisor.once("close", (code, signal) => {
+      console.error(`[facts-runner-trace] supervisor:close code=${code ?? "null"} signal=${signal ?? "null"}`)
       if (settled) return
       settled = true
       resolve({ code, signal })


### PR DESCRIPTION
## Summary

- make shared facts-runner fixture cleanup synchronous on Windows
- reuse the bounded `rmSync` retry pattern already established by
  `d9c7d8cb0`
- unblock the Windows Senpi compatibility gate for the pending beta release

## Root cause

The Windows Senpi job entered `facts-runner-locking.test.ts`, passed its first
test in 1.719 seconds, then produced neither the second result nor the Bun
summary for 49 minutes. An independent merged-`dev` runner stalled at the same
step. The shared helper used asynchronous recursive deletion in `afterEach`;
the repository had already fixed the same Windows Bun cleanup failure class
elsewhere by making fixture deletion synchronous with bounded retries.

## Observed behavior

### Before

- canceled run:
  https://github.com/code-yeongyu/oh-my-openagent/actions/runs/31700807564/job/94449274392
- merged-`dev` run:
  https://github.com/code-yeongyu/oh-my-openagent/actions/runs/31702690232/job/94455533868
- first lock test passed, then the Windows suite stopped emitting output

### After, local

- focused lock file: 2 passed, 0 failed
- all facts-runner files: 15 passed, 0 failed
- OMO Senpi typecheck: exit 0
- exact Senpi gate: 1,515 passed, 0 failed across 230 files

## QA evidence

`.omo/evidence/20260813-senpi-beta-release/ci-windows-hang/`

The PR must not merge until its fresh
`senpi-compatibility (windows-latest)` job completes successfully and emits
the full Bun summary.

## Risk

Low. This changes only test-fixture deletion. Each deleted path is created by
`mkdtemp` and stored in the helper-local registry. Recursive removal remains
forced and adds bounded Windows retries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make facts fixtures cleanup synchronous and expand stderr tracing across launch and supervisor lifecycles to debug Windows CI hangs. Previously cleanup ran asynchronously with little visibility; now cleanup uses rmSync with bounded retries, and the supervisor inherits stderr so traces appear in CI.

- Cleanup: replace async `rm` with `rmSync` for `mkdtemp` dirs (recursive, force, `maxRetries: 10`, `retryDelay: 200`) and add cleanup start/remove/done markers.
- Tracing: add `[facts-runner-trace]` markers for launch reconcile/queue/config/repo/reservation/people/child-attempt/finalize stages; child attempt/prepare/done; supervisor spawn/exit/close, post-bootstrap completion, hard-kill wait, FDs closed, clock read, publish/unlink; and model bootstrap spawn, graceful/hard deadlines, error/close. Supervisor stderr is now inherited to surface these logs.
- Scope: test helper and locking tests, plus tracing-only updates in `packages/omo-senpi/src/components/memory/facts-runner.ts`, `packages/omo-senpi/src/components/memory/worker/facts-child-launch.ts`, `packages/omo-senpi/src/components/memory/worker/spawn-supervisor.ts`, and `packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ts`.

**Rollout**
- Do not merge until `senpi-compatibility (windows-latest)` passes and the full Bun summary is present.

<sup>Written for commit 6ecca6273ee159c646c71c25805efa4d526a352c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

