### PR TITLE
fix(omo-native): honor target path semantics

### DIFF
--- a/packages/omo-native/bin/lib/bun-runtime.js
+++ b/packages/omo-native/bin/lib/bun-runtime.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process"
 import { existsSync, realpathSync } from "node:fs"
 import { homedir as osHomedir } from "node:os"
-import { delimiter, join } from "node:path"
+import { posix, win32 } from "node:path"
 import { propagateResult } from "./child-process.js"
 
 // A bun global install lives under <BUN_ROOT>/install/global/, and `bun add -g` links the launcher
@@ -16,8 +16,12 @@ function normalize(path) {
   return path.replaceAll("\\", "/").replaceAll(/\/{2,}/g, "/")
 }
 
-function bunRoot(env, homedir) {
-  return env.BUN_INSTALL ? env.BUN_INSTALL : join(homedir(), ".bun")
+function pathApi(platform) {
+  return platform === "win32" ? win32 : posix
+}
+
+function bunRoot(env, homedir, platform) {
+  return env.BUN_INSTALL ? env.BUN_INSTALL : pathApi(platform).join(homedir(), ".bun")
 }
 
 /**
@@ -26,8 +30,8 @@ function bunRoot(env, homedir) {
  * different spellings - `/tmp` against `/private/tmp` on macOS, or any symlinked home - and a real
  * bun install would silently fail to be recognized. A root that does not exist is used verbatim.
  */
-function canonicalRoot(env, homedir, realpath) {
-  const root = bunRoot(env, homedir)
+function canonicalRoot(env, homedir, platform, realpath) {
+  const root = bunRoot(env, homedir, platform)
   try {
     return realpath(root)
   } catch {
@@ -39,6 +43,10 @@ function binaryName(platform) {
   return platform === "win32" ? "bun.exe" : "bun"
 }
 
+function pathDelimiter(platform) {
+  return platform === "win32" ? ";" : ":"
+}
+
 /**
  * True when the executed script belongs to a Bun global install. The caller passes the script's
  * REAL path: the launcher is reached through a symlink under the bun root's bin directory, and
@@ -47,8 +55,9 @@ function binaryName(platform) {
 export function isUnderBunGlobalTree(scriptRealPath, options = {}) {
   const env = options.env ?? process.env
   const homedir = options.homedir ?? osHomedir
+  const platform = options.platform ?? process.platform
   const realpath = options.realpath ?? realpathSync
-  const root = normalize(canonicalRoot(env, homedir, realpath)).replace(/\/+$/, "")
+  const root = normalize(canonicalRoot(env, homedir, platform, realpath)).replace(/\/+$/, "")
   return normalize(scriptRealPath).startsWith(`${root}${GLOBAL_TREE_MARKER}`)
 }
 
@@ -67,19 +76,23 @@ export function findBunBinary(options = {}) {
   const homedir = options.homedir ?? osHomedir
   const platform = options.platform ?? process.platform
   const exists = options.exists ?? existsSync
+  const paths = pathApi(platform)
   const name = binaryName(platform)
 
-  const candidates = [join(bunRoot(env, homedir), "bin", name), join(homedir(), ".bun", "bin", name)]
+  const candidates = [
+    paths.join(bunRoot(env, homedir, platform), "bin", name),
+    paths.join(homedir(), ".bun", "bin", name),
+  ]
   for (const candidate of candidates) {
     if (exists(candidate)) return candidate
   }
 
   const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path")
-  const entries = pathKey ? (env[pathKey] ?? "").split(delimiter).filter(Boolean) : []
+  const entries = pathKey ? (env[pathKey] ?? "").split(pathDelimiter(platform)).filter(Boolean) : []
   for (const entry of entries) {
     for (const extension of pathExtensions(env, platform)) {
       // On win32 the name already carries .exe; PATHEXT decides which other spellings are runnable.
-      const candidate = join(entry, platform === "win32" ? `bun${extension}` : name)
+      const candidate = paths.join(entry, platform === "win32" ? `bun${extension}` : name)
       if (exists(candidate)) return candidate
     }
   }

--- a/packages/omo-native/test/bun-runtime.test.ts
+++ b/packages/omo-native/test/bun-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { join } from "node:path"
+import { join, win32 } from "node:path"
 import {
   findBunBinary,
   isUnderBunGlobalTree,
@@ -189,7 +189,7 @@ describe("bun runtime re-exec", () => {
     describe("#when the host is Windows", () => {
       test("#then the .exe spelling is discovered", () => {
         // given
-        const winBun = join(WIN_HOME, ".bun", "bin", "bun.exe")
+        const winBun = win32.join(WIN_HOME, ".bun", "bin", "bun.exe")
         // when
         const found = findBunBinary({
           env: {},
@@ -199,6 +199,20 @@ describe("bun runtime re-exec", () => {
         })
         // then
         expect(found).toBe(winBun)
+      })
+
+      test("#then semicolon-delimited PATH entries are searched", () => {
+        // given
+        const onPath = win32.join("C:\\", "tools", "bun.EXE")
+        // when
+        const found = findBunBinary({
+          env: { PATH: `C:\\nowhere;C:\\tools` },
+          homedir: () => WIN_HOME,
+          platform: "win32",
+          exists: existsOnly(onPath),
+        })
+        // then
+        expect(found).toBe(onPath)
       })
     })
 


### PR DESCRIPTION
## Summary

Fix `omo-ai` Bun binary lookup so injected target-platform tests use that
platform's path API and PATH delimiter instead of the host process's.

This unblocks the beta.17 Windows release-state matrix, where a Linux lookup
case intentionally runs on Windows and must still parse `/usr/local/bin` using
POSIX semantics.

## Root cause

`findBunBinary` accepted an injected `platform`, but used host-bound
`node:path.join` and `node:path.delimiter`. On Windows:

- a simulated Linux PATH was split with `;`, so `/usr/local/bin/bun` was never
  considered;
- simulated Windows paths built on a non-Windows host could use the wrong
  separators.

## Fix

- Select `node:path.posix` or `node:path.win32` from the effective target
  platform.
- Split PATH with `:` for POSIX targets and `;` for Windows targets.
- Add a Windows semicolon-delimited PATH regression test.

## QA

- `bun test packages/omo-native/test/bun-runtime.test.ts`: 24 passed, 0 failed.
- Clean-environment `bun test packages/omo-native/test`: 132 passed, 0 failed.
- `tsgo --noEmit -p packages/omo-native/tsconfig.json`: passed.
- LSP initially timed out refreshing after the worktree install; the package
  typecheck is the authoritative diagnostic gate and is clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the target platform’s path API and PATH delimiter when resolving the Bun binary in `omo-native`. Previously we used the host’s `path.join` and delimiter, which caused PATH parsing and candidate paths to be wrong in cross-platform runs (e.g., Linux PATH on Windows).

- Selects `node:path.posix` or `node:path.win32` by the target platform; splits PATH with `:` on POSIX and `;` on Windows; builds candidates with the target API.
- Updates `canonicalRoot`/`bunRoot` to use the target API; uses `win32.join` in tests; adds a regression test for semicolon-delimited PATH on Windows.
- No public API changes; callers can continue injecting `platform` as before.

<sup>Written for commit 74aa8ac58491fcee814890d19e2020e2279bd8df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

