### PR TITLE
fix(omo-opencode): rebuild Sisyphus prompt on same-family model switch (#6966)

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,23 @@
+## 2026-08-18 — Rebuild the Sisyphus runtime prompt on same-family model switches
+
+The Sisyphus runtime prompt reconciler skipped every rebuild whose runtime
+model shared the configured model's broad prompt family. The `fallback`
+family is not prompt-uniform: `buildFallbackSisyphusPrompt` applies
+Gemini-specific override blocks, and other families bake model-dependent
+sections (GPT identity text, claude/non-claude planner sections). Switching
+between same-family models in the TUI (e.g. Gemini -> MiniMax-M3 or
+DeepSeek -> MiniMax-M3) therefore kept the previous model's baked prompt in
+place, and the active model reported a stale identity (issue #6966).
+
+The reconciler now skips only when the runtime model is exactly the model the
+baked prompt was built for, and the existing rebuilt-versus-baked equality
+check suppresses genuine no-op switches (DeepSeek and MiniMax bake
+byte-identical fallback bodies, verified against the real prompt builder).
+The system-transform handler canonicalizes the opencode hook model record to
+`<providerID>/<id>` so bare builtin-provider ids compare exactly. Rebuild work
+per request is unchanged for cross-family switches; same-family switches now
+rebuild like cross-family ones already did.
+
 ## 2026-08-17 — Track Senpi 2026.8.17 for the omo-ai beta line
 
 All active native Senpi pins now use `2026.8.17` across the root workspace,

--- a/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.ts
@@ -108,8 +108,8 @@ export function maybeCreateSisyphusConfig(input: {
   })
 
   // The body above is baked from the *configured* model. If the user switches to
-  // a different model family in the TUI, the system-transform hook rebuilds the
-  // prompt for the runtime model using this captured pipeline (issue #5297/#5316).
+  // a different model in the TUI, the system-transform hook rebuilds the
+  // prompt for the runtime model using this captured pipeline (issue #5297/#5316/#6966).
   setSisyphusRuntimePromptContext({
     configuredModel: sisyphusModel,
     bakedPrompt: sisyphusConfig.prompt ?? "",

--- a/packages/omo-opencode/src/agents/sisyphus-agent-factory.test.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-agent-factory.test.ts
@@ -165,6 +165,38 @@ describe("createSisyphusAgent", () => {
     });
   });
 
+  describe("#given fallback-family Sisyphus models", () => {
+    test("#when baking prompts for Gemini vs MiniMax #then the fallback family is not prompt-uniform", () => {
+      // given - both models resolve to the broad fallback family
+      const geminiModel = "google/gemini-3.1-pro";
+      const minimaxModel = "minimax-coding-plan/MiniMax-M3";
+      expect(resolveSisyphusPromptFamily(geminiModel)).toBe("fallback");
+      expect(resolveSisyphusPromptFamily(minimaxModel)).toBe("fallback");
+
+      // when
+      const geminiPrompt = createSisyphusAgent(geminiModel).prompt;
+      const minimaxPrompt = createSisyphusAgent(minimaxModel).prompt;
+
+      // then - Gemini fallback overrides are baked in; MiniMax bakes the plain body
+      expect(geminiPrompt).toContain("TOOL_CALL_MANDATE");
+      expect(minimaxPrompt).not.toContain("TOOL_CALL_MANDATE");
+      expect(geminiPrompt).not.toBe(minimaxPrompt);
+    });
+
+    test("#when baking prompts for DeepSeek vs MiniMax #then the plain fallback bodies are identical", () => {
+      // given - neither model triggers fallback overrides
+      const deepseekModel = "deepseek/deepseek-v4-pro";
+      const minimaxModel = "minimax-coding-plan/MiniMax-M3";
+
+      // when
+      const deepseekPrompt = createSisyphusAgent(deepseekModel).prompt;
+      const minimaxPrompt = createSisyphusAgent(minimaxModel).prompt;
+
+      // then - genuine no-op swaps are detectable by prompt equality (#6966)
+      expect(deepseekPrompt).toBe(minimaxPrompt);
+    });
+  });
+
   describe("#given a Gemini model", () => {
     test("#when creating the agent #then uses the Gemini-corrected prompt with thinking enabled", () => {
       // given

--- a/packages/omo-opencode/src/agents/sisyphus-runtime-prompt-reconciler.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-runtime-prompt-reconciler.ts
@@ -1,9 +1,11 @@
-import { resolveSisyphusPromptFamily } from "./sisyphus-agent-factory";
-
 /**
  * Context captured at Sisyphus registration so the per-request system-transform
  * hook can rebuild the prompt for the model actually selected at runtime.
  *
+ * - `configuredModel` is the exact model `bakedPrompt` was built for. It is the
+ *   "last built model": the prompt is baked only at registration, and opencode
+ *   re-assembles the system array from the agent config on every request, so
+ *   nothing else can become the currently baked prompt mid-session.
  * - `bakedPrompt` is the exact prompt string registered (body + overrides + env),
  *   used to locate the entry to replace in the runtime system array.
  * - `rebuildPromptForModel` re-runs the same registration pipeline with a
@@ -27,15 +29,22 @@ export function clearSisyphusRuntimePromptContext(): void {
 
 /**
  * The Sisyphus prompt body is baked at registration from the *configured* model
- * in `.omo/omo.jsonc`. When the user switches to a different model family
- * in the TUI, the entire baked body is the wrong family for the runtime model
+ * in `.omo/omo.jsonc`. When the user switches to a different model in
+ * the TUI, the baked body may be wrong for the runtime model
  * (issue #5297/#5316): a GPT-configured agent run on a non-GPT model still
  * carries the whole GPT-5.5 body, not just one apply_patch line.
  *
  * The system-transform hook is the only per-request seam that knows the runtime
- * model, so rebuild the whole prompt for the runtime family and swap it in here
- * rather than patching individual family-specific lines (which can never convert
+ * model, so rebuild the whole prompt for the runtime model and swap it in here
+ * rather than patching individual model-specific lines (which can never convert
  * a GPT body into a non-GPT one).
+ *
+ * The skip must key on the exact model, not the broad prompt family: the
+ * `fallback` family is not prompt-uniform (Gemini fallback overrides, GPT
+ * identity text, claude/non-claude sections), so a same-family switch such as
+ * Gemini -> MiniMax-M3 or DeepSeek -> MiniMax-M3 can still leave the previous
+ * model's body in place (issue #6966). Genuine no-op switches (models whose
+ * rebuilt prompt is byte-identical to the baked one) are suppressed below.
  *
  * Returns true if a swap was performed.
  */
@@ -45,11 +54,8 @@ export function reconcileSisyphusRuntimePrompt(
 ): boolean {
   if (!runtimeModel || !context) return false
 
-  // Same family => the baked body already matches the runtime model; leave it.
-  if (
-    resolveSisyphusPromptFamily(runtimeModel) ===
-    resolveSisyphusPromptFamily(context.configuredModel)
-  ) {
+  // Same exact model => the baked body already matches the runtime model; leave it.
+  if (runtimeModel === context.configuredModel) {
     return false
   }
 

--- a/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-reconciler.test.ts
+++ b/packages/omo-opencode/src/plugin/sisyphus-runtime-prompt-reconciler.test.ts
@@ -11,6 +11,9 @@ import {
 
 const GPT_MODEL = "openai/gpt-5.5"
 const NON_GPT_MODEL = "opencode-go/qwen3.7-plus"
+const GEMINI_FALLBACK_MODEL = "google/gemini-3.1-pro"
+const DEEPSEEK_FALLBACK_MODEL = "deepseek/deepseek-v4-pro"
+const MINIMAX_FALLBACK_MODEL = "minimax-coding-plan/MiniMax-M3"
 
 // Mirror what maybeCreateSisyphusConfig captures at registration: the baked GPT
 // prompt plus a rebuild closure that re-runs the factory for a different model.
@@ -20,6 +23,19 @@ function registerGptSisyphus(): string {
     configuredModel: GPT_MODEL,
     bakedPrompt: baked,
     rebuildPromptForModel: (model) => createSisyphusAgent(model, [], [], [], []).prompt ?? "",
+  })
+  return baked
+}
+
+// Same registration mirror for a fallback-family model (issue #6966): the
+// fallback family is not prompt-uniform, so the baked body is model-dependent.
+function registerFallbackSisyphus(model: string): string {
+  const baked = createSisyphusAgent(model, [], [], [], []).prompt ?? ""
+  setSisyphusRuntimePromptContext({
+    configuredModel: model,
+    bakedPrompt: baked,
+    rebuildPromptForModel: (runtimeModel) =>
+      createSisyphusAgent(runtimeModel, [], [], [], []).prompt ?? "",
   })
   return baked
 }
@@ -93,5 +109,67 @@ describe("Sisyphus runtime prompt family reconciliation (#5297/#5316)", () => {
 
     expect(output.system[0]).not.toContain("based on GPT-5.5")
     expect(output.system[0]).not.toContain(GPT_APPLY_PATCH_GUIDANCE)
+  })
+})
+
+describe("Sisyphus runtime prompt same-family reconciliation (#6966)", () => {
+  test("#given a Gemini fallback body #when run on a MiniMax fallback model #then the Gemini override body is rebuilt", () => {
+    const baked = registerFallbackSisyphus(GEMINI_FALLBACK_MODEL)
+    // sanity: both models share the broad fallback family, yet the real prompt
+    // builder bakes Gemini-only overrides into the configured body
+    expect(baked).toContain("TOOL_CALL_MANDATE")
+    expect(createSisyphusAgent(MINIMAX_FALLBACK_MODEL, [], [], [], []).prompt).not.toBe(baked)
+
+    const system = [baked]
+    const swapped = reconcileSisyphusRuntimePrompt(system, MINIMAX_FALLBACK_MODEL)
+
+    expect(swapped).toBe(true)
+    expect(system[0]).not.toContain("TOOL_CALL_MANDATE")
+    expect(system[0]).toBe(createSisyphusAgent(MINIMAX_FALLBACK_MODEL, [], [], [], []).prompt)
+  })
+
+  test("#given a DeepSeek fallback body #when run on a MiniMax fallback model #then the identical rebuild is suppressed", () => {
+    const baked = registerFallbackSisyphus(DEEPSEEK_FALLBACK_MODEL)
+    // sanity: plain fallback bodies for DeepSeek and MiniMax bake byte-identical
+    expect(createSisyphusAgent(MINIMAX_FALLBACK_MODEL, [], [], [], []).prompt).toBe(baked)
+
+    const system = [baked]
+    const swapped = reconcileSisyphusRuntimePrompt(system, MINIMAX_FALLBACK_MODEL)
+
+    expect(swapped).toBe(false)
+    expect(system[0]).toBe(baked)
+  })
+
+  test("#given a Gemini fallback body #when run on the same exact model #then the body is left untouched", () => {
+    const baked = registerFallbackSisyphus(GEMINI_FALLBACK_MODEL)
+    const system = [baked]
+    expect(reconcileSisyphusRuntimePrompt(system, GEMINI_FALLBACK_MODEL)).toBe(false)
+    expect(system[0]).toBe(baked)
+  })
+
+  test("#given the full system-transform handler #when the runtime model is a bare-id MiniMax #then the Gemini body is reconciled end-to-end", async () => {
+    const baked = registerFallbackSisyphus(GEMINI_FALLBACK_MODEL)
+    const handler = createSystemTransformHandler()
+    const output = { system: [baked] }
+
+    await handler(
+      { sessionID: "s", model: { id: "MiniMax-M3", providerID: "minimax-coding-plan" } },
+      output,
+    )
+
+    expect(output.system[0]).not.toContain("TOOL_CALL_MANDATE")
+  })
+
+  test("#given the full system-transform handler #when the bare-id runtime model is the configured model #then the body is left untouched", async () => {
+    const baked = registerFallbackSisyphus(GEMINI_FALLBACK_MODEL)
+    const handler = createSystemTransformHandler()
+    const output = { system: [baked] }
+
+    await handler(
+      { sessionID: "s", model: { id: "gemini-3.1-pro", providerID: "google" } },
+      output,
+    )
+
+    expect(output.system[0]).toBe(baked)
   })
 })

--- a/packages/omo-opencode/src/plugin/system-transform.ts
+++ b/packages/omo-opencode/src/plugin/system-transform.ts
@@ -3,6 +3,20 @@ import { reconcileSisyphusRuntimePrompt } from "../agents/sisyphus-runtime-promp
 
 const ULTRAWORK_MODE_TAG = "<ultrawork-mode>"
 
+/**
+ * Collapse the opencode hook model record into the canonical
+ * `"<providerID>/<id>"` string used throughout OMO (model ids arrive bare for
+ * builtin providers). Ids that already carry a provider prefix pass through
+ * unchanged so both hook payload shapes stay comparable.
+ */
+function toCanonicalModel(
+  model: { id: string; providerID: string } | undefined,
+): string | undefined {
+  if (!model?.id) return undefined
+  if (model.id.includes("/") || !model.providerID) return model.id
+  return `${model.providerID}/${model.id}`
+}
+
 export function createSystemTransformHandler(
   defaultMode?: DefaultModeConfig,
   getUltraworkMessage?: (agentName?: string, modelID?: string) => string,
@@ -11,11 +25,11 @@ export function createSystemTransformHandler(
   output: { system: string[] },
 ) => Promise<void> {
   return async (input, output): Promise<void> => {
-    // The Sisyphus prompt body is model-family-specific and baked at registration
+    // The Sisyphus prompt body is model-specific and baked at registration
     // from the *configured* model in .omo/omo.jsonc. This per-request hook
     // is the only seam that knows the model actually selected at runtime, so
-    // rebuild the whole body for the runtime model family here (issue #5297).
-    reconcileSisyphusRuntimePrompt(output.system, input.model?.id)
+    // rebuild the whole body for the runtime model here (issue #5297/#6966).
+    reconcileSisyphusRuntimePrompt(output.system, toCanonicalModel(input.model))
 
     if (!defaultMode?.ultrawork || !getUltraworkMessage) return
 


### PR DESCRIPTION
## Summary

- Switching the TUI model between two models that share the broad `fallback` prompt family (e.g. Gemini -> MiniMax-M3, or DeepSeek -> MiniMax-M3) kept the previously baked Sisyphus prompt body in place, so the active model kept reporting the previous model's identity.
- The reconciler's skip was keyed on prompt-family equality, but the `fallback` family is not prompt-uniform: `buildFallbackSisyphusPrompt` applies Gemini-specific override blocks (`applyGeminiFallbackOverrides`, `sisyphus-dynamic-prompt.ts`), and other families bake model-dependent sections (GPT identity text via `getGptPromptIdentity`, claude/non-claude planner/delegation sections).
- The skip is now keyed on the exact runtime model that produced the baked prompt; genuine no-op switches (models whose rebuilt prompt is byte-identical) are suppressed by the existing `rebuilt === bakedPrompt` guard.

## Changes

- `packages/omo-opencode/src/agents/sisyphus-runtime-prompt-reconciler.ts` — replace the `resolveSisyphusPromptFamily` equality early-return with `runtimeModel === context.configuredModel` (the exact model the baked prompt was built for); drop the now-unused family import; document why family equality is insufficient (#6966). `configuredModel` is the "last built model": the prompt is baked only at registration, and opencode core re-assembles the system array from the agent config on every request (`sst/opencode` `packages/opencode/src/session/llm/request.ts:58-73` builds `system` fresh per model request from `input.agent.prompt` before triggering `experimental.chat.system.transform`), so a mutable tracker updated after a swap would skip required re-swaps on the next request and reintroduce staleness.
- `packages/omo-opencode/src/plugin/system-transform.ts` — canonicalize the opencode hook model record to `"<providerID>/<id>"` (mirrors `normalizeModelToCanonicalString`'s convention) before passing it to the reconciler, so bare builtin-provider ids compare exactly against the canonical configured model; prefixed ids pass through unchanged.
- `packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.ts` — comment-only truthfulness fix at the registration seam ("model family" -> "model").
- Tests: `sisyphus-runtime-prompt-reconciler.test.ts` gains a `#6966` describe (Gemini->MiniMax swap, DeepSeek->MiniMax suppressed no-op, same-exact-model skip, and two end-to-end handler cases incl. bare-id canonicalization); `sisyphus-agent-factory.test.ts` pins that the real prompt builder bakes different fallback bodies for Gemini vs MiniMax and byte-identical bodies for DeepSeek vs MiniMax.
- `changes.md` — dated entry at the top in the existing style.

## QA & Evidence

- **What was tested:** `cd packages/omo-opencode && bun test src/plugin/sisyphus-runtime-prompt-reconciler.test.ts src/agents/sisyphus-agent-factory.test.ts`
  **Observed result (RED, before the fix):** 20 pass / 2 fail — the two #6966 drivers failed exactly as expected:
  - `#given a Gemini fallback body #when run on a MiniMax fallback model #then the Gemini override body is rebuilt` — `error: expect(received).toBe(expected)` at `sisyphus-runtime-prompt-reconciler.test.ts:126` (`Expected: true / Received: false` — the family early-return suppressed the swap).
  - `#given the full system-transform handler #when the runtime model is a bare-id MiniMax #then the Gemini body is reconciled end-to-end` — `error: expect(received).not.toContain(expected)` (`Expected to not contain: "TOOL_CALL_MANDATE"` — the stale Gemini override block survived the switch).
  **Observed result (GREEN, after the fix):** 22 pass / 0 fail.
  **Artifact:** terminal transcripts captured in the task report; commands re-runnable as written.
  **Why sufficient:** the failing assertions exercise the exact reported scenario (same-family switch leaves model-dependent prompt text stale) against the real `createSisyphusAgent` builder, and the DeepSeek->MiniMax case pins that genuinely identical bodies are still suppressed (no behavior change where none is needed).
- **What was tested:** neighboring suites for both touched directories: `bun test src/plugin/` -> 331 pass / 0 fail (49 files); `bun test src/agents/` -> 308 pass / 0 fail (29 files).
- **What was tested:** `bun run typecheck` in `packages/omo-opencode` (`tsgo --noEmit -p tsconfig.json`) -> exit 0.
- **Builder verification (pre-implementation probe):** `createSisyphusAgent("google/gemini-3.1-pro")` prompt is 32945 chars and contains `TOOL_CALL_MANDATE`/`GEMINI_TOOL_GUIDE`; `createSisyphusAgent("minimax-coding-plan/MiniMax-M3")` is 22680 chars without them; `createSisyphusAgent("deepseek/deepseek-v4-pro")` is byte-identical to the MiniMax body. Both facts are now pinned as tests.

## Risks & Residuals

- Same-family model switches now rebuild the prompt per request exactly like cross-family switches already did — one extra prompt assembly (~30KB string stitching) per request whose runtime model differs from the configured one; negligible next to the LLM call. **Accepted.**
- Canonicalization is format-tolerant (bare id + providerID, or already-prefixed id); if a future opencode version changes the hook payload shape, the `includes("/")` passthrough keeps both shapes comparable. **Not applicable** beyond existing hook-input tolerance already present in the handler.
- Deliberately NOT changed: `resolveSisyphusPromptFamily` and the factory routing (still the source of truth for which body to bake); `SisyphusRuntimePromptContext` shape (no new mutable field — per-request re-assembly in opencode core makes mid-session trackers incorrect, documented in the type comment); the substring-replace swap mechanics; ultrawork injection in the same handler.

## Automated Checks

```bash
cd packages/omo-opencode
bun test src/plugin/sisyphus-runtime-prompt-reconciler.test.ts src/agents/sisyphus-agent-factory.test.ts  # 22 pass, 0 fail
bun test src/plugin/                                                                                      # 331 pass, 0 fail
bun test src/agents/                                                                                      # 308 pass, 0 fail
bun run typecheck                                                                                         # exit 0
```

Fixes #6966


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the Sisyphus runtime prompt when switching between models in the same family. Previously we skipped rebuilds on prompt-family equality, which left model-specific content (e.g., Gemini fallback overrides) stale; now we skip only when the runtime model equals the configured model, and still suppress true no-ops via byte-equality.

- `packages/omo-opencode/src/agents/sisyphus-runtime-prompt-reconciler.ts`: replace family-based early return with `runtimeModel === context.configuredModel`; remove the family import; document why family equality is insufficient.
- `packages/omo-opencode/src/plugin/system-transform.ts`: canonicalize hook model records to `"<providerID>/<id>"` before reconciliation so bare IDs compare correctly.
- Tests: add cases for Gemini→MiniMax rebuild, DeepSeek→MiniMax no-op, exact-model skip, and end-to-end handler with bare-id inputs; all suites pass.
- Impact: same-family switches may trigger one prompt rebuild (~30KB) per request; negligible compared to the LLM call.

<sup>Written for commit a01c16c5b8f2025a62dbe82fd780f6f0b1f8a81e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/6998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

