### PR TITLE
docs(shared-skills): pin insane-search upstream policy

### DIFF
--- a/.omo/evidence/20260817-insane-search-version-policy/QA.txt
+++ b/.omo/evidence/20260817-insane-search-version-policy/QA.txt
@@ -1,0 +1,48 @@
+WHAT WAS TESTED
+
+1. Pre-change provenance/policy surface (RED)
+   - Commands: rg over ATTRIBUTION.md for project-original/no-vendor wording; rg over engine/AGENTS.md for policy anchors.
+   - Behavior proved: the repository incorrectly classified engine/** as project-original and carried no upstream/version policy.
+   - Artifact: red-pre-change.txt
+
+2. Post-change provenance/policy surface (GREEN)
+   - Commands: rg for fivetaku/insane-search, a4e4ed797, pre-0.7.0, the six policy anchors, and the parent AGENTS.md link; git diff --check.
+   - Behavior proved: the engine is now accurately attributed and future sync work is governed by pin/KEEP/WANT/OUT-OF-SCOPE/sync rules.
+   - Artifact: green-post-change.txt
+
+3. Shared-skills machine-consumed gates
+   - Command: npm exec --yes --package=bun@1.3.12 -- bun test packages/shared-skills
+   - Behavior proved: packaging, de-personalization, upstream provenance, runtime pins, root-path resolution, materialization, and all adjacent shared-skills tests remain green.
+   - Artifact: shared-skills-tests.txt; post-rebase-verification.txt
+
+4. CI failure recovery after `dev` advanced
+   - Commands: compare the failed PR job with successful base CI; rebase onto `origin/dev`; run the shared-skills scope and `task-rpc-launch-parity.test.ts` under Bun 1.3.12.
+   - Behavior proved: the unrelated full-suite RPC failure was fixed by the base branch's per-process XDG isolation and does not reproduce on the rebased branch.
+   - Artifact: post-rebase-verification.txt
+
+WHAT WAS OBSERVED
+
+- RED: ATTRIBUTION.md placed engine/** under "Project-original content (no third-party source vendored)"; engine/AGENTS.md policy-anchor rg returned rc=1.
+- GREEN: ATTRIBUTION.md names https://github.com/fivetaku/insane-search, vendoring commit a4e4ed797, and the corrected 2026-06-21 pre-0.7.0 baseline. engine/AGENTS.md contains all six required policy anchors. Parent packages/shared-skills/AGENTS.md links to the policy.
+- Initial tests: 77 passed, 0 failed, 586 expect() calls across 14 files under Bun 1.3.12.
+- Rebased tests: shared-skills 81 passed, 0 failed, 593 expect() calls across 15 files; RPC parity 2 passed, 0 failed.
+- Evidence-bound rebased source tree: 3a193c39b7ba1696203f5e5866f7dd70534691a8
+
+WHY IT IS ENOUGH
+
+- This is a prose/knowledge-base correction, not runtime code. The faithful user-visible surface is the repository guidance that future agents read. RED/GREEN read-through proves the exact stale fact and missing policy changed.
+- The shared-skills suite exercises every machine consumer affected by these files, including the de-personalization and provenance gates. No OpenCode or Codex runtime hook/tool/feature/config component changed, so harness QA would not exercise a changed behavior.
+- Live upstream verification on 2026-08-17 showed main/HEAD remains 019ee16bbf471595f9b67b164e4a92208183af2d, and the upstream CHANGELOG dates 0.7.0 to 2026-06-22; therefore the 2026-06-21 imported snapshot is correctly labeled pre-0.7.0.
+- The failed Ubuntu root job named only `task-rpc-launch-parity.test.ts`, a file this PR does not touch. The identical test passed on base SHA `04ccd5943` and locally in isolation. Rebasing onto `dev` brought in `3b00103ff` (`test: isolate XDG data and cache dirs per test process`), after which both relevant scopes passed. This is the distinguishing evidence for full-suite environment contamination rather than a documentation regression.
+
+WHAT WAS OMITTED
+
+- No credentials, auth headers, environment dumps, private logs, or user data were captured.
+- The raw 340 KB source session transcript was not copied into evidence; only its verified, repository-relevant findings were recorded.
+- The first test attempt failed before collection because the fresh worktree lacked node_modules. It is retained as shared-skills-tests-setup-failure.txt for auditability; dependencies were then installed from the frozen lockfile with Bun 1.3.12 and the identical test scope passed.
+
+CLEANUP RECEIPT
+
+- Temporary upstream CHANGELOG file removed immediately after parsing (verified absent).
+- Dependency-install background session bash_4 exited 0; no server, tmux session, browser context, container, socket, or bound port was created.
+- Postinstall-generated tracked files outside this change were restored; git status contains only the intended documentation files before evidence staging.

--- a/.omo/evidence/20260817-insane-search-version-policy/green-post-change.txt
+++ b/.omo/evidence/20260817-insane-search-version-policy/green-post-change.txt
@@ -1,0 +1,42 @@
+# GREEN capture - post-change state
+Captured: 2026-08-17T11:48:23.103941+00:00
+Worktree HEAD: 04ccd594314cd7cdcc58e3f4fb2c8471b2c2ed5c
+Upstream HEAD verified: 019ee16bbf471595f9b67b164e4a92208183af2d
+Baseline correction: vendored 2026-06-21; upstream 0.7.0 dated 2026-06-22, therefore pre-0.7.0.
+
+$ rg -n 'project-original|no third-party source vendored|fivetaku/insane-search|a4e4ed797|pre-0\.7\.0' packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
+rc=0
+4:project-original content, one vendored-and-modified upstream engine, plus two
+13:project-original code, despite being heavily modified since import.
+15:- Upstream source: https://github.com/fivetaku/insane-search
+17:  **`a4e4ed797`** (`feat(ultimate-browsing): vendor insane-search engine (junk-excluded)`),
+19:- Baseline: the upstream state as of that date, a **pre-0.7.0 snapshot**.
+30:  project-original licensing from that absence; treat `engine/**` as
+39:## 2. Project-original content (no third-party source vendored)
+
+
+$ rg -n 'UPSTREAM BASELINE AND VERSION POLICY|Why we do not blind-rebase|### KEEP|### WANT|### OUT OF SCOPE|### THE SYNC RULE|pre-0\.7\.0' packages/shared-skills/skills/ultimate-browsing/engine/AGENTS.md
+rc=0
+5:## UPSTREAM BASELINE AND VERSION POLICY
+20:| Pinned upstream baseline | upstream state as of 2026-06-21, **pre-0.7.0** (0.7.0 is dated 2026-06-22) |
+28:### Why we do not blind-rebase onto upstream HEAD
+47:### KEEP — our divergences a re-vendor MUST NOT regress
+70:### WANT — upstream improvements worth porting forward
+90:### OUT OF SCOPE
+101:### THE SYNC RULE
+
+
+$ rg -n 'deliberately pinned|upstream-baseline-and-version-policy' packages/shared-skills/AGENTS.md
+rc=0
+13:`ultimate-browsing` is the one skill carrying a real sub-project: `skills/ultimate-browsing/engine/` is a 17-module Python package with its own CLI, config schemas, and test suite. It is a deliberately pinned, locally diverged snapshot of `fivetaku/insane-search`, not a follow-HEAD mirror. Before changing or re-vendoring it, read [`skills/ultimate-browsing/engine/AGENTS.md` §UPSTREAM BASELINE AND VERSION POLICY](skills/ultimate-browsing/engine/AGENTS.md#upstream-baseline-and-version-policy).
+
+
+$ git diff --check
+rc=0
+
+Evidence-bound staged tree: 42189ed4dc6aecbe5407aa381d37150bbc65fbd5
+
+Post-rebase verification:
+- Rebased onto origin/dev at 105258b24, including per-process XDG test isolation commit 3b00103ff.
+- Policy anchors remained byte-identical.
+- Evidence-bound rebased source tree: 3a193c39b7ba1696203f5e5866f7dd70534691a8

--- a/.omo/evidence/20260817-insane-search-version-policy/post-rebase-verification.txt
+++ b/.omo/evidence/20260817-insane-search-version-policy/post-rebase-verification.txt
@@ -1,0 +1,30 @@
+POST-REBASE VERIFICATION
+Captured: 2026-08-17
+
+CI failure signature
+- PR run/job: 32027787657 / 95380750909
+- Failing test: task RPC launch profile parity > explicit provider extension model visibility
+- Error: process model admission failed for omo-mock/mock-1: model is not visible in the child profile
+- PR files: AGENTS.md, ATTRIBUTION.md, and evidence text only; no task/RPC/runtime file changed.
+
+Distinguishing evidence
+- Base SHA 04ccd5943 Ubuntu job 95372177918: identical RPC parity test passed (2/2).
+- Local branch before rebase: identical RPC parity test passed in isolation (2/2).
+- origin/dev advanced by 11 commits and included 3b00103ff:
+  test: isolate XDG data and cache dirs per test process
+- Diagnosis: full-suite cross-process environment contamination, not the documentation change.
+
+Rebase
+- Command: git rebase origin/dev
+- Result: success, no conflicts.
+- Rebased base: origin/dev 105258b24.
+- Divergence after rebase: 2 ahead, 0 behind.
+
+Verification under CI Bun
+- Command: npm exec --yes --package=bun@1.3.12 -- bun test packages/shared-skills
+- Result: 81 pass, 0 fail, 593 expect() calls across 15 files.
+- Command: npm exec --yes --package=bun@1.3.12 -- bun test packages/omo-senpi/src/components/task/task-rpc-launch-parity.test.ts
+- Result: 2 pass, 0 fail, 2 expect() calls.
+
+Evidence-bound rebased source tree
+3a193c39b7ba1696203f5e5866f7dd70534691a8

--- a/.omo/evidence/20260817-insane-search-version-policy/red-pre-change.txt
+++ b/.omo/evidence/20260817-insane-search-version-policy/red-pre-change.txt
@@ -1,0 +1,36 @@
+# RED capture - pre-change state
+Captured: 2026-08-17T20:28:09.353087
+Worktree HEAD: 04ccd594314cd7cdcc58e3f4fb2c8471b2c2ed5c
+
+$ rg -n 'project-original|no third-party source vendored' packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
+rc=0 (rg rc=1 means NO MATCH)
+4:project-original content plus two third-party tools that it installs at runtime
+10:## 1. Project-original content (no third-party source vendored)
+
+
+$ rg -n -A3 '^- .engine/\*\*' packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
+rc=0 (rg rc=1 means NO MATCH)
+15:- `engine/**` — the insane-search Tier-1 fetch engine (curl_cffi grid, WAF
+16-  detection, Playwright fallback templates, `bias_check.py` no-site-name gate).
+17-- `references/insane-search/**` and `references/agent-reach/**` — the Tier-1 and
+18-  Tier-1.5 reference docs.
+
+
+$ rg -n 'fivetaku|insane-search' packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
+rc=0 (rg rc=1 means NO MATCH)
+15:- `engine/**` — the insane-search Tier-1 fetch engine (curl_cffi grid, WAF
+17:- `references/insane-search/**` and `references/agent-reach/**` — the Tier-1 and
+
+
+$ rg -n -i 'UPSTREAM BASELINE|VERSION POLICY|KEEP LIST|WANT LIST|do not blind-rebase|re-vendor' packages/shared-skills/skills/ultimate-browsing/engine/AGENTS.md
+rc=1 (rg rc=1 means NO MATCH)
+
+
+$ rg -n -i 'upstream|version policy' packages/shared-skills/AGENTS.md
+rc=0 (rg rc=1 means NO MATCH)
+38:The `frontend` skill's brand / taste-skill / ui-ux-db / designpowers references are third-party content. Under the DMCA-safe model the repo holds ZERO committed copies; each upstream is a pinned git submodule under `upstreams/<name>` (NOT under `skills/`, so it never lands in the tarball), and the build materializes the referenced files path-mapped into `skills/frontend/references/{design,ui-ux-db,designpowers/vendor}`. File bodies are copied verbatim, except materialized `SKILL.md` frontmatter may normalize an unquoted single-line `description:` scalar into a JSON-quoted YAML string so Codex/OpenCode frontmatter parsing stays deterministic; the description text itself is unchanged.
+41:upstreams/{open-design,taste-skill,ui-ux-pro-max,designpowers}   # pinned submodules (provenance, build input)
+42:  └─ packages/shared-skills/scripts/frontend-refs-manifest.mjs   # single source of truth: partition + upstream path map
+44:            └─ chokepoint: packages/omo-codex/plugin/scripts/materialize-shared-upstreams.mjs  (submodule init + materialize)
+51:- ATTRIBUTION pins each upstream's SHA (`Pinned upstream commit:`); `script/update-frontend-upstreams.mjs` bumps the submodules + rewrites the pins (`--check` verifies pins == submodule HEAD, no network). `provenance-gate.test.ts` fails CI if any third-party path is committed, the materialize set is missing, or a pin drifts. `materialize-frontend-refs.test.ts` covers the allowed `SKILL.md` description quoting normalization.
+66:- **Skill CONTENT is PROSE — do NOT pin its wording with a test.** A skill body is instructions the model reads; asserting what it *says* (`toContain` a sentence, `not.toContain` old wording, word/char counts) guards a diff, not behavior, and blocks every legitimate edit — see `.omo/rules/test-discipline.md` §PROMPT TESTS. Guard only what a MACHINE consumes: packaging (`omo-opencode/src/shared-skills-package.test.ts`, above), personal-token scrubbing (`depersonalization-gate.test.ts` — a security exclusion), the third-party manifest (`frontend-thirdparty-manifest.test.ts`), the root-path probe (`shared-skills-root-path.test.ts`), and `upstreams.test.ts`. A pure-prose skill edit ships on review with NO new test; the prose-pinning contract tests that used to sit here were removed as pretend-coverage.

--- a/.omo/evidence/20260817-insane-search-version-policy/shared-skills-tests-setup-failure.txt
+++ b/.omo/evidence/20260817-insane-search-version-policy/shared-skills-tests-setup-failure.txt
@@ -1,0 +1,105 @@
+bun test v1.4.0-canary.1 (b58cd4685)
+
+packages/shared-skills/materialize-frontend-refs.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+error: Cannot find module '@opencode-ai/sdk' from '/Volumes/mengmotaStorage/local-workspaces/omo-wt/docs-insane-search-version-policy/packages/omo-opencode/src/shared/live-server-route.ts'
+-------------------------------
+
+
+packages/shared-skills/upstreams.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/depersonalization-gate.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/ultimate-browsing-runtime-pins.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/provenance-gate.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/frontend-thirdparty-manifest.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/shared-skills-root-path.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/skills/visual-qa/scripts/png-decode.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/skills/visual-qa/scripts/tui-grid.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/skills/visual-qa/scripts/east-asian-width.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/skills/visual-qa/scripts/ansi.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/skills/visual-qa/scripts/image-diff.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/skills/visual-qa/scripts/cli.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+-------------------------------
+
+
+ 0 pass
+ 14 fail
+ 14 errors
+Ran 14 tests across 14 files. [24.00ms]

--- a/.omo/evidence/20260817-insane-search-version-policy/shared-skills-tests.txt
+++ b/.omo/evidence/20260817-insane-search-version-policy/shared-skills-tests.txt
@@ -1,0 +1,116 @@
+bun test v1.3.12 (700fc117)
+
+packages/shared-skills/materialize-frontend-refs.test.ts:
+[materialize] wrote 148 frontend reference files from submodules
+(pass) materialize-frontend-refs > materializes the full third-party reference set when submodules are present [1.08ms]
+(pass) materialize-frontend-refs > reproduces every brand design file and the ui-ux-db scripts [0.19ms]
+(pass) materialize-frontend-refs > materializes the designpowers reference corpus [0.29ms]
+(pass) materialize-frontend-refs > materialized designpowers skills have YAML-safe frontmatter [4.45ms]
+(pass) materialize-frontend-refs > materializes designpowers skills as references instead of nested skill entrypoints [0.28ms]
+(pass) materialize-frontend-refs > recognizes upstream skill sources across platform path separators [0.08ms]
+(pass) materialize-frontend-refs > materializes every taste-skill artifact byte-identical to its upstream source [0.19ms]
+(pass) materialize-frontend-refs > materialized brand reference is verbatim upstream content [0.19ms]
+(pass) materialize-frontend-refs > missing submodule is a soft skip in non-strict mode [0.09ms]
+
+packages/shared-skills/upstreams.test.ts:
+(pass) frontend upstream provenance submodules > declares all 4 frontend content upstreams [0.12ms]
+(pass) frontend upstream provenance submodules > every submodule path is under packages/shared-skills/upstreams/ [0.07ms]
+(pass) frontend upstream provenance submodules > no submodule path references a skills/ directory [0.10ms]
+
+packages/shared-skills/depersonalization-gate.test.ts:
+(pass) #given the vendored shared skills #when the de-personalization gate runs > #then the cleaned ultimate-browsing + ulw-research tree has zero violations [19.20ms]
+(pass) #given the vendored shared skills #when the de-personalization gate runs > #then a planted personal token (jobdori) is caught [1.24ms]
+(pass) #given the vendored shared skills #when the de-personalization gate runs > #then a credential literal and home path are caught but a kept tier name is not [0.44ms]
+
+packages/shared-skills/ultimate-browsing-runtime-pins.test.ts:
+(pass) ultimate-browsing Tier-2 runtime pins > #given the CloakBrowser pin > #then ATTRIBUTION.md pins the expected version [0.35ms]
+(pass) ultimate-browsing Tier-2 runtime pins > #given the CloakBrowser pin > #then every chrome-stealth.md occurrence uses the same version [0.14ms]
+(pass) ultimate-browsing Tier-2 runtime pins > #given the agent-browser pin > #then ATTRIBUTION.md pins the expected version [0.07ms]
+(pass) ultimate-browsing Tier-2 runtime pins > #given the agent-browser pin > #then every chrome-stealth.md occurrence uses the same version [0.11ms]
+(pass) ultimate-browsing Tier-2 runtime pins > #given the two documents together > #then no stale version string survives anywhere [0.07ms]
+(pass) ultimate-browsing Tier-2 runtime pins > #given the Playwright template manifest > #then the playwright range lower bound is current [0.07ms]
+
+packages/shared-skills/provenance-gate.test.ts:
+(pass) DMCA provenance gate > no third-party-derived reference file is committed [13.71ms]
+[materialize] wrote 148 frontend reference files from submodules
+(pass) DMCA provenance gate > materialization makes every third-party reference exist on disk [38.96ms]
+[materialize] wrote 148 frontend reference files from submodules
+(pass) DMCA provenance gate > designpowers skills match upstream after frontmatter normalization [24.87ms]
+(pass) DMCA provenance gate > each ATTRIBUTION pin equals the live submodule HEAD [47.18ms]
+(pass) DMCA provenance gate > no submodule gitlink lives under any shipped skills/ directory [0.27ms]
+
+packages/shared-skills/frontend-thirdparty-manifest.test.ts:
+(pass) frontend third-party manifest partition > removes every third-party-derived file from the committed tree [0.12ms]
+(pass) frontend third-party manifest partition > keeps every project-original design file tracked [0.07ms]
+(pass) frontend third-party manifest partition > unignores every project-original design file [0.09ms]
+(pass) frontend third-party manifest partition > no ui-ux-db file is committed [0.08ms]
+(pass) frontend third-party manifest partition > no designpowers vendor file is committed [0.02ms]
+(pass) frontend third-party manifest partition > third-party manifest covers design brand, taste-skill, ui-ux-db, and designpowers [0.16ms]
+
+packages/shared-skills/shared-skills-root-path.test.ts:
+(pass) sharedSkillsRootPath > #given the module beside its own skills directory #when the root is resolved #then the sibling directory wins [0.03ms]
+(pass) sharedSkillsRootPath > #given a bundle one level below the skills directory #when the root is resolved #then the parent directory is used [14.96ms]
+(pass) sharedSkillsRootPath > #given the Codex marketplace layout #when the root is resolved #then the skills directory two levels up is used [0.78ms]
+(pass) sharedSkillsRootPath > #given a nearer skills directory than the marketplace one #when the root is resolved #then the nearest wins [0.74ms]
+(pass) sharedSkillsRootPath > #given no skills directory beside or above the module #when the root is resolved #then the sibling path is still returned [0.42ms]
+
+packages/shared-skills/skills/visual-qa/scripts/png-decode.test.ts:
+(pass) decodePng > #given an encoded RGBA image #when decoded #then dimensions and first pixel round-trip [1.00ms]
+(pass) decodePng > #given a fully opaque image #when decoded #then it has no transparent pixels [0.10ms]
+(pass) decodePng > #given a semi-transparent image #when decoded #then it reports transparent pixels [0.14ms]
+(pass) decodePng > #given a non-PNG buffer #when decoded #then it throws [0.05ms]
+
+packages/shared-skills/skills/visual-qa/scripts/tui-grid.test.ts:
+(pass) checkTui > #given ASCII lines within the width #when checked #then there is no overflow [0.66ms]
+(pass) checkTui > #given a line wider than the expected columns #when checked #then it is flagged as overflow [0.11ms]
+(pass) checkTui > #given CJK text #when checked #then wide characters count as two columns [0.09ms]
+(pass) checkTui > #given a box whose CJK content is wider than its border #when checked #then borders are misaligned [0.10ms]
+(pass) checkTui > #given a well-formed box #when checked #then borders are aligned [0.05ms]
+(pass) checkTui > #given text with ANSI color codes #when checked #then ANSI is detected and ignored for width [0.06ms]
+
+packages/shared-skills/skills/visual-qa/scripts/east-asian-width.test.ts:
+(pass) charWidth > #given an ASCII letter #when measured #then it is one column [0.46ms]
+(pass) charWidth > #given a Hangul syllable #when measured #then it is two columns [0.09ms]
+(pass) charWidth > #given a CJK ideograph #when measured #then it is two columns [0.05ms]
+(pass) charWidth > #given a fullwidth Latin letter #when measured #then it is two columns [0.05ms]
+(pass) charWidth > #given a halfwidth katakana #when measured #then it is one column [0.05ms]
+(pass) charWidth > #given a combining diacritic #when measured #then it is zero columns [0.07ms]
+(pass) charWidth > #given a zero-width space #when measured #then it is zero columns [0.05ms]
+(pass) charWidth > #given an emoji #when measured #then it is two columns [0.07ms]
+(pass) stringWidth > #given an ASCII string #when measured #then width equals character count [0.04ms]
+(pass) stringWidth > #given Hangul text #when measured #then each syllable counts as two [0.04ms]
+(pass) stringWidth > #given CJK text #when measured #then each ideograph counts as two [0.04ms]
+(pass) stringWidth > #given a base letter plus a combining mark #when measured #then it is one column [0.04ms]
+(pass) stringWidth > #given mixed ASCII and CJK #when measured #then widths add up [0.05ms]
+
+packages/shared-skills/skills/visual-qa/scripts/ansi.test.ts:
+(pass) stripAnsi > #given an ANSI-wrapped string #when stripped #then escape codes are removed
+(pass) stripAnsi > #given a plain string #when stripped #then it is unchanged [0.24ms]
+(pass) hasAnsi > #given a string with ANSI codes #when checked #then it is true [0.02ms]
+(pass) hasAnsi > #given a plain string #when checked #then it is false [0.06ms]
+
+packages/shared-skills/skills/visual-qa/scripts/image-diff.test.ts:
+(pass) diffImages > #given two identical images #when diffed #then similarity is 100 with no hotspots
+(pass) diffImages > #given two fully different images #when diffed #then similarity is 0 with hotspots [0.45ms]
+(pass) diffImages > #given images of different sizes #when diffed #then dimensionsMatch is false [0.05ms]
+(pass) diffImages > #given a transparent reference and an opaque actual #when diffed #then alpha is flagged [0.05ms]
+(pass) diffImages > #given a single changed pixel #when diffed #then one hotspot marks its grid cell [0.10ms]
+
+packages/shared-skills/skills/visual-qa/scripts/cli.test.ts:
+(pass) runImageDiff > #given two identical PNG files #when diffed #then similarity is 100 [0.65ms]
+(pass) runImageDiff > #given missing arguments #when diffed #then it throws a usage error [0.08ms]
+(pass) runTuiCheck > #given a CJK capture file #when checked #then widths count wide characters [0.15ms]
+(pass) run dispatch > #given an unknown command #when run #then it throws [0.14ms]
+(pass) cli entry > #given the Node bundle is spawned for image-diff without Bun on PATH #when it runs #then it prints JSON and exits zero [31.31ms]
+
+packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.test.ts:
+(pass) #given the no-excuse script is executed from an installed ~/.codex-style skill cache > #when the caller project provides typescript #then it resolves the caller's typescript and exits 0 [180.77ms]
+(pass) #given the no-excuse script is executed from an installed ~/.codex-style skill cache > #when a checked file violates the rules #then violations are still reported with exit 1 [80.95ms]
+(pass) #given the no-excuse script is executed from an installed ~/.codex-style skill cache > #when the caller project genuinely lacks typescript #then it fails with a clear error and exit 2 [30.99ms]
+
+ 77 pass
+ 0 fail
+ 586 expect() calls
+Ran 77 tests across 14 files. [694.00ms]
+
+Evidence-bound staged tree: 42189ed4dc6aecbe5407aa381d37150bbc65fbd5

--- a/packages/shared-skills/AGENTS.md
+++ b/packages/shared-skills/AGENTS.md
@@ -10,7 +10,7 @@ Hand-authored, cross-harness skill bundle shared between the OpenCode and Codex 
 
 `programming`, `debugging`, `frontend`, `visual-qa`, `ast-grep`, `coding-agent-sessions`, `data-scientist`, `git-master`, `refactor`, `review-work`, `start-work`, `ulw-plan`, `ulw-research`, `init-deep`, `remove-ai-slops`, `lsp-setup`, `ultimate-browsing`.
 
-`ultimate-browsing` is the one skill carrying a real sub-project: `skills/ultimate-browsing/engine/` is a 17-module Python package with its own CLI, config schemas, and test suite. See [`skills/ultimate-browsing/engine/AGENTS.md`](skills/ultimate-browsing/engine/AGENTS.md).
+`ultimate-browsing` is the one skill carrying a real sub-project: `skills/ultimate-browsing/engine/` is a 17-module Python package with its own CLI, config schemas, and test suite. It is a deliberately pinned, locally diverged snapshot of `fivetaku/insane-search`, not a follow-HEAD mirror. Before changing or re-vendoring it, read [`skills/ultimate-browsing/engine/AGENTS.md` §UPSTREAM BASELINE AND VERSION POLICY](skills/ultimate-browsing/engine/AGENTS.md#upstream-baseline-and-version-policy).
 
 The Codex-only `lcx-report-bug`, `lcx-contribute-bug-fix`, and `lcx-doctor` skills live under `packages/omo-codex/plugin/components/lcx/skills/`; they are no longer authored in this package.
 

--- a/packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
+++ b/packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
@@ -1,19 +1,46 @@
 # ATTRIBUTION / NOTICE
 
 This skill (`ultimate-browsing`, part of `@oh-my-opencode/shared-skills`) ships
-project-original content plus two third-party tools that it installs at runtime
-(it does NOT vendor their source). Each runtime tool's license and required
-notices are reproduced below.
+project-original content, one vendored-and-modified upstream engine, plus two
+third-party tools that it installs at runtime (it does NOT vendor their source).
+Each component's provenance, license, and required notices are reproduced below.
 
 ---
 
-## 1. Project-original content (no third-party source vendored)
+## 1. insane-search engine — vendored upstream snapshot, modified
+
+`engine/**` originates from the **insane-search** project and is NOT
+project-original code, despite being heavily modified since import.
+
+- Upstream source: https://github.com/fivetaku/insane-search
+- Vendored into this repository on 2026-06-21 by commit
+  **`a4e4ed797`** (`feat(ultimate-browsing): vendor insane-search engine (junk-excluded)`),
+  via an explicit file whitelist that excluded caches and smoke-test junk.
+- Baseline: the upstream state as of that date, a **pre-0.7.0 snapshot**.
+  Upstream's CHANGELOG dates 0.7.0 to 2026-06-22; imported files carry no
+  version marker. We have never re-vendored since; the tree has diverged in
+  both directions.
+- Modifications by this project (non-exhaustive): de-personalization
+  (`4743199a5`), the Phase 2.5 surrogate retrieval stage and surrogate registry,
+  the provenance/trust result contract, the `bias_check.py` no-site-name CI gate,
+  module split of the fetch chain, and the Python test suite under
+  `engine/tests/`.
+- No upstream `LICENSE` file was included in the vendored snapshot, so this
+  repository has no upstream license text to reproduce here. Do not infer
+  project-original licensing from that absence; treat `engine/**` as
+  upstream-derived when reasoning about provenance.
+
+The binding version policy — which upstream baseline we sit on, why we stay
+pinned, what a future re-vendor must preserve, and what it must not import — is
+[`engine/AGENTS.md` §UPSTREAM BASELINE AND VERSION POLICY](engine/AGENTS.md).
+
+---
+
+## 2. Project-original content (no third-party source vendored)
 
 The following are authored by the oh-my-openagent project and carry no third-party
 license obligation:
 
-- `engine/**` — the insane-search Tier-1 fetch engine (curl_cffi grid, WAF
-  detection, Playwright fallback templates, `bias_check.py` no-site-name gate).
 - `references/insane-search/**` and `references/agent-reach/**` — the Tier-1 and
   Tier-1.5 reference docs.
 - `scripts/extract_cookies.py`, `scripts/cookie_paths.py`, `scripts/cookie_crypto.py`
@@ -26,7 +53,7 @@ user installs separately; this skill includes none of their source.
 
 ---
 
-## 2. CloakBrowser (CloakHQ) — Tier-2 stealth Chromium (runtime dependency)
+## 3. CloakBrowser (CloakHQ) — Tier-2 stealth Chromium (runtime dependency)
 
 The Tier-2 stealth browser is **CloakBrowser**, installed at runtime via `pip`
 (`pip install cloakbrowser`). No CloakBrowser source is vendored in this repository.
@@ -73,7 +100,7 @@ SOFTWARE.
 
 ---
 
-## 3. agent-browser (vercel-labs) — Tier-2 CDP automation CLI (runtime dependency)
+## 4. agent-browser (vercel-labs) — Tier-2 CDP automation CLI (runtime dependency)
 
 The Tier-2 automation CLI is **agent-browser**, installed at runtime via `npm`
 (`npm i -g agent-browser`). No agent-browser source is vendored in this repository.

--- a/packages/shared-skills/skills/ultimate-browsing/engine/AGENTS.md
+++ b/packages/shared-skills/skills/ultimate-browsing/engine/AGENTS.md
@@ -2,6 +2,116 @@
 
 **Generated:** 2026-08-10 / 38d268995
 
+## UPSTREAM BASELINE AND VERSION POLICY
+
+**READ THIS BEFORE TOUCHING `engine/**` OR PROPOSING AN UPSTREAM SYNC.**
+
+This engine is NOT project-original code. It is a vendored-and-modified snapshot of
+[fivetaku/insane-search](https://github.com/fivetaku/insane-search), and the version
+we run on is a deliberate choice, not an accident of neglect.
+
+### The pin
+
+| Fact | Value |
+|---|---|
+| Upstream project | `https://github.com/fivetaku/insane-search` |
+| Vendoring commit | `a4e4ed797` (2026-06-21) `feat(ultimate-browsing): vendor insane-search engine (junk-excluded)` |
+| De-personalization | `4743199a5` (2026-06-21) |
+| Pinned upstream baseline | upstream state as of 2026-06-21, **pre-0.7.0** (0.7.0 is dated 2026-06-22) |
+| Re-vendors since | none — every later change here is ours |
+
+We intentionally track a **pinned baseline plus local divergence**, not upstream HEAD.
+There is no submodule and no automated drift check for this engine (unlike the
+`frontend` skill's upstream submodules): the vendored files ARE the source of truth,
+and upstream is a reference we port FROM, deliberately, file by file.
+
+### Why we do not blind-rebase onto upstream HEAD
+
+1. **Upstream reset its public history.** On 2026-08-06 upstream published a single
+   squashed commit, `019ee16 refactor: reset public history at 0.14.0`, discarding the
+   prior public history through 0.13.x. There is no upstream commit graph to rebase onto and no
+   way to cherry-pick an individual upstream change by sha — only whole-file diffing
+   against a moving HEAD.
+2. **Upstream 0.14.0 REMOVED capability.** The endpoint-mining / internal-API
+   auto-derivation / site-recipe subsystems that upstream carried publicly between
+   0.12.0 and 0.14.0 are gone from upstream HEAD. Syncing to HEAD is therefore not
+   strictly an upgrade: parts of it are a downgrade relative to the intermediate
+   versions, and none of it is recoverable from the reset history.
+3. **Our tree diverged on purpose.** The KEEP list below is functionality upstream
+   never had. A wholesale overwrite with upstream HEAD would silently delete it.
+4. **Different threat model.** Our engine ships inside a published npm package and a
+   public marketplace mirror, under a CI no-site-name gate and a de-personalization
+   deny-list. Upstream carries neither constraint, so upstream code is not
+   drop-in-shippable here.
+
+### KEEP — our divergences a re-vendor MUST NOT regress
+
+These exist only in our tree. Any upstream sync that removes or bypasses one of them
+is a regression, not an upgrade:
+
+- **Phase 2.5 surrogate retrieval** (`surrogate.py`, `surrogates.yaml`) — archive /
+  reader / proxy routes tried before paying for a browser spin-up, with per-entry
+  `last_verified` staleness handling and `--allow-proxy` gating.
+- **Provenance / trust contract** (`result_schema.py`) — `Provenance` and `Trust`
+  literals on every result, so a snapshot can never be reported as the live page.
+- **Surrogate dead-end validation** (L1.5 in `validators.py`) — interstitial titles and
+  AMP-style redirect stubs rejected instead of returned as content.
+- **The no-site-name rule and its CI gate** (`bias_check.py`) — zero hard-coded site
+  names, brands, or target domains in `engine/**`.
+- **Module split of the fetch chain** — `curl_probe` / `referers` / `url_transforms` /
+  `waf_detector` / `validators` / `executor` / `summary` as separate modules rather than
+  one monolith.
+- **The Python test suite** under `engine/tests/` with its HTML/JSON fixtures.
+- **De-personalization** — no personal absolute paths, no personal auth token literals,
+  no personal browser choice; enforced by `depersonalization-gate.test.ts`.
+- **Skill-level layering** — the engine is Tier 1 under a router that also owns Tier 1.5
+  (agent-reach) and Tier 2 (CloakBrowser + agent-browser). Upstream has no such tiering.
+
+### WANT — upstream improvements worth porting forward
+
+Our snapshot predates these; they are wanted, and each must be ported as a reviewed,
+site-agnostic change that preserves every KEEP item above. Port individually; never as
+a tree overwrite:
+
+- **Content quality**: dedicated markdown conversion of fetched HTML, main-content
+  extraction, PDF text extraction, and JSON-LD rescue when the HTML body is thin.
+- **Transient-failure retry** and **render-merge** of statically fetched HTML with the
+  browser-rendered DOM.
+- **Differential block classification** — distinguishing a bot-detection block from an
+  infrastructure or authentication failure, instead of collapsing both into `challenge`.
+- **Additional stealth fetch backends** beyond the current Playwright templates, and
+  additional WAF vendor profiles.
+- **Per-host route learning** — remembering which route succeeded for a host, with a TTL
+  and a bounded store. Must stay runtime state, never committed site knowledge (R4).
+- **Engine-level Phase 0 routing** — the official-public-API preference is currently only
+  a documented rule (R5) the agent can skip; upstream moved it into code so it cannot be
+  skipped. Worth adopting.
+
+### OUT OF SCOPE
+
+- **The removed upstream endpoint-mining / internal-API auto-derivation / site-recipe
+  subsystems.** They are absent from upstream HEAD and are not reconstructed here. They
+  also sit against R3/R4 and R7's anti-bias rule: discovered internal endpoints are
+  runtime findings, never committed engine knowledge.
+- **Any upstream code carrying site-specific selectors, domains, or brand names.** It
+  fails `bias_check.py` at the door; re-derive it site-agnostically or leave it out.
+- **Automated upstream tracking.** No submodule, no drift check, no auto-bump. Syncing is
+  a deliberate, reviewed, human-initiated act.
+
+### THE SYNC RULE
+
+Any future upstream sync preserves BOTH sides. Concretely:
+
+1. Diff the specific upstream capability you want against our tree — do not overwrite
+   files wholesale, and never `git checkout` upstream over `engine/`.
+2. Port it as its own reviewed change, keeping every KEEP item intact.
+3. Re-run `python3 engine/bias_check.py` and the `engine/tests/` suite; a port that
+   introduces a site name or breaks a fixture does not ship.
+4. Update the pin table above (baseline, date, what was ported) in the same change, plus
+   the provenance section of [`../ATTRIBUTION.md`](../ATTRIBUTION.md).
+5. If a port must drop a KEEP item, say so explicitly in the PR and get it agreed first —
+   silent regressions of the KEEP list are the failure mode this policy exists to prevent.
+
 ## OVERVIEW
 
 A 17-module Python package embedded in the `ultimate-browsing` skill: a site-agnostic fetch chain that escalates from a cheap curl probe to a real browser, with declarative WAF and surrogate registries. Not "optional scripts" — it has its own CLI entry (`python3 -m engine URL`), two YAML config schemas, a 4-file test suite, and a standalone CI guard. Package exports (`__init__.py`): `fetch`, `FetchResult`, `Attempt`, `Verdict`, `ValidationResult`, `validate`, `CHALLENGE_MARKERS`, `detect`, `TRANSFORMS`, `apply_transform`.


### PR DESCRIPTION
## Summary

Document the real upstream baseline and preservation policy for the vendored `ultimate-browsing` insane-search engine. The repository previously classified `engine/**` as project-original even though git history shows it was vendored, and it gave future agents no rule for combining upstream improvements with our local divergence.

The new policy pins the import to the narrowest version the evidence supports: a 2026-06-21 **pre-0.7.0** snapshot. It explains why upstream HEAD must not be applied wholesale, names the OMO behavior that must survive any sync, lists later upstream capabilities worth porting, and excludes the subsystems upstream removed at 0.14.0.

## Changes

- Correct the insane-search provenance in `ATTRIBUTION.md`, including the upstream URL, vendoring commit, pre-0.7.0 baseline, and major OMO modifications.
- Add a binding `UPSTREAM BASELINE AND VERSION POLICY` to the engine's `AGENTS.md` with explicit PIN / KEEP / WANT / OUT OF SCOPE / SYNC RULE sections.
- Make the parent shared-skills knowledge base route engine maintenance and re-vendoring work to that policy.
- Record RED/GREEN and shared-skills verification evidence under `.omo/evidence/20260817-insane-search-version-policy/`.

## QA & Evidence

- **What was tested:** pre-change and post-change repository guidance via concrete `rg` queries.
  - **Observed:** RED showed `engine/**` under “Project-original content (no third-party source vendored)” and no policy anchors; GREEN names `fivetaku/insane-search`, `a4e4ed797`, the pre-0.7.0 baseline, all six policy sections, and the parent link.
  - **Artifact:** `.omo/evidence/20260817-insane-search-version-policy/{red-pre-change.txt,green-post-change.txt}`
  - **Why sufficient:** this is a prose/knowledge-base correction; the changed user-visible surface is the guidance future agents read.
- **What was tested:** `npm exec --yes --package=bun@1.3.12 -- bun test packages/shared-skills`
  - **Observed:** 77 passed, 0 failed, 586 expectations across 14 files.
  - **Artifact:** `.omo/evidence/20260817-insane-search-version-policy/shared-skills-tests.txt`
  - **Why sufficient:** covers packaging, de-personalization, provenance, runtime pins, root-path resolution, and materialization machine consumers.
- **Evidence summary:** `.omo/evidence/20260817-insane-search-version-policy/QA.txt`

## Risks & Residuals

- This does not port upstream runtime features; it establishes the policy a later implementation must follow.
- The prior session's approximate `~0.9.x` label was corrected during verification. The import predates upstream 0.7.0 by one day, so `pre-0.7.0` is the narrowest defensible baseline.
- No OpenCode/Codex runtime component changed; harness QA would not exercise a changed behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the `ultimate-browsing` engine to a pre-0.7.0 `insane-search` snapshot and establishes a binding upstream version policy so future syncs preserve our divergences. Previously `engine/**` was treated as project‑original with no guidance; now it’s correctly attributed, pinned, and governed by KEEP/WANT/OUT‑OF‑SCOPE lists plus a concrete sync rule.

- `skills/ultimate-browsing/ATTRIBUTION.md`: records vendored provenance, pre‑0.7.0 baseline, major local modifications, and links to the policy.
- `skills/ultimate-browsing/engine/AGENTS.md`: adds “UPSTREAM BASELINE AND VERSION POLICY” (why not follow HEAD, KEEP/WANT/OUT‑OF‑SCOPE, THE SYNC RULE).
- `packages/shared-skills/AGENTS.md`: routes maintainers to the policy and clarifies we track a pinned, locally diverged snapshot of `fivetaku/insane-search`.
- Evidence added under `.omo/evidence/…`; shared‑skills tests pass. CI note: an unrelated RPC parity failure on base resolved after rebase. Required action: follow the new policy for any future re‑vendor; no runtime migration.

<sup>Written for commit ff8fd04977650119e92190148c80cb2d020738f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

