### PR TITLE
ci(lint): fetch actionlint installer via authenticated pinned contents API

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -18,8 +18,19 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install actionlint
+        env:
+          # Anonymous raw.githubusercontent.com requests from shared runner IPs
+          # are throttled to HTTP 429. The authenticated contents API draws from
+          # the token quota instead, so the pinned installer fetch is stable.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.10/scripts/download-actionlint.bash)
+          set -euo pipefail
+          curl --fail --location --silent --show-error \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "Accept: application/vnd.github.raw+json" \
+            --output download-actionlint.bash \
+            "https://api.github.com/repos/rhysd/actionlint/contents/scripts/download-actionlint.bash?ref=v1.7.10"
+          bash download-actionlint.bash 1.7.10
 
       - name: Run actionlint
         run: ./actionlint -color -shellcheck=""

--- a/script/actionlint-bootstrap-workflow.test.ts
+++ b/script/actionlint-bootstrap-workflow.test.ts
@@ -1,0 +1,109 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { load } from "js-yaml"
+
+const workflowPath = new URL("../.github/workflows/lint-workflows.yml", import.meta.url)
+const installStepName = "Install actionlint"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readInstallStep(): Record<string, unknown> {
+  const workflow = load(readFileSync(workflowPath, "utf8"))
+  if (!isRecord(workflow) || !isRecord(workflow.jobs)) throw new Error("lint-workflows.yml has no jobs")
+
+  const actionlintJob = workflow.jobs["actionlint"]
+  if (!isRecord(actionlintJob) || !Array.isArray(actionlintJob.steps)) {
+    throw new Error("lint-workflows.yml actionlint job has no steps")
+  }
+
+  const installStep = actionlintJob.steps.find(
+    (step): boolean => isRecord(step) && step["name"] === installStepName,
+  )
+  if (!isRecord(installStep)) throw new Error(`lint-workflows.yml has no "${installStepName}" step`)
+
+  return installStep
+}
+
+function readInstallStepRun(): string {
+  const run = readInstallStep()["run"]
+  if (typeof run !== "string") throw new Error(`"${installStepName}" step has no run script`)
+
+  return run
+}
+
+describe("actionlint bootstrap workflow", () => {
+  test("#given the actionlint install step #when inspected #then it authenticates the pinned fetch with the workflow token", () => {
+    // given
+    const installStep = readInstallStep()
+
+    // when
+    const env = installStep["env"]
+
+    // then
+    expect(isRecord(env), "install step must pass a token via env").toBe(true)
+    if (isRecord(env)) {
+      expect(env["GITHUB_TOKEN"], "GITHUB_TOKEN must come from github.token").toBe("${{ github.token }}")
+    }
+  })
+
+  test("#given an HTTP error from the bootstrap fetch #when the install step runs #then curl exits non-zero instead of piping the error body into bash", () => {
+    // given
+    const run = readInstallStepRun()
+
+    // when
+    const failsCleanly = /(^|\s)--fail(\s|$)/.test(run)
+    const pipesIntoBash = /bash\s*</.test(run)
+
+    // then
+    expect(failsCleanly, "curl must pass --fail so 4xx/5xx responses fail the step").toBe(true)
+    expect(pipesIntoBash, "no curl output may be executed via bash <( or bash <").toBe(false)
+  })
+
+  test("#given the actionlint installer script fetch #when inspected #then it uses the authenticated pinned contents API endpoint", () => {
+    // given
+    const run = readInstallStepRun()
+
+    // when
+    const pinnedUrl = run.match(/https:\/\/api\.github\.com\/repos\/rhysd\/actionlint\/contents\/scripts\/download-actionlint\.bash\?ref=v\d+\.\d+\.\d+/)
+
+    // then
+    expect(pinnedUrl, "fetch URL must be the api.github.com contents endpoint pinned to a tag").not.toBeNull()
+    expect(run.includes("Authorization: Bearer"), "fetch must send a Bearer authorization header").toBe(true)
+    expect(
+      run.includes("Accept: application/vnd.github.raw+json"),
+      "fetch must negotiate raw content, not the JSON metadata envelope",
+    ).toBe(true)
+    expect(run.includes("raw.githubusercontent.com"), "fetch must not use the throttled raw host").toBe(false)
+  })
+
+  test("#given the pinned installer script #when it runs #then the version argument matches the fetched tag", () => {
+    // given
+    const run = readInstallStepRun()
+
+    // when
+    const refTag = run.match(/\?ref=v(\d+\.\d+\.\d+)/)?.[1]
+    const versionArg = run.match(/bash download-actionlint\.bash (\d+\.\d+\.\d+)/)?.[1]
+
+    // then
+    expect(refTag, "ref tag must pin the installer script version").toBeDefined()
+    expect(versionArg, "the installer must be invoked with an explicit version").toBeDefined()
+    expect(versionArg, "installer version argument must match the pinned ref tag").toBe(refTag)
+  })
+
+  test("#given the install step #when inspected #then it does not mask bootstrap failures with retries", () => {
+    // given
+    const run = readInstallStepRun()
+    const installStep = readInstallStep()
+
+    // when
+    const retryConstructs = /(^|\s)(for\s|until\s)|\|\|\s*true/.test(run)
+
+    // then
+    expect(retryConstructs, "the bootstrap must fail fast, not retry through failures").toBe(false)
+    expect(installStep["continue-on-error"], "the step must not swallow failures").toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

The `Lint Workflows` job's `Install actionlint` step fetched the pinned upstream installer by piping an anonymous `raw.githubusercontent.com` curl straight into `bash`, with no `--fail`. During GitHub's current throttling of raw/codeload (HTTP 429), the 429 response body was executed as a shell script and the job died with a bogus syntax error (run 32038787530: `/dev/fd/63: line 1: 429:: command not found`, then `syntax error near unexpected token '('`). This PR makes that bootstrap authenticated, version-pinned, and fail-clean, without adding any retry or fallback that could mask a real failure.

## Changes

- `.github/workflows/lint-workflows.yml`, `Install actionlint` step only:
  - Wires `GITHUB_TOKEN: ${{ github.token }}` (workflow already grants `permissions: contents: read`).
  - Fetches the same pinned script (`v1.7.10`) through `https://api.github.com/repos/rhysd/actionlint/contents/scripts/download-actionlint.bash?ref=v1.7.10` with `Authorization: Bearer` and `Accept: application/vnd.github.raw+json`, writing to disk (`--output`), never executing a response stream.
  - Uses `curl --fail --location --silent --show-error` plus `set -euo pipefail`, so any HTTP error fails the step cleanly instead of piping an error body onward.
  - Invokes the installer with an explicit `1.7.10` argument (the upstream script's built-in default is a stale `1.7.9`, so the explicit arg is what actually pins the binary). The binary itself comes from the release CDN, which was healthy throughout.
- `script/actionlint-bootstrap-workflow.test.ts` (new): machine-consumed contract on the bootstrap step, written failing-first. It parses the workflow YAML and asserts: token wiring; `--fail` present; no `bash <` execution of curl output; authenticated pinned `api.github.com` contents URL (and no `raw.githubusercontent.com`); installer version argument matches the pinned `ref` tag; and no retry constructs or `continue-on-error`.

## QA & Evidence

- **What was tested:** failing-first contract suite against the unmodified dev workflow, then against the patched one (`bun test script/actionlint-bootstrap-workflow.test.ts`).
  **Observed result:** 4/5 assertions failed before the fix (token wiring, `--fail`, pinned authenticated URL, tag/arg consistency); 5/5 pass after. With the adjacent job-summary audit: 9/9 pass, 72 expect calls.
  **Artifact:** `.omo/evidence/20260817-actionlint-auth-bootstrap/test-before.txt`, `test-after.txt` (worktree-local; summarized in `what-was-tested.md`).
- **What was tested:** the new step's commands verbatim on a real machine (authenticated pinned fetch, `bash download-actionlint.bash 1.7.10`, then `./actionlint -color -shellcheck=""` over the repository, including the edited workflow).
  **Observed result:** installer fetched over the authenticated contents API during the ongoing raw/codeload throttling; actionlint 1.7.10 downloaded from the release CDN; lint exited 0.
  **Artifact:** `.omo/evidence/20260817-actionlint-auth-bootstrap/actionlint-local-run.txt`.
- **What was tested:** endpoint status matrix captured during the incident (anonymous vs Bearer).
  **Observed result:** `raw.githubusercontent.com` 429 both anonymous and authenticated; `codeload.github.com` 429 both; `api.github.com` contents 200 authenticated (token core quota); release CDN 200.
  **Artifact:** `.omo/evidence/20260817-actionlint-auth-bootstrap/http-endpoint-matrix.txt`.
- **Static:** `bun run typecheck:script` and root `bun run typecheck` clean for the new test file.

## Incident separation (explicit non-claims)

- The dev CI failures downloading the pinned `oven-sh/setup-bun` action tarball from `codeload.github.com` (run 32038787496, `Set up job` stage, runner-side 429 after the runner's own 3-attempt backoff) are an external GitHub throttling incident. No workflow edit can authenticate or relocate the runner's action downloads. This PR does NOT claim to fix that class and adds no retry to paper over it.
- Sequencing note: this branch was rebased onto current `origin/dev` (988c753b7) and re-verified after review feedback; it intentionally shares no files with the Senpi bundle-build lane.

## Risks & Residuals

- The contents-API fetch depends on `github.token` with `contents: read` (already granted); if the upstream tag `v1.7.10` were ever deleted the step fails loudly, which is the intended behavior.
- Full local `bun test` in the task worktree showed pre-existing failures in install-codex/Senpi bundle-stamp tests caused by the worktree lacking generated Senpi bundle artifacts (separate lane), not by this change; the focused suites, typecheck, and actionlint are green.
- CI on this PR may still be affected by the external GitHub throttling incident; if a required check fails there for 429-at-action-download reasons, that is infra, not this patch.

## Related Issues

Unblocks the `Lint Workflows` required base-branch gate that PR #6937 currently stacks on.
