### PR TITLE
fix(runtime-fallback): retry content filter errors

### DIFF
--- a/packages/model-core/src/runtime-fallback-content-filter-error.test.ts
+++ b/packages/model-core/src/runtime-fallback-content-filter-error.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+
+import { isRuntimeFallbackRetryableError } from "./runtime-fallback-error-classifier"
+
+const DEFAULT_RETRY_CODES = [429, 500, 502, 503, 504] as const
+
+describe("runtime fallback content filter errors", () => {
+  test("retries provider ContentFilterError payloads without broadening validation errors", () => {
+    //#given
+    const errors = [
+      {
+        name: "ContentFilterError",
+        message: "The response was blocked by the provider's content filter",
+      },
+      {
+        name: "ValidationError",
+        statusCode: 400,
+        message: "Invalid request payload",
+      },
+    ] as const
+
+    //#when
+    const retryable = errors.map((error) =>
+      isRuntimeFallbackRetryableError(error, DEFAULT_RETRY_CODES),
+    )
+
+    //#then
+    expect(retryable).toEqual([true, false])
+  })
+})

--- a/packages/model-core/src/runtime-fallback-retryable-patterns.ts
+++ b/packages/model-core/src/runtime-fallback-retryable-patterns.ts
@@ -16,6 +16,7 @@ export const RUNTIME_FALLBACK_RETRYABLE_ERROR_PATTERNS = [
   /service.?unavailable/i,
   /overloaded/i,
   /temporarily.?unavailable/i,
+  /content[-_\s]?filter/i,
   /try.?again/i,
   /(?:^|\s)429(?:\s|$)/,
   /(?:^|\s)503(?:\s|$)/,


### PR DESCRIPTION
## Summary

Treat provider content-filter responses as retryable runtime fallback errors. The shared model-core pattern now recognizes `ContentFilterError` payloads whose message says the response was blocked by a content filter, so the OpenCode adapter can advance its configured fallback chain instead of stopping silently.

The regression test also pins an unrelated HTTP 400 validation error as non-retryable.

## Tests / QA

- Failing-first proof: the new focused test initially failed with expected `[true, false]` and received `[false, false]`.
- `bun test packages/model-core/src/runtime-fallback-content-filter-error.test.ts packages/model-core/src/runtime-fallback-error-classifier.test.ts` (7 passed)
- `bun run --cwd packages/model-core test` (357 passed)
- `bun test packages/omo-opencode/src/hooks/runtime-fallback/error-classifier.test.ts packages/omo-opencode/src/hooks/runtime-fallback/session-status-handler.test.ts` (35 passed)
- `bun run --cwd packages/model-core typecheck`
- `bun build packages/model-core/src/index.ts --target bun --outfile <isolated temp file>` (35 modules bundled; artifact removed after verification)
- Data-shaped classifier probe: ContentFilterError returned `retryable: true`; validation, abort, and context-overflow cases returned `retryable: false`.
- Sanitized local evidence: `.omo/evidence/20260819-issue-6796/`

## Risk

Low. This adds one narrow built-in message pattern and does not change status-code handling, fallback state, configuration, or dependencies. The main risk is a false-positive retry for an unrelated message containing `content filter`; the validation control and existing abort/context-overflow tests remain green.

Related: #6796