### PR TITLE
test: stabilize test process setup and Senpi lifecycle cleanup

### DIFF
--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/README.md
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/README.md
@@ -6,7 +6,7 @@ Started: 2026-08-17
 
 Branch: `fix/test-process-stability-20260817-ulw`
 
-Base: `581881f38bd906e3fd1e9f225cf81a35dbcc81db`
+Base: `ed723a3901fd6c14ea55b21aa8afcac28a87b6d7`
 
 This PR owns only deterministic test-process setup and failure-path cleanup:
 
@@ -48,4 +48,3 @@ Secret-bearing environment dumps, tokens, authentication headers, and private lo
 - `origin/dev` already includes PR #6925 at the branch base.
 - The main checkout is dirty and is never used for task commands.
 - All task commands use this worktree explicitly.
-

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/README.md
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/README.md
@@ -1,0 +1,51 @@
+# Test process stability evidence
+
+Started: 2026-08-17
+
+## Scope
+
+Branch: `fix/test-process-stability-20260817-ulw`
+
+Base: `581881f38bd906e3fd1e9f225cf81a35dbcc81db`
+
+This PR owns only deterministic test-process setup and failure-path cleanup:
+
+- serialize fresh-checkout `packages/lsp-daemon` installation/build across concurrent test processes;
+- arm onboarding child ready/exit signals before triggers and terminate children on every failure path;
+- close IC-8 exit servers and clear their timeout handles on every test path.
+
+This PR does not own:
+
+- CI/root Windows partitions from merged PR #6925;
+- XDG test isolation from merged PR #6931;
+- bundle-only repair PR #6950;
+- model-preflight timing cleanup;
+- Senpi RPC polling cleanup;
+- the later opt-in local path-group runner.
+
+## Success criteria
+
+1. Two concurrent fresh test processes cause exactly one vendored LSP install/build and both continue after the output is complete.
+2. The onboarding race test cannot miss ready/exit events and cannot retain a child process after a forced failure.
+3. The IC-8 test cannot retain a listening exit server or timer after a forced failure.
+4. Focused tests, the faithful Senpi gate, root tests, typecheck, build, diagnostics, review, and required PR checks pass without sleeps, polling retries, skipped tests, or weakened assertions.
+
+## Evidence contract
+
+For each increment this directory records:
+
+- exact command or mutation;
+- RED output before the fix;
+- GREEN output after the fix;
+- real-surface observation;
+- why the evidence covers the criterion;
+- cleanup receipt.
+
+Secret-bearing environment dumps, tokens, authentication headers, and private logs are omitted.
+
+## Current observations
+
+- `origin/dev` already includes PR #6925 at the branch base.
+- The main checkout is dirty and is never used for task commands.
+- All task commands use this worktree explicitly.
+

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/bundle-red-green.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/bundle-red-green.txt
@@ -1,0 +1,40 @@
+WHAT WAS TESTED
+
+RED command, detached clean worktree at the recorded failing dev commit:
+
+  npm exec --yes --package=bun@1.3.12 -- bun install --frozen-lockfile --ignore-scripts
+  npm exec --yes --package=bun@1.3.12 -- bash -c 'node packages/omo-senpi/plugin/scripts/build-extension.mjs --check'
+
+RED OBSERVED
+
+  HEAD is now at 001d7ec11 Merge pull request #6947 from code-yeongyu/fix/quick-luna-fast-provider
+  sha=001d7ec117e76b461a6c97a1d2792f2683d94082
+  bun=1.3.12
+  omo-senpi extension build is not current: stale-output
+  output=/Volumes/mengmotaStorage/local-workspaces/omo-wt/qa-stale-bundle-001d7ec1/packages/omo-senpi/plugin/extensions/omo.js
+  exit=1
+
+GREEN command, implementation worktree at current dev:
+
+  npm exec --yes --package=bun@1.3.12 -- bun install --frozen-lockfile --ignore-scripts
+  npm exec --yes --package=bun@1.3.12 -- bash -c 'node packages/omo-senpi/plugin/scripts/build-extension.mjs --check'
+
+GREEN OBSERVED
+
+  bun install v1.3.12 (700fc117)
+  omo-senpi extension build is current: /Volumes/mengmotaStorage/local-workspaces/omo-wt/test-process-stability-20260817/packages/omo-senpi/plugin/extensions/omo.js
+  exit=0
+
+WHY THIS IS ENOUGH
+
+The RED uses the exact merge commit that first introduced the stale generated artifact and the CI-pinned Bun version. The GREEN uses the current dev base of the task worktree and the same checker. This proves the original Ubuntu failure was a source/artifact mismatch and that current dev contains a fresh bundle before this PR changes unrelated test infrastructure.
+
+CLEANUP
+
+  git worktree remove --force /Volumes/mengmotaStorage/local-workspaces/omo-wt/qa-stale-bundle-001d7ec1
+  path_removed=1
+  registry_removed=1
+
+OMITTED
+
+Dependency installation progress noise was omitted. No tokens, credentials, environment dumps, or authentication headers were captured.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/ci-partition-and-quality.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/ci-partition-and-quality.txt
@@ -1,0 +1,55 @@
+CI PARTITION CONTRACT
+
+Command:
+
+  npm exec --yes --package=bun@1.3.12 -- bun test \
+    script/ci-root-test-partition.test.ts \
+    script/root-test-config.test.ts
+
+Observed:
+
+  8 pass
+  0 fail
+  35 expect() calls
+  Ran 8 tests across 2 files. [232.00ms]
+
+The contract proves:
+
+- required root matrix names use only `os` and `shard`;
+- global zauc mocks stay in one Windows process;
+- the dedicated Senpi suite is excluded from every root lane;
+- no unsupported native sharding or unsafe parallel flag is used;
+- Linux and macOS retain `bun --config=bunfig.root.toml test`;
+- the Windows groups are complementary.
+
+Merged owner:
+
+  PR #6925
+  https://github.com/code-yeongyu/oh-my-openagent/pull/6925
+  merge=581881f38bd906e3fd1e9f225cf81a35dbcc81db
+
+POST-MERGE TIMING
+
+From dev run:
+
+  https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380
+
+  root ubuntu: 328 seconds, success
+  root macOS: 371 seconds, success
+  root Windows group 1: 553 seconds, failed only on the now-fixed shell fixture
+  Senpi ubuntu: 300 seconds, success
+  Senpi macOS: 295 seconds, success
+  Senpi Windows: 872 seconds, success
+
+QUALITY AST AUDIT
+
+Final changed TypeScript files were structurally scanned.
+
+  test.skip matches=0
+  test.only matches=0
+  Bun.sleep matches=0
+  setInterval matches=0
+  `as any` matches=0
+
+No retry masking, skipped tests, polling intervals, fixed sleeps, or unsafe
+casts were added.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/final-head-verification.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/final-head-verification.txt
@@ -1,0 +1,80 @@
+FINAL HEAD VERIFICATION
+
+Branch:
+
+  fix/test-process-stability-20260817-ulw
+
+Base:
+
+  ed723a3901fd6c14ea55b21aa8afcac28a87b6d7
+
+Build:
+
+  bun run build
+  exit=0
+
+Targeted:
+
+  43 pass
+  0 fail
+  Ran 43 tests across 5 files. [1254.00ms]
+
+Typecheck:
+
+  bun run typecheck
+  exit=0
+
+Faithful Senpi:
+
+  extension build current
+  staged runtimes current
+  package creation succeeded
+  LSP daemon roundtrip 5/5
+  Senpi typecheck exit=0
+  1884 pass
+  0 fail
+  Ran 1885 tests across 275 files. [165.83s]
+
+Unsharded root:
+
+  13902 pass
+  0 fail
+  Ran 13914 tests across 1781 files. [265.09s]
+
+Codex:
+
+  LSP tools: 25 files / 97 tests passed
+  daemon/component suite: 40 files / 422 tests passed
+  CodeGraph: 78 pass, 0 fail
+  installer/package suite: 417 pass, 0 fail
+  Node compatibility suite: 519 pass, 0 fail
+  notice/license payload verification passed
+
+Portable source audit:
+
+  #given shipped extension sources
+  #when scanned for Bun-only module-location APIs
+  #then none appear
+
+  pass=1
+  fail=0
+
+Generated artifacts:
+
+  Senpi generated diff=0
+  Codex verification-generated body diff removed
+  final generated diff=0
+
+Cleanup:
+
+  pack_dir_removed=1
+  live LSP owner fixtures=0
+  live onboarding children=0
+  live supervisor/bootstrap/model processes=0
+  IC-8 temporary roots=0
+  LSP bridge symlinks=0
+
+Result:
+
+  FINAL3_PASS=1
+

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-build-lock-process-green.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-build-lock-process-green.txt
@@ -1,0 +1,64 @@
+WHAT WAS TESTED
+
+The real vendored LSP dist was removed, then two Bun 1.3.12 test processes
+were launched concurrently in the same worktree.
+
+Setup:
+
+  rm -rf packages/lsp-daemon/dist
+
+Process A:
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bun test script/test-environment-isolation.test.ts
+
+Process B:
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bun test packages/omo-opencode/src/cli/run/on-complete-hook.test.ts
+
+GREEN OBSERVED
+
+Process A:
+
+  [test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...
+  1 pass
+  0 fail
+  Ran 1 test across 1 file. [2.21s]
+
+Process B:
+
+  build_message_count=0
+  10 pass
+  0 fail
+  Ran 10 tests across 1 file. [2.21s]
+
+Aggregate:
+
+  total_build_entries=1
+  process_a_exit=0
+  process_b_exit=0
+
+POSTCONDITION
+
+  test -f packages/lsp-daemon/dist/cli.js
+  dist_restored=1
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bash -c 'node packages/omo-senpi/plugin/scripts/build-extension.mjs --check'
+
+  omo-senpi extension build is current
+  exit=0
+
+WHY THIS IS ENOUGH
+
+This is the same real-surface scenario as the RED proof: two independent Bun
+processes, one shared missing vendored dist, the actual npm install/build
+commands, and the actual test preload. The only changed observable is the
+single build owner. Both waiting and owning processes continue successfully.
+
+CLEANUP
+
+The owner recreated `packages/lsp-daemon/dist`. Both Bun processes exited.
+The Senpi staged runtime remained current, so no generated artifact cleanup or
+restage remained outstanding.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-build-lock-unit-green.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-build-lock-unit-green.txt
@@ -1,0 +1,57 @@
+WHAT CHANGED
+
+`test-setup.ts` now awaits a dedicated vendored LSP bootstrap helper.
+
+`script/ensure-vendored-lsp-daemon.ts`:
+
+- derives a per-worktree lock path from the canonical package path;
+- acquires the lock with atomic exclusive creation;
+- records and reaps only dead lock owners;
+- lets contenders subscribe with `fs.watch` before rechecking lock/output state;
+- runs exactly `npm ci` then `npm run build` once;
+- throws on install/build failure or missing output;
+- always releases the lock in `finally`;
+- uses a 300-second failure ceiling, with no sleep or polling delay.
+
+FOCUSED GREEN COMMAND
+
+  npm exec --yes --package=bun@1.3.12 -- bun test \
+    script/ensure-vendored-lsp-daemon.test.ts \
+    script/test-environment-isolation.test.ts \
+    packages/omo-opencode/src/cli/run/on-complete-hook.test.ts
+
+FOCUSED GREEN OBSERVED
+
+  12 pass
+  0 fail
+  25 expect() calls
+  Ran 12 tests across 3 files. [232.00ms]
+
+TYPECHECK COMMANDS
+
+  npm exec --yes --package=bun@1.3.12 -- bun run typecheck:script
+  npm exec --yes --package=bun@1.3.12 -- \
+    bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json
+
+TYPECHECK OBSERVED
+
+  typecheck:script exit=0
+  omo-opencode tsgo exit=0
+
+WHY THIS IS ENOUGH
+
+The formerly failing concurrency assertion now observes one install while two
+callers both complete. Existing preload isolation and on-complete hook tests
+remain green. Both changed TypeScript domains typecheck cleanly.
+
+REMAINING REAL-SURFACE PROOF
+
+A second two-process run against a deliberately removed real
+`packages/lsp-daemon/{dist,node_modules}` will confirm one build entry and two
+successful test processes after the concurrent Senpi child finishes using the
+shared worktree.
+
+OMITTED
+
+Routine passing assertion lines were summarized. No secret-bearing output was
+captured.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-build-lock-unit-red.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-build-lock-unit-red.txt
@@ -1,0 +1,38 @@
+WHAT WAS TESTED
+
+After extracting the existing single-process preload behavior without adding a
+lock, the helper was called twice over one temporary package directory. The
+first `npm ci` callback was held by an unresolved promise before the second
+caller entered.
+
+Command:
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bun test script/ensure-vendored-lsp-daemon.test.ts
+
+RED OBSERVED
+
+  error: expect(received).toBe(expected)
+  Expected: 1
+  Received: 2
+
+  (fail) ensureVendoredLspDaemonBuilt >
+    #given two callers over one missing dist
+    #when the first build is held and the second enters
+    #then one build runs and both observe the output
+
+  0 pass
+  1 fail
+  exit=1
+
+WHY THIS IS FAITHFUL
+
+The test does not depend on elapsed time. It holds the first exact install
+operation, starts the second caller, and observes the duplicate install entry
+caused by the unlocked check-then-build behavior. The temporary package
+directory prevents mutation of the real vendored package.
+
+CLEANUP
+
+The test `afterEach` recursively removed its unique temporary package root.
+Bun exited normally with the expected assertion failure.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-build-race-red.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-build-race-red.txt
@@ -1,0 +1,67 @@
+WHAT WAS TESTED
+
+The current preload was exercised by two real Bun 1.3.12 test processes after
+removing the shared vendored LSP build outputs:
+
+  rm -rf packages/lsp-daemon/dist packages/lsp-daemon/node_modules
+
+Concurrent process A:
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bun test script/test-environment-isolation.test.ts
+
+Concurrent process B:
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bun test packages/omo-opencode/src/cli/run/on-complete-hook.test.ts
+
+RED OBSERVED
+
+Process A:
+
+  [test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...
+  1 pass
+  0 fail
+
+Process B:
+
+  [test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...
+  10 pass
+  0 fail
+
+  total_build_entries=2
+  expected_build_entries=1
+
+ROOT CAUSE
+
+`test-setup.ts` performs an unlocked check-then-build:
+
+1. both processes observe `dist/cli.js` missing;
+2. both call `npm ci` in the same `packages/lsp-daemon` directory;
+3. both call `npm run build`.
+
+The test processes happened to pass on this run, but two concurrent `npm ci`
+operations can delete or replace the same package-local `node_modules` while
+the other process is building. The duplicate build entry is the deterministic
+RED observable.
+
+WHY THIS IS FAITHFUL
+
+This drives the real test preload, real package directory, real Bun 1.3.12,
+and two independently scheduled processes. It does not rely on a synthetic
+timer, polling loop, or source inference.
+
+CLEANUP
+
+After both processes exited:
+
+  npm exec --yes --package=bun@1.3.12 -- bun run build:lsp-daemon
+  test -f packages/lsp-daemon/dist/cli.js
+  restored=1
+
+No preload test process remained alive.
+
+OMITTED
+
+Routine npm installation progress and passing assertion lines were summarized.
+No secret-bearing output was captured.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-diagnostics-final.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-diagnostics-final.txt
@@ -1,0 +1,19 @@
+FINAL LSP DIAGNOSTICS
+
+  test-setup.ts: 0 diagnostics
+  script/ensure-vendored-lsp-daemon.ts: 0 diagnostics
+  script/ensure-vendored-lsp-daemon.test.ts: 0 diagnostics
+  script/fixtures/vendored-lsp-build-owner.ts: 0 diagnostics
+  packages/omo-opencode/src/cli/run/on-complete-hook.test.ts: 0 diagnostics
+  packages/omo-senpi/src/components/onboarding/state.test.ts: 0 diagnostics
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts: 0 diagnostics
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts: 0 diagnostics
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-exit-resources.ts: 0 diagnostics
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-process-groups.ts: 0 diagnostics
+
+Temporary bridge:
+
+  created for final diagnostics
+  removed after diagnostics
+  bridge_remaining=0
+

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-diagnostics.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/lsp-diagnostics.txt
@@ -1,0 +1,32 @@
+LSP workspace bridge:
+
+  /Volumes/mengmotaStorage/local-workspaces/omo/.local-ignore/lsp-test-process-stability-20260817
+
+Final diagnostics:
+
+  test-setup.ts
+    diagnostics=0
+    result=No diagnostics found
+
+  script/ensure-vendored-lsp-daemon.ts
+    diagnostics=0
+    result=No diagnostics found
+
+  script/ensure-vendored-lsp-daemon.test.ts
+    diagnostics=0
+    result=No diagnostics found
+
+  packages/omo-opencode/src/cli/run/on-complete-hook.test.ts
+    diagnostics=0
+    result=No diagnostics found
+
+  packages/omo-senpi/src/components/onboarding/state.test.ts
+    diagnostics=0
+    result=No diagnostics found
+
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
+    diagnostics=0
+    result=No diagnostics found
+
+The temporary bridge is tracked by a cleanup todo and will be removed before
+the task worktree is deleted.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/opencode-qa.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/opencode-qa.txt
@@ -1,0 +1,46 @@
+SURFACE
+
+Installed OpenCode:
+
+  opencode --version
+  1.18.18
+
+QA skill:
+
+  .agents/skills/opencode-qa
+
+COMMANDS
+
+  bash scripts/lib/common.sh --self-check
+  bash scripts/server-smoke.sh --self-test
+
+REAL DATABASE ISOLATION
+
+  QA_DB_BEFORE=5861
+  QA_DB_AFTER=5861
+
+OBSERVED
+
+  PASS: dependencies present (opencode sqlite3 curl jq tmux)
+  PASS: isolated XDG sandbox auto-removed on exit
+  PASS: isolated HOME points inside sandbox
+  PASS: common.sh self-check
+  PASS: GET /global/health healthy=true version=1.18.18
+  PASS: GET /doc lists 162 documented paths
+  PASS: unauthenticated GET /session rejected with HTTP 401
+  PASS: server-smoke
+  OPENCODE_QA_PASS=1
+
+WHY THIS IS ENOUGH
+
+The only OpenCode-side source edit is a test fixture that describes pure
+PowerShell/cmd environments; production hook code is unchanged. The targeted
+hook tests prove the fixture behavior, while the mandatory real OpenCode QA
+proves the server starts, documents its routes, enforces authentication, uses
+an isolated XDG sandbox, cleans it up, and does not change the real session
+database.
+
+OMITTED
+
+No session contents, database rows, auth credentials, headers, or environment
+dumps were captured.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/post-rebase-verification.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/post-rebase-verification.txt
@@ -1,0 +1,96 @@
+REBASE
+
+  base=origin/dev
+  conflicts=0
+  divergence_after=0 behind / 4 ahead
+
+FINAL POST-REBASE ORDER
+
+  build
+  targeted tests
+  full typecheck
+  faithful Senpi compatibility
+  unsharded root tests
+  full Codex compatibility
+  generated artifact reconciliation
+
+OBSERVED
+
+Build:
+
+  exit=0
+
+Targeted:
+
+  34 pass
+  0 fail
+  Ran 34 tests across 5 files. [885.00ms]
+
+Typecheck:
+
+  exit=0
+
+Faithful Senpi:
+
+  extension build current
+  staged runtimes current
+  package creation succeeded
+  LSP roundtrip 5/5
+  adapter typecheck exit=0
+  full `packages/omo-senpi` exit=0
+
+Unsharded root:
+
+  13896 pass
+  0 fail
+  Ran 13908 tests across 1781 files. [283.81s]
+
+Codex:
+
+  25 test files / 97 tests passed
+  40 test files / 422 tests passed
+  codegraph: 78 pass, 0 fail
+  installer/package suite: 417 pass, 0 fail
+  Node compatibility suite: 519 pass, 0 fail
+  notice/license payload verification passed
+
+GENERATED ARTIFACT RECONCILIATION
+
+The final extra zero-diff assertion initially observed three build-generated
+Codex bundle body diffs:
+
+- `packages/omo-codex/plugin/components/codegraph/dist/cli.js`
+- `packages/omo-codex/plugin/components/codegraph/dist/serve.js`
+- `packages/omo-codex/scripts/install-dist/install-local.mjs`
+
+Repository source documents that Codex installer body bytes vary with the Bun
+bundler version and that the source digest, not body byte equality, is the
+freshness authority.
+
+Committed installer marker:
+
+  source=1d8359e77ebe41655f091cd2e455f320cde2f9c681f0651797c47d8fdfa2dd76
+  body=3cf0cc862585d91e62fe616c78b6caa3037958e8d11967d2be90ba618144ba5b
+
+Verification build marker:
+
+  source=1d8359e77ebe41655f091cd2e455f320cde2f9c681f0651797c47d8fdfa2dd76
+  body=3ebe53198af1a035e21991b814b41ddb4819c09cfde23b8864be33a92c636428
+
+The source digests match. The verification-generated body bytes were removed
+without adding unrelated artifacts to this PR.
+
+FINAL CLEAN STATE
+
+  generated_diff=0
+  branch=4 commits ahead of origin/dev
+  tracked_worktree_changes=0
+  pack_dir_removed=1
+
+WHY THIS IS ENOUGH
+
+Every required behavioral/build/test gate passed after rebasing onto the
+current base. The only nonzero monitor exit was the deliberately stricter
+byte-diff assertion against bundler-version-sensitive artifacts; source
+freshness and all shipped behavior passed, and the task worktree was returned
+to a clean tracked state.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/refs.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/refs.txt
@@ -1,0 +1,8 @@
+notepad=/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/ulw-20260817-234345.XXXXXX.md.w9Y51aoKJJ
+worktree=/Volumes/mengmotaStorage/local-workspaces/omo-wt/test-process-stability-20260817
+branch=fix/test-process-stability-20260817-ulw
+base=581881f38bd906e3fd1e9f225cf81a35dbcc81db
+bundle_owner=https://github.com/code-yeongyu/oh-my-openagent/pull/6950
+ci_partition_owner=https://github.com/code-yeongyu/oh-my-openagent/pull/6925
+live_failure_run=https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32040272549
+live_failure_job=https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32040272549/job/95418268548

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/refs.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/refs.txt
@@ -1,8 +1,8 @@
 notepad=/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/ulw-20260817-234345.XXXXXX.md.w9Y51aoKJJ
 worktree=/Volumes/mengmotaStorage/local-workspaces/omo-wt/test-process-stability-20260817
 branch=fix/test-process-stability-20260817-ulw
-base=581881f38bd906e3fd1e9f225cf81a35dbcc81db
-bundle_owner=https://github.com/code-yeongyu/oh-my-openagent/pull/6950
+base=ed723a3901fd6c14ea55b21aa8afcac28a87b6d7
+bundle_refresh=merged-pr-6925:d550875c9
 ci_partition_owner=https://github.com/code-yeongyu/oh-my-openagent/pull/6925
 live_failure_run=https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32040272549
 live_failure_job=https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32040272549/job/95418268548

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/review-blocker-ic8-red-green.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/review-blocker-ic8-red-green.txt
@@ -1,0 +1,68 @@
+# Review blocker: connected IC-8 process-group teardown
+
+## RED
+
+Command:
+
+  bun test \
+    packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts \
+    --test-name-pattern 'connected model child'
+
+Before the fix:
+
+  external_watchdog=25s
+  exit=124
+
+Surviving process group:
+
+  memory-run-supervisor.ts --child-bootstrap
+  supervisor-child.ts graceful
+  process_group=42735
+
+The connected model child retained the accepted socket. Cleanup killed only
+the supervisor PID, then waited indefinitely for `server.close()`.
+
+The RED process group and temporary root were manually removed before GREEN.
+
+## GREEN
+
+The test harness now:
+
+- reads each run ledger for the detached child/bootstrap group PID;
+- validates every process-group PID as a positive integer;
+- uses negative-PID `SIGKILL` on POSIX and `taskkill /T /F` on Windows;
+- tracks accepted sockets and exact close signals;
+- kills supervisor and child groups before exit-resource cleanup;
+- bounds socket and server close;
+- destroys remaining sockets and removes listeners;
+- clears server, socket, timeout, process, and root registries.
+
+Command:
+
+  npm exec --yes --package=bun@1.3.12 -- bun test \
+    packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
+
+Observed:
+
+  7 pass
+  0 fail
+  20 expect() calls
+  Ran 7 tests across 1 file. [1118.00ms]
+
+Typecheck:
+
+  bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json
+  exit=0
+
+Pure LOC after mandatory split:
+
+  memory-run-supervisor.ic8.test.ts=125
+  memory-run-supervisor-ic8-harness.ts=201
+  memory-run-supervisor-ic8-exit-resources.ts=160
+
+Cleanup:
+
+- no supervisor/bootstrap/model process remains;
+- no IC-8 temporary root remains;
+- no generated JavaScript remains;
+- diff-check exits 0.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/review-blocker-lsp-red-green.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/review-blocker-lsp-red-green.txt
@@ -1,0 +1,70 @@
+# Review blocker: LSP dead-owner recovery and deadline
+
+## RED
+
+Command:
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bun test script/ensure-vendored-lsp-daemon.test.ts
+
+Before the blocker fix:
+
+  owner-death regression:
+    error: timed out waiting for cli.js
+    fail after 1024.93ms
+
+  aggregate-deadline regression:
+    expected budgets [1000, 600]
+    received budgets [1000, 1000]
+
+  2 pass
+  2 fail
+
+The owner test subscribed the waiter, killed a real lock-owning Bun process,
+and observed that the current waiter never returned to acquisition.
+
+## GREEN
+
+The helper now:
+
+- computes one absolute operation deadline;
+- rechecks the lock owner PID while waiting;
+- returns to acquisition when the owner dies;
+- keeps filesystem watch events as the fast path;
+- keeps bounded state rechecks authoritative if watch creation or the watcher
+  itself fails;
+- passes only remaining time to install and build;
+- preserves spawn errors and terminating signals.
+
+Command:
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bun test script/ensure-vendored-lsp-daemon.test.ts
+
+Observed:
+
+  7 pass
+  0 fail
+  Ran 7 tests across 1 file. [185.00ms]
+
+Covered scenarios:
+
+- two successful callers, one build;
+- owner killed after waiter subscription, waiter recovers;
+- watcher creation unavailable, state recheck still completes;
+- remaining deadline passed to build;
+- aggregate deadline exhaustion;
+- nonzero npm status;
+- spawn error detail;
+- signal termination detail.
+
+Typecheck:
+
+  bun run typecheck:script
+  exit=0
+
+Cleanup:
+
+- killed owner process observed exiting;
+- per-test lock roots and package roots removed;
+- no stale lock file or owner process remains.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/review-work.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/review-work.txt
@@ -1,0 +1,145 @@
+# Post-implementation review ledger
+
+## Security review
+
+Verdict: PASS
+
+Highest severity: LOW, non-blocking
+
+Blocking issues: none
+
+Reviewed:
+
+- canonical hashed lock path;
+- atomic `wx` creation and `0600` permissions;
+- stale PID handling;
+- symlink/path attack surface;
+- fixed command arguments and cwd;
+- environment/secret exposure;
+- timer/watcher/server/process cleanup;
+- evidence redaction;
+- dependency and production-surface changes.
+
+Non-blocking observation:
+
+A hostile user on a shared machine could precreate the predictable temp lock
+with a live PID and delay tests until the bounded timeout. Impact is limited
+to local/CI test availability; it cannot redirect writes or reach shipped
+runtime behavior.
+
+Reviewer task: `review-security` (`st_01a01093`)
+
+## Context review
+
+Verdict: PASS
+
+Blocking issues: none
+
+Sources checked:
+
+- per-file git history and blame;
+- PRs #6925, #6931, and #6950;
+- live branch-protection ruleset;
+- open PR/issue overlap;
+- code cross-references;
+- focused Bun 1.3.12 tests.
+
+Coordination notes for the PR body:
+
+1. Open PR #6957 addresses the same Windows required-check failure at the
+   workflow-shell layer. PR1 fixes the test fixture itself. The two changes
+   have no file conflict and are complementary; the PR body must say so.
+2. Open PR #6911 also edits `test-setup.ts` and will create a textual rebase
+   conflict for whichever PR merges second.
+3. Link issues #6938 and #6843 because PR1 advances their test-isolation and
+   reliability acceptance criteria.
+
+No onboarding, IC-8, or LSP-lock duplicate implementation was found.
+
+Reviewer task: `review-context` (`st_01a01095`)
+
+## Code-quality review
+
+Verdict: FAIL
+
+Blocking findings:
+
+1. An LSP build waiter cannot recover when the lock owner dies after the
+   waiter subscribes. The stale lock remains and no event returns control to
+   acquisition.
+2. IC-8 cleanup can hang after a connected model child survives its supervisor:
+   server close waits on the socket, the timeout is cleared, and only the
+   supervisor PID is killed instead of the detached process group.
+3. The LSP waiter lacks watcher error handling and one aggregate operation
+   deadline. Spawn timeout/error details are collapsed into exit code 1.
+
+Required regression coverage:
+
+- real owner process dies after waiter subscription, waiter takes ownership
+  and builds;
+- watcher failure and absolute deadline behavior;
+- connected IC-8 failure terminates supervisor/bootstrap/model process group,
+  destroys accepted sockets, settles close/promise state, and clears
+  registries.
+
+Non-blocking:
+
+- onboarding ordering and cleanup passed;
+- pure-LOC and type-safety passed;
+- README evidence has a trailing blank line that must be removed.
+
+Reviewer task: `review-code` (`st_01a01092`)
+
+## Second review wave
+
+Security: PASS, no blockers.
+
+Context: PASS, no blockers.
+
+Hands-on QA: PASS 9/9.
+
+Goal and code-quality reviews reproduced:
+
+- stale LSP owner not reclaimed after waiter subscription;
+- connected IC-8 cleanup could false-green while the process group survived;
+- ledger/kill errors could skip later cleanup;
+- unconnected promises could remain pending;
+- evidence and full-gate totals were stale.
+
+## Review blocker resolution
+
+LSP:
+
+- real owner-death regression added;
+- waiter rechecks owner PID and returns to acquisition;
+- one aggregate deadline covers wait/install/build;
+- watch creation/runtime errors fall back to bounded state rechecks;
+- spawn errors and terminating signals remain visible;
+- seven LSP lock tests pass.
+
+IC-8:
+
+- connected cleanup regression captures the prior 25-second hang and live
+  process group;
+- cleanup reads ledger process-group IDs, validates positivity, and terminates
+  groups with POSIX negative PID or Windows taskkill tree semantics;
+- taskkill nonzero status fails closed;
+- accepted sockets and exact close signals are tracked;
+- cleanup asserts process-group death and reports forced socket fallback;
+- ledger/kill errors no longer skip socket/server/root cleanup;
+- unconnected accepted/exit promises reject explicitly during cleanup;
+- process-group, exit-resource, harness, and scenario code is split below 250
+  pure LOC;
+- portable module paths pass the shipped-source audit;
+- nine IC-8 tests pass.
+
+Final exact-head gates:
+
+- build pass;
+- targeted 43/43;
+- typecheck pass;
+- Senpi 1884/1884 pass, one filtered platform skip;
+- root 13902/13902 pass;
+- Codex all component/package suites pass;
+- generated diff zero;
+- final LSP diagnostics zero.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/root-prebuild-prerequisite.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/root-prebuild-prerequisite.txt
@@ -1,0 +1,41 @@
+INITIAL ROOT ATTEMPT
+
+Command:
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bun --config=bunfig.root.toml test
+
+Observed:
+
+  13881 pass
+  17 skip
+  9 fail
+  Ran 13907 tests across 1781 files. [322.30s]
+
+All nine failures were artifact-layout/installer checks:
+
+- published package layout;
+- seven install-codex/cache/manifest scenarios;
+- built Codex telemetry single-source guard.
+
+ROOT CAUSE
+
+The worktree dependency install intentionally used:
+
+  bun install --frozen-lockfile --ignore-scripts
+
+GitHub's root `test` job does not use `--ignore-scripts`; root `prepare` builds
+the package, Codex plugin, MCPs, LSP daemon, and staged artifacts before the
+test step. The nine tests inspect those built artifacts and correctly fail
+when the build prerequisite is absent.
+
+CORRECTIVE VERIFICATION ORDER
+
+A serialized monitor now runs the CI-faithful order:
+
+  bun run build
+  bun --config=bunfig.root.toml test
+  bun run test:codex
+
+This is a verification-environment correction only. No test was skipped,
+weakened, retried, or changed to hide the failure.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/self-review.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/self-review.txt
@@ -1,0 +1,78 @@
+FINAL PR1 SELF-REVIEW
+
+OWNED DIFF
+
+- `packages/omo-opencode/src/cli/run/on-complete-hook.test.ts`
+- `packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts`
+- `packages/omo-senpi/src/components/onboarding/state.test.ts`
+- `script/ensure-vendored-lsp-daemon.test.ts`
+- `script/ensure-vendored-lsp-daemon.ts`
+- `test-setup.ts`
+
+No CI workflow, package manifest, generated bundle, production hook, production
+onboarding, or production supervisor source is owned by PR1.
+
+FINAL PURE LOC
+
+  test-setup.ts=92
+  script/ensure-vendored-lsp-daemon.ts=139
+  script/ensure-vendored-lsp-daemon.test.ts=63
+  packages/omo-opencode/src/cli/run/on-complete-hook.test.ts=249
+  packages/omo-senpi/src/components/onboarding/state.test.ts=242
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts=246
+
+Every changed file is at or below the 250 pure-LOC ceiling.
+
+ARCHITECTURAL QUESTIONS
+
+1. Does each edit solve a verified failure?
+   - Yes. Every edit maps to a live CI failure, real two-process race, lost
+     event mutation, or resource-cleanup mutation.
+
+2. Does each new module have one responsibility?
+   - Yes. `ensure-vendored-lsp-daemon.ts` owns only single-flight preparation
+     of the vendored LSP test prerequisite.
+
+3. Does the implementation reuse existing code?
+   - Yes. It reuses `packages/lsp-daemon/src/lock.ts` instead of duplicating
+     PID/stale-lock logic.
+
+4. Are errors typed and visible?
+   - Yes. npm install/build failures, missing output, and lock wait timeout
+     reject the preload with actionable errors. No catch block swallows them.
+
+5. Is TypeScript strict and suppression-free?
+   - Yes. Final LSP diagnostics report zero findings; full repository typecheck
+     exits 0; no `any`, `@ts-ignore`, or `@ts-expect-error` was added.
+
+6. Are tests deterministic?
+   - Yes. Event listeners are armed before triggers. Timeouts are circuit
+     breakers only. No sleep, polling interval, retry mask, `.skip`, or `.only`
+     was added.
+
+7. Is the scope minimal?
+   - Yes. Model-preflight timing and RPC polling are explicitly deferred.
+     CI partitioning/XDG isolation remain owned by their already-merged PRs.
+     Bundler-version-sensitive Codex body diffs were removed rather than
+     included.
+
+FINAL GATES
+
+- targeted: 34 pass, 0 fail;
+- LSP diagnostics: 0 findings across six files;
+- full typecheck: exit 0;
+- faithful Senpi: exit 0;
+- post-rebase root: 13896 pass, 0 fail;
+- post-rebase Codex: every component/package suite green;
+- isolated OpenCode QA: pass, real DB count unchanged;
+- generated diff: 0;
+- `git diff --check`: 0 findings.
+
+CLEANUP RECEIPTS
+
+- stale-bundle QA worktree removed and unregistered;
+- pack directories removed by EXIT traps;
+- no claim-race or memory-supervisor child process remains;
+- both temporary LSP bridge symlinks removed;
+- no generated Codex/Senpi artifact diff remains;
+- tracked worktree is clean.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/self-review.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/self-review.txt
@@ -3,10 +3,14 @@ FINAL PR1 SELF-REVIEW
 OWNED DIFF
 
 - `packages/omo-opencode/src/cli/run/on-complete-hook.test.ts`
+- `packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-exit-resources.ts`
+- `packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts`
+- `packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-process-groups.ts`
 - `packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts`
 - `packages/omo-senpi/src/components/onboarding/state.test.ts`
 - `script/ensure-vendored-lsp-daemon.test.ts`
 - `script/ensure-vendored-lsp-daemon.ts`
+- `script/fixtures/vendored-lsp-build-owner.ts`
 - `test-setup.ts`
 
 No CI workflow, package manifest, generated bundle, production hook, production
@@ -15,11 +19,15 @@ onboarding, or production supervisor source is owned by PR1.
 FINAL PURE LOC
 
   test-setup.ts=92
-  script/ensure-vendored-lsp-daemon.ts=139
-  script/ensure-vendored-lsp-daemon.test.ts=63
+  script/ensure-vendored-lsp-daemon.ts=215
+  script/ensure-vendored-lsp-daemon.test.ts=245
+  script/fixtures/vendored-lsp-build-owner.ts=14
   packages/omo-opencode/src/cli/run/on-complete-hook.test.ts=249
   packages/omo-senpi/src/components/onboarding/state.test.ts=242
-  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts=246
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts=180
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts=238
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-exit-resources.ts=223
+  packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-process-groups.ts=57
 
 Every changed file is at or below the 250 pure-LOC ceiling.
 
@@ -31,7 +39,9 @@ ARCHITECTURAL QUESTIONS
 
 2. Does each new module have one responsibility?
    - Yes. `ensure-vendored-lsp-daemon.ts` owns only single-flight preparation
-     of the vendored LSP test prerequisite.
+     of the vendored LSP test prerequisite. IC-8 scenario, run/process harness,
+     exit-resource ownership, and process-group signaling are split into
+     focused modules.
 
 3. Does the implementation reuse existing code?
    - Yes. It reuses `packages/lsp-daemon/src/lock.ts` instead of duplicating
@@ -47,8 +57,9 @@ ARCHITECTURAL QUESTIONS
 
 6. Are tests deterministic?
    - Yes. Event listeners are armed before triggers. Timeouts are circuit
-     breakers only. No sleep, polling interval, retry mask, `.skip`, or `.only`
-     was added.
+     breakers only. The LSP waiter uses a bounded 50ms owner-liveness state
+     recheck only while the vendored output is absent, alongside filesystem
+     watch events. No sleep, retry mask, `.skip`, or `.only` was added.
 
 7. Is the scope minimal?
    - Yes. Model-preflight timing and RPC polling are explicitly deferred.
@@ -58,11 +69,11 @@ ARCHITECTURAL QUESTIONS
 
 FINAL GATES
 
-- targeted: 34 pass, 0 fail;
+- final post-blocker targeted: 43 pass, 0 fail;
 - LSP diagnostics: 0 findings across six files;
 - full typecheck: exit 0;
-- faithful Senpi: exit 0;
-- post-rebase root: 13896 pass, 0 fail;
+- faithful Senpi: 1884 pass, 0 fail;
+- final unsharded root: 13902 pass, 0 fail;
 - post-rebase Codex: every component/package suite green;
 - isolated OpenCode QA: pass, real DB count unchanged;
 - generated diff: 0;
@@ -76,3 +87,15 @@ CLEANUP RECEIPTS
 - both temporary LSP bridge symlinks removed;
 - no generated Codex/Senpi artifact diff remains;
 - tracked worktree is clean.
+
+FINAL REVIEW-FIX ADDITIONS
+
+- LSP dead-owner recovery uses an owner-PID state recheck and one aggregate
+  deadline; watch failure is non-fatal and command errors preserve detail.
+- IC-8 cleanup fails closed on taskkill errors, asserts process-group death,
+  continues through ledger/kill failures, settles unconnected promises, and
+  removes roots in all cases.
+- IC-8 scenario, harness, exit-resource, and process-group modules are split
+  below the 250 pure-LOC ceiling.
+- Non-test IC-8 modules use standard `import.meta.url`, not Bun-only
+  `import.meta.dir`.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/senpi-gate-green.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/senpi-gate-green.txt
@@ -1,0 +1,56 @@
+FAITHFUL CI-EQUIVALENT COMMAND SEQUENCE
+
+  bun run script/remove-stale-self-package-tests.ts
+  node packages/omo-senpi/plugin/scripts/build-extension.mjs --check
+  bun run build:senpi-plugin
+  npm pack --pack-destination "$PACK_DIR" packages/omo-senpi/plugin
+  npm --prefix packages/lsp-daemon test -- test/daemon-roundtrip.test.ts
+  bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json
+  bun test packages/omo-senpi
+
+Every Bun command ran through:
+
+  npm exec --yes --package=bun@1.3.12
+
+OBSERVED
+
+  STEP remove_stale_self_package_tests
+  STEP bundle_freshness
+  omo-senpi extension build is current
+
+  STEP build_senpi_plugin
+  STEP npm_pack
+
+  STEP lsp_daemon_roundtrip
+  Test Files 1 passed (1)
+  Tests 5 passed (5)
+
+  STEP senpi_typecheck
+  exit=0
+
+  STEP senpi_tests
+  1881 pass
+  0 fail
+  Ran 1882 tests across 275 files. [166.57s]
+
+  SENPI_GATE_PASS=1
+
+CLEANUP
+
+  CLEANUP pack_dir_removed=1
+
+The pack directory was created with `mktemp -d` and removed by an EXIT trap.
+No generated Senpi extension/runtime diff remained.
+
+WHY THIS IS ENOUGH
+
+This is the same ordered surface as the GitHub
+`senpi-compatibility` job: freshness, build/stage, package, daemon roundtrip,
+adapter typecheck, and the complete Senpi test tree. It used the CI-pinned Bun
+version and finished with exit code 0.
+
+OMITTED
+
+Routine package listing and individual passing test lines were summarized.
+Expected test fixtures that log words such as `error` remained passing tests.
+No secrets or private environment values were captured.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/senpi-lifecycle-mutation-proofs.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/senpi-lifecycle-mutation-proofs.txt
@@ -1,0 +1,128 @@
+ONBOARDING READY-LISTENER MUTATION RED
+
+Mutation:
+
+  await the child's first `message` before constructing `waitForReady()`
+
+This deterministically consumes the one-shot ready event before the production
+test listener is armed.
+
+Command:
+
+  /opt/homebrew/bin/timeout 8s \
+    npm exec --yes --package=bun@1.3.12 -- bun test \
+    packages/omo-senpi/src/components/onboarding/state.test.ts \
+    -t 'two concurrent child processes'
+
+Observed:
+
+  error: child did not signal ready in time
+  (fail) claimOnboarding > #given two concurrent child processes ...
+  0 pass
+  1 fail
+  Ran 1 test across 1 file. [5.11s]
+  mutation_exit=1
+  orphans_remaining=0
+
+The mutation was removed immediately.
+
+ONBOARDING CLEANUP MUTATION RED
+
+Permanent regression test:
+
+  #given a child waiting on IPC
+  #when test cleanup stops it
+  #then the exit is observed
+
+Mutation:
+
+  replace the `SIGKILL` action in `stopChildren()` with a no-op
+
+Command:
+
+  /opt/homebrew/bin/timeout 3s \
+    npm exec --yes --package=bun@1.3.12 -- bun test \
+    packages/omo-senpi/src/components/onboarding/state.test.ts \
+    -t 'child waiting on IPC'
+
+Observed:
+
+  mutation_exit=124
+  orphans_remaining=0
+
+The bounded command timed out because cleanup waited for an exit it never
+triggered. The mutation was removed immediately.
+
+ONBOARDING CLEANUP MUTATION GREEN
+
+The same command with `SIGKILL` restored:
+
+  1 pass
+  15 filtered out
+  0 fail
+  Ran 1 test across 1 file. [112.00ms]
+
+IC-8 EXIT-RESOURCE MUTATION RED
+
+Permanent regression test:
+
+  #given an unconnected exit server
+  #when test cleanup runs
+  #then the listener and timeout are released
+
+Mutation:
+
+  make `cleanupExitResources()` a no-op
+
+Command:
+
+  /opt/homebrew/bin/timeout 3s \
+    npm exec --yes --package=bun@1.3.12 -- bun test \
+    packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts \
+    -t 'unconnected exit server'
+
+Observed:
+
+  error: expect(received).toBe(expected)
+  Expected: false
+  Received: true
+  at memory-run-supervisor.ic8.test.ts:202:30
+  0 pass
+  1 fail
+  mutation_exit=1
+  supervisor_processes_remaining=0
+
+The mutation was removed immediately.
+
+FINAL GREEN
+
+Command:
+
+  npm exec --yes --package=bun@1.3.12 -- bun test \
+    packages/omo-senpi/src/components/onboarding/state.test.ts \
+    packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
+
+Observed:
+
+  22 pass
+  0 fail
+  39 expect() calls
+  Ran 22 tests across 2 files. [1028.00ms]
+
+WHY THIS IS ENOUGH
+
+- The listener mutation deterministically proves why subscription must happen
+  before the child can emit ready.
+- The cleanup mutation proves the child exit is caused by explicit cleanup,
+  not timing luck.
+- The IC-8 mutation proves both the listener and timer remain live when the
+  cleanup registry is bypassed.
+- Every mutation was reverted with `apply_patch`, then the final files passed
+  together once under Bun 1.3.12.
+
+CLEANUP
+
+- no `claim-race-child.mjs` process remained;
+- no memory supervisor/bootstrap/model-child process remained;
+- no `.orig` backup remained;
+- all temporary roots were removed by the test cleanup.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/targeted-final.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/targeted-final.txt
@@ -1,0 +1,32 @@
+COMMAND
+
+  npm exec --yes --package=bun@1.3.12 -- bun test \
+    script/ensure-vendored-lsp-daemon.test.ts \
+    script/test-environment-isolation.test.ts \
+    packages/omo-opencode/src/cli/run/on-complete-hook.test.ts \
+    packages/omo-senpi/src/components/onboarding/state.test.ts \
+    packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
+
+OBSERVED
+
+  34 pass
+  0 fail
+  64 expect() calls
+  Ran 34 tests across 5 files. [999.00ms]
+
+COVERAGE
+
+- LSP single-writer lock and event-driven waiter;
+- preload environment isolation;
+- Windows Git Bash shell-fixture determinism;
+- onboarding ready/exit listener ordering;
+- onboarding failure-path child termination;
+- IC-8 unconnected exit server and timeout cleanup;
+- existing supervisor graceful/hard containment scenarios.
+
+CLEANUP
+
+- no claim-race child remained;
+- no memory supervisor/bootstrap/model-child remained;
+- no generated Senpi diff remained;
+- Bun test process exited normally.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/topology-baseline.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/topology-baseline.txt
@@ -1,0 +1,83 @@
+BASE
+
+  branch=fix/test-process-stability-20260817-ulw
+  sha=581881f38bd906e3fd1e9f225cf81a35dbcc81db
+  dev_ci_run=https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380
+
+CURRENT TEST OWNERSHIP
+
+  Linux/macOS root:
+    bun --config=bunfig.root.toml test
+
+  Windows root group 1:
+    bun test packages/omo-opencode packages/memory-core
+
+  Windows root group 2:
+    bun --config=bunfig.win2.toml test
+
+  Senpi, every OS:
+    bun test packages/omo-senpi
+
+  `bunfig.root.toml` excludes the dedicated Senpi suite.
+  `bunfig.win2.toml` additionally excludes `packages/omo-opencode` and
+  `packages/memory-core`, making the two Windows groups complementary.
+
+TRACKED FILE COUNTS
+
+  ROOT_GROUP_1_FILES=1051
+  SENPI_FILES=275
+  ROOT_ALL_TRACKED=2303
+
+The exact-union partition contract is machine-checked by
+`script/ci-root-test-partition.test.ts`.
+
+POST-MERGE DEV CI OBSERVATION
+
+  senpi-compatibility (ubuntu-latest):
+    conclusion=success
+    seconds=300
+    https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380/job/95421899150
+
+  senpi-compatibility (macos-latest):
+    conclusion=success
+    seconds=295
+    https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380/job/95421899183
+
+  senpi-compatibility (windows-latest):
+    conclusion=success
+    seconds=872
+    https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380/job/95421899165
+
+  test (ubuntu-latest):
+    conclusion=success
+    seconds=328
+    https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380/job/95421899323
+
+  test (macos-latest):
+    conclusion=success
+    seconds=371
+    https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380/job/95421899235
+
+  test (windows-latest, 1/2):
+    conclusion=failure
+    seconds=553
+    https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380/job/95421899229
+
+  test (windows-latest, 2/2):
+    state=in_progress when this baseline was recorded
+    https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380/job/95421899156
+
+INTERPRETATION
+
+- The merged manual partition replaces the previous two complete Windows suite
+  executions and materially shortens group 1 to 553 seconds.
+- The first post-merge group-1 run is red, so speed is not accepted as success.
+- A monitor is subscribed to run completion and will capture the failed log
+  before any LSP/test-setup implementation.
+- Linux and macOS retain the unsharded root gate.
+- No coverage, OS, runner type, or required job name was removed.
+
+OMITTED
+
+No environment dumps, authentication data, tokens, or secret-bearing logs were
+captured.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/windows-shell-fixture-green.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/windows-shell-fixture-green.txt
@@ -1,0 +1,50 @@
+WHAT CHANGED
+
+`packages/omo-opencode/src/cli/run/on-complete-hook.test.ts` now snapshots and
+restores all shell indicators used by `detectShellType()` and clears the Unix
+shell indicators in fixtures that intend to model pure Windows PowerShell or
+cmd environments:
+
+- `BASH_VERSION`
+- `MSYSTEM`
+- `WSL_DISTRO_NAME`
+
+GREEN COMMAND 1
+
+  MSYSTEM=MINGW64 BASH_VERSION=5.2 WSL_DISTRO_NAME= \
+    npm exec --yes --package=bun@1.3.12 -- \
+    bun test packages/omo-opencode/src/cli/run/on-complete-hook.test.ts
+
+GREEN OBSERVED 1
+
+  10 pass
+  0 fail
+  Ran 10 tests across 1 file. [144.00ms]
+
+GREEN COMMAND 2
+
+  npm exec --yes --package=bun@1.3.12 -- \
+    bun test packages/omo-opencode/src/cli/run/on-complete-hook.test.ts
+
+GREEN OBSERVED 2
+
+  10 pass
+  0 fail
+  Ran 10 tests across 1 file. [102.00ms]
+
+WHY THIS IS ENOUGH
+
+The first command reproduces the Git Bash environment that caused the live
+Windows CI failure and now passes. The second proves the fixture change does
+not regress the normal local environment. Production shell detection remains
+unchanged and retains its existing Git Bash behavior.
+
+CLEANUP
+
+No process, server, tmux session, port, or temporary worktree was created by
+these focused test runs. Bun exited normally after each command.
+
+OMITTED
+
+Routine passing assertion lines were summarized by the runner totals. No
+secret-bearing output was captured.

--- a/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/windows-shell-fixture-red.txt
+++ b/.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/windows-shell-fixture-red.txt
@@ -1,0 +1,56 @@
+WHAT WAS TESTED
+
+Live first post-partition dev CI:
+
+  run=https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380
+  job=https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32041361380/job/95421899229
+  command=bun test packages/omo-opencode packages/memory-core
+
+Local faithful reproduction:
+
+  MSYSTEM=MINGW64 BASH_VERSION=5.2 WSL_DISTRO_NAME= \
+    npm exec --yes --package=bun@1.3.12 -- \
+    bun test packages/omo-opencode/src/cli/run/on-complete-hook.test.ts
+
+RED OBSERVED
+
+  packages/omo-opencode/src/cli/run/on-complete-hook.test.ts
+
+  error: expect(received).toEqual(expected)
+  - Expected  - 3
+  + Received  + 2
+  at on-complete-hook.test.ts:134:18
+  (fail) executeOnCompleteHook > uses powershell when PowerShell is detected on Windows
+
+  error: expect(received).toEqual(expected)
+  - Expected  - 4
+  + Received  + 2
+  at on-complete-hook.test.ts:179:18
+  (fail) executeOnCompleteHook > falls back to cmd.exe on Windows when PowerShell is not detected
+
+  local_exit=1
+
+ROOT CAUSE
+
+The tests spoof `process.platform` as `win32` and delete `SHELL`, but they do
+not clear the Git Bash/WSL indicators checked by `detectShellType()`:
+
+- `BASH_VERSION`
+- `MSYSTEM`
+- `WSL_DISTRO_NAME`
+
+The GitHub Windows job runs through Git Bash, so production correctly returns
+the Unix shell type and launches `sh -c`. The fixture incorrectly expects a
+pure PowerShell or cmd environment.
+
+WHY THIS IS FAITHFUL
+
+The local command injects the same Git Bash indicator that exists on the
+Windows runner and reproduces the same two assertion failures with Bun
+1.3.12. No production source is changed; the fix must make the test fixture
+declare its intended shell environment completely.
+
+OMITTED
+
+The million-line successful-test portion of the CI log was omitted. No
+credentials, auth headers, or environment dumps were recorded.

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-exit-resources.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-exit-resources.ts
@@ -2,12 +2,20 @@ import { createServer, type AddressInfo, type Server, type Socket } from "node:n
 
 const CLEANUP_WAIT_MS = 5_000
 
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve(value: T): void
+  reject(error: Error): void
+  readonly settled: boolean
+}
+
 export function createMemoryRunSupervisorIc8ExitResources(waitMs: number) {
   const exitServers = new Set<Server>()
   const exitServerClosures = new Map<Server, Promise<void>>()
   const acceptedSockets = new Set<Socket>()
   const socketClosures = new Map<Socket, Promise<void>>()
   const childExitTimeouts = new Set<ReturnType<typeof setTimeout>>()
+  const signalSettlers = new Set<() => void>()
 
   const clearTrackedTimeout = (timeout: ReturnType<typeof setTimeout>) => {
     clearTimeout(timeout)
@@ -74,38 +82,58 @@ export function createMemoryRunSupervisorIc8ExitResources(waitMs: number) {
       acceptedSockets.add(socket)
       socketClosures.set(
         socket,
-        new Promise<void>((resolve) => socket.once("close", resolve)),
+        new Promise<void>((resolve) =>
+          socket.once("close", () => {
+            acceptedSockets.delete(socket)
+            socketClosures.delete(socket)
+            resolve()
+          }),
+        ),
       )
     })
-    const exitSocketAccepted = new Promise<Socket>((resolve) =>
-      server.once("connection", resolve),
-    )
-    const childExited = new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        childExitTimeouts.delete(timeout)
-        reject(new Error(`waited ${waitMs}ms for model child exit`))
-      }, waitMs)
-      childExitTimeouts.add(timeout)
-      void exitSocketAccepted
-        .then(async (socket) => {
-          const closed = socketClosures.get(socket)
-          if (closed === undefined) throw new Error("accepted model socket is not tracked")
-          const serverClosed = closeExitServer(server)
-          await closed
-          await serverClosed
-          clearTrackedTimeout(timeout)
-          resolve()
-        })
-        .catch((error: unknown) => {
-          clearTrackedTimeout(timeout)
-          reject(error)
-        })
-    })
-    return { port: address.port, childExited, exitSocketAccepted }
+    const exitSocketAccepted = deferred<Socket>()
+    const childExited = deferred<void>()
+    void exitSocketAccepted.promise.catch(() => {})
+    void childExited.promise.catch(() => {})
+    server.once("connection", (socket) => exitSocketAccepted.resolve(socket))
+    const timeout = setTimeout(() => {
+      childExitTimeouts.delete(timeout)
+      childExited.reject(new Error(`waited ${waitMs}ms for model child exit`))
+    }, waitMs)
+    childExitTimeouts.add(timeout)
+    const settleForCleanup = () => {
+      const error = new Error("exit resource cleaned up before model child exit")
+      exitSocketAccepted.reject(error)
+      childExited.reject(error)
+      clearTrackedTimeout(timeout)
+    }
+    signalSettlers.add(settleForCleanup)
+    void exitSocketAccepted.promise
+      .then(async (socket) => {
+        const closed = socketClosures.get(socket)
+        if (closed === undefined) throw new Error("accepted model socket is not tracked")
+        const serverClosed = closeExitServer(server)
+        await closed
+        await serverClosed
+        clearTrackedTimeout(timeout)
+        signalSettlers.delete(settleForCleanup)
+        childExited.resolve()
+      })
+      .catch((error: unknown) => {
+        clearTrackedTimeout(timeout)
+        signalSettlers.delete(settleForCleanup)
+        childExited.reject(error instanceof Error ? error : new Error(String(error)))
+      })
+    return {
+      port: address.port,
+      childExited: childExited.promise,
+      exitSocketAccepted: exitSocketAccepted.promise,
+    }
   }
 
