### PR TITLE
fix(lsp-core): allow read-only LSP tools on files outside request cwd

### DIFF
--- a/packages/lsp-core/src/lsp/client-wrapper-outside-cwd.test.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper-outside-cwd.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { createStandaloneMcpRequestContext, runWithRequestContext } from "../request-context.js";
+import { findWorkspaceRoot, resolveReadablePathInsideContext, resolvePathInsideContext } from "./client-wrapper.js";
+import { LspInvalidPathError } from "./errors.js";
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function tempRoot(prefix: string): string {
+	const root = mkdtempSync(join(tmpdir(), prefix));
+	tempDirectories.push(root);
+	return root;
+}
+
+describe("LSP read-only access outside request cwd", () => {
+	it("#given an absolute file outside cwd #when resolving a read path #then returns the canonical path", () => {
+		const root = tempRoot("lsp-outcwd-root-");
+		const outside = tempRoot("lsp-outcwd-outside-");
+		const outsideFile = join(outside, "probe.ts");
+		writeFileSync(outsideFile, "export const value = 1;\n");
+
+		const resolved = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+			resolveReadablePathInsideContext(outsideFile),
+		);
+
+		expect(resolved).toBe(realpathSync(outsideFile));
+	});
+
+	it("#given an outside file inside its own marked project #when inferring workspace #then uses that project root", () => {
+		const root = tempRoot("lsp-outcwd-marker-root-");
+		const outside = tempRoot("lsp-outcwd-marker-outside-");
+		mkdirSync(join(outside, ".git"), { recursive: true });
+		mkdirSync(join(outside, "src"), { recursive: true });
+		const outsideFile = join(outside, "src", "probe.ts");
+		writeFileSync(outsideFile, "export const value = 1;\n");
+
+		const workspace = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+			findWorkspaceRoot(outsideFile),
+		);
+
+		expect(workspace).toBe(realpathSync(outside));
+	});
+
+	it("#given an outside file without any marker #when inferring workspace #then falls back to its own directory", () => {
+		const root = tempRoot("lsp-outcwd-nomarker-root-");
+		const outside = tempRoot("lsp-outcwd-nomarker-outside-");
+		const outsideFile = join(outside, "probe.ts");
+		writeFileSync(outsideFile, "export const value = 1;\n");
+
+		const workspace = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+			findWorkspaceRoot(outsideFile),
+		);
+
+		expect(workspace).toBe(realpathSync(outside));
+	});
+
+	it("#given an outside file #when resolving a mutating path #then still rejects to keep writes confined", () => {
+		const root = tempRoot("lsp-outcwd-write-root-");
+		const outside = tempRoot("lsp-outcwd-write-outside-");
+		const outsideFile = join(outside, "probe.ts");
+		writeFileSync(outsideFile, "export const value = 1;\n");
+
+		expect(() =>
+			runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+				resolvePathInsideContext(outsideFile),
+			),
+		).toThrow(LspInvalidPathError);
+	});
+});

--- a/packages/lsp-core/src/lsp/client-wrapper.test.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.test.ts
@@ -36,17 +36,17 @@ describe("LSP client path confinement", () => {
 		expect(workspace).toBe(realpathSync(root));
 	});
 
