### PR TITLE
test(senpi-task): cover terminal DAG wait races

### DIFF
--- a/packages/senpi-task/src/dag/e2e-happy.test.ts
+++ b/packages/senpi-task/src/dag/e2e-happy.test.ts
@@ -8,7 +8,7 @@ import { OmoTaskSettingsSchema } from "@oh-my-opencode/omo-config-core"
 
 import { createTaskManager } from "../manager/manager"
 import type { ManagedChildHandle } from "../manager/child-handle"
-import type { ChildPlanner, ManagedRunner, ManagedStartSpec } from "../manager/types"
+import type { AdmitResident, ChildPlanner, ManagedRunner, ManagedStartSpec } from "../manager/types"
 import { createTaskRecordStore } from "../store"
 import type { DagDefinition, DagNodeInput } from "./graph"
 import { createDagWaitSurface, type DagRunResult } from "./handle"
@@ -90,7 +90,7 @@ type E2eFixture = {
   readonly running: (runId: DagRunId) => Promise<DagRunRecordV1>
 }
 
-function e2eFixture(): E2eFixture {
+function e2eFixture(options: { readonly admit?: AdmitResident } = {}): E2eFixture {
   const project = tempProject()
   const store = createDagFileStore({ project_dir: project })
   const taskStore = createTaskRecordStore({ project_dir: project })
@@ -101,6 +101,7 @@ function e2eFixture(): E2eFixture {
     planner,
     config: OmoTaskSettingsSchema.parse({ default_concurrency: 16, max_depth: 1 }),
     cwd: project,
+    ...(options.admit === undefined ? {} : { admit: options.admit }),
   })
   let nextRun = 0
   const manager = createDagManager({
@@ -209,6 +210,22 @@ function assertArtifacts(fixture: E2eFixture, runId: DagRunId, key: string, node
 
 function runFiles(store: DagFileStore): readonly string[] {
   return fs.readdirSync(store.paths.runs).filter((entry) => entry.endsWith(".json")).sort()
+}
+
+function within<T>(promise: Promise<T>, ms = 200): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms)
+    void promise.then(
+      (value) => {
+        clearTimeout(timeout)
+        resolve(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timeout)
+        reject(error)
+      },
+    )
+  })
 }
 
 describe("DAG happy-path end to end", () => {
@@ -392,5 +409,50 @@ describe("DAG happy-path end to end", () => {
       ["verify"],
     ]))
     assertArtifacts(fixture, started.details.run_id, "sdk-flow", ["spec", "implement", "verify"])
+  })
+
+  test("#given all first-wave starts hit the resident child cap #when the shipped SDK waits #then it returns the terminal residency failures instead of hanging", async () => {
+    // given
+    const fixture = e2eFixture({
+      admit: () => Promise.resolve({ kind: "rejected", message: "resident child cap reached" }),
+    })
+    Reflect.set(globalThis, "tool", {
+      dag: async (args: { readonly action: string; readonly definition?: DagDefinition; readonly run_id?: string }) => {
+        if (args.action === "start" && args.definition !== undefined) {
+          const started = await fixture.start(args.definition)
+          return { details: { kind: "started", run_id: started.snapshot.runId, reused: started.reused, snapshot: started.snapshot } }
+        }
+        if (args.action === "wait" && args.run_id !== undefined) {
+          const result = await fixture.wait(args.run_id as DagRunId)
+          return { details: { kind: "waited", run_id: args.run_id, result } }
+        }
+        throw new Error(`unexpected SDK action ${args.action}`)
+      },
+    })
+    const sdk = await import(`${sdkPath}?residency-denied`) as {
+      readonly start: (definition: DagDefinition) => Promise<{ readonly run_id: DagRunId }>
+      readonly wait: (runId: string) => Promise<{ readonly details: { readonly result: DagRunResult } }>
+    }
+    const input = definition("sdk-residency-denied", [
+      categoryNode("first"),
+      agentNode("second"),
+    ])
+
+    // when
+    const started = await sdk.start(input)
+    const waited = await within(sdk.wait(started.run_id))
+
+    // then
+    expect(waited.details.result.status).toBe("failed")
+    expect(Object.fromEntries(
+      Object.entries(waited.details.result.nodes).map(([id, result]) => [
+        id,
+        result.state === "failed" ? result.error.code : result.state,
+      ]),
+    )).toEqual({
+      first: "residency_denied",
+      second: "residency_denied",
+    })
+    expect(fixture.events(started.run_id).at(-1)?.type).toBe("dag.run.failed")
   })
 })

--- a/packages/senpi-task/src/dag/handle.test.ts
+++ b/packages/senpi-task/src/dag/handle.test.ts
@@ -90,6 +90,22 @@ function counts(nodes: readonly DagNode[]): DagNodeCounts {
   return tally
 }
 
