### PR TITLE
docs(release): document failed publish recovery

### DIFF
--- a/docs/reference/release-process.md
+++ b/docs/reference/release-process.md
@@ -16,6 +16,44 @@ CI green is required for release readiness, but CI does not replace manual verif
 
 For the `omo-ai` package (the senpi-native edition, beta channel only), see the [omo-ai publishing runbook](./omo-ai-publishing.md): bootstrap state, the beta-gate mechanism, the Trusted Publisher merge gate, and the first-beta-release checklist.
 
+## Resuming a Failed Publish
+
+For a transient failure, retry only the failed jobs and their dependencies:
+
+```bash
+gh run rerun --failed <run-id>
+```
+
+A rerun keeps the original workflow revision, dispatch SHA, and inputs. Use a fresh dispatch instead when the correction must change any of those values, such as a workflow or source fix merged after the failed run, an incorrect version or bump, or different `skip_platform` or `publish_lazycodex` inputs. Before a release-state commit or tag exists, a fresh dispatch is also the clean recovery when replacing the failed attempt because no durable release identity exists yet. Do not pass `prepared_release_sha`; that input is internal to the workflow's second dispatch.
+
+For example, a new explicit-version attempt is dispatched from `dev` with all intended public inputs:
+
+```bash
+gh workflow run publish.yml --ref dev \
+  -f bump=patch \
+  -f version=<version> \
+  -f skip_platform=false \
+  -f publish_lazycodex=true
+```
+
+A failure before release state exists may still be rerun when it is purely transient and the original SHA and inputs remain correct. Once the workflow has created a `release: v<version>` commit, a `v<version>` tag, or any npm publication, resume the existing attempt rather than starting another one. The existing run is safe to resume because `publish.yml` has these explicit idempotency guards:
+
+- `prepare-release-state` / `Prepare and merge release state before publishing` returns the SHA from an existing `refs/tags/v${VERSION}` tag, or reuses an existing `release: v${VERSION}` commit on the base branch, before attempting to stamp another release.
+- `dispatch-provenance-safe-publish` / `Tag prepared source and dispatch provenance-safe publish` reuses an existing tag only when it resolves to the prepared release SHA. It fails closed when the tag points to any other SHA.
+- `publish-platform` delegates platform publication to `publish-platform.yml`, whose `Check if already published` steps probe both platform package families and skip versions already present in npm.
+- `publish-main` / `Check if already published`, `Check if oh-my-openagent already published`, and `Check if lazycodex-ai already published` probe npm and gate each corresponding publish step with the probe's `skip` output.
+- `release-metadata` / `Calculate omo-ai metadata` exposes `already_published`; `publish-main` gates the omo-ai build and `Publish omo-ai (beta only)` step when that immutable version already exists.
+- `release` / `Sync LazyCodex Codex marketplace` checks the staged marketplace payload with `git diff --cached --quiet` and does not commit or push when it is unchanged. `Create LazyCodex GitHub release` and `Create GitHub release` likewise view an existing release before creating one.
+
+The workflow uses two dispatches. The first run has an empty `prepared_release_sha`; it runs the gates, prepares or reuses release state, creates or validates the tag, and dispatches a second run from that tag. The second run carries the exact prepared SHA in `prepared_release_sha`; only this run can execute `publish-platform`, `publish-main`, and `release`.
+
+Rerun the run that owns the failed work:
+
+- If preparation, tagging, or the provenance-safe follow-up dispatch failed, rerun the first run's ID.
+- If a platform package, wrapper package, omo-ai publication, marketplace sync, or GitHub release failed, rerun the second, prepared-SHA run's ID. Rerunning the first run would target the dispatcher, not the failed publishing jobs.
+
+Never hand-publish an npm package or hand-create or move a release tag to work around a failed run. Never use `--admin`, disable required checks, or otherwise bypass a red check. Fix the failed gate, then use the appropriate rerun or fresh dispatch path above.
+
 ## Post-Fix Repro Verification
 
 Race-condition and concurrency fixes must include reporter-verified repro confirmation before the originating issue is closed. CI green is necessary but not sufficient for this class of fix.

