### PR TITLE
fix(deps): patch npm audit transitive advisories

### DIFF
--- a/.omo/evidence/20260817-npm-audit-fix/cleanup-receipt.txt
+++ b/.omo/evidence/20260817-npm-audit-fix/cleanup-receipt.txt
@@ -1,0 +1,26 @@
+Cleanup command:
+cd /Volumes/mengmotaStorage/local-workspaces/omo-wt/fix-npm-audit-remediation
+rm -rf \
+  node_modules \
+  packages/lsp-tools-mcp/node_modules \
+  packages/lsp-daemon/node_modules \
+  packages/omo-codex/plugin/node_modules
+
+Verification:
+Each of the four paths was tested with `test ! -e`.
+
+Result:
+PASS. Root and all three package dependency trees created for QA are absent.
+
+Other QA resources:
+- codex-qa helpers self-cleaned isolated CODEX_HOME directories
+- codex-qa helpers stopped their local mock model processes
+- GitHub run watcher was explicitly killed after the linked job result was
+  captured
+- all three explore children reached terminal completion
+- background `test:codex` session exited 0
+
+Remaining generated tracked churn:
+Root build materialization changed unrelated generated bundles in the
+task-owned worktree. They are deliberately not staged and will be discarded
+when the merged task worktree is removed.

--- a/.omo/evidence/20260817-npm-audit-fix/codex-app-server-proof.txt
+++ b/.omo/evidence/20260817-npm-audit-fix/codex-app-server-proof.txt
@@ -1,0 +1,18 @@
+Command:
+cd .agents/skills/codex-qa
+OMO_CODEX_SOURCE_ROOT=<task-worktree> bash scripts/app-server-drive.sh --plugin
+
+Exit code:
+0
+
+Observed first-party behavior:
+- real Codex app-server started against an isolated CODEX_HOME
+- local mock model completed the turn without an external model API call
+- notification stream contained hook/started events from the local plugin
+- notification stream contained hook/completed events for sessionStart
+- plugin source paths resolved inside the isolated plugin cache
+- real ~/.codex/config.toml SHA-256 was unchanged
+
+Binary result:
+PASS. The locally built plugin installed and its hook fired through the real
+Codex app-server surface.

--- a/.omo/evidence/20260817-npm-audit-fix/codex-install-verify.txt
+++ b/.omo/evidence/20260817-npm-audit-fix/codex-install-verify.txt
@@ -1,0 +1,22 @@
+Command:
+cd .agents/skills/codex-qa
+OMO_CODEX_SOURCE_ROOT=<task-worktree> bash scripts/install-verify.sh --self-test
+
+First parallel attempt:
+- exit 1
+- cause: concurrent app-server and install lanes contended on the shared
+  worktree's git config lock
+- disposition: not treated as a pass; rerun alone
+
+Sequential retry:
+- exit 0
+- PASS: plugin cache present (5.0.0-beta.8)
+- PASS: config.toml enables omo@sisyphuslabs
+- PASS: component bins linked in sandbox (10 bins)
+- PASS: agent TOMLs linked in sandbox
+- PASS: real ~/.codex/config.toml unchanged
+- PASS: install-verify
+
+Isolation:
+The helper created and removed its own temporary CODEX_HOME. The host
+`~/.codex/config.toml` SHA-256 was unchanged before and after.

--- a/.omo/evidence/20260817-npm-audit-fix/green-lsp-daemon.json
+++ b/.omo/evidence/20260817-npm-audit-fix/green-lsp-daemon.json
@@ -1,0 +1,15 @@
+{
+  "command": "npm --prefix packages/lsp-daemon audit --json --package-lock-only",
+  "exit_code": 0,
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    }
+  },
+  "vulnerabilities": {}
+}

--- a/.omo/evidence/20260817-npm-audit-fix/green-lsp-tools-mcp.json
+++ b/.omo/evidence/20260817-npm-audit-fix/green-lsp-tools-mcp.json
@@ -1,0 +1,15 @@
+{
+  "command": "npm --prefix packages/lsp-tools-mcp audit --json --package-lock-only",
+  "exit_code": 0,
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    }
+  },
+  "vulnerabilities": {}
+}

