### PR TITLE
ci(release): rebuild Senpi bundles into the release commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -531,9 +531,14 @@ jobs:
           npm --prefix packages/omo-codex/plugin install --package-lock-only --ignore-scripts --no-audit --fund=false
           bun install --lockfile-only
 
+          # The version bump restamps OMO_SENPI_PACKAGE_VERSION inside the committed Senpi
+          # bundles; rebuild them so the release commit passes bundle-freshness CI.
+          node packages/omo-senpi/plugin/scripts/build-extension.mjs
+
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add package.json packages/omo-native/package.json packages/oh-my-opencode-*/package.json packages/omo-senpi/package.json packages/omo-senpi/plugin/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/package-lock.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
+          git add -f packages/omo-senpi/plugin/extensions
           git diff --cached --quiet || git commit -m "release: v${VERSION}"
           git push --force-with-lease origin "HEAD:${RELEASE_BRANCH}"
 

--- a/.omo/evidence/20260817-release-gate-repair/README.md
+++ b/.omo/evidence/20260817-release-gate-repair/README.md
@@ -1,0 +1,20 @@
+# beta.8 release-gate repair evidence
+
+## What was tested
+- The exact release-state failure surface: a version-bumped tree exactly as prepare-release-state produces it.
+- RED/GREEN for both root causes and the full release-branch CI battery locally.
+
+## What was observed
+- RED-A: product-identity expected 5.0.0-beta.7, received 5.0.0-beta.8 on the bumped tree (the exact ubuntu CI failure).
+- GREEN-A: dynamic stamped-version expectation passes 9/9 on the bumped tree and on unbumped dev.
+- RED-B: the new workflow pin failed against the unmodified publish.yml.
+- GREEN-B: pin passes after the prepare step rebuilds + force-stages Senpi bundles.
+- SIMULATION: exact prepare bump sequence + rebuild committed on a local sim branch, then frozen install, bundle-freshness --check, stale-copy cleanup, full root bun test, typecheck, test:codex, and build all green (sim-battery.txt).
+
+## Why it is enough
+- The battery is the release-branch CI surface (test matrix essence + senpi-compatibility gate + codex gate + typecheck + build) executed on the exact tree the release PR will carry.
+- No product code changed; both defects were release-pipeline seams.
+
+## What was omitted
+- Windows is not runnable locally (Parallels unavailable); Windows shards run in PR/release CI on the same deterministic tests.
+- Raw 15k-line logs are summarized; no secrets captured.

--- a/.omo/evidence/20260817-release-gate-repair/baseline-a-unbumped.txt
+++ b/.omo/evidence/20260817-release-gate-repair/baseline-a-unbumped.txt
@@ -1,0 +1,17 @@
+bun test v1.3.12 (700fc117)
+
+packages/omo-senpi/src/components/telemetry/product-identity.test.ts:
+(pass) OmO Native product identity > #given the native product #when config is created #then identity derivation and effective geoip settings are fixed [1.53ms]
+(pass) OmO Native product identity > #given an explicit agent directory #when the native state path is resolved #then it is nested under omo-senpi [0.55ms]
+(pass) OmO Native product identity > #given a machine state directory #when session ids are hashed #then the persisted salt is stable and raw ids stay distinct [1.28ms]
+(pass) OmO Native product identity > #given a deleted salt #when another session id is hashed #then the salt is recreated without throwing [4.78ms]
+(pass) OmO Native product identity > #given an unwritable state path #when a session id is hashed #then fallback identity stays stable without throwing [0.31ms]
+(pass) OmO Native product identity > #given a known provider with an unknown custom model #when masked #then only model_id becomes custom [0.11ms]
+(pass) OmO Native product identity > #given senpi-task builtins #when telemetry allowlists are loaded #then names exactly match imported sources [0.03ms]
+(pass) OmO Native product identity > #given the tracked-call cap #when the widest wave histogram is encoded #then it stays inside the 64 character privacy limit [0.11ms]
+(pass) OmO Native product identity > #given static telemetry inventories #when inspected #then they and every property allowlist are frozen [0.29ms]
+
+ 9 pass
+ 0 fail
+ 161 expect() calls
+Ran 9 tests across 1 file. [861.00ms]

