### PR TITLE
feat(omo-senpi): make eval the default mass-ulw surface and add orchestration patterns

### DIFF
--- a/.omo/evidence/20260818-mass-ulw-eval-orchestration/README.md
+++ b/.omo/evidence/20260818-mass-ulw-eval-orchestration/README.md
@@ -1,0 +1,16 @@
+# mass-ulw eval orchestration + eval-default + category ladder — QA evidence (2026-08-18)
+
+## What was tested
+- `node packages/omo-senpi/plugin/scripts/sync-skills.mjs` — regenerated tree ships the edited SKILL.md + planning.md.
+- `bun test` on skills-sync, mass-ulw-protocol-doc, native-skill-sources — the three machine gates over skill content/registration.
+- rg checks: `^## Python` gone from SKILL.md; "eval is the default", "difficulty ladder", "Eval orchestration patterns" present.
+
+## What was observed
+- 19 pass / 0 fail across the three suites (see qa-output.txt).
+- Source-verified before writing: `max_runs_per_session` default 16 (senpi-task/src/dag/types.ts:84); node outputs stored and returned in full with no truncation (results.ts artifactRef carries sha256+bytes only).
+
+## Why it is enough
+Prose-only change to one skill; the three suites are the only machine consumers of skill content and registration. No prose-pinning tests were added per repo test discipline.
+
+## What was omitted
+No secret-bearing output produced.

--- a/.omo/evidence/20260818-mass-ulw-eval-orchestration/qa-output.txt
+++ b/.omo/evidence/20260818-mass-ulw-eval-orchestration/qa-output.txt
@@ -1,0 +1,13 @@
+=== tests ===
+
+ 19 pass
+ 0 fail
+ 240 expect() calls
+Ran 19 tests across 3 files. [120.00ms]
+=== python block gone, eval default present ===
+packages/omo-senpi/skills/mass-ulw/SKILL.md:22:## Running a dag - eval is the default
+packages/omo-senpi/skills/mass-ulw/references/planning.md:30:The difficulty ladder, bottom rung first:
+packages/omo-senpi/skills/mass-ulw/references/planning.md:57:## Eval orchestration patterns
+=== git status ===
+ M packages/omo-senpi/skills/mass-ulw/SKILL.md
+ M packages/omo-senpi/skills/mass-ulw/references/planning.md

