### PR TITLE
test(memory): fix date-dependent reflection completion test failures

### DIFF
--- a/packages/omo-senpi/src/components/memory/worker/completion.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/completion.test.ts
@@ -24,6 +24,8 @@ import { realpathSync } from "node:fs"
 const roots: string[] = []
 afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
 
+const FIXED_RECENT_TIMESTAMP = new Date(Date.now() - 60_000).toISOString()
+
 function record(): ReflectionCompletionRecord {
   return {
     schemaVersion: 1,
@@ -36,8 +38,8 @@ function record(): ReflectionCompletionRecord {
     trigger: "dream",
     origin: "shutdown",
     outcome: "merged",
-    startedAt: "2026-08-09T12:00:00.000Z",
-    finishedAt: "2026-08-09T12:00:01.000Z",
+    startedAt: FIXED_RECENT_TIMESTAMP,
+    finishedAt: FIXED_RECENT_TIMESTAMP,
     delivery: { status: "pending" },
   }
 }
@@ -128,7 +130,7 @@ describe("reflection completion flow", () => {
       trigger: "dream",
       origin: "shutdown",
       outcome: "merged",
-      finishedAt: "2026-08-09T12:00:01.000Z",
+      finishedAt: FIXED_RECENT_TIMESTAMP,
     })
   })
 
@@ -146,7 +148,7 @@ describe("reflection completion flow", () => {
     expect(reflection.outcomes).toEqual([{
       runId: "run-offline",
       outcome: "merged",
-      finishedAt: "2026-08-09T12:00:01.000Z",
+      finishedAt: FIXED_RECENT_TIMESTAMP,
     }])
   })
 


### PR DESCRIPTION
The `record()` factory in `completion.test.ts` hardcoded `finishedAt: '2026-08-09T12:00:01.000Z'`, which aged past the 7-day `COMPLETION_MAX_AGE_MS` cutoff on 2026-08-16. Records at or past 7 days are treated as stale and skip `deliverReflectionCompletion`, so `api.entries` stays empty while the test expects length 1. Two assertions also inlined `new Date(Date.now() - 60_000).toISOString()` which differed from `record()`'s value on every call, breaking `toEqual` checks.

Fix: module-level `FIXED_RECENT_TIMESTAMP` computed once at import time (1 minute ago), used in both `record()` and all inline assertions. Every call within a run agrees on the same fresh date.

This fixes 5 failing tests that block CI on dev (senpi-compatibility ubuntu/macos/windows + test ubuntu/macos).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes date-dependent failures in reflection completion tests by replacing hardcoded past timestamps with a module-level recent timestamp. Previously, records exceeded the 7‑day `COMPLETION_MAX_AGE_MS` and inline time assertions diverged, skipping `deliverReflectionCompletion` and failing 5 tests; now records are fresh and assertions use the same value.

- Defines `FIXED_RECENT_TIMESTAMP` (now − 1 minute) at module scope and uses it in `record()` and related expectations.
- Changes are test-only and stabilize CI across platforms.

<sup>Written for commit 0512e0c72fec5a6fa35cdd835d98497d6d8caf2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

