### PR TITLE
test(omo-senpi): bound Windows toolkit staging

### DIFF
--- a/packages/omo-senpi/plugin/scripts/stage-agent-toolkit.test.mjs
+++ b/packages/omo-senpi/plugin/scripts/stage-agent-toolkit.test.mjs
@@ -8,6 +8,7 @@ import { afterEach, describe, test } from "node:test"
 import { checkAgentToolkitFresh, stageAgentToolkit } from "./stage-agent-toolkit.mjs"
 
 const tempDirs = []
+const STAGING_TEST_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 5_000
 
 async function makeFixture() {
   const root = await mkdtemp(join(tmpdir(), "omo-senpi-agent-toolkit-stage-test-"))
@@ -27,7 +28,7 @@ afterEach(async () => {
 })
 
 describe("agent-toolkit runtime staging", () => {
-  test("#given a standalone ulw-loop bundle #when staged #then dispatcher and executable shims are self-contained", async () => {
+  test("#given a standalone ulw-loop bundle #when staged #then dispatcher and executable shims are self-contained", { timeout: STAGING_TEST_TIMEOUT_MS }, async () => {
     const fixture = await makeFixture()
 
     const result = await stageAgentToolkit({ ...fixture, buildBundle: false })
@@ -49,7 +50,7 @@ describe("agent-toolkit runtime staging", () => {
     assert.equal(probe.status, 0, probe.stderr)
   })
 
-  test("#given a staged toolkit #when freshness is checked #then runtime artifacts and source bytes must match", async () => {
+  test("#given a staged toolkit #when freshness is checked #then runtime artifacts and source bytes must match", { timeout: STAGING_TEST_TIMEOUT_MS }, async () => {
     const fixture = await makeFixture()
     await stageAgentToolkit({ ...fixture, buildBundle: false })
 
@@ -60,7 +61,7 @@ describe("agent-toolkit runtime staging", () => {
     assert.equal(await readFile(join(fixture.targetDir, "directive.md"), "utf8"), await readFile(fixture.directiveEntry, "utf8"))
   })
 
-  test("#given an identical staged toolkit #when staged again #then preserves the target directory identity", async () => {
+  test("#given an identical staged toolkit #when staged again #then preserves the target directory identity", { timeout: STAGING_TEST_TIMEOUT_MS }, async () => {
     const fixture = await makeFixture()
     await stageAgentToolkit({ ...fixture, buildBundle: false })
     const before = await stat(fixture.targetDir)
@@ -70,7 +71,7 @@ describe("agent-toolkit runtime staging", () => {
     assert.equal((await stat(fixture.targetDir)).ino, before.ino)
   })
 
-  test("#given a malformed staged toolkit #when staged again #then replaces the stale directory shape", async () => {
+  test("#given a malformed staged toolkit #when staged again #then replaces the stale directory shape", { timeout: STAGING_TEST_TIMEOUT_MS }, async () => {
     const fixture = await makeFixture()
     await stageAgentToolkit({ ...fixture, buildBundle: false })
     await rm(join(fixture.targetDir, "ulw-loop"), { recursive: true, force: true })
@@ -81,7 +82,7 @@ describe("agent-toolkit runtime staging", () => {
     assert.equal(await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8"), await readFile(fixture.sourceEntry, "utf8"))
   })
 
-  test("#given a partial Windows backup copy #when staging fails #then removes backup debris and preserves the target", async () => {
+  test("#given a partial Windows backup copy #when staging fails #then removes backup debris and preserves the target", { timeout: STAGING_TEST_TIMEOUT_MS }, async () => {
     const fixture = await makeFixture()
     await stageAgentToolkit({ ...fixture, buildBundle: false })
     const original = await readFile(join(fixture.targetDir, "ulw-loop", "cli.js"), "utf8")
@@ -108,7 +109,7 @@ describe("agent-toolkit runtime staging", () => {
     )
   })
 
-  test("#given an unknown component #when dispatched #then it exits one and lists ulw-loop", async () => {
+  test("#given an unknown component #when dispatched #then it exits one and lists ulw-loop", { timeout: STAGING_TEST_TIMEOUT_MS }, async () => {
     const fixture = await makeFixture()
     await stageAgentToolkit({ ...fixture, buildBundle: false })
 


### PR DESCRIPTION
## Summary

- give all six subprocess-heavy agent-toolkit staging tests an explicit Windows 30s / other-platform 5s `node:test` timeout
- use the options-object form honored by Bun 1.3.12 and Node
- leave production staging behavior unchanged

## Root cause

Dev CI run `31702690232`, Windows job `94455533787`, timed out the first staging test after 5.672s. Shared `afterEach` cleanup then deleted active fixtures, producing the two misleading ENOENT annotations.

## Failing-first and GREEN proof

- unfixed real-file copy with forced win32 and a 7s body: failed at 5.001s
- corrected real-file copy with forced win32 and the same 7s body: passed at 7.8s, 6/0
- isolated corrected suite: 6/0
- rerun-each=20: 120/0
- native OMO Senpi package gate: 1,515/0
- `node --test`: 6/0

## Scope

One test file only. `stage-agent-toolkit.mjs` is unchanged. The deterministic port and tmux timer fixes remain separate atomic PRs.

## CI expectation

The Windows root job should show the first staging test passing with no `Unhandled error between tests`/ENOENT cascade. The port assertion is fixed separately in PR #6837.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds `node:test` timeouts for `omo-senpi` agent-toolkit staging tests to 30s on Windows and 5s on other platforms to prevent Windows CI timeouts and ENOENT cascades. Production staging is unchanged.

- Applies `{ timeout: STAGING_TEST_TIMEOUT_MS }` to six subprocess-heavy tests and adds a platform-aware constant.
- Uses the options-object form compatible with Node and Bun 1.3.12.
- Scope: tests only; `stage-agent-toolkit.mjs` is unchanged.
- CI expectation: Windows job no longer times out or triggers `Unhandled error between tests`/ENOENT.

<sup>Written for commit 7b7ab55dead184a6a20d3695bc69881f1cb5dada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

