### PR TITLE
ci(publish): reuse successful release gates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,68 @@ permissions:
   actions: write
 
 jobs:
+  gate-reuse:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+    outputs:
+      skip_gates: ${{ steps.reuse.outputs.skip_gates }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Determine whether release gates can be reused
+        id: reuse
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREPARED_RELEASE_SHA: ${{ inputs.prepared_release_sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$PREPARED_RELEASE_SHA" ]; then
+            echo "skip_gates=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping duplicate gates on the release preparation dispatch."
+            exit 0
+          fi
+
+          CHECK_RUNS="$(gh api --method GET \
+            "repos/${{ github.repository }}/commits/${PREPARED_RELEASE_SHA}/check-runs" \
+            -f per_page=100 \
+            -f filter=latest \
+            --paginate \
+            --slurp)"
+          REQUIRED_CHECKS='["test","typecheck","codex-compatibility (ubuntu-latest)","codex-compatibility (macos-latest)","codex-compatibility (windows-latest)"]'
+
+          if jq -e --argjson required "$REQUIRED_CHECKS" '
+            [.[].check_runs[] | select(.name as $name | $required | index($name))] as $runs
+            | (($runs | map(.name) | unique | sort) == ($required | sort))
+              and ($runs | all(.conclusion == "success"))
+          ' <<< "$CHECK_RUNS" >/dev/null; then
+            echo "skip_gates=true" >> "$GITHUB_OUTPUT"
+            echo "All required release gates already succeeded on ${PREPARED_RELEASE_SHA}."
+          else
+            echo "skip_gates=false" >> "$GITHUB_OUTPUT"
+            echo "Required release gates are missing, incomplete, or unsuccessful on ${PREPARED_RELEASE_SHA}."
+          fi
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        env:
+          JOB_SUMMARY_TITLE: Release gate reuse decision
+          JOB_SUMMARY_STATUS: ${{ job.status }}
+          JOB_SUMMARY_DETAILS: |
+            - Skips duplicate gates on the preparation dispatch, which cannot publish.
+            - Reuses gates on a prepared SHA only when every required check run is successful.
+            - Fails closed when GitHub check-run state cannot be read.
+          JOB_SUMMARY_NEXT: Retry after GitHub check-run state is available, or fix any missing or unsuccessful release gate.
+        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
+
   test:
     runs-on: ubuntu-latest
+    needs: [gate-reuse]
+    if: needs.gate-reuse.outputs.skip_gates != 'true'
     steps:
       - uses: actions/checkout@v5
 
@@ -81,6 +141,8 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    needs: [gate-reuse]
+    if: needs.gate-reuse.outputs.skip_gates != 'true'
     steps:
       - uses: actions/checkout@v5
 
@@ -116,6 +178,8 @@ jobs:
 
   codex-compatibility:
     runs-on: ${{ matrix.os }}
+    needs: [gate-reuse]
+    if: needs.gate-reuse.outputs.skip_gates != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -368,13 +432,14 @@ jobs:
 
   prepare-release-state:
     runs-on: ubuntu-latest
-    needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata]
+    needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata]
     if: >-
       always() &&
       github.repository == 'code-yeongyu/oh-my-openagent' &&
-      needs.test.result == 'success' &&
-      needs.typecheck.result == 'success' &&
-      needs.codex-compatibility.result == 'success' &&
+      needs.gate-reuse.result == 'success' &&
+      contains(fromJSON('["success","skipped"]'), needs.test.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.typecheck.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.codex-compatibility.result) &&
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success'
     permissions:
@@ -583,14 +648,15 @@ jobs:
 
   publish-main:
     runs-on: ubuntu-latest
-    needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]
+    needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]
     if: >-
       always() &&
       github.repository == 'code-yeongyu/oh-my-openagent' &&
       inputs.prepared_release_sha != '' &&
-      needs.test.result == 'success' &&
-      needs.typecheck.result == 'success' &&
-      needs.codex-compatibility.result == 'success' &&
+      needs.gate-reuse.result == 'success' &&
+      contains(fromJSON('["success","skipped"]'), needs.test.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.typecheck.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.codex-compatibility.result) &&
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success' &&
       needs.prepare-release-state.result == 'success' &&
@@ -1074,15 +1140,16 @@ jobs:
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   publish-platform:
-    needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state]
+    needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state]
     if: >-
       always() &&
       github.repository == 'code-yeongyu/oh-my-openagent' &&
       inputs.prepared_release_sha != '' &&
       inputs.skip_platform != true &&
