### PR TITLE
test(omo-senpi): anchor doctor reflection-streak fixture to the clock

### DIFF
--- a/packages/omo-senpi/src/components/memory/commands/doctor.test.ts
+++ b/packages/omo-senpi/src/components/memory/commands/doctor.test.ts
@@ -188,7 +188,9 @@ describe("/doctor", () => {
     const { identity, pi, ctx } = await harness()
     const completions = join(identity.identityPaths.reflection, "completions")
     await mkdir(completions, { recursive: true })
+    const failureBaseMs = Date.now() - 3 * 60 * 60_000
     for (let index = 0; index < 3; index += 1) {
+      const startedAtMs = failureBaseMs + index * 60_000
       await writeFile(join(completions, `run-${index}.json`), `${JSON.stringify({
         schemaVersion: 1,
         runId: `run-${index}`,
@@ -199,8 +201,8 @@ describe("/doctor", () => {
         outcome: "failed",
         reason: "model-not-found",
         detail: "configured model unavailable",
-        startedAt: `2026-08-12T0${index}:00:00.000Z`,
-        finishedAt: `2026-08-12T0${index}:01:00.000Z`,
+        startedAt: new Date(startedAtMs).toISOString(),
+        finishedAt: new Date(startedAtMs + 60_000).toISOString(),
         delivery: { status: index === 2 ? "pending" : "consumed" },
       })}\n`)
     }


### PR DESCRIPTION
## Problem

`senpi-compatibility` is red on `dev` across ubuntu, macOS and Windows, blocking every PR:

```
(fail) /doctor > #given repeated model-not-found reflection failures #when doctor runs
                 #then reflection health and remediation are reported
1968 pass / 1 fail
```

## Root cause: a time-bomb fixture, not a code regression

`readReflectionHealth()` drops a trailing failure streak once its newest failure is older than `REFLECTION_HEALTH_STALE_MS` (7 days) — deliberate behaviour from `29625adfc fix(memory): stop alerting on stale reflection failure streaks`, so an identity that stopped reflecting does not nag forever off a frozen burst.

The test wrote completion records stamped `2026-08-12T0…` and asserted `[warn]`. On **2026-08-19** those records crossed the 7-day bound, so the streak legitimately collapsed to 0 and doctor correctly reported `[ok]`. The test failed on a calendar boundary rather than on a commit — which is why it went red on three platforms with no related code change.

The product behaviour is correct. Only the fixture was time-dependent, so this PR touches **the test only**.

## Fix

Fixture timestamps now derive from the current clock (`Date.now() - 3h`, one minute apart), keeping them inside the staleness window forever. The case still proves that three recent consecutive failures raise the warning plus remediation.

Sibling coverage in `worker/health.test.ts` was never affected — it injects an explicit `{ now }` into `readReflectionHealth`. `checkReflectionHealth()` takes no clock, which is why `doctor.test.ts` was the only test of this class.

## Evidence

- Repaired test: **16 pass / 0 fail**.
- **Mutation proof** (the fixture change must not be a rubber stamp): forcing the severity gate to `level: "ok"` turns the test **red** (15 pass / 1 fail); restoring it turns it **green** (16/16). The assertion still fails for the regression it names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the /doctor reflection-health test fixture to the current clock to remove time-based flakiness. Previously, hardcoded 2026-08-12 timestamps aged past the 7-day window so `readReflectionHealth()` returned [ok] instead of [warn]; now the timestamps stay fresh and the warning holds.

- Change is limited to `packages/omo-senpi/src/components/memory/commands/doctor.test.ts`; no runtime behavior changed.
- Timestamps derive from `Date.now() - 3h` with one-minute spacing to keep three consecutive failures inside the staleness window.
- Verified by mutation: forcing the severity gate to "ok" fails the test; restoring it passes.

<sup>Written for commit dbaab6cb7b9fbfb3642cc87337b36533ab615cc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

