### PR TITLE
feat(opencode): retain multiple BTW side sessions

### DIFF
--- a/docs/guide/btw.md
+++ b/docs/guide/btw.md
@@ -1,6 +1,6 @@
 # BTW Side Conversations
 
-`/btw` opens a temporary side conversation without interrupting or adding
+`/btw` opens retained side conversations without interrupting or adding
 messages to the main conversation.
 
 Use it while the main agent is working when you need a quick explanation,
@@ -16,40 +16,57 @@ status check, or related question:
 /side explain the current test failure
 ```
 
-Entering `/btw` without a question opens an empty side conversation. Type the
-question after the side view appears.
+Entering `/btw` without a question opens the BTW picker. The picker summarizes
+the main conversation and every retained side, then lets you open one or create
+a new empty side.
 
 ## What happens
 
 1. OMO records a stable message boundary in the current conversation.
-2. The TUI creates a visually empty temporary session with the same model and
+2. The TUI creates a visually empty retained session with the same model and
    agent.
 3. The model receives the most recent main-conversation context through that
    boundary as read-only background, capped at 64 messages and 64 KiB. The
    inherited messages are not written into the side transcript.
 4. The main conversation keeps running independently.
-5. Closing BTW aborts any active side turn and deletes the temporary session.
+5. Returning with `Esc Esc` keeps the side available. Destructive `Ctrl+C`
+   aborts the visible side turn and deletes only that side.
 
 The side question and answer never enter the main session. Returning to the
 main session shows the same transcript and task state it had before BTW opened.
+Each later `/btw <question>` creates another side instead of reusing an earlier
+one. Starting BTW while viewing a side creates a sibling under the same main
+conversation.
 
 ## Controls
 
 | Action | Control |
 | --- | --- |
-| Start with a question | `/btw <question>` |
-| Start with an empty composer | `/btw` |
+| Create a new side with a question | `/btw <question>` |
+| Open the session picker | `/btw` |
 | Alias | `/side [question]` |
-| Switch between main and BTW | `Ctrl+/` |
-| Close BTW from an empty side composer | `Ctrl+C` |
+| Open the picker from any related view | `Ctrl+/` |
+| Return to Main without deletion | `Esc Esc` |
+| Delete the visible side from an empty composer | `Ctrl+C` |
 
-Terminals that encode `Ctrl+/` as `Ctrl+_` are supported automatically.
+Terminals that encode `Ctrl+/` as `Ctrl+_` or `Ctrl+7` are supported
+automatically.
+
+The picker has three sections:
+
+- **Main conversation** opens the original transcript.
+- **Retained BTW sessions** lists `BTW #1`, `BTW #2`, and later sides
+  oldest-first with question summaries.
+- **Actions** contains **New BTW**.
+
+The current destination is selected when the picker opens. Both the picker and
+long BTW transcripts use native mouse-wheel scrolling.
 
 The prompt status area reports these states:
 
 - `BTW starting...`
-- `BTW open · ctrl+/ switch`
-- `BTW from main · main working · ctrl+/ switch · ctrl+c close`
+- `BTW retained · ctrl+/ picker`
+- `BTW #2 · main working · esc esc return · ctrl+/ picker · ctrl+c delete`
 - `BTW closing...`
 
 `main working` changes to `main ready`, `main needs input`, or
@@ -60,18 +77,17 @@ The prompt status area reports these states:
 - BTW is available after the current session has at least one stable message.
 - BTW drafts are text-only. If the composer has an attachment, remove it before
   starting BTW; the parent draft and attachment remain untouched.
-- Only one BTW conversation can be open at a time.
-- A BTW conversation cannot open another BTW conversation.
+- Multiple BTW conversations can be retained under one main conversation.
+- Starting from a BTW view creates a sibling side, never a nested side.
 - File and external-state changes are discouraged unless the side request asks
   for them explicitly.
 - Side conversations do not delegate work to subagents.
 
 OpenAI Codex can present its side thread inside the native Codex TUI. OpenCode's
-plugin API does not expose that split presentation, so OMO uses a dedicated
-session route and `Ctrl+/` switching while preserving the same isolation and
-temporary-session behavior.
+plugin API does not expose that split presentation, so OMO uses retained
+session routes and a native picker while preserving the same transcript
+isolation.
 
-If OpenCode exits unexpectedly, the metadata-marked BTW session can remain in
-the session list. Delete it like any other abandoned session. Reattaching to a
-BTW session briefly shows `BTW from main · reattaching...` while parent metadata
-loads.
+Retained BTW sessions survive TUI reloads. Reattaching briefly shows
+`BTW from main · reattaching...` while parent metadata loads. Use `Ctrl+C` from
+an empty side composer when you want to delete that side.

--- a/packages/omo-opencode/src/features/btw-side/tui-controller-types.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-controller-types.ts
@@ -56,3 +56,9 @@ export type BtwSideState =
   | { phase: "open"; parentSessionID: string; sideSessionID: string; owned: boolean }
   | { phase: "closing"; parentSessionID: string; sideSessionID: string; owned: boolean }
 
+export type BtwSideRecord = {
+  parentSessionID: string
+  sideSessionID: string
+  owned: boolean
+}
+

