### PR TITLE
ci: stop running the omo-senpi suite twice per OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         # packages/omo-senpi is covered by the senpi-compatibility job. A dedicated config
         # preserves every root ignore while adding Senpi; the CLI path-ignore flag replaces
         # bunfig.toml's list and would re-include web, vendored, plugin, and upstream tests.
-        run: bun test -c bunfig.root.toml${{ matrix.shard && format(' --shard={0}', matrix.shard) || '' }}
+        run: bun --config=bunfig.root.toml test${{ matrix.shard && format(' --shard={0}', matrix.shard) || '' }}
 
       - name: Write job summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,11 @@ jobs:
         working-directory: packages/lsp-daemon
 
       - name: Run tests
-        run: bun test${{ matrix.shard && format(' --shard={0}', matrix.shard) || '' }}
+        # packages/omo-senpi is covered by the senpi-compatibility job, which builds the
+        # plugin first; running it here too duplicated 46% of the Windows suite. The flag is
+        # per-invocation on purpose - a bunfig pathIgnorePatterns entry would also suppress
+        # the senpi job's own explicit `bun test packages/omo-senpi`.
+        run: bun test --path-ignore-patterns="packages/omo-senpi/**"${{ matrix.shard && format(' --shard={0}', matrix.shard) || '' }}
 
       - name: Write job summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,11 +119,10 @@ jobs:
         working-directory: packages/lsp-daemon
 
       - name: Run tests
-        # packages/omo-senpi is covered by the senpi-compatibility job, which builds the
-        # plugin first; running it here too duplicated 46% of the Windows suite. The flag is
-        # per-invocation on purpose - a bunfig pathIgnorePatterns entry would also suppress
-        # the senpi job's own explicit `bun test packages/omo-senpi`.
-        run: bun test --path-ignore-patterns="packages/omo-senpi/**"${{ matrix.shard && format(' --shard={0}', matrix.shard) || '' }}
+        # packages/omo-senpi is covered by the senpi-compatibility job. A dedicated config
+        # preserves every root ignore while adding Senpi; the CLI path-ignore flag replaces
+        # bunfig.toml's list and would re-include web, vendored, plugin, and upstream tests.
+        run: bun test -c bunfig.root.toml${{ matrix.shard && format(' --shard={0}', matrix.shard) || '' }}
 
       - name: Write job summary
         if: always()

--- a/bunfig.root.toml
+++ b/bunfig.root.toml
@@ -1,0 +1,15 @@
+[test]
+preload = ["./test-env.ts", "./test-setup.ts"]
+pathIgnorePatterns = [
+  "dist/**",
+  "packages/web/**",
+  "packages/lsp-tools-mcp/**",
+  "packages/lsp-daemon/**",
+  "packages/omo-codex/plugin/**",
+  "packages/omo-codex/scripts/**",
+  "packages/shared-skills/upstreams/**",
+  "packages/omo-senpi/**",
+]
+
+[loader]
+".md" = "text"

--- a/script/root-test-config.test.ts
+++ b/script/root-test-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, readFileSync } from "node:fs"
+
+const baseConfigPath = new URL("../bunfig.toml", import.meta.url)
+const rootConfigPath = new URL("../bunfig.root.toml", import.meta.url)
+const workflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
+
+function quotedPatterns(config: string): readonly string[] {
+  return [...config.matchAll(/"([^"]+\/\*\*)"/g)].map((match) => match[1] ?? "")
+}
+
+describe("root test Bun config", () => {
+  test("#given package-specific CI jobs #when the root suite config is inspected #then every base ignore remains active", () => {
+    expect(existsSync(rootConfigPath)).toBe(true)
+    if (!existsSync(rootConfigPath)) return
+
+    const basePatterns = quotedPatterns(readFileSync(baseConfigPath, "utf8"))
+    const rootPatterns = quotedPatterns(readFileSync(rootConfigPath, "utf8"))
+
+    for (const pattern of basePatterns) {
+      expect(rootPatterns).toContain(pattern)
+    }
+  })
+
+  test("#given the dedicated Senpi compatibility job #when root tests run #then omo-senpi is excluded", () => {
+    expect(existsSync(rootConfigPath)).toBe(true)
+    if (!existsSync(rootConfigPath)) return
+
+    expect(quotedPatterns(readFileSync(rootConfigPath, "utf8"))).toContain("packages/omo-senpi/**")
+  })
+
+  test("#given the dedicated root config #when CI invokes Bun #then the config is passed after the test command", () => {
+    expect(readFileSync(workflowPath, "utf8")).toContain("run: bun test -c bunfig.root.toml")
+  })
+})

