### PR TITLE
feat(omo-native): re-exec the launcher under bun for bun-installed users

### DIFF
--- a/packages/omo-native/bin/lib/bun-runtime.js
+++ b/packages/omo-native/bin/lib/bun-runtime.js
@@ -1,0 +1,127 @@
+import { spawnSync } from "node:child_process"
+import { existsSync, realpathSync } from "node:fs"
+import { homedir as osHomedir } from "node:os"
+import { delimiter, join } from "node:path"
+import { propagateResult } from "./child-process.js"
+
+// A bun global install lives under <BUN_ROOT>/install/global/, and `bun add -g` links its bin
+// through a symlink in <BUN_ROOT>/bin. The link target is what identifies the install, so every
+// comparison below runs on a real path.
+const GLOBAL_TREE_MARKER = "/install/global/"
+
+// Both sides of the tree comparison are reduced to one spelling: backslashes become forward
+// slashes so Windows paths match, and repeated separators collapse because BUN_INSTALL is
+// user-supplied and a value like `/tmp//bunroot` would otherwise never prefix-match a real path.
+function normalize(path) {
+  return path.replaceAll("\\", "/").replaceAll(/\/{2,}/g, "/")
+}
+
+function bunRoot(env, homedir) {
+  return env.BUN_INSTALL ? env.BUN_INSTALL : join(homedir(), ".bun")
+}
+
+/**
+ * Node resolves the main module to its real path, so the script side of the comparison is already
+ * canonical. The root has to be canonicalized too or the two sides can name the same directory in
+ * different spellings - `/tmp` against `/private/tmp` on macOS, or any symlinked home - and a real
+ * bun install would silently fail to be recognized. A root that does not exist is used verbatim.
+ */
+function canonicalRoot(env, homedir, realpath) {
+  const root = bunRoot(env, homedir)
+  try {
+    return realpath(root)
+  } catch {
+    return root
+  }
+}
+
+function binaryName(platform) {
+  return platform === "win32" ? "bun.exe" : "bun"
+}
+
+/**
+ * True when the executed script belongs to a Bun global install. The caller passes the script's
+ * REAL path: `~/.bun/bin/omo` is a symlink into the tree, so the link itself never matches.
+ */
+export function isUnderBunGlobalTree(scriptRealPath, options = {}) {
+  const env = options.env ?? process.env
+  const homedir = options.homedir ?? osHomedir
+  const realpath = options.realpath ?? realpathSync
+  const root = normalize(canonicalRoot(env, homedir, realpath)).replace(/\/+$/, "")
+  return normalize(scriptRealPath).startsWith(`${root}${GLOBAL_TREE_MARKER}`)
+}
+
+function pathExtensions(env, platform) {
+  if (platform !== "win32") return [""]
+  const configured = env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD"
+  return configured.split(";").filter(Boolean)
+}
+
+/**
+ * Locates the bun binary this machine would run. Absence is a normal answer - a user who installed
+ * omo with npm has no bun, and the launcher simply stays on node.
+ */
+export function findBunBinary(options = {}) {
+  const env = options.env ?? process.env
+  const homedir = options.homedir ?? osHomedir
+  const platform = options.platform ?? process.platform
+  const exists = options.exists ?? existsSync
+  const name = binaryName(platform)
+
+  const candidates = [join(bunRoot(env, homedir), "bin", name), join(homedir(), ".bun", "bin", name)]
+  for (const candidate of candidates) {
+    if (exists(candidate)) return candidate
+  }
+
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path")
+  const entries = pathKey ? (env[pathKey] ?? "").split(delimiter).filter(Boolean) : []
+  for (const entry of entries) {
+    for (const extension of pathExtensions(env, platform)) {
+      // On win32 the name already carries .exe; PATHEXT decides which other spellings are runnable.
+      const candidate = join(entry, platform === "win32" ? `bun${extension}` : name)
+      if (exists(candidate)) return candidate
+    }
+  }
+  return undefined
+}
+
+/**
+ * The whole policy in one place, first match wins:
+ *   1. already on bun            -> stay (the loop guard; without it a re-exec would recurse)
+ *   2. OMO_RUNTIME=node          -> stay (explicit user override beats detection)
+ *   3. OMO_RUNTIME=bun + bun     -> re-exec
+ *   4. bun global install + bun  -> re-exec (the reason this module exists)
+ *   5. anything else             -> stay
+ */
+export function resolveBunReexec(input) {
+  const env = input.env ?? process.env
+  const versions = input.versions ?? process.versions
+  if (versions.bun) return { reexec: false }
+  const requested = env.OMO_RUNTIME
+  if (requested === "node") return { reexec: false }
+  if (requested !== "bun" && !isUnderBunGlobalTree(input.scriptPath, input)) return { reexec: false }
+  const bunPath = findBunBinary(input)
+  if (!bunPath) return { reexec: false }
+  return { reexec: true, bunPath }
+}
+
+/**
+ * Runs the decision. Returns true when bun took over the process, in which case the caller must
+ * return immediately: the child has already run to completion and its exit status is propagated.
+ *
+ * Node's execArgv is deliberately dropped - node flags are not bun flags, and forwarding them
+ * would fail the very launch this re-exec is meant to make work.
+ */
+export function maybeReexecUnderBun(input) {
+  const decision = resolveBunReexec(input)
+  if (!decision.reexec) return false
+  const spawn = input.spawn ?? spawnSync
+  const propagate = input.propagate ?? propagateResult
+  const argv = input.argv ?? process.argv
+  const result = spawn(decision.bunPath, [input.scriptPath, ...argv.slice(2)], {
+    stdio: "inherit",
+    windowsHide: true,
+  })
+  propagate(result)
+  return true
+}

