### PR TITLE
feat(omo-senpi): add capacity model and dag-or-team guidance to mass-ulw planning

### DIFF
--- a/.omo/evidence/20260818-mass-ulw-usage-patterns/README.md
+++ b/.omo/evidence/20260818-mass-ulw-usage-patterns/README.md
@@ -1,0 +1,15 @@
+# mass-ulw usage-patterns (capacity model, dag-or-team, trigger runs, failure modes) — QA evidence (2026-08-18)
+
+## What was tested
+- `node packages/omo-senpi/plugin/scripts/sync-skills.mjs` — regenerated tree ships the edited planning.md.
+- `bun test` on skills-sync, mass-ulw-protocol-doc, native-skill-sources — the three machine gates.
+- rg checks: "Reading this file is not planning", "Capacity model", "Trigger-launched runs", "Dag or team", "quiet widget is not a stall", "Provider storms amplify" present in both source and shipped planning.md.
+
+## What was observed
+- 19 pass / 0 fail / 240 expect() calls (see qa-output.txt). Only planning.md modified; SKILL.md untouched (the mandatory-read gate already routes every dag author through planning.md).
+
+## Why it is enough
+Prose-only change to one reference file; the three suites are the only machine consumers of skill content and registration. No prose-pinning tests per repo test discipline. New content verified this session against live runs: 5-slot limiter + rolling refill (run dag_f7d0063c), 64-node/16-run caps (dag/types.ts), queued-not-stuck + transition-lag self-heal (HWP session journal), provider start-storm (51-node batch, all leaves failed at start).
+
+## What was omitted
+No secret-bearing output produced. No overlap with in-flight feat/dag-definition-library (it adds a new dag-library skill; zero shared files).

--- a/.omo/evidence/20260818-mass-ulw-usage-patterns/qa-output.txt
+++ b/.omo/evidence/20260818-mass-ulw-usage-patterns/qa-output.txt
@@ -1,0 +1,31 @@
+bun test v1.4.0-canary.1 (b58cd4685)
+
+packages/omo-senpi/src/skills-sync.test.ts:
+(pass) OMO Senpi scoped skill sync > #given the telemetry builtin skill allowlist #when compared with packaged skills #then it stays exact and frozen [0.55ms]
+(pass) OMO Senpi scoped skill sync > #given synced skill output #when inspected #then exactly 23 roots exist with valid names [0.28ms]
+(pass) OMO Senpi scoped skill sync > #given synced skill roots #when frontmatter is parsed #then every root skill has name, description, and valid values [0.85ms]
+(pass) OMO Senpi scoped skill sync > #given codex-derived and native skill roots #when scanned #then no Codex or multi-agent harness guidance survives [1.25ms]
+(pass) OMO Senpi scoped skill sync > #given native senpi skills #when synced output is compared #then they ship verbatim modulo blank-line normalization [0.49ms]
+(pass) OMO Senpi scoped skill sync > #given start-work skill #when inspected #then session ids reference senpi, not codex [0.09ms]
+(pass) OMO Senpi scoped skill sync > #given start-work skill #when inspected #then the senpi banner advertises senpi watcher tools, not a codex wait idiom [0.11ms]
+(pass) OMO Senpi scoped skill sync > #given synced skill tree #when inspected #then no codex-only display metadata is packaged [2.19ms]
+(pass) OMO Senpi scoped skill sync > #given ported orchestration skills #when scanned #then no foreign-harness delegation guidance survives [0.43ms]
+(pass) OMO Senpi scoped skill sync > #given frontend skill #when inspected #then materialized design references exist [0.06ms]
+
+packages/omo-senpi/plugin/scripts/native-skill-sources.test.mjs:
+(pass) createNativeSkillSources > #given the registry #when ordered names are extracted #then they match the expected alphabetical sequence including onboarding [0.56ms]
+(pass) createNativeSkillSources > #given the registry #when the name set is built #then it contains exactly the same entries as the ordered list [0.11ms]
+(pass) createNativeSkillSources > #given each source entry #when the path is resolved #then it points to an existing directory under the native skills root [0.17ms]
+(pass) createNativeSkillSources > #given onboarding skill #when checked #then it is present in the registry at the correct position [0.09ms]
+
+packages/omo-senpi/src/components/task/mass-ulw-protocol-doc.test.ts:
+(pass) mass-ulw protocol doc > #given every backticked omo.dag.* name in the doc > #when checked against the shipped bridge and handler sources > #then each name exists as a string literal in the source [0.10ms]
+(pass) mass-ulw protocol doc > #given every backticked omo.dag.* name in the doc > #when checked against the shipped bridge and handler sources > #then the doc covers all four channels and all four request methods [0.07ms]
+(pass) mass-ulw protocol doc > #given every backticked dag.* journaled event type in the doc > #when compared with DAG_RUN_EVENT_TYPES > #then each doc type is a shipped type and every shipped type is documented [0.09ms]
+(pass) mass-ulw protocol doc > #given the documented overflow payload fields > #when compared with the shipped event union > #then the field names match exactly [0.13ms]
+(pass) mass-ulw protocol doc > #given the documented error codes > #when compared with DAG_RPC_ERROR_CODES > #then every shipped code appears in the doc [0.07ms]
+
+ 19 pass
+ 0 fail
+ 240 expect() calls
+Ran 19 tests across 3 files. [121.00ms]