--- a/.omo/evidence/20260817-release-gate-repair/green-a-product-identity-bumped.txt
+++ b/.omo/evidence/20260817-release-gate-repair/green-a-product-identity-bumped.txt
@@ -1,0 +1,17 @@
+bun test v1.3.12 (700fc117)
+
+packages/omo-senpi/src/components/telemetry/product-identity.test.ts:
+(pass) OmO Native product identity > #given the native product #when config is created #then identity derivation and effective geoip settings are fixed [1.45ms]
+(pass) OmO Native product identity > #given an explicit agent directory #when the native state path is resolved #then it is nested under omo-senpi [0.34ms]
+(pass) OmO Native product identity > #given a machine state directory #when session ids are hashed #then the persisted salt is stable and raw ids stay distinct [3.69ms]
+(pass) OmO Native product identity > #given a deleted salt #when another session id is hashed #then the salt is recreated without throwing [0.88ms]
+(pass) OmO Native product identity > #given an unwritable state path #when a session id is hashed #then fallback identity stays stable without throwing [0.17ms]
+(pass) OmO Native product identity > #given a known provider with an unknown custom model #when masked #then only model_id becomes custom [0.13ms]
+(pass) OmO Native product identity > #given senpi-task builtins #when telemetry allowlists are loaded #then names exactly match imported sources [0.11ms]
+(pass) OmO Native product identity > #given the tracked-call cap #when the widest wave histogram is encoded #then it stays inside the 64 character privacy limit [0.10ms]
+(pass) OmO Native product identity > #given static telemetry inventories #when inspected #then they and every property allowlist are frozen [0.15ms]
+
+ 9 pass
+ 0 fail
+ 161 expect() calls
+Ran 9 tests across 1 file. [750.00ms]

--- a/.omo/evidence/20260817-release-gate-repair/green-b-workflow-pin.txt
+++ b/.omo/evidence/20260817-release-gate-repair/green-b-workflow-pin.txt
@@ -1,0 +1,34 @@
+NEW FILE:
+bun test v1.3.12 (700fc117)
+
+script/publish-release-bundle-rebuild.test.ts:
+(pass) test workflows > rebuilds version-stamped Senpi bundles into the release commit [12.41ms]
+
+ 1 pass
+ 0 fail
+ 3 expect() calls
+Ran 1 test across 1 file. [394.00ms]
+
+
+OLD FILE:
+bun test v1.3.12 (700fc117)
+
+script/publish-workflow.test.ts:
+(pass) test workflows > use pure bun test for workflows [31.48ms]
+(pass) test workflows > prepares vendored lsp-tools-mcp before publish workflow tests and typecheck [0.23ms]
+(pass) test workflows > builds publish-main from the prepared release SHA [0.22ms]
+(pass) test workflows > dispatches a source-pinned publish run before provenance-bearing release operations [0.34ms]
+(pass) test workflows > runs Codex compatibility checks before publish jobs [0.25ms]
+(pass) test workflows > exercise root checks across linux macos and windows [0.14ms]
+(pass) test workflows > runs codex compatibility checks on every supported os without serializing build [0.07ms]
+(pass) test workflows > runs Codex compatibility tests with Node available for the self-built MCP runtimes [0.17ms]
+(pass) test workflows > sets up Bun before vendored lsp-tools-mcp builds in publish workflow jobs [0.27ms]
+(pass) test workflows > builds bundled MCP runtimes before Codex compatibility tests [0.19ms]
+(pass) test workflows > runs Git Bash installer regressions in Codex compatibility checks [0.21ms]
+(pass) test workflows > tracks the nested Codex plugin lockfile used by npm ci [25.48ms]
+(pass) test workflows > pins every workflow Bun setup to the tested runtime [0.88ms]
+
+ 13 pass
+ 0 fail
+ 66 expect() calls
+Ran 13 tests across 1 file. [491.00ms]

--- a/.omo/evidence/20260817-release-gate-repair/no-excuse-gates.txt
+++ b/.omo/evidence/20260817-release-gate-repair/no-excuse-gates.txt
@@ -1,0 +1,13 @@
+== loc_test rc=0 ==
+     133
+
+== loc_wf rc=0 ==
+     258
+
+== no_excuse rc=0 ==
+No violations in 2 file(s).
+
+== yaml_parse rc=0 ==
+YAML_OK
+
+== diffcheck rc=0 ==

