### PR TITLE
fix(keyword-detector): ignore ulw skill names

### DIFF
--- a/.omo/evidence/20260819-issue-6876/README.md
+++ b/.omo/evidence/20260819-issue-6876/README.md
@@ -1,0 +1,20 @@
+# Issue #6876 QA evidence
+
+## Behavioral RED
+
+`red-focused-test.txt` records the regression-test-only run against `e199029e1`: 5 passed, 1 failed. Both `ulw-plan` and `ulw-research` reached the real keyword hook and produced an unexpected ultrawork toast, while the `ulw-loop` positive control passed.
+
+## GREEN gates
+
+- `npx --yes bun test packages/omo-opencode/src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts`
+  - 6 passed, 0 failed, 25 assertions.
+- `npx --yes bun test packages/omo-opencode/src/hooks/keyword-detector`
+  - 92 passed, 0 failed, 245 assertions.
+- `npx --yes bun x tsgo --noEmit -p packages/omo-opencode/tsconfig.json`
+  - Exit code 0.
+- `npx --yes bun .omo/evidence/20260819-issue-6876/probe.ts`
+  - Eight boundary cases matched expectations: standalone `ulw`, `ultrawork`, and `ulw-loop` activate; `ulw-plan` and `ulw-research` variants do not.
+- `npx --yes bun build packages/omo-opencode/src/hooks/keyword-detector/constants.ts --target=bun --outfile=.omo/evidence/20260819-issue-6876/constants.bundle.js`
+  - Bundled 311 modules successfully; the temporary bundle was removed after verification.
+
+The repository prepare build reached the known Windows-only `lsp-tools-mcp` POSIX `rm` portability failure. Focused tests, the complete keyword-detector suite, package typechecking, and the isolated boundary probe are independent of that unrelated build limitation.

--- a/.omo/evidence/20260819-issue-6876/probe.ts
+++ b/.omo/evidence/20260819-issue-6876/probe.ts
@@ -1,0 +1,23 @@
+import { KEYWORD_DETECTORS } from "../../../packages/omo-opencode/src/hooks/keyword-detector/constants"
+
+const detector = KEYWORD_DETECTORS.find((candidate) => candidate.type === "ultrawork")
+if (!detector) throw new Error("ultrawork detector not found")
+
+const scenarios = [
+  { text: "ulw", expected: true },
+  { text: "please use ulw now", expected: true },
+  { text: "ultrawork", expected: true },
+  { text: "ulw-loop", expected: true },
+  { text: "ulw-plan", expected: false },
+  { text: "please use ULW-PLAN for this", expected: false },
+  { text: "ulw-research", expected: false },
+  { text: "please use ulw-research for this", expected: false },
+]
+
+const results = scenarios.map(({ text, expected }) => {
+  const actual = detector.pattern.test(text)
+  return { text, expected, actual, passed: actual === expected }
+})
+
+console.log(JSON.stringify(results, null, 2))
+if (results.some((result) => !result.passed)) process.exitCode = 1

--- a/.omo/evidence/20260819-issue-6876/red-focused-test.txt
+++ b/.omo/evidence/20260819-issue-6876/red-focused-test.txt
@@ -1,0 +1,32 @@
+Command:
+npx --yes bun@1.3.12 test packages/omo-opencode/src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts
+
+Tree-under-test:
+e199029e1be0bc10bd10c5fbae8e60e3523c967d plus the regression-test-only working-tree diff
+
+Exit code: 1
+
+Observed summary:
+bun test v1.3.12 (700fc117)
+5 pass
+1 fail
+18 expect() calls
+Ran 6 tests across 1 file.
+
+Failing assertion:
+Test: #given ulw-plan and ulw-research skill names #when chat.message fires #then ultrawork stays inactive
+Expected toastCalls length: 0
+Received toastCalls length: 1
+Location: packages/omo-opencode/src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts:160
+
+Control observation:
+The new `ulw-loop` boundary test passed, as did all four pre-existing standalone `ulw` / `ultrawork` trigger tests.
+
+Interpretation:
+The regression test reaches the real OpenCode keyword hook and reproduces the false activation before any production code change. This is a behavioral RED, not an infrastructure failure.
+
+Environment note:
+The worktree initially lacked node_modules. A frozen Bun 1.3.12 install populated dependencies. Its prepare build reached the unrelated Windows-only lsp-tools-mcp `rm` portability failure; the focused test itself then executed normally. The one generated tracked installer artifact produced during prepare was restored to HEAD before implementation.
+
+Secrets/omissions:
+No environment dump, credentials, auth headers, or tokens are included.

