### PR TITLE
test(utils): make port auto-selection deterministic

### DIFF
--- a/packages/utils/src/port-utils.test.ts
+++ b/packages/utils/src/port-utils.test.ts
@@ -20,10 +20,10 @@ type TimeoutProbeResult = {
   server: Server | undefined
 }
 
-type AvailabilityProbeResult = {
+type AvailabilityProbeResult<Result> = {
   errorMessage: string | undefined
   probedPorts: number[]
-  selectedPort: number | undefined
+  selectedResult: Result | undefined
 }
 
 function getRequiredPropertyDescriptor(target: object, propertyName: string): PropertyDescriptor {
@@ -282,15 +282,16 @@ async function runTimedOutAvailabilityProbe(port: number): Promise<TimeoutProbeR
   }
 }
 
-async function runAvailabilityProbe(
+async function runAvailabilityProbe<Result>(
   startPort: number,
-  unavailableProbeCount: number
-): Promise<AvailabilityProbeResult> {
+  unavailableProbeCount: number,
+  operation: () => Promise<Result>,
+): Promise<AvailabilityProbeResult<Result>> {
   const listenDescriptor = getRequiredPropertyDescriptor(Server.prototype, "listen")
   const closeDescriptor = getRequiredPropertyDescriptor(Server.prototype, "close")
   const probedPorts: number[] = []
   let errorMessage: string | undefined
-  let selectedPort: number | undefined
+  let selectedResult: Result | undefined
 
   Object.defineProperty(Server.prototype, "listen", {
     configurable: true,
@@ -317,14 +318,14 @@ async function runAvailabilityProbe(
 
   try {
     try {
-      selectedPort = await findAvailablePort(startPort)
+      selectedResult = await operation()
     } catch (error) {
       if (!(error instanceof Error)) {
         throw error
       }
       errorMessage = error.message
     }
-    return { errorMessage, probedPorts, selectedPort }
+    return { errorMessage, probedPorts, selectedResult }
   } finally {
     Object.defineProperty(Server.prototype, "listen", listenDescriptor)
     Object.defineProperty(Server.prototype, "close", closeDescriptor)
@@ -433,7 +434,11 @@ describe("port-utils", () => {
     test("#when the first three ports are blocked #then returns the next free port", async () => {
       const startPort = 40_000
 
-      const { errorMessage, probedPorts, selectedPort } = await runAvailabilityProbe(startPort, 3)
+      const { errorMessage, probedPorts, selectedResult: selectedPort } = await runAvailabilityProbe(
+        startPort,
+        3,
+        () => findAvailablePort(startPort),
+      )
 
       expect(selectedPort).toBe(startPort + 3)
       expect(errorMessage).toBeUndefined()
@@ -443,7 +448,11 @@ describe("port-utils", () => {
     test("#when every attempted port is blocked #then throws", async () => {
       const startPort = 40_000
 
-      const { errorMessage, probedPorts, selectedPort } = await runAvailabilityProbe(startPort, MAX_PORT_ATTEMPTS)
+      const { errorMessage, probedPorts, selectedResult: selectedPort } = await runAvailabilityProbe(
+        startPort,
+        MAX_PORT_ATTEMPTS,
+        () => findAvailablePort(startPort),
+      )
 
       expect(selectedPort).toBeUndefined()
       expect(errorMessage).toBe(`No available port found in range ${startPort}-${startPort + MAX_PORT_ATTEMPTS - 1}`)
@@ -461,11 +470,17 @@ describe("port-utils", () => {
     })
 
     test("#when the preferred port is blocked #then returns the next port with auto-selection", async () => {
-      const preferredPort = await findContiguousAvailableStart(2)
-      await startTrackedServer(preferredPort)
+      const preferredPort = 40_000
 
-      const result = await getAvailableServerPort(preferredPort)
-      expect(result).toEqual({ port: preferredPort + 1, wasAutoSelected: true })
+      const { errorMessage, probedPorts, selectedResult } = await runAvailabilityProbe(
+        preferredPort,
+        1,
+        () => getAvailableServerPort(preferredPort),
+      )
+
+      expect(selectedResult).toEqual({ port: preferredPort + 1, wasAutoSelected: true })
+      expect(errorMessage).toBeUndefined()
+      expect(probedPorts).toEqual([preferredPort, preferredPort + 1])
     })
   })
 


### PR DESCRIPTION
## Summary

- remove the real-socket TOCTOU race from the final `getAvailableServerPort` auto-selection test
- reuse the existing deterministic `Server.prototype.listen` probe seam
- assert the exact probe order and typed wrapper result without changing production code

## Root cause

Dev CI run `31702690232`, Windows job `94455533787`, expected the adjacent released port but production correctly skipped to the following port when the adjacent candidate was unavailable. The test assumed ownership of an unreserved external resource.

## RED / GREEN

- RED mutation: deliberately held the adjacent candidate; old exact `+1` assertion failed, 0 pass / 1 fail
- focused GREEN: 1 pass / 0 fail
- full `port-utils.test.ts`: 12 pass / 0 fail
- full utils package independently reviewed: 498 pass / 0 fail
- utils typecheck: clean

Evidence: `.omo/evidence/20260813-senpi-beta-release/windows-port-race/`

## Scope

One test file only. `packages/utils/src/port-utils.ts` is unchanged. The unrelated Windows staging ENOENT and macOS tmux failures remain separate atomic repairs.

## CI expectation

The Windows root job may remain red until the separate staging timeout repair lands. This PR passes its intended gate when the prior `port-utils.test.ts:468` annotation is absent and all OS typechecks remain green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes port auto-selection tests deterministic to remove the Windows TOCTOU race. Previously the test bound a real socket and assumed `+1` on the preferred port; now it uses the `Server.prototype.listen` probe seam, asserts probe order, and validates the typed wrapper result. Production behavior is unchanged.

- Changes are limited to `packages/utils/src/port-utils.test.ts`.
- `runAvailabilityProbe` now accepts an operation and returns `selectedResult` to verify `getAvailableServerPort` deterministically.
- Tests simulate blocked ports and assert `[preferred, preferred + 1]` probe order and `{ port, wasAutoSelected }` result.

<sup>Written for commit 9ab4cd9d1a616004b1a8c40d4abc53f6a7889a75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

