### PR TITLE
test(omo-opencode): isolate tmux polling timers

### DIFF
--- a/packages/omo-opencode/src/features/tmux-subagent/manager.test.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/manager.test.ts
@@ -4,6 +4,7 @@ import type { TmuxConfig } from '../../config/schema'
 import type { WindowState, PaneAction } from './types'
 import type { ActionResult, ExecuteContext } from './action-executor'
 import type { TmuxSessionManager as TmuxSessionManagerType, TmuxUtilDeps } from './manager'
+import { TmuxPollingManager } from './polling-manager'
 import * as sharedModule from '../../shared'
 import * as sharedTmuxOriginal from '../../shared/tmux'
 
@@ -248,6 +249,7 @@ function getFailedReadinessSessions(manager: object): Map<string, { sessionId: s
 describe('TmuxSessionManager', () => {
   beforeEach(() => {
     mock.restore()
+    spyOn(TmuxPollingManager.prototype, 'startPolling').mockImplementation(() => {})
     registerModuleMocks()
     mockQueryWindowState.mockClear()
     mockPaneExists.mockClear()
@@ -1701,6 +1703,7 @@ describe('TmuxSessionManager', () => {
       expect(mockExecuteActions).toHaveBeenCalledTimes(1)
       expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
       expect(getTrackedSessions(manager).has('ses_wait')).toBe(true)
+      expect(Reflect.get(Reflect.get(manager, 'pollingManager'), 'pollInterval')).toBeUndefined()
     })
 
     test('#given readiness probe fails #when onSessionCreated runs #then it logs the structured error and does not spawn a pane', async () => {


### PR DESCRIPTION
## Summary

- stop tmux manager unit tests from scheduling real two-second polling intervals
- assert a successful spawn leaves no live polling interval
- eliminate cross-test `respawn-pane` contamination of the shared runner fake on macOS

## Root cause

Dev CI macOS job `94455533798` expected the runner test's `display-message` command but captured `respawn-pane` for manager fixture `ses_retry_once`. Manager tests had left real polling intervals alive; after their mocks were restored, a leaked poll activated the pane while `runner.test.ts` exposed fake cmux through PATH and overwrote the capture file.

## RED / GREEN

- RED: removing the spy leaves `pollingManager.pollInterval` live and the focused assertion fails
- focused GREEN: 1/0
- manager + adapter runner + tmux-core runner suites: 90/0
- vendored lsp-daemon: 153/0
- exact CI-prepared root suite with Bun 1.3.12: 15,035 pass, 11 skip, 0 fail
- omo-opencode typecheck: clean

## OpenCode QA

Isolated server smoke passed: health healthy, 162 OpenAPI paths, unauthenticated session rejected, and host OpenCode session count stayed 5,848 before/after.

Evidence: `.omo/evidence/20260813-tmux-manager-test-timer-isolation/`

## Scope

One test file, three additions, no production changes. The Windows staging and port repairs are separate PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaked tmux polling timers in `TmuxSessionManager` tests that caused unexpected pane respawns in other suites on macOS CI. Tests previously scheduled real two‑second polls; now they stub polling and verify no interval remains after spawn.

- Stub `TmuxPollingManager.prototype.startPolling` to a no‑op in `beforeEach`.
- Assert `pollingManager.pollInterval` is undefined after a successful spawn.
- Test‑only change in `packages/omo-opencode/src/features/tmux-subagent/manager.test.ts`; no production code changes. Reduces cross‑test contamination and macOS CI flakes.

<sup>Written for commit 9cfe40b76137e199c09c9fb881133d08a0862f02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

