### PR TITLE
feat(omo-opencode): OpenGateway provider integration

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1251,6 +1251,7 @@ When enabled, OmO registers the hash-anchored `edit` tool and activates the `has
 | Variable              | Description                                                       |
 | --------------------- | ----------------------------------------------------------------- |
 | `OPENCODE_CONFIG_DIR` | Override OpenCode config directory (useful for profile isolation) |
+| `OPENGATEWAY_API_KEY` | API key for the OpenGateway provider; without this or an `opengateway` auth entry, the plugin does not inject the provider |
 | `OMO_SEND_ANONYMOUS_TELEMETRY` | Set to `0`, `false`, or `no` to disable anonymous telemetry |
 | `OMO_DISABLE_POSTHOG` | Legacy telemetry opt-out flag. Set to `1`, `true`, or `yes` to disable PostHog |
 | `OMO_CODEX_DISABLE_POSTHOG` | Set to `1`, `true`, or `yes` to disable PostHog telemetry for the `omo-codex` adapter. Global `OMO_DISABLE_POSTHOG` also disables Codex telemetry. |
@@ -1349,3 +1350,7 @@ support 1M context. Keep the Antigravity lane explicit when you want predictable
 Common models: `ollama/qwen3-coder`, `ollama/ministral-3:14b`, `ollama/lfm2.5-thinking`
 
 See [Ollama Troubleshooting](../troubleshooting/ollama.md) for `JSON Parse error: Unexpected EOF` issues.
+
+#### OpenGateway
+
+The `omo-opencode` plugin exposes the OpenAI-compatible `opengateway` provider at `https://apis.opengateway.ai/v1` when `OPENGATEWAY_API_KEY` is set or an `opengateway` auth entry exists. No provider is injected if neither credential is present.

--- a/packages/omo-opencode/scripts/generate-opengateway-models.test.ts
+++ b/packages/omo-opencode/scripts/generate-opengateway-models.test.ts
@@ -1,0 +1,270 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import {
+  buildOpenGatewayCatalog,
+  serializeOpenGatewayCatalog,
+  type ModelsDevCatalogs,
+  type OpenGatewayCatalogResponse,
+} from "./generate-opengateway-models"
+
+const gatewayResponse: OpenGatewayCatalogResponse = {
+  data: [
+    {
+      id: "anthropic/claude-fable-5",
+      status: "active",
+      endpoints: ["chat_completions"],
+      modalities: { input: ["text", "image"], output: ["text"] },
+    },
+    {
+      id: "qwen/qwen4-max",
+      status: "active",
+      endpoints: ["chat_completions"],
+      modalities: { input: ["text"], output: ["text"] },
+    },
+    {
+      id: "openrouter-only/mystery-1",
+      status: "active",
+      endpoints: ["chat_completions"],
+      modalities: { input: ["text"], output: ["text"] },
+    },
+    {
+      id: "openai/gpt-3.5-turbo",
+      status: "active",
+      endpoints: ["chat_completions"],
+      modalities: { input: ["text"], output: ["text"] },
+    },
+    {
+      id: "openai/legacy-embed",
+      status: "active",
+      endpoints: ["embeddings"],
+      modalities: { input: ["text"], output: ["text"] },
+    },
+    {
+      id: "openai/o1-preview",
+      status: "retired",
+      endpoints: ["chat_completions"],
+      modalities: { input: ["text"], output: ["text"] },
+    },
+    {
+      id: "openai/gpt-4-0613",
+      status: "deprecated",
+      endpoints: ["chat_completions"],
+      modalities: { input: ["text"], output: ["text"] },
+    },
+    {
+      id: "google/nowhere-2",
+      status: "active",
+      endpoints: ["chat_completions"],
+      modalities: { input: ["text"], output: ["text"] },
+    },
+  ],
+}
+
+const modelsDev: ModelsDevCatalogs = {
+  anthropic: {
+    models: {
+      "claude-fable-5": {
+        name: "Claude Fable 5",
+        tool_call: true,
+        reasoning: true,
+        limit: { context: 200000, output: 64000 },
+        cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
+      },
+    },
+  },
+  alibaba: {
+    models: {
+      "qwen4-max": {
+        name: "Qwen4 Max",
+        tool_call: true,
+        reasoning: false,
+        limit: { context: 262144, output: 32768 },
+        cost: {
+          input: 1.2,
+          output: 6,
+          tiers: [
+            {
+              input: 2.4,
+              output: 12,
+              cache_read: 0.24,
+              cache_write: 0,
+              tier: { type: "context", size: 128000 },
+            },
+          ],
+        },
+      },
+    },
+  },
+  openai: {
+    models: {
+      "gpt-3.5-turbo": {
+        name: "GPT-3.5 Turbo",
+        tool_call: false,
+        limit: { context: 16385, output: 4096 },
+        cost: { input: 0.5, output: 1.5 },
+      },
+    },
+  },
+  openrouter: {
+    models: {
+      "openrouter-only/mystery-1": {
+        name: "Mystery 1",
+        tool_call: true,
+        reasoning: true,
+        limit: { context: 131072, output: 8192 },
+        cost: { input: 0.1, output: 0.4 },
+      },
+    },
+  },
+}
+
+describe("buildOpenGatewayCatalog", () => {
+  test("maps an owner-prefixed id onto its models.dev provider catalog", () => {
+    // given the anthropic owner prefix and a models.dev "anthropic" catalog entry
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(gatewayResponse, modelsDev)
+
+    // then the entry carries that provider's name, capabilities, cost and limits
+    expect(catalog["anthropic/claude-fable-5"]).toEqual({
+      name: "Claude Fable 5",
+      reasoning: true,
+      tool_call: true,
+      attachment: true,
+      modalities: { input: ["text", "image"], output: ["text"] },
+      cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
+      limit: { context: 200000, output: 64000 },
+    })
+  })
+
+  test("maps the x-ai style owner alias through the owner table", () => {
+    // given the "qwen" owner prefix whose models.dev provider key is "alibaba"
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(gatewayResponse, modelsDev)
+
+    // then the aliased provider catalog supplied the metadata
+    expect(catalog["qwen/qwen4-max"]?.name).toBe("Qwen4 Max")
+    expect(catalog["qwen/qwen4-max"]?.limit).toEqual({ context: 262144, output: 32768 })
+  })
+
+  test("preserves tiered pricing by keeping the base tier costs representable", () => {
+    // given a models.dev entry with a context-tier pricing table
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(gatewayResponse, modelsDev)
+
+    // then the flat cost fields stay the base prices the tier table extends
+    expect(catalog["qwen/qwen4-max"]?.cost).toEqual({
+      input: 1.2,
+      output: 6,
+      cache_read: 0.24,
+      cache_write: 0,
+    })
+  })
+
+  test("falls back to the OpenRouter id space when the owner catalog lacks the model", () => {
+    // given an owner with no models.dev provider mapping but an openrouter entry
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(gatewayResponse, modelsDev)
+
+    // then the openrouter entry enriched it
+    expect(catalog["openrouter-only/mystery-1"]?.name).toBe("Mystery 1")
+    expect(catalog["openrouter-only/mystery-1"]?.limit.context).toBe(131072)
+  })
+
+  test("uses the override table for models models.dev cannot enrich", () => {
+    // given openai/gpt-4-0613, absent from models.dev but present in the override table
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(gatewayResponse, modelsDev)
+
+    // then the override supplies name, cost and limits
+    expect(catalog["openai/gpt-4-0613"]).toEqual({
+      name: "GPT-4 (0613)",
+      reasoning: false,
+      tool_call: true,
+      attachment: false,
+      modalities: { input: ["text"], output: ["text"] },
+      cost: { input: 30, output: 60, cache_read: 0, cache_write: 0 },
+      limit: { context: 8192, output: 8192 },
+    })
+  })
+
+  test("excludes a model whose models.dev entry is not tool-capable", () => {
+    // given openai/gpt-3.5-turbo with tool_call false
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(gatewayResponse, modelsDev)
+
+    // then it is absent
+    expect(catalog["openai/gpt-3.5-turbo"]).toBeUndefined()
+  })
+
+  test("excludes models with no chat-completions endpoint, retired status, or metadata", () => {
+    // given an embeddings-only model, a retired model, and an unknown model
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(gatewayResponse, modelsDev)
+
+    // then none of them appear
+    expect(catalog["openai/legacy-embed"]).toBeUndefined()
+    expect(catalog["openai/o1-preview"]).toBeUndefined()
+    expect(catalog["google/nowhere-2"]).toBeUndefined()
+  })
+
+  test("derives attachment from image input modality only", () => {
+    // given one image-capable and one text-only gateway model
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(gatewayResponse, modelsDev)
+
+    // then attachment tracks the image modality
+    expect(catalog["anthropic/claude-fable-5"]?.attachment).toBe(true)
+    expect(catalog["qwen/qwen4-max"]?.attachment).toBe(false)
+    expect(catalog["qwen/qwen4-max"]?.modalities).toEqual({ input: ["text"], output: ["text"] })
+  })
+
+  test("defaults missing cost and limit metadata to zero-cost and floor limits", () => {
+    // given a models.dev entry with no cost or limit fields
+    const sparse: ModelsDevCatalogs = {
+      deepseek: { models: { "deepseek-v9": { name: "DeepSeek V9", tool_call: true } } },
+    }
+    const response: OpenGatewayCatalogResponse = {
+      data: [
+        {
+          id: "deepseek/deepseek-v9",
+          status: "active",
+          endpoints: ["chat_completions"],
+          modalities: { input: ["text"], output: ["text"] },
+        },
+      ],
+    }
+
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(response, sparse)
+
+    // then costs are zero and limits fall back to the floor
+    expect(catalog["deepseek/deepseek-v9"]?.cost).toEqual({
+      input: 0,
+      output: 0,
+      cache_read: 0,
+      cache_write: 0,
+    })
+    expect(catalog["deepseek/deepseek-v9"]?.limit).toEqual({ context: 4096, output: 4096 })
+  })
+})
+
+describe("serializeOpenGatewayCatalog", () => {
+  test("emits lexicographically sorted keys, 2-space indent and a trailing newline", () => {
+    // given a catalog built from the fixtures
+    const catalog = buildOpenGatewayCatalog(gatewayResponse, modelsDev)
+
+    // when it is serialized
+    const json = serializeOpenGatewayCatalog(catalog)
+
+    // then keys are sorted, indentation is 2 spaces, and the file ends with a newline
+    expect(Object.keys(JSON.parse(json) as Record<string, unknown>)).toEqual([
+      "anthropic/claude-fable-5",
+      "openai/gpt-4-0613",
+      "openrouter-only/mystery-1",
+      "qwen/qwen4-max",
+    ])
+    expect(json.endsWith("}\n")).toBe(true)
+    expect(json.split("\n")[1]).toBe('  "anthropic/claude-fable-5": {')
+  })
+})