--- a/packages/omo-senpi/skills/mass-ulw/references/planning.md
+++ b/packages/omo-senpi/skills/mass-ulw/references/planning.md
@@ -1,6 +1,6 @@
 ---
 name: mass-ulw
-description: Mandatory planning reference for the mass-ulw skill - read in full BEFORE defining any graph. Covers decomposition doctrine, category routing, concurrency and write-scope rules, the node prompt contract, the verification wave, and the failure playbook.
+description: Mandatory planning reference for the mass-ulw skill - read in full BEFORE defining any graph. Covers decomposition doctrine, category routing, the capacity model and write-scope rules, dag-or-team selection, the node prompt contract, the verification wave, and the failure playbook.
 metadata:
   short-description: How to plan a dag - decomposition, categories, node prompts, verification
 ---
@@ -8,6 +8,8 @@ metadata:
 # mass-ulw planning reference
 
 Read this file IN FULL before you define any graph. A graph defined without it is unplanned work: real runs without this doctrine collapse to three `deep` nodes with no verification. Every section below exists because its absence was observed failing.
+
+Reading this file is not planning. Before `start`, write the run plan in one breath and then execute THAT plan: the topology (waves, plus the chain points where you synthesize between runs), wave sizes against the capacity model below, a one-line reason for every non-`quick` category, and the verification wave. When reality forces a change, replan out loud instead of drifting node by node.
 
 ## Decomposition doctrine
 
@@ -57,6 +59,7 @@ A graph whose every node is `deep` is a routing failure: it pays the most expens
 - **Disjoint write scopes or serialize.** No two nodes that can run in parallel may edit the same file. If two lanes must touch the same files, chain them with `dependsOn` or merge them into one node. Declare each node's read/write scope inside its prompt.
 - **Never add a dependency to pass data.** If node B needs a fact node A produces, that is a real dependency - but if B only needs a fact YOU already know, paste the fact into B's prompt and leave the edge out.
 - **Dependency matrix self-check before `start`:** every `dependsOn` id exists in the graph; no cycles; no node depends on something it does not actually consume; every wave has at least one runnable node.
+- **Capacity model.** Nodes run as background tasks under a per-model slot limiter - default 5 concurrent, overridable via `task.default_concurrency` / provider / model concurrency in omo config (0 = unbounded). Nodes past the limit queue FIFO and roll in as slots free, so a wave wider than the slots still completes, serialized in chunks. Hard caps: 64 nodes per run, 16 runs per session. The wave-sizing target above is this slot budget, not a taste number.
 
 ## Eval orchestration patterns
 
