### PR TITLE
test: give the remaining shared-prefix suites unique temp roots

### DIFF
--- a/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.test.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.test.ts
@@ -1,16 +1,21 @@
 /// <reference types="bun-types" />
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
-const TEST_DIR = join(tmpdir(), "mcp-loader-test-" + Date.now())
-const TEST_HOME = join(TEST_DIR, "home")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let TEST_HOME = ""
 
 describe("getSystemMcpServerNames", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "mcp-loader-test-"))
+    TEST_HOME = join(TEST_DIR, "home")
     mkdirSync(TEST_HOME, { recursive: true })
     process.env.HOME = TEST_HOME
     process.env.CLAUDE_CONFIG_DIR = join(TEST_HOME, ".claude")

--- a/packages/mcp-client-core/src/mcp-oauth/storage.test.ts
+++ b/packages/mcp-client-core/src/mcp-oauth/storage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test"
 import { createHash } from "node:crypto"
-import { existsSync, mkdirSync, rmSync, readFileSync, statSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, rmSync, readFileSync, statSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
@@ -18,14 +18,18 @@ function expectedServerHash(serverHost: string, resource: string): string {
 }
 
 describe("mcp-oauth storage", () => {
-  const TEST_CONFIG_DIR = join(tmpdir(), "mcp-oauth-test-" + Date.now())
+  // mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+  // return the same millisecond, so sibling suites sharing this prefix collided on one
+  // directory and each teardown removed the other's live fixture. On Windows, removing an
+  // in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+  let TEST_CONFIG_DIR = ""
   let originalConfigDir: string | undefined
 
   beforeEach(() => {
     originalConfigDir = process.env.OPENCODE_CONFIG_DIR
     process.env.OPENCODE_CONFIG_DIR = TEST_CONFIG_DIR
     if (!existsSync(TEST_CONFIG_DIR)) {
-      mkdirSync(TEST_CONFIG_DIR, { recursive: true })
+      TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "mcp-oauth-test-"))
     }
   })
 

--- a/packages/omo-opencode/src/features/claude-code-mcp-loader/loader.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-mcp-loader/loader.test.ts
@@ -1,16 +1,21 @@
 /// <reference types="bun-types" />
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
-const TEST_DIR = join(tmpdir(), "mcp-loader-test-" + Date.now())
-const TEST_HOME = join(TEST_DIR, "home")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let TEST_HOME = ""
 
 describe("getSystemMcpServerNames", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "mcp-loader-test-"))
+    TEST_HOME = join(TEST_DIR, "home")
     mkdirSync(TEST_HOME, { recursive: true })
     process.env.HOME = TEST_HOME
     process.env.CLAUDE_CONFIG_DIR = join(TEST_HOME, ".claude")

--- a/packages/omo-opencode/src/features/mcp-oauth/storage.test.ts
+++ b/packages/omo-opencode/src/features/mcp-oauth/storage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test"
 import { createHash } from "node:crypto"
