### PR TITLE
fix(task): show categories in delegated session titles

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
@@ -121,4 +121,51 @@ describe("BackgroundManager session permission", () => {
       ],
     })
   })
+
+  test("prefixes the category in the child session title", async () => {
+    // given
+    const createCalls: Array<Record<string, unknown>> = []
+    const promptStarted = Promise.withResolvers<void>()
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/parent" } }),
+        create: async (input: Record<string, unknown>) => {
+          createCalls.push(input)
+          return { data: { id: "ses_child" } }
+        },
+        promptAsync: async () => {
+          promptStarted.resolve()
+          return {}
+        },
+        abort: async () => ({}),
+      },
+    }
+    const manager = new BackgroundManager({ pluginContext: unsafeTestValue<PluginInput>({ client, directory: tmpdir() }) })
+    const timeout = Promise.withResolvers<never>()
+    const timeoutID = setTimeout(
+      () => timeout.reject(new Error("waited 1s for categorized child session prompt")),
+      1_000,
+    )
+
+    // when
+    try {
+      await manager.launch({
+        description: "Test task",
+        prompt: "Do something",
+        agent: "explore",
+        parentSessionId: "ses_parent",
+        parentMessageId: "msg_parent",
+        category: "quick",
+      })
+      await Promise.race([promptStarted.promise, timeout.promise])
+
+      // then
+      expect(createCalls).toHaveLength(1)
+      const body = createCalls[0]?.body as Record<string, unknown> | undefined
+      expect(body?.title).toBe("[quick] Test task (@explore subagent)")
+    } finally {
+      clearTimeout(timeoutID)
+      await manager.shutdown()
+    }
+  })
 })

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -760,7 +760,7 @@ export class BackgroundManager {
     const createResult = await this.client.session.create({
       body: {
         parentID: input.parentSessionId,
-        title: `${input.description} (@${input.agent} subagent)`,
+        title: `${input.category ? `[${input.category}] ` : ""}${input.description} (@${input.agent} subagent)`,
         ...(input.sessionPermission ? { permission: input.sessionPermission } : {}),
         ...(input.model
           ? {

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.test.ts
@@ -35,4 +35,32 @@ describe("createSyncSession", () => {
       ],
     })
   })
+
+  test("prefixes the category in the child session title", async () => {
+    // given
+    const createCalls: Array<Record<string, unknown>> = []
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/parent" } }),
+        create: async (input: Record<string, unknown>) => {
+          createCalls.push(input)
+          return { data: { id: "ses_child" } }
+        },
+      },
+    }
+    const input = {
+      parentSessionID: "ses_parent",
+      agentToUse: "explore",
+      description: "test task",
+      defaultDirectory: "/fallback",
+      category: "quick",
+    }
+
+    // when
+    await createSyncSession(client as never, input)
+
+    // then
+    const body = createCalls[0]?.body as Record<string, unknown> | undefined
+    expect(body?.title).toBe("[quick] test task (@explore subagent)")
+  })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.ts
@@ -9,6 +9,7 @@ export async function createSyncSession(
     agentToUse: string
     description: string
     defaultDirectory: string
+    category?: string
     categoryModel?: DelegatedModelConfig
   }
 ): Promise<{ ok: true; sessionID: string; parentDirectory: string } | { ok: false; error: string }> {
@@ -18,7 +19,7 @@ export async function createSyncSession(
   const createResult = await client.session.create({
     body: {
       parentID: input.parentSessionID,
-      title: `${input.description} (@${input.agentToUse} subagent)`,
+      title: `${input.category ? `[${input.category}] ` : ""}${input.description} (@${input.agentToUse} subagent)`,
       permission: QUESTION_DENIED_SESSION_PERMISSION,
       ...(input.categoryModel
         ? {

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task-runner.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task-runner.ts
@@ -184,6 +184,7 @@ export async function runSyncTaskLoop(input: SyncTaskRunnerInput): Promise<strin
         agentToUse,
         description: args.description,
         defaultDirectory: directory,
+        category: args.category,
         categoryModel: nextFallbackModel,
       })
       if (!retrySessionResult.ok) {

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task.test.ts
@@ -618,11 +618,13 @@ describe("executeSyncTask - cleanup on error paths", () => {
 
     const { executeSyncTask } = require("./sync-task")
     const createdSessions: string[] = []
+    const createSessionInputs: Array<{ category?: string }> = []
     const attemptedModels: Array<{ providerID: string; modelID: string; variant?: string } | undefined> = []
     const polledSessions: string[] = []
 
     const deps = {
-      createSyncSession: async () => {
+      createSyncSession: async (_client: unknown, input: { category?: string }) => {
+        createSessionInputs.push(input)
         const sessionID = createdSessions.length === 0 ? "ses_first" : "ses_second"
         createdSessions.push(sessionID)
         return { ok: true as const, sessionID }
@@ -681,6 +683,9 @@ describe("executeSyncTask - cleanup on error paths", () => {
     }, "sisyphus-junior", initialModel, undefined, undefined, fallbackChain, deps)
 
     expect(createdSessions).toEqual(["ses_first", "ses_second"])
+    expect(createSessionInputs).toHaveLength(2)
+    expect(createSessionInputs[0]?.category).toBe("quick")
+    expect(createSessionInputs[1]?.category).toBe("quick")
     expect(polledSessions).toEqual(["ses_first", "ses_second"])
     expect(attemptedModels).toEqual([
       { providerID: "genai-proxy-openai", modelID: "gpt-5.6-luna-fast", variant: undefined },

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
@@ -42,6 +42,7 @@ export async function executeSyncTask(
       agentToUse,
       description: args.description,
       defaultDirectory: directory,
+      category: args.category,
       categoryModel,
     })
 

--- a/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
@@ -4619,7 +4619,7 @@ describe("sisyphus-task", () => {
   })
 
   describe("session title and metadata format (OpenCode compatibility)", () => {
-    test("sync session title follows OpenCode format: '{description} (@{agent} subagent)'", async () => {
+    test("categorized sync session persists an OpenCode-compatible category-prefixed child title", async () => {
       // given
       const { createDelegateTask } = require("./tools")
       let createBody: CapturedSessionCreateBody = {}
@@ -4668,8 +4668,8 @@ describe("sisyphus-task", () => {
         toolContext
       )
 
-      // then - title should follow OpenCode format
-      expect(createBody.title).toBe("Implement feature X (@Sisyphus-Junior subagent)")
+      // then - title should prefix the category while preserving the OpenCode agent suffix
+      expect(createBody.title).toBe("[quick] Implement feature X (@Sisyphus-Junior subagent)")
     }, { timeout: 10000 })
 
     test("sync task output includes <task_metadata> block with session_id", async () => {


### PR DESCRIPTION
Related: #6854

## Summary

- prefix categorized delegated child-session titles with `[category]`
- preserve the existing OpenCode-compatible agent suffix and category-less behavior
- keep the category visible across initial, retry, and background delegation paths

## Verification

- focused delegation and background suites: 31 passed
- routing suite: 4 passed
- repository typecheck
- targeted OpenCode bundle build (1,987 modules)
- isolated OpenCode 1.18.18 run persisted a `[quick]` child title