### PR TITLE
ci: keep ordinary pull-request CI on ubuntu, keep full 3-OS coverage where it matters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [master, dev]
   pull_request:
     branches: [master, dev]
+    # `labeled` lets the ci:full-matrix label retrigger CI; concurrency cancel-in-progress absorbs bot-label churn.
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +22,7 @@ jobs:
       generated_release_push: ${{ steps.classify.outputs.generated_release_push }}
       web_only: ${{ steps.classify.outputs.web_only }}
       run_heavy: ${{ steps.classify.outputs.run_heavy }}
+      full_matrix: ${{ steps.classify.outputs.full_matrix }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -31,6 +34,8 @@ jobs:
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
+          HEAD_REF: ${{ github.head_ref || '' }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) || '[]' }}
         run: |
           set -euo pipefail
 
@@ -51,11 +56,14 @@ jobs:
             --message "$HEAD_COMMIT_MESSAGE" \
             --diff-available "$DIFF_AVAILABLE" \
             --merge-parents "$MERGE_PARENTS" \
+            --head-ref "$HEAD_REF" \
+            --labels "${PR_LABELS:-[]}" \
             < "$PATHS_FILE")"
 
           jq -r '"generated_release_push=\(.generatedReleasePush)"' <<< "$MODE_JSON" >> "$GITHUB_OUTPUT"
           jq -r '"web_only=\(.webOnly)"' <<< "$MODE_JSON" >> "$GITHUB_OUTPUT"
           jq -r '"run_heavy=\(.runHeavy)"' <<< "$MODE_JSON" >> "$GITHUB_OUTPUT"
+          jq -r '"full_matrix=\(.fullMatrix)"' <<< "$MODE_JSON" >> "$GITHUB_OUTPUT"
           jq . <<< "$MODE_JSON"
 
       - name: Write job summary
@@ -68,7 +76,8 @@ jobs:
             - Generated release push: `${{ steps.classify.outputs.generated_release_push || 'unknown' }}`.
             - Web-only change: `${{ steps.classify.outputs.web_only || 'unknown' }}`.
             - Run heavy validation: `${{ steps.classify.outputs.run_heavy || 'unknown' }}`.
-          JOB_SUMMARY_NEXT: Classification failures default to heavy validation; inspect the changed-path diff and event metadata.
+            - Full 3-OS matrix: `${{ steps.classify.outputs.full_matrix || 'unknown' }}` (false keeps heavy work on ubuntu; add the `ci:full-matrix` label to force it).
+          JOB_SUMMARY_NEXT: Classification failures default to heavy validation on the full matrix; inspect the changed-path diff and event metadata.
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   # Block PRs targeting master branch (comment + auto-close, then fail the check)
@@ -151,12 +160,12 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           # Test legs run 1.3.14: the Windows partition was validated under it
           # and 1.3.12 hangs on windows-latest in the ast-grep install-script
@@ -165,39 +174,39 @@ jobs:
 
 
       - uses: actions/cache@v5
-        if: runner.os != 'Windows' && needs.ci-mode.outputs.run_heavy == 'true'
+        if: runner.os != 'Windows' && needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun install --frozen-lockfile
 
       - name: Remove stale self-package test copies
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun run script/remove-stale-self-package-tests.ts
 
       # The full install runs the root `prepare` (`bun run build`), whose
       # `build:lsp-daemon` step already runs `npm ci && npm run build` in
       # packages/lsp-daemon, so its node_modules and dist exist before the tests.
       - name: Run vendored lsp-daemon tests
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: npm test
         working-directory: packages/lsp-daemon
 
       # Git Bash sets SHELL/MSYSTEM on Windows, which makes process-platform
       # tests observe sh instead of the native PowerShell/cmd execution path.
       - name: Run tests
-        if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun --config=bunfig.root.toml test
 
       - name: Run tests
-        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '1/2'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '1/2' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun test packages/omo-opencode packages/memory-core
 
       - name: Run tests
