### PR TITLE
test: give MCP loader suites unique temp roots instead of a clock-derived name

### DIFF
--- a/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/scope-filtering.test.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/scope-filtering.test.ts
@@ -1,22 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "fs"
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
 import { shouldLoadMcpServer } from "./scope-filter"
 
-const TEST_DIR = join(tmpdir(), `mcp-scope-filtering-test-${Date.now()}`)
-const TEST_HOME = join(TEST_DIR, "home")
+// mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+// process return the same millisecond, so sibling suites collided on one directory and
+// each afterEach removed the other's live fixture. On Windows, removing an in-use tree
+// blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let testDir = ""
+let testHome = ""
 const ORIGINAL_HOME = process.env.HOME
 const ORIGINAL_USERPROFILE = process.env.USERPROFILE
 const ORIGINAL_CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR
 
 describe("loadMcpConfigs", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
-    mkdirSync(TEST_HOME, { recursive: true })
-    process.env.HOME = TEST_HOME
-    process.env.USERPROFILE = TEST_HOME
-    process.env.CLAUDE_CONFIG_DIR = join(TEST_HOME, ".claude")
+    testDir = realpathSync(mkdtempSync(join(tmpdir(), "mcp-scope-filtering-test-")))
+    testHome = join(testDir, "home")
+    mkdirSync(testHome, { recursive: true })
+    process.env.HOME = testHome
+    process.env.USERPROFILE = testHome
+    process.env.CLAUDE_CONFIG_DIR = join(testHome, ".claude")
     mock.module("../../shared/logger", () => ({
       log: () => {},
     }))
@@ -39,7 +44,7 @@ describe("loadMcpConfigs", () => {
     } else {
       process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CLAUDE_CONFIG_DIR
     }
-    rmSync(TEST_DIR, { recursive: true, force: true })
+    rmSync(testDir, { recursive: true, force: true })
   })
 
   describe("#given local MCP scope checks", () => {
@@ -95,7 +100,7 @@ describe("loadMcpConfigs", () => {
   describe("#given user-scoped MCP entries with local scope metadata", () => {
     it("#when loading configs #then only servers matching the current project path are loaded", async () => {
       writeFileSync(
-        join(TEST_HOME, ".claude.json"),
+        join(testHome, ".claude.json"),
         JSON.stringify({
           mcpServers: {
             globalServer: {
@@ -106,13 +111,13 @@ describe("loadMcpConfigs", () => {
               command: "npx",
               args: ["matching-local"],
               scope: "local",
-              projectPath: TEST_DIR,
+              projectPath: testDir,
             },
             nonMatchingLocal: {
               command: "npx",
               args: ["non-matching-local"],
               scope: "local",
-              projectPath: join(TEST_DIR, "other-project"),
+              projectPath: join(testDir, "other-project"),
             },
             missingProjectPath: {
               command: "npx",
@@ -124,7 +129,7 @@ describe("loadMcpConfigs", () => {
       )
 
       const originalCwd = process.cwd()
-      process.chdir(TEST_DIR)
+      process.chdir(testDir)
 
       try {
         const { loadMcpConfigs } = await import("./loader")

--- a/packages/claude-code-compat-core/src/features/claude-code-plugin-loader/mcp-server-loader.test.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-plugin-loader/mcp-server-loader.test.ts
@@ -1,20 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "fs"
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
 import type { LoadedPlugin } from "./types"
 
-const TEST_DIR = join(tmpdir(), `plugin-mcp-loader-test-${Date.now()}`)
-const PROJECT_DIR = join(TEST_DIR, "project")
-const PROJECT_SUBDIRECTORY = join(PROJECT_DIR, "packages", "app")
-const PLUGIN_DIR = join(TEST_DIR, "plugin")
-const MCP_CONFIG_PATH = join(PLUGIN_DIR, "mcp.json")
+// mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+// process return the same millisecond, so sibling suites collided on one directory and
+// each afterEach removed the other's live fixture. On Windows, removing an in-use tree
+// blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let testDir = ""
+let projectDir = ""
+let projectSubdirectory = ""
+let pluginDir = ""
+let mcpConfigPath = ""
 
 describe("loadPluginMcpServers", () => {
   beforeEach(() => {
-    mkdirSync(PROJECT_DIR, { recursive: true })
-    mkdirSync(PROJECT_SUBDIRECTORY, { recursive: true })
-    mkdirSync(PLUGIN_DIR, { recursive: true })
+    testDir = realpathSync(mkdtempSync(join(tmpdir(), "plugin-mcp-loader-test-")))
+    projectDir = join(testDir, "project")
+    projectSubdirectory = join(projectDir, "packages", "app")
+    pluginDir = join(testDir, "plugin")
+    mcpConfigPath = join(pluginDir, "mcp.json")
+    mkdirSync(projectDir, { recursive: true })
+    mkdirSync(projectSubdirectory, { recursive: true })
+    mkdirSync(pluginDir, { recursive: true })
     mock.module("../../shared/logger", () => ({
       log: () => {},
     }))
@@ -22,13 +31,13 @@ describe("loadPluginMcpServers", () => {
 
   afterEach(() => {
     mock.restore()
-    rmSync(TEST_DIR, { recursive: true, force: true })
+    rmSync(testDir, { recursive: true, force: true })
   })
 
   describe("#given plugin MCP entries with local scope metadata", () => {
     it("#when loading plugin MCP servers from a project subdirectory #then only entries within the same project are included", async () => {
       writeFileSync(
-        MCP_CONFIG_PATH,
+        mcpConfigPath,
         JSON.stringify({
           mcpServers: {
             globalServer: {
@@ -39,19 +48,19 @@ describe("loadPluginMcpServers", () => {
               command: "npx",
               args: ["matching-plugin-local"],
               scope: "local",
-              projectPath: PROJECT_DIR,
+              projectPath: projectDir,
             },
             nonMatchingLocal: {
               command: "npx",
               args: ["non-matching-plugin-local"],
               scope: "local",
-              projectPath: join(PROJECT_DIR, "other-project"),
+              projectPath: join(projectDir, "other-project"),
             },
             parentLocal: {
               command: "npx",
               args: ["parent-plugin-local"],
               scope: "local",
-              projectPath: join(PROJECT_SUBDIRECTORY, "nested-project"),
+              projectPath: join(projectSubdirectory, "nested-project"),
             },
           },
         })
@@ -61,13 +70,13 @@ describe("loadPluginMcpServers", () => {
         name: "demo-plugin",
         version: "1.0.0",
         scope: "project",
-        installPath: PLUGIN_DIR,
+        installPath: pluginDir,
         pluginKey: "demo-plugin@test",
-        mcpPath: MCP_CONFIG_PATH,
+        mcpPath: mcpConfigPath,
       }
 
       const originalCwd = process.cwd()
-      process.chdir(PROJECT_SUBDIRECTORY)
+      process.chdir(projectSubdirectory)
 
       try {
         const { loadPluginMcpServers } = await import(`./mcp-server-loader?t=${Date.now()}`)

--- a/packages/omo-opencode/src/features/claude-code-mcp-loader/scope-filtering.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-mcp-loader/scope-filtering.test.ts
@@ -1,22 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "fs"
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
 import { shouldLoadMcpServer } from "./scope-filter"
 
-const TEST_DIR = join(tmpdir(), `mcp-scope-filtering-test-${Date.now()}`)
-const TEST_HOME = join(TEST_DIR, "home")
+// mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+// process return the same millisecond, so sibling suites collided on one directory and
+// each afterEach removed the other's live fixture. On Windows, removing an in-use tree
+// blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let testDir = ""
+let testHome = ""
 const ORIGINAL_HOME = process.env.HOME
 const ORIGINAL_USERPROFILE = process.env.USERPROFILE
 const ORIGINAL_CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR
 
 describe("loadMcpConfigs", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
-    mkdirSync(TEST_HOME, { recursive: true })
-    process.env.HOME = TEST_HOME
-    process.env.USERPROFILE = TEST_HOME
-    process.env.CLAUDE_CONFIG_DIR = join(TEST_HOME, ".claude")
+    testDir = realpathSync(mkdtempSync(join(tmpdir(), "mcp-scope-filtering-test-")))
+    testHome = join(testDir, "home")
+    mkdirSync(testHome, { recursive: true })
+    process.env.HOME = testHome
+    process.env.USERPROFILE = testHome
+    process.env.CLAUDE_CONFIG_DIR = join(testHome, ".claude")
     mock.module("../../shared/logger", () => ({
       log: () => {},
     }))
@@ -39,7 +44,7 @@ describe("loadMcpConfigs", () => {
     } else {
       process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CLAUDE_CONFIG_DIR
     }
-    rmSync(TEST_DIR, { recursive: true, force: true })
+    rmSync(testDir, { recursive: true, force: true })
   })
 
   describe("#given local MCP scope checks", () => {
@@ -95,7 +100,7 @@ describe("loadMcpConfigs", () => {
   describe("#given user-scoped MCP entries with local scope metadata", () => {
     it("#when loading configs #then only servers matching the current project path are loaded", async () => {
       writeFileSync(
-        join(TEST_HOME, ".claude.json"),
+        join(testHome, ".claude.json"),
         JSON.stringify({
           mcpServers: {
             globalServer: {
@@ -106,13 +111,13 @@ describe("loadMcpConfigs", () => {
               command: "npx",
               args: ["matching-local"],
               scope: "local",
-              projectPath: TEST_DIR,
+              projectPath: testDir,
             },
             nonMatchingLocal: {
               command: "npx",
               args: ["non-matching-local"],
               scope: "local",
-              projectPath: join(TEST_DIR, "other-project"),
+              projectPath: join(testDir, "other-project"),
             },
             missingProjectPath: {
               command: "npx",
@@ -124,7 +129,7 @@ describe("loadMcpConfigs", () => {
       )
 
       const originalCwd = process.cwd()
-      process.chdir(TEST_DIR)
+      process.chdir(testDir)
 
       try {
         const { loadMcpConfigs } = await import("./loader")

--- a/packages/omo-opencode/src/features/claude-code-plugin-loader/mcp-server-loader.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-plugin-loader/mcp-server-loader.test.ts
@@ -1,26 +1,29 @@
-import { afterEach, beforeEach, describe, expect, it, mock, setDefaultTimeout } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "fs"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
 import type { LoadedPlugin } from "./types"
 
-const TEST_DIR = join(tmpdir(), `plugin-mcp-loader-test-${Date.now()}`)
-const PROJECT_DIR = join(TEST_DIR, "project")
-const PROJECT_SUBDIRECTORY = join(PROJECT_DIR, "packages", "app")
-const PLUGIN_DIR = join(TEST_DIR, "plugin")
-const MCP_CONFIG_PATH = join(PLUGIN_DIR, "mcp.json")
-
-// Bun honours a preload's setDefaultTimeout only for the FIRST test file of a run, so this file
-// falls back to the built-in 5000ms. That budget covers the beforeEach/afterEach hooks too - and a
-// hook timeout ignores a test's own `}, N)` argument - so the windows runner timed the hooks out
-// while building the plugin fixture tree. Set the floor here, where Bun does honour it.
-setDefaultTimeout(process.platform === "win32" ? 60_000 : 20_000)
+// mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+// process return the same millisecond, so sibling suites collided on one directory and
+// each afterEach removed the other's live fixture. On Windows, removing an in-use tree
+// blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let testDir = ""
+let projectDir = ""
+let projectSubdirectory = ""
+let pluginDir = ""
+let mcpConfigPath = ""
 
 describe("loadPluginMcpServers", () => {
   beforeEach(() => {
-    mkdirSync(PROJECT_DIR, { recursive: true })
-    mkdirSync(PROJECT_SUBDIRECTORY, { recursive: true })
-    mkdirSync(PLUGIN_DIR, { recursive: true })
+    testDir = realpathSync(mkdtempSync(join(tmpdir(), "plugin-mcp-loader-test-")))
+    projectDir = join(testDir, "project")
+    projectSubdirectory = join(projectDir, "packages", "app")
+    pluginDir = join(testDir, "plugin")
+    mcpConfigPath = join(pluginDir, "mcp.json")
+    mkdirSync(projectDir, { recursive: true })
+    mkdirSync(projectSubdirectory, { recursive: true })
+    mkdirSync(pluginDir, { recursive: true })
     mock.module("../../shared/logger", () => ({
       log: () => {},
     }))
@@ -28,13 +31,13 @@ describe("loadPluginMcpServers", () => {
 
   afterEach(() => {
     mock.restore()
-    rmSync(TEST_DIR, { recursive: true, force: true })
+    rmSync(testDir, { recursive: true, force: true })
   })
 
   describe("#given plugin MCP entries with local scope metadata", () => {
     it("#when loading plugin MCP servers from a project subdirectory #then only entries within the same project are included", async () => {
       writeFileSync(
-        MCP_CONFIG_PATH,
+        mcpConfigPath,
         JSON.stringify({
           mcpServers: {
             globalServer: {
@@ -45,19 +48,19 @@ describe("loadPluginMcpServers", () => {
               command: "npx",
               args: ["matching-plugin-local"],
               scope: "local",
-              projectPath: PROJECT_DIR,
+              projectPath: projectDir,
             },
             nonMatchingLocal: {
               command: "npx",
               args: ["non-matching-plugin-local"],
               scope: "local",
-              projectPath: join(PROJECT_DIR, "other-project"),
+              projectPath: join(projectDir, "other-project"),
             },
             parentLocal: {
               command: "npx",
               args: ["parent-plugin-local"],
               scope: "local",
-              projectPath: join(PROJECT_SUBDIRECTORY, "nested-project"),
+              projectPath: join(projectSubdirectory, "nested-project"),
             },
           },
         })
@@ -67,13 +70,13 @@ describe("loadPluginMcpServers", () => {
         name: "demo-plugin",
         version: "1.0.0",
         scope: "project",
-        installPath: PLUGIN_DIR,
+        installPath: pluginDir,
         pluginKey: "demo-plugin@test",
-        mcpPath: MCP_CONFIG_PATH,
+        mcpPath: mcpConfigPath,
       }
 
       const originalCwd = process.cwd()
-      process.chdir(PROJECT_SUBDIRECTORY)
+      process.chdir(projectSubdirectory)
 
       try {
         const { loadPluginMcpServers } = await import(`./mcp-server-loader?t=${Date.now()}`)


### PR DESCRIPTION
## Problem

`test (windows-latest, 1/2)` intermittently fails with:

```
(fail) loadMcpConfigs > #given user-scoped MCP entries with local scope metadata
       > #when loading configs #then only servers matching the current project path are loaded [6850.78ms]
  ^ a beforeEach/afterEach hook timed out for this test.
```

The same test runs in **0.67ms** locally. Seen on #7039; the shard also failed on a different timing-sensitive test on #7033.

## Root cause: a shared fixture directory, not slowness

Two MCP loader suites compute their temp root at **import time** from `Date.now()`:

| suite | temp root |
|---|---|
| `scope-filtering.test.ts` | `mcp-scope-filtering-test-${Date.now()}` |
| `mcp-server-loader.test.ts` | `plugin-mcp-loader-test-${Date.now()}` |

Each suite is **duplicated** across `claude-code-compat-core` and `omo-opencode`, and consecutive `Date.now()` calls in one process return the same millisecond:

```
file A TEST_DIR: .../T/mcp-scope-filtering-test-1787130765044
file B TEST_DIR: .../T/mcp-scope-filtering-test-1787130765044
COLLIDE? true
```

So both copies resolve to the **same directory**. Each `afterEach` then runs `rmSync(TEST_DIR, { recursive: true, force: true })` over the tree the other copy is still using. On Windows, removing an in-use tree blocks and retries until the hook budget expires — the reported hook timeout. On Linux/macOS the same removal usually wins the race silently, which is why it presents as Windows-only and load-order dependent.

## Fix

Allocate the root with `mkdtempSync` in `beforeEach`, so the OS guarantees uniqueness and no suite can delete another's live fixture:

```
mkdtemp A: .../T/mcp-scope-probe-R7N2SQ
mkdtemp B: .../T/mcp-scope-probe-s8NmT2
COLLIDE? false
```

The path goes through `realpathSync` because the loaders compare `projectPath` against `process.cwd()`, which is already canonical. Verified this is load-bearing, not cargo-cult — after `chdir(raw)`:

```
cwd === raw?       false
cwd === canonical? true
```

An uncanonicalized fixture path would silently fail the `containsPath` match.

**This also removes the `setDefaultTimeout(win32 ? 60_000 : 20_000)` floor** added to `mcp-server-loader.test.ts` in b16ef0f84. That commit raised the budget for this same collision; once the suites stop sharing a directory it is unnecessary. Fixing the cause rather than widening the timeout is the point of this PR.

Assertions are unchanged.

## Verification

| check | result |
|---|---|
| both `scope-filtering.test.ts` copies together | 10 pass / 0 fail |
| both `mcp-server-loader.test.ts` copies together | 2 pass / 0 fail |
| all four touched files together | 12 pass / 0 fail (26 assertions) |
| `bun test packages/omo-opencode packages/memory-core` (exact shard 1/2 scope) | **8785 pass / 1 skip / 0 fail**, 1049 files |
| `tsgo` on both packages | exit 0 |

Workaround audit over the four changed files: **0** added `setDefaultTimeout`/`setTimeout`/`sleep`/`retry`/`.skip`/`.only`, and **3** `setDefaultTimeout` lines removed. No test was deleted, skipped, or relocated.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes MCP loader test suites by creating unique temp roots with mkdtempSync (canonicalized via realpathSync) in beforeEach instead of using a Date.now-based name at import time. This removes cross-suite directory collisions that caused Windows hook timeouts and lets us drop the elevated setDefaultTimeout.

- Applies to both duplicated suites in `packages/claude-code-compat-core` and `packages/omo-opencode`.
- Old behavior: both suites could resolve to the same temp dir; afterEach recursively removed a directory still in use, causing “a beforeEach/afterEach hook timed out” on Windows.
- New behavior: per-suite unique temp root; cleanup targets that suite’s own dir only.
- realpathSync is required because loaders compare projectPath against canonical process.cwd(); without it, local scope matching can silently fail.
- Assertions unchanged; no sleeps/retries added; removed the `setDefaultTimeout` floor from the plugin loader test.

<sup>Written for commit 007a58c69b6d68399fed0b6e80f94a971910a2a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