--- a/packages/omo-native/bin/lib/bun-runtime.js
+++ b/packages/omo-native/bin/lib/bun-runtime.js
@@ -4,9 +4,9 @@ import { homedir as osHomedir } from "node:os"
 import { delimiter, join } from "node:path"
 import { propagateResult } from "./child-process.js"
 
-// A bun global install lives under <BUN_ROOT>/install/global/, and `bun add -g` links its bin
-// through a symlink in <BUN_ROOT>/bin. The link target is what identifies the install, so every
-// comparison below runs on a real path.
+// A bun global install lives under <BUN_ROOT>/install/global/, and `bun add -g` links the launcher
+// into <BUN_ROOT>/bin. The link TARGET is what identifies the install, so every comparison below
+// runs on a real path.
 const GLOBAL_TREE_MARKER = "/install/global/"
 
 // Both sides of the tree comparison are reduced to one spelling: backslashes become forward
@@ -41,7 +41,8 @@ function binaryName(platform) {
 
 /**
  * True when the executed script belongs to a Bun global install. The caller passes the script's
- * REAL path: `~/.bun/bin/omo` is a symlink into the tree, so the link itself never matches.
+ * REAL path: the launcher is reached through a symlink under the bun root's bin directory, and
+ * that link lives outside the global tree, so the link path itself never matches.
  */
 export function isUnderBunGlobalTree(scriptRealPath, options = {}) {
   const env = options.env ?? process.env

--- a/packages/omo-native/bin/lib/launcher.js
+++ b/packages/omo-native/bin/lib/launcher.js
@@ -68,6 +68,9 @@ function senpiEnvironment(senpiRoot) {
   // senpi's footer reads this marker to show the OmO Native badge for omo-ai installs, which load
   // the plugin via --extension and therefore never match the settings-packages detection gates.
   env.OMO_NATIVE = "1"
+  // This launcher already decided which runtime the product runs on, possibly by re-execing itself
+  // under bun. Handing that answer down stops the engine from making its own, conflicting choice.
+  env.SENPI_RUNTIME = process.versions.bun ? "bun" : "node"
   env.SENPI_BRAND = JSON.stringify(brandProfile())
 
   const binDir = nearestNodeBin(senpiRoot)

--- a/packages/omo-native/bin/omo.js
+++ b/packages/omo-native/bin/omo.js
@@ -1,10 +1,19 @@
 #!/usr/bin/env node
+import { fileURLToPath } from "node:url"
+import { maybeReexecUnderBun } from "./lib/bun-runtime.js"
 import { runLauncher } from "./lib/launcher.js"
 import { runSetup } from "./lib/setup-import.js"
 
 try {
-  if (process.argv[2] === "setup") await runSetup(process.argv.slice(3))
-  else await runLauncher()
+  // A `bun add -g omo-ai` install is reached through a symlink in ~/.bun/bin, and node resolves the
+  // main module to its real path, so this URL already points inside the bun global tree. Handing
+  // that install back to bun keeps the engine on the runtime the user installed it with; every
+  // other install, and an explicit OMO_RUNTIME=node, stays on node.
+  const reexeced = maybeReexecUnderBun({ scriptPath: fileURLToPath(import.meta.url) })
+  if (!reexeced) {
+    if (process.argv[2] === "setup") await runSetup(process.argv.slice(3))
+    else await runLauncher()
+  }
 } catch (error) {
   console.error(`omo: ${error.message}`)
   process.exitCode = 1

--- a/packages/omo-native/test/bun-runtime.test.ts
+++ b/packages/omo-native/test/bun-runtime.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, test } from "bun:test"
+import { join } from "node:path"
+import {
+  findBunBinary,
+  isUnderBunGlobalTree,
+  maybeReexecUnderBun,
+  resolveBunReexec,
+} from "../bin/lib/bun-runtime.js"
+
+type Options = {
+  env?: Record<string, string | undefined>
+  homedir?: () => string
+  platform?: string
+  exists?: (path: string) => boolean
+  realpath?: (path: string) => string
+}
+
+const POSIX_HOME = "/home/dev"
+const WIN_HOME = String.raw`C:\Users\dev`
+
+/**
+ * Every case injects this so no assertion ever touches the host filesystem: the real realpathSync
+ * would resolve nothing for these invented paths, and on a machine where one of them happened to
+ * exist the result would change. Cases about symlink resolution inject their own mapping.
+ */
+const identityRealpath = (path: string): string => path
+
+function existsOnly(...present: string[]): (path: string) => boolean {
+  const set = new Set(present)
+  return (path) => set.has(path)
+}
+
+function bunTreePackage(bunRoot: string, separator = "/"): string {
+  return [bunRoot, "install", "global", "node_modules", "omo-ai", "bin", "omo.js"].join(separator)
+}
+
+describe("bun runtime re-exec", () => {
+  describe("#given a script path and an injected home", () => {
+    describe("#when the script sits inside the default bun global tree", () => {
+      test("#then it is recognized as a bun global install", () => {
+        // given
+        const script = bunTreePackage(join(POSIX_HOME, ".bun"))
+        // when
+        const under = isUnderBunGlobalTree(script, {
+          env: {},
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          realpath: identityRealpath,
+        })
+        // then
+        expect(under).toBe(true)
+      })
+
+      test("#then a symlinked bun root is resolved before comparing", () => {
+        // The script path node hands over is already realpathed, so a BUN_INSTALL naming a symlink
+        // (macOS /tmp -> /private/tmp, or a symlinked home) would otherwise never prefix-match the
+        // very install it points at. Caught by real-surface QA, pinned here.
+        const options: Options = {
+          env: { BUN_INSTALL: "/tmp/bunroot" },
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          realpath: (path) => (path === "/tmp/bunroot" ? "/private/tmp/bunroot" : path),
+        }
+        // when / then
+        expect(isUnderBunGlobalTree(bunTreePackage("/private/tmp/bunroot"), options)).toBe(true)
+      })
+
+      test("#then an unresolvable bun root falls back to its literal spelling", () => {
+        // given
+        const options: Options = {
+          env: { BUN_INSTALL: "/opt/bunroot" },
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          realpath: () => {
+            throw new Error("ENOENT")
+          },
+        }
+        // when / then
+        expect(isUnderBunGlobalTree(bunTreePackage("/opt/bunroot"), options)).toBe(true)
+      })
+
+      test("#then BUN_INSTALL relocates the tree that counts", () => {
+        // given
+        const relocated = "/opt/bunroot"
+        const options: Options = {
+          env: { BUN_INSTALL: relocated },
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          realpath: identityRealpath,
+        }
+        // when / then
+        expect(isUnderBunGlobalTree(bunTreePackage(relocated), options)).toBe(true)
+        expect(isUnderBunGlobalTree(bunTreePackage(join(POSIX_HOME, ".bun")), options)).toBe(false)
+      })
+
+      test("#then redundant separators in BUN_INSTALL still match", () => {
+        // BUN_INSTALL is user-supplied, and a TMPDIR ending in a slash yields values like
+        // `/tmp//root`. A raw prefix comparison misses those, so the launcher would silently
+        // refuse to re-exec a genuine bun install. Caught by real-surface QA, pinned here.
+        const options: Options = {
+          env: { BUN_INSTALL: "/var/tmp//bunroot" },
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          realpath: identityRealpath,
+        }
+        // when / then
+        expect(isUnderBunGlobalTree(bunTreePackage("/var/tmp/bunroot"), options)).toBe(true)
+      })
+
+      test("#then a trailing separator in BUN_INSTALL still matches", () => {
+        // given
+        const options: Options = {
+          env: { BUN_INSTALL: "/var/tmp/bunroot/" },
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          realpath: identityRealpath,
+        }
+        // when / then
+        expect(isUnderBunGlobalTree(bunTreePackage("/var/tmp/bunroot"), options)).toBe(true)
+      })
+
+      test("#then a Windows backslash path still matches the tree", () => {
+        // given
+        const script = bunTreePackage(String.raw`C:\Users\dev\.bun`, "\\")
+        // when
+        const under = isUnderBunGlobalTree(script, {
+          env: {},
+          homedir: () => WIN_HOME,
+          platform: "win32",
+          realpath: identityRealpath,
+        })
+        // then
+        expect(under).toBe(true)
+      })
+    })
+
+    describe("#when the script sits in an npm global layout", () => {
+      test("#then it is not a bun global install", () => {
+        // given
+        const script = "/usr/local/lib/node_modules/omo-ai/bin/omo.js"
+        // when
+        const under = isUnderBunGlobalTree(script, {
+          env: {},
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          realpath: identityRealpath,
+        })
+        // then
+        expect(under).toBe(false)
+      })
+    })
+  })
+
+  describe("#given a bun binary lookup", () => {
+    describe("#when BUN_INSTALL names an existing binary", () => {
+      test("#then that binary wins over the home default", () => {
+        // given
+        const relocated = "/opt/bunroot"
+        const preferred = join(relocated, "bin", "bun")
+        const fallback = join(POSIX_HOME, ".bun", "bin", "bun")
+        // when
+        const found = findBunBinary({
+          env: { BUN_INSTALL: relocated },
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          exists: existsOnly(preferred, fallback),
+        })
+        // then
+        expect(found).toBe(preferred)
+      })
+    })
+
+    describe("#when only PATH holds a bun binary", () => {
+      test("#then the PATH entry is used", () => {
+        // given
+        const onPath = "/usr/local/bin/bun"
+        // when
+        const found = findBunBinary({
+          env: { PATH: `/nowhere:${"/usr/local/bin"}` },
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          exists: existsOnly(onPath),
+        })
+        // then
+        expect(found).toBe(onPath)
+      })
+    })
+
+    describe("#when the host is Windows", () => {
+      test("#then the .exe spelling is discovered", () => {
+        // given
+        const winBun = join(WIN_HOME, ".bun", "bin", "bun.exe")
+        // when
+        const found = findBunBinary({
+          env: {},
+          homedir: () => WIN_HOME,
+          platform: "win32",
+          exists: existsOnly(winBun),
+        })
+        // then
+        expect(found).toBe(winBun)
+      })
+    })
+
+    describe("#when no bun binary exists anywhere", () => {
+      test("#then the lookup reports nothing instead of throwing", () => {
+        // given
+        const options: Options = {
+          env: { PATH: "/usr/bin" },
+          homedir: () => POSIX_HOME,
+          platform: "linux",
+          exists: () => false,
+        }
+        // when
+        const found = findBunBinary(options)
+        // then
+        expect(found).toBeUndefined()
+      })
+    })
+  })
+
+  describe("#given the re-exec decision table", () => {
+    const bunPath = join(POSIX_HOME, ".bun", "bin", "bun")
+    const treeScript = bunTreePackage(join(POSIX_HOME, ".bun"))
+    const plainScript = "/usr/local/lib/node_modules/omo-ai/bin/omo.js"
+
+    function decide(overrides: {
+      scriptPath?: string
+      env?: Record<string, string | undefined>
+      versions?: Record<string, string | undefined>
+      exists?: (path: string) => boolean
+    } = {}) {
+      return resolveBunReexec({
+        scriptPath: overrides.scriptPath ?? treeScript,
+        env: overrides.env ?? {},
+        versions: overrides.versions ?? {},
+        homedir: () => POSIX_HOME,
+        platform: "linux",
+        exists: overrides.exists ?? existsOnly(bunPath),
+        realpath: identityRealpath,
+      })
+    }
+
+    describe("#when the process already runs on bun", () => {
+      test("#then it stays, so a re-exec can never loop", () => {
+        // given / when
+        const decision = decide({ versions: { bun: "1.4.0" }, env: { OMO_RUNTIME: "bun" } })
+        // then
+        expect(decision).toEqual({ reexec: false })
+      })
+    })
+
+    describe("#when OMO_RUNTIME pins node", () => {
+      test("#then it stays even inside the bun global tree", () => {
+        // given / when
+        const decision = decide({ env: { OMO_RUNTIME: "node" } })
+        // then
+        expect(decision).toEqual({ reexec: false })
+      })
+    })
+
+    describe("#when OMO_RUNTIME asks for bun", () => {
+      test("#then it re-execs with the discovered binary even outside the tree", () => {
+        // given / when
+        const decision = decide({ scriptPath: plainScript, env: { OMO_RUNTIME: "bun" } })
+        // then
+        expect(decision).toEqual({ reexec: true, bunPath })
+      })
+
+      test("#then a missing bun binary leaves the process on node", () => {
+        // given / when
+        const decision = decide({ scriptPath: plainScript, env: { OMO_RUNTIME: "bun" }, exists: () => false })
+        // then
+        expect(decision).toEqual({ reexec: false })
+      })
+    })
+
+    describe("#when the script is installed in the bun global tree", () => {
+      test("#then it re-execs under bun", () => {
+        // given / when
+        const decision = decide()
+        // then
+        expect(decision).toEqual({ reexec: true, bunPath })
+      })
+
+      test("#then a relocated BUN_INSTALL tree is honored", () => {
+        // given
+        const relocated = "/opt/bunroot"
+        const relocatedBun = join(relocated, "bin", "bun")
+        // when
+        const decision = decide({
+          scriptPath: bunTreePackage(relocated),
+          env: { BUN_INSTALL: relocated },
+          exists: existsOnly(relocatedBun),
+        })
+        // then
+        expect(decision).toEqual({ reexec: true, bunPath: relocatedBun })
+      })
+
+      test("#then a tree without any bun binary stays on node", () => {
+        // given / when
+        const decision = decide({ exists: () => false })
+        // then
+        expect(decision).toEqual({ reexec: false })
+      })
+    })
+
+    describe("#when the script came from an npm global install", () => {
+      test("#then it stays on node although bun is installed", () => {
+        // given / when
+        const decision = decide({ scriptPath: plainScript })
+        // then
+        expect(decision).toEqual({ reexec: false })
+      })
+    })
+  })
+
+  describe("#given the executing re-exec entry point", () => {
+    const bunPath = join(POSIX_HOME, ".bun", "bin", "bun")
+    const treeScript = bunTreePackage(join(POSIX_HOME, ".bun"))
+
+    test("#then the script and its arguments are handed to bun with inherited stdio", () => {
+      // given
+      const calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = []
+      const propagated: Array<Record<string, unknown>> = []
+      // when
+      const consumed = maybeReexecUnderBun({
+        scriptPath: treeScript,
+        argv: ["node", treeScript, "say", "hi"],
+        env: {},
+        versions: {},
+        homedir: () => POSIX_HOME,
+        platform: "linux",
+        exists: existsOnly(bunPath),
+        realpath: identityRealpath,
+        spawn: (command: string, args: string[], options: Record<string, unknown>) => {
+          calls.push({ command, args, options })
+          return { status: 0, signal: null }
+        },
+        propagate: (result: Record<string, unknown>) => {
+          propagated.push(result)
+        },
+      })
+      // then
+      expect(consumed).toBe(true)
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.command).toBe(bunPath)
+      expect(calls[0]?.args).toEqual([treeScript, "say", "hi"])
+      expect(calls[0]?.options).toMatchObject({ stdio: "inherit", windowsHide: true })
+      expect(propagated).toEqual([{ status: 0, signal: null }])
+    })
+
+    test("#then a stay decision spawns nothing and lets the caller continue", () => {
+      // given
+      let spawned = 0
+      // when
+      const consumed = maybeReexecUnderBun({
+        scriptPath: treeScript,
+        argv: ["node", treeScript, "say", "hi"],
+        env: { OMO_RUNTIME: "node" },
+        versions: {},
+        homedir: () => POSIX_HOME,
+        platform: "linux",
+        exists: existsOnly(bunPath),
+        realpath: identityRealpath,
+        spawn: () => {
+          spawned += 1
+          return { status: 0, signal: null }
+        },
+        propagate: () => {},
+      })
+      // then
+      expect(consumed).toBe(false)
+      expect(spawned).toBe(0)
+    })
+
+    test("#then a bun process already running never re-execs itself", () => {
+      // given
+      let spawned = 0
+      // when
+      const consumed = maybeReexecUnderBun({
+        scriptPath: treeScript,
+        argv: ["bun", treeScript],
+        env: {},
+        versions: { bun: "1.4.0" },
+        homedir: () => POSIX_HOME,
+        platform: "linux",
+        exists: existsOnly(bunPath),
+        realpath: identityRealpath,
+        spawn: () => {
+          spawned += 1
+          return { status: 0, signal: null }
+        },
+        propagate: () => {},
+      })
+      // then
+      expect(consumed).toBe(false)
+      expect(spawned).toBe(0)
+    })
+  })
+})

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -129,6 +129,22 @@ function capture(fixture: Fixture): { argv: string[]; env: NodeJS.ProcessEnv; ta
   return JSON.parse(readFileSync(fixture.captureFile, "utf8"))
 }
 
+/**
+ * Resolves a real interpreter for the runtime under test. `bun test` runs on bun and node ships as
+ * a sibling of it (and vice versa), but neither is guaranteed, so a missing interpreter skips its
+ * case rather than failing on the host's toolchain.
+ */
+function runtimeInterpreter(runtime: "node" | "bun"): string | undefined {
+  const current = runtime === "bun" ? Boolean(process.versions.bun) : !process.versions.bun
+  if (current) return process.execPath
+  const name = process.platform === "win32" ? `${runtime}.exe` : runtime
+  const sibling = join(dirname(process.execPath), name)
+  if (existsSync(sibling)) return sibling
+  const located = spawnSync(process.platform === "win32" ? "where" : "which", [runtime], { encoding: "utf8" })
+  const resolved = located.status === 0 ? located.stdout.split(/\r?\n/)[0]?.trim() : undefined
+  return resolved ? resolved : undefined
+}
+
 function expectedBunUpdateCommand(packageRoot: string): string {
   const quotedRoot = process.platform === "win32"
     ? `"${packageRoot.replaceAll("\\", "/")}"`
@@ -208,6 +224,31 @@ describe("omo launcher", () => {
           changelogUrl: "https://github.com/code-yeongyu/oh-my-openagent/releases",
         })
       })
+
+      // The launcher may re-exec itself under bun; whichever runtime wins, the engine must be told
+      // about it so it never flips back and spawns a second interpreter of its own. Both spellings
+      // are driven through a real interpreter, because the value has to track the process that
+      // actually runs the launcher rather than a constant either side could drift away from.
+      for (const runtime of ["node", "bun"] as const) {
+        const interpreter = runtimeInterpreter(runtime)
+        // Skipping is visible in the report; silently passing on a host without the interpreter
+        // would let the contract rot unnoticed.
+        test.skipIf(!interpreter)(`#then a launcher running on ${runtime} tells the engine SENPI_RUNTIME=${runtime}`, () => {
+          const fixture = createFixture()
+          // OMO_RUNTIME pins the decision, so this asserts the reported value and never depends on
+          // whether the host happens to have omo installed in a bun global tree.
+          const result = spawnSync(interpreter ?? process.execPath, [fixture.launcher, "say", "hi"], {
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              CAPTURE_FILE: fixture.captureFile,
+              OMO_RUNTIME: runtime,
+            },
+          })
+          expect(result.status).toBe(0)
+          expect(capture(fixture).env.SENPI_RUNTIME).toBe(runtime)
+        })
+      }
 
       test("#then OMO_BIN names this launcher, so the product never resolves to the bare engine", () => {
         const fixture = createFixture({ hoisted: true })

--- a/script/agent-command-string-audit.allowlist.json
+++ b/script/agent-command-string-audit.allowlist.json
@@ -26,6 +26,7 @@
     "packages/omo-codex/README.md: omo get-local-version",
     "packages/omo-native/AGENTS.md: omo doctor",
     "packages/omo-native/bin/lib/agent-dir.js: omo doctor",
+    "packages/omo-native/test/bun-runtime.test.ts: /bin/omo x2",
     "packages/omo-native/test/doctor.test.ts: omo doctor x2",
     "packages/omo-opencode/src/cli/doctor/checks/codex-components.test.ts: omo doctor",
     "packages/omo-opencode/src/cli/doctor/checks/codex-components.ts: omo doctor",


### PR DESCRIPTION
## Summary

A user who runs `bun add -g omo-ai` gets `~/.bun/bin/omo`, a symlink into the Bun global tree. The shebang in `bin/omo.js` still says `node`, so the product silently ran on the runtime the user did not pick. This makes the launcher notice that install and hand the process back to bun, and it tells the spawned senpi engine which runtime won so the decision is made exactly once per launch.

Users who installed with npm are unaffected, and a machine with no bun binary stays on node without an error.

## Changes

**`packages/omo-native/bin/lib/bun-runtime.js`** (new) - pure, injectable helpers:

- `isUnderBunGlobalTree(scriptRealPath, opts)` - the executed script's real path sits under `<BUN_ROOT>/install/global/`, where `BUN_ROOT` is `BUN_INSTALL` or `~/.bun`. The real path matters because `~/.bun/bin/omo` is a symlink and the link itself never matches.
- `findBunBinary(opts)` - `BUN_INSTALL/bin/bun` -> `~/.bun/bin/bun` -> PATH scan, honoring `PATHEXT` and the `.exe` suffix on win32. Missing bun is a normal answer, never an error.
- `resolveBunReexec(input)` - the decision table, first match wins: already on bun -> stay (loop guard); `OMO_RUNTIME=node` -> stay; `OMO_RUNTIME=bun` + bun found -> re-exec; bun global tree + bun found -> re-exec; otherwise stay.
- `maybeReexecUnderBun(...)` - executes the decision via `spawnSync` and the existing `propagateResult`, returning `true` when a re-exec consumed the process. Node's `execArgv` is deliberately dropped, since node flags are not bun flags.

**`packages/omo-native/bin/omo.js`** - first thing in the `try` block; when it re-execs, nothing else runs and the exit status is already propagated. Covers both the setup and launcher paths.

**`packages/omo-native/bin/lib/launcher.js`** - `senpiEnvironment()` sets `SENPI_RUNTIME` to the runtime actually executing the launcher, so the engine inherits the decision rather than re-deciding. The engine side honors it as a hard answer (landed separately in the senpi repo).

## QA & Evidence

Evidence: `.omo/evidence/20260822-launcher-bun-auto-runtime/` (gitignored), see `README.md` there.

Real-surface run (`06-qa-real-surface.txt`) builds a throwaway `BUN_INSTALL` tree with a logging bun shim plus a copy of the real `bin/`, then drives the real `bin/omo.js` through node:

| Case | Expected | Observed |
|---|---|---|
| script inside the bun tree | re-exec | shim `INVOKED`, `argv: <omo.js> --version` |
| same + `OMO_RUNTIME=node` | stay | no shim log, node answered `--version` |
| repo checkout, no bun tree | stay | no shim log, normal launcher output |

**The real-surface QA caught two production bugs the unit tests missed**, both in the tree-path comparison, both now fixed and pinned by regression tests:

1. Interior duplicate separators. macOS `TMPDIR` ends in `/`, so `BUN_INSTALL` arrived as `/var/.../T//omo-...` and the prefix comparison missed the install. `BUN_INSTALL` is user-supplied, so this is a real-world shape, not a temp-dir quirk.
2. An unresolved symlink on the root side. Node realpaths the main module, so the script arrived as `/private/var/...` while the root stayed `/var/...`; the two named the same directory and never matched. The root is now canonicalized through an injectable `realpath`, falling back to the literal value when it does not resolve. A symlinked `$HOME` reproduces the same failure against `~/.bun`.

Tests:

- RED captured before implementation (`01-red-bun-runtime.txt`), GREEN after (`02-green-bun-runtime.txt`).
- `bun test packages/omo-native`: **118 pass, 13 fail**. The same suite with this change stashed away is **93 pass, 13 fail** (`04-baseline-preexisting-failures.txt`), and the 13 failing test names are identical between the two runs. They are pre-existing `omo doctor` / `omo setup` failures on `dev`, untouched here. This change adds 25 passing tests and zero new failures.
- `tsgo --noEmit -p packages/omo-native/tsconfig.json` clean (`05-typecheck.txt`).

Unit tests are fully hermetic: every helper takes injected `env` / `homedir` / `platform` / `exists` / `realpath`, so nothing reads the host PATH or the host `~/.bun`. That is deliberate for the Windows shards on Bun 1.4, where a real bun is present and a host-reading test would pass or fail by accident. The real `~/.bun` was never written and never used as a binary source; the `~/.bun/bin` digest is recorded before and after in the transcript and is unchanged.

## Risks

- The re-exec is not driven against a real bun binary end to end - the QA shim stands in for one and exits 0. The forwarded argv shape is pinned by unit test and matches what `spawnNode` already sends in production.
- Behavior change is scoped to bun global installs: an npm install, a repo checkout, and a machine without bun all take the same path they did before.
- Re-exec costs one extra process spawn on affected installs, paid once per launch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-execs the `omo` launcher under Bun for users who installed with `bun add -g`, so the runtime matches the install choice. Previously these users ran under Node due to the Node shebang; now the launcher detects Bun global installs and hands execution to Bun, and the engine inherits the decision.

- Detects Bun global installs by checking the executed script’s real path under `<BUN_ROOT>/install/global/`, normalizing separators and resolving a symlinked root so comparisons don’t miss valid installs (handles Windows backslashes, duplicate/trailing separators).
- Re-exec policy: already on Bun or `OMO_RUNTIME=node` => stay; `OMO_RUNTIME=bun` with Bun found => re-exec; Bun global install with Bun found => re-exec; missing Bun => stay. Drops Node `execArgv` and propagates the child’s exit; adds one extra spawn only when re-execing.
- Sets `SENPI_RUNTIME` to the actual runtime so the engine does not re-decide and flip-flop.
- No change for npm installs or hosts without Bun; loop-safe.
- Tests cover detection and handoff on Node and Bun using hermetic inputs; updates `script/agent-command-string-audit.allowlist.json` to keep the “bare omo” command-string audit green for new fixtures/comments.

<sup>Written for commit 27ba9b56ac875412e07b4d1636f08ab118f67a5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

