### PR TITLE
fix(shared-skills): report an uninitialized upstream as itself

### DIFF
--- a/packages/shared-skills/provenance-gate.test.ts
+++ b/packages/shared-skills/provenance-gate.test.ts
@@ -25,7 +25,16 @@ function trackedFrontendReferenceFiles(): string[] {
 }
 
 function submoduleHead(name: string): string {
-	return git(["-C", join(upstreamsRoot, name), "rev-parse", "HEAD"]);
+	const submodulePath = join(upstreamsRoot, name);
+	// An uninitialized submodule is an empty directory inside the parent repo, so `git -C` there
+	// resolves to the PARENT repo and returns its HEAD - which reads as a drifted pin. Fail as the
+	// real condition instead.
+	if (!existsSync(join(submodulePath, ".git"))) {
+		throw new Error(
+			`upstream submodule '${name}' is not initialized - run: git submodule update --init --recursive`,
+		);
+	}
+	return git(["-C", submodulePath, "rev-parse", "HEAD"]);
 }
 
 describe("DMCA provenance gate", () => {


### PR DESCRIPTION
## Problem

`provenance-gate.test.ts` reads each upstream's HEAD with:

```ts
git(["-C", join(upstreamsRoot, name), "rev-parse", "HEAD"])
```

When a submodule is **not initialized**, that path is an ordinary empty directory inside the parent repo. `git -C` therefore resolves to the PARENT repository and returns the parent's HEAD. The gate compares that value against the pin recorded in `ATTRIBUTION.md`, they differ, and it reports:

```
each ATTRIBUTION pin equals the live submodule HEAD  ... FAIL
```

That is a DMCA-provenance-shaped alarm for what is actually a missing checkout. The message points at pin drift, so the natural next step is to go auditing `ATTRIBUTION.md` and the upstream SHAs — none of which is the problem.

This is not hypothetical: it cost real debugging time on a fresh worktree and produced an incorrect "pre-existing pin failure" claim in a PR description before the true cause was found.

## Reproduction

In a scratch repo, an empty directory returns the parent's commit verbatim:

```
$ git -C upstreams/fake-mod rev-parse HEAD
ea8efea56586bfc2dd98b9735251b4e765491eff   # identical to the parent repo HEAD
$ test -e upstreams/fake-mod/.git && echo yes || echo no
no
```

The absent `.git` is the signal that distinguishes "submodule missing" from "pin drifted".

## Change

Guard the read on that signal. An absent `.git` now throws the real reason plus the command that fixes it:

```
upstream submodule 'taste-skill' is not initialized - run: git submodule update --init --recursive
```

This does not weaken the gate. Initialization is a precondition for checking a pin at all; previously an unmet precondition was silently reinterpreted as a compliance violation, and now it is reported as an unmet precondition. A genuinely drifted pin still fails exactly as before.

## Verification

Both paths exercised locally, on real submodule state rather than mocks:

| Case | Result |
|---|---|
| Upstreams initialized (healthy path, as in CI) | `bun test packages/shared-skills/provenance-gate.test.ts` → **5 pass, 0 fail** |
| `taste-skill/.git` temporarily moved aside | Fails with `upstream submodule 'taste-skill' is not initialized - run: git submodule update --init --recursive`; the other four gate tests still pass |
| Submodule restored | `git submodule status` shows `b17742737e796305d829b3ad39eda3add0d79060` — back at its pinned SHA |

CI checks out with submodules, so the healthy path is what runs there and it is unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report uninitialized upstream submodules explicitly in `packages/shared-skills/provenance-gate.test.ts` to avoid false pin-drift failures. Old behavior: `git -C upstreams/<name> rev-parse HEAD` returned the parent repo HEAD when the submodule was missing, and the gate failed as drift; new behavior: detect a missing `.git` in the submodule path and throw an actionable error. CI and healthy paths are unchanged.

- Required action: If this error occurs locally, run: git submodule update --init --recursive.

<sup>Written for commit ad3116b4d13daee9817e56b3862ff6aa20459c69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