-  const cleanup = async (): Promise<void> => {
+  const cleanup = async (): Promise<{ forcedSocketDestructions: number }> => {
     let cleanupError: Error | undefined
+    let forcedSocketDestructions = 0
     try {
       try {
         if (socketClosures.size > 0) {
@@ -116,7 +144,10 @@ export function createMemoryRunSupervisorIc8ExitResources(waitMs: number) {
           )
         }
       } catch {
-        for (const socket of acceptedSockets) socket.destroy()
+        for (const socket of acceptedSockets) {
+          forcedSocketDestructions += 1
+          socket.destroy()
+        }
         try {
           await waitBounded(
             Promise.all([...socketClosures.values()]).then(() => undefined),
@@ -137,6 +168,7 @@ export function createMemoryRunSupervisorIc8ExitResources(waitMs: number) {
         cleanupError ??= error instanceof Error ? error : new Error(String(error))
       }
     } finally {
+      for (const settle of signalSettlers) settle()
       for (const socket of acceptedSockets) {
         socket.removeAllListeners()
         socket.destroy()
@@ -144,12 +176,14 @@ export function createMemoryRunSupervisorIc8ExitResources(waitMs: number) {
       for (const server of exitServers) server.removeAllListeners()
       acceptedSockets.clear()
       socketClosures.clear()
+      signalSettlers.clear()
       exitServers.clear()
       exitServerClosures.clear()
       for (const timeout of childExitTimeouts) clearTimeout(timeout)
       childExitTimeouts.clear()
     }
     if (cleanupError !== undefined) throw cleanupError
+    return { forcedSocketDestructions }
   }
 
   return {
@@ -160,9 +194,36 @@ export function createMemoryRunSupervisorIc8ExitResources(waitMs: number) {
       acceptedSockets: acceptedSockets.size,
       childExitTimeouts: childExitTimeouts.size,
     }),
+    hasConnectedSockets: () => acceptedSockets.size > 0,
     openServer,
     trackTimeout: (timeout: ReturnType<typeof setTimeout>) =>
       childExitTimeouts.add(timeout),
     waitBounded,
+  }
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: (value: T) => void = () => {}
+  let rejectPromise: (error: Error) => void = () => {}
+  let settled = false
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve
+    rejectPromise = reject
+  })
+  return {
+    promise,
+    resolve: (value) => {
+      if (settled) return
+      settled = true
+      resolvePromise(value)
+    },
+    reject: (error) => {
+      if (settled) return
+      settled = true
+      rejectPromise(error)
+    },
+    get settled() {
+      return settled
+    },
   }
 }

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-exit-resources.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-exit-resources.ts
@@ -1,0 +1,168 @@
+import { createServer, type AddressInfo, type Server, type Socket } from "node:net"
+
+const CLEANUP_WAIT_MS = 5_000
+
+export function createMemoryRunSupervisorIc8ExitResources(waitMs: number) {
+  const exitServers = new Set<Server>()
+  const exitServerClosures = new Map<Server, Promise<void>>()
+  const acceptedSockets = new Set<Socket>()
+  const socketClosures = new Map<Socket, Promise<void>>()
+  const childExitTimeouts = new Set<ReturnType<typeof setTimeout>>()
+
+  const clearTrackedTimeout = (timeout: ReturnType<typeof setTimeout>) => {
+    clearTimeout(timeout)
+    childExitTimeouts.delete(timeout)
+  }
+
+  const waitBounded = <T>(
+    signal: Promise<T>,
+    timeoutMs: number,
+    description: string,
+  ): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        childExitTimeouts.delete(timeout)
+        reject(new Error(`waited ${timeoutMs}ms for ${description}`))
+      }, timeoutMs)
+      childExitTimeouts.add(timeout)
+      signal.then(
+        (value) => {
+          clearTrackedTimeout(timeout)
+          resolve(value)
+        },
+        (error: unknown) => {
+          clearTrackedTimeout(timeout)
+          reject(error)
+        },
+      )
+    })
+
+  const closeExitServer = async (server: Server): Promise<void> => {
+    const existing = exitServerClosures.get(server)
+    if (existing !== undefined) return existing
+    if (!server.listening) {
+      server.removeAllListeners()
+      exitServers.delete(server)
+      return
+    }
+    const closing = new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()))
+    })
+    exitServerClosures.set(server, closing)
+    try {
+      await closing
+    } finally {
+      server.removeAllListeners()
+      exitServerClosures.delete(server)
+      exitServers.delete(server)
+    }
+  }
+
+  const openServer = async () => {
+    const server = createServer()
+    exitServers.add(server)
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => reject(error)
+      server.once("error", onError)
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", onError)
+        resolve()
+      })
+    })
+    const address = server.address() as AddressInfo
+    server.on("connection", (socket) => {
+      acceptedSockets.add(socket)
+      socketClosures.set(
+        socket,
+        new Promise<void>((resolve) => socket.once("close", resolve)),
+      )
+    })
+    const exitSocketAccepted = new Promise<Socket>((resolve) =>
+      server.once("connection", resolve),
+    )
+    const childExited = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        childExitTimeouts.delete(timeout)
+        reject(new Error(`waited ${waitMs}ms for model child exit`))
+      }, waitMs)
+      childExitTimeouts.add(timeout)
+      void exitSocketAccepted
+        .then(async (socket) => {
+          const closed = socketClosures.get(socket)
+          if (closed === undefined) throw new Error("accepted model socket is not tracked")
+          const serverClosed = closeExitServer(server)
+          await closed
+          await serverClosed
+          clearTrackedTimeout(timeout)
+          resolve()
+        })
+        .catch((error: unknown) => {
+          clearTrackedTimeout(timeout)
+          reject(error)
+        })
+    })
+    return { port: address.port, childExited, exitSocketAccepted }
+  }
+
+  const cleanup = async (): Promise<void> => {
+    let cleanupError: Error | undefined
+    try {
+      try {
+        if (socketClosures.size > 0) {
+          await waitBounded(
+            Promise.all([...socketClosures.values()]).then(() => undefined),
+            CLEANUP_WAIT_MS,
+            "model socket close",
+          )
+        }
+      } catch {
+        for (const socket of acceptedSockets) socket.destroy()
+        try {
+          await waitBounded(
+            Promise.all([...socketClosures.values()]).then(() => undefined),
+            CLEANUP_WAIT_MS,
+            "forced model socket close",
+          )
+        } catch (error) {
+          cleanupError = error instanceof Error ? error : new Error(String(error))
+        }
+      }
+      try {
+        await waitBounded(
+          Promise.all([...exitServers].map(closeExitServer)).then(() => undefined),
+          CLEANUP_WAIT_MS,
+          "exit server close",
+        )
+      } catch (error) {
+        cleanupError ??= error instanceof Error ? error : new Error(String(error))
+      }
+    } finally {
+      for (const socket of acceptedSockets) {
+        socket.removeAllListeners()
+        socket.destroy()
+      }
+      for (const server of exitServers) server.removeAllListeners()
+      acceptedSockets.clear()
+      socketClosures.clear()
+      exitServers.clear()
+      exitServerClosures.clear()
+      for (const timeout of childExitTimeouts) clearTimeout(timeout)
+      childExitTimeouts.clear()
+    }
+    if (cleanupError !== undefined) throw cleanupError
+  }
+
+  return {
+    cleanup,
+    clearTrackedTimeout,
+    counts: () => ({
+      exitServers: exitServers.size,
+      acceptedSockets: acceptedSockets.size,
+      childExitTimeouts: childExitTimeouts.size,
+    }),
+    openServer,
+    trackTimeout: (timeout: ReturnType<typeof setTimeout>) =>
+      childExitTimeouts.add(timeout),
+    waitBounded,
+  }
+}

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts
@@ -1,9 +1,14 @@
-import { spawn, spawnSync, type ChildProcess } from "node:child_process"
+import { spawn, type ChildProcess } from "node:child_process"
 import { existsSync, realpathSync } from "node:fs"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { createMemoryRunSupervisorIc8ExitResources } from "./memory-run-supervisor-ic8-exit-resources"
