### PR TITLE
ci: eliminate duplicate release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,13 @@ jobs:
             : > "$PATHS_FILE"
           fi
 
+          MERGE_PARENTS="$(git show -s --format=%P "$GITHUB_SHA" | wc -w)"
+
           MODE_JSON="$(node script/ci-fast-path.mjs \
             --event "$GITHUB_EVENT_NAME" \
             --message "$HEAD_COMMIT_MESSAGE" \
             --diff-available "$DIFF_AVAILABLE" \
+            --merge-parents "$MERGE_PARENTS" \
             < "$PATHS_FILE")"
 
           jq -r '"generated_release_push=\(.generatedReleasePush)"' <<< "$MODE_JSON" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,16 +155,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          # Windows legs run 1.3.14: the Windows partition was validated under
-          # it and 1.3.12 hangs on windows-latest in the ast-grep install-script
-          # timeout race. Other legs keep the repo pin.
-          bun-version: ${{ matrix.os == 'windows-latest' && '1.3.14' || '1.3.12' }}
+          # Test legs run 1.3.14: the Windows partition was validated under it
+          # and 1.3.12 hangs on windows-latest in the ast-grep install-script
+          # timeout race.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: runner.os != 'Windows' && needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ matrix.os == 'windows-latest' && '1.3.14' || '1.3.12' }}-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -194,7 +194,11 @@ jobs:
 
       - name: Run tests
         if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '2/2'
-        run: bun --config=bunfig.win2.toml test
+        shell: pwsh
+        run: |
+          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          bun --config=bunfig.win2.parallel.toml test --parallel
 
       - name: Write job summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,13 +155,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.14"
+          # Windows legs run 1.3.14: the Windows partition was validated under
+          # it and 1.3.12 hangs on windows-latest in the ast-grep install-script
+          # timeout race. Other legs keep the repo pin.
+          bun-version: ${{ matrix.os == 'windows-latest' && '1.3.14' || '1.3.12' }}
 
       - uses: actions/cache@v5
-        if: runner.os != 'Windows' && needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-${{ matrix.os == 'windows-latest' && '1.3.14' || '1.3.12' }}-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -179,8 +182,8 @@ jobs:
         run: npm test
         working-directory: packages/lsp-daemon
 
-      # Do not use shell: bash on Windows bun test. Git Bash sets SHELL/MSYSTEM so
-      # executeOnCompleteHook tests spawn sh -c instead of powershell/cmd.
+      # Git Bash sets SHELL/MSYSTEM on Windows, which makes process-platform
+      # tests observe sh instead of the native PowerShell/cmd execution path.
       - name: Run tests
         if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows'
         run: bun --config=bunfig.root.toml test
@@ -191,11 +194,7 @@ jobs:
 
       - name: Run tests
         if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '2/2'
-        shell: pwsh
-        run: |
-          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          bun --config=bunfig.win2.parallel.toml test --parallel
+        run: bun --config=bunfig.win2.toml test
 
       - name: Write job summary
         if: always()
@@ -225,13 +224,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.3.12"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -277,13 +276,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.3.12"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -349,13 +348,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.3.12"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -415,7 +414,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.3.12"
 
       - name: Run published lazycodex-ai smoke commands
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -482,13 +481,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.3.12"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -535,13 +534,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.3.12"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -586,12 +585,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.3.12"
 
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -641,7 +640,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.3.12"
 
       - name: Generate release notes
         id: notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '2/2'
         shell: pwsh
         run: |
-          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts
+          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts packages/senpi-task/src/dag/scheduler.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           bun --config=bunfig.win2.parallel.toml test --parallel
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
           # timeout race.
           bun-version: "1.3.14"
 
+
       - uses: actions/cache@v5
         if: runner.os != 'Windows' && needs.ci-mode.outputs.run_heavy == 'true'
         with:
@@ -228,13 +229,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -280,13 +281,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -352,13 +353,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -418,7 +419,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Run published lazycodex-ai smoke commands
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -485,13 +486,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -538,13 +539,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         if: needs.ci-mode.outputs.run_heavy == 'true'
@@ -589,12 +590,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -644,7 +645,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.12"
+          bun-version: "1.3.14"
 
       - name: Generate release notes
         id: notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,60 @@ permissions:
   contents: read
 
 jobs:
+  ci-mode:
+    runs-on: ubuntu-latest
+    outputs:
+      generated_release_push: ${{ steps.classify.outputs.generated_release_push }}
+      web_only: ${{ steps.classify.outputs.web_only }}
+      run_heavy: ${{ steps.classify.outputs.run_heavy }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Classify CI mode
+        id: classify
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
+        run: |
+          set -euo pipefail
+
+          PATHS_FILE="$RUNNER_TEMP/ci-changed-paths"
+          DIFF_AVAILABLE=true
+          if [ -z "$BASE_SHA" ] ||
+             [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] ||
+             ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null ||
+             ! git diff --name-only -z "$BASE_SHA" "$GITHUB_SHA" > "$PATHS_FILE"; then
+            DIFF_AVAILABLE=false
+            : > "$PATHS_FILE"
+          fi
+
+          MODE_JSON="$(node script/ci-fast-path.mjs \
+            --event "$GITHUB_EVENT_NAME" \
+            --message "$HEAD_COMMIT_MESSAGE" \
+            --diff-available "$DIFF_AVAILABLE" \
+            < "$PATHS_FILE")"
+
+          jq -r '"generated_release_push=\(.generatedReleasePush)"' <<< "$MODE_JSON" >> "$GITHUB_OUTPUT"
+          jq -r '"web_only=\(.webOnly)"' <<< "$MODE_JSON" >> "$GITHUB_OUTPUT"
+          jq -r '"run_heavy=\(.runHeavy)"' <<< "$MODE_JSON" >> "$GITHUB_OUTPUT"
+          jq . <<< "$MODE_JSON"
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        env:
+          JOB_SUMMARY_TITLE: CI execution mode
+          JOB_SUMMARY_STATUS: ${{ job.status }}
+          JOB_SUMMARY_DETAILS: |
+            - Generated release push: `${{ steps.classify.outputs.generated_release_push || 'unknown' }}`.
+            - Web-only change: `${{ steps.classify.outputs.web_only || 'unknown' }}`.
+            - Run heavy validation: `${{ steps.classify.outputs.run_heavy || 'unknown' }}`.
+          JOB_SUMMARY_NEXT: Classification failures default to heavy validation; inspect the changed-path diff and event metadata.
+        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
+
   # Block PRs targeting master branch (comment + auto-close, then fail the check)
   block-master-pr:
     runs-on: ubuntu-latest
@@ -77,6 +131,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   test:
+    needs: [ci-mode]
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.os == 'windows-latest' && 60 || 30 }}
     strategy:
@@ -93,44 +148,49 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           bun-version: "1.3.14"
 
       - uses: actions/cache@v5
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun install --frozen-lockfile
 
       - name: Remove stale self-package test copies
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun run script/remove-stale-self-package-tests.ts
 
       # The full install runs the root `prepare` (`bun run build`), whose
       # `build:lsp-daemon` step already runs `npm ci && npm run build` in
       # packages/lsp-daemon, so its node_modules and dist exist before the tests.
       - name: Run vendored lsp-daemon tests
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: npm test
         working-directory: packages/lsp-daemon
 
       # Do not use shell: bash on Windows bun test. Git Bash sets SHELL/MSYSTEM so
       # executeOnCompleteHook tests spawn sh -c instead of powershell/cmd.
       - name: Run tests
-        if: runner.os != 'Windows'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows'
         run: bun --config=bunfig.root.toml test
 
       - name: Run tests
-        if: matrix.shard == '1/2'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '1/2'
         run: bun test packages/omo-opencode packages/memory-core
 
       - name: Run tests
-        if: matrix.shard == '2/2'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '2/2'
         shell: pwsh
         run: |
           bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts
@@ -152,27 +212,33 @@ jobs:
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   typecheck:
+    needs: [ci-mode]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           bun-version: "1.3.14"
 
       - uses: actions/cache@v5
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Type check
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun run typecheck
 
       - name: Write job summary
@@ -188,6 +254,7 @@ jobs:
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   codex-compatibility:
+    needs: [ci-mode]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -203,27 +270,31 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           bun-version: "1.3.14"
 
       - uses: actions/cache@v5
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run full Codex compatibility suite
-        if: matrix.suite == 'full'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'full'
         run: bun run test:codex
 
       - name: Build Codex platform smoke prerequisites
-        if: matrix.suite == 'platform'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'platform'
         run: |
           bun run build:codex-install
           bun run build:git-bash-mcp
@@ -233,7 +304,7 @@ jobs:
           bun run --cwd packages/omo-codex/plugin build
 
       - name: Run Codex platform smoke tests (.mjs via node --test)
-        if: matrix.suite == 'platform'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'platform'
         run: >-
           node --test
           packages/omo-codex/scripts/install-local.test.mjs
@@ -244,7 +315,7 @@ jobs:
           packages/omo-codex/plugin/test/install-time-build-runtime.test.mjs
 
       - name: Run Codex platform smoke tests (.ts via bun test)
-        if: matrix.suite == 'platform'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'platform'
         run: bun test packages/omo-opencode/src/cli/cli-installer.platform.test.ts
 
       - name: Write job summary
@@ -261,6 +332,7 @@ jobs:
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   senpi-compatibility:
+    needs: [ci-mode]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -270,35 +342,41 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           bun-version: "1.3.14"
 
       - uses: actions/cache@v5
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Remove stale self-package test copies
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun run script/remove-stale-self-package-tests.ts
 
       # Linux only: digestBuildSources hashes repo-relative paths (build-extension.mjs:140,143),
       # which are backslash-separated on Windows, so the source digest is platform-dependent and
       # a committed artifact can never match on every OS. One platform is enough to catch drift.
       - name: Verify committed Senpi plugin bundle is current
-        if: matrix.os == 'ubuntu-latest'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           set -euo pipefail
           node packages/omo-senpi/plugin/scripts/build-extension.mjs --check
 
       - name: Run Senpi compatibility tests
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -325,18 +403,22 @@ jobs:
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   lazycodex-published-smoke:
+    needs: [ci-mode]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/setup-node@v6
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           bun-version: "1.3.14"
 
       - name: Run published lazycodex-ai smoke commands
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         env:
           HOME: ${{ runner.temp }}/lazycodex-published-smoke/home
           CODEX_HOME: ${{ runner.temp }}/lazycodex-published-smoke/codex
@@ -388,6 +470,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   build:
+    needs: [ci-mode]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -397,26 +480,32 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           bun-version: "1.3.14"
 
       - uses: actions/cache@v5
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun run build
 
       - name: Verify build output
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: |
           test -f dist/index.js || (echo "ERROR: dist/index.js not found!" && exit 1)
           test -f dist/index.d.ts || (echo "ERROR: dist/index.d.ts not found!" && exit 1)
 
       - name: Verify dist bundle tests
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun test packages/omo-opencode/src/shared/dist-bundle-bun-globals.test.ts packages/omo-opencode/src/shared/dist-bundle-prompt-content.test.ts
 
       - name: Write job summary
@@ -433,33 +522,41 @@ jobs:
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   omo-ai-payload-check:
+    needs: [ci-mode]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           bun-version: "1.3.14"
 
       - uses: actions/cache@v5
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun install --frozen-lockfile
 
       - name: Build omo-native
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun run build:omo-native
 
       - name: Verify omo-ai payload
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: node script/verify-omo-ai-payload.mjs
 
       - name: Dry-run publish
+        if: needs.ci-mode.outputs.run_heavy == 'true'
         run: npm publish --dry-run --ignore-scripts --tag beta
         working-directory: packages/omo-native
 
@@ -478,7 +575,7 @@ jobs:
 
   auto-commit-schema:
     runs-on: ubuntu-latest
