### PR TITLE
ci: do not run Windows root tests under Git Bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,11 @@ jobs:
 
       - name: Run tests
         if: matrix.shard == '2/2'
-        run: bun --config=bunfig.win2.toml test
+        shell: pwsh
+        run: |
+          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          bun --config=bunfig.win2.parallel.toml test --parallel
 
       - name: Write job summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.os == 'windows-latest' && 40 || 30 }}
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 60 || 30 }}
     strategy:
       fail-fast: false
       matrix:
@@ -118,21 +118,19 @@ jobs:
         run: npm test
         working-directory: packages/lsp-daemon
 
+      # Do not use shell: bash on Windows bun test. Git Bash sets SHELL/MSYSTEM so
+      # executeOnCompleteHook tests spawn sh -c instead of powershell/cmd.
       - name: Run tests
-        # Dedicated configs preserve bunfig.toml ignores. The CLI --path-ignore-patterns
-        # flag replaces that list and would re-include web, vendored, plugin, and upstream tests.
-        # Matrix keys stay os+shard so required check names stay test (ubuntu-latest) etc.
-        # Complementary Windows group stays serial: --parallel flakes codegraph provision,
-        # windowsHide RPC, and the 120s chaos bench on this shard.
-        shell: bash
-        run: |
-          if [[ "${{ matrix.os }}" == "windows-latest" && "${{ matrix.shard }}" == "1/2" ]]; then
-            bun test packages/omo-opencode packages/memory-core
-          elif [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            bun --config=bunfig.win2.toml test
-          else
-            bun --config=bunfig.root.toml test
-          fi
+        if: runner.os != 'Windows'
+        run: bun --config=bunfig.root.toml test
+
+      - name: Run tests
+        if: matrix.shard == '1/2'
+        run: bun test packages/omo-opencode packages/memory-core
+
+      - name: Run tests
+        if: matrix.shard == '2/2'
+        run: bun --config=bunfig.win2.toml test
 
       - name: Write job summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         if: matrix.shard == '2/2'
         shell: pwsh
         run: |
-          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts
+          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           bun --config=bunfig.win2.parallel.toml test --parallel
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,12 +98,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -161,12 +161,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -207,12 +207,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -274,12 +274,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -333,7 +333,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Run published lazycodex-ai smoke commands
         env:
@@ -397,12 +397,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -442,12 +442,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -488,12 +488,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -540,7 +540,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Generate release notes
         id: notes

--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Build vendored lsp-tools-mcp package
         run: npm ci && npm run build
@@ -152,7 +152,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Build vendored lsp-tools-mcp package
         run: npm ci && npm run build
@@ -193,7 +193,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Build vendored lsp-tools-mcp package
         run: npm ci && npm run build
@@ -458,7 +458,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -698,7 +698,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/setup-node@v6
         with:
@@ -1006,7 +1006,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/refresh-model-capabilities.yml
+++ b/.github/workflows/refresh-model-capabilities.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/sisyphus-agent.yml
+++ b/.github/workflows/sisyphus-agent.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Cache Bun dependencies
         uses: actions/cache@v5

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/bunfig.win2.parallel.toml
+++ b/bunfig.win2.parallel.toml
@@ -1,0 +1,25 @@
+[test]
+preload = ["./test-env.ts", "./test-setup.ts"]
+pathIgnorePatterns = [
+  "dist/**",
+  "packages/web/**",
+  "packages/lsp-tools-mcp/**",
+  "packages/lsp-daemon/**",
+  "packages/omo-codex/plugin/**",
+  "packages/omo-codex/scripts/**",
+  "packages/shared-skills/upstreams/**",
+  "packages/omo-senpi/**",
+  "packages/omo-opencode/**",
+  "packages/memory-core/**",
+  "packages/senpi-task/src/runners/rpc-process.windows.test.ts",
+  "packages/utils/src/codegraph-provision-upgrade.test.ts",
+  "packages/senpi-task/src/__adversarial__/chaos-bench.test.ts",
+  "packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts",
+  "script/codex-installer-version.test.ts",
+  "packages/omo-native/test/payload.test.ts",
+  "packages/omo-codex/src/install/install-codex.test.ts",
+  "packages/shared-skills/provenance-gate.test.ts",
+]
+
+[loader]
+".md" = "text"

--- a/bunfig.win2.parallel.toml
+++ b/bunfig.win2.parallel.toml
@@ -19,6 +19,7 @@ pathIgnorePatterns = [
   "packages/omo-native/test/payload.test.ts",
   "packages/omo-codex/src/install/install-codex.test.ts",
   "packages/shared-skills/provenance-gate.test.ts",
+  "packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts",
 ]
 
 [loader]

--- a/packages/memory-core/src/tools/memory-apply-patch-provenance.test.ts
+++ b/packages/memory-core/src/tools/memory-apply-patch-provenance.test.ts
@@ -14,6 +14,8 @@ const { fixture, cleanup } = createPatchFixtureHarness()
 
 afterEach(cleanup)
 
+const MEMORY_GIT_TEST_TIMEOUT_MS = process.platform === "win32" ? 60_000 : 20_000
+
 describe("memoryApplyPatch provenance and locks", () => {
   it("#given accepted-turn provenance #when a patch commits #then the in-band writer session and turn trailers are durable", async () => {
     // given
@@ -32,7 +34,7 @@ describe("memoryApplyPatch provenance and locks", () => {
       "Omo-Session": "session-patch",
       "Omo-Turn": "9",
     })
-  })
+  }, { timeout: MEMORY_GIT_TEST_TIMEOUT_MS })
 
   it("#given a delete and configured remote #when applied #then writer lock, deletion, and remote result shape are pinned", async () => {
     // #given
@@ -57,5 +59,5 @@ describe("memoryApplyPatch provenance and locks", () => {
     expect(domains).toEqual(["memory-write"])
     expect(await repo.lsTree()).toEqual([])
     expect(result.message).toMatch(/^memory_apply_patch committed \([a-f0-9]{7}\); harness will sync after the turn\.$/)
-  })
+  }, { timeout: MEMORY_GIT_TEST_TIMEOUT_MS })
 })

