### PR TITLE
fix(tui): hide disabled agents from idle roster

### DIFF
--- a/.omo/evidence/20260819-issue-6866/README.md
+++ b/.omo/evidence/20260819-issue-6866/README.md
@@ -1,0 +1,21 @@
+# Issue #6866 QA evidence
+
+## Scenario
+
+Resolve the idle TUI roster from an isolated project configuration that disables the legacy `Sisyphus` agent name. Verify that the normalized `sisyphus` row is absent while another enabled agent and the `deep` category remain visible.
+
+## Commands and results
+
+- RED: `npx --yes bun test packages/omo-opencode/src/features/tui-sidebar/roster-resolver.test.ts`
+  - 3 passed, 1 failed.
+  - The new assertion expected `sisyphus` to be absent but received `true`.
+- GREEN: `npx --yes bun test packages/omo-opencode/src/features/tui-sidebar/roster-resolver.test.ts`
+  - 4 passed, 0 failed, 12 assertions.
+- Typecheck: `npx --yes bun x tsgo --noEmit -p packages/omo-opencode/tsconfig.json`
+  - Exit code 0.
+- Targeted bundle: `npx --yes bun build packages/omo-opencode/src/features/tui-sidebar/roster-resolver.ts --target=bun --outfile=.omo/evidence/20260819-issue-6866/roster-resolver.bundle.js`
+  - Bundled 553 modules successfully; the temporary bundle was removed after verification.
+- Isolated probe: `npx --yes bun .omo/evidence/20260819-issue-6866/probe.ts`
+  - Observed `disabledAgentPresent=false`, `enabledAgentPresent=true`, and `categoryPresent=true`; exit code 0.
+
+The initial dependency bootstrap attempted the repository-wide postinstall build and was stopped when it remained blocked cloning the unrelated `nexu-io/open-design` shared-skill upstream. The focused package gates above do not depend on that external clone.

--- a/.omo/evidence/20260819-issue-6866/probe.ts
+++ b/.omo/evidence/20260819-issue-6866/probe.ts
@@ -1,0 +1,35 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { resolveRoster } from "../../../packages/omo-opencode/src/features/tui-sidebar/roster-resolver"
+
+const root = join(tmpdir(), `omo-issue-6866-${Date.now()}`)
+const project = join(root, "project")
+const configDir = join(project, ".omo")
+
+try {
+  mkdirSync(configDir, { recursive: true })
+  process.env.HOME = root
+  process.env.OPENCODE_CONFIG_DIR = join(root, "opencode")
+  process.env.XDG_CONFIG_HOME = join(root, "xdg")
+  writeFileSync(
+    join(configDir, "omo.jsonc"),
+    `${JSON.stringify({ "[opencode]": { disabled_agents: ["Sisyphus"] } }, null, 2)}\n`,
+    "utf-8",
+  )
+
+  const rows = resolveRoster(project)
+  const result = {
+    disabledAgentPresent: rows.some((row) => row.label === "sisyphus"),
+    enabledAgentPresent: rows.some((row) => row.label === "oracle"),
+    categoryPresent: rows.some((row) => row.label === "deep"),
+  }
+
+  console.log(JSON.stringify(result, null, 2))
+  if (result.disabledAgentPresent || !result.enabledAgentPresent || !result.categoryPresent) {
+    process.exitCode = 1
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}

--- a/packages/omo-opencode/src/features/tui-sidebar/roster-resolver.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/roster-resolver.test.ts
@@ -91,6 +91,27 @@ describe("resolveRoster", () => {
     })
   })
 
+  it("#given disabled agent aliases #when resolving roster #then it omits only those agents", () => {
+    withIsolatedConfig("disabled-agents", (root) => {
+      // given
+      const project = join(root, "project")
+      writeJson(join(project, ".omo", "omo.jsonc"), {
+        "[opencode]": {
+          disabled_agents: ["Sisyphus", "Hephaestus (Deep Agent)"],
+        },
+      })
+
+      // when
+      const rows = resolveRoster(project)
+
+      // then
+      expect(rows.some((row) => row.label === "sisyphus")).toBe(false)
+      expect(rows.some((row) => row.label === "hephaestus")).toBe(false)
+      expect(rows.some((row) => row.label === "oracle")).toBe(true)
+      expect(rows.some((row) => row.label === "deep")).toBe(true)
+    })
+  })
+
   it("#given malformed config #when resolving roster #then it still returns resolver rows", () => {
     withIsolatedConfig("malformed", (root) => {
       // given

--- a/packages/omo-opencode/src/features/tui-sidebar/roster-resolver.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/roster-resolver.ts
@@ -2,6 +2,7 @@ import { getModelResolutionInfoWithOverrides } from "../../cli/doctor/checks/mod
 import type { OmoConfig } from "../../cli/doctor/checks/model-resolution-types"
 import type { OhMyOpenCodeConfig } from "../../config"
 import { validatePluginConfig } from "../../config/validate"
+import { AGENT_NAME_MAP } from "../../shared/migration"
 import type { RosterRow } from "./state-types"
 
 type ResolutionEntry = {
@@ -65,11 +66,19 @@ function toModelResolutionConfig(config: OhMyOpenCodeConfig): OmoConfig {
   return { agents, categories }
 }
 
+function normalizeAgentName(name: string): string {
+  return (AGENT_NAME_MAP[name.toLowerCase()] ?? AGENT_NAME_MAP[name] ?? name).toLowerCase()
+}
+
 export function resolveRoster(directory: string): RosterRow[] {
   try {
     const config = validatePluginConfig(directory).config
     const resolution = getModelResolutionInfoWithOverrides(toModelResolutionConfig(config))
-    return [...resolution.agents, ...resolution.categories]
+    const disabledAgentNames = new Set((config.disabled_agents ?? []).map(normalizeAgentName))
+    const enabledAgents = resolution.agents.filter(
+      (entry) => !disabledAgentNames.has(normalizeAgentName(entry.name)),
+    )
+    return [...enabledAgents, ...resolution.categories]
       .map(toRosterRow)
       .sort((left, right) => left.label.localeCompare(right.label))
   } catch (error) {


### PR DESCRIPTION
## Summary

- filter disabled agents out of the idle TUI model roster
- normalize disabled names with the same migration aliases used by agent registration
- preserve category rows and enabled agent rows

## Tests and QA

- `npx --yes bun test packages/omo-opencode/src/features/tui-sidebar/roster-resolver.test.ts` (4 passed, 0 failed)
- `npx --yes bun x tsgo --noEmit -p packages/omo-opencode/tsconfig.json`
- targeted Bun bundle of `roster-resolver.ts`
- isolated roster probe covering a legacy disabled-agent alias, an enabled agent, and a category

The repository-wide postinstall build was not used as a gate because it remained blocked cloning the unrelated `nexu-io/open-design` shared-skill upstream on this Windows runner. Focused tests, package typechecking, the targeted bundle, and the isolated probe all pass.

## Risk

Low. The change only filters agent rows after model resolution; category resolution and ordering are unchanged.

Related: #6866