-	it("#given an absolute file outside context cwd #when resolving #then rejects before workspace inference", () => {
+	it("#given an absolute file outside context cwd #when resolving #then infers the file's own project root", () => {
 		const root = tempRoot("lsp-client-wrapper-cwd-");
 		const outside = tempRoot("lsp-client-wrapper-outside-");
 		mkdirSync(join(outside, ".git"), { recursive: true });
 		writeFileSync(join(outside, "file.ts"), "export const outside = true;\n");
 
-		expect(() =>
-			runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
-				findWorkspaceRoot(join(outside, "file.ts")),
-			),
-		).toThrow(LspInvalidPathError);
+		const workspace = runWithRequestContext(createStandaloneMcpRequestContext({ cwd: root }), () =>
+			findWorkspaceRoot(join(outside, "file.ts")),
+		);
+
+		expect(workspace).toBe(realpathSync(outside));
 	});
 
 	it("#given a symlink inside cwd that points outside #when resolving read path #then keeps lexical path and cwd root", () => {

--- a/packages/lsp-core/src/lsp/client-wrapper.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.ts
@@ -16,11 +16,11 @@ import {
 	LspServerLookupError,
 } from "./errors.js";
 import { getLspManager, type LspManager } from "./manager.js";
+import { findWorkspaceRootOutsideContext } from "./outside-context-workspace.js";
 import { loadInstallDecision } from "./server-install-state.js";
 import { findServerForExtension } from "./server-resolution.js";
 import type { ServerLookupResult } from "./types.js";
-
-const WORKSPACE_MARKERS = [".git", "package.json", "pyproject.toml", "Cargo.toml", "go.mod", "pom.xml", "build.gradle"];
+import { WORKSPACE_MARKERS } from "./workspace-markers.js";
 
 export function isDirectoryPath(filePath: string): boolean {
 	try {
@@ -38,6 +38,8 @@ export function findWorkspaceRoot(filePath: string): string {
 	if (!isDirectoryPath(dir)) {
 		dir = dirname(dir);
 	}
+
+	if (!isPathInside(cwd, abs)) return findWorkspaceRootOutsideContext(dir);
 
 	const fallbackRoot = nearestExistingDirectoryInsideContext(dir, cwd) ?? cwd;
 	while (isPathInside(cwd, dir)) {
@@ -64,10 +66,7 @@ export function resolveReadablePathInsideContext(filePath: string): string {
 	const rebased = rebaseThroughCanonicalAncestor(abs, cwd);
 	if (rebased !== undefined) return rebased;
 
-	const canonical = canonicalizeExistingOrNearestAncestor(abs);
-	if (isPathInside(cwd, canonical)) return canonical;
-
-	throw new LspInvalidPathError(`LSP file path must be inside request cwd: ${filePath}`);
+	return canonicalizeExistingOrNearestAncestor(abs);
 }
 
 export function resolvePathInsideContext(filePath: string): string {

--- a/packages/lsp-core/src/lsp/outside-context-workspace.ts
+++ b/packages/lsp-core/src/lsp/outside-context-workspace.ts
@@ -1,0 +1,33 @@
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { WORKSPACE_MARKERS } from "./workspace-markers.js";
+
+/** Read-only tools accept out-of-cwd files, so cwd cannot bound this search; the fallback keeps the server scoped to the file's own directory. */
+export function findWorkspaceRootOutsideContext(directory: string): string {
+	const marked = nearestMarkedAncestor(directory);
+	if (marked !== undefined) return marked;
+	return realpathSync(nearestExistingAncestor(directory));
+}
+
+function nearestMarkedAncestor(directory: string): string | undefined {
+	let current = directory;
+	for (;;) {
+		if (existsSync(current) && WORKSPACE_MARKERS.some((marker) => existsSync(join(current, marker)))) {
+			return realpathSync(current);
+		}
+		const parent = dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+}
+
+function nearestExistingAncestor(directory: string): string {
+	let current = directory;
+	while (!existsSync(current)) {
+		const parent = dirname(current);
+		if (parent === current) return current;
+		current = parent;
+	}
+	return current;
+}

--- a/packages/lsp-core/src/lsp/workspace-markers.ts
+++ b/packages/lsp-core/src/lsp/workspace-markers.ts
@@ -1,0 +1,1 @@
+export const WORKSPACE_MARKERS = [".git", "package.json", "pyproject.toml", "Cargo.toml", "go.mod", "pom.xml", "build.gradle"] as const;


### PR DESCRIPTION
## Problem

Read-only LSP requests rejected any absolute path outside the request cwd:

```
LSP file path must be inside request cwd: /tmp/ulw-uaproxy/proxy.ts
```

This fires constantly in real sessions whenever the agent inspects a scratch file under `/tmp`, a sibling checkout, or a git worktree while the session is rooted somewhere else. Sessions were falling back to remote `tsgo` runs just to typecheck a file the LSP could have answered for. It reproduces on this very PR: editing files in an `omo-wt/` worktree from a session rooted elsewhere makes every post-edit diagnostics hook fail.

## Fix

- `resolveReadablePathInsideContext()` canonicalizes out-of-cwd paths instead of throwing.
- `findWorkspaceRoot()` delegates to a new `findWorkspaceRootOutsideContext()` when the file falls outside cwd: it walks the file's **own** ancestry for a workspace marker and falls back to the nearest existing directory, so the language server stays scoped to that file's project rather than to an unrelated cwd.
- `WORKSPACE_MARKERS` moved to its own module, shared by both paths.

**The write boundary is deliberately unchanged.** `resolvePathInsideContext()` — used by `lsp_rename` and workspace edits — still rejects out-of-cwd paths, so mutations remain confined to the request cwd. Read anywhere, write only inside cwd.

Because `lsp-core` backs `lsp-tools-mcp`, `lsp-daemon`, and `omo-senpi`, this one change fixes every harness.

## Evidence

**RED → GREEN at the real tool surface**, identical invocation (`cwd=packages/lsp-core`, `target=/tmp/ulw-lsp-outcwd-probe/src/proxy.ts`):

| | Result |
|---|---|
| before | `LspInvalidPathError: LSP file path must be inside request cwd: /tmp/ulw-lsp-outcwd-probe/src/proxy.ts` |
| after | `resolved: /private/tmp/ulw-lsp-outcwd-probe/src/proxy.ts`, `workspaceRoot: /private/tmp/ulw-lsp-outcwd-probe` |

**Unit seam** — `client-wrapper-outside-cwd.test.ts` captured RED first (3 fail / 1 pass; the pass was the mutation guard that must stay), then GREEN:

- resolves an out-of-cwd read path
- infers the outside file's own marked project root
- falls back to the file's directory when unmarked
- **still rejects the mutating path** (write confinement preserved)

**Regression:** `bun test` in `lsp-core` → 91 pass / 0 fail across 20 files; `omo-senpi/src/components/lsp` → 22 pass / 0 fail; `tsgo --noEmit` clean.

The one existing test that encoded the old reject-contract for read paths was rewritten to assert the new root inference; adversarial workspace-edit tests are untouched and still green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows read-only LSP tools in `lsp-core` to operate on files outside the request cwd. Previously these requests errored; now reads canonicalize the path and infer the file’s own workspace, while writes remain confined to the cwd.

- `resolveReadablePathInsideContext()` accepts out-of-cwd absolute paths and returns the canonical path.
- `findWorkspaceRoot()` delegates to `findWorkspaceRootOutsideContext()` for out-of-cwd files: walk ancestry for workspace markers and fall back to the nearest existing directory; `WORKSPACE_MARKERS` moved to `workspace-markers.ts`.
- Write confinement is unchanged: `resolvePathInsideContext()` still rejects out-of-cwd paths (rename/workspace edits stay inside cwd).
- Tests: added `client-wrapper-outside-cwd.test.ts`; updated `client-wrapper.test.ts` to assert outside-project root inference. Improves behavior in `lsp-tools-mcp`, `lsp-daemon`, and `omo-senpi`; no migration required.

<sup>Written for commit 5e13e4ab8b3686c8ce9afee3eeef187fef02bc86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