+function within<T>(promise: Promise<T>, ms = 200): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms)
+    void promise.then(
+      (value) => {
+        clearTimeout(timeout)
+        resolve(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timeout)
+        reject(error)
+      },
+    )
+  })
+}
+
 // Stands in for the scheduler's reducer (todos 9-11): the events under test only need to move the
 // run to a terminal status with terminal node states already folded into the checkpoint.
 function applyEvent(checkpoint: DagRunRecordV1, event: DagRunEvent): DagRunRecordV1 {
@@ -235,6 +251,35 @@ describe("createDagWaitSurface wait terminal projection", () => {
     expect(result.status).toBe("completed")
     expect(result.nodes.plan).toEqual({ state: "completed", taskId: "task-plan", output: "plan output" })
     expect(harness.store.readEvents(runId, 0, { limit: 100 }).headSeq).toBe(seqBefore)
+  })
+
+  test("#given a run terminalizes during live subscription setup #when wait registers #then the final checkpoint read resolves without an event callback", async () => {
+    // given
+    const store = createDagFileStore({ project_dir: tempProject() })
+    const running = record([node("plan", { state: "running", taskId: "task-plan" })])
+    store.writeCheckpoint(runId, running)
+    store.writeResult(runId, "plan", "plan output")
+    const completed = {
+      ...running,
+      status: "completed",
+      completedAt: at,
+      nodes: [node("plan", { state: "completed", taskId: "task-plan", completedAt: at })],
+    } satisfies DagRunRecordV1
+    const surface = createDagWaitSurface({
+      store,
+      subscribe: () => {
+        store.writeCheckpoint(runId, completed)
+        return () => undefined
+      },
+    })
+
+    // when
+    const result = await within(surface.wait(runId, parentSessionId))
+
+    // then
+    expect(result.status).toBe("completed")
+    expect(result.nodes.plan).toEqual({ state: "completed", taskId: "task-plan", output: "plan output" })
+    expect(surface.waiterCount(runId)).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Summary

- lock the wait-surface subscribe-then-reread ordering with a deterministic regression
- exercise the shipped JavaScript DAG SDK when every first-wave child is rejected by the resident cap
- prove the all-denied scheduler path returns a terminal failed result instead of leaving `sdk.wait()` pending

## Why

A production incident was diagnosed as an all-first-wave `residency_denied` DAG followed by an eval cell waiting for four hours. Architecture review found that `origin/dev` already has the correct production invariants:

- the scheduler fails closed when denied nodes have no attached task that can free capacity
- the wait surface subscribes to durable and live events before rereading the terminal checkpoint
- the SDK delegates directly to the host DAG tool

The missing protection was integrated regression coverage across those seams.

## RED -> GREEN

1. Removed the final post-subscription checkpoint reread:
   - RED: the new registration-window test timed out
   - GREEN: restoring production resolves `completed` and clears waiter bookkeeping
2. Disabled the scheduler's no-progress residency fail-closed branch:
   - RED: shipped `sdk.wait()` timed out
   - GREEN: restoring production returns `failed`, with both first-wave nodes carrying `residency_denied`

## Verification

- `bun test packages/senpi-task/src/dag/handle.test.ts packages/senpi-task/src/dag/scheduler.test.ts packages/senpi-task/src/dag/e2e-happy.test.ts` — 42 pass
- `bun test packages/omo-senpi/src/components/task/dag-e2e-lifecycle.test.ts` — 7 pass
- `bun test packages/senpi-task` — 1629 pass, 1 platform skip
- `bun run typecheck:packages` — pass
- `bun run build` — pass
- `node packages/omo-senpi/scripts/qa/drive.mjs --self-test` — pass
- `node packages/omo-senpi/scripts/qa/drive.mjs` — pass; isolated agent dir, real Senpi untouched
- `SENPI_BIN="$(command -v senpi)" node packages/omo-senpi/scripts/qa/task-e2e.mjs` — pass; real task lifecycle through the installed Senpi binary

## Known unrelated repository failures

- `bun run test:senpi` currently reports failures in quick-pinned memory cleanup, init-deep advisor timing/state, and OmO Native identity.
- The full workspace run likewise reports unrelated installer/init-deep/OmO Native failures.
- This PR changes only two DAG test files; the complete `packages/senpi-task` suite and all adjacent DAG lifecycle tests pass.

## Scope

Test-only. No production behavior or public API changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests that lock in terminal DAG wait behavior when capacity is denied and when a run completes during wait-surface subscription. This protects against `sdk.wait()` hangs and ensures waiter bookkeeping clears.

- Add e2e in `packages/senpi-task/src/dag/e2e-happy.test.ts`: inject `admit` to reject all first-wave children, drive the shipped SDK via `tool.dag`, and assert `sdk.wait()` returns `failed` with per-node `residency_denied` and a final `dag.run.failed` event.
- Add unit in `packages/senpi-task/src/dag/handle.test.ts`: when `createDagWaitSurface` subscribes and the run terminalizes immediately, the final checkpoint reread resolves without an event callback and `waiterCount` returns to 0.
- Small helpers and types: introduce `within()` timeout helper in both tests and plumb `AdmitResident` into the e2e fixture. Test-only; no production or public API changes.

<sup>Written for commit 8cb02b44982dde7c9c216a2ba0186ac46477147e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