-    needs: [test, typecheck, codex-compatibility, senpi-compatibility, build, omo-ai-payload-check]
+    needs: [ci-mode, test, typecheck, codex-compatibility, senpi-compatibility, build, omo-ai-payload-check]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     permissions:
       contents: write
@@ -528,8 +625,11 @@ jobs:
 
   draft-release:
     runs-on: ubuntu-latest
-    needs: [test, typecheck, codex-compatibility, senpi-compatibility, build, omo-ai-payload-check]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    needs: [ci-mode, test, typecheck, codex-compatibility, senpi-compatibility, build, omo-ai-payload-check]
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/dev' &&
+      needs.ci-mode.outputs.run_heavy == 'true'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -493,6 +493,7 @@ jobs:
           BASE_REF="${RELEASE_REF:-dev}"
 
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          trap 'git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"' EXIT
           git push --force-with-lease origin "HEAD:${RELEASE_BRANCH}"
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -367,7 +367,7 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      release_sha: ${{ steps.prepare.outputs.release_sha }}
+      release_sha: ${{ steps.publish_state.outputs.release_sha || steps.prepare.outputs.release_sha }}
     steps:
       # The PAT checks out with persist-credentials disabled: repo-controlled
       # generation below must never be able to read the release credential from
@@ -388,13 +388,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      - name: Prepare and merge release state before publishing
+      - name: Prepare release state (generation)
         id: prepare
+        # Generation only: this step runs repo-controlled scripts and package
+        # managers, so it carries NO form of the release PAT in its environment.
+        # Credential-bearing operations live in the next step.
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
           OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
           RELEASE_REF: ${{ github.ref_name }}
-          RELEASE_PAT: ${{ secrets.GH_PAT }}
           PREPARED_RELEASE_SHA: ${{ inputs.prepared_release_sha }}
         run: |
           set -euo pipefail
@@ -405,6 +407,7 @@ jobs:
               exit 1
             fi
             echo "release_sha=${PREPARED_RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "needs_push=false" >> "$GITHUB_OUTPUT"
             echo "Publishing from prepared source ${PREPARED_RELEASE_SHA}"
             exit 0
           fi
@@ -417,6 +420,7 @@ jobs:
           if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
             RELEASE_SHA="$(git rev-list --max-count=1 "refs/tags/v${VERSION}")"
             echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "needs_push=false" >> "$GITHUB_OUTPUT"
             echo "Release tag v${VERSION} already exists locally at ${RELEASE_SHA}"
             exit 0
           fi
@@ -424,6 +428,7 @@ jobs:
           RELEASE_SHA="$(git rev-list --max-count=1 --grep="^release: v${VERSION}$" "origin/${BASE_REF}" 2>/dev/null || true)"
           if [ -n "$RELEASE_SHA" ]; then
             echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "needs_push=false" >> "$GITHUB_OUTPUT"
             echo "Release commit already exists on origin/${BASE_REF}: ${RELEASE_SHA}"
             exit 0
           fi
@@ -434,6 +439,7 @@ jobs:
           if [ "$CURRENT_VERSION" = "$VERSION" ]; then
             RELEASE_SHA="$(git rev-parse HEAD)"
             echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "needs_push=false" >> "$GITHUB_OUTPUT"
             echo "origin/${BASE_REF} is already stamped as v${VERSION}: ${RELEASE_SHA}"
             exit 0
           fi
@@ -466,10 +472,29 @@ jobs:
           git add -f packages/omo-senpi/plugin/extensions
           git diff --cached --quiet || git commit -m "release: v${VERSION}"
 
-          # Credential boundary: everything above is repo-controlled generation
-          # that must not see the PAT; everything below needs it.
-          export GH_TOKEN="$RELEASE_PAT"
+          echo "needs_push=true" >> "$GITHUB_OUTPUT"
+          echo "release_branch=${RELEASE_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Release state generated on ${RELEASE_BRANCH}; handing off to the privileged publish step."
+
+      - name: Publish prepared release state
+        id: publish_state
+        if: steps.prepare.outputs.needs_push == 'true'
+        # The only credential-bearing step: git push + gh PR operations. It runs
+        # no repo-controlled generation scripts. The PAT is injected into the
+        # git remote URL just for the push and removed immediately after.
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          VERSION: ${{ needs.release-metadata.outputs.version }}
+          RELEASE_BRANCH: ${{ steps.prepare.outputs.release_branch }}
+          RELEASE_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          BASE_REF="${RELEASE_REF:-dev}"
+
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push --force-with-lease origin "HEAD:${RELEASE_BRANCH}"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
           retry_gh() {
             local description="$1"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,15 +43,12 @@ jobs:
   gate-reuse:
     runs-on: ubuntu-latest
     permissions:
-      checks: read
+      actions: read
       contents: read
-    outputs:
-      skip_gates: ${{ steps.reuse.outputs.skip_gates }}
     steps:
       - uses: actions/checkout@v5
 
-      - name: Determine whether release gates can be reused
-        id: reuse
+      - name: Require successful CI for prepared release source
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,30 +57,78 @@ jobs:
           set -euo pipefail
 
           if [ -z "$PREPARED_RELEASE_SHA" ]; then
-            echo "skip_gates=true" >> "$GITHUB_OUTPUT"
             echo "Skipping duplicate gates on the release preparation dispatch."
             exit 0
           fi
 
-          CHECK_RUNS="$(gh api --method GET \
-            "repos/${{ github.repository }}/commits/${PREPARED_RELEASE_SHA}/check-runs" \
-            -f per_page=100 \
-            -f filter=latest \
-            --paginate \
-            --slurp)"
-          REQUIRED_CHECKS='["test","typecheck","codex-compatibility (ubuntu-latest)","codex-compatibility (macos-latest)","codex-compatibility (windows-latest)"]'
+          retry_gh() {
+            local description="$1"
+            shift
+            local output=""
+            for api_retry in 1 2 3 4 5; do
+              if output="$("$@" 2>&1)"; then
+                printf '%s' "$output"
+                return 0
+              fi
+              echo "${description}: retry ${api_retry}/5" >&2
+              echo "$output" >&2
+              if [ "$api_retry" != "5" ]; then sleep 5; fi
+            done
+            echo "::error::${description} failed after 5 retries; GitHub API may be down." >&2
+            return 1
+          }
 
-          if jq -e --argjson required "$REQUIRED_CHECKS" '
-            [.[].check_runs[] | select(.name as $name | $required | index($name))] as $runs
-            | (($runs | map(.name) | unique | sort) == ($required | sort))
-              and ($runs | all(.conclusion == "success"))
-          ' <<< "$CHECK_RUNS" >/dev/null; then
-            echo "skip_gates=true" >> "$GITHUB_OUTPUT"
-            echo "All required release gates already succeeded on ${PREPARED_RELEASE_SHA}."
-          else
-            echo "skip_gates=false" >> "$GITHUB_OUTPUT"
-            echo "Required release gates are missing, incomplete, or unsuccessful on ${PREPARED_RELEASE_SHA}."
-          fi
+          for attempt in $(seq 1 120); do
+            RUNS="$(retry_gh "Read CI workflow runs" gh api --method GET \
+              "repos/${{ github.repository }}/actions/workflows/ci.yml/runs" \
+              -f head_sha="$PREPARED_RELEASE_SHA" \
+              -f event=push \
+              -f per_page=100)"
+
+            SUCCESS_ID="$(jq -r --arg sha "$PREPARED_RELEASE_SHA" '
+              [
+                .workflow_runs[]
+                | select(
+                    .head_sha == $sha
+                    and .event == "push"
+                    and .status == "completed"
+                    and .conclusion == "success"
+                  )
+              ]
+              | sort_by(.created_at)
+              | last
+              | .id // empty
+            ' <<< "$RUNS")"
+            if [ -n "$SUCCESS_ID" ]; then
+              echo "CI workflow run ${SUCCESS_ID} succeeded for ${PREPARED_RELEASE_SHA}."
+              exit 0
+            fi
+
+            ACTIVE_COUNT="$(jq -r --arg sha "$PREPARED_RELEASE_SHA" '
+              [.workflow_runs[] | select(.head_sha == $sha and .event == "push" and .status != "completed")]
+              | length
+            ' <<< "$RUNS")"
+            COMPLETED_COUNT="$(jq -r --arg sha "$PREPARED_RELEASE_SHA" '
+              [.workflow_runs[] | select(.head_sha == $sha and .event == "push" and .status == "completed")]
+              | length
+            ' <<< "$RUNS")"
+
+            if [ "$ACTIVE_COUNT" = "0" ] && [ "$COMPLETED_COUNT" != "0" ]; then
+              jq -r --arg sha "$PREPARED_RELEASE_SHA" '
+                .workflow_runs[]
+                | select(.head_sha == $sha and .event == "push")
+                | "CI run \(.id): status=\(.status), conclusion=\(.conclusion), url=\(.html_url)"
+              ' <<< "$RUNS"
+              echo "::error::CI completed without a successful run for ${PREPARED_RELEASE_SHA}."
+              exit 1
+            fi
+
+            echo "Waiting for successful CI on ${PREPARED_RELEASE_SHA} (attempt ${attempt}/120)."
+            sleep 15
+          done
+
+          echo "::error::Timed out waiting for successful CI on ${PREPARED_RELEASE_SHA}."
+          exit 1
 
       - name: Write job summary
         if: always()
@@ -92,133 +137,10 @@ jobs:
           JOB_SUMMARY_TITLE: Release gate reuse decision
           JOB_SUMMARY_STATUS: ${{ job.status }}
           JOB_SUMMARY_DETAILS: |
-            - Skips duplicate gates on the preparation dispatch, which cannot publish.
-            - Reuses gates on a prepared SHA only when every required check run is successful.
-            - Fails closed when GitHub check-run state cannot be read.
-          JOB_SUMMARY_NEXT: Retry after GitHub check-run state is available, or fix any missing or unsuccessful release gate.
-        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
-
-  test:
-    runs-on: ubuntu-latest
-    needs: [gate-reuse]
-    if: needs.gate-reuse.outputs.skip_gates != 'true'
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Build vendored lsp-tools-mcp package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-tools-mcp
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build vendored lsp-daemon package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-daemon
-
-      - name: Run tests
-        run: bun test
-
-      - name: Write job summary
-        if: always()
-        shell: bash
-        env:
-          JOB_SUMMARY_TITLE: Release test gate
-          JOB_SUMMARY_STATUS: ${{ job.status }}
-          JOB_SUMMARY_DETAILS: |
-            - Builds vendored LSP packages before release tests.
-            - Runs the full root `bun test` suite before publishing.
-          JOB_SUMMARY_NEXT: Fix the first failing test or vendored package build before rerunning release.
-        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
-
-  typecheck:
-    runs-on: ubuntu-latest
-    needs: [gate-reuse]
-    if: needs.gate-reuse.outputs.skip_gates != 'true'
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Build vendored lsp-tools-mcp package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-tools-mcp
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Type check
-        run: bun run typecheck
-
-      - name: Write job summary
-        if: always()
-        shell: bash
-        env:
-          JOB_SUMMARY_TITLE: Release typecheck gate
-          JOB_SUMMARY_STATUS: ${{ job.status }}
-          JOB_SUMMARY_DETAILS: |
-            - Builds vendored LSP tooling.
-            - Runs `bun run typecheck` before any publish job can start.
-          JOB_SUMMARY_NEXT: Start with the first TypeScript diagnostic; release jobs stay blocked until this is green.
-        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
-
-  codex-compatibility:
-    runs-on: ${{ matrix.os }}
-    needs: [gate-reuse]
-    if: needs.gate-reuse.outputs.skip_gates != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Build vendored lsp-tools-mcp package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-tools-mcp
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Build vendored lsp-daemon package
-        run: npm ci && npm run build
-        working-directory: packages/lsp-daemon
-
-      - name: Run Codex compatibility tests
-        run: bun run test:codex
-
-      - name: Write job summary
-        if: always()
-        shell: bash
-        env:
-          JOB_SUMMARY_TITLE: Release Codex compatibility (${{ matrix.os }})
-          JOB_SUMMARY_STATUS: ${{ job.status }}
-          JOB_SUMMARY_DETAILS: |
-            - Builds MCP runtime prerequisites.
-            - Runs `bun run test:codex` across the supported OS matrix.
-          JOB_SUMMARY_NEXT: Inspect the first failing Codex component or installer test for `${{ matrix.os }}`.
+            - Skips release validation on the preparation dispatch, which cannot publish.
+            - Waits for a successful CI push workflow run on the exact prepared SHA.
+            - Fails closed when CI fails, is cancelled, times out, or cannot be read.
+          JOB_SUMMARY_NEXT: Rerun CI on the prepared SHA or fix its failed workflow before publishing.
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   preflight-trust:
@@ -432,14 +354,11 @@ jobs:
 
   prepare-release-state:
     runs-on: ubuntu-latest
-    needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata]
+    needs: [gate-reuse, preflight-trust, release-metadata]
     if: >-
       always() &&
       github.repository == 'code-yeongyu/oh-my-openagent' &&
       needs.gate-reuse.result == 'success' &&
