### PR TITLE
test(omo-senpi): budget DAG wake redelivery past the 5s default

### DIFF
--- a/packages/omo-senpi/src/components/task/dag-runtime.test.ts
+++ b/packages/omo-senpi/src/components/task/dag-runtime.test.ts
@@ -364,7 +364,7 @@ describe("assembled DAG runtime", () => {
     ])
     expect(coordinator.pendingCount()).toBe(0)
     runtime.dispose()
-  })
+  }, { timeout: 15_000 })
 
   test("#given a live task component runtime #when a two-node dag runs #then scheduler, artifacts, rpc, widget, and one wake all observe the same run", async () => {
     // given


### PR DESCRIPTION
## Why

Run `32056243565` `senpi-compatibility (windows-latest)`: one flake —

```
(fail) assembled DAG runtime > #given a terminal wake buffered during compaction ... [6872.10ms]
  ^ this test timed out after 5000ms.
```

Sibling live-DAG cases in the same file already carry `{ timeout: 15_000 }` from `954a6278b` ("stabilize loaded Windows gates"). This case missed that budget.

## What

`packages/omo-senpi/src/components/task/dag-runtime.test.ts`: add the same `{ timeout: 15_000 }` to the compaction wake-redelivery test.

## QA

- Local: `bun test packages/omo-senpi/src/components/task/dag-runtime.test.ts` -> 10 pass / 0 fail
- CI must show senpi-compatibility (windows) green

Merge with a merge commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the timeout for the "terminal wake buffered during compaction" DAG-runtime test from the 5s default to 15s to deflake Windows CI. Previously the test timed out at 5s; now it has a 15s budget aligned with sibling live-DAG tests. No runtime behavior changes.

**Review notes**
- Single change in `packages/omo-senpi/src/components/task/dag-runtime.test.ts`: add `{ timeout: 15_000 }` to the compaction wake-redelivery test.
- Matches the 15s budget already used by adjacent live-DAG cases to account for Windows variability.

<sup>Written for commit 46fd850cfa58919700a8d651298409a03130659f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

