### PR TITLE
fix(publish): run registry probes after the release exists

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -648,6 +648,10 @@ jobs:
 
   publish-main:
     runs-on: ubuntu-latest
+    # post-publish-verify runs the published-package probes in a job that cannot block the release, so the
+    # lazycodex publish decision has to cross the job boundary as an output.
+    outputs:
+      lazycodex_publish_skipped: ${{ steps.check-lazycodex.outputs.skip }}
     needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]
     if: >-
       always() &&
@@ -917,208 +921,6 @@ jobs:
         working-directory: packages/omo-native
         run: npm publish --ignore-scripts --access public --provenance --tag beta
 
-      - name: Wait for omo-ai registry readiness
-        env:
-          OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
-          ALREADY_PUBLISHED: ${{ needs.release-metadata.outputs.already_published }}
-        run: |
-          set -euo pipefail
-
-          for attempt in $(seq 1 5); do
-            IMMUTABLE_VERSION=$(npm view omo-ai@$OMO_AI_VERSION version 2>/dev/null || true)
-            BETA_READY=true
-            if [ "$ALREADY_PUBLISHED" != "true" ]; then
-              BETA_VERSION=$(npm view omo-ai dist-tags.beta 2>/dev/null || true)
-              [ "$BETA_VERSION" = "$OMO_AI_VERSION" ] || BETA_READY=false
-            fi
-
-            if [ "$IMMUTABLE_VERSION" = "$OMO_AI_VERSION" ] && [ "$BETA_READY" = "true" ]; then
-              echo "omo-ai@$OMO_AI_VERSION is ready"
-              break
-            fi
-
-            if [ "$attempt" = "5" ]; then
-              echo "::error::omo-ai@$OMO_AI_VERSION was not ready after 5 attempts"
-              exit 1
-            fi
-            echo "Waiting for omo-ai@$OMO_AI_VERSION registry propagation (attempt ${attempt}/5)"
-            sleep 15
-          done
-
-      - name: Guard omo-ai dist-tags
-        env:
-          OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
-          ALREADY_PUBLISHED: ${{ needs.release-metadata.outputs.already_published }}
-        run: |
-          set -euo pipefail
-
-          LATEST_VERSION=$(npm view omo-ai dist-tags.latest 2>/dev/null || true)
-          if [ "$LATEST_VERSION" != "0.0.0-beta.0" ]; then
-            echo "::error::omo-ai latest must remain pinned to 0.0.0-beta.0, got ${LATEST_VERSION:-missing}. Remediate with: npm dist-tag add omo-ai@0.0.0-beta.0 latest"
-            exit 1
-          fi
-
-          if [ "$ALREADY_PUBLISHED" != "true" ]; then
-            BETA_VERSION=$(npm view omo-ai dist-tags.beta 2>/dev/null || true)
-            if [ "$BETA_VERSION" != "$OMO_AI_VERSION" ]; then
-              echo "::error::omo-ai beta points to ${BETA_VERSION:-missing}, expected $OMO_AI_VERSION"
-              exit 1
-            fi
-          fi
-
-      - name: Verify omo-ai live install
-        env:
-          OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
-          ALREADY_PUBLISHED: ${{ needs.release-metadata.outputs.already_published }}
-        run: |
-          set -euo pipefail
-
-          EXACT_VERIFIED=false
-          for attempt in $(seq 1 5); do
-            EXACT_PREFIX=$(mktemp -d "$RUNNER_TEMP/omoai-exact-${attempt}.XXXXXX")
-            if npm i -g "omo-ai@$OMO_AI_VERSION" --prefix "$EXACT_PREFIX" &&
-               [ "$(jq -r '.version' "$EXACT_PREFIX/lib/node_modules/omo-ai/package.json")" = "$OMO_AI_VERSION" ] &&
-               "$EXACT_PREFIX/bin/omo" --version; then
-              EXACT_VERIFIED=true
-              rm -rf "$EXACT_PREFIX"
-              break
-            fi
-            rm -rf "$EXACT_PREFIX"
-            if [ "$attempt" != "5" ]; then
-              echo "Waiting for omo-ai@$OMO_AI_VERSION install propagation (attempt ${attempt}/5)"
-              sleep 15
-            fi
-          done
-          if [ "$EXACT_VERIFIED" != "true" ]; then
-            echo "::error::Exact-version live install failed for omo-ai@$OMO_AI_VERSION"
-            exit 1
-          fi
-
-          if [ "$ALREADY_PUBLISHED" != "true" ]; then
-            BETA_PREFIX=$(mktemp -d "$RUNNER_TEMP/omoai-beta.XXXXXX")
-            npm i -g omo-ai@beta --prefix "$BETA_PREFIX"
-            BETA_INSTALLED_VERSION=$(jq -r '.version' "$BETA_PREFIX/lib/node_modules/omo-ai/package.json")
-            rm -rf "$BETA_PREFIX"
-            if [ "$BETA_INSTALLED_VERSION" != "$OMO_AI_VERSION" ]; then
-              echo "::error::omo-ai@beta installed $BETA_INSTALLED_VERSION, expected $OMO_AI_VERSION"
-              exit 1
-            fi
-          fi
-
-          BARE_PREFIX=$(mktemp -d "$RUNNER_TEMP/omoai-bare.XXXXXX")
-          BARE_ERROR="$RUNNER_TEMP/omoai-bare-error.txt"
-          if npm i -g omo-ai --prefix "$BARE_PREFIX" 2>"$BARE_ERROR"; then
-            rm -rf "$BARE_PREFIX" "$BARE_ERROR"
-            echo "::error::Bare omo-ai install unexpectedly succeeded; the beta-only channel is broken"
-            exit 1
-          fi
-          if ! grep -q "ETARGET" "$BARE_ERROR"; then
-            cat "$BARE_ERROR" >&2
-            rm -rf "$BARE_PREFIX" "$BARE_ERROR"
-            echo "::error::Bare omo-ai install failed without the required ETARGET beta gate"
-            exit 1
-          fi
-          rm -rf "$BARE_PREFIX" "$BARE_ERROR"
-
-      - name: Smoke test published lazycodex-ai
-        if: inputs.publish_lazycodex == true && steps.check-lazycodex.outputs.skip != 'true'
-        env:
-          OMO_VERSION: ${{ needs.release-metadata.outputs.version }}
-          DIST_TAG: ${{ needs.release-metadata.outputs.dist_tag }}
-        run: |
-          set -euo pipefail
-
-          # Upgrade simulation: an existing install carries a legacy `omo` wrapper in the
-          # Codex bin dir. A marker-bearing wrapper is ours and must be reclaimed by the
-          # install; an unmarked file is user-owned and must survive byte-identical.
-          simulate_legacy_omo_upgrade() {
-            package_spec="$1"
-            scenario_root="$2"
-            seeded_kind="$3"
-            (
-              export HOME="$scenario_root/home"
-              export CODEX_HOME="$scenario_root/codex"
-              export CODEX_LOCAL_BIN_DIR="$scenario_root/bin"
-              mkdir -p "$HOME" "$CODEX_HOME" "$CODEX_LOCAL_BIN_DIR" "$scenario_root/cwd"
-              cd "$scenario_root/cwd"
-
-              if [ "$seeded_kind" = "marked" ]; then
-                printf '#!/bin/sh\n# OMO_GENERATED_RUNTIME_WRAPPER\nexit 0\n' > "$CODEX_LOCAL_BIN_DIR/omo"
-              else
-                printf '#!/bin/sh\n# user-owned omo, never generated by this installer\nexit 0\n' > "$CODEX_LOCAL_BIN_DIR/omo"
-              fi
-              chmod +x "$CODEX_LOCAL_BIN_DIR/omo"
-              cp "$CODEX_LOCAL_BIN_DIR/omo" "$scenario_root/omo.seeded"
-
-              npx -y "$package_spec" install --no-tui --codex-autonomous >/dev/null 2>&1 || return 1
-              [ -x "$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ] || return 1
-
-              if [ "$seeded_kind" = "marked" ]; then
-                if [ -e "$CODEX_LOCAL_BIN_DIR/omo" ]; then
-                  echo "::error::marker-bearing legacy omo wrapper survived the install"
-                  return 1
-                fi
-              else
-                if ! cmp -s "$scenario_root/omo.seeded" "$CODEX_LOCAL_BIN_DIR/omo"; then
-                  echo "::error::user-owned omo file was modified by the install"
-                  return 1
-                fi
-              fi
-            )
-          }
-
-          smoke_lazycodex_package() {
-            package_spec="$1"
-            for attempt in $(seq 1 12); do
-              SMOKE_DIR=$(mktemp -d)
-              export HOME="$SMOKE_DIR/home"
-              export CODEX_HOME="$SMOKE_DIR/codex"
-              export CODEX_LOCAL_BIN_DIR="$SMOKE_DIR/bin"
-              mkdir -p "$HOME" "$CODEX_HOME" "$CODEX_LOCAL_BIN_DIR" "$SMOKE_DIR/cwd"
-              cd "$SMOKE_DIR/cwd"
-              expected_install_output="npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous"
-              expected_doctor_output_prefix="codex exec "
-              expected_doctor_hint="Use \$omo:lcx-doctor"
-
-              if npx_install_output=$(npx -y "$package_spec" --dry-run install --no-tui --codex-autonomous 2>&1) &&
-                 npx_doctor_output=$(npx -y "$package_spec" --dry-run doctor 2>&1) &&
-                 [ "$npx_install_output" = "$expected_install_output" ] &&
-                 case "$npx_doctor_output" in "$expected_doctor_output_prefix"*) true ;; *) false ;; esac &&
-                 case "$npx_doctor_output" in *"--sandbox danger-full-access"*) true ;; *) false ;; esac &&
-                 case "$npx_doctor_output" in *"$expected_doctor_hint"*) true ;; *) false ;; esac &&
-                 case "$npx_doctor_output" in *"--model"*|*"gpt-5.5-codex-mini"*) false ;; *) true ;; esac &&
-                 npx -y "$package_spec" install --no-tui --codex-autonomous &&
-                 [ -x "$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ] &&
-                 [ ! -e "$CODEX_LOCAL_BIN_DIR/omo" ] &&
-                 omo_agent_toolkit_version_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" --version 2>&1) &&
-                 [ "$omo_agent_toolkit_version_output" = "$OMO_VERSION" ] &&
-                 ulw_loop_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ulw-loop --help 2>&1) &&
-                 printf "%s" "$ulw_loop_output" | grep -q "ulw-loop" &&
-                 simulate_legacy_omo_upgrade "$package_spec" "$SMOKE_DIR/upgrade-marked" marked &&
-                 simulate_legacy_omo_upgrade "$package_spec" "$SMOKE_DIR/upgrade-unmarked" unmarked; then
-                echo "$npx_install_output"
-                echo "$npx_doctor_output"
-                echo "omo-agent-toolkit --version: $omo_agent_toolkit_version_output"
-                echo "omo-agent-toolkit ulw-loop: $ulw_loop_output"
-                cd "$GITHUB_WORKSPACE"
-                rm -rf "$SMOKE_DIR"
-                return 0
-              fi
-
-              cd "$GITHUB_WORKSPACE"
-              rm -rf "$SMOKE_DIR"
-              echo "Waiting for ${package_spec} registry propagation (attempt ${attempt}/12)"
-              sleep 10
-            done
-            echo "::error::Published LazyCodex smoke failed for ${package_spec}"
-            return 1
-          }
-
-          smoke_lazycodex_package "lazycodex-ai@${OMO_VERSION}"
-          if [ -z "$DIST_TAG" ]; then
-            smoke_lazycodex_package "lazycodex-ai@latest"
-          fi
-
       - name: Restore package.json after lazycodex-ai publish attempt
         if: always() && inputs.publish_lazycodex == true && steps.check-lazycodex.outputs.skip != 'true'
         run: |