--- a/packages/omo-opencode/src/hooks/keyword-detector/constants.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/constants.ts
@@ -33,7 +33,7 @@ export type KeywordDetector = {
 export const KEYWORD_DETECTORS: KeywordDetector[] = [
   {
     type: "ultrawork",
-    pattern: /\b(ultrawork|ulw)\b/i,
+    pattern: /\b(?:ultrawork|ulw(?!-(?:plan|research)))\b/i,
     message: getUltraworkMessage,
   },
   {

--- a/packages/omo-opencode/src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts
@@ -135,4 +135,48 @@ describe("keyword-detector ultrawork edge trigger", () => {
     expect(startLoopCalls).toHaveLength(0)
     expect(output.parts[0]?.text).toContain("what is ultrawork")
   })
+
+  test("#given ulw-plan and ulw-research skill names #when chat.message fires #then ultrawork stays inactive", async () => {
+    // given
+    const prompts = [
+      "ulw-plan",
+      "please run ulw-plan for this",
+      "ulw-research",
+      "please run ULW-RESEARCH for this",
+    ]
+
+    for (const prompt of prompts) {
+      const toastCalls: string[] = []
+      const hook = createKeywordDetectorHook(createMockPluginInput(toastCalls))
+      const output = {
+        message: {} as Record<string, unknown>,
+        parts: [{ type: "text", text: prompt }],
+      }
+
+      // when
+      await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, output)
+
+      // then
+      expect(toastCalls).toHaveLength(0)
+      expect(output.parts[0]?.text).toBe(prompt)
+    }
+  })
+
+  test("#given ulw-loop skill name #when chat.message fires #then the distinct ultrawork loop boundary still activates", async () => {
+    // given
+    const toastCalls: string[] = []
+    const hook = createKeywordDetectorHook(createMockPluginInput(toastCalls))
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "use ulw-loop for this task" }],
+    }
+
+    // when
+    await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, output)
+
+    // then
+    expect(toastCalls).toContain("Ultrawork Mode Activated")
+    expect(output.parts[0]?.text).toContain("<ultrawork-mode>")
+    expect(output.parts[0]?.text).toContain("use ulw-loop for this task")
+  })
 })


### PR DESCRIPTION
## Summary

- port the existing Codex negative lookahead to the OpenCode ultrawork detector
- keep standalone `ulw`, `ultrawork`, and the distinct `ulw-loop` boundary active
- prevent `ulw-plan` and `ulw-research` skill names from double-injecting ultrawork mode

## Tests and QA

- `npx --yes bun test packages/omo-opencode/src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts` (6 passed)
- `npx --yes bun test packages/omo-opencode/src/hooks/keyword-detector` (92 passed)
- `npx --yes bun x tsgo --noEmit -p packages/omo-opencode/tsconfig.json`
- targeted Bun bundle of `constants.ts`
- isolated eight-case detector boundary probe

The repository prepare build still reaches the known Windows-only `lsp-tools-mcp` POSIX `rm` portability failure. The focused tests, complete detector suite, package typecheck, targeted bundle, and isolated probe pass independently.

## Risk

Low. The regex change matches the established Codex detector and only narrows two hyphenated skill-name boundaries.

Related: #6876