@@ -89,6 +92,8 @@ if (findings.includes("critical")) {
 
 **Concurrent runs.** Distinct keys run concurrently (default cap: `task.dag.max_runs_per_session` = 16). When two graphs are independent, start both and `Promise.all([sdk.wait(a), sdk.wait(b)])`.
 
+**Trigger-launched runs.** A run does not have to start from a user turn: a monitor hit, a goal-loop wake, or a task-completion notification can be the trigger, and the cell that fires on the wake builds and starts the next graph. Conditional pipelines live in your code, never in the definition - the graph itself has no branch construct.
+
 **Adaptive retries.** Read `result.nodes[id].error`, then start a NARROWER graph under a NEW key (`${key}-retry-1`) - re-issuing a changed definition under the old key is a definition conflict, and re-issuing the SAME definition under the old key reuses finished nodes instead of retrying.
 
 **Progressive snapshots.** Between waits, `snapshot(run_id)` reports per-node states; use it to prepare downstream work while lanes finish. Never spin an empty poll loop - `wait()` is the default.
@@ -97,6 +102,14 @@ Two caveats:
 
 - Node outputs are stored and returned IN FULL, with no truncation - when embedding an output into a later prompt, quote or summarize the relevant part. Pasting an unbounded output into a prompt drowns it.
 - `wait()` blocks the cell until the run settles. Do independent cell work BEFORE awaiting, or run the cell detached.
+
+## Dag or team
+
+The dag is not the only fan-out surface, and picking the wrong one strands the run. Decide before you plan:
+
+- **Chained dags** (the multi-run composition above) when the work is stage-shaped: every stage is a static graph and you synthesize between stages. Journaled resume, idempotent keys, and the `/dag` view come free.
+- **A `team_create` team** when workers must talk DURING the work: broadcasting leads the moment they surface, multi-round debate, or members accumulating investigation context across re-tasking. A dag node is a one-shot prompt; it cannot take a new lead mid-run.
+- **ulw-research requests go to the team path.** Cross-critique and expand loops are team mechanics; use a dag for the independent harvest stages only.
 
 ## Node prompt contract
 
@@ -129,4 +142,6 @@ Rules that make node prompts obeyed:
 
 - **A failed node blocks only its dependents.** Read the node's error first; the fix is usually a NARROWER respawn, not a rerun of the graph.
 - **Respawn small.** Re-`start` with the same `key` and definition reuses finished nodes' outputs - completed work is never redone. Change only what the failure taught you; never re-issue a changed definition under an old key to sneak past a conflict.
+- **A quiet widget is not a stall.** Nodes past the slot limit sit in `scheduled` with their task queued, so `0 running` mid-wave means waiting for slots, not death. A node whose task already completed can also take a moment to show its transition; the run folds it on the next event. Check node task states before concluding anything.
+- **Provider storms amplify under fan-out.** If many wave-1 nodes fail AT START within seconds, never even attaching a task, the provider or model route is erroring - your prompts are fine. Stop launching, fix the route, then re-`start` with the same key and definition: finished nodes are reused.
 - **Cancel is for abandoning the goal**, not for impatience. A running node is alive; elapsed time alone never justifies cancelling. When you do cancel, pass a reason so the run record says why.


### PR DESCRIPTION
## What changed

`skills/mass-ulw/references/planning.md` gains the orchestration usage patterns verified against live runs this session, each placed inside its owning section (no bolt-on):

- **Plan contract** (intro): reading the reference is not planning — before `start`, write the run plan (topology with the chain points where you synthesize between runs, wave sizes against the capacity model, one-line reasons for non-`quick` categories, the verification wave) and execute THAT plan; replan out loud instead of drifting node by node.
- **Capacity model** (Concurrency and write-scope rules): per-model slot limiter (default 5 concurrent; `task.default_concurrency` / provider / model overrides, 0 = unbounded), FIFO queue with rolling refill, hard caps 64 nodes/run and 16 runs/session — ties the 5-8 wave-sizing target to the actual slot budget.
- **Trigger-launched runs** (Eval orchestration patterns): a monitor hit, goal-loop wake, or task-completion notification can launch the next graph; conditional pipelines live in the driving code, never in the definition.
- **Dag or team** (new short section): chained dags for stage-shaped work with lead synthesis between runs; `team_create` when workers must talk mid-work (lead broadcasts, debate rounds, accumulated member context); ulw-research requests go to the team path.
- **Failure playbook**: a quiet widget is not a stall (over-limit nodes sit in `scheduled` with queued tasks; completed tasks fold in on the next event); provider storms amplify under fan-out (wave-1 start failures within seconds mean the route is erroring, not the prompts).

Frontmatter description updated to name the new coverage. `SKILL.md` is untouched — the mandatory-read gate already forces every graph author through `planning.md`.

Every added line is a fact verified this session against source or a live run journal: the 5-slot limiter and rolling refill (run `dag_f7d0063c`), the 64-node/16-run caps (`senpi-task/src/dag/types.ts`), the queued-not-stuck widget semantics and transition-lag self-heal (HWP session events), and a 51-node batch whose leaves all failed at start inside 2s during a provider error storm.

## Verification

- `node packages/omo-senpi/plugin/scripts/sync-skills.mjs` — regenerated tree ships the edited planning.md.
- `bun test` skills-sync + mass-ulw-protocol-doc + native-skill-sources: **19 pass / 0 fail / 240 expect() calls**.
- rg: all six new markers present in source and shipped copies.
- Evidence: `.omo/evidence/20260818-mass-ulw-usage-patterns/`.

## Notes

- Prose-only change; the three suites above are the only machine consumers of skill content.
- Zero file overlap with in-flight `feat/dag-definition-library` (that branch adds a new `dag-library` skill + runtime; this touches only the mass-ulw reference), so either merge order is clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live-verified capacity model and “dag or team” guidance to the mass‑ulw planning reference so graph authors size waves to real slot limits, launch follow‑on runs from triggers, and pick the correct fan‑out surface. This aligns planning with runtime behavior and reduces false stall diagnoses.

- Documents per‑model slot limiter (default 5; `task.default_concurrency`/provider/model overrides; FIFO queue), and hard caps (64 nodes/run, 16 runs/session); ties wave sizing to this budget.
- Adds trigger‑launched runs guidance (monitors, goal‑loop wakes, task notifications) and clarifies that conditional pipelines live in code, not graph definitions.
- Introduces “Dag or team” selection: chained dags for stage‑shaped work with between‑run synthesis; `team_create` when mid‑work discussion or debate is required; route ulw‑research to the team path.
- Expands failure playbook: queued widgets are not stalls; transition lag self‑heals; provider start‑error storms under fan‑out point to the route, not prompts; prefer narrow respawn or re‑start with the same key to reuse finished nodes.
- Updates `packages/omo-senpi/skills/mass-ulw/references/planning.md` frontmatter description; ships QA evidence under `.omo/evidence/20260818-mass-ulw-usage-patterns/`. No runtime changes; 19 tests pass to confirm shipped docs and invariants.

<sup>Written for commit bcdf146cb802bb4e4237f7a792760510b151ec45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