--- a/packages/omo-senpi/skills/mass-ulw/SKILL.md
+++ b/packages/omo-senpi/skills/mass-ulw/SKILL.md
@@ -19,7 +19,9 @@ A run is a declarative definition: a stable `key` (idempotency: re-starting the 
 
 Route every node by `category` using the routing table in `references/planning.md`; the run executes nodes in parallel waves as their dependencies clear.
 
-## JS SDK
+## Running a dag - eval is the default
+
+Build and run every dag INSIDE an eval cell. The eval kernel installs the `tool.dag` proxy and the extension publishes a small JS SDK at `OMO_DAG_SDK_ROOT`; driving runs from a cell is what unlocks the orchestration patterns in `references/planning.md` (data-driven graph construction, multi-run composition, concurrent runs, adaptive retries).
 
 JS cells import the SDK from the path the extension publishes:
 
@@ -37,25 +39,7 @@ const result = await sdk.wait(run.run_id)
 
 `define` builds the definition and rejects duplicate node ids locally, before anything is started. `start`, `attach`, `snapshot`, `wait`, and `cancel` are the whole surface.
 
-## Python
-
-Python can't import an ESM module, so there's no SDK there. Call the tool directly with plain dicts:
-
-```python
-run = tool.dag({
-    "action": "start",
-    "definition": {
-        "key": "docs-refresh",
-        "name": "Docs refresh",
-        "nodes": [
-            {"id": "audit", "category": "explore", "prompt": "Audit docs/ for stale API references and list each stale file with the outdated claim."},
-            {"id": "rewrite", "category": "writing", "prompt": "Rewrite every stale page under docs/ against the current API surface in src/.", "dependsOn": ["audit"]},
-            {"id": "verify", "category": "quick", "prompt": "Check every code sample under docs/ compiles and every internal link resolves.", "dependsOn": ["rewrite"]}
-        ]
-    }
-})
-result = tool.dag({"action": "wait", "run_id": run["run_id"]})
-```
+Python cells cannot import the ESM SDK; call `tool.dag({...})` directly with the same payload shape the SDK produces. Prefer a JS cell whenever the run involves any orchestration beyond a single `start` + `wait`.
 
 ## Run lifecycle
 

--- a/packages/omo-senpi/skills/mass-ulw/references/planning.md
+++ b/packages/omo-senpi/skills/mass-ulw/references/planning.md
@@ -25,17 +25,24 @@ Read this file IN FULL before you define any graph. A graph defined without it i
 
 ## Category routing
 
-`category` routes the node to a model and a worker profile. Choose the CHEAPEST category that can do the node well. `deep` is not the default - it is the escalation.
+`category` routes the node to a model and a worker profile. **Start every node at `quick` and climb the ladder only as far as the work's difficulty demands. Specialty categories are never rungs - they are chosen only when the work itself is specialty.**
+
+The difficulty ladder, bottom rung first:
+
+1. **`quick`** - THE DEFAULT. Mechanical, single-file, or pattern-following work. Every node starts here in your head; you need a reason to leave it.
+2. **`unspecified-low`** - the piece is small but not mechanical: a few files, or a judgment call a template cannot make.
+3. **`unspecified-high`** - a standard multi-file feature or fix with real integration surface.
+
+Escalate a node only with a one-line reason you could say out loud ("touches six files across three packages"). If you cannot name the reason, the node stays at `quick`.
+
+Specialty categories - chosen by the KIND of work, never by difficulty:
 
 | Category | Route a node here when |
 | --- | --- |
-| `quick` | Mechanical, single-file, or pattern-following work. THE DEFAULT for every splittable piece. |
-| `unspecified-low` | Small miscellaneous work that does not fit a specialty. |
-| `unspecified-high` | Standard multi-file feature or fix. |
 | `visual-engineering` | Frontend, UI, styling, animation. |
 | `writing` | Docs, prose, technical writing. |
 | `git` | Git operations only. |
-| `deep` | Hairy debugging or cross-module reasoning that simpler categories already failed or would fail on. |
+| `deep` | Hairy debugging or cross-module reasoning that a ladder rung already failed on, or clearly cannot hold. |
 | `ultrabrain` | At most ONE node per graph - the single genuinely hard reasoning problem everything else depends on. |
 
 A graph whose every node is `deep` is a routing failure: it pays the most expensive worker for mechanical lanes and starves the one lane that needed the horsepower.
@@ -46,6 +53,46 @@ A graph whose every node is `deep` is a routing failure: it pays the most expens
 - **Disjoint write scopes or serialize.** No two nodes that can run in parallel may edit the same file. If two lanes must touch the same files, chain them with `dependsOn` or merge them into one node. Declare each node's read/write scope inside its prompt.
 - **Never add a dependency to pass data.** If node B needs a fact node A produces, that is a real dependency - but if B only needs a fact YOU already know, paste the fact into B's prompt and leave the edge out.
 - **Dependency matrix self-check before `start`:** every `dependsOn` id exists in the graph; no cycles; no node depends on something it does not actually consume; every wave has at least one runnable node.
+
+## Eval orchestration patterns
+
+The dag surface is built to be driven from an eval cell: the JS SDK is a thin proxy over the `dag` tool, and a settled run returns every node's output text to the cell (`result.nodes[id].output`). That makes the cell the meta-orchestrator AROUND runs, not just a launcher. The patterns below are all standard practice - use them.
+
+**Data-driven graph construction.** Build the node list in a loop from runtime data, so fan-out width is decided by what actually exists, not by what you guessed up front:
+
+```js
+const sdk = await import(`${env("OMO_DAG_SDK_ROOT")}/sdk.js`)
+const targets = await glob("packages/*/src/index.ts")
+const dag = sdk.define({ key: `audit-${today}`, name: "Repo audit" })
+for (const t of targets) {
+  dag.node({ id: `audit-${slug(t)}`, category: "quick", prompt: `TASK: Audit ${t} for stale API references. DELIVERABLE: ... VERIFY: ... STOP WHEN: ...` })
+}
+dag.node({ id: "synthesize", category: "unspecified-high", prompt: "...", dependsOn: targets.map(slug) })
+const run = await sdk.start(dag)
+```
+
+**Multi-run composition - the cell is the glue between runs.** `dependsOn` never passes data inside a run, but the cell passes data BETWEEN runs: wait for run 1, read its node outputs, and paste the relevant facts into run 2's prompts. Branching on results is plain JavaScript, so arbitrary conditional workflows fall out naturally:
+
+```js
+const probe = await sdk.wait((await sdk.start(probeDag)).run_id)
+const findings = probe.nodes["probe"].output
+if (findings.includes("critical")) {
+  const fix = sdk.define({ key: `fix-${today}`, name: "Fix" })
+  fix.node({ id: "fix", category: "deep", prompt: `TASK: ... FINDINGS:\n${findings}` })
+  await sdk.start(fix)
+}
+```
+
+**Concurrent runs.** Distinct keys run concurrently (default cap: `task.dag.max_runs_per_session` = 16). When two graphs are independent, start both and `Promise.all([sdk.wait(a), sdk.wait(b)])`.
+
+**Adaptive retries.** Read `result.nodes[id].error`, then start a NARROWER graph under a NEW key (`${key}-retry-1`) - re-issuing a changed definition under the old key is a definition conflict, and re-issuing the SAME definition under the old key reuses finished nodes instead of retrying.
+
+**Progressive snapshots.** Between waits, `snapshot(run_id)` reports per-node states; use it to prepare downstream work while lanes finish. Never spin an empty poll loop - `wait()` is the default.
+
+Two caveats:
+
+- Node outputs are stored and returned IN FULL, with no truncation - when embedding an output into a later prompt, quote or summarize the relevant part. Pasting an unbounded output into a prompt drowns it.
+- `wait()` blocks the cell until the run settles. Do independent cell work BEFORE awaiting, or run the cell detached.
 
 ## Node prompt contract
 


### PR DESCRIPTION
## What changed

- **`references/planning.md` — new "Eval orchestration patterns" section.** The dag surface is built to be driven from an eval cell (`wait()` returns each node's output text via `DagRunResult.nodes[id].output`), and the skill now teaches the patterns that unlock:
  - **Data-driven graph construction** — build the node list in a loop from runtime data; fan-out width decided by what exists.
  - **Multi-run composition** — `dependsOn` never passes data inside a run, but the cell passes data BETWEEN runs: read run 1's node outputs, paste the relevant facts into run 2's prompts, branch in plain JS.
  - **Concurrent runs** — distinct keys run concurrently (source-verified default: `task.dag.max_runs_per_session` = 16, `senpi-task/src/dag/types.ts:84`).
  - **Adaptive retries** — narrower graph under a NEW key (same key + changed definition = conflict).
  - **Progressive snapshots** — prepare downstream work between waits; never empty-poll.
  - Caveats verified in source before writing: node outputs are stored/returned IN FULL (no truncation, `results.ts`), so quote/summarize when embedding; `wait()` blocks the cell.
- **`references/planning.md` — category routing is now a difficulty ladder.** Every node starts at `quick` and climbs to `unspecified-low` → `unspecified-high` only with a nameable one-line reason; specialty categories (`visual-engineering`, `writing`, `git`, `deep`, `ultrabrain`) are chosen by KIND of work, never by difficulty. `ultrabrain` stays capped at one node per graph.
- **`SKILL.md` — eval is the default surface.** `## Running a dag - eval is the default` replaces the bare JS SDK section; the standalone Python walkthrough is removed in favor of a one-line `tool.dag` note. All remaining examples are eval-cell JS.

## Why

The skill taught a static 3-node example and a parallel Python walkthrough, hiding the surface's real power: the eval cell as meta-orchestrator around runs. Session archaeology showed agents defaulting to `deep` for everything; the ladder makes `quick` the explicit default with escalation only on a nameable reason.

## QA / evidence

Evidence: `.omo/evidence/20260818-mass-ulw-eval-orchestration/`.

- `sync-skills.mjs` regenerated; `bun test` on skills-sync + mass-ulw-protocol-doc + native-skill-sources: **19 pass / 0 fail**.
- rg-verified: no `## Python` section remains; eval-default heading, ladder, and patterns section present.
- Prose-only change; no prose-pinning tests added per repo test discipline.

## Residual risk

Low. No product code touched; dag runtime/SDK/RPC unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes eval-cell JS the default surface for the `mass-ulw` dag skill in `omo-senpi`, adds eval orchestration patterns, and turns category routing into a difficulty ladder. Previously the docs centered a static JS SDK section and a full Python walkthrough; now eval drives orchestration, Python is a one-line `tool.dag` note, and `quick` is the explicit default with escalation only on a nameable reason. Docs-only; runtime/SDK/RPC unchanged.

**Reviewer focus**
- `packages/omo-senpi/skills/mass-ulw/SKILL.md`: replaces “JS SDK” with “Running a dag - eval is the default”; removes the standalone Python walkthrough; notes that Python must call `tool.dag({...})`; examples are eval-cell JS.
- `packages/omo-senpi/skills/mass-ulw/references/planning.md`: adds “Eval orchestration patterns” (data-driven graph construction, multi-run composition, concurrent runs; default cap 16; adaptive retries under a new key; progressive snapshots) and two caveats (node outputs returned in full; `wait()` blocks the cell). Rewrites category routing as a difficulty ladder (`quick` → `unspecified-low` → `unspecified-high`), keeps specialty categories by kind of work, and caps `ultrabrain` at one node.
- Evidence under `.omo/evidence/20260818-mass-ulw-eval-orchestration/`: 19 tests pass; defaults source-verified (`task.dag.max_runs_per_session` = 16; full outputs stored/returned).
- No code migration required. Prefer a JS eval cell for any orchestration; in Python, call `tool.dag({...})` directly. Use a new run key for retries.

<sup>Written for commit 64de84939bc9e50b6c37993f535180a55cdb1224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