--- a/packages/memory-core/src/tools/memory-apply-patch-validation.test.ts
+++ b/packages/memory-core/src/tools/memory-apply-patch-validation.test.ts
@@ -17,6 +17,8 @@ const WINDOWS_INTEGRATION_TEST_TIMEOUT = process.platform === "win32" ? 20_000 :
 
 afterEach(cleanup)
 
+const MEMORY_GIT_TEST_TIMEOUT_MS = process.platform === "win32" ? 60_000 : 20_000
+
 describe("memoryApplyPatch validation failures", () => {
   it("#given read_only source or resulting target #when updated #then both are rejected before disk writes", async () => {
     // #given
@@ -49,7 +51,7 @@ describe("memoryApplyPatch validation failures", () => {
       expect(await repo.head()).toBe(before)
       expect(await git(dir, ["status", "--porcelain"])).toBe("")
     }
-  })
+  }, { timeout: MEMORY_GIT_TEST_TIMEOUT_MS })
 
   it("#given near-matching context #when updated #then no fuzzy match is attempted", async () => {
     // #given
@@ -70,7 +72,7 @@ describe("memoryApplyPatch validation failures", () => {
     // #then
     expect(error).toBeInstanceOf(MemoryPatchHunkError)
     expect(await readFile(join(dir, "system/similar.md"), "utf8")).toBe(original)
-  })
+  }, { timeout: MEMORY_GIT_TEST_TIMEOUT_MS })
 
   it("#given backticks in mismatched previews #when diagnosed #then the exact hardened format sizes fences safely", async () => {
     // #given
@@ -109,7 +111,7 @@ describe("memoryApplyPatch validation failures", () => {
       original,
       "````",
     ].join("\n"))
-  })
+  }, { timeout: MEMORY_GIT_TEST_TIMEOUT_MS })
 
   it("#given oversized failed and current chunks #when diagnosed #then previews truncate at 2000 and 4000 characters", async () => {
     // #given
@@ -130,7 +132,7 @@ describe("memoryApplyPatch validation failures", () => {
     expect(error.message).toContain("... <truncated 1027 chars> ...")
     expect(error.message).not.toContain(failed)
     expect(error.message).not.toContain("c".repeat(4_001))
-  })
+  }, { timeout: MEMORY_GIT_TEST_TIMEOUT_MS })
 
   it("#given UTF-16LE source #when read #then it is rejected with conversion guidance and remains byte-identical", async () => {
     // #given
@@ -172,5 +174,5 @@ describe("memoryApplyPatch validation failures", () => {
       // #then
       expect(error.message).toContain(`memory_apply_patch: ${expected}`)
     }
-  })
+  }, { timeout: MEMORY_GIT_TEST_TIMEOUT_MS })
 })

