### PR TITLE
test(senpi-task): set DAG happy-path timeout in-file

### DIFF
--- a/packages/senpi-task/src/dag/e2e-happy.test.ts
+++ b/packages/senpi-task/src/dag/e2e-happy.test.ts
@@ -1,5 +1,5 @@
 // allow: SIZE_OK - one end-to-end fixture proves the assembled manager, scheduler, task manager, wait surface, SDK, and durable store agree across all happy-path graph shapes.
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import * as fs from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -16,6 +16,12 @@ import { createDagManager, type DagManager, type DagRunRecordV1, type DagStartRe
 import { createDagScheduler, type DagScheduler } from "./scheduler"
 import { createDagFileStore, type DagFileStore } from "./store"
 import type { DagRunEvent, DagRunId } from "./types"
+
+// bunfig preloads test-setup.ts to raise the default timeout, but Bun honours a preload's
+// setDefaultTimeout only for the FIRST test file of a run; every later file silently reverts to
+// the built-in 5000ms. Windows job 96304719047 in run 32328567654 measured the diamond case at
+// 5759ms against that 5000ms floor. Set the floor here, where Bun does honour it.
+setDefaultTimeout(process.platform === "win32" ? 60_000 : 20_000)
 
 const cleanupRoots: string[] = []
 const parentSessionId = "session-e2e-parent"
@@ -336,7 +342,7 @@ describe("DAG happy-path end to end", () => {
     ])
     expect(Object.values(result.nodes).every((node) => node.state === "completed" && node.output.startsWith("output:"))).toBe(true)
     assertArtifacts(fixture, result.runId, input.key, input.nodes.map((node) => node.id))
-  }, process.platform === "win32" ? 15_000 : 5_000)
+  })
 
   test("#given a completed run key #when the identical definition starts again #then the same run is reused without a second run file or event", async () => {
     // given


### PR DESCRIPTION
## Summary

Windows CI can execute `packages/senpi-task/src/dag/e2e-happy.test.ts` as a later Bun test file, where Bun silently falls back to its built-in 5-second timeout instead of honoring the preload's timeout. A recorded dev job then timed out the diamond DAG case at 5.759 seconds.

This test-only change applies the same in-file timeout floor already used by the sibling DAG scheduler and failure suites. It also removes the now-redundant timeout attached to only the mixed-route test, leaving one consistent timeout mechanism for the entire file.

## Changes

- Import and call `setDefaultTimeout` inside the happy-path DAG suite.
- Use the sibling-proven floor: 60 seconds on Windows and 20 seconds elsewhere.
- Remove the mixed-route case's isolated 15-second/5-second timeout argument.
- Keep all production DAG code and assertions unchanged.

## QA & Evidence

- **Historical reproduction:** Windows job `96304719047` in run `32328567654` failed the diamond case at 5759 ms against Bun's effective 5000 ms default.
- **Failing-first contract:** a temporary machine-consumed source-contract test failed with `0 pass / 2 fail` before the change because the file-level timeout was absent and the per-test override remained.
- **Green contract:** the same contract passed `2 pass / 0 fail` after the change.
- **Focused behavior:** diamond DAG, mixed-route DAG, PR #7066 subscription-window regression, and PR #7066 residency-denied regression all pass.
- **Repeatability:** the complete `e2e-happy.test.ts` suite passed five consecutive runs, each `6 pass / 0 fail`.
- **Package gate:** `bun test packages/senpi-task` — 1629 pass, 1 pre-existing Windows-only skip, 0 fail.
- **Type safety:** `tsgo --noEmit -p packages/senpi-task/tsconfig.json` and changed-file LSP diagnostics are clean.
- **Cleanup:** temporary source-contract files, debug journal, and RED sandbox were removed; the worktree contains only this tracked test-file change.

Local evidence is under `.omo/evidence/20260820-dag-happy-timeout/` in the task worktree and is intentionally not committed.

## Risks & Residuals

- This raises only the test-suite failure ceiling; it does not add sleeps, polling, retries, or change synchronization.
- The timeout remains a circuit breaker, not a synchronization mechanism.
- Current exact-`dev` CI is otherwise green; this specifically prevents the observed Windows runner budget cliff from recurring when the file is not first in the process.

## Related Issues

- Follow-up to #7066.
- Tracks the remaining Windows CI signature in #6976; that issue will be updated and closed only after this PR is merged and CI is green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets an in-file timeout for the DAG happy-path E2E tests in `senpi-task` so Windows CI no longer falls back to Bun’s 5s default on later files. Previously the suite relied on a preload and one per-test override; now it uses `setDefaultTimeout` (60s on Windows, 20s elsewhere) and removes the per-test timeout.

- Import and call `setDefaultTimeout` in `packages/senpi-task/src/dag/e2e-happy.test.ts`.
- Remove the mixed-route test’s explicit timeout; the suite uses one consistent default.
- Test-only change; no production code touched.

<sup>Written for commit 7366a54cafe0f8bb015122f0cecbbc0e6a84f825. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

