### PR TITLE
test(lsp-daemon): budget per-test timeouts above subprocess guards

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -155,3 +155,22 @@ The release also includes `d694add58dd1` (`fix(omo-native): emit doctor report
 atomically`). Doctor output now becomes visible only after a complete report is
 ready, so consumers must not reintroduce partially written report files or
 split the atomic write path during future release refactors.
+
+## 2026-08-18 — Make the lsp-daemon test budget dominate its subprocess budgets
+
+`packages/lsp-daemon/vitest.config.ts` declared no `testTimeout`, so vitest's
+5s default applied while `test/qa-driver-portability.test.ts` granted its `bun`
+cancellation smoke 10s (an `execFileSync` timeout and a `setTimeout` guard
+around its `spawn`). The harness therefore killed the test before the inner
+guard could ever fire, so a slow-but-correct subprocess reported `Test timed out
+in 5000ms` instead of an assertion result. Windows CI runners routinely spend
+more than 5s spawning `bun`, which is why "Run vendored lsp-daemon tests" failed
+on `windows-latest` with no product defect behind it.
+
+The package now sets `testTimeout`/`hookTimeout` to 30s, exported from the
+config as `TEST_TIMEOUT_MS` alongside the documented `MAX_IN_TEST_BUDGET_MS`
+ceiling of 10s. The invariant is that the harness budget strictly exceeds every
+budget a test grants a subprocess or timed promise; `test/test-timeout-budget.test.ts`
+reads both the configured value and the real budgets out of the test sources and
+fails if that ordering is ever reintroduced. Keep the bound proportionate: it
+exists to survive a cold Windows process spawn, not to hide a genuine hang.

--- a/packages/lsp-daemon/test/daemon-roundtrip.test.ts
+++ b/packages/lsp-daemon/test/daemon-roundtrip.test.ts
@@ -10,7 +10,6 @@ import { daemonTestPaths } from "./daemon-path-fixture.js";
 
 const tempDirectories: string[] = [];
 const servers: DaemonServerHandle[] = [];
