### PR TITLE
fix(ci): install actionlint from pinned release binary

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -19,7 +19,16 @@ jobs:
 
       - name: Install actionlint
         run: |
-          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.10/scripts/download-actionlint.bash)
+          set -euo pipefail
+          # Download the pinned release binary directly instead of piping the
+          # raw.githubusercontent install script into bash. Raw content fetches
+          # get 429-rate-limited under CI load, which makes bash try to execute
+          # the error page (see 2026-08-17 Lint Workflows outage).
+          curl -sSfL -o actionlint.tar.gz \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.10/actionlint_1.7.10_linux_amd64.tar.gz
+          echo "f4c76b71db5755a713e6055cbb0857ed07e103e028bda117817660ebadb4386f  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+          rm actionlint.tar.gz
 
       - name: Run actionlint
         run: ./actionlint -color -shellcheck=""


### PR DESCRIPTION
## Summary
Every Lint Workflows run on 2026-08-17 failed with:
```
/dev/fd/63: line 1: 429:: command not found
/dev/fd/63: line 2: syntax error near unexpected token `('
```

The install step fetched the actionlint install script from `raw.githubusercontent.com` and piped it into bash. Under heavy CI load, GitHub rate-limits raw content fetches (429), so bash executed the error page instead of the script.

## Fix
Download the pinned `actionlint 1.7.10` linux/amd64 binary directly from GitHub **releases**, verifying it against the published sha256 checksum (`f4c76b71...4386f`). Release assets are not subject to the raw-content abuse limits, and the checksum pin makes the artifact tamper-evident.

## Verification
Download + checksum + tar listing verified locally; the exact commands in the workflow run cleanly.