### PR TITLE
fix(ast-grep-mcp): drop oneOf/not from the advertised scan schema

### DIFF
--- a/packages/ast-grep-mcp/src/mcp-schema.test.ts
+++ b/packages/ast-grep-mcp/src/mcp-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { AST_GREP_MCP_TOOLS } from "./mcp";
+import { SCAN_TOOL_DESCRIPTION, scanInputSchema } from "./tools/scan";
 
 // The advertised inputSchema is the ONLY contract a client sees before it calls a tool.
 // Anything the parser rejects at execution time but the schema accepts is a lie the model
@@ -29,48 +30,57 @@ function propertyOf(name: string, property: string): Schema {
   return value;
 }
 
-/**
- * Minimal validator covering exactly the keywords these descriptors use for the
- * rule-source contract: required, not.required and oneOf. Deliberately hand-rolled —
- * the package ships bun-types only, and pulling a JSON Schema engine in for three
- * keywords would be a heavier dependency than the assertion is worth.
- */
-function satisfies(schema: Schema, value: Record<string, unknown>): boolean {
-  const required = schema.required;
-  if (Array.isArray(required) && !required.every((key) => typeof key === "string" && value[key] !== undefined)) {
-    return false;
-  }
-  const negated = schema.not;
-  if (negated !== undefined && satisfies(negated as Schema, value)) return false;
-  const oneOf = schema.oneOf;
-  if (Array.isArray(oneOf)) {
-    const matched = oneOf.filter((branch) => satisfies(branch as Schema, value)).length;
-    if (matched !== 1) return false;
-  }
-  return true;
-}
+describe("ast_grep descriptors: client-safe composition", () => {
+  it("#given every advertised inputSchema #when walked to any depth #then no oneOf/anyOf/allOf/not appears", () => {
+    // Cursor's AgentService gateway cannot carry JSON-Schema composition keywords in an
+    // advertised tool inputSchema: the protobuf conversion fails upstream and the WHOLE run
+    // dies with a wrapped `resource_exhausted`. The parsers enforce every contract the schema
+    // cannot express (scan rule-source exclusivity included), so these keys must never ship.
+    const COMPOSITION_KEYS = new Set(["oneOf", "anyOf", "allOf", "not"]);
+    const offenders: string[] = [];
+    const walk = (node: unknown, trail: string): void => {
+      if (Array.isArray(node)) {
+        node.forEach((item, index) => walk(item, `${trail}[${index}]`));
+        return;
+      }
+      if (typeof node !== "object" || node === null) return;
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        if (COMPOSITION_KEYS.has(key)) offenders.push(`${trail}.${key}`);
+        walk(value, `${trail}.${key}`);
+      }
+    };
+    for (const tool of AST_GREP_MCP_TOOLS) walk(tool.inputSchema, tool.name);
+    expect(offenders).toEqual([]);
+  });
+});
 
 describe("ast_grep scan descriptor: rule-source exclusivity", () => {
-  it("#given the scan schema #when inspected #then it publishes the ruleFile XOR inlineRules oneOf", () => {
+  // The XOR contract cannot ride in the schema (see the composition test above), so it is
+  // published in prose the model reads and enforced by the parser that runs the call.
+  it("#given the scan schema #when inspected #then exclusivity is published without composition keywords", () => {
     const schema = schemaOf("scan");
-    expect(schema.oneOf).toEqual([
-      { type: "object", required: ["ruleFile"], not: { required: ["inlineRules"] } },
-      { type: "object", required: ["inlineRules"], not: { required: ["ruleFile"] } },
-    ]);
+    expect(schema.oneOf).toBeUndefined();
     expect(schema.required).toEqual(["paths"]);
+    expect(String(propertyOf("scan", "ruleFile").description)).toContain("Mutually exclusive with inlineRules");
+    expect(String(propertyOf("scan", "inlineRules").description)).toContain("Mutually exclusive with ruleFile");
+    expect(String(SCAN_TOOL_DESCRIPTION)).toContain("Provide either ruleFile or inlineRules");
   });
 
-  it("#given scan args with NO rule source #when validated against the descriptor #then they are schema-invalid", () => {
-    expect(satisfies(schemaOf("scan"), { paths: ["src"] })).toBe(false);
+  it("#given scan args with NO rule source #when parsed #then the parser rejects them", () => {
+    expect(() => scanInputSchema.parse({ paths: ["src"] })).toThrow(
+      "Exactly one of ruleFile or inlineRules must be provided",
+    );
   });
 
-  it("#given scan args with BOTH rule sources #when validated against the descriptor #then they are schema-invalid", () => {
-    expect(satisfies(schemaOf("scan"), { paths: ["src"], ruleFile: "r.yml", inlineRules: "id: x" })).toBe(false);
+  it("#given scan args with BOTH rule sources #when parsed #then the parser rejects them", () => {
+    expect(() => scanInputSchema.parse({ paths: ["src"], ruleFile: "r.yml", inlineRules: "id: x" })).toThrow(
+      "Exactly one of ruleFile or inlineRules must be provided",
+    );
   });
 
-  it("#given scan args with exactly one rule source #when validated against the descriptor #then they are schema-valid", () => {
-    expect(satisfies(schemaOf("scan"), { paths: ["src"], ruleFile: "r.yml" })).toBe(true);
-    expect(satisfies(schemaOf("scan"), { paths: ["src"], inlineRules: "id: x" })).toBe(true);
+  it("#given scan args with exactly one rule source #when parsed #then the parser accepts them", () => {
+    expect(() => scanInputSchema.parse({ paths: ["src"], ruleFile: "r.yml" })).not.toThrow();
+    expect(() => scanInputSchema.parse({ paths: ["src"], inlineRules: "id: x" })).not.toThrow();
   });
 });
 

--- a/packages/ast-grep-mcp/src/mcp.ts
+++ b/packages/ast-grep-mcp/src/mcp.ts
@@ -189,11 +189,11 @@ export const AST_GREP_MCP_TOOLS: readonly McpToolDescriptor[] = [
       },
       required: ["paths"],
       // Exactly one explicit rule source per call (ub §11): ruleFile XOR inlineRules.
-      // Advertised so a client sees the contract before the parser rejects the call.
-      oneOf: [
-        { type: "object", required: ["ruleFile"], not: { required: ["inlineRules"] } },
-        { type: "object", required: ["inlineRules"], not: { required: ["ruleFile"] } },
-      ],
+      // The contract is published in both property descriptions and enforced by
+      // parseScanInput, NOT by a schema-level oneOf/not: Cursor's AgentService gateway
+      // cannot convert JSON-Schema composition keywords to protobuf and kills the entire
+      // run with a wrapped `resource_exhausted` when it meets one. Same reasoning as the
+      // byte budgets above — the parser stays authoritative, the schema stays portable.
       additionalProperties: false,
     },
   },


### PR DESCRIPTION
## Problem

Cursor's `AgentService/Run` cannot convert JSON-Schema composition keywords to protobuf. When an advertised MCP tool's `inputSchema` contains `oneOf`/`not`, the gateway fails the **entire request** and surfaces it as a wrapped `resource_exhausted` — a fake quota error, zero tokens spent, the whole session dead. Merely having this MCP server attached was enough to kill a run.

`scan` was the only descriptor in the repo shipping composition keywords (the `ruleFile` XOR `inlineRules` block).

Field evidence (isolated in a live session before this fix):

| Schema | Result |
|---|---|
| fake tool with only `oneOf` | rejected |
| `scan` with `oneOf` removed | OK |
| `scan` as shipped | rejected |

## Fix

Remove the `oneOf`/`not` block from the advertised `scan` schema. The exclusivity contract never needed to live there:

- `parseScanInput` already rejects both-or-neither with `Exactly one of ruleFile or inlineRules must be provided`, **before** anything spawns (`executeScan` returns `INVALID_ARGUMENT` in the preflight phase).
- Both property descriptions and the tool description already publish the rule to the model.

This mirrors the reasoning this file already applies to the byte budgets: the parser stays authoritative, the schema stays portable across clients.

## Tests

- **New walker guard** — fails the build if *any* advertised `inputSchema` grows `oneOf`/`anyOf`/`allOf`/`not` at any depth. Captured RED before the fix (`scan.oneOf`, `scan.oneOf[0].not`, `scan.oneOf[1].not`), green after.
- **Rule-source suite realigned** — now pins the contract where it is actually enforced (the parser) instead of the descriptor; the hand-rolled `satisfies` JSON-Schema mini-validator is gone with the keywords it existed to check.
- `bun test` in `packages/ast-grep-mcp`: **308 pass / 0 fail** (2 pre-existing Windows-only skips). `bun run typecheck` clean.

## Manual QA

Booted the real stdio server and spoke a Cursor-shaped handshake (`initialize` → `notifications/initialized` → `tools/list`):

```
--- composition keys present: NONE (clean)
```

The `scan` schema a client now receives keeps `Mutually exclusive with inlineRules` / `Mutually exclusive with ruleFile` in the property descriptions, with no composition keywords anywhere in the payload.

## Note on senpi

senpi ≥ `v2026.8.18-3` independently sanitizes `oneOf`/`anyOf`/`allOf` out of advertised Cursor tool schemas (`sanitizeCursorToolSchema`, commit `9df9c438a`), so senpi hosts on that release or newer were already shielded. This fix removes the poison at the source, which matters for every other MCP client (Cursor desktop included) and for hosts still on older senpi builds.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes JSON‑Schema composition keywords from the advertised `scan` tool schema to prevent Cursor runs from dying with a wrapped resource_exhausted error. Previously, `oneOf`/`not` in `inputSchema` caused AgentService protobuf conversion to fail; the parser already enforces the exclusivity contract, so behavior is unchanged for callers.

- Drops `oneOf`/`not` from `scan`’s `inputSchema`; property and tool descriptions still state “ruleFile XOR inlineRules,” and the parser enforces it preflight.
- Adds a guard test that walks every advertised `inputSchema` and fails the build if any `oneOf`/`anyOf`/`allOf`/`not` appears.
- Updates the rule-source tests to target the parser and removes the ad‑hoc schema mini‑validator.
- No client migration required; clients now receive a composition‑free schema while keeping the same contract.

<sup>Written for commit f63ae64ddbdafe389b1f526e73157faa415d75bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

