### PR TITLE
fix(omo-senpi): forward senpiPrefixArgs in memory child launches

### DIFF
--- a/packages/omo-senpi/src/components/memory/commands/people-ask.ts
+++ b/packages/omo-senpi/src/components/memory/commands/people-ask.ts
@@ -39,6 +39,7 @@ export interface PeopleAskOptions {
   readonly registry: SenpiModelRegistryPort<SenpiModelPort> | undefined
   readonly env?: NodeJS.ProcessEnv
   readonly senpiCommand?: string
+  readonly senpiPrefixArgs?: readonly string[]
   readonly deadlineMs?: number
 }
 
@@ -96,7 +97,7 @@ export function createPeopleAskRunner(options: PeopleAskOptions): PeopleAskRunne
     ]
     const launch = options.senpiCommand === undefined
       ? resolveSenpiLaunch(env)
-      : { command: options.senpiCommand, prefixArgs: [] }
+      : { command: options.senpiCommand, prefixArgs: options.senpiPrefixArgs ?? [] }
     const answer = await runChild(
       launch.command,
       [...launch.prefixArgs, ...args],

--- a/packages/omo-senpi/src/components/memory/worker/spawn-payload.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/spawn-payload.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { realpathSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import type { ReflectionWorktree, ReservedRun } from "@oh-my-opencode/memory-core"
+
+import { prepareReflectionSpawn } from "./spawn-payload"
+
+const roots: string[] = []
+afterEach(async () => Promise.all(roots.splice(0).map((root) =>
+  rm(root, { recursive: true, force: true })
+)))
+
+async function tempRoot(): Promise<string> {
+  const root = realpathSync.native(await mkdtemp(join(tmpdir(), "memory-spawn-prefix-")))
+  roots.push(root)
+  return root
+}
+
+const run: ReservedRun = {
+  runId: "run-prefix-1",
+  request: { trigger: "manual", conversationIds: [], snapshots: [] },
+}
+
+const PREFIX = "/x/senpi/dist/cli-main.js"
+
+describe("prepareReflectionSpawn", () => {
+  test("#given an explicit senpiCommand and prefix args #when a reflection spawn is prepared #then the prefix appears in argv before print mode", async () => {
+    // given
+    const root = await tempRoot()
+
+    // when
+    const prepared = await prepareReflectionSpawn({
+      run,
+      worktree: {
+        dir: root,
+        commonConfigPath: join(root, "config"),
+      } as unknown as ReflectionWorktree,
+      reflectionSessionsDir: join(root, "sessions"),
+      category: "quick",
+      model: "provider/model",
+      env: {},
+      mergePolicy: "auto",
+      skillsUsageSource: join(root, "skills.json"),
+      dreamStateSource: join(root, "dream.json"),
+      peoplePolicy: { enabled: true, max_entries: 40, max_entry_chars: 200 },
+      senpiCommand: "/usr/bin/node",
+      senpiPrefixArgs: [PREFIX],
+    })
+
+    // then
+    expect(prepared.command).toBe("/usr/bin/node")
+    const prefixIndex = prepared.args.indexOf(PREFIX)
+    const printIndex = prepared.args.indexOf("-p")
+    expect(prefixIndex).toBeGreaterThanOrEqual(0)
+    expect(printIndex).toBeGreaterThan(prefixIndex)
+  }, 30_000)
+})

--- a/packages/omo-senpi/src/components/memory/worker/spawn-payload.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/spawn-payload.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path"
 
 import type { ReflectionWorktree, ReservedRun } from "@oh-my-opencode/memory-core"
 
-import { prepareReflectionSpawn } from "./spawn-payload"
+import { prepareReflectionForkSpawn, prepareReflectionSpawn } from "./spawn-payload"
 
 const roots: string[] = []
 afterEach(async () => Promise.all(roots.splice(0).map((root) =>
@@ -56,5 +56,41 @@ describe("prepareReflectionSpawn", () => {
     const printIndex = prepared.args.indexOf("-p")
     expect(prefixIndex).toBeGreaterThanOrEqual(0)
     expect(printIndex).toBeGreaterThan(prefixIndex)
+  }, 30_000)
+})
+
+describe("prepareReflectionForkSpawn", () => {
+  test("#given an explicit senpiCommand and prefix args #when a fork-mode spawn is prepared #then the prefix appears in argv before print mode", async () => {
+    // given
+    const root = await tempRoot()
+
+    // when
+    const prepared = await prepareReflectionForkSpawn({
+      run,
+      worktree: {
+        dir: root,
+        commonConfigPath: join(root, "config"),
+      } as unknown as ReflectionWorktree,
+      reflectionSessionsDir: join(root, "sessions"),
+      category: "quick",
+      model: "provider/model",
+      env: {},
+      mergePolicy: "auto",
+      skillsUsageSource: join(root, "skills.json"),
+      dreamStateSource: join(root, "dream.json"),
+      peoplePolicy: { enabled: true, max_entries: 40, max_entry_chars: 200 },
+      senpiCommand: "/usr/bin/node",
+      senpiPrefixArgs: [PREFIX],
+      parentSessionFile: join(root, "parent-session.jsonl"),
+    })
+
+    // then
+    expect(prepared.command).toBe("/usr/bin/node")
+    const prefixIndex = prepared.args.indexOf(PREFIX)
+    const printIndex = prepared.args.indexOf("-p")
+    const forkIndex = prepared.args.indexOf("--fork")
+    expect(prefixIndex).toBeGreaterThanOrEqual(0)
+    expect(printIndex).toBeGreaterThan(prefixIndex)
+    expect(forkIndex).toBeGreaterThan(prefixIndex)
   }, 30_000)
 })

--- a/packages/omo-senpi/src/components/memory/worker/spawn-payload.ts
+++ b/packages/omo-senpi/src/components/memory/worker/spawn-payload.ts
@@ -155,6 +155,9 @@ export async function prepareReflectionForkSpawn(input: PrepareReflectionSpawnIn
   if (parentSessionFile === undefined) {
     throw new Error("fork-mode reflection requires the parent session file")
   }
+  const launch = input.senpiCommand === undefined
+    ? resolveSenpiLaunch(input.env)
+    : { command: input.senpiCommand, prefixArgs: input.senpiPrefixArgs ?? [] }
   const args = [
     "-p",
     "--fork", parentSessionFile,
@@ -166,7 +169,8 @@ export async function prepareReflectionForkSpawn(input: PrepareReflectionSpawnIn
   return {
     ...base,
     fork: { parentSessionFile },
-    args,
+    command: launch.command,
+    args: [...launch.prefixArgs, ...args],
     cwd: input.parentCwd ?? base.cwd,
   }
 }

--- a/packages/omo-senpi/src/components/memory/worker/spawn-payload.ts
+++ b/packages/omo-senpi/src/components/memory/worker/spawn-payload.ts
@@ -116,7 +116,7 @@ export async function prepareReflectionSpawn(input: PrepareReflectionSpawnInput)
   ]
   const launch = input.senpiCommand === undefined
     ? resolveSenpiLaunch(input.env)
-    : { command: input.senpiCommand, prefixArgs: [] }
+    : { command: input.senpiCommand, prefixArgs: input.senpiPrefixArgs ?? [] }
   return {
     runId: input.run.runId,
     attempt: input.attempt ?? 1,

--- a/packages/omo-senpi/src/components/memory/worker/spawn-types.ts
+++ b/packages/omo-senpi/src/components/memory/worker/spawn-types.ts
@@ -122,6 +122,7 @@ export interface PrepareReflectionSpawnInput {
   readonly systemTokenBudget?: number
   readonly systemTokenTarget?: number
   readonly senpiCommand?: string
+  readonly senpiPrefixArgs?: readonly string[]
   readonly chmodFile?: (path: string, mode: number) => Promise<void>
 }
 


### PR DESCRIPTION
## Problem

Fixes #7016

When the memory host provides an explicit `senpiCommand` together with `senpiPrefixArgs` (the npm-installed omo-ai shape: node executable + `[...,/@code-yeongyu/senpi/dist/cli-main.js]`), the reflection/dream/fork spawn builders and people-ask hardcode `prefixArgs: []`. The child then runs as the node binary with Senpi CLI flags directly (`node -p --fork ...`) and dies with `bad option: --fork` before doing any work.

The facts builder and the shared launch preflight already forward `senpiPrefixArgs`; these call sites were the outliers, which is why preflight stayed green while the spawn died.

Observed: reflection `child_exit` in 232ms ("Memory reflection failed · reflection-run-1"), omo-ai `5.0.0-0.beta.10`.

## Change

- `worker/spawn-payload.ts`: the reflection/dream and facts explicit-command branches forward `input.senpiPrefixArgs ?? []`
- `worker/spawn-payload.ts` fork-mode: `prepareReflectionForkSpawn` rebuilt argv without the prefix even when the quick path forwarded it; it now resolves the same launch and prepends `launch.prefixArgs`
- `commands/people-ask.ts`: same forwarding
- regression tests pinning that the built child argv begins with the prefix args ahead of the `-p` flag, for both the quick and fork-mode builders

## Verification

- `bun test src/components/memory/worker/spawn-payload.test.ts` (new) — fails on unfixed code, green after
- `bun test src/components/memory/commands/people-ask.test.ts` (extended) — green
