### PR TITLE
fix(audit): update allowlist line refs for omo doctor after docs refresh

### DIFF
--- a/script/agent-command-string-audit.allowlist.json
+++ b/script/agent-command-string-audit.allowlist.json
@@ -24,8 +24,8 @@
   "docs": [
     ".agents/skills/codex-qa/SKILL.md:72: omo get-local-version",
     ".github/workflows/publish.yml:915: /bin/omo",
-    "AGENTS.md:411: omo doctor",
-    "CLAUDE.md:411: omo doctor",
+    "AGENTS.md:412: omo doctor",
+    "CLAUDE.md:412: omo doctor",
     "packages/omo-codex/README.md:52: omo get-local-version",
     "packages/omo-native/AGENTS.md:12: omo doctor",
     "packages/omo-native/bin/lib/agent-dir.js:8: omo doctor",


### PR DESCRIPTION
## Summary
`docs: refresh knowledge base snapshot and add component guides` (3dd88267f) added a line to AGENTS.md/CLAUDE.md, shifting the `omo doctor` hit from line 411 to 412. The agent command string audit pins exact `file:line` refs in its allowlist, so **every test job on dev is failing** ([run 32008958907](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32008958907) — ubuntu, macos, and both windows shards) and it also poisoned the [5.0.0-beta.8 release run](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32009839893).

## Fix
Bump the two allowlist entries to `:412`. Verified locally: the audit test passes.

## Note
This audit's exact-line pinning means any docs edit above the reference breaks dev CI deterministically — might be worth relaxing to `file: command` (no line) in a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures by updating the agent command string audit allowlist to reflect a docs shift of “omo doctor” from line 411 to 412. Previously the audit pinned `AGENTS.md:411` and `CLAUDE.md:411`, causing all dev jobs to fail; now both entries point to `:412`, restoring passing audits.

**Review notes**
- Change is limited to `script/agent-command-string-audit.allowlist.json` (two updated refs).
- Updated refs: `AGENTS.md:412: omo doctor` and `CLAUDE.md:412: omo doctor`.
- No runtime impact or migration; this only unblocks CI.

<sup>Written for commit 6dcf22dccde0531f977f0ae40df0bec99b8c8ca8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