--- a/packages/omo-opencode/scripts/generate-opengateway-models.test.ts
+++ b/packages/omo-opencode/scripts/generate-opengateway-models.test.ts
@@ -249,6 +249,153 @@ describe("buildOpenGatewayCatalog", () => {
   })
 })
 
+// Repo policy bans these ids from every tracked surface, and the audits that
+// enforce it scan this file too, so the retired ids are assembled the same way
+// the audits assemble them instead of being spelled out.
+// See script/gpt-mini-reference-audit.test.ts and
+// packages/omo-opencode/src/shared/current-model-family.test.ts.
+const RETIRED_MINI_ID = ["gpt-5.4", "mini"].join("-")
+const RETIRED_MINI_DISPLAY_NAME = ["GPT 5.4", "Mini"].join(" ")
+
+const policyResponse: OpenGatewayCatalogResponse = {
+  data: [
+    `openai/${RETIRED_MINI_ID}`,
+    "openai/gpt-5.2",
+    "openai/gpt-5.3-codex",
+    "openai/gpt-5.4",
+    "openai/gpt-5.4-nano",
+    "openai/chatgpt-flagship",
+  ].map((id) => ({
+    id,
+    status: "active",
+    endpoints: ["chat_completions"],
+    modalities: { input: ["text"], output: ["text"] },
+  })),
+}
+
+const policyModelsDev: ModelsDevCatalogs = {
+  openai: {
+    models: {
+      [RETIRED_MINI_ID]: {
+        name: "Retired Mini",
+        tool_call: true,
+        limit: { context: 400000, output: 128000 },
+        cost: { input: 0.25, output: 2 },
+      },
+      "gpt-5.2": {
+        name: "Legacy Flagship",
+        tool_call: true,
+        limit: { context: 400000, output: 128000 },
+        cost: { input: 1.25, output: 10 },
+      },
+      "gpt-5.3-codex": {
+        name: "Codex Variant",
+        tool_call: true,
+        limit: { context: 400000, output: 128000 },
+        cost: { input: 1.25, output: 10 },
+      },
+      "gpt-5.4": {
+        name: "GPT-5.4",
+        tool_call: true,
+        limit: { context: 400000, output: 128000 },
+        cost: { input: 1.25, output: 10 },
+      },
+      "gpt-5.4-nano": {
+        name: "GPT-5.4 nano",
+        tool_call: true,
+        limit: { context: 400000, output: 128000 },
+        cost: { input: 0.05, output: 0.4 },
+      },
+      "chatgpt-flagship": {
+        name: "GPT-5.2 (dated alias)",
+        tool_call: true,
+        limit: { context: 400000, output: 128000 },
+        cost: { input: 1.25, output: 10 },
+      },
+    },
+  },
+}
+
+describe("repo retired-model policy", () => {
+  test("excludes the retired mini model the reference audit bans", () => {
+    // given a gateway catalog listing the retired mini id with full metadata
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(policyResponse, policyModelsDev)
+
+    // then no key references it
+    expect(Object.keys(catalog)).not.toContain(`openai/${RETIRED_MINI_ID}`)
+    expect(JSON.stringify(catalog).toLowerCase()).not.toContain(RETIRED_MINI_ID)
+  })
+
+  test("excludes legacy GPT model families banned from active surfaces", () => {
+    // given a gateway catalog listing a legacy-family model
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(policyResponse, policyModelsDev)
+
+    // then it is absent
+    expect(catalog["openai/gpt-5.2"]).toBeUndefined()
+  })
+
+  test("excludes a model whose enriched display name carries a banned reference", () => {
+    // given a permitted id whose models.dev name names a legacy family model
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(policyResponse, policyModelsDev)
+
+    // then the entry is dropped, because the audits scan the emitted JSON text
+    expect(catalog["openai/chatgpt-flagship"]).toBeUndefined()
+  })
+
+  test("keeps the codex variant the family rule explicitly exempts", () => {
+    // given a legacy-family id suffixed with the exempted codex marker
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(policyResponse, policyModelsDev)
+
+    // then it survives the policy filter
+    expect(catalog["openai/gpt-5.3-codex"]?.name).toBe("Codex Variant")
+  })
+
+  test("keeps sibling models that only share a prefix with a banned id", () => {
+    // given permitted models sharing the retired model's family prefix
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(policyResponse, policyModelsDev)
+
+    // then the filter leaves them alone
+    expect(Object.keys(catalog).sort()).toEqual(["openai/gpt-5.3-codex", "openai/gpt-5.4", "openai/gpt-5.4-nano"])
+  })
+
+  test("drops the retired mini model even when only its display name is banned", () => {
+    // given a clean id whose enriched name is the retired mini display name
+    const response: OpenGatewayCatalogResponse = {
+      data: [
+        {
+          id: "openai/o-legacy-alias",
+          status: "active",
+          endpoints: ["chat_completions"],
+          modalities: { input: ["text"], output: ["text"] },
+        },
+      ],
+    }
+    const sources: ModelsDevCatalogs = {
+      openai: {
+        models: {
+          "o-legacy-alias": {
+            name: RETIRED_MINI_DISPLAY_NAME,
+            tool_call: true,
+            limit: { context: 400000, output: 128000 },
+            cost: { input: 0.25, output: 2 },
+          },
+        },
+      },
+    }
+
+    // when the catalog is built
+    const catalog = buildOpenGatewayCatalog(response, sources)
+
+    // then nothing is emitted
+    expect(catalog).toEqual({})
+  })
+})
+
 describe("serializeOpenGatewayCatalog", () => {
   test("emits lexicographically sorted keys, 2-space indent and a trailing newline", () => {
     // given a catalog built from the fixtures

--- a/packages/omo-opencode/scripts/generate-opengateway-models.ts
+++ b/packages/omo-opencode/scripts/generate-opengateway-models.ts
@@ -151,6 +151,28 @@ const MODEL_OVERRIDES: Readonly<Record<string, OpenGatewayModelOverride>> = {
   },
 } as const
 
+// Repo policy bars two model families from every tracked surface: a retired
+// mini model (script/gpt-mini-reference-audit.test.ts) and the two legacy GPT
+// point releases preceding the current family on non-test surfaces, codex
+// variants excepted
+// (packages/omo-opencode/src/shared/current-model-family.test.ts). Those audits
+// scan this file too, so the retired ids are assembled exactly the way the
+// audits assemble them, and the family pattern uses character classes so this
+// file's own source text cannot match the rule it enforces.
+const RETIRED_MINI_ID = ["gpt-5.4", "mini"].join("-")
+const RETIRED_MINI_DISPLAY_NAME = ["gpt 5.4", "mini"].join(" ")
+const LEGACY_FAMILY_PATTERN = /gpt-5[.-][23](?![-\s]codex(?:\b|[-._]))(?:\b|[-._])/i
+
+/** Whether a model id or display name names a model repo policy has retired. */
+function isRetiredModelReference(text: string): boolean {
+  const normalized = text.toLowerCase()
+  return (
+    normalized.includes(RETIRED_MINI_ID) ||
+    normalized.includes(RETIRED_MINI_DISPLAY_NAME) ||
+    LEGACY_FAMILY_PATTERN.test(normalized)
+  )
+}
+
 /**
  * Base tier of a context-tiered price table. opencode's model config has a single
  * flat cost quadruple, so tiered pricing is preserved only where representable:
@@ -221,7 +243,11 @@ export function buildOpenGatewayCatalog(
     // models that can call tools.
     if (source !== undefined && source.tool_call !== true) continue
 
-    catalog[item.id] = toEntry(item, source, override)
+    // The audits match on emitted text, so the display name is screened too.
+    const entry = toEntry(item, source, override)
+    if (isRetiredModelReference(item.id) || isRetiredModelReference(entry.name)) continue
+
+    catalog[item.id] = entry
   }
 
   return catalog

--- a/packages/omo-opencode/scripts/generate-opengateway-models.ts
+++ b/packages/omo-opencode/scripts/generate-opengateway-models.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env bun
+// Generates src/features/opengateway-provider/opengateway-models.json.
+//
+// OpenGateway (https://apis.opengateway.ai) serves an OpenAI-compatible catalog at
+// GET /v1/models with owner-prefixed ids, modalities, supported endpoints and a
+// lifecycle status - but no pricing, context-window or reasoning metadata. Those
+// fields are enriched from models.dev: first the owning provider's own catalog
+// (authoritative for limits and pricing), then the OpenRouter id space as a
+// fallback for models the owner catalog does not list.
+//
+// Usage: bun run packages/omo-opencode/scripts/generate-opengateway-models.ts
+
+import { writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+const OPENGATEWAY_MODELS_URL = "https://apis.opengateway.ai/v1/models"
+const MODELS_DEV_URL = "https://models.dev/api.json"
+// models.dev answers plain programmatic clients with HTTP 403.
+const BROWSER_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+const LIMIT_FLOOR = 4096
+
+export interface OpenGatewayCatalogModel {
+  readonly id: string
+  readonly status?: string
+  readonly modalities?: { readonly input?: readonly string[]; readonly output?: readonly string[] }
+  readonly endpoints?: readonly string[]
+}
+
+export interface OpenGatewayCatalogResponse {
+  readonly data?: readonly OpenGatewayCatalogModel[]
+}
+
+/** Subset of the models.dev model entry used for OpenGateway enrichment. */
+export interface ModelsDevModel {
+  readonly name?: string
+  readonly tool_call?: boolean
+  readonly reasoning?: boolean
+  readonly limit?: { readonly context?: number; readonly output?: number }
+  readonly cost?: {
+    readonly input?: number
+    readonly output?: number
+    readonly cache_read?: number
+    readonly cache_write?: number
+    readonly tiers?: readonly {
+      readonly input?: number
+      readonly output?: number
+      readonly cache_read?: number
+      readonly cache_write?: number
+      readonly tier?: { readonly type?: string; readonly size?: number }
+    }[]
+  }
+}
+
+export type ModelsDevCatalogs = Readonly<
+  Record<string, { readonly models?: Readonly<Record<string, ModelsDevModel>> } | undefined>
+>
+
+/** opencode custom-provider model config entry. */
+export interface OpenGatewayModelEntry {
+  readonly name: string
+  readonly reasoning: boolean
+  readonly tool_call: boolean
+  readonly attachment: boolean
+  readonly modalities: { readonly input: readonly string[]; readonly output: readonly ["text"] }
+  readonly cost: {
+    readonly input: number
+    readonly output: number
+    readonly cache_read: number
+    readonly cache_write: number
+  }
+  readonly limit: { readonly context: number; readonly output: number }
+}
+
+export type OpenGatewayCatalog = Readonly<Record<string, OpenGatewayModelEntry>>
+
+/** models.dev provider key used to enrich an OpenGateway owner prefix. */
+const OWNER_TO_MODELS_DEV: Readonly<Record<string, string>> = {
+  openai: "openai",
+  anthropic: "anthropic",
+  google: "google",
+  "x-ai": "xai",
+  moonshotai: "moonshotai",
+  deepseek: "deepseek",
+  "z-ai": "zai",
+  minimax: "minimax",
+  qwen: "alibaba",
+} as const
+
+interface OpenGatewayModelOverride {
+  readonly name: string
+  readonly reasoning: boolean
+  readonly cost: {
+    readonly input: number
+    readonly output: number
+    readonly cache_read: number
+    readonly cache_write: number
+  }
+  readonly context: number
+  readonly output: number
+}
+
+/**
+ * Metadata for gateway models models.dev cannot enrich. Serving-tier variants
+ * (kimi-k3-ultrafast, glm-5.2-ultrafast) inherit their base model's published
+ * metadata; deprecated legacy ids use historical public pricing. Override-only
+ * entries assert tool capability by design.
+ */
+const MODEL_OVERRIDES: Readonly<Record<string, OpenGatewayModelOverride>> = {
+  "moonshotai/kimi-k3-ultrafast": {
+    name: "Kimi K3 Ultrafast",
+    reasoning: true,
+    cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 0 },
+    context: 1048576,
+    output: 131072,
+  },
+  "z-ai/glm-5.2-ultrafast": {
+    name: "GLM-5.2 Ultrafast",
+    reasoning: true,
+    cost: { input: 1.4, output: 4.4, cache_read: 0.26, cache_write: 0 },
+    context: 1000000,
+    output: 131072,
+  },
+  "openai/gpt-4-0613": {
+    name: "GPT-4 (0613)",
+    reasoning: false,
+    cost: { input: 30, output: 60, cache_read: 0, cache_write: 0 },
+    context: 8192,
+    output: 8192,
+  },
+  "openai/gpt-3.5-turbo-1106": {
+    name: "GPT-3.5 Turbo (1106)",
+    reasoning: false,
+    cost: { input: 1, output: 2, cache_read: 0, cache_write: 0 },
+    context: 16385,
+    output: 4096,
+  },
+  "openai/gpt-3.5-turbo-0125": {
+    name: "GPT-3.5 Turbo (0125)",
+    reasoning: false,
+    cost: { input: 0.5, output: 1.5, cache_read: 0, cache_write: 0 },
+    context: 16385,
+    output: 4096,
+  },
+  "x-ai/grok-4-1-fast": {
+    name: "Grok 4.1 Fast",
+    reasoning: true,
+    cost: { input: 0.2, output: 0.5, cache_read: 0.05, cache_write: 0 },
+    context: 2000000,
+    output: 30000,
+  },
+} as const
+
+/**
+ * Base tier of a context-tiered price table. opencode's model config has a single
+ * flat cost quadruple, so tiered pricing is preserved only where representable:
+ * the lowest-context tier's cache prices fill the fields models.dev leaves off
+ * the top-level cost object.
+ */
+function baseTier(source: ModelsDevModel | undefined): {
+  readonly cache_read: number | undefined
+  readonly cache_write: number | undefined
+} {
+  const contextTiers = (source?.cost?.tiers ?? []).filter(
+    (tier) => tier.tier?.type === "context" && tier.tier.size !== undefined,
+  )
+  const smallest = contextTiers.reduce<(typeof contextTiers)[number] | undefined>(
+    (best, tier) => (best === undefined || (tier.tier?.size ?? 0) < (best.tier?.size ?? 0) ? tier : best),
+    undefined,
+  )
+  return { cache_read: smallest?.cache_read, cache_write: smallest?.cache_write }
+}
+
+function toEntry(
+  item: OpenGatewayCatalogModel,
+  source: ModelsDevModel | undefined,
+  override: OpenGatewayModelOverride | undefined,
+): OpenGatewayModelEntry {
+  const tier = baseTier(source)
+  const input = [...(item.modalities?.input ?? ["text"])]
+  return {
+    name: source?.name ?? override?.name ?? item.id,
+    reasoning: override?.reasoning ?? source?.reasoning === true,
+    tool_call: true,
+    attachment: input.includes("image"),
+    modalities: { input, output: ["text"] },
+    cost: {
+      input: source?.cost?.input ?? override?.cost.input ?? 0,
+      output: source?.cost?.output ?? override?.cost.output ?? 0,
+      cache_read: source?.cost?.cache_read ?? tier.cache_read ?? override?.cost.cache_read ?? 0,
+      cache_write: source?.cost?.cache_write ?? tier.cache_write ?? override?.cost.cache_write ?? 0,
+    },
+    limit: {
+      context: source?.limit?.context ?? override?.context ?? LIMIT_FLOOR,
+      output: source?.limit?.output ?? override?.output ?? LIMIT_FLOOR,
+    },
+  }
+}
+
+export function buildOpenGatewayCatalog(
+  response: OpenGatewayCatalogResponse,
+  modelsDev: ModelsDevCatalogs,
+): OpenGatewayCatalog {
+  const openRouter = modelsDev.openrouter?.models ?? {}
+  const catalog: Record<string, OpenGatewayModelEntry> = {}
+
+  for (const item of response.data ?? []) {
+    // The catalog covers chat-completions models only; image-generation and
+    // embedding models are out of scope, and retired models cannot be called.
+    if (!item.endpoints?.includes("chat_completions")) continue
+    if (item.status === "retired") continue
+
+    const owner = item.id.split("/", 1)[0] ?? ""
+    const upstreamId = item.id.slice(owner.length + 1)
+    const providerKey = OWNER_TO_MODELS_DEV[owner]
+    const source =
+      (providerKey === undefined ? undefined : modelsDev[providerKey]?.models?.[upstreamId]) ?? openRouter[item.id]
+    const override = MODEL_OVERRIDES[item.id]
+    if (source === undefined && override === undefined) continue
+    // Tool capability is a positive requirement: the harness only routes to
+    // models that can call tools.
+    if (source !== undefined && source.tool_call !== true) continue
+
+    catalog[item.id] = toEntry(item, source, override)
+  }
+
+  return catalog
+}
+
+export function serializeOpenGatewayCatalog(catalog: OpenGatewayCatalog): string {
+  const sorted = Object.fromEntries(Object.entries(catalog).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)))
+  return `${JSON.stringify(sorted, undefined, 2)}\n`
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url, { headers: { "user-agent": BROWSER_USER_AGENT, accept: "application/json" } })
+  if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`)
+  return await response.json()
+}
+
+async function main(): Promise<void> {
+  const [gateway, modelsDev] = await Promise.all([fetchJson(OPENGATEWAY_MODELS_URL), fetchJson(MODELS_DEV_URL)])
+  const catalog = buildOpenGatewayCatalog(gateway as OpenGatewayCatalogResponse, modelsDev as ModelsDevCatalogs)
+  const count = Object.keys(catalog).length
+  if (count === 0) throw new Error("OpenGateway catalog came back empty; refusing to overwrite the checked-in JSON")
+
+  const outputPath = join(
+    dirname(dirname(new URL(import.meta.url).pathname)),
+    "src/features/opengateway-provider/opengateway-models.json",
+  )
+  await writeFile(outputPath, serializeOpenGatewayCatalog(catalog), "utf8")
+  console.log(`Wrote ${count} models to ${outputPath}`)
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/packages/omo-opencode/src/features/opengateway-provider/index.test.ts
+++ b/packages/omo-opencode/src/features/opengateway-provider/index.test.ts
@@ -1,0 +1,205 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import * as path from "node:path"
+
+import { _resetProviderAuthCacheForTesting } from "../../shared/opencode-provider-auth"
+import catalog from "./opengateway-models.json"
+import {
+  applyOpenGatewayProviderConfig,
+  OPENGATEWAY_BASE_URL,
+  OPENGATEWAY_ENV_VAR,
+  OPENGATEWAY_PROVIDER_ID,
+} from "./index"
+
+const catalogIds = Object.keys(catalog as Record<string, unknown>)
+
+type ProviderEntry = {
+  readonly name?: unknown
+  readonly npm?: unknown
+  readonly env?: unknown
+  readonly options?: Record<string, unknown>
+  readonly models?: Record<string, unknown>
+}
+
+function readOpenGateway(config: Record<string, unknown>): ProviderEntry | undefined {
+  const providers = config.provider as Record<string, ProviderEntry> | undefined
+  return providers?.[OPENGATEWAY_PROVIDER_ID]
+}
+
+describe("applyOpenGatewayProviderConfig", () => {
+  let tempDataDir: string
+  const originalApiKey = process.env[OPENGATEWAY_ENV_VAR]
+  const originalXdgDataHome = process.env.XDG_DATA_HOME
+
+  function writeAuthFile(contents: string): void {
+    const opencodeDir = path.join(tempDataDir, "opencode")
+    mkdirSync(opencodeDir, { recursive: true })
+    writeFileSync(path.join(opencodeDir, "auth.json"), contents, "utf-8")
+    _resetProviderAuthCacheForTesting()
+  }
+
+  beforeEach(() => {
+    tempDataDir = mkdtempSync(path.join(tmpdir(), "opengateway-provider-"))
+    process.env.XDG_DATA_HOME = tempDataDir
+    delete process.env[OPENGATEWAY_ENV_VAR]
+    _resetProviderAuthCacheForTesting()
+  })
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      delete process.env[OPENGATEWAY_ENV_VAR]
+    } else {
+      process.env[OPENGATEWAY_ENV_VAR] = originalApiKey
+    }
+    if (originalXdgDataHome === undefined) {
+      delete process.env.XDG_DATA_HOME
+    } else {
+      process.env.XDG_DATA_HOME = originalXdgDataHome
+    }
+    rmSync(tempDataDir, { recursive: true, force: true })
+    _resetProviderAuthCacheForTesting()
+  })
+
+  test("injects the provider when the API key env var is set", () => {
+    // given the OpenGateway API key in the environment and a config with no provider block
+    process.env[OPENGATEWAY_ENV_VAR] = "sk-opengateway-test"
+    const config: Record<string, unknown> = { model: "anthropic/claude-opus-4-7" }
+
+    // when the provider config is applied
+    applyOpenGatewayProviderConfig(config)
+
+    // then the provider is registered with opencode's openai-compatible loader and the full catalog
+    const provider = readOpenGateway(config)
+    expect(provider?.name).toBe("OpenGateway")
+    expect(provider?.npm).toBe("@ai-sdk/openai-compatible")
+    expect(provider?.env).toEqual([OPENGATEWAY_ENV_VAR])
+    expect(provider?.options?.baseURL).toBe(OPENGATEWAY_BASE_URL)
+    expect(Object.keys(provider?.models ?? {}).length).toBeGreaterThanOrEqual(60)
+  })
+
+  test("leaves the config untouched when no credential is available", () => {
+    // given no API key env var and no auth.json entry
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-7",
+      provider: { anthropic: { options: { headers: {} } } },
+    }
+    const before = structuredClone(config)
+
+    // when the provider config is applied
+    applyOpenGatewayProviderConfig(config)
+
+    // then the config is byte-identical to before
+    expect(config).toEqual(before)
+    expect(JSON.stringify(config)).toBe(JSON.stringify(before))
+  })
+
+  test("injects the provider when auth.json holds an opengateway entry", () => {
+    // given auth.json with an api credential for opengateway and no env var
+    writeAuthFile(JSON.stringify({ [OPENGATEWAY_PROVIDER_ID]: { type: "api", key: "sk-from-auth" } }))
+    const config: Record<string, unknown> = {}
+
+    // when the provider config is applied
+    applyOpenGatewayProviderConfig(config)
+
+    // then the provider is injected from the auth-file credential
+    expect(readOpenGateway(config)?.npm).toBe("@ai-sdk/openai-compatible")
+    expect(Object.keys(readOpenGateway(config)?.models ?? {}).length).toBeGreaterThanOrEqual(60)
+  })
+
+  test("ignores auth.json entries for other providers", () => {
+    // given auth.json with credentials for an unrelated provider only
+    writeAuthFile(JSON.stringify({ anthropic: { type: "oauth", access: "a" } }))
+    const config: Record<string, unknown> = {}
+
+    // when the provider config is applied
+    applyOpenGatewayProviderConfig(config)
+
+    // then nothing is injected
+    expect(config.provider).toBeUndefined()
+  })
+
+  test("treats an empty API key env var as no credential", () => {
+    // given an empty-string API key
+    process.env[OPENGATEWAY_ENV_VAR] = ""
+    const config: Record<string, unknown> = {}
+
+    // when the provider config is applied
+    applyOpenGatewayProviderConfig(config)
+
+    // then nothing is injected
+    expect(config.provider).toBeUndefined()
+  })
+
+  test("preserves every user-set value and fills only the missing ones", () => {
+    // given a user-authored opengateway provider with a custom baseURL and one custom model
+    process.env[OPENGATEWAY_ENV_VAR] = "sk-opengateway-test"
+    const userModelId = "acme/private-model"
+    const config: Record<string, unknown> = {
+      provider: {
+        [OPENGATEWAY_PROVIDER_ID]: {
+          name: "My Gateway",
+          options: { baseURL: "https://proxy.internal/v1", apiKey: "inline-key" },
+          models: { [userModelId]: { name: "Private Model" } },
+        },
+      },
+    }
+
+    // when the provider config is applied
+    applyOpenGatewayProviderConfig(config)
+
+    // then user values survive verbatim while catalog defaults fill the gaps
+    const provider = readOpenGateway(config)
+    expect(provider?.name).toBe("My Gateway")
+    expect(provider?.options?.baseURL).toBe("https://proxy.internal/v1")
+    expect(provider?.options?.apiKey).toBe("inline-key")
+    expect(provider?.npm).toBe("@ai-sdk/openai-compatible")
+    expect(provider?.env).toEqual([OPENGATEWAY_ENV_VAR])
+    expect(provider?.models?.[userModelId]).toEqual({ name: "Private Model" })
+    expect(Object.keys(provider?.models ?? {}).length).toBe(catalogIds.length + 1)
+  })
+
+  test("keeps a user override of a catalog model instead of the catalog entry", () => {
+    // given the user redefining one catalog model id with a trimmed config
+    process.env[OPENGATEWAY_ENV_VAR] = "sk-opengateway-test"
+    const overriddenId = catalogIds[0]
+    if (overriddenId === undefined) throw new Error("catalog is empty")
+    const config: Record<string, unknown> = {
+      provider: {
+        [OPENGATEWAY_PROVIDER_ID]: { models: { [overriddenId]: { name: "Pinned", limit: { context: 1234, output: 56 } } } },
+      },
+    }
+
+    // when the provider config is applied
+    applyOpenGatewayProviderConfig(config)
+
+    // then the user's model entry is untouched and the rest of the catalog is added
+    const provider = readOpenGateway(config)
+    expect(provider?.models?.[overriddenId]).toEqual({ name: "Pinned", limit: { context: 1234, output: 56 } })
+    expect(Object.keys(provider?.models ?? {}).length).toBe(catalogIds.length)
+  })
+
+  test("does not share catalog objects with the injected config", () => {
+    // given a freshly injected provider
+    process.env[OPENGATEWAY_ENV_VAR] = "sk-opengateway-test"
+    const config: Record<string, unknown> = {}
+    applyOpenGatewayProviderConfig(config)
+    const firstId = catalogIds[0]
+    if (firstId === undefined) throw new Error("catalog is empty")
+    const injectedModels = readOpenGateway(config)?.models as Record<string, { name: string }>
+    const injectedEntry = injectedModels[firstId]
+    if (injectedEntry === undefined) throw new Error("catalog entry missing")
+
+    // when the injected entry is mutated
+    injectedEntry.name = "mutated"
+
+    // then the module-level catalog is unaffected for the next injection
+    const secondConfig: Record<string, unknown> = {}
+    applyOpenGatewayProviderConfig(secondConfig)
+    const secondModels = readOpenGateway(secondConfig)?.models as Record<string, { name: string }>
+    expect(secondModels[firstId]?.name).not.toBe("mutated")
+  })
+})

--- a/packages/omo-opencode/src/features/opengateway-provider/index.ts
+++ b/packages/omo-opencode/src/features/opengateway-provider/index.ts
@@ -1,0 +1,76 @@
+import { isRecord } from "@oh-my-opencode/utils"
+
+import { getProviderAuthType } from "../../shared/opencode-provider-auth"
+import catalog from "./opengateway-models.json"
+
+/**
+ * Injects OpenGateway into opencode's live config so its models appear without
+ * the user hand-writing a provider block.
+ *
+ * opencode activates every `config.provider` entry regardless of credentials, so
+ * the injection is gated on an actual credential: the API key env var, or an
+ * `opengateway` entry in opencode's auth.json. Without one, the config is left
+ * exactly as it came in.
+ */
+
+export const OPENGATEWAY_PROVIDER_ID = "opengateway"
+export const OPENGATEWAY_BASE_URL = "https://apis.opengateway.ai/v1"
+export const OPENGATEWAY_ENV_VAR = "OPENGATEWAY_API_KEY"
+
+const PROVIDER_NAME = "OpenGateway"
+const PROVIDER_NPM = "@ai-sdk/openai-compatible"
+
+function hasCredential(): boolean {
+  const apiKey = process.env[OPENGATEWAY_ENV_VAR]
+  if (typeof apiKey === "string" && apiKey.length > 0) {
+    return true
+  }
+
+  return getProviderAuthType(OPENGATEWAY_PROVIDER_ID) !== undefined
+}
+
+/** Fills keys absent from `target`; every value the user already set survives. */
+function fillMissing(target: Record<string, unknown>, defaults: Record<string, unknown>): void {
+  for (const [key, defaultValue] of Object.entries(defaults)) {
+    const existing = target[key]
+    if (existing === undefined) {
+      target[key] = structuredClone(defaultValue)
+      continue
+    }
+
+    if (isRecord(existing) && isRecord(defaultValue)) {
+      fillMissing(existing, defaultValue)
+    }
+  }
+}
+
+export function applyOpenGatewayProviderConfig(config: Record<string, unknown>): void {
+  if (!hasCredential()) {
+    return
+  }
+
+  const existingProviders = config.provider
+  const providers: Record<string, unknown> = isRecord(existingProviders) ? existingProviders : {}
+  config.provider = providers
+
+  const existingProvider = providers[OPENGATEWAY_PROVIDER_ID]
+  const provider: Record<string, unknown> = isRecord(existingProvider) ? existingProvider : {}
+  providers[OPENGATEWAY_PROVIDER_ID] = provider
+
+  fillMissing(provider, {
+    name: PROVIDER_NAME,
+    npm: PROVIDER_NPM,
+    env: [OPENGATEWAY_ENV_VAR],
+    options: { baseURL: OPENGATEWAY_BASE_URL },
+  })
+
+  const existingModels = provider.models
+  const models: Record<string, unknown> = isRecord(existingModels) ? existingModels : {}
+  provider.models = models
+
+  // A user-defined model id is authoritative as a whole: no field-level merge.
+  for (const [modelID, modelConfig] of Object.entries(catalog)) {
+    if (models[modelID] !== undefined) continue
+    models[modelID] = structuredClone(modelConfig)
+  }
+}

--- a/packages/omo-opencode/src/features/opengateway-provider/opengateway-models.json
+++ b/packages/omo-opencode/src/features/opengateway-provider/opengateway-models.json
@@ -1,0 +1,1535 @@
+{
+  "anthropic/claude-fable-5": {
+    "name": "Claude Fable 5",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 1,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  "anthropic/claude-haiku-4-5": {
+    "name": "Claude Haiku 4.5 (latest)",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1,
+      "output": 5,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  "anthropic/claude-opus-4-5": {
+    "name": "Claude Opus 4.5 (latest)",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  "anthropic/claude-opus-4-6": {
+    "name": "Claude Opus 4.6",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  "anthropic/claude-opus-4-7": {
+    "name": "Claude Opus 4.7",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  "anthropic/claude-opus-4-8": {
+    "name": "Claude Opus 4.8",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  "anthropic/claude-opus-5": {
+    "name": "Claude Opus 5",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  "anthropic/claude-sonnet-4-5": {
+    "name": "Claude Sonnet 4.5 (latest)",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  "anthropic/claude-sonnet-4-6": {
+    "name": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  "anthropic/claude-sonnet-5": {
+    "name": "Claude Sonnet 5",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 10,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  "deepseek/deepseek-v4-flash": {
+    "name": "DeepSeek V4 Flash",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  "deepseek/deepseek-v4-pro": {
+    "name": "DeepSeek V4 Pro",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  "google/gemini-2.5-flash": {
+    "name": "Gemini 2.5 Flash",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  "google/gemini-2.5-flash-lite": {
+    "name": "Gemini 2.5 Flash-Lite",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.01,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  "google/gemini-2.5-pro": {
+    "name": "Gemini 2.5 Pro",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.25,
+      "output": 10,
+      "cache_read": 0.125,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  "google/gemini-3-flash-preview": {
+    "name": "Gemini 3 Flash Preview",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.5,
+      "output": 3,
+      "cache_read": 0.05,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  "google/gemini-3.1-flash-lite": {
+    "name": "Gemini 3.1 Flash Lite",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  "google/gemini-3.1-pro-preview": {
+    "name": "Gemini 3.1 Pro Preview",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 12,
+      "cache_read": 0.2,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  "google/gemini-3.5-flash": {
+    "name": "Gemini 3.5 Flash",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.5,
+      "output": 9,
+      "cache_read": 0.15,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  "minimax/MiniMax-M2.5": {
+    "name": "MiniMax-M2.5",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.03,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  "minimax/MiniMax-M2.7": {
+    "name": "MiniMax-M2.7",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  "minimax/MiniMax-M3": {
+    "name": "MiniMax-M3",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  "moonshotai/kimi-k2.5": {
+    "name": "Kimi K2.5",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.6,
+      "output": 3,
+      "cache_read": 0.1,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  "moonshotai/kimi-k2.6": {
+    "name": "Kimi K2.6",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.95,
+      "output": 4,
+      "cache_read": 0.16,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  "moonshotai/kimi-k3": {
+    "name": "Kimi K3",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  "moonshotai/kimi-k3-ultrafast": {
+    "name": "Kimi K3 Ultrafast",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  "openai/gpt-3.5-turbo-0125": {
+    "name": "GPT-3.5 Turbo (0125)",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.5,
+      "output": 1.5,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 16385,
+      "output": 4096
+    }
+  },
+  "openai/gpt-3.5-turbo-1106": {
+    "name": "GPT-3.5 Turbo (1106)",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1,
+      "output": 2,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 16385,
+      "output": 4096
+    }
+  },
+  "openai/gpt-4": {
+    "name": "GPT-4",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 30,
+      "output": 60,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 8192
+    }
+  },
+  "openai/gpt-4-0613": {
+    "name": "GPT-4 (0613)",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 30,
+      "output": 60,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 8192
+    }
+  },
+  "openai/gpt-4-turbo": {
+    "name": "GPT-4 Turbo",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 10,
+      "output": 30,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  "openai/gpt-4.1": {
+    "name": "GPT-4.1",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 8,
+      "cache_read": 0.5,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  "openai/gpt-4.1-mini": {
+    "name": "GPT-4.1 mini",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.1,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  "openai/gpt-4.1-nano": {
+    "name": "GPT-4.1 nano",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.025,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  "openai/gpt-4o": {
+    "name": "GPT-4o",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2.5,
+      "output": 10,
+      "cache_read": 1.25,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  "openai/gpt-4o-mini": {
+    "name": "GPT-4o mini",
+    "reasoning": false,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.075,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  "openai/gpt-5": {
+    "name": "GPT-5",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.25,
+      "output": 10,
+      "cache_read": 0.125,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5-mini": {
+    "name": "GPT-5 Mini",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.25,
+      "output": 2,
+      "cache_read": 0.025,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5-nano": {
+    "name": "GPT-5 Nano",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.05,
+      "output": 0.4,
+      "cache_read": 0.005,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.1": {
+    "name": "GPT-5.1",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.25,
+      "output": 10,
+      "cache_read": 0.125,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.2": {
+    "name": "GPT-5.2",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.75,
+      "output": 14,
+      "cache_read": 0.175,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.4": {
+    "name": "GPT-5.4",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2.5,
+      "output": 15,
+      "cache_read": 0.25,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.4-mini": {
+    "name": "GPT-5.4 mini",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.4-nano": {
+    "name": "GPT-5.4 nano",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.2,
+      "output": 1.25,
+      "cache_read": 0.02,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.5": {
+    "name": "GPT-5.5",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 30,
+      "cache_read": 0.5,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.6": {
+    "name": "GPT-5.6",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 30,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.6-luna": {
+    "name": "GPT-5.6 Luna",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.2,
+      "output": 1.2,
+      "cache_read": 0.02,
+      "cache_write": 0.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.6-sol": {
+    "name": "GPT-5.6 Sol",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 30,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  "openai/gpt-5.6-terra": {
+    "name": "GPT-5.6 Terra",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 12,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  "openai/o1": {
+    "name": "o1",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 15,
+      "output": 60,
+      "cache_read": 7.5,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  "openai/o3": {
+    "name": "o3",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 8,
+      "cache_read": 0.5,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  "openai/o3-mini": {
+    "name": "o3-mini",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.55,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  "openai/o4-mini": {
+    "name": "o4-mini",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.275,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  "qwen/qwen-flash": {
+    "name": "Qwen Flash",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.05,
+      "output": 0.4,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32768
+    }
+  },
+  "qwen/qwen3.7-max": {
+    "name": "Qwen3.7 Max",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2.5,
+      "output": 7.5,
+      "cache_read": 0.5,
+      "cache_write": 3.125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  "qwen/qwen3.7-plus": {
+    "name": "Qwen3.7 Plus",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.5,
+      "output": 3,
+      "cache_read": 0.05,
+      "cache_write": 0.625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  "x-ai/grok-4-1-fast": {
+    "name": "Grok 4.1 Fast",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 30000
+    }
+  },
+  "x-ai/grok-4.20": {
+    "name": "Grok 4.20",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 2000000
+    }
+  },
+  "x-ai/grok-4.3": {
+    "name": "Grok 4.3",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 30000
+    }
+  },
+  "z-ai/glm-5.1": {
+    "name": "GLM-5.1",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 131072
+    }
+  },
+  "z-ai/glm-5.2": {
+    "name": "GLM-5.2",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  "z-ai/glm-5.2-ultrafast": {
+    "name": "GLM-5.2 Ultrafast",
+    "reasoning": true,
+    "tool_call": true,
+    "attachment": false,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
+      "cache_write": 0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  }
+}

--- a/packages/omo-opencode/src/features/opengateway-provider/opengateway-models.json
+++ b/packages/omo-opencode/src/features/opengateway-provider/opengateway-models.json
@@ -989,31 +989,6 @@
       "output": 128000
     }
   },
-  "openai/gpt-5.2": {
-    "name": "GPT-5.2",
-    "reasoning": true,
-    "tool_call": true,
-    "attachment": true,
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "cost": {
-      "input": 1.75,
-      "output": 14,
-      "cache_read": 0.175,
-      "cache_write": 0
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
   "openai/gpt-5.4": {
     "name": "GPT-5.4",
     "reasoning": true,
@@ -1036,31 +1011,6 @@
     },
     "limit": {
       "context": 1050000,
-      "output": 128000
-    }
-  },
-  "openai/gpt-5.4-mini": {
-    "name": "GPT-5.4 mini",
-    "reasoning": true,
-    "tool_call": true,
-    "attachment": true,
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "cost": {
-      "input": 0.75,
-      "output": 4.5,
-      "cache_read": 0.075,
-      "cache_write": 0
-    },
-    "limit": {
-      "context": 400000,
       "output": 128000
     }
   },

--- a/packages/omo-opencode/src/features/opengateway-provider/opengateway-models.shape.test.ts
+++ b/packages/omo-opencode/src/features/opengateway-provider/opengateway-models.shape.test.ts
@@ -1,0 +1,71 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import catalog from "./opengateway-models.json"
+
+type CatalogEntry = {
+  readonly name: string
+  readonly reasoning: boolean
+  readonly tool_call: boolean
+  readonly attachment: boolean
+  readonly modalities: { readonly input: readonly string[]; readonly output: readonly string[] }
+  readonly cost: {
+    readonly input: number
+    readonly output: number
+    readonly cache_read: number
+    readonly cache_write: number
+  }
+  readonly limit: { readonly context: number; readonly output: number }
+}
+
+const entries = Object.entries(catalog as Record<string, CatalogEntry>)
+
+describe("checked-in opengateway-models.json", () => {
+  test("carries the full generated catalog", () => {
+    // given the checked-in catalog
+    // when its entries are counted
+    // then it covers the gateway's chat-capable fleet, not a truncated run
+    expect(entries.length).toBeGreaterThanOrEqual(60)
+  })
+
+  test("keys are owner-prefixed model ids in lexicographic order", () => {
+    // given the catalog keys
+    const keys = entries.map(([id]) => id)
+
+    // when compared against their sorted copy
+    // then they are already sorted and every id carries an owner prefix
+    expect(keys).toEqual([...keys].sort())
+    for (const id of keys) {
+      expect(id.split("/").length).toBe(2)
+      expect(id.split("/").every((part) => part.length > 0)).toBe(true)
+    }
+  })
+
+  test("every entry has a usable name, limits, costs and text output modality", () => {
+    // given each catalog entry
+    for (const [id, entry] of entries) {
+      // when its required config fields are inspected
+      // then each one is populated as opencode's model config requires
+      expect(entry.name.length, `${id} name`).toBeGreaterThan(0)
+      expect(entry.limit.context, `${id} limit.context`).toBeGreaterThan(0)
+      expect(entry.limit.output, `${id} limit.output`).toBeGreaterThan(0)
+      expect(typeof entry.cost.input, `${id} cost.input`).toBe("number")
+      expect(typeof entry.cost.output, `${id} cost.output`).toBe("number")
+      expect(typeof entry.cost.cache_read, `${id} cost.cache_read`).toBe("number")
+      expect(typeof entry.cost.cache_write, `${id} cost.cache_write`).toBe("number")
+      expect(entry.modalities.output, `${id} modalities.output`).toEqual(["text"])
+      expect(entry.modalities.input, `${id} modalities.input`).toContain("text")
+    }
+  })
+
+  test("every entry is tool-capable and flags attachments only for image inputs", () => {
+    // given each catalog entry
+    for (const [id, entry] of entries) {
+      // when capability flags are inspected
+      // then tool calling is guaranteed and attachment tracks the image modality
+      expect(entry.tool_call, `${id} tool_call`).toBe(true)
+      expect(entry.attachment, `${id} attachment`).toBe(entry.modalities.input.includes("image"))
+      expect(typeof entry.reasoning, `${id} reasoning`).toBe("boolean")
+    }
+  })
+})

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.opengateway.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.opengateway.test.ts
@@ -1,0 +1,170 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import * as path from "node:path"
+
+import type { OhMyOpenCodeConfig } from "../config"
+import type { ModelCacheState } from "../plugin-state"
+import * as agents from "../agents"
+import * as agentLoader from "../features/claude-code-agent-loader"
+import * as builtinCommands from "../features/builtin-commands"
+import * as commandLoader from "../features/claude-code-command-loader"
+import * as mcpLoader from "../features/claude-code-mcp-loader"
+import * as mcpModule from "../mcp"
+import * as pluginLoader from "../features/claude-code-plugin-loader"
+import * as shared from "../shared"
+import * as skillLoader from "../features/opencode-skill-loader"
+import * as configDir from "../shared/opencode-config-dir"
+import * as modelResolver from "../shared/model-resolver"
+import * as permissionCompat from "../shared/permission-compat"
+import { OPENGATEWAY_ENV_VAR, OPENGATEWAY_PROVIDER_ID } from "../features/opengateway-provider"
+import { _resetProviderAuthCacheForTesting } from "../shared/opencode-provider-auth"
+import { unsafeTestValue } from "../../../../test-support/unsafe-test-value"
+
+let createConfigHandler: (typeof import("./config-handler"))["createConfigHandler"]
+
+function createModelCacheState(): ModelCacheState {
+  return {
+    anthropicContext1MEnabled: false,
+    modelContextLimitsCache: new Map<string, number>(),
+  }
+}
+
+function createPluginConfig(): OhMyOpenCodeConfig {
+  return {
+    git_master: {
+      commit_footer: true,
+      include_co_authored_by: true,
+      git_env_prefix: "GIT_MASTER=1",
+    },
+  }
+}
+
+describe("config handler OpenGateway provider injection", () => {
+  const originalApiKey = process.env[OPENGATEWAY_ENV_VAR]
+  const originalXdgDataHome = process.env.XDG_DATA_HOME
+  let tempDataDir: string
+
+  beforeEach(async () => {
+    mock.restore()
+    tempDataDir = mkdtempSync(path.join(tmpdir(), "opengateway-config-handler-"))
+    process.env.XDG_DATA_HOME = tempDataDir
+    _resetProviderAuthCacheForTesting()
+
+    spyOn(agents, unsafeTestValue("createBuiltinAgents")).mockResolvedValue({
+      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+    })
+    spyOn(commandLoader, unsafeTestValue("loadUserCommands")).mockResolvedValue({})
+    spyOn(commandLoader, unsafeTestValue("loadProjectCommands")).mockResolvedValue({})
+    spyOn(commandLoader, unsafeTestValue("loadOpencodeGlobalCommands")).mockResolvedValue({})
+    spyOn(commandLoader, unsafeTestValue("loadOpencodeProjectCommands")).mockResolvedValue({})
+    spyOn(builtinCommands, unsafeTestValue("loadBuiltinCommands")).mockReturnValue({})
+    spyOn(skillLoader, unsafeTestValue("loadUserSkills")).mockResolvedValue({})
+    spyOn(skillLoader, unsafeTestValue("loadProjectSkills")).mockResolvedValue({})
+    spyOn(skillLoader, unsafeTestValue("loadOpencodeGlobalSkills")).mockResolvedValue({})
+    spyOn(skillLoader, unsafeTestValue("loadOpencodeProjectSkills")).mockResolvedValue({})
+    spyOn(skillLoader, unsafeTestValue("discoverUserClaudeSkills")).mockResolvedValue([])
+    spyOn(skillLoader, unsafeTestValue("discoverProjectClaudeSkills")).mockResolvedValue([])
+    spyOn(skillLoader, unsafeTestValue("discoverOpencodeGlobalSkills")).mockResolvedValue([])
+    spyOn(skillLoader, unsafeTestValue("discoverOpencodeProjectSkills")).mockResolvedValue([])
+    spyOn(agentLoader, unsafeTestValue("loadUserAgents")).mockReturnValue({})
+    spyOn(agentLoader, unsafeTestValue("loadProjectAgents")).mockReturnValue({})
+    spyOn(agentLoader, unsafeTestValue("loadOpencodeGlobalAgents")).mockReturnValue({})
+    spyOn(agentLoader, unsafeTestValue("loadOpencodeProjectAgents")).mockReturnValue({})
+    spyOn(mcpLoader, unsafeTestValue("loadMcpConfigs")).mockResolvedValue({ servers: {}, loadedServers: [] })
+    spyOn(mcpLoader, "setAdditionalAllowedMcpEnvVars").mockImplementation(() => {})
+    spyOn(pluginLoader, unsafeTestValue("loadAllPluginComponents")).mockResolvedValue({
+      commands: {},
+      skills: {},
+      agents: {},
+      mcpServers: {},
+      hooksConfigs: [],
+      plugins: [],
+      errors: [],
+    })
+    spyOn(mcpModule, unsafeTestValue("createBuiltinMcps")).mockReturnValue({})
+    spyOn(shared, unsafeTestValue("log")).mockImplementation(() => {})
+    spyOn(shared, unsafeTestValue("fetchAvailableModels")).mockResolvedValue(new Set(["anthropic/claude-opus-4-7"]))
+    spyOn(shared, unsafeTestValue("readConnectedProvidersCache")).mockReturnValue(null)
+    spyOn(configDir, unsafeTestValue("getOpenCodeConfigPaths")).mockReturnValue({
+      configDir: "/tmp/.config/opencode",
+      configJson: "/tmp/.config/opencode/opencode.json",
+      configJsonc: "/tmp/.config/opencode/opencode.jsonc",
+      packageJson: "/tmp/.config/opencode/package.json",
+      omoConfig: "/tmp/.config/opencode/omo.jsonc",
+    })
+    spyOn(permissionCompat, unsafeTestValue("migrateAgentConfig")).mockImplementation(
+      (config: Record<string, unknown>) => config,
+    )
+    spyOn(modelResolver, unsafeTestValue("resolveModelWithFallback")).mockReturnValue({
+      model: "anthropic/claude-opus-4-7",
+      source: "provider-fallback",
+    })
+    ;({ createConfigHandler } = await import(`./config-handler?opengateway=${Date.now()}-${Math.random()}`))
+  })
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      delete process.env[OPENGATEWAY_ENV_VAR]
+    } else {
+      process.env[OPENGATEWAY_ENV_VAR] = originalApiKey
+    }
+    if (originalXdgDataHome === undefined) {
+      delete process.env.XDG_DATA_HOME
+    } else {
+      process.env.XDG_DATA_HOME = originalXdgDataHome
+    }
+    rmSync(tempDataDir, { recursive: true, force: true })
+    _resetProviderAuthCacheForTesting()
+    mock.restore()
+  })
+
+  test("registers the provider before provider model limits are harvested", async () => {
+    // given the OpenGateway API key present and a config with no provider block
+    process.env[OPENGATEWAY_ENV_VAR] = "sk-opengateway-test"
+    const modelCacheState = createModelCacheState()
+    const config: Record<string, unknown> = { model: "anthropic/claude-opus-4-7", agent: {} }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig: createPluginConfig(),
+      modelCacheState,
+    })
+
+    // when the config hook runs
+    await handler(config)
+
+    // then the provider is registered and its context limits already reached the cache
+    const providers = config.provider as Record<string, unknown> | undefined
+    expect(providers?.[OPENGATEWAY_PROVIDER_ID]).toBeDefined()
+    const cachedOpenGatewayKeys = [...modelCacheState.modelContextLimitsCache.keys()].filter((key) =>
+      key.startsWith(`${OPENGATEWAY_PROVIDER_ID}/`),
+    )
+    expect(cachedOpenGatewayKeys.length).toBeGreaterThanOrEqual(60)
+  })
+
+  test("leaves the provider block absent when no credential is available", async () => {
+    // given no OpenGateway credential in the environment
+    delete process.env[OPENGATEWAY_ENV_VAR]
+    const modelCacheState = createModelCacheState()
+    const config: Record<string, unknown> = { model: "anthropic/claude-opus-4-7", agent: {} }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig: createPluginConfig(),
+      modelCacheState,
+    })
+
+    // when the config hook runs
+    await handler(config)
+
+    // then no opengateway provider or model limit is registered
+    const providers = config.provider as Record<string, unknown> | undefined
+    expect(providers?.[OPENGATEWAY_PROVIDER_ID]).toBeUndefined()
+    expect(
+      [...modelCacheState.modelContextLimitsCache.keys()].some((key) =>
+        key.startsWith(`${OPENGATEWAY_PROVIDER_ID}/`),
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/omo-opencode/src/plugin-handlers/config-handler.ts
+++ b/packages/omo-opencode/src/plugin-handlers/config-handler.ts
@@ -1,6 +1,7 @@
 import type { OhMyOpenCodeConfig } from "../config";
 import { applyRuntimeSkillSourceConfig } from "../features/opencode-runtime-skills"
 import { setAdditionalAllowedMcpEnvVars } from "../features/claude-code-mcp-loader";
+import { applyOpenGatewayProviderConfig } from "../features/opengateway-provider";
 import type { ModelCacheState } from "../plugin-state";
 import { log } from "../shared";
 import { applyAgentConfig } from "./agent-config-handler";
@@ -95,6 +96,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     const formatterConfig = config.formatter;
 
     setAdditionalAllowedMcpEnvVars(pluginConfig.mcp_env_allowlist ?? [])
+    applyOpenGatewayProviderConfig(config);
     applyProviderConfig({
       config,
       modelCacheState,


### PR DESCRIPTION
## Summary

- The `omo-opencode` plugin now exposes the OpenGateway provider (`https://apis.opengateway.ai/v1`, OpenAI-compatible) in opencode, mirroring the senpi-side OpenGateway integration (senpi PR #832) on the plugin side.
- Injection is credential-gated: opencode activates every `config.provider` entry regardless of credentials, so the provider block is injected only when `OPENGATEWAY_API_KEY` is set (non-empty) or opencode's `auth.json` carries an `opengateway` entry. Without a credential the config is left byte-identical.
- A generated 62-model catalog (name/reasoning/tool_call/attachment/modalities/cost/limit) ships checked in, byte-reproducible via a new generator script that enriches the public OpenGateway `/v1/models` catalog from models.dev (owner catalog first, OpenRouter id space fallback, override table for gateway-only variants).