@@ -1326,4 +1128,243 @@ jobs:
             - Syncs LazyCodex marketplace payload and creates GitHub releases.
             - Attempts the protected `master` mirror update after release.
           JOB_SUMMARY_NEXT: Inspect the first failing release-state, marketplace sync, or GitHub release step.
+        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
+
+  post-publish-verify:
+    runs-on: ubuntu-latest
+    needs: [release-metadata, prepare-release-state, publish-main, release]
+    # Post-publish verification runs AFTER the release exists. These probes assert registry state that is
+    # already public by this point, so blocking the release job on them could only produce the worst
+    # outcome: packages on npm with no GitHub release and no marketplace sync. A failure here is still a
+    # red job that must be investigated - it just cannot strand a published release.
+    if: >-
+      always() &&
+      inputs.prepared_release_sha != '' &&
+      needs.release-metadata.result == 'success' &&
+      needs.publish-main.result == 'success' &&
+      needs.release.result == 'success'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare-release-state.outputs.release_sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Wait for omo-ai registry readiness
+        env:
+          OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
+          ALREADY_PUBLISHED: ${{ needs.release-metadata.outputs.already_published }}
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 5); do
+            IMMUTABLE_VERSION=$(npm view omo-ai@$OMO_AI_VERSION version 2>/dev/null || true)
+            BETA_READY=true
+            if [ "$ALREADY_PUBLISHED" != "true" ]; then
+              BETA_VERSION=$(npm view omo-ai dist-tags.beta 2>/dev/null || true)
+              [ "$BETA_VERSION" = "$OMO_AI_VERSION" ] || BETA_READY=false
+            fi
+
+            if [ "$IMMUTABLE_VERSION" = "$OMO_AI_VERSION" ] && [ "$BETA_READY" = "true" ]; then
+              echo "omo-ai@$OMO_AI_VERSION is ready"
+              break
+            fi
+
+            if [ "$attempt" = "5" ]; then
+              echo "::error::omo-ai@$OMO_AI_VERSION was not ready after 5 attempts"
+              exit 1
+            fi
+            echo "Waiting for omo-ai@$OMO_AI_VERSION registry propagation (attempt ${attempt}/5)"
+            sleep 15
+          done
+
+      - name: Guard omo-ai dist-tags
+        env:
+          OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
+          ALREADY_PUBLISHED: ${{ needs.release-metadata.outputs.already_published }}
+        run: |
+          set -euo pipefail
+
+          LATEST_VERSION=$(npm view omo-ai dist-tags.latest 2>/dev/null || true)
+          if [ "$LATEST_VERSION" != "0.0.0-beta.0" ]; then
+            echo "::error::omo-ai latest must remain pinned to 0.0.0-beta.0, got ${LATEST_VERSION:-missing}. Remediate with: npm dist-tag add omo-ai@0.0.0-beta.0 latest"
+            exit 1
+          fi
+
+          if [ "$ALREADY_PUBLISHED" != "true" ]; then
+            BETA_VERSION=$(npm view omo-ai dist-tags.beta 2>/dev/null || true)
+            if [ "$BETA_VERSION" != "$OMO_AI_VERSION" ]; then
+              echo "::error::omo-ai beta points to ${BETA_VERSION:-missing}, expected $OMO_AI_VERSION"
+              exit 1
+            fi
+          fi
+
+      - name: Verify omo-ai live install
+        env:
+          OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
+          ALREADY_PUBLISHED: ${{ needs.release-metadata.outputs.already_published }}
+        run: |
+          set -euo pipefail
+
+          EXACT_VERIFIED=false
+          for attempt in $(seq 1 5); do
+            EXACT_PREFIX=$(mktemp -d "$RUNNER_TEMP/omoai-exact-${attempt}.XXXXXX")
+            if npm i -g "omo-ai@$OMO_AI_VERSION" --prefix "$EXACT_PREFIX" &&
+               [ "$(jq -r '.version' "$EXACT_PREFIX/lib/node_modules/omo-ai/package.json")" = "$OMO_AI_VERSION" ] &&
+               "$EXACT_PREFIX/bin/omo" --version; then
+              EXACT_VERIFIED=true
+              rm -rf "$EXACT_PREFIX"
+              break
+            fi
+            rm -rf "$EXACT_PREFIX"
+            if [ "$attempt" != "5" ]; then
+              echo "Waiting for omo-ai@$OMO_AI_VERSION install propagation (attempt ${attempt}/5)"
+              sleep 15
+            fi
+          done
+          if [ "$EXACT_VERIFIED" != "true" ]; then
+            echo "::error::Exact-version live install failed for omo-ai@$OMO_AI_VERSION"
+            exit 1
+          fi
+
+          if [ "$ALREADY_PUBLISHED" != "true" ]; then
+            BETA_PREFIX=$(mktemp -d "$RUNNER_TEMP/omoai-beta.XXXXXX")
+            npm i -g omo-ai@beta --prefix "$BETA_PREFIX"
+            BETA_INSTALLED_VERSION=$(jq -r '.version' "$BETA_PREFIX/lib/node_modules/omo-ai/package.json")
+            rm -rf "$BETA_PREFIX"
+            if [ "$BETA_INSTALLED_VERSION" != "$OMO_AI_VERSION" ]; then
+              echo "::error::omo-ai@beta installed $BETA_INSTALLED_VERSION, expected $OMO_AI_VERSION"
+              exit 1
+            fi
+          fi
+
+          BARE_PREFIX=$(mktemp -d "$RUNNER_TEMP/omoai-bare.XXXXXX")
+          BARE_ERROR="$RUNNER_TEMP/omoai-bare-error.txt"
+          if npm i -g omo-ai --prefix "$BARE_PREFIX" 2>"$BARE_ERROR"; then
+            rm -rf "$BARE_PREFIX" "$BARE_ERROR"
+            echo "::error::Bare omo-ai install unexpectedly succeeded; the beta-only channel is broken"
+            exit 1
+          fi
+          if ! grep -q "ETARGET" "$BARE_ERROR"; then
+            cat "$BARE_ERROR" >&2
+            rm -rf "$BARE_PREFIX" "$BARE_ERROR"
+            echo "::error::Bare omo-ai install failed without the required ETARGET beta gate"
+            exit 1
+          fi
+          rm -rf "$BARE_PREFIX" "$BARE_ERROR"
+
+      - name: Smoke test published lazycodex-ai
+        if: inputs.publish_lazycodex == true && needs.publish-main.outputs.lazycodex_publish_skipped != 'true'
+        env:
+          OMO_VERSION: ${{ needs.release-metadata.outputs.version }}
+          DIST_TAG: ${{ needs.release-metadata.outputs.dist_tag }}
+        run: |
+          set -euo pipefail
+
+          # Upgrade simulation: an existing install carries a legacy `omo` wrapper in the
+          # Codex bin dir. A marker-bearing wrapper is ours and must be reclaimed by the
+          # install; an unmarked file is user-owned and must survive byte-identical.
+          simulate_legacy_omo_upgrade() {
+            package_spec="$1"
+            scenario_root="$2"
+            seeded_kind="$3"
+            (
+              export HOME="$scenario_root/home"
+              export CODEX_HOME="$scenario_root/codex"
+              export CODEX_LOCAL_BIN_DIR="$scenario_root/bin"
+              mkdir -p "$HOME" "$CODEX_HOME" "$CODEX_LOCAL_BIN_DIR" "$scenario_root/cwd"
+              cd "$scenario_root/cwd"
+
+              if [ "$seeded_kind" = "marked" ]; then
+                printf '#!/bin/sh\n# OMO_GENERATED_RUNTIME_WRAPPER\nexit 0\n' > "$CODEX_LOCAL_BIN_DIR/omo"
+              else
+                printf '#!/bin/sh\n# user-owned omo, never generated by this installer\nexit 0\n' > "$CODEX_LOCAL_BIN_DIR/omo"
+              fi
+              chmod +x "$CODEX_LOCAL_BIN_DIR/omo"
+              cp "$CODEX_LOCAL_BIN_DIR/omo" "$scenario_root/omo.seeded"
+
+              npx -y "$package_spec" install --no-tui --codex-autonomous >/dev/null 2>&1 || return 1
+              [ -x "$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ] || return 1
+
+              if [ "$seeded_kind" = "marked" ]; then
+                if [ -e "$CODEX_LOCAL_BIN_DIR/omo" ]; then
+                  echo "::error::marker-bearing legacy omo wrapper survived the install"
+                  return 1
+                fi
+              else
+                if ! cmp -s "$scenario_root/omo.seeded" "$CODEX_LOCAL_BIN_DIR/omo"; then
+                  echo "::error::user-owned omo file was modified by the install"
+                  return 1
+                fi
+              fi
+            )
+          }
+
+          smoke_lazycodex_package() {
+            package_spec="$1"
+            for attempt in $(seq 1 12); do
+              SMOKE_DIR=$(mktemp -d)
+              export HOME="$SMOKE_DIR/home"
+              export CODEX_HOME="$SMOKE_DIR/codex"
+              export CODEX_LOCAL_BIN_DIR="$SMOKE_DIR/bin"
+              mkdir -p "$HOME" "$CODEX_HOME" "$CODEX_LOCAL_BIN_DIR" "$SMOKE_DIR/cwd"
+              cd "$SMOKE_DIR/cwd"
+              expected_install_output="npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous"
+              expected_doctor_output_prefix="codex exec "
+              expected_doctor_hint="Use \$omo:lcx-doctor"
+
+              if npx_install_output=$(npx -y "$package_spec" --dry-run install --no-tui --codex-autonomous 2>&1) &&
+                 npx_doctor_output=$(npx -y "$package_spec" --dry-run doctor 2>&1) &&
+                 [ "$npx_install_output" = "$expected_install_output" ] &&
+                 case "$npx_doctor_output" in "$expected_doctor_output_prefix"*) true ;; *) false ;; esac &&
+                 case "$npx_doctor_output" in *"--sandbox danger-full-access"*) true ;; *) false ;; esac &&
+                 case "$npx_doctor_output" in *"$expected_doctor_hint"*) true ;; *) false ;; esac &&
+                 case "$npx_doctor_output" in *"--model"*|*"gpt-5.5-codex-mini"*) false ;; *) true ;; esac &&
+                 npx -y "$package_spec" install --no-tui --codex-autonomous &&
+                 [ -x "$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ] &&
+                 [ ! -e "$CODEX_LOCAL_BIN_DIR/omo" ] &&
+                 omo_agent_toolkit_version_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" --version 2>&1) &&
+                 [ "$omo_agent_toolkit_version_output" = "$OMO_VERSION" ] &&
+                 ulw_loop_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ulw-loop --help 2>&1) &&
+                 printf "%s" "$ulw_loop_output" | grep -q "ulw-loop" &&
+                 simulate_legacy_omo_upgrade "$package_spec" "$SMOKE_DIR/upgrade-marked" marked &&
+                 simulate_legacy_omo_upgrade "$package_spec" "$SMOKE_DIR/upgrade-unmarked" unmarked; then
+                echo "$npx_install_output"
+                echo "$npx_doctor_output"
+                echo "omo-agent-toolkit --version: $omo_agent_toolkit_version_output"
+                echo "omo-agent-toolkit ulw-loop: $ulw_loop_output"
+                cd "$GITHUB_WORKSPACE"
+                rm -rf "$SMOKE_DIR"
+                return 0
+              fi
+
+              cd "$GITHUB_WORKSPACE"
+              rm -rf "$SMOKE_DIR"
+              echo "Waiting for ${package_spec} registry propagation (attempt ${attempt}/12)"
+              sleep 10
+            done
+            echo "::error::Published LazyCodex smoke failed for ${package_spec}"
+            return 1
+          }
+
+          smoke_lazycodex_package "lazycodex-ai@${OMO_VERSION}"
+          if [ -z "$DIST_TAG" ]; then
+            smoke_lazycodex_package "lazycodex-ai@latest"
+          fi
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        env:
+          JOB_SUMMARY_TITLE: Post-publish verification
+          JOB_SUMMARY_STATUS: ${{ job.status }}
+          JOB_SUMMARY_DETAILS: |
+            - Waits for omo-ai registry readiness and guards its dist-tags.
+            - Verifies the omo-ai live install and smoke-tests the published LazyCodex package.
+            - Runs after the GitHub release so propagation delays cannot strand a published release.
+          JOB_SUMMARY_NEXT: Investigate the failing registry probe; the release itself already exists.
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -45,6 +45,7 @@ const workflowExpectations = [
       "dispatch-provenance-safe-publish",
       "publish-main",
       "release",
+      "post-publish-verify",
     ],
   },
   { path: ".github/workflows/refresh-model-capabilities.yml", jobs: ["refresh"] },