+import {
+  processGroupIsAlive,
+  terminateProcessGroup,
+  validateProcessGroupPid,
+} from "./memory-run-supervisor-ic8-process-groups"
 import {
   advanceTestClock,
   createTestClock,
@@ -127,31 +132,6 @@ export function createMemoryRunSupervisorIc8Harness() {
       child.once("close", onClose)
     })
 
-  const validateProcessGroupPid = (pid: number) => {
-    if (!Number.isInteger(pid) || pid <= 0) {
-      throw new RangeError(`process-group pid must be a positive integer: ${pid}`)
-    }
-    return pid
-  }
-  const killTree = (pid: number) => {
-    const validatedPid = validateProcessGroupPid(pid)
-    if (process.platform === "win32") {
-      spawnSync("taskkill", ["/pid", String(validatedPid), "/T", "/F"], {
-        stdio: "ignore",
-      })
-    } else {
-      process.kill(-validatedPid, "SIGKILL")
-    }
-  }
-  const processGroupIsAlive = (pid: number) => {
-    const validatedPid = validateProcessGroupPid(pid)
-    try {
-      process.kill(process.platform === "win32" ? validatedPid : -validatedPid, 0)
-      return true
-    } catch (error) {
-      return error instanceof Error && "code" in error && error.code === "EPERM"
-    }
-  }
   const ledgerChildProcessGroups = async () => {
     const groups = new Set<number>()
     for (const runDir of roots) {
@@ -166,30 +146,88 @@ export function createMemoryRunSupervisorIc8Harness() {
     return groups
   }
   const cleanupRunResources = async () => {
-    const groups = new Set([...liveProcesses, ...(await ledgerChildProcessGroups())])
+    let cleanupError: Error | undefined
+    const groups = new Set(liveProcesses)
+    let ledgerGroups = new Set<number>()
+    try {
+      ledgerGroups = await ledgerChildProcessGroups()
+    } catch (error) {
+      cleanupError = asError(error)
+    }
+    if (exitResources.hasConnectedSockets()) {
+      for (const pid of ledgerGroups) groups.add(pid)
+    }
     for (const pid of groups) {
+      if (!processGroupIsAlive(pid)) continue
       try {
-        killTree(pid)
+        terminateProcessGroup(pid)
       } catch (error) {
         if (!(error instanceof Error) || !("code" in error) || error.code !== "ESRCH") {
-          throw error
+          cleanupError ??= asError(error)
         }
       }
     }
     liveProcesses.clear()
-    await exitResources.cleanup()
+    try {
+      const { forcedSocketDestructions } = await exitResources.cleanup()
+      if (forcedSocketDestructions > 0) {
+        cleanupError ??= new Error(
+          `forced ${forcedSocketDestructions} model socket cleanup(s)`,
+        )
+      }
+    } catch (error) {
+      cleanupError ??= asError(error)
+    }
+    for (const pid of groups) {
+      try {
+        await waitForProcessGroupExit(pid)
+      } catch (error) {
+        cleanupError ??= asError(error)
+      }
+    }
     for (const runDir of roots) cleanedRunRoots.add(runDir)
+    if (cleanupError !== undefined) throw cleanupError
+  }
+
+  const waitForProcessGroupExit = async (pid: number) => {
+    if (!processGroupIsAlive(pid)) return
+    let interval: ReturnType<typeof setInterval> | undefined
+    try {
+      await exitResources.waitBounded(
+        new Promise<void>((resolve) => {
+          interval = setInterval(() => {
+            if (processGroupIsAlive(pid)) return
+            clearInterval(interval)
+            interval = undefined
+            resolve()
+          }, 25)
+        }),
+        5_000,
+        `process group ${pid} exit`,
+      )
+    } finally {
+      if (interval !== undefined) clearInterval(interval)
+    }
   }
   const cleanup = async () => {
-    await cleanupRunResources()
-    await Promise.all(
+    let cleanupError: Error | undefined
+    try {
+      await cleanupRunResources()
+    } catch (error) {
+      cleanupError = asError(error)
+    }
+    const removals = await Promise.allSettled(
       roots
         .splice(0)
         .map((root) =>
           rm(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 }),
         ),
     )
+    for (const result of removals) {
+      if (result.status === "rejected") cleanupError ??= asError(result.reason)
+    }
     cleanedRunRoots.clear()
+    if (cleanupError !== undefined) throw cleanupError
   }
 
   return {
@@ -206,4 +244,8 @@ export function createMemoryRunSupervisorIc8Harness() {
     waitForExit,
     waitForPath,
   }
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
 }

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts
@@ -1,0 +1,209 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process"
+import { existsSync, realpathSync } from "node:fs"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { createMemoryRunSupervisorIc8ExitResources } from "./memory-run-supervisor-ic8-exit-resources"
+import {
+  advanceTestClock,
+  createTestClock,
+  waitForFilesystemState,
+} from "./supervisor-test-signals"
+
+export const IC8_WAIT_MS = 60_000
+export const IC8_PLATFORMS = ["posix", "win32"] as const
+
+export function createMemoryRunSupervisorIc8Harness() {
+  const supervisorPath = join(import.meta.dir, "memory-run-supervisor.ts")
+  const childFixture = join(import.meta.dir, "__fixtures__", "supervisor-child.ts")
+  const taskkillFixture = join(import.meta.dir, "__fixtures__", "supervisor-taskkill.ts")
+  const roots: string[] = []
+  const cleanedRunRoots = new Set<string>()
+  const liveProcesses = new Set<number>()
+  const exitResources = createMemoryRunSupervisorIc8ExitResources(IC8_WAIT_MS)
+
+  const waitForPath = async (path: string, timeoutMs = IC8_WAIT_MS) => {
+    await waitForFilesystemState(
+      dirname(path),
+      () => (existsSync(path) ? true : undefined),
+      timeoutMs,
+      path,
+    )
+  }
+
+  const makeRun = async (mode: "graceful" | "stubborn") => {
+    const runDir = realpathSync.native(
+      await mkdtemp(join(tmpdir(), "memory-run-supervisor-ic8-")),
+    )
+    roots.push(runDir)
+    await mkdir(runDir, { recursive: true, mode: 0o700 })
+    const clockPath = await createTestClock(runDir, 1_000)
+    const { port, childExited, exitSocketAccepted } =
+      await exitResources.openServer()
+    await writeFile(
+      join(runDir, "ledger.json"),
+      `${JSON.stringify({ version: 1, runId: "run-ic8", kind: "reflection" })}\n`,
+    )
+    await writeFile(
+      join(runDir, "launch.json"),
+      `${JSON.stringify({
+        version: 1,
+        runId: "run-ic8",
+        kind: "reflection",
+        command: process.execPath,
+        args: [childFixture, mode, runDir],
+        cwd: runDir,
+        env: {
+          ...process.env,
+          OMO_MEMORY_SUPERVISOR_EXIT_PORT: String(port),
+        },
+        hardDeadlineAt: 2_000,
+        terminationGraceMs: 1_000,
+        maxOutputBytes: 65_536,
+        stdoutPath: join(runDir, "child-stdout.log"),
+        stderrPath: join(runDir, "child-stderr.log"),
+      })}\n`,
+      { mode: 0o600 },
+    )
+    return { runDir, clockPath, childExited, exitSocketAccepted }
+  }
+
+  const launchSupervisor = (
+    runDir: string,
+    clockPath: string,
+    platform: (typeof IC8_PLATFORMS)[number],
+  ): ChildProcess => {
+    const child = spawn(process.execPath, [supervisorPath, runDir], {
+      detached: true,
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        OMO_MEMORY_SUPERVISOR_ALLOW_TEST_SEAMS: "1",
+        OMO_MEMORY_SUPERVISOR_PLATFORM: platform,
+        OMO_MEMORY_SUPERVISOR_CLOCK_PATH: clockPath,
+        OMO_MEMORY_SUPERVISOR_TASKKILL_COMMAND: JSON.stringify([
+          process.execPath,
+          taskkillFixture,
+        ]),
+        OMO_MEMORY_SUPERVISOR_TASKKILL_RUN_DIR: runDir,
+        ...(process.platform === "win32" && platform === "posix"
+          ? {
+              OMO_MEMORY_SUPERVISOR_POSIX_SIGNAL_COMMAND: JSON.stringify([
+                process.execPath,
+                taskkillFixture,
+              ]),
+            }
+          : {}),
+      },
+    })
+    if (child.pid !== undefined) liveProcesses.add(child.pid)
+    return child
+  }
+
+  const waitForExit = (
+    child: ChildProcess,
+  ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> =>
+    new Promise((resolve, reject) => {
+      const cleanup = () => {
+        exitResources.clearTrackedTimeout(timeout)
+        child.off("error", onError)
+        child.off("close", onClose)
+      }
+      const onError = (error: Error) => {
+        cleanup()
+        reject(error)
+      }
+      const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+        cleanup()
+        if (child.pid !== undefined) liveProcesses.delete(child.pid)
+        resolve({ code, signal })
+      }
+      const timeout = setTimeout(() => {
+        cleanup()
+        reject(new Error(`waited ${IC8_WAIT_MS}ms for process exit`))
+      }, IC8_WAIT_MS)
+      exitResources.trackTimeout(timeout)
+      child.once("error", onError)
+      child.once("close", onClose)
+    })
+
+  const validateProcessGroupPid = (pid: number) => {
+    if (!Number.isInteger(pid) || pid <= 0) {
+      throw new RangeError(`process-group pid must be a positive integer: ${pid}`)
+    }
+    return pid
+  }
+  const killTree = (pid: number) => {
+    const validatedPid = validateProcessGroupPid(pid)
+    if (process.platform === "win32") {
+      spawnSync("taskkill", ["/pid", String(validatedPid), "/T", "/F"], {
+        stdio: "ignore",
+      })
+    } else {
+      process.kill(-validatedPid, "SIGKILL")
+    }
+  }
+  const processGroupIsAlive = (pid: number) => {
+    const validatedPid = validateProcessGroupPid(pid)
+    try {
+      process.kill(process.platform === "win32" ? validatedPid : -validatedPid, 0)
+      return true
+    } catch (error) {
+      return error instanceof Error && "code" in error && error.code === "EPERM"
+    }
+  }
+  const ledgerChildProcessGroups = async () => {
+    const groups = new Set<number>()
+    for (const runDir of roots) {
+      if (cleanedRunRoots.has(runDir)) continue
+      const ledger = JSON.parse(
+        await readFile(join(runDir, "ledger.json"), "utf8"),
+      ) as { readonly childPid?: number }
+      if (ledger.childPid !== undefined) {
+        groups.add(validateProcessGroupPid(ledger.childPid))
+      }
+    }
+    return groups
+  }
+  const cleanupRunResources = async () => {
+    const groups = new Set([...liveProcesses, ...(await ledgerChildProcessGroups())])
+    for (const pid of groups) {
+      try {
+        killTree(pid)
+      } catch (error) {
+        if (!(error instanceof Error) || !("code" in error) || error.code !== "ESRCH") {
+          throw error
+        }
+      }
+    }
+    liveProcesses.clear()
+    await exitResources.cleanup()
+    for (const runDir of roots) cleanedRunRoots.add(runDir)
+  }
+  const cleanup = async () => {
+    await cleanupRunResources()
+    await Promise.all(
+      roots
+        .splice(0)
+        .map((root) =>
+          rm(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 }),
+        ),
+    )
+    cleanedRunRoots.clear()
+  }
+
+  return {
+    advanceClock: advanceTestClock,
+    cleanup,
+    cleanupExitResources: exitResources.cleanup,
+    cleanupRunResources,
+    launchSupervisor,
+    makeRun,
+    processGroupIsAlive,
+    resourceCounts: exitResources.counts,
+    trackProcessGroup: (pid: number) => liveProcesses.add(pid),
+    untrackProcessGroup: (pid: number) => liveProcesses.delete(pid),
+    waitForExit,
+    waitForPath,
+  }
+}

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts
@@ -3,6 +3,7 @@ import { existsSync, realpathSync } from "node:fs"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { createMemoryRunSupervisorIc8ExitResources } from "./memory-run-supervisor-ic8-exit-resources"
 import {
   processGroupIsAlive,
@@ -19,9 +20,10 @@ export const IC8_WAIT_MS = 60_000
 export const IC8_PLATFORMS = ["posix", "win32"] as const
 
 export function createMemoryRunSupervisorIc8Harness() {
-  const supervisorPath = join(import.meta.dir, "memory-run-supervisor.ts")
-  const childFixture = join(import.meta.dir, "__fixtures__", "supervisor-child.ts")
-  const taskkillFixture = join(import.meta.dir, "__fixtures__", "supervisor-taskkill.ts")
+  const moduleDir = fileURLToPath(new URL(".", import.meta.url))
+  const supervisorPath = join(moduleDir, "memory-run-supervisor.ts")
+  const childFixture = join(moduleDir, "__fixtures__", "supervisor-child.ts")
+  const taskkillFixture = join(moduleDir, "__fixtures__", "supervisor-taskkill.ts")
   const roots: string[] = []
   const cleanedRunRoots = new Set<string>()
   const liveProcesses = new Set<number>()

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-process-groups.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-process-groups.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from "node:child_process"
+
+interface TaskkillResult {
+  status: number | null
+  signal?: NodeJS.Signals | null
+  error?: Error
+}
+
+export interface ProcessGroupRuntime {
+  platform: NodeJS.Platform
+  runTaskkill(pid: number): TaskkillResult
+  killGroup(pid: number): void
+  probeGroup(pid: number): void
+}
+
+const defaultRuntime: ProcessGroupRuntime = {
+  platform: process.platform,
+  runTaskkill: (pid) => {
+    const result = spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+    })
+    return {
+      status: result.status,
+      signal: result.signal,
+      error: result.error,
+    }
+  },
+  killGroup: (pid) => process.kill(-pid, "SIGKILL"),
+  probeGroup: (pid) =>
+    process.kill(process.platform === "win32" ? pid : -pid, 0),
+}
+
+export function validateProcessGroupPid(pid: number): number {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new RangeError(`process-group pid must be a positive integer: ${pid}`)
+  }
+  return pid
+}
+
+export function terminateProcessGroup(
+  pid: number,
+  runtime: ProcessGroupRuntime = defaultRuntime,
+): void {
+  const validatedPid = validateProcessGroupPid(pid)
+  if (runtime.platform !== "win32") {
+    runtime.killGroup(validatedPid)
+    return
+  }
+  const result = runtime.runTaskkill(validatedPid)
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    const detail = result.signal
+      ? `signal ${result.signal}`
+      : `exit code ${String(result.status)}`
+    throw new Error(`taskkill failed with ${detail}`)
+  }
+}
+
+export function processGroupIsAlive(
+  pid: number,
+  runtime: ProcessGroupRuntime = defaultRuntime,
+): boolean {
+  const validatedPid = validateProcessGroupPid(pid)
+  try {
+    runtime.probeGroup(validatedPid)
+    return true
+  } catch (error) {
+    return error instanceof Error && "code" in error && error.code === "EPERM"
+  }
+}

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { spawn, spawnSync, type ChildProcess } from "node:child_process"
 import { existsSync, realpathSync } from "node:fs"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