--- a/.omo/evidence/20260817-npm-audit-fix/green-omo-codex-plugin.json
+++ b/.omo/evidence/20260817-npm-audit-fix/green-omo-codex-plugin.json
@@ -1,0 +1,15 @@
+{
+  "command": "npm --prefix packages/omo-codex/plugin audit --json --package-lock-only",
+  "exit_code": 0,
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    }
+  },
+  "vulnerabilities": {}
+}

--- a/.omo/evidence/20260817-npm-audit-fix/red-lsp-daemon.json
+++ b/.omo/evidence/20260817-npm-audit-fix/red-lsp-daemon.json
@@ -1,0 +1,34 @@
+{
+  "command": "npm --prefix packages/lsp-daemon audit --json --package-lock-only",
+  "exit_code": 1,
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 2,
+      "critical": 0,
+      "total": 2
+    }
+  },
+  "vulnerabilities": {
+    "nanoid": {
+      "severity": "high",
+      "installed": "3.3.12",
+      "affected_range": "<=3.3.17",
+      "advisories": [
+        "GHSA-28wg-ghj8-5hjv",
+        "GHSA-2v37-7h3g-55p8"
+      ]
+    },
+    "postcss": {
+      "severity": "high",
+      "installed": "8.5.15",
+      "affected_range": "<=8.5.22",
+      "advisories": [
+        "GHSA-r28c-9q8g-f849",
+        "GHSA-fxqj-rqcc-2cmp"
+      ]
+    }
+  }
+}

--- a/.omo/evidence/20260817-npm-audit-fix/red-lsp-tools-mcp.json
+++ b/.omo/evidence/20260817-npm-audit-fix/red-lsp-tools-mcp.json
@@ -1,0 +1,34 @@
+{
+  "command": "npm --prefix packages/lsp-tools-mcp audit --json --package-lock-only",
+  "exit_code": 1,
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 2,
+      "critical": 0,
+      "total": 2
+    }
+  },
+  "vulnerabilities": {
+    "nanoid": {
+      "severity": "high",
+      "installed": "3.3.12",
+      "affected_range": "<=3.3.17",
+      "advisories": [
+        "GHSA-28wg-ghj8-5hjv",
+        "GHSA-2v37-7h3g-55p8"
+      ]
+    },
+    "postcss": {
+      "severity": "high",
+      "installed": "8.5.15",
+      "affected_range": "<=8.5.22",
+      "advisories": [
+        "GHSA-r28c-9q8g-f849",
+        "GHSA-fxqj-rqcc-2cmp"
+      ]
+    }
+  }
+}

--- a/.omo/evidence/20260817-npm-audit-fix/red-omo-codex-plugin.json
+++ b/.omo/evidence/20260817-npm-audit-fix/red-omo-codex-plugin.json
@@ -1,0 +1,34 @@
+{
+  "command": "npm --prefix packages/omo-codex/plugin audit --json --package-lock-only",
+  "exit_code": 1,
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 2,
+      "critical": 0,
+      "total": 2
+    }
+  },
+  "vulnerabilities": {
+    "nanoid": {
+      "severity": "high",
+      "installed": "3.3.12",
+      "affected_range": "<=3.3.17",
+      "advisories": [
+        "GHSA-28wg-ghj8-5hjv",
+        "GHSA-2v37-7h3g-55p8"
+      ]
+    },
+    "postcss": {
+      "severity": "high",
+      "installed": "8.5.15",
+      "affected_range": "<=8.5.22",
+      "advisories": [
+        "GHSA-r28c-9q8g-f849",
+        "GHSA-fxqj-rqcc-2cmp"
+      ]
+    }
+  }
+}

