### PR TITLE
fix(senpi): gate Windows RPC external termination facts

### DIFF
--- a/packages/omo-senpi/scripts/qa/task-rpc-e2e-scenarios.mjs
+++ b/packages/omo-senpi/scripts/qa/task-rpc-e2e-scenarios.mjs
@@ -90,6 +90,13 @@ export async function killSenpiHost(child, terminate = killProcessGroup) {
   return terminate(child.pid)
 }
 
+export function externalTerminationMatchesPlatformFacts(record, platform, terminationInjected) {
+  if (!terminationInjected) return false
+  if (record?.status !== "error") return false
+  if (record.killed === true) return true
+  return platform === "win32" && record.error_message === "RPC child exited with code 1"
+}
+
 function waitForChildClose(child, timeoutMs) {
   if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve()
   return new Promise((resolve, reject) => {
@@ -117,19 +124,21 @@ export async function runKillCheck(senpiBin) {
   try {
     const running = await pollRecord(stateDir, (r) => r.name === "pk" && runningRpcChild(r), 40_000)
     if (running === undefined) {
-      return { check: "kill_marks_error_killed_true", verdict: "FAIL", reason: "no running rpc child appeared to kill" }
+      return { check: "external_termination_records_platform_facts", verdict: "FAIL", reason: "no running rpc child appeared to kill" }
     }
+    let terminationInjected = false
     try {
-      process.kill(running.pid, "SIGKILL")
+      terminationInjected = process.kill(running.pid, "SIGKILL")
     } catch {
-      // already gone counts as killed
+      // A child that exited before the injection cannot prove external termination.
     }
-    const errored = await pollRecord(stateDir, (r) => r.task_id === running.task_id && r.status === "error" && r.killed === true, 15_000)
+    const errored = await pollRecord(stateDir, (r) => r.task_id === running.task_id && r.status === "error", 15_000)
+    const matchesPlatformFacts = externalTerminationMatchesPlatformFacts(errored, process.platform, terminationInjected)
     return {
-      check: "kill_marks_error_killed_true",
-      verdict: errored ? "PASS" : "FAIL",
-      ...(errored ? {} : { reason: "kill did not yield status=error killed:true" }),
-      facts: { pid: running.pid, killed: errored?.killed ?? false, error_excerpt: (errored?.error_message ?? "").slice(0, 120) },
+      check: "external_termination_records_platform_facts",
+      verdict: matchesPlatformFacts ? "PASS" : "FAIL",
+      ...(matchesPlatformFacts ? {} : { reason: terminationInjected ? "external termination did not yield platform-appropriate error facts" : "rpc child exited before external termination could be injected" }),
+      facts: { pid: running.pid, terminationInjected, killed: errored?.killed ?? false, error_excerpt: (errored?.error_message ?? "").slice(0, 120) },
     }
   } finally {
     await cleanupSenpiHost(parent)

--- a/packages/omo-senpi/scripts/qa/task-rpc-e2e-scenarios.test.mjs
+++ b/packages/omo-senpi/scripts/qa/task-rpc-e2e-scenarios.test.mjs
@@ -1,6 +1,51 @@
 import { expect, test } from "bun:test"
 
-import { killSenpiHost } from "./task-rpc-e2e-scenarios.mjs"
+import { externalTerminationMatchesPlatformFacts, killSenpiHost } from "./task-rpc-e2e-scenarios.mjs"
+
+test("#given Windows omits signal provenance #when an externally terminated task reports code 1 #then the record matches platform facts", () => {
+  expect(externalTerminationMatchesPlatformFacts({
+    status: "error",
+    killed: false,
+    error_message: "RPC child exited with code 1",
+  }, "win32", true)).toBe(true)
+})
+
+test("#given Windows preserves signal provenance #when an externally terminated task is marked killed #then the stronger record still matches", () => {
+  expect(externalTerminationMatchesPlatformFacts({ status: "error", killed: true }, "win32", true)).toBe(true)
+})
+
+test("#given a child exits before termination injection #when its Windows code-1 record is evaluated #then it cannot prove external termination", () => {
+  expect(externalTerminationMatchesPlatformFacts({
+    status: "error",
+    killed: false,
+    error_message: "RPC child exited with code 1",
+  }, "win32", false)).toBe(false)
+})
+
+test("#given Windows reports malformed crash facts #when external termination is evaluated #then the record does not match", () => {
+  expect(externalTerminationMatchesPlatformFacts({
+    status: "error",
+    killed: false,
+    error_message: "RPC child exited unexpectedly",
+  }, "win32", true)).toBe(false)
+  expect(externalTerminationMatchesPlatformFacts({
+    status: "error",
+    killed: false,
+    error_message: "prefix RPC child exited with code 1 suffix",
+  }, "win32", true)).toBe(false)
+})
+
+test("#given POSIX preserves signal provenance #when an externally terminated task is marked killed #then the record matches", () => {
+  expect(externalTerminationMatchesPlatformFacts({ status: "error", killed: true }, "linux", true)).toBe(true)
+})
+
+test("#given POSIX reports only a nonzero exit #when external termination is evaluated #then killed provenance is still required", () => {
+  expect(externalTerminationMatchesPlatformFacts({
+    status: "error",
+    killed: false,
+    error_message: "RPC child exited with code 1",
+  }, "linux", true)).toBe(false)
+})
 
 test("#given a live Senpi QA host #when it is killed #then teardown routes through tree termination", async () => {
   const calls = []

--- a/packages/omo-senpi/scripts/qa/task-rpc-e2e.windows.test.ts
+++ b/packages/omo-senpi/scripts/qa/task-rpc-e2e.windows.test.ts
@@ -154,6 +154,7 @@ test.skipIf(!isWin32)(
     const payload = parsed as DriverPayload
     const route = check(payload, "process_mode_routes_to_rpc_runner")
     const spawnProof = check(payload, "spawn_process_pid_and_session_jsonl")
+    const externalTermination = check(payload, "external_termination_records_platform_facts")
     const leakProof = check(payload, "no_leaked_rpc_child_pids")
 
     // then
@@ -163,6 +164,7 @@ test.skipIf(!isWin32)(
     expect(route?.facts?.pid).toBeGreaterThan(0)
     expect(spawnProof?.verdict).toBe("PASS")
     expect(spawnProof?.facts?.sessionJsonl).toBe(true)
+    expect(externalTermination?.verdict).toBe("PASS")
     expect(payload.realCredentialsUntouched).toBe(true)
     expect(payload.wholeDirDigestStable).toBe(true)
     expect(leakProof?.verdict).toBe("PASS")


### PR DESCRIPTION
## Summary

- evaluate externally terminated RPC task records against facts the host platform can actually preserve
- require a successful termination injection and exact Windows code-1 diagnostic, while keeping POSIX `killed:true` semantics
- make the Windows production wrapper assert the external-termination subcheck instead of only printing it

## Context

Issue #6976 records repeated `kill_marks_error_killed_true` failures on Windows. Node reports the injected `SIGKILL` there as exit code 1 with no signal, so the production classifier correctly preserves it as a crash-shaped record rather than inventing signal provenance.

This change is limited to the QA contract. It does not change the production exit classifier, dependencies, public APIs, or timeout budgets.

## Validation

- focused scenario + RPC classifier/process tests: 27 passed, 1 pre-existing Windows signal test skipped, 0 failed, 55 assertions
- `tsgo --noEmit` passed for `packages/omo-senpi` and `packages/senpi-task`
- local `build:senpi-plugin` passed
- `git diff --check` passed
- isolated Windows wrapper preserved credential and directory digests, removed its sandbox, and leaked zero PIDs

## Residual verification

The current `dev` branch fails the isolated Windows wrapper before this scenario can inject termination: no task record is persisted (`wiringFixed=false`). The same separate signature is recorded in the latest #6976 maintainer comment and current Windows Senpi CI. The wrapper remains fail-closed, and the external-termination path should be rerun after that prerequisite regression is repaired.

The best-effort broad package suites were stopped after 12 CPU-active minutes without a final summary; one observed existing failure was a Windows symlink `EPERM` on a host without developer-mode privilege. Focused tests, both package typechecks, and the packaged Senpi build completed successfully.