-import { existsSync, mkdirSync, rmSync, readFileSync, statSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, rmSync, readFileSync, statSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
@@ -18,14 +18,18 @@ function expectedServerHash(serverHost: string, resource: string): string {
 }
 
 describe("mcp-oauth storage", () => {
-  const TEST_CONFIG_DIR = join(tmpdir(), "mcp-oauth-test-" + Date.now())
+  // mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+  // return the same millisecond, so sibling suites sharing this prefix collided on one
+  // directory and each teardown removed the other's live fixture. On Windows, removing an
+  // in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+  let TEST_CONFIG_DIR = ""
   let originalConfigDir: string | undefined
 
   beforeEach(() => {
     originalConfigDir = process.env.OPENCODE_CONFIG_DIR
     process.env.OPENCODE_CONFIG_DIR = TEST_CONFIG_DIR
     if (!existsSync(TEST_CONFIG_DIR)) {
-      mkdirSync(TEST_CONFIG_DIR, { recursive: true })
+      TEST_CONFIG_DIR = mkdtempSync(join(tmpdir(), "mcp-oauth-test-"))
     }
   })
 

--- a/packages/omo-opencode/src/features/opencode-skill-loader/loader.test.ts
+++ b/packages/omo-opencode/src/features/opencode-skill-loader/loader.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
-const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -19,7 +23,8 @@ function createTestSkill(name: string, content: string, mcpJson?: object): strin
 
 describe("skill loader MCP parsing", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "skill-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/async-loader-concurrency.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/async-loader-concurrency.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync, chmodSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, chmodSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 import type { LoadedSkill } from "./types"
 
-const TEST_DIR = join(tmpdir(), "async-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -27,7 +31,8 @@ function createDirectSkill(name: string, content: string): string {
 
 describe("async-loader", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "async-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/async-loader-discovery-mcp.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/async-loader-discovery-mcp.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync, chmodSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, chmodSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 import type { LoadedSkill } from "./types"
 
-const TEST_DIR = join(tmpdir(), "async-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -27,7 +31,8 @@ function createDirectSkill(name: string, content: string): string {
 
 describe("async-loader", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "async-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/async-loader-path-and-mcp.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/async-loader-path-and-mcp.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync, chmodSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, chmodSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 import type { LoadedSkill } from "./types"
 
-const TEST_DIR = join(tmpdir(), "async-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -27,7 +31,8 @@ function createDirectSkill(name: string, content: string): string {
 
 describe("async-loader", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "async-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/async-loader.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/async-loader.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync, chmodSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, chmodSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 import type { LoadedSkill } from "./types"
 
-const TEST_DIR = join(tmpdir(), "async-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -27,7 +31,8 @@ function createDirectSkill(name: string, content: string): string {
 
 describe("async-loader", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "async-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader-allowed-tools.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader-allowed-tools.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
-const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -19,7 +23,8 @@ function createTestSkill(name: string, content: string, mcpJson?: object): strin
 
 describe("skill loader MCP parsing", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "skill-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader-deduplication.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader-deduplication.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
-const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -19,7 +23,8 @@ function createTestSkill(name: string, content: string, mcpJson?: object): strin
 
 describe("skill loader MCP parsing", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "skill-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader-project-discovery.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader-project-discovery.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
-const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -19,7 +23,8 @@ function createTestSkill(name: string, content: string, mcpJson?: object): strin
 
 describe("skill loader MCP parsing", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "skill-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader-skill-lookup.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader-skill-lookup.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
-const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -19,7 +23,8 @@ function createTestSkill(name: string, content: string, mcpJson?: object): strin
 
 describe("skill loader MCP parsing", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "skill-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {

--- a/packages/skills-loader-core/src/features/opencode-skill-loader/loader.test.ts
+++ b/packages/skills-loader-core/src/features/opencode-skill-loader/loader.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
-const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+// mkdtempSync, never a clock-derived name: consecutive Date.now() calls in one process
+// return the same millisecond, so sibling suites sharing this prefix collided on one
+// directory and each teardown removed the other's live fixture. On Windows, removing an
+// in-use tree blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
+let TEST_DIR = ""
+let SKILLS_DIR = ""
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -19,7 +23,8 @@ function createTestSkill(name: string, content: string, mcpJson?: object): strin
 
 describe("skill loader MCP parsing", () => {
   beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "skill-loader-test-"))
+    SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
   })
 
   afterEach(() => {


### PR DESCRIPTION
Completes the sweep started in #7043 (`d9cb02fec`) and #7046 (`6b7619c7e`).

## Why these were missed

My earlier survey used a regex written for **template literals** and ran through `rg --type ts`, which also skipped `packages/omo-codex/plugin/**` and `src/__tests__/**`. These four groups build the name by **concatenation**, so they were invisible to it:

```ts
const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
```

I posted a correction on #7046; the "zero remaining" claim there was wrong. Re-surveying merged `dev` with `git grep` (no type filter, both quote styles, and checking for an `mkdtemp` wrapper) gives 1237 `join(tmpdir(), …)` sites — 1062 already safe, 175 unwrapped, and **4 real colliding groups**:

| prefix | packages | files |
|---|---|---|
| `mcp-loader-test-` | claude-code-compat-core + omo-opencode | 2 |
| `mcp-oauth-test-` | mcp-client-core + omo-opencode | 2 |
| `skill-loader-test-` | skills-loader-core + omo-opencode | 6 |
| `async-loader-test-` | skills-loader-core | 4 |

With **six** suites sharing one directory, the collision is closer to certain than occasional. Consecutive `Date.now()` calls in one process return the same millisecond, both suites resolve the same path, and each teardown runs `rmSync(root, { recursive: true, force: true })` over a tree another suite is still using. On Windows, removing an in-use tree blocks and retries until the hook budget expires.

Two other shared prefixes were checked and are **not** defects, so they are left alone: `comment-checker-debug.log` is a deliberate shared debug-log path (no fixture tree, no `rmSync`), and `qa-memory-home` has `rmSync=0` in all three files.

## The subtle part

Moving the root into a hook is not sufficient on its own. Twelve of these files derive paths from the root **at module scope**:

```ts
let TEST_DIR = ""
const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")   // -> ".opencode/skills"
```

Evaluated at import time that resolves against an empty root and silently becomes a **relative** path, so fixtures land in the repo instead of the temp directory. My first pass did exactly this and the suites caught it: **66 pass / 41 fail**, plus 31 stray `.opencode/skills/*` dirs and a `home/` tree written into the working copy. Those derived paths now move into the hook too. Derived paths inside test bodies already run after the hook and are untouched.

## Verification

| check | result |
|---|---|
| all 14 files in ONE process | **107 pass / 0 fail** (253 assertions) |
| `claude-code-compat-core` + `mcp-client-core` | 193 pass / 0 fail |
| `bun test packages/omo-opencode packages/memory-core` (shard 1/2 scope) | **8779 pass / 6 skip / 1 fail** |
| `tsgo` — all four touched packages | exit 0 |
| repo working copy after the run | no stray fixtures recreated |

The single shard failure is `dist bundle prompt content`, which asserts `dist/index.js` exists and is labelled CI-only in the test itself. It fails locally only because I installed with `--ignore-scripts`, so the bundle was never built; no changed file is involved.

Worth noting: four skill-resolution failures I initially took for pre-existing were in fact caused by the stray fixtures from my own broken first pass. After cleaning those, the shard went from `8775 pass / 5 fail` to `8779 pass / 1 fail`, and the run no longer recreates them — which is also the clearest evidence the fix holds.

Audit scoped to the 14 changed files: **0** added `setDefaultTimeout`/`setTimeout`/`sleep`/`retry`/`.skip`/`.only`, **0** test declarations removed, **0** `expect()` lines touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky test teardowns by giving each affected suite a unique OS-managed temp root. Previously tests used clock-based directories shared by multiple suites; now they use mkdtempSync and derive paths after the root is set.

- Affected prefixes across `claude-code-compat-core`, `mcp-client-core`, `skills-loader-core`, and `omo-opencode`: mcp-loader-test-, mcp-oauth-test-, skill-loader-test-, async-loader-test-.
- Change: replace join(tmpdir(), "prefix-" + Date.now()) with mkdtempSync(join(tmpdir(), "prefix-")) inside beforeEach; move derived paths (e.g., SKILLS_DIR, TEST_HOME) from module scope into the hook.
- Impact: removes cross-suite collisions and Windows teardown timeouts; no assertion or runtime code changes; no migrations.

<sup>Written for commit 2b9754f97bde17a7c8a973a4b21e9ef40e33c3d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

