### PR TITLE
fix(audit): retarget omo doctor allowlist pins after AGENTS.md drift

### DIFF
--- a/script/agent-command-string-audit.allowlist.json
+++ b/script/agent-command-string-audit.allowlist.json
@@ -24,8 +24,8 @@
   "docs": [
     ".agents/skills/codex-qa/SKILL.md:72: omo get-local-version",
     ".github/workflows/publish.yml:915: /bin/omo",
-    "AGENTS.md:411: omo doctor",
-    "CLAUDE.md:411: omo doctor",
+    "AGENTS.md:412: omo doctor",
+    "CLAUDE.md:412: omo doctor",
     "packages/omo-codex/README.md:52: omo get-local-version",
     "packages/omo-native/AGENTS.md:12: omo doctor",
     "packages/omo-native/bin/lib/agent-dir.js:8: omo doctor",


### PR DESCRIPTION
## Summary

`script/agent-command-string-audit.test.ts` pins every allowed command-string hit as `file:LINE`. The knowledge base refresh in `3dd88267f` added a line above the `omo doctor` reference in `AGENTS.md`, shifting it from line 411 to 412; `CLAUDE.md` is a symlink to `AGENTS.md`, so it drifted identically.

The audit has been failing on `dev` ever since. Because it runs inside the root suite, it turns the ubuntu and windows `test` jobs red on **every open pull request**, not just this one.

## Changes

- `script/agent-command-string-audit.allowlist.json`: `AGENTS.md:411` -> `AGENTS.md:412` and `CLAUDE.md:411` -> `CLAUDE.md:412`, both for `omo doctor`.

## QA & Evidence

- **What was tested:** `bun test script/agent-command-string-audit.test.ts`, before and after the change, with dependencies installed.
- **Observed result:**
  - RED (pins reverted): `0 pass, 1 fail` — the diff shows exactly `-411 / +412` for the two entries and nothing else.
  - GREEN (pins retargeted): `1 pass, 0 fail`.
- **Why sufficient:** the audit is the thing under test, and it is the exact check failing in CI. The two-line diff matches the reported drift precisely.
- **Confirmed source of the drift:** `grep -n 'omo doctor' AGENTS.md` now reports line 412, and `ls -l CLAUDE.md` confirms the symlink to `AGENTS.md`.

## Risks & Residuals

- **No rule is weakened.** No allowlist entry is added or removed and no audit logic changes; only two stale line references are corrected. A genuinely new unallowlisted command string would still fail the audit.
- **This class of drift will recur** whenever a line is inserted above a pinned reference in a documentation file. Making the audit resilient to line movement is a larger change and deliberately out of scope here, since the immediate need is to unblock the merge queue.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing agent command-string audit by retargeting `omo doctor` allowlist pins after `AGENTS.md` shifted. Old behavior: audit expected line 411 and failed; new behavior: pins point to 412 and tests pass. No rule changes.

**Review notes**
- Update `script/agent-command-string-audit.allowlist.json`: `AGENTS.md:411` → `AGENTS.md:412`, `CLAUDE.md:411` → `CLAUDE.md:412` (symlink).
- Restores green ubuntu/windows root test jobs; no entries added or removed.

<sup>Written for commit 277d1342efd996b9d7a5b353bc0ddb28cd76f762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