-const WINDOWS_INTEGRATION_TEST_TIMEOUT = process.platform === "win32" ? 20_000 : 5_000;
 
 afterEach(async () => {
 	for (const server of servers.splice(0)) await server.close();
@@ -47,7 +46,7 @@ describe("daemon roundtrip", () => {
 
 		expect(result.content[0]?.type).toBe("text");
 		expect(result.content[0]?.text).toContain("Configured LSP servers");
-	}, WINDOWS_INTEGRATION_TEST_TIMEOUT);
+	});
 
 	it("#given a running daemon #when two calls race #then both receive responses", async () => {
 		const paths = tempPaths();

--- a/packages/lsp-daemon/test/test-timeout-budget.test.ts
+++ b/packages/lsp-daemon/test/test-timeout-budget.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { MAX_IN_TEST_BUDGET_MS, TEST_TIMEOUT_MS } from "../vitest.config.js";
+
+const testDirectory = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * Numeric literals a test hands to a subprocess or a timed promise guard:
+ * `timeout: 10_000` option bags, and `setTimeout(..., 10_000)` deadlines.
+ * Underscore digit separators are preserved so `10_000` is read as 10000.
+ */
+const budgetPatterns = [/\btimeout:\s*([\d_]+)\b/g, /\bsetTimeout\([\s\S]*?,\s*([\d_]+)\s*\)/g] as const;
+
+interface Budget {
+	readonly file: string;
+	readonly milliseconds: number;
+}
+
+function declaredBudgets(): readonly Budget[] {
+	const budgets: Budget[] = [];
+	for (const file of readdirSync(testDirectory).filter((name) => name.endsWith(".test.ts"))) {
+		// This guard's own patterns would otherwise match themselves.
+		if (file === "test-timeout-budget.test.ts") continue;
+		const source = readFileSync(join(testDirectory, file), "utf8");
+		for (const pattern of budgetPatterns) {
+			for (const match of source.matchAll(pattern)) {
+				const raw = match[1];
+				if (raw === undefined) continue;
+				const milliseconds = Number.parseInt(raw.replaceAll("_", ""), 10);
+				// Sub-second values are intra-test sequencing waits, not process budgets.
+				if (Number.isNaN(milliseconds) || milliseconds < 1_000) continue;
+				budgets.push({ file, milliseconds });
+			}
+		}
+	}
+	return budgets;
+}
+
+describe("per-test timeout budget", () => {
+	it("#given the vitest config #when tests grant a subprocess budget #then the harness budget strictly exceeds every one of them", () => {
+		const budgets = declaredBudgets();
+
+		// Guards against the patterns silently matching nothing after a refactor.
+		expect(budgets.length).toBeGreaterThan(0);
+
+		const offenders = budgets.filter((budget) => budget.milliseconds >= TEST_TIMEOUT_MS);
+		expect(offenders).toEqual([]);
+	});
+
+	it("#given the documented ceiling #when compared to the real budgets #then it matches the largest one the suite grants", () => {
+		const largest = Math.max(...declaredBudgets().map((budget) => budget.milliseconds));
+
+		expect(largest).toBe(MAX_IN_TEST_BUDGET_MS);
+		expect(TEST_TIMEOUT_MS).toBeGreaterThan(MAX_IN_TEST_BUDGET_MS);
+	});
+});

--- a/packages/lsp-daemon/vitest.config.ts
+++ b/packages/lsp-daemon/vitest.config.ts
@@ -1,9 +1,36 @@
 import { defineConfig } from "vitest/config";
 
+/**
+ * Largest budget any test in this package grants a subprocess or a timed
+ * promise guard. Currently `test/qa-driver-portability.test.ts`, which gives the
+ * `bun` cancellation smoke 10s both as an `execFileSync` timeout and as a
+ * `setTimeout` guard around its `spawn`.
+ */
+export const MAX_IN_TEST_BUDGET_MS = 10_000;
+
+/**
+ * Per-test budget for the whole package.
+ *
+ * This MUST strictly exceed `MAX_IN_TEST_BUDGET_MS`: a test that grants its own
+ * child process N ms cannot pass if the harness kills the test before that
+ * child's guard can fire, so the inner guard becomes unreachable and a
+ * slow-but-correct subprocess reports as `Test timed out` instead of the real
+ * assertion. Windows CI runners routinely spend >5s spawning `bun`, which is
+ * how the vitest 5s default turned correct tests red.
+ *
+ * 30s is deliberately only 3x the largest inner budget: enough headroom for a
+ * cold Windows process spawn on top of a 10s guard, still low enough that a
+ * genuine hang fails the job in seconds rather than sitting until the
+ * workflow-level timeout.
+ */
+export const TEST_TIMEOUT_MS = 30_000;
+
 export default defineConfig({
 	test: {
 		include: ["test/**/*.test.ts"],
 		environment: "node",
 		pool: "threads",
+		testTimeout: TEST_TIMEOUT_MS,
+		hookTimeout: TEST_TIMEOUT_MS,
 	},
 });


### PR DESCRIPTION
## Problem

The CI step **"Run vendored lsp-daemon tests"** (`.github/workflows/ci.yml:184-187`, `npm test` = `vitest --run` with `working-directory: packages/lsp-daemon`) fails on `windows-latest` with `Error: Test timed out in 5000ms.` — never with an assertion failure.

Motivating CI failures:

- [job 95667880824](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/95667880824) (PR #6997) — 3 tests failed: `test/auth-ownership.test.ts:94`, `test/proxy.test.ts:51`, `test/qa-driver-portability.test.ts:40`
- [job 95688876759](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/95688876759) (PR #7003) — only `test/qa-driver-portability.test.ts:40`

Context: flake tracker #6976 (broader; not closed by this PR).

## Root cause

`packages/lsp-daemon/vitest.config.ts` declared **no `testTimeout`**, so vitest's default **5000 ms** per-test budget applied.

But `packages/lsp-daemon/test/qa-driver-portability.test.ts` grants its own child process **10 000 ms**:

- `test/qa-driver-portability.test.ts:44` — `execFileSync("bun", [scripts/qa/cancellation-smoke.mjs, repoRoot], { timeout: 10_000 })`
- `test/qa-driver-portability.test.ts:66` — `spawn(...)` of the same smoke wrapped in a `setTimeout(..., 10_000)` guard

The budgets are inverted: the harness kills the test at 5 s while the test believes its subprocess has 10 s. **The inner 10 s guard is unreachable**, and any subprocess that legitimately takes >5 s can never pass — routine on `windows-latest`, where a cold `bun` spawn alone can exceed 5 s. This is a harness budget defect, not a product defect: baseline on macOS with the correct bootstrap is fully green (20 files / 153 tests).

## Mechanism and why

An explicit package-wide **`testTimeout` (+ `hookTimeout`) of 30 s** in `vitest.config.ts`, exported as `TEST_TIMEOUT_MS` alongside a documented `MAX_IN_TEST_BUDGET_MS = 10_000` ceiling.

Why config-wide rather than per-test arguments: I audited **all** of `packages/lsp-daemon/test/**` for `execFileSync` / `execFile` / `spawn` / `spawnSync` / `setTimeout` guards, and several subprocess sites grant their child an **unbounded** budget:

| Site | Budget granted to child / promise |
|---|---|
| `qa-driver-portability.test.ts:44` | `execFileSync` bun smoke, `timeout: 10_000` |
| `qa-driver-portability.test.ts:66` | `spawn` bun smoke + `setTimeout` guard `10_000` |
| `ensure-daemon.test.ts:150` | `spawnSync("bun", ["--eval", …])` — **unbounded** |
| `paths.test.ts:64,77,84` | `execFileSync(process.execPath, …)` — **unbounded** |
| `clean-dist.test.ts:28` | `execFileSync(process.execPath, …)` — **unbounded** |
| `proxy-lifecycle.test.ts:230`, `proxy-startup-watchdog.test.ts:142` | `bounded()` guard `1_000` |
| `daemon-client-retry.test.ts:70` | `waitForCount` guard `1_000` |

Per-test annotations would only patch the three tests CI happened to catch and leave every unbounded `spawnSync`/`execFileSync` site pinned at 5 s — exactly the sites that produced the `auth-ownership` and `proxy` failures in job 95667880824. One config value fixes the invariant for every test uniformly.

**Numbers:** largest in-test budget **10 000 ms** < per-test harness budget **30 000 ms**. 30 s is deliberately only 3x the largest inner guard — enough headroom for a cold Windows process spawn stacked on a 10 s guard, still low enough that a genuine hang fails in seconds instead of hanging to the workflow-level timeout. It is not an absurd global that hides hangs.

I also removed the now-redundant per-test override in `daemon-roundtrip.test.ts` (`process.platform === "win32" ? 20_000 : 5_000`). It was a narrower special case of this exact bug and, at 5 000 ms on non-Windows, would have *undercut* the new global on one test.

**Assertions and behavior under test are unchanged.** No test skipped, deleted, loosened, or `.only`'d; no subprocess call removed.

## RED evidence

I can't rent a Windows runner, so the same failure mode is reproduced deterministically by shrinking the harness budget below the local subprocess cost instead of slowing the machine. These subprocess tests take 113 ms and 124 ms locally, so `--testTimeout=50` recreates the inversion exactly.

```
$ npx vitest --run test/qa-driver-portability.test.ts --testTimeout=50

 ❯ test/qa-driver-portability.test.ts (3 tests | 2 failed) 193ms
     × #given the native platform #when the cancellation smoke runs #then it binds the production endpoint kind 124ms
     × #given a closed output reader #when the cancellation smoke reports its result #then it cannot exit successfully 52ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/qa-driver-portability.test.ts > LSP QA driver portability > #given the native platform #when the cancellation smoke runs #then it binds the production endpoint kind
Error: Test timed out in 50ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
 ❯ test/qa-driver-portability.test.ts:40:2
     38|  });
     39|
     40|  it("#given the native platform #when the cancellation smoke runs #the…
       |  ^
     41|   const output = execFileSync("bun", [join(repositoryRoot, cancellatio…
     42|    cwd: repositoryRoot,

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  test/qa-driver-portability.test.ts > LSP QA driver portability > #given a closed output reader #when the cancellation smoke reports its result #then it cannot exit successfully
Error: Test timed out in 50ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
 ❯ test/qa-driver-portability.test.ts:51:2

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

Same signature as CI: `Test timed out` at `qa-driver-portability.test.ts:40`, never an assertion failure. It proves the harness kills a *correct* subprocess.

## GREEN evidence

Targeted run — the same file that was RED, now taking its budget from the config:

```
$ npx vitest --run test/qa-driver-portability.test.ts

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  296ms
```

Full suite (`npm test`, i.e. the exact CI command, in `packages/lsp-daemon`):

```
$ npm test
> @code-yeongyu/lsp-daemon@0.1.0 test
> vitest --run

 Test Files  21 passed (21)
      Tests  155 passed (155)
   Duration  1.65s
```

Baseline was 20 files / 153 tests; this is 21 / 155 (+1 file, +2 regression-guard tests), zero skipped, zero failing.

## Regression guard + mutation proof

`packages/lsp-daemon/test/test-timeout-budget.test.ts` asserts the invariant. It **reads the configured value** (`TEST_TIMEOUT_MS` imported from `vitest.config.ts`, not a duplicated literal) and scrapes the **real** in-test budgets out of every sibling test source (`timeout: N` option bags and `setTimeout(…, N)` deadlines), then asserts no declared budget is `>= TEST_TIMEOUT_MS`. It also pins `MAX_IN_TEST_BUDGET_MS` to the largest budget actually found, so raising a subprocess guard past the documented ceiling fails too. A `budgets.length > 0` assertion keeps the scrape from silently matching nothing after a refactor.

Mutation proof — temporarily reverted `TEST_TIMEOUT_MS` to the old effective `5_000`:

```
$ npx vitest --run test/test-timeout-budget.test.ts     # with TEST_TIMEOUT_MS = 5_000

+   {
+     "file": "qa-driver-portability.test.ts",
+     "milliseconds": 10000,
+   },
+ ]
 ❯ test/test-timeout-budget.test.ts:51:21
     50|   const offenders = budgets.filter((budget) => budget.milliseconds >= …
     51|   expect(offenders).toEqual([]);
       |                     ^

 FAIL  test/test-timeout-budget.test.ts > per-test timeout budget > #given the documented ceiling #when compared to the real budgets #then it matches the largest one the suite grants
AssertionError: expected 5000 to be greater than 10000
 ❯ test/test-timeout-budget.test.ts:58:27

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

Restored:

```
$ npx vitest --run test/test-timeout-budget.test.ts     # with TEST_TIMEOUT_MS = 30_000

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

The guard fails for the right reason and names the offending site.

## Other checks

- `npx tsc --noEmit` — clean. No `@ts-ignore`, no `any`, no suppressions.
- `npx biome check .` — **15 errors before and after**, all pre-existing formatting drift in files this PR never touches (`src/client.ts`, `src/proxy.ts`, `test/proxy.test.ts`, …). Verified identical on a pristine `origin/dev` checkout of the same worktree. My three files are individually clean (`biome check vitest.config.ts test/test-timeout-budget.test.ts test/daemon-roundtrip.test.ts` → no errors). Left alone to keep this PR scoped.
- Bootstrap was the real CI one (`bun install --frozen-lockfile` at the repo root, which runs `prepare` → `build:lsp-daemon` and links `@oh-my-opencode/lsp-core` + `@oh-my-opencode/mcp-stdio-core`), so the runs above are genuine and not import failures.

## Files changed

| File | +/- |
|---|---|
| `packages/lsp-daemon/vitest.config.ts` | +27 |
| `packages/lsp-daemon/test/test-timeout-budget.test.ts` | +60 (new) |
| `packages/lsp-daemon/test/daemon-roundtrip.test.ts` | +1 / -2 |
| `changes.md` | +19 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Windows CI flakes by making the `lsp-daemon` test harness timeout exceed any subprocess guard. Previously Vitest’s 5s default killed tests that granted 10s to child processes, so correct runs failed with “Test timed out” instead of assertions.

- Set package-wide `testTimeout` and `hookTimeout` to 30_000 ms in `packages/lsp-daemon/vitest.config.ts`; export `TEST_TIMEOUT_MS` and a 10_000 ms ceiling `MAX_IN_TEST_BUDGET_MS`.
- Add `test/test-timeout-budget.test.ts` to assert the harness budget strictly exceeds all in-test budgets and that the documented ceiling matches the largest real budget.
- Remove the per-test timeout override from `test/daemon-roundtrip.test.ts` now covered by the global budget.
- No product changes. CI should stabilize on `windows-latest`. When adding tests, keep any subprocess/timer budget ≤ `MAX_IN_TEST_BUDGET_MS` or raise the ceiling with justification.

<sup>Written for commit 208f2696e1264391be21e9661805a22e34e77530. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

