### PR TITLE
test(senpi-task): budget Windows DAG residency e2e

### DIFF
--- a/packages/senpi-task/src/dag/e2e-failure.test.ts
+++ b/packages/senpi-task/src/dag/e2e-failure.test.ts
@@ -719,7 +719,7 @@ for (let seq = 1; seq <= stopAt; seq += 1) {
     expect(fixture.events(result.runId).filter((event) =>
       event.type === "dag.node.transitioned" && event.to === "failed",
     )).toHaveLength(0)
-  })
+  }, process.platform === "win32" ? 30_000 : 5_000)
 
   test("#given expired terminal artifacts and equally old live artifacts #when retention runs #then events, results, and skills are pruned only for the terminal run", () => {
     // given


### PR DESCRIPTION
## Summary

Gives the real seven-node DAG residency-admission E2E a bounded Windows-only integration-test budget.

PR #6936 Windows shard 2/2 completed the scenario in 5.188 seconds, 188ms beyond Bun's generic five-second
ceiling. The run had 15,680 passing tests and this single timeout. The scenario is event-driven; no assertion,
wait, scheduler, residency, or production behavior failed.

This PR replaces only that test call's timeout argument:

- Windows: 30 seconds
- every other platform: existing 5 seconds

No sleeps, retries, or weakened assertions are introduced.

## Verification

- Faithful RED: Actions run `32030005350`, Windows shard 2/2.
- Focused real DAG engine file: 10 pass / 0 fail / 59 assertions.
- Repeated complete focused file: 10 / 10 runs green.
- `tsgo --noEmit -p packages/senpi-task/tsconfig.json`: clean.
- TypeScript no-excuse audit: clean.
- Diff: one insertion / one deletion; zero net lines.

## Scope

PR #6902 contains the same scenario budget plus unrelated Windows bundle-launch work. This atomic PR does not
modify that unrelated work. `e2e-failure.test.ts` is pre-existing oversized test debt; a later refactor should
split its failure-order, crash-recovery, residency, and retention scenarios.

Plan: .omo/plans/publish-pipeline-hardening.md


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusts the seven-node DAG residency-admission e2e test timeout to prevent Windows-only flake. Previously the test used a 5s ceiling on all platforms; now Windows uses 30s while others remain at 5s.

- Changes only the timeout argument for that test in `senpi-task` at `packages/senpi-task/src/dag/e2e-failure.test.ts` (+1/-1 line).
- Addresses a 188ms over-ceiling timeout on loaded Windows runners; production behavior, waits, retries, and assertions are unchanged.
- Verified with focused runs and typecheck; prior Windows shard showed the single timeout among 15,680 passing tests.

<sup>Written for commit 99ca5bbb35eacdcf1ef932fa229100805658dbad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