--- a/.omo/evidence/20260817-release-gate-repair/red-a-product-identity.txt
+++ b/.omo/evidence/20260817-release-gate-repair/red-a-product-identity.txt
@@ -1,0 +1,30 @@
+bun test v1.3.12 (700fc117)
+
+packages/omo-senpi/src/components/telemetry/product-identity.test.ts:
+43 | 
+44 |     expect(OMO_NATIVE_POSTHOG_API_KEY).not.toBe(UNCONFIGURED_POSTHOG_API_KEY)
+45 |     expect(isConfiguredTelemetryApiKey(OMO_NATIVE_POSTHOG_API_KEY)).toBe(true)
+46 |     expect(config.platform).toBe("omo-senpi")
+47 |     expect(config.machineIdPrefix).toBe("omo-senpi:")
+48 |     expect(config.packageVersion).toBe("5.0.0-beta.7")
+                                       ^
+error: expect(received).toBe(expected)
+
+Expected: "5.0.0-beta.7"
+Received: "5.0.0-beta.8"
+
+      at <anonymous> (/Volumes/mengmotaStorage/local-workspaces/omo-wt/diag-publish-parity/packages/omo-senpi/src/components/telemetry/product-identity.test.ts:48:35)
+(fail) OmO Native product identity > #given the native product #when config is created #then identity derivation and effective geoip settings are fixed [5.56ms]
+(pass) OmO Native product identity > #given an explicit agent directory #when the native state path is resolved #then it is nested under omo-senpi [0.65ms]
+(pass) OmO Native product identity > #given a machine state directory #when session ids are hashed #then the persisted salt is stable and raw ids stay distinct [1.25ms]
+(pass) OmO Native product identity > #given a deleted salt #when another session id is hashed #then the salt is recreated without throwing [1.02ms]
+(pass) OmO Native product identity > #given an unwritable state path #when a session id is hashed #then fallback identity stays stable without throwing [0.10ms]
+(pass) OmO Native product identity > #given a known provider with an unknown custom model #when masked #then only model_id becomes custom [0.26ms]
+(pass) OmO Native product identity > #given senpi-task builtins #when telemetry allowlists are loaded #then names exactly match imported sources [0.12ms]
+(pass) OmO Native product identity > #given the tracked-call cap #when the widest wave histogram is encoded #then it stays inside the 64 character privacy limit [0.29ms]
+(pass) OmO Native product identity > #given static telemetry inventories #when inspected #then they and every property allowlist are frozen [0.29ms]
+
+ 8 pass
+ 1 fail
+ 158 expect() calls
+Ran 9 tests across 1 file. [1313.00ms]

--- a/.omo/evidence/20260817-release-gate-repair/red-b-workflow-pin.txt
+++ b/.omo/evidence/20260817-release-gate-repair/red-b-workflow-pin.txt
@@ -1,0 +1,35 @@
+bun test v1.3.12 (700fc117)
+
+script/publish-workflow.test.ts:
+(pass) test workflows > use pure bun test for workflows [1.23ms]
+(pass) test workflows > prepares vendored lsp-tools-mcp before publish workflow tests and typecheck [0.11ms]
+(pass) test workflows > builds publish-main from the prepared release SHA [0.22ms]
+131 |     const rebuildPrecedesCommit =
+132 |       prepareJob.indexOf("node packages/omo-senpi/plugin/scripts/build-extension.mjs") <
+133 |       prepareJob.indexOf('git commit -m "release: v${VERSION}"')
+134 | 
+135 |     // #then
+136 |     expect(rebuildsBundles, "the version bump restamps OMO_SENPI_PACKAGE_VERSION, so the release commit must rebuild the Senpi bundles").toBe(true)
+                                                                                                                                               ^
+error: the version bump restamps OMO_SENPI_PACKAGE_VERSION, so the release commit must rebuild the Senpi bundles
+
+Expected: true
+Received: false
+
+      at <anonymous> (/Volumes/mengmotaStorage/local-workspaces/omo-wt/diag-publish-parity/script/publish-workflow.test.ts:136:138)
+(fail) test workflows > rebuilds version-stamped Senpi bundles into the release commit [0.25ms]
+(pass) test workflows > dispatches a source-pinned publish run before provenance-bearing release operations [0.19ms]
+(pass) test workflows > runs Codex compatibility checks before publish jobs [0.07ms]
+(pass) test workflows > exercise root checks across linux macos and windows [0.12ms]
+(pass) test workflows > runs codex compatibility checks on every supported os without serializing build [0.10ms]
+(pass) test workflows > runs Codex compatibility tests with Node available for the self-built MCP runtimes [0.23ms]
+(pass) test workflows > sets up Bun before vendored lsp-tools-mcp builds in publish workflow jobs [0.01ms]
+(pass) test workflows > builds bundled MCP runtimes before Codex compatibility tests [0.23ms]
+(pass) test workflows > runs Git Bash installer regressions in Codex compatibility checks [0.14ms]
+(pass) test workflows > tracks the nested Codex plugin lockfile used by npm ci [13.75ms]
+(pass) test workflows > pins every workflow Bun setup to the tested runtime [1.41ms]
+
+ 13 pass
+ 1 fail
+ 67 expect() calls
+Ran 14 tests across 1 file. [106.00ms]

