### PR TITLE
feat(omo-senpi): strengthen split-first parallel-quick doctrine in mass-ulw

### DIFF
--- a/.omo/evidence/20260818-mass-ulw-parallel-quick/README.md
+++ b/.omo/evidence/20260818-mass-ulw-parallel-quick/README.md
@@ -1,0 +1,15 @@
+# mass-ulw split-first parallel-quick doctrine — QA evidence (2026-08-18)
+
+## What was tested
+- `node packages/omo-senpi/plugin/scripts/sync-skills.mjs` — regenerated tree ships the edited planning.md.
+- `bun test` on skills-sync, mass-ulw-protocol-doc, native-skill-sources — the three machine gates.
+- rg checks: "Split first, route second", "Do not split when", "SURVIVES splitting" present in planning.md.
+
+## What was observed
+- 19 pass / 0 fail (see qa-output.txt). Only planning.md modified.
+
+## Why it is enough
+Prose-only change to one reference file; the three suites are the only machine consumers of skill content and registration. No prose-pinning tests per repo test discipline.
+
+## What was omitted
+No secret-bearing output produced.

--- a/.omo/evidence/20260818-mass-ulw-parallel-quick/qa-output.txt
+++ b/.omo/evidence/20260818-mass-ulw-parallel-quick/qa-output.txt
@@ -1,0 +1,10 @@
+=== tests ===
+ 19 pass
+ 0 fail
+ 240 expect() calls
+Ran 19 tests across 3 files. [122.00ms]
+=== doctrine present ===
+16:**Split first, route second.** The default question is never "which category does this chunk need" but "how do I turn this chunk into more `quick` nodes". When work splits into independent pieces and those pieces can run in parallel SAFELY - disjoint write scopes, self-contained prompts, each piece verifiable on its own - many small `quick` nodes in parallel beat one big node on a smarter model, every time the split exists. Parallel quick lanes finish sooner, fail in isolation (one lane's failure never sinks the wave), and cost less per unit of work. Reach for a bigger model only for what SURVIVES splitting: the piece that cannot be decomposed without losing the whole-problem context it needs.
+18:**Do not split when:** (1) the pieces would share a write scope you cannot untangle - serialize or merge instead of pretending independence; (2) the work is one coherent judgment that needs the whole problem in view (a design decision, a root-cause diagnosis) - splitting it produces confident partial answers, not a verdict; (3) the pieces get so small that spawn and coordination overhead costs more than the work itself - a node that takes longer to brief than to execute belongs folded into its neighbor.
+=== git status ===
+ M packages/omo-senpi/skills/mass-ulw/references/planning.md

--- a/packages/omo-senpi/skills/mass-ulw/references/planning.md
+++ b/packages/omo-senpi/skills/mass-ulw/references/planning.md
@@ -13,13 +13,17 @@ Read this file IN FULL before you define any graph. A graph defined without it i
 
 **TOPOLOGY LOCK first.** Before writing any node, enumerate the 1-6 top-level components that can each succeed or fail independently. Every node you define traces to exactly one component. Do not collapse a multi-component request into one blob node because it "looks small" - and do not invent components the request does not have.
 
-**Wave sizing.** Target 5-8 nodes per parallel wave; fewer than 3 means under-splitting. Split along the axis that makes pieces independent:
+**Split first, route second.** The default question is never "which category does this chunk need" but "how do I turn this chunk into more `quick` nodes". When work splits into independent pieces and those pieces can run in parallel SAFELY - disjoint write scopes, self-contained prompts, each piece verifiable on its own - many small `quick` nodes in parallel beat one big node on a smarter model, every time the split exists. Parallel quick lanes finish sooner, fail in isolation (one lane's failure never sinks the wave), and cost less per unit of work. Reach for a bigger model only for what SURVIVES splitting: the piece that cannot be decomposed without losing the whole-problem context it needs.
+
+**Do not split when:** (1) the pieces would share a write scope you cannot untangle - serialize or merge instead of pretending independence; (2) the work is one coherent judgment that needs the whole problem in view (a design decision, a root-cause diagnosis) - splitting it produces confident partial answers, not a verdict; (3) the pieces get so small that spawn and coordination overhead costs more than the work itself - a node that takes longer to brief than to execute belongs folded into its neighbor.
+
+**Wave sizing.** Target 5-8 nodes per parallel wave; fewer than 3 means under-splitting. A wave of eight `quick` nodes is healthier than a wave of three `deep` ones. Split along the axis that makes pieces independent:
 
 - **By component** - each independently-shippable part is its own lane.
 - **By file domain** - when one component spans disjoint file sets, one node per set.
 - **By phase** - collect lanes (investigate, in parallel) -> verify lanes (falsify the collections) -> synthesize (turn verified facts into the deliverable).
 
-**Default shape is fan-out, then fan-in.** N parallel lanes with no dependencies, then one synthesis node that depends on all of them. A 2-node graph with no dependency between the nodes is not a dag - use plain parallel `task` spawns instead. Reach for `dag` when ordering itself is the point.
+**Default shape is fan-out, then fan-in.** N parallel lanes with no dependencies, then one synthesis node that depends on all of them. The synthesis node starts cheap too (`quick` or `unspecified-low`): merging verified pieces is mechanical unless the merge itself needs judgment. A 2-node graph with no dependency between the nodes is not a dag - use plain parallel `task` spawns instead. Reach for `dag` when ordering itself is the point.
 
 **Split implementation from its test? No.** One node owns one deliverable end to end: the change AND its proof. A node that only writes code and a node that only tests it serialize on the same files and double the coordination cost.
 
@@ -33,7 +37,7 @@ The difficulty ladder, bottom rung first:
 2. **`unspecified-low`** - the piece is small but not mechanical: a few files, or a judgment call a template cannot make.
 3. **`unspecified-high`** - a standard multi-file feature or fix with real integration surface.
 
-Escalate a node only with a one-line reason you could say out loud ("touches six files across three packages"). If you cannot name the reason, the node stays at `quick`.
+Escalate a node only with a one-line reason you could say out loud ("touches six files across three packages") - and only AFTER the split-first doctrine has been applied: a chunk that decomposes into safe parallel `quick` pieces was never a ladder candidate. If you cannot name the reason, the node stays at `quick`.
 
 Specialty categories - chosen by the KIND of work, never by difficulty:
 


### PR DESCRIPTION
## What changed

`references/planning.md` gains the split-first doctrine, placed surgically inside the existing sections (no bolt-on):

- **Split first, route second** (Decomposition): the default question is never "which category does this chunk need" but "how do I turn this chunk into more `quick` nodes". When work splits into independent pieces that are safe to run in parallel - disjoint write scopes, self-contained prompts, per-piece verification - many small `quick` nodes beat one big node on a smarter model: faster, failure-isolated, cheaper. Bigger models are reserved for what SURVIVES splitting (the piece that needs whole-problem context).
- **Do not split when**: (1) the pieces would share an un-untangleable write scope, (2) the work is one coherent judgment (design decision, root-cause diagnosis) - splitting yields confident partial answers, not a verdict, (3) pieces so small that spawn/coordination overhead exceeds the work.
- **Wave sizing**: a wave of eight `quick` nodes is healthier than three `deep` ones.
- **Fan-in**: the synthesis node starts cheap too (`quick`/`unspecified-low`) unless the merge itself needs judgment.
- **Ladder gating**: category escalation now applies only AFTER split-first - a chunk that decomposes into safe parallel `quick` pieces was never a ladder candidate.

## Why

The ladder alone still let agents route whole chunks to `deep`/`ultrabrain` when decomposition into parallel `quick` lanes was the better play. This makes the parallel-quick fan-out the explicit default and the smart-model node the residue.

## QA / evidence

`.omo/evidence/20260818-mass-ulw-parallel-quick/` - sync-skills regenerated; skills-sync + mass-ulw-protocol-doc + native-skill-sources: **19 pass / 0 fail**. Prose-only; no prose-pinning tests per repo discipline.

## Residual risk

Low. No product code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes split-first, parallel-quick fan-out the default in mass-ulw planning, reserving larger models for work that survives splitting. Previously the ladder could route whole chunks to `deep`/`ultrabrain`; now authors split into safe parallel `quick` nodes, start fan-in cheap, and escalate only after split-first.

**Summary**
- Adds “Split first, route second” to `packages/omo-senpi/skills/mass-ulw/references/planning.md`.
- Defines three no-split conditions: shared write scope, one coherent judgment, or spawn/coordination cost exceeding the work.
- Updates wave guidance: prefer 5–8 parallel `quick` nodes; start synthesis nodes as `quick`/`unspecified-low`.
- Gates ladder escalation to occur only after split-first; require a one-line reason for any escalation.

**Review and rollout**
- No product code changes; no migrations. Graph authors should apply split-first, keep synthesis nodes cheap, and escalate only with a stated reason.
- QA evidence added under `.omo/evidence/20260818-mass-ulw-parallel-quick/` (19 pass / 0 fail).

<sup>Written for commit 31e5f2df591355e315170da6fad0c581ba564ef9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

