### PR TITLE
test(omo-senpi): surface rpc child exit facts in the task e2e driver

### DIFF
--- a/packages/omo-senpi/scripts/qa/task-rpc-e2e-scenarios.mjs
+++ b/packages/omo-senpi/scripts/qa/task-rpc-e2e-scenarios.mjs
@@ -63,6 +63,20 @@ export function prepareScenarioSandbox(projectConfig = PROJECT_OMO_CONFIG) {
   return { sandbox, sessionDir, stateDir: join(sandbox.cwd, ".omo", "senpi-task") }
 }
 
+// When the driver reports "no task record persisted" the child's own exit status and stderr are the only
+// evidence that explains WHY nothing was written, and spawnSync already collects both. Returning undefined
+// for a clean run keeps passing payloads byte-identical; a failed run carries the diagnostic instead of
+// discarding it, which is what made the windows-latest failures in #6976 undiagnosable across repeated reruns.
+export function summarizeDriveFailure(run) {
+  if (run.status === 0 && run.signal === null) return undefined
+  return {
+    childExitStatus: run.status,
+    childSignal: run.signal,
+    childStderrExcerpt: run.stderr.trim().slice(0, 2000),
+    childStdoutBytes: run.stdout.length,
+  }
+}
+
 export function driveSenpi(senpiBin, sandbox, sessionDir, parentSteps, childSteps = CHILD_STEPS_COMPLETE, prompt = "run the rpc-process task e2e") {
   writeScript(sandbox, parentSteps, childSteps)
   const run = spawnSync(senpiBin, childArgv(sessionDir, prompt), {

--- a/packages/omo-senpi/scripts/qa/task-rpc-e2e-scenarios.test.mjs
+++ b/packages/omo-senpi/scripts/qa/task-rpc-e2e-scenarios.test.mjs
@@ -1,6 +1,37 @@
 import { expect, test } from "bun:test"
 
-import { killSenpiHost } from "./task-rpc-e2e-scenarios.mjs"
+import { killSenpiHost, summarizeDriveFailure } from "./task-rpc-e2e-scenarios.mjs"
+
+test("#given a senpi host run that persisted no task record #when the failure is summarized #then the child exit and stderr are surfaced", () => {
+  const summary = summarizeDriveFailure({
+    status: 1,
+    signal: null,
+    stdout: "",
+    stderr: "Error: cannot find module '@code-yeongyu/senpi/rpc-entry'\n",
+  })
+
+  expect(summary).toEqual({
+    childExitStatus: 1,
+    childSignal: null,
+    childStderrExcerpt: "Error: cannot find module '@code-yeongyu/senpi/rpc-entry'",
+    childStdoutBytes: 0,
+  })
+})
+
+test("#given a clean senpi host run #when the failure is summarized #then no diagnostic noise is attached", () => {
+  expect(summarizeDriveFailure({ status: 0, signal: null, stdout: "{}\n", stderr: "" })).toBeUndefined()
+})
+
+test("#given a killed senpi host run #when the failure is summarized #then the signal is surfaced without stderr", () => {
+  const summary = summarizeDriveFailure({ status: null, signal: "SIGKILL", stdout: "", stderr: "" })
+
+  expect(summary).toEqual({
+    childExitStatus: null,
+    childSignal: "SIGKILL",
+    childStderrExcerpt: "",
+    childStdoutBytes: 0,
+  })
+})
 
 test("#given a live Senpi QA host #when it is killed #then teardown routes through tree termination", async () => {
   const calls = []

--- a/packages/omo-senpi/scripts/qa/task-rpc-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/task-rpc-e2e.mjs
@@ -8,7 +8,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url))
 const { digestDirectory } = await import(pathToFileURL(join(scriptDir, "drive.mjs")).href)
 const { CREDENTIAL_FILES, digestCredentialFiles, parseEvents, readRecords, analyzeSpawn, analyzeRpcRouting, eventsMentionSteerAck, statusSnapshots, liveRecordRpcChildPids, recordRpcChildPids, sleep } =
   await import(pathToFileURL(join(scriptDir, "task-rpc-e2e-helpers.mjs")).href)
-const { SCENARIO_A_STEPS, prepareScenarioSandbox, driveSenpi, runKillCheck, runReconcileCheck } =
+const { SCENARIO_A_STEPS, prepareScenarioSandbox, driveSenpi, runKillCheck, runReconcileCheck, summarizeDriveFailure } =
   await import(pathToFileURL(join(scriptDir, "task-rpc-e2e-scenarios.mjs")).href)
 const realSenpiAgentDir = join(homedir(), ".senpi", "agent")
 
@@ -47,6 +47,7 @@ async function runChecks(senpiBin, sandbox, sessionDir, stateDir) {
   const checks = []
   const a = driveSenpi(senpiBin, sandbox, sessionDir, SCENARIO_A_STEPS)
   const aEvents = parseEvents(a.stdout)
+  const childDiagnostic = summarizeDriveFailure(a)
   const routing = analyzeRpcRouting(readRecords(stateDir))
   checks.push({ check: "process_mode_routes_to_rpc_runner", verdict: routing.routed ? "PASS" : "FAIL", ...(routing.reason && { reason: routing.reason }), facts: routing.facts })
   const spawn = analyzeSpawn(readRecords(stateDir), stateDir)
@@ -74,7 +75,7 @@ async function runChecks(senpiBin, sandbox, sessionDir, stateDir) {
   killProcessTree(stateDir)
   const leakedPids = await waitForRecordedPidsToExit(stateDir)
   checks.push({ check: "no_leaked_rpc_child_pids", verdict: leakedPids.length === 0 ? "PASS" : "FAIL", ...(leakedPids.length > 0 && { reason: `leaked pids ${leakedPids.join(",")}` }), facts: { leakedPids } })
-  return { checks, leakedPids, spawnPass: spawn.pass, routed: routing.routed }
+  return { checks, leakedPids, spawnPass: spawn.pass, routed: routing.routed, childDiagnostic }
 }
 
 async function waitForRecordedPidsToExit(stateDir, timeoutMs = 5_000) {
@@ -99,7 +100,7 @@ async function main() {
   const { sandbox, sessionDir, stateDir } = prepareScenarioSandbox()
   let payload
   try {
-    const { checks, leakedPids, spawnPass, routed } = await runChecks(senpiBin, sandbox, sessionDir, stateDir)
+    const { checks, leakedPids, spawnPass, routed, childDiagnostic } = await runChecks(senpiBin, sandbox, sessionDir, stateDir)
     const afterCreds = digestCredentialFiles(realSenpiAgentDir)
     const wholeDirDigestStable = beforeWholeDir === digestDirectory(realSenpiAgentDir)
     const realCredentialsUntouched = beforeCreds === afterCreds
@@ -120,12 +121,13 @@ async function main() {
       sandboxAgentDir: sandbox.agentDir,
       sandboxCwd: sandbox.cwd,
       wiringFixed: routed,
+      ...(childDiagnostic === undefined ? {} : { childDiagnostic }),
       ...(spawnPass
         ? {}
         : {
             productGap: routed
               ? "execution_mode:'process' routes to the rpc runner, but no real detached child spawned with a pid + child session JSONL. Expected after the spawn-strategy fix: buildRpcSpawn must spawn the senpi EXECUTABLE ('<exe> --mode rpc'), not require.resolve('@code-yeongyu/senpi/rpc-entry') which senpi's loader alias hijacks; and RpcRunnerSpec must thread the model + the parent's -e extensions so a keyless mock child can run."
-              : "execution_mode:'process' did not reach the rpc runner - the process slot still aliases the in-process runner. Fix engine.ts runners.process to createRpcManagedRunner(new RpcProcessRunner()).",
+              : "execution_mode:'process' produced no usable task record. NOTE: this branch does NOT prove a runner-wiring defect - it also fires when the sandbox state dir holds zero task records (analyzeRpcRouting returns reason 'no task record persisted'), i.e. the child never persisted anything. Read `childDiagnostic` (child exit status/signal/stderr) and the routing `reason` before touching runner wiring; DEFAULT_RUNNER_FACTORIES.process already builds createRpcManagedRunner(new RpcProcessRunner()).",
           }),
     }
   } finally {


### PR DESCRIPTION
## Problem

`senpi-compatibility (windows-latest)` has been red across effectively every open PR, tracked in #6976. The driver payload reported:

```
"check": "process_mode_routes_to_rpc_runner", "verdict": "FAIL", "reason": "no task record persisted"
"productGap": "execution_mode:'process' did not reach the rpc runner - the process slot still aliases
               the in-process runner. Fix engine.ts runners.process to createRpcManagedRunner(...)"
```

Two things made this cluster far more expensive to debug than it needed to be.

**1. The suggested fix is already in the tree.** `DEFAULT_RUNNER_FACTORIES.process` → `buildProcessRunner` (`packages/omo-senpi/src/components/task/engine-runners.ts:64-65`) already returns exactly `createRpcManagedRunner(new RpcProcessRunner({ ... }))`. That productGap string is selected by a ternary on `routed`, and `analyzeRpcRouting` (`task-rpc-e2e-helpers.mjs:75-77`) returns `routed: false` with reason `"no task record persisted"` whenever `readRecords(stateDir)` is empty. An empty sandbox state dir therefore prints wiring advice for wiring that is already correct.

**2. The evidence that would explain the empty state dir was thrown away.** `driveSenpi` returns `{ status, signal, stdout, stderr }`, but `runChecks` bound it and read only `.stdout`. The child's exit status, signal, and stderr were collected by `spawnSync` and silently dropped, so six runs plus their reruns produced no actionable information about *why* nothing was persisted.

## Change

- Add `summarizeDriveFailure(run)`, returning `undefined` for a clean run so passing payloads stay byte-identical, and a `childDiagnostic` (exit status, signal, stderr excerpt capped at 2000 chars, stdout size) otherwise.
- Attach `childDiagnostic` to failing driver payloads only.
- Reword the `routed === false` productGap to point at `childDiagnostic` and the routing reason, and state explicitly that this branch does **not** prove a wiring defect.

This is diagnostic plumbing for the QA driver. No product code changes.

## Verification

RED first — the new tests failed with `SyntaxError: Export named 'summarizeDriveFailure' not found`, then GREEN:

```
bun test packages/omo-senpi/scripts/qa/task-rpc-e2e-scenarios.test.mjs
5 pass, 0 fail   (3 new + 2 pre-existing)

bun test packages/omo-senpi/scripts/qa/
73 pass, 1 skip, 0 fail   (skip = the win32-only driver test)
```

End-to-end through the real driver, reproducing the exact CI condition with a stub binary that exits non-zero and persists nothing:

```json
{
  "result": "FAIL",
  "childDiagnostic": {
    "childExitStatus": 1,
    "childSignal": null,
    "childStderrExcerpt": "FAKE CHILD: rpc entry could not be resolved",
    "childStdoutBytes": 0
  },
  "routing_reason": ["no task record persisted"]
}
```

Before this change that identical run surfaced only `no task record persisted` plus the misleading wiring advice.

## Relationship to the other #6976 PRs

Complementary, not overlapping:

- **#7026** fixes the `registerMemoryUsage` signature in `memory-usage-tracker.ts`; it does not touch the RPC path, which is why it stays red on this job.
- **#7027** rewrites `runKillCheck` and adds `externalTerminationMatchesPlatformFacts` in the same two QA files, but in different hunks — these merge cleanly.

Neither addresses the discarded child diagnostics. With this in, the next Windows run should finally say why no record is written.

Refs #6976


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces RPC child exit facts in the task E2E driver to explain “no task record persisted” failures in Windows CI (#6976). Previously the driver dropped the child’s exit status/signal/stderr and implied a wiring defect; now failing payloads include a child diagnostic and the guidance points to that evidence.

- Add summarizeDriveFailure: returns undefined on clean runs; otherwise returns childDiagnostic { childExitStatus, childSignal, childStderrExcerpt (<=2000 chars), childStdoutBytes }. Attach only on failing payloads so passing payloads remain byte-identical.
- Reword productGap when routing is false: clarify this does not prove a runner-wiring defect and direct reviewers to childDiagnostic and the routing reason.
- Add focused tests for summarizeDriveFailure (non-zero exit, clean run, killed run) and plumb the diagnostic through the task RPC E2E driver.
- Scope: QA driver/tests in packages/omo-senpi/scripts/qa only; no product code changes.
- Rollout: If anything consumes the driver payload, allow an optional childDiagnostic field on failures; no changes needed for passing runs.

<sup>Written for commit 56e36a67f2bbac433db0be8aeae04bf6d3539143. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