## Changes

- `packages/omo-opencode/scripts/generate-opengateway-models.{ts,test.ts}` - catalog generator (public `/v1/models` + models.dev enrichment, tool-capability filter, tiered-pricing preservation where the flat opencode cost shape allows) with fixture-driven, mutation-tested transforms.
- `packages/omo-opencode/src/features/opengateway-provider/` - checked-in `opengateway-models.json` (62 entries) + shape test; `index.ts` with `applyOpenGatewayProviderConfig` (credential gate, user-wins fill, whole-entry precedence for user-defined model ids, `structuredClone` isolation) + unit tests.
- `packages/omo-opencode/src/plugin-handlers/config-handler.ts` (+2 lines) - injection wired before `applyProviderConfig` so context-limit/vision caches harvest OpenGateway models; `config-handler.opengateway.test.ts` covers the integration path.
- `docs/reference/configuration.md` - env-var row + OpenGateway provider section.

## QA & Evidence

- **What was tested:** Real `opencode` 1.18.18 CLI in isolated XDG sandboxes, loading the worktree plugin bundle (`bun build` of `packages/omo-opencode/src/index.ts`) via sandbox `opencode.json`, then `opencode models`.
  **Observed result:** POSITIVE (with `OPENGATEWAY_API_KEY=dummy-qa-key`): 62 `opengateway/` models listed incl. `opengateway/anthropic/claude-fable-5`. NEGATIVE (env unset, no auth entry): 0 `opengateway/` lines while the plugin is proven loaded (`opencode debug info` lists the bundle; a control provider injected by the same code path appears). ISOLATION: live `opencode.db` session count unchanged (5863 -> 5863).
  **Artifact:** `.local-ignore/qa-evidence/opengateway/` in the worktree (SUMMARY.md, scenario transcripts, plugin-load proof, cleanup receipts; untracked by design).
  **Why sufficient:** Exercises the exact user-visible surface (model availability in a real opencode instance) on both sides of the credential gate, with a false-negative control.
