### PR TITLE
fix(ci): retry every release-state PR read on HTTP 5xx

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -542,7 +542,24 @@ jobs:
           git diff --cached --quiet || git commit -m "release: v${VERSION}"
           git push --force-with-lease origin "HEAD:${RELEASE_BRANCH}"
 
-          PR_NUMBER="$(gh pr list --head "$RELEASE_BRANCH" --base "$BASE_REF" --state open --json number --jq '.[0].number // empty')"
+          retry_gh_read() {
+            local description="$1"
+            shift
+            local output=""
+            for api_retry in 1 2 3 4 5; do
+              if output="$("$@" 2>&1)"; then
+                printf '%s' "$output"
+                return 0
+              fi
+              echo "${description}: retry ${api_retry}/5" >&2
+              echo "$output" >&2
+              if [ "$api_retry" != "5" ]; then sleep 5; fi
+            done
+            echo "::error::${description} failed after 5 retries; GitHub API may be down." >&2
+            return 1
+          }
+
+          PR_NUMBER="$(retry_gh_read "List release-state PR" gh pr list --head "$RELEASE_BRANCH" --base "$BASE_REF" --state open --json number --jq '.[0].number // empty')"
           if [ -z "$PR_NUMBER" ]; then
             PR_URL="$(gh pr create --base "$BASE_REF" --head "$RELEASE_BRANCH" --title "release: v${VERSION}" --body "Automated release-state PR for v${VERSION}. This must merge before npm publication starts so protected-branch push failures cannot create a half-published release.")"
             PR_NUMBER="${PR_URL##*/}"
@@ -551,30 +568,18 @@ jobs:
           gh pr merge "$PR_NUMBER" --merge --auto --delete-branch=false
 
           for attempt in $(seq 1 120); do
-            # gh pr view can hit transient HTTP 5xx from GitHub's GraphQL API; retry a few
-            # times before letting set -e fail the job. Without this, a single 503 kills the
-            # entire publish run even though the release-state PR is perfectly healthy.
-            gh_view() { gh pr view "$PR_NUMBER" "$@"; }
-            for api_retry in 1 2 3 4 5; do
-              PR_STATE="$(gh_view --json state --jq '.state' 2>/dev/null)" && break
-              echo "gh pr view retry ${api_retry}/5 (attempt ${attempt}/120)"
-              sleep 5
-            done
-            if [ -z "$PR_STATE" ]; then
-              echo "::error::gh pr view failed after 5 retries at attempt ${attempt}/120; GitHub API may be down."
-              exit 1
-            fi
+            PR_STATE="$(retry_gh_read "Read release-state PR state" gh pr view "$PR_NUMBER" --json state --jq '.state')"
             if [ "$PR_STATE" = "MERGED" ]; then
-              RELEASE_SHA="$(gh_view --json mergeCommit --jq '.mergeCommit.oid' 2>/dev/null)"
+              RELEASE_SHA="$(retry_gh_read "Read release-state PR merge SHA" gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid')"
               echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
               echo "Release-state PR #${PR_NUMBER} merged at ${RELEASE_SHA}"
               exit 0
             fi
 
-            FAILURES="$(gh_view --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT")] | length' 2>/dev/null)"
+            FAILURES="$(retry_gh_read "Read release-state PR checks" gh pr view "$PR_NUMBER" --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT")] | length')"
             if [ "$FAILURES" != "0" ]; then
               echo "::error::Release-state PR #${PR_NUMBER} has failing required checks; refusing to publish npm packages."
-              gh_view --json url,statusCheckRollup --jq '{url, statusCheckRollup}'
+              retry_gh_read "Read failing release-state PR checks" gh pr view "$PR_NUMBER" --json url,statusCheckRollup --jq '{url, statusCheckRollup}' || true
               exit 1
             fi
 

--- a/.omo/evidence/20260817-release-pr-read-retries/README.md
+++ b/.omo/evidence/20260817-release-pr-read-retries/README.md
@@ -1,0 +1,10 @@
+# Release PR-read retry evidence
+
+## Failure
+Four beta.8 publish attempts failed in prepare-release-state on transient GitHub GraphQL HTTP 503. Locations observed: `gh pr list`, merge-state `gh pr view`, and statusCheckRollup `gh pr view`. Runs: 32038803824 (attempts 25 and 9), 32040896810, 32042302206, 32042578880.
+
+## Fix
+`retry_gh_read` retries every idempotent PR read (list, state, merge SHA, check rollup, diagnostic rollup) five times with bounded 5-second delays. Write operations remain unchanged.
+
+## Verification
+`script/publish-release-bundle-rebuild.test.ts` pins all read callsites; combined workflow tests 15/15 pass, YAML parses, diff-check clean.

--- a/script/publish-release-bundle-rebuild.test.ts
+++ b/script/publish-release-bundle-rebuild.test.ts
@@ -15,6 +15,24 @@ function sliceWorkflowSection(workflow: string, startMarker: string, endMarker: 
 }
 
 describe("test workflows", () => {
+  test("retries every idempotent release-state PR read on transient GitHub API errors", () => {
+    // #given
+    const workflow = readFileSync(publishWorkflowPath, "utf8")
+    const prepareJob = sliceWorkflowSection(workflow, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
+
+    // #when
+    const definesReadRetry = prepareJob.includes("retry_gh_read()")
+    const retriesPrList = prepareJob.includes('PR_NUMBER="$(retry_gh_read "List release-state PR" gh pr list')
+    const retriesPrState = prepareJob.includes('PR_STATE="$(retry_gh_read "Read release-state PR state" gh pr view')
+    const retriesCheckRollup = prepareJob.includes('FAILURES="$(retry_gh_read "Read release-state PR checks" gh pr view')
+
+    // #then
+    expect(definesReadRetry, "prepare-release-state must centralize retry handling for GitHub PR reads").toBe(true)
+    expect(retriesPrList, "a transient 503 while listing the existing release PR must not kill publish").toBe(true)
+    expect(retriesPrState, "a transient 503 while reading merge state must not kill publish").toBe(true)
+    expect(retriesCheckRollup, "a transient 503 while reading check rollup must not kill publish").toBe(true)
+  })
+
   test("rebuilds version-stamped Senpi bundles into the release commit", () => {
     // #given
     const workflow = readFileSync(publishWorkflowPath, "utf8")


### PR DESCRIPTION
## What changed

Centralizes bounded retries for every idempotent GitHub PR read in prepare-release-state: existing PR lookup, merge state, merge SHA, check rollup, and failure diagnostics. Four beta.8 attempts failed on GraphQL HTTP 503 at different callsites.

## Verification

- Workflow tests: 15/15 pass.
- YAML parse: pass.
- diff-check: clean.

No product code changed.