-      needs.test.result == 'success' &&
-      needs.typecheck.result == 'success' &&
-      needs.codex-compatibility.result == 'success' &&
+      needs.gate-reuse.result == 'success' &&
+      contains(fromJSON('["success","skipped"]'), needs.test.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.typecheck.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.codex-compatibility.result) &&
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success' &&
       needs.prepare-release-state.result == 'success'

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -35,6 +35,7 @@ const workflowExpectations = [
   {
     path: ".github/workflows/publish.yml",
     jobs: [
+      "gate-reuse",
       "test",
       "typecheck",
       "codex-compatibility",

--- a/script/publish-gate-reuse-workflow.test.ts
+++ b/script/publish-gate-reuse-workflow.test.ts
@@ -1,0 +1,93 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const publishWorkflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
+
+function sliceWorkflowSection(workflow: string, startMarker: string, endMarker: string): string {
+  const start = workflow.indexOf(startMarker)
+  const end = workflow.indexOf(endMarker, start)
+  if (start < 0 || end < 0 || end <= start) {
+    throw new Error(`missing workflow section between ${startMarker} and ${endMarker}`)
+  }
+  return workflow.slice(start, end)
+}
+
+function sliceWorkflowSectionToEnd(workflow: string, startMarker: string): string {
+  const start = workflow.indexOf(startMarker)
+  if (start < 0) throw new Error(`missing workflow section starting at ${startMarker}`)
+  return workflow.slice(start)
+}
+
+const skippedResultCondition = (job: string): string =>
+  `contains(fromJSON('["success","skipped"]'), needs.${job}.result)`
+
+describe("publish gate reuse", () => {
+  test("exposes a fail-closed gate reuse decision before release gates", () => {
+    const workflow = readFileSync(publishWorkflowPath, "utf8")
+    const gateReuseJob = sliceWorkflowSection(workflow, "  gate-reuse:", "  test:")
+
+    expect(gateReuseJob).toContain("runs-on: ubuntu-latest")
+    expect(gateReuseJob).toContain("skip_gates: ${{ steps.reuse.outputs.skip_gates }}")
+    expect(gateReuseJob).toContain("PREPARED_RELEASE_SHA: ${{ inputs.prepared_release_sha }}")
+    expect(gateReuseJob).toContain('if [ -z "$PREPARED_RELEASE_SHA" ]')
+    expect(gateReuseJob).toContain('echo "skip_gates=true" >> "$GITHUB_OUTPUT"')
+    expect(gateReuseJob).toContain("gh api")
+    expect(gateReuseJob).toContain("commits/${PREPARED_RELEASE_SHA}/check-runs")
+    expect(gateReuseJob).toContain("--paginate")
+    for (const checkName of [
+      "test",
+      "typecheck",
+      "codex-compatibility (ubuntu-latest)",
+      "codex-compatibility (macos-latest)",
+      "codex-compatibility (windows-latest)",
+    ]) {
+      expect(gateReuseJob).toContain(checkName)
+    }
+    expect(gateReuseJob).toContain('all(.conclusion == "success")')
+    expect(gateReuseJob).toContain("set -euo pipefail")
+    expect(gateReuseJob).not.toContain("continue-on-error")
+    expect(gateReuseJob).not.toContain("|| true")
+    expect(gateReuseJob).toContain("name: Write job summary")
+    expect(gateReuseJob).toContain(".github/scripts/write-job-summary.sh")
+  })
+
+  test("skips each release gate only when gate reuse says checks are reusable", () => {
+    const workflow = readFileSync(publishWorkflowPath, "utf8")
+    const testJob = sliceWorkflowSection(workflow, "  test:", "  typecheck:")
+    const typecheckJob = sliceWorkflowSection(workflow, "  typecheck:", "  codex-compatibility:")
+    const codexJob = sliceWorkflowSection(workflow, "  codex-compatibility:", "  preflight-trust:")
+
+    for (const job of [testJob, typecheckJob, codexJob]) {
+      expect(job).toContain("needs: [gate-reuse]")
+      expect(job).toContain("if: needs.gate-reuse.outputs.skip_gates != 'true'")
+    }
+  })
+
+  test("accepts skipped reusable gates while requiring gate-reuse itself to succeed", () => {
+    const workflow = readFileSync(publishWorkflowPath, "utf8")
+    const prepareJob = sliceWorkflowSection(workflow, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
+    const publishMainJob = sliceWorkflowSection(workflow, "  publish-main:", "  publish-platform:")
+    const publishPlatformJob = sliceWorkflowSection(workflow, "  publish-platform:", "  release:")
+
+    for (const job of [prepareJob, publishMainJob, publishPlatformJob]) {
+      expect(job).toContain("gate-reuse")
+      expect(job).toContain("needs.gate-reuse.result == 'success'")
+      expect(job).toContain(skippedResultCondition("test"))
+      expect(job).toContain(skippedResultCondition("typecheck"))
+      expect(job).toContain(skippedResultCondition("codex-compatibility"))
+    }
+  })
+
+  test("keeps every publication surface pinned to a prepared release SHA", () => {
+    const workflow = readFileSync(publishWorkflowPath, "utf8")
+    const publishMainJob = sliceWorkflowSection(workflow, "  publish-main:", "  publish-platform:")
+    const publishPlatformJob = sliceWorkflowSection(workflow, "  publish-platform:", "  release:")
+    const releaseJob = sliceWorkflowSectionToEnd(workflow, "  release:")
+
+    expect(publishMainJob).toContain("inputs.prepared_release_sha != ''")
+    expect(publishPlatformJob).toContain("inputs.prepared_release_sha != ''")
+    expect(releaseJob).toContain("inputs.prepared_release_sha != ''")
+  })
+})

--- a/script/publish-release-platform-workflow.test.ts
+++ b/script/publish-release-platform-workflow.test.ts
@@ -31,7 +31,7 @@ describe("release and platform publish workflows", () => {
     const platformUsesMetadata = workflow.includes("version: ${{ needs.release-metadata.outputs.version }}") &&
       workflow.includes("dist_tag: ${{ needs.release-metadata.outputs.dist_tag }}")
     const mainWaitsForPlatform = workflow.includes(
-      "needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
+      "needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
     ) &&
       workflow.includes("inputs.skip_platform == true || needs.publish-platform.result == 'success'")
     const releaseUsesMetadata = workflow.includes("VERSION: ${{ needs.release-metadata.outputs.version }}")

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -172,14 +172,14 @@ describe("test workflows", () => {
     const runsCodexCommand = codexCompatibilityJob.includes("run: bun run test:codex")
     const publishMainNeedsCodex =
       workflow.includes(
-        "needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
+        "needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
       ) &&
-      workflow.includes("needs.codex-compatibility.result == 'success'")
+      workflow.includes("contains(fromJSON('[\"success\",\"skipped\"]'), needs.codex-compatibility.result)")
     const publishPlatformNeedsCodex =
       workflow.includes(
-        "needs: [test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state]",
+        "needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state]",
       ) &&
-      workflow.includes("needs.codex-compatibility.result == 'success'")
+      workflow.includes("contains(fromJSON('[\"success\",\"skipped\"]'), needs.codex-compatibility.result)")
 
     // #then
     expect(hasCodexMatrixJob, "publish workflow must expose a Codex compatibility job").toBe(true)


### PR DESCRIPTION
## Summary

Removes one full duplicate release gate matrix and safely reuses already-green checks on retries.

The first publish dispatch cannot publish anything: `publish-main`, `publish-platform`, and `release` all
require `inputs.prepared_release_sha != ''`. Its only purpose is to create/merge the release-state PR and
redispatch the exact prepared SHA. Running test, typecheck, and the three-OS Codex matrix before that PR's own
required checks was therefore duplicate work.

This PR adds a fail-closed `gate-reuse` job:

- first dispatch (`prepared_release_sha == ''`) -> skips the three duplicate gate jobs;
- prepared-SHA dispatch -> queries check-runs for that exact SHA and skips only when `test`, `typecheck`, and
  all three Codex matrix checks are already successful;
- missing, pending, failed, or API-error evidence -> gates run normally / publication stays blocked.

Downstream jobs accept `skipped` only when `gate-reuse` itself succeeded. Every publication surface remains
pinned to `prepared_release_sha != ''`; preflight trust, release-state merge, platform-package existence, and
provenance constraints are unchanged.

## Failing-first proof

`script/publish-gate-reuse-workflow.test.ts` was added before the workflow implementation and failed because
`gate-reuse` did not exist, the gates had no reuse condition, and downstream jobs rejected skipped results.
After implementation all four contract tests pass.

## Verification

- Focused workflow guards: 30 pass / 0 fail / 210 assertions.
- `actionlint .github/workflows/publish.yml`: clean.
- Bun YAML parse: 11 jobs including `gate-reuse`.
- All existing exact `needs:` / publication-SHA / job-summary pins updated in lockstep.

## Dependency

PR #6920 removes the file:LINE command-audit fragility that otherwise makes any publish.yml line movement
fail the root suite. Rebase this PR onto dev after #6920 merges; do not add another line-pin bump here.

Plan: .omo/plans/publish-pipeline-hardening.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses successful release gates in `publish.yml` to remove duplicate work and keep publication fail-closed. Previously `test`, `typecheck`, and the three-OS Codex matrix ran before and after release-state preparation; now the prep dispatch skips them and retries reuse green checks on the prepared SHA.

- Adds a `gate-reuse` job that reads GitHub check runs for the prepared SHA and outputs `skip_gates`.
- First dispatch (no prepared SHA): skips `test`, `typecheck`, and `codex-compatibility`.
- Prepared-SHA dispatch: skips those gates only when all required check runs are successful; otherwise runs them.
- `prepare-release-state`, `publish-main`, and `publish-platform` accept skipped gates only when `gate-reuse` succeeded; all publication paths still require `inputs.prepared_release_sha != ''`.
- Fails closed when check-run state is missing, pending, failed, or unreadable.
- Adds contract tests for reuse behavior; updates workflow assertions; keeps `actionlint` and YAML validation clean.

**Rollout**
- Required: merge PR #6920 first, then rebase on `dev`.
- No caller changes; retries on a prepared SHA automatically reuse existing green checks.

<sup>Written for commit f057c7e943834feb18225469f86f00b6524c84ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

