### PR TITLE
test: budget three Windows-slow suites past the 5s default

### DIFF
--- a/packages/memory-core/src/compile/compile.test.ts
+++ b/packages/memory-core/src/compile/compile.test.ts
@@ -32,7 +32,9 @@ describe("compileMemoryBlock", () => {
     expect(block).not.toContain("EXTERNAL_BODY_SENTINEL")
     expect(block).not.toContain("BINARY_BODY_SENTINEL")
     expect(block).not.toContain("SKILL_BODY_SENTINEL")
-  })
+    // Loaded Windows runners push these git fixtures past the 5s default; the work stays
+    // deterministic (~230ms locally), so only the ceiling moves.
+  }, 30_000)
 
   it("#given a committed persona and identity #when compiled #then both projection paths share the self section and metadata remains structured", async () => {
     // given

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-leader.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-leader.test.ts
@@ -139,5 +139,7 @@ describe("createTeamIdleWakeHint leader delivery", () => {
 
     const unreadMessages = await listUnreadMessages(teamRunId, "lead", config)
     expect(unreadMessages.map((message) => message.body)).toEqual(completionBodies)
-  })
+    // Loaded Windows runners push this past the 5s default; the waits stay event-driven
+    // (~11ms locally), so only the ceiling moves.
+  }, 30_000)
 })

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint.test.ts
@@ -572,7 +572,9 @@ describe("createTeamIdleWakeHint", () => {
 
     const processedEntries = await readdir(path.join(getInboxDir(resolveBaseDir(config), teamRunId, "worker"), "processed"))
     expect(processedEntries.sort()).toEqual(messageIds.map((messageId) => `${messageId}.json`).sort())
-  })
+    // Loaded Windows runners push this past the 5s default; the waits stay event-driven
+    // (~60ms locally), so only the ceiling moves.
+  }, 30_000)
 
   test("acks pending reserved live-delivery messages on idle", async () => {
     // given


### PR DESCRIPTION
## Problem

`test (windows-latest, 1/2)` fails on `dev` with a different test each run, always a
timeout at the same 5000ms default ceiling:

| run | failing test | duration |
|---|---|---|
| 1 | `compileMemoryBlock … structural contract` | 5004ms |
| 2 | `createTeamIdleWakeHint leader delivery … every completion wakes the leader` | 5223ms |
| 3 | `createTeamIdleWakeHint … acks pending messages on idle` | 6579ms |

Three different tests hitting the same ceiling — while shard 2/2 passes cleanly every
time — is shard-wide timing pressure on the Windows runner, not three broken tests.

This blocks the release pipeline: `publish.yml`'s `gate-reuse` job requires a completed
successful `ci.yml` run at the prepared release SHA, so the shard failure prevents
publishing.

## Why a budget rather than a rewrite

All three tests are deterministic and fast locally (repeated runs, this machine):

| test | runs | slowest | budget |
|---|---|---|---|
| `compileMemoryBlock` | 8/8 pass | 234ms | 5000ms |
| `team-idle-wake-hint-leader` | 5/5 pass | 11ms | 5000ms |
| `team-idle-wake-hint` | 5/5 pass | 60ms | 5000ms |

None of them assert timing behavior, and their waits are already event-driven — they
await exact filesystem/process signals rather than sleeping. The 5000ms value is a
harness ceiling, not part of the contract under test, so raising it does not weaken
any assertion. A genuine hang still fails at 30s.

This follows the existing precedent in this repository for Windows-slow tests:

- `171439584` test(omo-senpi): budget DAG RPC Windows file-store test → `}, 30_000)`
- `c69a29440` test(memory-core): budget Windows cache integration
- `6d58cd0ec` widen the non-deadline supervisor budget

## Change

Three per-test budget arguments plus comments explaining why. No assertions, mocks,
sleeps, or waits touched.

## Verification

- `bun test packages/memory-core/src/compile/compile.test.ts` → 5 pass, 0 fail
- `bun test packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint.test.ts packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-leader.test.ts` → 16 pass, 0 fail


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Budgets three Windows-slow tests to 30s (up from the 5s default) to stop intermittent timeouts on the `windows-latest` shard 1/2 and unblock the release gate.

- Tests updated: `packages/memory-core` compileMemoryBlock; `packages/omo-opencode` team-idle-wake-hint and team-idle-wake-hint-leader.
- Only per-test timeout arguments and comments changed; no assertions/mocks/waits modified. Tests remain event-driven and still fail on genuine hangs at 30s.
- CI impact: stabilizes shard 1/2 and restores the `publish.yml` gate that requires a successful `ci.yml` run.

<sup>Written for commit 1e1724f3a3f745cb90f03e8ea0884f4dbad070b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

