### PR TITLE
fix(background-agent): restore completion notifications on latest OpenCode

### DIFF
--- a/packages/omo-opencode/src/shared/live-server-route-directory.test.ts
+++ b/packages/omo-opencode/src/shared/live-server-route-directory.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { unsafeTestValue } from "../../../../test-support/unsafe-test-value"
+import {
+  _setFetchImplementationForTesting,
+  initLiveServerRoute,
+  resetLiveServerRouteForTesting,
+  resolveDispatchClient,
+} from "./live-server-route"
+
+const SERVER_URL = new URL("http://127.0.0.1:19999")
+
+afterEach(() => {
+  resetLiveServerRouteForTesting()
+})
+
+describe("live server route directory context", () => {
+  test("#given generated live client #when session status is requested #then registered directory reaches the listener", async () => {
+    //#given
+    const seenUrls: string[] = []
+    const fakeFetch: typeof fetch = async (input) => {
+      const url = input instanceof Request ? input.url : String(input)
+      seenUrls.push(url)
+      if (url.includes("/global/health") || url.includes("/session/ses_directory")) {
+        return new Response("{}", { status: 200 })
+      }
+      return Response.json({})
+    }
+    _setFetchImplementationForTesting(fakeFetch)
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fakeFetch
+    const inProcessClient = {}
+    initLiveServerRoute({
+      serverUrl: SERVER_URL,
+      directory: "/tmp/project with spaces",
+      inProcessClient,
+    })
+
+    try {
+      //#when
+      const result = await resolveDispatchClient(inProcessClient, "ses_directory")
+      const client = unsafeTestValue<{ session: { status: () => Promise<unknown> } }>(result.client)
+      await client.session.status()
+
+      //#then
+      const statusUrl = seenUrls.find((url) => url.includes("/session/status"))
+      expect(statusUrl).toBeDefined()
+      expect(new URL(statusUrl ?? SERVER_URL).searchParams.get("directory")).toBe("/tmp/project with spaces")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/packages/omo-opencode/src/shared/live-server-route.ts
+++ b/packages/omo-opencode/src/shared/live-server-route.ts
@@ -23,6 +23,7 @@ type SessionAffinityEntry = {
 
 type RouteRegistration = {
   serverUrl: URL | undefined
+  directory: string
   liveClient: unknown
   available: boolean | undefined
   probeTimestamp: number
@@ -69,6 +70,7 @@ export function initLiveServerRoute(opts: {
 }): void {
   const registration: RouteRegistration = {
     serverUrl: opts.serverUrl,
+    directory: opts.directory,
     liveClient: undefined,
     available: undefined,
     probeTimestamp: 0,
@@ -243,7 +245,10 @@ function getOrBuildLiveClient(registration: RouteRegistration): unknown {
   if (!registration.serverUrl) {
     return undefined
   }
-  const client = createOpencodeClientSdk({ baseUrl: registration.serverUrl.toString() })
+  const client = createOpencodeClientSdk({
+    baseUrl: registration.serverUrl.toString(),
+    directory: registration.directory,
+  })
   injectServerAuthIntoClient(client)
   registration.liveClient = client
   return registration.liveClient


### PR DESCRIPTION
## Summary

Restores parent-session completion notifications for background `explore` / `librarian` tasks on current OpenCode releases.

Discord report from seelosc:

> "After a background task like explore/librarian, the complete notification is not coming into the feed to alert sisyphus to pull"
>
> "I'm guessing this broke with the latest opencode update?"

## Root cause

OpenCode v1.17+ moved plugin event delivery from the legacy Bus subscription to the location-scoped EventV2 listener and routes plugin SDK calls through the active live listener. OMO already has a live-listener compatibility route, but `packages/omo-opencode/src/shared/live-server-route.ts:getOrBuildLiveClient()` constructed that SDK client with only `baseUrl` and dropped the plugin registration's directory.

The parent-wake path uses the routed client for `session.status()` activity checks before injecting the `<system-reminder>`. Without the directory query, latest OpenCode can resolve status against the wrong/default instance. The completion wake remains deferred and never reaches the parent feed, leaving Sisyphus waiting as instructed by the delegate-task output.

Upstream behavior change: anomalyco/opencode commit `7f571d36ea` (`refactor(core): move database schema ownership`) replaced plugin `Bus.subscribeAll()` delivery with `EventV2Bridge.events.listen()` filtered by `event.location.directory`; current releases also use the active listener for plugin SDK requests.

## Fix

Persist the registered plugin directory in the live-route registration and pass it to `createOpencodeClient`. The generated SDK now appends the correct directory to live-listener status and prompt requests while retaining the existing health and session-affinity safeguards.

## Test evidence

RED before the fix:

```text
Expected: "/tmp/project with spaces"
Received: null
(fail) ... registered directory reaches the listener
```

GREEN after the fix:

```text
4 pass
0 fail
9 expect() calls
```

Commands:

```bash
bun test packages/omo-opencode/src/shared/live-server-route-directory.test.ts packages/omo-opencode/src/features/background-agent/parent-wake-live-read.test.ts --bail
bun run typecheck
bun run /Users/yeongyu/.bun/install/global/node_modules/omo-ai/plugin/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-opencode/src/shared/live-server-route.ts packages/omo-opencode/src/shared/live-server-route-directory.test.ts
bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check
```

All exited 0.

## Scope

Compatibility fix only. No polling/prose workaround and no changes to background-task semantics.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores parent-session completion notifications for background `explore`/`librarian` tasks on OpenCode v1.17+. Previously, the live listener SDK client dropped the registered directory, routing `session.status()` to the wrong/default instance and suppressing the parent wake; now the client includes the directory so notifications reach the parent feed.

**Review notes**
- `RouteRegistration` now persists `directory`; `initLiveServerRoute` forwards it.
- `getOrBuildLiveClient` passes `directory` to `createOpencodeClientSdk`; health/session-affinity logic is unchanged.
- New test `packages/omo-opencode/src/shared/live-server-route-directory.test.ts` verifies the directory query reaches the listener.

<sup>Written for commit 91353a8b6db5b0db901952b9665da4df33dde13f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

