### PR TITLE
test(memory): budget reservation finalization on Windows

### DIFF
--- a/packages/memory-core/src/facts/recovery-reservation-finalization.test.ts
+++ b/packages/memory-core/src/facts/recovery-reservation-finalization.test.ts
@@ -108,7 +108,7 @@ describe("facts deletion reservation finalization", () => {
     if (foreignIdentity === undefined) throw new Error("foreign directory was not installed")
     expect({ dev: retained.dev, ino: retained.ino }).toEqual(foreignIdentity)
     await expectNoReceipt(repo, recovery.batchId)
-  })
+  }, WINDOWS_INTEGRATION_TEST_TIMEOUT)
 
   test("does not overwrite a newer foreign file while restoring a mismatched claim", async () => {
     const { dir, repo } = await fixture()
@@ -156,7 +156,7 @@ describe("facts deletion reservation finalization", () => {
     expect((await repo.pathState.capture(september)).index).toEqual(indexBefore.get(september)?.index ?? null)
     expect(await repo.pathState.capture(september)).toEqual(recovery.paths.find((entry) => entry.path === september)!.pre)
     await expectNoReceipt(repo, recovery.batchId)
-  })
+  }, WINDOWS_INTEGRATION_TEST_TIMEOUT)
 
   test("does not overwrite a newer foreign directory while restoring a mismatched claim", async () => {
     const { dir, repo } = await fixture()
@@ -210,7 +210,7 @@ describe("facts deletion reservation finalization", () => {
     expect(await indexIdentity(repo, september)).toBe(septemberIndexBefore)
     expect(await repo.pathState.capture(september)).toEqual(recovery.paths.find((entry) => entry.path === september)!.pre)
     await expectNoReceipt(repo, recovery.batchId)
-  })
+  }, WINDOWS_INTEGRATION_TEST_TIMEOUT)
 
   test("preserves a foreign file replacing the verified reservation and returns parent_dirty", async () => {
     const { dir, repo } = await fixture()


### PR DESCRIPTION
## Summary

- apply the existing `WINDOWS_INTEGRATION_TEST_TIMEOUT` to the three facts
  reservation-finalization integration tests that omitted it
- keep the already-covered fourth test and all production Git/recovery logic
  unchanged
- restore the merged `dev` Windows root gate after three tests exceeded Bun's
  observed five-second per-test limit

## Why

Merged `dev` workflow
[31745835595](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/31745835595),
Windows root job
[94600043942](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/31745835595/job/94600043942),
failed three real-Git cases at 5015–5235 ms. The fourth case already used
`WINDOWS_INTEGRATION_TEST_TIMEOUT` and passed.

After Bun timed out the async test bodies, `afterEach` removed their temporary
repositories. A still-running body later reached `git hash-object` and reported
`fatal: not a git repository`; that was teardown fallout, not a production Git
failure.

Although the root preload intends a larger Windows default, the actual Bun
1.3.12 CI job enforced five seconds for these three cases. An isolated
two-file Bun 1.3.12 probe reproduced the mechanism: after the preload set
30 seconds, an earlier test file's `setDefaultTimeout(5_000)` changed the
shared runner default and a later unannotated test failed at 5002 ms.
Explicitly using the same bounded per-test budget as the fourth case makes
this suite independent of test discovery order without changing production
behavior.

## Observed QA

- `npx -y bun@1.3.12 test packages/memory-core/src/facts/recovery-reservation-finalization.test.ts`
  - 4 passed, 0 failed
- `npx -y bun@1.3.12 test packages/memory-core`
  - 493 passed, 0 failed
- `npx -y bun@1.3.12 run --cwd packages/memory-core typecheck`
  - exit 0
- `git diff --check`
  - clean

## Required CI evidence before merge

- fresh `test (windows-latest)` completes with a zero-failure summary
- normal PR test/typecheck/build compatibility matrix is green
- fresh post-merge `dev` workflow is fully green before beta publication resumes

## Risk

Low. This is a test-only three-line correction using a constant and API form
already present in the same file. Production code, Git retries, cleanup, and
test timeout values are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies `WINDOWS_INTEGRATION_TEST_TIMEOUT` to three Windows reservation-finalization integration tests to prevent Bun’s 5s default from causing timeouts and teardown-induced false Git errors. Previously these tests ran without an explicit budget; now they use the same per-test budget as the existing fourth case, with no production behavior changes.

- Only changes `packages/memory-core/src/facts/recovery-reservation-finalization.test.ts`: adds the timeout argument to three `test(...)` calls.
- Stabilizes Windows CI regardless of test discovery order; Git/recovery logic and cleanup remain unchanged.

<sup>Written for commit 29ec975fae096f9e453115ce6a575ef9848e3882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