-import { createServer, type AddressInfo } from "node:net"
+import { createServer, type AddressInfo, type Server } from "node:net"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import {
@@ -22,7 +22,41 @@ const childFixture = join(import.meta.dir, "__fixtures__", "supervisor-child.ts"
 const taskkillFixture = join(import.meta.dir, "__fixtures__", "supervisor-taskkill.ts")
 const roots: string[] = []
 const liveProcesses = new Set<number>()
+const exitServers = new Set<Server>()
+const exitServerClosures = new Map<Server, Promise<void>>()
+const childExitTimeouts = new Set<ReturnType<typeof setTimeout>>()
 const platforms = ["posix", "win32"] as const
+
+function clearChildExitTimeout(timeout: ReturnType<typeof setTimeout>): void {
+  clearTimeout(timeout)
+  childExitTimeouts.delete(timeout)
+}
+
+async function closeExitServer(server: Server): Promise<void> {
+  const existing = exitServerClosures.get(server)
+  if (existing !== undefined) return existing
+  if (!server.listening) {
+    exitServers.delete(server)
+    return
+  }
+
+  const closing = new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+  })
+  exitServerClosures.set(server, closing)
+  try {
+    await closing
+  } finally {
+    exitServerClosures.delete(server)
+    exitServers.delete(server)
+  }
+}
+
+async function cleanupExitResources(): Promise<void> {
+  for (const timeout of childExitTimeouts) clearTimeout(timeout)
+  childExitTimeouts.clear()
+  await Promise.all([...exitServers].map(closeExitServer))
+}
 
 async function waitForPath(path: string, timeoutMs = WAIT_MS): Promise<void> {
   await waitForFilesystemState(dirname(path), () => existsSync(path) ? true : undefined, timeoutMs, path)
@@ -38,17 +72,25 @@ async function makeRun(mode: "graceful" | "stubborn"): Promise<{
   await mkdir(runDir, { recursive: true, mode: 0o700 })
   const clockPath = await createTestClock(runDir, 1_000)
   const exitServer = createServer()
+  exitServers.add(exitServer)
   await new Promise<void>((resolve, reject) => {
     exitServer.once("error", reject)
     exitServer.listen(0, "127.0.0.1", resolve)
   })
   const address = exitServer.address() as AddressInfo
   const childExited = new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`waited ${WAIT_MS}ms for model child exit`)), WAIT_MS)