--- a/.omo/evidence/20260817-npm-audit-fix/red-release-install.txt
+++ b/.omo/evidence/20260817-npm-audit-fix/red-release-install.txt
@@ -1,0 +1,14 @@
+Command:
+npm --prefix packages/lsp-daemon ci
+
+Exit code:
+0
+
+Observed audit warning:
+2 high severity vulnerabilities
+Run `npm audit fix` to address all issues.
+
+Binary interpretation:
+The linked publish-path install succeeds, but npm reports the same two
+actionable high-severity vulnerable package records captured by the three
+RED JSON audits.

--- a/.omo/evidence/20260817-npm-audit-fix/release-path.txt
+++ b/.omo/evidence/20260817-npm-audit-fix/release-path.txt
@@ -1,0 +1,33 @@
+All commands ran in:
+/Volumes/mengmotaStorage/local-workspaces/omo-wt/fix-npm-audit-remediation
+
+packages/lsp-tools-mcp
+- npm ci: exit 0
+- npm run build: exit 0
+- npm test: exit 0
+- npm run typecheck: exit 0
+
+packages/lsp-daemon
+- npm ci: exit 0
+- npm run build: exit 0
+- npm test: exit 0
+- npm run typecheck: exit 0
+- npm run smoke:client-package: exit 0
+
+packages/omo-codex/plugin
+- npm ci: exit 0
+- initial npm test: exit 1 because generated skill copies were absent in the
+  fresh worktree
+- bun install --frozen-lockfile at repository root: exit 0
+- npm run build: exit 0 and materialized the documented generated assets
+- npm test: exit 0
+
+Interpretation:
+The fixed locks are accepted by frozen installs, both Node-targeted packages
+build and test successfully, and the Codex plugin build/test path succeeds
+after its documented root-workspace materialization precondition.
+
+Generated-file note:
+The root install/build regenerated tracked bundles unrelated to this lockfile
+change. They are deliberately excluded from the commit; only the three
+package-lock.json files and reviewer-readable evidence are in scope.

--- a/.omo/evidence/20260817-npm-audit-fix/repository-gates.txt
+++ b/.omo/evidence/20260817-npm-audit-fix/repository-gates.txt
@@ -1,0 +1,21 @@
+Codex compatibility gate
+- command: bun run test:codex
+- exit code: 0
+- final Node test runner result: 519 tests, 519 pass, 0 fail,
+  0 cancelled, 0 skipped
+
+Repository typecheck
+- command: bun run typecheck
+- exit code: 0
+- covered root tsgo, script typecheck, and package typechecks
+
+Repository build
+- command: bun run build
+- exit code: 0
+- covered the main package build plus Codex component build path
+
+Diagnostics note
+The intended source diff contains package-lock.json files only. Lockfiles have
+no language-server semantic surface; JSON parsing, npm frozen installs,
+package builds/tests/typechecks, the Codex gate, and the repository build are
+the relevant validators.

--- a/.omo/evidence/20260817-npm-audit-fix/self-review.txt
+++ b/.omo/evidence/20260817-npm-audit-fix/self-review.txt
@@ -1,0 +1,35 @@
+Tier:
+HEAVY remains correct because this is dependency-security remediation on the
+release build path.
+
+Intended diff review:
+- exactly three package-lock.json files
+- 21 added lines and 21 removed lines
+- every changed line belongs to one of:
+  - nanoid 3.3.12 -> 3.3.18
+  - postcss 8.5.15 -> 8.5.23
+  - PostCSS nanoid requirement ^3.3.12 -> ^3.3.16
+  - matching npm registry URLs and integrity hashes
+- `git diff --check` exit 0
+- no manifest override or audit-policy weakening
+
+Lock semantics:
+- all three locks parse as JSON
+- all three frozen npm installs exit 0
+- all three resolve nanoid 3.3.18 and postcss 8.5.23
+
+Criterion coverage:
+- RED: three exit-1 audits plus the exact npm ci warning
+- GREEN: three identical exit-0 audits with zero findings
+- release regression: package installs, builds, tests, typechecks, and smoke
+- real surface: isolated Codex install plus real app-server hook proof
+- adjacent regression: full test:codex, repository typecheck, repository build
+
+Generated churn:
+Root materialization updated tracked bundles unrelated to this lockfile
+remediation. Those paths are not part of the intended diff and will not be
+staged or committed.
+
+Verdict:
+PASS. The smallest lockfile-only remediation satisfies all evidence-backed
+criteria without expanding policy or runtime scope.