--- a/.omo/plans/beta8-release-gate-repair.md
+++ b/.omo/plans/beta8-release-gate-repair.md
@@ -1,0 +1,22 @@
+# beta.8 release-gate repair: version-stamped test + release bundle rebuild
+
+## Evidence
+- Publish run 32035291056 / job 95404552495: release-state PR #6855 red on the version-bumped tree.
+- Red 1: packages/omo-senpi/src/components/telemetry/product-identity.test.ts:48 pins "5.0.0-beta.7"; bumped tree returns 5.0.0-beta.8.
+- Red 2: senpi-compatibility "omo-senpi extension build is not current: stale-output" because the release commit bumps packages/omo-senpi/plugin/package.json without rebuilding plugin/extensions bundles. beta.7 shipped only via manual rebuild commit dc14e9518.
+
+## Changes
+1. product-identity.test.ts: derive expected packageVersion from root package.json (independent read), pinning the fallback derivation contract instead of a literal.
+2. .github/workflows/publish.yml prepare-release-state: after `bun install --lockfile-only`, run `node packages/omo-senpi/plugin/scripts/build-extension.mjs` (bun 1.3.12 already on PATH) and force-add the rebuilt bundles into the release commit.
+3. script/publish-workflow.test.ts: pin that the prepare step rebuilds + stages extension bundles before the release commit.
+
+## Verification
+- RED: current test against jq-bumped root package.json (Expected beta.7 / Received beta.8); new workflow pin against current YAML.
+- GREEN: focused test + pin after fixes.
+- STRICT local release simulation on a committed simulation branch: exact prepare bump sequence + rebuild, then the full release-branch CI surface locally with CI Bun 1.3.12:
+  a) the exact senpi-compatibility check block from ci.yml,
+  b) script/remove-stale-self-package-tests.ts + full root bun test,
+  c) bun run typecheck,
+  d) bun run test:codex,
+  e) bun run build.
+- Only after all local gates green: PR, CI, merge, redispatch publish.

--- a/packages/omo-senpi/src/components/telemetry/product-identity.test.ts
+++ b/packages/omo-senpi/src/components/telemetry/product-identity.test.ts
@@ -37,6 +37,17 @@ function useTemporaryAgentDir(): string {
   return root
 }
 