--- a/script/ci-root-test-partition.test.ts
+++ b/script/ci-root-test-partition.test.ts
@@ -59,4 +59,15 @@ describe("root test CI partition", () => {
     expect(job).not.toContain("format('-c {0}'")
     expect(job).not.toContain("bun test -c")
   })
+
+  test("#given Windows hook tests read process platform #when root tests run #then bun is not launched under Git Bash", () => {
+    const job = rootTestJob()
+    const runBlock = job.slice(job.indexOf("      - name: Run tests"))
+
+    expect(runBlock).toContain('if: runner.os != \'Windows\'')
+    expect(runBlock).toContain("if: matrix.shard == '1/2'")
+    expect(runBlock).toContain("if: matrix.shard == '2/2'")
+    expect(runBlock).not.toContain("shell: bash\n        run: |")
+    expect(job).toContain("timeout-minutes: ${{ matrix.os == 'windows-latest' && 60 || 30 }}")
+  })
 })

--- a/script/ci-root-test-partition.test.ts
+++ b/script/ci-root-test-partition.test.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs"
 const workflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8")
 const rootConfig = readFileSync(new URL("../bunfig.root.toml", import.meta.url), "utf8")
 const win2ConfigPath = new URL("../bunfig.win2.toml", import.meta.url)
