### PR TITLE
docs(omo-senpi): size dag waves by work grain in mass-ulw planning

### DIFF
--- a/packages/omo-senpi/skills/mass-ulw/references/planning.md
+++ b/packages/omo-senpi/skills/mass-ulw/references/planning.md
@@ -19,13 +19,15 @@ Reading this file is not planning. Before `start`, write the run plan in one bre
 
 **Do not split when:** (1) the pieces would share a write scope you cannot untangle - serialize or merge instead of pretending independence; (2) the work is one coherent judgment that needs the whole problem in view (a design decision, a root-cause diagnosis) - splitting it produces confident partial answers, not a verdict; (3) the pieces get so small that spawn and coordination overhead costs more than the work itself - a node that takes longer to brief than to execute belongs folded into its neighbor.
 
-**Wave sizing.** Target 5-8 nodes per parallel wave; fewer than 3 means under-splitting. A wave of eight `quick` nodes is healthier than a wave of three `deep` ones. Split along the axis that makes pieces independent:
+**Wave sizing.** Size the wave to the work's natural grain: one node per genuinely independent chunk, whether that is five or sixty. Fewer than 3 means under-splitting. A wave of twelve `quick` nodes is healthier than a wave of three `deep` ones. Never merge independent chunks to make a wave look smaller - the slot limiter (capacity model below) serializes execution, and on `quick` map/research waves coverage beats cost: budget discipline lives in category routing, not node count. A wave wider than ~10 fans in through aggregator or verification nodes reading bounded per-node file reports - the lead never reads N raw outputs. Split along the axis that makes pieces independent:
 
 - **By component** - each independently-shippable part is its own lane.
 - **By file domain** - when one component spans disjoint file sets, one node per set.
 - **By phase** - collect lanes (investigate, in parallel) -> verify lanes (falsify the collections) -> synthesize (turn verified facts into the deliverable).
 
 **Default shape is fan-out, then fan-in.** N parallel lanes with no dependencies, then one synthesis node that depends on all of them. The synthesis node starts cheap too (`quick` or `unspecified-low`): merging verified pieces is mechanical unless the merge itself needs judgment. A 2-node graph with no dependency between the nodes is not a dag - use plain parallel `task` spawns instead. Reach for `dag` when ordering itself is the point.
+
+**Mass harvests: nodes are not units of work.** When a research or scan wave must cover thousands of sources or files (a 10,000-source harvest is legitimate when the work demands it), shard items INTO nodes instead of one node per item: each `quick` node owns a batch sized by its report contract - collect ~50-200 items and write ONE bounded file report (<= 5k tokens) to a ledger path - so `N_nodes = ceil(total_items / items_per_node)`. Under the default caps that is ~100k items per session before touching a knob; past one run's cap, chain runs with the multi-run composition below and give every run its own aggregator node, so synthesis reads per-run digests, never raw node outputs.
 
 **Split implementation from its test? No.** One node owns one deliverable end to end: the change AND its proof. A node that only writes code and a node that only tests it serialize on the same files and double the coordination cost.
 
@@ -59,7 +61,7 @@ A graph whose every node is `deep` is a routing failure: it pays the most expens
 - **Disjoint write scopes or serialize.** No two nodes that can run in parallel may edit the same file. If two lanes must touch the same files, chain them with `dependsOn` or merge them into one node. Declare each node's read/write scope inside its prompt.
 - **Never add a dependency to pass data.** If node B needs a fact node A produces, that is a real dependency - but if B only needs a fact YOU already know, paste the fact into B's prompt and leave the edge out.
 - **Dependency matrix self-check before `start`:** every `dependsOn` id exists in the graph; no cycles; no node depends on something it does not actually consume; every wave has at least one runnable node.
-- **Capacity model.** Nodes run as background tasks under a per-model slot limiter - default 5 concurrent, overridable via `task.default_concurrency` / provider / model concurrency in omo config (0 = unbounded). Nodes past the limit queue FIFO and roll in as slots free, so a wave wider than the slots still completes, serialized in chunks. Hard caps: 64 nodes per run, 16 runs per session. The wave-sizing target above is this slot budget, not a taste number.
+- **Capacity model.** Nodes run as background tasks under a per-model slot limiter - default 5 concurrent, overridable via `task.default_concurrency` / provider / model concurrency in omo config (0 = unbounded). Nodes past the limit queue FIFO and roll in as slots free, so a wave wider than the slots still completes, serialized in chunks: width costs queue time, never correctness - raise `task.default_concurrency` when wall-clock matters. Caps default to 64 nodes per run and 16 runs per session; `task.dag.max_nodes_per_run` / `task.dag.max_runs_per_session` raise them when a run genuinely needs more.
 
 ## Eval orchestration patterns
 


### PR DESCRIPTION
## Why
`planning.md`'s "Target 5-8 nodes per parallel wave" reads as a decomposition cap, inducing exactly the under-splitting the doctrine elsewhere fights ("real runs collapse to three `deep` nodes"). The runtime never needed that cap: the per-model slot limiter serializes wide waves (width costs queue time, not correctness), and the 64-node/16-run caps are config defaults enforced in `senpi-task/src/dag/graph.ts` + `store.ts` (`task.dag.max_nodes_per_run` / `max_runs_per_session`), not physics.

## What
- **Wave sizing**: grain-based — one node per genuinely independent chunk; `<3` still flags under-splitting; coverage-beats-cost scoped to `quick` map/research waves; fan-in contract for waves wider than ~10 (aggregator/verification nodes read bounded per-node file reports; the lead never reads N raw outputs).
- **Capacity model**: caps reframed as config defaults with the exact knobs; the "slot budget, not a taste number" sentence pointed at the deleted 5-8 target and is removed with it.
- **Mass harvests (new)**: nodes are not units of work — `N_nodes = ceil(total_items / items_per_node)` with ~50-200 items per `quick` node bounded by the <=5k-token report contract; past one run's cap, chain runs with per-run aggregator fan-in. A 10,000-source research harvest is ~100 quick nodes = 2 chained runs at defaults; ~100k items/session before touching a knob.

## Out of scope
ulw-plan's "Target 5-8 todos per wave" (`scaffold-plan.mjs`, `full-workflow.md`) sizes plan-execution todos, a different doctrine — intentionally untouched.

## QA
- `git grep` for the replaced phrases (`slot budget, not a taste number`, `Hard caps: 64 nodes`) → zero tracked matches.
- `bun test packages/omo-senpi/src/components/mass-ulw/mass-ulw.test.ts packages/omo-senpi/src/components/task/mass-ulw-protocol-doc.test.ts` → 16 pass / 0 fail.
- Prose-only change: no machine consumer pins the amended sentences, so no new prose test per repo test discipline.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sizes DAG waves by natural work grain and removes the “5–8 nodes” target; documents mass-harvest sharding and reframes capacity caps as configurable defaults. This clarifies that width affects queue time, not correctness, and preserves fan-in via bounded per-node reports.

- Review: confirm no remaining references to the old numeric target; verify `task.default_concurrency`, `task.dag.max_nodes_per_run`, and `task.dag.max_runs_per_session` names and defaults are accurate.
- Validate: mass-harvest guidance (~50–200 items per `quick` node; <=5k-token per-node report; per-run aggregators) matches current constraints.
- Scope: `ulw-plan` todo wave guidance remains unchanged.
- Migration: none; docs-only.

<sup>Written for commit 465ed64282917c1fc21cb203f2b647d973b2ba94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

