### PR TITLE
test: isolate XDG data and cache dirs per test process

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,5 @@
 [test]
-preload = ["./test-setup.ts"]
+preload = ["./test-env.ts", "./test-setup.ts"]
 pathIgnorePatterns = ["dist/**", "packages/web/**", "packages/lsp-tools-mcp/**", "packages/lsp-daemon/**", "packages/omo-codex/plugin/**", "packages/omo-codex/scripts/**", "packages/shared-skills/upstreams/**"]
 
 [loader]

--- a/test-env.ts
+++ b/test-env.ts
@@ -1,0 +1,19 @@
+/// <reference types="bun-types" />
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+// Preloaded ahead of test-setup.ts on purpose.
+//
+// packages/omo-opencode/src/shared/opencode-storage-paths.ts evaluates OPENCODE_STORAGE at
+// import time, and RULES_INJECTOR_STORAGE derives from it. ES imports hoist above every
+// statement in a module body, so test-setup.ts cannot redirect those paths from its own
+// body - the constants are already frozen by the time its first line runs. The redirect
+// therefore has to happen in an earlier preload.
+//
+// This also makes `bun test --parallel` safe: each worker is a separate process, so a
+// per-process directory means workers no longer share one cache/storage tree and stop
+// deleting each other's fixtures in beforeEach/afterEach.
+const xdgRoot = mkdtempSync(join(tmpdir(), "omo-test-xdg-"))
+process.env.XDG_DATA_HOME = join(xdgRoot, "data")
+process.env.XDG_CACHE_HOME = join(xdgRoot, "cache")


### PR DESCRIPTION
## Summary

`test-setup.ts` deletes the omo cache directory and the rules-injector storage in `beforeEach` and `afterEach`, but both resolve to constant, machine-wide paths. Under `bun test --parallel` each worker is a separate process pointing at the same two directories, so workers delete each other's fixtures mid-run and tests fail non-deterministically.

This points those two roots at a per-process temp directory, which makes the suite hermetic and makes `--parallel` adoptable.

## Why the fix cannot live in test-setup.ts

`opencode-storage-paths.ts:4` evaluates `OPENCODE_STORAGE` at import time and `rules-injector/constants.ts:3` derives `RULES_INJECTOR_STORAGE` from it. `test-setup.ts` imports that constant at the top, and ES imports hoist above every statement in the module body — so the paths are already frozen before its first line runs. The redirect therefore has to happen in an **earlier preload**, which is what `test-env.ts` is.

Both resolvers already read the environment (`data-path.ts` `getCacheDir` reads `XDG_CACHE_HOME`; `utils/xdg-data-dir.ts:22` reads `XDG_DATA_HOME`), so no production path logic changes.

## Changes

- New `test-env.ts`: allocates one temp directory per process and points `XDG_DATA_HOME` / `XDG_CACHE_HOME` at it.
- `bunfig.toml`: `preload = ["./test-env.ts", "./test-setup.ts"]` — order is load-bearing.

## QA & Evidence

Measured on bun **1.3.14** (the version CI can actually install), same worktree and install for every run.

| run | wall | distinct failures |
|---|---|---|
| parallel, before | 190.81s | 17 |
| parallel, after | **121.49s** | **15** (0 new) |
| serial, before | 544.21s | 21 |
| serial, after | 591.30s | **14** |

- **Fixed:** `storage > reads back only the requested session data from session-scoped files` and `plugin init performance > stays within the empty project init budget`. Both were losing their fixtures to another worker.
- **No regression:** zero new failures in the parallel comparison; serial failures dropped as well.
- **Targeted serial checks:** rules-injector 82 pass / 0 fail; telemetry 45 pass / 1 fail, where that one is the built-bundle guard already red in the baseline.
- **Artifact:** `.omo/evidence/20260817-test-parallel-worker-isolation/before-after.txt`

The residual failures in both columns are artifacts of this worktree's deliberately degraded install (`--ignore-scripts` plus only `build:lsp-daemon`), which leaves codex/telemetry bundles unbuilt. They fail identically with and without this change, and CI installs normally.

## Risks & Residuals

- **`test-setup.ts` deliberately did not set XDG_\*** ("config-dir tests control those themselves"). That is why the full serial suite was re-run rather than only the parallel one: failures went down, not up, and the suites that manage XDG themselves were checked directly.
- **Serial wall time moved 544s -> 591s.** Same machine, but the runs were not contention-isolated, so I would treat that as noise rather than a claimed regression or improvement.
- **This PR does not enable `--parallel` in CI.** That needs a bun version where the flag exists and is a separate change on top of #6925.

## Related

- #6925 bumps CI to bun 1.3.14, which is the prerequisite for turning `--parallel` on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates XDG data and cache directories per test process to make `bun test --parallel` deterministic. Previously workers shared machine-wide paths and deleted each other’s fixtures; now an early preload assigns each process its own temp root and avoids writes to `~/.cache/omo`.

**Review**
- Add `test-env.ts` to create a per-process temp root and set `XDG_DATA_HOME` and `XDG_CACHE_HOME`.
- Update `bunfig.toml` to preload `test-env.ts` before `test-setup.ts`; order is required because storage paths are derived at import time.
- No production path logic changes; existing resolvers already read these env variables.

<sup>Written for commit 3b00103ff7c4b4a5bad51dde1b4fac3b6f1ac48a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