-        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '2/2'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '2/2' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         shell: pwsh
         run: |
           bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts packages/senpi-task/src/dag/scheduler.test.ts
@@ -277,31 +286,31 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           bun-version: "1.3.14"
 
       - uses: actions/cache@v5
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run full Codex compatibility suite
-        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'full'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'full' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun run test:codex
 
       - name: Build Codex platform smoke prerequisites
-        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'platform'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'platform' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: |
           bun run build:codex-install
           bun run build:git-bash-mcp
@@ -311,7 +320,7 @@ jobs:
           bun run --cwd packages/omo-codex/plugin build
 
       - name: Run Codex platform smoke tests (.mjs via node --test)
-        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'platform'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'platform' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: >-
           node --test
           packages/omo-codex/scripts/install-local.test.mjs
@@ -322,7 +331,7 @@ jobs:
           packages/omo-codex/plugin/test/install-time-build-runtime.test.mjs
 
       - name: Run Codex platform smoke tests (.ts via bun test)
-        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'platform'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.suite == 'platform' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun test packages/omo-opencode/src/cli/cli-installer.platform.test.ts
 
       - name: Write job summary
@@ -349,27 +358,27 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v6
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           bun-version: "1.3.14"
 
       - uses: actions/cache@v5
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Remove stale self-package test copies
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun run script/remove-stale-self-package-tests.ts
 
       # Linux only: digestBuildSources hashes repo-relative paths (build-extension.mjs:140,143),
@@ -383,7 +392,7 @@ jobs:
           node packages/omo-senpi/plugin/scripts/build-extension.mjs --check
 
       - name: Run Senpi compatibility tests
-        if: needs.ci-mode.outputs.run_heavy == 'true'
+        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         shell: bash
         run: |
           set -euo pipefail