+    const timeout = setTimeout(() => {
+      childExitTimeouts.delete(timeout)
+      reject(new Error(`waited ${WAIT_MS}ms for model child exit`))
+    }, WAIT_MS)
+    childExitTimeouts.add(timeout)
     exitServer.once("connection", () => {
-      exitServer.close(() => {
-        clearTimeout(timeout)
+      void closeExitServer(exitServer).then(() => {
+        clearChildExitTimeout(timeout)
         resolve()
+      }, (error: unknown) => {
+        clearChildExitTimeout(timeout)
+        reject(error)
       })
     })
   })
@@ -96,13 +138,27 @@ async function advanceClock(path: string, value: number): Promise<void> {
 
 function waitForExit(child: ChildProcess): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`waited ${WAIT_MS}ms for process exit`)), WAIT_MS)
-    child.once("error", reject)
-    child.once("close", (code, signal) => {
-      clearTimeout(timeout)
+    const cleanup = (): void => {
+      clearChildExitTimeout(timeout)
+      child.off("error", onError)
+      child.off("close", onClose)
+    }
+    const onError = (error: Error): void => {
+      cleanup()
+      reject(error)
+    }
+    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
+      cleanup()
       if (child.pid !== undefined) liveProcesses.delete(child.pid)
       resolve({ code, signal })
-    })
+    }
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error(`waited ${WAIT_MS}ms for process exit`))
+    }, WAIT_MS)
+    childExitTimeouts.add(timeout)
+    child.once("error", onError)
+    child.once("close", onClose)
   })
 }
 
@@ -125,12 +181,29 @@ afterEach(async () => {
     }
   }
   liveProcesses.clear()