--- a/packages/lsp-daemon/package-lock.json
+++ b/packages/lsp-daemon/package-lock.json
@@ -1121,9 +1121,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -1181,9 +1181,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1201,7 +1201,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/packages/lsp-tools-mcp/package-lock.json
+++ b/packages/lsp-tools-mcp/package-lock.json
@@ -1121,9 +1121,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -1178,9 +1178,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1198,7 +1198,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/packages/omo-codex/plugin/package-lock.json
+++ b/packages/omo-codex/plugin/package-lock.json
@@ -1534,9 +1534,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -1590,9 +1590,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1610,7 +1610,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},


### PR DESCRIPTION
## What changed

- refresh `nanoid` from `3.3.12` to `3.3.18` in all three tracked npm
  lockfiles
- refresh `postcss` from `8.5.15` to `8.5.23`
- keep the remediation lockfile-only because the existing semver ranges
  already admit the patched releases
- add reviewer-readable RED/GREEN and isolated Codex QA evidence

## Why

The successful beta.8 publish job emitted a non-blocking npm audit warning.
Current `dev` still reproduced two high-severity vulnerable package records in
each tracked npm lockfile:

- `nanoid`: GHSA-28wg-ghj8-5hjv and GHSA-2v37-7h3g-55p8
- `postcss`: GHSA-r28c-9q8g-f849 and GHSA-fxqj-rqcc-2cmp

The shared dependency path is `vitest -> vite -> postcss -> nanoid`.

## Observed behavior

Before:

- all three `npm audit --json --package-lock-only` commands exited `1`
- each reported 2 high vulnerability package records
- the publish-path `npm ci` succeeded but printed `2 high severity vulnerabilities`

After:

- all three identical audit commands exit `0`
- all report zero total/high/critical vulnerabilities
- frozen installs accept every updated lockfile

## Verification

- `npm ci`, build, tests, and typecheck: `packages/lsp-tools-mcp`
- `npm ci`, build, tests, typecheck, and client-package smoke:
  `packages/lsp-daemon`
- Codex plugin build and 519-test compatibility gate
- isolated `codex-qa` install verification
- real Codex app-server plugin hook proof with local mock model
- `bun run test:codex`
- `bun run typecheck`
- `bun run build`

Evidence is committed under:
`.omo/evidence/20260817-npm-audit-fix/`

## Residual risk

Low. No manifest, runtime source, audit policy, or package API changed. The
diff only refreshes vulnerable transitive lock resolutions within existing
declared ranges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches transitive security advisories by updating lockfile resolutions to `nanoid@3.3.18` and `postcss@8.5.23`. Previously `npm audit --package-lock-only` exited 1 with two high findings; now audits exit 0 with none. No manifest, runtime, or API changes.

**Review notes**
- Scope: modifies only `packages/lsp-daemon/package-lock.json`, `packages/lsp-tools-mcp/package-lock.json`, and `packages/omo-codex/plugin/package-lock.json`; adds reviewer evidence under `.omo/evidence/20260817-npm-audit-fix/` (no runtime effect).
- Changes: `postcss` 8.5.23 and `nanoid` 3.3.18; `postcss`’s `nanoid` requirement moves to `^3.3.16`. Dependency path: `vitest -> vite -> postcss -> nanoid`.
- Validation: audits now report zero findings; frozen installs, builds, tests, and typechecks pass; Codex plugin install and real app-server hook proof succeed. No rollout or migration actions required.

<sup>Written for commit 3ad3a1beb4c8089b714d523ad168da17f0e3b495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