--- a/script/publish-resume-idempotency.test.ts
+++ b/script/publish-resume-idempotency.test.ts
@@ -1,0 +1,137 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const publishWorkflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
+
+export const resumeGuardFindings = {
+  prepareExistingTagReuse: "prepare-release-state must reuse an existing release tag",
+  prepareExistingCommitReuse: "prepare-release-state must reuse an existing release commit",
+  dispatchTagShaMismatchRefusal: "dispatch-provenance-safe-publish must reject an existing tag at a different SHA",
+  ohMyOpencodePublishedProbe: "publish-main must skip an already-published oh-my-opencode version",
+  ohMyOpenagentPublishedProbe: "publish-main must skip an already-published oh-my-openagent version",
+  lazycodexPublishedProbe: "publish-main must skip an already-published lazycodex-ai version",
+  omoAiPublishedMetadata: "release-metadata must expose whether omo-ai is already published",
+  marketplaceUnchangedNoOp: "release must leave an unchanged LazyCodex marketplace untouched",
+  preparedShaDispatchRouting: "the prepared SHA must select and pin the provenance-bearing publish run",
+} as const
+
+function section(workflowText: string, startMarker: string, endMarker?: string): string {
+  const start = workflowText.indexOf(startMarker)
+  const end = endMarker === undefined ? workflowText.length : workflowText.indexOf(endMarker, start)
+  if (start < 0 || end < 0 || end <= start) return ""
+  return workflowText.slice(start, end)
+}
+
+function hasAll(text: string, required: readonly string[]): boolean {
+  return required.every((value) => text.includes(value))
+}
+
+export function assertResumeGuards(workflowText: string): string[] {
+  const findings: string[] = []
+  const releaseMetadata = section(workflowText, "  release-metadata:", "  prepare-release-state:")
+  const prepareReleaseState = section(workflowText, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
+  const prepareTagReuse = section(
+    prepareReleaseState,
+    '          if git rev-parse -q --verify "refs/tags/v${VERSION}"',
+    '          RELEASE_SHA="$(git rev-list --max-count=1 --grep=',
+  )
+  const prepareCommitReuse = section(
+    prepareReleaseState,
+    '          RELEASE_SHA="$(git rev-list --max-count=1 --grep=',
+    '          git checkout -B "$RELEASE_BRANCH"',
+  )
+  const dispatchPublish = section(workflowText, "  dispatch-provenance-safe-publish:", "  publish-main:")
+  const dispatchExistingTag = section(
+    dispatchPublish,
+    '          if git rev-parse -q --verify "refs/tags/v${VERSION}"',
+    "          else\n            git tag",
+  )
+  const publishMain = section(workflowText, "  publish-main:", "  publish-platform:")
+  const opencodeProbe = section(publishMain, "      - name: Check if already published", "      - name: Check if oh-my-openagent already published")
+  const openagentProbe = section(publishMain, "      - name: Check if oh-my-openagent already published", "      - name: Check if lazycodex-ai already published")
+  const lazycodexProbe = section(publishMain, "      - name: Check if lazycodex-ai already published", "      - name: Update version")
+  const omoAiMetadata = section(releaseMetadata, "      - name: Calculate omo-ai metadata", "      - name: Write job summary")
+  const release = section(workflowText, "  release:")
+  const marketplaceSync = section(release, "      - name: Sync LazyCodex Codex marketplace", "      - name: Resolve LazyCodex release payload")
+
+  if (!hasAll(prepareTagReuse, [
+    'git rev-parse -q --verify "refs/tags/v${VERSION}"',
+    'RELEASE_SHA="$(git rev-list --max-count=1 "refs/tags/v${VERSION}")"',
+    'echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"',
+    'echo "Release tag v${VERSION} already exists locally at ${RELEASE_SHA}"',
+    "exit 0",
+  ])) findings.push(resumeGuardFindings.prepareExistingTagReuse)
+
+  if (!hasAll(prepareCommitReuse, [
+    'git rev-list --max-count=1 --grep="^release: v${VERSION}$" "origin/${BASE_REF}"',
+    'echo "Release commit already exists on origin/${BASE_REF}: ${RELEASE_SHA}"',
+    "if [ -n \"$RELEASE_SHA\" ]; then",
+    "exit 0",
+  ])) findings.push(resumeGuardFindings.prepareExistingCommitReuse)
+
+  if (!hasAll(dispatchExistingTag, [
+    'if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then',
+    'echo "::error::Existing tag v${VERSION} points to ${TAG_SHA}, not prepared release SHA ${RELEASE_SHA}."',
+    "exit 1",
+  ])) findings.push(resumeGuardFindings.dispatchTagShaMismatchRefusal)
+
+  const packageProbes = [
+    [resumeGuardFindings.ohMyOpencodePublishedProbe, opencodeProbe, "id: check", "https://registry.npmjs.org/oh-my-opencode/${VERSION}", "if: steps.check.outputs.skip != 'true'"],
+    [resumeGuardFindings.ohMyOpenagentPublishedProbe, openagentProbe, "id: check-openagent", "https://registry.npmjs.org/oh-my-openagent/${VERSION}", "if: steps.check-openagent.outputs.skip != 'true'"],
+    [resumeGuardFindings.lazycodexPublishedProbe, lazycodexProbe, "id: check-lazycodex", "https://registry.npmjs.org/lazycodex-ai/${VERSION}", "steps.check-lazycodex.outputs.skip != 'true'"],
+  ] as const
+  for (const [finding, probe, stepId, registryUrl, publishCondition] of packageProbes) {
+    if (!hasAll(probe, [stepId, registryUrl, 'echo "skip=true" >> "$GITHUB_OUTPUT"']) || !publishMain.includes(publishCondition)) {
+      findings.push(finding)
+    }
+  }
+
+  if (!releaseMetadata.includes("already_published: ${{ steps.omo-ai.outputs.already_published }}") || !hasAll(omoAiMetadata, [
+    'https://registry.npmjs.org/omo-ai/${OMO_AI_VERSION}',
+    'echo "already_published=true" >> "$GITHUB_OUTPUT"',
+    'echo "already_published=false" >> "$GITHUB_OUTPUT"',
+  ]) || !publishMain.includes("if: needs.release-metadata.outputs.already_published != 'true'")) {
+    findings.push(resumeGuardFindings.omoAiPublishedMetadata)
+  }
+
+  if (!hasAll(marketplaceSync, [
+    "if git diff --cached --quiet; then",
+    'echo "LazyCodex marketplace already up to date"',
+    "else",
+    'git push origin HEAD:main',
+  ])) findings.push(resumeGuardFindings.marketplaceUnchangedNoOp)
+
+  if (!hasAll(workflowText, [
+    "prepared_release_sha:",
+    "inputs.prepared_release_sha == ''",
+    "inputs.prepared_release_sha != ''",
+    'gh workflow run publish.yml --ref "v${VERSION}"',
+    '-f "prepared_release_sha=${RELEASE_SHA}"',
+    'if [ "$PREPARED_RELEASE_SHA" != "$GITHUB_SHA" ]; then',
+  ])) findings.push(resumeGuardFindings.preparedShaDispatchRouting)
+
+  return findings
+}
+
+describe("publish resume idempotency", () => {
+  test("keeps every resumability guard in the real publish workflow", () => {
+    const workflowText = readFileSync(publishWorkflowPath, "utf8")
+
+    expect(assertResumeGuards(workflowText)).toEqual([])
+  })
+
+  test("reports the exact guard removed by an in-memory mutation", () => {
+    const workflowText = readFileSync(publishWorkflowPath, "utf8")
+    const mutatedWorkflow = workflowText.replace(
+      'if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then',
+      'if false; then # mutation: mismatch refusal removed',
+    )
+
+    expect(mutatedWorkflow).not.toBe(workflowText)
+    expect(assertResumeGuards(mutatedWorkflow)).toEqual([
+      resumeGuardFindings.dispatchTagShaMismatchRefusal,
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Documents the exact safe recovery path for a failed publish and pins every workflow guard that makes
failed-jobs-only reruns safe.

The publish workflow is already substantially idempotent, but that contract was implicit. The new runbook
section tells release operators which run in the two-dispatch chain to rerun, when
`gh run rerun --failed <run-id>` is safe, when a fresh dispatch is required, and why hand-publishing,
hand-tagging, `--admin`, or check bypasses are forbidden.

`script/publish-resume-idempotency.test.ts` pins the mechanisms the runbook relies on:

- existing release tag reuse and tag/SHA mismatch refusal;
- existing `release: vX.Y.Z` commit reuse;
- per-package npm already-published probes;
- omo-ai `already_published` metadata;
- unchanged LazyCodex marketplace no-op path.

The checker is a pure function over workflow text, and an in-memory mutation test proves it names the exact
missing guard rather than merely passing on the current file.

## Verification

- Focused guard: 2 pass / 0 fail / 3 assertions.
- Full `bun test script/`: 234 pass / 0 fail / 919 assertions.
- Every runbook statement cross-checked against the current publish.yml step names and control flow.

Plan: .omo/plans/publish-pipeline-hardening.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the safe recovery path for a failed publish and adds a test that pins `publish.yml`’s resume-idempotency guards. This makes implicit behavior explicit and prevents unsafe manual recovery.

- Clarifies when to rerun failed jobs vs dispatch a fresh publish, which run to rerun in the two-dispatch chain, and forbids manual npm publishes, tag moves, `--admin`, or check bypasses.
- Adds `script/publish-resume-idempotency.test.ts` to assert guards in `publish.yml`: existing tag reuse and SHA-mismatch refusal; reuse of existing `release: vX.Y.Z` commits; npm already-published probes for `oh-my-opencode`, `oh-my-openagent`, and `lazycodex-ai`; `omo-ai` `already_published` gating; LazyCodex marketplace no-op on unchanged payload; prepared-SHA dispatch routing.
- No workflow changes; this PR updates docs and introduces guard-pinning tests.

<sup>Written for commit 4c4553fd79a4379bd9f26f7298ff13c46f26928a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

