### PR TITLE
test(omo-senpi): retry EFAULT during memory test teardown

### DIFF
--- a/packages/omo-senpi/src/components/memory/compaction-survival.test.ts
+++ b/packages/omo-senpi/src/components/memory/compaction-survival.test.ts
@@ -6,7 +6,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test"
 import { createHash } from "node:crypto"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -32,6 +32,7 @@ import {
 } from "./memory.test-support"
 import { resolveReflectionTriggerConfig } from "./trigger-wiring"
 import { realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 const SESSION_ID = "session-compaction-survival"
 const BASE_SYSTEM_PROMPT = "You are senpi, a coding agent."
@@ -43,7 +44,7 @@ const cleanups: Array<() => Promise<void>> = []
 
 afterEach(async () => {
   for (const cleanup of cleanups.splice(0)) await cleanup()
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(roots.splice(0).map((root) => rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 interface CompactionFixture {

--- a/packages/omo-senpi/src/components/memory/context.test.ts
+++ b/packages/omo-senpi/src/components/memory/context.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import { buildIdentityPaths } from "@oh-my-opencode/memory-core"
 
@@ -9,7 +10,7 @@ import { createMemoryIdentityContext, ensureIdentityRuntimeDirs } from "./contex
 
 const roots: string[] = []
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 describe("memory identity context", () => {

--- a/packages/omo-senpi/src/components/memory/dream-selector.test.ts
+++ b/packages/omo-senpi/src/components/memory/dream-selector.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import {
   REFLECTION_STATE_SCHEMA_VERSION,
@@ -24,7 +25,7 @@ const NOW = new Date("2026-08-10T12:00:00.000Z")
 const tempDirs: string[] = []
 
 afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(tempDirs.splice(0).map((dir) => rmEfaultTolerant(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 function textEntry(

--- a/packages/omo-senpi/src/components/memory/facts-wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/facts-wiring.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, mkdir, readdir, rm } from "node:fs/promises"
+import { mkdtemp, mkdir, readdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -12,13 +12,14 @@ import {
 
 import { createMemoryFactsWiring } from "./facts-wiring"
 import { realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 const IDENTITY = "facts-wiring-agent"
 const SESSION = "session-alpha"
 const tempDirs: string[] = []
 
 afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(tempDirs.splice(0).map((dir) => rmEfaultTolerant(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 async function fixture(): Promise<MemoryIdentityPaths> {

--- a/packages/omo-senpi/src/components/memory/guard.test.ts
+++ b/packages/omo-senpi/src/components/memory/guard.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join, relative } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import { buildIdentityPaths } from "@oh-my-opencode/memory-core"
 
@@ -13,7 +14,7 @@ import { componentContext } from "./memory.test-support"
 const roots: string[] = []
 
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 type GuardFixture = {

--- a/packages/omo-senpi/src/components/memory/index.test.ts
+++ b/packages/omo-senpi/src/components/memory/index.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import { OmoMemorySettingsSchema } from "@oh-my-opencode/omo-config-core"
 import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
@@ -12,7 +13,7 @@ import { SOUL_UPDATED_ENTRY_TYPE } from "./soul-notice"
 
 const roots: string[] = []
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 function fixture(): { cwd: string; memoryHome: string } {

--- a/packages/omo-senpi/src/components/memory/journal-wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/journal-wiring.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import {
   buildIdentityPaths,
@@ -14,7 +15,7 @@ import { createMemoryJournalWiring } from "./journal-wiring"
 
 const roots: string[] = []
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 function fixture(): { readonly paths: MemoryIdentityPaths } {

--- a/packages/omo-senpi/src/components/memory/memory-notice-wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/memory-notice-wiring.test.ts
@@ -4,9 +4,10 @@
 // single-consumption test pins that invariant with a counting wrapper around the REAL consumer.
 import { afterEach, describe, expect, test } from "bun:test"
 import { realpathSync } from "node:fs"
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { access, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import type { ThemeColor } from "@code-yeongyu/senpi"
 import { buildIdentityPaths } from "@oh-my-opencode/memory-core"
@@ -27,7 +28,7 @@ const IDENTITY = "memory-notice-agent"
 const roots: string[] = []
 
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(roots.splice(0).map((root) => rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 async function fixture(): Promise<{ context: MemoryIdentityContext }> {

--- a/packages/omo-senpi/src/components/memory/memory-rpc-bridge.test.ts
+++ b/packages/omo-senpi/src/components/memory/memory-rpc-bridge.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { realpathSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import { GitMemoryRepo, buildIdentityPaths } from "@oh-my-opencode/memory-core"
 
@@ -19,7 +20,7 @@ import { createMemoryRpcGitRepo } from "./memory-rpc-snapshot-state"
 
 const roots: string[] = []
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(roots.splice(0).map((root) => rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 interface FakeRpcHost {

--- a/packages/omo-senpi/src/components/memory/memory-rpc-snapshot-state.test.ts
+++ b/packages/omo-senpi/src/components/memory/memory-rpc-snapshot-state.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { realpathSync } from "node:fs"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import { GitMemoryRepo, buildIdentityPaths } from "@oh-my-opencode/memory-core"
 
@@ -18,7 +19,7 @@ import {
 const tempDirs: string[] = []
 
 afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(tempDirs.splice(0).map((dir) => rmEfaultTolerant(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 async function fixtureRepo(): Promise<{ dir: string; repo: GitMemoryRepo; head: string }> {

--- a/packages/omo-senpi/src/components/memory/memory-rpc-wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/memory-rpc-wiring.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { realpathSync, rmSync } from "node:fs"
+import { realpathSync } from "node:fs"
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import { buildIdentityPaths, GitMemoryRepo, type ReservedRun } from "@oh-my-opencode/memory-core"
 
@@ -27,7 +28,7 @@ import { recordReflectionCompletion, type ReflectionCompletionRecord } from "./w
 
 const roots: string[] = []
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 class RpcFakeExtensionAPI extends MemoryFakeExtensionAPI {

--- a/packages/omo-senpi/src/components/memory/nudge-wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/nudge-wiring.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import type { ThemeColor } from "@code-yeongyu/senpi"
 import { GitMemoryRepo, buildIdentityPaths } from "@oh-my-opencode/memory-core"
@@ -52,7 +53,7 @@ function disposition(inputId: string, value: "handled" | "queued" | "started" | 
 }
 
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(roots.splice(0).map((root) => rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 describe("createMemoryNudgeWiring", () => {
@@ -143,7 +144,7 @@ describe("createMemoryNudgeWiring", () => {
   test("#given a threshold on an identity with no repository yet #when nudge state resolves #then the fresh-session baseline is used without requiring git history", async () => {
     // given
     const { context } = await fixture()
-    await rm(context.identityPaths.repo, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+    await rmEfaultTolerant(context.identityPaths.repo, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
     const repo = new GitMemoryRepo({ dir: context.identityPaths.repo, agentId: context.identity })
     const pi = new MemoryFakeExtensionAPI()
     const wiring = createMemoryNudgeWiring({

--- a/packages/omo-senpi/src/components/memory/policy-guard.test.ts
+++ b/packages/omo-senpi/src/components/memory/policy-guard.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import { buildIdentityPaths } from "@oh-my-opencode/memory-core"
 
@@ -20,7 +21,7 @@ import {
 const roots: string[] = []
 
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 class PolicyCapturingFakeExtensionAPI extends FakeExtensionAPI {

--- a/packages/omo-senpi/src/components/memory/prompt.test.ts
+++ b/packages/omo-senpi/src/components/memory/prompt.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -22,13 +22,14 @@ import {
 } from "./prompt"
 import { MEMORY_PRESSURE_SOFT_RATIO } from "./status"
 import { realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 const IDENTITY = "prompt-agent"
 
 const tempDirs: string[] = []
 
 afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(tempDirs.splice(0).map((dir) => rmEfaultTolerant(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 class CountingRepo extends GitMemoryRepo {

--- a/packages/omo-senpi/src/components/memory/sandbox-absent-paths.test.ts
+++ b/packages/omo-senpi/src/components/memory/sandbox-absent-paths.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import type { ReflectionSpawnArgs } from "./worker/spawn"
 import { buildSandboxTransform, SandboxUnavailableError } from "./sandbox"
@@ -14,7 +15,7 @@ import { buildSandboxTransform, SandboxUnavailableError } from "./sandbox"
 
 const roots: string[] = []
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 function fixture(): { readonly root: string; readonly worktree: string; readonly gitCommonDir: string; readonly payload: string } {

--- a/packages/omo-senpi/src/components/memory/sandbox-facts.test.ts
+++ b/packages/omo-senpi/src/components/memory/sandbox-facts.test.ts
@@ -1,14 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, mkdirSync, realpathSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import type { FactsSpawnArgs } from "./worker/spawn"
 import { buildFactsSandboxTransform, SandboxUnavailableError } from "./sandbox"
 
 const roots: string[] = []
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 interface LockFixture {

--- a/packages/omo-senpi/src/components/memory/sandbox-lock-invariants.test.ts
+++ b/packages/omo-senpi/src/components/memory/sandbox-lock-invariants.test.ts
@@ -1,14 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import type { FactsSpawnArgs } from "./worker/spawn"
 import { buildFactsSandboxTransform, SandboxUnavailableError } from "./sandbox"
 
 const roots: string[] = []
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 const seatbeltTest = test.skipIf(process.platform !== "darwin" || !existsSync("/usr/bin/sandbox-exec"))

--- a/packages/omo-senpi/src/components/memory/sandbox.test.ts
+++ b/packages/omo-senpi/src/components/memory/sandbox.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, mkdirSync, realpathSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { basename, dirname, join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import type { ReflectionSpawnArgs } from "./worker/spawn"
 import {
@@ -12,7 +13,7 @@ import {
 
 const roots: string[] = []
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 function fixture(): {

--- a/packages/omo-senpi/src/components/memory/shutdown-drain.test.ts
+++ b/packages/omo-senpi/src/components/memory/shutdown-drain.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readdir, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import { TranscriptJournal, resolveMemoryIdentity, type TranscriptEntry } from "@oh-my-opencode/memory-core"
 
@@ -20,7 +21,7 @@ const SESSION = "session-drain"
 const tempDirs: string[] = []
 
 afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(tempDirs.splice(0).map((dir) => rmEfaultTolerant(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 function recordingLogger(): { logger: ComponentLogger; warnings: string[] } {

--- a/packages/omo-senpi/src/components/memory/skills-scope.test.ts
+++ b/packages/omo-senpi/src/components/memory/skills-scope.test.ts
@@ -40,10 +40,11 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { mkdir, mkdtemp } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import { buildIdentityPaths } from "@oh-my-opencode/memory-core"
 
@@ -63,7 +64,7 @@ const IDENTITY = "skills-scope-agent"
 const tempDirs: string[] = []
 
 afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(tempDirs.splice(0).map((dir) => rmEfaultTolerant(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 async function fixture(createSkills = true): Promise<{ context: MemoryIdentityContext; skillsDir: string }> {

--- a/packages/omo-senpi/src/components/memory/status-live-wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/status-live-wiring.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp } from "node:fs/promises"
 import { realpathSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import { buildIdentityPaths } from "@oh-my-opencode/memory-core"
 
@@ -13,7 +14,7 @@ import { createMemoryFooterStatusLive } from "./status-live-wiring"
 
 const roots: string[] = []
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(roots.splice(0).map((root) => rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 interface FakeTimers extends MemoryFooterTimers {

--- a/packages/omo-senpi/src/components/memory/status.test.ts
+++ b/packages/omo-senpi/src/components/memory/status.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import { GitMemoryRepo, buildIdentityPaths } from "@oh-my-opencode/memory-core"
 
@@ -15,7 +16,7 @@ import {
 
 const roots: string[] = []
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 interface RecordingUi {

--- a/packages/omo-senpi/src/components/memory/teardown.test-support.test.ts
+++ b/packages/omo-senpi/src/components/memory/teardown.test-support.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  rmEfaultTolerant,
+  rmSyncEfaultTolerant,
+  TEARDOWN_FAILURE_PREFIX,
+  type RmAsyncFn,
+  type RmSyncFn,
+} from "./teardown.test-support"
+
+function errno(code: string, message = `${code}: simulated`): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code })
+}
+
+describe("rmSyncEfaultTolerant", () => {
+  test("#given rmSync throws EFAULT once then succeeds #when teardown runs #then the path is removed", () => {
+    let calls = 0
+    const rmSync: RmSyncFn = () => {
+      calls += 1
+      if (calls === 1) throw errno("EFAULT", "bad address in system call argument")
+    }
+
+    rmSyncEfaultTolerant("/tmp/omo-teardown-efault-once", { recursive: true, force: true }, {
+      rmSync,
+      sleep: () => {},
+    })
+
+    expect(calls).toBe(2)
+  })
+
+  test("#given rmSync always throws ENOENT #when teardown runs #then the original error is rethrown immediately", () => {
+    const error = errno("ENOENT", "no such file or directory")
+    let calls = 0
+    const rmSync: RmSyncFn = () => {
+      calls += 1
+      throw error
+    }
+
+    let thrown: unknown
+    try {
+      rmSyncEfaultTolerant("/tmp/omo-teardown-enoent", { recursive: true, force: true }, {
+        rmSync,
+        sleep: () => {
+          throw new Error("sleep must not run for non-EFAULT")
+        },
+      })
+    } catch (caught) {
+      thrown = caught
+    }
+
+    expect(thrown).toBe(error)
+    expect(calls).toBe(1)
+  })
+
+  test("#given rmSync always throws EFAULT #when the retry budget is exhausted #then the error message starts with teardown-failure:", () => {
+    let calls = 0
+    const rmSync: RmSyncFn = () => {
+      calls += 1
+      throw errno("EFAULT", "bad address in system call argument")
+    }
+
+    let thrown: unknown
+    try {
+      rmSyncEfaultTolerant("/tmp/omo-teardown-efault-exhausted", { recursive: true, force: true }, {
+        rmSync,
+        sleep: () => {},
+        efaultAttempts: 3,
+      })
+    } catch (caught) {
+      thrown = caught
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).message.startsWith(TEARDOWN_FAILURE_PREFIX)).toBe(true)
+    expect(calls).toBe(3)
+  })
+})
+
+describe("rmEfaultTolerant", () => {
+  test("#given rm throws EFAULT once then succeeds #when teardown runs #then the path is removed", async () => {
+    let calls = 0
+    const rm: RmAsyncFn = async () => {
+      calls += 1
+      if (calls === 1) throw errno("EFAULT", "bad address in system call argument")
+    }
+
+    await rmEfaultTolerant("/tmp/omo-teardown-efault-once-async", { recursive: true, force: true }, {
+      rm,
+      sleep: async () => {},
+    })
+
+    expect(calls).toBe(2)
+  })
+
+  test("#given rm always throws ENOENT #when teardown runs #then the original error is rethrown immediately", async () => {
+    const error = errno("ENOENT", "no such file or directory")
+    let calls = 0
+    const rm: RmAsyncFn = async () => {
+      calls += 1
+      throw error
+    }
+
+    let thrown: unknown
+    try {
+      await rmEfaultTolerant("/tmp/omo-teardown-enoent-async", { recursive: true, force: true }, {
+        rm,
+        sleep: async () => {
+          throw new Error("sleep must not run for non-EFAULT")
+        },
+      })
+    } catch (caught) {
+      thrown = caught
+    }
+
+    expect(thrown).toBe(error)
+    expect(calls).toBe(1)
+  })
+
+  test("#given rm always throws EFAULT #when the retry budget is exhausted #then the error message starts with teardown-failure:", async () => {
+    let calls = 0
+    const rm: RmAsyncFn = async () => {
+      calls += 1
+      throw errno("EFAULT", "bad address in system call argument")
+    }
+
+    let thrown: unknown
+    try {
+      await rmEfaultTolerant("/tmp/omo-teardown-efault-exhausted-async", { recursive: true, force: true }, {
+        rm,
+        sleep: async () => {},
+        efaultAttempts: 3,
+      })
+    } catch (caught) {
+      thrown = caught
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).message.startsWith(TEARDOWN_FAILURE_PREFIX)).toBe(true)
+    expect(calls).toBe(3)
+  })
+})

--- a/packages/omo-senpi/src/components/memory/teardown.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/teardown.test-support.ts
@@ -1,0 +1,107 @@
+import { rmSync as nodeRmSync } from "node:fs"
+import { rm as nodeRm } from "node:fs/promises"
+
+export const TEARDOWN_FAILURE_PREFIX = "teardown-failure:"
+
+export type TeardownRmOptions = {
+  recursive?: boolean
+  force?: boolean
+  maxRetries?: number
+  retryDelay?: number
+}
+
+export type RmSyncFn = (path: string, options?: TeardownRmOptions) => void
+export type RmAsyncFn = (path: string, options?: TeardownRmOptions) => Promise<void>
+export type SleepSyncFn = (ms: number) => void
+export type SleepAsyncFn = (ms: number) => Promise<void>
+
+export type RmSyncEfaultTolerantDeps = {
+  rmSync?: RmSyncFn
+  sleep?: SleepSyncFn
+  efaultAttempts?: number
+  efaultDelayMs?: number
+}
+
+export type RmEfaultTolerantDeps = {
+  rm?: RmAsyncFn
+  sleep?: SleepAsyncFn
+  efaultAttempts?: number
+  efaultDelayMs?: number
+}
+
+const DEFAULT_OPTIONS: TeardownRmOptions = {
+  recursive: true,
+  force: true,
+  maxRetries: 10,
+  retryDelay: 200,
+}
+
+const DEFAULT_EFAULT_ATTEMPTS = 3
+const DEFAULT_EFAULT_DELAY_MS = 50
+
+function defaultSleepSync(ms: number): void {
+  Bun.sleepSync(ms)
+}
+
+function defaultSleepAsync(ms: number): Promise<void> {
+  return Bun.sleep(ms)
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (error !== null && typeof error === "object" && "code" in error && typeof error.code === "string") {
+    return error.code
+  }
+  return undefined
+}
+
+function teardownFailure(path: string, attempts: number, cause: unknown): Error {
+  const error = new Error(`${TEARDOWN_FAILURE_PREFIX} EFAULT persisted after ${attempts} attempts removing ${path}`)
+  error.cause = cause
+  return error
+}
+
+export function rmSyncEfaultTolerant(
+  path: string,
+  options: TeardownRmOptions = DEFAULT_OPTIONS,
+  deps: RmSyncEfaultTolerantDeps = {},
+): void {
+  const rm = deps.rmSync ?? nodeRmSync
+  const sleep = deps.sleep ?? defaultSleepSync
+  const attempts = deps.efaultAttempts ?? DEFAULT_EFAULT_ATTEMPTS
+  const delayMs = deps.efaultDelayMs ?? DEFAULT_EFAULT_DELAY_MS
+  let lastError: unknown
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      rm(path, options)
+      return
+    } catch (error) {
+      if (errorCode(error) !== "EFAULT") throw error
+      lastError = error
+      if (attempt + 1 < attempts) sleep(delayMs)
+    }
+  }
+  throw teardownFailure(path, attempts, lastError)
+}
+
+export async function rmEfaultTolerant(
+  path: string,
+  options: TeardownRmOptions = DEFAULT_OPTIONS,
+  deps: RmEfaultTolerantDeps = {},
+): Promise<void> {
+  const rm = deps.rm ?? nodeRm
+  const sleep = deps.sleep ?? defaultSleepAsync
+  const attempts = deps.efaultAttempts ?? DEFAULT_EFAULT_ATTEMPTS
+  const delayMs = deps.efaultDelayMs ?? DEFAULT_EFAULT_DELAY_MS
+  let lastError: unknown
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      await rm(path, options)
+      return
+    } catch (error) {
+      if (errorCode(error) !== "EFAULT") throw error
+      lastError = error
+      if (attempt + 1 < attempts) await sleep(delayMs)
+    }
+  }
+  throw teardownFailure(path, attempts, lastError)
+}

--- a/packages/omo-senpi/src/components/memory/tools.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/tools.test-support.ts
@@ -1,9 +1,10 @@
 import { afterEach } from "bun:test"
 import { execFile } from "node:child_process"
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { promisify } from "node:util"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import {
   GitMemoryRepo,
@@ -32,7 +33,7 @@ const WINDOWS_CLEANUP_RACE_CODES = new Set(["EBUSY", "ENOTEMPTY", "EPERM"])
 // test file's budget - the exact shape of the tools-apply-patch timeout on CI.
 async function removeRoot(root: string): Promise<void> {
   try {
-    await rm(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 })
+    await rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 })
   } catch (error) {
     // A lingering Windows handle can outlast the bounded retry window. Ignore only that platform's
     // known cleanup races; every other cleanup defect still fails loudly.

--- a/packages/omo-senpi/src/components/memory/wiring-mcp-notice.test.ts
+++ b/packages/omo-senpi/src/components/memory/wiring-mcp-notice.test.ts
@@ -2,10 +2,11 @@
 // the shared receipt consumer - otherwise the knob is decorative on the search surface, exactly
 // the way it would have been if only the direct tool's renderResult honoured it.
 import { afterEach, describe, expect, test } from "bun:test"
-import { realpathSync, rmSync } from "node:fs"
+import { realpathSync } from "node:fs"
 import { mkdir, mkdtemp } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import { resolveMemoryIdentity } from "@oh-my-opencode/memory-core"
 
@@ -32,7 +33,7 @@ const roots: string[] = []
 
 afterEach(() => {
   for (const root of roots.splice(0)) {
-    rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+    rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
   }
 })
 

--- a/packages/omo-senpi/src/components/memory/wiring-write-notice.test.ts
+++ b/packages/omo-senpi/src/components/memory/wiring-write-notice.test.ts
@@ -1,10 +1,11 @@
 // The write-notice gate lives in config, so the registration seam must actually carry it to the
 // registered tool's renderer - otherwise the knob is decorative.
 import { afterEach, describe, expect, test } from "bun:test"
-import { realpathSync, rmSync } from "node:fs"
+import { realpathSync } from "node:fs"
 import { mkdir, mkdtemp } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "./teardown.test-support"
 
 import { resolveMemoryIdentity } from "@oh-my-opencode/memory-core"
 
@@ -22,7 +23,7 @@ const roots: string[] = []
 
 afterEach(() => {
   for (const root of roots.splice(0)) {
-    rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+    rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
   }
 })
 

--- a/packages/omo-senpi/src/components/memory/wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/wiring.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { realpathSync } from "node:fs"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmEfaultTolerant } from "./teardown.test-support"
 
 import { buildIdentityPaths, GitMemoryRepo, resolveMemoryIdentity } from "@oh-my-opencode/memory-core"
 import type { MemoryIdentityRuntime } from "./identity-runtime"
@@ -38,7 +39,7 @@ async function removeWhenReleased(root: string): Promise<void> {
   const deadline = Date.now() + TEMP_ROOT_RELEASE_TIMEOUT_MS
   for (;;) {
     try {
-      await rm(root, { recursive: true, force: true })
+      await rmEfaultTolerant(root, { recursive: true, force: true })
       return
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code

--- a/packages/omo-senpi/src/components/memory/worker/completion.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/completion.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -20,9 +20,10 @@ import {
 } from "./completion"
 import { CapturedCompletionApi } from "./runner.test-support"
 import { realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "../teardown.test-support"
 
 const roots: string[] = []
-afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
 
 const FIXED_NOW_MS = Date.parse("2026-08-16T12:00:00.000Z")
 const FIXED_RECENT_TIMESTAMP = new Date(FIXED_NOW_MS - 60_000).toISOString()

--- a/packages/omo-senpi/src/components/memory/worker/dream-dispatch.integration.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/dream-dispatch.integration.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { existsSync, realpathSync } from "node:fs"
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
+import { rmEfaultTolerant } from "../teardown.test-support"
 
 import {
   GitMemoryRepo,
@@ -27,7 +28,7 @@ const childFixture = join(import.meta.dir, "__fixtures__", "dream-child.ts")
 const supervisorFixture = join(import.meta.dir, "memory-run-supervisor.ts")
 const roots: string[] = []
 
-afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
 
 async function launchDream(
   people: { enabled: boolean; max_entries: number; max_entry_chars: number },

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor-ic8-harness.ts
@@ -1,9 +1,10 @@
 import { spawn, type ChildProcess } from "node:child_process"
 import { existsSync, realpathSync } from "node:fs"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { rmEfaultTolerant } from "../teardown.test-support"
 import { createMemoryRunSupervisorIc8ExitResources } from "./memory-run-supervisor-ic8-exit-resources"
 import {
   processGroupIsAlive,
@@ -222,7 +223,7 @@ export function createMemoryRunSupervisorIc8Harness() {
       roots
         .splice(0)
         .map((root) =>
-          rm(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 }),
+          rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 }),
         ),
     )
     for (const result of removals) {

--- a/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.integration.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.integration.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { spawn, spawnSync, type ChildProcess } from "node:child_process"
 import { existsSync, realpathSync } from "node:fs"
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
+import { rmEfaultTolerant } from "../teardown.test-support"
 import {
   advanceTestClock,
   createTestClock,
@@ -29,7 +30,7 @@ const WINDOWS_CLEANUP_RACE_CODES = new Set(["EBUSY", "ENOTEMPTY", "EPERM"])
 // platform's known cleanup races are tolerated while every other cleanup defect fails loudly.
 async function removeRoot(root: string): Promise<void> {
   try {
-    await rm(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 })
+    await rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 })
   } catch (error) {
     if (
       process.platform === "win32"

--- a/packages/omo-senpi/src/components/memory/worker/run-reconciliation.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/run-reconciliation.test.ts
@@ -15,9 +15,10 @@ import {
 import { reconcileReflectionRuns } from "./run-reconciliation"
 import { writeRunJsonAtomic } from "./run-artifacts"
 import { existsSync, realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "../teardown.test-support"
 
 const roots: string[] = []
-afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
 
 async function fixture(trigger: "step-count" | "dream" = "step-count") {
   const root = realpathSync.native(await mkdtemp(join(tmpdir(), "reflection-reconcile-")))
@@ -269,7 +270,7 @@ describe("reflection and dream run reconciliation", () => {
   test("#given old pre-launch reservations with unverifiable or reused launcher pids #when reconciled #then only confirmed pid reuse releases the reservation", async () => {
     // given
     const unknown = await fixture()
-    await rm(unknown.runDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+    await rmEfaultTolerant(unknown.runDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 
     // when
     const untouched = await reconcileReflectionRuns({

--- a/packages/omo-senpi/src/components/memory/worker/runner-finalization.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/runner-finalization.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { readFile, rm } from "node:fs/promises"
+import { readFile } from "node:fs/promises"
 import { join } from "node:path"
+import { rmEfaultTolerant } from "../teardown.test-support"
 
 import { createRunnerHarness, type RunnerHarness } from "./runner.test-support"
 
 const harnesses: RunnerHarness[] = []
-afterEach(async () => Promise.all(harnesses.splice(0).map((item) => rm(item.root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
+afterEach(async () => Promise.all(harnesses.splice(0).map((item) => rmEfaultTolerant(item.root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
 
 describe("live reflection run finalization", () => {
   test("#given a successful supervised run #when the parent finalizer completes #then final is published after integration and the merge carries its run receipt", async () => {

--- a/packages/omo-senpi/src/components/memory/worker/runner-fork-spawn.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/runner-fork-spawn.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "../teardown.test-support"
 
 import { createRunnerHarness } from "./runner.test-support"
 
@@ -12,7 +13,7 @@ const roots: string[] = []
 setDefaultTimeout(60_000)
 
 afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
 })
 
 const LUNA = { input: 0.25, cacheRead: 0.025, output: 2.00 }

--- a/packages/omo-senpi/src/components/memory/worker/runner.integration.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/runner.integration.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { existsSync } from "node:fs"
-import { readFile, readdir, rm } from "node:fs/promises"
+import { readFile, readdir } from "node:fs/promises"
 import { join } from "node:path"
+import { rmEfaultTolerant } from "../teardown.test-support"
 
 import { GitMemoryRepo } from "@oh-my-opencode/memory-core"
 import { OmoMemorySettingsSchema, type OmoConfig } from "@oh-my-opencode/omo-config-core"
@@ -23,7 +24,7 @@ const WINDOWS_CLEANUP_RACE_CODES = new Set(["EBUSY", "ENOTEMPTY", "EPERM"])
 // cleanup races so every other cleanup defect still fails loudly.
 async function removeRoot(root: string): Promise<void> {
   try {
-    await rm(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 })
+    await rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 30, retryDelay: 200 })
   } catch (error) {
     if (
       process.platform === "win32"

--- a/packages/omo-senpi/src/components/memory/worker/spawn.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/spawn.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { isAbsolute, join } from "node:path"
 
@@ -9,11 +9,12 @@ import { loadedMemoryConfig, memorySettings } from "../memory.test-support"
 import { prepareReflectionCandidateSpawn } from "./reflection-spawn-input"
 import { prepareFactsSpawn, prepareReflectionForkSpawn, prepareReflectionSpawn } from "./spawn"
 import { existsSync, realpathSync } from "node:fs"
+import { rmEfaultTolerant } from "../teardown.test-support"
 
 const roots: string[] = []
 
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
+  await Promise.all(roots.splice(0).map((root) => rmEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 
 function chmodFailure(code: string): NodeJS.ErrnoException {

--- a/packages/omo-senpi/src/mcp/memory-server.test.ts
+++ b/packages/omo-senpi/src/mcp/memory-server.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { createHash } from "node:crypto"
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { rmSyncEfaultTolerant } from "../components/memory/teardown.test-support"
 
 import { GitMemoryRepo, buildIdentityPaths, parseMemoryFile } from "@oh-my-opencode/memory-core"
 
@@ -26,7 +27,7 @@ function fixture() {
 afterEach(() => {
   // Windows keeps git's handles open briefly after the child exits, so a bare recursive remove
   // throws EBUSY and fails the test that already passed. Retry the unlink instead.
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+  for (const root of roots.splice(0)) rmSyncEfaultTolerant(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
 })
 
 // Each case drives real git subprocesses through a fresh repository; the 5s default is not a


### PR DESCRIPTION
## Summary

Windows CI failed an otherwise-green memory test because `afterEach` teardown threw `EFAULT` from `fs.rmSync` while deleting a unique temp directory. Bun's `rm`/`rmSync` retry set is `{EBUSY, EMFILE, ENFILE, ENOTEMPTY, EPERM}` — `EFAULT` is not retried and fails the test immediately. This PR adds a test-only helper that retries `EFAULT` within a small budget and migrates memory-component teardown call sites onto it. No production source changes.

Observed in [CI run 32243430643](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32243430643), `senpi-compatibility (windows-latest)`, Bun 1.3.14:

```
EFAULT: bad address in system call argument, rm C:\Users\runneradmin\AppData\Local\Temp\omo-memory-footer-wiring-xxI3Ny
```

The failing test was "once-only footer gate"; its own assertions had already passed.

## Changes

- **Helper contract** (`packages/omo-senpi/src/components/memory/teardown.test-support.ts`): call `rmSync`/`rm` with the existing options (so Bun still retries the lock-style errno set). If the call throws `EFAULT`, retry a few times with a short delay (`rm` + `sleep` injectable for tests). Any other errno is rethrown immediately. When the `EFAULT` budget is exhausted, throw an error whose message starts with `teardown-failure:` so triage cannot confuse it with a behavior regression.
- **RED then GREEN unit tests** for the three stub contracts: EFAULT once then success; always-ENOENT rethrows the same error immediately; always-EFAULT yields the `teardown-failure:` prefix.
- **Mechanical migration** of memory-component `afterEach` teardowns that used the `maxRetries` pattern (36 files). `components/memory/commands/` is untouched.

Upstream: https://github.com/oven-sh/bun/issues/39708 (Windows recursive temp-dir `EFAULT`; related but different repro: https://github.com/oven-sh/bun/issues/36984).

## QA & Evidence

Evidence dir: `.omo/evidence/20260820-memory-teardown-efault/` (gitignored; captured in the worktree).

- **What was tested:** naive rethrow helper vs `teardown.test-support.test.ts`
  - **Observed result:** 2 pass / 4 fail (ENOENT immediate rethrow passed; EFAULT-once and exhausted-budget failed on sync and async)
  - **Artifact:** `red-helper.txt`
  - **Why sufficient:** failing-first proof that the retry and prefix contracts are real

- **What was tested:** same tests after implementing EFAULT retry
  - **Observed result:** 6 pass / 0 fail
  - **Artifact:** `green-helper.txt` / `green-helper-HEAD.txt`
  - **Why sufficient:** the three stub contracts hold

- **What was tested:** `bun test packages/omo-senpi/src/components/memory packages/omo-senpi/src/mcp/memory-server.test.ts` on pristine `origin/dev` vs this branch
  - **Observed result:** baseline 899 pass / 0 fail / 132 files; post-migration 905 pass / 0 fail / 133 files (+6 helper tests). Failure sets both empty.
  - **Artifact:** `baseline-memory-tests.txt`, `post-migration-memory-tests.txt`, `suite-comparison.txt`
  - **Why sufficient:** migration did not introduce regressions vs the pristine memory suite

- **What was tested:** `bun run typecheck`
  - **Observed result:** exit 0
  - **Artifact:** `typecheck.txt`
  - **Why sufficient:** no production types and the helper types check

`ci:full-matrix` is applied so Windows sees this before merge. `senpi-compatibility (windows-latest)` and `test (windows-latest, 2/2)` are not required; judge them by signature. Files are not platform-sensitive.

## Risks & Residuals

- **EFAULT still exhausts the budget:** mitigated — leftover throw is prefixed `teardown-failure:` so it cannot be misread as a product assertion failure.
- **Non-EFAULT errnos:** accepted — rethrown immediately; Bun `maxRetries` still covers the lock-style set.
- **commands/ teardowns:** accepted — sibling lane owns that directory.
- **Upstream Bun fault:** accepted — tracked at oven-sh/bun#39708; this PR only hardens tests.

## Related Issues

- CI occurrence: https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32243430643
- Bun: https://github.com/oven-sh/bun/issues/39708


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes Windows CI by retrying EFAULT during memory test teardown. Previously `fs.rm`/`fs.rmSync` failed immediately on EFAULT; tests now use wrappers that retry EFAULT briefly and prefix exhausted failures with "teardown-failure:". No production code changes.

- Introduces `rmEfaultTolerant` and `rmSyncEfaultTolerant` (packages/omo-senpi/src/components/memory/teardown.test-support.ts): forward existing rm options, retry EFAULT a few times with a short delay (defaults: 3 attempts, 50 ms), rethrow non-EFAULT immediately, and prefix exhausted errors with `teardown-failure:`.
- Adds unit tests for: EFAULT-once then success, ENOENT immediate rethrow, and EFAULT budget exhaustion.
- Migrates memory and worker test teardowns to the helpers (36 files); `components/memory/commands/` unchanged.

<sup>Written for commit 6b32bf3af2742f606041c7d105460199e3d22d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

