### PR TITLE
test: give the last shared-prefix suites unique temp roots

### DIFF
--- a/packages/claude-code-compat-core/src/features/claude-code-command-loader/loader.test.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-command-loader/loader.test.ts
@@ -1,13 +1,17 @@
 import { execFileSync } from "node:child_process"
 import { promises as fs } from "node:fs"
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import * as loader from "./loader"
 import { getCommandLoaderCacheKey } from "./loader-cache"
 
-const TEST_DIR = join(tmpdir(), `claude-code-command-loader-${Date.now()}`)
+// mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+// process return the same millisecond, so sibling suites collided on one directory and
+// each teardown removed the other's live fixture. On Windows, removing an in-use tree
+// blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
 
 function writeCommand(directory: string, name: string, description: string): void {
   mkdirSync(directory, { recursive: true })
@@ -22,7 +26,7 @@ describe("claude-code command loader", () => {
   let originalOpencodeConfigDir: string | undefined
 
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "claude-code-command-loader-"))
     originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
     originalOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR
 

--- a/packages/omo-opencode/src/features/claude-code-command-loader/loader.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-command-loader/loader.test.ts
@@ -1,12 +1,16 @@
 import { promises as fs } from "node:fs"
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import * as loader from "./loader"
 import { getCommandLoaderCacheKey } from "./loader-cache"
 
-const TEST_DIR = join(tmpdir(), `claude-code-command-loader-${Date.now()}`)
+// mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+// process return the same millisecond, so sibling suites collided on one directory and
+// each teardown removed the other's live fixture. On Windows, removing an in-use tree
+// blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
 
 function writeCommand(directory: string, name: string, description: string): void {
   mkdirSync(directory, { recursive: true })
@@ -21,7 +25,7 @@ describe("claude-code command loader", () => {
   let originalOpencodeConfigDir: string | undefined
 
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "claude-code-command-loader-"))
     originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
     originalOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR
 

--- a/packages/omo-opencode/src/features/opencode-skill-loader/config-source-discovery.test.ts
+++ b/packages/omo-opencode/src/features/opencode-skill-loader/config-source-discovery.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "fs"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs"
 import { join } from "path"
 import { homedir, tmpdir } from "os"
 import { SkillsConfigSchema } from "../../config/schema/skills"
 import { discoverConfigSourceSkills, normalizePathForGlob } from "./config-source-discovery"
 
-const TEST_DIR = join(tmpdir(), `config-source-discovery-test-${Date.now()}`)
+// mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+// process return the same millisecond, so sibling suites collided on one directory and
+// each teardown removed the other's live fixture. On Windows, removing an in-use tree
+// blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
 
 function writeSkill(path: string, name: string, description: string): void {
   mkdirSync(path, { recursive: true })
@@ -17,7 +21,7 @@ function writeSkill(path: string, name: string, description: string): void {
 
 describe("config source discovery", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "config-source-discovery-test-"))
   })
 
   afterEach(() => {

--- a/packages/omo-opencode/src/features/opencode-skill-loader/merger/config-skill-entry-loader.test.ts
+++ b/packages/omo-opencode/src/features/opencode-skill-loader/merger/config-skill-entry-loader.test.ts
@@ -1,18 +1,27 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test"
-import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { SkillDefinition } from "../../../config/schema"
 import { configEntryToLoadedSkill } from "./config-skill-entry-loader"
 
 describe("configEntryToLoadedSkill", () => {
-  const fixtureRoot = join(tmpdir(), `config-skill-entry-loader-${Date.now()}`)
-  const configDir = join(fixtureRoot, "config")
-  const allowedSkillPath = join(configDir, "allowed-skill.md")
-  const linkedSecretSkillPath = join(configDir, "linked-secret-skill.md")
-  const outsideSkillPath = join(fixtureRoot, "secret-skill.md")
+  // mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+  // process return the same millisecond, so sibling suites collided on one directory and
+  // each teardown removed the other's live fixture. On Windows, removing an in-use tree
+  // blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+  let fixtureRoot = ""
+  let configDir = ""
+  let allowedSkillPath = ""
+  let linkedSecretSkillPath = ""
+  let outsideSkillPath = ""
 
   beforeAll(() => {
+    fixtureRoot = mkdtempSync(join(tmpdir(), "config-skill-entry-loader-"))
+    configDir = join(fixtureRoot, "config")
+    allowedSkillPath = join(configDir, "allowed-skill.md")
+    linkedSecretSkillPath = join(configDir, "linked-secret-skill.md")
+    outsideSkillPath = join(fixtureRoot, "secret-skill.md")
     mkdirSync(configDir, { recursive: true })
     writeFileSync(
       allowedSkillPath,

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/config-source-discovery.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/config-source-discovery.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "fs"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs"
 import { join } from "path"
 import { homedir, tmpdir } from "os"
 import { SkillsConfigSchema } from "../../config/skills"
 import { discoverConfigSourceSkills, normalizePathForGlob } from "./config-source-discovery"
 
-const TEST_DIR = join(tmpdir(), `config-source-discovery-test-${Date.now()}`)
+// mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+// process return the same millisecond, so sibling suites collided on one directory and
+// each teardown removed the other's live fixture. On Windows, removing an in-use tree
+// blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
 
 function writeSkill(path: string, name: string, description: string): void {
   mkdirSync(path, { recursive: true })
@@ -17,7 +21,7 @@ function writeSkill(path: string, name: string, description: string): void {
 
 describe("config source discovery", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "config-source-discovery-test-"))
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/merger/config-skill-entry-loader.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/merger/config-skill-entry-loader.test.ts
@@ -1,18 +1,27 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test"
-import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { SkillDefinition } from "../../../types"
 import { configEntryToLoadedSkill } from "./config-skill-entry-loader"
 
 describe("configEntryToLoadedSkill", () => {
-  const fixtureRoot = join(tmpdir(), `config-skill-entry-loader-${Date.now()}`)
-  const configDir = join(fixtureRoot, "config")
-  const allowedSkillPath = join(configDir, "allowed-skill.md")
-  const linkedSecretSkillPath = join(configDir, "linked-secret-skill.md")
-  const outsideSkillPath = join(fixtureRoot, "secret-skill.md")
+  // mkdtempSync, never a Date.now()-derived name: consecutive Date.now() calls in one
+  // process return the same millisecond, so sibling suites collided on one directory and
+  // each teardown removed the other's live fixture. On Windows, removing an in-use tree
+  // blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+  let fixtureRoot = ""
+  let configDir = ""
+  let allowedSkillPath = ""
+  let linkedSecretSkillPath = ""
+  let outsideSkillPath = ""
 
   beforeAll(() => {
+    fixtureRoot = mkdtempSync(join(tmpdir(), "config-skill-entry-loader-"))
+    configDir = join(fixtureRoot, "config")
+    allowedSkillPath = join(configDir, "allowed-skill.md")
+    linkedSecretSkillPath = join(configDir, "linked-secret-skill.md")
+    outsideSkillPath = join(fixtureRoot, "secret-skill.md")
     mkdirSync(configDir, { recursive: true })
     writeFileSync(
       allowedSkillPath,


### PR DESCRIPTION
Follow-up to #7043 (`d9cb02fec`), which fixed two of these collision pairs. A repo-wide survey found three more.

## Survey

Across 166 `join(tmpdir(), ...)` sites (133 distinct prefixes), exactly 12 prefixes were shared by 2+ files. Nine of those already include `Math.random()` / `randomUUID` / `process.pid` and therefore cannot collide. That left four randomness-free pairs — two fixed in #7043, and these three:

| prefix | packages |
|---|---|
| `claude-code-command-loader-` | claude-code-compat-core + omo-opencode |
| `config-skill-entry-loader-` | skills-loader-core + omo-opencode |
| `config-source-discovery-test-` | skills-loader-core + omo-opencode |

Each pair is a core suite plus its shim-package copy, so both exercise identical code.

## Problem

Consecutive `Date.now()` calls in one process return the same millisecond:

```
claude-code-command-loader-     A == B   COLLIDE? true
config-skill-entry-loader-      A == B   COLLIDE? true
config-source-discovery-test-   A == B   COLLIDE? true
```

So both copies of each pair resolved the **same** directory, and each teardown ran `rmSync(root, { recursive: true, force: true })` over the tree the other copy was still using. On Windows, removing an in-use tree blocks and retries until the hook budget expires — surfacing as `a beforeEach/afterEach hook timed out`. On Linux/macOS the removal usually wins the race silently, which is why this presents as Windows-only and load-order dependent.

## Fix

Allocate the root with `mkdtempSync` so the OS guarantees uniqueness:

```
mkdtempSync A = .../collide3-probe-pB5SIl
mkdtempSync B = .../collide3-probe-vU9Sqm
COLLIDE? false
```

The two `beforeAll` suites also declared their fixture paths as `const` derived from the root, so those become `let` and are assigned once the root exists.

Unlike the pair in #7043, **none** of these suites calls `process.chdir` or compares against a canonical path (verified per file: `process.chdir=0`, `realpathSync=0`, `resolve(=0`), so no `realpathSync` wrapping is needed here. Applying it anyway would have been cargo-cult.

## Verification

| check | result |
|---|---|
| all 6 touched files in ONE process | 36 pass / 0 fail (58 assertions) |
| `claude-code-compat-core` + `skills-loader-core` | 413 pass / 0 fail, 57 files |
| `bun test packages/omo-opencode packages/memory-core` (shard 1/2 scope) | **8785 pass / 1 skip / 0 fail**, 1049 files |
| `tsgo` — all three touched packages | exit 0 |
| repo-wide re-survey | **zero** randomness-free prefixes shared by 2+ files |

Audit scoped to the six changed files: **0** added `setDefaultTimeout`/`setTimeout`/`sleep`/`retry`/`.skip`/`.only`, **0** test declarations removed, **0** `expect()` lines touched. No test was deleted, skipped, or relocated; the shim-package copies are kept.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tests now create unique temp roots with mkdtempSync instead of Date.now-based names. Old: core and shim suites with shared prefixes often resolved the same directory and teardowns deleted in-use trees, causing Windows beforeEach/afterEach timeouts. New: each suite gets an OS-unique directory, eliminating collisions.

- Touched suites: claude-code-command-loader, config-source-discovery, and config-skill-entry-loader across `claude-code-compat-core`, `skills-loader-core`, and `omo-opencode`.
- Converted import-time const paths to let and assign them after creating the temp root in beforeEach/beforeAll.
- No chdir/realpath usage in these suites; no path canonicalization changes needed. Assertions and coverage unchanged.
- Repo survey now shows zero randomness-free temp prefixes shared by multiple files. Expected effect: remove Windows-only flakiness from tempdir collisions.

<sup>Written for commit 319fadf85fa3bfb3d6a23fd4f944072ab92d8e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