+// The stamped workspace version is the contract, not any single literal: the release pipeline
+// stamps this package.json on the release branch, so a pinned literal breaks every release cut.
+function readStampedWorkspaceVersion(): string {
+  const parsed: unknown = JSON.parse(readFileSync(new URL("../../../package.json", import.meta.url), "utf8"))
+  if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const version = Reflect.get(parsed, "version")
+    if (typeof version === "string") return version
+  }
+  throw new Error("packages/omo-senpi/package.json must expose a string version")
+}
+
 describe("OmO Native product identity", () => {
   test("#given the native product #when config is created #then identity derivation and effective geoip settings are fixed", () => {
     const config = createOmoNativeProductConfig()
@@ -45,7 +56,7 @@ describe("OmO Native product identity", () => {
     expect(isConfiguredTelemetryApiKey(OMO_NATIVE_POSTHOG_API_KEY)).toBe(true)
     expect(config.platform).toBe("omo-senpi")
     expect(config.machineIdPrefix).toBe("omo-senpi:")
-    expect(config.packageVersion).toBe("5.0.0-beta.7")
+    expect(config.packageVersion).toBe(readStampedWorkspaceVersion())
     expect(config.productEnvPrefix).toBe("OMO_SENPI")
     expect(config.disableGeoip ?? false).toBe(false)
     expect(getTelemetryApiKey({ POSTHOG_API_KEY: "env-project-key" }, config.defaultApiKey)).toBe("env-project-key")

--- a/script/publish-release-bundle-rebuild.test.ts
+++ b/script/publish-release-bundle-rebuild.test.ts
@@ -1,0 +1,35 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const publishWorkflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
+
+function sliceWorkflowSection(workflow: string, startMarker: string, endMarker: string): string {
+  const start = workflow.indexOf(startMarker)
+  const end = workflow.indexOf(endMarker, start)
+  if (start < 0 || end < 0 || end <= start) {
+    throw new Error(`missing workflow section between ${startMarker} and ${endMarker}`)
+  }
+  return workflow.slice(start, end)
+}
+
+describe("test workflows", () => {
+  test("rebuilds version-stamped Senpi bundles into the release commit", () => {
+    // #given
+    const workflow = readFileSync(publishWorkflowPath, "utf8")
+    const prepareJob = sliceWorkflowSection(workflow, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
+
+    // #when
+    const rebuildsBundles = prepareJob.includes("node packages/omo-senpi/plugin/scripts/build-extension.mjs")
+    const stagesBundles = prepareJob.includes("git add -f packages/omo-senpi/plugin/extensions")
+    const rebuildPrecedesCommit =
+      prepareJob.indexOf("node packages/omo-senpi/plugin/scripts/build-extension.mjs") <
+      prepareJob.indexOf('git commit -m "release: v${VERSION}"')
+
+    // #then
+    expect(rebuildsBundles, "the version bump restamps OMO_SENPI_PACKAGE_VERSION, so the release commit must rebuild the Senpi bundles").toBe(true)
+    expect(stagesBundles, "rebuilt bundles live in an ignored path and must be force-staged into the release commit").toBe(true)
+    expect(rebuildPrecedesCommit, "the rebuild must land in the release commit, not after it").toBe(true)
+  })
+})


### PR DESCRIPTION
## What changed

Two release-pipeline defects made the beta.8 release-state PR (#6855) red on its version-bumped tree, which correctly tripped the publish fail-safe:

1. `product-identity.test.ts` pinned `packageVersion` to the literal `5.0.0-beta.7`. Every release cut re-stamps `packages/omo-senpi/package.json`, so this test breaks each release. It now derives the expectation from that manifest (the stamped-version contract, not a literal).
2. `prepare-release-state` bumps versions but never rebuilds the Senpi extension bundles, so the release branch fails `build-extension.mjs --check` (beta.7 shipped only via the manual rebuild commit `dc14e9518`). The prepare step now rebuilds the bundles with the workflow Bun pin and force-stages them into the `release:` commit.

Pinned by `script/publish-release-bundle-rebuild.test.ts`.

## Evidence

`.omo/evidence/20260817-release-gate-repair/`
- RED-A: bumped-tree mismatch (exact CI failure) -> GREEN-A 9/9 after the dynamic expectation.
- RED-B: pin vs old YAML -> GREEN-B after the workflow edit.
- SIMULATION: the exact prepare bump sequence plus rebuild, committed on a local sim branch, then frozen install, bundle-freshness `--check`, stale-copy cleanup, full root `bun test`, `typecheck`, `test:codex`, and `build` all executed locally with CI Bun 1.3.12 (sim-battery.txt).

## Risk

Test + workflow only; no product code. Windows is not runnable locally; the same deterministic suites run on the Windows shards in PR and release CI.

Fixes the failures tracked in #6938.
