### PR TITLE
test(omo-opencode): raise the host-zod copy ceiling windows overshoots

### DIFF
--- a/packages/omo-opencode/src/features/claude-code-plugin-loader/mcp-server-loader.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-plugin-loader/mcp-server-loader.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock, setDefaultTimeout } from "bun:test"
 import { mkdirSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
@@ -9,6 +9,12 @@ const PROJECT_DIR = join(TEST_DIR, "project")
 const PROJECT_SUBDIRECTORY = join(PROJECT_DIR, "packages", "app")
 const PLUGIN_DIR = join(TEST_DIR, "plugin")
 const MCP_CONFIG_PATH = join(PLUGIN_DIR, "mcp.json")
+
+// Bun honours a preload's setDefaultTimeout only for the FIRST test file of a run, so this file
+// falls back to the built-in 5000ms. That budget covers the beforeEach/afterEach hooks too - and a
+// hook timeout ignores a test's own `}, N)` argument - so the windows runner timed the hooks out
+// while building the plugin fixture tree. Set the floor here, where Bun does honour it.
+setDefaultTimeout(process.platform === "win32" ? 60_000 : 20_000)
 
 describe("loadPluginMcpServers", () => {
   beforeEach(() => {

--- a/packages/omo-opencode/src/plugin/normalize-tool-arg-schemas.test.ts
+++ b/packages/omo-opencode/src/plugin/normalize-tool-arg-schemas.test.ts
@@ -93,9 +93,10 @@ describe("normalizeToolArgSchemas", () => {
     expect(afterQuery?.description).toBe("Free-text search query")
     expect(afterQuery?.title).toBe("Query")
     expect(afterQuery?.examples).toEqual(["issue 2314"])
-    // loadSeparateHostZodModule cpSync-copies the whole zod package; Windows CI
+    // loadSeparateHostZodModule cpSync-copies the whole zod package and then dynamically
+    // imports the copy; Windows CI
     // runners exceed the 5s default on that copy alone
-  }, 15000)
+  }, 60_000)
 })
 
 describe("sanitizeJsonSchema", () => {


### PR DESCRIPTION
The separate-host-zod case cpSync-copies the whole zod package then dynamically imports the copy. The 15000ms ceiling is too tight on Windows CI: the release-state PR for v5.0.0-beta.11 timed out at 17095ms on `test (windows-latest, 1/2)`, failing a required check so `prepare-release-state` refused to publish. The same shard passes on other runs, so this is a marginal ceiling, not a regression. Raised to 60s; assertions untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes Windows CI by raising timeouts in `packages/omo-opencode` tests that overshoot Bun’s defaults. The host-`zod` copy/import test moves from 15s to 60s, and the MCP server loader suite sets a file-level default timeout (60s on Windows, 20s elsewhere) to cover slow hooks.

- Test-only; assertions unchanged; hung operations still fail after 60s. Avoids hook timeouts when `bun:test` applies a preload default only to the first file.
- Changes in: `packages/omo-opencode/src/plugin/normalize-tool-arg-schemas.test.ts`, `packages/omo-opencode/src/features/claude-code-plugin-loader/mcp-server-loader.test.ts`.

<sup>Written for commit b16ef0f84ca12e002dc523931e8f30c5c38468ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