--- a/script/omo-ai-publish-shape.test.ts
+++ b/script/omo-ai-publish-shape.test.ts
@@ -148,16 +148,19 @@ describe("omo-ai publish workflow shape", () => {
   })
 
   test("always runs readiness, dist-tag guard, and live verification", () => {
+    // These probes moved out of publish-main into post-publish-verify: they assert registry state that is
+    // already public once publish-main succeeds, so gating the release job on them could only strand a
+    // published release. They stay unconditional inside their new job.
     for (const name of ["Wait for omo-ai registry readiness", "Guard omo-ai dist-tags", "Verify omo-ai live install"]) {
-      const step = namedStep("publish-main", name)
+      const step = namedStep("post-publish-verify", name)
       expect(step).not.toHaveProperty("if")
       expect(step.env?.OMO_AI_VERSION).toBe("${{ needs.release-metadata.outputs.omo_ai_version }}")
       expect(step.env?.ALREADY_PUBLISHED).toBe("${{ needs.release-metadata.outputs.already_published }}")
     }
 
-    expect(namedStep("publish-main", "Wait for omo-ai registry readiness").run).toContain("npm view omo-ai@$OMO_AI_VERSION version")
-    expect(namedStep("publish-main", "Guard omo-ai dist-tags").run).toContain("0.0.0-beta.0")
-    const liveRun = namedStep("publish-main", "Verify omo-ai live install").run ?? ""
+    expect(namedStep("post-publish-verify", "Wait for omo-ai registry readiness").run).toContain("npm view omo-ai@$OMO_AI_VERSION version")
+    expect(namedStep("post-publish-verify", "Guard omo-ai dist-tags").run).toContain("0.0.0-beta.0")
+    const liveRun = namedStep("post-publish-verify", "Verify omo-ai live install").run ?? ""
     expect(liveRun).toContain('npm i -g "omo-ai@$OMO_AI_VERSION"')
     expect(liveRun).toContain("lib/node_modules/omo-ai/package.json")
     expect(liveRun).toContain('"$EXACT_PREFIX/bin/omo" --version')

--- a/script/publish-lazycodex-workflow.test.ts
+++ b/script/publish-lazycodex-workflow.test.ts
@@ -298,17 +298,19 @@ describe("LazyCodex publish workflow", () => {
     const workflow = readFileSync(publishWorkflowPath, "utf8")
     const publishIndex = workflow.indexOf("name: Publish lazycodex-ai")
     const smokeIndex = workflow.indexOf("name: Smoke test published lazycodex-ai")
-    const restoreIndex = workflow.indexOf("name: Restore package.json after lazycodex-ai publish attempt")
+    // The smoke moved out of publish-main into the post-publish-verify job, which runs after the release
+    // exists, so it is no longer bounded by the publish-main package restore step.
+    const postPublishVerifyIndex = workflow.indexOf("  post-publish-verify:")
     const smokeStep = sliceWorkflowSection(
       workflow,
       "      - name: Smoke test published lazycodex-ai",
-      "      - name: Restore package.json after lazycodex-ai publish attempt",
+      "      - name: Write job summary",
     )
 
     // #when
-    const smokeRunsAfterPublishBeforeRestore = publishIndex >= 0 &&
-      smokeIndex > publishIndex &&
-      restoreIndex > smokeIndex
+    const smokeRunsAfterPublishInPostVerifyJob = publishIndex >= 0 &&
+      postPublishVerifyIndex > publishIndex &&
+      smokeIndex > postPublishVerifyIndex
     const smokesReleaseVersion = smokeStep.includes('smoke_lazycodex_package "lazycodex-ai@${OMO_VERSION}"')
     const smokesStableLatestOnly = smokeStep.includes('if [ -z "$DIST_TAG" ]; then') &&
       smokeStep.includes('smoke_lazycodex_package "lazycodex-ai@latest"')
@@ -350,7 +352,10 @@ describe("LazyCodex publish workflow", () => {
       smokeStep.includes('if ! cmp -s "$scenario_root/omo.seeded" "$CODEX_LOCAL_BIN_DIR/omo"; then')
 
     // #then
-    expect(smokeRunsAfterPublishBeforeRestore, "post-publish smoke must run after lazycodex publish and before package restore").toBe(true)
+    expect(
+      smokeRunsAfterPublishInPostVerifyJob,
+      "post-publish smoke must run after the lazycodex publish, inside the post-publish-verify job that cannot block the release",
+    ).toBe(true)
     expect(smokesReleaseVersion, "post-publish smoke must verify the exact release version").toBe(true)
     expect(smokesStableLatestOnly, "post-publish smoke must verify latest only for stable releases").toBe(true)
     expect(retriesRegistryPropagation, "post-publish smoke must tolerate npm registry propagation").toBe(true)

--- a/script/publish-post-verify-workflow.test.ts
+++ b/script/publish-post-verify-workflow.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const workflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
+// Windows checks YAML out with CRLF; normalize once so step lookups stay platform-independent.
+const workflowText = readFileSync(workflowPath, "utf8").replace(/\r\n/g, "\n")
+
+interface Step {
+  name?: string
+  if?: string
+}
+
+interface Job {
+  needs?: string[] | string
+  if?: string
+  steps?: Step[]
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>
+}
+
+const workflow = Bun.YAML.parse(workflowText) as Workflow
+
+const POST_PUBLISH_STEPS = [
+  "Wait for omo-ai registry readiness",
+  "Guard omo-ai dist-tags",
+  "Verify omo-ai live install",
+  "Smoke test published lazycodex-ai",
+]
+
+function job(name: string): Job {
+  const found = workflow.jobs?.[name]
+  expect(found, `publish.yml must define the ${name} job`).toBeDefined()
+  return found as Job
+}
+
+function stepNames(name: string): string[] {
+  return (job(name).steps ?? []).map((step) => step.name ?? "")
+}
+
+function needsOf(name: string): string[] {
+  const needs = job(name).needs ?? []
+  return Array.isArray(needs) ? needs : [needs]
+}
+
+describe("publish post-publish verification", () => {
+  describe("#given registry propagation must not hold the release hostage", () => {
+    test("#when publish-main is inspected #then it no longer carries the post-publish verification steps", () => {
+      const names = stepNames("publish-main")
+      expect(
+        POST_PUBLISH_STEPS.filter((step) => names.includes(step)),
+        "post-publish verification must not sit between npm publish and the release job",
+      ).toEqual([])
+    })
+
+    test("#when the workflow is parsed #then post-publish-verify owns every one of those steps", () => {
+      const names = stepNames("post-publish-verify")
+      expect(POST_PUBLISH_STEPS.filter((step) => !names.includes(step))).toEqual([])
+    })
+
+    test("#when post-publish-verify is wired #then it runs after the release job", () => {
+      expect(needsOf("post-publish-verify")).toContain("release")
+    })
+
+    test("#when the release job is wired #then it never waits on post-publish-verify", () => {
+      expect(needsOf("release")).not.toContain("post-publish-verify")
+    })
+
+    test("#when post-publish-verify completes #then it writes a job summary like every other publish job", () => {
+      expect(stepNames("post-publish-verify")).toContain("Write job summary")
+    })
+  })
+
+  describe("#given pre-publish gating must stay intact", () => {
+    test("#when publish-main is inspected #then it still refuses to publish without platform packages", () => {
+      expect(stepNames("publish-main")).toContain("Verify platform packages are published")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Moves registry-dependent post-publish probes out of `publish-main` and into a dedicated
`post-publish-verify` job that runs after the GitHub release exists.

Before this PR, npm publication was followed by 202 lines of registry readiness, dist-tag, live-install and
LazyCodex smoke checks inside `publish-main`. Since `release` required `publish-main`, a propagation delay or
probe flake left packages public on npm but suppressed the GitHub release, changelog, and marketplace sync.
The probes cannot undo publication, so that was the least safe ordering.

## Combined workflow after #6935

This branch is rebased onto the merged gate-reuse workflow and preserves both contracts:

- `publish-main` needs `gate-reuse` and accepts reusable skipped gates only through #6935's fail-closed logic;
- `publish-main.outputs.lazycodex_publish_skipped` crosses the job boundary safely;
- new `post-publish-verify` needs `release` and owns all four probes;
- `release` never waits on post-publish verification;
- platform-package existence remains a hard pre-publish gate.

## Failing-first proof

`script/publish-post-verify-workflow.test.ts` was written before implementation: 4 failures / 2 control
passes because the new job did not exist and publish-main still owned the probes. It is now 6/6.

## Verification

- Combined PR2+PR3 guard set: 49 pass / 0 fail / 329 assertions across seven workflow test files.
- `actionlint .github/workflows/publish.yml`: clean.
- Bun YAML parse: 12 jobs; publish-main needs gate-reuse; post-publish-verify needs release.
- Full `script/` in the rsync-created worktree: 245 pass / 1 materialization prerequisite failure. The missing
  14 Codex `dist` payloads are generated by CI's normal `bun install`; prior PR3 CI did not fail this check.
- The prior cross-job `steps.check-lazycodex` reference was caught by actionlint and replaced with the typed
  `publish-main` job output.

## Residual risk

A release can be visible before the post-publish probes finish. The npm packages are already public at that
point under both designs; this ordering ensures users also receive release notes and marketplace metadata.
Probe failures stay red and must be investigated.

Plan: .omo/plans/publish-pipeline-hardening.md
