### PR TITLE
test(omo-native): make path fixtures platform explicit

### DIFF
--- a/packages/omo-native/test/bun-runtime.test.ts
+++ b/packages/omo-native/test/bun-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { join, win32 } from "node:path"
+import { posix, win32 } from "node:path"
 import {
   findBunBinary,
   isUnderBunGlobalTree,
@@ -39,7 +39,7 @@ describe("bun runtime re-exec", () => {
     describe("#when the script sits inside the default bun global tree", () => {
       test("#then it is recognized as a bun global install", () => {
         // given
-        const script = bunTreePackage(join(POSIX_HOME, ".bun"))
+        const script = bunTreePackage(posix.join(POSIX_HOME, ".bun"))
         // when
         const under = isUnderBunGlobalTree(script, {
           env: {},
@@ -90,7 +90,7 @@ describe("bun runtime re-exec", () => {
         }
         // when / then
         expect(isUnderBunGlobalTree(bunTreePackage(relocated), options)).toBe(true)
-        expect(isUnderBunGlobalTree(bunTreePackage(join(POSIX_HOME, ".bun")), options)).toBe(false)
+        expect(isUnderBunGlobalTree(bunTreePackage(posix.join(POSIX_HOME, ".bun")), options)).toBe(false)
       })
 
       test("#then redundant separators in BUN_INSTALL still match", () => {
@@ -156,8 +156,8 @@ describe("bun runtime re-exec", () => {
       test("#then that binary wins over the home default", () => {
         // given
         const relocated = "/opt/bunroot"
-        const preferred = join(relocated, "bin", "bun")
-        const fallback = join(POSIX_HOME, ".bun", "bin", "bun")
+        const preferred = posix.join(relocated, "bin", "bun")
+        const fallback = posix.join(POSIX_HOME, ".bun", "bin", "bun")
         // when
         const found = findBunBinary({
           env: { BUN_INSTALL: relocated },
@@ -234,8 +234,8 @@ describe("bun runtime re-exec", () => {
   })
 
   describe("#given the re-exec decision table", () => {
-    const bunPath = join(POSIX_HOME, ".bun", "bin", "bun")
-    const treeScript = bunTreePackage(join(POSIX_HOME, ".bun"))
+    const bunPath = posix.join(POSIX_HOME, ".bun", "bin", "bun")
+    const treeScript = bunTreePackage(posix.join(POSIX_HOME, ".bun"))
     const plainScript = "/usr/local/lib/node_modules/omo-ai/bin/omo.js"
 
     function decide(overrides: {
@@ -300,7 +300,7 @@ describe("bun runtime re-exec", () => {
       test("#then a relocated BUN_INSTALL tree is honored", () => {
         // given
         const relocated = "/opt/bunroot"
-        const relocatedBun = join(relocated, "bin", "bun")
+        const relocatedBun = posix.join(relocated, "bin", "bun")
         // when
         const decision = decide({
           scriptPath: bunTreePackage(relocated),
@@ -330,8 +330,8 @@ describe("bun runtime re-exec", () => {
   })
 
   describe("#given the executing re-exec entry point", () => {
-    const bunPath = join(POSIX_HOME, ".bun", "bin", "bun")
-    const treeScript = bunTreePackage(join(POSIX_HOME, ".bun"))
+    const bunPath = posix.join(POSIX_HOME, ".bun", "bin", "bun")
+    const treeScript = bunTreePackage(posix.join(POSIX_HOME, ".bun"))
 
     test("#then the script and its arguments are handed to bun with inherited stdio", () => {
       // given


### PR DESCRIPTION
## Summary

Make the Bun runtime tests use explicit target-platform path semantics instead
of the CI host's `node:path.join`.

This is the test-side companion to #7140. The implementation now correctly
uses `posix` for injected Linux targets and `win32` for injected Windows
targets, so the fixtures must construct their expected paths the same way.

## Root cause

Nine Linux fixtures used host-bound `join()`. On Windows they produced
backslash paths such as `\home\dev\.bun\bin\bun`, while the target-aware
implementation correctly returned `/home/dev/.bun/bin/bun`.

## Fix

- Replace all nine Linux fixture joins with `posix.join`.
- Keep Windows fixtures on `win32.join`.

## QA

- `bun test packages/omo-native/test/bun-runtime.test.ts`: 24 passed, 0 failed.
- Clean-environment `bun test packages/omo-native/test`: 132 passed, 0 failed.
- `tsgo --noEmit -p packages/omo-native/tsconfig.json`: passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `omo-native` Bun runtime tests use explicit platform path semantics so expectations match the target platform instead of the CI host. Linux fixtures now use `posix.join` and Windows fixtures continue to use `win32.join`, fixing cases where host-bound `join` from `node:path` produced backslashes on Windows.

- Only `packages/omo-native/test/bun-runtime.test.ts` changes: replace host `join` with `posix` and update Linux path joins; keep Windows joins via `win32`.
- Verify expectations align with target platform: injected Linux => POSIX paths; injected Windows => Win32 paths.
- No runtime code changes or user-facing behavior.

<sup>Written for commit dcbe734a6ea3b6c5d9a07e18a3db68247ed8ad73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