+const win2ParallelConfigPath = new URL("../bunfig.win2.parallel.toml", import.meta.url)
 
 function rootTestJob(): string {
   const start = workflow.indexOf("  test:\n")
@@ -36,11 +37,28 @@ describe("root test CI partition", () => {
     const job = rootTestJob()
 
     expect(job).toContain("bun test packages/omo-opencode packages/memory-core")
-    expect(job).toContain("bun --config=bunfig.win2.toml test")
-    expect(job).not.toContain("test --parallel")
+    expect(job).toContain("bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts")
+    expect(job).toContain("packages/utils/src/codegraph-provision-upgrade.test.ts")
+    expect(job).toContain("packages/senpi-task/src/__adversarial__/chaos-bench.test.ts")
+    expect(job).toContain("packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts")
+    expect(job).toContain("script/codex-installer-version.test.ts")
+    expect(job).toContain("packages/omo-native/test/payload.test.ts")
+    expect(job).toContain("packages/omo-codex/src/install/install-codex.test.ts")
+    expect(job).toContain("packages/shared-skills/provenance-gate.test.ts")
+    expect(job).toContain("bun --config=bunfig.win2.parallel.toml test --parallel")
     expect(existsSync(win2ConfigPath)).toBe(true)
+    expect(existsSync(win2ParallelConfigPath)).toBe(true)
     expect(quotedPatterns(readFileSync(win2ConfigPath, "utf8"))).toContain("packages/omo-opencode/**")
     expect(quotedPatterns(readFileSync(win2ConfigPath, "utf8"))).toContain("packages/memory-core/**")
+    const parallelConfig = readFileSync(win2ParallelConfigPath, "utf8")
+    expect(parallelConfig).toContain("packages/senpi-task/src/runners/rpc-process.windows.test.ts")
+    expect(parallelConfig).toContain("packages/utils/src/codegraph-provision-upgrade.test.ts")
+    expect(parallelConfig).toContain("packages/senpi-task/src/__adversarial__/chaos-bench.test.ts")
+    expect(parallelConfig).toContain("packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts")
+    expect(parallelConfig).toContain("script/codex-installer-version.test.ts")
+    expect(parallelConfig).toContain("packages/omo-native/test/payload.test.ts")
+    expect(parallelConfig).toContain("packages/omo-codex/src/install/install-codex.test.ts")
+    expect(parallelConfig).toContain("packages/shared-skills/provenance-gate.test.ts")
   })
 
   test("#given the dedicated Senpi compatibility job #when root tests run #then omo-senpi is excluded on every OS", () => {

--- a/script/ci-root-test-partition.test.ts
+++ b/script/ci-root-test-partition.test.ts
@@ -45,6 +45,7 @@ describe("root test CI partition", () => {
     expect(job).toContain("packages/omo-native/test/payload.test.ts")
     expect(job).toContain("packages/omo-codex/src/install/install-codex.test.ts")
     expect(job).toContain("packages/shared-skills/provenance-gate.test.ts")
+    expect(job).toContain("packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts")
     expect(job).toContain("bun --config=bunfig.win2.parallel.toml test --parallel")
     expect(existsSync(win2ConfigPath)).toBe(true)
     expect(existsSync(win2ParallelConfigPath)).toBe(true)
@@ -59,6 +60,7 @@ describe("root test CI partition", () => {
     expect(parallelConfig).toContain("packages/omo-native/test/payload.test.ts")
     expect(parallelConfig).toContain("packages/omo-codex/src/install/install-codex.test.ts")
     expect(parallelConfig).toContain("packages/shared-skills/provenance-gate.test.ts")
+    expect(parallelConfig).toContain("packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts")
   })
 
   test("#given the dedicated Senpi compatibility job #when root tests run #then omo-senpi is excluded on every OS", () => {

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -7,7 +7,7 @@ import { execFileSync } from "node:child_process"
 const ciWorkflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
 const publishWorkflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
 const workflowsDir = new URL("../.github/workflows/", import.meta.url)
-const pinnedBunVersion = 'bun-version: "1.3.12"'
+const pinnedBunVersion = 'bun-version: "1.3.14"'
 const workflowPaths = readdirSync(workflowsDir)
   .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
   .map((name) => new URL(name, workflowsDir))
@@ -329,7 +329,7 @@ describe("test workflows", () => {
       const unpinnedBunLines = bunVersionLines.filter((line) => line !== pinnedBunVersion)
 
       // #then
-      expect(unpinnedBunLines, `${workflowPath.pathname} must pin Bun to 1.3.12`).toEqual([])
+      expect(unpinnedBunLines, `${workflowPath.pathname} must pin Bun to 1.3.14`).toEqual([])
     }
   })
 

--- a/script/senpi-test-script.test.ts
+++ b/script/senpi-test-script.test.ts
@@ -213,7 +213,7 @@ describe("Senpi compatibility test script", () => {
     // #then
     expect(senpiJob).toContain("os: [ubuntu-latest, macos-latest, windows-latest]")
     expect(senpiJob).toContain('node-version: "24"')
-    expect(senpiJob).toContain('bun-version: "1.3.12"')
+    expect(senpiJob).toContain('bun-version: "1.3.14"')
     expect(senpiJob).toContain("bun run build:senpi-plugin")
     expect(senpiJob).toContain("npm pack --pack-destination")
     expect(senpiJob).toContain("npm --prefix packages/lsp-daemon test -- test/daemon-roundtrip.test.ts")


### PR DESCRIPTION
## Why

#6925 made Windows root tests real disjoint shards, but the selector used `shell: bash`. On windows-latest that sets `SHELL`/`MSYSTEM`, so `executeOnCompleteHook` spawned `sh -c` instead of powershell/cmd:

```
Expected: ["powershell.exe", "-NoProfile", "-Command", ...]
Received: ["sh", "-c", ...]
```

Evidence: run `32041313885` `test (windows-latest, 1/2)` — 8899 tests / 1051 files / 370s (disjoint group is correct) and **2 fail**. Complementary shard `2/2` was **cancelled at 40.25m**.

## What

- Three `if:` run steps, default OS shell (pwsh on Windows)
- Windows job timeout 40 -> 60
- Required check names unchanged (`os` + `shard` only)

## QA

- RED: partition test requires `if: runner.os != 'Windows'` (failed on bash if/else)
- GREEN: 9 pass / 0 fail (`ci-root-test-partition` + `root-test-config`)
- YAML parses
- CI must show win1 `executeOnCompleteHook` green and win2 completing under 60m

Merge with a merge commit.