--- a/script/root-test-config.test.ts
+++ b/script/root-test-config.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, test } from "bun:test"
 import { existsSync, readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 
+const repoRoot = fileURLToPath(new URL("..", import.meta.url))
 const baseConfigPath = new URL("../bunfig.toml", import.meta.url)
 const rootConfigPath = new URL("../bunfig.root.toml", import.meta.url)
 const workflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
 
 function quotedPatterns(config: string): readonly string[] {
   return [...config.matchAll(/"([^"]+\/\*\*)"/g)].map((match) => match[1] ?? "")
+}
+
+function spawnBun(args: readonly string[]): string {
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, ...args],
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  return `${new TextDecoder().decode(result.stdout)}${new TextDecoder().decode(result.stderr)}`
 }
 
 describe("root test Bun config", () => {
@@ -29,7 +41,19 @@ describe("root test Bun config", () => {
     expect(quotedPatterns(readFileSync(rootConfigPath, "utf8"))).toContain("packages/omo-senpi/**")
   })
 
-  test("#given the dedicated root config #when CI invokes Bun #then the config is passed after the test command", () => {
-    expect(readFileSync(workflowPath, "utf8")).toContain("run: bun test -c bunfig.root.toml")
+  test("#given bun 1.3.x test argv #when CI selects the dedicated config #then --config= is passed before test", () => {
+    const workflow = readFileSync(workflowPath, "utf8")
+    expect(workflow).toContain("run: bun --config=bunfig.root.toml test")
+    expect(workflow).not.toContain("bun test -c")
+    expect(workflow).not.toContain("bun test --config")
+  })
+
+  test("#given bunfig.root.toml #when bun loads it via --config= #then Senpi tests are ignored", () => {
+    const output = spawnBun([
+      "--config=bunfig.root.toml",
+      "test",
+      "packages/omo-senpi/src/components/memory/status.test.ts",
+    ])
+    expect(output).toContain("filters did not match any test files")
   })
 })


### PR DESCRIPTION
## Summary

`packages/omo-senpi` already has a dedicated merge-blocking job, `senpi-compatibility`, which builds the plugin, packs it, typechecks it, and then runs `bun test packages/omo-senpi`. The root test suite picked the same files up as well, so 273 test files ran twice on every OS. This scopes the root job's invocation so each file runs once, in the job that owns it.

## Changes

- Root `test` job now runs `bun test --path-ignore-patterns="packages/omo-senpi/**"`, composing with the existing `--shard` expression.
- A comment records why this is a per-invocation flag rather than a `bunfig.toml` entry, so the safer-looking config change is not "restored" later.

## QA & Evidence

- **What was tested:** that the exclusion removes the duplicate from the root run *without* touching the senpi job's own explicit invocation.
- **Observed result:**
  - bare run + flag over `memory-core` + `omo-senpi` -> 546 tests / 67 files (omo-senpi dropped, the other package intact)
  - `bun test packages/omo-senpi` (the senpi job's command, unchanged) -> **1877 tests across 273 files**, unaffected
- **Why sufficient:** the second measurement is the safety property. `pathIgnorePatterns` in `bunfig.toml` is global, so adding `"packages/omo-senpi/**"` there also suppresses the senpi job's explicit path — that configuration reports `5748 files were searched` and runs **zero** tests, silently deleting 273 files of coverage while CI stays green. The CLI flag is scoped to the invocation that sets it. This was caught before commit and the config approach was reverted.
- **Coverage ownership:** running all 273 files *without* `build:senpi-plugin` fails 11 tests — `OMO Senpi scoped skill sync` (7), `runSenpiInstaller source refresh` (3), `omo-senpi ultrawork component` (1). They assert on staged build artifacts, confirming `senpi-compatibility` is the correct owner rather than an incidental duplicate.
- **Artifact:** `.omo/evidence/20260817-senpi-test-dedupe/red-duplication.txt`

## Measured impact

From the per-file timings of run 32011189074:

| OS | omo-senpi share of the root suite |
|---|---|
| windows | 10.9m of 24.0m (**46%**) |
| ubuntu | 2.8m of 6.9m (41%) |

## Risks & Residuals

- **Root suite no longer catches omo-senpi breakage.** Accepted: `senpi-compatibility` is merge-blocking on all three OSes, and `senpi-test-script.test.ts` asserts that job's shape, so the coverage cannot silently disappear.
- **Independent of the bun pin.** This PR does not depend on #6925 and can land in either order.
- **Pre-existing, unrelated:** `script/agent-command-string-audit.test.ts` fails on `dev` today (allowlist `file:LINE` drift). Not touched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops running `packages/omo-senpi` tests in the root CI job; they now run only in the merge‑blocking `senpi-compatibility` job that builds the plugin. Previously these files ran twice per OS; now they run once in the job that owns their artifacts. Impact: removes ~46% of Windows root suite time and ~41% of Ubuntu root suite time.

- Root job runs `bun test -c bunfig.root.toml` (composed with `--shard`). The dedicated config preserves all base ignores and adds `packages/omo-senpi/**`.
- Base `bunfig.toml` remains unchanged, so `senpi-compatibility` (`bun test packages/omo-senpi`) still runs all 273 files and stays merge‑blocking on all OSes.
- Adds `script/root-test-config.test.ts` to assert base ignores are preserved, Senpi is excluded in the root config, and CI invokes `bun test -c bunfig.root.toml`.
- Avoids the CLI `--path-ignore-patterns` flag, which replaces the ignore list and would re‑include web, vendored, plugin, and upstream tests and could suppress Senpi coverage in its own job.

<sup>Written for commit 67591743c9252e8df061639c453786bec5dd6c6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

