### PR TITLE
test(omo-senpi): pin RPC parity to package-local CLI

### DIFF
--- a/packages/omo-senpi/src/components/task/task-rpc-launch-parity.test.ts
+++ b/packages/omo-senpi/src/components/task/task-rpc-launch-parity.test.ts
@@ -1,18 +1,29 @@
 import { mkdtempSync, rmSync } from "node:fs"
+import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { afterEach, describe, expect, test } from "bun:test"
 
 import type { RpcRunnerSpec } from "@oh-my-opencode/senpi-task"
 import { createRpcModelAdmission } from "@oh-my-opencode/senpi-task/rpc-model-admission"
-import { buildRpcModelCatalogSpawn } from "@oh-my-opencode/senpi-task/rpc-spawn"
+import { buildRpcModelCatalogSpawn, type RpcSpawnDescriptor } from "@oh-my-opencode/senpi-task/rpc-spawn"
 
 const agentDirs: string[] = []
 const mockProviderExtension = fileURLToPath(
   new URL("../../../scripts/qa/mock-provider/index.ts", import.meta.url),
 )
 const rootSuiteBaselineEnv: NodeJS.ProcessEnv = { ...process.env }
+const senpiPackageDir = dirname(createRequire(import.meta.url).resolve("@code-yeongyu/senpi/package.json"))
+const senpiRpcEntry = join(senpiPackageDir, "dist", "rpc-entry.js")
+
+function buildPinnedCatalogSpawn(spec: RpcRunnerSpec, parentEnv: NodeJS.ProcessEnv): RpcSpawnDescriptor {
+  return buildRpcModelCatalogSpawn(spec, {
+    parentEnv,
+    resolveSenpiExecutable: () => null,
+    resolveRpcEntry: () => senpiRpcEntry,
+  })
+}
 
 function createAdmission() {
   const agentDir = mkdtempSync(join(tmpdir(), "omo-task-rpc-model-profile-"))
@@ -25,10 +36,7 @@ function createAdmission() {
     PI_CODING_AGENT_DIR: agentDir,
   }
   return createRpcModelAdmission({
-    buildSpawn: (spec) => buildRpcModelCatalogSpawn(spec, {
-      parentEnv,
-      resolveSenpiExecutable: () => null,
-    }),
+    buildSpawn: (spec) => buildPinnedCatalogSpawn(spec, parentEnv),
   })
 }
 
@@ -50,6 +58,21 @@ afterEach(() => {
 })
 
 describe("task RPC launch profile parity", () => {
+  test("#given ambient PATH resolves a foreign senpi #when the catalog spawn is built #then it pins the package-local CLI", () => {
+    // given
+    const spec = makeSpec([mockProviderExtension])
+
+    // when
+    const descriptor = buildPinnedCatalogSpawn(spec, {
+      ...rootSuiteBaselineEnv,
+      PATH: join(tmpdir(), "foreign-senpi-bin"),
+    })
+
+    // then
+    expect(descriptor.command).toBe(process.execPath)
+    expect(descriptor.args[0]).toBe(join(senpiPackageDir, "dist", "cli.js"))
+  })
+
   test("#given an explicit provider extension #when process model admission runs #then its model is visible without credentials", async () => {
     // given
     const admit = createAdmission()


### PR DESCRIPTION
## Summary

Makes the RPC model-catalog parity fixture deterministic by pinning it to the workspace-installed Senpi CLI
instead of allowing ambient `PATH` to select a stale/global launcher.

The earlier env snapshot fixed one pollution route, but the descriptor still called the normal executable
resolver. In the full root suite, another test could affect launcher visibility before this module loaded and
the detached catalog probe would list zero useful mock models. Focused runs passed because the expected
launcher happened to be first on PATH.

This PR resolves `@code-yeongyu/senpi/package.json`, derives its `dist/rpc-entry.js`, and injects the existing
fallback seam so the descriptor is always `process.execPath` plus that package's adjacent `dist/cli.js`.
A new contract test poisons PATH and proves the foreign launcher cannot be selected.

## Failing-first evidence

PR #6935 run `32030003281`: 15,712 tests passed and the only failure was
`task RPC launch profile parity ... explicit provider extension ... model is visible without credentials`.
This is the real full-suite surface; retrying it would mask the nondeterminism.

## Verification

- Focused real child probe: 3 pass / 0 fail.
- Same real child probe repeated sequentially: 20 / 20 runs green.
- `tsgo --noEmit -p packages/omo-senpi/tsconfig.json`: clean.
- Task RPC QA driver `--self-test`: `SELF-TEST OK`.
- TypeScript no-excuse audit: clean.
- `bun run test:senpi`: 1,877 pass / 1 Windows-only skip / 0 fail / 5,373 assertions.
- CI Bun 1.3.12 extension build + `--check`: current; no generated bundle diff.
- Changed file: 78 pure LOC.

## Dependency

PR #6935 should rebase after this merges, then rerun its previously failing Ubuntu root job. No failed-job
rerun is used as evidence for this fix.

Plan: .omo/plans/publish-pipeline-hardening.md


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the RPC model-catalog parity fixture to the workspace-installed Senpi CLI to remove PATH nondeterminism. Previously the test could launch a foreign/global `senpi` from PATH and hide the mock provider model; now it always runs `process.execPath` with the package-local `dist/cli.js`, making the parity test deterministic across the full suite.

**Review notes**
- Resolves `@code-yeongyu/senpi/package.json` to compute `dist/rpc-entry.js`; passes it via `resolveRpcEntry` and nulls `resolveSenpiExecutable` in `buildRpcModelCatalogSpawn`.
- Replaces the fixture’s spawn builder with a pinned variant; adds a test that poisons PATH and asserts the descriptor uses the package-local CLI.
- Scope: test-only change in `packages/omo-senpi/src/components/task/task-rpc-launch-parity.test.ts`; no runtime impact.

<sup>Written for commit e6db2b5f818167f323da95c0e0b6ab9b8874f9d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