-      contains(fromJSON('["success","skipped"]'), needs.test.result) &&
-      contains(fromJSON('["success","skipped"]'), needs.typecheck.result) &&
-      contains(fromJSON('["success","skipped"]'), needs.codex-compatibility.result) &&
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success'
     permissions:
@@ -453,6 +372,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
 
       - run: git fetch --force --tags
 
@@ -469,7 +389,7 @@ jobs:
           VERSION: ${{ needs.release-metadata.outputs.version }}
           OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
           RELEASE_REF: ${{ github.ref_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           PREPARED_RELEASE_SHA: ${{ inputs.prepared_release_sha }}
         run: |
           set -euo pipefail
@@ -542,7 +462,7 @@ jobs:
           git diff --cached --quiet || git commit -m "release: v${VERSION}"
           git push --force-with-lease origin "HEAD:${RELEASE_BRANCH}"
 
-          retry_gh_read() {
+          retry_gh() {
             local description="$1"
             shift
             local output=""
@@ -559,27 +479,67 @@ jobs:
             return 1
           }
 
-          PR_NUMBER="$(retry_gh_read "List release-state PR" gh pr list --head "$RELEASE_BRANCH" --base "$BASE_REF" --state open --json number --jq '.[0].number // empty')"
+          create_release_pr() {
+            local pr_url=""
+            local recovered_number=""
+            for api_retry in 1 2 3 4 5; do
+              if pr_url="$(gh pr create --base "$BASE_REF" --head "$RELEASE_BRANCH" --title "release: v${VERSION}" --body "Automated release-state PR for v${VERSION}. This must merge before npm publication starts so protected-branch push failures cannot create a half-published release." 2>&1)"; then
+                printf '%s' "${pr_url##*/}"
+                return 0
+              fi
+              echo "Create release-state PR: retry ${api_retry}/5" >&2
+              echo "$pr_url" >&2
+              recovered_number="$(retry_gh "Recover created release-state PR" gh pr list --head "$RELEASE_BRANCH" --base "$BASE_REF" --state open --json number --jq '.[0].number // empty')"
+              if [ -n "$recovered_number" ]; then
+                printf '%s' "$recovered_number"
+                return 0
+              fi
+              if [ "$api_retry" != "5" ]; then sleep 5; fi
+            done
+            echo "::error::Create release-state PR failed after 5 retries." >&2
+            return 1
+          }
+
+          enable_release_auto_merge() {
+            local output=""
+            local enabled=""
+            for api_retry in 1 2 3 4 5; do
+              if output="$(gh pr merge "$PR_NUMBER" --merge --auto --delete-branch=false 2>&1)"; then
+                printf '%s' "$output"
+                return 0
+              fi
+              echo "Enable release-state PR auto-merge: retry ${api_retry}/5" >&2
+              echo "$output" >&2
+              enabled="$(retry_gh "Read release-state PR auto-merge" gh pr view "$PR_NUMBER" --json autoMergeRequest --jq '.autoMergeRequest != null')"
+              if [ "$enabled" = "true" ]; then
+                return 0
+              fi
+              if [ "$api_retry" != "5" ]; then sleep 5; fi
+            done
+            echo "::error::Enable release-state PR auto-merge failed after 5 retries." >&2
+            return 1
+          }
+
+          PR_NUMBER="$(retry_gh "List release-state PR" gh pr list --head "$RELEASE_BRANCH" --base "$BASE_REF" --state open --json number --jq '.[0].number // empty')"
           if [ -z "$PR_NUMBER" ]; then
-            PR_URL="$(gh pr create --base "$BASE_REF" --head "$RELEASE_BRANCH" --title "release: v${VERSION}" --body "Automated release-state PR for v${VERSION}. This must merge before npm publication starts so protected-branch push failures cannot create a half-published release.")"
-            PR_NUMBER="${PR_URL##*/}"
+            PR_NUMBER="$(create_release_pr)"
           fi
 
-          gh pr merge "$PR_NUMBER" --merge --auto --delete-branch=false
+          enable_release_auto_merge
 
           for attempt in $(seq 1 120); do
-            PR_STATE="$(retry_gh_read "Read release-state PR state" gh pr view "$PR_NUMBER" --json state --jq '.state')"
+            PR_STATE="$(retry_gh "Read release-state PR state" gh pr view "$PR_NUMBER" --json state --jq '.state')"
             if [ "$PR_STATE" = "MERGED" ]; then
-              RELEASE_SHA="$(retry_gh_read "Read release-state PR merge SHA" gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid')"
+              RELEASE_SHA="$(retry_gh "Read release-state PR merge SHA" gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid')"
               echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
               echo "Release-state PR #${PR_NUMBER} merged at ${RELEASE_SHA}"
               exit 0
             fi
 
-            FAILURES="$(retry_gh_read "Read release-state PR checks" gh pr view "$PR_NUMBER" --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT")] | length')"
+            FAILURES="$(retry_gh "Read release-state PR checks" gh pr view "$PR_NUMBER" --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT")] | length')"
             if [ "$FAILURES" != "0" ]; then
               echo "::error::Release-state PR #${PR_NUMBER} has failing required checks; refusing to publish npm packages."
-              retry_gh_read "Read failing release-state PR checks" gh pr view "$PR_NUMBER" --json url,statusCheckRollup --jq '{url, statusCheckRollup}' || true
+              retry_gh "Read failing release-state PR checks" gh pr view "$PR_NUMBER" --json url,statusCheckRollup --jq '{url, statusCheckRollup}' || true
               exit 1
             fi
 
@@ -674,15 +634,12 @@ jobs:
     # lazycodex publish decision has to cross the job boundary as an output.
     outputs:
       lazycodex_publish_skipped: ${{ steps.check-lazycodex.outputs.skip }}
-    needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]
+    needs: [gate-reuse, preflight-trust, release-metadata, prepare-release-state, publish-platform]
     if: >-
       always() &&
       github.repository == 'code-yeongyu/oh-my-openagent' &&
       inputs.prepared_release_sha != '' &&
       needs.gate-reuse.result == 'success' &&
-      contains(fromJSON('["success","skipped"]'), needs.test.result) &&
-      contains(fromJSON('["success","skipped"]'), needs.typecheck.result) &&
-      contains(fromJSON('["success","skipped"]'), needs.codex-compatibility.result) &&
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success' &&
       needs.prepare-release-state.result == 'success' &&
@@ -964,16 +921,13 @@ jobs:
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   publish-platform:
-    needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state]
+    needs: [gate-reuse, preflight-trust, release-metadata, prepare-release-state]
     if: >-
       always() &&
       github.repository == 'code-yeongyu/oh-my-openagent' &&
       inputs.prepared_release_sha != '' &&
       inputs.skip_platform != true &&
       needs.gate-reuse.result == 'success' &&
-      contains(fromJSON('["success","skipped"]'), needs.test.result) &&
-      contains(fromJSON('["success","skipped"]'), needs.typecheck.result) &&
-      contains(fromJSON('["success","skipped"]'), needs.codex-compatibility.result) &&
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success' &&
       needs.prepare-release-state.result == 'success'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,11 +78,14 @@ jobs:
             return 1
           }
 
+          # The prepared source is validated either by the post-merge push run or
+          # by the release-state PR's own pull_request run at the exact SHA
+          # (the grep/tag short-circuits return the stamp commit, which only
+          # ever has a pull_request run). Both are full ci.yml executions.
           for attempt in $(seq 1 120); do
             RUNS="$(retry_gh "Read CI workflow runs" gh api --method GET \
               "repos/${{ github.repository }}/actions/workflows/ci.yml/runs" \
               -f head_sha="$PREPARED_RELEASE_SHA" \
-              -f event=push \
               -f per_page=100)"
 
             SUCCESS_ID="$(jq -r --arg sha "$PREPARED_RELEASE_SHA" '
@@ -90,7 +93,6 @@ jobs:
                 .workflow_runs[]
                 | select(
                     .head_sha == $sha
-                    and .event == "push"
                     and .status == "completed"
                     and .conclusion == "success"
                   )
@@ -105,18 +107,18 @@ jobs:
             fi
 
             ACTIVE_COUNT="$(jq -r --arg sha "$PREPARED_RELEASE_SHA" '
-              [.workflow_runs[] | select(.head_sha == $sha and .event == "push" and .status != "completed")]
+              [.workflow_runs[] | select(.head_sha == $sha and .status != "completed")]
               | length
             ' <<< "$RUNS")"
             COMPLETED_COUNT="$(jq -r --arg sha "$PREPARED_RELEASE_SHA" '
-              [.workflow_runs[] | select(.head_sha == $sha and .event == "push" and .status == "completed")]
+              [.workflow_runs[] | select(.head_sha == $sha and .status == "completed")]
               | length
             ' <<< "$RUNS")"
 
             if [ "$ACTIVE_COUNT" = "0" ] && [ "$COMPLETED_COUNT" != "0" ]; then
               jq -r --arg sha "$PREPARED_RELEASE_SHA" '
                 .workflow_runs[]
-                | select(.head_sha == $sha and .event == "push")
+                | select(.head_sha == $sha)
                 | "CI run \(.id): status=\(.status), conclusion=\(.conclusion), url=\(.html_url)"
               ' <<< "$RUNS"
               echo "::error::CI completed without a successful run for ${PREPARED_RELEASE_SHA}."
@@ -362,17 +364,20 @@ jobs:
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success'
     permissions:
-      actions: read
       contents: write
-      id-token: write
       pull-requests: write
     outputs:
       release_sha: ${{ steps.prepare.outputs.release_sha }}
     steps:
+      # The PAT checks out with persist-credentials disabled: repo-controlled
+      # generation below must never be able to read the release credential from
+      # git config. The token is exported explicitly only when the generated
+      # release state is ready to be pushed.
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
+          persist-credentials: false
 
       - run: git fetch --force --tags
 
@@ -389,7 +394,7 @@ jobs:
           VERSION: ${{ needs.release-metadata.outputs.version }}
           OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
           RELEASE_REF: ${{ github.ref_name }}
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          RELEASE_PAT: ${{ secrets.GH_PAT }}
           PREPARED_RELEASE_SHA: ${{ inputs.prepared_release_sha }}
         run: |
           set -euo pipefail
@@ -460,6 +465,10 @@ jobs:
           git add package.json packages/omo-native/package.json packages/oh-my-opencode-*/package.json packages/omo-senpi/package.json packages/omo-senpi/plugin/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/package-lock.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
           git add -f packages/omo-senpi/plugin/extensions
           git diff --cached --quiet || git commit -m "release: v${VERSION}"