--- a/packages/omo-opencode/src/features/btw-side/tui-controller.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-controller.test.ts
@@ -130,7 +130,7 @@ describe("createBtwSideController", () => {
     // then
     expect(harness.createSession).toHaveBeenCalledTimes(1)
     expect(harness.createSession.mock.calls[0]?.[0]).toMatchObject({
-      title: "BTW · Implement BTW",
+      title: "BTW · what changed?",
       agent: "sisyphus",
       model: {
         providerID: "openai",
@@ -402,6 +402,78 @@ describe("createBtwSideController", () => {
     expect(harness.createSession).toHaveBeenCalledTimes(1)
   })
 
+  it("#given a retained side #when a second inline BTW starts from its parent #then a distinct side receives the second question", async () => {
+    // given
+    let sideIndex = 0
+    const createSession = mock(async () => {
+      sideIndex += 1
+      return {
+        id: `ses_side_${sideIndex}`,
+        title: `BTW ${sideIndex}`,
+      }
+    })
+    const harness = createHarness({ createSession })
+    const firstParentPrompt = createPromptRef("/btw first retained question")
+    const firstSidePrompt = createPromptRef("")
+    const secondParentPrompt = createPromptRef("/btw second retained question")
+    const secondSidePrompt = createPromptRef("")
+
+    // when
+    await harness.controller.startFromPrompt(firstParentPrompt)
+    harness.controller.attachPromptRef("ses_side_1", firstSidePrompt)
+    harness.controller.toggle()
+    await harness.controller.startFromPrompt(secondParentPrompt)
+    harness.controller.attachPromptRef("ses_side_2", secondSidePrompt)
+
+    // then
+    expect(createSession).toHaveBeenCalledTimes(2)
+    expect(firstSidePrompt.input).toBe("first retained question")
+    expect(firstSidePrompt.submitted()).toBe(1)
+    expect(secondSidePrompt.input).toBe("second retained question")
+    expect(secondSidePrompt.submitted()).toBe(1)
+    expect(harness.navigations).toEqual([
+      "ses_side_1",
+      "ses_parent",
+      "ses_side_2",
+    ])
+  })
+
+  it("#given a visible retained side #when inline BTW starts again #then the new side is a sibling of the same parent", async () => {
+    // given
+    let sideIndex = 0
+    const createSession = mock(async () => {
+      sideIndex += 1
+      return {
+        id: `ses_side_${sideIndex}`,
+        title: `BTW ${sideIndex}`,
+      }
+    })
+    const harness = createHarness({ createSession })
+    await harness.controller.startFromPrompt(
+      createPromptRef("/btw first retained question"),
+    )
+
+    // when
+    await harness.controller.startFromPrompt(
+      createPromptRef("/btw sibling retained question"),
+    )
+
+    // then
+    expect(createSession).toHaveBeenCalledTimes(2)
+    expect(createSession.mock.calls[1]?.[0]).toMatchObject({
+      metadata: {
+        [BTW_SIDE_METADATA_KEY]: {
+          parent_session_id: "ses_parent",
+          boundary_message_id: "msg_parent_done",
+        },
+      },
+    })
+    expect(harness.navigations).toEqual([
+      "ses_side_1",
+      "ses_side_2",
+    ])
+  })
+
   it("#given an active side #when close runs #then it returns to the parent and deletes the side", async () => {
     // given
     const harness = createHarness()
@@ -415,6 +487,40 @@ describe("createBtwSideController", () => {
     expect(harness.navigations).toEqual(["ses_side", "ses_parent"])
     expect(harness.deleted).toEqual(["ses_side"])
     expect(harness.controller.state()).toEqual({ phase: "closed" })
+  })
+
+  it("#given two retained sides #when the visible side closes #then only that side is deleted", async () => {
+    // given
+    let sideIndex = 0
+    const harness = createHarness({
+      createSession: async () => {
+        sideIndex += 1
+        return {
+          id: `ses_side_${sideIndex}`,
+          title: `BTW ${sideIndex}`,
+        }
+      },
+    })
+    await harness.controller.startFromPrompt(
+      createPromptRef("/btw first retained question"),
+    )
+    harness.controller.toggle()
+    await harness.controller.startFromPrompt(
+      createPromptRef("/btw second retained question"),
+    )
+
+    // when
+    await harness.controller.close()
+
+    // then
+    expect(harness.aborted).toEqual(["ses_side_2"])
+    expect(harness.deleted).toEqual(["ses_side_2"])
+    expect(harness.navigations).toEqual([
+      "ses_side_1",
+      "ses_parent",
+      "ses_side_2",
+      "ses_parent",
+    ])
   })
 
   it("#given an attachment-only side composer #when close availability is checked #then Ctrl+C does not intercept the draft", async () => {
@@ -565,7 +671,7 @@ describe("createBtwSideController", () => {
     expect(harness.controller.state()).toEqual({ phase: "closed" })
   })
 
-  it("#given an active side #when navigation leaves both related sessions #then the side is discarded", async () => {
+  it("#given a retained side #when navigation opens an unrelated session #then the side remains available", async () => {
     // given
     const harness = createHarness()
     await harness.controller.startFromPrompt(createPromptRef("/btw"))
@@ -574,8 +680,8 @@ describe("createBtwSideController", () => {
     await harness.controller.handleNavigation("ses_unrelated")
 
     // then
-    expect(harness.deleted).toEqual(["ses_side"])
-    expect(harness.controller.state()).toEqual({ phase: "closed" })
+    expect(harness.aborted).toEqual([])
+    expect(harness.deleted).toEqual([])
   })
 
   it("#given an active side is deleted externally #when the event arrives #then the parent route is restored", async () => {
@@ -646,7 +752,19 @@ describe("createBtwSideController", () => {
 
     // then
     expect(harness.navigations).toEqual(["ses_side", "ses_parent"])
-    expect(harness.controller.state()).toEqual({ phase: "closed" })
+    expect(harness.controller.state()).toEqual({
+      phase: "open",
+      parentSessionID: "ses_parent",
+      sideSessionID: "ses_side",
+      owned: true,
+    })
+    expect(harness.controller.sides()).toEqual([
+      {
+        parentSessionID: "ses_parent",
+        sideSessionID: "ses_side",
+        owned: true,
+      },
+    ])
     expect(harness.toasts).toContain(
       "Unable to delete BTW. Delete the abandoned side session manually.",
     )

--- a/packages/omo-opencode/src/features/btw-side/tui-controller.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-controller.test.ts
@@ -708,6 +708,7 @@ describe("createBtwSideController", () => {
 
     // then
     expect(harness.navigations).toEqual(["ses_side"])
+    expect(harness.deleted).toEqual(["ses_side"])
     expect(harness.controller.state()).toEqual({ phase: "closed" })
     expect(harness.toasts).toContain(
       "BTW detached because its main session was deleted.",
@@ -781,6 +782,55 @@ describe("createBtwSideController", () => {
     // then
     expect(harness.deleted).toEqual([])
     expect(harness.aborted).toEqual([])
+    expect(harness.controller.state()).toEqual({ phase: "closed" })
+  })
+
+  it("#given catalog adoption arrives out of order #when canonical numbers are supplied #then status numbering matches picker order", () => {
+    // given
+    const harness = createHarness()
+    harness.controller.adopt("ses_parent", "ses_side_2")
+
+    // when
+    harness.controller.adopt("ses_parent", "ses_side_1", 1)
+    harness.controller.adopt("ses_parent", "ses_side_2", 2)
+
+    // then
+    expect(harness.controller.sideNumber("ses_side_1")).toBe(1)
+    expect(harness.controller.sideNumber("ses_side_2")).toBe(2)
+  })
+
+  it("#given a sibling remains #when close and disposal overlap #then disposal resolves after the current side closes", async () => {
+    // given
+    const deletion = createDeferred<void>()
+    let sideIndex = 0
+    const harness = createHarness({
+      createSession: async () => {
+        sideIndex += 1
+        return {
+          id: `ses_side_${sideIndex}`,
+          title: `BTW ${sideIndex}`,
+        }
+      },
+      deleteSession: async () => deletion.promise,
+    })
+    await harness.controller.startFromPrompt(
+      createPromptRef("/btw first"),
+    )
+    harness.controller.toggle()
+    await harness.controller.startFromPrompt(
+      createPromptRef("/btw second"),
+    )
+    harness.controller.toggle()
+    harness.controller.toggle()
+    const close = harness.controller.close()
+    const dispose = harness.controller.dispose()
+
+    // when
+    deletion.resolve()
+    await Promise.all([close, dispose])
+
+    // then
+    expect(harness.deleted).toEqual([])
     expect(harness.controller.state()).toEqual({ phase: "closed" })
   })
 

--- a/packages/omo-opencode/src/features/btw-side/tui-controller.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-controller.ts
@@ -28,6 +28,7 @@ export function createBtwSideController(
   const closedWaiters = new Set<() => void>()
   const deletedSessionIDs = new Set<string>()
   const retainedSides = new Map<string, BtwSideRecord>()
+  const sideNumbers = new Map<string, number>()
   const promptQueue = createBtwPromptQueue()
 
   function rememberDeletedSession(sessionID: string): void {
@@ -109,8 +110,8 @@ export function createBtwSideController(
       ?? currentSessionID
   }
 
-  async function startFromPrompt(promptRef: BtwPromptRef): Promise<void> {
-    if (disposed) return
+  async function startFromPrompt(promptRef: BtwPromptRef): Promise<boolean> {
+    if (disposed) return false
     if (
       currentState.phase === "creating" ||
       currentState.phase === "closing"
@@ -120,7 +121,7 @@ export function createBtwSideController(
           ? "BTW is already starting."
           : "BTW is still closing.",
       )
-      return
+      return false
     }
 
     const previousState = currentState
@@ -129,7 +130,7 @@ export function createBtwSideController(
       promptRef,
       rootParentForCurrentSession(),
     )
-    if (!prepared) return
+    if (!prepared) return false
     const restoreDraftIfUnchanged = (): void => {
       if (prepared.consumeDraft && promptRef.input.length === 0) {
         promptRef.set(prepared.originalDraft)
@@ -159,7 +160,7 @@ export function createBtwSideController(
         if (isCreatingGeneration(creatingGeneration)) {
           setState(previousState)
         }
-        return
+        return false
       }
       if (disposed || !isCreatingGeneration(creatingGeneration)) {
         if (disposed) {
@@ -173,7 +174,7 @@ export function createBtwSideController(
         } catch {
           dependencies.showToast("Unable to remove cancelled BTW.")
         }
-        return
+        return false
       }
       if (prepared.question.length > 0) {
         promptQueue.queue(sideSession.id, prepared.question)
@@ -189,18 +190,20 @@ export function createBtwSideController(
         ...retainedSide,
       })
       dependencies.navigateSession(sideSession.id)
+      return true
     } catch {
       if (disposed) {
         setState({ phase: "closed" })
-        return
+        return false
       }
       if (!isCreatingGeneration(creatingGeneration)) {
         restoreDraftIfUnchanged()
-        return
+        return false
       }
       restoreDraftIfUnchanged()
       setState(previousState)
       dependencies.showToast("Unable to start BTW.")
+      return false
     } finally {
       activeCreationOperations.delete(creationOperation)
       resolveCreationFinished()
@@ -252,6 +255,7 @@ export function createBtwSideController(
     if (!isClosingGeneration(closingGeneration)) return
     if (!deleted) {
       promptQueue.clear(openState.sideSessionID)
+      setState({ phase: "closed" })
       setState(stateForSession(openState.parentSessionID))
       dependencies.showToast(
         "Unable to delete BTW. Delete the abandoned side session manually.",
@@ -259,7 +263,9 @@ export function createBtwSideController(
       return
     }
     retainedSides.delete(openState.sideSessionID)
+    sideNumbers.delete(openState.sideSessionID)
     promptQueue.clear(openState.sideSessionID)
+    setState({ phase: "closed" })
     setState(stateForSession(openState.parentSessionID))
   }
 
@@ -302,6 +308,7 @@ export function createBtwSideController(
     const deletedSide = retainedSides.get(sessionID)
     if (deletedSide) {
       retainedSides.delete(sessionID)
+      sideNumbers.delete(sessionID)
       promptQueue.clear(sessionID)
       if (dependencies.getCurrentSessionID() === sessionID) {
         dependencies.navigateSession(deletedSide.parentSessionID)
@@ -320,8 +327,29 @@ export function createBtwSideController(
           : undefined
       for (const side of detachedSides) {
         if (side.sideSessionID === closingSideID) continue
+        const sideNumber = sideNumbers.get(side.sideSessionID)
         retainedSides.delete(side.sideSessionID)
+        sideNumbers.delete(side.sideSessionID)
         promptQueue.clear(side.sideSessionID)
+        void deleteBtwSide({
+          sessionID: side.sideSessionID,
+          deleteSession: dependencies.deleteSession,
+          showToast: dependencies.showToast,
+          failureMessage:
+            "Unable to delete BTW after Main was removed. Delete the abandoned side session manually.",
+        }).then((deleted) => {
+          if (deleted || disposed) return
+          retainedSides.set(side.sideSessionID, side)
+          if (sideNumber !== undefined) {
+            sideNumbers.set(side.sideSessionID, sideNumber)
+          }
+          if (
+            dependencies.getCurrentSessionID() ===
+            side.sideSessionID
+          ) {
+            setState(stateForSession(side.sideSessionID))
+          }
+        })
       }
       if (closingSideID) {
         skipClosingParentNavigation = true
@@ -346,13 +374,20 @@ export function createBtwSideController(
     )
   }
 
-  function adopt(parentSessionID: string, sideSessionID: string): void {
+  function adopt(
+    parentSessionID: string,
+    sideSessionID: string,
+    sideNumber?: number,
+  ): void {
     const retainedSide: BtwSideRecord = {
       parentSessionID,
       sideSessionID,
       owned: false,
     }
     retainedSides.set(sideSessionID, retainedSide)
+    if (sideNumber !== undefined) {
+      sideNumbers.set(sideSessionID, sideNumber)
+    }
     if (dependencies.getCurrentSessionID() === sideSessionID) {
       setState({
         phase: "open",
@@ -379,6 +414,8 @@ export function createBtwSideController(
     sides: (): BtwSideRecord[] => [...retainedSides.values()],
     side: (sessionID: string): BtwSideRecord | undefined =>
       retainedSides.get(sessionID),
+    sideNumber: (sessionID: string): number | undefined =>
+      sideNumbers.get(sessionID),
     rootParent: (sessionID: string): string =>
       retainedSides.get(sessionID)?.parentSessionID ?? sessionID,
     startFromPrompt,
@@ -401,6 +438,7 @@ export function createBtwSideController(
       } else if (currentState.phase === "closing") {
         skipClosingParentNavigation = true
         await waitUntilClosed()
+        setState({ phase: "closed" })
       } else if (currentState.phase === "open") {
         setState({ phase: "closed" })
       }

--- a/packages/omo-opencode/src/features/btw-side/tui-controller.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-controller.ts
@@ -1,6 +1,7 @@
 import type {
   BtwPromptRef,
   BtwSideControllerDependencies,
+  BtwSideRecord,
   BtwSideState,
 } from "./tui-controller-types"
 import {
@@ -26,6 +27,7 @@ export function createBtwSideController(
   }>()
   const closedWaiters = new Set<() => void>()
   const deletedSessionIDs = new Set<string>()
+  const retainedSides = new Map<string, BtwSideRecord>()
   const promptQueue = createBtwPromptQueue()
 
   function rememberDeletedSession(sessionID: string): void {
@@ -76,18 +78,57 @@ export function createBtwSideController(
     promptQueue.attach(sessionID, promptRef)
   }
 
+  function latestSideForParent(parentSessionID: string): BtwSideRecord | undefined {
+    return [...retainedSides.values()]
+      .reverse()
+      .find((side) => side.parentSessionID === parentSessionID)
+  }
+
+  function stateForSession(sessionID: string | undefined): BtwSideState {
+    if (!sessionID) return { phase: "closed" }
+    const side = retainedSides.get(sessionID)
+    if (side) {
+      return {
+        phase: "open",
+        ...side,
+      }
+    }
+    const retained = latestSideForParent(sessionID)
+    return retained
+      ? {
+          phase: "open",
+          ...retained,
+        }
+      : { phase: "closed" }
+  }
+
+  function rootParentForCurrentSession(): string | undefined {
+    const currentSessionID = dependencies.getCurrentSessionID()
+    if (!currentSessionID) return undefined
+    return retainedSides.get(currentSessionID)?.parentSessionID
+      ?? currentSessionID
+  }
+
   async function startFromPrompt(promptRef: BtwPromptRef): Promise<void> {
     if (disposed) return
-    if (currentState.phase !== "closed") {
+    if (
+      currentState.phase === "creating" ||
+      currentState.phase === "closing"
+    ) {
       dependencies.showToast(
         currentState.phase === "creating"
           ? "BTW is already starting."
-          : "A BTW conversation is already open.",
+          : "BTW is still closing.",
       )
       return
     }
 
-    const prepared = prepareBtwSideStart(dependencies, promptRef)
+    const previousState = currentState
+    const prepared = prepareBtwSideStart(
+      dependencies,
+      promptRef,
+      rootParentForCurrentSession(),
+    )
     if (!prepared) return
     const restoreDraftIfUnchanged = (): void => {
       if (prepared.consumeDraft && promptRef.input.length === 0) {
@@ -116,7 +157,7 @@ export function createBtwSideController(
       if (deletedSessionIDs.delete(sideSession.id)) {
         if (!disposed) restoreDraftIfUnchanged()
         if (isCreatingGeneration(creatingGeneration)) {
-          setState({ phase: "closed" })
+          setState(previousState)
         }
         return
       }
@@ -125,6 +166,7 @@ export function createBtwSideController(
           setState({ phase: "closed" })
         } else {
           restoreDraftIfUnchanged()
+          setState(previousState)
         }
         try {
           await dependencies.deleteSession(sideSession.id)
@@ -136,11 +178,15 @@ export function createBtwSideController(
       if (prepared.question.length > 0) {
         promptQueue.queue(sideSession.id, prepared.question)
       }
-      setState({
-        phase: "open",
+      const retainedSide: BtwSideRecord = {
         parentSessionID: prepared.parentSessionID,
         sideSessionID: sideSession.id,
         owned: true,
+      }
+      retainedSides.set(sideSession.id, retainedSide)
+      setState({
+        phase: "open",
+        ...retainedSide,
       })
       dependencies.navigateSession(sideSession.id)
     } catch {
@@ -153,7 +199,7 @@ export function createBtwSideController(
         return
       }
       restoreDraftIfUnchanged()
-      setState({ phase: "closed" })
+      setState(previousState)
       dependencies.showToast("Unable to start BTW.")
     } finally {
       activeCreationOperations.delete(creationOperation)
@@ -174,8 +220,11 @@ export function createBtwSideController(
   }
 
   async function close(): Promise<void> {
-    if (currentState.phase !== "open") return
-    const openState = currentState
+    const currentSessionID = dependencies.getCurrentSessionID()
+    const openState = currentSessionID
+      ? retainedSides.get(currentSessionID)
+      : undefined
+    if (!openState) return
     skipClosingParentNavigation = false
     const closingState = {
       phase: "closing",
@@ -203,14 +252,15 @@ export function createBtwSideController(
     if (!isClosingGeneration(closingGeneration)) return
     if (!deleted) {
       promptQueue.clear(openState.sideSessionID)
-      setState({ phase: "closed" })
+      setState(stateForSession(openState.parentSessionID))
       dependencies.showToast(
         "Unable to delete BTW. Delete the abandoned side session manually.",
       )
       return
     }
+    retainedSides.delete(openState.sideSessionID)
     promptQueue.clear(openState.sideSessionID)
-    setState({ phase: "closed" })
+    setState(stateForSession(openState.parentSessionID))
   }
 
   async function handleNavigation(sessionID: string): Promise<void> {
@@ -222,7 +272,7 @@ export function createBtwSideController(
             operation.restoreDraftIfUnchanged()
           }
         }
-        setState({ phase: "closed" })
+        setState(stateForSession(sessionID))
       }
       return
     }
@@ -235,39 +285,7 @@ export function createBtwSideController(
       }
       return
     }
-    if (currentState.phase !== "open") return
-    if (
-      sessionID === currentState.parentSessionID ||
-      sessionID === currentState.sideSessionID
-    ) {
-      return
-    }
-    const openState = currentState
-    setState({
-      phase: "closing",
-      parentSessionID: openState.parentSessionID,
-      sideSessionID: openState.sideSessionID,
-      owned: openState.owned,
-    })
-    const closingGeneration = stateGeneration
-    if (openState.owned) {
-      await abortBtwSide({
-        sessionID: openState.sideSessionID,
-        abortSession: dependencies.abortSession,
-        showToast: dependencies.showToast,
-      })
-      if (!isClosingGeneration(closingGeneration)) return
-      await deleteBtwSide({
-        sessionID: openState.sideSessionID,
-        deleteSession: dependencies.deleteSession,
-        showToast: dependencies.showToast,
-        failureMessage: "Unable to discard BTW.",
-      })
-      if (!isClosingGeneration(closingGeneration)) return
-    }
-    if (!isClosingGeneration(closingGeneration)) return
-    promptQueue.clear(openState.sideSessionID)
-    setState({ phase: "closed" })
+    setState(stateForSession(sessionID))
   }
 
   function handleSessionDeleted(sessionID: string): void {
@@ -281,34 +299,34 @@ export function createBtwSideController(
       }
       return
     }
-    if (
-      currentState.phase === "closing" &&
-      sessionID === currentState.parentSessionID
-    ) {
-      skipClosingParentNavigation = true
-      return
-    }
-    if (
-      currentState.phase !== "open" &&
-      currentState.phase !== "closing"
-    ) {
-      return
-    }
-    if (sessionID === currentState.sideSessionID) {
-      const parentSessionID = currentState.parentSessionID
-      promptQueue.clear(currentState.sideSessionID)
-      setState({ phase: "closed" })
+    const deletedSide = retainedSides.get(sessionID)
+    if (deletedSide) {
+      retainedSides.delete(sessionID)
+      promptQueue.clear(sessionID)
       if (dependencies.getCurrentSessionID() === sessionID) {
-        dependencies.navigateSession(parentSessionID)
+        dependencies.navigateSession(deletedSide.parentSessionID)
       }
+      setState(stateForSession(deletedSide.parentSessionID))
       return
     }
-    if (sessionID === currentState.parentSessionID) {
-      const sideSessionID = currentState.sideSessionID
-      promptQueue.clear(sideSessionID)
-      setState({ phase: "closed" })
-      if (dependencies.getCurrentSessionID() === sessionID) {
-        dependencies.navigateSession(sideSessionID)
+    const detachedSides = [...retainedSides.values()].filter(
+      (side) => side.parentSessionID === sessionID,
+    )
+    if (detachedSides.length > 0) {
+      const closingSideID =
+        currentState.phase === "closing" &&
+        sessionID === currentState.parentSessionID
+          ? currentState.sideSessionID
+          : undefined
+      for (const side of detachedSides) {
+        if (side.sideSessionID === closingSideID) continue
+        retainedSides.delete(side.sideSessionID)
+        promptQueue.clear(side.sideSessionID)
+      }
+      if (closingSideID) {
+        skipClosingParentNavigation = true
+      } else {
+        setState({ phase: "closed" })
       }
       dependencies.showToast(
         "BTW detached because its main session was deleted.",
@@ -317,32 +335,57 @@ export function createBtwSideController(
   }
 
   function canCloseCurrentSide(): boolean {
-    if (currentState.phase !== "open") return false
-    if (dependencies.getCurrentSessionID() !== currentState.sideSessionID) {
-      return false
-    }
+    const currentSessionID = dependencies.getCurrentSessionID()
+    const currentSide = currentSessionID
+      ? retainedSides.get(currentSessionID)
+      : undefined
+    if (!currentSide) return false
     return (
-      promptQueue.input(currentState.sideSessionID).length === 0 &&
-      !promptQueue.hasAttachments(currentState.sideSessionID)
+      promptQueue.input(currentSide.sideSessionID).length === 0 &&
+      !promptQueue.hasAttachments(currentSide.sideSessionID)
     )
   }
 
   function adopt(parentSessionID: string, sideSessionID: string): void {
-    if (currentState.phase !== "closed") return
-    setState({
-      phase: "open",
+    const retainedSide: BtwSideRecord = {
       parentSessionID,
       sideSessionID,
       owned: false,
+    }
+    retainedSides.set(sideSessionID, retainedSide)
+    if (dependencies.getCurrentSessionID() === sideSessionID) {
+      setState({
+        phase: "open",
+        ...retainedSide,
+      })
+    }
+  }
+
+  function returnToParent(): void {
+    const currentSessionID = dependencies.getCurrentSessionID()
+    const currentSide = currentSessionID
+      ? retainedSides.get(currentSessionID)
+      : undefined
+    if (!currentSide) return
+    dependencies.navigateSession(currentSide.parentSessionID)
+    setState({
+      phase: "open",
+      ...currentSide,
     })
   }
 
   return {
     state: (): BtwSideState => currentState,
+    sides: (): BtwSideRecord[] => [...retainedSides.values()],
+    side: (sessionID: string): BtwSideRecord | undefined =>
+      retainedSides.get(sessionID),
+    rootParent: (sessionID: string): string =>
+      retainedSides.get(sessionID)?.parentSessionID ?? sessionID,
     startFromPrompt,
     attachPromptRef,
     toggle,
     close,
+    returnToParent,
     handleNavigation,
     handleSessionDeleted,
     canCloseCurrentSide,
@@ -358,8 +401,6 @@ export function createBtwSideController(
       } else if (currentState.phase === "closing") {
         skipClosingParentNavigation = true
         await waitUntilClosed()
-      } else if (currentState.phase === "open" && currentState.owned) {
-        await handleNavigation("")
       } else if (currentState.phase === "open") {
         setState({ phase: "closed" })
       }

--- a/packages/omo-opencode/src/features/btw-side/tui-escape-return.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-escape-return.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it, mock } from "bun:test"
+import type { KeyEvent } from "@opentui/core"
+import type { KeyInputContext } from "@opentui/keymap"
+
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { registerBtwSideKeymap } from "./tui-keymap"
+
+describe("registerBtwSideKeymap escape return", () => {
+  it("#given an idle visible side #when Escape is pressed twice consecutively #then only the second press returns to the parent", () => {
+    // given
+    let keyInterceptor:
+      | ((context: KeyInputContext<KeyEvent>) => void)
+      | undefined
+    const returnToParent = mock(() => undefined)
+    const firstConsume = mock(() => undefined)
+    const secondConsume = mock(() => undefined)
+    const api = unsafeTestValue({
+      keymap: {
+        registerLayer: () => () => undefined,
+        intercept: (
+          name: string,
+          interceptor: (context: KeyInputContext<KeyEvent>) => void,
+        ) => {
+          if (name === "key") keyInterceptor = interceptor
+          return () => undefined
+        },
+        clearPendingSequence: () => undefined,
+      },
+      mode: {
+        current: () => "base",
+      },
+      ui: {
+        dialog: {
+          open: false,
+        },
+      },
+    })
+    const controller = unsafeTestValue({
+      state: () => ({
+        phase: "open",
+        parentSessionID: "ses_parent",
+        sideSessionID: "ses_side",
+        owned: true,
+      }),
+      toggle: () => undefined,
+      canCloseCurrentSide: () => true,
+      close: async () => undefined,
+    })
+
+    registerBtwSideKeymap(unsafeTestValue({
+      api,
+      controller,
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker: async () => undefined,
+      isCurrentSideIdle: () => true,
+      returnToParent,
+    }))
+    const escapeEvent = unsafeTestValue({
+      name: "escape",
+      eventType: "press",
+    })
+
+    // when
+    keyInterceptor?.(unsafeTestValue({
+      event: escapeEvent,
+      setData: () => undefined,
+      getData: () => undefined,
+      consume: firstConsume,
+    }))
+    keyInterceptor?.(unsafeTestValue({
+      event: escapeEvent,
+      setData: () => undefined,
+      getData: () => undefined,
+      consume: secondConsume,
+    }))
+
+    // then
+    expect(keyInterceptor).toBeInstanceOf(Function)
+    expect(firstConsume).not.toHaveBeenCalled()
+    expect(secondConsume).toHaveBeenCalledWith({
+      preventDefault: true,
+      stopPropagation: true,
+    })
+    expect(returnToParent).toHaveBeenCalledTimes(1)
+  })
+
+  it("#given a busy visible side #when Escape is pressed #then host interruption remains unconsumed", () => {
+    // given
+    let keyInterceptor:
+      | ((context: KeyInputContext<KeyEvent>) => void)
+      | undefined
+    const consume = mock(() => undefined)
+    const returnToParent = mock(() => undefined)
+    const api = unsafeTestValue({
+      keymap: {
+        registerLayer: () => () => undefined,
+        intercept: (
+          name: string,
+          interceptor: (context: KeyInputContext<KeyEvent>) => void,
+        ) => {
+          if (name === "key") keyInterceptor = interceptor
+          return () => undefined
+        },
+        clearPendingSequence: () => undefined,
+      },
+      mode: {
+        current: () => "base",
+      },
+      ui: {
+        dialog: {
+          open: false,
+        },
+      },
+    })
+
+    registerBtwSideKeymap(unsafeTestValue({
+      api,
+      controller: {
+        state: () => ({ phase: "closed" }),
+        toggle: () => undefined,
+        canCloseCurrentSide: () => false,
+        close: async () => undefined,
+      },
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker: async () => undefined,
+      isCurrentSideIdle: () => false,
+      returnToParent,
+    }))
+
+    // when
+    keyInterceptor?.(unsafeTestValue({
+      event: {
+        name: "escape",
+        eventType: "press",
+      },
+      setData: () => undefined,
+      getData: () => undefined,
+      consume,
+    }))
+
+    // then
+    expect(keyInterceptor).toBeInstanceOf(Function)
+    expect(consume).not.toHaveBeenCalled()
+    expect(returnToParent).not.toHaveBeenCalled()
+  })
+
+  it("#given one pending Escape #when a non-Escape key intervenes #then the next Escape starts a fresh sequence", () => {
+    // given
+    let keyInterceptor:
+      | ((context: KeyInputContext<KeyEvent>) => void)
+      | undefined
+    const returnToParent = mock(() => undefined)
+    const api = unsafeTestValue({
+      keymap: {
+        registerLayer: () => () => undefined,
+        intercept: (
+          _name: string,
+          interceptor: (context: KeyInputContext<KeyEvent>) => void,
+        ) => {
+          keyInterceptor = interceptor
+          return () => undefined
+        },
+        clearPendingSequence: () => undefined,
+      },
+      mode: {
+        current: () => "base",
+      },
+      ui: {
+        dialog: {
+          open: false,
+        },
+      },
+    })
+    registerBtwSideKeymap(unsafeTestValue({
+      api,
+      controller: {
+        state: () => ({ phase: "closed" }),
+        canCloseCurrentSide: () => false,
+        close: async () => undefined,
+      },
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker: async () => undefined,
+      isCurrentSideIdle: () => true,
+      returnToParent,
+    }))
+    const press = (name: string) => {
+      keyInterceptor?.(unsafeTestValue({
+        event: {
+          name,
+          eventType: "press",
+        },
+        setData: () => undefined,
+        getData: () => undefined,
+        consume: () => undefined,
+      }))
+    }
+
+    // when
+    press("escape")
+    press("a")
+    press("escape")
+
+    // then
+    expect(returnToParent).not.toHaveBeenCalled()
+  })
+
+  it("#given one pending Escape #when a dialog opens #then dialog Escape resets the sequence", () => {
+    // given
+    let dialogOpen = false
+    let keyInterceptor:
+      | ((context: KeyInputContext<KeyEvent>) => void)
+      | undefined
+    const returnToParent = mock(() => undefined)
+    const api = unsafeTestValue({
+      keymap: {
+        registerLayer: () => () => undefined,
+        intercept: (
+          _name: string,
+          interceptor: (context: KeyInputContext<KeyEvent>) => void,
+        ) => {
+          keyInterceptor = interceptor
+          return () => undefined
+        },
+        clearPendingSequence: () => undefined,
+      },
+      mode: {
+        current: () => "base",
+      },
+      ui: {
+        dialog: {
+          get open() {
+            return dialogOpen
+          },
+        },
+      },
+    })
+    registerBtwSideKeymap(unsafeTestValue({
+      api,
+      controller: {
+        state: () => ({ phase: "closed" }),
+        canCloseCurrentSide: () => false,
+        close: async () => undefined,
+      },
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker: async () => undefined,
+      isCurrentSideIdle: () => true,
+      returnToParent,
+    }))
+    const pressEscape = () => {
+      keyInterceptor?.(unsafeTestValue({
+        event: {
+          name: "escape",
+          eventType: "press",
+        },
+        setData: () => undefined,
+        getData: () => undefined,
+        consume: () => undefined,
+      }))
+    }
+
+    // when
+    pressEscape()
+    dialogOpen = true
+    pressEscape()
+    dialogOpen = false
+    pressEscape()
+
+    // then
+    expect(returnToParent).not.toHaveBeenCalled()
+  })
+
+  it("#given one pending Escape #when navigation resets controls #then the next Escape does not return", () => {
+    // given
+    let keyInterceptor:
+      | ((context: KeyInputContext<KeyEvent>) => void)
+      | undefined
+    const returnToParent = mock(() => undefined)
+    const registration = registerBtwSideKeymap(unsafeTestValue({
+      api: {
+        keymap: {
+          registerLayer: () => () => undefined,
+          intercept: (
+            _name: string,
+            interceptor: (context: KeyInputContext<KeyEvent>) => void,
+          ) => {
+            keyInterceptor = interceptor
+            return () => undefined
+          },
+          clearPendingSequence: () => undefined,
+        },
+        mode: {
+          current: () => "base",
+        },
+        ui: {
+          dialog: {
+            open: false,
+          },
+        },
+      },
+      controller: {
+        state: () => ({ phase: "closed" }),
+        canCloseCurrentSide: () => false,
+        close: async () => undefined,
+      },
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker: async () => undefined,
+      isCurrentSideIdle: () => true,
+      returnToParent,
+    }))
+    const pressEscape = () => {
+      keyInterceptor?.(unsafeTestValue({
+        event: {
+          name: "escape",
+          eventType: "press",
+        },
+        setData: () => undefined,
+        getData: () => undefined,
+        consume: () => undefined,
+      }))
+    }
+
+    // when
+    pressEscape()
+    registration.resetEscapeSequence()
+    pressEscape()
+
+    // then
+    expect(returnToParent).not.toHaveBeenCalled()
+  })
+})

--- a/packages/omo-opencode/src/features/btw-side/tui-escape-return.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-escape-return.test.ts
@@ -332,4 +332,64 @@ describe("registerBtwSideKeymap escape return", () => {
     // then
     expect(returnToParent).not.toHaveBeenCalled()
   })
+
+  it("#given one pending Escape #when a held Escape repeats #then a later press starts a fresh sequence", () => {
+    // given
+    let keyInterceptor:
+      | ((context: KeyInputContext<KeyEvent>) => void)
+      | undefined
+    const returnToParent = mock(() => undefined)
+    registerBtwSideKeymap(unsafeTestValue({
+      api: {
+        keymap: {
+          registerLayer: () => () => undefined,
+          intercept: (
+            _name: string,
+            interceptor: (context: KeyInputContext<KeyEvent>) => void,
+          ) => {
+            keyInterceptor = interceptor
+            return () => undefined
+          },
+          clearPendingSequence: () => undefined,
+        },
+        mode: {
+          current: () => "base",
+        },
+        ui: {
+          dialog: {
+            open: false,
+          },
+        },
+      },
+      controller: {
+        state: () => ({ phase: "closed" }),
+        canCloseCurrentSide: () => false,
+        close: async () => undefined,
+      },
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker: async () => undefined,
+      isCurrentSideIdle: () => true,
+      returnToParent,
+    }))
+    const sendEscape = (eventType: "press" | "repeat") => {
+      keyInterceptor?.(unsafeTestValue({
+        event: {
+          name: "escape",
+          eventType,
+        },
+        setData: () => undefined,
+        getData: () => undefined,
+        consume: () => undefined,
+      }))
+    }
+
+    // when
+    sendEscape("press")
+    sendEscape("repeat")
+    sendEscape("press")
+
+    // then
+    expect(returnToParent).not.toHaveBeenCalled()
+  })
 })

--- a/packages/omo-opencode/src/features/btw-side/tui-escape-return.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-escape-return.ts
@@ -18,7 +18,7 @@ export function createBtwEscapeReturn(args: {
       context.event.eventType !== "press" ||
       context.event.name !== "escape"
     ) {
-      if (context.event.eventType === "press") reset()
+      if (context.event.eventType !== "release") reset()
       return
     }
     if (args.isDialogOpen() || !args.isCurrentSideIdle()) {

--- a/packages/omo-opencode/src/features/btw-side/tui-escape-return.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-escape-return.ts
@@ -1,0 +1,46 @@
+import type { KeyEvent } from "@opentui/core"
+import type { KeyInputContext } from "@opentui/keymap"
+
+export function createBtwEscapeReturn(args: {
+  isCurrentSideIdle: () => boolean
+  isDialogOpen: () => boolean
+  clearPending: () => void
+  returnToParent: () => void
+}) {
+  let firstEscapePending = false
+
+  function reset(): void {
+    firstEscapePending = false
+  }
+
+  function handle(context: KeyInputContext<KeyEvent>): void {
+    if (
+      context.event.eventType !== "press" ||
+      context.event.name !== "escape"
+    ) {
+      if (context.event.eventType === "press") reset()
+      return
+    }
+    if (args.isDialogOpen() || !args.isCurrentSideIdle()) {
+      reset()
+      return
+    }
+    if (!firstEscapePending) {
+      firstEscapePending = true
+      return
+    }
+
+    reset()
+    args.clearPending()
+    context.consume({
+      preventDefault: true,
+      stopPropagation: true,
+    })
+    args.returnToParent()
+  }
+
+  return {
+    handle,
+    reset,
+  }
+}

--- a/packages/omo-opencode/src/features/btw-side/tui-keymap.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-keymap.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it, mock } from "bun:test"
+import type { KeyEvent } from "@opentui/core"
+import type {
+  KeyInputContext,
+  RawInputContext,
+} from "@opentui/keymap"
 
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import { registerBtwSideKeymap } from "./tui-keymap"
@@ -79,5 +84,176 @@ describe("registerBtwSideKeymap", () => {
     )
     expect(openPicker).toHaveBeenCalledTimes(1)
     expect(toggle).not.toHaveBeenCalled()
+  })
+
+  it("#given xterm encodes Ctrl slash as control underscore #when intercepted #then the picker command dispatches before host handling", () => {
+    // given
+    let keyInterceptor:
+      | ((context: KeyInputContext<KeyEvent>) => void)
+      | undefined
+    const openPicker = mock(async () => undefined)
+    const consume = mock(() => undefined)
+    const api = unsafeTestValue({
+      keymap: {
+        registerLayer: () => () => undefined,
+        intercept: (
+          _name: string,
+          interceptor: (context: KeyInputContext<KeyEvent>) => void,
+        ) => {
+          keyInterceptor = interceptor
+          return () => undefined
+        },
+        clearPendingSequence: () => undefined,
+      },
+      mode: {
+        current: () => "base",
+      },
+      ui: {
+        dialog: {
+          open: false,
+        },
+      },
+    })
+    registerBtwSideKeymap(unsafeTestValue({
+      api,
+      controller: {
+        state: () => ({ phase: "closed" }),
+        canCloseCurrentSide: () => false,
+        close: async () => undefined,
+      },
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker,
+      isCurrentSideIdle: () => false,
+      returnToParent: () => undefined,
+    }))
+
+    // when
+    keyInterceptor?.(unsafeTestValue({
+      event: {
+        name: "_",
+        ctrl: true,
+        eventType: "press",
+      },
+      setData: () => undefined,
+      getData: () => undefined,
+      consume,
+    }))
+
+    // then
+    expect(consume).toHaveBeenCalledWith({
+      preventDefault: true,
+      stopPropagation: true,
+    })
+    expect(openPicker).toHaveBeenCalledTimes(1)
+  })
+
+  it("#given xterm emits the Ctrl slash control byte #when raw input arrives #then parsing is stopped and the picker opens", () => {
+    // given
+    let rawInterceptor:
+      | ((context: RawInputContext) => void)
+      | undefined
+    const openPicker = mock(async () => undefined)
+    const stop = mock(() => undefined)
+    const api = unsafeTestValue({
+      keymap: {
+        registerLayer: () => () => undefined,
+        intercept: (
+          name: string,
+          interceptor: (context: RawInputContext) => void,
+        ) => {
+          if (name === "raw") rawInterceptor = interceptor
+          return () => undefined
+        },
+        clearPendingSequence: () => undefined,
+      },
+      mode: {
+        current: () => "base",
+      },
+      ui: {
+        dialog: {
+          open: false,
+        },
+        toast: () => undefined,
+      },
+    })
+    registerBtwSideKeymap(unsafeTestValue({
+      api,
+      controller: {
+        state: () => ({ phase: "closed" }),
+        canCloseCurrentSide: () => false,
+        close: async () => undefined,
+      },
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker,
+      isCurrentSideIdle: () => false,
+      returnToParent: () => undefined,
+    }))
+
+    // when
+    rawInterceptor?.({
+      sequence: "\u001f",
+      stop,
+    })
+
+    // then
+    expect(stop).toHaveBeenCalledTimes(1)
+    expect(openPicker).toHaveBeenCalledTimes(1)
+  })
+
+  it("#given the parser drops xterm Ctrl slash #when raw stdin receives it #then BTW opens the picker once", async () => {
+    // given
+    let stdinData: ((data: Buffer) => void) | undefined
+    const openPicker = mock(async () => undefined)
+    const api = unsafeTestValue({
+      keymap: {
+        registerLayer: () => () => undefined,
+        intercept: () => () => undefined,
+        clearPendingSequence: () => undefined,
+      },
+      mode: {
+        current: () => "base",
+      },
+      ui: {
+        dialog: {
+          open: false,
+        },
+        toast: () => undefined,
+      },
+      renderer: {
+        stdin: {
+          prependListener: (
+            _name: string,
+            handler: (data: Buffer) => void,
+          ) => {
+            stdinData = handler
+          },
+          off: () => undefined,
+        },
+      },
+    })
+    registerBtwSideKeymap(unsafeTestValue({
+      api,
+      controller: {
+        state: () => ({ phase: "closed" }),
+        canCloseCurrentSide: () => false,
+        close: async () => undefined,
+      },
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker,
+      isCurrentSideIdle: () => false,
+      returnToParent: () => undefined,
+    }))
+
+    // when
+    stdinData?.(Buffer.from("paste\u001fcontent"))
+    stdinData?.(Buffer.from([0x1f]))
+    stdinData?.(Buffer.from([0x1f]))
+    await Promise.resolve()
+
+    // then
+    expect(openPicker).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/omo-opencode/src/features/btw-side/tui-keymap.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-keymap.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, mock } from "bun:test"
+
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { registerBtwSideKeymap } from "./tui-keymap"
+
+type TestCommand = {
+  name: string
+  run?: () => void | Promise<void>
+}
+
+type TestLayer = {
+  commands?: TestCommand[]
+  bindings?: Array<{
+    key: string
+    cmd: string
+  }>
+}
+
+describe("registerBtwSideKeymap", () => {
+  it("#given retained BTW sessions #when switch bindings register #then every Ctrl slash encoding opens the picker", async () => {
+    // given
+    const layers: TestLayer[] = []
+    const openPicker = mock(async () => undefined)
+    const toggle = mock(() => undefined)
+    const api = unsafeTestValue({
+      keymap: {
+        registerLayer: (layer: TestLayer) => {
+          layers.push(layer)
+          return () => undefined
+        },
+      },
+      mode: {
+        current: () => "base",
+      },
+    })
+    const controller = unsafeTestValue({
+      state: () => ({
+        phase: "open",
+        parentSessionID: "ses_parent",
+        sideSessionID: "ses_side",
+        owned: true,
+      }),
+      toggle,
+      canCloseCurrentSide: () => true,
+      close: async () => undefined,
+    })
+
+    // when
+    registerBtwSideKeymap(unsafeTestValue({
+      api,
+      controller,
+      activePromptRef: () => undefined,
+      openBtw: async () => undefined,
+      openPicker,
+    }))
+    const switchCommand = layers
+      .flatMap((layer) => layer.commands ?? [])
+      .find((command) => command.name === "omo.btw.toggle")
+    await switchCommand?.run?.()
+
+    // then
+    expect(
+      layers.flatMap((layer) => layer.bindings ?? []),
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          key: "ctrl+/",
+          cmd: "omo.btw.toggle",
+        },
+        {
+          key: "ctrl+_",
+          cmd: "omo.btw.toggle",
+        },
+        {
+          key: "ctrl+7",
+          cmd: "omo.btw.toggle",
+        },
+      ]),
+    )
+    expect(openPicker).toHaveBeenCalledTimes(1)
+    expect(toggle).not.toHaveBeenCalled()
+  })
+})

--- a/packages/omo-opencode/src/features/btw-side/tui-keymap.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-keymap.ts
@@ -1,13 +1,24 @@
 import type {
+  KeyEvent,
   TuiPluginApi,
   TuiPromptRef,
 } from "@opencode-ai/plugin/tui"
+import type { KeyInputContext } from "@opentui/keymap"
 
+import { log } from "../../shared/logger"
 import { isBtwCommandDraft } from "./btw-command-draft"
 import type { createBtwSideController } from "./tui-controller"
 import { createBtwEscapeReturn } from "./tui-escape-return"
 
 type BtwSideController = ReturnType<typeof createBtwSideController>
+
+function isBtwPickerKey(event: KeyEvent): boolean {
+  return (
+    event.eventType === "press" &&
+    event.ctrl &&
+    (event.name === "/" || event.name === "_" || event.name === "7")
+  )
+}
 
 export type BtwSideKeymapRegistration = {
   unregister: Array<() => void>
@@ -29,16 +40,96 @@ export function registerBtwSideKeymap(args: {
     clearPending: () => args.api.keymap.clearPendingSequence(),
     returnToParent: args.returnToParent,
   })
-  const unregisterEscape =
+  let shortcutOpening = false
+  const openPickerFromShortcut = (name: string): void => {
+    if (shortcutOpening) return
+    shortcutOpening = true
+    log("[btw-side] Picker keyboard shortcut intercepted", {
+      name,
+    })
+    escapeReturn.reset()
+    args.api.keymap.clearPendingSequence?.()
+    void args.openPicker()
+      .catch((error) => {
+        log("[btw-side] Failed to open picker from keyboard shortcut", {
+          error,
+        })
+        args.api.ui.toast({
+          variant: "error",
+          message: "Unable to open BTW conversations.",
+        })
+      })
+      .finally(() => {
+        shortcutOpening = false
+      })
+  }
+  const interceptKey = (context: KeyInputContext<KeyEvent>): void => {
+    if (isBtwPickerKey(context.event)) {
+      context.consume({
+        preventDefault: true,
+        stopPropagation: true,
+      })
+      openPickerFromShortcut(context.event.name)
+      return
+    }
+    escapeReturn.handle(context)
+  }
+  const internalKeyInput = args.api.renderer?._internalKeyInput
+  // OpenTUI runs these global listeners before focused Prompt key bindings.
+  // Keep the keymap interceptor below as a fallback when this hook is absent.
+  const handleGlobalKeypress = (event: KeyEvent): void => {
+    interceptKey({
+      event,
+      setData: () => undefined,
+      getData: () => undefined,
+      consume: (options) => {
+        if (options?.preventDefault !== false) event.preventDefault()
+        if (options?.stopPropagation !== false) event.stopPropagation()
+      },
+    })
+  }
+  internalKeyInput?.prependListener?.(
+    "keypress",
+    handleGlobalKeypress,
+  )
+  const unregisterGlobalKeypress = (): void => {
+    internalKeyInput?.off?.("keypress", handleGlobalKeypress)
+  }
+  const handleStdinData = (data: string | Buffer): void => {
+    const sequence =
+      typeof data === "string" ? data : data.toString("utf8")
+    // xterm emits every Ctrl slash alias as 0x1f, which OpenTUI drops pre-keymap.
+    if (sequence !== "\u001f") return
+    openPickerFromShortcut("ctrl+/")
+  }
+  args.api.renderer?.stdin?.prependListener?.("data", handleStdinData)
+  const unregisterStdinData = (): void => {
+    args.api.renderer?.stdin?.off?.("data", handleStdinData)
+  }
+  const unregisterRawShortcut =
     args.api.keymap.intercept?.(
-      "key",
-      escapeReturn.handle,
+      "raw",
+      (context) => {
+        if (context.sequence !== "\u001f") return
+        context.stop()
+        openPickerFromShortcut("ctrl+/")
+      },
       {
-        priority: 50_000,
+        priority: Number.MAX_SAFE_INTEGER,
       },
     ) ?? (() => undefined)
+  const unregisterEscape = internalKeyInput
+    ? () => undefined
+    : (
+        args.api.keymap.intercept?.(
+          "key",
+          interceptKey,
+          {
+            priority: Number.MAX_SAFE_INTEGER,
+          },
+        ) ?? (() => undefined)
+      )
   const unregisterCommandLayer = args.api.keymap.registerLayer({
-    mode: args.api.mode.current(),
     priority: 20_000,
     commands: [
       {
@@ -55,7 +146,7 @@ export function registerBtwSideKeymap(args: {
         title: "Switch BTW conversation",
         hidden: true,
         enabled: true,
-        run: () => args.openPicker(),
+        run: () => openPickerFromShortcut("binding"),
       },
       {
         name: "omo.btw.close",
@@ -66,6 +157,27 @@ export function registerBtwSideKeymap(args: {
       },
     ],
     bindings: [
+      {
+        key: {
+          name: "_",
+          ctrl: true,
+        },
+        cmd: "omo.btw.toggle",
+      },
+      {
+        key: {
+          name: "/",
+          ctrl: true,
+        },
+        cmd: "omo.btw.toggle",
+      },
+      {
+        key: {
+          name: "7",
+          ctrl: true,
+        },
+        cmd: "omo.btw.toggle",
+      },
       {
         key: "ctrl+/",
         cmd: "omo.btw.toggle",
@@ -88,7 +200,6 @@ export function registerBtwSideKeymap(args: {
   })
 
   const unregisterInlineLayer = args.api.keymap.registerLayer({
-    mode: args.api.mode.current(),
     priority: 10_000,
     enabled: () => {
       const promptRef = args.activePromptRef()
@@ -104,6 +215,9 @@ export function registerBtwSideKeymap(args: {
 
   return {
     unregister: [
+      unregisterStdinData,
+      unregisterGlobalKeypress,
+      unregisterRawShortcut,
       unregisterEscape,
       unregisterInlineLayer,
       unregisterCommandLayer,

--- a/packages/omo-opencode/src/features/btw-side/tui-keymap.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-keymap.ts
@@ -5,15 +5,38 @@ import type {
 
 import { isBtwCommandDraft } from "./btw-command-draft"
 import type { createBtwSideController } from "./tui-controller"
+import { createBtwEscapeReturn } from "./tui-escape-return"
 
 type BtwSideController = ReturnType<typeof createBtwSideController>
+
+export type BtwSideKeymapRegistration = {
+  unregister: Array<() => void>
+  resetEscapeSequence: () => void
+}
 
 export function registerBtwSideKeymap(args: {
   api: TuiPluginApi
   controller: BtwSideController
   activePromptRef: () => TuiPromptRef | undefined
   openBtw: () => Promise<void>
-}): Array<() => void> {
+  openPicker: () => Promise<void>
+  isCurrentSideIdle: () => boolean
+  returnToParent: () => void
+}): BtwSideKeymapRegistration {
+  const escapeReturn = createBtwEscapeReturn({
+    isCurrentSideIdle: args.isCurrentSideIdle,
+    isDialogOpen: () => args.api.ui.dialog?.open ?? false,
+    clearPending: () => args.api.keymap.clearPendingSequence(),
+    returnToParent: args.returnToParent,
+  })
+  const unregisterEscape =
+    args.api.keymap.intercept?.(
+      "key",
+      escapeReturn.handle,
+      {
+        priority: 50_000,
+      },
+    ) ?? (() => undefined)
   const unregisterCommandLayer = args.api.keymap.registerLayer({
     mode: args.api.mode.current(),
     priority: 20_000,
@@ -31,8 +54,8 @@ export function registerBtwSideKeymap(args: {
         name: "omo.btw.toggle",
         title: "Switch BTW conversation",
         hidden: true,
-        enabled: () => args.controller.state().phase === "open",
-        run: () => args.controller.toggle(),
+        enabled: true,
+        run: () => args.openPicker(),
       },
       {
         name: "omo.btw.close",
@@ -49,6 +72,10 @@ export function registerBtwSideKeymap(args: {
       },
       {
         key: "ctrl+_",
+        cmd: "omo.btw.toggle",
+      },
+      {
+        key: "ctrl+7",
         cmd: "omo.btw.toggle",
       },
       {
@@ -75,6 +102,13 @@ export function registerBtwSideKeymap(args: {
     ],
   })
 
-  return [unregisterInlineLayer, unregisterCommandLayer]
+  return {
+    unregister: [
+      unregisterEscape,
+      unregisterInlineLayer,
+      unregisterCommandLayer,
+    ],
+    resetEscapeSequence: escapeReturn.reset,
+  }
 }
 

--- a/packages/omo-opencode/src/features/btw-side/tui-picker-options.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-picker-options.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test"
+
+import { buildBtwPickerOptions } from "./tui-picker-options"
+import type { BtwSessionCatalog } from "./tui-session-catalog"
+
+describe("buildBtwPickerOptions", () => {
+  it("#given retained sides #when options build #then Main stable numbers summaries and New BTW are distinct", () => {
+    // given
+    const catalog: BtwSessionCatalog = {
+      main: {
+        id: "ses_parent",
+        title: "Main implementation",
+        time: {
+          created: 1,
+          updated: 10,
+        },
+      },
+      sides: [
+        {
+          id: "ses_side_1",
+          title: "BTW · first retained question",
+          time: {
+            created: 2,
+            updated: 20,
+          },
+        },
+        {
+          id: "ses_side_2",
+          title: "BTW · second retained question",
+          time: {
+            created: 3,
+            updated: 30,
+          },
+        },
+      ],
+    }
+
+    // when
+    const result = buildBtwPickerOptions(catalog, "ses_side_2")
+
+    // then
+    expect(result.options.map((option) => option.title)).toEqual([
+      "Main · Main implementation",
+      "BTW #1 · first retained question",
+      "BTW #2 · second retained question",
+      "New BTW",
+    ])
+    expect(result.options.map((option) => option.category)).toEqual([
+      "Main conversation",
+      "Retained BTW sessions",
+      "Retained BTW sessions",
+      "Actions",
+    ])
+    expect(result.current).toBe("session:ses_side_2")
+  })
+
+  it("#given untitled rows #when options build #then readable fallbacks replace empty labels", () => {
+    // given
+    const catalog: BtwSessionCatalog = {
+      main: {
+        id: "ses_parent",
+        title: "",
+        time: {
+          created: 1,
+          updated: 1,
+        },
+      },
+      sides: [
+        {
+          id: "ses_side",
+          title: "BTW · ",
+          time: {
+            created: 2,
+            updated: 2,
+          },
+        },
+      ],
+    }
+
+    // when
+    const result = buildBtwPickerOptions(catalog, "ses_parent")
+
+    // then
+    expect(result.options[0]?.title).toBe("Main · Untitled conversation")
+    expect(result.options[1]?.title).toBe("BTW #1 · Untitled side")
+  })
+})

--- a/packages/omo-opencode/src/features/btw-side/tui-picker-options.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-picker-options.test.ts
@@ -84,4 +84,36 @@ describe("buildBtwPickerOptions", () => {
     expect(result.options[0]?.title).toBe("Main · Untitled conversation")
     expect(result.options[1]?.title).toBe("BTW #1 · Untitled side")
   })
+
+  it("#given no retained sides #when options build #then an explanatory disabled row points to New BTW", () => {
+    // given
+    const catalog: BtwSessionCatalog = {
+      main: {
+        id: "ses_parent",
+        title: "Main",
+        time: {
+          created: 1,
+          updated: 1,
+        },
+      },
+      sides: [],
+    }
+
+    // when
+    const result = buildBtwPickerOptions(catalog, "ses_parent")
+
+    // then
+    expect(result.options).toEqual([
+      expect.objectContaining({
+        title: "Main · Main",
+      }),
+      expect.objectContaining({
+        title: "No retained BTW sessions yet",
+        disabled: true,
+      }),
+      expect.objectContaining({
+        title: "New BTW",
+      }),
+    ])
+  })
 })

--- a/packages/omo-opencode/src/features/btw-side/tui-picker-options.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-picker-options.ts
@@ -1,0 +1,93 @@
+import type { BtwSessionCatalog } from "./tui-session-catalog"
+
+const SESSION_VALUE_PREFIX = "session:"
+const NEW_VALUE_PREFIX = "new:"
+
+export type BtwPickerOption = {
+  title: string
+  value: string
+  description: string
+  category: string
+}
+
+export type BtwPickerSelection =
+  | {
+      type: "session"
+      sessionID: string
+    }
+  | {
+      type: "new"
+      parentSessionID: string
+    }
+
+function sessionValue(sessionID: string): string {
+  return `${SESSION_VALUE_PREFIX}${sessionID}`
+}
+
+function sideSummary(title: string): string {
+  const summary = title.replace(/^BTW\s*·\s*/, "").trim()
+  return summary || "Untitled side"
+}
+
+export function parseBtwPickerValue(
+  value: string,
+): BtwPickerSelection | undefined {
+  if (value.startsWith(SESSION_VALUE_PREFIX)) {
+    const sessionID = value.slice(SESSION_VALUE_PREFIX.length)
+    return sessionID
+      ? {
+          type: "session",
+          sessionID,
+        }
+      : undefined
+  }
+  if (value.startsWith(NEW_VALUE_PREFIX)) {
+    const parentSessionID = value.slice(NEW_VALUE_PREFIX.length)
+    return parentSessionID
+      ? {
+          type: "new",
+          parentSessionID,
+        }
+      : undefined
+  }
+  return undefined
+}
+
+export function buildBtwPickerOptions(
+  catalog: BtwSessionCatalog,
+  currentSessionID: string,
+): {
+  options: BtwPickerOption[]
+  current: string
+} {
+  const mainTitle = catalog.main.title.trim() || "Untitled conversation"
+  const options: BtwPickerOption[] = [
+    {
+      title: `Main · ${mainTitle}`,
+      value: sessionValue(catalog.main.id),
+      description: catalog.main.id,
+      category: "Main conversation",
+    },
+    ...catalog.sides.map((side, index) => ({
+      title: `BTW #${index + 1} · ${sideSummary(side.title)}`,
+      value: sessionValue(side.id),
+      description: side.id,
+      category: "Retained BTW sessions",
+    })),
+    {
+      title: "New BTW",
+      value: `${NEW_VALUE_PREFIX}${catalog.main.id}`,
+      description: "Start another retained side conversation",
+      category: "Actions",
+    },
+  ]
+  const current = options.some(
+    (option) => option.value === sessionValue(currentSessionID),
+  )
+    ? sessionValue(currentSessionID)
+    : sessionValue(catalog.main.id)
+  return {
+    options,
+    current,
+  }
+}

--- a/packages/omo-opencode/src/features/btw-side/tui-picker-options.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-picker-options.ts
@@ -8,6 +8,7 @@ export type BtwPickerOption = {
   value: string
   description: string
   category: string
+  disabled?: boolean
 }
 
 export type BtwPickerSelection =
@@ -68,6 +69,17 @@ export function buildBtwPickerOptions(
       description: catalog.main.id,
       category: "Main conversation",
     },
+    ...(catalog.sides.length === 0
+      ? [
+          {
+            title: "No retained BTW sessions yet",
+            value: "empty",
+            description: "Choose New BTW to start one",
+            category: "Retained BTW sessions",
+            disabled: true,
+          },
+        ]
+      : []),
     ...catalog.sides.map((side, index) => ({
       title: `BTW #${index + 1} · ${sideSummary(side.title)}`,
       value: sessionValue(side.id),

--- a/packages/omo-opencode/src/features/btw-side/tui-picker.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-picker.ts
@@ -21,14 +21,14 @@ export async function openBtwPicker(args: {
   api: TuiPluginApi
   controller: BtwSideController
   activePromptRef: () => TuiPromptRef | undefined
-}): Promise<void> {
+}): Promise<boolean> {
   const currentSessionID = currentTuiSessionID(args.api)
   if (!currentSessionID) {
     args.api.ui.toast({
       variant: "warning",
       message: "BTW is unavailable before the session starts.",
     })
-    return
+    return false
   }
 
   let loaded: Awaited<ReturnType<typeof loadBtwSessionCatalog>>
@@ -47,14 +47,21 @@ export async function openBtwPicker(args: {
       variant: "error",
       message: "Unable to list BTW conversations.",
     })
-    return
+    return false
+  }
+  if (!loaded.catalog && loaded.truncated) {
+    args.api.ui.toast({
+      variant: "warning",
+      message: "The BTW list is too large to show completely.",
+    })
+    return false
   }
   if (!loaded.catalog) {
     args.api.ui.toast({
       variant: "warning",
       message: "This BTW conversation no longer has a main session.",
     })
-    return
+    return false
   }
   if (loaded.truncated) {
     args.api.ui.toast({
@@ -63,8 +70,8 @@ export async function openBtwPicker(args: {
     })
   }
 
-  for (const side of loaded.catalog.sides) {
-    args.controller.adopt(loaded.catalog.main.id, side.id)
+  for (const [index, side] of loaded.catalog.sides.entries()) {
+    args.controller.adopt(loaded.catalog.main.id, side.id, index + 1)
   }
   const picker = buildBtwPickerOptions(
     loaded.catalog,
@@ -84,7 +91,6 @@ export async function openBtwPicker(args: {
     if (!selection) return
     if (selection.type === "new") {
       const promptRef = args.activePromptRef()
-      args.api.ui.dialog.clear()
       if (!promptRef) {
         args.api.ui.toast({
           variant: "warning",
@@ -92,7 +98,10 @@ export async function openBtwPicker(args: {
         })
         return
       }
-      await args.controller.startFromPrompt(adaptTuiPromptRef(promptRef))
+      const started = await args.controller.startFromPrompt(
+        adaptTuiPromptRef(promptRef),
+      )
+      if (started) args.api.ui.dialog.clear()
       return
     }
 
@@ -128,4 +137,5 @@ export async function openBtwPicker(args: {
       onSelect: (option) => select(option.value),
     }),
   )
+  return true
 }

--- a/packages/omo-opencode/src/features/btw-side/tui-picker.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-picker.ts
@@ -1,0 +1,131 @@
+import type {
+  TuiPluginApi,
+  TuiPromptRef,
+} from "@opencode-ai/plugin/tui"
+
+import { log } from "../../shared/logger"
+import type { createBtwSideController } from "./tui-controller"
+import {
+  buildBtwPickerOptions,
+  parseBtwPickerValue,
+} from "./tui-picker-options"
+import { loadBtwSessionCatalog } from "./tui-session-catalog"
+import {
+  adaptTuiPromptRef,
+  currentTuiSessionID,
+} from "./tui-session-bridge"
+
+type BtwSideController = ReturnType<typeof createBtwSideController>
+
+export async function openBtwPicker(args: {
+  api: TuiPluginApi
+  controller: BtwSideController
+  activePromptRef: () => TuiPromptRef | undefined
+}): Promise<void> {
+  const currentSessionID = currentTuiSessionID(args.api)
+  if (!currentSessionID) {
+    args.api.ui.toast({
+      variant: "warning",
+      message: "BTW is unavailable before the session starts.",
+    })
+    return
+  }
+
+  let loaded: Awaited<ReturnType<typeof loadBtwSessionCatalog>>
+  try {
+    loaded = await loadBtwSessionCatalog({
+      currentSessionID,
+      directory: args.api.state.path.directory,
+      listSessions: (input) => args.api.client.session.list(input),
+    })
+  } catch (error) {
+    log("[btw-side] Failed to list BTW sessions", {
+      currentSessionID,
+      error,
+    })
+    args.api.ui.toast({
+      variant: "error",
+      message: "Unable to list BTW conversations.",
+    })
+    return
+  }
+  if (!loaded.catalog) {
+    args.api.ui.toast({
+      variant: "warning",
+      message: "This BTW conversation no longer has a main session.",
+    })
+    return
+  }
+  if (loaded.truncated) {
+    args.api.ui.toast({
+      variant: "warning",
+      message: "The BTW list is too large to show completely.",
+    })
+  }
+
+  for (const side of loaded.catalog.sides) {
+    args.controller.adopt(loaded.catalog.main.id, side.id)
+  }
+  const picker = buildBtwPickerOptions(
+    loaded.catalog,
+    currentSessionID,
+  )
+
+  async function refreshStaleSelection(sessionID: string): Promise<void> {
+    args.api.ui.toast({
+      variant: "warning",
+      message: `BTW session ${sessionID} no longer exists. Refreshing the list.`,
+    })
+    await openBtwPicker(args)
+  }
+
+  async function select(value: string): Promise<void> {
+    const selection = parseBtwPickerValue(value)
+    if (!selection) return
+    if (selection.type === "new") {
+      const promptRef = args.activePromptRef()
+      args.api.ui.dialog.clear()
+      if (!promptRef) {
+        args.api.ui.toast({
+          variant: "warning",
+          message: "BTW is unavailable before the session starts.",
+        })
+        return
+      }
+      await args.controller.startFromPrompt(adaptTuiPromptRef(promptRef))
+      return
+    }
+
+    try {
+      const response = await args.api.client.session.get({
+        sessionID: selection.sessionID,
+        directory: args.api.state.path.directory,
+      })
+      if (response.error !== undefined || response.data === undefined) {
+        await refreshStaleSelection(selection.sessionID)
+        return
+      }
+    } catch (error) {
+      log("[btw-side] Failed to validate picker selection", {
+        sessionID: selection.sessionID,
+        error,
+      })
+      await refreshStaleSelection(selection.sessionID)
+      return
+    }
+    args.api.ui.dialog.clear()
+    args.api.route.navigate("session", {
+      sessionID: selection.sessionID,
+    })
+  }
+
+  args.api.ui.dialog.replace(() =>
+    args.api.ui.DialogSelect<string>({
+      title: "BTW conversations",
+      placeholder: "Choose Main, a retained BTW, or New BTW",
+      options: picker.options,
+      current: picker.current,
+      onSelect: (option) => select(option.value),
+    }),
+  )
+}

--- a/packages/omo-opencode/src/features/btw-side/tui-session-catalog.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-session-catalog.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, mock } from "bun:test"
+
+import { BTW_SIDE_METADATA_KEY } from "./metadata"
+import {
+  classifyBtwSessionCatalog,
+  loadBtwSessionCatalog,
+  type BtwCatalogSession,
+} from "./tui-session-catalog"
+
+function session(input: {
+  id: string
+  title?: string
+  created: number
+  updated?: number
+  parentSessionID?: string
+}): BtwCatalogSession {
+  return {
+    id: input.id,
+    title: input.title ?? input.id,
+    time: {
+      created: input.created,
+      updated: input.updated ?? input.created,
+    },
+    ...(input.parentSessionID
+      ? {
+          metadata: {
+            [BTW_SIDE_METADATA_KEY]: {
+              version: 1,
+              parent_session_id: input.parentSessionID,
+              boundary_message_id: "msg_boundary",
+            },
+          },
+        }
+      : {}),
+  }
+}
+
+describe("loadBtwSessionCatalog", () => {
+  it("#given a full first response #when the catalog loads #then it widens the limit until every retained side is visible", async () => {
+    // given
+    const sessions = [
+      session({ id: "ses_parent", created: 1 }),
+      session({
+        id: "ses_side_1",
+        created: 2,
+        parentSessionID: "ses_parent",
+      }),
+      session({
+        id: "ses_side_2",
+        created: 3,
+        parentSessionID: "ses_parent",
+      }),
+    ]
+    const listSessions = mock(async ({ limit }: { limit: number }) => ({
+      data: sessions.slice(0, limit),
+    }))
+
+    // when
+    const result = await loadBtwSessionCatalog({
+      currentSessionID: "ses_parent",
+      directory: "/tmp/project",
+      listSessions,
+      initialLimit: 2,
+      maximumLimit: 8,
+    })
+
+    // then
+    expect(listSessions.mock.calls.map(([input]) => input.limit)).toEqual([
+      2,
+      4,
+    ])
+    expect(result.catalog?.sides.map((side) => side.id)).toEqual([
+      "ses_side_1",
+      "ses_side_2",
+    ])
+    expect(result.truncated).toBe(false)
+  })
+
+  it("#given a full maximum response #when the catalog loads #then it reports possible truncation", async () => {
+    // given
+    const sessions = Array.from({ length: 4 }, (_, index) =>
+      session({
+        id: index === 0 ? "ses_parent" : `ses_side_${index}`,
+        created: index,
+        ...(index > 0 ? { parentSessionID: "ses_parent" } : {}),
+      }),
+    )
+
+    // when
+    const result = await loadBtwSessionCatalog({
+      currentSessionID: "ses_parent",
+      directory: "/tmp/project",
+      listSessions: async ({ limit }) => ({
+        data: sessions.slice(0, limit),
+      }),
+      initialLimit: 2,
+      maximumLimit: 4,
+    })
+
+    // then
+    expect(result.truncated).toBe(true)
+  })
+})
+
+describe("classifyBtwSessionCatalog", () => {
+  it("#given mixed metadata rows #when a parent catalog is classified #then only valid matching sides remain oldest first", () => {
+    // given
+    const sessions = [
+      session({ id: "ses_parent", created: 1 }),
+      session({
+        id: "ses_side_newer",
+        title: "BTW · newer",
+        created: 30,
+        updated: 100,
+        parentSessionID: "ses_parent",
+      }),
+      session({
+        id: "ses_side_older",
+        title: "BTW · older",
+        created: 20,
+        updated: 200,
+        parentSessionID: "ses_parent",
+      }),
+      session({ id: "ses_other_parent", created: 2 }),
+      session({
+        id: "ses_other_side",
+        created: 3,
+        parentSessionID: "ses_other_parent",
+      }),
+      {
+        ...session({ id: "ses_invalid", created: 4 }),
+        metadata: {
+          [BTW_SIDE_METADATA_KEY]: {
+            version: 99,
+            parent_session_id: "ses_parent",
+            boundary_message_id: "msg_boundary",
+          },
+        },
+      },
+    ]
+
+    // when
+    const result = classifyBtwSessionCatalog(sessions, "ses_parent")
+
+    // then
+    expect(result?.main.id).toBe("ses_parent")
+    expect(result?.sides.map((side) => side.id)).toEqual([
+      "ses_side_older",
+      "ses_side_newer",
+    ])
+  })
+
+  it("#given a retained side route #when its catalog is classified #then it resolves the original parent scope", () => {
+    // given
+    const sessions = [
+      session({ id: "ses_parent", created: 1 }),
+      session({
+        id: "ses_side_1",
+        created: 2,
+        parentSessionID: "ses_parent",
+      }),
+      session({
+        id: "ses_side_2",
+        created: 3,
+        parentSessionID: "ses_parent",
+      }),
+    ]
+
+    // when
+    const result = classifyBtwSessionCatalog(sessions, "ses_side_2")
+
+    // then
+    expect(result?.main.id).toBe("ses_parent")
+    expect(result?.sides.map((side) => side.id)).toEqual([
+      "ses_side_1",
+      "ses_side_2",
+    ])
+  })
+
+  it("#given a stale side whose parent row is missing #when classified #then no unsafe navigation catalog is returned", () => {
+    // given
+    const sessions = [
+      session({
+        id: "ses_orphan",
+        created: 2,
+        parentSessionID: "ses_missing",
+      }),
+    ]
+
+    // when
+    const result = classifyBtwSessionCatalog(sessions, "ses_orphan")
+
+    // then
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/omo-opencode/src/features/btw-side/tui-session-catalog.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-session-catalog.ts
@@ -1,0 +1,108 @@
+import { getBtwSideMetadata } from "./metadata"
+
+const DEFAULT_INITIAL_LIMIT = 100
+const DEFAULT_MAXIMUM_LIMIT = 65_536
+
+export type BtwCatalogSession = {
+  id: string
+  title: string
+  metadata?: Record<string, unknown>
+  time: {
+    created: number
+    updated: number
+  }
+}
+
+export type BtwSessionCatalog = {
+  main: BtwCatalogSession
+  sides: BtwCatalogSession[]
+}
+
+type BtwSessionListInput = {
+  directory: string
+  roots: false
+  limit: number
+}
+
+type BtwSessionListResponse = {
+  data?: BtwCatalogSession[]
+  error?: unknown
+}
+
+type LoadBtwSessionCatalogInput = {
+  currentSessionID: string
+  directory: string
+  listSessions: (
+    input: BtwSessionListInput,
+  ) => Promise<BtwSessionListResponse>
+  initialLimit?: number
+  maximumLimit?: number
+}
+
+export function classifyBtwSessionCatalog(
+  sessions: BtwCatalogSession[],
+  currentSessionID: string,
+): BtwSessionCatalog | undefined {
+  const sessionsByID = new Map(
+    sessions.map((session) => [session.id, session]),
+  )
+  const current = sessionsByID.get(currentSessionID)
+  if (!current) return undefined
+
+  const rootSessionID =
+    getBtwSideMetadata(current)?.parent_session_id ?? current.id
+  const main = sessionsByID.get(rootSessionID)
+  if (!main || getBtwSideMetadata(main)) return undefined
+
+  const sides = sessions
+    .filter(
+      (session) =>
+        getBtwSideMetadata(session)?.parent_session_id === rootSessionID,
+    )
+    .sort(
+      (left, right) =>
+        left.time.created - right.time.created ||
+        left.id.localeCompare(right.id),
+    )
+  return {
+    main,
+    sides,
+  }
+}
+
+export async function loadBtwSessionCatalog(
+  input: LoadBtwSessionCatalogInput,
+): Promise<{
+  catalog: BtwSessionCatalog | undefined
+  truncated: boolean
+}> {
+  const maximumLimit = input.maximumLimit ?? DEFAULT_MAXIMUM_LIMIT
+  let limit = Math.min(
+    input.initialLimit ?? DEFAULT_INITIAL_LIMIT,
+    maximumLimit,
+  )
+
+  while (true) {
+    const response = await input.listSessions({
+      directory: input.directory,
+      roots: false,
+      limit,
+    })
+    if (response.error !== undefined) {
+      throw new Error("Unable to list BTW sessions")
+    }
+    const sessions = response.data ?? []
+    const fullResponse = sessions.length >= limit
+    const atMaximum = limit >= maximumLimit
+    if (!fullResponse || atMaximum) {
+      return {
+        catalog: classifyBtwSessionCatalog(
+          sessions,
+          input.currentSessionID,
+        ),
+        truncated: fullResponse && atMaximum,
+      }
+    }
+    limit = Math.min(limit * 2, maximumLimit)
+  }
+}

--- a/packages/omo-opencode/src/features/btw-side/tui-side-start.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-side-start.ts
@@ -23,8 +23,8 @@ export type PreparedBtwSideStart = {
 export function prepareBtwSideStart(
   dependencies: BtwSideControllerDependencies,
   promptRef: BtwPromptRef,
+  parentSessionID = dependencies.getCurrentSessionID(),
 ): PreparedBtwSideStart | undefined {
-  const parentSessionID = dependencies.getCurrentSessionID()
   if (!parentSessionID) {
     dependencies.showToast("BTW is unavailable before the session starts.")
     return undefined
@@ -46,13 +46,14 @@ export function prepareBtwSideStart(
 
   const originalDraft = promptRef.input
   const parsed = parseBtwQuestion(originalDraft)
+  const summary = parsed.question.replace(/\s+/g, " ").trim()
   return {
     parentSessionID,
     originalDraft,
     consumeDraft: parsed.consumeDraft,
     question: parsed.question,
     createInput: {
-      title: `BTW · ${parentSession.title}`,
+      title: `BTW · ${(summary || "New side").slice(0, 64)}`,
       ...(parentSession.agent ? { agent: parentSession.agent } : {}),
       ...(parentSession.model
         ? {

--- a/packages/omo-opencode/src/features/btw-side/tui-wiring.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-wiring.test.ts
@@ -199,7 +199,7 @@ function createPickerHarness(promptInput = "/btw") {
         return () => undefined
       },
       intercept: () => () => undefined,
-      clearPending: () => undefined,
+      clearPendingSequence: () => undefined,
     },
     mode: {
       current: () => "base",

--- a/packages/omo-opencode/src/features/btw-side/tui-wiring.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-wiring.test.ts
@@ -66,13 +66,25 @@ type TestDialogSelectProps = {
   onSelect?: (option: TestDialogOption) => void | Promise<void>
 }
 
-function createPickerHarness(promptInput = "/btw") {
+function createPickerHarness(
+  promptInput = "/btw",
+  parentMessages = [
+    {
+      id: "msg_parent",
+      role: "user",
+      time: {
+        created: 1,
+      },
+    },
+  ],
+) {
   let routeSessionID = "ses_parent"
   let currentPromptInput = promptInput
   const layers: TestLayer[] = []
   const slots: TestSlotRegistration[] = []
   const dialogSelections: TestDialogSelectProps[] = []
   const toasts: string[] = []
+  let dialogClears = 0
   const sessions = [
     {
       id: "ses_parent",
@@ -146,15 +158,7 @@ function createPickerHarness(promptInput = "/btw") {
       session: {
         get: (sessionID: string) =>
           sessions.find((session) => session.id === sessionID),
-        messages: () => [
-          {
-            id: "msg_parent",
-            role: "user",
-            time: {
-              created: 1,
-            },
-          },
-        ],
+        messages: () => parentMessages,
         status: () => ({
           type: "idle",
         }),
@@ -236,7 +240,9 @@ function createPickerHarness(promptInput = "/btw") {
         replace: (render: () => unknown) => {
           render()
         },
-        clear: () => undefined,
+        clear: () => {
+          dialogClears += 1
+        },
         get open() {
           return dialogSelections.length > 0
         },
@@ -282,6 +288,7 @@ function createPickerHarness(promptInput = "/btw") {
     toasts,
     currentSessionID: () => routeSessionID,
     promptInput: () => currentPromptInput,
+    dialogClears: () => dialogClears,
   }
 }
 
@@ -365,6 +372,7 @@ describe("registerBtwSideTui", () => {
     // then
     expect(harness.dialogSelections).toHaveLength(1)
     expect(harness.createSession).not.toHaveBeenCalled()
+    expect(harness.promptInput()).toBe("")
   })
 
   it("#given retained BTW options #when a side is selected #then the dialog clears and that session opens", async () => {
@@ -420,6 +428,36 @@ describe("registerBtwSideTui", () => {
     expect(harness.createSession).toHaveBeenCalledTimes(1)
     expect(harness.currentSessionID()).toBe("ses_new_side")
     expect(harness.promptInput()).toBe("")
+  })
+
+  it("#given New BTW cannot establish a stable boundary #when selected #then the picker stays open for another choice", async () => {
+    // given
+    const harness = createPickerHarness("/btw", [])
+    await registerBtwSideTui(harness.api, harness.solid)
+    harness.slots[0]?.slots.session_prompt?.({}, {
+      session_id: "ses_parent",
+      visible: true,
+      disabled: false,
+    })
+    const openCommand = harness.layers
+      .flatMap((layer) => layer.commands ?? [])
+      .find((command) => command.name === "omo.btw.open")
+    await openCommand?.run?.()
+    const newSide = harness.dialogSelections[0]?.options.find(
+      (option) => option.title === "New BTW",
+    )
+
+    // when
+    if (newSide) {
+      await harness.dialogSelections[0]?.onSelect?.(newSide)
+    }
+
+    // then
+    expect(harness.createSession).not.toHaveBeenCalled()
+    expect(harness.dialogClears()).toBe(0)
+    expect(harness.toasts).toContain(
+      "BTW is unavailable before the session starts.",
+    )
   })
 
   it("#given a deleted picker row #when it is selected #then a precise warning appears and the picker refreshes", async () => {
@@ -651,7 +689,6 @@ describe("registerBtwSideTui", () => {
     await openCommand?.run?.()
 
     // then
-    expect(layers.every((layer) => layer.mode === "base")).toBe(true)
     expect(openCommand).toMatchObject({
       namespace: "palette",
       enabled: true,
@@ -714,9 +751,11 @@ describe("registerBtwSideTui", () => {
     const sideStatus = slotRegistration?.slots.session_prompt_right?.({}, {
       session_id: "ses_side",
     }) as TestNode
-    expect(parentStatus.children).toContain("BTW open · ctrl+/ switch")
+    expect(parentStatus.children).toContain(
+      "BTW retained · ctrl+/ picker",
+    )
     expect(sideStatus.children).toContain(
-      "BTW from main · main ready · ctrl+/ switch · ctrl+c close",
+      "BTW side · main ready · esc esc return · ctrl+/ picker · ctrl+c delete",
     )
     expect(disposers).toHaveLength(1)
     expect(deleteSession).not.toHaveBeenCalled()

--- a/packages/omo-opencode/src/features/btw-side/tui-wiring.test.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-wiring.test.ts
@@ -51,7 +51,416 @@ type TestSlotRegistration = {
   >
 }
 
+type TestDialogOption = {
+  title: string
+  value: unknown
+  description?: string
+  category?: string
+  disabled?: boolean
+}
+
+type TestDialogSelectProps = {
+  title: string
+  options: TestDialogOption[]
+  current?: unknown
+  onSelect?: (option: TestDialogOption) => void | Promise<void>
+}
+
+function createPickerHarness(promptInput = "/btw") {
+  let routeSessionID = "ses_parent"
+  let currentPromptInput = promptInput
+  const layers: TestLayer[] = []
+  const slots: TestSlotRegistration[] = []
+  const dialogSelections: TestDialogSelectProps[] = []
+  const toasts: string[] = []
+  const sessions = [
+    {
+      id: "ses_parent",
+      title: "Parent",
+      time: {
+        created: 1,
+        updated: 1,
+      },
+    },
+    {
+      id: "ses_side_1",
+      title: "BTW · first retained question",
+      time: {
+        created: 2,
+        updated: 2,
+      },
+      metadata: {
+        [BTW_SIDE_METADATA_KEY]: {
+          version: 1,
+          parent_session_id: "ses_parent",
+          boundary_message_id: "msg_parent",
+        },
+      },
+    },
+    {
+      id: "ses_side_2",
+      title: "BTW · second retained question",
+      time: {
+        created: 3,
+        updated: 3,
+      },
+      metadata: {
+        [BTW_SIDE_METADATA_KEY]: {
+          version: 1,
+          parent_session_id: "ses_parent",
+          boundary_message_id: "msg_parent",
+        },
+      },
+    },
+  ]
+  const listSessions = mock(async () => ({
+    data: sessions,
+  }))
+  const createSession = mock(async () => ({
+    data: {
+      id: "ses_new_side",
+      title: "BTW · New side",
+    },
+  }))
+  const promptRef = {
+    focused: true,
+    get current() {
+      return {
+        input: currentPromptInput,
+        parts: [],
+      }
+    },
+    set(next: { input: string }) {
+      currentPromptInput = next.input
+    },
+    reset: () => undefined,
+    blur: () => undefined,
+    focus: () => undefined,
+    submit: () => undefined,
+  }
+  const api = unsafeTestValue({
+    state: {
+      path: {
+        directory: "/tmp/project",
+      },
+      session: {
+        get: (sessionID: string) =>
+          sessions.find((session) => session.id === sessionID),
+        messages: () => [
+          {
+            id: "msg_parent",
+            role: "user",
+            time: {
+              created: 1,
+            },
+          },
+        ],
+        status: () => ({
+          type: "idle",
+        }),
+        permission: () => [],
+        question: () => [],
+      },
+    },
+    client: {
+      session: {
+        list: listSessions,
+        get: async ({ sessionID }: { sessionID: string }) => ({
+          data: sessions.find((session) => session.id === sessionID),
+        }),
+        create: createSession,
+        abort: async () => ({
+          data: true,
+        }),
+        delete: async () => ({
+          data: true,
+        }),
+      },
+    },
+    route: {
+      get current() {
+        return {
+          name: "session",
+          params: {
+            sessionID: routeSessionID,
+          },
+        }
+      },
+      navigate: (_name: string, params: { sessionID: string }) => {
+        routeSessionID = params.sessionID
+      },
+    },
+    command: {
+      register: () => () => undefined,
+    },
+    keymap: {
+      registerLayer: (layer: TestLayer) => {
+        layers.push(layer)
+        return () => undefined
+      },
+      intercept: () => () => undefined,
+      clearPending: () => undefined,
+    },
+    mode: {
+      current: () => "base",
+    },
+    slots: {
+      register: (registration: TestSlotRegistration) => {
+        slots.push(registration)
+        return "omo-btw-picker-slots"
+      },
+    },
+    event: {
+      on: () => () => undefined,
+    },
+    ui: {
+      Prompt: (props: {
+        ref?: (ref: typeof promptRef | undefined) => void
+      }) => {
+        props.ref?.(promptRef)
+        return {
+          tag: "prompt",
+        }
+      },
+      DialogSelect: (props: TestDialogSelectProps) => {
+        dialogSelections.push(props)
+        return {
+          tag: "dialog-select",
+        }
+      },
+      Slot: () => undefined,
+      toast: ({ message }: { message: string }) => {
+        toasts.push(message)
+      },
+      dialog: {
+        replace: (render: () => unknown) => {
+          render()
+        },
+        clear: () => undefined,
+        get open() {
+          return dialogSelections.length > 0
+        },
+      },
+    },
+    theme: {
+      current: {
+        textMuted: "#888888",
+      },
+    },
+    renderer: {
+      requestRender: () => undefined,
+    },
+    lifecycle: {
+      signal: new AbortController().signal,
+      onDispose: () => () => undefined,
+    },
+  })
+  const solid = unsafeTestValue({
+    createElement: (tag: string): TestNode => ({
+      tag,
+      props: {},
+      children: [],
+    }),
+    insert: (node: TestNode, child: unknown) => {
+      node.children.push(child)
+    },
+    setProp: (node: TestNode, name: string, value: unknown) => {
+      node.props[name] = value
+    },
+  })
+
+  return {
+    api,
+    solid,
+    layers,
+    slots,
+    dialogSelections,
+    listSessions,
+    createSession,
+    promptRef,
+    sessions,
+    toasts,
+    currentSessionID: () => routeSessionID,
+    promptInput: () => currentPromptInput,
+  }
+}
+
 describe("registerBtwSideTui", () => {
+  it("#given retained BTW metadata #when the bare command opens #then the catalog lists the parent and every retained side", async () => {
+    // given
+    const harness = createPickerHarness()
+    await registerBtwSideTui(harness.api, harness.solid)
+    harness.slots[0]?.slots.session_prompt?.({}, {
+      session_id: "ses_parent",
+      visible: true,
+      disabled: false,
+    })
+    const openCommand = harness.layers
+      .flatMap((layer) => layer.commands ?? [])
+      .find((command) => command.name === "omo.btw.open")
+
+    // when
+    await openCommand?.run?.()
+
+    // then
+    expect(harness.listSessions).toHaveBeenCalled()
+    expect(harness.dialogSelections[0]?.options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: expect.stringContaining("Main"),
+        }),
+        expect.objectContaining({
+          title: expect.stringContaining("first retained question"),
+        }),
+        expect.objectContaining({
+          title: expect.stringContaining("second retained question"),
+        }),
+      ]),
+    )
+  })
+
+  it("#given two retained sides #when picker options render #then stable numbers and summaries distinguish every destination", async () => {
+    // given
+    const harness = createPickerHarness()
+    await registerBtwSideTui(harness.api, harness.solid)
+    harness.slots[0]?.slots.session_prompt?.({}, {
+      session_id: "ses_parent",
+      visible: true,
+      disabled: false,
+    })
+    const openCommand = harness.layers
+      .flatMap((layer) => layer.commands ?? [])
+      .find((command) => command.name === "omo.btw.open")
+
+    // when
+    await openCommand?.run?.()
+
+    // then
+    expect(
+      harness.dialogSelections[0]?.options.map((option) => option.title),
+    ).toEqual([
+      expect.stringContaining("Main"),
+      expect.stringContaining("BTW #1"),
+      expect.stringContaining("BTW #2"),
+      expect.stringContaining("New BTW"),
+    ])
+  })
+
+  it("#given a bare BTW draft #when open runs #then it opens the picker without creating a session", async () => {
+    // given
+    const harness = createPickerHarness()
+    await registerBtwSideTui(harness.api, harness.solid)
+    harness.slots[0]?.slots.session_prompt?.({}, {
+      session_id: "ses_parent",
+      visible: true,
+      disabled: false,
+    })
+    const openCommand = harness.layers
+      .flatMap((layer) => layer.commands ?? [])
+      .find((command) => command.name === "omo.btw.open")
+
+    // when
+    await openCommand?.run?.()
+
+    // then
+    expect(harness.dialogSelections).toHaveLength(1)
+    expect(harness.createSession).not.toHaveBeenCalled()
+  })
+
+  it("#given retained BTW options #when a side is selected #then the dialog clears and that session opens", async () => {
+    // given
+    const harness = createPickerHarness()
+    await registerBtwSideTui(harness.api, harness.solid)
+    harness.slots[0]?.slots.session_prompt?.({}, {
+      session_id: "ses_parent",
+      visible: true,
+      disabled: false,
+    })
+    const openCommand = harness.layers
+      .flatMap((layer) => layer.commands ?? [])
+      .find((command) => command.name === "omo.btw.open")
+    await openCommand?.run?.()
+    const secondSide = harness.dialogSelections[0]?.options.find(
+      (option) => option.title.includes("BTW #2"),
+    )
+
+    // when
+    if (secondSide) {
+      await harness.dialogSelections[0]?.onSelect?.(secondSide)
+    }
+
+    // then
+    expect(harness.currentSessionID()).toBe("ses_side_2")
+  })
+
+  it("#given the BTW picker #when New BTW is selected #then a distinct side is created only after selection", async () => {
+    // given
+    const harness = createPickerHarness()
+    await registerBtwSideTui(harness.api, harness.solid)
+    harness.slots[0]?.slots.session_prompt?.({}, {
+      session_id: "ses_parent",
+      visible: true,
+      disabled: false,
+    })
+    const openCommand = harness.layers
+      .flatMap((layer) => layer.commands ?? [])
+      .find((command) => command.name === "omo.btw.open")
+    await openCommand?.run?.()
+    const newSide = harness.dialogSelections[0]?.options.find(
+      (option) => option.title === "New BTW",
+    )
+    expect(harness.createSession).not.toHaveBeenCalled()
+
+    // when
+    if (newSide) {
+      await harness.dialogSelections[0]?.onSelect?.(newSide)
+    }
+
+    // then
+    expect(harness.createSession).toHaveBeenCalledTimes(1)
+    expect(harness.currentSessionID()).toBe("ses_new_side")
+    expect(harness.promptInput()).toBe("")
+  })
+
+  it("#given a deleted picker row #when it is selected #then a precise warning appears and the picker refreshes", async () => {
+    // given
+    const harness = createPickerHarness()
+    await registerBtwSideTui(harness.api, harness.solid)
+    harness.slots[0]?.slots.session_prompt?.({}, {
+      session_id: "ses_parent",
+      visible: true,
+      disabled: false,
+    })
+    const openCommand = harness.layers
+      .flatMap((layer) => layer.commands ?? [])
+      .find((command) => command.name === "omo.btw.open")
+    await openCommand?.run?.()
+    const deletedSide = harness.dialogSelections[0]?.options.find(
+      (option) => option.title.includes("BTW #2"),
+    )
+    const deletedIndex = harness.sessions.findIndex(
+      (session) => session.id === "ses_side_2",
+    )
+    harness.sessions.splice(deletedIndex, 1)
+
+    // when
+    if (deletedSide) {
+      await harness.dialogSelections[0]?.onSelect?.(deletedSide)
+    }
+
+    // then
+    expect(harness.currentSessionID()).toBe("ses_parent")
+    expect(harness.toasts).toContain(
+      "BTW session ses_side_2 no longer exists. Refreshing the list.",
+    )
+    expect(harness.dialogSelections).toHaveLength(2)
+    expect(
+      harness.dialogSelections[1]?.options.some(
+        (option) => option.title.includes("second retained question"),
+      ),
+    ).toBe(false)
+  })
+
   it("#given a real-shaped TUI API #when inline BTW runs #then a side session opens and both status surfaces render", async () => {
     // given
     let routeName = "session"
@@ -62,14 +471,7 @@ describe("registerBtwSideTui", () => {
     const slots: TestSlotRegistration[] = []
     const disposers: Array<() => void | Promise<void>> = []
     const toasts: string[] = []
-    let resolveDeleted!: () => void
-    const deleted = new Promise<void>((resolve) => {
-      resolveDeleted = resolve
-    })
-    const deleteSession = mock(async () => {
-      resolveDeleted()
-      return { data: true }
-    })
+    const deleteSession = mock(async () => ({ data: true }))
     const createSession = mock(async () => ({
       data: {
         id: "ses_side",
@@ -322,9 +724,11 @@ describe("registerBtwSideTui", () => {
     // when
     routeName = "home"
     promptRefCallbacks.at(-1)?.(undefined)
-    await deleted
+    for (const dispose of disposers) {
+      await dispose()
+    }
 
     // then
-    expect(deleteSession).toHaveBeenCalledTimes(1)
+    expect(deleteSession).not.toHaveBeenCalled()
   })
 })

--- a/packages/omo-opencode/src/features/btw-side/tui-wiring.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-wiring.ts
@@ -13,7 +13,9 @@ import { createBtwParentValidator } from "./tui-parent-validator"
 import {
   createBtwSideController,
 } from "./tui-controller"
+import { parseBtwQuestion } from "./btw-command-draft"
 import { registerBtwSideKeymap } from "./tui-keymap"
+import { openBtwPicker } from "./tui-picker"
 import {
   adaptTuiPromptRef,
   createBtwControllerDependencies,
@@ -156,27 +158,10 @@ export async function registerBtwSideTui<Node>(
     const sessionID = currentTuiSessionID(api)
     if (sessionID) await adoptSideSession(sessionID)
     if (!isCurrentTuiSession(api, sessionID)) return
-    const cachedSession = sessionID
-      ? adoptionCache.read(sessionID)
-      : { hydrated: false as const }
-    if (cachedSession.hydrated && cachedSession.metadata) {
-      api.ui.toast({
-        variant: "warning",
-        message: "BTW is unavailable inside another BTW conversation.",
-      })
-      return
-    }
     if (sessionID && adoptionFailures.has(sessionID)) {
       api.ui.toast({
         variant: "warning",
         message: "Unable to verify whether this is a BTW conversation.",
-      })
-      return
-    }
-    if (controller.state().phase !== "closed") {
-      api.ui.toast({
-        variant: "warning",
-        message: "BTW is unavailable inside another BTW conversation.",
       })
       return
     }
@@ -188,7 +173,16 @@ export async function registerBtwSideTui<Node>(
       })
       return
     }
-    await controller.startFromPrompt(adaptTuiPromptRef(promptRef))
+    const parsed = parseBtwQuestion(promptRef.current.input)
+    if (parsed.consumeDraft && parsed.question.length > 0) {
+      await controller.startFromPrompt(adaptTuiPromptRef(promptRef))
+      return
+    }
+    await openBtwPicker({
+      api,
+      controller,
+      activePromptRef,
+    })
   }
 
   const unregisterSlashCommand =
@@ -197,7 +191,7 @@ export async function registerBtwSideTui<Node>(
         title: "BTW side conversation",
         value: "omo.btw.slash",
         description:
-          "Start a temporary side conversation without interrupting the main turn",
+          "Start or switch retained side conversations without interrupting the main turn",
         category: "Session",
         enabled: true,
         slash: {

--- a/packages/omo-opencode/src/features/btw-side/tui-wiring.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-wiring.ts
@@ -92,7 +92,6 @@ export async function registerBtwSideTui<Node>(
   }
 
   function adoptSideSession(sessionID: string): Promise<void> | undefined {
-    if (controller.state().phase !== "closed") return
     const pending = adoptionRequests.get(sessionID)
     if (pending) return pending
     const cached = adoptionCache.read(sessionID)
@@ -178,19 +177,26 @@ export async function registerBtwSideTui<Node>(
       await controller.startFromPrompt(adaptTuiPromptRef(promptRef))
       return
     }
+    const opened = await openBtwPicker({
+      api,
+      controller,
+      activePromptRef,
+    })
+    if (opened && parsed.consumeDraft) {
+      promptRef.set({
+        ...promptRef.current,
+        input: "",
+      })
+    }
+  }
+
+  const showBtwPicker = async (): Promise<void> => {
     await openBtwPicker({
       api,
       controller,
       activePromptRef,
     })
   }
-
-  const showBtwPicker = (): Promise<void> =>
-    openBtwPicker({
-      api,
-      controller,
-      activePromptRef,
-    })
 
   const unregisterSlashCommand =
     api.command?.register(() => [
@@ -220,7 +226,9 @@ export async function registerBtwSideTui<Node>(
       return (
         sessionID !== undefined &&
         controller.side(sessionID) !== undefined &&
-        api.state.session.status(sessionID)?.type === "idle"
+        api.state.session.status(sessionID)?.type !== "busy" &&
+        api.state.session.permission(sessionID).length === 0 &&
+        api.state.session.question(sessionID).length === 0
       )
     },
     returnToParent: controller.returnToParent,
@@ -262,7 +270,9 @@ export async function registerBtwSideTui<Node>(
                         value.session_id === state.sideSessionID
                       : false
                 if (isRelated) return
-                await controller.waitUntilClosed()
+                if (state.phase === "closing") {
+                  await controller.waitUntilClosed()
+                }
                 if (currentTuiSessionID(api) === value.session_id) {
                   await adoptSideSession(value.session_id)
                 }
@@ -296,12 +306,15 @@ export async function registerBtwSideTui<Node>(
           state.phase === "open" &&
           value.session_id === state.parentSessionID
         ) {
-          label = "BTW open · ctrl+/ switch"
+          label = "BTW retained · ctrl+/ picker"
         } else if (
           state.phase === "open" &&
           value.session_id === state.sideSessionID
         ) {
-          label = `BTW from main · ${parentTuiStatusLabel(api, state.parentSessionID)} · ctrl+/ switch · ctrl+c close`
+          const sideNumber = controller.sideNumber(state.sideSessionID)
+          const sideLabel =
+            sideNumber === undefined ? "BTW side" : `BTW #${sideNumber}`
+          label = `${sideLabel} · ${parentTuiStatusLabel(api, state.parentSessionID)} · esc esc return · ctrl+/ picker · ctrl+c delete`
         } else if (
           state.phase === "closing" &&
           value.session_id === state.sideSessionID

--- a/packages/omo-opencode/src/features/btw-side/tui-wiring.ts
+++ b/packages/omo-opencode/src/features/btw-side/tui-wiring.ts
@@ -185,6 +185,13 @@ export async function registerBtwSideTui<Node>(
     })
   }
 
+  const showBtwPicker = (): Promise<void> =>
+    openBtwPicker({
+      api,
+      controller,
+      activePromptRef,
+    })
+
   const unregisterSlashCommand =
     api.command?.register(() => [
       {
@@ -202,11 +209,21 @@ export async function registerBtwSideTui<Node>(
       },
     ]) ?? (() => undefined)
 
-  const unregisterKeymap = registerBtwSideKeymap({
+  const keymapRegistration = registerBtwSideKeymap({
     api,
     controller,
     activePromptRef,
     openBtw,
+    openPicker: showBtwPicker,
+    isCurrentSideIdle: () => {
+      const sessionID = currentTuiSessionID(api)
+      return (
+        sessionID !== undefined &&
+        controller.side(sessionID) !== undefined &&
+        api.state.session.status(sessionID)?.type === "idle"
+      )
+    },
+    returnToParent: controller.returnToParent,
   })
 
   api.slots.register({
@@ -224,6 +241,7 @@ export async function registerBtwSideTui<Node>(
           ref: (promptRef) => {
             value.ref?.(promptRef)
             if (promptRef) {
+              keymapRegistration.resetEscapeSequence()
               promptRefs.set(value.session_id, promptRef)
               log("[btw-side] TUI prompt ref attached", {
                 sessionID: value.session_id,
@@ -251,6 +269,7 @@ export async function registerBtwSideTui<Node>(
               })()
               return
             }
+            keymapRegistration.resetEscapeSequence()
             promptRefs.delete(value.session_id)
             controller.attachPromptRef(value.session_id, undefined)
             void controller.handleNavigation(
@@ -313,7 +332,7 @@ export async function registerBtwSideTui<Node>(
   api.lifecycle.onDispose(async () => {
     adoptionGuard.dispose()
     unregisterSlashCommand()
-    for (const unregister of unregisterKeymap) unregister()
+    for (const unregister of keymapRegistration.unregister) unregister()
     unsubscribeDeleted()
     await controller.dispose()
   })

--- a/script/qa/web-terminal-visual-qa.mjs
+++ b/script/qa/web-terminal-visual-qa.mjs
@@ -30,6 +30,8 @@ Inputs:
   --from-file <path>     Render an existing raw terminal byte stream through xterm.js (replay; no interaction).
   --input <token>        Scripted interaction, repeatable, applied in order THROUGH the browser terminal.
                          Literal text is typed; {Enter} {Tab} {Escape} {ArrowDown} {Ctrl+C} etc. are pressed as keys.
+                         {WheelUp} and {WheelDown} send real browser mouse-wheel input over the xterm viewport.
+                         {CtrlSlashByte} and {Ctrl7Byte} send their shared exact terminal control byte.
   --cwd <path>           Working directory for --command. Default: current directory.
   --cols <n> / --rows <n>  Terminal geometry. Default: 120 x 32.
   --dwell-ms <n>         Milliseconds to let the TUI settle after input before capture. Default: 1500.

--- a/script/qa/xterm-live-terminal.d.mts
+++ b/script/qa/xterm-live-terminal.d.mts
@@ -1,0 +1,5 @@
+export function driveInput(
+  page: unknown,
+  inputs: readonly string[],
+  keyDelayMs: number,
+): Promise<void>

--- a/script/qa/xterm-live-terminal.mjs
+++ b/script/qa/xterm-live-terminal.mjs
@@ -80,10 +80,26 @@ const NAMED_KEYS = new Set([
 // An `input` token wrapped in {Braces} is pressed as a named key; anything else
 // is typed literally. Both flow through the browser terminal (xterm onData ->
 // pty), so the interaction is genuinely driven in the web terminal.
-async function driveInput(page, inputs, keyDelayMs) {
+export async function driveInput(page, inputs, keyDelayMs) {
   for (const raw of inputs) {
     const match = /^\{(.+)\}$/.exec(raw);
-    if (match && NAMED_KEYS.has(match[1])) {
+    if (
+      match?.[1] === "CtrlSlashByte" ||
+      match?.[1] === "Ctrl7Byte"
+    ) {
+      await page.evaluate((data) => window.__ptyInput(data), "\u001f");
+    } else if (match && /^(WheelUp|WheelDown)$/.test(match[1])) {
+      const terminal = await page.$(".xterm-screen");
+      const bounds = await terminal?.boundingBox();
+      if (!bounds) throw new Error("xterm viewport unavailable for wheel input");
+      await page.mouse.move(
+        bounds.x + bounds.width / 2,
+        bounds.y + bounds.height / 2,
+      );
+      await page.mouse.wheel({
+        deltaY: match[1] === "WheelDown" ? 720 : -720,
+      });
+    } else if (match && NAMED_KEYS.has(match[1])) {
       await page.keyboard.press(match[1] === "Space" ? " " : match[1], { delay: 15 });
     } else if (match && /^Ctrl\+(.)$/i.test(match[1])) {
       const key = /^Ctrl\+(.)$/i.exec(match[1])[1];

--- a/script/web-terminal-visual-qa.test.ts
+++ b/script/web-terminal-visual-qa.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, mock, test } from "bun:test"
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { BUILT_IN_REDACTION_RULE_COUNT } from "./qa/web-terminal-redaction.mjs"
+import { unsafeTestValue } from "../test-support/unsafe-test-value"
 
 const helperFilePath = fileURLToPath(new URL("./qa/web-terminal-visual-qa.mjs", import.meta.url))
 
@@ -117,6 +118,87 @@ describe("web terminal visual QA helper", () => {
     expect(stdoutText).toContain("xterm.js")
     expect(stdoutText).toContain("NEVER tmux")
     expect(stdoutText).toContain("The raw --command string is never stored")
+  })
+
+  test("#given wheel input tokens #when driving the browser terminal #then mouse wheel events target the xterm viewport", async () => {
+    // given
+    const module = await import("./qa/xterm-live-terminal.mjs") as {
+      driveInput?: (
+        page: unknown,
+        inputs: readonly string[],
+        keyDelayMs: number,
+      ) => Promise<void>
+    }
+    const wheel = mock(async () => undefined)
+    const move = mock(async () => undefined)
+    const page = unsafeTestValue({
+      $: async () => ({
+        boundingBox: async () => ({
+          x: 10,
+          y: 20,
+          width: 120,
+          height: 80,
+        }),
+      }),
+      mouse: {
+        move,
+        wheel,
+      },
+      keyboard: {
+        press: async () => undefined,
+        down: async () => undefined,
+        up: async () => undefined,
+        type: async () => undefined,
+      },
+    })
+
+    // when
+    expect(module.driveInput).toBeInstanceOf(Function)
+    if (!module.driveInput) return
+    await module.driveInput(page, ["{WheelDown}", "{WheelUp}"], 0)
+
+    // then
+    expect(move).toHaveBeenCalledTimes(2)
+    expect(move).toHaveBeenNthCalledWith(1, 70, 60)
+    expect(move).toHaveBeenNthCalledWith(2, 70, 60)
+    expect(wheel).toHaveBeenNthCalledWith(1, {
+      deltaY: 720,
+    })
+    expect(wheel).toHaveBeenNthCalledWith(2, {
+      deltaY: -720,
+    })
+  })
+
+  test("#given the Ctrl slash byte token #when driving the browser bridge #then the exact terminal control sequence reaches the PTY", async () => {
+    // given
+    const module = await import("./qa/xterm-live-terminal.mjs") as {
+      driveInput?: (
+        page: unknown,
+        inputs: readonly string[],
+        keyDelayMs: number,
+      ) => Promise<void>
+    }
+    const evaluate = mock(async (
+      _callback: unknown,
+      _data: string,
+    ) => undefined)
+    const page = unsafeTestValue({
+      evaluate,
+    })
+
+    // when
+    expect(module.driveInput).toBeInstanceOf(Function)
+    if (!module.driveInput) return
+    await module.driveInput(
+      page,
+      ["{CtrlSlashByte}", "{Ctrl7Byte}"],
+      0,
+    )
+
+    // then
+    expect(evaluate).toHaveBeenCalledTimes(2)
+    expect(evaluate.mock.calls[0]?.[1]).toBe("\u001f")
+    expect(evaluate.mock.calls[1]?.[1]).toBe("\u001f")
   })
 
   test("#given conflicting sources #when both --from-file and --command are given #then it errors", async () => {


### PR DESCRIPTION
## Summary

- make every `/btw <question>` create a distinct retained side session
- add a native DialogSelect picker for Main, numbered BTW summaries, and New BTW
- make `Esc Esc` return non-destructively and keep `Ctrl+C` scoped to deleting the visible side
- route Ctrl+/, Ctrl+_, and Ctrl+7 terminal encodings to the picker, including OpenTUI pre-parser handling
- preserve retained sides across TUI reloads and keep metadata-based transcript isolation
- add native xterm wheel QA support for picker and transcript verification

## Observed behavior

- real OpenCode 1.18.18 TUI created two separate metadata-marked BTW sessions
- bare `/btw` rendered Main, BTW #1, BTW #2, and New BTW in the picker
- `Esc Esc` returned to Main while retaining the side; picker selection reopened BTW #1 after a new TUI process
- Ctrl alias terminal byte opened the picker; `Ctrl+C` removed only BTW #2
- SQLite showed the Main transcript contained only the Main prompt/response, while side prompts and 12 scroll probes remained only in BTW #1
- native browser wheel input scrolled both DialogSelect and the retained side transcript
- isolated host DB proof: 7614 sessions before and 7614 after

QA evidence is recorded under `.omo/evidence/20260821-btw-multi-session-picker/` in the task worktree, including `FINAL_QA.md`, `FINAL_VERIFICATION.txt`, and xterm screenshots.

## Verification

- `bun test ./packages/omo-opencode/src/features/btw-side` - 69 pass, 0 fail
- `bun test ./script/web-terminal-visual-qa.test.ts` - 7 pass, 0 fail
- `bun run typecheck` - pass
- `bun run build` - pass
- `opencode-qa` common self-check and TUI smoke self-test - pass
- real isolated xterm/OpenCode TUI and SQLite QA - pass

## Residual risk

- OpenTUI drops the traditional `0x1f` Ctrl-slash byte before keymap dispatch, so the TUI adapter observes that exact byte at stdin while retaining structured-key and keymap fallbacks for other terminals. The in-flight gate deduplicates overlapping paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains multiple BTW side conversations and adds a native picker. Previously `/btw` opened a single temporary side and Ctrl+/ switched; now each `/btw <question>` creates a new retained side, bare `/btw` opens a picker, and sides persist across TUI reloads while keeping transcript isolation.

- The controller tracks many sides per main; Esc Esc returns to Main without deletion; Ctrl+C deletes only the visible side when its composer is empty. Starting BTW from a side creates a sibling, not a nested side.
- Picker: native DialogSelect lists Main, numbered BTW sessions (oldest-first, summarized), and New BTW; both picker and long transcripts support mouse-wheel scrolling.
- Keymap: Ctrl+/, Ctrl+_, and Ctrl+7 open the picker. Pre-parser handling consumes the xterm control byte (0x1f) to ensure the picker opens before host keymap processing.
- Catalog: expands session listing until the full BTW set is visible or a maximum is reached; assigns stable numbers used in status; sides are re-adopted after reloads.
- `/btw` without a question now opens the picker instead of an empty side composer. The “switch” binding now opens the picker.
- Updated `docs/guide/btw.md`; added focused tests and QA helpers. Core changes are in `packages/omo-opencode/src/features/btw-side` (controller, keymap, picker, catalog, escape-return). Uses `@opencode-ai/plugin/tui` and `@opentui/*` key input hooks.

- Migration actions:
  - No API changes. If you automated “Ctrl+/ switch,” expect the picker to open. Educate users that Esc Esc returns, and Ctrl+C deletes only the current side.

<sup>Written for commit 8bf9fb7abac8a31333fd2d52a75da6083fbc8453. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