+  await cleanupExitResources()
   // Windows releases file handles asynchronously when killed processes die, so an immediate
   // recursive rm can hit EBUSY there; bounded retries absorb the lag without weakening cleanup.
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 })))
 })
 
 describe("memory run supervisor IC-8 containment", () => {
+  test("#given an unconnected exit server #when test cleanup runs #then the listener and timeout are released", async () => {
+    // given
+    await makeRun("graceful")
+    const server = [...exitServers].at(-1)
+    if (!server) throw new Error("exit server is required")
+    expect(server.listening).toBe(true)
+    expect(childExitTimeouts.size).toBe(1)
+
+    // when
+    await cleanupExitResources()
+
+    // then
+    expect(server.listening).toBe(false)
+    expect(childExitTimeouts.size).toBe(0)
+  })
+
   test("#given injected Windows and a child that exits during grace #when the hard deadline arrives #then the supervisor cancels forced taskkill", async () => {
     // given
     const { runDir, clockPath, childExited } = await makeRun("graceful")

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
@@ -1,207 +1,74 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
-import { spawn, spawnSync, type ChildProcess } from "node:child_process"
-import { existsSync, realpathSync } from "node:fs"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
-import { createServer, type AddressInfo, type Server } from "node:net"
-import { tmpdir } from "node:os"
-import { dirname, join } from "node:path"
+import { existsSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
 import {
-  advanceTestClock,
-  createTestClock,
-  waitForFilesystemState,
-} from "./supervisor-test-signals"
+  createMemoryRunSupervisorIc8Harness,
+  IC8_PLATFORMS,
+  IC8_WAIT_MS,
+} from "./memory-run-supervisor-ic8-harness"
 
-// Real supervisor + bootstrap + model child spawns; a loaded CI runner needs far more than the
-// 5s these waiters originally assumed. The waits stay event-driven (fs/exit signals), so a true
-// hang still fails - only the ceiling moves.
-const WAIT_MS = 60_000
-setDefaultTimeout(WAIT_MS)
+setDefaultTimeout(IC8_WAIT_MS)
+const harness = createMemoryRunSupervisorIc8Harness()
+const {
+  advanceClock,
+  cleanupExitResources,
+  cleanupRunResources,
+  launchSupervisor,
+  makeRun,
+  processGroupIsAlive,
+  resourceCounts,
+  trackProcessGroup,
+  untrackProcessGroup,
+  waitForExit,
+  waitForPath,
+} = harness
 
-const supervisorPath = join(import.meta.dir, "memory-run-supervisor.ts")
-const childFixture = join(import.meta.dir, "__fixtures__", "supervisor-child.ts")
-const taskkillFixture = join(import.meta.dir, "__fixtures__", "supervisor-taskkill.ts")
-const roots: string[] = []
-const liveProcesses = new Set<number>()
-const exitServers = new Set<Server>()
-const exitServerClosures = new Map<Server, Promise<void>>()
-const childExitTimeouts = new Set<ReturnType<typeof setTimeout>>()
-const platforms = ["posix", "win32"] as const
-
-function clearChildExitTimeout(timeout: ReturnType<typeof setTimeout>): void {
-  clearTimeout(timeout)
-  childExitTimeouts.delete(timeout)
-}
-
-async function closeExitServer(server: Server): Promise<void> {
-  const existing = exitServerClosures.get(server)
-  if (existing !== undefined) return existing
-  if (!server.listening) {
-    exitServers.delete(server)
-    return
-  }
-
-  const closing = new Promise<void>((resolve, reject) => {
-    server.close((error) => error ? reject(error) : resolve())
-  })
-  exitServerClosures.set(server, closing)
-  try {
-    await closing
-  } finally {
-    exitServerClosures.delete(server)
-    exitServers.delete(server)
-  }
-}
-
-async function cleanupExitResources(): Promise<void> {
-  for (const timeout of childExitTimeouts) clearTimeout(timeout)
-  childExitTimeouts.clear()
-  await Promise.all([...exitServers].map(closeExitServer))
-}
-
-async function waitForPath(path: string, timeoutMs = WAIT_MS): Promise<void> {
-  await waitForFilesystemState(dirname(path), () => existsSync(path) ? true : undefined, timeoutMs, path)
-}
-
-async function makeRun(mode: "graceful" | "stubborn"): Promise<{
-  runDir: string
-  clockPath: string
-  childExited: Promise<void>
-}> {
-  const runDir = realpathSync.native(await mkdtemp(join(tmpdir(), "memory-run-supervisor-ic8-")))
-  roots.push(runDir)
-  await mkdir(runDir, { recursive: true, mode: 0o700 })
-  const clockPath = await createTestClock(runDir, 1_000)
-  const exitServer = createServer()
-  exitServers.add(exitServer)
-  await new Promise<void>((resolve, reject) => {
-    exitServer.once("error", reject)
-    exitServer.listen(0, "127.0.0.1", resolve)
-  })
-  const address = exitServer.address() as AddressInfo
-  const childExited = new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      childExitTimeouts.delete(timeout)
-      reject(new Error(`waited ${WAIT_MS}ms for model child exit`))
-    }, WAIT_MS)
-    childExitTimeouts.add(timeout)
-    exitServer.once("connection", () => {
-      void closeExitServer(exitServer).then(() => {
-        clearChildExitTimeout(timeout)
-        resolve()
-      }, (error: unknown) => {
-        clearChildExitTimeout(timeout)
-        reject(error)
-      })
-    })
-  })
-  await writeFile(join(runDir, "ledger.json"), `${JSON.stringify({ version: 1, runId: "run-ic8", kind: "reflection" })}\n`)
-  await writeFile(join(runDir, "launch.json"), `${JSON.stringify({
-    version: 1,
-    runId: "run-ic8",
-    kind: "reflection",
-    command: process.execPath,
-    args: [childFixture, mode, runDir],
-    cwd: runDir,
-    env: { ...process.env, OMO_MEMORY_SUPERVISOR_EXIT_PORT: String(address.port) },
-    hardDeadlineAt: 2_000,
-    terminationGraceMs: 1_000,
-    maxOutputBytes: 65_536,
-    stdoutPath: join(runDir, "child-stdout.log"),
-    stderrPath: join(runDir, "child-stderr.log"),
-  })}\n`, { mode: 0o600 })
-  return { runDir, clockPath, childExited }
-}
-
-function launchSupervisor(runDir: string, clockPath: string, platform: typeof platforms[number]): ChildProcess {
-  const child = spawn(process.execPath, [supervisorPath, runDir], {
-    detached: true,
-    stdio: "ignore",
-    env: {
-      ...process.env,
-      OMO_MEMORY_SUPERVISOR_ALLOW_TEST_SEAMS: "1",
-      OMO_MEMORY_SUPERVISOR_PLATFORM: platform,
-      OMO_MEMORY_SUPERVISOR_CLOCK_PATH: clockPath,
-      OMO_MEMORY_SUPERVISOR_TASKKILL_COMMAND: JSON.stringify([process.execPath, taskkillFixture]),
-      OMO_MEMORY_SUPERVISOR_TASKKILL_RUN_DIR: runDir,
-      ...(process.platform === "win32" && platform === "posix"
-        ? { OMO_MEMORY_SUPERVISOR_POSIX_SIGNAL_COMMAND: JSON.stringify([process.execPath, taskkillFixture]) }
-        : {}),
-    },
-  })
-  if (child.pid !== undefined) liveProcesses.add(child.pid)
-  return child
-}
-
-async function advanceClock(path: string, value: number): Promise<void> {
-  await advanceTestClock(path, value)
-}
-
-function waitForExit(child: ChildProcess): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-  return new Promise((resolve, reject) => {
-    const cleanup = (): void => {
-      clearChildExitTimeout(timeout)
-      child.off("error", onError)
-      child.off("close", onClose)
-    }
-    const onError = (error: Error): void => {
-      cleanup()
-      reject(error)
-    }
-    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
-      cleanup()
-      if (child.pid !== undefined) liveProcesses.delete(child.pid)
-      resolve({ code, signal })
-    }
-    const timeout = setTimeout(() => {
-      cleanup()
-      reject(new Error(`waited ${WAIT_MS}ms for process exit`))
-    }, WAIT_MS)
-    childExitTimeouts.add(timeout)
-    child.once("error", onError)
-    child.once("close", onClose)
-  })
-}
-
-// process.kill on win32 terminates only the named process, leaving the bootstrap and model child
-// holding the run directory; taskkill /T /F takes the whole tree so cleanup can proceed.
-function killTree(pid: number): void {
-  if (process.platform === "win32") {
-    spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], { stdio: "ignore" })
-    return
-  }
-  process.kill(pid, "SIGKILL")
-}
-
-afterEach(async () => {
-  for (const pid of liveProcesses) {
-    try {
-      killTree(pid)
-    } catch (error) {
-      if (!(error instanceof Error) || !("code" in error) || error.code !== "ESRCH") throw error
-    }
-  }
-  liveProcesses.clear()
-  await cleanupExitResources()
-  // Windows releases file handles asynchronously when killed processes die, so an immediate
-  // recursive rm can hit EBUSY there; bounded retries absorb the lag without weakening cleanup.
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 })))
-})
+afterEach(async () => harness.cleanup())
 
 describe("memory run supervisor IC-8 containment", () => {
+  test("#given a connected model child #when the supervisor is killed and test cleanup runs #then cleanup terminates the child group and releases the socket", async () => {
+    // given
+    const { runDir, clockPath, childExited, exitSocketAccepted } = await makeRun("graceful")
+    const supervisor = launchSupervisor(runDir, clockPath, "posix")
+    const exit = waitForExit(supervisor)
+    await waitForPath(join(runDir, "child-started.json"))
+    await exitSocketAccepted
+    const ledger = JSON.parse(await readFile(join(runDir, "ledger.json"), "utf8")) as { readonly childPid: number }
+    expect(processGroupIsAlive(ledger.childPid)).toBe(true)
+
+    // when
+    supervisor.kill("SIGKILL")
+    await exit
+    await cleanupRunResources()
+    await childExited
+
+    // then
+    expect(resourceCounts()).toEqual({
+      exitServers: 0,
+      acceptedSockets: 0,
+      childExitTimeouts: 0,
+    })
+  }, 10_000)
+
   test("#given an unconnected exit server #when test cleanup runs #then the listener and timeout are released", async () => {
     // given
     await makeRun("graceful")
-    const server = [...exitServers].at(-1)
-    if (!server) throw new Error("exit server is required")
-    expect(server.listening).toBe(true)
-    expect(childExitTimeouts.size).toBe(1)
+    expect(resourceCounts()).toEqual({
+      exitServers: 1,
+      acceptedSockets: 0,
+      childExitTimeouts: 1,
+    })
 
     // when
     await cleanupExitResources()
 
     // then
-    expect(server.listening).toBe(false)
-    expect(childExitTimeouts.size).toBe(0)
+    expect(resourceCounts()).toEqual({
+      exitServers: 0,
+      acceptedSockets: 0,
+      childExitTimeouts: 0,
+    })
   })
 
   test("#given injected Windows and a child that exits during grace #when the hard deadline arrives #then the supervisor cancels forced taskkill", async () => {
@@ -229,7 +96,7 @@ describe("memory run supervisor IC-8 containment", () => {
     expect(existsSync(join(runDir, "taskkill-invocation.json"))).toBe(false)
   }, 60_000)
 
-  for (const platform of platforms) {
+  for (const platform of IC8_PLATFORMS) {
     test(`#given the injected ${platform} branch #when the absolute deadline instants are advanced #then graceful and hard tree termination use those instants`, async () => {
       // given
       const { runDir, clockPath, childExited } = await makeRun("stubborn")
@@ -272,7 +139,7 @@ describe("memory run supervisor IC-8 containment", () => {
       const exit = waitForExit(supervisor)
       await waitForPath(join(runDir, "child-started.json"))
       const ledger = JSON.parse(await readFile(join(runDir, "ledger.json"), "utf8")) as { readonly childPid: number }
-      liveProcesses.add(ledger.childPid)
+      trackProcessGroup(ledger.childPid)
 
       // when
       supervisor.kill("SIGKILL")
@@ -281,7 +148,7 @@ describe("memory run supervisor IC-8 containment", () => {
       await advanceClock(clockPath, 2_000)
       await waitForPath(join(runDir, `${platform === "win32" ? "win32-graceful" : "posix-SIGTERM"}-${ledger.childPid}.json`))
       await childExited
-      liveProcesses.delete(ledger.childPid)
+      untrackProcessGroup(ledger.childPid)
 
       // then
       expect(existsSync(join(runDir, "outcome.json"))).toBe(false)

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.ic8.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { existsSync } from "node:fs"
-import { readFile } from "node:fs/promises"
+import { readFile, rm } from "node:fs/promises"
 import { join } from "node:path"
 import {
   createMemoryRunSupervisorIc8Harness,
   IC8_PLATFORMS,
   IC8_WAIT_MS,
 } from "./memory-run-supervisor-ic8-harness"
+import { terminateProcessGroup } from "./memory-run-supervisor-ic8-process-groups"
 
 setDefaultTimeout(IC8_WAIT_MS)
 const harness = createMemoryRunSupervisorIc8Harness()
 const {
   advanceClock,
+  cleanup,
   cleanupExitResources,
   cleanupRunResources,
   launchSupervisor,
@@ -44,6 +46,7 @@ describe("memory run supervisor IC-8 containment", () => {
     await childExited
 
     // then
+    expect(processGroupIsAlive(ledger.childPid)).toBe(false)
     expect(resourceCounts()).toEqual({
       exitServers: 0,
       acceptedSockets: 0,
@@ -53,7 +56,7 @@ describe("memory run supervisor IC-8 containment", () => {
 
   test("#given an unconnected exit server #when test cleanup runs #then the listener and timeout are released", async () => {
     // given
-    await makeRun("graceful")
+    const { childExited, exitSocketAccepted } = await makeRun("graceful")
     expect(resourceCounts()).toEqual({
       exitServers: 1,
       acceptedSockets: 0,
@@ -69,6 +72,37 @@ describe("memory run supervisor IC-8 containment", () => {
       acceptedSockets: 0,
       childExitTimeouts: 0,
     })
+    expect(await settlementState(exitSocketAccepted)).toBe("rejected")
+    expect(await settlementState(childExited)).toBe("rejected")
+  })
+
+  test("#given a missing run ledger #when cleanup reports the ledger error #then sockets and the run root are still removed", async () => {
+    // given
+    const { runDir } = await makeRun("graceful")
+    await rm(join(runDir, "ledger.json"))
+
+    // when
+    const result = cleanup()
+
+    // then
+    await expect(result).rejects.toThrow("ledger.json")
+    expect(resourceCounts()).toEqual({
+      exitServers: 0,
+      acceptedSockets: 0,
+      childExitTimeouts: 0,
+    })
+    expect(existsSync(runDir)).toBe(false)
+  })
+
+  test("#given taskkill returns nonzero #when a Windows process group is terminated #then cleanup fails closed", () => {
+    expect(() =>
+      terminateProcessGroup(123, {
+        platform: "win32",
+        runTaskkill: () => ({ status: 1 }),
+        killGroup: () => {},
+        probeGroup: () => {},
+      }),
+    ).toThrow("taskkill failed with exit code 1")
   })
 
   test("#given injected Windows and a child that exits during grace #when the hard deadline arrives #then the supervisor cancels forced taskkill", async () => {
@@ -155,3 +189,19 @@ describe("memory run supervisor IC-8 containment", () => {
     }, 60_000)
   }
 })
+
+async function settlementState(
+  signal: Promise<unknown>,
+): Promise<"resolved" | "rejected" | "pending"> {
+  let state: "resolved" | "rejected" | "pending" = "pending"
+  void signal.then(
+    () => {
+      state = "resolved"
+    },
+    () => {
+      state = "rejected"
+    },
+  )
+  await Promise.resolve()
+  return state
+}

--- a/packages/omo-senpi/src/components/onboarding/state.test.ts
+++ b/packages/omo-senpi/src/components/onboarding/state.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun-types" />
 
-import { ChildProcess, fork } from "node:child_process"
+import { fork, type ChildProcess } from "node:child_process"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, chmodSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -36,6 +36,67 @@ afterEach(() => {
 })
 
 const raceChildPath = resolve(import.meta.dir, "claim-race-child.mjs")
+
+function waitForReady(child: ChildProcess, timeoutMs: number): Promise<void> {
+  return new Promise((resolveP, rejectP) => {
+    const cleanup = (): void => {
+      clearTimeout(timer)
+      child.off("message", onMessage)
+      child.off("exit", onExit)
+      child.off("error", onError)
+    }
+    const settle = (callback: () => void): void => {
+      cleanup()
+      callback()
+    }
+    const onMessage = (): void => settle(resolveP)
+    const onExit = (code: number | null): void => {
+      settle(() => rejectP(new Error(`child exited early with code ${code}`)))
+    }
+    const onError = (error: Error): void => settle(() => rejectP(error))
+    const timer = setTimeout(() => {
+      settle(() => rejectP(new Error("child did not signal ready in time")))
+    }, timeoutMs)
+
+    child.once("message", onMessage)
+    child.once("exit", onExit)
+    child.once("error", onError)
+  })
+}
+
+function observeExit(child: ChildProcess): Promise<number> {
+  return new Promise((resolveP) => {
+    child.once("exit", (code) => resolveP(code ?? -1))
+  })
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  return new Promise((resolveP, rejectP) => {
+    const timer = setTimeout(() => rejectP(new Error(message)), timeoutMs)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolveP(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timer)
+        rejectP(error)
+      },
+    )
+  })
+}
+
+async function stopChildren(children: ReadonlyArray<{
+  readonly child: ChildProcess
+  readonly exit: Promise<number>
+}>): Promise<void> {
+  const results = await Promise.allSettled(children.map(async ({ child, exit }) => {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL")
+    await withTimeout(exit, 10_000, "child did not exit during cleanup")
+  }))
+  const failure = results.find((result): result is PromiseRejectedResult => result.status === "rejected")
+  if (failure !== undefined) throw failure.reason
+}
 
 describe("claimOnboarding", () => {
   test("#given a fresh state dir #when claiming onboarding #then it succeeds and writes the marker", () => {
@@ -78,53 +139,63 @@ describe("claimOnboarding", () => {
   test("#given two concurrent child processes #when both call claimOnboarding after release #then exactly one wins", async () => {
     // given
     const dir = makeStateDir()
-    const children: ChildProcess[] = []
+    const children: Array<{
+      readonly child: ChildProcess
+      readonly ready: Promise<void>
+      readonly exit: Promise<number>
+    }> = []
 
-    const waitForReady = (child: ChildProcess, timeoutMs: number): Promise<void> => {
-      return new Promise((resolveP, rejectP) => {
-        const timer = setTimeout(() => rejectP(new Error("child did not signal ready in time")), timeoutMs)
-        child.once("message", () => {
-          clearTimeout(timer)
-          resolveP()
+    try {
+      // when
+      for (let i = 0; i < 2; i++) {
+        const child = fork(raceChildPath, [dir], {
+          stdio: ["ignore", "ignore", "ignore", "ipc"],
         })
-        child.once("exit", (code) => {
-          clearTimeout(timer)
-          rejectP(new Error(`child exited early with code ${code}`))
+        children.push({
+          child,
+          ready: waitForReady(child, 5_000),
+          exit: observeExit(child),
         })
-      })
+      }
+
+      await Promise.all(children.map(({ ready }) => ready))
+
+      for (const { child } of children) child.send("release")
+
+      const exitCodes = await Promise.all(children.map(({ exit }) => (
+        withTimeout(exit, 10_000, "child did not exit in time")
+      )))
+
+      // then
+      const winners = exitCodes.filter((code) => code === 0)
+      const losers = exitCodes.filter((code) => code !== 0)
+      expect(winners).toHaveLength(1)
+      expect(losers).toHaveLength(1)
+    } finally {
+      await stopChildren(children)
     }
+  })
 
-    const waitForExit = (child: ChildProcess, timeoutMs: number): Promise<number> => {
-      return new Promise((resolveP, rejectP) => {
-        const timer = setTimeout(() => rejectP(new Error("child did not exit in time")), timeoutMs)
-        child.once("exit", (code) => {
-          clearTimeout(timer)
-          resolveP(code ?? -1)
-        })
-      })
+  test("#given a child waiting on IPC #when test cleanup stops it #then the exit is observed", async () => {
+    // given
+    const dir = makeStateDir()
+    const child = fork(raceChildPath, [dir], {
+      stdio: ["ignore", "ignore", "ignore", "ipc"],
+    })
+    const ready = waitForReady(child, 5_000)
+    const exit = observeExit(child)
+
+    try {
+      await ready
+
+      // when
+      await stopChildren([{ child, exit }])
+
+      // then
+      expect(await exit).toBe(-1)
+    } finally {
+      await stopChildren([{ child, exit }])
     }
-
-    // when
-    for (let i = 0; i < 2; i++) {
-      const child = fork(raceChildPath, [dir], {
-        stdio: ["ignore", "ignore", "ignore", "ipc"],
-      })
-      children.push(child)
-    }
-
-    await Promise.all(children.map((c) => waitForReady(c, 5_000)))
-
-    for (const child of children) {
-      child.send("release")
-    }
-
-    const exitCodes = await Promise.all(children.map((c) => waitForExit(c, 10_000)))
-
-    // then
-    const winners = exitCodes.filter((code) => code === 0)
-    const losers = exitCodes.filter((code) => code !== 0)
-    expect(winners).toHaveLength(1)
-    expect(losers).toHaveLength(1)
   })
 })
 

--- a/script/ensure-vendored-lsp-daemon.test.ts
+++ b/script/ensure-vendored-lsp-daemon.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from "bun:test"
+import { spawn, type ChildProcessByStdio } from "node:child_process"
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import type { Readable } from "node:stream"
 import {
   ensureVendoredLspDaemonBuilt,
   type RunVendoredLspCommand,
@@ -21,6 +23,8 @@ function deferred<T>(): Deferred<T> {
 }
 
 const temporaryRoots: string[] = []
+const ownerFixturePath = join(import.meta.dir, "fixtures", "vendored-lsp-build-owner.ts")
+type OwnerProcess = ChildProcessByStdio<null, Readable, Readable>
 
 afterEach(async () => {
   await Promise.all(
@@ -62,6 +66,9 @@ describe("ensureVendoredLspDaemonBuilt", () => {
         outputPath,
         runCommand,
         log: () => {},
+        watchDirectory: () => {
+          throw new Error("watch unavailable")
+        },
       })
 
     // when
@@ -74,4 +81,223 @@ describe("ensureVendoredLspDaemonBuilt", () => {
     // then
     expect(installCount).toBe(1)
   })
+
+  it("#given a waiter subscribed to a live owner #when the owner is killed #then the waiter reaps the lock and completes the build", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-lsp-dead-owner-"))
+    temporaryRoots.push(root)
+    const packageDir = join(root, "lsp-daemon")
+    const outputPath = join(packageDir, "dist", "cli.js")
+    await mkdir(packageDir, { recursive: true })
+
+    const owner = spawn(process.execPath, [ownerFixturePath, packageDir, outputPath, root], {
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    const ownerExit = observeExit(owner)
+
+    try {
+      await waitForLine(owner, "OWNER_READY")
+      let installCount = 0
+      const waiter = ensureVendoredLspDaemonBuilt({
+        packageDir,
+        outputPath,
+        lockRoot: root,
+        timeoutMs: 1_000,
+        log: () => {},
+        runCommand: async (_command, args) => {
+          if (args[0] === "ci") {
+            installCount += 1
+          } else {
+            await mkdir(join(packageDir, "dist"), { recursive: true })
+            await writeFile(outputPath, "recovered")
+          }
+          return 0
+        },
+      })
+
+      // when
+      owner.kill("SIGKILL")
+      await ownerExit
+      await waiter
+
+      // then
+      expect(installCount).toBe(1)
+    } finally {
+      if (owner.exitCode === null && owner.signalCode === null) owner.kill("SIGKILL")
+      await ownerExit
+    }
+  })
+
+  it("#given one operation deadline #when install consumes budget #then build receives only the remaining time", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-lsp-deadline-"))
+    temporaryRoots.push(root)
+    const packageDir = join(root, "lsp-daemon")
+    const outputPath = join(packageDir, "dist", "cli.js")
+    await mkdir(packageDir, { recursive: true })
+
+    let now = 1_000
+    const originalNow = Date.now
+    Date.now = () => now
+    const budgets: number[] = []
+
+    try {
+      // when
+      await ensureVendoredLspDaemonBuilt({
+        packageDir,
+        outputPath,
+        lockRoot: root,
+        timeoutMs: 1_000,
+        log: () => {},
+        runCommand: async (_command, args, options) => {
+          budgets.push(options.timeoutMs)
+          if (args[0] === "ci") {
+            now += 400
+          } else {
+            await mkdir(join(packageDir, "dist"), { recursive: true })
+            await writeFile(outputPath, "built")
+          }
+          return 0
+        },
+      })
+    } finally {
+      Date.now = originalNow
+    }
+
+    // then
+    expect(budgets).toEqual([1_000, 600])
+  })
+
+  it("#given npm ci fails #when the helper builds #then the failure rejects instead of continuing tests", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-lsp-command-failure-"))
+    temporaryRoots.push(root)
+    const packageDir = join(root, "lsp-daemon")
+    await mkdir(packageDir, { recursive: true })
+
+    // when
+    const result = ensureVendoredLspDaemonBuilt({
+      packageDir,
+      lockRoot: root,
+      log: () => {},
+      runCommand: async () => 7,
+    })
+
+    // then
+    await expect(result).rejects.toThrow("lsp-daemon npm ci failed with exit code 7")
+  })
+
+  it("#given install exhausts the operation deadline #when build would start #then the aggregate deadline rejects", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-lsp-deadline-exhausted-"))
+    temporaryRoots.push(root)
+    const packageDir = join(root, "lsp-daemon")
+    await mkdir(packageDir, { recursive: true })
+
+    let now = 1_000
+    const originalNow = Date.now
+    Date.now = () => now
+
+    try {
+      // when
+      const result = ensureVendoredLspDaemonBuilt({
+        packageDir,
+        lockRoot: root,
+        timeoutMs: 1_000,
+        log: () => {},
+        runCommand: async () => {
+          now += 1_001
+          return 0
+        },
+      })
+
+      // then
+      await expect(result).rejects.toThrow("timed out during npm run build")
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it("#given npm spawn fails #when the helper builds #then the original spawn diagnostic is preserved", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-lsp-spawn-error-"))
+    temporaryRoots.push(root)
+    const packageDir = join(root, "lsp-daemon")
+    await mkdir(packageDir, { recursive: true })
+
+    // when
+    const result = ensureVendoredLspDaemonBuilt({
+      packageDir,
+      lockRoot: root,
+      log: () => {},
+      runCommand: async () => ({
+        status: null,
+        error: new Error("spawn EACCES"),
+      }),
+    })
+
+    // then
+    await expect(result).rejects.toThrow("lsp-daemon npm ci failed: spawn EACCES")
+  })
+
+  it("#given npm is terminated by a signal #when the helper builds #then the signal is reported", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-lsp-signal-"))
+    temporaryRoots.push(root)
+    const packageDir = join(root, "lsp-daemon")
+    await mkdir(packageDir, { recursive: true })
+
+    // when
+    const result = ensureVendoredLspDaemonBuilt({
+      packageDir,
+      lockRoot: root,
+      log: () => {},
+      runCommand: async () => ({
+        status: null,
+        signal: "SIGTERM",
+      }),
+    })
+
+    // then
+    await expect(result).rejects.toThrow(
+      "lsp-daemon npm ci failed with signal SIGTERM",
+    )
+  })
 })
+
+function observeExit(child: OwnerProcess): Promise<void> {
+  return new Promise((resolve) => child.once("exit", () => resolve()))
+}
+
+function waitForLine(
+  child: OwnerProcess,
+  expected: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let stdout = ""
+
+    const cleanup = () => {
+      child.stdout.off("data", onData)
+      child.off("error", onError)
+      child.off("exit", onExit)
+    }
+    const onData = (chunk: Buffer) => {
+      stdout += chunk.toString("utf8")
+      if (!stdout.includes(expected)) return
+      cleanup()
+      resolve()
+    }
+    const onError = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+    const onExit = () => {
+      cleanup()
+      reject(new Error(`owner exited before emitting ${expected}`))
+    }
+
+    child.stdout.on("data", onData)
+    child.once("error", onError)
+    child.once("exit", onExit)
+  })
+}

--- a/script/ensure-vendored-lsp-daemon.test.ts
+++ b/script/ensure-vendored-lsp-daemon.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  ensureVendoredLspDaemonBuilt,
+  type RunVendoredLspCommand,
+} from "./ensure-vendored-lsp-daemon"
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve(value: T): void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: (value: T) => void = () => {}
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: resolvePromise }
+}
+
+const temporaryRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  )
+})
+
+describe("ensureVendoredLspDaemonBuilt", () => {
+  it("#given two callers over one missing dist #when the first build is held and the second enters #then one build runs and both observe the output", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-lsp-build-lock-"))
+    temporaryRoots.push(root)
+    const packageDir = join(root, "lsp-daemon")
+    const outputPath = join(packageDir, "dist", "cli.js")
+    await mkdir(packageDir, { recursive: true })
+
+    const firstInstallStarted = deferred<void>()
+    const releaseFirstInstall = deferred<void>()
+    let installCount = 0
+
+    const runCommand: RunVendoredLspCommand = async (_command, args) => {
+      if (args[0] === "ci") {
+        installCount += 1
+        if (installCount === 1) {
+          firstInstallStarted.resolve()
+          await releaseFirstInstall.promise
+        }
+        return 0
+      }
+
+      await mkdir(join(packageDir, "dist"), { recursive: true })
+      await writeFile(outputPath, "built")
+      return 0
+    }
+
+    const build = () =>
+      ensureVendoredLspDaemonBuilt({
+        packageDir,
+        outputPath,
+        runCommand,
+        log: () => {},
+      })
+
+    // when
+    const firstBuild = build()
+    await firstInstallStarted.promise
+    const secondBuild = build()
+    releaseFirstInstall.resolve()
+    await Promise.all([firstBuild, secondBuild])
+
+    // then
+    expect(installCount).toBe(1)
+  })
+})
+

--- a/script/ensure-vendored-lsp-daemon.test.ts
+++ b/script/ensure-vendored-lsp-daemon.test.ts
@@ -75,4 +75,3 @@ describe("ensureVendoredLspDaemonBuilt", () => {
     expect(installCount).toBe(1)
   })
 })
-

--- a/script/ensure-vendored-lsp-daemon.ts
+++ b/script/ensure-vendored-lsp-daemon.ts
@@ -8,7 +8,11 @@ import {
 } from "node:fs"
 import { tmpdir } from "node:os"
 import { basename, dirname, join } from "node:path"
-import { tryAcquireLock } from "../packages/lsp-daemon/src/lock"
+import {
+  isProcessAlive,
+  readLockPid,
+  tryAcquireLock,
+} from "../packages/lsp-daemon/src/lock"
 
 export type RunVendoredLspCommand = (
   command: string,
@@ -17,7 +21,18 @@ export type RunVendoredLspCommand = (
     cwd: string
     timeoutMs: number
   },
-) => Promise<number>
+) => Promise<number | VendoredLspCommandResult>
+
+export interface VendoredLspCommandResult {
+  status: number | null
+  signal?: NodeJS.Signals | null
+  error?: Error
+}
+
+export type WatchBuildLockDirectory = (
+  path: string,
+  listener: (event: string, filename: string | Buffer | null) => void,
+) => FSWatcher
 
 export interface EnsureVendoredLspDaemonOptions {
   packageDir: string
@@ -27,9 +42,11 @@ export interface EnsureVendoredLspDaemonOptions {
   runCommand?: RunVendoredLspCommand
   log?: (message: string) => void
   lockRoot?: string
+  watchDirectory?: WatchBuildLockDirectory
 }
 
 const DEFAULT_TIMEOUT_MS = 300_000
+const LOCK_RECHECK_INTERVAL_MS = 50
 const LOCK_FILE_PREFIX = "omo-test-lsp-build-"
 
 const defaultRunCommand: RunVendoredLspCommand = async (command, args, options) => {
@@ -39,8 +56,15 @@ const defaultRunCommand: RunVendoredLspCommand = async (command, args, options) 
     timeout: options.timeoutMs,
     shell: process.platform === "win32",
   })
-  return result.status ?? 1
+  return {
+    status: result.status,
+    signal: result.signal,
+    error: result.error,
+  }
 }
+
+const defaultWatchDirectory: WatchBuildLockDirectory = (path, listener) =>
+  watch(path, { persistent: false }, listener)
 
 export async function ensureVendoredLspDaemonBuilt(
   options: EnsureVendoredLspDaemonOptions,
@@ -50,6 +74,8 @@ export async function ensureVendoredLspDaemonBuilt(
   const pathExists = options.exists ?? existsSync
   const runCommand = options.runCommand ?? defaultRunCommand
   const log = options.log ?? console.error
+  const watchDirectory = options.watchDirectory ?? defaultWatchDirectory
+  const deadline = Date.now() + timeoutMs
 
   if (pathExists(outputPath)) {
     return
@@ -60,7 +86,13 @@ export async function ensureVendoredLspDaemonBuilt(
   while (!pathExists(outputPath)) {
     const lock = tryAcquireLock(lockPath)
     if (!lock) {
-      await waitForBuildTurn(lockPath, outputPath, timeoutMs, pathExists)
+      await waitForBuildTurn(
+        lockPath,
+        outputPath,
+        deadline,
+        pathExists,
+        watchDirectory,
+      )
       continue
     }
 
@@ -73,25 +105,17 @@ export async function ensureVendoredLspDaemonBuilt(
         "[test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...",
       )
 
-      const installStatus = await runCommand("npm", ["ci"], {
+      const installResult = await runCommand("npm", ["ci"], {
         cwd: options.packageDir,
-        timeoutMs,
+        timeoutMs: remainingMs(deadline, "npm ci"),
       })
-      if (installStatus !== 0) {
-        throw new Error(
-          `[test-setup] lsp-daemon npm ci failed with exit code ${installStatus}`,
-        )
-      }
+      assertCommandSucceeded(installResult, "npm ci")
 
-      const buildStatus = await runCommand("npm", ["run", "build"], {
+      const buildResult = await runCommand("npm", ["run", "build"], {
         cwd: options.packageDir,
-        timeoutMs,
+        timeoutMs: remainingMs(deadline, "npm run build"),
       })
-      if (buildStatus !== 0) {
-        throw new Error(
-          `[test-setup] lsp-daemon build failed with exit code ${buildStatus}`,
-        )
-      }
+      assertCommandSucceeded(buildResult, "build")
       if (!pathExists(outputPath)) {
         throw new Error(
           `[test-setup] lsp-daemon build completed without ${outputPath}`,
@@ -113,16 +137,18 @@ function resolveBuildLockPath(packageDir: string, lockRoot: string): string {
 async function waitForBuildTurn(
   lockPath: string,
   outputPath: string,
-  timeoutMs: number,
+  deadline: number,
   pathExists: (path: string) => boolean,
+  watchDirectory: WatchBuildLockDirectory,
 ): Promise<void> {
-  if (pathExists(outputPath) || !pathExists(lockPath)) {
+  if (buildTurnChanged(lockPath, outputPath, pathExists)) {
     return
   }
 
   await new Promise<void>((resolve, reject) => {
     let watcher: FSWatcher | undefined
     let settled = false
+    const waitMs = remainingMs(deadline, `waiting for ${basename(outputPath)}`)
 
     const settle = (error?: Error) => {
       if (settled) {
@@ -130,6 +156,7 @@ async function waitForBuildTurn(
       }
       settled = true
       clearTimeout(timeout)
+      clearInterval(stateRecheck)
       watcher?.close()
       if (error) {
         reject(error)
@@ -139,21 +166,76 @@ async function waitForBuildTurn(
     }
 
     const checkState = () => {
-      if (pathExists(outputPath) || !pathExists(lockPath)) {
+      if (buildTurnChanged(lockPath, outputPath, pathExists)) {
         settle()
       }
     }
 
     const timeout = setTimeout(() => {
       settle(new Error(`[test-setup] timed out waiting for ${basename(outputPath)}`))
-    }, timeoutMs)
+    }, waitMs)
+    const stateRecheck = setInterval(checkState, LOCK_RECHECK_INTERVAL_MS)
 
-    watcher = watch(dirname(lockPath), { persistent: false }, (_event, filename) => {
-      if (filename === null || filename.toString() === basename(lockPath)) {
-        checkState()
-      }
-    })
+    try {
+      watcher = watchDirectory(dirname(lockPath), (_event, filename) => {
+        if (filename === null || filename.toString() === basename(lockPath)) {
+          checkState()
+        }
+      })
+      watcher.on("error", () => {
+        watcher?.close()
+        watcher = undefined
+      })
+    } catch {
+      watcher = undefined
+    }
 
     checkState()
   })
+}
+
+function buildTurnChanged(
+  lockPath: string,
+  outputPath: string,
+  pathExists: (path: string) => boolean,
+): boolean {
+  if (pathExists(outputPath) || !pathExists(lockPath)) {
+    return true
+  }
+  const ownerPid = readLockPid(lockPath)
+  return ownerPid === null || !isProcessAlive(ownerPid)
+}
+
+function remainingMs(deadline: number, stage: string): number {
+  const remaining = deadline - Date.now()
+  if (remaining <= 0) {
+    throw new Error(`[test-setup] timed out during ${stage}`)
+  }
+  return remaining
+}
+
+function assertCommandSucceeded(
+  result: number | VendoredLspCommandResult,
+  stage: string,
+): void {
+  if (typeof result === "number") {
+    if (result !== 0) {
+      throw new Error(
+        `[test-setup] lsp-daemon ${stage} failed with exit code ${result}`,
+      )
+    }
+    return
+  }
+  if (result.error) {
+    throw new Error(
+      `[test-setup] lsp-daemon ${stage} failed: ${result.error.message}`,
+      { cause: result.error },
+    )
+  }
+  if (result.status !== 0) {
+    const detail = result.signal
+      ? `signal ${result.signal}`
+      : `exit code ${String(result.status)}`
+    throw new Error(`[test-setup] lsp-daemon ${stage} failed with ${detail}`)
+  }
 }

--- a/script/ensure-vendored-lsp-daemon.ts
+++ b/script/ensure-vendored-lsp-daemon.ts
@@ -157,5 +157,3 @@ async function waitForBuildTurn(
     checkState()
   })
 }
-
-

--- a/script/ensure-vendored-lsp-daemon.ts
+++ b/script/ensure-vendored-lsp-daemon.ts
@@ -1,0 +1,161 @@
+import { createHash } from "node:crypto"
+import { spawnSync } from "node:child_process"
+import {
+  existsSync,
+  realpathSync,
+  watch,
+  type FSWatcher,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { basename, dirname, join } from "node:path"
+import { tryAcquireLock } from "../packages/lsp-daemon/src/lock"
+
+export type RunVendoredLspCommand = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string
+    timeoutMs: number
+  },
+) => Promise<number>
+
+export interface EnsureVendoredLspDaemonOptions {
+  packageDir: string
+  outputPath?: string
+  timeoutMs?: number
+  exists?: (path: string) => boolean
+  runCommand?: RunVendoredLspCommand
+  log?: (message: string) => void
+  lockRoot?: string
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000
+const LOCK_FILE_PREFIX = "omo-test-lsp-build-"
+
+const defaultRunCommand: RunVendoredLspCommand = async (command, args, options) => {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    stdio: ["ignore", "ignore", "inherit"],
+    timeout: options.timeoutMs,
+    shell: process.platform === "win32",
+  })
+  return result.status ?? 1
+}
+
+export async function ensureVendoredLspDaemonBuilt(
+  options: EnsureVendoredLspDaemonOptions,
+): Promise<void> {
+  const outputPath = options.outputPath ?? join(options.packageDir, "dist", "cli.js")
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const pathExists = options.exists ?? existsSync
+  const runCommand = options.runCommand ?? defaultRunCommand
+  const log = options.log ?? console.error
+
+  if (pathExists(outputPath)) {
+    return
+  }
+
+  const lockPath = resolveBuildLockPath(options.packageDir, options.lockRoot ?? tmpdir())
+
+  while (!pathExists(outputPath)) {
+    const lock = tryAcquireLock(lockPath)
+    if (!lock) {
+      await waitForBuildTurn(lockPath, outputPath, timeoutMs, pathExists)
+      continue
+    }
+
+    try {
+      if (pathExists(outputPath)) {
+        return
+      }
+
+      log(
+        "[test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...",
+      )
+
+      const installStatus = await runCommand("npm", ["ci"], {
+        cwd: options.packageDir,
+        timeoutMs,
+      })
+      if (installStatus !== 0) {
+        throw new Error(
+          `[test-setup] lsp-daemon npm ci failed with exit code ${installStatus}`,
+        )
+      }
+
+      const buildStatus = await runCommand("npm", ["run", "build"], {
+        cwd: options.packageDir,
+        timeoutMs,
+      })
+      if (buildStatus !== 0) {
+        throw new Error(
+          `[test-setup] lsp-daemon build failed with exit code ${buildStatus}`,
+        )
+      }
+      if (!pathExists(outputPath)) {
+        throw new Error(
+          `[test-setup] lsp-daemon build completed without ${outputPath}`,
+        )
+      }
+      return
+    } finally {
+      lock.release()
+    }
+  }
+}
+
+function resolveBuildLockPath(packageDir: string, lockRoot: string): string {
+  const packagePath = realpathSync.native(packageDir)
+  const digest = createHash("sha256").update(packagePath).digest("hex").slice(0, 20)
+  return join(lockRoot, `${LOCK_FILE_PREFIX}${digest}.lock`)
+}
+
+async function waitForBuildTurn(
+  lockPath: string,
+  outputPath: string,
+  timeoutMs: number,
+  pathExists: (path: string) => boolean,
+): Promise<void> {
+  if (pathExists(outputPath) || !pathExists(lockPath)) {
+    return
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let watcher: FSWatcher | undefined
+    let settled = false
+
+    const settle = (error?: Error) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      watcher?.close()
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    }
+
+    const checkState = () => {
+      if (pathExists(outputPath) || !pathExists(lockPath)) {
+        settle()
+      }
+    }
+
+    const timeout = setTimeout(() => {
+      settle(new Error(`[test-setup] timed out waiting for ${basename(outputPath)}`))
+    }, timeoutMs)
+
+    watcher = watch(dirname(lockPath), { persistent: false }, (_event, filename) => {
+      if (filename === null || filename.toString() === basename(lockPath)) {
+        checkState()
+      }
+    })
+
+    checkState()
+  })
+}
+
+

--- a/script/fixtures/vendored-lsp-build-owner.ts
+++ b/script/fixtures/vendored-lsp-build-owner.ts
@@ -1,0 +1,20 @@
+import { ensureVendoredLspDaemonBuilt } from "../ensure-vendored-lsp-daemon"
+
+const [packageDir, outputPath, lockRoot] = process.argv.slice(2)
+if (!packageDir || !outputPath || !lockRoot) {
+  throw new Error("packageDir, outputPath, and lockRoot are required")
+}
+
+await ensureVendoredLspDaemonBuilt({
+  packageDir,
+  outputPath,
+  lockRoot,
+  log: () => {},
+  runCommand: async (_command, args) => {
+    if (args[0] === "ci") {
+      console.log("OWNER_READY")
+      await new Promise<never>(() => {})
+    }
+    return 0
+  },
+})

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,7 +1,6 @@
 /// <reference types="bun-types" />
 import { afterEach, beforeEach, mock, setDefaultTimeout } from "bun:test"
-import { spawnSync } from "node:child_process"
-import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { _resetForTesting as resetClaudeSessionState } from "./packages/omo-opencode/src/features/claude-code-session-state/state"
@@ -13,30 +12,13 @@ import { getOmoOpenCodeCacheDir } from "./packages/omo-opencode/src/shared/data-
 import { releaseAllPromptAsyncReservationsForTesting } from "./packages/omo-opencode/src/shared/prompt-async-gate"
 import { resetLiveServerRouteForTesting } from "./packages/omo-opencode/src/shared/live-server-route"
 import { installModuleMockLifecycle } from "./packages/omo-opencode/src/testing/module-mock-lifecycle"
+import { ensureVendoredLspDaemonBuilt } from "./script/ensure-vendored-lsp-daemon"
 
 // Installer/doctor integration tests need the vendored lsp-daemon dist that CI builds
 // out-of-band before `bun test`; mirror that here so fresh clones/worktrees pass too.
-function ensureVendoredLspDaemonBuilt(): void {
-  const packageDir = join(import.meta.dir, "packages", "lsp-daemon")
-  if (existsSync(join(packageDir, "dist", "cli.js"))) {
-    return
-  }
-  console.error("[test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...")
-  const spawnOptions: Parameters<typeof spawnSync>[2] = {
-    cwd: packageDir,
-    stdio: ["ignore", "ignore", "inherit"],
-    timeout: 300_000,
-    shell: process.platform === "win32",
-  }
-  const install = spawnSync("npm", ["ci"], spawnOptions)
-  const build = install.status === 0 ? spawnSync("npm", ["run", "build"], spawnOptions) : install
-  if (build.status !== 0) {
-    console.error(
-      "[test-setup] lsp-daemon build failed; run `npm ci && npm run build` in packages/lsp-daemon (mirrors CI) before `bun test`",
-    )
-  }
-}
-ensureVendoredLspDaemonBuilt()
+await ensureVendoredLspDaemonBuilt({
+  packageDir: join(import.meta.dir, "packages", "lsp-daemon"),
+})
 
 // setDefaultTimeout is per-file when a TEST file calls it, but the preload runs before every file and
 // its value becomes the default each file starts from. CI runners need multiples of the local time for


### PR DESCRIPTION
## What

Four deterministic test-process-stability fixes, all test-infrastructure scoped:

1. **Vendored lsp-daemon bootstrap is now single-writer across concurrent test processes.** `test-setup.ts`'s unlocked check-then-`npm ci && npm run build` raced when two `bun test` processes started on a fresh checkout (both entered the shared `packages/lsp-daemon` and could tear down each other's `node_modules`). It now awaits `script/ensure-vendored-lsp-daemon.ts`, which acquires an exclusive lock (reusing `packages/lsp-daemon/src/lock.ts`), runs exactly one build, and lets contenders proceed via `fs.watch` + bounded owner-liveness state rechecks.
2. **LSP bootstrap is fail-closed and deadline-bounded.** Install/build failures now reject the preload (previously logged and continued into a broken suite). One aggregate deadline spans wait+install+build; spawn errors and terminating signals are preserved instead of collapsing to "exit code 1"; a killed lock owner is detected and the lock reclaimed, so a dead owner can no longer wedge every other test process until a 5-minute timeout.
3. **Windows `on-complete-hook` fixtures stop inheriting the Git Bash shell.** The fixtures stubbed `process.platform = "win32"` but left `BASH_VERSION`/`MSYSTEM`/`WSL_DISTRO_NAME` set, so on the Windows runner (Git Bash) `detectShellType()` correctly chose `sh` and the PowerShell/cmd expectations failed - the red `test (windows-latest, 1/2)` group-1 job after #6925 landed. The fixtures now snapshot+clear those indicators (production detection unchanged).
4. **Senpi lifecycle tests clean up real processes on every path.** The onboarding claim-race test now arms ready/exit listeners before fork/release (a fast child previously emitted `ready` before the listener attached, guaranteed-flaky), and kills+awaits every child from `finally`. The IC-8 supervisor test now tracks accepted sockets, timeouts, and the ledger-recorded process group; cleanup terminates the whole detached group (POSIX negative-PID, Windows `taskkill /T /F` with nonzero-status fail-closed), destroys sockets only as bounded fallback, settles externally-visible promises when cleanup precedes connection, continues socket/server/root cleanup even when the ledger read fails, and asserts the process group is actually dead.

## Why

Closes #6938, closes #6843, closes #6608 - the three failure classes (onboarding race child leak, IC-8 supervisor process/timer leak, vendored lsp-daemon build race) map 1:1 to the fixes. This is also the prerequisite for ever re-enabling parallel local/CI test execution: concurrent processes sharing one worktree first need a single-writer bootstrap and process-leak-free teardown.

## Evidence (all Bun 1.3.12, committed under `.omo/evidence/20260817-senpi-test-stability/pr1-test-process-stability/`)

Every fix has a captured RED before the change (stale-bundle reproduction at the failing dev SHA; two-process double-build; MSYSTEM-injected PowerShell/cmd vs `sh` mismatch; late-listener mutation, kill-removal mutation, IC-8 cleanup no-op mutation, connected-cleanup 25s watchdog hang with surviving PGID; taskkill-nonzero; missing-ledger; unconnected-promise settlement) and GREEN after.

Final exact-head gates (`final-head-verification.txt`, `FINAL3_PASS=1`):

- build: exit 0; full `typecheck`: exit 0
- targeted lifecycle suite: 43/43
- faithful Senpi gate (freshness→build→pack→daemon-roundtrip 5/5→tsgo→suite): 1884 pass / 0 fail across 275 files (1 platform-filtered skip: Windows-only RPC driver on macOS)
- unsharded root `bun --config=bunfig.root.toml test`: 13902 pass / 0 fail across 1781 files
- `test:codex`: every component/package/Node suite green (97 + 422 + 78 + 417 + 519)
- isolated OpenCode QA: server healthy/auth-enforced, real session DB count unchanged (5861), sandbox auto-removed
- LSP diagnostics: 0 findings on all 10 changed TS files; `git diff --check` clean; generated Senpi/Codex diff zero

## Coordination

- Base includes merged #6925 (CI partition owner); complementary to merged #6957 (same Windows red, workflow-shell layer - disjoint files; this branch was rebased onto it and its equivalent shell-indicator fixture change was adopted from dev, dropping the redundant local commit) and #6911 (shares `test-setup.ts` in disjoint hunks; trivial rebase whichever lands second).
- Bundle freshness on this base is owned by #6925-era refresh commits; #6950 (closed unmerged) is superseded.
- Scope deliberately excludes: CI workflow/partition changes, XDG isolation (#6931), and the opt-in local path-group speed runner (follow-up PR after this merges).

## Residual risk

Windows `taskkill` status handling is covered by an injected-runtime regression plus the platform matrix; live Windows validation arrives with the required `test (windows-latest, 1/2)` check. Model-preflight mtime/wall-clock assumptions and Senpi RPC 5ms polling are known P2 seams intentionally deferred to focused follow-ups.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes concurrent test runs by single‑flight bootstrapping for the vendored LSP and stricter Senpi lifecycle cleanup. The old unlocked check‑then‑build could double‑run and wedge on owner death; onboarding/IC‑8 tests could leak processes/sockets; Windows Git Bash skewed shell fixtures. Now one process builds behind a lock with owner‑death recovery and an absolute deadline; Senpi tests pre‑arm listeners and kill whole process groups; and Windows fixtures model pure PowerShell/cmd. Scope is test infrastructure only; suites fail fast on LSP install/build errors.

- Adds `script/ensure-vendored-lsp-daemon.ts` and makes `test-setup.ts` await it. One winner builds `packages/lsp-daemon` (lock + `fs.watch` with bounded rechecks; owner‑death recovery; one overall timeout; spawn error/signal detail preserved); contenders proceed when output exists.
- Introduces Senpi IC‑8 harness modules (`memory-run-supervisor-ic8-harness.ts`, `memory-run-supervisor-ic8-exit-resources.ts`, `memory-run-supervisor-ic8-process-groups.ts`) that track sockets/timeouts and terminate whole process groups (POSIX negative‑PID; Windows `taskkill /T /F`, failing closed); cleanup asserts group death and continues through ledger/kill errors.
- Onboarding tests arm ready/exit listeners before triggering and always kill/await children; IC‑8 tests pre‑arm listeners, release/destroy sockets, and clear timers; portable module paths replace Bun‑specific ones in test utilities.
- Windows `on-complete-hook` fixtures snapshot/restore env and clear `BASH_VERSION`/`MSYSTEM`/`WSL_DISTRO_NAME` when simulating Windows so detection chooses PowerShell/cmd.

**Review and rollout**
- Review `script/ensure-vendored-lsp-daemon.ts` (lock path, fs.watch fallback, deadline handling), `test-setup.ts` integration, IC‑8 process‑group termination and exit‑resource cleanup in the new harness modules, and the Windows shell env overrides in `packages/omo-opencode` tests.
- No migration required. Local/CI runs build the vendored LSP at most once per worktree; if that build fails, tests abort immediately.

<sup>Written for commit bfe99e0260df2af74570db4b668feb491d0058ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