--- a/script/ci-fast-path.full-matrix.test.ts
+++ b/script/ci-fast-path.full-matrix.test.ts
@@ -1,0 +1,258 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { load } from "js-yaml"
+
+const classifierPath = new URL("./ci-fast-path.mjs", import.meta.url)
+const ciWorkflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
+
+const UBUNTU_OR_FULL_MATRIX =
+  "(matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')"
+
+interface FullMatrixMode {
+  readonly generatedReleasePush: boolean
+  readonly webOnly: boolean
+  readonly runHeavy: boolean
+  readonly fullMatrix: boolean
+}
+
+interface ClassifyInput {
+  readonly eventName: string
+  readonly message?: string
+  readonly changedPaths?: readonly string[]
+  readonly diffAvailable?: boolean
+  readonly mergeParents?: number
+  readonly headRef?: string
+  readonly labels?: readonly string[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function classify(input: ClassifyInput): FullMatrixMode {
+  const changedPaths = input.changedPaths ?? []
+  const stdout = execFileSync(
+    "node",
+    [
+      fileURLToPath(classifierPath),
+      "--event",
+      input.eventName,
+      "--message",
+      input.message ?? "chore: routine change",
+      "--diff-available",
+      String(input.diffAvailable ?? true),
+      "--merge-parents",
+      String(input.mergeParents ?? 1),
+      "--head-ref",
+      input.headRef ?? "",
+      "--labels",
+      JSON.stringify(input.labels ?? []),
+    ],
+    {
+      encoding: "utf8",
+      input: changedPaths.length === 0 ? "" : `${changedPaths.join("\0")}\0`,
+    },
+  )
+  const parsed: unknown = JSON.parse(stdout)
+  if (!isRecord(parsed)) throw new Error("classifier output must be an object")
+  const generatedReleasePush = parsed["generatedReleasePush"]
+  const webOnly = parsed["webOnly"]
+  const runHeavy = parsed["runHeavy"]
+  const fullMatrix = parsed["fullMatrix"]
+  if (
+    typeof generatedReleasePush !== "boolean" ||
+    typeof webOnly !== "boolean" ||
+    typeof runHeavy !== "boolean" ||
+    typeof fullMatrix !== "boolean"
+  ) {
+    throw new Error("classifier output must contain boolean CI mode fields including fullMatrix")
+  }
+  return { generatedReleasePush, webOnly, runHeavy, fullMatrix }
+}
+
+function workflowJobs(): Record<string, unknown> {
+  const parsed: unknown = load(readFileSync(ciWorkflowPath, "utf8"))
+  if (!isRecord(parsed)) throw new Error("ci.yml must parse as an object")
+  const jobs = parsed["jobs"]
+  if (!isRecord(jobs)) throw new Error("ci.yml must define jobs")
+  return jobs
+}
+
+function jobSteps(jobName: string): readonly Record<string, unknown>[] {
+  const job = workflowJobs()[jobName]
+  if (!isRecord(job)) throw new Error(`ci.yml must define ${jobName}`)
+  const steps = job["steps"]
+  if (!Array.isArray(steps)) throw new Error(`${jobName} must define steps`)
+  return steps.filter(isRecord)
+}
+
+describe("full-matrix classification", () => {
+  describe("#given a push event", () => {
+    test("#then the full matrix always runs", () => {
+      // given / when
+      const mode = classify({ eventName: "push", changedPaths: ["packages/utils/src/index.ts"] })
+
+      // then
+      expect(mode.fullMatrix).toBe(true)
+    })
+  })
+
+  describe("#given an ordinary pull request touching platform-neutral paths", () => {
+    test("#then the full matrix is skipped", () => {
+      // given / when
+      const mode = classify({
+        eventName: "pull_request",
+        headRef: "feature/tidy-docs",
+        changedPaths: ["packages/utils/src/index.ts", "packages/model-core/src/index.ts"],
+      })
+
+      // then
+      expect(mode.fullMatrix).toBe(false)
+      expect(mode.runHeavy).toBe(true)
+    })
+  })
+
+  describe("#given a release-state head branch", () => {
+    test.each([
+      "release/v5.0.0-source-state",
+      "release/v5.0.0-beta.11-source-state",
+    ])("#then %s forces the full matrix", (headRef) => {
+      // given / when
+      const mode = classify({
+        eventName: "pull_request",
+        headRef,
+        changedPaths: ["package.json"],
+      })
+
+      // then
+      expect(mode.fullMatrix).toBe(true)
+    })
+  })
+
+  describe("#given the ci:full-matrix label", () => {
+    test("#then the full matrix is forced on an otherwise neutral pull request", () => {
+      // given / when
+      const mode = classify({
+        eventName: "pull_request",
+        headRef: "feature/tidy-docs",
+        changedPaths: ["packages/utils/src/index.ts"],
+        labels: ["bug", "ci:full-matrix"],
+      })
+
+      // then
+      expect(mode.fullMatrix).toBe(true)
+    })
+  })
+
+  describe("#given a platform-sensitive changed path", () => {
+    test.each([
+      ["basename contains windows", "packages/senpi-task/src/runners/rpc-process.windows.test.ts"],
+      ["basename contains win32", "packages/utils/src/spawn-win32.ts"],
+      ["powershell script", "script/qa/run-smoke.ps1"],
+      ["ci workflow", ".github/workflows/ci.yml"],
+      ["classifier itself", "script/ci-fast-path.mjs"],
+      ["windows shard bunfig", "bunfig.win2.parallel.toml"],
+    ])("#then %s forces the full matrix", (_name, changedPath) => {
+      // given / when
+      const mode = classify({
+        eventName: "pull_request",
+        headRef: "feature/tidy-docs",
+        changedPaths: ["packages/utils/src/index.ts", changedPath],
+      })
+
+      // then
+      expect(mode.fullMatrix).toBe(true)
+    })
+  })
+
+  describe("#given the diff is unavailable", () => {
+    test("#then the classifier fails open to the full matrix", () => {
+      // given / when
+      const mode = classify({
+        eventName: "pull_request",
+        headRef: "feature/tidy-docs",
+        diffAvailable: false,
+      })
+
+      // then
+      expect(mode.fullMatrix).toBe(true)
+    })
+  })
+})
+
+describe("full-matrix workflow wiring", () => {
+  describe("#given the ci-mode job", () => {
+    test("#then it exposes full_matrix and feeds head ref plus labels to the classifier", () => {
+      // given
+      const ciMode = workflowJobs()["ci-mode"]
+      if (!isRecord(ciMode)) throw new Error("ci.yml must define ci-mode")
+      const outputs = ciMode["outputs"]
+      if (!isRecord(outputs)) throw new Error("ci-mode must declare outputs")
+      const classifyStep = jobSteps("ci-mode").find((step) => step["id"] === "classify")
+      if (classifyStep === undefined) throw new Error("ci-mode must define the classify step")
+      const env = classifyStep["env"]
+      if (!isRecord(env)) throw new Error("classify step must define env")
+
+      // then
+      expect(String(outputs["full_matrix"])).toContain("steps.classify.outputs.full_matrix")
+      expect(String(env["HEAD_REF"])).toContain("github.head_ref")
+      expect(String(env["PR_LABELS"])).toContain("github.event.pull_request.labels")
+      expect(String(classifyStep["run"])).toContain("--head-ref")
+      expect(String(classifyStep["run"])).toContain("--labels")
+    })
+  })
+
+  describe("#given the pull_request trigger", () => {
+    test("#then labeled events retrigger CI", () => {
+      // given
+      const parsed: unknown = load(readFileSync(ciWorkflowPath, "utf8"))
+      if (!isRecord(parsed)) throw new Error("ci.yml must parse as an object")
+      const triggers = parsed["on"] ?? parsed[true as unknown as string]
+      if (!isRecord(triggers)) throw new Error("ci.yml must define triggers")
+      const pullRequest = triggers["pull_request"]
+      if (!isRecord(pullRequest)) throw new Error("ci.yml must define pull_request triggers")
+
+      // then
+      expect(pullRequest["types"]).toEqual(["opened", "synchronize", "reopened", "labeled"])
+    })
+  })
+
+  describe("#given the OS matrix jobs", () => {
+    test.each(["test", "codex-compatibility", "senpi-compatibility"])(
+      "#then every heavy step in %s is ubuntu-first",
+      (jobName) => {
+        // given
+        const heavySteps = jobSteps(jobName).filter((step) =>
+          String(step["if"] ?? "").includes("run_heavy"),
+        )
+
+        // then
+        expect(heavySteps.length).toBeGreaterThan(0)
+        for (const step of heavySteps) {
+          expect(String(step["if"])).toContain(UBUNTU_OR_FULL_MATRIX)
+        }
+      },
+    )
+
+    test.each(["test", "codex-compatibility", "senpi-compatibility"])(
+      "#then checkout and summary steps in %s stay unconditional",
+      (jobName) => {
+        // given
+        const steps = jobSteps(jobName)
+        const checkout = steps.find((step) => String(step["uses"] ?? "").startsWith("actions/checkout"))
+        const summary = steps.find((step) => step["name"] === "Write job summary")
+        if (checkout === undefined || summary === undefined) {
+          throw new Error(`${jobName} must define checkout and summary steps`)
+        }
+
+        // then
+        expect(checkout["if"]).toBeUndefined()
+        expect(String(summary["if"])).toBe("always()")
+      },
+    )
+  })
+})

--- a/script/ci-fast-path.full-matrix.test.ts
+++ b/script/ci-fast-path.full-matrix.test.ts
@@ -233,7 +233,16 @@ describe("full-matrix workflow wiring", () => {
         // then
         expect(heavySteps.length).toBeGreaterThan(0)
         for (const step of heavySteps) {
-          expect(String(step["if"])).toContain(UBUNTU_OR_FULL_MATRIX)
+          const condition = String(step["if"])
+          const ubuntuFirst =
+            condition.includes(UBUNTU_OR_FULL_MATRIX) ||
+            // A step already pinned to ubuntu can never reach a non-ubuntu leg.
+            condition.includes("matrix.os == 'ubuntu-latest' &&") ||
+            condition.endsWith("matrix.os == 'ubuntu-latest'")
+          expect({ step: step["name"] ?? step["uses"], ubuntuFirst }).toEqual({
+            step: step["name"] ?? step["uses"],
+            ubuntuFirst: true,
+          })
         }
       },
     )

--- a/script/ci-fast-path.mjs
+++ b/script/ci-fast-path.mjs
@@ -5,6 +5,15 @@ import { pathToFileURL } from "node:url"
 
 const generatedReleaseMerge =
   /^Merge pull request #[0-9]+ from code-yeongyu\/release\/v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?-source-state$/
+const releaseStateHeadRef = /^release\/v.+-source-state$/
+const fullMatrixLabel = "ci:full-matrix"
+// Diffs that can change how a non-Linux runner behaves, or that change the
+// skip decision itself, must be proven on all three operating systems.
+const platformSensitiveExactPaths = new Set([
+  ".github/workflows/ci.yml",
+  "script/ci-fast-path.mjs",
+  "bunfig.win2.parallel.toml",
+])
 
 function parseArguments(argv) {
   const values = new Map()
@@ -27,6 +36,14 @@ function parseMergeParents(value) {
   return count
 }
 
+function parseLabels(value) {
+  const parsed = JSON.parse(value)
+  if (!Array.isArray(parsed) || parsed.some((label) => typeof label !== "string")) {
+    throw new Error(`expected a JSON array of label names, received ${value}`)
+  }
+  return parsed
+}
+
 function parseBoolean(value) {
   if (value === "true") return true
   if (value === "false") return false
@@ -46,7 +63,22 @@ function isWebPath(path) {
   )
 }
 
-export function classifyCiMode({ eventName, headCommitMessage, changedPaths, diffAvailable, mergeParentCount }) {
+function isPlatformSensitivePath(path) {
+  if (platformSensitiveExactPaths.has(path)) return true
+  if (path.endsWith(".ps1")) return true
+  const basename = path.slice(path.lastIndexOf("/") + 1).toLowerCase()
+  return basename.includes("windows") || basename.includes("win32")
+}
+
+export function classifyCiMode({
+  eventName,
+  headCommitMessage,
+  changedPaths,
+  diffAvailable,
+  mergeParentCount,
+  headRef = "",
+  labels = [],
+}) {
   const subject = headCommitMessage.split("\n", 1)[0] ?? ""
   // Provenance is machine-derived, never prose alone: an actual merge commit
   // (exactly two parents) whose subject matches the generated release shape.
@@ -57,11 +89,20 @@ export function classifyCiMode({ eventName, headCommitMessage, changedPaths, dif
     isRealMerge &&
     generatedReleaseMerge.test(subject)
   const webOnly = diffAvailable && changedPaths.length > 0 && changedPaths.every(isWebPath)
+  // Ubuntu-first is a pull-request optimization only, and it fails open: any
+  // event we cannot fully inspect keeps all three operating systems.
+  const fullMatrix =
+    eventName === "push" ||
+    !diffAvailable ||
+    releaseStateHeadRef.test(headRef) ||
+    labels.includes(fullMatrixLabel) ||
+    changedPaths.some(isPlatformSensitivePath)
 
   return {
     generatedReleasePush,
     webOnly,
     runHeavy: !(generatedReleasePush || webOnly),
+    fullMatrix,
   }
 }
 
@@ -86,6 +127,8 @@ if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.a
     changedPaths: readChangedPaths(readFileSync(0)),
     diffAvailable: parseBoolean(diffAvailable),
     mergeParentCount: parseMergeParents(mergeParents),
+    headRef: args.get("head-ref") ?? "",
+    labels: parseLabels(args.get("labels") ?? "[]"),
   })
   process.stdout.write(`${JSON.stringify(mode)}\n`)
 }


### PR DESCRIPTION
## Summary

Ordinary pull requests currently pay for a full three-operating-system matrix on every push, even
when the diff cannot possibly behave differently on macOS or Windows. On the measured baseline
Windows is about 57 percent and macOS about 20 percent of per-run compute, and the Windows
`senpi-compatibility` leg alone averages 870 seconds.

This PR makes ordinary pull requests ubuntu-first: the non-ubuntu legs still start, still report
their required status contexts, and still succeed, but they skip setup, cache, install, and test
steps. Full three-OS coverage is preserved wherever it actually matters: every push, every
release-state branch, every platform-sensitive diff, any run whose diff cannot be computed, and any
pull request carrying the new `ci:full-matrix` label.

No matrix leg is removed and no matrix is made dynamic, so all ten required status contexts on
`dev` keep the exact names the ruleset expects.

## Changes

**Classifier (`script/ci-fast-path.mjs`)**

- `classifyCiMode` gains `headRef` and `labels` inputs and a new `fullMatrix` output. The CLI gains
  `--head-ref` and `--labels` (a JSON array string defaulting to `[]`), both optional, so the
  existing call shape keeps working.
- `fullMatrix` is true when any of these hold: the event is a push; the diff is unavailable (fail
  open); the head ref matches `release/v<semver>-source-state`; the labels include
  `ci:full-matrix`; or any changed path is platform-sensitive.
- Platform-sensitive means the lowercased basename contains `windows` or `win32`, the path ends in
  `.ps1`, or the path is exactly `.github/workflows/ci.yml`, `script/ci-fast-path.mjs`, or
  `bunfig.win2.parallel.toml`. The last three are the files that decide the skip itself, so a diff
  touching them must be proven on every operating system.
- `runHeavy`, `webOnly`, and `generatedReleasePush` semantics are unchanged.

**Workflow (`.github/workflows/ci.yml`)**

- `ci-mode` passes `HEAD_REF` and the pull-request label names into the classifier and publishes
  `full_matrix` as a job output; the job summary now reports it alongside the existing modes.
- The `pull_request` trigger gains explicit `types: [opened, synchronize, reopened, labeled]` so
  adding the label retriggers CI immediately. Bot-label churn is absorbed by the existing
  `cancel-in-progress` concurrency group.
- In `test`, `codex-compatibility`, and `senpi-compatibility` only, every step previously gated on
  `run_heavy` gains the conjunct
  `(matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')`.
  `checkout` and the `always()` summary steps stay unconditional, which is what keeps the required
  contexts reporting green rather than disappearing.
- `typecheck`, `build`, `omo-ai-payload-check`, `lazycodex-published-smoke`, `draft-release`, and
  `auto-commit-schema` are untouched.

**Label**

- `ci:full-matrix` created on the repository as the manual escape hatch.

## QA & Evidence

Evidence directory: `.omo/evidence/20260819-ci-ubuntu-first-pr-matrix/`

- **What was tested:** the `fullMatrix` truth table, written as failing tests before the
  implementation existed.
  **Observed result:** 17 failures on the first run, covering push, ordinary pull request, both
  release-state branch shapes, the label, all six platform-sensitive path rules, the unavailable
  diff, and the workflow wiring. After the implementation and the workflow change, 33 of 33 pass.
  **Artifact:** `01-red-bun-test.log` (RED), `04-green-bun-test.log` (GREEN)
  **Why sufficient:** each branch of the `fullMatrix` decision has its own failing-first case, so no
  rule is satisfied incidentally.

- **What was tested:** `bun run typecheck:script`.
  **Observed result:** clean, exit 0.
  **Artifact:** `02-typecheck-script.log`
  **Why sufficient:** the new test file is inside the script TypeScript project.

- **What was tested:** the real classifier binary driven from a shell exactly as CI drives it, for
  an ordinary pull request, a release-state head ref, the label, this PR's own platform-sensitive
  diff shape, a push, an unavailable diff, the legacy argument set with no new flags, GitHub's
  pretty-printed multi-line `toJSON` label rendering, and the empty-label push case.
  **Observed result:** ordinary pull request yields `fullMatrix: false`; every escape hatch yields
  `fullMatrix: true`; the legacy argument set still classifies (`webOnly: true` for a web-only
  diff); multi-line label JSON parses; an empty `PR_LABELS` falls back to `[]`.
  **Artifact:** `03-cli-simulation.log`
  **Why sufficient:** this exercises the actual command line the workflow runs, including the two
  argument shapes GitHub can produce for labels, rather than only the exported function.

- **What was tested:** `actionlint -shellcheck= .github/workflows/ci.yml` (v1.7.12, matching the
  repository's `lint-workflows.yml` invocation).
  **Observed result:** clean, exit 0.
  **Artifact:** `05-actionlint.log`
  **Why sufficient:** the change is mostly expression syntax, which is exactly what actionlint
  validates.

- **What was tested:** the whole `script/` suite for regressions.
  **Observed result:** 305 pass, 2 fail. Both failures reproduce identically on unmodified
  `origin/dev` with this diff stashed; they depend on built Codex install payloads that a fresh
  worktree lacks and CI produces.
  **Artifact:** `06-script-suite.log`
  **Why sufficient:** it separates pre-existing worktree-local failures from anything this diff
  could have caused.

- **What was tested:** the escape hatch on this very PR. Because the diff touches
  `.github/workflows/ci.yml` and `script/ci-fast-path.mjs`, both platform-sensitive, this PR's own
  run must classify as `fullMatrix: true` and execute the complete three-OS matrix.
  **Observed result:** recorded from the live run; see the artifact below.
  **Artifact:** `08-full-matrix-proof.json`
  **Why sufficient:** it proves the ubuntu-first path does not silently disable non-ubuntu coverage
  for the class of change most likely to break it.

## Risks & Residuals

- **A macOS- or Windows-only regression slips through an ordinary pull request.** Mitigated but not
  eliminated. Diffs that name a platform, ship PowerShell, or change the gate itself always fan out,
  and every push to `dev` runs the full matrix, so a regression is caught at merge rather than at
  release. The `ci:full-matrix` label is the deliberate manual override for anything the heuristic
  cannot see. Accepted.
- **Release readiness.** The `gate-reuse` job in `publish.yml` needs a green `ci.yml` run on the
  prepared release SHA, and release-state pull requests use `release/v<semver>-source-state` head
  branches. That branch shape is an explicit `fullMatrix` trigger and pushes always fan out, so
  release SHAs keep full coverage. Mitigated.
- **Classifier failure.** Any run where the diff cannot be computed fails open to the full matrix,
  matching the existing `runHeavy` fail-open behavior. Mitigated.
- **Required contexts.** No matrix leg is removed and the matrix stays static, so all ten required
  contexts still report. Non-ubuntu legs pass by skipping steps rather than by disappearing.
  Mitigated.
- **`senpi-compatibility` on macOS and Windows is not a required context** and is unchanged in that
  respect; this PR only changes when its heavy steps run.

## Note on the skip-path evidence

Any pull request opened from a branch containing this change necessarily has
`.github/workflows/ci.yml` and `script/ci-fast-path.mjs` in its diff, and both are
platform-sensitive by this change's own design. So this PR, and any pre-merge scratch PR branched
from it, classifies `full_matrix: true` and runs everything. That is the escape hatch behaving
correctly, but it means the ordinary-pull-request skip cannot be observed on a real runner until
this change is on `dev`.

Pre-merge, the skip is established by the unit truth table (the ordinary-pull-request case yields
`false`) plus a parsed audit of the workflow proving every heavy step in the three matrix jobs is
guarded while `checkout` and the `always()` summary stay unconditional, which is what keeps the
required contexts green rather than absent. That audit is pinned by a test so it cannot rot. The
empirical observation on real macOS and Windows runners is a follow-up against `dev` once this
lands. Details in `.omo/evidence/20260819-ci-ubuntu-first-pr-matrix/11-skip-path-evidence-scope.md`.

A throwaway draft PR (#7040) was opened to attempt that observation, hit the limitation above, and
was closed without merging with its branch deleted.