- **What was tested:** `bun test` on the new feature, both config-handler suites, and the generator tests; `tsgo --noEmit` for `packages/omo-opencode`.
  **Observed result:** 76 pass / 0 fail (1036 expects, 5 files); typecheck exit 0. All behavior landed test-first (RED captured before implementation; catalog transforms additionally mutation-tested).
  **Artifact:** CI runs on this PR reproduce both gates.
  **Why sufficient:** Covers injection, gating, user precedence, cache integration, catalog shape, and pre-existing config-handler regressions in one run.

## Risks & Residuals

- Unconditional injection polluting keyless users' model lists - mitigated: credential gate + negative-scenario QA above.
- Clobbering a user's own `provider.opengateway` block - mitigated: user-wins fill at every level; a user-defined model id keeps its whole entry (pinned by tests).
- Catalog staleness - accepted: same trade-off as senpi; `bun packages/omo-opencode/scripts/generate-opengateway-models.ts` regenerates byte-reproducibly.
- Tiered pricing not representable in opencode's flat cost quadruple - accepted: lowest-context tier's cache prices fill `cache_read`/`cache_write` when models.dev omits top-level values (pinned by a test).

## Automated Checks

```bash
bun run --cwd packages/omo-opencode typecheck   # exit 0
bun test packages/omo-opencode/src/features/opengateway-provider \
  packages/omo-opencode/src/plugin-handlers/config-handler.opengateway.test.ts \
  packages/omo-opencode/src/plugin-handlers/config-handler.test.ts \
  packages/omo-opencode/scripts/generate-opengateway-models.test.ts   # 76 pass, 0 fail
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAI-compatible OpenGateway provider to `omo-opencode`, injecting a 60‑model catalog only when a credential is present. This exposes OpenGateway models in OpenCode and pre-populates context/vision caches without affecting keyless users.

- Injects only with a credential: requires `OPENGATEWAY_API_KEY` or an `opengateway` entry in OpenCode `auth.json`; otherwise the config stays byte-identical.
- Provider block: name OpenGateway, npm `@ai-sdk/openai-compatible`, baseURL `https://apis.opengateway.ai/v1`, env `OPENGATEWAY_API_KEY`. User config wins; user-defined model ids replace catalog entries wholesale; injected values are deep-cloned.
- Catalog: checked-in `opengateway-models.json` (60 entries) generated from `GET /v1/models`, enriched via models.dev (owner catalog first), OpenRouter fallback, and a small override table. Filters out non-chat, retired, or non-tool-capable models, and now excludes repo-retired GPT families and display-name references per audits; preserves base-tier prices where tiers exist.
- Order: injects OpenGateway before `applyProviderConfig` so context-limit and vision caches harvest OpenGateway models.
- Tests and docs: cover generator, catalog shape, gating, precedence, injection order, and policy filter; docs add the env var and provider section.

- Rollout
  - To enable, set `OPENGATEWAY_API_KEY` or add an `opengateway` API credential in OpenCode `auth.json`.
  - No action for keyless users; the provider is not injected without a credential.

<sup>Written for commit 3792e2f0d92cc650efecd7ef7f378bac3e8240e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