+
+          # Credential boundary: everything above is repo-controlled generation
+          # that must not see the PAT; everything below needs it.
+          export GH_TOKEN="$RELEASE_PAT"
           git push --force-with-lease origin "HEAD:${RELEASE_BRANCH}"
 
           retry_gh() {

--- a/bunfig.win2.parallel.toml
+++ b/bunfig.win2.parallel.toml
@@ -20,6 +20,7 @@ pathIgnorePatterns = [
   "packages/omo-codex/src/install/install-codex.test.ts",
   "packages/shared-skills/provenance-gate.test.ts",
   "packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts",
+  "packages/senpi-task/src/dag/scheduler.test.ts",
 ]
 
 [loader]

--- a/packages/utils/src/ast-grep/install-script.test.ts
+++ b/packages/utils/src/ast-grep/install-script.test.ts
@@ -85,6 +85,40 @@ describe("runAstGrepSkillInstall", () => {
     expect(kills).toBe(1)
   })
 
+  test("#given a child that ignores termination #when the timeout fires #then the invocation rejects instead of hanging", async () => {
+    // given
+    const neverSettles = new Promise<AstGrepInstallSpawnOutcome>(() => {})
+    const spawnProcess: AstGrepInstallSpawn = () => ({
+      kill: () => undefined,
+      outcome: neverSettles,
+    })
+
+    // when: race against an explicit 3s circuit breaker so a regression fails fast instead of hanging the runner.
+    let hung = false
+    const breaker = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        hung = true
+        reject(new Error("waited 3s for the kill-ignored rejection, never fired"))
+      }, 3_000)
+    })
+
+    // then: the deadline race must settle as a failed outcome naming the ignored termination.
+    const result = await Promise.race([
+      runAstGrepSkillInstall({
+        fileExists: (filePath) => filePath.endsWith("install.sh"),
+        platform: "linux",
+        skillDir: "/skills/ast-grep",
+        spawnProcess,
+        targetDir: "/home/test/.omo/runtime/ast-grep/linux-x64",
+        timeoutMs: 5,
+      }),
+      breaker,
+    ])
+    expect(hung).toBe(false)
+    expect(result.kind).toBe("failed")
+    if (result.kind === "failed") expect(result.reason).toContain("ignored termination")
+  })
+
   test("#given Windows and pwsh is missing #when provisioning runs #then powershell.exe is tried next", async () => {
     // given
     const commands: string[] = []

--- a/packages/utils/src/ast-grep/install-script.ts
+++ b/packages/utils/src/ast-grep/install-script.ts
@@ -109,11 +109,14 @@ async function runInvocation(input: {
 }): Promise<TimedInvocationOutcome> {
   const child = input.spawnProcess(input.invocation.command, input.invocation.args, { cwd: input.skillDir, env: input.env })
   let timedOut = false
+  // The timeout MUST stay ref'd: it is the only producer of progress when the
+  // child never exits. An unref'd timer can be starved by the runtime's event
+  // loop (observed hanging the Windows test runner for the full job ceiling),
+  // and clearTimeout in the finally block already prevents leaks.
   const timeout = setTimeout(() => {
     timedOut = true
     child.kill()
   }, input.timeoutMs)
-  timeout.unref?.()
   try {
     const outcome = await child.outcome
     return timedOut ? { kind: "timed-out" } : outcome

--- a/packages/utils/src/ast-grep/install-script.ts
+++ b/packages/utils/src/ast-grep/install-script.ts
@@ -5,7 +5,8 @@ import { join } from "node:path"
 import { runtimeSlug } from "./sg-manifest"
 
 export const AST_GREP_BIN_DIR_ENV_KEY = "OMO_AST_GREP_BIN_DIR"
-export const AST_GREP_INSTALL_TIMEOUT_MS = 30_000
+export const KILL_GRACE_MS = 1_000
+const AST_GREP_INSTALL_TIMEOUT_MS = 30_000
 
 export type AstGrepInstallSpawnOutcome =
   | { readonly kind: "exit"; readonly code: number | null; readonly signal: NodeJS.Signals | null }
@@ -113,15 +114,33 @@ async function runInvocation(input: {
   // child never exits. An unref'd timer can be starved by the runtime's event
   // loop (observed hanging the Windows test runner for the full job ceiling),
   // and clearTimeout in the finally block already prevents leaks.
+  let terminateDeadline: (() => void) | undefined
+  let terminateDeadlineGrace: ReturnType<typeof setTimeout> | undefined
+  const killIgnored = new Promise<never>((_, reject) => {
+    terminateDeadline = () => reject(new Error("ast-grep install child ignored termination"))
+  })
   const timeout = setTimeout(() => {
     timedOut = true
     child.kill()
+    // Grace period for kill() to settle the outcome; a child that ignores
+    // termination must fail loudly instead of hanging the caller forever.
+    terminateDeadlineGrace = setTimeout(() => terminateDeadline?.(), KILL_GRACE_MS)
   }, input.timeoutMs)
   try {
-    const outcome = await child.outcome
-    return timedOut ? { kind: "timed-out" } : outcome
+    const outcome = await Promise.race([child.outcome, killIgnored])
+    if (timedOut) return { kind: "timed-out" }
+    return outcome
+  } catch (error) {
+    // The child ignored termination past the grace deadline: fail loudly with
+    // a named reason instead of hanging the caller forever. Spawn-error shape
+    // carries the reason through the caller's failedReason mapping.
+    if (error instanceof Error && error.message.includes("ignored termination")) {
+      return { kind: "spawn-error", error, missingExecutable: false }
+    }
+    throw error
   } finally {
     clearTimeout(timeout)
+    if (terminateDeadlineGrace !== undefined) clearTimeout(terminateDeadlineGrace)
   }
 }
 

--- a/script/ci-fast-path.mjs
+++ b/script/ci-fast-path.mjs
@@ -19,6 +19,14 @@ function parseArguments(argv) {
   return values
 }
 
+function parseMergeParents(value) {
+  const count = Number(value)
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error(`expected non-negative integer merge parents, received ${value}`)
+  }
+  return count
+}
+
 function parseBoolean(value) {
   if (value === "true") return true
   if (value === "false") return false
@@ -38,9 +46,16 @@ function isWebPath(path) {
   )
 }
 
-export function classifyCiMode({ eventName, headCommitMessage, changedPaths, diffAvailable }) {
+export function classifyCiMode({ eventName, headCommitMessage, changedPaths, diffAvailable, mergeParentCount }) {
   const subject = headCommitMessage.split("\n", 1)[0] ?? ""
-  const generatedReleasePush = eventName === "push" && generatedReleaseMerge.test(subject)
+  // Provenance is machine-derived, never prose alone: an actual merge commit
+  // (exactly two parents) whose subject matches the generated release shape.
+  const isRealMerge = mergeParentCount === 2
+  const generatedReleasePush =
+    eventName === "push" &&
+    diffAvailable &&
+    isRealMerge &&
+    generatedReleaseMerge.test(subject)
   const webOnly = diffAvailable && changedPaths.length > 0 && changedPaths.every(isWebPath)
 
   return {
@@ -55,8 +70,14 @@ if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.a
   const eventName = args.get("event")
   const headCommitMessage = args.get("message")
   const diffAvailable = args.get("diff-available")
-  if (eventName === undefined || headCommitMessage === undefined || diffAvailable === undefined) {
-    throw new Error("--event, --message, and --diff-available are required")
+  const mergeParents = args.get("merge-parents")
+  if (
+    eventName === undefined ||
+    headCommitMessage === undefined ||
+    diffAvailable === undefined ||
+    mergeParents === undefined
+  ) {
+    throw new Error("--event, --message, --diff-available, and --merge-parents are required")
   }
 
   const mode = classifyCiMode({
@@ -64,6 +85,7 @@ if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.a
     headCommitMessage,
     changedPaths: readChangedPaths(readFileSync(0)),
     diffAvailable: parseBoolean(diffAvailable),
+    mergeParentCount: parseMergeParents(mergeParents),
   })
   process.stdout.write(`${JSON.stringify(mode)}\n`)
 }

--- a/script/ci-fast-path.mjs
+++ b/script/ci-fast-path.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "node:fs"
+import { pathToFileURL } from "node:url"
 
 const generatedReleaseMerge =
   /^Merge pull request #[0-9]+ from code-yeongyu\/release\/v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?-source-state$/
@@ -49,7 +50,7 @@ export function classifyCiMode({ eventName, headCommitMessage, changedPaths, dif
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const args = parseArguments(process.argv.slice(2))
   const eventName = args.get("event")
   const headCommitMessage = args.get("message")

--- a/script/ci-fast-path.mjs
+++ b/script/ci-fast-path.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs"
+
+const generatedReleaseMerge =
+  /^Merge pull request #[0-9]+ from code-yeongyu\/release\/v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?-source-state$/
+
+function parseArguments(argv) {
+  const values = new Map()
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]
+    const value = argv[index + 1]
+    if (key === undefined || value === undefined || !key.startsWith("--")) {
+      throw new Error("expected --key value arguments")
+    }
+    values.set(key.slice(2), value)
+  }
+  return values
+}
+
+function parseBoolean(value) {
+  if (value === "true") return true
+  if (value === "false") return false
+  throw new Error(`expected boolean, received ${value}`)
+}
+
+function readChangedPaths(input) {
+  if (input.length === 0) return []
+  return input.toString("utf8").split("\0").filter((path) => path.length > 0)
+}
+
+function isWebPath(path) {
+  return (
+    path.startsWith("packages/web/") ||
+    path.startsWith("docs/") ||
+    path === ".github/workflows/web-ci.yml"
+  )
+}
+
+export function classifyCiMode({ eventName, headCommitMessage, changedPaths, diffAvailable }) {
+  const subject = headCommitMessage.split("\n", 1)[0] ?? ""
+  const generatedReleasePush = eventName === "push" && generatedReleaseMerge.test(subject)
+  const webOnly = diffAvailable && changedPaths.length > 0 && changedPaths.every(isWebPath)
+
+  return {
+    generatedReleasePush,
+    webOnly,
+    runHeavy: !(generatedReleasePush || webOnly),
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArguments(process.argv.slice(2))
+  const eventName = args.get("event")
+  const headCommitMessage = args.get("message")
+  const diffAvailable = args.get("diff-available")
+  if (eventName === undefined || headCommitMessage === undefined || diffAvailable === undefined) {
+    throw new Error("--event, --message, and --diff-available are required")
+  }
+
+  const mode = classifyCiMode({
+    eventName,
+    headCommitMessage,
+    changedPaths: readChangedPaths(readFileSync(0)),
+    diffAvailable: parseBoolean(diffAvailable),
+  })
+  process.stdout.write(`${JSON.stringify(mode)}\n`)
+}

--- a/script/ci-fast-path.test.ts
+++ b/script/ci-fast-path.test.ts
@@ -37,6 +37,7 @@ function classify(
   message: string,
   changedPaths: readonly string[],
   diffAvailable = true,
+  mergeParents = 2,
 ): CiMode | undefined {
   if (!existsSync(classifierPath)) return undefined
   const pathInput = changedPaths.length === 0 ? "" : `${changedPaths.join("\0")}\0`
@@ -50,6 +51,8 @@ function classify(
       message,
       "--diff-available",
       String(diffAvailable),
+      "--merge-parents",
+      String(mergeParents),
     ],
     { encoding: "utf8", input: pathInput },
   )
@@ -118,6 +121,18 @@ describe("CI fast-path classifier", () => {
     },
   ])("$name", ({ event, message, paths, expected }) => {
     expect(classify(event, message, paths)).toEqual(expected)
+  })
+
+  test("fails closed when a release-looking push is not a real merge commit", () => {
+    const message = "Merge pull request #6955 from code-yeongyu/release/v5.0.0-beta.8-source-state"
+    const mode = classify("push", message, ["package.json"], true, 1)
+    expect(mode).toEqual({ generatedReleasePush: false, webOnly: false, runHeavy: true })
+  })
+
+  test("fails closed when a release-looking merge push has no available diff", () => {
+    const message = "Merge pull request #6955 from code-yeongyu/release/v5.0.0-beta.8-source-state"
+    const mode = classify("push", message, ["package.json"], false, 2)
+    expect(mode).toEqual({ generatedReleasePush: false, webOnly: false, runHeavy: true })
   })
 
   test("fails closed when the diff is unavailable or empty", () => {

--- a/script/ci-fast-path.test.ts
+++ b/script/ci-fast-path.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from "bun:test"
 import { execFileSync } from "node:child_process"
 import { existsSync, readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import { load } from "js-yaml"
 
 const classifierPath = new URL("./ci-fast-path.mjs", import.meta.url)
@@ -42,7 +43,7 @@ function classify(
   const stdout = execFileSync(
     "node",
     [
-      classifierPath.pathname,
+      fileURLToPath(classifierPath),
       "--event",
       eventName,
       "--message",

--- a/script/ci-fast-path.test.ts
+++ b/script/ci-fast-path.test.ts
@@ -1,0 +1,181 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { execFileSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import { load } from "js-yaml"
+
+const classifierPath = new URL("./ci-fast-path.mjs", import.meta.url)
+const ciWorkflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
+const webWorkflowPath = new URL("../.github/workflows/web-ci.yml", import.meta.url)
+
+interface CiMode {
+  readonly generatedReleasePush: boolean
+  readonly webOnly: boolean
+  readonly runHeavy: boolean
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseWorkflow(path: URL): Record<string, unknown> {
+  const parsed: unknown = load(readFileSync(path, "utf8"))
+  if (!isRecord(parsed)) throw new Error(`${path.pathname} must parse as an object`)
+  return parsed
+}
+
+function workflowJobs(path: URL): Record<string, unknown> {
+  const jobs = parseWorkflow(path)["jobs"]
+  if (!isRecord(jobs)) throw new Error(`${path.pathname} must define jobs`)
+  return jobs
+}
+
+function classify(
+  eventName: string,
+  message: string,
+  changedPaths: readonly string[],
+  diffAvailable = true,
+): CiMode | undefined {
+  if (!existsSync(classifierPath)) return undefined
+  const pathInput = changedPaths.length === 0 ? "" : `${changedPaths.join("\0")}\0`
+  const stdout = execFileSync(
+    "node",
+    [
+      classifierPath.pathname,
+      "--event",
+      eventName,
+      "--message",
+      message,
+      "--diff-available",
+      String(diffAvailable),
+    ],
+    { encoding: "utf8", input: pathInput },
+  )
+  const parsed: unknown = JSON.parse(stdout)
+  if (!isRecord(parsed)) throw new Error("classifier output must be an object")
+  const generatedReleasePush = parsed["generatedReleasePush"]
+  const webOnly = parsed["webOnly"]
+  const runHeavy = parsed["runHeavy"]
+  if (
+    typeof generatedReleasePush !== "boolean" ||
+    typeof webOnly !== "boolean" ||
+    typeof runHeavy !== "boolean"
+  ) {
+    throw new Error("classifier output must contain boolean CI mode fields")
+  }
+  return { generatedReleasePush, webOnly, runHeavy }
+}
+
+describe("CI fast-path classifier", () => {
+  test("ships the classifier consumed by CI", () => {
+    expect(existsSync(classifierPath)).toBe(true)
+  })
+
+  test.each([
+    {
+      name: "release-state pull request",
+      event: "pull_request",
+      message: "release: v5.0.0-beta.8",
+      paths: ["package.json"],
+      expected: { generatedReleasePush: false, webOnly: false, runHeavy: true },
+    },
+    {
+      name: "ordinary source push",
+      event: "push",
+      message: "fix(core): preserve validation",
+      paths: ["packages/model-core/src/index.ts"],
+      expected: { generatedReleasePush: false, webOnly: false, runHeavy: true },
+    },
+    {
+      name: "generated release merge push",
+      event: "push",
+      message: "Merge pull request #6955 from code-yeongyu/release/v5.0.0-beta.8-source-state",
+      paths: ["package.json", "bun.lock"],
+      expected: { generatedReleasePush: true, webOnly: false, runHeavy: false },
+    },
+    {
+      name: "direct release commit",
+      event: "push",
+      message: "release: v5.0.0-beta.8",
+      paths: ["package.json"],
+      expected: { generatedReleasePush: false, webOnly: false, runHeavy: true },
+    },
+    {
+      name: "web-only pull request",
+      event: "pull_request",
+      message: "feat(web): update landing page",
+      paths: ["packages/web/app/page.tsx", "docs/guide/install.md"],
+      expected: { generatedReleasePush: false, webOnly: true, runHeavy: false },
+    },
+    {
+      name: "mixed web and root change",
+      event: "pull_request",
+      message: "feat: update web and runtime",
+      paths: ["packages/web/app/page.tsx", "packages/model-core/src/index.ts"],
+      expected: { generatedReleasePush: false, webOnly: false, runHeavy: true },
+    },
+  ])("$name", ({ event, message, paths, expected }) => {
+    expect(classify(event, message, paths)).toEqual(expected)
+  })
+
+  test("fails closed when the diff is unavailable or empty", () => {
+    expect(classify("push", "fix: unknown diff", [], false)).toEqual({
+      generatedReleasePush: false,
+      webOnly: false,
+      runHeavy: true,
+    })
+    expect(classify("push", "fix: empty diff", [])).toEqual({
+      generatedReleasePush: false,
+      webOnly: false,
+      runHeavy: true,
+    })
+  })
+})
+
+describe("CI fast-path workflow wiring", () => {
+  test("preserves required job identities while gating expensive work", () => {
+    const jobs = workflowJobs(ciWorkflowPath)
+    const mode = jobs["ci-mode"]
+    if (!isRecord(mode)) throw new Error("CI must define ci-mode")
+
+    for (const jobName of [
+      "test",
+      "typecheck",
+      "codex-compatibility",
+      "senpi-compatibility",
+      "lazycodex-published-smoke",
+      "build",
+      "omo-ai-payload-check",
+    ]) {
+      const job = jobs[jobName]
+      if (!isRecord(job)) throw new Error(`CI must define ${jobName}`)
+      expect(job["needs"]).toContain("ci-mode")
+    }
+  })
+
+  test("keeps schema generation on master and skips duplicate draft generation", () => {
+    const jobs = workflowJobs(ciWorkflowPath)
+    const schema = jobs["auto-commit-schema"]
+    const draft = jobs["draft-release"]
+    if (!isRecord(schema) || !isRecord(draft)) throw new Error("CI write jobs must exist")
+
+    expect(String(schema["if"])).toContain("refs/heads/master")
+    expect(String(schema["if"])).not.toContain("run_heavy")
+    expect(String(draft["if"])).toContain("needs.ci-mode.outputs.run_heavy == 'true'")
+  })
+
+  test("keeps the Web CI path contract aligned with classifier inputs", () => {
+    const webWorkflow = parseWorkflow(webWorkflowPath)
+    const triggers = webWorkflow["on"]
+    if (!isRecord(triggers)) throw new Error("Web CI must define triggers")
+    const pullRequest = triggers["pull_request"]
+    if (!isRecord(pullRequest)) throw new Error("Web CI must define pull_request")
+
+    expect(pullRequest["paths"]).toEqual([
+      "packages/web/**",
+      "docs/**",
+      ".github/workflows/web-ci.yml",
+    ])
+  })
+})

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -16,6 +16,7 @@ const workflowExpectations = [
   {
     path: ".github/workflows/ci.yml",
     jobs: [
+      "ci-mode",
       "block-master-pr",
       "test",
       "typecheck",
@@ -36,9 +37,6 @@ const workflowExpectations = [
     path: ".github/workflows/publish.yml",
     jobs: [
       "gate-reuse",
-      "test",
-      "typecheck",
-      "codex-compatibility",
       "preflight-trust",
       "release-metadata",
       "prepare-release-state",

--- a/script/ci-root-test-partition.test.ts
+++ b/script/ci-root-test-partition.test.ts
@@ -84,9 +84,9 @@ describe("root test CI partition", () => {
     const job = rootTestJob()
     const runBlock = job.slice(job.indexOf("      - name: Run tests"))
 
-    expect(runBlock).toContain('if: runner.os != \'Windows\'')
-    expect(runBlock).toContain("if: matrix.shard == '1/2'")
-    expect(runBlock).toContain("if: matrix.shard == '2/2'")
+    expect(runBlock).toContain("if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows'")
+    expect(runBlock).toContain("if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '1/2'")
+    expect(runBlock).toContain("if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '2/2'")
     expect(runBlock).not.toContain("shell: bash\n        run: |")
     expect(job).toContain("timeout-minutes: ${{ matrix.os == 'windows-latest' && 60 || 30 }}")
   })
@@ -97,6 +97,6 @@ describe("root test CI partition", () => {
     const cacheEnd = job.indexOf("      - name: Install dependencies", cacheStart)
     const cacheStep = job.slice(cacheStart, cacheEnd)
 
-    expect(cacheStep).toContain("if: runner.os != 'Windows'")
+    expect(cacheStep).toContain("if: runner.os != 'Windows' && needs.ci-mode.outputs.run_heavy == 'true'")
   })
 })

--- a/script/omo-ai-publish-shape.test.ts
+++ b/script/omo-ai-publish-shape.test.ts
@@ -104,7 +104,7 @@ describe("omo-ai publish workflow shape", () => {
   })
 
   test("stamps omo-native in both release paths and stages its manifest", () => {
-    const prepare = namedStep("prepare-release-state", "Prepare and merge release state before publishing")
+    const prepare = namedStep("prepare-release-state", "Prepare release state (generation)")
     const update = namedStep("publish-main", "Update version")
     const stampLine = `jq --arg v "$OMO_AI_VERSION" '.version = $v' packages/omo-native/package.json > tmp.json && mv tmp.json packages/omo-native/package.json`
 

--- a/script/publish-gate-reuse-workflow.test.ts
+++ b/script/publish-gate-reuse-workflow.test.ts
@@ -112,6 +112,12 @@ describe("publish gate reuse", () => {
       expect(privilegedStep).not.toContain(repoControlled)
     }
 
+    // The token-bearing remote URL must be removed even when git push fails
+    // under set -euo pipefail: an EXIT trap restores the clean URL before any
+    // later repo-controlled step (the always() summary) can read .git/config.
+    expect(privilegedStep).toContain("trap 'git remote set-url origin")
+    expect(privilegedStep).toContain("https://github.com/\${GITHUB_REPOSITORY}.git\"' EXIT")
+
     // Least-scope permissions: this job needs neither Actions reads nor OIDC.
     expect(prepareJob).not.toContain("id-token: write")
     expect(prepareJob).not.toContain("actions: read")

--- a/script/publish-gate-reuse-workflow.test.ts
+++ b/script/publish-gate-reuse-workflow.test.ts
@@ -20,64 +20,58 @@ function sliceWorkflowSectionToEnd(workflow: string, startMarker: string): strin
   return workflow.slice(start)
 }
 
-const skippedResultCondition = (job: string): string =>
-  `contains(fromJSON('["success","skipped"]'), needs.${job}.result)`
-
 describe("publish gate reuse", () => {
-  test("exposes a fail-closed gate reuse decision before release gates", () => {
+  test("waits for a successful CI push workflow run on the exact prepared SHA", () => {
     const workflow = readFileSync(publishWorkflowPath, "utf8")
-    const gateReuseJob = sliceWorkflowSection(workflow, "  gate-reuse:", "  test:")
+    const gateReuseJob = sliceWorkflowSection(workflow, "  gate-reuse:", "  preflight-trust:")
 
-    expect(gateReuseJob).toContain("runs-on: ubuntu-latest")
-    expect(gateReuseJob).toContain("skip_gates: ${{ steps.reuse.outputs.skip_gates }}")
+    expect(gateReuseJob).toContain("actions: read")
     expect(gateReuseJob).toContain("PREPARED_RELEASE_SHA: ${{ inputs.prepared_release_sha }}")
     expect(gateReuseJob).toContain('if [ -z "$PREPARED_RELEASE_SHA" ]')
-    expect(gateReuseJob).toContain('echo "skip_gates=true" >> "$GITHUB_OUTPUT"')
-    expect(gateReuseJob).toContain("gh api")
-    expect(gateReuseJob).toContain("commits/${PREPARED_RELEASE_SHA}/check-runs")
-    expect(gateReuseJob).toContain("--paginate")
-    for (const checkName of [
-      "test",
-      "typecheck",
-      "codex-compatibility (ubuntu-latest)",
-      "codex-compatibility (macos-latest)",
-      "codex-compatibility (windows-latest)",
-    ]) {
-      expect(gateReuseJob).toContain(checkName)
-    }
-    expect(gateReuseJob).toContain('all(.conclusion == "success")')
+    expect(gateReuseJob).toContain("actions/workflows/ci.yml/runs")
+    expect(gateReuseJob).toContain("head_sha")
+    expect(gateReuseJob).toContain("event=push")
+    expect(gateReuseJob).toContain('.head_sha == $sha')
+    expect(gateReuseJob).toContain('.event == "push"')
+    expect(gateReuseJob).toContain('.status == "completed"')
+    expect(gateReuseJob).toContain('.conclusion == "success"')
+    expect(gateReuseJob).toContain("retry_gh")
     expect(gateReuseJob).toContain("set -euo pipefail")
+    expect(gateReuseJob).not.toContain("check-runs")
+    expect(gateReuseJob).not.toContain("REQUIRED_CHECKS")
     expect(gateReuseJob).not.toContain("continue-on-error")
-    expect(gateReuseJob).not.toContain("|| true")
-    expect(gateReuseJob).toContain("name: Write job summary")
-    expect(gateReuseJob).toContain(".github/scripts/write-job-summary.sh")
   })
 
-  test("skips each release gate only when gate reuse says checks are reusable", () => {
-    const workflow = readFileSync(publishWorkflowPath, "utf8")
-    const testJob = sliceWorkflowSection(workflow, "  test:", "  typecheck:")
-    const typecheckJob = sliceWorkflowSection(workflow, "  typecheck:", "  codex-compatibility:")
-    const codexJob = sliceWorkflowSection(workflow, "  codex-compatibility:", "  preflight-trust:")
-
-    for (const job of [testJob, typecheckJob, codexJob]) {
-      expect(job).toContain("needs: [gate-reuse]")
-      expect(job).toContain("if: needs.gate-reuse.outputs.skip_gates != 'true'")
-    }
-  })
-
-  test("accepts skipped reusable gates while requiring gate-reuse itself to succeed", () => {
+  test("removes release-local test jobs and gates publication on CI reuse", () => {
     const workflow = readFileSync(publishWorkflowPath, "utf8")
     const prepareJob = sliceWorkflowSection(workflow, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
     const publishMainJob = sliceWorkflowSection(workflow, "  publish-main:", "  publish-platform:")
     const publishPlatformJob = sliceWorkflowSection(workflow, "  publish-platform:", "  release:")
 
+    expect(workflow).not.toContain("\n  test:\n")
+    expect(workflow).not.toContain("\n  typecheck:\n")
+    expect(workflow).not.toContain("\n  codex-compatibility:\n")
     for (const job of [prepareJob, publishMainJob, publishPlatformJob]) {
       expect(job).toContain("gate-reuse")
       expect(job).toContain("needs.gate-reuse.result == 'success'")
-      expect(job).toContain(skippedResultCondition("test"))
-      expect(job).toContain(skippedResultCondition("typecheck"))
-      expect(job).toContain(skippedResultCondition("codex-compatibility"))
+      expect(job).not.toContain("needs.test")
+      expect(job).not.toContain("needs.typecheck")
+      expect(job).not.toContain("needs.codex-compatibility")
     }
+  })
+
+  test("uses a workflow-capable token and retries release PR writes", () => {
+    const workflow = readFileSync(publishWorkflowPath, "utf8")
+    const prepareJob = sliceWorkflowSection(workflow, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
+
+    expect(prepareJob).toContain("token: ${{ secrets.GH_PAT }}")
+    expect(prepareJob).toContain("GH_TOKEN: ${{ secrets.GH_PAT }}")
+    expect(prepareJob).toContain("create_release_pr()")
+    expect(prepareJob).toContain("enable_release_auto_merge()")
+    expect(prepareJob).toContain("gh pr create")
+    expect(prepareJob).toContain("gh pr merge")
+    expect(prepareJob).toContain('retry_gh "Read release-state PR state" gh pr view')
+    expect(prepareJob).toContain('retry_gh "Read release-state PR checks" gh pr view')
   })
 
   test("keeps every publication surface pinned to a prepared release SHA", () => {

--- a/script/publish-gate-reuse-workflow.test.ts
+++ b/script/publish-gate-reuse-workflow.test.ts
@@ -30,11 +30,14 @@ describe("publish gate reuse", () => {
     expect(gateReuseJob).toContain('if [ -z "$PREPARED_RELEASE_SHA" ]')
     expect(gateReuseJob).toContain("actions/workflows/ci.yml/runs")
     expect(gateReuseJob).toContain("head_sha")
-    expect(gateReuseJob).toContain("event=push")
+    // The exact-SHA predicate accepts either the post-merge push run or the
+    // release PR's pull_request run: the grep/tag short-circuits return the
+    // stamp commit, which only ever has a pull_request run.
     expect(gateReuseJob).toContain('.head_sha == $sha')
-    expect(gateReuseJob).toContain('.event == "push"')
     expect(gateReuseJob).toContain('.status == "completed"')
     expect(gateReuseJob).toContain('.conclusion == "success"')
+    expect(gateReuseJob).not.toContain('event=push')
+    expect(gateReuseJob).not.toContain('.event == "push"')
     expect(gateReuseJob).toContain("retry_gh")
     expect(gateReuseJob).toContain("set -euo pipefail")
     expect(gateReuseJob).not.toContain("check-runs")
@@ -65,13 +68,35 @@ describe("publish gate reuse", () => {
     const prepareJob = sliceWorkflowSection(workflow, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
 
     expect(prepareJob).toContain("token: ${{ secrets.GH_PAT }}")
-    expect(prepareJob).toContain("GH_TOKEN: ${{ secrets.GH_PAT }}")
+    expect(prepareJob).toContain("RELEASE_PAT: ${{ secrets.GH_PAT }}")
+    expect(prepareJob).toContain('export GH_TOKEN="$RELEASE_PAT"')
     expect(prepareJob).toContain("create_release_pr()")
     expect(prepareJob).toContain("enable_release_auto_merge()")
     expect(prepareJob).toContain("gh pr create")
     expect(prepareJob).toContain("gh pr merge")
     expect(prepareJob).toContain('retry_gh "Read release-state PR state" gh pr view')
     expect(prepareJob).toContain('retry_gh "Read release-state PR checks" gh pr view')
+  })
+
+  test("scopes the release PAT away from repo-controlled generation", () => {
+    const workflow = readFileSync(publishWorkflowPath, "utf8")
+    const prepareJob = sliceWorkflowSection(workflow, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
+
+    // The checkout must not leave the PAT in git config for repo scripts to read.
+    expect(prepareJob).toContain("persist-credentials: false")
+
+    // Every repo-controlled generation step must complete before the token exists.
+    const lastGeneration = prepareJob.lastIndexOf("build-extension.mjs")
+    const tokenIntroduction = prepareJob.indexOf("export GH_TOKEN")
+    expect(lastGeneration).toBeGreaterThan(-1)
+    expect(tokenIntroduction).toBeGreaterThan(lastGeneration)
+
+    // No env-level GH_TOKEN blanket exposure for the whole step.
+    expect(prepareJob).not.toContain("GH_TOKEN: ${{ secrets.GH_PAT }}")
+
+    // Least-scope permissions: this job needs neither Actions reads nor OIDC.
+    expect(prepareJob).not.toContain("id-token: write")
+    expect(prepareJob).not.toContain("actions: read")
   })
 
   test("keeps every publication surface pinned to a prepared release SHA", () => {

--- a/script/publish-gate-reuse-workflow.test.ts
+++ b/script/publish-gate-reuse-workflow.test.ts
@@ -68,8 +68,6 @@ describe("publish gate reuse", () => {
     const prepareJob = sliceWorkflowSection(workflow, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
 
     expect(prepareJob).toContain("token: ${{ secrets.GH_PAT }}")
-    expect(prepareJob).toContain("RELEASE_PAT: ${{ secrets.GH_PAT }}")
-    expect(prepareJob).toContain('export GH_TOKEN="$RELEASE_PAT"')
     expect(prepareJob).toContain("create_release_pr()")
     expect(prepareJob).toContain("enable_release_auto_merge()")
     expect(prepareJob).toContain("gh pr create")
@@ -85,14 +83,34 @@ describe("publish gate reuse", () => {
     // The checkout must not leave the PAT in git config for repo scripts to read.
     expect(prepareJob).toContain("persist-credentials: false")
 
-    // Every repo-controlled generation step must complete before the token exists.
-    const lastGeneration = prepareJob.lastIndexOf("build-extension.mjs")
-    const tokenIntroduction = prepareJob.indexOf("export GH_TOKEN")
-    expect(lastGeneration).toBeGreaterThan(-1)
-    expect(tokenIntroduction).toBeGreaterThan(lastGeneration)
+    // Generation and privileged publication are separate steps: the generation
+    // step must carry no form of the PAT in its environment at all.
+    const generationStep = prepareJob.slice(
+      prepareJob.indexOf("name: Prepare release state"),
+      prepareJob.indexOf("name: Publish prepared release state"),
+    )
+    expect(generationStep).not.toContain("GH_PAT")
+    expect(generationStep).not.toContain("RELEASE_PAT")
+    expect(generationStep).not.toContain("GH_TOKEN")
 
-    // No env-level GH_TOKEN blanket exposure for the whole step.
-    expect(prepareJob).not.toContain("GH_TOKEN: ${{ secrets.GH_PAT }}")
+    // The privileged step owns the only credential and runs no repo-controlled
+    // generation scripts that could read it.
+    const privilegedStep = prepareJob.slice(
+      prepareJob.indexOf("name: Publish prepared release state"),
+      prepareJob.indexOf("name: Write job summary"),
+    )
+    expect(privilegedStep).toContain("GH_TOKEN: ${{ secrets.GH_PAT }}")
+    for (const repoControlled of [
+      "node packages/",
+      "jq -",
+      "npm --prefix",
+      "bun install",
+      "bun run",
+      "build-extension",
+      "sync-version",
+    ]) {
+      expect(privilegedStep).not.toContain(repoControlled)
+    }
 
     // Least-scope permissions: this job needs neither Actions reads nor OIDC.
     expect(prepareJob).not.toContain("id-token: write")

--- a/script/publish-release-bundle-rebuild.test.ts
+++ b/script/publish-release-bundle-rebuild.test.ts
@@ -15,22 +15,26 @@ function sliceWorkflowSection(workflow: string, startMarker: string, endMarker: 
 }
 
 describe("test workflows", () => {
-  test("retries every idempotent release-state PR read on transient GitHub API errors", () => {
+  test("retries release-state PR reads and writes on transient GitHub API errors", () => {
     // #given
     const workflow = readFileSync(publishWorkflowPath, "utf8")
     const prepareJob = sliceWorkflowSection(workflow, "  prepare-release-state:", "  dispatch-provenance-safe-publish:")
 
     // #when
-    const definesReadRetry = prepareJob.includes("retry_gh_read()")
-    const retriesPrList = prepareJob.includes('PR_NUMBER="$(retry_gh_read "List release-state PR" gh pr list')
-    const retriesPrState = prepareJob.includes('PR_STATE="$(retry_gh_read "Read release-state PR state" gh pr view')
-    const retriesCheckRollup = prepareJob.includes('FAILURES="$(retry_gh_read "Read release-state PR checks" gh pr view')
+    const definesRetry = prepareJob.includes("retry_gh()")
+    const retriesPrList = prepareJob.includes('PR_NUMBER="$(retry_gh "List release-state PR" gh pr list')
+    const retriesPrState = prepareJob.includes('PR_STATE="$(retry_gh "Read release-state PR state" gh pr view')
+    const retriesCheckRollup = prepareJob.includes('FAILURES="$(retry_gh "Read release-state PR checks" gh pr view')
+    const retriesPrCreate = prepareJob.includes("create_release_pr()") && prepareJob.includes("gh pr create")
+    const retriesAutoMerge = prepareJob.includes("enable_release_auto_merge()") && prepareJob.includes("gh pr merge")
 
     // #then
-    expect(definesReadRetry, "prepare-release-state must centralize retry handling for GitHub PR reads").toBe(true)
+    expect(definesRetry, "prepare-release-state must centralize retry handling for GitHub PR reads").toBe(true)
     expect(retriesPrList, "a transient 503 while listing the existing release PR must not kill publish").toBe(true)
     expect(retriesPrState, "a transient 503 while reading merge state must not kill publish").toBe(true)
     expect(retriesCheckRollup, "a transient 503 while reading check rollup must not kill publish").toBe(true)
+    expect(retriesPrCreate, "a transient create response failure must recover the created release PR").toBe(true)
+    expect(retriesAutoMerge, "a transient auto-merge response failure must verify whether auto-merge was enabled").toBe(true)
   })
 
   test("rebuilds version-stamped Senpi bundles into the release commit", () => {

--- a/script/publish-release-platform-workflow.test.ts
+++ b/script/publish-release-platform-workflow.test.ts
@@ -31,7 +31,7 @@ describe("release and platform publish workflows", () => {
     const platformUsesMetadata = workflow.includes("version: ${{ needs.release-metadata.outputs.version }}") &&
       workflow.includes("dist_tag: ${{ needs.release-metadata.outputs.dist_tag }}")
     const mainWaitsForPlatform = workflow.includes(
-      "needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
+      "needs: [gate-reuse, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
     ) &&
       workflow.includes("inputs.skip_platform == true || needs.publish-platform.result == 'success'")
     const releaseUsesMetadata = workflow.includes("VERSION: ${{ needs.release-metadata.outputs.version }}")

--- a/script/publish-release-platform-workflow.test.ts
+++ b/script/publish-release-platform-workflow.test.ts
@@ -127,7 +127,7 @@ describe("release and platform publish workflows", () => {
   test("regenerates and commits release lockfiles only in the prepared source state", () => {
     // #given
     const workflow = readFileSync(publishWorkflowPath, "utf8")
-    const prepareStep = sliceWorkflowSection(workflow, "      - name: Prepare and merge release state before publishing", "      - name: Write job summary")
+    const prepareStep = sliceWorkflowSection(workflow, "      - name: Prepare release state (generation)", "      - name: Publish prepared release state")
     const releaseJob = workflow.slice(workflow.indexOf("  release:"))
     const codexLockfileCommand = "npm --prefix packages/omo-codex/plugin install --package-lock-only --ignore-scripts --no-audit --fund=false"
     const codexLockfilePath = "packages/omo-codex/plugin/package-lock.json"

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -20,10 +20,6 @@ const workflowChecks = [
       "run: bun test packages/omo-opencode/src/shared/dist-bundle-bun-globals.test.ts",
     ],
   },
-  {
-    path: publishWorkflowPath,
-    testRuns: ["run: bun test"],
-  },
 ]
 
 function sliceWorkflowSection(workflow: string, startMarker: string, endMarker: string): string {
@@ -45,15 +41,6 @@ function sliceWorkflowSectionToEnd(workflow: string, startMarker: string): strin
 
 function normalizeWorkflowText(workflow: string): string {
   return workflow.replace(/\r\n/g, "\n")
-}
-
-function expectBunSetupBeforeLspToolsBuild(workflowSection: string, label: string): void {
-  const bunSetupIndex = workflowSection.indexOf("uses: oven-sh/setup-bun@v2")
-  const lspBuildIndex = workflowSection.indexOf("name: Build vendored lsp-tools-mcp package")
-
-  expect(bunSetupIndex, `${label} must setup Bun`).toBeGreaterThanOrEqual(0)
-  expect(lspBuildIndex, `${label} must build lsp-tools-mcp`).toBeGreaterThanOrEqual(0)
-  expect(bunSetupIndex, `${label} must setup Bun before lsp-tools-mcp build`).toBeLessThan(lspBuildIndex)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -80,28 +67,6 @@ describe("test workflows", () => {
         expect(workflow).toContain(testRun)
       }
     }
-  })
-
-  test("prepares vendored lsp-tools-mcp before publish workflow tests and typecheck", () => {
-    // #given
-    const workflow = readFileSync(publishWorkflowPath, "utf8")
-    const testJob = sliceWorkflowSection(workflow, "  test:", "  typecheck:")
-    const typecheckJob = sliceWorkflowSection(workflow, "  typecheck:", "  preflight-trust:")
-
-    // #when
-    const testHasNodeSetup = testJob.includes('node-version: "24"')
-    const testBuildsLspToolsMcp = testJob.includes("name: Build vendored lsp-tools-mcp package") &&
-      testJob.includes("working-directory: packages/lsp-tools-mcp")
-
-    const typecheckHasNodeSetup = typecheckJob.includes('node-version: "24"')
-    const typecheckBuildsLspToolsMcp = typecheckJob.includes("name: Build vendored lsp-tools-mcp package") &&
-      typecheckJob.includes("working-directory: packages/lsp-tools-mcp")
-
-    // #then
-    expect(testHasNodeSetup, "publish test job must setup Node for MCP package builds").toBe(true)
-    expect(testBuildsLspToolsMcp, "publish test job must build lsp-tools-mcp before bun test").toBe(true)
-    expect(typecheckHasNodeSetup, "publish typecheck job must setup Node for MCP package builds").toBe(true)
-    expect(typecheckBuildsLspToolsMcp, "publish typecheck job must build lsp-tools-mcp before bun run typecheck").toBe(true)
   })
 
   test("builds publish-main from the prepared release SHA", () => {
@@ -155,42 +120,6 @@ describe("test workflows", () => {
     expect(releaseDoesNotRestampOrRetag, "the provenance-bearing release run must not mutate its release source").toBe(true)
   })
 
-  test("runs Codex compatibility checks before publish jobs", () => {
-    // #given
-    const workflow = readFileSync(publishWorkflowPath, "utf8")
-    const codexCompatibilityJob = sliceWorkflowSection(workflow, "  codex-compatibility:", "  preflight-trust:")
-
-    // #when
-    const hasCodexMatrixJob = workflow.includes("codex-compatibility:")
-    const hasSupportedOsMatrix = codexCompatibilityJob.includes("os: [ubuntu-latest, macos-latest, windows-latest]")
-    const hasNodeSetup = codexCompatibilityJob.includes('node-version: "24"')
-    const buildsLspToolsMcp =
-      codexCompatibilityJob.includes("name: Build vendored lsp-tools-mcp package") &&
-      codexCompatibilityJob.includes("working-directory: packages/lsp-tools-mcp") &&
-      codexCompatibilityJob.indexOf("name: Build vendored lsp-tools-mcp package") <
-        codexCompatibilityJob.indexOf("name: Run Codex compatibility tests")
-    const runsCodexCommand = codexCompatibilityJob.includes("run: bun run test:codex")
-    const publishMainNeedsCodex =
-      workflow.includes(
-        "needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
-      ) &&
-      workflow.includes("contains(fromJSON('[\"success\",\"skipped\"]'), needs.codex-compatibility.result)")
-    const publishPlatformNeedsCodex =
-      workflow.includes(
-        "needs: [gate-reuse, test, typecheck, codex-compatibility, preflight-trust, release-metadata, prepare-release-state]",
-      ) &&
-      workflow.includes("contains(fromJSON('[\"success\",\"skipped\"]'), needs.codex-compatibility.result)")
-
-    // #then
-    expect(hasCodexMatrixJob, "publish workflow must expose a Codex compatibility job").toBe(true)
-    expect(hasSupportedOsMatrix, "publish Codex compatibility must cover supported OSes").toBe(true)
-    expect(hasNodeSetup, "publish Codex compatibility must setup Node for MCP package builds").toBe(true)
-    expect(buildsLspToolsMcp, "publish Codex compatibility must build lsp-tools-mcp before bun run test:codex").toBe(true)
-    expect(runsCodexCommand, "publish Codex compatibility must run the shared Codex test script").toBe(true)
-    expect(publishMainNeedsCodex, "main wrapper publish must wait for Codex compatibility").toBe(true)
-    expect(publishPlatformNeedsCodex, "platform publish must wait for Codex compatibility").toBe(true)
-  })
-
   test("exercise root checks across linux macos and windows", () => {
     // #given
     const workflow = readFileSync(ciWorkflowPath, "utf8")
@@ -216,9 +145,13 @@ describe("test workflows", () => {
     const hasCodexMatrixJob = workflow.includes("codex-compatibility:")
     const hasSupportedOsMatrix = codexCompatibilityJob.includes("os: [ubuntu-latest, macos-latest, windows-latest]")
     const hasCodexCommand = workflow.includes("run: bun run test:codex")
-    const buildWaitsForChecks = buildJob.includes("needs:")
+    const buildWaitsOnlyForMode =
+      buildJob.includes("needs: [ci-mode]") &&
+      !buildJob.includes("needs: [test") &&
+      !buildJob.includes("needs: [typecheck")
     const buildHasReadOnlyContentsPermission = buildJob.includes("permissions:\n      contents: read")
-    const allRootChecks = "needs: [test, typecheck, codex-compatibility, senpi-compatibility, build, omo-ai-payload-check]"
+    const allRootChecks =
+      "needs: [ci-mode, test, typecheck, codex-compatibility, senpi-compatibility, build, omo-ai-payload-check]"
     const writeGateNeedsAllChecks = autoCommitSchemaJob.includes(allRootChecks)
     const draftReleaseNeedsAllChecks = draftReleaseJob.includes(allRootChecks)
 
@@ -226,7 +159,7 @@ describe("test workflows", () => {
     expect(hasCodexMatrixJob, "CI must expose a Codex compatibility matrix job").toBe(true)
     expect(hasSupportedOsMatrix, "CI Codex compatibility must cover supported OSes").toBe(true)
     expect(hasCodexCommand, "Codex compatibility job must run the shared Codex test script").toBe(true)
-    expect(buildWaitsForChecks, "Build has no artifact dependency on test/typecheck/codex and must not serialize CI").toBe(false)
+    expect(buildWaitsOnlyForMode, "Build may wait for classification but must stay parallel with validation jobs").toBe(true)
     expect(buildHasReadOnlyContentsPermission, "Parallel build must explicitly stay read-only; write actions belong behind the all-check gate").toBe(true)
     expect(writeGateNeedsAllChecks, "Schema auto-commit must wait for all root checks and build").toBe(true)
     expect(draftReleaseNeedsAllChecks, "Draft release must wait for all root checks and build").toBe(true)
@@ -244,23 +177,6 @@ describe("test workflows", () => {
 
     expect(hasNodeSetup, "Codex compatibility must setup Node for MCP package builds").toBe(true)
     expect(runsCodexTests, "Codex compatibility must run bun run test:codex").toBe(true)
-  })
-
-  test("sets up Bun before vendored lsp-tools-mcp builds in publish workflow jobs", () => {
-    // #given
-    // ci.yml no longer pre-builds lsp-tools-mcp in any job: typecheck/codex/build
-    // dropped it as redundant (typecheck needs no build; test:codex and bun run
-    // build self-build it), and the test job's full install rebuilds it via prepare.
-    // publish.yml still pre-builds it, so the ordering guard still applies there.
-    const publishWorkflow = readFileSync(publishWorkflowPath, "utf8")
-    const publishTestJob = sliceWorkflowSection(publishWorkflow, "  test:", "  typecheck:")
-    const publishTypecheckJob = sliceWorkflowSection(publishWorkflow, "  typecheck:", "  codex-compatibility:")
-    const publishCodexCompatibilityJob = sliceWorkflowSection(publishWorkflow, "  codex-compatibility:", "  preflight-trust:")
-
-    // #then
-    expectBunSetupBeforeLspToolsBuild(publishTestJob, "publish test job")
-    expectBunSetupBeforeLspToolsBuild(publishTypecheckJob, "publish typecheck job")
-    expectBunSetupBeforeLspToolsBuild(publishCodexCompatibilityJob, "publish Codex compatibility job")
   })
 
   test("builds bundled MCP runtimes before Codex compatibility tests", () => {

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -7,7 +7,7 @@ import { execFileSync } from "node:child_process"
 const ciWorkflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
 const publishWorkflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
 const workflowsDir = new URL("../.github/workflows/", import.meta.url)
-const pinnedBunVersion = 'bun-version: "1.3.12"'
+const pinnedBunVersion = 'bun-version: "1.3.14"'
 const workflowPaths = readdirSync(workflowsDir)
   .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
   .map((name) => new URL(name, workflowsDir))
@@ -242,19 +242,10 @@ describe("test workflows", () => {
       const bunVersionLines = workflow.match(/bun-version: .*/g) ?? []
 
       // #when
-      // Upstream pins the root test job to 1.3.14 outright (the runtime the
-      // Windows partition was validated under); every other job stays on the
-      // repo pin 1.3.12 so committed Senpi bundle checks match.
-      const testJobPin = 'bun-version: "1.3.14"'
-      const unpinnedBunLines = bunVersionLines.filter(
-        (line) => line !== pinnedBunVersion && line !== testJobPin,
-      )
+      const unpinnedBunLines = bunVersionLines.filter((line) => line !== pinnedBunVersion)
 
       // #then
-      expect(unpinnedBunLines, `${workflowPath.pathname} must pin Bun to an exact version`).toEqual([])
-      if (workflowPath.pathname.endsWith("/ci.yml")) {
-        expect(bunVersionLines, "ci.yml must keep exactly one test-job 1.3.14 pin").toContain(testJobPin)
-      }
+      expect(unpinnedBunLines, `${workflowPath.pathname} must pin Bun to 1.3.14`).toEqual([])
     }
   })
 

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -7,7 +7,7 @@ import { execFileSync } from "node:child_process"
 const ciWorkflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
 const publishWorkflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
 const workflowsDir = new URL("../.github/workflows/", import.meta.url)
-const pinnedBunVersion = 'bun-version: "1.3.14"'
+const pinnedBunVersion = 'bun-version: "1.3.12"'
 const workflowPaths = readdirSync(workflowsDir)
   .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
   .map((name) => new URL(name, workflowsDir))
@@ -242,10 +242,20 @@ describe("test workflows", () => {
       const bunVersionLines = workflow.match(/bun-version: .*/g) ?? []
 
       // #when
-      const unpinnedBunLines = bunVersionLines.filter((line) => line !== pinnedBunVersion)
+      // The root test job pins a per-OS pair: Windows legs run 1.3.14 (the
+      // runtime the Windows partition was validated under), everything else
+      // stays on the repo pin 1.3.12 so committed Senpi bundle checks match.
+      const windowsTestPin =
+        "bun-version: ${{ matrix.os == 'windows-latest' && '1.3.14' || '1.3.12' }}"
+      const unpinnedBunLines = bunVersionLines.filter(
+        (line) => line !== pinnedBunVersion && line !== windowsTestPin,
+      )
 
       // #then
-      expect(unpinnedBunLines, `${workflowPath.pathname} must pin Bun to 1.3.14`).toEqual([])
+      expect(unpinnedBunLines, `${workflowPath.pathname} must pin Bun to an exact version`).toEqual([])
+      if (workflowPath.pathname.endsWith("/ci.yml")) {
+        expect(bunVersionLines, "ci.yml must keep exactly one per-OS Windows test pin").toContain(windowsTestPin)
+      }
     }
   })
 

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -242,19 +242,18 @@ describe("test workflows", () => {
       const bunVersionLines = workflow.match(/bun-version: .*/g) ?? []
 
       // #when
-      // The root test job pins a per-OS pair: Windows legs run 1.3.14 (the
-      // runtime the Windows partition was validated under), everything else
-      // stays on the repo pin 1.3.12 so committed Senpi bundle checks match.
-      const windowsTestPin =
-        "bun-version: ${{ matrix.os == 'windows-latest' && '1.3.14' || '1.3.12' }}"
+      // Upstream pins the root test job to 1.3.14 outright (the runtime the
+      // Windows partition was validated under); every other job stays on the
+      // repo pin 1.3.12 so committed Senpi bundle checks match.
+      const testJobPin = 'bun-version: "1.3.14"'
       const unpinnedBunLines = bunVersionLines.filter(
-        (line) => line !== pinnedBunVersion && line !== windowsTestPin,
+        (line) => line !== pinnedBunVersion && line !== testJobPin,
       )
 
       // #then
       expect(unpinnedBunLines, `${workflowPath.pathname} must pin Bun to an exact version`).toEqual([])
       if (workflowPath.pathname.endsWith("/ci.yml")) {
-        expect(bunVersionLines, "ci.yml must keep exactly one per-OS Windows test pin").toContain(windowsTestPin)
+        expect(bunVersionLines, "ci.yml must keep exactly one test-job 1.3.14 pin").toContain(testJobPin)
       }
     }
   })


### PR DESCRIPTION
## Summary

This removes repeated release validation and the manual rescue step from the
two-phase publish workflow. The prepared release SHA now waits for one
successful `CI` push run, automated release PR operations use the
workflow-capable PAT with bounded recovery, and generated release/web-only
events keep required check names while skipping duplicate heavy work.

## Changes

### Release publication

- Replace commit-wide check-name matching with a fail-closed wait for a
  successful `ci.yml` push run on the exact `prepared_release_sha`.
- Remove the duplicate publish-local test, typecheck, and Codex compatibility
  jobs.
- Use `GH_PAT` for release-state checkout, push, PR creation, and auto-merge so
  the release PR triggers normal workflow events.
- Recover transient PR create/auto-merge response failures by re-reading the
  resulting PR state before retrying.
- Preserve tag-pinned self-dispatch and every prepared-SHA provenance guard.

### CI execution mode

- Add a fail-closed classifier consumed by `ci.yml`.
- Keep all required matrix job identities instantiated.
- Skip only expensive steps for exact generated release merge pushes and
  Web-CI-owned changes.
- Keep release-state PRs and ordinary source changes on full validation.
- Preserve master schema generation and suppress duplicate draft generation
  after a release-state merge.

## QA & Evidence

- **What was tested:** failing-first workflow regression tests on unmodified
  `dev`.
  - **Observed result:** 13 expected failures covering stale check matching,
    duplicate publish jobs, missing PAT/retry behavior, missing classifier, and
    missing CI-mode wiring.
  - **Artifact:** local `.omo/evidence/20260817-release-ci-deduplication/RED.md`
    (ignored by repository policy).
  - **Why sufficient:** each requested behavior failed before workflow edits.

- **What was tested:** all workflow-focused tests.
  - **Command:** `bunx bun@1.3.12 test script/*workflow.test.ts script/ci-fast-path.test.ts`
  - **Observed result:** 59 passed, 0 failed, 327 assertions.
  - **Why sufficient:** covers release reuse, PAT/retries, provenance, required
    check identities, classifier branches, schema/draft behavior, and adjacent
    publication contracts.

- **What was tested:** full repository suite with CI’s pinned Bun.
  - **Command:** `bunx bun@1.3.12 test`
  - **Observed result:** 15,782 passed, 0 failed across 2,056 files.
  - **Why sufficient:** proves the workflow-test changes coexist with every
    repository package and integration test.

- **What was tested:** typecheck and build.
  - **Commands:** `bun run typecheck`; `bunx bun@1.3.12 install --frozen-lockfile`
    (runs the repository build during `prepare`).
  - **Observed result:** both completed successfully.
  - **Why sufficient:** validates TypeScript and generated build surfaces.

- **What was tested:** workflow syntax.
  - **Command:** `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10 -color -shellcheck='' .github/workflows/*.yml`
  - **Observed result:** exit 0, no diagnostics.
  - **Why sufficient:** runs the exact actionlint version pinned by CI. The
    GitHub download script was rate-limited, so Go’s module proxy supplied the
    same version.

- **What was tested:** real classifier CLI.
  - **Observed result:** generated release and web-only inputs selected
    lightweight mode; ordinary, mixed, direct-release, unavailable-diff, and
    malformed-input cases failed closed or returned heavy mode as specified.
  - **Artifact:** local
    `.omo/evidence/20260817-release-ci-deduplication/MANUAL-QA.md`.
  - **Why sufficient:** drives the exact script invoked by CI, including its
    negative input surface.

## Risks & Residuals

- Required GitHub check names are unchanged; lightweight events still launch
  each required job and report success after checkout/summary-only execution.
- The generated-release predicate is deliberately exact and owner-scoped.
  Unknown merge formats and missing diffs run full CI.
- Publication remains blocked unless a successful `CI` push run exists for the
  immutable prepared SHA.
- YAML LSP is unavailable on this workstation; exact-version actionlint is the
  authoritative YAML/workflow validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates duplicate release validation and gates publication on a single successful `ci.yml` run for the prepared release SHA. Previously `publish.yml` re‑ran tests/typecheck/Codex; now it reuses the exact‑SHA CI run, fast‑paths generated release merges and web‑only changes, and isolates the release PAT to a dedicated publish step.

- `publish.yml`: waits (with retries/timeout) for a successful `ci.yml` workflow run on `prepared_release_sha` via the Actions API; accepts either the post‑merge push or the release PR run; removes publish‑local test/typecheck/Codex jobs; fails closed if CI is missing/unsuccessful.
- Credentials isolation: checkout uses `persist-credentials: false`; “Prepare release state (generation)” runs without a PAT; a dedicated “Publish prepared release state” injects `GH_PAT` only for `git push`/`gh pr`, restores a clean remote via an EXIT trap even on push failure, retries PR create/auto‑merge with recovery, and blocks publication on failing required checks.
- `ci.yml`: adds a `ci-mode` classifier (`script/ci-fast-path.mjs`) that preserves required job identities but runs heavy steps only when `run_heavy` is true; draft release runs only in heavy mode; schema generation stays master‑only.
- CI stability: runs Windows tests under the native shell, runs the DAG scheduler test serially, skips the Windows cache where needed, pins Bun 1.3.14 across CI, and fixes an `ast-grep` installer hang by keeping the timeout ref’d with a 1s grace deadline (with a unit test). Updates `bunfig.win2.parallel.toml` to ignore the scheduler test in parallel runs.
- Tests updated to reflect the split generation/publish steps.

- Required: add repository secret `GH_PAT` (scopes: repo, workflow). Verify the publish gate uses the exact prepared head SHA, the PAT stays out of repo‑controlled generation, and CI jobs retain required check identities while skipping heavy work when `run_heavy` is false.

<sup>Written for commit 5ef5cbd964257af8cc41d03503ba3acf339f2878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

